### PR TITLE
fix(client): fix flaky tests for dedicated worker leader election

### DIFF
--- a/packages/core/echo/echo-pipeline/src/space/space-protocol.test.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space-protocol.test.ts
@@ -16,8 +16,7 @@ import { TestAgentBuilder, TestFeedBuilder } from '../testing';
 import { AuthStatus, MOCK_AUTH_PROVIDER, MOCK_AUTH_VERIFIER, SpaceProtocol } from './space-protocol';
 
 describe('space/space-protocol', () => {
-  // Flaky.
-  test('two peers discover each other via presence', async () => {
+  test('two peers discover each other via presence', { timeout: 15_000 }, async () => {
     const builder = new TestAgentBuilder();
     onTestFinished(async () => {
       await builder.close();
@@ -44,12 +43,12 @@ describe('space/space-protocol', () => {
 
     await expect
       .poll(() => presence1.getPeersOnline().some(({ identityKey }) => identityKey.equals(peer2.identityKey)), {
-        timeout: 1_000,
+        timeout: 10_000,
       })
       .toBeTruthy();
     await expect
       .poll(() => presence2.getPeersOnline().some(({ identityKey }) => identityKey.equals(peer1.identityKey)), {
-        timeout: 1_000,
+        timeout: 10_000,
       })
       .toBeTruthy();
   });

--- a/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.test.ts
+++ b/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.test.ts
@@ -46,8 +46,7 @@ describe('DedicatedWorkerClientServices', { timeout: 1_000, retry: 0 }, () => {
     expect(client2.halo.identity.get()).toEqual(identity);
   });
 
-  // Flaky.
-  test('leader goes from first client to second', async () => {
+  test('leader goes from first client to second', { timeout: 10_000 }, async () => {
     log.break();
     const testBuilder = new TestBuilder();
     onTestFinished(() => testBuilder.destroy());
@@ -60,14 +59,21 @@ describe('DedicatedWorkerClientServices', { timeout: 1_000, retry: 0 }, () => {
     await using client2 = await new Client({ services: services2 }).initialize();
     expect(client2.halo.identity.get()).toEqual(identity);
 
+    const reconnected = new Trigger();
+    services2.reconnected.on(() => {
+      reconnected.wake();
+    });
+
     await client1.destroy();
+
+    // Wait for services2 to reconnect as the new leader with the same persisted storage.
+    await asyncTimeout(reconnected.wait(), 5_000);
 
     expect(client2.halo.identity.get()).toEqual(identity);
     log.break();
   });
 
-  // TODO(wittjosiah): Using shared storage fixes this test but that doesn't seem like a realistic solution.
-  test.fails('identity subscription survives leader change', { timeout: 2_000 }, async () => {
+  test('identity subscription survives leader change', { timeout: 10_000 }, async () => {
     const testBuilder = new TestBuilder();
     onTestFinished(() => testBuilder.destroy());
 
@@ -95,13 +101,13 @@ describe('DedicatedWorkerClientServices', { timeout: 1_000, retry: 0 }, () => {
     await client1.destroy();
 
     // Wait for client2 to reconnect to the new worker.
-    await asyncTimeout(reconnected.wait(), 1000);
+    await asyncTimeout(reconnected.wait(), 5_000);
 
     // Update display name after leader change.
     await client2.halo.updateProfile({ displayName: updatedDisplayName });
 
     // Subscription should still receive the update.
-    await asyncTimeout(trigger.wait(), 500);
+    await asyncTimeout(trigger.wait(), 3_000);
     expect(client2.halo.identity.get()!.profile?.displayName).toEqual(updatedDisplayName);
   });
 });

--- a/packages/sdk/client/src/testing/test-worker-factory.ts
+++ b/packages/sdk/client/src/testing/test-worker-factory.ts
@@ -2,12 +2,16 @@
 // Copyright 2026 DXOS.org
 //
 
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import { WorkerRuntime } from '@dxos/client-services';
 import { Config } from '@dxos/config';
 import { Resource } from '@dxos/context';
 import { log } from '@dxos/log';
 import { createWorkerPort } from '@dxos/rpc-tunnel';
-import { layerMemory as sqliteLayerMemory } from '@dxos/sql-sqlite/platform';
+import { layerFile } from '@dxos/sql-sqlite/platform';
 
 import { STORAGE_LOCK_KEY } from '../lock-key';
 import type { DedicatedWorkerMessage } from '../services/dedicated/types';
@@ -15,10 +19,22 @@ import type { DedicatedWorkerMessage } from '../services/dedicated/types';
 /**
  * In-thread worker for testing purposes.
  * Creates a WorkerRuntime in the same thread using MessageChannel for communication.
+ * Uses a shared file-based storage directory so all data (identity, spaces) persists
+ * across leader changes, mirroring production behavior.
  */
 export class TestWorkerFactory extends Resource {
+  readonly #storageDir: string;
+  readonly #sqliteFile: string;
+
   constructor(private readonly _config?: Config) {
     super();
+    this.#storageDir = path.join(os.tmpdir(), `dxos-test-worker-${crypto.randomUUID()}`);
+    this.#sqliteFile = path.join(this.#storageDir, 'echo.sqlite');
+    fs.mkdirSync(this.#storageDir, { recursive: true });
+  }
+
+  protected override async _close(): Promise<void> {
+    fs.rmSync(this.#storageDir, { recursive: true, force: true });
   }
 
   /**
@@ -28,7 +44,7 @@ export class TestWorkerFactory extends Resource {
     log('worker-entrypoint');
     const messageChannel = new MessageChannel();
 
-    let runtime: WorkerRuntime;
+    let runtime: WorkerRuntime | undefined;
     /**
      * Client that owns the worker.
      */
@@ -37,9 +53,30 @@ export class TestWorkerFactory extends Resource {
     const tabsProcessed = new Set<string>();
 
     // Lock release mechanism - holds the lock until runtime stops.
-    let releaseLock: () => void;
+    let releaseLock!: () => void;
     const lockPromise = new Promise<void>((resolve) => {
       releaseLock = resolve;
+    });
+
+    // Proxy port2 to intercept close() and stop the runtime.
+    // In production, when a Worker is terminated, the browser automatically releases
+    // all navigator.locks it holds. This proxy simulates that behavior for the
+    // in-thread test worker by triggering runtime.stop() when close() is called.
+    const proxyPort = new Proxy(messageChannel.port2, {
+      get(target, prop, _receiver) {
+        if (prop === 'close') {
+          return () => {
+            target.close();
+            void runtime?.stop();
+          };
+        }
+        const value = Reflect.get(target, prop, target);
+        return typeof value === 'function' ? (value as Function).bind(target) : value;
+      },
+      set(target, prop, value) {
+        (target as any)[prop] = value;
+        return true;
+      },
     });
 
     // Lock ensures only a single worker is running.
@@ -51,7 +88,17 @@ export class TestWorkerFactory extends Resource {
             owningClientId = ev.data.ownerClientId ?? ev.data.clientId;
             runtime = new WorkerRuntime({
               configProvider: async () => {
-                return this._config ?? new Config();
+                return new Config({
+                  version: 1,
+                  runtime: {
+                    client: {
+                      storage: {
+                        persistent: true,
+                        dataRoot: this.#storageDir,
+                      },
+                    },
+                  },
+                });
               },
               onStop: async () => {
                 // Close the port and release the lock.
@@ -62,11 +109,12 @@ export class TestWorkerFactory extends Resource {
               acquireLock: async () => {},
               releaseLock: () => {},
               automaticallyConnectWebrtc: false,
-              // Use in-memory SQLite for testing instead of OPFS which only works in browsers.
-              sqliteLayer: sqliteLayerMemory,
+              // Use a shared file-based SQLite so data persists across leader changes,
+              // matching production OPFS behavior.
+              sqliteLayer: layerFile(this.#sqliteFile),
             });
             await runtime.start();
-            this._ctx.onDispose(() => runtime.stop());
+            this._ctx.onDispose(() => runtime!.stop());
             messageChannel.port1.postMessage({
               type: 'ready',
               livenessLockKey: runtime.livenessLockKey,
@@ -95,12 +143,12 @@ export class TestWorkerFactory extends Resource {
 
             // Will block until the other side finishes the handshake.
             {
-              const session = await runtime.createSession({
+              const session = await runtime!.createSession({
                 systemPort: createWorkerPort({ port: systemChannel.port2 }),
                 appPort: createWorkerPort({ port: appChannel.port2 }),
               });
               if (ev.data.clientId === owningClientId) {
-                runtime.connectWebrtcBridge(session);
+                runtime!.connectWebrtcBridge(session);
               }
             }
             break;
@@ -116,6 +164,6 @@ export class TestWorkerFactory extends Resource {
       await lockPromise;
     });
 
-    return messageChannel.port2;
+    return proxyPort;
   }
 }


### PR DESCRIPTION
## Summary

- **`space-protocol.test.ts`**: Fixes the `'two peers discover each other via presence'` test (marked `// Flaky.`) by increasing the `expect.poll` timeout from 1 s to 10 s and adding a 15 s test-level timeout. Gossip-based presence discovery can legitimately take several seconds under load.

- **`dedicated-worker-client-services.test.ts`** + **`TestWorkerFactory`**: Fixes two tests that were broken due to a STORAGE_LOCK_KEY deadlock and lack of persistent storage across leader changes:
  - `'leader goes from first client to second'` (was marked `// Flaky.`)
  - `'identity subscription survives leader change'` (was marked `test.fails`)

## Root causes fixed

### 1. STORAGE_LOCK_KEY deadlock in TestWorkerFactory
In the test, `TestWorkerFactory.make()` holds `STORAGE_LOCK_KEY` for the lifetime of the `WorkerRuntime` via `navigator.locks.request(STORAGE_LOCK_KEY, async () => { ...; await lockPromise; })`. The `lockPromise` only resolved when `testBuilder.destroy()` was called in `onTestFinished` — after the test body. This meant the second leader could never acquire `STORAGE_LOCK_KEY` during the test, deadlocking leader election.

**Fix**: A `Proxy` wraps the returned `MessagePort`. When `LeaderSession._close()` calls `port.close()`, the proxy intercepts it and calls `runtime.stop()`. This triggers `onStop → releaseLock()`, resolving `lockPromise` and releasing the lock — exactly mirroring what a real browser does when a Worker is `terminate()`d.

### 2. Identity not persisted across leader changes
`MetadataStore` (identity records) and feed storage use `random-access-storage`, which defaults to RAM in tests. When `WorkerRuntime` stopped and a new one started, the identity was lost.

**Fix**: `TestWorkerFactory` now uses a temp directory with `{ persistent: true, dataRoot: tempDir }` config, giving each test its own persistent `NodeStorage`. The SQLite file (echo database) lives in the same temp directory. The directory is cleaned up in `_close()`.

## Test plan
- [x] `space-protocol.test.ts` — all 3 tests pass
- [x] `dedicated-worker-client-services.test.ts` — all 5 tests pass (including the two previously flaky/failing ones)

https://claude.ai/code/session_01TMeaCRckD2dh3fKUwnxVXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMeaCRckD2dh3fKUwnxVXy)_