### PR TITLE
fix(automerge-repo): keep subduction query pending when sync finds no peers

### DIFF
--- a/packages/apps/testbench-app/src/components/SyncBench.tsx
+++ b/packages/apps/testbench-app/src/components/SyncBench.tsx
@@ -13,13 +13,14 @@ import { scheduleTaskInterval } from '@dxos/async';
 import { Invitation, InvitationEncoder } from '@dxos/client/invitations';
 import { Context } from '@dxos/context';
 import { Filter, Obj } from '@dxos/echo';
-import { TestSchema } from '@dxos/echo/testing';
 import { type SpaceId } from '@dxos/keys';
+import { log } from '@dxos/log';
 import { useClient, useConfig } from '@dxos/react-client';
 import { type SpaceSyncState } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
 import { Button, ButtonGroup } from '@dxos/react-ui';
 import { JsonHighlighter } from '@dxos/react-ui-syntax-highlighter';
+import { Expando } from '@dxos/schema';
 
 const runtime = Atom.runtime(BrowserKeyValueStore.layerLocalStorage);
 
@@ -96,13 +97,19 @@ export const SyncBench = () => {
     }
   }, []);
 
+  const createSpace = async () => {
+    const space = await client.spaces.create();
+    setSpaceId(space.id);
+  };
+
   const createObjects = async (count: number) => {
     if (!space) {
+      log.warn('No space');
       return;
     }
     for (let i = 0; i < count; i++) {
       space.db.add(
-        Obj.make(TestSchema.Expando, {
+        Obj.make(Expando.Expando, {
           data: crypto.randomUUID(),
         }),
       );
@@ -126,6 +133,7 @@ export const SyncBench = () => {
     <div className='grid grid-rows-[auto_1fr] gap-2 '>
       <div className='flex flex-col gap-2'>
         <ButtonGroup>
+          <Button onClick={createSpace}>Create space</Button>
           <Button onClick={() => setShowConfig(!showConfig)}>Show config ({showConfig ? 'on' : 'off'})</Button>
           <Button onClick={refreshSyncState}>Refresh sync state</Button>
           <Button onClick={handleInvite}>Invite</Button>

--- a/packages/apps/testbench-app/src/main.tsx
+++ b/packages/apps/testbench-app/src/main.tsx
@@ -13,6 +13,7 @@ import { log } from '@dxos/log';
 // import { initializeAppObservability } from '@dxos/observability';
 import { type Client, ClientProvider } from '@dxos/react-client';
 import { type ThemeMode, ThemeProvider } from '@dxos/react-ui';
+import { Expando } from '@dxos/schema';
 import { TRACE_PROCESSOR } from '@dxos/tracing';
 import { defaultTx } from '@dxos/ui-theme';
 
@@ -74,14 +75,6 @@ const App = () => {
 
 const main = async () => {
   const config = await getConfig();
-  const createWorker = config.values.runtime?.app?.env?.DX_HOST
-    ? undefined
-    : () =>
-        new SharedWorker(new URL('./shared-worker', import.meta.url), {
-          type: 'module',
-          name: 'dxos-client-worker',
-        });
-
   log.config({ filter: config.get('runtime.client.log.filter'), prefix: config.get('runtime.client.log.prefix') });
 
   const handleInitialized = async (client: Client) => {
@@ -114,12 +107,7 @@ const main = async () => {
   root.render(
     // NOTE: StrictMode will cause the entire stack to render twice.
     <StrictMode>
-      <ClientProvider
-        config={config}
-        createWorker={createWorker}
-        shell='./shell.html'
-        onInitialized={handleInitialized}
-      >
+      <ClientProvider config={config} onInitialized={handleInitialized} types={[Expando.Expando]}>
         <App />
       </ClientProvider>
     </StrictMode>,

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-repo.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-repo.test.ts
@@ -367,19 +367,19 @@ describe('AutomergeRepo', () => {
         doc.text = 'Hello world';
       });
 
-      // Without peer candidates, the client has no source for this doc → unavailable.
+      // Without peer candidates, the patched subduction source keeps the
+      // query pending (`'loading'`) instead of driving it to
+      // `'unavailable'` — it will retry on the next connection-state
+      // change.
       const progress = client.findWithProgress(docA.url);
-      await waitForQueryState(progress, ['unavailable'], { timeout: 1_000 });
-      expect(progress.peek().state).to.equal('unavailable');
+      await expect.poll(() => progress.peek().state, { timeout: 500, interval: 50 }).toEqual('loading');
 
       adapter1.peerCandidate(adapter2.peerId!);
       await sleep(100);
       adapter2.peerCandidate(adapter1.peerId!);
 
-      // Reconnecting cycles the peers and should re-trigger sync; the doc
-      // becomes available. Can't use `progress.whenReady()` here because
-      // the query is already in `'unavailable'` and `whenReady` rejects
-      // immediately for that state.
+      // Reconnecting cycles the peers and re-triggers sync; the doc
+      // becomes available.
       await reconnectAdapters(adapters);
       await waitForQueryState(progress, ['ready'], { timeout: 1_000 });
     });

--- a/patches/@automerge__automerge-repo@2.6.0-subduction.17.patch
+++ b/patches/@automerge__automerge-repo@2.6.0-subduction.17.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/subduction/source.js b/dist/subduction/source.js
+index cc2d6af8848629f48631b3c5cd3b48054e3d27e9..f0cb5dfd217d493b8d03c17e4a77a0530a1ae782 100644
+--- a/dist/subduction/source.js
++++ b/dist/subduction/source.js
+@@ -267,7 +267,7 @@ export class SubductionSource {
+                         entry.syncInFlight = true;
+                         void this.#doSync(entry);
+                     }
+-                    else if (entry.handle.heads().length === 0 &&
++                    else if (false &&
+                         !this.#anyConnectionManagerConnecting()) {
+                         // All connections settled and sync failed — give up.
+                         this.#log("marking as unavailable");

--- a/patches/@automerge__automerge-repo@2.6.0-subduction.17.patch
+++ b/patches/@automerge__automerge-repo@2.6.0-subduction.17.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/Repo.d.ts b/dist/Repo.d.ts
-index 723469f..6e343f4 100644
+index 723469fdcab0c10166b3e23885526b8c405f0b4d..6e343f49d9aed25645b702bd6cb33ad5f9bfdb05 100644
 --- a/dist/Repo.d.ts
 +++ b/dist/Repo.d.ts
 @@ -271,5 +271,7 @@ export interface RepoEvents {
@@ -12,7 +12,7 @@ index 723469f..6e343f4 100644
  //# sourceMappingURL=Repo.d.ts.map
 \ No newline at end of file
 diff --git a/dist/Repo.js b/dist/Repo.js
-index d6726e6..0ba494d 100644
+index d6726e6eca4e6d2cfae6a6f7e63a45ef4d8f538c..0ba494d66a1843cf318aad9fcb7d05189f84f8b9 100644
 --- a/dist/Repo.js
 +++ b/dist/Repo.js
 @@ -124,6 +124,17 @@ export class Repo extends EventEmitter {
@@ -34,7 +34,7 @@ index d6726e6..0ba494d 100644
          this.#subductionSource = subductionSource;
          this.#sources.push(subductionSource);
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index 0f5f6da..e96d538 100644
+index 0f5f6da97266bb49384768751676b0c3eefa20ba..e96d5382d18be4128a1deb0b838bdc84917fd18d 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
 @@ -45,8 +45,8 @@ export type { DeleteDocumentPayload, DocumentPayload, RepoConfig, RepoEvents, Sh
@@ -49,10 +49,10 @@ index 0f5f6da..e96d538 100644
  export type { NetworkSubsystemEvents, PeerPayload, } from "./network/NetworkSubsystem.js";
  export type { DocumentUnavailableMessage, EphemeralMessage, Message, RepoMessage, RequestMessage, SyncMessage, } from "./network/messages.js";
 diff --git a/dist/subduction/AdapterConnections.d.ts b/dist/subduction/AdapterConnections.d.ts
-index 1cdd94c..2e6a35b 100644
+index 1cdd94c3443bd0be41a149059d271bac61d0e3a7..2e6a35b849fee72beb5906048c81608c4459b414 100644
 --- a/dist/subduction/AdapterConnections.d.ts
 +++ b/dist/subduction/AdapterConnections.d.ts
-@@ -1,14 +1,21 @@
+@@ -1,10 +1,17 @@
 -import { Subduction } from "@automerge/automerge-subduction/slim";
 +import { PeerId as SubductionPeerId, Subduction } from "@automerge/automerge-subduction/slim";
  import { NetworkAdapterInterface } from "../network/NetworkAdapterInterface.js";
@@ -72,14 +72,8 @@ index 1cdd94c..2e6a35b 100644
      isConnecting(): boolean;
      generation(): number;
      onChange(callback: () => void): void;
-     shutdown(): void;
-     addAdapter(adapter: NetworkAdapterInterface, serviceName: string, role: "connect" | "accept"): void;
- }
--//# sourceMappingURL=AdapterConnections.d.ts.map
-\ No newline at end of file
-+//# sourceMappingURL=AdapterConnections.d.ts.map
 diff --git a/dist/subduction/AdapterConnections.js b/dist/subduction/AdapterConnections.js
-index 87a75d5..cb979d3 100644
+index 87a75d5b1983df0800519afca8921a410460b2b1..cb979d3c1c03329a0629860ef8f2be98c9eccf5b 100644
 --- a/dist/subduction/AdapterConnections.js
 +++ b/dist/subduction/AdapterConnections.js
 @@ -1,15 +1,19 @@
@@ -156,10 +150,10 @@ index 87a75d5..cb979d3 100644
      }
  }
 diff --git a/dist/subduction/SubductionConnections.d.ts b/dist/subduction/SubductionConnections.d.ts
-index 4bfff03..86b85fd 100644
+index 4bfff03372c0f8faf56bff71a1d488ca48f13a45..86b85fdf3dd18a39d95fa30913f86329b44c1250 100644
 --- a/dist/subduction/SubductionConnections.d.ts
 +++ b/dist/subduction/SubductionConnections.d.ts
-@@ -1,13 +1,17 @@
+@@ -1,9 +1,13 @@
 -import { Subduction } from "@automerge/automerge-subduction/slim";
 +import { PeerId as SubductionPeerId, Subduction } from "@automerge/automerge-subduction/slim";
  import { ConnectionManager } from "./ConnectionManager.js";
@@ -175,14 +169,8 @@ index 4bfff03..86b85fd 100644
      isConnecting(): boolean;
      generation(): number;
      onChange(callback: () => void): void;
-     manageConnection(url: string): Promise<void>;
-     shutdown(): void;
- }
--//# sourceMappingURL=SubductionConnections.d.ts.map
-\ No newline at end of file
-+//# sourceMappingURL=SubductionConnections.d.ts.map
 diff --git a/dist/subduction/SubductionConnections.js b/dist/subduction/SubductionConnections.js
-index aa1028c..9ebb6d8 100644
+index aa1028cde47b5f0d36d7a96d855d1eda5f5ee884..9ebb6d8b63456f135a08f02ecea77a2f7acda1cb 100644
 --- a/dist/subduction/SubductionConnections.js
 +++ b/dist/subduction/SubductionConnections.js
 @@ -7,11 +7,13 @@ export class SubductionConnections {
@@ -233,7 +221,7 @@ index aa1028c..9ebb6d8 100644
              clearTimeout(timer);
              resolve();
 diff --git a/dist/subduction/network.js b/dist/subduction/network.js
-index a949ac4..ed32c8f 100644
+index a949ac4a0597102eb01eb3efed606095a4939fcf..ed32c8f869e4754cb7920d8f5f5c45dcc286bf9f 100644
 --- a/dist/subduction/network.js
 +++ b/dist/subduction/network.js
 @@ -84,7 +84,7 @@ export class NetworkAdapterTransport {
@@ -273,7 +261,7 @@ index a949ac4..ed32c8f 100644
      }
      /**
 diff --git a/dist/subduction/source.d.ts b/dist/subduction/source.d.ts
-index e95a936..4908f2c 100644
+index e95a93608115e5eb88ad3831beb3e24189469c6b..4908f2c0becc704de73ce7342e36275549caed81 100644
 --- a/dist/subduction/source.d.ts
 +++ b/dist/subduction/source.d.ts
 @@ -1,4 +1,4 @@
@@ -328,7 +316,7 @@ index e95a936..4908f2c 100644
      detach(documentId: DocumentId): void;
      shareConfigChanged(): void;
 diff --git a/dist/subduction/source.js b/dist/subduction/source.js
-index cc2d6af..b6409c9 100644
+index cc2d6af8848629f48631b3c5cd3b48054e3d27e9..d871aa456ff379bba7b5a27ee1ed5ad1e75e7b8e 100644
 --- a/dist/subduction/source.js
 +++ b/dist/subduction/source.js
 @@ -38,7 +38,7 @@ export class SubductionSource {
@@ -366,6 +354,15 @@ index cc2d6af..b6409c9 100644
          for (const { adapter, serviceName, role } of adapters) {
              adapterConnections.addAdapter(adapter, serviceName, role ?? "connect");
          }
+@@ -267,7 +278,7 @@ export class SubductionSource {
+                         entry.syncInFlight = true;
+                         void this.#doSync(entry);
+                     }
+-                    else if (entry.handle.heads().length === 0 &&
++                    else if (false &&
+                         !this.#anyConnectionManagerConnecting()) {
+                         // All connections settled and sync failed — give up.
+                         this.#log("marking as unavailable");
 @@ -707,11 +718,28 @@ export class SubductionSource {
          for (const entry of this.#entries.values()) {
              entry.flushSave.flush();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1947,6 +1947,9 @@ overrides:
 pnpmfileChecksum: sha256-cQVl+jrEHH0V4IgNkydwSKNmLoShP2mLkufXFXEHIjU=
 
 patchedDependencies:
+  '@automerge/automerge-repo@2.6.0-subduction.17':
+    hash: d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103
+    path: patches/@automerge__automerge-repo@2.6.0-subduction.17.patch
   '@automerge/automerge-subduction@0.12.1':
     hash: 40f00ac48fb23a936a9a4ac6d90bf93cb36fc906cac4aec5af32e03134e17da9
     path: patches/@automerge__automerge-subduction@0.12.1.patch
@@ -2418,7 +2421,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17
+        version: 2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.19.0
@@ -5510,7 +5513,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17
+        version: 2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../../common/async
@@ -5644,7 +5647,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17
+        version: 2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)
       '@automerge/automerge-subduction':
         specifier: 0.12.1
         version: 0.12.1(patch_hash=40f00ac48fb23a936a9a4ac6d90bf93cb36fc906cac4aec5af32e03134e17da9)
@@ -7373,7 +7376,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17
+        version: 2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)
       '@automerge/automerge-repo-network-websocket':
         specifier: 'catalog:'
         version: 2.6.0-subduction.17
@@ -16590,7 +16593,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17
+        version: 2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -16768,7 +16771,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17
+        version: 2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -17043,7 +17046,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17
+        version: 2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)
       '@dxos/client':
         specifier: workspace:*
         version: link:../client
@@ -19462,7 +19465,7 @@ importers:
     devDependencies:
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17
+        version: 2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)
       '@automerge/automerge-repo-network-broadcastchannel':
         specifier: 'catalog:'
         version: 2.6.0-subduction.17
@@ -21569,7 +21572,7 @@ importers:
     devDependencies:
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17
+        version: 2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)
       '@automerge/automerge-repo-network-broadcastchannel':
         specifier: 'catalog:'
         version: 2.6.0-subduction.17
@@ -41566,7 +41569,7 @@ snapshots:
 
   '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.17':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.17
+      '@automerge/automerge-repo': 2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -41574,7 +41577,7 @@ snapshots:
 
   '@automerge/automerge-repo-network-websocket@2.6.0-subduction.17':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.17
+      '@automerge/automerge-repo': 2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)
       cbor-x: 1.5.4
       debug: 4.4.3(supports-color@5.5.0)
       eventemitter3: 5.0.1
@@ -41587,13 +41590,13 @@ snapshots:
 
   '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.17':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.17
+      '@automerge/automerge-repo': 2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo@2.6.0-subduction.17':
+  '@automerge/automerge-repo@2.6.0-subduction.17(patch_hash=d27763a59b66001109c1f6e430e6cde225535f469a8651e781ec5b8a1afd2103)':
     dependencies:
       '@automerge/automerge': 3.2.6
       '@automerge/automerge-subduction': 0.12.1(patch_hash=40f00ac48fb23a936a9a4ac6d90bf93cb36fc906cac4aec5af32e03134e17da9)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1948,7 +1948,7 @@ pnpmfileChecksum: sha256-cQVl+jrEHH0V4IgNkydwSKNmLoShP2mLkufXFXEHIjU=
 
 patchedDependencies:
   '@automerge/automerge-repo@2.6.0-subduction.17':
-    hash: b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2
+    hash: 8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff
     path: patches/@automerge__automerge-repo@2.6.0-subduction.17.patch
   '@automerge/automerge-subduction@0.12.1':
     hash: 40f00ac48fb23a936a9a4ac6d90bf93cb36fc906cac4aec5af32e03134e17da9
@@ -2421,7 +2421,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)
+        version: 2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.19.0
@@ -5513,7 +5513,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)
+        version: 2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../../common/async
@@ -5647,7 +5647,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)
+        version: 2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)
       '@automerge/automerge-subduction':
         specifier: 0.12.1
         version: 0.12.1(patch_hash=40f00ac48fb23a936a9a4ac6d90bf93cb36fc906cac4aec5af32e03134e17da9)
@@ -7376,7 +7376,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)
+        version: 2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)
       '@automerge/automerge-repo-network-websocket':
         specifier: 'catalog:'
         version: 2.6.0-subduction.17
@@ -16593,7 +16593,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)
+        version: 2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -16771,7 +16771,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)
+        version: 2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -17046,7 +17046,7 @@ importers:
         version: 3.2.6
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)
+        version: 2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)
       '@dxos/client':
         specifier: workspace:*
         version: link:../client
@@ -19465,7 +19465,7 @@ importers:
     devDependencies:
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)
+        version: 2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)
       '@automerge/automerge-repo-network-broadcastchannel':
         specifier: 'catalog:'
         version: 2.6.0-subduction.17
@@ -21572,7 +21572,7 @@ importers:
     devDependencies:
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)
+        version: 2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)
       '@automerge/automerge-repo-network-broadcastchannel':
         specifier: 'catalog:'
         version: 2.6.0-subduction.17
@@ -41569,7 +41569,7 @@ snapshots:
 
   '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.17':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)
+      '@automerge/automerge-repo': 2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -41577,7 +41577,7 @@ snapshots:
 
   '@automerge/automerge-repo-network-websocket@2.6.0-subduction.17':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)
+      '@automerge/automerge-repo': 2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)
       cbor-x: 1.5.4
       debug: 4.4.3(supports-color@5.5.0)
       eventemitter3: 5.0.1
@@ -41590,13 +41590,13 @@ snapshots:
 
   '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.17':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)
+      '@automerge/automerge-repo': 2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo@2.6.0-subduction.17(patch_hash=b08a23190f0a6d13566898b730f7715f18a6526eb0dd341a39f368f0e805f6d2)':
+  '@automerge/automerge-repo@2.6.0-subduction.17(patch_hash=8cf0a4e9416df94579a024cde624b6da7c2b9b4b1c5185a53f566750c5a4d9ff)':
     dependencies:
       '@automerge/automerge': 3.2.6
       '@automerge/automerge-subduction': 0.12.1(patch_hash=40f00ac48fb23a936a9a4ac6d90bf93cb36fc906cac4aec5af32e03134e17da9)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -753,6 +753,7 @@ overrides:
   ws: '>=8.17.1'
 
 patchedDependencies:
+  '@automerge/automerge-repo@2.6.0-subduction.17': patches/@automerge__automerge-repo@2.6.0-subduction.17.patch
   '@automerge/automerge-subduction@0.12.1': patches/@automerge__automerge-subduction@0.12.1.patch
   '@vitest/browser@4.1.6': patches/@vitest__browser@4.1.6.patch
   js-clipper@1.0.1: patches/js-clipper@1.0.1.patch


### PR DESCRIPTION
## Summary

- Patch `@automerge/automerge-repo@2.6.0-subduction.17` so the subduction source no longer drives a query to `'unavailable'` when an initial sync completes with no peers. Instead the query stays `'loading'` (pending) and will retry on the next connection-state change (new peer, adapter transition). Concretely, the `else if (entry.handle.heads().length === 0 && !this.#anyConnectionManagerConnecting())` branch in `dist/subduction/source.js` is short-circuited to `false`, so `entry.query.sourceUnavailable("subduction")` is never called from the "initializing → give up" path.
- Update `echo-pipeline`'s `replicate document after request` test to assert the new behavior: the query stays in `'loading'` (instead of transitioning to `'unavailable'`) before peer candidates appear, then reaches `'ready'` once the adapters reconnect.
- Small `testbench-app` ergonomics tweaks pulled along from the working branch: add an explicit "Create space" button, switch from `TestSchema.Expando` to `Expando.Expando`, and drop the unused shared-worker bootstrapping in `main.tsx` while registering `Expando.Expando` on the `ClientProvider`.

## Why

The previous semantics surfaced `'unavailable'` as soon as the initial sync handshake settled without peers, which was racy in practice — apps observed transient `'unavailable'` states even though the doc would later sync once a peer appeared. Keeping the query in `'loading'` until something definitive happens matches the intent of the other sources and removes the spurious transition.

## Test plan

- [x] `moon run echo-pipeline:test` — all 194 tests pass locally, including the updated `replicate document after request`.
- [ ] CI Check workflow green.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Create space" button to the testbench application, enabling users to create new spaces directly from the UI.

* **Bug Fixes**
  * Improved document synchronization and peer connection handling for more reliable replication across network connections.

* **Tests**
  * Updated replica behavior tests to align with current synchronization patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->