### PR TITLE
feat(react-ui-sfx): add canvas-based Pulse component

### DIFF
--- a/packages/ui/react-ui-sfx/src/components/Pulse/Pulse.stories.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Pulse/Pulse.stories.tsx
@@ -1,0 +1,198 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Button, Panel, Toolbar } from '@dxos/react-ui';
+import { withLayout, withTheme } from '@dxos/react-ui/testing';
+
+import { Pulse, type PulseProps, type PulseSignal } from './Pulse';
+
+const DefaultStory = (props: PulseProps) => {
+  const [active, setActive] = useState(props.active ?? true);
+
+  return (
+    <Panel.Root>
+      <Panel.Toolbar asChild>
+        <Toolbar.Root>
+          <Button onClick={() => setActive((a) => !a)}>{active ? 'Stop' : 'Start'}</Button>
+        </Toolbar.Root>
+      </Panel.Toolbar>
+      <Panel.Content classNames='flex items-center justify-center'>
+        <Pulse {...props} active={active} />
+      </Panel.Content>
+    </Panel.Root>
+  );
+};
+
+const meta = {
+  title: 'ui/react-ui-sfx/Pulse',
+  component: Pulse,
+  render: DefaultStory,
+  decorators: [withTheme(), withLayout({ layout: 'fullscreen' })],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof Pulse>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Radial wave emanating from the center.
+const radialWave: PulseSignal = (i, j, time) => {
+  const dx = i - 7 / 2;
+  const dy = j - 7 / 2;
+  const distance = Math.sqrt(dx * dx + dy * dy);
+  return 0.5 + 0.5 * Math.sin(time * 2 - distance * 0.9);
+};
+
+export const Default: Story = {
+  args: {
+    dim: 8,
+    maxRadius: 10,
+    minRadius: 1,
+    gap: 6,
+    smoothing: 0.2,
+    classNames: 'text-primary-500',
+    getSignal: radialWave,
+  },
+};
+
+// Each column pulses with a phase-shifted sine — vertical bars sweeping across the grid.
+const sweep: PulseSignal = (i, _j, time) => 0.5 + 0.5 * Math.sin(time * 3 + i * 0.6);
+
+export const Sweep: Story = {
+  args: {
+    dim: 12,
+    maxRadius: 6,
+    minRadius: 0,
+    gap: 4,
+    smoothing: 0.3,
+    classNames: 'text-emerald-500',
+    getSignal: sweep,
+  },
+};
+
+// Grows the single dot under the cursor; smoothing eases it back down when the cursor moves or leaves.
+const Pointer = (props: PulseProps) => {
+  const { maxRadius = 8, gap = 4 } = props;
+  const stride = 2 * maxRadius + gap;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const cursorRef = useRef<{ i: number; j: number } | null>(null);
+
+  const onMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const canvas = containerRef.current?.querySelector('canvas');
+      if (!canvas) {
+        return;
+      }
+      const rect = canvas.getBoundingClientRect();
+      const px = event.clientX - rect.left;
+      const py = event.clientY - rect.top;
+      if (px < 0 || py < 0 || px >= rect.width || py >= rect.height) {
+        cursorRef.current = null;
+        return;
+      }
+      cursorRef.current = { i: Math.floor(px / stride), j: Math.floor(py / stride) };
+    },
+    [stride],
+  );
+
+  const onLeave = useCallback(() => {
+    cursorRef.current = null;
+  }, []);
+
+  const getSignal = useCallback<PulseSignal>((i, j) => {
+    const cursor = cursorRef.current;
+    return cursor && cursor.i === i && cursor.j === j ? 1 : 0;
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      onPointerMove={onMove}
+      onPointerLeave={onLeave}
+      className='flex grow items-center justify-center'
+    >
+      <Pulse {...props} getSignal={getSignal} />
+    </div>
+  );
+};
+
+export const PointerDriven: Story = {
+  render: (props) => (
+    <Panel.Root>
+      <Panel.Content classNames='flex items-center justify-center'>
+        <Pointer {...props} />
+      </Panel.Content>
+    </Panel.Root>
+  ),
+  args: {
+    dim: 8,
+    maxRadius: 6,
+    minRadius: 0.5,
+    gap: 2,
+    smoothing: 0.04,
+    growSmoothing: 1,
+    classNames: 'text-sky-500',
+  },
+};
+
+// Randomly pings dots that then decay back to zero.
+const RandomPing = (props: PulseProps) => {
+  const { dim = 4 } = props;
+  const valuesRef = useRef<Float32Array>(new Float32Array(dim * dim));
+  const lastTimeRef = useRef(0);
+
+  useEffect(() => {
+    valuesRef.current = new Float32Array(dim * dim);
+    lastTimeRef.current = 0;
+  }, [dim]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      valuesRef.current[Math.floor(Math.random() * valuesRef.current.length)] = 1;
+    }, 100);
+    return () => clearInterval(interval);
+  }, [dim]);
+
+  const getSignal = useCallback<PulseSignal>(
+    (i, j, time) => {
+      if (time !== lastTimeRef.current) {
+        const dt = lastTimeRef.current === 0 ? 0 : time - lastTimeRef.current;
+        // Exponential decay; half-life ≈ 0.46s.
+        const decay = Math.exp(-dt * 1.5);
+        const values = valuesRef.current;
+        for (let k = 0; k < values.length; k++) {
+          values[k] *= decay;
+        }
+        lastTimeRef.current = time;
+      }
+      return valuesRef.current[i * dim + j];
+    },
+    [dim],
+  );
+
+  return <Pulse {...props} getSignal={getSignal} />;
+};
+
+export const Icon: Story = {
+  render: (props) => (
+    <Panel.Root>
+      <Panel.Content classNames='flex items-center justify-center'>
+        <RandomPing {...props} />
+      </Panel.Content>
+    </Panel.Root>
+  ),
+  args: {
+    dim: 4,
+    maxRadius: 3,
+    minRadius: 0.5,
+    gap: 0,
+    smoothing: 0.5,
+    classNames: 'text-primary-500',
+  },
+};

