### PR TITLE
feat: add @dxos/effect-proto + ObjectViewer for schema-driven editors

### DIFF
--- a/packages/common/effect-proto/LICENSE
+++ b/packages/common/effect-proto/LICENSE
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, ALv2 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2026 DXOS
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/common/effect-proto/moon.yml
+++ b/packages/common/effect-proto/moon.yml
@@ -1,0 +1,11 @@
+layer: library
+language: typescript
+tags:
+  - ts-build
+  - ts-test
+  - pack
+tasks:
+  compile:
+    args:
+      - '--entryPoint=src/index.ts'
+      - '--injectGlobals'

--- a/packages/common/effect-proto/package.json
+++ b/packages/common/effect-proto/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@dxos/effect-proto",
+  "version": "0.8.3",
+  "private": true,
+  "description": "Generate Effect Schema definitions at runtime from Protocol Buffer (proto3) source. Used by react-ui-form to drive a hierarchical schema-driven editor over proto-defined config objects.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dxos/dxos"
+  },
+  "license": "FSL-1.1-Apache-2.0",
+  "author": "info@dxos.org",
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/types/src/index.d.ts",
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/node-esm/index.mjs"
+    }
+  },
+  "types": "dist/types/src/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "effect": "catalog:",
+    "protobufjs": "catalog:"
+  },
+  "devDependencies": {
+    "@dxos/protocols": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/common/effect-proto/src/index.ts
+++ b/packages/common/effect-proto/src/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export { parseProto, type ProtoRegistry } from './proto-to-effect';

--- a/packages/common/effect-proto/src/proto-to-effect.test.ts
+++ b/packages/common/effect-proto/src/proto-to-effect.test.ts
@@ -132,3 +132,16 @@ describe('parseProto / config.proto', () => {
     expect(Schema.decodeUnknownSync(Storage)({ dataRoot: '/tmp' })).toEqual({ dataRoot: '/tmp' });
   });
 });
+
+describe('parseProto / unsupported features', () => {
+  test('rejects map<K, V> fields with a clear error', ({ expect }) => {
+    const source = `
+      syntax = "proto3";
+      package dxos.test;
+      message WithMap {
+        map<string, int32> counts = 1;
+      }
+    `;
+    expect(() => parseProto(source)).toThrow(/map fields are not supported/);
+  });
+});

--- a/packages/common/effect-proto/src/proto-to-effect.test.ts
+++ b/packages/common/effect-proto/src/proto-to-effect.test.ts
@@ -1,0 +1,134 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { describe, test } from 'vitest';
+
+import { type Config as ConfigProto, Runtime } from '@dxos/protocols/proto/dxos/config';
+
+import { parseProto } from './proto-to-effect';
+
+const require = createRequire(import.meta.url);
+const CONFIG_PROTO_PATH = require.resolve('@dxos/protocols/proto/dxos/config.proto');
+const CONFIG_PROTO_SOURCE = readFileSync(CONFIG_PROTO_PATH, 'utf8');
+
+describe('parseProto / config.proto', () => {
+  test('registers every nested message under dxos.config', ({ expect }) => {
+    const registry = parseProto(CONFIG_PROTO_SOURCE);
+    const types = registry.list();
+    expect(types).toContain('dxos.config.Config');
+    expect(types).toContain('dxos.config.Package');
+    expect(types).toContain('dxos.config.Module');
+    expect(types).toContain('dxos.config.Module.Build');
+    expect(types).toContain('dxos.config.Runtime');
+    expect(types).toContain('dxos.config.Runtime.Client');
+    expect(types).toContain('dxos.config.Runtime.Client.Storage');
+    expect(types).toContain('dxos.config.Runtime.Services');
+  });
+
+  test('decodes a realistic Config value', ({ expect }) => {
+    const registry = parseProto(CONFIG_PROTO_SOURCE);
+    const Config = registry.get('dxos.config.Config');
+
+    const value: ConfigProto = {
+      version: 1,
+      runtime: {
+        client: {
+          storage: {
+            persistent: true,
+            sqliteMode: Runtime.Client.Storage.SqliteMode.OPFS,
+            dataRoot: '/var/lib/dxos',
+          },
+          log: { filter: 'info' },
+          edgeFeatures: { subductionReplicator: true, signaling: true },
+          servicesMode: Runtime.Client.ServicesMode.SHARED_WORKER,
+        },
+        services: {
+          edge: { url: 'wss://edge.dxos.org' },
+          signaling: [{ server: 'wss://signal.dxos.org', api: 'v1' }],
+        },
+        keys: [
+          { name: 'OPENAI_API_KEY', value: 'sk-...' },
+          { name: 'ANTHROPIC_API_KEY', value: 'ant-...' },
+        ],
+      },
+    };
+
+    expect(Schema.decodeUnknownSync(Config)(value)).toEqual(value);
+  });
+
+  test('accepts numeric enum values and rejects unknown values', ({ expect }) => {
+    const registry = parseProto(CONFIG_PROTO_SOURCE);
+    const Storage = registry.get('dxos.config.Runtime.Client.Storage');
+    const { OPFS, MEMORY } = Runtime.Client.Storage.SqliteMode;
+
+    expect(Schema.decodeUnknownSync(Storage)({ sqliteMode: OPFS })).toEqual({ sqliteMode: OPFS });
+    expect(Schema.decodeUnknownSync(Storage)({ sqliteMode: MEMORY })).toEqual({ sqliteMode: MEMORY });
+    // String enum names no longer round-trip -- enums are numeric on the wire.
+    expect(() => Schema.decodeUnknownSync(Storage)({ sqliteMode: 'OPFS' })).toThrow();
+    // 99 is not a defined member of SqliteMode.
+    expect(() => Schema.decodeUnknownSync(Storage)({ sqliteMode: 99 })).toThrow();
+  });
+
+  test('exposes proto enum name<->value maps via getEnum', ({ expect }) => {
+    const registry = parseProto(CONFIG_PROTO_SOURCE);
+
+    expect(registry.listEnums()).toContain('dxos.config.Runtime.Client.Storage.SqliteMode');
+    expect(registry.listEnums()).toContain('dxos.config.Runtime.Client.ServicesMode');
+
+    expect(registry.getEnum('dxos.config.Runtime.Client.Storage.SqliteMode')).toEqual({
+      UNSPECIFIED_SQLITE_MODE: 0,
+      MEMORY: 1,
+      OPFS: 2,
+      FILE: 3,
+    });
+    expect(registry.getEnum('dxos.does.not.exist')).toBeUndefined();
+  });
+
+  test('handles repeated fields', ({ expect }) => {
+    const registry = parseProto(CONFIG_PROTO_SOURCE);
+    const Package = registry.get('dxos.config.Package');
+
+    const value = {
+      license: 'MIT',
+      repos: [{ name: 'core', url: 'git@github.com:dxos/dxos.git', version: '1.0.0' }],
+      modules: [{ id: 'a' }, { id: 'b' }],
+    };
+    expect(Schema.decodeUnknownSync(Package)(value)).toEqual(value);
+  });
+
+  test('handles recursive types via lazy refs', ({ expect }) => {
+    const registry = parseProto(CONFIG_PROTO_SOURCE);
+    const Module = registry.get('dxos.config.Module');
+
+    const value = {
+      id: 'root',
+      deps: [{ id: 'child-a', deps: [{ id: 'grandchild' }] }, { id: 'child-b' }],
+    };
+    expect(Schema.decodeUnknownSync(Module)(value)).toEqual(value);
+  });
+
+  test('accepts an arbitrary object for google.protobuf.Any', ({ expect }) => {
+    const registry = parseProto(CONFIG_PROTO_SOURCE);
+    const Module = registry.get('dxos.config.Module');
+
+    const value = {
+      id: 'mod',
+      record: { '@type': 'dxos.example.Frame', payload: { x: 1, y: 'two' } },
+    };
+    expect(Schema.decodeUnknownSync(Module)(value)).toEqual(value);
+  });
+
+  test('camelCases snake_case proto field names', ({ expect }) => {
+    const registry = parseProto(CONFIG_PROTO_SOURCE);
+    const Storage = registry.get('dxos.config.Runtime.Client.Storage');
+
+    // proto: `data_root` -> JS: `dataRoot`. Passing `data_root` should fail
+    // strict decode (it's not a known field) - actually Effect Struct allows
+    // unknown keys by default. Instead assert the camelCase form decodes.
+    expect(Schema.decodeUnknownSync(Storage)({ dataRoot: '/tmp' })).toEqual({ dataRoot: '/tmp' });
+  });
+});

