### PR TITLE
fix(assistant-toolkit): use queue DXN for agent worker trigger

### DIFF
--- a/packages/core/compute/assistant-toolkit/src/blueprints/project-wizard/functions/sync-triggers.ts
+++ b/packages/core/compute/assistant-toolkit/src/blueprints/project-wizard/functions/sync-triggers.ts
@@ -104,27 +104,30 @@ const syncAgentTriggers = (agent: Agent.Agent): Effect.Effect<void, never, Datab
     }
 
     if ((agent.filterEvents ?? true) && agent.feed) {
-      yield* Database.add(
-        Trigger.make({
-          [Obj.Parent]: agent,
-          [Obj.Meta]: {
-            keys: [
-              { source: AGENT_TRIGGER_EXTENSION_KEY, id: agent.id },
-              {
-                source: AGENT_TRIGGER_TARGET_EXTENSION_KEY,
-                id: Obj.getDXN(agent)?.toString() ?? '',
-              },
-            ],
-          },
-          function: Ref.make(Operation.serialize(AgentWorker)),
-          enabled: triggersEnabled,
-          spec: Trigger.specQueue(agent.feed.dxn.toString()),
-          input: {
-            agent: Ref.make(agent),
-            event: '{{event}}',
-          },
-        }),
-      );
+      const agentFeedOption = yield* Database.loadOption(agent.feed);
+      if (Option.isSome(agentFeedOption) && Feed.getQueueDxn(agentFeedOption.value)) {
+        yield* Database.add(
+          Trigger.make({
+            [Obj.Parent]: agent,
+            [Obj.Meta]: {
+              keys: [
+                { source: AGENT_TRIGGER_EXTENSION_KEY, id: agent.id },
+                {
+                  source: AGENT_TRIGGER_TARGET_EXTENSION_KEY,
+                  id: Obj.getDXN(agent)?.toString() ?? '',
+                },
+              ],
+            },
+            function: Ref.make(Operation.serialize(AgentWorker)),
+            enabled: triggersEnabled,
+            spec: Trigger.specFeed(agentFeedOption.value),
+            input: {
+              agent: Ref.make(agent),
+              event: '{{event}}',
+            },
+          }),
+        );
+      }
     }
 
     // Timer trigger bypasses the qualifier and invokes the agent worker directly on a schedule.


### PR DESCRIPTION
## Summary

When `agent.filterEvents` is enabled and the agent has a `feed`, `syncAgentTriggers` was creating a worker trigger whose `spec.queue` came from `agent.feed.dxn` — i.e. the **echo-form** DXN of the `Feed` echo object (`dxn:echo:@:<spaceId>:<echoId>`).

The trigger dispatcher requires `spec.queue` to be a **queue-form** DXN (`dxn:queue:<subspaceTag>:<spaceId>:<queueId>`):

- `trigger-dispatcher.ts:460` calls `QueueService.getQueue(DXN.parse(spec.queue))` for queue triggers.
- `QueueImpl` constructor (`queue.ts:134`) calls `dxn.asQueueDXN()`.
- `asQueueDXN()` (`dxn.ts:291-294`) returns `undefined` for any DXN whose kind is not `QUEUE`.
- `queueId ?? failedInvariant()` then trips, so the worker trigger never matches anything.

This branch loads the feed and uses `Trigger.specFeed(...)` (which internally calls `Feed.getQueueDxn(...)`), mirroring the qualifier branch above (line 95). Same guard against feeds that aren't yet stored in a space.

## Test plan

- [x] `moon run assistant-toolkit:build`, `:lint`, `:test` — clean (37 passed / 4 skipped, including the 2 existing `SyncTriggers` tests in `blueprints/project/blueprint.test.ts`).
- [x] `moon run functions-runtime:test` — clean (57 passed / 9 skipped).
- [ ] CI: pre-ci on this branch surfaced 3 unrelated failures (memoized-LLM cache miss in `browser/blueprint.test.ts`, missing `DISCORD_TOKEN` in `discord/fetch-messages.test.ts`, and a flaky timeout in `plugin-code/bundle.test.ts` — confirmed flaky on `main` before this change). None touch trigger/queue/feed code.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced agent feed trigger validation to ensure feeds are properly loaded and verified before activation. This change strengthens the trigger creation process and prevents configuration errors that could impact agent performance and system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->