### PR TITLE
fix(publish): ensure all publishable packages have publishConfig.access=public

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,49 +42,6 @@ concurrency:
 
 # https://moonrepo.dev/docs/guides/ci
 jobs:
-  publish-config:
-    name: Verify publish config
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Check all publishable packages have publishConfig.access=public
-        run: |
-          python3 - << 'PYEOF'
-          import json, os, sys
-          from pathlib import Path
-
-          errors = []
-          roots = ['packages', 'vendor']
-
-          for root in roots:
-            for pkg_json in Path(root).rglob('package.json'):
-              parts = pkg_json.parts
-              if 'node_modules' in parts or '__fixtures__' in parts:
-                continue
-              try:
-                p = json.loads(pkg_json.read_text())
-              except Exception:
-                continue
-              name = p.get('name')
-              if not name or p.get('private'):
-                continue
-              access = p.get('publishConfig', {}).get('access', '')
-              if access != 'public':
-                errors.append(f"  {name} ({pkg_json}): publishConfig.access is '{access or '(not set)'}'")
-
-          if errors:
-            print('ERROR: The following publishable packages are missing publishConfig.access = "public".')
-            print('Add "publishConfig": { "access": "public" } to their package.json.')
-            print()
-            for e in sorted(errors):
-              print(e)
-            sys.exit(1)
-
-          print(f'OK: all publishable packages have publishConfig.access = "public"')
-          PYEOF
-
   check:
     permissions:
       contents: read
@@ -120,6 +77,9 @@ jobs:
 
       - name: Check for import cycles
         run: pnpm run check-cycles
+
+      - name: Check publish config
+        run: pnpm run check-publish-config
 
       - name: Check formatting
         run: pnpm run format-check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,6 +42,49 @@ concurrency:
 
 # https://moonrepo.dev/docs/guides/ci
 jobs:
+  publish-config:
+    name: Verify publish config
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check all publishable packages have publishConfig.access=public
+        run: |
+          python3 - << 'PYEOF'
+          import json, os, sys
+          from pathlib import Path
+
+          errors = []
+          roots = ['packages', 'vendor']
+
+          for root in roots:
+            for pkg_json in Path(root).rglob('package.json'):
+              parts = pkg_json.parts
+              if 'node_modules' in parts or '__fixtures__' in parts:
+                continue
+              try:
+                p = json.loads(pkg_json.read_text())
+              except Exception:
+                continue
+              name = p.get('name')
+              if not name or p.get('private'):
+                continue
+              access = p.get('publishConfig', {}).get('access', '')
+              if access != 'public':
+                errors.append(f"  {name} ({pkg_json}): publishConfig.access is '{access or '(not set)'}'")
+
+          if errors:
+            print('ERROR: The following publishable packages are missing publishConfig.access = "public".')
+            print('Add "publishConfig": { "access": "public" } to their package.json.')
+            print()
+            for e in sorted(errors):
+              print(e)
+            sys.exit(1)
+
+          print(f'OK: all publishable packages have publishConfig.access = "public"')
+          PYEOF
+
   check:
     permissions:
       contents: read

--- a/.github/workflows/scripts/publish.sh
+++ b/.github/workflows/scripts/publish.sh
@@ -32,17 +32,17 @@ if [ -n "$NPM_TOKEN" ]; then
 fi
 
 if [ "$DX_ENVIRONMENT" = "production" ]; then
-  pnpm --filter-prod="./packages/**" --filter-prod="./vendor/**" publish --no-git-checks --provenance --tag=latest
-  moon run :publish -- --provenance --tag latest
+  pnpm --filter="./packages/**" --filter="./vendor/**" publish --no-git-checks --provenance --access public --tag=latest
+  moon run :publish -- --provenance --access public --tag latest
 elif [ "$DX_ENVIRONMENT" = "staging" ]; then
-  pnpm --filter-prod="./packages/**" --filter-prod="./vendor/**" publish --no-git-checks --provenance --tag=next
-  moon run :publish -- --provenance --tag next
+  pnpm --filter="./packages/**" --filter="./vendor/**" publish --no-git-checks --provenance --access public --tag=next
+  moon run :publish -- --provenance --access public --tag next
 elif [ "$DX_ENVIRONMENT" = "main" ]; then
