### PR TITLE
feat(plugin-map): sync center/zoom between map and globe modes

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -46,6 +46,12 @@
       "port": 9010
     },
     {
+      "name": "plugin-map-storybook",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@dxos/plugin-map", "exec", "storybook", "dev", "--port", "9010", "--no-open"],
+      "port": 9010
+    },
+    {
       "name": "docs",
       "runtimeExecutable": "moon",
       "runtimeArgs": ["run", "docs:serve"],

--- a/packages/plugins/plugin-map/.storybook/main.mts
+++ b/packages/plugins/plugin-map/.storybook/main.mts
@@ -1,0 +1,9 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { createConfig } from '../../../../tools/storybook-react/.storybook/main';
+
+export const stories = ['../src/**/*.stories.tsx'];
+
+export default createConfig({ stories });

--- a/packages/plugins/plugin-map/.storybook/manager-head.html
+++ b/packages/plugins/plugin-map/.storybook/manager-head.html
@@ -1,0 +1,1 @@
+../../../../tools/storybook-react/.storybook/manager-head.html

--- a/packages/plugins/plugin-map/.storybook/preview-head.html
+++ b/packages/plugins/plugin-map/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+../../../../tools/storybook-react/.storybook/preview-head.html

--- a/packages/plugins/plugin-map/.storybook/preview.mts
+++ b/packages/plugins/plugin-map/.storybook/preview.mts
@@ -1,0 +1,8 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { preview } from '../../../../tools/storybook-react/.storybook/preview';
+
+export * from '../../../../tools/storybook-react/.storybook/preview';
+export default preview;

--- a/packages/plugins/plugin-map/moon.yml
+++ b/packages/plugins/plugin-map/moon.yml
@@ -3,7 +3,9 @@ language: typescript
 tags:
   - ts-build
   - ts-test
+  - ts-test-storybook
   - pack
+  - storybook
 tasks:
   compile:
     args:

--- a/packages/plugins/plugin-map/src/components/Globe/GlobeControl.tsx
+++ b/packages/plugins/plugin-map/src/components/Globe/GlobeControl.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { type ThemeMode, useAsyncState, useThemeContext } from '@dxos/react-ui';
 import {
@@ -11,6 +11,8 @@ import {
   type GlobeController,
   type GlobeRootProps,
   type LatLngLiteral,
+  geoToPosition,
+  positionToRotation,
   useDrag,
   useGlobeZoomHandler,
   useTour,
@@ -78,16 +80,42 @@ const globeStyles = (themeMode: ThemeMode) =>
         },
       };
 
-export type GlobeControlProps = GeoControlProps & GlobeRootProps;
+export type GlobeControlProps = GeoControlProps &
+  GlobeRootProps & {
+    onChange?: (ev: { center: LatLngLiteral; zoom: number }) => void;
+  };
 
 export const GlobeControl = composable<HTMLDivElement, GlobeControlProps>(
-  ({ center, zoom, markers = [], selected = [], onToggle, ...props }, forwardedRef) => {
+  ({ center, zoom, markers = [], selected = [], onToggle, onChange, ...props }, forwardedRef) => {
     const [topology] = useAsyncState(loadTopology);
     const { themeMode } = useThemeContext();
     const styles = globeStyles(themeMode);
 
+    // Capture the initial position once at mount and convert to a rotation. Passing rotation
+    // directly bypasses the center→rotation effect chain in Globe.Canvas (which can race with
+    // the first paint) and avoids feedback loops when updates bubble back through onChange.
+    const initialRotation = useMemo(() => (center ? positionToRotation(geoToPosition(center)) : undefined), []);
+    const initialZoom = useMemo(() => zoom, []);
+
     const [controller, setController] = useState<GlobeController | null>();
-    const handleZoomAction = useGlobeZoomHandler(controller);
+    const baseZoomHandler = useGlobeZoomHandler(controller);
+
+    const emitChange = useCallback(() => {
+      if (!controller) {
+        return;
+      }
+
+      const [lng, lat] = controller.projection.rotate();
+      onChange?.({ center: { lat: -lat, lng: -lng }, zoom: controller.zoom });
+    }, [controller, onChange]);
+
+    const handleZoomAction = useCallback<NonNullable<ControlProps['onAction']>>(
+      (action) => {
+        baseZoomHandler?.(action);
+        requestAnimationFrame(emitChange);
+      },
+      [baseZoomHandler, emitChange],
+    );
 
     const features = useMemo(
       () => ({
@@ -114,7 +142,14 @@ export const GlobeControl = composable<HTMLDivElement, GlobeControlProps>(
 
     const [moved, setMoved] = useState(false);
     useDrag(controller, {
-      onUpdate: () => setMoved(true),
+      onUpdate: ({ type }) => {
+        if (type === 'move') {
+          setMoved(true);
+        }
+        if (type === 'end') {
+          emitChange();
+        }
+      },
     });
 
     // TODO(burdon): Redo.
@@ -131,6 +166,8 @@ export const GlobeControl = composable<HTMLDivElement, GlobeControlProps>(
     const handleAction: ControlProps['onAction'] = (action) => {
       switch (action) {
         case 'toggle': {
+          // Emit the live position so the next control inherits the user's current view.
+          emitChange();
           onToggle?.();
           break;
         }
@@ -144,7 +181,7 @@ export const GlobeControl = composable<HTMLDivElement, GlobeControlProps>(
     };
 
     return (
-      <Globe.Root {...composableProps(props)} center={center} zoom={zoom} ref={forwardedRef}>
+      <Globe.Root {...composableProps(props)} rotation={initialRotation} zoom={initialZoom} ref={forwardedRef}>
         <Globe.Canvas
           ref={setController}
           topology={topology}

--- a/packages/plugins/plugin-map/src/components/Map/MapControl.tsx
+++ b/packages/plugins/plugin-map/src/components/Map/MapControl.tsx
@@ -27,12 +27,18 @@ export const MapControl = composable<HTMLDivElement, MapControlProps>(
       (action) => {
         switch (action) {
           case 'toggle': {
+            // Emit the live position so the next control inherits the user's current view.
+            const center = controller?.getCenter();
+            const zoom = controller?.getZoom();
+            if (center && typeof zoom === 'number') {
+              onChange?.({ center, zoom });
+            }
             onToggle?.();
             break;
           }
         }
       },
-      [onToggle],
+      [controller, onChange, onToggle],
     );
 
     return (

--- a/packages/plugins/plugin-map/src/containers/MapArticle/MapArticle.stories.tsx
+++ b/packages/plugins/plugin-map/src/containers/MapArticle/MapArticle.stories.tsx
@@ -1,0 +1,37 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import React, { useMemo } from 'react';
+
+import { withClientProvider } from '@dxos/react-client/testing';
+import { withLayout, withTheme } from '@dxos/react-ui/testing';
+
+import { translations } from '#translations';
+import { Map } from '#types';
+
+import { MapArticle } from './MapArticle';
+
+type DefaultStoryProps = {};
+
+const DefaultStory = (_: DefaultStoryProps) => {
+  const map = useMemo(() => Map.make({ name: 'Story map' }), []);
+  return <MapArticle role='article' attendableId='story' subject={map} />;
+};
+
+const meta = {
+  title: 'plugins/plugin-map/containers/MapArticle',
+  component: DefaultStory,
+  decorators: [withTheme(), withLayout({ layout: 'fullscreen' }), withClientProvider({ createIdentity: true })],
+  parameters: {
+    layout: 'fullscreen',
+    translations,
+  },
+} satisfies Meta<typeof DefaultStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/plugins/plugin-map/src/containers/MapArticle/MapArticle.tsx
+++ b/packages/plugins/plugin-map/src/containers/MapArticle/MapArticle.tsx
@@ -3,7 +3,7 @@
 //
 
 import * as Predicate from 'effect/Predicate';
-import React, { Fragment, useCallback, useMemo, useState } from 'react';
+import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useSchemaFilter, type AppSurface } from '@dxos/app-toolkit/ui';
 import { Filter, Obj, Query } from '@dxos/echo';
@@ -59,6 +59,18 @@ export const MapArticle = ({
     center: centerProp ?? DEFAULT_CENTER,
     zoom: zoomProp ?? DEFAULT_ZOOM,
   });
+
+  // Sync internal viewport when caller-provided center/zoom change so that MapArticle
+  // remains usable as a controlled component.
+  useEffect(() => {
+    if (centerProp === undefined && zoomProp === undefined) {
+      return;
+    }
+    setViewport((prev) => ({
+      center: centerProp ?? prev.center,
+      zoom: zoomProp ?? prev.zoom,
+    }));
+  }, [centerProp, zoomProp]);
 
   const db = object && Obj.getDatabase(object);
   const [view] = useObject(object?.view);

--- a/packages/plugins/plugin-map/src/containers/MapArticle/MapArticle.tsx
+++ b/packages/plugins/plugin-map/src/containers/MapArticle/MapArticle.tsx
@@ -3,19 +3,39 @@
 //
 
 import * as Predicate from 'effect/Predicate';
-import React, { Fragment, useMemo } from 'react';
+import React, { Fragment, useCallback, useMemo, useState } from 'react';
 
 import { useSchemaFilter, type AppSurface } from '@dxos/app-toolkit/ui';
 import { Filter, Obj, Query } from '@dxos/echo';
 import { useObject, useQuery, useSchema } from '@dxos/react-client/echo';
-import { Panel as DxPanel, Flex, type FlexProps, useControlledState } from '@dxos/react-ui';
+import { Panel, Flex, type FlexProps, useControlledState } from '@dxos/react-ui';
 import { useSelected } from '@dxos/react-ui-attention';
-import { type GeoMarker, type MapRootProps } from '@dxos/react-ui-geo';
+import { type GeoMarker, type LatLngLiteral, type MapRootProps } from '@dxos/react-ui-geo';
 import { getTagFromQuery, getTypenameFromQuery } from '@dxos/schema';
 import { getDeep } from '@dxos/util';
 
 import { type GeoControlProps, GlobeControl, MapControl } from '#components';
 import { type Map } from '#types';
+
+// Shared defaults so toggling between map and globe starts at the same position
+// when the user hasn't interacted yet.
+const DEFAULT_CENTER: LatLngLiteral = { lat: 48, lng: 0 };
+const DEFAULT_ZOOM = 5;
+
+// Zoom conversion between Map (Leaflet) and Globe (orthographic scale).
+// Defined by two anchor points: linear between, linearly extrapolated outside.
+const ZOOM_ANCHORS: { map: [number, number]; globe: [number, number] } = {
+  map: [4, 6],
+  globe: [2.5, 9],
+};
+
+const interpolate = (value: number, from: [number, number], to: [number, number]) => {
+  const t = (value - from[0]) / (from[1] - from[0]);
+  return to[0] + t * (to[1] - to[0]);
+};
+
+const mapMapToGlobeZoom = (zoom: number) => interpolate(zoom, ZOOM_ANCHORS.map, ZOOM_ANCHORS.globe);
+const mapGlobeToMapZoom = (zoom: number) => interpolate(zoom, ZOOM_ANCHORS.globe, ZOOM_ANCHORS.map);
 
 export type MapControlType = 'globe' | 'map';
 
@@ -24,10 +44,23 @@ export type MapArticleProps = AppSurface.ObjectArticleProps<
   GeoControlProps & Pick<MapRootProps, 'onChange'> & { type?: MapControlType }
 >;
 
-export const MapArticle = ({ role, subject: object, type: typeProp = 'map', ...props }: MapArticleProps) => {
+export const MapArticle = ({
+  role,
+  subject: object,
+  attendableId: _attendableId,
+  type: typeProp = 'map',
+  center: centerProp,
+  zoom: zoomProp,
+  onChange,
+  ...props
+}: MapArticleProps) => {
   const [type, setType] = useControlledState(typeProp);
-  const db = object && Obj.getDatabase(object);
+  const [viewport, setViewport] = useState<{ center: LatLngLiteral; zoom: number }>({
+    center: centerProp ?? DEFAULT_CENTER,
+    zoom: zoomProp ?? DEFAULT_ZOOM,
+  });
 
+  const db = object && Obj.getDatabase(object);
   const [view] = useObject(object?.view);
   const typename = view?.query ? getTypenameFromQuery(view.query.ast) : undefined;
   const tag = view?.query ? getTagFromQuery(view.query.ast) : undefined;
@@ -67,18 +100,51 @@ export const MapArticle = ({ role, subject: object, type: typeProp = 'map', ...p
   const selected = useSelected(typename, 'multi');
   const Root = role === 'section' ? Container : Fragment;
 
+  // Store zoom in map units; convert when emitted by the globe.
+  const handleMapChange = useCallback(
+    (ev: { center: LatLngLiteral; zoom: number }) => {
+      setViewport(ev);
+      onChange?.(ev);
+    },
+    [onChange],
+  );
+  const handleGlobeChange = useCallback(
+    (ev: { center: LatLngLiteral; zoom: number }) => {
+      const mapped = { center: ev.center, zoom: mapGlobeToMapZoom(ev.zoom) };
+      setViewport(mapped);
+      onChange?.(mapped);
+    },
+    [onChange],
+  );
+
   return (
     <Root>
-      <DxPanel.Root>
-        <DxPanel.Content>
+      <Panel.Root>
+        <Panel.Content>
           {type === 'map' && (
-            <MapControl markers={markers} selected={selected} onToggle={() => setType('globe')} {...props} />
+            <MapControl
+              {...props}
+              markers={markers}
+              selected={selected}
+              center={viewport.center}
+              zoom={viewport.zoom}
+              onChange={handleMapChange}
+              onToggle={() => setType('globe')}
+            />
           )}
           {type === 'globe' && (
-            <GlobeControl markers={markers} selected={selected} onToggle={() => setType('map')} {...props} />
+            <GlobeControl
+              {...props}
+              markers={markers}
+              selected={selected}
+              center={viewport.center}
+              zoom={mapMapToGlobeZoom(viewport.zoom)}
+              onChange={handleGlobeChange}
+              onToggle={() => setType('map')}
+            />
           )}
-        </DxPanel.Content>
-      </DxPanel.Root>
+        </Panel.Content>
+      </Panel.Root>
     </Root>
   );
 };

--- a/packages/plugins/plugin-map/vitest.config.ts
+++ b/packages/plugins/plugin-map/vitest.config.ts
@@ -10,4 +10,5 @@ import { createConfig } from '../../../vitest.base.config';
 export default createConfig({
   dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
   node: true,
+  storybook: true,
 });

--- a/packages/ui/react-ui-geo/src/components/Globe/Globe.tsx
+++ b/packages/ui/react-ui-geo/src/components/Globe/Globe.tsx
@@ -128,11 +128,20 @@ const getProjection = (type: GlobeCanvasProps['projection'] = 'orthographic'): G
 // Root
 //
 
+const DEFAULT_ZOOM = 1.5;
+
 type GlobeRootProps = Partial<Pick<GlobeContextType, 'center' | 'zoom' | 'translation' | 'rotation'>>;
 
 const GlobeRoot = composable<HTMLDivElement, GlobeRootProps>(
   (
-    { children, center: centerProp, zoom: zoomProp, translation: translationProp, rotation: rotationProp, ...props },
+    {
+      children,
+      center: centerProp,
+      zoom: zoomProp = DEFAULT_ZOOM,
+      translation: translationProp,
+      rotation: rotationProp,
+      ...props
+    },
     forwardedRef,
   ) => {
     const localRef = useRef<HTMLDivElement>(null);
@@ -140,7 +149,7 @@ const GlobeRoot = composable<HTMLDivElement, GlobeRootProps>(
     const { width, height } = useResizeDetector<HTMLDivElement>({ targetRef: localRef });
 
     const [center, setCenter] = useControlledState(centerProp);
-    const [zoom, setZoom] = useControlledState(zoomProp ?? 4);
+    const [zoom, setZoom] = useControlledState(zoomProp);
     const [translation, setTranslation] = useControlledState<Point>(translationProp);
     const [rotation, setRotation] = useControlledState<Vector>(rotationProp);
 
@@ -205,10 +214,10 @@ const GlobeCanvas = forwardRef<GlobeController, GlobeCanvasProps>(
       useGlobeContext();
     const zoomRef = useDynamicRef(zoom);
 
-    // Update rotation.
+    // Update rotation when the center changes. Preserve current zoom — callers can set zoom
+    // independently via the `zoom` prop or `setZoom` on the controller.
     useEffect(() => {
       if (center) {
-        setZoom(1);
         setRotation(positionToRotation(geoToPosition(center)));
       }
     }, [center]);

--- a/packages/ui/react-ui-geo/src/components/Map/Map.tsx
+++ b/packages/ui/react-ui-geo/src/components/Map/Map.tsx
@@ -233,11 +233,11 @@ const MapMarkers = ({ selected, markers }: MapMarkersProps) => {
   // Fit the viewport around the markers. When there are no markers, leave the current view alone
   // so caller-provided center/zoom (or the user's prior interaction) is preserved.
   useEffect(() => {
-    if (markers.length > 0) {
+    if (markers && markers.length > 0) {
       const bounds = latLngBounds(markers.map((marker) => marker.location));
       map.fitBounds(bounds);
     }
-  }, [markers]);
+  }, [markers, map]);
 
   return (
     <>

--- a/packages/ui/react-ui-geo/src/components/Map/Map.tsx
+++ b/packages/ui/react-ui-geo/src/components/Map/Map.tsx
@@ -30,6 +30,8 @@ const defaults = {
 //
 
 type MapController = {
+  getCenter: () => LatLngLiteral | undefined;
+  getZoom: () => number | undefined;
   setCenter: (center: LatLngLiteral, zoom?: number) => void;
   setZoom: (cb: (zoom: number) => number) => void;
 };
@@ -97,6 +99,11 @@ const MapContent = forwardRef<MapController, MapContentProps>(
     useImperativeHandle(
       forwardedRef,
       () => ({
+        getCenter: () => {
+          const center = mapRef.current?.getCenter();
+          return center ? { lat: center.lat, lng: center.lng } : undefined;
+        },
+        getZoom: () => mapRef.current?.getZoom(),
         setCenter: (center: LatLngLiteral, zoom?: number) => {
           mapRef.current?.setView(center, zoom);
         },
@@ -158,7 +165,7 @@ const MapTiles = (_props: MapTilesProps) => {
   const { onChange } = useMapContext(MAP_TILES_NAME);
 
   useMapEvents({
-    zoomstart: (ev) => {
+    moveend: (ev) => {
       onChange?.({
         center: ev.target.getCenter(),
         zoom: ev.target.getZoom(),
@@ -223,13 +230,12 @@ type MapMarkersProps = {
 const MapMarkers = ({ selected, markers }: MapMarkersProps) => {
   const map = useMap();
 
-  // Set the viewport around the markers, or show the whole world map if `markers` is empty.
+  // Fit the viewport around the markers. When there are no markers, leave the current view alone
+  // so caller-provided center/zoom (or the user's prior interaction) is preserved.
   useEffect(() => {
     if (markers.length > 0) {
       const bounds = latLngBounds(markers.map((marker) => marker.location));
       map.fitBounds(bounds);
-    } else {
-      map.setView(defaults.center, defaults.zoom);
     }
   }, [markers]);
 


### PR DESCRIPTION
## Summary

- Adds a `MapArticle` story and makes the viewport (center + zoom) carry over when the user toggles between the map and globe sub-components.
- Wires `plugin-map` into the shared `storybook-react` setup so the story is discoverable via `moon run plugin-map:storybook`.
- Fixes a few small `@dxos/react-ui-geo` issues that were preventing the handoff from working.

## What changed

**`plugin-map`**

- `MapArticle` now owns a `viewport` state seeded from props or shared defaults; both modes start at the same position. On toggle, the active control reads its live center/zoom from its controller and emits it via `onChange` just before flipping the mode, so the next-mounted control inherits the latest view.
- `MapControl` and `GlobeControl` emit `onChange` on user interaction (Leaflet `moveend`, globe drag-end and zoom action) and at toggle time.
- Zoom is translated between the controls' native ranges using a two-anchor linear interpolation (`map 4 ↔ globe 2.5`, `map 6 ↔ globe 9`), since Map (Leaflet, ~1..15) and Globe (orthographic scale) use different units.
- `GlobeControl` converts the captured center to a rotation at mount and passes it directly to `Globe.Root`, bypassing the `center → rotation` effect chain that was racing with the first paint and causing the globe to render at (0, 0).
- New `MapArticle.stories.tsx` (Default story) demonstrating the toggle.
- Wired up storybook: `moon.yml` tags (`storybook`, `ts-test-storybook`) + `.storybook/` config files matching the plugin-chess/plugin-board pattern.

**`react-ui-geo`**

- `Map.Tiles`: emits `onChange` on `moveend` (final values) instead of `zoomstart`.
- `Map.Markers`: stops resetting to default `{lat:51, lng:0, zoom:4}` when the marker set is empty — the caller-provided / user-interacted view is preserved.
- `MapController`: extended with `getCenter()` / `getZoom()` so callers can read the live position synchronously at toggle time.
- `Globe.Canvas`: removed `setZoom(1)` from the center-changed effect; the provided zoom is now preserved when rotating to a new center.

## Test plan

- [x] `moon run plugin-map:build`
- [x] `moon run plugin-map:lint -- --fix`
- [x] `moon run plugin-map:test`
- [x] `moon run react-ui-geo:build`
- [ ] Open `plugins/plugin-map/containers/MapArticle/Default` in storybook, pan the map, click toggle, confirm the globe rotates to the same location at a comparable zoom; drag the globe, toggle back, confirm the map mounts at that position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Globe and map controls now emit live viewport updates via onChange; MapArticle syncs map↔globe zoom and manages a single viewport state.
  * Added Storybook stories for the map plugin to preview components.

* **Bug Fixes**
  * Map view no longer resets when markers are absent; viewport is preserved.

* **Chores**
  * Added Storybook configuration and test/CI metadata for the map plugin.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->