### PR TITLE
feat(plugins): add workerd plugin variants for headless runtimes

### DIFF
--- a/packages/plugins/plugin-assistant/moon.yml
+++ b/packages/plugins/plugin-assistant/moon.yml
@@ -13,6 +13,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/AssistantPlugin.ts'
       - '--entryPoint=src/AssistantPlugin.node.ts'
+      - '--entryPoint=src/AssistantPlugin.workerd.ts'
       - '--entryPoint=src/blueprints/index.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'

--- a/packages/plugins/plugin-assistant/package.json
+++ b/packages/plugins/plugin-assistant/package.json
@@ -50,10 +50,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/AssistantPlugin.workerd.ts",
         "node": "./src/AssistantPlugin.node.ts",
         "default": "./src/AssistantPlugin.tsx"
       },
       "types": "./dist/types/src/AssistantPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/AssistantPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/AssistantPlugin.node.mjs",
       "default": "./dist/lib/neutral/AssistantPlugin.mjs"
     },

--- a/packages/plugins/plugin-assistant/src/AssistantPlugin.workerd.ts
+++ b/packages/plugins/plugin-assistant/src/AssistantPlugin.workerd.ts
@@ -1,0 +1,40 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { AiContext } from '@dxos/assistant';
+import { Agent, Chat, McpServer, Memory, Plan } from '@dxos/assistant-toolkit';
+import { Blueprint, Routine } from '@dxos/compute';
+import { Sequence } from '@dxos/conductor';
+import { Feed } from '@dxos/echo';
+import { Text } from '@dxos/schema';
+import { HasSubject, Message } from '@dxos/types';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+
+export const AssistantPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({
+    schema: [
+      Chat.Chat,
+      Chat.CompanionTo,
+      Blueprint.Blueprint,
+      AiContext.Binding,
+      Feed.Feed,
+      HasSubject.HasSubject,
+      Message.Message,
+      Routine.Routine,
+      Agent.Agent,
+      McpServer.McpServer,
+      Plan.Plan,
+      Sequence.Sequence,
+      Memory.Memory,
+      Text.Text,
+    ],
+  }),
+  Plugin.make,
+);
+
+export default AssistantPlugin;

--- a/packages/plugins/plugin-assistant/src/AssistantPlugin.workerd.ts
+++ b/packages/plugins/plugin-assistant/src/AssistantPlugin.workerd.ts
@@ -11,6 +11,7 @@ import { Sequence } from '@dxos/conductor';
 import { Feed } from '@dxos/echo';
 import { Text } from '@dxos/schema';
 import { HasSubject, Message } from '@dxos/types';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 

--- a/packages/plugins/plugin-automation/moon.yml
+++ b/packages/plugins/plugin-automation/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/AutomationPlugin.tsx'
       - '--entryPoint=src/AutomationPlugin.node.ts'
+      - '--entryPoint=src/AutomationPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/capabilities/node.ts'
       - '--entryPoint=src/components/index.ts'

--- a/packages/plugins/plugin-automation/package.json
+++ b/packages/plugins/plugin-automation/package.json
@@ -49,10 +49,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/AutomationPlugin.workerd.ts",
         "node": "./src/AutomationPlugin.node.ts",
         "default": "./src/AutomationPlugin.tsx"
       },
       "types": "./dist/types/src/AutomationPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/AutomationPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/AutomationPlugin.node.mjs",
       "default": "./dist/lib/neutral/AutomationPlugin.mjs"
     },

--- a/packages/plugins/plugin-automation/src/AutomationPlugin.workerd.ts
+++ b/packages/plugins/plugin-automation/src/AutomationPlugin.workerd.ts
@@ -5,6 +5,7 @@
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { Operation, Trace, Trigger } from '@dxos/compute';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 

--- a/packages/plugins/plugin-automation/src/AutomationPlugin.workerd.ts
+++ b/packages/plugins/plugin-automation/src/AutomationPlugin.workerd.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Operation, Trace, Trigger } from '@dxos/compute';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+
+export const AutomationPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [Operation.PersistentOperation, Trigger.Trigger, Trace.Message] }),
+  Plugin.make,
+);
+
+export default AutomationPlugin;

--- a/packages/plugins/plugin-calls/moon.yml
+++ b/packages/plugins/plugin-calls/moon.yml
@@ -10,6 +10,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/CallsPlugin.tsx'
       - '--entryPoint=src/CallsPlugin.node.ts'
+      - '--entryPoint=src/CallsPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/containers/index.ts'

--- a/packages/plugins/plugin-calls/package.json
+++ b/packages/plugins/plugin-calls/package.json
@@ -41,10 +41,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/CallsPlugin.workerd.ts",
         "node": "./src/CallsPlugin.node.ts",
         "default": "./src/CallsPlugin.tsx"
       },
       "types": "./dist/types/src/CallsPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/CallsPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/CallsPlugin.node.mjs",
       "default": "./dist/lib/neutral/CallsPlugin.mjs"
     },

--- a/packages/plugins/plugin-calls/src/CallsPlugin.workerd.ts
+++ b/packages/plugins/plugin-calls/src/CallsPlugin.workerd.ts
@@ -1,0 +1,10 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { meta } from '#meta';
+
+export const CallsPlugin = Plugin.define(meta).pipe(Plugin.make);
+
+export default CallsPlugin;

--- a/packages/plugins/plugin-calls/src/CallsPlugin.workerd.ts
+++ b/packages/plugins/plugin-calls/src/CallsPlugin.workerd.ts
@@ -3,6 +3,7 @@
 //
 
 import { Plugin } from '@dxos/app-framework';
+
 import { meta } from '#meta';
 
 export const CallsPlugin = Plugin.define(meta).pipe(Plugin.make);

--- a/packages/plugins/plugin-chess/moon.yml
+++ b/packages/plugins/plugin-chess/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/ChessPlugin.tsx'
       - '--entryPoint=src/ChessPlugin.node.ts'
+      - '--entryPoint=src/ChessPlugin.workerd.ts'
       - '--entryPoint=src/blueprints/index.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'

