### PR TITLE
feat(introspect-tools): add outputSchema to ToolMetadata

### DIFF
--- a/packages/reflect/introspect-tools/src/metadata.test.ts
+++ b/packages/reflect/introspect-tools/src/metadata.test.ts
@@ -1,0 +1,55 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { TOOL_METADATA } from './metadata';
+
+// Top-level field key each tool's outputSchema must expose. MCP requires
+// `structuredContent` to be a JSON object, so every tool wraps its
+// result(s) under a stable key — this is the contract downstream
+// consumers (e.g. dxos/edge introspect-service) bind to.
+const EXPECTED_OUTPUT_KEYS: Record<string, string> = {
+  list_packages: 'packages',
+  get_package: 'package',
+  list_symbols: 'symbols',
+  find_symbol: 'matches',
+  get_symbol: 'symbol',
+  list_plugins: 'plugins',
+  list_surfaces: 'surfaces',
+  list_capabilities: 'capabilities',
+  list_operations: 'operations',
+  list_schemas: 'schemas',
+  list_idioms: 'idioms',
+};
+
+describe('TOOL_METADATA', () => {
+  test('every entry declares title, description, inputSchema, outputSchema', ({ expect }) => {
+    for (const [name, meta] of Object.entries(TOOL_METADATA)) {
+      expect(meta.title, `${name}.title`).toBeTypeOf('string');
+      expect(meta.description, `${name}.description`).toBeTypeOf('string');
+      expect(meta.inputSchema, `${name}.inputSchema`).toBeDefined();
+      expect(meta.inputSchema.fields, `${name}.inputSchema.fields`).toBeDefined();
+      expect(meta.outputSchema, `${name}.outputSchema`).toBeDefined();
+      expect(meta.outputSchema.fields, `${name}.outputSchema.fields`).toBeDefined();
+    }
+  });
+
+  test('outputSchema top-level key matches the documented convention', ({ expect }) => {
+    for (const [name, expectedKey] of Object.entries(EXPECTED_OUTPUT_KEYS)) {
+      const meta = TOOL_METADATA[name];
+      expect(meta, `tool ${name} missing from TOOL_METADATA`).toBeDefined();
+      const keys = Object.keys(meta.outputSchema.fields);
+      expect(keys, `${name}.outputSchema fields`).toEqual([expectedKey]);
+    }
+  });
+
+  test('all registered tools have an expected output key entry', ({ expect }) => {
+    // Catches new tools added to TOOL_METADATA without a corresponding
+    // documented output-key convention.
+    for (const name of Object.keys(TOOL_METADATA)) {
+      expect(EXPECTED_OUTPUT_KEYS[name], `tool ${name} missing from EXPECTED_OUTPUT_KEYS`).toBeDefined();
+    }
+  });
+});

