### PR TITLE
ci: run pkg.pr.new workflow on every push to main

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -2,6 +2,9 @@ name: pkg.pr.new
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Adds a `push` trigger on `main` to the `pkg.pr.new` workflow so it publishes preview packages on every commit to main (in addition to manual `workflow_dispatch` runs).
- The existing concurrency group (`${{ github.workflow }}-${{ github.ref }}`) ensures rapid sequential commits cancel in-progress runs rather than queueing.

## Test plan
- [ ] Confirm the workflow run is triggered automatically after merge to main.
- [ ] Verify pkg.pr.new publish step still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow automation to trigger automatically on updates to the main branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->