--- a/packages/plugins/plugin-chess/package.json
+++ b/packages/plugins/plugin-chess/package.json
@@ -45,10 +45,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/ChessPlugin.workerd.ts",
         "node": "./src/ChessPlugin.node.ts",
         "default": "./src/ChessPlugin.tsx"
       },
       "types": "./dist/types/src/ChessPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/ChessPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/ChessPlugin.node.mjs",
       "default": "./dist/lib/neutral/ChessPlugin.mjs"
     },

--- a/packages/plugins/plugin-chess/src/ChessPlugin.workerd.ts
+++ b/packages/plugins/plugin-chess/src/ChessPlugin.workerd.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+import { Chess } from '#types';
+
+export const ChessPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [Chess.State] }),
+  Plugin.make,
+);
+
+export default ChessPlugin;

--- a/packages/plugins/plugin-chess/src/ChessPlugin.workerd.ts
+++ b/packages/plugins/plugin-chess/src/ChessPlugin.workerd.ts
@@ -4,6 +4,7 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 import { Chess } from '#types';

--- a/packages/plugins/plugin-client/moon.yml
+++ b/packages/plugins/plugin-client/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/ClientPlugin.ts'
       - '--entryPoint=src/ClientPlugin.node.ts'
+      - '--entryPoint=src/ClientPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/capabilities/node.ts'
       - '--entryPoint=src/components/index.ts'

--- a/packages/plugins/plugin-client/package.json
+++ b/packages/plugins/plugin-client/package.json
@@ -45,10 +45,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/ClientPlugin.workerd.ts",
         "node": "./src/ClientPlugin.node.ts",
         "default": "./src/ClientPlugin.ts"
       },
       "types": "./dist/types/src/ClientPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/ClientPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/ClientPlugin.node.mjs",
       "default": "./dist/lib/neutral/ClientPlugin.mjs"
     },

--- a/packages/plugins/plugin-client/src/ClientPlugin.workerd.ts
+++ b/packages/plugins/plugin-client/src/ClientPlugin.workerd.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+
+export const ClientPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  Plugin.make,
+);
+
+export default ClientPlugin;

--- a/packages/plugins/plugin-debug/moon.yml
+++ b/packages/plugins/plugin-debug/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/DebugPlugin.tsx'
       - '--entryPoint=src/DebugPlugin.node.ts'
+      - '--entryPoint=src/DebugPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/containers/index.ts'

--- a/packages/plugins/plugin-debug/package.json
+++ b/packages/plugins/plugin-debug/package.json
@@ -35,10 +35,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/DebugPlugin.workerd.ts",
         "node": "./src/DebugPlugin.node.ts",
         "default": "./src/DebugPlugin.tsx"
       },
       "types": "./dist/types/src/DebugPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/DebugPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/DebugPlugin.node.mjs",
       "default": "./dist/lib/neutral/DebugPlugin.mjs"
     },

--- a/packages/plugins/plugin-debug/src/DebugPlugin.workerd.ts
+++ b/packages/plugins/plugin-debug/src/DebugPlugin.workerd.ts
@@ -3,6 +3,7 @@
 //
 
 import { Plugin } from '@dxos/app-framework';
+
 import { meta } from '#meta';
 import { type DebugPluginOptions } from '#types';
 

--- a/packages/plugins/plugin-debug/src/DebugPlugin.workerd.ts
+++ b/packages/plugins/plugin-debug/src/DebugPlugin.workerd.ts
@@ -1,0 +1,11 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { meta } from '#meta';
+import { type DebugPluginOptions } from '#types';
+
+export const DebugPlugin = Plugin.define<DebugPluginOptions>(meta).pipe(Plugin.make);
+
+export default DebugPlugin;

--- a/packages/plugins/plugin-deck/moon.yml
+++ b/packages/plugins/plugin-deck/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/DeckPlugin.ts'
       - '--entryPoint=src/DeckPlugin.node.ts'
+      - '--entryPoint=src/DeckPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/containers/index.ts'

--- a/packages/plugins/plugin-deck/package.json
+++ b/packages/plugins/plugin-deck/package.json
@@ -45,10 +45,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/DeckPlugin.workerd.ts",
         "node": "./src/DeckPlugin.node.ts",
         "default": "./src/DeckPlugin.ts"
       },
       "types": "./dist/types/src/DeckPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/DeckPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/DeckPlugin.node.mjs",
       "default": "./dist/lib/neutral/DeckPlugin.mjs"
     },

--- a/packages/plugins/plugin-deck/src/DeckPlugin.workerd.ts
+++ b/packages/plugins/plugin-deck/src/DeckPlugin.workerd.ts
@@ -1,0 +1,15 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+
+export const DeckPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  Plugin.make,
+);
+
+export default DeckPlugin;

--- a/packages/plugins/plugin-deck/src/DeckPlugin.workerd.ts
+++ b/packages/plugins/plugin-deck/src/DeckPlugin.workerd.ts
@@ -4,6 +4,7 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 

--- a/packages/plugins/plugin-files/moon.yml
+++ b/packages/plugins/plugin-files/moon.yml
@@ -10,6 +10,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/FilesPlugin.tsx'
       - '--entryPoint=src/FilesPlugin.node.ts'
+      - '--entryPoint=src/FilesPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/containers/index.ts'

--- a/packages/plugins/plugin-files/package.json
+++ b/packages/plugins/plugin-files/package.json
@@ -40,10 +40,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/FilesPlugin.workerd.ts",
         "node": "./src/FilesPlugin.node.ts",
         "default": "./src/FilesPlugin.tsx"
       },
       "types": "./dist/types/src/FilesPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/FilesPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/FilesPlugin.node.mjs",
       "default": "./dist/lib/neutral/FilesPlugin.mjs"
     },

--- a/packages/plugins/plugin-files/src/FilesPlugin.workerd.ts
+++ b/packages/plugins/plugin-files/src/FilesPlugin.workerd.ts
@@ -1,0 +1,15 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+
+export const FilesPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  Plugin.make,
+);
+
+export default FilesPlugin;

--- a/packages/plugins/plugin-files/src/FilesPlugin.workerd.ts
+++ b/packages/plugins/plugin-files/src/FilesPlugin.workerd.ts
@@ -4,6 +4,7 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 

--- a/packages/plugins/plugin-game/moon.yml
+++ b/packages/plugins/plugin-game/moon.yml
@@ -10,6 +10,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/GamePlugin.tsx'
       - '--entryPoint=src/GamePlugin.node.tsx'
