### PR TITLE
fix(composer-app): escape text in playwright thread selectors

### DIFF
--- a/packages/apps/composer-app/src/playwright/plugins/thread.ts
+++ b/packages/apps/composer-app/src/playwright/plugins/thread.ts
@@ -15,13 +15,12 @@ export const Thread = {
 
   getComments: (page: Page) => page.getByTestId('cm-comment'),
 
-  getComment: (page: Page, text: string) =>
-    page.getByTestId('cm-comment').filter({ has: page.locator(`span:has-text("${text}")`) }),
+  getComment: (page: Page, text: string) => page.getByTestId('cm-comment').filter({ hasText: text }),
 
   getThreads: (page: Page) => page.getByTestId('thread'),
 
   getThread: (page: Page, text: string) =>
-    page.getByTestId('thread').filter({ has: page.locator(`[data-testid="thread.heading"]:has-text("${text}")`) }),
+    page.getByTestId('thread').filter({ has: page.getByTestId('thread.heading').filter({ hasText: text }) }),
 
   getCurrentThread: (page: Page) => page.locator('[data-testid=thread][aria-current="location"]'),
 
@@ -29,10 +28,7 @@ export const Thread = {
 
   getMessages: (thread: Locator) => thread.getByTestId('thread.message'),
 
-  getMessage: (thread: Locator, current: string) =>
-    thread.getByTestId('thread.message').filter({
-      has: thread.page().locator(`div:has-text("${current}")`),
-    }),
+  getMessage: (thread: Locator, current: string) => thread.getByTestId('thread.message').filter({ hasText: current }),
 
   addMessage: async (thread: Locator, message: string) => {
     const input = thread.getByRole('textbox').last();


### PR DESCRIPTION
## Summary
- Playwright tests in `comments.spec.ts` interpolate lorem-ipsum text into `:has-text(\"...\")` CSS selectors. When the text contains a quote or newline (e.g. `editorText.slice(0, 10)` landing on a paragraph break), the CSS parser fails with `BADSTRING`.
- Switch `Thread.getComment` / `getThread` / `getMessage` to `filter({ hasText })`, which takes a JS string and escapes safely.

Failing job this fixes: https://github.com/dxos/dxos/actions/runs/26111894749/job/76791033699

## Test plan
- [ ] CI: `composer-app:e2e` passes for the previously failing cases:
  - [ ] `comments.spec.ts › undo delete thread` (firefox)
  - [ ] `comments.spec.ts › selecting comment highlights thread and vice versa` (webkit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated test automation code to use modern selector patterns for improved maintainability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->