### PR TITLE
fix(plugin-debug): collapse object panel rows by default in database panel

### DIFF
--- a/packages/devtools/devtools/src/components/ObjectsTree.tsx
+++ b/packages/devtools/devtools/src/components/ObjectsTree.tsx
@@ -190,21 +190,12 @@ const ExpandedKeySchema = Schema.TemplateLiteralParser(
   Schema.Number,
 );
 
-const AUTO_EXPAND_LEVEL = 3;
-
 class ObjectsTreeModel {
   #onSelect: (entity: Entity.Snapshot) => void;
   #database: Database.Database;
   #root: Entity.Unknown | null;
   #atoms = Atom.family((anchor: string | null) => this.#makeNodeAtom(anchor));
-  #expandedState = Atom.family((key: string) => {
-    const [id, _, level] = Schema.decodeUnknownSync(ExpandedKeySchema)(key);
-    if (level <= AUTO_EXPAND_LEVEL) {
-      return Atom.make(true);
-    } else {
-      return Atom.make(false);
-    }
-  });
+  #expandedState = Atom.family((_key: string) => Atom.make(false));
 
   constructor(database: Database.Database, root: Entity.Unknown | null, onSelect: (entity: Entity.Snapshot) => void) {
     this.#database = database;


### PR DESCRIPTION
## Summary

- Remove auto-expand behavior from `ObjectsTree` so all rows start collapsed by default in the R0 "Database" panel (`space-objects` deck companion)
- Previously, rows at tree levels 1–3 were auto-expanded (`AUTO_EXPAND_LEVEL = 3`); now all rows start collapsed and expand on user interaction

## Test plan

- [ ] Open Composer and enable the "Database" panel in the R0 (right icon strip)
- [ ] Verify that all rows in the object tree start collapsed
- [ ] Verify that clicking the toggle on a row still expands/collapses it correctly

https://claude.ai/code/session_01JjAZPkiJdnsaBwKjp32QQi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjAZPkiJdnsaBwKjp32QQi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Objects Tree component initialization behavior: tree nodes no longer automatically expand based on their depth level by default. All nodes now start in a collapsed state, providing a cleaner and more predictable user interface while allowing users to manually expand only the tree sections they need to examine or explore.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->