--- a/packages/reflect/introspect-tools/src/metadata.ts
+++ b/packages/reflect/introspect-tools/src/metadata.ts
@@ -17,6 +17,17 @@ import { effectFieldsToZod } from '@dxos/effect-zod';
 import { trim } from '@dxos/util';
 
 import {
+  CapabilitySchema,
+  IdiomSchema,
+  OperationSchema,
+  PackageSchema,
+  PluginSchema,
+  SchemaSchema,
+  SurfaceSchema,
+  SymbolDetailSchema,
+  SymbolMatchSchema,
+} from './output-schemas';
+import {
   FindSymbolInput,
   GetPackageInput,
   GetSymbolInput,
@@ -53,6 +64,15 @@ export type ToolMetadata = {
    * (react-ui-form, etc.) use this directly.
    */
   inputSchema: Schema.Struct<any>;
+
+  /**
+   * Effect Schema struct describing the tool's success return shape.
+   * MCP's `structuredContent` must be a JSON object, so each tool wraps
+   * its item(s) under a stable top-level key (e.g. `{ packages: [...] }`,
+   * `{ package: null | {...} }`). Consumers building Effect AI Tools can
+   * pass this directly as `success` to `Tool.make`.
+   */
+  outputSchema: Schema.Struct<any>;
 };
 
 /**
@@ -72,6 +92,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
       Returns lightweight rows; call get_package for dependency and entry-point detail.
     `,
     inputSchema: ListPackagesInput,
+    outputSchema: Schema.Struct({ packages: Schema.Array(PackageSchema) }),
   },
   get_package: {
     title: 'Get package detail',
@@ -81,6 +102,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
       Use after list_packages or when the user references a package directly.
     `,
     inputSchema: GetPackageInput,
+    outputSchema: Schema.Struct({ package: Schema.NullOr(PackageSchema) }),
   },
   list_symbols: {
     title: 'List all exported symbols of a package',
@@ -90,6 +112,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
       Returns lightweight rows with refs you can pass to get_symbol; capped at 30 — refine with \`kind\` or call get_symbol directly.
     `,
     inputSchema: ListSymbolsInput,
+    outputSchema: Schema.Struct({ symbols: Schema.Array(SymbolMatchSchema) }),
   },
   find_symbol: {
     title: 'Find an exported symbol by name',
@@ -99,6 +122,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
       Returns refs you can pass to get_symbol. Ranking: exact match, then prefix, then substring.
     `,
     inputSchema: FindSymbolInput,
+    outputSchema: Schema.Struct({ matches: Schema.Array(SymbolMatchSchema) }),
   },
   get_symbol: {
     title: 'Get symbol detail',
@@ -108,6 +132,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
       Pass include=["source"] to expand the full declaration text, include=["jsdoc"] for the full JSDoc body.
     `,
     inputSchema: GetSymbolInput,
+    outputSchema: Schema.Struct({ symbol: Schema.NullOr(SymbolDetailSchema) }),
   },
   list_plugins: {
     title: 'List Composer plugins',
@@ -117,6 +142,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
       Filter by \`id\` substring (e.g. "markdown") to narrow the list.
     `,
     inputSchema: ListPluginsInput,
+    outputSchema: Schema.Struct({ plugins: Schema.Array(PluginSchema) }),
   },
   list_surfaces: {
     title: 'List surfaces',
@@ -126,6 +152,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
       Filter by \`id\` (plugin id) to scope to a single plugin's surfaces.
     `,
     inputSchema: ListSurfacesInput,
+    outputSchema: Schema.Struct({ surfaces: Schema.Array(SurfaceSchema) }),
   },
   list_capabilities: {
     title: 'List capability contributions',
@@ -134,6 +161,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
       keys are produced (or required) by which plugins. Filter by \`id\` (plugin id) to scope to a single plugin.
     `,
     inputSchema: ListCapabilitiesInput,
+    outputSchema: Schema.Struct({ capabilities: Schema.Array(CapabilitySchema) }),
   },
   list_operations: {
     title: 'List operations',
@@ -145,6 +173,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
       to scope to a single plugin.
     `,
     inputSchema: ListOperationsInput,
+    outputSchema: Schema.Struct({ operations: Schema.Array(OperationSchema) }),
   },
   list_schemas: {
     title: 'List schemas',
@@ -154,6 +183,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
       Filter by \`id\` (plugin id, e.g. "org.dxos.plugin.markdown") to scope to a single plugin's schemas.
     `,
     inputSchema: ListSchemasInput,
+    outputSchema: Schema.Struct({ schemas: Schema.Array(SchemaSchema) }),
   },
   list_idioms: {
     title: 'List idioms',
@@ -166,6 +196,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
       (\`symbol\`, \`story\`, \`test\`).
     `,
     inputSchema: ListIdiomsInput,
+    outputSchema: Schema.Struct({ idioms: Schema.Array(IdiomSchema) }),
   },
 };
 


### PR DESCRIPTION
## Summary

- Add `outputSchema: Schema.Struct<any>` to `ToolMetadata` in `@dxos/introspect-tools`.
- Populate each `TOOL_METADATA` entry with its conventional wrapper struct (e.g. `{ packages: Array(PackageSchema) }`, `{ package: NullOr(PackageSchema) }`, …) using the item schemas already exported from `./output-schemas`.
- Add `src/metadata.test.ts` asserting every entry declares an `outputSchema` and that its top-level field key matches the documented convention, so future tools can't silently omit it.

## Why

MCP requires `structuredContent` to be a JSON object, not a bare array. Downstream consumers (notably `dxos/edge`'s `packages/experimental/introspect-service/src/mcp/tools.ts`) have been maintaining a parallel local table of `Schema.Struct({ key: Array(ItemSchema) })` wrappers for every tool — adding or renaming a tool required edits in both repos.

This change moves that wrapper convention into the single source of truth so consumers can write, per tool:

```ts
Tool.make(name, {
  description: TOOL_METADATA[name].description,
  parameters:  TOOL_METADATA[name].inputSchema.fields,
  success:     TOOL_METADATA[name].outputSchema,
});
```

This PR unblocks `dxos/edge` introspect-service from maintaining its parallel output-schema table; the downstream change lands separately.

## Out of scope

- No changes to item schemas (`PackageSchema`, `SymbolMatchSchema`, …) — `PackageSchema`'s required `version`/`private` fields still don't match `dxos/edge`'s `cache.json` v3 shape; that's tracked in the consumer.
- No Toolkit-factory helper and no `@effect/ai` dep — this package stays browser-safe.

## Test plan

- [x] `moon run introspect-tools:build`
- [x] `moon run introspect-tools:test` — 3 passed (metadata.test.ts)
- [x] `moon run introspect-tools:lint`
- [x] `moon run introspect-mcp:build` (spreads `TOOL_METADATA[name]` into `ToolDefinition`; verified no type breakage)
- [x] `moon run react-ui-introspect:build` (consumes `TOOL_METADATA`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite to validate output schema declarations for all registered tools, ensuring consistent documentation of return data structures.

* **Chores**
  * Extended tool metadata definitions to include output schema specifications across all tool entries for improved schema documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->