### PR TITLE
fix(echo-pipeline): bump timeout on documents-loaded-from-disk replication test

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-repo-subduction.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-repo-subduction.test.ts
@@ -139,7 +139,7 @@ describe('AutomergeRepo with Subduction', () => {
         .toEqual(['Hello world', 'Hello world', 'Hello world']);
     });
 
-    test('documents loaded from disk get replicated', async () => {
+    test('documents loaded from disk get replicated', { timeout: 15_000 }, async () => {
       const storage = await createLevelAdapter();
       let url: AutomergeUrl | undefined;
 
@@ -160,7 +160,10 @@ describe('AutomergeRepo with Subduction', () => {
       await hostHandle.whenReady();
       await expect.poll(() => hostHandle.doc()?.text, { timeout: 5_000 }).toEqual('foo');
       const peer2Handle = await findInStates<any>(peer2, hostHandle.url, FIND_STATES);
-      await expect.poll(() => peer2Handle.doc(), { timeout: 5_000 }).toEqual(hostHandle.doc());
+      // Bumped from 5_000 to 10_000: on a loaded CI box, the subduction RequestId
+      // round-trip can hit its internal timeout (~5 s) and only the heal retry succeeds,
+      // pushing past the original 5 s window. See the same fix on `accept/connect syncs`.
+      await expect.poll(() => peer2Handle.doc(), { timeout: 10_000 }).toEqual(hostHandle.doc());
     });
 
     test('client creates doc and Repo persists it to disk', async () => {


### PR DESCRIPTION
## Summary

Fixes the `AutomergeRepo with Subduction > network > documents loaded from disk get replicated` test that was quarantined by Trunk as flaky.

- Adds a `{ timeout: 15_000 }` test-level timeout (was using the default 5 s)
- Bumps the `expect.poll` timeout for peer2 replication from `5_000` to `10_000` ms

## Root cause

On a loaded CI box, the subduction `RequestId` round-trip can hit its internal ~5 s timeout. Only the heal-scheduler retry then succeeds, which pushes past the original 5 s poll window and causes a timeout failure. This is the exact same root cause documented in the `accept/connect syncs` test in the same file, which was previously bumped from 5 000 to 10 000 ms.

## Verification

- Checked Trunk: this test was quarantined in CI run `26210450396` (PR #11416's CI run from 2026-05-21)
- No existing open PR was fixing this specific test
- Pattern mirrors the established fix already applied to `accept/connect syncs` in the same file

https://claude.ai/code/session_01UJdxdpNz7VrqSXwUBQoFRf

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJdxdpNz7VrqSXwUBQoFRf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by adjusting timeout configurations and adding clarifying comments for timing behavior during continuous integration environments.

**Note:** This release contains no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->