### PR TITLE
fix(functions): add blueprintRegistry option to FunctionWrappingOptions

### DIFF
--- a/packages/core/compute/compute/src/Blueprint.ts
+++ b/packages/core/compute/compute/src/Blueprint.ts
@@ -6,6 +6,7 @@
 
 import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
 import * as Schema from 'effect/Schema';
 
 import { ToolId } from '@dxos/ai';
@@ -191,7 +192,22 @@ export class Registry {
   }
 }
 
-export class RegistryService extends Context.Tag('@dxos/blueprints/RegistryService')<RegistryService, Registry>() {}
+export class RegistryService extends Context.Tag('@dxos/blueprints/RegistryService')<RegistryService, Registry>() {
+  static notAvailable = Layer.succeed(RegistryService, {
+    get blueprints(): Blueprint[] {
+      throw new Error('Blueprint registry not available');
+    },
+    getByKey(_key: string): Blueprint | undefined {
+      throw new Error('Blueprint registry not available');
+    },
+    query(): Blueprint[] {
+      throw new Error('Blueprint registry not available');
+    },
+    updateBlueprints() {
+      throw new Error('Blueprint registry not available');
+    },
+  } as unknown as Registry);
+}
 
 /**
  * Resolves a blueprint from the registry.

--- a/packages/core/compute/functions/src/protocol/protocol.ts
+++ b/packages/core/compute/functions/src/protocol/protocol.ts
@@ -12,6 +12,7 @@ import * as SchemaAST from 'effect/SchemaAST';
 import { AiModelResolver, AiService, OpaqueToolkit } from '@dxos/ai';
 import { AnthropicResolver } from '@dxos/ai/resolvers';
 import {
+  Blueprint,
   FunctionError,
   InvalidOperationInputError,
   InvalidOperationOutputError,
@@ -48,6 +49,12 @@ export interface FunctionWrappingOptions {
    * Toolkits to make available via the `OpaqueToolkitProvider`.
    */
   toolkits?: OpaqueToolkit.OpaqueToolkit[];
+
+  /**
+   * Blueprint registry to expose as `Blueprint.RegistryService` inside handler Effects.
+   * Required for operations that declare `Blueprint.RegistryService` in their `services` list.
+   */
+  blueprintRegistry?: Blueprint.Registry;
 }
 
 /**
@@ -235,6 +242,10 @@ class FunctionContext extends Resource {
       types: this.opts.types?.length ?? 0,
     });
 
+    const blueprintRegistryLayer = this.opts.blueprintRegistry
+      ? Layer.succeed(Blueprint.RegistryService, this.opts.blueprintRegistry)
+      : Blueprint.RegistryService.notAvailable;
+
     return Layer.mergeAll(
       dbLayer,
       queuesLayer,
@@ -245,6 +256,7 @@ class FunctionContext extends Resource {
       aiLayer,
       OpaqueToolkit.providerLayer(OpaqueToolkit.merge(...(this.opts.toolkits ?? []))),
       traceWriterLayer,
+      blueprintRegistryLayer,
 
       // `FunctionInvocationService` is deprecated; new code should yield `Operation.Service`.
       // The cloudflare wrapper provides only the unavailable layer to satisfy the (still-present)


### PR DESCRIPTION
## Summary

- Adds `blueprintRegistry?: Blueprint.Registry` to `FunctionWrappingOptions` so callers can inject `Blueprint.RegistryService` into handler Effects via the standard Effect layer mechanism
- Adds `Blueprint.RegistryService.notAvailable` following the same pattern as `Database.notAvailable` and `AiService.notAvailable` — used as the default when no registry is provided
- Wires `blueprintRegistryLayer` into `FunctionContext.createLayer()` so it's automatically available to any operation handler that declares `Blueprint.RegistryService` in its `services` list

This eliminates the need for the `withBlueprintRegistryProvider` wrapper hack in upstream consumer code, which wrapped handler Effects externally and required an unsafe `(handler as any)` cast to bypass the type system.

## Test plan

- [ ] `moon run compute:test` passes
- [ ] `moon run functions:test` passes
- [ ] Upstream callers (e.g. `compute-intrinsics` worker) can pass `blueprintRegistry` directly to `wrapFunctionHandler` and remove the `withBlueprintRegistryProvider` wrapper

https://claude.ai/code/session_01JH3zaSFoSU9iB6nGdDyPyt

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH3zaSFoSU9iB6nGdDyPyt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for injecting a Blueprint registry into the function runtime context
  * Implemented fallback error handling when the blueprint registry is unavailable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->