### PR TITLE
fix(views): use Filter.typename for RuntimeType schemas in Table/Kanban/Map/Masonry queries

### DIFF
--- a/packages/plugins/plugin-kanban/src/containers/KanbanArticle/KanbanArticle.tsx
+++ b/packages/plugins/plugin-kanban/src/containers/KanbanArticle/KanbanArticle.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useContext, useMemo } from 'react';
 
 import { useCapabilities, useOperationInvoker } from '@dxos/app-framework/ui';
 import { AppCapabilities } from '@dxos/app-toolkit';
-import { type AppSurface } from '@dxos/app-toolkit/ui';
+import { useSchemaFilter, type AppSurface } from '@dxos/app-toolkit/ui';
 import { Filter, Obj, Query, type Ref, Type } from '@dxos/echo';
 import { AtomObj, AtomQuery } from '@dxos/echo-atom';
 import { useObject, useSchema } from '@dxos/react-client/echo';
@@ -47,18 +47,14 @@ const ViewKanbanArticle = ({ role, subject: object }: KanbanArticleProps) => {
     [schemaFromDb, schemas, typename],
   );
 
+  const baseFilter = useSchemaFilter(cardSchema);
   const items = useMemo(() => {
     if (!db) {
       return null;
     }
-    const baseFilter = cardSchema
-      ? cardSchema instanceof Type.RuntimeType
-        ? Filter.typename(cardSchema.typename)
-        : Filter.type(cardSchema)
-      : Filter.nothing();
     const query = tag ? Query.select(baseFilter).select(Filter.tag(tag)) : Query.select(baseFilter);
     return AtomQuery.make(db, query);
-  }, [db, cardSchema, tag]);
+  }, [db, baseFilter, tag]);
 
   const projection = useProjectionModel(cardSchema, object, registry);
   const change = useEchoChangeCallback(object);

--- a/packages/plugins/plugin-kanban/src/containers/KanbanArticle/KanbanArticle.tsx
+++ b/packages/plugins/plugin-kanban/src/containers/KanbanArticle/KanbanArticle.tsx
@@ -51,7 +51,11 @@ const ViewKanbanArticle = ({ role, subject: object }: KanbanArticleProps) => {
     if (!db) {
       return null;
     }
-    const baseFilter = cardSchema ? Filter.type(cardSchema) : Filter.nothing();
+    const baseFilter = cardSchema
+      ? cardSchema instanceof Type.RuntimeType
+        ? Filter.typename(cardSchema.typename)
+        : Filter.type(cardSchema)
+      : Filter.nothing();
     const query = tag ? Query.select(baseFilter).select(Filter.tag(tag)) : Query.select(baseFilter);
     return AtomQuery.make(db, query);
   }, [db, cardSchema, tag]);

--- a/packages/plugins/plugin-map/src/containers/MapArticle/MapArticle.tsx
+++ b/packages/plugins/plugin-map/src/containers/MapArticle/MapArticle.tsx
@@ -5,8 +5,8 @@
 import * as Predicate from 'effect/Predicate';
 import React, { Fragment, useMemo } from 'react';
 
-import { type AppSurface } from '@dxos/app-toolkit/ui';
-import { Filter, Obj, Query, Type } from '@dxos/echo';
+import { useSchemaFilter, type AppSurface } from '@dxos/app-toolkit/ui';
+import { Filter, Obj, Query } from '@dxos/echo';
 import { useObject, useQuery, useSchema } from '@dxos/react-client/echo';
 import { Panel as DxPanel, Flex, type FlexProps, useControlledState } from '@dxos/react-ui';
 import { useSelected } from '@dxos/react-ui-attention';
