### PR TITLE
fix(echo): support Uint8Array serialization in ECHO objects

### DIFF
--- a/packages/common/util/src/map-values.ts
+++ b/packages/common/util/src/map-values.ts
@@ -52,6 +52,9 @@ class DeepMapper {
         res[i] = this._map(value[i], i);
       }
       return res;
+    } else if (ArrayBuffer.isView(value)) {
+      // Typed arrays (Uint8Array, etc.) are opaque leaf values, not POJOs to recurse into.
+      return value;
     } else if (value !== null && typeof value === 'object') {
       const res: any = {};
       this._cyclic.set(value, res);
@@ -112,6 +115,9 @@ class DeepMapperAsync {
         res[i] = await this._map(value[i], i);
       }
       return res;
+    } else if (ArrayBuffer.isView(value)) {
+      // Typed arrays (Uint8Array, etc.) are opaque leaf values, not POJOs to recurse into.
+      return value;
     } else if (value !== null && typeof value === 'object') {
       const res: any = {};
       this._cyclic.set(value, res);

--- a/packages/common/util/src/uint8array.ts
+++ b/packages/common/util/src/uint8array.ts
@@ -47,10 +47,18 @@ export type EncodedUint8Array = { '/': { bytes: string } };
 
 const toUnpaddedBase64 = (bytes: Uint8Array): string => arrayToBuffer(bytes).toString('base64').replace(/=+$/, '');
 
+/**
+ * Encode a `Uint8Array` as the DAG-JSON bytes form `{ '/': { bytes: '<base64-no-padding>' } }`.
+ */
 export const encodeUint8ArrayToJson = (bytes: Uint8Array): EncodedUint8Array => ({
   '/': { bytes: toUnpaddedBase64(bytes) },
 });
 
+/**
+ * Type-guard that returns true iff `value` is the DAG-JSON bytes form produced by
+ * {@link encodeUint8ArrayToJson} — an object with exactly one key `'/'` whose value is an
+ * object with exactly one string key `bytes`.
+ */
 export const isEncodedUint8Array = (value: unknown): value is EncodedUint8Array => {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     return false;
@@ -65,5 +73,9 @@ export const isEncodedUint8Array = (value: unknown): value is EncodedUint8Array 
   return Object.keys(inner).length === 1 && typeof inner.bytes === 'string';
 };
 
+/**
+ * Decode a DAG-JSON bytes form (as produced by {@link encodeUint8ArrayToJson}) back to a
+ * `Uint8Array`. The base64 string is tolerated with or without padding.
+ */
 export const decodeUint8ArrayFromJson = (encoded: EncodedUint8Array): Uint8Array =>
   bufferToArray(Buffer.from(encoded['/'].bytes, 'base64'));

--- a/packages/common/util/src/uint8array.ts
+++ b/packages/common/util/src/uint8array.ts
@@ -35,3 +35,29 @@ export const bufferToArray = (buffer: Buffer): Uint8Array => {
 export const stringToArray = (string: string): Uint8Array => bufferToArray(Buffer.from(string, 'hex'));
 
 export const arrayToString = (array: Uint8Array): string => arrayToBuffer(array).toString('hex');
+
+/**
+ * Marker key used to represent a `Uint8Array` in JSON.
+ * Mirrors the `'/'` convention used by encoded references.
+ */
+export const UINT8ARRAY_JSON_KEY = '/uint8array';
+
+/**
+ * JSON-safe representation of a `Uint8Array`.
+ * The bytes are encoded as a base64 string under the {@link UINT8ARRAY_JSON_KEY} marker.
+ */
+export type EncodedUint8Array = { [UINT8ARRAY_JSON_KEY]: string };
+
+export const encodeUint8ArrayToJson = (bytes: Uint8Array): EncodedUint8Array => ({
+  [UINT8ARRAY_JSON_KEY]: arrayToBuffer(bytes).toString('base64'),
+});
+
+export const isEncodedUint8Array = (value: unknown): value is EncodedUint8Array =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  typeof (value as any)[UINT8ARRAY_JSON_KEY] === 'string' &&
+  Object.keys(value).length === 1;
+
+export const decodeUint8ArrayFromJson = (encoded: EncodedUint8Array): Uint8Array =>
+  bufferToArray(Buffer.from(encoded[UINT8ARRAY_JSON_KEY], 'base64'));

--- a/packages/common/util/src/uint8array.ts
+++ b/packages/common/util/src/uint8array.ts
@@ -37,27 +37,33 @@ export const stringToArray = (string: string): Uint8Array => bufferToArray(Buffe
 export const arrayToString = (array: Uint8Array): string => arrayToBuffer(array).toString('hex');
 
 /**
- * Marker key used to represent a `Uint8Array` in JSON.
- * Mirrors the `'/'` convention used by encoded references.
+ * JSON-safe representation of a `Uint8Array`, per the IPLD DAG-JSON spec.
+ * https://ipld.io/specs/codecs/dag-json/spec/#bytes
+ *
+ * Bytes are encoded as `{ "/": { "bytes": "<base64-no-padding>" } }`.
+ * Distinguishable from encoded references `{ "/": "<string>" }` by the type of the `/` value.
  */
-export const UINT8ARRAY_JSON_KEY = '/uint8array';
+export type EncodedUint8Array = { '/': { bytes: string } };
 
-/**
- * JSON-safe representation of a `Uint8Array`.
- * The bytes are encoded as a base64 string under the {@link UINT8ARRAY_JSON_KEY} marker.
- */
-export type EncodedUint8Array = { [UINT8ARRAY_JSON_KEY]: string };
+const toUnpaddedBase64 = (bytes: Uint8Array): string => arrayToBuffer(bytes).toString('base64').replace(/=+$/, '');
 
 export const encodeUint8ArrayToJson = (bytes: Uint8Array): EncodedUint8Array => ({
-  [UINT8ARRAY_JSON_KEY]: arrayToBuffer(bytes).toString('base64'),
+  '/': { bytes: toUnpaddedBase64(bytes) },
 });
 
-export const isEncodedUint8Array = (value: unknown): value is EncodedUint8Array =>
-  typeof value === 'object' &&
-  value !== null &&
-  !Array.isArray(value) &&
-  typeof (value as any)[UINT8ARRAY_JSON_KEY] === 'string' &&
-  Object.keys(value).length === 1;
+export const isEncodedUint8Array = (value: unknown): value is EncodedUint8Array => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  if (Object.keys(value).length !== 1) {
+    return false;
+  }
+  const inner = (value as any)['/'];
+  if (typeof inner !== 'object' || inner === null || Array.isArray(inner)) {
+    return false;
+  }
+  return Object.keys(inner).length === 1 && typeof inner.bytes === 'string';
+};
 
 export const decodeUint8ArrayFromJson = (encoded: EncodedUint8Array): Uint8Array =>
-  bufferToArray(Buffer.from(encoded[UINT8ARRAY_JSON_KEY], 'base64'));
+  bufferToArray(Buffer.from(encoded['/'].bytes, 'base64'));

--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
@@ -982,4 +982,26 @@ describe('Reactive Object with ECHO database', () => {
     // Verify the original object still has its keys.
     expect(Obj.getMeta(newObj).keys).to.have.length(2);
   });
+
+  describe('Uint8Array fields', () => {
+    const Blob = Schema.Struct({
+      name: Schema.String,
+      bytes: Schema.Uint8ArrayFromSelf,
+    }).pipe(Type.object({ typename: 'com.example.type.blob', version: '0.1.0' }));
+
+    test('stored natively in automerge and round-trip through ECHO', async () => {
+      const { db } = await builder.createDatabase({ types: [Blob] });
+      const bytes = new Uint8Array([0, 1, 2, 3, 250, 251, 252, 253, 254, 255]);
+
+      const obj = db.add(Obj.make(Blob, { name: 'blob', bytes }));
+      expect(obj.bytes).toBeInstanceOf(Uint8Array);
+      expect(Array.from(obj.bytes)).toEqual(Array.from(bytes));
+
+      // Verify the underlying automerge value is a Uint8Array, not the encoded JSON form.
+      const core = getObjectCore(obj);
+      const raw = core.getDecoded(['data', 'bytes']);
+      expect(raw).toBeInstanceOf(Uint8Array);
+      expect(Array.from(raw as Uint8Array)).toEqual(Array.from(bytes));
+    });
+  });
 });

