### PR TITLE
chore(publish): mark unpublished plugins as private

### DIFF
--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -87,6 +87,9 @@ jobs:
         id: npm-publish
         run: .github/workflows/scripts/publish.sh
         if: env.BRANCH == 'production' || env.BRANCH == 'staging' || github.event.inputs.publish_npm == 'true'
+        env:
+          DISCORD_NPM_PUBLISH_WEBHOOK: ${{ secrets.DISCORD_NPM_PUBLISH_WEBHOOK }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Bundle Apps
         run: .github/workflows/scripts/bundle-apps.sh

--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -89,7 +89,6 @@ jobs:
         if: env.BRANCH == 'production' || env.BRANCH == 'staging' || github.event.inputs.publish_npm == 'true'
         env:
           DISCORD_NPM_PUBLISH_WEBHOOK: ${{ secrets.DISCORD_NPM_PUBLISH_WEBHOOK }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Bundle Apps
         run: .github/workflows/scripts/bundle-apps.sh

--- a/.github/workflows/scripts/publish.sh
+++ b/.github/workflows/scripts/publish.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 
 GREEN=4783872
 RED=16711680
@@ -25,12 +25,6 @@ function notifyStart() {
 
 notifyStart;
 
-# NPM_TOKEN is used as fallback for packages without trusted publisher configured.
-# Packages with trusted publisher will automatically use OIDC (no token needed).
-# Once all packages have trusted publisher, this line can be removed.
-if [ -n "$NPM_TOKEN" ]; then
-  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-fi
 
 if [ "$DX_ENVIRONMENT" = "production" ]; then
   pnpm --filter-prod="./packages/**" --filter-prod="./vendor/**" publish --no-git-checks --provenance --tag=latest

--- a/.github/workflows/scripts/publish.sh
+++ b/.github/workflows/scripts/publish.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 
 GREEN=4783872
 RED=16711680

--- a/packages/plugins/plugin-code/package.json
+++ b/packages/plugins/plugin-code/package.json
@@ -130,7 +130,5 @@
     "react": "catalog:",
     "react-dom": "catalog:"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/packages/plugins/plugin-crm/package.json
+++ b/packages/plugins/plugin-crm/package.json
@@ -103,7 +103,5 @@
     "vite": "catalog:",
     "vitest": "catalog:"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/packages/plugins/plugin-crx/package.json
+++ b/packages/plugins/plugin-crx/package.json
@@ -92,7 +92,5 @@
     "@dxos/react-ui": "workspace:*",
     "react": "catalog:"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/packages/plugins/plugin-doctor/package.json
+++ b/packages/plugins/plugin-doctor/package.json
@@ -115,7 +115,5 @@
     "react": "catalog:",
     "react-dom": "catalog:"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/packages/plugins/plugin-feed/package.json
+++ b/packages/plugins/plugin-feed/package.json
@@ -135,7 +135,5 @@
     "react": "catalog:",
     "react-dom": "catalog:"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/packages/plugins/plugin-gallery/package.json
+++ b/packages/plugins/plugin-gallery/package.json
@@ -121,7 +121,5 @@
     "react": "catalog:",
     "react-dom": "catalog:"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/packages/plugins/plugin-generator/package.json
+++ b/packages/plugins/plugin-generator/package.json
@@ -122,7 +122,5 @@
     "react": "catalog:",
     "react-dom": "catalog:"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/packages/plugins/plugin-sequencer/package.json
+++ b/packages/plugins/plugin-sequencer/package.json
@@ -119,7 +119,5 @@
     "react": "catalog:",
     "react-dom": "catalog:"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/packages/plugins/plugin-sidekick/package.json
+++ b/packages/plugins/plugin-sidekick/package.json
@@ -109,7 +109,5 @@
     "react": "catalog:",
     "react-dom": "catalog:"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/packages/plugins/plugin-spacetime/package.json
+++ b/packages/plugins/plugin-spacetime/package.json
@@ -116,7 +116,5 @@
     "react": "catalog:",
     "react-dom": "catalog:"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/packages/plugins/plugin-support/package.json
+++ b/packages/plugins/plugin-support/package.json
@@ -151,7 +151,5 @@
     "react": "catalog:",
     "react-dom": "catalog:"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/packages/plugins/plugin-tictactoe/package.json
+++ b/packages/plugins/plugin-tictactoe/package.json
@@ -108,7 +108,5 @@
     "react": "catalog:",
     "react-dom": "catalog:"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }


### PR DESCRIPTION
These 12 packages have never been published to npm and don't have Trusted Publishing (OIDC) configured, causing `EAUTH` on provenance publish:

- `@dxos/plugin-doctor`
- `@dxos/plugin-generator`
- `@dxos/plugin-sequencer`
- `@dxos/plugin-support`
- `@dxos/plugin-feed`
- `@dxos/plugin-spacetime`
- `@dxos/plugin-sidekick`
- `@dxos/plugin-crm`
- `@dxos/plugin-crx`
- `@dxos/plugin-code`
- `@dxos/plugin-tictactoe`
- `@dxos/plugin-gallery`

Marking them `private` skips them in the publish run until Trusted Publishing is configured for each on npm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow to use Discord webhook notifications for npm releases.
  * Multiple plugins have been marked as private and will no longer be published to npm, restricting their distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->