### PR TITLE
chore(claude): allow read-only Trunk MCP tools without permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,10 +7,6 @@
     "playwright@claude-plugins-official": true
   },
   "permissions": {
-    "allow": [
-      "mcp__Trunk__search-test",
-      "mcp__Trunk__investigate-ci-failure",
-      "mcp__Trunk__detect-frameworks"
-    ]
+    "allow": ["mcp__Trunk__search-test", "mcp__Trunk__investigate-ci-failure", "mcp__Trunk__detect-frameworks"]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,5 +5,14 @@
     "linear@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
     "playwright@claude-plugins-official": true
+  },
+  "permissions": {
+    "allow": [
+      "mcp__Trunk__fix-flaky-test",
+      "mcp__Trunk__search-test",
+      "mcp__Trunk__investigate-ci-failure",
+      "mcp__Trunk__setup-trunk-uploads",
+      "mcp__Trunk__detect-frameworks"
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,10 +8,8 @@
   },
   "permissions": {
     "allow": [
-      "mcp__Trunk__fix-flaky-test",
       "mcp__Trunk__search-test",
       "mcp__Trunk__investigate-ci-failure",
-      "mcp__Trunk__setup-trunk-uploads",
       "mcp__Trunk__detect-frameworks"
     ]
   }


### PR DESCRIPTION
## Summary

- Adds three read-only Trunk MCP tools to `permissions.allow` in `.claude/settings.json` so Claude can query Trunk Flaky Tests without a permission prompt each time.
- Write-side tools (`fix-flaky-test`, `setup-trunk-uploads`) are intentionally excluded and will still prompt for confirmation.

## Tools allowed

- `mcp__Trunk__search-test` — search for test cases by name
- `mcp__Trunk__investigate-ci-failure` — look up test failures from a CI run
- `mcp__Trunk__detect-frameworks` — detect test frameworks in the repo

https://claude.ai/code/session_016EeKQoQjVP5g3cbwYeYYCK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration for internal tool integrations: added a permissions whitelist to enable selected internal automation/plugins and ensured the plugin configuration block is properly closed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->