--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
@@ -989,7 +989,7 @@ describe('Reactive Object with ECHO database', () => {
       bytes: Schema.Uint8ArrayFromSelf,
     }).pipe(Type.object({ typename: 'com.example.type.blob', version: '0.1.0' }));
 
-    test('stored natively in automerge and round-trip through ECHO', async () => {
+    test('stored natively in automerge and round-trip through ECHO', async ({ expect }) => {
       const { db } = await builder.createDatabase({ types: [Blob] });
       const bytes = new Uint8Array([0, 1, 2, 3, 250, 251, 252, 253, 254, 255]);
 

--- a/packages/core/echo/echo/src/internal/Obj/json-serializer.test.ts
+++ b/packages/core/echo/echo/src/internal/Obj/json-serializer.test.ts
@@ -132,7 +132,7 @@ describe('Object JSON serializer', () => {
     );
     interface Blob extends Schema.Schema.Type<typeof Blob> {}
 
-    test('round-trips Uint8Array field through JSON with schema', async () => {
+    test('round-trips Uint8Array field through JSON with schema', async ({ expect }) => {
       const bytes = new Uint8Array([0, 1, 2, 3, 250, 251, 252, 253, 254, 255]);
       const blob = Obj.make(Blob, { name: 'blob', bytes });
 
@@ -148,7 +148,7 @@ describe('Object JSON serializer', () => {
       expect(Array.from(blobFromJson.bytes)).toEqual(Array.from(bytes));
     });
 
-    test('round-trips Uint8Array field through JSON without schema resolver', async () => {
+    test('round-trips Uint8Array field through JSON without schema resolver', async ({ expect }) => {
       const bytes = new Uint8Array([10, 20, 30, 40, 50]);
       const blob = Obj.make(Blob, { name: 'blob', bytes });
 

--- a/packages/core/echo/echo/src/internal/Obj/json-serializer.test.ts
+++ b/packages/core/echo/echo/src/internal/Obj/json-serializer.test.ts
@@ -9,13 +9,13 @@ import { DXN } from '@dxos/keys';
 
 import * as Obj from '../../Obj';
 import { TestSchema } from '../../testing';
+import * as Type from '../../Type';
 import { getSchemaDXN, getSchemaTypename, getTypeDXN, getTypename } from '../Annotation';
 import { getMetaChecked } from '../common/api';
 import { makeObject } from '../common/proxy';
 import { ATTR_TYPE, EntityKind, KindId, MetaId, TypeId, getSchema } from '../common/types';
 import { RelationSourceId, RelationTargetId, getObjectDXN } from '../Entity';
 import { Ref, StaticRefResolver } from '../Ref';
-import * as Type from '../../Type';
 import { createObject } from './create-object';
 import { objectFromJSON, objectToJSON } from './json-serializer';
 

--- a/packages/core/echo/echo/src/internal/Obj/json-serializer.test.ts
+++ b/packages/core/echo/echo/src/internal/Obj/json-serializer.test.ts
@@ -2,6 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
+import * as Schema from 'effect/Schema';
 import { describe, expect, test } from 'vitest';
 
 import { DXN } from '@dxos/keys';
@@ -14,6 +15,7 @@ import { makeObject } from '../common/proxy';
 import { ATTR_TYPE, EntityKind, KindId, MetaId, TypeId, getSchema } from '../common/types';
 import { RelationSourceId, RelationTargetId, getObjectDXN } from '../Entity';
 import { Ref, StaticRefResolver } from '../Ref';
+import * as Type from '../../Type';
 import { createObject } from './create-object';
 import { objectFromJSON, objectToJSON } from './json-serializer';
 
@@ -116,5 +118,48 @@ describe('Object JSON serializer', () => {
     expect(expandoFromJson.id).toBe(expando.id);
     expect(expandoFromJson.message).toBe('local-only');
     expect((expandoFromJson as any)[ATTR_TYPE]).toBeUndefined();
+  });
+
+  describe('Uint8Array', () => {
+    const Blob = Schema.Struct({
+      name: Schema.String,
+      bytes: Schema.Uint8ArrayFromSelf,
+    }).pipe(
+      Type.object({
+        typename: 'com.example.type.blob',
+        version: '0.1.0',
+      }),
+    );
+    interface Blob extends Schema.Schema.Type<typeof Blob> {}
+
+    test('round-trips Uint8Array field through JSON with schema', async () => {
+      const bytes = new Uint8Array([0, 1, 2, 3, 250, 251, 252, 253, 254, 255]);
+      const blob = Obj.make(Blob, { name: 'blob', bytes });
+
+      const blobJson = objectToJSON(blob);
+      // JSON must round-trip through stringify/parse without loss.
+      const roundTripped = JSON.parse(JSON.stringify(blobJson));
+
+      const refResolver = new StaticRefResolver().addSchema(Blob);
+      const blobFromJson = (await objectFromJSON(roundTripped, { refResolver })) as Blob;
+
+      expect(blobFromJson.name).toBe('blob');
+      expect(blobFromJson.bytes).toBeInstanceOf(Uint8Array);
+      expect(Array.from(blobFromJson.bytes)).toEqual(Array.from(bytes));
+    });
+
+    test('round-trips Uint8Array field through JSON without schema resolver', async () => {
+      const bytes = new Uint8Array([10, 20, 30, 40, 50]);
+      const blob = Obj.make(Blob, { name: 'blob', bytes });
+
+      const blobJson = objectToJSON(blob);
+      const roundTripped = JSON.parse(JSON.stringify(blobJson));
+
+      const blobFromJson = (await objectFromJSON(roundTripped)) as Blob;
+
+      expect(blobFromJson.name).toBe('blob');
+      expect(blobFromJson.bytes).toBeInstanceOf(Uint8Array);
+      expect(Array.from(blobFromJson.bytes)).toEqual(Array.from(bytes));
+    });
   });
 });

--- a/packages/core/echo/echo/src/internal/Obj/json-serializer.ts
+++ b/packages/core/echo/echo/src/internal/Obj/json-serializer.ts
@@ -8,7 +8,7 @@ import { raise } from '@dxos/debug';
 import { type EncodedReference, ObjectStructure, isEncodedReference } from '@dxos/echo-protocol';
 import { assertArgument, invariant } from '@dxos/invariant';
 import { DXN, ObjectId } from '@dxos/keys';
-import { assumeType, deepMapValues, visitValues } from '@dxos/util';
+import { assumeType, decodeUint8ArrayFromJson, deepMapValues, isEncodedUint8Array, visitValues } from '@dxos/util';
 
 import type * as Database from '../../Database';
 import type * as Obj from '../../Obj';
@@ -95,7 +95,7 @@ export const objectFromJSON = async (
   const type = DXN.parse(jsonData[ATTR_TYPE]);
   const schema = await refResolver?.resolveSchema(type);
   invariant(schema === undefined || Schema.isSchema(schema));
-  const decodedInput = stripInternalJsonKeys(jsonData);
+  const decodedInput = restoreUint8Arrays(stripInternalJsonKeys(jsonData));
 
   let obj: any;
   if (schema != null) {
@@ -174,10 +174,25 @@ const decodeGeneric = (jsonData: unknown, options: { refResolver?: RefResolver }
     if (isEncodedReference(value)) {
       return refFromEncodedReference(value, options.refResolver);
     }
+    if (isEncodedUint8Array(value)) {
+      return decodeUint8ArrayFromJson(value);
+    }
 
     return visitor(value);
   });
 };
+
+/**
+ * Recursively replaces encoded `Uint8Array` JSON markers with actual `Uint8Array` instances.
+ * Runs before schema decoding so `Schema.Uint8ArrayFromSelf` sees real bytes.
+ */
+const restoreUint8Arrays = (data: unknown): any =>
+  deepMapValues(data, (value, recurse) => {
+    if (isEncodedUint8Array(value)) {
+      return decodeUint8ArrayFromJson(value);
+    }
+    return recurse(value);
+  });
 
 const stripInternalJsonKeys = (jsonData: unknown) => {
   const {

--- a/packages/core/echo/echo/src/internal/common/proxy/json-serializer.ts
+++ b/packages/core/echo/echo/src/internal/common/proxy/json-serializer.ts
@@ -5,7 +5,7 @@
 import { type ObjectMeta } from '@dxos/echo-protocol';
 import { invariant } from '@dxos/invariant';
 import { DXN } from '@dxos/keys';
-import { deepMapValues } from '@dxos/util';
+import { deepMapValues, encodeUint8ArrayToJson } from '@dxos/util';
 
 import { Ref } from '../../Ref';
 import {
@@ -79,6 +79,9 @@ const serializeData = (data: unknown) => {
     if (Ref.isRef(value)) {
       // TODO(dmaretskyi): Should this be configurable?
       return value.noInline().encode();
+    }
+    if (value instanceof Uint8Array) {
+      return encodeUint8ArrayToJson(value);
     }
 
     return recurse(value);


### PR DESCRIPTION
## Summary

- Schemas using `Schema.Uint8ArrayFromSelf` (e.g. `File.bytes`) previously failed to round-trip through `Obj.toJSON`/`Obj.fromJSON`. `deepMapValues` treated typed arrays as POJOs and `for...in` iteration produced `{"0":0,"1":1,...}`, which `Schema.Uint8ArrayFromSelf` then rejected on decode.
- `Uint8Array` is now JSON-encoded as `{"/uint8array":"<base64>"}` (mirroring the `"/"` encoded-reference convention) and restored to real `Uint8Array` instances before schema decoding.
- `deepMapValues`/`deepMapValuesAsync` now treat any `ArrayBuffer.isView` value as a leaf, so typed arrays survive recursion in any caller.

closes DX-950

## Test plan

- [x] New `Uint8Array` round-trip tests in `json-serializer.test.ts` (schema-resolved path + generic decode path, both through `JSON.stringify`/`JSON.parse`)
- [x] `moon run echo:test` — 306 passed
- [x] `moon run util:test` — 101 passed
- [x] `moon run echo-db:test` — 571 passed
- [x] `moon run util:lint echo:lint -- --fix` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end JSON encoding/decoding support for binary data, enabling reliable transfer and storage of Uint8Array values.

* **Improvements**
  * Typed arrays are now treated as opaque leaf values during recursive processing, preventing unintended traversal or mutation of binary buffers.

* **Tests**
  * Added tests to verify binary fields persist correctly and round-trip through JSON and database operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->