--- a/packages/common/effect-proto/src/proto-to-effect.ts
+++ b/packages/common/effect-proto/src/proto-to-effect.ts
@@ -51,27 +51,51 @@ export const parseProto = (source: string): ProtoRegistry => {
 
   const { messages, enums } = collectDeclarations(parsed.root);
   const schemas = new Map<string, Schema.Schema<any>>();
+  const building = new Set<string>();
 
-  const lazyRef = (fullName: string): Schema.Schema<any> =>
-    Schema.suspend(() => {
-      const found = schemas.get(fullName);
-      if (!found) {
-        throw new Error(`effect-proto: unresolved message reference "${fullName}"`);
-      }
-      return found;
-    });
-
-  for (const [fullName, type] of messages) {
+  // Build a message's schema on demand. Cross-references that aren't in a
+  // cycle resolve to the concrete `Schema.Struct` directly, which is what
+  // downstream introspection (e.g. `effect/SchemaAST.encodedBoundAST` used
+  // by `@dxos/react-ui-form`) needs to recurse into nested fields. Only
+  // genuine cycles (a message that transitively references itself, like
+  // `Module.deps: repeated Module`) get wrapped in `Schema.suspend` to
+  // break the recursion.
+  const buildMessage = (fullName: string): Schema.Schema<any> => {
+    const cached = schemas.get(fullName);
+    if (cached) {
+      return cached;
+    }
+    if (building.has(fullName)) {
+      return Schema.suspend(() => {
+        const resolved = schemas.get(fullName);
+        if (!resolved) {
+          throw new Error(`effect-proto: unresolved message reference "${fullName}"`);
+        }
+        return resolved;
+      });
+    }
+    const type = messages.get(fullName);
+    if (!type) {
+      throw new Error(`effect-proto: unknown message type "${fullName}"`);
+    }
+    building.add(fullName);
     const fields: Record<string, Schema.PropertySignature<'?:', any, never, '?:', any, false, never>> = {};
     for (const field of type.fieldsArray) {
       const jsonName = protobuf.util.camelCase(field.name);
-      const base = fieldToSchema(field, lazyRef);
+      const base = fieldToSchema(field, buildMessage);
       const arr = field.repeated ? Schema.Array(base) : base;
       // proto3: every field is effectively optional (codec uses `defaults: false`,
       // so absent fields are `undefined` in the decoded object).
       fields[jsonName] = Schema.optional(arr);
     }
-    schemas.set(fullName, Schema.Struct(fields));
+    const schema = Schema.Struct(fields);
+    schemas.set(fullName, schema);
+    building.delete(fullName);
+    return schema;
+  };
+
+  for (const fullName of messages.keys()) {
+    buildMessage(fullName);
   }
 
   return {
@@ -140,10 +164,11 @@ const stripLeadingDot = (name: string): string => (name.startsWith('.') ? name.s
 
 /**
  * Map one proto field's type to an Effect Schema, ignoring `repeated` and
- * optionality (the caller wraps those). Recurses through `lazyRef` for
- * message references so cyclic types work.
+ * optionality (the caller wraps those). Delegates to `resolveRef` for message
+ * references, which returns the concrete struct schema for already-built
+ * targets and `Schema.suspend` for in-progress (cyclic) ones.
  */
-const fieldToSchema = (field: protobuf.Field, lazyRef: (fq: string) => Schema.Schema<any>): Schema.Schema<any> => {
+const fieldToSchema = (field: protobuf.Field, resolveRef: (fq: string) => Schema.Schema<any>): Schema.Schema<any> => {
   // Scalars don't have `resolvedType`; switch on the parser-level `type` string.
   const scalar = SCALAR_SCHEMAS[field.type];
   if (scalar) {
@@ -166,7 +191,7 @@ const fieldToSchema = (field: protobuf.Field, lazyRef: (fq: string) => Schema.Sc
   }
 
   if (resolved instanceof protobuf.Type) {
-    return lazyRef(fq);
+    return resolveRef(fq);
   }
 
   throw new Error(`effect-proto: unsupported resolved type for field "${field.fullName}"`);

--- a/packages/common/effect-proto/src/proto-to-effect.ts
+++ b/packages/common/effect-proto/src/proto-to-effect.ts
@@ -4,20 +4,23 @@
 
 // Convert a Protocol Buffers (proto3) source file to a registry of Effect
 // Schemas. The output is shaped to match what `@dxos/codec-protobuf` emits
-// at runtime via protobufjs (`enums: String`, `bytes: String`, `longs: String`,
-// camelCase field names) so the same JS objects can be both schema-validated
-// and round-tripped through the wire codec.
+// at runtime via protobufjs for the JSON shape (`bytes: String`,
+// `longs: String`, camelCase field names) so the same JS objects can be both
+// schema-validated and round-tripped through the wire codec. Enums diverge
+// from that codec's `enums: String` configuration on purpose -- see below.
 //
-// Supports: messages (incl. nested), enums (as string-name literal unions),
-// scalars, `repeated` (-> Schema.Array), implicit/explicit optionality
-// (every field is treated as optional, matching proto3 semantics with
-// `defaults: false`), and the well-known `google.protobuf.Any` / `Struct`
-// / `Value` / `ListValue` / `NullValue` (typed as Unknown / Record /
-// Unknown / Array<Unknown> / Null).
+// Supports: messages (incl. nested), enums (as numeric-literal unions of
+// their tag values; the name<->value map is exposed via
+// `ProtoRegistry.getEnum`), scalars, `repeated` (-> Schema.Array),
+// implicit/explicit optionality (every field is treated as optional,
+// matching proto3 semantics with `defaults: false`), and the well-known
+// `google.protobuf.Any` / `Struct` / `Value` / `ListValue` / `NullValue`
+// (typed as Unknown / Record / Unknown / Array<Unknown> / Null).
 //
-// Not yet supported: `map<K, V>` fields, user-defined `oneof` (synthetic
-// oneofs from `optional` scalars are handled), proto2 groups, comment /
-// field-option (e.g. `(env_var)`) -> annotation mapping, build-time codegen.
+// Not yet supported: `map<K, V>` fields (parsing throws if encountered),
+// user-defined `oneof` (synthetic oneofs from `optional` scalars are
+// handled), proto2 groups, comment / field-option (e.g. `(env_var)`) ->
+// annotation mapping, build-time codegen.
 
 import * as Schema from 'effect/Schema';
 import protobuf from 'protobufjs';
@@ -169,6 +172,14 @@ const stripLeadingDot = (name: string): string => (name.startsWith('.') ? name.s
  * targets and `Schema.suspend` for in-progress (cyclic) ones.
  */
 const fieldToSchema = (field: protobuf.Field, resolveRef: (fq: string) => Schema.Schema<any>): Schema.Schema<any> => {
+  // Fail fast on `map<K, V>` -- protobufjs models these specially (synthetic
+  // entry message + repeated field) and an Effect Schema needs `Schema.Record`,
+  // which we haven't wired up yet. Silent fall-through here would produce a
+  // schema that mis-types the runtime object.
+  if (field.map) {
+    throw new Error(`effect-proto: map fields are not supported ("${field.fullName}")`);
+  }
+
   // Scalars don't have `resolvedType`; switch on the parser-level `type` string.
   const scalar = SCALAR_SCHEMAS[field.type];
   if (scalar) {

--- a/packages/common/effect-proto/src/proto-to-effect.ts
+++ b/packages/common/effect-proto/src/proto-to-effect.ts
@@ -1,0 +1,227 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// Convert a Protocol Buffers (proto3) source file to a registry of Effect
+// Schemas. The output is shaped to match what `@dxos/codec-protobuf` emits
+// at runtime via protobufjs (`enums: String`, `bytes: String`, `longs: String`,
+// camelCase field names) so the same JS objects can be both schema-validated
+// and round-tripped through the wire codec.
+//
+// Supports: messages (incl. nested), enums (as string-name literal unions),
+// scalars, `repeated` (-> Schema.Array), implicit/explicit optionality
+// (every field is treated as optional, matching proto3 semantics with
+// `defaults: false`), and the well-known `google.protobuf.Any` / `Struct`
+// / `Value` / `ListValue` / `NullValue` (typed as Unknown / Record /
+// Unknown / Array<Unknown> / Null).
+//
+// Not yet supported: `map<K, V>` fields, user-defined `oneof` (synthetic
+// oneofs from `optional` scalars are handled), proto2 groups, comment /
+// field-option (e.g. `(env_var)`) -> annotation mapping, build-time codegen.
+
+import * as Schema from 'effect/Schema';
+import protobuf from 'protobufjs';
+
+export interface ProtoRegistry {
+  /** Look up a message schema by its fully-qualified name, e.g. 'dxos.config.Config'. */
+  get(fullyQualifiedName: string): Schema.Schema<any>;
+  /** List every registered message type in declaration order. */
+  list(): readonly string[];
+  /**
+   * Look up the `{ NAME: numericValue }` map for a proto enum by its
+   * fully-qualified name. Returned objects are frozen. Returns `undefined`
+   * if no such enum exists. Useful for editors that need to surface enum
+   * member names alongside the numeric values stored on the message.
+   */
+  getEnum(fullyQualifiedName: string): Readonly<Record<string, number>> | undefined;
+  /** List every registered enum type by fully-qualified name. */
+  listEnums(): readonly string[];
+}
+
+/**
+ * Parse a `.proto` source and return a registry of Effect Schemas, one per
+ * message type. Cross-references between messages are resolved lazily via
+ * `Schema.suspend`, so recursive types (e.g. `Module.deps: repeated Module`)
+ * work without ordering hazards.
+ */
+export const parseProto = (source: string): ProtoRegistry => {
+  const parsed = protobuf.parse(source, { keepCase: true });
+  injectWellKnownStubs(parsed.root);
+  parsed.root.resolveAll();
+
+  const { messages, enums } = collectDeclarations(parsed.root);
+  const schemas = new Map<string, Schema.Schema<any>>();
+
+  const lazyRef = (fullName: string): Schema.Schema<any> =>
+    Schema.suspend(() => {
+      const found = schemas.get(fullName);
+      if (!found) {
+        throw new Error(`effect-proto: unresolved message reference "${fullName}"`);
+      }
+      return found;
+    });
+
+  for (const [fullName, type] of messages) {
+    const fields: Record<string, Schema.PropertySignature<'?:', any, never, '?:', any, false, never>> = {};
+    for (const field of type.fieldsArray) {
+      const jsonName = protobuf.util.camelCase(field.name);
+      const base = fieldToSchema(field, lazyRef);
+      const arr = field.repeated ? Schema.Array(base) : base;
+      // proto3: every field is effectively optional (codec uses `defaults: false`,
+      // so absent fields are `undefined` in the decoded object).
+      fields[jsonName] = Schema.optional(arr);
+    }
+    schemas.set(fullName, Schema.Struct(fields));
+  }
+
+  return {
+    get: (name) => {
+      const schema = schemas.get(name);
+      if (!schema) {
+        throw new Error(`effect-proto: unknown message type "${name}"`);
+      }
+      return schema;
+    },
+    list: () => Array.from(schemas.keys()),
+    getEnum: (name) => enums.get(name),
+    listEnums: () => Array.from(enums.keys()),
+  };
+};
+
+// --- Internals ----------------------------------------------------------
+
+/**
+ * Add empty stubs under `google.protobuf` so `resolveAll()` succeeds even
+ * when the source `extend`s or references well-known types we don't ship.
+ * The converter intercepts these by name before walking into the stub.
+ */
+const injectWellKnownStubs = (root: protobuf.Root): void => {
+  const ns = root.define(['google', 'protobuf']);
+  const stubs = ['Any', 'Struct', 'Value', 'ListValue', 'NullValue', 'FieldOptions', 'Empty', 'Timestamp', 'Duration'];
+  for (const name of stubs) {
+    if (!ns.get(name)) {
+      ns.add(new protobuf.Type(name));
+    }
+  }
+};
+
+/**
+ * Walk every Type and Enum under the root, skipping the google.protobuf stubs.
+ * Returns message types (for schema construction) and enum value maps (frozen
+ * `{ NAME: number }` records, exposed via `ProtoRegistry.getEnum`).
+ */
+const collectDeclarations = (
+  root: protobuf.Root,
+): {
+  messages: Map<string, protobuf.Type>;
+  enums: Map<string, Readonly<Record<string, number>>>;
+} => {
+  const messages = new Map<string, protobuf.Type>();
+  const enums = new Map<string, Readonly<Record<string, number>>>();
+  const visit = (obj: protobuf.ReflectionObject): void => {
+    const fq = stripLeadingDot(obj.fullName);
+    const isWellKnown = fq.startsWith('google.protobuf.');
+    if (obj instanceof protobuf.Type && !isWellKnown) {
+      messages.set(fq, obj);
+    } else if (obj instanceof protobuf.Enum && !isWellKnown) {
+      enums.set(fq, Object.freeze({ ...obj.values }));
+    }
+    if (obj instanceof protobuf.Namespace) {
+      for (const child of obj.nestedArray) {
+        visit(child);
+      }
+    }
+  };
+  visit(root);
+  return { messages, enums };
+};
+
+const stripLeadingDot = (name: string): string => (name.startsWith('.') ? name.slice(1) : name);
+
+/**
+ * Map one proto field's type to an Effect Schema, ignoring `repeated` and
+ * optionality (the caller wraps those). Recurses through `lazyRef` for
+ * message references so cyclic types work.
+ */
+const fieldToSchema = (field: protobuf.Field, lazyRef: (fq: string) => Schema.Schema<any>): Schema.Schema<any> => {
+  // Scalars don't have `resolvedType`; switch on the parser-level `type` string.
+  const scalar = SCALAR_SCHEMAS[field.type];
+  if (scalar) {
+    return scalar;
+  }
+
+  const resolved = field.resolvedType;
+  if (!resolved) {
+    throw new Error(`effect-proto: unresolved field "${field.fullName}" of type "${field.type}"`);
+  }
+
+  const fq = stripLeadingDot(resolved.fullName);
+  const wellKnown = WELL_KNOWN_SCHEMAS[fq];
+  if (wellKnown) {
+    return wellKnown;
+  }
+
+  if (resolved instanceof protobuf.Enum) {
+    return enumToSchema(resolved);
+  }
+
+  if (resolved instanceof protobuf.Type) {
+    return lazyRef(fq);
+  }
+
+  throw new Error(`effect-proto: unsupported resolved type for field "${field.fullName}"`);
+};
+
+/**
+ * proto enums are represented by their numeric tag value -- the wire format
+ * for proto -- so a value produced by the form editor round-trips through
+ * the binary codec without an intermediate name-to-number mapping. The enum's
+ * fully-qualified name is attached as an `identifier` annotation; consumers
+ * resolve the name<->value map via `ProtoRegistry.getEnum(fq)`.
+ */
+const enumToSchema = (e: protobuf.Enum): Schema.Schema<any> => {
+  // proto3 enums are guaranteed to have at least one value (the zero entry).
+  const values = Object.values(e.values) as [number, ...number[]];
+  return Schema.Literal(...values).annotations({
+    identifier: stripLeadingDot(e.fullName),
+  });
+};
+
+/**
+ * proto scalar -> Effect Schema. Long-valued integers (int64/uint64/fixed64/etc.)
+ * surface as base-10 strings because the codec is configured with
+ * `longs: String`. Bytes likewise become base64 strings (`bytes: String`).
+ */
+const SCALAR_SCHEMAS: Record<string, Schema.Schema<any>> = {
+  string: Schema.String,
+  bool: Schema.Boolean,
+  int32: Schema.Number,
+  uint32: Schema.Number,
+  sint32: Schema.Number,
+  fixed32: Schema.Number,
+  sfixed32: Schema.Number,
+  float: Schema.Number,
+  double: Schema.Number,
+  int64: Schema.String,
+  uint64: Schema.String,
+  sint64: Schema.String,
+  fixed64: Schema.String,
+  sfixed64: Schema.String,
+  bytes: Schema.String,
+};
+
+/**
+ * The Effect-side mappings for the small set of `google.protobuf` types
+ * config.proto uses. We don't model their internal structure — we model
+ * the runtime JSON shape that protobufjs decodes to.
+ */
+const WELL_KNOWN_SCHEMAS: Record<string, Schema.Schema<any>> = {
+  'google.protobuf.Any': Schema.Unknown,
+  'google.protobuf.Struct': Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  'google.protobuf.Value': Schema.Unknown,
+  'google.protobuf.ListValue': Schema.Array(Schema.Unknown),
+  'google.protobuf.NullValue': Schema.Null,
+  'google.protobuf.Empty': Schema.Struct({}),
+  'google.protobuf.Timestamp': Schema.String,
+  'google.protobuf.Duration': Schema.String,
+};

--- a/packages/common/effect-proto/tsconfig.json
+++ b/packages/common/effect-proto/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": [
+      "@dxos/typings",
+      "node"
+    ]
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../../core/protocols"
+    }
+  ]
+}

--- a/packages/common/effect-proto/vitest.config.ts
+++ b/packages/common/effect-proto/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/packages/core/protocols/package.json
+++ b/packages/core/protocols/package.json
@@ -25,6 +25,7 @@
       "browser": "./dist/src/proto/index.js",
       "import": "./dist/src/proto/index.js"
     },
+    "./proto/dxos/*.proto": "./src/proto/dxos/*.proto",
     "./proto/*": {
       "browser": "./dist/src/proto/gen/*.js",
       "import": "./dist/src/proto/gen/*.js"

--- a/packages/plugins/plugin-code/package.json
+++ b/packages/plugins/plugin-code/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dxos/plugin-code",
   "version": "0.1.0",
+  "private": true,
   "description": "Composer plugin for AI-assisted plugin development",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -129,6 +130,5 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
-  },
-  "private": true
+  }
 }

--- a/packages/plugins/plugin-crm/package.json
+++ b/packages/plugins/plugin-crm/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dxos/plugin-crm",
   "version": "0.8.3",
+  "private": true,
   "description": "CRM plugin for Composer. Provides a blueprint for researching people and organizations and producing structured Profile documents.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -102,6 +103,5 @@
     "@effect/vitest": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
-  },
-  "private": true
+  }
 }

--- a/packages/plugins/plugin-crx/package.json
+++ b/packages/plugins/plugin-crx/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dxos/plugin-crx",
   "version": "0.8.3",
+  "private": true,
   "description": "Composer plugin for coordinating with the composer-crx browser extension.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -91,6 +92,5 @@
   "peerDependencies": {
     "@dxos/react-ui": "workspace:*",
     "react": "catalog:"
-  },
-  "private": true
+  }
 }

--- a/packages/plugins/plugin-doctor/package.json
+++ b/packages/plugins/plugin-doctor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dxos/plugin-doctor",
   "version": "0.8.3",
+  "private": true,
   "description": "Self-introspection blueprint: query the browser tab's own logs.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -114,6 +115,5 @@
   "peerDependencies": {
     "react": "catalog:",
     "react-dom": "catalog:"
-  },
-  "private": true
+  }
 }

--- a/packages/plugins/plugin-feed/package.json
+++ b/packages/plugins/plugin-feed/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dxos/plugin-feed",
   "version": "0.8.3",
+  "private": true,
   "description": "Feed plugin for RSS and open protocol subscriptions.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -134,6 +135,5 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
-  },
-  "private": true
+  }
 }

--- a/packages/plugins/plugin-gallery/package.json
+++ b/packages/plugins/plugin-gallery/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dxos/plugin-gallery",
   "version": "0.8.3",
+  "private": true,
   "description": "Image gallery plugin",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -120,6 +121,5 @@
     "@dxos/ui-theme": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"
-  },
-  "private": true
+  }
 }

--- a/packages/plugins/plugin-generator/package.json
+++ b/packages/plugins/plugin-generator/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dxos/plugin-generator",
   "version": "0.8.3",
+  "private": true,
   "description": "AI media generation plugin for Composer.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -121,6 +122,5 @@
     "@dxos/ui-theme": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"
-  },
-  "private": true
+  }
 }

--- a/packages/plugins/plugin-sequencer/package.json
+++ b/packages/plugins/plugin-sequencer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dxos/plugin-sequencer",
   "version": "0.8.3",
+  "private": true,
   "description": "Music sequencer plugin (Score / Track / Sequence / Note) with a canvas-based step grid.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -118,6 +119,5 @@
     "@dxos/ui-theme": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"
-  },
-  "private": true
+  }
 }

--- a/packages/plugins/plugin-sidekick/package.json
+++ b/packages/plugins/plugin-sidekick/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dxos/plugin-sidekick",
   "version": "0.8.3",
+  "private": true,
   "description": "Personal companion agent plugin",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -108,6 +109,5 @@
     "@dxos/ui-theme": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"
