### PR TITLE
fix(plugin-assistant): register AiService LayerSpec before ProcessManager builds

### DIFF
--- a/packages/core/compute/functions-runtime/src/agent-service/AgentService.ts
+++ b/packages/core/compute/functions-runtime/src/agent-service/AgentService.ts
@@ -137,7 +137,9 @@ export const layer = (opts?: {
               return cached;
             }
 
-            const target = Obj.getDXN(feed).toString();
+            const feedDxn = Obj.getDXN(feed);
+            const target = feedDxn.toString();
+            const spaceId = feedDxn.asEchoDXN()?.spaceId;
             const executable = AgentProcess({
               systemPrompt: opts?.systemPrompt,
               model: options?.model ?? opts?.model,
@@ -153,6 +155,7 @@ export const layer = (opts?: {
               handle = yield* processManager.spawn(executable, {
                 name: 'agent',
                 target,
+                environment: spaceId ? { space: spaceId } : undefined,
                 traceMeta: {
                   conversationId: feed.id,
                 },

--- a/packages/plugins/plugin-assistant/src/AssistantPlugin.node.ts
+++ b/packages/plugins/plugin-assistant/src/AssistantPlugin.node.ts
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Plugin } from '@dxos/app-framework';
+import { ActivationEvents, Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { AiContext } from '@dxos/assistant';
 import { Agent, Chat, McpServer, Memory, Plan } from '@dxos/assistant-toolkit';
@@ -12,8 +12,17 @@ import { Feed } from '@dxos/echo';
 import { Text } from '@dxos/schema';
 import { HasSubject, Message } from '@dxos/types';
 
-import { AppGraphBuilder, BlueprintDefinition, CreateObject, OperationHandler } from '#capabilities';
+import {
+  AiService,
+  AppGraphBuilder,
+  BlueprintDefinition,
+  CreateObject,
+  EdgeModelResolver,
+  LocalModelResolver,
+  OperationHandler,
+} from '#capabilities';
 import { meta } from '#meta';
+import { AssistantEvents } from '#types';
 
 export const AssistantPlugin = Plugin.define(meta).pipe(
   AppPlugin.addAppGraphModule({ activate: AppGraphBuilder }),
@@ -37,6 +46,19 @@ export const AssistantPlugin = Plugin.define(meta).pipe(
       Memory.Memory,
       Text.Text,
     ],
+  }),
+  Plugin.addModule({
+    activatesOn: AssistantEvents.SetupAiServiceProviders,
+    activate: EdgeModelResolver,
+  }),
+  Plugin.addModule({
+    activatesOn: AssistantEvents.SetupAiServiceProviders,
+    activate: LocalModelResolver,
+  }),
+  Plugin.addModule({
+    firesBeforeActivation: [AssistantEvents.SetupAiServiceProviders],
+    activatesOn: ActivationEvents.SetupProcessManager,
+    activate: AiService,
   }),
   Plugin.make,
 );

--- a/packages/plugins/plugin-assistant/src/AssistantPlugin.test.ts
+++ b/packages/plugins/plugin-assistant/src/AssistantPlugin.test.ts
@@ -2,9 +2,12 @@
 // Copyright 2026 DXOS.org
 //
 
+import * as Effect from 'effect/Effect';
 import { describe, test } from 'vitest';
 
+import { AiService } from '@dxos/ai';
 import { AppActivationEvents } from '@dxos/app-toolkit';
+import { ServiceResolver } from '@dxos/compute';
 import { ClientPlugin } from '@dxos/plugin-client/plugin';
 import { createComposerTestApp } from '@dxos/plugin-testing/harness';
 
@@ -31,5 +34,16 @@ describe('AssistantPlugin', () => {
 
     // OperationHandler auto-cascades from ProcessManagerPlugin.
     expect(harness.manager.getActive()).toContain(moduleId('OperationHandler'));
+
+    // AiService module must activate on SetupProcessManager (before the process manager is built).
+    expect(harness.manager.getActive()).toContain(moduleId('AiService'));
+
+    // AiService must be resolvable via the process manager's ServiceResolver.
+    await harness.runPromise(
+      Effect.gen(function* () {
+        const aiService = yield* AiService.AiService;
+        expect(aiService).toBeDefined();
+      }).pipe(Effect.provide(ServiceResolver.provide({}, AiService.AiService))),
+    );
   });
 });

--- a/packages/plugins/plugin-assistant/src/AssistantPlugin.ts
+++ b/packages/plugins/plugin-assistant/src/AssistantPlugin.ts
@@ -100,7 +100,7 @@ export const AssistantPlugin = Plugin.define(meta).pipe(
   Plugin.addModule({
     firesBeforeActivation: [AssistantEvents.SetupAiServiceProviders],
     // TODO(dmaretskyi): This should activate lazily when the AI chat is used.
-    activatesOn: ActivationEvents.Startup,
+    activatesOn: ActivationEvents.SetupProcessManager,
     activate: AiService,
   }),
   Plugin.addModule({


### PR DESCRIPTION
## Summary

- **Root cause**: `AiService` module was activating on `Startup` alongside `ProcessManagerPlugin`. Since `Capability.getAll(Capabilities.LayerSpec)` is a synchronous snapshot, `ProcessManagerPlugin` built its `LayerStack` before `AiService` had contributed its `aiServiceSpec`. Result: `AiService.AiService` was never in the LayerStack, causing `ServiceNotAvailable` errors when chat tried to resolve it.
- **Fix**: Changed `AiService` module's `activatesOn` from `ActivationEvents.Startup` to `ActivationEvents.SetupProcessManager`. Since `SetupProcessManager` fires as a `firesBeforeActivation` event of `ProcessManagerPlugin`, the `AiService` LayerSpec is guaranteed to be contributed before the LayerStack is built.
- **Node.js test variant**: Added `AiService`, `EdgeModelResolver`, and `LocalModelResolver` to `AssistantPlugin.node.ts` (the stripped-down Node.js build used by tests) so the AiService path can be tested in Node environments.
- **Test**: Added assertions to `AssistantPlugin.test.ts` verifying that `AiService` activates on `SetupProcessManager` and is resolvable via the process manager's `ServiceResolver`.

## Test plan

- [x] `moon run plugin-assistant:test -- src/AssistantPlugin.test.ts` passes (75/75 tests, 2 skipped)
- [x] `moon run plugin-assistant:build` succeeds cleanly
- [ ] Verify assistant chat no longer shows `ServiceNotAvailable: Service not available: @dxos/ai/AiService` in the browser app

https://claude.ai/code/session_012naqyAGVJzRspH1zPpfbaV

---
_Generated by [Claude Code](https://claude.ai/code/session_012naqyAGVJzRspH1zPpfbaV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * AI service initialization now occurs earlier in the app lifecycle.
  * Model resolution improved via additional resolver modules and adjusted activation sequencing.
  * Agent session routing now includes optional space-scoped environment when available, improving process targeting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->