+      - '--entryPoint=src/GamePlugin.workerd.tsx'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/containers/index.ts'

--- a/packages/plugins/plugin-game/package.json
+++ b/packages/plugins/plugin-game/package.json
@@ -36,10 +36,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/GamePlugin.workerd.tsx",
         "node": "./src/GamePlugin.node.tsx",
         "default": "./src/GamePlugin.tsx"
       },
       "types": "./dist/types/src/GamePlugin.d.ts",
+      "workerd": "./dist/lib/neutral/GamePlugin.workerd.mjs",
       "node": "./dist/lib/neutral/GamePlugin.node.mjs",
       "default": "./dist/lib/neutral/GamePlugin.mjs"
     },

--- a/packages/plugins/plugin-game/src/GamePlugin.workerd.tsx
+++ b/packages/plugins/plugin-game/src/GamePlugin.workerd.tsx
@@ -1,0 +1,15 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { meta } from '#meta';
+import { Game } from '#types';
+
+export const GamePlugin = Plugin.define(meta).pipe(
+  AppPlugin.addSchemaModule({ schema: [Game] }),
+  Plugin.make,
+);
+
+export default GamePlugin;

--- a/packages/plugins/plugin-game/src/GamePlugin.workerd.tsx
+++ b/packages/plugins/plugin-game/src/GamePlugin.workerd.tsx
@@ -4,12 +4,10 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
+
 import { meta } from '#meta';
 import { Game } from '#types';
 
-export const GamePlugin = Plugin.define(meta).pipe(
-  AppPlugin.addSchemaModule({ schema: [Game] }),
-  Plugin.make,
-);
+export const GamePlugin = Plugin.define(meta).pipe(AppPlugin.addSchemaModule({ schema: [Game] }), Plugin.make);
 
 export default GamePlugin;

--- a/packages/plugins/plugin-inbox/moon.yml
+++ b/packages/plugins/plugin-inbox/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/InboxPlugin.tsx'
       - '--entryPoint=src/InboxPlugin.node.ts'
+      - '--entryPoint=src/InboxPlugin.workerd.ts'
       - '--entryPoint=src/blueprints/index.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/capabilities/node.ts'

--- a/packages/plugins/plugin-inbox/package.json
+++ b/packages/plugins/plugin-inbox/package.json
@@ -54,10 +54,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/InboxPlugin.workerd.ts",
         "node": "./src/InboxPlugin.node.ts",
         "default": "./src/InboxPlugin.tsx"
       },
       "types": "./dist/types/src/InboxPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/InboxPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/InboxPlugin.node.mjs",
       "default": "./dist/lib/neutral/InboxPlugin.mjs"
     },

--- a/packages/plugins/plugin-inbox/src/InboxPlugin.workerd.ts
+++ b/packages/plugins/plugin-inbox/src/InboxPlugin.workerd.ts
@@ -5,6 +5,7 @@
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { Event, Message } from '@dxos/types';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 import { Calendar, Mailbox } from '#types';

--- a/packages/plugins/plugin-inbox/src/InboxPlugin.workerd.ts
+++ b/packages/plugins/plugin-inbox/src/InboxPlugin.workerd.ts
@@ -1,0 +1,20 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Event, Message } from '@dxos/types';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+import { Calendar, Mailbox } from '#types';
+
+export const InboxPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({
+    schema: [Event.Event, Mailbox.Mailbox, Calendar.Calendar, Message.Message],
+  }),
+  Plugin.make,
+);
+
+export default InboxPlugin;

--- a/packages/plugins/plugin-integration/moon.yml
+++ b/packages/plugins/plugin-integration/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/IntegrationPlugin.ts'
       - '--entryPoint=src/IntegrationPlugin.node.ts'
+      - '--entryPoint=src/IntegrationPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/capabilities/node.ts'
       - '--entryPoint=src/components/index.ts'

--- a/packages/plugins/plugin-integration/package.json
+++ b/packages/plugins/plugin-integration/package.json
@@ -49,10 +49,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/IntegrationPlugin.workerd.ts",
         "node": "./src/IntegrationPlugin.node.ts",
         "default": "./src/IntegrationPlugin.ts"
       },
       "types": "./dist/types/src/IntegrationPlugin.d.ts",
+      "workerd": "./dist/lib/node-esm/IntegrationPlugin.workerd.mjs",
       "node": "./dist/lib/node-esm/IntegrationPlugin.node.mjs",
       "default": "./dist/lib/neutral/IntegrationPlugin.mjs"
     },

--- a/packages/plugins/plugin-integration/src/IntegrationPlugin.workerd.ts
+++ b/packages/plugins/plugin-integration/src/IntegrationPlugin.workerd.ts
@@ -5,6 +5,7 @@
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { AccessToken } from '@dxos/types';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 import { Integration } from '#types';

--- a/packages/plugins/plugin-integration/src/IntegrationPlugin.workerd.ts
+++ b/packages/plugins/plugin-integration/src/IntegrationPlugin.workerd.ts
@@ -1,0 +1,18 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { AccessToken } from '@dxos/types';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+import { Integration } from '#types';
+
+export const IntegrationPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [AccessToken.AccessToken, Integration.Integration] }),
+  Plugin.make,
+);
+
+export default IntegrationPlugin;

--- a/packages/plugins/plugin-kanban/moon.yml
+++ b/packages/plugins/plugin-kanban/moon.yml
@@ -14,6 +14,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/KanbanPlugin.tsx'
       - '--entryPoint=src/KanbanPlugin.node.ts'
+      - '--entryPoint=src/KanbanPlugin.workerd.ts'
       - '--entryPoint=src/blueprints/index.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'

--- a/packages/plugins/plugin-kanban/package.json
+++ b/packages/plugins/plugin-kanban/package.json
@@ -50,10 +50,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/KanbanPlugin.workerd.ts",
         "node": "./src/KanbanPlugin.node.ts",
         "default": "./src/KanbanPlugin.tsx"
       },
       "types": "./dist/types/src/KanbanPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/KanbanPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/KanbanPlugin.node.mjs",
       "default": "./dist/lib/neutral/KanbanPlugin.mjs"
     },