-  pnpm --filter-prod="./packages/**" --filter-prod="./vendor/**" publish --no-git-checks --provenance --tag=main
-  moon run :publish -- --provenance --tag main
+  pnpm --filter="./packages/**" --filter="./vendor/**" publish --no-git-checks --provenance --access public --tag=main
+  moon run :publish -- --provenance --access public --tag main
 elif [ "$DX_ENVIRONMENT" = "labs" ]; then
-  pnpm --filter-prod="./packages/**" --filter-prod="./vendor/**" publish --no-git-checks --provenance --tag=labs
-  moon run :publish -- --provenance --tag labs
+  pnpm --filter="./packages/**" --filter="./vendor/**" publish --no-git-checks --provenance --access public --tag=labs
+  moon run :publish -- --provenance --access public --tag labs
 fi
 
 if [[ $? -eq 0 ]]; then

--- a/.github/workflows/scripts/publish.sh
+++ b/.github/workflows/scripts/publish.sh
@@ -33,17 +33,17 @@ if [ -n "$NPM_TOKEN" ]; then
 fi
 
 if [ "$DX_ENVIRONMENT" = "production" ]; then
-  pnpm --filter="./packages/**" --filter="./vendor/**" publish --no-git-checks --provenance --access public --tag=latest
-  moon run :publish -- --provenance --access public --tag latest
+  pnpm --filter-prod="./packages/**" --filter-prod="./vendor/**" publish --no-git-checks --provenance --tag=latest
+  moon run :publish -- --provenance --tag latest
 elif [ "$DX_ENVIRONMENT" = "staging" ]; then
-  pnpm --filter="./packages/**" --filter="./vendor/**" publish --no-git-checks --provenance --access public --tag=next
-  moon run :publish -- --provenance --access public --tag next
+  pnpm --filter-prod="./packages/**" --filter-prod="./vendor/**" publish --no-git-checks --provenance --tag=next
+  moon run :publish -- --provenance --tag next
 elif [ "$DX_ENVIRONMENT" = "main" ]; then
-  pnpm --filter="./packages/**" --filter="./vendor/**" publish --no-git-checks --provenance --access public --tag=main
-  moon run :publish -- --provenance --access public --tag main
+  pnpm --filter-prod="./packages/**" --filter-prod="./vendor/**" publish --no-git-checks --provenance --tag=main
+  moon run :publish -- --provenance --tag main
 elif [ "$DX_ENVIRONMENT" = "labs" ]; then
-  pnpm --filter="./packages/**" --filter="./vendor/**" publish --no-git-checks --provenance --access public --tag=labs
-  moon run :publish -- --provenance --access public --tag labs
+  pnpm --filter-prod="./packages/**" --filter-prod="./vendor/**" publish --no-git-checks --provenance --tag=labs
+  moon run :publish -- --provenance --tag labs
 fi
 
 if [[ $? -eq 0 ]]; then

--- a/.github/workflows/scripts/publish.sh
+++ b/.github/workflows/scripts/publish.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 GREEN=4783872
 RED=16711680

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "moon run :build",
     "changed-packages": "scripts/changed",
     "check-cycles": "node scripts/check-cycles.mjs",
+    "check-publish-config": "node scripts/check-publish-config.mjs",
     "create-worktree": "./scripts/create-worktree",
     "format": "oxfmt",
     "format-check": "oxfmt --check",