--- a/packages/ui/react-ui-sfx/src/components/Pulse/Pulse.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Pulse/Pulse.tsx
@@ -3,7 +3,7 @@
 //
 
 import { useAnimationFrame } from 'motion/react';
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 
 import { type ThemedClassName } from '@dxos/react-ui';
 import { mx } from '@dxos/ui-theme';
@@ -52,10 +52,6 @@ export const Pulse = ({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const radiiRef = useRef<Float32Array>(new Float32Array(dim * dim));
 
-  useEffect(() => {
-    radiiRef.current = new Float32Array(dim * dim);
-  }, [dim]);
-
   const stride = 2 * maxRadius + gap;
   const size = dim * stride - gap;
 
@@ -79,6 +75,10 @@ export const Pulse = ({
     ctx.clearRect(0, 0, size, size);
     ctx.fillStyle = color === 'currentColor' ? getComputedStyle(canvas).color : color;
 
+    // Resize the radii buffer in sync with `dim` to avoid out-of-bounds access on the frame after dim changes.
+    if (radiiRef.current.length !== dim * dim) {
+      radiiRef.current = new Float32Array(dim * dim);
+    }
     const radii = radiiRef.current;
     const seconds = time / 1_000;
     for (let i = 0; i < dim; i++) {

--- a/packages/ui/react-ui-sfx/src/components/Pulse/Pulse.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Pulse/Pulse.tsx
@@ -1,0 +1,106 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { useAnimationFrame } from 'motion/react';
+import React, { useEffect, useRef } from 'react';
+
+import { type ThemedClassName } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+export type PulseSignal = (i: number, j: number, time: number) => number;
+
+export type PulseProps = ThemedClassName<{
+  /** Grid dimension; renders `dim × dim` dots. */
+  dim?: number;
+  /** Maximum dot radius in CSS pixels (reached when the signal is 1). */
+  maxRadius?: number;
+  /** Minimum dot radius in CSS pixels (reached when the signal is 0). */
+  minRadius?: number;
+  /** Spacing between adjacent dot cells in CSS pixels. */
+  gap?: number;
+  /**
+   * Signal driving each dot, called every animation frame.
+   * Return a value in [0, 1]; values are clamped. Ignore `i`/`j` for uniform pulsing.
+   */
+  getSignal?: PulseSignal;
+  /** Tween factor toward the target radius each frame (0..1). Higher = snappier. */
+  smoothing?: number;
+  /** Optional override applied only when growing (target above current). Defaults to `smoothing`. Set to `1` for instant attack with a slow release. */
+  growSmoothing?: number;
+  /** Canvas fill color; resolves `currentColor` from the element's computed style. */
+  color?: string;
+  /** When false, all dots ease toward `minRadius`. */
+  active?: boolean;
+}>;
+
+/**
+ * Canvas-rendered `n × n` matrix of circles whose radii grow and shrink in response to an arbitrary signal.
+ */
+export const Pulse = ({
+  classNames,
+  dim = 8,
+  maxRadius = 8,
+  minRadius = 0,
+  gap = 4,
+  getSignal,
+  smoothing = 0.2,
+  growSmoothing,
+  color = 'currentColor',
+  active = true,
+}: PulseProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const radiiRef = useRef<Float32Array>(new Float32Array(dim * dim));
+
+  useEffect(() => {
+    radiiRef.current = new Float32Array(dim * dim);
+  }, [dim]);
+
+  const stride = 2 * maxRadius + gap;
+  const size = dim * stride - gap;
+
+  useAnimationFrame((time) => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      return;
+    }
+
+    const dpr = window.devicePixelRatio || 1;
+    const pixelSize = Math.max(1, Math.round(size * dpr));
+    if (canvas.width !== pixelSize || canvas.height !== pixelSize) {
+      canvas.width = pixelSize;
+      canvas.height = pixelSize;
+    }
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, size, size);
+    ctx.fillStyle = color === 'currentColor' ? getComputedStyle(canvas).color : color;
+
+    const radii = radiiRef.current;
+    const seconds = time / 1_000;
+    for (let i = 0; i < dim; i++) {
+      for (let j = 0; j < dim; j++) {
+        const idx = i * dim + j;
+        const raw = active && getSignal ? getSignal(i, j, seconds) : 0;
+        const clamped = raw < 0 ? 0 : raw > 1 ? 1 : raw;
+        const target = minRadius + (maxRadius - minRadius) * clamped;
+        const delta = target - radii[idx];
+        const factor = delta > 0 ? (growSmoothing ?? smoothing) : smoothing;
+        radii[idx] += delta * factor;
+        const r = radii[idx];
+        if (r > 0.25) {
+          const cx = i * stride + maxRadius;
+          const cy = j * stride + maxRadius;
+          ctx.beginPath();
+          ctx.arc(cx, cy, r, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+    }
+  });
+
+  return <canvas ref={canvasRef} className={mx('block', classNames)} style={{ width: size, height: size }} />;
+};

--- a/packages/ui/react-ui-sfx/src/components/Pulse/index.ts
+++ b/packages/ui/react-ui-sfx/src/components/Pulse/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+export * from './Pulse';

--- a/packages/ui/react-ui-sfx/src/components/index.ts
+++ b/packages/ui/react-ui-sfx/src/components/index.ts
@@ -6,5 +6,6 @@ export * from './Chaos';
 export * from './Hello';
 export * from './Matrix';
 export * from './Oscilloscope';
+export * from './Pulse';
 export * from './Spinner';
 export * from './Waveform';


### PR DESCRIPTION
## Summary

- Adds a new `Pulse` component to `@dxos/react-ui-sfx`: a canvas-rendered `n × n` matrix of circles whose radii grow and shrink in response to an arbitrary per-dot signal function.
- Uses `motion/react`'s `useAnimationFrame` for the draw loop; per-dot radii ease toward the signal-driven target each frame with optional asymmetric attack/release (`smoothing` for release, optional `growSmoothing` override for attack).
- DPR-aware backing buffer, `currentColor` resolution, `active` toggle (eases all dots to `minRadius` when false).

## Stories

- **Default** — radial wave from the grid centre.
- **Sweep** — phase-shifted column sine bars.
- **PointerDriven** — instant grow on the dot under the cursor, slow shrink-back when the cursor moves or leaves.
- **Icon** — small grid that randomly pings dots with exponential decay.

## Test plan

- [x] `moon run react-ui-sfx:build` clean
- [x] `moon run react-ui-sfx:lint` clean
- [x] `pnpm format` (oxfmt) clean
- [x] `moon run react-ui-sfx:test` (no test files)
- [x] Storybook verified for all four stories in the local preview (animation, pointer interaction, ping/decay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Pulse component: an animated visual that renders a customizable grid of circles with adjustable dimensions, radii, spacing, colors, and smoothing behavior.
  * Added four interactive Storybook variations demonstrating different animation patterns: Default (radial sine), Sweep (phase-shifted vertical), PointerDriven (cursor-tracked), and Icon (randomized pings with decay).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->