--- a/packages/plugins/plugin-kanban/src/KanbanPlugin.workerd.ts
+++ b/packages/plugins/plugin-kanban/src/KanbanPlugin.workerd.ts
@@ -4,6 +4,7 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 import { Kanban } from '#types';

--- a/packages/plugins/plugin-kanban/src/KanbanPlugin.workerd.ts
+++ b/packages/plugins/plugin-kanban/src/KanbanPlugin.workerd.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+import { Kanban } from '#types';
+
+export const KanbanPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [Kanban.Kanban] }),
+  Plugin.make,
+);
+
+export default KanbanPlugin;

--- a/packages/plugins/plugin-map-solid/moon.yml
+++ b/packages/plugins/plugin-map-solid/moon.yml
@@ -10,6 +10,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/MapPlugin.tsx'
       - '--entryPoint=src/MapPlugin.node.ts'
+      - '--entryPoint=src/MapPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/meta.ts'

--- a/packages/plugins/plugin-map-solid/package.json
+++ b/packages/plugins/plugin-map-solid/package.json
@@ -30,10 +30,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/MapPlugin.workerd.ts",
         "node": "./src/MapPlugin.node.ts",
         "default": "./src/MapPlugin.tsx"
       },
       "types": "./dist/types/src/MapPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/MapPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/MapPlugin.node.mjs",
       "default": "./dist/lib/neutral/MapPlugin.mjs"
     }

--- a/packages/plugins/plugin-map-solid/src/MapPlugin.workerd.ts
+++ b/packages/plugins/plugin-map-solid/src/MapPlugin.workerd.ts
@@ -1,0 +1,10 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { meta } from '#meta';
+
+export const MapPlugin = Plugin.define(meta).pipe(Plugin.make);
+
+export default MapPlugin;

--- a/packages/plugins/plugin-map-solid/src/MapPlugin.workerd.ts
+++ b/packages/plugins/plugin-map-solid/src/MapPlugin.workerd.ts
@@ -3,6 +3,7 @@
 //
 
 import { Plugin } from '@dxos/app-framework';
+
 import { meta } from '#meta';
 
 export const MapPlugin = Plugin.define(meta).pipe(Plugin.make);

--- a/packages/plugins/plugin-map/moon.yml
+++ b/packages/plugins/plugin-map/moon.yml
@@ -10,6 +10,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/MapPlugin.tsx'
       - '--entryPoint=src/MapPlugin.node.ts'
+      - '--entryPoint=src/MapPlugin.workerd.ts'
       - '--entryPoint=src/blueprints/index.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'

--- a/packages/plugins/plugin-map/package.json
+++ b/packages/plugins/plugin-map/package.json
@@ -45,10 +45,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/MapPlugin.workerd.ts",
         "node": "./src/MapPlugin.node.ts",
         "default": "./src/MapPlugin.tsx"
       },
       "types": "./dist/types/src/MapPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/MapPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/MapPlugin.node.mjs",
       "default": "./dist/lib/neutral/MapPlugin.mjs"
     },

--- a/packages/plugins/plugin-map/src/MapPlugin.workerd.ts
+++ b/packages/plugins/plugin-map/src/MapPlugin.workerd.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+import { Map } from '#types';
+
+export const MapPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [Map.Map] }),
+  Plugin.make,
+);
+
+export default MapPlugin;

--- a/packages/plugins/plugin-map/src/MapPlugin.workerd.ts
+++ b/packages/plugins/plugin-map/src/MapPlugin.workerd.ts
@@ -4,6 +4,7 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 import { Map } from '#types';

--- a/packages/plugins/plugin-markdown/moon.yml
+++ b/packages/plugins/plugin-markdown/moon.yml
@@ -13,6 +13,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/MarkdownPlugin.tsx'
       - '--entryPoint=src/MarkdownPlugin.node.ts'
+      - '--entryPoint=src/MarkdownPlugin.workerd.ts'
       - '--entryPoint=src/blueprints/index.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/capabilities/node.ts'

--- a/packages/plugins/plugin-markdown/package.json
+++ b/packages/plugins/plugin-markdown/package.json
@@ -54,10 +54,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/MarkdownPlugin.workerd.ts",
         "node": "./src/MarkdownPlugin.node.ts",
         "default": "./src/MarkdownPlugin.tsx"
       },
       "types": "./dist/types/src/MarkdownPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/MarkdownPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/MarkdownPlugin.node.mjs",
       "default": "./dist/lib/neutral/MarkdownPlugin.mjs"
     },

--- a/packages/plugins/plugin-markdown/src/MarkdownPlugin.workerd.ts
+++ b/packages/plugins/plugin-markdown/src/MarkdownPlugin.workerd.ts
@@ -1,0 +1,18 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Text } from '@dxos/schema';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+import { Markdown } from '#types';
+
+export const MarkdownPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [Markdown.Document, Text.Text] }),
+  Plugin.make,
+);
+
+export default MarkdownPlugin;

--- a/packages/plugins/plugin-markdown/src/MarkdownPlugin.workerd.ts
+++ b/packages/plugins/plugin-markdown/src/MarkdownPlugin.workerd.ts
@@ -5,6 +5,7 @@
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { Text } from '@dxos/schema';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 import { Markdown } from '#types';

--- a/packages/plugins/plugin-navtree/moon.yml
+++ b/packages/plugins/plugin-navtree/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/NavTreePlugin.tsx'
       - '--entryPoint=src/NavTreePlugin.node.ts'
+      - '--entryPoint=src/NavTreePlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/containers/index.ts'

--- a/packages/plugins/plugin-navtree/package.json
+++ b/packages/plugins/plugin-navtree/package.json
@@ -45,10 +45,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/NavTreePlugin.workerd.ts",
         "node": "./src/NavTreePlugin.node.ts",
         "default": "./src/NavTreePlugin.tsx"
       },
       "types": "./dist/types/src/NavTreePlugin.d.ts",
+      "workerd": "./dist/lib/neutral/NavTreePlugin.workerd.mjs",
       "node": "./dist/lib/neutral/NavTreePlugin.node.mjs",
       "default": "./dist/lib/neutral/NavTreePlugin.mjs"
     },

--- a/packages/plugins/plugin-navtree/src/NavTreePlugin.workerd.ts
+++ b/packages/plugins/plugin-navtree/src/NavTreePlugin.workerd.ts
@@ -1,0 +1,15 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+
+export const NavTreePlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  Plugin.make,
+);
+
+export default NavTreePlugin;