--- a/packages/core/compute-runtime/package.json
+++ b/packages/core/compute-runtime/package.json
@@ -61,5 +61,8 @@
   },
   "peerDependencies": {
     "effect": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-attention/package.json
+++ b/packages/plugins/plugin-attention/package.json
@@ -81,5 +81,8 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-client/package.json
+++ b/packages/plugins/plugin-client/package.json
@@ -152,5 +152,8 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-deck/package.json
+++ b/packages/plugins/plugin-deck/package.json
@@ -155,5 +155,8 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-graph/package.json
+++ b/packages/plugins/plugin-graph/package.json
@@ -80,5 +80,8 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-map/package.json
+++ b/packages/plugins/plugin-map/package.json
@@ -146,5 +146,8 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-navtree/package.json
+++ b/packages/plugins/plugin-navtree/package.json
@@ -150,5 +150,8 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-observability/package.json
+++ b/packages/plugins/plugin-observability/package.json
@@ -121,5 +121,8 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-settings/package.json
+++ b/packages/plugins/plugin-settings/package.json
@@ -63,5 +63,8 @@
   "peerDependencies": {
     "effect": "catalog:",
     "react": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-space/package.json
+++ b/packages/plugins/plugin-space/package.json
@@ -183,5 +183,8 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-thread/package.json
+++ b/packages/plugins/plugin-thread/package.json
@@ -176,5 +176,8 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-wnfs/package.json
+++ b/packages/plugins/plugin-wnfs/package.json
@@ -143,5 +143,8 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/ui/brand/package.json
+++ b/packages/ui/brand/package.json
@@ -46,5 +46,8 @@
     "@phosphor-icons/react": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/ui/lit-grid/package.json
+++ b/packages/ui/lit-grid/package.json
@@ -41,5 +41,8 @@
   "devDependencies": {
     "@dxos/random": "workspace:*",
     "@dxos/test-utils": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/scripts/check-publish-config.mjs
+++ b/scripts/check-publish-config.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'fs';
+import { globby } from 'globby';
+
+const files = await globby(['{packages,vendor}/**/package.json'], {
+  ignore: ['**/node_modules/**', '**/__fixtures__/**'],
+});
+
+const errors = [];
+
+for (const file of files) {
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    continue;
+  }
+
+  if (!pkg.name || pkg.private) {
+    continue;
+  }
+
+  const access = pkg.publishConfig?.access;
+  if (access !== 'public') {
+    errors.push(`  ${pkg.name} (${file}): publishConfig.access is '${access ?? '(not set)'}'`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error('ERROR: The following publishable packages are missing publishConfig.access = "public".');
+  console.error('Add "publishConfig": { "access": "public" } to their package.json.');
+  console.error('');
+  for (const error of errors.sort()) {
+    console.error(error);
+  }
+  process.exit(1);
+}
+
+console.log(`OK: all ${files.length} publishable packages have publishConfig.access = "public".`);


### PR DESCRIPTION
## Problem

`@dxos/plugin-markdown` (and ~52 other packages) stopped being published after commit `e55b51de96` ("refactor: Use ProcessManager to run composer operations").

**Root cause:** `@dxos/compute-runtime` was a brand-new scoped package with no `publishConfig`. npm defaults new scoped packages to **restricted** access on first publish. pnpm then silently skips any package whose prod-dependency chain contains a restricted/unresolvable package — no error, the publish job exits green. The chain: `plugin-markdown` → `plugin-client` → `plugin-observability` → `@dxos/observability` → `app-framework` → **`@dxos/compute-runtime`** (restricted).

## Fix

### 1. `publishConfig.access=public` on 14 packages
Added the missing field to `@dxos/compute-runtime` (the root cause) and 13 others that were also lacking it: `@dxos/brand`, `@dxos/lit-grid`, and 11 `plugin-*` packages.

> ⚠️ **Manual action still required:** someone with npm org admin rights must run `npm access public @dxos/compute-runtime` to fix the already-restricted package on the registry.

### 2. CI check (`pnpm run check-publish-config`)
Added `scripts/check-publish-config.mjs` and a step in the `check` job that fails CI if any non-private named package is missing `publishConfig.access = "public"`. Prevents this class of silent publish failure from recurring.

### 3. `set -euo pipefail` in `publish.sh`
Without this, a failing publish command (e.g. a 403 auth error) is silently ignored — bash continues to the next command and the job exits green. This makes any publish error immediately fatal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made publishing scripts more robust to failures.
  * Added a CI check step to verify publishConfig.access is set to "public" for publishable packages.
  * Introduced a project script to scan package manifests and enforce publishConfig.access = "public".
  * Added publishConfig (access: "public") to multiple package manifests to ensure consistent publish behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->