### PR TITLE
feat(composer-app): add Playwright e2e tests for inbox plugin

### DIFF
--- a/packages/apps/composer-app/src/playwright/inbox.spec.ts
+++ b/packages/apps/composer-app/src/playwright/inbox.spec.ts
@@ -44,6 +44,8 @@ test.describe('Inbox plugin', () => {
     if (!process.env.GOOGLE_TEST_USER_PASSWORD) {
       test.skip(true, 'GOOGLE_TEST_USER_PASSWORD env var not set');
     }
+    // Google sign-in + OAuth round-trip needs more time than the default 60 s.
+    test.setTimeout(180_000);
 
     await host.createSpace();
     await host.createObject({ type: 'Mailbox', name: 'Test Inbox' });
@@ -87,22 +89,44 @@ test.describe('Inbox plugin', () => {
       ]);
     }
 
+    // Some OAuth apps get a "This app isn't verified" warning. Handle it by
+    // clicking "Advanced" then the "unsafe" proceed link.
+    const advancedLink = popup.getByText('Advanced');
+    const advancedVisible = await advancedLink
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (advancedVisible) {
+      await advancedLink.click();
+      await popup.locator('a', { hasText: /unsafe/i }).click();
+    }
+
     // Grant access on the OAuth consent screen if it appears.
     const allowButton = popup.getByRole('button', { name: /Allow/i });
     const allowVisible = await allowButton
-      .waitFor({ state: 'visible', timeout: 10_000 })
+      .waitFor({ state: 'visible', timeout: 20_000 })
       .then(() => true)
       .catch(() => false);
     if (allowVisible) {
       await allowButton.click();
     }
 
-    // Popup closes once Edge has received the token and posted back to the opener.
-    await popup.waitForEvent('close', { timeout: 60_000 });
+    // Once Google redirects to Edge's callback, Edge posts the token to
+    // window.opener. The IntegrationCoordinator processes the postMessage,
+    // persists the AccessToken + Integration, and navigates the deck away from
+    // the Mailbox to the new Integration view — making "No integrations
+    // configured" disappear from the plank. We watch for this side-effect
+    // instead of relying on popup.close(), since Edge may not always call
+    // window.close() before the navigation completes.
+    await expect(plank.locator.getByText('No integrations configured')).not.toBeVisible({ timeout: 90_000 });
 
-    // After the popup closes the coordinator persists the AccessToken and
-    // Integration objects and links the Mailbox as a sync target. Click back on
-    // the mailbox to verify it transitioned out of the "no integration" empty state.
+    // Close the popup if Edge didn't — it is no longer needed.
+    if (!popup.isClosed()) {
+      await popup.close();
+    }
+
+    // The coordinator navigated to the Integration view; click back to the
+    // Mailbox to verify it transitioned out of the "no integration" empty state.
     await host.getObjectByName('Test Inbox').click({ delay: 100 });
 
     await expect(plank.locator.getByText('No integrations configured')).not.toBeVisible({ timeout: 10_000 });

--- a/packages/apps/composer-app/src/playwright/inbox.spec.ts
+++ b/packages/apps/composer-app/src/playwright/inbox.spec.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-import { type Page, expect, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 import { log } from '@dxos/log';
 
@@ -14,46 +14,7 @@ if (process.env.DX_PWA !== 'false') {
 }
 
 const INBOX_PLUGIN_ID = 'org.dxos.plugin.inbox';
-
-// Intercepts the Edge OAuth initiation request and the resulting popup page,
-// completing the OAuth flow immediately with the provided access token instead
-// of redirecting to Google. Routes POST /oauth/initiate to return a synthetic
-// authUrl, then routes GET /oauth-test-stub to serve HTML that posts the result
-// back to window.opener so the coordinator's origin check passes.
-const setupOAuthSimulation = async (page: Page, accessToken: string): Promise<void> => {
-  await page.context().route('**/oauth/initiate', async (route) => {
-    const edgeOrigin = new URL(route.request().url()).origin;
-    const body = JSON.parse(route.request().postData() ?? '{}') as { accessTokenId?: string };
-    const accessTokenId = body.accessTokenId ?? '';
-
-    await route.fulfill({
-      contentType: 'application/json',
-      body: JSON.stringify({
-        success: true,
-        data: {
-          authUrl: `${edgeOrigin}/oauth-test-stub?accessTokenId=${encodeURIComponent(accessTokenId)}&accessToken=${encodeURIComponent(accessToken)}`,
-        },
-      }),
-    });
-  });
-
-  await page.context().route('**/oauth-test-stub*', async (route) => {
-    const url = new URL(route.request().url());
-    const payload = JSON.stringify({
-      success: true,
-      accessTokenId: url.searchParams.get('accessTokenId') ?? '',
-      accessToken: url.searchParams.get('accessToken') ?? '',
-    });
-
-    await route.fulfill({
-      contentType: 'text/html',
-      body: `<!DOCTYPE html><html><body><script>
-        window.opener?.postMessage(${payload}, '*');
-        setTimeout(() => window.close(), 200);
-      </script></body></html>`,
-    });
-  });
-};
+const GOOGLE_TEST_EMAIL = 'test@braneframe.com';
 
 test.describe('Inbox plugin', () => {
   let host: AppManager;
@@ -82,16 +43,13 @@ test.describe('Inbox plugin', () => {
   });
 
   test('connect gmail', async ({ browserName }) => {
-    // Popup interception is not reliable in WebKit.
+    // Popup navigation is not reliable in WebKit.
     if (browserName === 'webkit') {
-      test.skip(true, 'OAuth popup interception not supported in WebKit');
+      test.skip(true, 'OAuth popup not supported in WebKit');
     }
-    if (!process.env.GOOGLE_ACCESS_TOKEN) {
-      test.skip(true, 'GOOGLE_ACCESS_TOKEN env var not set');
+    if (!process.env.GOOGLE_TEST_USER_PASSWORD) {
+      test.skip(true, 'GOOGLE_TEST_USER_PASSWORD env var not set');
     }
-
-    // Intercept the Edge OAuth flow so no browser popup to Google is needed.
-    await setupOAuthSimulation(host.page, process.env.GOOGLE_ACCESS_TOKEN!);
 
     await host.createSpace();
     await host.createObject({ type: 'Mailbox', name: 'Test Inbox' });
@@ -102,21 +60,44 @@ test.describe('Inbox plugin', () => {
     const connectButton = plank.locator.getByRole('button', { name: /Connect Gmail/i });
     await expect(connectButton).toBeVisible();
 
-    // Click "Connect Gmail". The integration coordinator opens a popup pointing
-    // at the synthetic OAuth URL. Our stub page immediately posts the result
-    // back to window.opener and closes the popup.
+    // Open the OAuth popup.
     const popupPromise = host.page.waitForEvent('popup');
     await connectButton.click();
     const popup = await popupPromise;
-    await popup.waitForEvent('close', { timeout: 10_000 });
+
+    // Wait for Google sign-in page to load (relay page first, then redirects to Google).
+    await popup.waitForURL(/accounts\.google\.com/, { timeout: 15_000 });
+
+    // Handle "Choose an account" screen if the test account already has a session.
+    const chooseAccount = popup.getByText(GOOGLE_TEST_EMAIL);
+    if (await chooseAccount.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await chooseAccount.click();
+    } else {
+      // Email step.
+      await popup.fill('input[type="email"]', GOOGLE_TEST_EMAIL);
+      await popup.click('#identifierNext');
+      await popup.waitForSelector('input[type="password"]', { state: 'visible', timeout: 10_000 });
+
+      // Password step.
+      await popup.fill('input[type="password"]', process.env.GOOGLE_TEST_USER_PASSWORD!);
+      await popup.click('#passwordNext');
+    }
+
+    // Grant access on the OAuth consent screen if it appears.
+    const allowButton = popup.getByRole('button', { name: /Allow/i });
+    if (await allowButton.isVisible({ timeout: 10_000 }).catch(() => false)) {
+      await allowButton.click();
+    }
+
+    // Popup closes once Edge has received the token and posted back to the opener.
+    await popup.waitForEvent('close', { timeout: 30_000 });
 
     // After the popup closes the coordinator persists the AccessToken and
-    // Integration objects, links the Mailbox as a sync target, and navigates
-    // the deck to show the new Integration. Click back on the mailbox to verify
-    // it transitioned out of the "no integration" empty state.
+    // Integration objects and links the Mailbox as a sync target. Click back on
+    // the mailbox to verify it transitioned out of the "no integration" empty state.
     await host.getObjectByName('Test Inbox').click({ delay: 100 });
 
-    await expect(plank.locator.getByText('No integrations configured')).not.toBeVisible({ timeout: 5_000 });
-    await expect(plank.locator.getByText('Mailbox empty')).toBeVisible({ timeout: 5_000 });
+    await expect(plank.locator.getByText('No integrations configured')).not.toBeVisible({ timeout: 10_000 });
+    await expect(plank.locator.getByText('Mailbox empty')).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/packages/apps/composer-app/src/playwright/inbox.spec.ts
+++ b/packages/apps/composer-app/src/playwright/inbox.spec.ts
@@ -13,7 +13,6 @@ if (process.env.DX_PWA !== 'false') {
   process.exit(1);
 }
 
-const INBOX_PLUGIN_ID = 'org.dxos.plugin.inbox';
 const GOOGLE_TEST_EMAIL = 'test@braneframe.com';
 
 test.describe('Inbox plugin', () => {
@@ -22,8 +21,6 @@ test.describe('Inbox plugin', () => {
   test.beforeEach(async ({ browser }) => {
     host = new AppManager(browser, false);
     await host.init();
-    await host.openPluginRegistry();
-    await host.enablePlugin(INBOX_PLUGIN_ID);
   });
 
   test.afterEach(async () => {
@@ -73,14 +70,20 @@ test.describe('Inbox plugin', () => {
     if (await chooseAccount.isVisible({ timeout: 3_000 }).catch(() => false)) {
       await chooseAccount.click();
     } else {
-      // Email step.
+      // Email step — Google uses different button IDs across versions; target by role.
       await popup.fill('input[type="email"]', GOOGLE_TEST_EMAIL);
-      await popup.click('#identifierNext');
+      await popup.getByRole('button', { name: 'Next' }).click();
       await popup.waitForSelector('input[type="password"]', { state: 'visible', timeout: 10_000 });
 
-      // Password step.
-      await popup.fill('input[type="password"]', process.env.GOOGLE_TEST_USER_PASSWORD!);
-      await popup.click('#passwordNext');
+      // Password step — type character-by-character to trigger Google's change
+      // listeners (fill() sets the value directly and may bypass React event handlers).
+      const passwordInput = popup.locator('input[type="password"]');
+      await passwordInput.click();
+      await passwordInput.type(process.env.GOOGLE_TEST_USER_PASSWORD!, { delay: 50 });
+      await Promise.all([
+        popup.waitForURL((url) => !url.href.includes('/challenge/pwd'), { timeout: 15_000 }),
+        passwordInput.press('Enter'),
+      ]);
     }
 
     // Grant access on the OAuth consent screen if it appears.
@@ -90,7 +93,7 @@ test.describe('Inbox plugin', () => {
     }
 
     // Popup closes once Edge has received the token and posted back to the opener.
-    await popup.waitForEvent('close', { timeout: 30_000 });
+    await popup.waitForEvent('close', { timeout: 60_000 });
 
     // After the popup closes the coordinator persists the AccessToken and
     // Integration objects and links the Mailbox as a sync target. Click back on

--- a/packages/apps/composer-app/src/playwright/inbox.spec.ts
+++ b/packages/apps/composer-app/src/playwright/inbox.spec.ts
@@ -1,0 +1,129 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Page, expect, test } from '@playwright/test';
+
+import { log } from '@dxos/log';
+
+import { AppManager } from './app-manager';
+
+if (process.env.DX_PWA !== 'false') {
+  log.error('PWA must be disabled to run e2e tests. Set DX_PWA=false before running again.');
+  process.exit(1);
+}
+
+const INBOX_PLUGIN_ID = 'org.dxos.plugin.inbox';
+
+/**
+ * Intercepts the Edge OAuth initiation request and the resulting popup page,
+ * completing the OAuth flow immediately with the provided access token instead
+ * of redirecting to Google.
+ *
+ * How it works:
+ * 1. Routes POST **/oauth/initiate → returns a synthetic authUrl at the same
+ *    Edge origin, carrying accessTokenId + accessToken as query params.
+ * 2. Routes GET **/oauth-test-stub → serves HTML that posts the result back to
+ *    window.opener. The message's event.origin equals the Edge origin, so it
+ *    passes the coordinator's origin check.
+ */
+const setupOAuthSimulation = async (page: Page, accessToken: string): Promise<void> => {
+  await page.context().route('**/oauth/initiate', async (route) => {
+    const edgeOrigin = new URL(route.request().url()).origin;
+    const body = JSON.parse(route.request().postData() ?? '{}') as { accessTokenId?: string };
+    const accessTokenId = body.accessTokenId ?? '';
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        data: {
+          authUrl: `${edgeOrigin}/oauth-test-stub?accessTokenId=${encodeURIComponent(accessTokenId)}&accessToken=${encodeURIComponent(accessToken)}`,
+        },
+      }),
+    });
+  });
+
+  await page.context().route('**/oauth-test-stub*', async (route) => {
+    const url = new URL(route.request().url());
+    const payload = JSON.stringify({
+      success: true,
+      accessTokenId: url.searchParams.get('accessTokenId') ?? '',
+      accessToken: url.searchParams.get('accessToken') ?? '',
+    });
+
+    await route.fulfill({
+      contentType: 'text/html',
+      body: `<!DOCTYPE html><html><body><script>
+        window.opener?.postMessage(${payload}, '*');
+        setTimeout(() => window.close(), 200);
+      </script></body></html>`,
+    });
+  });
+};
+
+test.describe('Inbox plugin', () => {
+  let host: AppManager;
+
+  test.beforeEach(async ({ browser }) => {
+    host = new AppManager(browser, false);
+    await host.init();
+    await host.openPluginRegistry();
+    await host.enablePlugin(INBOX_PLUGIN_ID);
+  });
+
+  test.afterEach(async () => {
+    await host.closePage();
+  });
+
+  test('create mailbox', async () => {
+    await host.createSpace();
+    await host.createObject({ type: 'Mailbox', name: 'Test Inbox' });
+
+    const plank = host.deck.plank();
+    // The mailbox article opens in the deck. With no Gmail integration connected
+    // the empty-state warning is displayed.
+    await expect(plank.locator.getByText('No integrations configured')).toBeVisible();
+    // The connect button must be visible so the user can start the OAuth flow.
+    await expect(plank.locator.getByRole('button', { name: /Connect Gmail/i })).toBeVisible();
+  });
+
+  test('connect gmail', async ({ browserName }) => {
+    // Popup interception is not reliable in WebKit.
+    if (browserName === 'webkit') {
+      test.skip(true, 'OAuth popup interception not supported in WebKit');
+    }
+    if (!process.env.GOOGLE_ACCESS_TOKEN) {
+      test.skip(true, 'GOOGLE_ACCESS_TOKEN env var not set');
+    }
+
+    // Intercept the Edge OAuth flow so no browser popup to Google is needed.
+    await setupOAuthSimulation(host.page, process.env.GOOGLE_ACCESS_TOKEN!);
+
+    await host.createSpace();
+    await host.createObject({ type: 'Mailbox', name: 'Test Inbox' });
+
+    const plank = host.deck.plank();
+    await expect(plank.locator.getByText('No integrations configured')).toBeVisible();
+
+    const connectButton = plank.locator.getByRole('button', { name: /Connect Gmail/i });
+    await expect(connectButton).toBeVisible();
+
+    // Click "Connect Gmail". The integration coordinator opens a popup pointing
+    // at the synthetic OAuth URL. Our stub page immediately posts the result
+    // back to window.opener and closes the popup.
+    const popupPromise = host.page.waitForEvent('popup');
+    await connectButton.click();
+    const popup = await popupPromise;
+    await popup.waitForEvent('close', { timeout: 10_000 });
+
+    // After the popup closes the coordinator persists the AccessToken and
+    // Integration objects, links the Mailbox as a sync target, and navigates
+    // the deck to show the new Integration. Click back on the mailbox to verify
+    // it transitioned out of the "no integration" empty state.
+    await host.getObjectByName('Test Inbox').click({ delay: 100 });
+
+    await expect(plank.locator.getByText('No integrations configured')).not.toBeVisible({ timeout: 5_000 });
+    await expect(plank.locator.getByText('Mailbox empty')).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/packages/apps/composer-app/src/playwright/inbox.spec.ts
+++ b/packages/apps/composer-app/src/playwright/inbox.spec.ts
@@ -4,13 +4,10 @@
 
 import { expect, test } from '@playwright/test';
 
-import { log } from '@dxos/log';
-
 import { AppManager } from './app-manager';
 
 if (process.env.DX_PWA !== 'false') {
-  log.error('PWA must be disabled to run e2e tests. Set DX_PWA=false before running again.');
-  process.exit(1);
+  throw new Error('PWA must be disabled to run e2e tests. Set DX_PWA=false before running again.');
 }
 
 const GOOGLE_TEST_EMAIL = 'test@braneframe.com';
@@ -67,7 +64,11 @@ test.describe('Inbox plugin', () => {
 
     // Handle "Choose an account" screen if the test account already has a session.
     const chooseAccount = popup.getByText(GOOGLE_TEST_EMAIL);
-    if (await chooseAccount.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    const accountVisible = await chooseAccount
+      .waitFor({ state: 'visible', timeout: 3_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (accountVisible) {
       await chooseAccount.click();
     } else {
       // Email step — Google uses different button IDs across versions; target by role.
@@ -88,7 +89,11 @@ test.describe('Inbox plugin', () => {
 
     // Grant access on the OAuth consent screen if it appears.
     const allowButton = popup.getByRole('button', { name: /Allow/i });
-    if (await allowButton.isVisible({ timeout: 10_000 }).catch(() => false)) {
+    const allowVisible = await allowButton
+      .waitFor({ state: 'visible', timeout: 10_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (allowVisible) {
       await allowButton.click();
     }
 

--- a/packages/apps/composer-app/src/playwright/inbox.spec.ts
+++ b/packages/apps/composer-app/src/playwright/inbox.spec.ts
@@ -15,18 +15,11 @@ if (process.env.DX_PWA !== 'false') {
 
 const INBOX_PLUGIN_ID = 'org.dxos.plugin.inbox';
 
-/**
- * Intercepts the Edge OAuth initiation request and the resulting popup page,
- * completing the OAuth flow immediately with the provided access token instead
- * of redirecting to Google.
- *
- * How it works:
- * 1. Routes POST **/oauth/initiate → returns a synthetic authUrl at the same
- *    Edge origin, carrying accessTokenId + accessToken as query params.
- * 2. Routes GET **/oauth-test-stub → serves HTML that posts the result back to
- *    window.opener. The message's event.origin equals the Edge origin, so it
- *    passes the coordinator's origin check.
- */
+// Intercepts the Edge OAuth initiation request and the resulting popup page,
+// completing the OAuth flow immediately with the provided access token instead
+// of redirecting to Google. Routes POST /oauth/initiate to return a synthetic
+// authUrl, then routes GET /oauth-test-stub to serve HTML that posts the result
+// back to window.opener so the coordinator's origin check passes.
 const setupOAuthSimulation = async (page: Page, accessToken: string): Promise<void> => {
   await page.context().route('**/oauth/initiate', async (route) => {
     const edgeOrigin = new URL(route.request().url()).origin;


### PR DESCRIPTION
## Summary

- Adds `inbox.spec.ts` Playwright e2e spec for the inbox plugin in the Composer app
- Tests two flows: creating a Mailbox object, and connecting Gmail via OAuth
- Uses Playwright route interception (`page.context().route()`) to simulate the full OAuth popup flow without real Google credentials — the stub serves HTML from the Edge origin so the coordinator's `event.origin` check passes

## Test plan

- `create mailbox` test: enables inbox plugin, creates a space and Mailbox, asserts empty-state UI shows "No integrations configured" and "Connect Gmail" button
- `connect gmail` test: requires `GOOGLE_ACCESS_TOKEN` env var (skip otherwise); intercepts `/oauth/initiate` and `/oauth-test-stub` to complete OAuth instantly; asserts mailbox transitions out of empty state and shows "Mailbox empty"
- WebKit is skipped for the OAuth test (popup interception unreliable)

> To run the `connect gmail` test in CI, add `GOOGLE_ACCESS_TOKEN` as a GitHub Actions secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for the Inbox plugin that verify the empty-state UI and visibility of the "Connect Gmail" action.
  * Added tests covering the Gmail connection flow, including sign-in/consent variations and verification that the inbox transitions from empty state to the connected mailbox view showing "Mailbox empty".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->