--- a/packages/plugins/plugin-navtree/src/NavTreePlugin.workerd.ts
+++ b/packages/plugins/plugin-navtree/src/NavTreePlugin.workerd.ts
@@ -4,6 +4,7 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 

--- a/packages/plugins/plugin-observability/moon.yml
+++ b/packages/plugins/plugin-observability/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/ObservabilityPlugin.ts'
       - '--entryPoint=src/ObservabilityPlugin.node.ts'
+      - '--entryPoint=src/ObservabilityPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/meta.ts'

--- a/packages/plugins/plugin-observability/package.json
+++ b/packages/plugins/plugin-observability/package.json
@@ -35,10 +35,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/ObservabilityPlugin.workerd.ts",
         "node": "./src/ObservabilityPlugin.node.ts",
         "default": "./src/ObservabilityPlugin.ts"
       },
       "types": "./dist/types/src/ObservabilityPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/ObservabilityPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/ObservabilityPlugin.node.mjs",
       "default": "./dist/lib/neutral/ObservabilityPlugin.mjs"
     },

--- a/packages/plugins/plugin-observability/src/ObservabilityPlugin.workerd.ts
+++ b/packages/plugins/plugin-observability/src/ObservabilityPlugin.workerd.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capabilities, Capability, Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Operation, OperationHandlerSet } from '@dxos/compute';
+import { meta } from '#meta';
+import { ObservabilityOperation } from '#types';
+
+export const ObservabilityPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({
+    activate: Capability.lazy('OperationHandler', () =>
+      Promise.resolve({
+        default: Capability.makeModule<OperationHandlerSet.OperationHandlerSet>(
+          Effect.fnUntraced(function* () {
+            return Capability.contributes(
+              Capabilities.OperationHandler,
+              OperationHandlerSet.make(Operation.withHandler(ObservabilityOperation.SendEvent, () => Effect.void)),
+            );
+          }),
+        ),
+      }),
+    ),
+  }),
+  Plugin.make,
+);
+
+export default ObservabilityPlugin;

--- a/packages/plugins/plugin-observability/src/ObservabilityPlugin.workerd.ts
+++ b/packages/plugins/plugin-observability/src/ObservabilityPlugin.workerd.ts
@@ -7,6 +7,7 @@ import * as Effect from 'effect/Effect';
 import { Capabilities, Capability, Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { Operation, OperationHandlerSet } from '@dxos/compute';
+
 import { meta } from '#meta';
 import { ObservabilityOperation } from '#types';
 

--- a/packages/plugins/plugin-pipeline/moon.yml
+++ b/packages/plugins/plugin-pipeline/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/PipelinePlugin.tsx'
       - '--entryPoint=src/PipelinePlugin.node.ts'
+      - '--entryPoint=src/PipelinePlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/containers/index.ts'

--- a/packages/plugins/plugin-pipeline/package.json
+++ b/packages/plugins/plugin-pipeline/package.json
@@ -40,10 +40,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/PipelinePlugin.workerd.ts",
         "node": "./src/PipelinePlugin.node.ts",
         "default": "./src/PipelinePlugin.tsx"
       },
       "types": "./dist/types/src/PipelinePlugin.d.ts",
+      "workerd": "./dist/lib/neutral/PipelinePlugin.workerd.mjs",
       "node": "./dist/lib/neutral/PipelinePlugin.node.mjs",
       "default": "./dist/lib/neutral/PipelinePlugin.mjs"
     },

--- a/packages/plugins/plugin-pipeline/src/PipelinePlugin.workerd.ts
+++ b/packages/plugins/plugin-pipeline/src/PipelinePlugin.workerd.ts
@@ -5,6 +5,7 @@
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { Pipeline } from '@dxos/types';
+
 import { meta } from '#meta';
 
 export const PipelinePlugin = Plugin.define(meta).pipe(

--- a/packages/plugins/plugin-pipeline/src/PipelinePlugin.workerd.ts
+++ b/packages/plugins/plugin-pipeline/src/PipelinePlugin.workerd.ts
@@ -1,0 +1,15 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Pipeline } from '@dxos/types';
+import { meta } from '#meta';
+
+export const PipelinePlugin = Plugin.define(meta).pipe(
+  AppPlugin.addSchemaModule({ schema: [Pipeline.Pipeline] }),
+  Plugin.make,
+);
+
+export default PipelinePlugin;

--- a/packages/plugins/plugin-presenter/moon.yml
+++ b/packages/plugins/plugin-presenter/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/PresenterPlugin.tsx'
       - '--entryPoint=src/PresenterPlugin.node.ts'
+      - '--entryPoint=src/PresenterPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/containers/index.ts'

--- a/packages/plugins/plugin-presenter/package.json
+++ b/packages/plugins/plugin-presenter/package.json
@@ -35,10 +35,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/PresenterPlugin.workerd.ts",
         "node": "./src/PresenterPlugin.node.ts",
         "default": "./src/PresenterPlugin.tsx"
       },
       "types": "./dist/types/src/PresenterPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/PresenterPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/PresenterPlugin.node.mjs",
       "default": "./dist/lib/neutral/PresenterPlugin.mjs"
     },

--- a/packages/plugins/plugin-presenter/src/PresenterPlugin.workerd.ts
+++ b/packages/plugins/plugin-presenter/src/PresenterPlugin.workerd.ts
@@ -3,6 +3,7 @@
 //
 
 import { Plugin } from '@dxos/app-framework';
+
 import { meta } from '#meta';
 
 export const PresenterPlugin = Plugin.define(meta).pipe(Plugin.make);

--- a/packages/plugins/plugin-presenter/src/PresenterPlugin.workerd.ts
+++ b/packages/plugins/plugin-presenter/src/PresenterPlugin.workerd.ts
@@ -1,0 +1,10 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { meta } from '#meta';
+
+export const PresenterPlugin = Plugin.define(meta).pipe(Plugin.make);
+
+export default PresenterPlugin;

--- a/packages/plugins/plugin-preview/moon.yml
+++ b/packages/plugins/plugin-preview/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/PreviewPlugin.tsx'
       - '--entryPoint=src/PreviewPlugin.node.ts'