@@ -32,14 +32,11 @@ export const MapArticle = ({ role, subject: object, type: typeProp = 'map', ...p
   const typename = view?.query ? getTypenameFromQuery(view.query.ast) : undefined;
   const tag = view?.query ? getTagFromQuery(view.query.ast) : undefined;
   const schema = useSchema(db, typename);
-  const query = useMemo(() => {
-    const baseFilter = schema
-      ? schema instanceof Type.RuntimeType
-        ? Filter.typename(schema.typename)
-        : Filter.type(schema)
-      : Filter.nothing();
-    return tag ? Query.select(baseFilter).select(Filter.tag(tag)) : Query.select(baseFilter);
-  }, [schema, tag]);
+  const baseFilter = useSchemaFilter(schema);
+  const query = useMemo(
+    () => (tag ? Query.select(baseFilter).select(Filter.tag(tag)) : Query.select(baseFilter)),
+    [baseFilter, tag],
+  );
   const objects = useQuery(db, query);
 
   const markers = objects

--- a/packages/plugins/plugin-map/src/containers/MapArticle/MapArticle.tsx
+++ b/packages/plugins/plugin-map/src/containers/MapArticle/MapArticle.tsx
@@ -6,7 +6,7 @@ import * as Predicate from 'effect/Predicate';
 import React, { Fragment, useMemo } from 'react';
 
 import { type AppSurface } from '@dxos/app-toolkit/ui';
-import { Filter, Obj, Query } from '@dxos/echo';
+import { Filter, Obj, Query, Type } from '@dxos/echo';
 import { useObject, useQuery, useSchema } from '@dxos/react-client/echo';
 import { Panel as DxPanel, Flex, type FlexProps, useControlledState } from '@dxos/react-ui';
 import { useSelected } from '@dxos/react-ui-attention';
@@ -33,7 +33,11 @@ export const MapArticle = ({ role, subject: object, type: typeProp = 'map', ...p
   const tag = view?.query ? getTagFromQuery(view.query.ast) : undefined;
   const schema = useSchema(db, typename);
   const query = useMemo(() => {
-    const baseFilter = schema ? Filter.type(schema) : Filter.nothing();
+    const baseFilter = schema
+      ? schema instanceof Type.RuntimeType
+        ? Filter.typename(schema.typename)
+        : Filter.type(schema)
+      : Filter.nothing();
     return tag ? Query.select(baseFilter).select(Filter.tag(tag)) : Query.select(baseFilter);
   }, [schema, tag]);
   const objects = useQuery(db, query);

--- a/packages/plugins/plugin-masonry/src/containers/MasonryContainer/MasonryContainer.tsx
+++ b/packages/plugins/plugin-masonry/src/containers/MasonryContainer/MasonryContainer.tsx
@@ -60,7 +60,11 @@ export const MasonryContainer = ({
   }, [schemas, typename, db]);
 
   const query = useMemo(() => {
-    const baseFilter = cardSchema ? Filter.type(cardSchema) : Filter.nothing();
+    const baseFilter = cardSchema
+      ? cardSchema instanceof Type.RuntimeType
+        ? Filter.typename(cardSchema.typename)
+        : Filter.type(cardSchema)
+      : Filter.nothing();
     return tag ? Query.select(baseFilter).select(Filter.tag(tag)) : Query.select(baseFilter);
   }, [cardSchema, tag]);
   const objects = useQuery(db, query);

--- a/packages/plugins/plugin-masonry/src/containers/MasonryContainer/MasonryContainer.tsx
+++ b/packages/plugins/plugin-masonry/src/containers/MasonryContainer/MasonryContainer.tsx
@@ -4,12 +4,11 @@
 
 import * as Function from 'effect/Function';
 import * as Option from 'effect/Option';
-import type * as Schema from 'effect/Schema';
 import React, { useEffect, useMemo, useState } from 'react';
 
 import { Surface, useCapabilities } from '@dxos/app-framework/ui';
 import { AppCapabilities } from '@dxos/app-toolkit';
-import { AppSurface, useObjectMenuItems } from '@dxos/app-toolkit/ui';
+import { AppSurface, useObjectMenuItems, useSchemaFilter } from '@dxos/app-toolkit/ui';
 import { Annotation, Filter, Obj, Query, type Ref, Type, type View } from '@dxos/echo';
 import { useObject, useQuery } from '@dxos/react-client/echo';
 import { Card, Panel, Toolbar } from '@dxos/react-ui';
@@ -37,7 +36,7 @@ export const MasonryContainer = ({
   const typename = view?.query ? getTypenameFromQuery(view.query.ast) : undefined;
   const tag = view?.query ? getTagFromQuery(view.query.ast) : undefined;
 
-  const [cardSchema, setCardSchema] = useState<Schema.Schema.AnyNoContext>();
+  const [cardSchema, setCardSchema] = useState<Type.AnyEntity>();
 
   useEffect(() => {
     const staticSchema = schemas.flat().find((schema) => Type.getTypename(schema) === typename);
@@ -59,14 +58,11 @@ export const MasonryContainer = ({
     }
   }, [schemas, typename, db]);
 
-  const query = useMemo(() => {
-    const baseFilter = cardSchema
-      ? cardSchema instanceof Type.RuntimeType
-        ? Filter.typename(cardSchema.typename)
-        : Filter.type(cardSchema)
-      : Filter.nothing();
-    return tag ? Query.select(baseFilter).select(Filter.tag(tag)) : Query.select(baseFilter);
-  }, [cardSchema, tag]);
+  const baseFilter = useSchemaFilter(cardSchema);
+  const query = useMemo(
+    () => (tag ? Query.select(baseFilter).select(Filter.tag(tag)) : Query.select(baseFilter)),
+    [baseFilter, tag],
+  );
   const objects = useQuery(db, query);
 
   const sortedObjects = useMemo(

--- a/packages/plugins/plugin-table/src/containers/TableArticle/TableArticle.tsx
+++ b/packages/plugins/plugin-table/src/containers/TableArticle/TableArticle.tsx
@@ -222,7 +222,7 @@ const useQueryWorkaround = (
     }
 
     return query;
-  }, [ast, schema]);
+  }, [ast, baseFilter]);
 
   return useQuery(db, query);
 };

--- a/packages/plugins/plugin-table/src/containers/TableArticle/TableArticle.tsx
+++ b/packages/plugins/plugin-table/src/containers/TableArticle/TableArticle.tsx
@@ -196,7 +196,14 @@ const useQueryWorkaround = (
 ) => {
   // Extract order and tag filter from query AST and apply them to the base filter query.
   const query = useMemo(() => {
-    const baseFilter = schema ? Filter.type(schema) : Filter.nothing();
+    // RuntimeType (database-registered schema) has an object-DXN identifier.
+    // Objects created from the original Effect schema use a type-DXN, so Filter.type()
+    // would produce the wrong DXN kind. Use Filter.typename() for RuntimeType schemas.
+    const baseFilter = schema
+      ? schema instanceof Type.RuntimeType
+        ? Filter.typename(schema.typename)
+        : Filter.type(schema)
+      : Filter.nothing();
     let query = Query.select(baseFilter);
 
     // Apply tag filter from the query AST.

--- a/packages/plugins/plugin-table/src/containers/TableArticle/TableArticle.tsx
+++ b/packages/plugins/plugin-table/src/containers/TableArticle/TableArticle.tsx
@@ -8,7 +8,7 @@ import React, { forwardRef, useCallback, useContext, useMemo, useRef } from 'rea
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { LayoutOperation, getObjectPathFromObject } from '@dxos/app-toolkit';
-import { useAppGraph, type AppSurface } from '@dxos/app-toolkit/ui';
+import { useAppGraph, useSchemaFilter, type AppSurface } from '@dxos/app-toolkit/ui';
 import { type Database, Filter, Obj, Order, Query, type QueryAST, Type } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
 import { useGlobalFilteredObjects } from '@dxos/plugin-search';
@@ -194,16 +194,9 @@ const useQueryWorkaround = (
   ast: QueryAST.Query | undefined,
   schema: Type.AnyEntity | undefined,
 ) => {
+  const baseFilter = useSchemaFilter(schema);
   // Extract order and tag filter from query AST and apply them to the base filter query.
   const query = useMemo(() => {
-    // RuntimeType (database-registered schema) has an object-DXN identifier.
-    // Objects created from the original Effect schema use a type-DXN, so Filter.type()
-    // would produce the wrong DXN kind. Use Filter.typename() for RuntimeType schemas.
-    const baseFilter = schema
-      ? schema instanceof Type.RuntimeType
-        ? Filter.typename(schema.typename)
-        : Filter.type(schema)
-      : Filter.nothing();
     let query = Query.select(baseFilter);
 
     // Apply tag filter from the query AST.

--- a/packages/sdk/app-toolkit/src/ui/hooks/index.ts
+++ b/packages/sdk/app-toolkit/src/ui/hooks/index.ts
@@ -6,5 +6,6 @@ export * from './useAppGraph';
 export * from './useActiveSpace';
 export * from './useLayout';
 export * from './useObjectMenuItems';
+export * from './useSchemaFilter';
 export * from './useShowItem';
 export * from './useTypeOptions';

--- a/packages/sdk/app-toolkit/src/ui/hooks/useSchemaFilter.ts
+++ b/packages/sdk/app-toolkit/src/ui/hooks/useSchemaFilter.ts
@@ -1,0 +1,23 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { useMemo } from 'react';
+
+import { Filter, Type } from '@dxos/echo';
+
+// TODO(wittjosiah): This should use the full query AST directly.
+//   That currently doesn't work for dynamic schema objects because their indexed typename is the schema object DXN.
+//   RuntimeType (database-registered schema) carries an object-DXN TypeIdentifierAnnotation, so Filter.type()
+//   would produce a filter that never matches objects tagged with a type-DXN (created from an unregistered
+//   Effect schema). Use Filter.typename() for RuntimeType to emit a type-DXN filter instead.
+export const useSchemaFilter = (schema: Type.AnyEntity | undefined): Filter.Any =>
+  useMemo(
+    () =>
+      schema instanceof Type.RuntimeType
+        ? Filter.typename(schema.typename)
+        : schema
+          ? Filter.type(schema)
+          : Filter.nothing(),
+    [schema],
+  );


### PR DESCRIPTION
## Summary

- `Filter.type(runtimeType)` emits an object-DXN filter (`dxn:echo:@:{id}`) because database-registered schemas carry an object-based `TypeIdentifierAnnotation`
- Objects created from the original Effect schema are tagged with a type-DXN (`dxn:type:{typename}:{version}`), so `compareTypename` falls back to strict `DXN.equals` — which never matches
- Fix: detect `RuntimeType` and use `Filter.typename(schema.typename)` instead, which produces a type-DXN filter that `compareTypename` handles with optional version matching

Affects `TableArticle`, `KanbanArticle` (`ViewKanbanArticle`), `MapArticle`, and `MasonryContainer`.

The root cause is documented in a TODO in `TableArticle`:
> This should use the full query AST directly. That currently doesn't work for dynamic schema objects because their indexed typename is the schema object DXN.

This fix handles the inverse case: objects indexed by type-DXN (created from an unregistered Effect schema) are invisible to `Filter.type(runtimeType)`. The `instanceof Type.RuntimeType` guard selects the correct filter kind at the call site.

## Test plan

- [ ] Open a space with a custom ECHO schema registered via `schemaRegistry.register()` (or loaded from a snapshot with a `PersistentSchema` object)
- [ ] Open a Table view bound to that schema — rows should appear
- [ ] Open a Kanban view bound to that schema — cards should appear in columns
- [ ] Verify Map and Masonry views likewise show objects for database-registered schemas
- [ ] Verify existing compiled schemas (Task, Person, etc.) continue to work normally in all four view types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a schema-based filter hook to standardize item queries across views.

* **Bug Fixes**
  * Ensured Kanban, Map, Masonry, and Table views use the standardized filter, improving correctness for runtime vs. standard schema types and fixing query dependency issues.

* **Chores**
  * Exposed the new filter hook in the UI toolkit for reuse.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->