### PR TITLE
feat(introspect-tools): add PluginsFile type

### DIFF
--- a/packages/plugins/plugin-assistant/src/containers/AgentProperties/AgentProperties.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/AgentProperties/AgentProperties.tsx
@@ -16,6 +16,7 @@ import { AtomObj } from '@dxos/echo-atom';
 import { log } from '@dxos/log';
 import { useQuery } from '@dxos/react-client/echo';
 import { Input, useTranslation } from '@dxos/react-ui';
+import { Form } from '@dxos/react-ui-form';
 import { FeedAnnotation } from '@dxos/schema';
 
 import { meta } from '#meta';
@@ -103,7 +104,7 @@ export const AgentProperties = ({ subject: agent }: AgentPropertiesProps) => {
   }
 
   return (
-    <div className='dx-expander flex flex-col'>
+    <Form.Section>
       <Input.Root>
         <Input.Label classNames='mt-form-gap'>{t('subscriptions.label')}</Input.Label>
       </Input.Root>
@@ -121,6 +122,6 @@ export const AgentProperties = ({ subject: agent }: AgentPropertiesProps) => {
           </div>
         </Input.Root>
       ))}
-    </div>
+    </Form.Section>
   );
 };

--- a/packages/reflect/introspect-tools/src/index.ts
+++ b/packages/reflect/introspect-tools/src/index.ts
@@ -36,6 +36,7 @@ export {
   type Plugin,
   type PluginDetail,
   type PluginId,
+  type PluginsFile,
   type SchemaContribution,
   type SourceLocation,
   type Surface,

--- a/packages/reflect/introspect-tools/src/output-schemas.ts
+++ b/packages/reflect/introspect-tools/src/output-schemas.ts
@@ -202,3 +202,22 @@ export const IdiomSchema = Schema.Struct({
   host: IdiomHostSchema,
 });
 export type Idiom = typeof IdiomSchema.Type;
+
+//
+// Sidecar file format
+//
+
+/**
+ * Shape of the `plugins.json` sidecar stored in R2 / written by the cache
+ * upload script. Uses plain mutable arrays so callers can work with standard
+ * JSON.parse output without readonly friction.
+ */
+export type PluginsFile = {
+  version: 1;
+  plugins: Plugin[];
+  surfaces: Surface[];
+  capabilities: Capability[];
+  operations: Operation[];
+  schemas: SchemaContribution[];
+  idioms?: Idiom[];
+};

--- a/packages/ui/react-ui-form/src/components/Form/Form.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/Form.tsx
@@ -301,7 +301,7 @@ FormActions.displayName = FORM_ACTIONS_NAME;
 
 const FORM_SECTION_NAME = 'Form.Section';
 
-type FormSectionProps = ThemedClassName<{ label: string; description?: string }>;
+type FormSectionProps = ThemedClassName<{ label?: string; description?: string }>;
 
 const FormSection = composable<HTMLDivElement, FormSectionProps>(
   ({ children, label, description, ...props }, forwardedRef) => {
@@ -310,7 +310,7 @@ const FormSection = composable<HTMLDivElement, FormSectionProps>(
         {...composableProps(props, { classNames: 'flex flex-col pt-form-section-gap first:pt-0' })}
         ref={forwardedRef}
       >
-        <h2 className='text-lg'>{label}</h2>
+        {label && <h2 className='text-lg'>{label}</h2>}
         {description && <p className='text-description'>{description}</p>}
         {children}
       </div>


### PR DESCRIPTION
## Summary

- Adds a plain-TypeScript `PluginsFile` type to `@dxos/introspect-tools` describing the `plugins.json` sidecar format stored in R2
- Uses mutable arrays so callers can work with standard `JSON.parse` output without readonly friction from Effect Schema's inferred types
- Exports from the package index alongside the existing plugin/idiom entry types

## Context

`plugins.json` is written by the cache upload script and read by `edge`'s `introspect-service`. Currently that service defines `PluginsFile` locally (it can't import from `@dxos/introspect` which is Node-only). Placing the type in `@dxos/introspect-tools` (the browser-safe contract package) makes it available to any consumer without pulling in Node-only deps.

Once this is published, the TODO in `edge`'s `introspect-service/src/cache/types.ts` can be resolved by replacing the local definition with an import.

## Test plan

- [ ] `moon run introspect-tools:build` passes
- [ ] Type is visible in the published `.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Form.Section component labels are now optional, allowing for more flexible form layouts without title headers.

* **Chores**
  * Enhanced plugin introspection tooling with new schema type definitions and improved component organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->