### PR TITLE
fix(plugin-support): pin Welcome node to top of personal space navtree

### DIFF
--- a/packages/plugins/plugin-support/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-support/src/capabilities/app-graph-builder.ts
@@ -117,8 +117,11 @@ export default Capability.makeModule(
       // Personal-space-only Welcome virtual node, hoisted to the top of the navtree.
       // The node is fully virtual (no backing ECHO object); the matching Article surface
       // is selected via the `welcome` literal subject. Gated by the `showWelcome` setting.
+      // The extension itself is positioned `first` so its node is inserted ahead of other
+      // `position: 'first'` siblings (Settings, Collections) under the personal space.
       GraphBuilder.createExtension({
         id: 'welcome',
+        position: 'first',
         match: AppNodeMatcher.whenSpace,
         connector: (space, get) => {
           if (!isPersonalSpace(space)) {


### PR DESCRIPTION
## Summary

Welcome now reliably appears first in the Personal Space navtree, above Settings and Collections.

## Why

The Welcome, Settings, and Collections extensions each contribute a virtual node with `position: 'first'` on the **node properties**. `byPosition` returns `0` between two `'first'` items, so stable sort preserves *insertion order* — and the Welcome extension happened to be registered last, so its node sank below the others.

Setting `position: 'first'` on the **extension itself** makes `_connectors` (in `app-graph/src/graph-builder.ts`) run the welcome extension ahead of the other unpositioned ones. The Welcome node is then inserted before Settings/Collections, and stable sort by node position keeps it on top.

## Test plan

- [x] Verified in browser (composer-app dev server): Personal Space navtree now shows Welcome → Settings → Collections → Database → DevTools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)