+      - '--entryPoint=src/PreviewPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/meta.ts'
       - '--entryPoint=src/plugin.ts'

--- a/packages/plugins/plugin-preview/package.json
+++ b/packages/plugins/plugin-preview/package.json
@@ -25,10 +25,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/PreviewPlugin.workerd.ts",
         "node": "./src/PreviewPlugin.node.ts",
         "default": "./src/PreviewPlugin.tsx"
       },
       "types": "./dist/types/src/PreviewPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/PreviewPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/PreviewPlugin.node.mjs",
       "default": "./dist/lib/neutral/PreviewPlugin.mjs"
     },

--- a/packages/plugins/plugin-preview/src/PreviewPlugin.workerd.ts
+++ b/packages/plugins/plugin-preview/src/PreviewPlugin.workerd.ts
@@ -1,0 +1,15 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Organization, Person } from '@dxos/types';
+import { meta } from '#meta';
+
+export const PreviewPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addSchemaModule({ schema: [Person.Person, Organization.Organization] }),
+  Plugin.make,
+);
+
+export default PreviewPlugin;

--- a/packages/plugins/plugin-preview/src/PreviewPlugin.workerd.ts
+++ b/packages/plugins/plugin-preview/src/PreviewPlugin.workerd.ts
@@ -5,6 +5,7 @@
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { Organization, Person } from '@dxos/types';
+
 import { meta } from '#meta';
 
 export const PreviewPlugin = Plugin.define(meta).pipe(

--- a/packages/plugins/plugin-registry/moon.yml
+++ b/packages/plugins/plugin-registry/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/RegistryPlugin.tsx'
       - '--entryPoint=src/RegistryPlugin.node.ts'
+      - '--entryPoint=src/RegistryPlugin.workerd.ts'
       - '--entryPoint=src/plugin.ts'
       - '--entryPoint=src/translations.ts'
       - '--platform=neutral'

--- a/packages/plugins/plugin-registry/package.json
+++ b/packages/plugins/plugin-registry/package.json
@@ -20,10 +20,12 @@
     "#operations": "./src/operations/index.ts",
     "#plugin": {
       "source": {
+        "workerd": "./src/RegistryPlugin.workerd.ts",
         "node": "./src/RegistryPlugin.node.ts",
         "default": "./src/RegistryPlugin.tsx"
       },
       "types": "./dist/types/src/RegistryPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/RegistryPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/RegistryPlugin.node.mjs",
       "default": "./dist/lib/neutral/RegistryPlugin.mjs"
     },

--- a/packages/plugins/plugin-registry/src/RegistryPlugin.workerd.ts
+++ b/packages/plugins/plugin-registry/src/RegistryPlugin.workerd.ts
@@ -3,6 +3,7 @@
 //
 
 import { Plugin } from '@dxos/app-framework';
+
 import { meta } from '#meta';
 
 export const RegistryPlugin = Plugin.define(meta).pipe(Plugin.make);

--- a/packages/plugins/plugin-registry/src/RegistryPlugin.workerd.ts
+++ b/packages/plugins/plugin-registry/src/RegistryPlugin.workerd.ts
@@ -1,0 +1,10 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { meta } from '#meta';
+
+export const RegistryPlugin = Plugin.define(meta).pipe(Plugin.make);
+
+export default RegistryPlugin;

--- a/packages/plugins/plugin-sample/moon.yml
+++ b/packages/plugins/plugin-sample/moon.yml
@@ -9,6 +9,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/SamplePlugin.ts'
       - '--entryPoint=src/SamplePlugin.node.ts'
+      - '--entryPoint=src/SamplePlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/capabilities/node.ts'
       - '--entryPoint=src/components/index.ts'

--- a/packages/plugins/plugin-sample/package.json
+++ b/packages/plugins/plugin-sample/package.json
@@ -45,10 +45,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/SamplePlugin.workerd.ts",
         "node": "./src/SamplePlugin.node.ts",
         "default": "./src/SamplePlugin.ts"
       },
       "types": "./dist/types/src/SamplePlugin.d.ts",
+      "workerd": "./dist/lib/neutral/SamplePlugin.workerd.mjs",
       "node": "./dist/lib/neutral/SamplePlugin.node.mjs",
       "default": "./dist/lib/neutral/SamplePlugin.mjs"
     },

--- a/packages/plugins/plugin-sample/src/SamplePlugin.workerd.ts
+++ b/packages/plugins/plugin-sample/src/SamplePlugin.workerd.ts
@@ -4,6 +4,7 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 import { SampleItem } from '#types';

--- a/packages/plugins/plugin-sample/src/SamplePlugin.workerd.ts
+++ b/packages/plugins/plugin-sample/src/SamplePlugin.workerd.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+import { SampleItem } from '#types';
+
+export const SamplePlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [SampleItem.SampleItem] }),
+  Plugin.make,
+);
+
+export default SamplePlugin;

--- a/packages/plugins/plugin-script/moon.yml
+++ b/packages/plugins/plugin-script/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/ScriptPlugin.tsx'
       - '--entryPoint=src/ScriptPlugin.node.ts'
+      - '--entryPoint=src/ScriptPlugin.workerd.ts'
       - '--entryPoint=src/blueprints/index.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/capabilities/node.ts'

--- a/packages/plugins/plugin-script/package.json
+++ b/packages/plugins/plugin-script/package.json
@@ -54,10 +54,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/ScriptPlugin.workerd.ts",
         "node": "./src/ScriptPlugin.node.ts",
         "default": "./src/ScriptPlugin.tsx"
       },
       "types": "./dist/types/src/ScriptPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/ScriptPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/ScriptPlugin.node.mjs",
       "default": "./dist/lib/neutral/ScriptPlugin.mjs"
     },

--- a/packages/plugins/plugin-script/src/ScriptPlugin.workerd.ts
+++ b/packages/plugins/plugin-script/src/ScriptPlugin.workerd.ts
@@ -5,6 +5,7 @@
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { Script } from '@dxos/compute';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 

--- a/packages/plugins/plugin-script/src/ScriptPlugin.workerd.ts
+++ b/packages/plugins/plugin-script/src/ScriptPlugin.workerd.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Script } from '@dxos/compute';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+
+export const ScriptPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [Script.Script] }),
+  Plugin.make,
+);
+
+export default ScriptPlugin;