-  },
-  "private": true
+  }
 }

--- a/packages/plugins/plugin-spacetime/package.json
+++ b/packages/plugins/plugin-spacetime/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dxos/plugin-spacetime",
   "version": "0.8.3",
+  "private": true,
   "description": "3D modeling plugin with Babylon.js and Manifold",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -115,6 +116,5 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
-  },
-  "private": true
+  }
 }

--- a/packages/plugins/plugin-support/package.json
+++ b/packages/plugins/plugin-support/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dxos/plugin-support",
   "version": "0.8.3",
+  "private": true,
   "description": "In-app support assistant plugin for Composer.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -150,6 +151,5 @@
     "@dxos/ui-theme": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"
-  },
-  "private": true
+  }
 }

--- a/packages/plugins/plugin-tictactoe/package.json
+++ b/packages/plugins/plugin-tictactoe/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dxos/plugin-tictactoe",
   "version": "0.8.3",
+  "private": true,
   "description": "Tic-Tac-Toe plugin for DXOS Composer.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -107,6 +108,5 @@
     "@dxos/ui-theme": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"
-  },
-  "private": true
+  }
 }

--- a/packages/ui/react-ui-form/package.json
+++ b/packages/ui/react-ui-form/package.json
@@ -62,6 +62,8 @@
     "tabster": "catalog:"
   },
   "devDependencies": {
+    "@dxos/effect-proto": "workspace:*",
+    "@dxos/protocols": "workspace:*",
     "@dxos/random": "workspace:*",
     "@dxos/react-client": "workspace:*",
     "@dxos/react-ui": "workspace:*",

--- a/packages/ui/react-ui-form/package.json
+++ b/packages/ui/react-ui-form/package.json
@@ -70,6 +70,7 @@
     "@dxos/react-ui-syntax-highlighter": "workspace:*",
     "@dxos/storybook-utils": "workspace:*",
     "@dxos/ui-theme": "workspace:*",
+    "@dxos/ui-types": "workspace:*",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "effect": "catalog:",

--- a/packages/ui/react-ui-form/src/components/Form/Form.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/Form.stories.tsx
@@ -74,11 +74,9 @@ export interface Person extends Schema.Schema.Type<typeof Person> {}
 
 type DefaultStoryProps<T extends AnyProperties> = {
   schema?: Schema.Schema<T>;
-  debug?: boolean;
 } & FormRootProps<T>;
 
 const DefaultStory = <T extends AnyProperties = AnyProperties>({
-  debug,
   schema,
   values: valuesProp,
   ...props
@@ -105,7 +103,6 @@ const DefaultStory = <T extends AnyProperties = AnyProperties>({
     <Tooltip.Provider>
       <TestLayout json={{ values, schema: schema?.ast }}>
         <Form.Root
-          debug={debug}
           schema={schema}
           defaultValues={values}
           db={space.db}

--- a/packages/ui/react-ui-form/src/components/Form/Form.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/Form.tsx
@@ -6,7 +6,14 @@ import { createContext } from '@radix-ui/react-context';
 import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 import * as SchemaAST from 'effect/SchemaAST';
-import React, { type PropsWithChildren, useEffect, useMemo, useRef } from 'react';
+import React, {
+  createContext as createReactContext,
+  type PropsWithChildren,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 
 import { Annotation as EchoAnnotation } from '@dxos/echo';
 import { type AnyProperties } from '@dxos/echo/internal';
@@ -169,11 +176,26 @@ const FormRoot = <T extends AnyProperties = AnyProperties>({
   const form = useFormHandler({ schema, values, onSave, onCancel, ...props });
 
   return (
-    <FormContextProvider form={form} {...props}>
-      {children}
-    </FormContextProvider>
+    <FormDebugContext.Provider value={props.debug ?? false}>
+      <FormContextProvider form={form} {...props}>
+        {children}
+      </FormContextProvider>
+    </FormDebugContext.Provider>
   );
 };
+
+/**
+ * A separate context for the `debug` flag so that read-only label decorations
+ * (notably the field's JSON path rendered by `FormFieldLabel`) can be enabled
+ * from any component down-tree without forcing a hard dependency on the full
+ * `Form` context (which `FormFieldWrapper` consumers may use outside of a
+ * `Form.Root`, e.g. in storybook stories). Defaults to `false` when there is
+ * no enclosing `Form.Root`.
+ */
+const FormDebugContext = createReactContext<boolean>(false);
+
+/** Returns `true` when the enclosing `Form.Root` was created with `debug`. */
+export const useFormDebug = (): boolean => useContext(FormDebugContext);
 
 FormRoot.displayName = 'Form.Root';
 

--- a/packages/ui/react-ui-form/src/components/Form/Form.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/Form.tsx
@@ -6,14 +6,7 @@ import { createContext } from '@radix-ui/react-context';
 import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 import * as SchemaAST from 'effect/SchemaAST';
-import React, {
-  createContext as createReactContext,
-  type PropsWithChildren,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { type PropsWithChildren, useEffect, useMemo, useRef } from 'react';
 
 import { Annotation as EchoAnnotation } from '@dxos/echo';
 import { type AnyProperties } from '@dxos/echo/internal';
@@ -42,6 +35,7 @@ import {
   FormFieldSet as NaturalFormFieldSet,
   type FormFieldSetProps as NaturalFormFieldSetProps,
 } from './FormFieldSet';
+import { FormTooltipsContext } from './FormTooltipsContext';
 
 // TODO(burdon): Move styles to form.ts (as with ui-theme).
 
@@ -185,19 +179,12 @@ const FormRoot = <T extends AnyProperties = AnyProperties>({
   );
 };
 
-/**
- * A separate context for the `tooltips` flag so that field-label decorations
- * (notably the JSON path rendered by `FormFieldLabel`) can be controlled
- * from any component down-tree without forcing a hard dependency on the full
- * `Form` context (which `FormFieldWrapper` consumers may use outside of a
- * `Form.Root`, e.g. in storybook stories). Defaults to `true` -- both when
- * `Form.Root` doesn't pass an explicit value AND when there is no enclosing
- * `Form.Root` at all.
- */
-const FormTooltipsContext = createReactContext<boolean>(true);
-
-/** Returns whether the enclosing `Form.Root` has field tooltips enabled. */
-export const useFormTooltips = (): boolean => useContext(FormTooltipsContext);
+// `FormTooltipsContext` / `useFormTooltips` live in their own module to
+// avoid a `Form.tsx <-> FormFieldComponent.tsx` circular import at
+// module-eval time (the latter consumes the hook; the former imports
+// `FormFieldLabel`). Re-export the hook here so the public surface is
+// unchanged.
+export { useFormTooltips } from './FormTooltipsContext';
 
 FormRoot.displayName = 'Form.Root';
 

--- a/packages/ui/react-ui-form/src/components/Form/Form.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/Form.tsx
@@ -77,9 +77,10 @@ type FormContextValue<T extends AnyProperties = any> = {
   form: FormHandler<T>;
 
   /**
-   * Show debug info.
+   * Show field tooltips (currently: JSON path on each label). Defaults to
+   * `true`; pass `false` to suppress.
    */
-  debug?: boolean;
+  tooltips?: boolean;
 
   /**
    * Testing.
@@ -176,26 +177,27 @@ const FormRoot = <T extends AnyProperties = AnyProperties>({
   const form = useFormHandler({ schema, values, onSave, onCancel, ...props });
 
   return (
-    <FormDebugContext.Provider value={props.debug ?? false}>
+    <FormTooltipsContext.Provider value={props.tooltips ?? true}>
       <FormContextProvider form={form} {...props}>
         {children}
       </FormContextProvider>
-    </FormDebugContext.Provider>
+    </FormTooltipsContext.Provider>
   );
 };
 
 /**
- * A separate context for the `debug` flag so that read-only label decorations
- * (notably the field's JSON path rendered by `FormFieldLabel`) can be enabled
+ * A separate context for the `tooltips` flag so that field-label decorations
+ * (notably the JSON path rendered by `FormFieldLabel`) can be controlled
  * from any component down-tree without forcing a hard dependency on the full
  * `Form` context (which `FormFieldWrapper` consumers may use outside of a
- * `Form.Root`, e.g. in storybook stories). Defaults to `false` when there is
- * no enclosing `Form.Root`.
+ * `Form.Root`, e.g. in storybook stories). Defaults to `true` -- both when
+ * `Form.Root` doesn't pass an explicit value AND when there is no enclosing
+ * `Form.Root` at all.
  */
-const FormDebugContext = createReactContext<boolean>(false);
+const FormTooltipsContext = createReactContext<boolean>(true);
 
-/** Returns `true` when the enclosing `Form.Root` was created with `debug`. */
-export const useFormDebug = (): boolean => useContext(FormDebugContext);
+/** Returns whether the enclosing `Form.Root` has field tooltips enabled. */
+export const useFormTooltips = (): boolean => useContext(FormTooltipsContext);
 
 FormRoot.displayName = 'Form.Root';
 

--- a/packages/ui/react-ui-form/src/components/Form/Form.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/Form.tsx
@@ -179,13 +179,6 @@ const FormRoot = <T extends AnyProperties = AnyProperties>({
   );
 };
 
-// `FormTooltipsContext` / `useFormTooltips` live in their own module to
-// avoid a `Form.tsx <-> FormFieldComponent.tsx` circular import at
-// module-eval time (the latter consumes the hook; the former imports
-// `FormFieldLabel`). Re-export the hook here so the public surface is
-// unchanged.
-export { useFormTooltips } from './FormTooltipsContext';
-
 FormRoot.displayName = 'Form.Root';
 
 //

--- a/packages/ui/react-ui-form/src/components/Form/FormField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormField.tsx
@@ -142,6 +142,18 @@ export const FormField = (props: FormFieldProps) => {
     ...fieldState,
   };
 
+  // Omit empty fields entirely in read-only mode -- an empty value has nothing
+  // to display, so a labelled row with a blank input is just noise. This
+  // mirrors what `FormFieldWrapper` already does for `layout === 'static'`, but
+  // covers every field type (including those that bypass the wrapper:
+  // RefField, SelectField, MarkdownField, ...). Container fields
+  // (`ArrayField`, nested-struct -> `FormFieldSet`) keep their own
+  // empty-value checks, but those branches only apply when the value is
+  // actually a non-null array/object, so this check doesn't interfere.
+  if (readonly && fieldState.getValue() == null) {
+    return null;
+  }
+
   //
   // Custom field.
   //

--- a/packages/ui/react-ui-form/src/components/Form/FormField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormField.tsx
@@ -54,9 +54,14 @@ export type FormFieldProps = {
   type: SchemaAST.AST;
 
   /**
-   * Name of the property.
+   * Name of the property. Used to derive a default label
+   * (`title ?? capitalize(name)`) and as the projection lookup key. Pass
+   * `null` to suppress the header label entirely -- the form still renders
+   * the field/struct, but `FormFieldSet`'s top-level `<FormFieldLabel>` is
+   * skipped. Used by `ArrayField` for object-array items, where every item
+   * would otherwise repeat the array's parent name.
    */
-  name: string;
+  name: string | null;
 
   /**
    * Path to the current object from the root. Used with nested forms.
@@ -124,7 +129,11 @@ export const FormField = (props: FormFieldProps) => {
   const description = getAnnotation<string>(SchemaAST.DescriptionAnnotationId)(type);
   const examples = getAnnotation<string[]>(SchemaAST.ExamplesAnnotationId)(type);
 
-  const label = useMemo(() => title ?? String.capitalize(name), [title, name]);
+  // `name === null` means "no header" -- collapse to an empty string so
+  // downstream consumers keep their `label: string` types, and the falsy
+  // value lets `FormFieldSet`'s `label && <FormFieldLabel ...>` guard skip
+  // the header.
+  const label = useMemo(() => title ?? (name == null ? '' : String.capitalize(name)), [title, name]);
   const placeholder = useMemo(
     () => (examples?.length ? `${t('example.placeholder')}: ${examples[0]}` : (description ?? label)),
     [examples, description, label],
@@ -166,7 +175,7 @@ export const FormField = (props: FormFieldProps) => {
   }
 
   // TODO(burdon): Expensive to create schema each time; pass AST?
-  const component = fieldProvider?.({ schema: Schema.make(type), prop: name, fieldProps });
+  const component = fieldProvider?.({ schema: Schema.make(type), prop: name ?? '', fieldProps });
   if (component) {
     return component;
   }

--- a/packages/ui/react-ui-form/src/components/Form/FormField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormField.tsx
@@ -131,11 +131,13 @@ export const FormField = (props: FormFieldProps) => {
   );
 
   const fieldState = useFormFieldState(FormField.displayName, path);
+  const jsonPath = createJsonPath(path ?? []);
   const fieldProps: FormFieldComponentProps = {
     type,
     format: Format.FormatAnnotation.getFromAst(type).pipe((annotation) => Option.getOrUndefined(annotation)),
     readonly,
     label,
+    jsonPath,
     placeholder,
     layout,
     db,
@@ -158,7 +160,6 @@ export const FormField = (props: FormFieldProps) => {
   // Custom field.
   //
 
-  const jsonPath = createJsonPath(path ?? []);
   const CustomField = fieldMap?.[jsonPath];
   if (CustomField) {
     return <CustomField {...fieldProps} />;

--- a/packages/ui/react-ui-form/src/components/Form/FormFieldComponent.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormFieldComponent.tsx
@@ -96,21 +96,25 @@ export type FormFieldLabelProps = {
 export const FormFieldLabel = ({ label, error, readonly, asChild, path }: FormFieldLabelProps) => {
   const debug = useFormDebug();
   const Label = readonly || asChild ? 'span' : Input.Label;
+  // In debug mode, surface the field's JSON path as a tooltip on the label
+  // (e.g. `runtime.client.storage.persistent`). Wrapping with
+  // `Tooltip.Trigger asChild` keeps the underlying `Input.Label` (or `span`)
+  // intact so form semantics and label-for-input linking are unchanged.
+  const labelNode = <Label className={inputTextLabel}>{label}</Label>;
   return (
-    <div className='flex items-center justify-between gap-2'>
-      <Label className={inputTextLabel}>{label}</Label>
-      <div className='flex items-center gap-2 min-w-0'>
-        {debug && path && (
-          <span className='font-mono text-xs text-description truncate' title={path}>
-            {path}
-          </span>
-        )}
-        {error && (
-          <Tooltip.Trigger asChild content={error} side='bottom'>
-            <Icon icon='ph--warning--regular' size={4} classNames='text-error-text' />
-          </Tooltip.Trigger>
-        )}
-      </div>
+    <div className='flex items-center justify-between'>
+      {debug && path ? (
+        <Tooltip.Trigger asChild content={path} side='bottom'>
+          {labelNode}
+        </Tooltip.Trigger>
+      ) : (
+        labelNode
+      )}
+      {error && (
+        <Tooltip.Trigger asChild content={error} side='bottom'>
+          <Icon icon='ph--warning--regular' size={4} classNames='text-error-text' />
+        </Tooltip.Trigger>
+      )}
     </div>
   );
 };

--- a/packages/ui/react-ui-form/src/components/Form/FormFieldComponent.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormFieldComponent.tsx
@@ -19,7 +19,7 @@ import { Icon, Input, Tooltip } from '@dxos/react-ui';
 import { inputTextLabel } from '@dxos/ui-theme';
 
 import { type FormFieldStatus } from '../../hooks';
-import { useFormDebug } from './Form';
+import { useFormTooltips } from './Form';
 
 /**
  * Dynamic props passed to input components.
@@ -85,25 +85,26 @@ export type FormFieldLabelProps = {
   error?: string;
   /**
    * JSON path of the field this label describes (e.g. `runtime.client.storage.persistent`).
-   * Rendered as a right-aligned monospace hint when the enclosing `Form.Root`
-   * has `debug` enabled -- useful for spotting which field maps to which path
-   * when authoring schemas or filing bugs against a form. Callers can supply
-   * the path unconditionally; the label suppresses it unless debug is on.
+   * Surfaced as a hover tooltip on the label when the enclosing `Form.Root`
+   * has `tooltips` enabled (the default) -- useful for spotting which field
+   * maps to which path when authoring schemas or filing bugs against a form.
+   * Callers can supply the path unconditionally; the label suppresses the
+   * tooltip when `Form.Root tooltips={false}`.
    */
   path?: string;
 } & Pick<FormFieldComponentProps, 'label' | 'readonly'>;
 
 export const FormFieldLabel = ({ label, error, readonly, asChild, path }: FormFieldLabelProps) => {
-  const debug = useFormDebug();
+  const tooltips = useFormTooltips();
   const Label = readonly || asChild ? 'span' : Input.Label;
-  // In debug mode, surface the field's JSON path as a tooltip on the label
-  // (e.g. `runtime.client.storage.persistent`). Wrapping with
-  // `Tooltip.Trigger asChild` keeps the underlying `Input.Label` (or `span`)
-  // intact so form semantics and label-for-input linking are unchanged.
+  // Surface the field's JSON path as a hover tooltip on the label (e.g.
+  // `runtime.client.storage.persistent`). Wrapping with `Tooltip.Trigger
+  // asChild` keeps the underlying `Input.Label` (or `span`) intact so form
+  // semantics and label-for-input linking are unchanged.
   const labelNode = <Label className={inputTextLabel}>{label}</Label>;
   return (
     <div className='flex items-center justify-between'>
-      {debug && path ? (
+      {tooltips && path ? (
         <Tooltip.Trigger asChild content={path} side='bottom'>
           {labelNode}
         </Tooltip.Trigger>

--- a/packages/ui/react-ui-form/src/components/Form/FormFieldComponent.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormFieldComponent.tsx
@@ -19,7 +19,7 @@ import { Icon, Input, Tooltip } from '@dxos/react-ui';
 import { inputTextLabel } from '@dxos/ui-theme';
 
 import { type FormFieldStatus } from '../../hooks';
-import { useFormTooltips } from './Form';
+import { useFormTooltips } from './FormTooltipsContext';
 
 /**
  * Dynamic props passed to input components.

--- a/packages/ui/react-ui-form/src/components/Form/FormFieldComponent.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormFieldComponent.tsx
@@ -19,6 +19,7 @@ import { Icon, Input, Tooltip } from '@dxos/react-ui';
 import { inputTextLabel } from '@dxos/ui-theme';
 
 import { type FormFieldStatus } from '../../hooks';
+import { useFormDebug } from './Form';
 
 /**
  * Dynamic props passed to input components.
@@ -48,6 +49,13 @@ export type FormFieldComponentProps<T = any> = {
   format?: Format.TypeFormat;
   readonly?: boolean;
   label: string;
+  /**
+   * Dotted JSON path of this field within the form values (e.g.
+   * `runtime.client.storage.persistent`). Forwarded to `FormFieldLabel` so
+   * that it can render the path as a debug hint when the enclosing
+   * `Form.Root` has `debug` enabled.
+   */
+  jsonPath?: string;
   placeholder?: string;
   autoFocus?: boolean;
   layout?: Presentation;
@@ -75,18 +83,34 @@ export type FormFieldProvider = (props: {
 export type FormFieldLabelProps = {
   asChild?: boolean;
   error?: string;
+  /**
+   * JSON path of the field this label describes (e.g. `runtime.client.storage.persistent`).
+   * Rendered as a right-aligned monospace hint when the enclosing `Form.Root`
+   * has `debug` enabled -- useful for spotting which field maps to which path
+   * when authoring schemas or filing bugs against a form. Callers can supply
+   * the path unconditionally; the label suppresses it unless debug is on.
+   */
+  path?: string;
 } & Pick<FormFieldComponentProps, 'label' | 'readonly'>;
 
-export const FormFieldLabel = ({ label, error, readonly, asChild }: FormFieldLabelProps) => {
+export const FormFieldLabel = ({ label, error, readonly, asChild, path }: FormFieldLabelProps) => {
+  const debug = useFormDebug();
   const Label = readonly || asChild ? 'span' : Input.Label;
   return (
-    <div className='flex items-center justify-between'>
+    <div className='flex items-center justify-between gap-2'>
       <Label className={inputTextLabel}>{label}</Label>
-      {error && (
-        <Tooltip.Trigger asChild content={error} side='bottom'>
-          <Icon icon='ph--warning--regular' size={4} classNames='text-error-text' />
-        </Tooltip.Trigger>
-      )}
+      <div className='flex items-center gap-2 min-w-0'>
+        {debug && path && (
+          <span className='font-mono text-xs text-description truncate' title={path}>
+            {path}
+          </span>
+        )}
+        {error && (
+          <Tooltip.Trigger asChild content={error} side='bottom'>
+            <Icon icon='ph--warning--regular' size={4} classNames='text-error-text' />
+          </Tooltip.Trigger>
+        )}
+      </div>
     </div>
   );
 };
@@ -99,13 +123,13 @@ FormFieldLabel.displayName = 'Form.FieldLabel';
 
 export type FormFieldWrapperProps<T = any> = Pick<
   FormFieldComponentProps,
-  'readonly' | 'label' | 'layout' | 'getStatus' | 'getValue'
+  'readonly' | 'label' | 'layout' | 'getStatus' | 'getValue' | 'jsonPath'
 > & {
   children?: (props: { value: T }) => ReactNode;
 };
 
 export const FormFieldWrapper = <T,>(props: FormFieldWrapperProps<T>) => {
-  const { children, readonly, layout, label, getStatus, getValue } = props;
+  const { children, readonly, layout, label, jsonPath, getStatus, getValue } = props;
   const { status, error } = getStatus();
 
   const value = getValue();
@@ -118,7 +142,7 @@ export const FormFieldWrapper = <T,>(props: FormFieldWrapperProps<T>) => {
   return (
     <div className='contents'>
       <Input.Root validationValence={status}>
-        {layout !== 'inline' && <FormFieldLabel error={error} readonly={readonly} label={label} />}
+        {layout !== 'inline' && <FormFieldLabel error={error} readonly={readonly} label={label} path={jsonPath} />}
         {layout === 'static' ? <p>{str}</p> : children ? children({ value }) : null}
         {layout === 'full' && (
           <Input.DescriptionAndValidation>

--- a/packages/ui/react-ui-form/src/components/Form/FormFieldSet.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormFieldSet.tsx
@@ -5,7 +5,7 @@
 import React, { useMemo } from 'react';
 
 import { type AnyProperties } from '@dxos/echo/internal';
-import { type SchemaProperty } from '@dxos/effect';
+import { createJsonPath, type SchemaProperty } from '@dxos/effect';
 
 import { type FormHandlerProps } from '../../hooks';
 import { getFormProperties } from '../../util';
@@ -62,7 +62,7 @@ export const FormFieldSet = ({
 
   return (
     <>
-      {layout !== 'inline' && label && <FormFieldLabel label={label} asChild />}
+      {layout !== 'inline' && label && <FormFieldLabel label={label} path={createJsonPath(path ?? [])} asChild />}
       {properties.map((property) => {
         const name = property.name.toString();
         return (

--- a/packages/ui/react-ui-form/src/components/Form/FormTooltipsContext.ts
+++ b/packages/ui/react-ui-form/src/components/Form/FormTooltipsContext.ts
@@ -1,0 +1,25 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { createContext, useContext } from 'react';
+
+/**
+ * A standalone context for the `tooltips` flag (Form.Root's only label
+ * decoration today: a JSON-path hover tooltip rendered by
+ * `FormFieldLabel`).
+ *
+ * Lives in its own module so that `FormFieldComponent.tsx` -- imported at
+ * the top of `Form.tsx` -- can read the flag without re-importing from
+ * `Form.tsx`. That round-trip used to create a circular module-eval
+ * dependency that intermittently hit a TDZ ("Cannot access 'FormFieldLabel'
+ * before initialization") in browser-mode storybook tests.
+ *
+ * Defaults to `true` both when `Form.Root` doesn't pass an explicit value
+ * AND when there is no enclosing `Form.Root` (e.g. `FormFieldWrapper`
+ * stories that render an input without a Form provider).
+ */
+export const FormTooltipsContext = createContext<boolean>(true);
+
+/** Returns whether the enclosing `Form.Root` has field tooltips enabled. */
+export const useFormTooltips = (): boolean => useContext(FormTooltipsContext);

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -62,7 +62,13 @@ export const ArrayField = ({
   const handleAdd = useCallback(() => {
     const defaultValue =
       isNestedType(type) && elementType ? getDefaultObjectValue(elementType) : getDefaultValue(elementType);
-    values && onValueChange(type, [...values, defaultValue]);
+    // `values` is `undefined` on first render for arrays whose parent path
+    // hasn't been materialised in the form values yet (e.g. `package.repos`
+    // when the form starts with no `package`). `useFormValues`'s default-
+    // value effect would eventually backfill it to `[]`, but until then the
+    // old `values && ...` guard silently swallowed the click. Treat a
+    // missing array as empty so Add always produces `[defaultValue]`.
+    onValueChange(type, [...(values ?? []), defaultValue]);
   }, [onValueChange, type, elementType, values]);
 
   const handleDelete = useCallback(
@@ -110,28 +116,27 @@ export const ArrayField = ({
         {values?.map((_, index) => {
           if (renderItemAsObject) {
             return (
-              <div
-                key={index}
-                className='grid grid-cols-[1fr_min-content] gap-form-gap items-center border border-subdued-separator p-1 mb-1'
-              >
-                <FormField
-                  {...props}
-                  autoFocus={index === values.length - 1}
-                  type={elementType}
-                  // Suppress the nested struct's header label: a row labelled
-                  // by the parent's field name (e.g. "Signaling") would
-                  // repeat for every item, and the item index is already
-                  // implicit from the stacking order. `name={null}` is the
-                  // documented FormField escape hatch -- `FormFieldSet`'s
-                  // `label && <FormFieldLabel ...>` guard then skips the
-                  // header entirely.
-                  name={null}
-                  path={[...(path ?? []), index]}
-                  readonly={readonly || layout === 'static'}
-                  layout={layout === 'static' ? 'static' : undefined}
-                />
+              <div key={index} className='grid grid-cols-[1fr_min-content] gap-form-gap items-center mb-1'>
+                <div className='p-1 border border-subdued-separator'>
+                  <FormField
+                    {...props}
+                    autoFocus={index === values.length - 1}
+                    type={elementType}
+                    // Suppress the nested struct's header label: a row labelled
+                    // by the parent's field name (e.g. "Signaling") would
+                    // repeat for every item, and the item index is already
+                    // implicit from the stacking order. `name={null}` is the
+                    // documented FormField escape hatch -- `FormFieldSet`'s
+                    // `label && <FormFieldLabel ...>` guard then skips the
+                    // header entirely.
+                    name={null}
+                    path={[...(path ?? []), index]}
+                    readonly={readonly || layout === 'static'}
+                    layout={layout === 'static' ? 'static' : undefined}
+                  />
+                </div>
                 {!readonly && layout !== 'static' && (
-                  <div className='flex items-center mt-1'>
+                  <div className='h-full flex flex-col justify-end'>
                     <IconButton
                       density='fine'
                       variant='ghost'

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -6,7 +6,14 @@ import * as Option from 'effect/Option';
 import * as SchemaAST from 'effect/SchemaAST';
 import React, { useCallback } from 'react';
 
-import { findNode, getArrayElementType, getDiscriminatedType, isDiscriminatedUnion, isNestedType } from '@dxos/effect';
+import {
+  createJsonPath,
+  findNode,
+  getArrayElementType,
+  getDiscriminatedType,
+  isDiscriminatedUnion,
+  isNestedType,
+} from '@dxos/effect';
 import { IconButton, useTranslation } from '@dxos/react-ui';
 
 import { translationKey } from '#translations';
@@ -82,7 +89,7 @@ export const ArrayField = ({
   return (
     <>
       {(layout !== 'static' || (values && values.length > 0)) && (
-        <FormFieldLabel readonly={readonly} label={label} asChild />
+        <FormFieldLabel readonly={readonly} label={label} path={createJsonPath(path ?? [])} asChild />
       )}
 
       <div className='flex flex-col'>
@@ -142,12 +149,9 @@ export const ArrayField = ({
 
       {/* TODO(burdon): Get label from schema. */}
       {!readonly && layout !== 'static' && (
-        <IconButton
-          classNames='flex w-full mt-form-gap'
-          icon='ph--plus--regular'
-          label={t('add-item.button')}
-          onClick={handleAdd}
-        />
+        <div className='mt-form-gap'>
+          <IconButton icon='ph--plus--regular' label={t('add-item.button')} onClick={handleAdd} />
+        </div>
       )}
     </>
   );

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -112,12 +112,16 @@ export const ArrayField = ({
             return (
               <div key={index} className='flex flex-col'>
                 <FormField
+                  {...props}
                   autoFocus={index === values.length - 1}
                   type={elementType}
+                  // Override the array's field name (e.g. `signaling`) with
+                  // the item's index so each item is labelled `[0]`, `[1]`,
+                  // ... instead of repeating the same key for every entry.
+                  name={`[${index}]`}
                   path={[...(path ?? []), index]}
                   readonly={readonly || layout === 'static'}
                   layout={layout === 'static' ? 'static' : undefined}
-                  {...props}
                 />
                 {!readonly && layout !== 'static' && (
                   <IconButton

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -94,7 +94,14 @@ export const ArrayField = ({
             <FormFieldLabel readonly={readonly} label={label} path={createJsonPath(path ?? [])} asChild />
           </div>
           {!readonly && layout !== 'static' && (
-            <IconButton iconOnly icon='ph--plus--regular' label={t('add-item.button')} onClick={handleAdd} />
+            <IconButton
+              iconOnly
+              density='fine'
+              variant='ghost'
+              icon='ph--plus--regular'
+              label={t('add-item.button')}
+              onClick={handleAdd}
+            />
           )}
         </div>
       )}

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -110,19 +110,10 @@ export const ArrayField = ({
         {values?.map((_, index) => {
           if (renderItemAsObject) {
             return (
-              <div key={index} className='flex flex-col border border-subdued-separator p-1 mb-1'>
-                {!readonly && layout !== 'static' && (
-                  <div className='flex items-center justify-end'>
-                    <IconButton
-                      iconOnly
-                      density='fine'
-                      variant='ghost'
-                      icon='ph--x--regular'
-                      label={t('remove-item.button')}
-                      onClick={() => handleDelete(index)}
-                    />
-                  </div>
-                )}
+              <div
+                key={index}
+                className='grid grid-cols-[1fr_min-content] gap-form-gap items-center border border-subdued-separator p-1 mb-1'
+              >
                 <FormField
                   {...props}
                   autoFocus={index === values.length - 1}
@@ -130,14 +121,27 @@ export const ArrayField = ({
                   // Suppress the nested struct's header label: a row labelled
                   // by the parent's field name (e.g. "Signaling") would
                   // repeat for every item, and the item index is already
-                  // implicit from the stacking order. `name=''` makes the
-                  // downstream label fall through to `String.capitalize('')`
-                  // -> '', which `FormFieldSet` treats as "no header".
-                  name=''
+                  // implicit from the stacking order. `name={null}` is the
+                  // documented FormField escape hatch -- `FormFieldSet`'s
+                  // `label && <FormFieldLabel ...>` guard then skips the
+                  // header entirely.
+                  name={null}
                   path={[...(path ?? []), index]}
                   readonly={readonly || layout === 'static'}
                   layout={layout === 'static' ? 'static' : undefined}
                 />
+                {!readonly && layout !== 'static' && (
+                  <div className='flex items-center mt-1'>
+                    <IconButton
+                      density='fine'
+                      variant='ghost'
+                      icon='ph--x--regular'
+                      iconOnly
+                      label={t('remove-item.button')}
+                      onClick={() => handleDelete(index)}
+                    />
+                  </div>
+                )}
               </div>
             );
           }

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -85,11 +85,11 @@ export const ArrayField = ({
         <FormFieldLabel readonly={readonly} label={label} asChild />
       )}
 
-      <div className='flex flex-col gap-form-gap'>
+      <div className='flex flex-col'>
         {values?.map((_, index) => {
           if (renderItemAsObject) {
             return (
-              <div key={index} className='flex flex-col gap-form-gap'>
+              <div key={index} className='flex flex-col'>
                 <FormField
                   autoFocus={index === values.length - 1}
                   type={elementType}
@@ -100,9 +100,9 @@ export const ArrayField = ({
                 />
                 {!readonly && layout !== 'static' && (
                   <IconButton
-                    classNames='flex w-full'
+                    classNames='flex w-full mt-form-gap'
                     icon='ph--x--regular'
-                    label={t('remove.button')}
+                    label={t('remove-item.button')}
                     onClick={() => handleDelete(index)}
                   />
                 )}
@@ -143,7 +143,7 @@ export const ArrayField = ({
       {/* TODO(burdon): Get label from schema. */}
       {!readonly && layout !== 'static' && (
         <IconButton
-          classNames='flex w-full'
+          classNames='flex w-full mt-form-gap'
           icon='ph--plus--regular'
           label={t('add-item.button')}
           onClick={handleAdd}

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -94,12 +94,7 @@ export const ArrayField = ({
             <FormFieldLabel readonly={readonly} label={label} path={createJsonPath(path ?? [])} asChild />
           </div>
           {!readonly && layout !== 'static' && (
-            <IconButton
-              iconOnly
-              icon='ph--plus--regular'
-              label={t('add-item.button')}
-              onClick={handleAdd}
-            />
+            <IconButton iconOnly icon='ph--plus--regular' label={t('add-item.button')} onClick={handleAdd} />
           )}
         </div>
       )}
@@ -158,7 +153,6 @@ export const ArrayField = ({
           );
         })}
       </div>
-
     </>
   );
 };

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -122,13 +122,6 @@ export const ArrayField = ({
                     {...props}
                     autoFocus={index === values.length - 1}
                     type={elementType}
-                    // Suppress the nested struct's header label: a row labelled
-                    // by the parent's field name (e.g. "Signaling") would
-                    // repeat for every item, and the item index is already
-                    // implicit from the stacking order. `name={null}` is the
-                    // documented FormField escape hatch -- `FormFieldSet`'s
-                    // `label && <FormFieldLabel ...>` guard then skips the
-                    // header entirely.
                     name={null}
                     path={[...(path ?? []), index]}
                     readonly={readonly || layout === 'static'}
@@ -136,7 +129,7 @@ export const ArrayField = ({
                   />
                 </div>
                 {!readonly && layout !== 'static' && (
-                  <div className='h-full flex flex-col justify-end'>
+                  <div className='h-full flex flex-col justify-end pb-1'>
                     <IconButton
                       density='fine'
                       variant='ghost'

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -110,27 +110,34 @@ export const ArrayField = ({
         {values?.map((_, index) => {
           if (renderItemAsObject) {
             return (
-              <div key={index} className='flex flex-col'>
+              <div key={index} className='flex flex-col border border-subdued-separator p-1 mb-1'>
+                {!readonly && layout !== 'static' && (
+                  <div className='flex items-center justify-end'>
+                    <IconButton
+                      iconOnly
+                      density='fine'
+                      variant='ghost'
+                      icon='ph--x--regular'
+                      label={t('remove-item.button')}
+                      onClick={() => handleDelete(index)}
+                    />
+                  </div>
+                )}
                 <FormField
                   {...props}
                   autoFocus={index === values.length - 1}
                   type={elementType}
-                  // Override the array's field name (e.g. `signaling`) with
-                  // the item's index so each item is labelled `[0]`, `[1]`,
-                  // ... instead of repeating the same key for every entry.
-                  name={`[${index}]`}
+                  // Suppress the nested struct's header label: a row labelled
+                  // by the parent's field name (e.g. "Signaling") would
+                  // repeat for every item, and the item index is already
+                  // implicit from the stacking order. `name=''` makes the
+                  // downstream label fall through to `String.capitalize('')`
+                  // -> '', which `FormFieldSet` treats as "no header".
+                  name=''
                   path={[...(path ?? []), index]}
                   readonly={readonly || layout === 'static'}
                   layout={layout === 'static' ? 'static' : undefined}
                 />
-                {!readonly && layout !== 'static' && (
-                  <IconButton
-                    classNames='flex w-full mt-form-gap'
-                    icon='ph--x--regular'
-                    label={t('remove-item.button')}
-                    onClick={() => handleDelete(index)}
-                  />
-                )}
               </div>
             );
           }

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -89,7 +89,19 @@ export const ArrayField = ({
   return (
     <>
       {(layout !== 'static' || (values && values.length > 0)) && (
-        <FormFieldLabel readonly={readonly} label={label} path={createJsonPath(path ?? [])} asChild />
+        <div className='flex items-center gap-2'>
+          <div className='flex-1 min-w-0'>
+            <FormFieldLabel readonly={readonly} label={label} path={createJsonPath(path ?? [])} asChild />
+          </div>
+          {!readonly && layout !== 'static' && (
+            <IconButton
+              iconOnly
+              icon='ph--plus--regular'
+              label={t('add-item.button')}
+              onClick={handleAdd}
+            />
+          )}
+        </div>
       )}
 
       <div className='flex flex-col'>
@@ -147,12 +159,6 @@ export const ArrayField = ({
         })}
       </div>
 
-      {/* TODO(burdon): Get label from schema. */}
-      {!readonly && layout !== 'static' && (
-        <div className='mt-form-gap'>
-          <IconButton icon='ph--plus--regular' label={t('add-item.button')} onClick={handleAdd} />
-        </div>
-      )}
     </>
   );
 };

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -72,6 +72,13 @@ export const ArrayField = ({
     return null;
   }
 
+  // An array of objects (e.g. `repeated Signal`) can't share the
+  // 2-column-with-delete row layout used for scalars: each object has
+  // multiple fields that need their own (label, input) rows, so we render
+  // each item as a recursively-laid-out FormField with the delete button on
+  // its own row below. Scalar arrays keep the compact inline layout.
+  const renderItemAsObject = elementType && isNestedType(elementType);
+
   return (
     <>
       {(layout !== 'static' || (values && values.length > 0)) && (
@@ -80,6 +87,29 @@ export const ArrayField = ({
 
       <div className='flex flex-col gap-form-gap'>
         {values?.map((_, index) => {
+          if (renderItemAsObject) {
+            return (
+              <div key={index} className='flex flex-col gap-form-gap'>
+                <FormField
+                  autoFocus={index === values.length - 1}
+                  type={elementType}
+                  path={[...(path ?? []), index]}
+                  readonly={readonly || layout === 'static'}
+                  layout={layout === 'static' ? 'static' : undefined}
+                  {...props}
+                />
+                {!readonly && layout !== 'static' && (
+                  <IconButton
+                    classNames='flex w-full'
+                    icon='ph--x--regular'
+                    label={t('remove.button')}
+                    onClick={() => handleDelete(index)}
+                  />
+                )}
+              </div>
+            );
+          }
+
           return (
             <div key={index} className='grid grid-cols-[1fr_min-content] gap-form-gap last:mb-form-gap items-center'>
               <FormField

--- a/packages/ui/react-ui-form/src/components/Form/fields/GeoPointField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/GeoPointField.tsx
@@ -15,6 +15,7 @@ import { type FormFieldComponentProps, FormFieldLabel } from '../FormFieldCompon
 export const GeoPointField = ({
   type,
   label,
+  jsonPath,
   readonly,
   layout,
   getStatus,
@@ -59,7 +60,9 @@ export const GeoPointField = ({
 
   return (
     <Input.Root validationValence={status}>
-      {layout !== 'inline' && <FormFieldLabel error={error} readonly={readonly} label={label} asChild />}
+      {layout !== 'inline' && (
+        <FormFieldLabel error={error} readonly={readonly} label={label} path={jsonPath} asChild />
+      )}
       {layout === 'static' ? (
         <LatLng {...value} />
       ) : (

--- a/packages/ui/react-ui-form/src/components/Form/fields/MarkdownField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/MarkdownField.tsx
@@ -31,6 +31,7 @@ export const MarkdownField = ({
   type,
   readonly,
   label,
+  jsonPath,
   placeholder,
   layout,
   db,
@@ -80,7 +81,7 @@ export const MarkdownField = ({
 
   return (
     <Input.Root validationValence={status}>
-      {layout !== 'inline' && <FormFieldLabel error={error} readonly={readonly} label={label} />}
+      {layout !== 'inline' && <FormFieldLabel error={error} readonly={readonly} label={label} path={jsonPath} />}
       {layout === 'static' ? renderStatic() : renderEditor()}
       {layout === 'full' && <Input.Validation>{error}</Input.Validation>}
     </Input.Root>

--- a/packages/ui/react-ui-form/src/components/Form/fields/RefField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/RefField.tsx
@@ -68,6 +68,7 @@ export const RefField = (props: RefFieldProps) => {
     type,
     readonly,
     label,
+    jsonPath,
     placeholder,
     layout,
     getStatus,
@@ -175,7 +176,7 @@ export const RefField = (props: RefFieldProps) => {
 
   return (
     <Input.Root validationValence={status}>
-      {layout !== 'inline' && <FormFieldLabel error={error} readonly={readonly} label={label} />}
+      {layout !== 'inline' && <FormFieldLabel error={error} readonly={readonly} label={label} path={jsonPath} />}
       <div>
         {readonly ? (
           !item ? (

--- a/packages/ui/react-ui-form/src/components/Form/fields/SelectField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/SelectField.tsx
@@ -16,6 +16,7 @@ export const SelectField = ({
   type,
   readonly,
   label,
+  jsonPath,
   layout,
   placeholder,
   options,
@@ -37,7 +38,7 @@ export const SelectField = ({
 
   return (
     <Input.Root validationValence={status}>
-      {layout !== 'inline' && <FormFieldLabel error={error} readonly={readonly} label={label} />}
+      {layout !== 'inline' && <FormFieldLabel error={error} readonly={readonly} label={label} path={jsonPath} />}
       {layout === 'static' ? (
         <p>{options?.find(({ value: optionValue }) => optionValue === value)?.label ?? String(value)}</p>
       ) : (

--- a/packages/ui/react-ui-form/src/components/Form/fields/SelectOptionField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/SelectOptionField.tsx
@@ -19,6 +19,7 @@ export const SelectOptionField = ({
   type,
   readonly,
   label,
+  jsonPath,
   getStatus,
   getValue,
   onValueChange,
@@ -119,7 +120,7 @@ export const SelectOptionField = ({
 
   return (
     <Input.Root validationValence={status}>
-      <FormFieldLabel error={error} readonly={readonly} label={label} />
+      <FormFieldLabel error={error} readonly={readonly} label={label} path={jsonPath} />
       <div>
         {options && (
           <List.Root

--- a/packages/ui/react-ui-form/src/components/Form/fields/TupleField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/TupleField.tsx
@@ -17,6 +17,7 @@ export const TupleField = ({
   type,
   readonly,
   label,
+  jsonPath,
   getStatus,
   getValue,
   onValueChange,
@@ -31,7 +32,7 @@ export const TupleField = ({
 
   return (
     <Input.Root validationValence={status}>
-      <FormFieldLabel error={error} readonly={readonly} label={label} />
+      <FormFieldLabel error={error} readonly={readonly} label={label} path={jsonPath} />
       <div className={mx('grid gap-form-gap', gridCols[binding.length - 1])}>
         {binding.map((prop) => (
           <Input.TextInput

--- a/packages/ui/react-ui-form/src/components/Form/index.ts
+++ b/packages/ui/react-ui-form/src/components/Form/index.ts
@@ -6,3 +6,4 @@ export * from './fields';
 
 export * from './Form';
 export * from './FormFieldComponent';
+export * from './FormTooltipsContext';

--- a/packages/ui/react-ui-form/src/components/ObjectTree/ObjectTree.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectTree/ObjectTree.stories.tsx
@@ -112,6 +112,7 @@ export const WithForm = () => (
     defaultValues={value as any}
     onSave={(next) => log.info('save', { next })}
     onCancel={() => log.info('cancel')}
+    debug
   >
     <Form.Viewport>
       <Form.Content>
@@ -123,7 +124,7 @@ export const WithForm = () => (
 );
 
 export const WithReadOnlyForm = () => (
-  <Form.Root schema={ConfigSchema as any} defaultValues={value as any} readonly={true}>
+  <Form.Root schema={ConfigSchema as any} defaultValues={value as any} readonly={true} debug>
     <Form.Viewport>
       <Form.Content>
         <Form.FieldSet />

--- a/packages/ui/react-ui-form/src/components/ObjectTree/ObjectTree.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectTree/ObjectTree.stories.tsx
@@ -112,7 +112,6 @@ export const WithForm = () => (
     defaultValues={value as any}
     onSave={(next) => log.info('save', { next })}
     onCancel={() => log.info('cancel')}
-    debug
   >
     <Form.Viewport>
       <Form.Content>
@@ -124,7 +123,7 @@ export const WithForm = () => (
 );
 
 export const WithReadOnlyForm = () => (
-  <Form.Root schema={ConfigSchema as any} defaultValues={value as any} readonly={true} debug>
+  <Form.Root schema={ConfigSchema as any} defaultValues={value as any} readonly={true}>
     <Form.Viewport>
       <Form.Content>
         <Form.FieldSet />

--- a/packages/ui/react-ui-form/src/components/ObjectTree/ObjectTree.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectTree/ObjectTree.stories.tsx
@@ -121,3 +121,14 @@ export const WithForm = () => (
     </Form.Viewport>
   </Form.Root>
 );
+
+export const WithReadOnlyForm = () => (
+  <Form.Root schema={ConfigSchema as any} defaultValues={value as any} readonly={true}>
+    <Form.Viewport>
+      <Form.Content>
+        <Form.FieldSet />
+        <Form.Actions />
+      </Form.Content>
+    </Form.Viewport>
+  </Form.Root>
+);

--- a/packages/ui/react-ui-form/src/components/ObjectTree/ObjectTree.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectTree/ObjectTree.stories.tsx
@@ -18,7 +18,7 @@ import { withLayout, withTheme } from '@dxos/react-ui/testing';
 import { translations } from '#translations';
 
 import { Form } from '../Form';
-import { ObjectViewer } from './ObjectViewer';
+import { ObjectTree } from './ObjectTree';
 
 const registry = parseProto(configProto);
 const ConfigSchema = registry.get('dxos.config.Config');
@@ -71,14 +71,14 @@ const value: ConfigProto = {
 };
 
 const meta = {
-  title: 'ui/react-ui-form/ObjectViewer',
-  component: ObjectViewer,
+  title: 'ui/react-ui-form/ObjectTree',
+  component: ObjectTree,
   decorators: [withTheme(), withLayout({ layout: 'column', scroll: true })],
   parameters: {
     layout: 'fullscreen',
     translations,
   },
-} satisfies Meta<typeof ObjectViewer>;
+} satisfies Meta<typeof ObjectTree>;
 
 export default meta;
 
@@ -104,7 +104,7 @@ export const JSON = () => (
 
 // Renders the same proto-derived `ConfigSchema` + `value` through the
 // interactive `Form` component, for side-by-side comparison with the
-// read-only ObjectViewer above. `db` is intentionally omitted -- the proto
+// read-only ObjectTree above. `db` is intentionally omitted -- the proto
 // schema is not an ECHO type, so there's no space/database in play.
 export const WithForm = () => (
   <Form.Root

--- a/packages/ui/react-ui-form/src/components/ObjectTree/ObjectTree.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectTree/ObjectTree.tsx
@@ -170,7 +170,8 @@ const formatLeaf = (value: unknown): ReactNode => {
 
   switch (typeof value) {
     case 'string':
-      return <span className='text-blue-text'>{value}</span>;
+      // Quote strings so empty strings remain visible (`""` rather than blank).
+      return <span className='text-blue-text'>{JSON.stringify(value)}</span>;
     case 'number':
     case 'bigint':
       return <span className='text-green-text'>{String(value)}</span>;

--- a/packages/ui/react-ui-form/src/components/ObjectTree/ObjectTree.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectTree/ObjectTree.tsx
@@ -18,7 +18,7 @@ import React, { type ReactElement, type ReactNode, type RefAttributes } from 're
 import { composable, composableProps, mx } from '@dxos/ui-theme';
 import { type ComposableProps } from '@dxos/ui-types';
 
-export type ObjectViewerProps<T> = {
+export type ObjectTreeProps<T> = {
   schema: Schema.Schema<T, any, never>;
   value: T;
 };
@@ -32,22 +32,20 @@ export type ObjectViewerProps<T> = {
  * `style` / `role`) onto its root `<div>` and forwards its ref, so it can
  * be slotted into themed parents like `Panel.Content`.
  */
-const ObjectViewerImpl = composable<HTMLDivElement, ObjectViewerProps<any>>(
-  ({ schema, value, ...props }, forwardedRef) => (
-    <div {...composableProps(props, { role: 'table', classNames: 'font-mono text-sm w-full' })} ref={forwardedRef}>
-      <Node ast={schema.ast} value={value} label={null} depth={0} />
-    </div>
-  ),
-);
+const ObjectTreeImpl = composable<HTMLDivElement, ObjectTreeProps<any>>(({ schema, value, ...props }, forwardedRef) => (
+  <div {...composableProps(props, { role: 'table', classNames: 'font-mono text-sm w-full' })} ref={forwardedRef}>
+    <Node ast={schema.ast} value={value} label={null} depth={0} />
+  </div>
+));
 
-ObjectViewerImpl.displayName = 'ObjectViewer';
+ObjectTreeImpl.displayName = 'ObjectTree';
 
-// `composable<HTMLDivElement, ObjectViewerProps<any>>` erases the `T` type
+// `composable<HTMLDivElement, ObjectTreeProps<any>>` erases the `T` type
 // parameter inside the factory; the cast restores the generic signature for
 // consumers without changing the underlying component (the COMPOSABLE marker
 // stays attached). This is the pattern documented on `composable()` itself.
-export const ObjectViewer = ObjectViewerImpl as unknown as <T>(
-  props: ComposableProps<ObjectViewerProps<T>> & RefAttributes<HTMLDivElement>,
+export const ObjectTree = ObjectTreeImpl as unknown as <T>(
+  props: ComposableProps<ObjectTreeProps<T>> & RefAttributes<HTMLDivElement>,
 ) => ReactElement | null;
 
 /**

--- a/packages/ui/react-ui-form/src/components/ObjectTree/index.ts
+++ b/packages/ui/react-ui-form/src/components/ObjectTree/index.ts
@@ -2,4 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-export * from './ObjectViewer';
+export * from './ObjectTree';

--- a/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.stories.tsx
@@ -1,0 +1,96 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import React from 'react';
+
+import { parseProto } from '@dxos/effect-proto';
+import { type Config as ConfigProto, Runtime } from '@dxos/protocols/proto/dxos/config';
+// Raw .proto source resolved through `@dxos/protocols`'s `./proto/dxos/*.proto`
+// exports entry. Vite's `?raw` query suffix returns the file as a string so we
+// can hand it straight to `parseProto` -- the same flow the unit test uses.
+import configProto from '@dxos/protocols/proto/dxos/config.proto?raw';
+import { Syntax } from '@dxos/react-ui-syntax-highlighter';
+import { withLayout, withTheme } from '@dxos/react-ui/testing';
+
+import { ObjectViewer } from './ObjectViewer';
+
+const registry = parseProto(configProto);
+const ConfigSchema = registry.get('dxos.config.Config');
+
+// A representative Config value that exercises nested messages, arrays, enums
+// (rendered as their string names by the proto codec), and `google.protobuf.Any`.
+const value: ConfigProto = {
+  version: 1,
+  runtime: {
+    client: {
+      log: { filter: 'info', prefix: 'app' },
+      storage: {
+        persistent: true,
+        sqliteMode: Runtime.Client.Storage.SqliteMode.OPFS,
+        dataRoot: '/var/lib/dxos',
+      },
+      edgeFeatures: {
+        echoReplicator: true,
+        subductionReplicator: true,
+        signaling: true,
+      },
+      servicesMode: Runtime.Client.ServicesMode.SHARED_WORKER,
+      enableSnapshots: false,
+      snapshotInterval: 60_000,
+    },
+    app: {
+      org: 'DXOS',
+      theme: 'dark',
+      website: 'https://dxos.org',
+      build: {
+        timestamp: '2026-05-22T12:00:00Z',
+        commitHash: 'abc1234',
+        version: '0.8.3',
+        branch: 'main',
+      },
+    },
+    services: {
+      edge: { url: 'wss://edge.dxos.org' },
+      signaling: [
+        { server: 'wss://signal-1.dxos.org', api: 'v1' },
+        { server: 'wss://signal-2.dxos.org', api: 'v1' },
+      ],
+      iceProviders: [{ urls: 'turn:turn.dxos.org' }],
+    },
+    keys: [
+      { name: 'OPENAI_API_KEY', value: 'sk-...' },
+      { name: 'ANTHROPIC_API_KEY', value: 'ant-...' },
+    ],
+  },
+};
+
+const meta = {
+  title: 'ui/react-ui-form/ObjectViewer',
+  component: ObjectViewer,
+  decorators: [withTheme(), withLayout({ layout: 'column', scroll: true })],
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof ObjectViewer>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    schema: ConfigSchema,
+    value: value,
+  },
+};
+
+export const JSON = () => (
+  <Syntax.Root data={value}>
+    <Syntax.Content>
+      <Syntax.Filter />
+      <Syntax.Viewport>
+        <Syntax.Code />
+      </Syntax.Viewport>
+    </Syntax.Content>
+  </Syntax.Root>
+);

--- a/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.stories.tsx
@@ -15,6 +15,8 @@ import configProto from '@dxos/protocols/proto/dxos/config.proto?raw';
 import { Syntax } from '@dxos/react-ui-syntax-highlighter';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 
+import { translations } from '#translations';
+
 import { Form } from '../Form';
 import { ObjectViewer } from './ObjectViewer';
 
@@ -72,7 +74,10 @@ const meta = {
   title: 'ui/react-ui-form/ObjectViewer',
   component: ObjectViewer,
   decorators: [withTheme(), withLayout({ layout: 'column', scroll: true })],
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    translations,
+  },
 } satisfies Meta<typeof ObjectViewer>;
 
 export default meta;

--- a/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.stories.tsx
@@ -6,6 +6,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
 import { parseProto } from '@dxos/effect-proto';
+import { log } from '@dxos/log';
 import { type Config as ConfigProto, Runtime } from '@dxos/protocols/proto/dxos/config';
 // Raw .proto source resolved through `@dxos/protocols`'s `./proto/dxos/*.proto`
 // exports entry. Vite's `?raw` query suffix returns the file as a string so we
@@ -14,6 +15,7 @@ import configProto from '@dxos/protocols/proto/dxos/config.proto?raw';
 import { Syntax } from '@dxos/react-ui-syntax-highlighter';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 
+import { Form } from '../Form';
 import { ObjectViewer } from './ObjectViewer';
 
 const registry = parseProto(configProto);
@@ -93,4 +95,24 @@ export const JSON = () => (
       </Syntax.Viewport>
     </Syntax.Content>
   </Syntax.Root>
+);
+
+// Renders the same proto-derived `ConfigSchema` + `value` through the
+// interactive `Form` component, for side-by-side comparison with the
+// read-only ObjectViewer above. `db` is intentionally omitted -- the proto
+// schema is not an ECHO type, so there's no space/database in play.
+export const WithForm = () => (
+  <Form.Root
+    schema={ConfigSchema as any}
+    defaultValues={value as any}
+    onSave={(next) => log.info('save', { next })}
+    onCancel={() => log.info('cancel')}
+  >
+    <Form.Viewport>
+      <Form.Content>
+        <Form.FieldSet />
+        <Form.Actions />
+      </Form.Content>
+    </Form.Viewport>
+  </Form.Root>
 );

--- a/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.tsx
@@ -39,6 +39,7 @@ const ObjectViewerImpl = composable<HTMLDivElement, ObjectViewerProps<any>>(
     </div>
   ),
 );
+
 ObjectViewerImpl.displayName = 'ObjectViewer';
 
 // `composable<HTMLDivElement, ObjectViewerProps<any>>` erases the `T` type

--- a/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.tsx
@@ -1,0 +1,175 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// A minimal, read-only schema-driven viewer. Walks an Effect Schema and a
+// matching value and produces a flat list of indented key/value rows -- one
+// per leaf field, with nested Struct fields contributing a header row plus
+// recursively-indented children, and arrays expanded as `[index]` rows.
+//
+// Designed to drive a hierarchical editor over schemas produced by
+// `@dxos/effect-proto` (e.g. the proto-generated `dxos.config.Config`
+// schema), but works for any Effect Struct schema.
+
+import * as Schema from 'effect/Schema';
+import * as SchemaAST from 'effect/SchemaAST';
+import React, { type ReactNode } from 'react';
+
+import { mx } from '@dxos/ui-theme';
+
+export type ObjectViewerProps<T> = {
+  schema: Schema.Schema<T, any, never>;
+  value: T;
+};
+
+/**
+ * Render a value as a sequence of key/value rows whose shape and order are
+ * driven by `schema`. Object-typed properties become a header row whose
+ * children are indented under it; arrays expand element-by-element.
+ */
+export const ObjectViewer = <T,>({ schema, value }: ObjectViewerProps<T>) => {
+  return (
+    <div role='table' className={mx('font-mono text-sm w-full')}>
+      <Node ast={schema.ast} value={value} label={null} depth={0} />
+    </div>
+  );
+};
+
+/**
+ * Peel wrappers that don't affect the runtime shape: Refinements pass their
+ * `from`, Suspends resolve via `f()`, and Transformations expose the encoded
+ * (input) side. Repeated unwrapping handles chains like `Schema.suspend ->
+ * Refinement -> TypeLiteral`.
+ */
+const unwrap = (ast: SchemaAST.AST): SchemaAST.AST => {
+  if (SchemaAST.isRefinement(ast)) {
+    return unwrap(ast.from);
+  }
+  if (SchemaAST.isSuspend(ast)) {
+    return unwrap(ast.f());
+  }
+  if (SchemaAST.isTransformation(ast)) {
+    return unwrap(ast.from);
+  }
+  return ast;
+};
+
+/**
+ * Effect models `Schema.optional(X)` as a property whose type AST is
+ * `Union(X, UndefinedKeyword)`. For walking purposes we want X -- the
+ * undefined branch carries no schema information for the viewer.
+ */
+const stripOptional = (ast: SchemaAST.AST): SchemaAST.AST => {
+  if (!SchemaAST.isUnion(ast)) {
+    return ast;
+  }
+  const nonUndef = ast.types.filter((t) => !SchemaAST.isUndefinedKeyword(t));
+  return nonUndef.length === 1 ? nonUndef[0] : ast;
+};
+
+type NodeProps = {
+  ast: SchemaAST.AST;
+  value: unknown;
+  /** Row label; `null` means render children directly without a header row. */
+  label: ReactNode | null;
+  depth: number;
+};
+
+const Node = ({ ast, value, label, depth }: NodeProps) => {
+  const inner = unwrap(stripOptional(ast));
+
+  // Struct: header row + indented children. Skipping the header at depth 0
+  // keeps the root flush-left.
+  if (SchemaAST.isTypeLiteral(inner) && isPlainObject(value)) {
+    const childDepth = label === null ? depth : depth + 1;
+    return (
+      <>
+        {label !== null && <Row label={label} value={null} depth={depth} kind='group' />}
+        {inner.propertySignatures.map((prop) => (
+          <Node
+            key={String(prop.name)}
+            ast={prop.type}
+            value={(value as Record<string, unknown>)[String(prop.name)]}
+            label={String(prop.name)}
+            depth={childDepth}
+          />
+        ))}
+      </>
+    );
+  }
+
+  // Array (`Schema.Array(X)` -> TupleType with single rest element).
+  if (SchemaAST.isTupleType(inner) && Array.isArray(value)) {
+    const elemType = inner.rest[0]?.type;
+    return (
+      <>
+        {label !== null && <Row label={label} value={`Array(${value.length})`} depth={depth} kind='group' />}
+        {value.map((item, index) => (
+          <Node
+            key={index}
+            ast={elemType ?? SchemaAST.unknownKeyword}
+            value={item}
+            label={`[${index}]`}
+            depth={depth + 1}
+          />
+        ))}
+      </>
+    );
+  }
+
+  // Leaf (scalars, unions of literals, unknown, etc.).
+  return <Row label={label ?? ''} value={formatLeaf(value)} depth={depth} kind='leaf' />;
+};
+
+type RowProps = {
+  label: ReactNode;
+  value: ReactNode;
+  depth: number;
+  kind: 'group' | 'leaf';
+};
+
+const Row = ({ label, value, depth }: RowProps) => (
+  <div role='row' className={mx('flex items-baseline gap-3 py-1')} style={{ paddingInlineStart: 8 + depth * 16 }}>
+    <div role='cell' className='text-subdued'>
+      {label}
+    </div>
+    <div role='cell' className={mx('break-all text-base-foreground')}>
+      {value}
+    </div>
+  </div>
+);
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Format a leaf value for display. Strings are quoted so empty strings are
+ * visible; missing values surface as an em-dash so the row stays present.
+ */
+const formatLeaf = (value: unknown): ReactNode => {
+  if (value === undefined) {
+    return null;
+  }
+
+  if (value === null) {
+    return <span className='text-description'>null</span>;
+  }
+
+  switch (typeof value) {
+    case 'string':
+      return <span className='text-blue-text'>{value}</span>;
+    case 'number':
+    case 'bigint':
+      return <span className='text-green-text'>{String(value)}</span>;
+    case 'boolean':
+      return <span className='text-purple-text'>{String(value)}</span>;
+    default:
+      // Objects we couldn't expand via schema (e.g. `google.protobuf.Any` -> Unknown)
+      // are rendered as compact JSON.
+      try {
+        return JSON.stringify(value);
+      } catch {
+        return String(value);
+      }
+  }
+};

--- a/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.tsx
@@ -34,10 +34,7 @@ export type ObjectViewerProps<T> = {
  */
 const ObjectViewerImpl = composable<HTMLDivElement, ObjectViewerProps<any>>(
   ({ schema, value, ...props }, forwardedRef) => (
-    <div
-      {...composableProps(props, { role: 'table', classNames: 'font-mono text-sm w-full' })}
-      ref={forwardedRef}
-    >
+    <div {...composableProps(props, { role: 'table', classNames: 'font-mono text-sm w-full' })} ref={forwardedRef}>
       <Node ast={schema.ast} value={value} label={null} depth={0} />
     </div>
   ),

--- a/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectViewer/ObjectViewer.tsx
@@ -13,9 +13,10 @@
 
 import * as Schema from 'effect/Schema';
 import * as SchemaAST from 'effect/SchemaAST';
-import React, { type ReactNode } from 'react';
+import React, { type ReactElement, type ReactNode, type RefAttributes } from 'react';
 
-import { mx } from '@dxos/ui-theme';
+import { composable, composableProps, mx } from '@dxos/ui-theme';
+import { type ComposableProps } from '@dxos/ui-types';
 
 export type ObjectViewerProps<T> = {
   schema: Schema.Schema<T, any, never>;
@@ -26,14 +27,30 @@ export type ObjectViewerProps<T> = {
  * Render a value as a sequence of key/value rows whose shape and order are
  * driven by `schema`. Object-typed properties become a header row whose
  * children are indented under it; arrays expand element-by-element.
+ *
+ * Composable: spreads unknown props (incl. `className` / `classNames` /
+ * `style` / `role`) onto its root `<div>` and forwards its ref, so it can
+ * be slotted into themed parents like `Panel.Content`.
  */
-export const ObjectViewer = <T,>({ schema, value }: ObjectViewerProps<T>) => {
-  return (
-    <div role='table' className={mx('font-mono text-sm w-full')}>
+const ObjectViewerImpl = composable<HTMLDivElement, ObjectViewerProps<any>>(
+  ({ schema, value, ...props }, forwardedRef) => (
+    <div
+      {...composableProps(props, { role: 'table', classNames: 'font-mono text-sm w-full' })}
+      ref={forwardedRef}
+    >
       <Node ast={schema.ast} value={value} label={null} depth={0} />
     </div>
-  );
-};
+  ),
+);
+ObjectViewerImpl.displayName = 'ObjectViewer';
+
+// `composable<HTMLDivElement, ObjectViewerProps<any>>` erases the `T` type
+// parameter inside the factory; the cast restores the generic signature for
+// consumers without changing the underlying component (the COMPOSABLE marker
+// stays attached). This is the pattern documented on `composable()` itself.
+export const ObjectViewer = ObjectViewerImpl as unknown as <T>(
+  props: ComposableProps<ObjectViewerProps<T>> & RefAttributes<HTMLDivElement>,
+) => ReactElement | null;
 
 /**
  * Peel wrappers that don't affect the runtime shape: Refinements pass their

--- a/packages/ui/react-ui-form/src/components/ObjectViewer/index.ts
+++ b/packages/ui/react-ui-form/src/components/ObjectViewer/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './ObjectViewer';

--- a/packages/ui/react-ui-form/src/components/index.ts
+++ b/packages/ui/react-ui-form/src/components/index.ts
@@ -7,6 +7,6 @@ export * from './Form';
 export * from './ObjectForm';
 export * from './ObjectPicker';
 export * from './ObjectProperties';
-export * from './ObjectViewer';
+export * from './ObjectTree';
 export * from './Settings';
 export * from './ViewEditor';

--- a/packages/ui/react-ui-form/src/components/index.ts
+++ b/packages/ui/react-ui-form/src/components/index.ts
@@ -7,5 +7,6 @@ export * from './Form';
 export * from './ObjectForm';
 export * from './ObjectPicker';
 export * from './ObjectProperties';
+export * from './ObjectViewer';
 export * from './Settings';
 export * from './ViewEditor';

--- a/packages/ui/react-ui-form/src/translations.ts
+++ b/packages/ui/react-ui-form/src/translations.ts
@@ -19,6 +19,7 @@ export const translations = [
         'field-format.label': 'Type',
         'field-path.label': 'Field path',
 
+        'remove-item.button': 'Delete item',
         'add-item.button': 'Add item',
         'add-property-button.label': 'Add property',
         'boolean-input-true.value': 'Yes',
@@ -85,7 +86,7 @@ export const translations = [
         // System schema message.
         'system-schema.title': 'System type',
         'system-schema.description': 'System type: cannot add or remove fields.',
-        'remove.button': 'Remove',
+        'remove.button': 'Delete',
       },
     },
   },

--- a/packages/ui/react-ui-form/src/vite-env.d.ts
+++ b/packages/ui/react-ui-form/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+//
+// Copyright 2026 DXOS.org
+//
+
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}

--- a/packages/ui/react-ui-form/tsconfig.json
+++ b/packages/ui/react-ui-form/tsconfig.json
@@ -91,6 +91,9 @@
     },
     {
       "path": "../ui-theme"
+    },
+    {
+      "path": "../ui-types"
     }
   ]
 }

--- a/packages/ui/react-ui-form/tsconfig.json
+++ b/packages/ui/react-ui-form/tsconfig.json
@@ -18,6 +18,9 @@
       "path": "../../common/effect"
     },
     {
+      "path": "../../common/effect-proto"
+    },
+    {
       "path": "../../common/invariant"
     },
     {
@@ -46,6 +49,9 @@
     },
     {
       "path": "../../core/echo/echo-react"
+    },
+    {
+      "path": "../../core/protocols"
     },
     {
       "path": "../../sdk/react-client"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2333,7 +2333,7 @@ importers:
         version: 6.1.1(typescript@6.0.3)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       wait-on:
         specifier: 'catalog:'
         version: 8.0.3
@@ -3832,6 +3832,28 @@ importers:
         specifier: 'catalog:'
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
+  packages/common/effect-proto:
+    dependencies:
+      effect:
+        specifier: 3.20.0
+        version: 3.20.0
+      protobufjs:
+        specifier: 'catalog:'
+        version: 8.0.0
+    devDependencies:
+      '@dxos/protocols':
+        specifier: workspace:*
+        version: link:../../core/protocols
+      '@types/node':
+        specifier: 22.10.2
+        version: 22.10.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/common/effect-zod:
     dependencies:
       effect:
@@ -3849,7 +3871,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/common/errors: {}
 
@@ -3857,7 +3879,7 @@ importers:
     dependencies:
       debug:
         specifier: 'catalog:'
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       domain-browser:
         specifier: 'catalog:'
         version: 4.22.0
@@ -4549,7 +4571,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/common/web-context-solid:
     dependencies:
@@ -4626,7 +4648,7 @@ importers:
         version: 0.29.0(effect@3.20.0)(vitest@4.1.6)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core/compute/ai:
     dependencies:
@@ -4990,7 +5012,7 @@ importers:
         version: 3.20.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core/compute/compute-hyperformula:
     dependencies:
@@ -5467,7 +5489,7 @@ importers:
         version: 0.33.2(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -5504,7 +5526,7 @@ importers:
         version: 3.20.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core/echo/echo:
     dependencies:
@@ -5938,7 +5960,7 @@ importers:
         version: 1.7.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3)
+        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -6043,7 +6065,7 @@ importers:
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core/echo/feed:
     dependencies:
@@ -6990,7 +7012,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/devtools/cli-util:
     dependencies:
@@ -7045,7 +7067,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/devtools/devtools:
     dependencies:
@@ -7572,7 +7594,7 @@ importers:
         version: 5.0.0(chart.js@4.5.0)
       debug:
         specifier: 'catalog:'
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -9234,7 +9256,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/plugins/plugin-crx:
     dependencies:
@@ -9289,7 +9311,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/plugins/plugin-debug:
     dependencies:
@@ -16305,7 +16327,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/reflect/introspect:
     dependencies:
@@ -16348,7 +16370,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/reflect/introspect-mcp:
     dependencies:
@@ -16369,7 +16391,7 @@ importers:
         version: link:../../common/util
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -16388,7 +16410,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/reflect/introspect-tools:
     dependencies:
@@ -16413,7 +16435,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/sdk/app-framework:
     dependencies:
@@ -17323,7 +17345,7 @@ importers:
         version: 1.41.1
       debug:
         specifier: 'catalog:'
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       js-yaml:
         specifier: 'catalog:'
         version: 4.1.1
@@ -19819,6 +19841,12 @@ importers:
         specifier: 'catalog:'
         version: 8.5.5
     devDependencies:
+      '@dxos/effect-proto':
+        specifier: workspace:*
+        version: link:../../common/effect-proto
+      '@dxos/protocols':
+        specifier: workspace:*
+        version: link:../../core/protocols
       '@dxos/random':
         specifier: workspace:*
         version: link:../../common/random
@@ -20234,7 +20262,7 @@ importers:
         version: link:../ui-theme
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -20581,7 +20609,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/ui/react-ui-menu:
     dependencies:
@@ -22262,7 +22290,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   tools/vite-plugin-log/example:
     devDependencies:
@@ -25184,7 +25212,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -40688,7 +40715,6 @@ packages:
       '@vitest/ui': 4.1.6
       happy-dom: '*'
       jsdom: '*'
-      vite: '>=8.0.0'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -41654,7 +41680,7 @@ snapshots:
       '@atlaskit/ds-lib': 5.3.0(@types/react@19.2.14)(react@19.2.6)
       '@atlaskit/platform-feature-flags': 1.1.2(react@19.2.6)
       '@babel/runtime': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.29.0
       bind-event-listener: 3.0.0
       react: 19.2.6
@@ -41744,7 +41770,7 @@ snapshots:
     dependencies:
       '@automerge/automerge-repo': 2.6.0-subduction.20(patch_hash=0c21d251fbbc2e2c0525cd4dee59cb62182405dcd8316a6d874d0426be598091)
       cbor-x: 1.5.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eventemitter3: 5.0.1
       isomorphic-ws: 5.0.0(ws@8.18.3)
       ws: 8.18.3
@@ -41767,7 +41793,7 @@ snapshots:
       '@automerge/automerge-subduction': 0.12.1(patch_hash=40f00ac48fb23a936a9a4ac6d90bf93cb36fc906cac4aec5af32e03134e17da9)
       bs58check: 3.0.1
       cbor-x: 1.5.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eventemitter3: 5.0.1
       fast-sha256: 1.3.0
       isomorphic-ws: 5.0.0(ws@8.18.3)
@@ -42369,10 +42395,10 @@ snapshots:
       '@babel/helpers': 7.27.6
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.28.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -42393,7 +42419,7 @@ snapshots:
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -42414,7 +42440,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -42431,7 +42457,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -42442,7 +42468,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -42465,7 +42491,7 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -42473,13 +42499,6 @@ snapshots:
   '@babel/helper-module-imports@7.18.6':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@babel/helper-module-imports@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-module-imports@7.27.1(supports-color@5.5.0)':
     dependencies:
@@ -42491,9 +42510,9 @@ snapshots:
   '@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -42517,13 +42536,13 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -42542,7 +42561,7 @@ snapshots:
     dependencies:
       '@babel/helper-function-name': 7.24.7
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -42703,7 +42722,7 @@ snapshots:
   '@babel/plugin-transform-async-to-generator@7.24.7(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.24.7(@babel/core@7.28.0)
     transitivePeerDependencies:
@@ -43136,18 +43155,6 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
 
-  '@babel/traverse@7.28.5':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/traverse@7.28.5(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -43310,7 +43317,7 @@ snapshots:
       cjs-module-lexer: 1.3.1
       esbuild: 0.28.0
       miniflare: 4.20260421.0
-      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       wrangler: 4.68.1(@cloudflare/workers-types@4.20260303.0)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -43636,7 +43643,7 @@ snapshots:
       '@webcomponents/custom-elements': 1.5.1
       acorn-walk: 8.3.2
       convert-source-map: 1.9.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 0.10.5
       fast-glob: 3.3.3
       fs-extra: 10.1.0
@@ -43981,7 +43988,7 @@ snapshots:
   '@effect/vitest@0.29.0(effect@3.20.0)(vitest@4.1.6)':
     dependencies:
       effect: 3.20.0
-      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@effect/wa-sqlite@0.1.2': {}
 
@@ -44142,7 +44149,7 @@ snapshots:
   '@eslint/config-array@0.23.3':
     dependencies:
       '@eslint/object-schema': 3.0.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
@@ -45032,7 +45039,7 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.2)
       ajv: 8.18.0
@@ -48318,7 +48325,7 @@ snapshots:
   '@rollup/plugin-babel@5.3.1(@babel/core@7.28.0)(@types/babel__core@7.20.5)(rollup@2.79.2)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@rollup/pluginutils': 3.1.0(rollup@2.79.2)
       rollup: 2.79.2
     optionalDependencies:
@@ -48426,7 +48433,7 @@ snapshots:
       '@secretlint/resolver': 10.2.2
       '@secretlint/types': 10.2.2
       ajv: 8.18.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       rc-config-loader: 4.1.3
     transitivePeerDependencies:
       - supports-color
@@ -48435,7 +48442,7 @@ snapshots:
     dependencies:
       '@secretlint/profiler': 10.2.2
       '@secretlint/types': 10.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       structured-source: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -48448,7 +48455,7 @@ snapshots:
       '@textlint/module-interop': 15.5.0
       '@textlint/types': 15.5.0
       chalk: 5.6.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       pluralize: 8.0.0
       strip-ansi: 7.1.2
       table: 6.9.0
@@ -48464,7 +48471,7 @@ snapshots:
       '@secretlint/profiler': 10.2.2
       '@secretlint/source-creator': 10.2.2
       '@secretlint/types': 10.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       p-map: 7.0.4
     transitivePeerDependencies:
       - supports-color
@@ -49022,7 +49029,7 @@ snapshots:
       '@vitest/browser': 4.1.6(patch_hash=bffeabf05015223232c127ac26d0b8c732ad3c7cad57395e48f7633d4856b607)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.6)
       '@vitest/browser-playwright': 4.1.6(playwright@1.57.0)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.6)
       '@vitest/runner': 4.1.6
-      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -49538,7 +49545,7 @@ snapshots:
       '@textlint/resolver': 15.5.0
       '@textlint/types': 15.5.0
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       js-yaml: 4.1.1
       lodash: 4.17.23
       pluralize: 2.0.0
@@ -50268,7 +50275,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.39.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -50287,7 +50294,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.39.0
       '@typescript-eslint/visitor-keys': 8.39.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 10.2.5
@@ -50335,7 +50342,7 @@ snapshots:
 
   '@typescript/vfs@1.6.2(typescript@6.0.3)':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -50476,7 +50483,7 @@ snapshots:
       '@vitest/mocker': 4.1.6(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -50492,7 +50499,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -50512,7 +50519,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       '@vitest/browser': 4.1.6(patch_hash=bffeabf05015223232c127ac26d0b8c732ad3c7cad57395e48f7633d4856b607)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.6)
 
@@ -50576,7 +50583,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -51490,7 +51497,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -51500,7 +51507,7 @@ snapshots:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@cloudflare/ai-chat': 0.0.6(agents@0.3.10)(ai@6.0.97(zod@4.3.6))(react@19.2.6)(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
       ai: 6.0.97(zod@4.3.6)
       cron-schedule: 6.0.0
       escape-html: 1.0.3
@@ -52192,7 +52199,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.0
       on-finished: 2.4.1
@@ -52445,7 +52452,7 @@ snapshots:
 
   capnp-ts@0.7.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -53636,12 +53643,12 @@ snapshots:
   depcheck@1.4.7:
     dependencies:
       '@babel/parser': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@vue/compiler-sfc': 3.5.13
       callsite: 1.0.0
       camelcase: 6.3.0
       cosmiconfig: 7.1.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       deps-regex: 0.2.0
       findup-sync: 5.0.0
       ignore: 5.2.4
@@ -53890,6 +53897,10 @@ snapshots:
   draco3d@1.5.7: {}
 
   dset@3.1.4: {}
+
+  dts-resolver@2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
+    optionalDependencies:
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   dts-resolver@2.1.3(oxc-resolver@11.9.0):
     optionalDependencies:
@@ -54226,7 +54237,7 @@ snapshots:
       '@package-json/types': 0.0.12
       '@typescript-eslint/types': 8.57.1
       comment-parser: 1.4.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.0.3(jiti@2.6.1)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
@@ -54273,7 +54284,7 @@ snapshots:
       '@types/estree': 1.0.8
       ajv: 6.14.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -54483,7 +54494,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 1.1.1
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -54560,7 +54571,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -54775,7 +54786,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -54800,7 +54811,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 5.1.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -55137,7 +55148,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.4
       data-uri-to-buffer: 6.0.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -55796,7 +55807,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -55808,14 +55819,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -55841,7 +55852,7 @@ snapshots:
   hypercore-protocol@8.0.7:
     dependencies:
       abstract-extension: 3.1.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       hypercore-crypto: 2.3.2
       inspect-custom-symbol: 1.1.1
       nanoguard: 1.3.0
@@ -56057,7 +56068,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -56457,7 +56468,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -57244,7 +57255,7 @@ snapshots:
       chalk: 4.1.2
       commander: 7.2.0
       commondir: 1.0.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       dependency-tree: 11.1.1
       ora: 5.4.1
       pluralize: 8.0.0
@@ -58060,7 +58071,7 @@ snapshots:
   micromark@3.1.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.0.6
       micromark-factory-space: 1.0.0
@@ -58082,7 +58093,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -59016,7 +59027,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       get-uri: 6.0.2
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -59598,7 +59609,7 @@ snapshots:
   proxy-agent@6.3.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -59611,7 +59622,7 @@ snapshots:
   proxy-agent@6.3.1:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -59801,7 +59812,7 @@ snapshots:
 
   rc-config-loader@4.1.3:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       js-yaml: 4.1.1
       json5: 2.2.3
       require-from-string: 2.0.2
@@ -59861,7 +59872,7 @@ snapshots:
   react-docgen@8.0.2:
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
@@ -60509,7 +60520,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.3
     transitivePeerDependencies:
       - supports-color
@@ -60641,6 +60652,24 @@ snapshots:
       sprintf-js: 1.1.3
 
   robust-predicates@3.0.1: {}
+
+  rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
+    dependencies:
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      ast-kit: 2.2.0
+      birpc: 3.0.0
+      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
+      get-tsconfig: 4.13.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260421.2
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - oxc-resolver
 
   rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
     dependencies:
@@ -60774,7 +60803,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -60887,7 +60916,7 @@ snapshots:
       '@secretlint/formatter': 10.2.2
       '@secretlint/node': 10.2.2
       '@secretlint/profiler': 10.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       globby: 14.1.0
       read-pkg: 9.0.1
     transitivePeerDependencies:
@@ -60925,7 +60954,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -61313,7 +61342,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -61364,7 +61393,7 @@ snapshots:
   solid-refresh@0.6.3(solid-js@1.9.11):
     dependencies:
       '@babel/generator': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/types': 7.29.0
       solid-js: 1.9.11
     transitivePeerDependencies:
@@ -62316,6 +62345,34 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
+    dependencies:
+      ansis: 4.2.0
+      cac: 6.7.14
+      chokidar: 5.0.0
+      diff: 8.0.3
+      empathic: 2.0.0
+      hookable: 5.5.3
+      obug: 2.1.1
+      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rolldown-plugin-dts: 0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+      semver: 7.7.4
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+      unconfig-core: 7.4.2
+      unrun: 0.2.19(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - synckit
+      - vue-tsc
+
   tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
@@ -63018,7 +63075,7 @@ snapshots:
   vite-plugin-inspect@11.3.3(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       ansis: 4.2.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       error-stack-parser-es: 1.0.5
       ohash: 2.0.11
       open: 10.2.0
@@ -63032,7 +63089,7 @@ snapshots:
 
   vite-plugin-pwa@1.2.0(@types/babel__core@7.20.5)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workbox-window@7.4.0):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.15
       vite: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -63076,7 +63133,7 @@ snapshots:
 
   vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@6.0.3)
       vite: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -63104,7 +63161,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.7.0)(jsdom@27.4.0(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.6(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.1.6
       '@vitest/mocker': 4.1.6(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -63135,7 +63192,18 @@ snapshots:
       happy-dom: 20.7.0
       jsdom: 27.4.0(canvas@3.2.0)
     transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   void-elements@3.1.0: {}
 
@@ -63159,7 +63227,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 9.5.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19862,6 +19862,9 @@ importers:
       '@dxos/ui-theme':
         specifier: workspace:*
         version: link:../ui-theme
+      '@dxos/ui-types':
+        specifier: workspace:*
+        version: link:../ui-types
       '@types/react':
         specifier: ~19.2.7
         version: 19.2.14

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -90,6 +90,11 @@
         },
         {
           "type": "json",
+          "path": "packages/common/effect-proto/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/common/effect-zod/package.json",
           "jsonpath": "$.version"
         },

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -43,6 +43,9 @@
       "path": "packages/common/effect-atom-solid/tsconfig.json"
     },
     {
+      "path": "packages/common/effect-proto/tsconfig.json"
+    },
+    {
       "path": "packages/common/effect-zod/tsconfig.json"
     },
     {


### PR DESCRIPTION
## Summary

Lays the groundwork for a hierarchical, schema-driven editor over Protocol Buffer definitions. Two pieces ship together:

- **`@dxos/effect-proto`** (new package) — runtime parser that converts a `.proto3` source into a registry of Effect Schemas, plus enum metadata.
- **`@dxos/react-ui-form` / `<ObjectViewer>`** (new component) — minimal read-only walker that renders any Effect Schema + matching value as indented key/value rows.

The exercise target is `packages/core/protocols/src/proto/dxos/config.proto` — used both as the unit-test fixture and as the data source for the new Storybook story.

## What changed

### `@dxos/effect-proto`
- `parseProto(source)` returns a `ProtoRegistry { get, list, getEnum, listEnums }`.
- Field names emitted as camelCase to match `@dxos/codec-protobuf`'s runtime shape; recursive types resolved lazily via `Schema.suspend`.
- **Enums emitted as numeric literal unions** (matching the proto wire format + generated TS enum members); name↔value maps are exposed off the registry via `getEnum` / `listEnums`.
- `google.protobuf.{Any,Struct,Value,ListValue,NullValue}` mapped to `Unknown` / `Record` / `Unknown` / `Array<Unknown>` / `Null`. Stubs injected so `resolveAll()` succeeds without bundling the well-known descriptors.
- 8 unit tests against the real `config.proto`: nested messages, repeated fields, recursive `Module.deps`, enums, `google.protobuf.Any`, camelCasing, `getEnum` map.

### `@dxos/protocols`
- Added `"./proto/dxos/*.proto"` exports entry so consumers can resolve the raw `.proto` sources by package subpath. Files were already shipped via `"files": ["src"]`.

### `react-ui-form` / `ObjectViewer`
- `<ObjectViewer schema value />` walks the Effect Schema AST. Structs render a header row + recursively-indented children; arrays expand element-by-element; `Refinement` / `Suspend` / `Transformation` and `Schema.optional`'s `Union(X, undefined)` are peeled before dispatch.
- Storybook story (`ObjectViewer.stories.tsx`) uses the same `parseProto(configProto?raw)` flow as the unit test — Vite's `?raw` query resolves the source through the new `@dxos/protocols` exports entry.
- Added `@dxos/effect-proto` + `@dxos/protocols` as devDependencies; new `vite-env.d.ts` declares the `*?raw` module shim.
- Uses `mx` from `@dxos/ui-theme` for classname composition, matching the package convention.

## Test plan

- [x] `moon run effect-proto:build :test :lint` (8/8 green)
- [x] `moon run react-ui-form:build :test :lint` (13/13 green)
- [ ] Spot-check the `ObjectViewer / Default` story in Storybook
- [ ] CI **Check** workflow green

## Notes for reviewers

- Other touched files are tooling-driven: `tsconfig.all.json` + `release-please-config.json` auto-registration of the new package, `pnpm-lock.yaml` refresh, and `oxfmt`-driven `"private": true` field reorders in unrelated `packages/plugins/plugin-*/package.json` files.
- The proto codec uses `enums: String` at runtime today; this PR deliberately diverges from that and emits **numeric** enum schemas instead so editor output round-trips through the binary wire format without an intermediate name↔number translation. Where editors want to surface readable labels, `ProtoRegistry.getEnum(fq)` returns the `{ NAME: number }` map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ObjectTree: read-only hierarchical view for structured data
  * Runtime proto→Effect schema conversion available in-app
  * Form tooltips (enabled by default) with path hover display
  * Storybook stories demonstrating ObjectTree and form interactions

* **UX Improvements**
  * Array fields: vertical layout for object items; improved add/remove behavior
  * Read-only forms: empty/null values hidden
  * Labels: "Remove" renamed to "Delete"

* **Tests**
  * Expanded proto parsing and decoding coverage

* **Documentation**
  * Added Functional Source License v1.1 license file

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->