### PR TITLE
fix(plugin-table): forward attendableId so wheel scroll reaches dx-grid

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -9,8 +9,8 @@
     },
     {
       "name": "composer-app",
-      "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "@dxos/composer-app", "exec", "vite", "dev", "--port", "5180", "--strictPort"],
+      "runtimeExecutable": "moon",
+      "runtimeArgs": ["run", "composer-app:serve", "--", "--port", "5180", "--strictPort"],
       "port": 5180,
       "autoPort": true
     },

--- a/packages/plugins/plugin-table/src/containers/TableArticle/TableArticle.tsx
+++ b/packages/plugins/plugin-table/src/containers/TableArticle/TableArticle.tsx
@@ -172,6 +172,7 @@ export const TableArticle = forwardRef<HTMLDivElement, TableArticleProps>(
             <TableComponent.Content
               classNames='border-t border-separator'
               key={attendableId}
+              attendableId={attendableId}
               model={model}
               presentation={presentation}
               schema={schema}

--- a/packages/ui/react-ui-table/src/components/Table/TableContent.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/TableContent.tsx
@@ -49,16 +49,17 @@ export type TableContentProps = {
   presentation?: TablePresentation;
   // TODO(burdon): Factor out attention.
   ignoreAttention?: boolean;
+  attendableId?: string;
   onCreate?: OnCreateHandler;
   onRowClick?: (row: any) => void;
   testId?: string;
 };
 
 export const TableContent = composable<HTMLDivElement, TableContentProps>(
-  ({ schema, model, presentation, ignoreAttention, onCreate, onRowClick, testId, ...props }, forwardedRef) => {
+  ({ schema, model, presentation, ignoreAttention, attendableId, onCreate, onRowClick, testId, ...props }, forwardedRef) => {
     const registry = useContext(RegistryContext);
     const [dxGrid, setDxGrid] = useState<DxGridElement | null>(null);
-    const { hasAttention } = useAttention(model?.id ?? 'table');
+    const { hasAttention } = useAttention(attendableId ?? model?.id ?? 'table');
     const modals = useMemo(() => new ModalController(registry), [registry]);
     const columnMeta = useAtomValue(model?.columnMeta ?? emptyColumnMeta);
     // Subscribe to rows atom to trigger re-render when rows change.

--- a/packages/ui/react-ui-table/src/components/Table/TableContent.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/TableContent.tsx
@@ -56,7 +56,10 @@ export type TableContentProps = {
 };
 
 export const TableContent = composable<HTMLDivElement, TableContentProps>(
-  ({ schema, model, presentation, ignoreAttention, attendableId, onCreate, onRowClick, testId, ...props }, forwardedRef) => {
+  (
+    { schema, model, presentation, ignoreAttention, attendableId, onCreate, onRowClick, testId, ...props },
+    forwardedRef,
+  ) => {
     const registry = useContext(RegistryContext);
     const [dxGrid, setDxGrid] = useState<DxGridElement | null>(null);
     const { hasAttention } = useAttention(attendableId ?? model?.id ?? 'table');


### PR DESCRIPTION
## Summary

- Wheel scroll inside tables in Composer (horizontal and vertical) was silently dropped — only programmatic `scrollToColumn` worked.
- Root cause: `TableContent` calls `event.stopPropagation()` in `onWheelCapture` when the table is unattended, which (via React's root-delegated event system) prevents the wheel event from ever reaching `<dx-grid>`. The attention check was keyed on `model.id` (a DXN), but the surrounding article surface registers attention under `attendableId` (a path), so `hasAttention` was always `false` inside an article — wheel scroll was permanently blocked even when the article had focus.
- Fix: add an optional `attendableId` prop to `TableContent` and forward it from `TableArticle`, so `useAttention` is keyed on the id the attention manager actually tracks. Storybook is unaffected (it already passes `ignoreAttention`).
- Bonus: switch the `composer-app` entry in `.claude/launch.json` from `pnpm exec vite dev` to `moon run composer-app:serve` so workspace prebuild deps are built before vite starts on a fresh checkout.

## Test plan

- [x] At a narrow viewport (e.g. 200px) where columns overflow the plank, wheel events on the table scroll columns horizontally (verified `posInline` advances and `visColMin/visColMax` shifts).
- [x] Reverse wheel returns scroll to 0.
- [x] At standard viewport (800px), wheel scroll exposes off-screen columns (`Status`, `Assigned`, `Estimate`, …).
- [x] Programmatic `scrollToColumn()` still works.
- [x] Storybook table stories continue to scroll (no change — they use `ignoreAttention`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced table components with flexible identification and improved attention tracking mechanisms for better management of complex data display scenarios

* **Chores**
  * Updated development environment configuration and build tooling for more efficient developer setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->