--- a/packages/plugins/plugin-sequencer/moon.yml
+++ b/packages/plugins/plugin-sequencer/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/SequencerPlugin.tsx'
       - '--entryPoint=src/SequencerPlugin.node.ts'
+      - '--entryPoint=src/SequencerPlugin.workerd.ts'
       - '--entryPoint=src/blueprints/index.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'

--- a/packages/plugins/plugin-sequencer/package.json
+++ b/packages/plugins/plugin-sequencer/package.json
@@ -36,10 +36,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/SequencerPlugin.workerd.ts",
         "node": "./src/SequencerPlugin.node.ts",
         "default": "./src/SequencerPlugin.tsx"
       },
       "types": "./dist/types/src/SequencerPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/SequencerPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/SequencerPlugin.node.mjs",
       "default": "./dist/lib/neutral/SequencerPlugin.mjs"
     },

--- a/packages/plugins/plugin-sequencer/src/SequencerPlugin.workerd.ts
+++ b/packages/plugins/plugin-sequencer/src/SequencerPlugin.workerd.ts
@@ -1,0 +1,15 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { meta } from '#meta';
+import { Score } from '#types';
+
+export const SequencerPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addSchemaModule({ schema: [Score.Score] }),
+  Plugin.make,
+);
+
+export default SequencerPlugin;

--- a/packages/plugins/plugin-sequencer/src/SequencerPlugin.workerd.ts
+++ b/packages/plugins/plugin-sequencer/src/SequencerPlugin.workerd.ts
@@ -4,6 +4,7 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
+
 import { meta } from '#meta';
 import { Score } from '#types';
 

--- a/packages/plugins/plugin-sheet/moon.yml
+++ b/packages/plugins/plugin-sheet/moon.yml
@@ -13,6 +13,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/SheetPlugin.tsx'
       - '--entryPoint=src/SheetPlugin.node.ts'
+      - '--entryPoint=src/SheetPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/containers/index.ts'

--- a/packages/plugins/plugin-sheet/package.json
+++ b/packages/plugins/plugin-sheet/package.json
@@ -40,10 +40,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/SheetPlugin.workerd.ts",
         "node": "./src/SheetPlugin.node.ts",
         "default": "./src/SheetPlugin.tsx"
       },
       "types": "./dist/types/src/SheetPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/SheetPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/SheetPlugin.node.mjs",
       "default": "./dist/lib/neutral/SheetPlugin.mjs"
     },

--- a/packages/plugins/plugin-sheet/src/SheetPlugin.workerd.ts
+++ b/packages/plugins/plugin-sheet/src/SheetPlugin.workerd.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+import { Sheet } from '#types';
+
+export const SheetPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [Sheet.Sheet] }),
+  Plugin.make,
+);
+
+export default SheetPlugin;

--- a/packages/plugins/plugin-sheet/src/SheetPlugin.workerd.ts
+++ b/packages/plugins/plugin-sheet/src/SheetPlugin.workerd.ts
@@ -4,6 +4,7 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 import { Sheet } from '#types';

--- a/packages/plugins/plugin-space/moon.yml
+++ b/packages/plugins/plugin-space/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/SpacePlugin.ts'
       - '--entryPoint=src/SpacePlugin.node.ts'
+      - '--entryPoint=src/SpacePlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/capabilities/node.ts'
       - '--entryPoint=src/components/index.ts'

--- a/packages/plugins/plugin-space/package.json
+++ b/packages/plugins/plugin-space/package.json
@@ -50,10 +50,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/SpacePlugin.workerd.ts",
         "node": "./src/SpacePlugin.node.ts",
         "default": "./src/SpacePlugin.ts"
       },
       "types": "./dist/types/src/SpacePlugin.d.ts",
+      "workerd": "./dist/lib/neutral/SpacePlugin.workerd.mjs",
       "node": "./dist/lib/neutral/SpacePlugin.node.mjs",
       "default": "./dist/lib/neutral/SpacePlugin.mjs"
     },

--- a/packages/plugins/plugin-space/src/SpacePlugin.workerd.ts
+++ b/packages/plugins/plugin-space/src/SpacePlugin.workerd.ts
@@ -1,0 +1,45 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Tag } from '@dxos/echo';
+import { DataTypes } from '@dxos/schema';
+import {
+  AnchoredTo,
+  Employer,
+  Event,
+  HasConnection,
+  HasRelationship,
+  HasSubject,
+  Organization,
+  Person,
+  Pipeline,
+  Task,
+} from '@dxos/types';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+
+export const SpacePlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({
+    schema: [
+      ...DataTypes,
+      AnchoredTo.AnchoredTo,
+      Employer.Employer,
+      Event.Event,
+      HasConnection.HasConnection,
+      HasRelationship.HasRelationship,
+      HasSubject.HasSubject,
+      Organization.Organization,
+      Person.Person,
+      Pipeline.Pipeline,
+      Tag.Tag,
+      Task.Task,
+    ],
+  }),
+  Plugin.make,
+);
+
+export default SpacePlugin;

--- a/packages/plugins/plugin-space/src/SpacePlugin.workerd.ts
+++ b/packages/plugins/plugin-space/src/SpacePlugin.workerd.ts
@@ -18,6 +18,7 @@ import {
   Pipeline,
   Task,
 } from '@dxos/types';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 

--- a/packages/plugins/plugin-table/moon.yml
+++ b/packages/plugins/plugin-table/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/TablePlugin.tsx'
       - '--entryPoint=src/TablePlugin.node.ts'
+      - '--entryPoint=src/TablePlugin.workerd.ts'
       - '--entryPoint=src/blueprints/index.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/containers/index.ts'

--- a/packages/plugins/plugin-table/package.json
+++ b/packages/plugins/plugin-table/package.json
@@ -40,10 +40,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/TablePlugin.workerd.ts",
         "node": "./src/TablePlugin.node.ts",
         "default": "./src/TablePlugin.tsx"
       },
       "types": "./dist/types/src/TablePlugin.d.ts",
+      "workerd": "./dist/lib/neutral/TablePlugin.workerd.mjs",
       "node": "./dist/lib/neutral/TablePlugin.node.mjs",
       "default": "./dist/lib/neutral/TablePlugin.mjs"
     },

--- a/packages/plugins/plugin-table/src/TablePlugin.workerd.ts
+++ b/packages/plugins/plugin-table/src/TablePlugin.workerd.ts
@@ -5,6 +5,7 @@
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { Table } from '@dxos/react-ui-table/types';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 

--- a/packages/plugins/plugin-table/src/TablePlugin.workerd.ts
+++ b/packages/plugins/plugin-table/src/TablePlugin.workerd.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Table } from '@dxos/react-ui-table/types';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+
+export const TablePlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [Table.Table] }),
+  Plugin.make,
+);
+
+export default TablePlugin;

--- a/packages/plugins/plugin-thread/moon.yml
+++ b/packages/plugins/plugin-thread/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/ThreadPlugin.tsx'
       - '--entryPoint=src/ThreadPlugin.node.ts'
+      - '--entryPoint=src/ThreadPlugin.workerd.ts'
       - '--entryPoint=src/blueprints/index.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'

--- a/packages/plugins/plugin-thread/package.json
+++ b/packages/plugins/plugin-thread/package.json
@@ -50,10 +50,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/ThreadPlugin.workerd.ts",
         "node": "./src/ThreadPlugin.node.ts",
         "default": "./src/ThreadPlugin.tsx"
       },
       "types": "./dist/types/src/ThreadPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/ThreadPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/ThreadPlugin.node.mjs",
       "default": "./dist/lib/neutral/ThreadPlugin.mjs"
     },

--- a/packages/plugins/plugin-thread/src/ThreadPlugin.workerd.ts
+++ b/packages/plugins/plugin-thread/src/ThreadPlugin.workerd.ts
@@ -1,0 +1,20 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { AnchoredTo, Channel, Message, Thread } from '@dxos/types';
+
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+
+export const ThreadPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({
+    schema: [AnchoredTo.AnchoredTo, Channel.Channel, Message.Message, Thread.Thread],
+  }),
+  Plugin.make,
+);
+
+export default ThreadPlugin;

--- a/packages/plugins/plugin-transcription/moon.yml
+++ b/packages/plugins/plugin-transcription/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/TranscriptionPlugin.tsx'
       - '--entryPoint=src/TranscriptionPlugin.node.ts'
+      - '--entryPoint=src/TranscriptionPlugin.workerd.ts'
       - '--entryPoint=src/blueprints/index.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'

--- a/packages/plugins/plugin-transcription/package.json
+++ b/packages/plugins/plugin-transcription/package.json
@@ -49,10 +49,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/TranscriptionPlugin.workerd.ts",
         "node": "./src/TranscriptionPlugin.node.ts",
         "default": "./src/TranscriptionPlugin.tsx"
       },
       "types": "./dist/types/src/TranscriptionPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/TranscriptionPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/TranscriptionPlugin.node.mjs",
       "default": "./dist/lib/neutral/TranscriptionPlugin.mjs"
     },

--- a/packages/plugins/plugin-transcription/src/TranscriptionPlugin.workerd.ts
+++ b/packages/plugins/plugin-transcription/src/TranscriptionPlugin.workerd.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Transcript } from '@dxos/types';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+
+export const TranscriptionPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [Transcript.Transcript] }),
+  Plugin.make,
+);
+
+export default TranscriptionPlugin;

--- a/packages/plugins/plugin-transcription/src/TranscriptionPlugin.workerd.ts
+++ b/packages/plugins/plugin-transcription/src/TranscriptionPlugin.workerd.ts
@@ -5,6 +5,7 @@
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { Transcript } from '@dxos/types';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 

--- a/packages/plugins/plugin-wnfs/moon.yml
+++ b/packages/plugins/plugin-wnfs/moon.yml
@@ -12,6 +12,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/WnfsPlugin.tsx'
       - '--entryPoint=src/WnfsPlugin.node.ts'
+      - '--entryPoint=src/WnfsPlugin.workerd.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/containers/index.ts'

--- a/packages/plugins/plugin-wnfs/package.json
+++ b/packages/plugins/plugin-wnfs/package.json
@@ -44,10 +44,12 @@
     },
     "#plugin": {
       "source": {
+        "workerd": "./src/WnfsPlugin.workerd.ts",
         "node": "./src/WnfsPlugin.node.ts",
         "default": "./src/WnfsPlugin.tsx"
       },
       "types": "./dist/types/src/WnfsPlugin.d.ts",
+      "workerd": "./dist/lib/neutral/WnfsPlugin.workerd.mjs",
       "node": "./dist/lib/neutral/WnfsPlugin.node.mjs",
       "default": "./dist/lib/neutral/WnfsPlugin.mjs"
     },

--- a/packages/plugins/plugin-wnfs/src/WnfsPlugin.workerd.ts
+++ b/packages/plugins/plugin-wnfs/src/WnfsPlugin.workerd.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+import { WnfsFile } from '#types';
+
+export const WnfsPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [WnfsFile.WnfsFile] }),
+  Plugin.make,
+);
+
+export default WnfsPlugin;

--- a/packages/plugins/plugin-wnfs/src/WnfsPlugin.workerd.ts
+++ b/packages/plugins/plugin-wnfs/src/WnfsPlugin.workerd.ts
@@ -4,6 +4,7 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
+
 import { OperationHandler } from '#capabilities';
 import { meta } from '#meta';
 import { WnfsFile } from '#types';


### PR DESCRIPTION
## Summary

- Add `*Plugin.workerd.ts(x)` for every existing `*Plugin.node.ts(x)` plugin (30 packages), registering only operation handler and schema modules where present.
- Wire `#plugin` package exports with a `workerd` condition (`source`, `types`, `workerd`, `node`, `default` key order; nested `source` uses `workerd` → `node` → `default`).
- Add `moon` compile entry points for each workerd plugin file.

## Motivation

Node plugin variants include UI/graph/create-object capabilities that do not run in workerd/Cloudflare function bundles. Workerd variants expose the minimal surface needed for operations and ECHO schema registration.

## Test plan

- [x] `moon run plugin-markdown:compile plugin-inbox:compile plugin-pipeline:compile plugin-space:compile`
- [ ] CI **Check** workflow passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Workerd platform support across the plugin ecosystem: plugins now include Workerd-targeted entrypoints, build outputs, and module resolution so they can be built and consumed on Workerd-based runtimes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->