### PR TITLE
refactor(react-ui): rename density tiers to lg/md/sm and add sm tier

### DIFF
--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatPrompt.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatPrompt.tsx
@@ -121,7 +121,7 @@ export const ChatPrompt = ({
     <div
       role='group'
       className={mx(
-        'flex flex-col w-full dx-density-fine',
+        'flex flex-col w-full dx-density-md',
         outline &&
           'bg-group-surface rounded-sm! border border-subdued-separator transition transition-border [&:has(.cm-content:focus)]:border-separator',
         classNames,

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/SelectWidget.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/SelectWidget.ts
@@ -31,7 +31,7 @@ export class SelectWidget extends WidgetType {
         ...this.options.map((option) =>
           Domino.of('button')
             .classNames('dx-button inline-block max-w-[100cqi]')
-            .attributes({ 'data-action': 'submit', 'data-value': option, 'data-density': 'fine' })
+            .attributes({ 'data-action': 'submit', 'data-value': option, 'data-density': 'md' })
             .text(option),
         ),
       ).root;

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/SuggestionWidget.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/SuggestionWidget.ts
@@ -26,7 +26,7 @@ export class SuggestionWidget extends WidgetType {
         Domino.of('button')
           .attributes({
             'data-action': 'submit',
-            'data-density': 'fine',
+            'data-density': 'md',
             'data-value': this.text,
           })
           .classNames(mx('dx-button gap-2 w-full overflow-hidden'))

--- a/packages/plugins/plugin-deck/src/containers/Plank/PlankComponent.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Plank/PlankComponent.tsx
@@ -145,7 +145,7 @@ export const PlankComponent = memo(
     const Root = part.startsWith('solo') ? 'article' : StackItem.Root;
     const fullscreen = layoutMode === 'solo--fullscreen';
     const classNames = [
-      'dx-attention-surface relative dx-focus-ring-inset-over-all dx-density-coarse',
+      'dx-attention-surface relative dx-focus-ring-inset-over-all dx-density-lg',
       isSolo && 'absolute inset-0',
       isSolo && mainIntrinsicSize,
       railGridHorizontal,

--- a/packages/plugins/plugin-deck/src/containers/Plank/PlankHeading.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Plank/PlankHeading.tsx
@@ -143,7 +143,7 @@ export const PlankHeading = memo(
         data-plank-heading
         style={iconSize(5)}
         classNames={[
-          'py-1 items-stretch gap-1 sticky left-12 dx-app-drag min-w-0 dx-contain-layout dx-density-coarse',
+          'py-1 items-stretch gap-1 sticky left-12 dx-app-drag min-w-0 dx-contain-layout dx-density-lg',
           part === 'solo'
             ? 'ps-[calc(env(safe-area-inset-left)+.25rem)] pe-[calc(env(safe-area-inset-right)+.25rem)]'
             : 'px-1',

--- a/packages/plugins/plugin-navtree/src/components/NavTree/NavTree.stories.tsx
+++ b/packages/plugins/plugin-navtree/src/components/NavTree/NavTree.stories.tsx
@@ -43,7 +43,7 @@ const StoryPlankHeading = ({ attendableId }: { attendableId: string }) => {
   return (
     <div className='flex p-1 items-center border-b border-separator'>
       <IconButton
-        density='coarse'
+        density='lg'
         icon='ph--circle--regular'
         label='Test'
         iconOnly

--- a/packages/plugins/plugin-navtree/src/components/NavTreeItem/NavTreeItemAction.tsx
+++ b/packages/plugins/plugin-navtree/src/components/NavTreeItem/NavTreeItemAction.tsx
@@ -15,14 +15,14 @@ import { type ActionProperties } from '#types';
 
 const fallbackIcon = 'ph--placeholder--regular';
 
-const fineActionButtonProps = {
+const mdActionButtonProps = {
   size: 4 as const,
-  density: 'fine' as const,
+  density: 'md' as const,
 };
 
-const coarseActionButtonProps = {
+const lgActionButtonProps = {
   size: 5 as const,
-  density: 'coarse' as const,
+  density: 'lg' as const,
 };
 
 export type NavTreeItemActionMenuProps = ActionProperties & {
@@ -47,7 +47,7 @@ export const NavTreeItemActionDropdownMenu = composable<HTMLButtonElement, NavTr
       <Menu.Root caller={caller} onAction={handleAction}>
         <Menu.Trigger asChild>
           <IconButton
-            {...(density === 'coarse' ? coarseActionButtonProps : fineActionButtonProps)}
+            {...(density === 'lg' ? lgActionButtonProps : mdActionButtonProps)}
             {...composableProps(props)}
             classNames={['shrink-0 px-2 pointer-fine:px-1', hoverableControlItem, hoverableOpenControlItem]}
             variant='ghost'
@@ -84,7 +84,7 @@ export const NavTreeItemMonolithicAction = (
   const runAction = useActionRunner();
   return (
     <IconButton
-      {...(density === 'coarse' ? coarseActionButtonProps : fineActionButtonProps)}
+      {...(density === 'lg' ? lgActionButtonProps : mdActionButtonProps)}
       variant={variant}
       classNames={[
         'shrink-0',

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
@@ -83,7 +83,7 @@ const L1PanelContent = ({ path, item, onBack }: Pick<L1PanelProps, 'open' | 'pat
   const navTreeContext = useNavTreeContext();
 
   return (
-    <DensityProvider density='fine'>
+    <DensityProvider density='md'>
       <L1PanelHeader path={path} item={item} onBack={onBack} />
       <ScrollArea.Root thin orientation='vertical'>
         <ScrollArea.Viewport>
@@ -125,11 +125,11 @@ const L1PanelHeader = ({ item, path, onBack }: Pick<L1PanelProps, 'item' | 'path
   return (
     <div
       data-tauri-drag-region
-      className='flex w-full items-center border-b border-subdued-separator dx-app-drag dx-density-coarse pe-1'
+      className='flex w-full items-center border-b border-subdued-separator dx-app-drag dx-density-lg pe-1'
     >
       {backCapableWorkspace ? (
         <IconButton
-          density='coarse'
+          density='lg'
           classNames={['shrink-0 px-2 pointer-fine:px-1', hoverableControlItem, hoverableOpenControlItem]}
           variant='ghost'
           icon='ph--caret-left--regular'
@@ -194,7 +194,7 @@ const MenuActions = ({
   if (menuActions.length === 1) {
     return (
       <IconButton
-        density='coarse'
+        density='lg'
         classNames={['shrink-0 px-2 pointer-fine:px-1', hoverableControlItem, hoverableOpenControlItem]}
         variant='ghost'
         icon={menuActions[0].properties?.icon ?? 'ph--placeholder--regular'}
@@ -210,7 +210,7 @@ const MenuActions = ({
     <Menu.Root caller={NAV_TREE_ITEM} onAction={onAction}>
       <Menu.Trigger asChild>
         <IconButton
-          density='coarse'
+          density='lg'
           classNames={['shrink-0 px-2 pointer-fine:px-1', hoverableControlItem, hoverableOpenControlItem]}
           variant='ghost'
           icon='ph--dots-three-vertical--regular'

--- a/packages/plugins/plugin-registry/src/components/PluginDetail/PluginDetail.tsx
+++ b/packages/plugins/plugin-registry/src/components/PluginDetail/PluginDetail.tsx
@@ -162,7 +162,7 @@ export const PluginDetail = composable<HTMLDivElement, PluginDetailProps>(
                 {failure && <PluginFailureBadge failure={failure} size={5} />}
               </div>
               {onInstall ? (
-                <Button density='fine' variant='primary' disabled={installing} onClick={onInstall}>
+                <Button density='md' variant='primary' disabled={installing} onClick={onInstall}>
                   {installing ? t('installing.label') : t('install.label')}
                 </Button>
               ) : (
@@ -280,7 +280,7 @@ export const PluginDetail = composable<HTMLDivElement, PluginDetailProps>(
                     </Select.Root>
                     {onInstallVersion && (
                       <Button
-                        density='fine'
+                        density='md'
                         variant='primary'
                         disabled={installing || selectedVersionTag === installedVersionTag}
                         onClick={onInstallVersion}

--- a/packages/plugins/plugin-registry/src/components/PluginList/PluginItem.tsx
+++ b/packages/plugins/plugin-registry/src/components/PluginList/PluginItem.tsx
@@ -185,17 +185,17 @@ export const PluginItem = ({
           <div className='grow' />
           <div className='pe-1'>
             {isUpdating ? (
-              <Button aria-describedby={descriptionId} density='fine' variant='primary' disabled>
+              <Button aria-describedby={descriptionId} density='md' variant='primary' disabled>
                 {t('updating.label')}
               </Button>
             ) : showUpdateButton ? (
-              <Button aria-describedby={descriptionId} density='fine' variant='primary' onClick={handleUpdate}>
+              <Button aria-describedby={descriptionId} density='md' variant='primary' onClick={handleUpdate}>
                 {t('update.label')}
               </Button>
             ) : showInstallButton ? (
               <Button
                 aria-describedby={descriptionId}
-                density='fine'
+                density='md'
                 variant='primary'
                 disabled={isInstalling}
                 onClick={handleInstall}

--- a/packages/plugins/plugin-simple-layout/src/components/Home/Home.tsx
+++ b/packages/plugins/plugin-simple-layout/src/components/Home/Home.tsx
@@ -104,7 +104,7 @@ const WorkspaceTile: MosaicStackTileComponent<Node.Node> = (props) => {
       onClick={handleSelect}
       ref={cardRef}
     >
-      <Card.Toolbar density='fine'>
+      <Card.Toolbar density='md'>
         <Avatar.Root>
           <Avatar.Content
             icon={data.properties.icon}

--- a/packages/plugins/plugin-simple-layout/src/components/SimpleLayout/AppBar.tsx
+++ b/packages/plugins/plugin-simple-layout/src/components/SimpleLayout/AppBar.tsx
@@ -48,11 +48,11 @@ export const AppBar = composable<HTMLDivElement, AppBarProps>(
     const AnchorRoot = popoverAnchorId ? Popover.Anchor : Fragment;
 
     return (
-      <DensityProvider density='fine'>
+      <DensityProvider density='md'>
         <Toolbar.Root
           {...composableProps(props, {
             role: 'banner',
-            classNames: 'grid grid-cols-[var(--dx-rail-size)_1fr_var(--dx-rail-size)] items-center dx-density-fine',
+            classNames: 'grid grid-cols-[var(--dx-rail-size)_1fr_var(--dx-rail-size)] items-center dx-density-md',
           })}
           ref={forwardedRef}
         >

--- a/packages/plugins/plugin-support/src/components/Tooltip/Tooltip.tsx
+++ b/packages/plugins/plugin-support/src/components/Tooltip/Tooltip.tsx
@@ -48,7 +48,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipRenderProps>(
         <div className='flex p-2'>
           <h2 className='grow px-2 py-1 text-lg font-medium text-accent-foreground'>{title}</h2>
           <IconButton
-            density='fine'
+            density='md'
             icon='ph--x--bold'
             iconOnly
             label={closeProps['aria-label']}

--- a/packages/sdk/shell/src/panels/JoinPanel/steps/InvitationAuthenticator.tsx
+++ b/packages/sdk/shell/src/panels/JoinPanel/steps/InvitationAuthenticator.tsx
@@ -70,7 +70,7 @@ export const InvitationAuthenticator = ({
             <Input.PinInput
               {...{
                 disabled,
-                density: 'coarse',
+                density: 'lg',
                 length: pinLength,
                 inputMode: 'numeric',
                 autoComplete: 'off',

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -102,7 +102,7 @@ export const ArrayField = ({
           {!readonly && layout !== 'static' && (
             <IconButton
               iconOnly
-              density='fine'
+              density='md'
               variant='ghost'
               icon='ph--plus--regular'
               label={t('add-item.button')}
@@ -131,7 +131,7 @@ export const ArrayField = ({
                 {!readonly && layout !== 'static' && (
                   <div className='h-full flex flex-col justify-end pb-1'>
                     <IconButton
-                      density='fine'
+                      density='md'
                       variant='ghost'
                       icon='ph--x--regular'
                       iconOnly

--- a/packages/ui/react-ui-form/src/components/Form/fields/SelectOptionField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/SelectOptionField.tsx
@@ -154,7 +154,7 @@ export const SelectOptionField = ({
                         />
                       </div>
                       {selected === item.id && (
-                        <div className='flex flex-col p-form-padding gap-form-gap dx-density-fine'>
+                        <div className='flex flex-col p-form-padding gap-form-gap dx-density-md'>
                           <Input.Label classNames='text-xs'>{t('select-option.label')}</Input.Label>
                           <div className='grid grid-cols-[1fr_min-content_min-content] gap-form-gap'>
                             <Input.TextInput

--- a/packages/ui/react-ui-list/src/components/Tree/TreeItemToggle.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/TreeItemToggle.tsx
@@ -21,7 +21,7 @@ export const TreeItemToggle = memo(
           data-testid='treeItem.toggle'
           aria-expanded={open}
           variant='ghost'
-          density='fine'
+          density='md'
           classNames={[
             'h-full w-6 px-0',
             '[&_svg]:transition-transform [&_svg]:duration-200',

--- a/packages/ui/react-ui-masonry/src/Masonry.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.tsx
@@ -127,7 +127,7 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
     const { Tile, columns, maxColumns, minColumnWidth, maxColumnWidth, gutter } = useMasonryContext('Masonry.Viewport');
     const { width } = useMasonryContentContext('Masonry.Viewport');
     const columnCount = useColumnCount(
-      width - (scrollbar.thin.size + scrollbar.thin.padding),
+      width - (scrollbar.md.size + scrollbar.md.padding),
       columns,
       maxColumns,
       minColumnWidth,

--- a/packages/ui/react-ui-stack/src/components/StackItem/StackItemContent.tsx
+++ b/packages/ui/react-ui-stack/src/components/StackItem/StackItemContent.tsx
@@ -39,7 +39,7 @@ export const StackItemContent = forwardRef<HTMLDivElement, StackItemContentProps
         {...props}
         style={style}
         className={mx(
-          'group grid grid-cols-[100%] dx-density-coarse',
+          'group grid grid-cols-[100%] dx-density-lg',
           stackItemSize === 'contain' && 'min-h-0 overflow-hidden',
           toolbar &&
             role === 'section' &&

--- a/packages/ui/react-ui-table/src/components/TableCellEditor/FormCellEditor.tsx
+++ b/packages/ui/react-ui-table/src/components/TableCellEditor/FormCellEditor.tsx
@@ -167,7 +167,7 @@ export const FormCellEditor = <T extends Type.AnyEntity = Type.AnyEntity>({
     <Popover.Root open={editing} onOpenChange={handleOpenChange}>
       <Popover.VirtualTrigger virtualRef={anchorRef} />
       <Popover.Portal>
-        <Popover.Content tabIndex={-1} classNames='dx-card-popover-width dx-density-fine'>
+        <Popover.Content tabIndex={-1} classNames='dx-card-popover-width dx-density-md'>
           <Popover.Arrow />
           <Popover.Viewport>
             <Form.Root

--- a/packages/ui/react-ui/src/components/Card/Card.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.tsx
@@ -83,7 +83,7 @@ const CardRoot = composable<HTMLDivElement, CardRootProps>(
     return (
       <Column.Root
         asChild
-        gutter={density === 'coarse' ? 'lg' : 'md'}
+        gutter={density === 'lg' ? 'lg' : density === 'sm' ? 'sm' : 'md'}
         classNames={tx('card.root', { border, fullWidth }, className)}
         role={role ?? 'group'}
       >

--- a/packages/ui/react-ui/src/components/DensityProvider/DensityProvider.tsx
+++ b/packages/ui/react-ui/src/components/DensityProvider/DensityProvider.tsx
@@ -14,7 +14,7 @@ export type DensityProviderProps = PropsWithChildren<{
   density?: Density;
 }>;
 
-export const DensityContext = createContext<DensityContextValue>({ density: 'fine' });
+export const DensityContext = createContext<DensityContextValue>({ density: 'md' });
 
 export const DensityProvider = ({ density, children }: DensityProviderProps) => (
   <DensityContext.Provider value={{ density }}>{children}</DensityContext.Provider>

--- a/packages/ui/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.stories.tsx
@@ -76,33 +76,48 @@ export default meta;
 
 type Story = StoryObj<DefaultStoryProps & Variant>;
 
-export const DensityCoarse: Story = {
+export const DensityLg: Story = {
   args: {
     kind: 'text',
     label: 'Input value',
-    placeholder: 'This is an input',
+    placeholder: 'This is a density:lg input',
     disabled: false,
     description: undefined,
     labelVisuallyHidden: false,
     descriptionVisuallyHidden: false,
     validationMessage: '',
     validationValence: undefined,
-    density: 'coarse',
+    density: 'lg',
   },
 };
 
-export const DensityFine: Story = {
+export const DensityMd: Story = {
   args: {
     kind: 'text',
     label: 'Input value',
-    placeholder: 'This is a density:fine input',
+    placeholder: 'This is a density:md input (default)',
     disabled: false,
     description: undefined,
     labelVisuallyHidden: false,
     descriptionVisuallyHidden: false,
     validationMessage: '',
     validationValence: undefined,
-    density: 'fine',
+    density: 'md',
+  },
+};
+
+export const DensitySm: Story = {
+  args: {
+    kind: 'text',
+    label: 'Input value',
+    placeholder: 'This is a density:sm input',
+    disabled: false,
+    description: undefined,
+    labelVisuallyHidden: false,
+    descriptionVisuallyHidden: false,
+    validationMessage: '',
+    validationValence: undefined,
+    density: 'sm',
   },
 };
 
@@ -186,7 +201,7 @@ export const PinInput: Story = {
     length: 6,
     description: 'Type in secret you received',
     pattern: '\\d*',
-    density: 'coarse',
+    density: 'lg',
   },
 };
 

--- a/packages/ui/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.stories.tsx
@@ -76,49 +76,17 @@ export default meta;
 
 type Story = StoryObj<DefaultStoryProps & Variant>;
 
-export const DensityLg: Story = {
-  args: {
-    kind: 'text',
-    label: 'Input value',
-    placeholder: 'This is a density:lg input',
-    disabled: false,
-    description: undefined,
-    labelVisuallyHidden: false,
-    descriptionVisuallyHidden: false,
-    validationMessage: '',
-    validationValence: undefined,
-    density: 'lg',
-  },
-};
-
-export const DensityMd: Story = {
-  args: {
-    kind: 'text',
-    label: 'Input value',
-    placeholder: 'This is a density:md input (default)',
-    disabled: false,
-    description: undefined,
-    labelVisuallyHidden: false,
-    descriptionVisuallyHidden: false,
-    validationMessage: '',
-    validationValence: undefined,
-    density: 'md',
-  },
-};
-
-export const DensitySm: Story = {
-  args: {
-    kind: 'text',
-    label: 'Input value',
-    placeholder: 'This is a density:sm input',
-    disabled: false,
-    description: undefined,
-    labelVisuallyHidden: false,
-    descriptionVisuallyHidden: false,
-    validationMessage: '',
-    validationValence: undefined,
-    density: 'sm',
-  },
+export const Density: Story = {
+  render: () => (
+    <div className='flex flex-col gap-4'>
+      {(['lg', 'md', 'sm'] as const).map((density) => (
+        <Input.Root key={density}>
+          <Input.Label>{`density="${density}"`}</Input.Label>
+          <Input.TextInput density={density} placeholder={`This is a density:${density} input`} />
+        </Input.Root>
+      ))}
+    </div>
+  ),
 };
 
 export const Subdued: Story = {

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
@@ -92,7 +92,7 @@ type ScrollAreaViewportProps = SlottableProps;
 const ScrollAreaViewport = slottable<HTMLDivElement>(({ children, asChild, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
   const options = useScrollAreaContext(SCROLLAREA_VIEWPORT_NAME);
-  const density = options.thin ? scrollbar.thin : scrollbar.coarse;
+  const density = options.thin ? scrollbar.md : scrollbar.lg;
   const { className, ...rest } = composableProps(props);
   const { style, ...restWithoutStyle } = rest as { style?: CSSProperties; [key: string]: any };
   const Comp = asChild ? Slot : Primitive.div;

--- a/packages/ui/react-ui/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/ui/react-ui/src/components/ThemeProvider/ThemeProvider.tsx
@@ -41,7 +41,7 @@ export const ThemeProvider = ({
   appNs,
   tx = (_path, _styleProps, ..._options) => undefined,
   themeMode = 'dark',
-  rootDensity = 'fine',
+  rootDensity = 'md',
   noCache,
   platform,
 }: ThemeProviderProps) => {

--- a/packages/ui/react-ui/src/playground/Custom.stories.tsx
+++ b/packages/ui/react-ui/src/playground/Custom.stories.tsx
@@ -12,15 +12,15 @@ const DefaultStory = ({ children, ...args }: Omit<ButtonProps, 'ref'>) => {
   return (
     <Tooltip.Provider>
       <div className='flex flex-col gap-6'>
-        {/* Large */}
+        {/* Large (40px) */}
         <div className='grid grid-cols-3 gap-4'>
           <div className='flex justify-center'>
-            <Button {...args} density='coarse'>
+            <Button {...args} density='lg'>
               {children}
             </Button>
           </div>
           <div className='flex justify-center'>
-            <IconButton {...args} label='Test' icon='ph--circle--regular' density='coarse' />
+            <IconButton {...args} label='Test' icon='ph--circle--regular' density='lg' />
           </div>
           <div className='flex justify-center'>
             <IconButton
@@ -28,21 +28,21 @@ const DefaultStory = ({ children, ...args }: Omit<ButtonProps, 'ref'>) => {
               label='Test'
               icon='ph--circle--regular'
               iconOnly
-              density='coarse'
+              density='lg'
               classNames='px-1.5'
             />
           </div>
         </div>
 
-        {/* Medium */}
+        {/* Medium (32px, default) */}
         <div className='grid grid-cols-3 gap-4'>
           <div className='flex justify-center'>
-            <Button {...args} density='fine'>
+            <Button {...args} density='md'>
               {children}
             </Button>
           </div>
           <div className='flex justify-center'>
-            <IconButton {...args} label='Test' icon='ph--circle--regular' density='fine' classNames='px-2' />
+            <IconButton {...args} label='Test' icon='ph--circle--regular' density='md' classNames='px-2' />
           </div>
           <div className='flex justify-center'>
             <IconButton
@@ -50,37 +50,24 @@ const DefaultStory = ({ children, ...args }: Omit<ButtonProps, 'ref'>) => {
               label='Test'
               icon='ph--circle--regular'
               iconOnly
-              density='fine'
+              density='md'
               classNames='py-1 px-1.5'
             />
           </div>
         </div>
 
-        {/* Small */}
+        {/* Small (28px) */}
         <div className='grid grid-cols-3 gap-4'>
           <div className='flex justify-center'>
-            <Button {...args} density='fine' classNames={'!h-[24px] !text-[14px] p-0 px-1.5 min-h-0'}>
+            <Button {...args} density='sm'>
               {children}
             </Button>
           </div>
           <div className='flex justify-center'>
-            <IconButton
-              {...args}
-              label='Test'
-              icon='ph--circle--regular'
-              density='fine'
-              classNames={'!h-[24px] !text-[14px] p-1 min-h-0 gap-0.5'}
-            />
+            <IconButton {...args} label='Test' icon='ph--circle--regular' density='sm' />
           </div>
           <div className='flex justify-center'>
-            <IconButton
-              {...args}
-              label='Test'
-              icon='ph--circle--regular'
-              iconOnly
-              density='fine'
-              classNames={'!h-[24px] !text-[14px] p-1 min-h-0'}
-            />
+            <IconButton {...args} label='Test' icon='ph--circle--regular' iconOnly density='sm' />
           </div>
         </div>
 

--- a/packages/ui/react-ui/src/playground/Custom.stories.tsx
+++ b/packages/ui/react-ui/src/playground/Custom.stories.tsx
@@ -23,14 +23,7 @@ const DefaultStory = ({ children, ...args }: Omit<ButtonProps, 'ref'>) => {
             <IconButton {...args} label='Test' icon='ph--circle--regular' density='lg' />
           </div>
           <div className='flex justify-center'>
-            <IconButton
-              {...args}
-              label='Test'
-              icon='ph--circle--regular'
-              iconOnly
-              density='lg'
-              classNames='px-1.5'
-            />
+            <IconButton {...args} label='Test' icon='ph--circle--regular' iconOnly density='lg' classNames='px-1.5' />
           </div>
         </div>
 

--- a/packages/ui/react-ui/src/testing/decorators/withLayoutVariants.tsx
+++ b/packages/ui/react-ui/src/testing/decorators/withLayoutVariants.tsx
@@ -42,7 +42,7 @@ export const withLayoutVariants = ({
     { elevation: 'positioned', surface: 'bg-card-surface' },
     { elevation: 'base', surface: 'bg-base-surface' },
   ],
-  densities = ['coarse'],
+  densities = ['md'],
 }: Config = {}): Decorator => {
   return (Story) => <Panel Story={Story} elevations={elevations} densities={densities} />;
 };

--- a/packages/ui/ui-editor/src/extensions/preview/preview.ts
+++ b/packages/ui/ui-editor/src/extensions/preview/preview.ts
@@ -229,7 +229,7 @@ class PreviewBlockWidget extends WidgetType {
 
   override toDOM(_view: EditorView) {
     const root = document.createElement('div');
-    root.classList.add('cm-preview-block', 'dx-density-fine');
+    root.classList.add('cm-preview-block', 'dx-density-md');
     this._options.addBlockContainer?.({ link: this._link, el: root });
     return root;
   }

--- a/packages/ui/ui-editor/src/extensions/scrolling/auto-scroll.ts
+++ b/packages/ui/ui-editor/src/extensions/scrolling/auto-scroll.ts
@@ -201,7 +201,7 @@ export const autoScroll = ({ scrollOnResize = true }: AutoScrollProps = {}) => {
             .attributes({ icon: 'ph--arrow-down--regular' });
           const button = Domino.of('button')
             .classNames('dx-button bg-accent-surface')
-            .attributes({ 'data-density': 'fine' })
+            .attributes({ 'data-density': 'md' })
             .append(icon)
             .on('click', () => {
               setPinned(true);

--- a/packages/ui/ui-theme/src/Theme.stories.tsx
+++ b/packages/ui/ui-theme/src/Theme.stories.tsx
@@ -206,7 +206,7 @@ export const Animation = {
   render: () => {
     return (
       <div className='absolute inset-0 grid place-items-center'>
-        <div className='dx-density-coarse border border-separator rounded-md'>
+        <div className='dx-density-lg border border-separator rounded-md'>
           <div
             className={mx(
               'flex items-center font-mono text-2xl text-test-experimental',

--- a/packages/ui/ui-theme/src/css/components/button.css
+++ b/packages/ui/ui-theme/src/css/components/button.css
@@ -77,8 +77,14 @@
   .dx-button:not([data-props~='wrap']) {
     @apply truncate;
   }
+  .dx-button[data-density='lg'] {
+    @apply min-h-[2.5rem] px-3;
+  }
+  .dx-button[data-density='sm'] {
+    @apply min-h-[1.75rem] px-2;
+  }
   @media (pointer: fine) {
-    .dx-button[data-density='fine'] {
+    .dx-button[data-density='md'] {
       @apply min-h-[2rem] px-2.5;
     }
   }

--- a/packages/ui/ui-theme/src/css/theme/spacing.css
+++ b/packages/ui/ui-theme/src/css/theme/spacing.css
@@ -34,7 +34,7 @@
   --spacing-form-section-gap: var(--spacing-trim-lg);
 
   /**
-   * Density: fine
+   * Density: md (default).
    */
   --spacing-form-padding: var(--spacing-trim-sm);
   --spacing-icon-button-padding: var(--spacing-trim-xs);
@@ -43,15 +43,22 @@
 
 @layer dx-tokens {
   /**
-   * TODO(burdon): Density: coarse
+   * Density: lg — large touch targets (~40px controls).
    */
-  /*
-  .dx-density-coarse {
+  .dx-density-lg {
     --spacing-form-padding: var(--spacing-trim-md);
     --spacing-icon-button-padding: var(--spacing-trim-sm);
     --spacing-scroll-padding: 8px;
   }
-  */
+
+  /**
+   * Density: sm — compact (~28px controls).
+   */
+  .dx-density-sm {
+    --spacing-form-padding: var(--spacing-trim-xs);
+    --spacing-icon-button-padding: var(--spacing-trim-xs);
+    --spacing-scroll-padding: 2px;
+  }
 }
 
 /**
@@ -69,9 +76,9 @@
     --dx-lacuna-6: 0.75rem;
 
     --dx-gutter-xs: 0.25rem; /* Input rings */
-    --dx-gutter-sm: 1rem;
-    --dx-gutter-md: 2rem; /* 32px (fine card) */
-    --dx-gutter-lg: 2.5rem; /* 40px (dialog, coarse card) */
+    --dx-gutter-sm: 1rem; /* 16px (sm density card) */
+    --dx-gutter-md: 2rem; /* 32px (md density card — default) */
+    --dx-gutter-lg: 2.5rem; /* 40px (dialog, lg density card) */
   }
 
   :root {
@@ -91,8 +98,9 @@
     --dx-modal-line: var(--dx-hair-line);
     --dx-grid-focus-indicator-width: var(--dx-hair-line);
 
-    --dx-input-fine: var(--dx-lacuna-3);
-    --dx-input-coarse: var(--dx-lacuna-4);
+    --dx-input-md: var(--dx-lacuna-3);
+    --dx-input-lg: var(--dx-lacuna-4);
+    --dx-input-sm: var(--dx-lacuna-3);
 
     --dx-default-icons-size: 1rem; /* size=4 */
   }

--- a/packages/ui/ui-theme/src/fragments/density.ts
+++ b/packages/ui/ui-theme/src/fragments/density.ts
@@ -4,13 +4,34 @@
 
 import { type Density } from '@dxos/ui-types';
 
-const fineBlockSize = 'min-h-[2.5rem] pointer-fine:min-h-[2rem]';
-const coarseBlockSize = 'min-h-[2.5rem]';
+const lgBlockSize = 'min-h-[2.5rem]';
+const mdBlockSize = 'min-h-[2.5rem] pointer-fine:min-h-[2rem]';
+const smBlockSize = 'min-h-[1.75rem]';
 
-const fineDimensions = `${fineBlockSize} px-2`;
-const coarseDimensions = `${coarseBlockSize} px-3`;
+const lgDimensions = `${lgBlockSize} px-3`;
+const mdDimensions = `${mdBlockSize} px-2`;
+const smDimensions = `${smBlockSize} px-1.5`;
 
-export const densityDimensions = (density: Density = 'fine') =>
-  density === 'fine' ? fineDimensions : coarseDimensions;
+export const densityDimensions = (density: Density = 'md') => {
+  switch (density) {
+    case 'lg':
+      return lgDimensions;
+    case 'sm':
+      return smDimensions;
+    case 'md':
+    default:
+      return mdDimensions;
+  }
+};
 
-export const densityBlockSize = (density: Density = 'fine') => (density === 'fine' ? fineBlockSize : coarseBlockSize);
+export const densityBlockSize = (density: Density = 'md') => {
+  switch (density) {
+    case 'lg':
+      return lgBlockSize;
+    case 'sm':
+      return smBlockSize;
+    case 'md':
+    default:
+      return mdBlockSize;
+  }
+};

--- a/packages/ui/ui-theme/src/theme/components/card.ts
+++ b/packages/ui/ui-theme/src/theme/components/card.ts
@@ -27,7 +27,7 @@ const cardRoot: ComponentFunction<CardStyleProps> = ({ border, fullWidth }, ...e
 
 const cardToolbar: ComponentFunction<CardStyleProps> = (_, ...etc) =>
   mx(
-    'dx-card__toolbar dx-density-fine bg-transparent p-0! gap-0! col-span-3 grid! grid-cols-subgrid! [contain:none]',
+    'dx-card__toolbar dx-density-md bg-transparent p-0! gap-0! col-span-3 grid! grid-cols-subgrid! [contain:none]',
     ...etc,
   );
 

--- a/packages/ui/ui-theme/src/theme/components/dialog.ts
+++ b/packages/ui/ui-theme/src/theme/components/dialog.ts
@@ -28,7 +28,7 @@ export const dialogOverlay: ComponentFunction<DialogStyleProps> = (_props, ...et
 export const dialogContent: ComponentFunction<DialogStyleProps> = ({ inOverlayLayout, size = 'md' }, ...etc) => {
   return mx(
     '@container',
-    'dx-dialog__content dx-focus-ring dx-modal-surface dx-density-coarse py-4',
+    'dx-dialog__content dx-focus-ring dx-modal-surface py-4',
     !inOverlayLayout && 'fixed z-50 top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%]',
     sizeMap[size],
     ...etc,
@@ -42,7 +42,7 @@ export const dialogBody: ComponentFunction<DialogStyleProps> = (_props, ...etc) 
   mx('dx-dialog__body dx-expander', withColumn.propagate(), ...etc);
 
 export const dialogActionBar: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
-  mx('dx-dialog__actionbar flex items-center pt-4 gap-2 dx-density-coarse', withColumn.center(), ...etc);
+  mx('dx-dialog__actionbar flex items-center pt-4 gap-2', withColumn.center(), ...etc);
 
 export const dialogTitle: ComponentFunction<DialogStyleProps> = ({ srOnly }, ...etc) =>
   mx('dx-dialog__title', srOnly && 'sr-only', ...etc);

--- a/packages/ui/ui-theme/src/theme/components/input.ts
+++ b/packages/ui/ui-theme/src/theme/components/input.ts
@@ -126,7 +126,7 @@ const inputSwitchThumb: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...e
 const inputWithSegmentsInput: ComponentFunction<InputStyleProps> = (props, ...etc) =>
   mx(
     'font-mono selection:bg-transparent mx-auto',
-    props.density === 'fine' ? 'text-base pointer-fine:text-sm' : 'text-lg',
+    props.density === 'lg' ? 'text-lg' : props.density === 'sm' ? 'text-sm' : 'text-base pointer-fine:text-sm',
     props.disabled && 'cursor-not-allowed',
     ...etc,
   );
@@ -134,7 +134,11 @@ const inputWithSegmentsInput: ComponentFunction<InputStyleProps> = (props, ...et
 const inputSegment: ComponentFunction<InputStyleProps> = (props, ...etc) =>
   mx(
     'flex items-center justify-center font-mono',
-    props.density === 'fine' ? 'size-10 pointer-fine:size-8 rounded-xs' : 'size-12 rounded-xs',
+    props.density === 'lg'
+      ? 'size-12 rounded-xs'
+      : props.density === 'sm'
+        ? 'size-7 rounded-xs'
+        : 'size-10 pointer-fine:size-8 rounded-xs',
     'bg-input-surface text-base-foreground transition-colors border border-separator',
     'data-[focused]:bg-attention-surface data-[focused]:border-focus-ring-subtle',
     'data-[focused]:ring-2 data-[focused]:ring-offset-0 data-[focused]:ring-focus-ring-subtle',

--- a/packages/ui/ui-theme/src/theme/components/list.ts
+++ b/packages/ui/ui-theme/src/theme/components/list.ts
@@ -18,7 +18,11 @@ export const listItem: ComponentFunction<ListStyleProps> = ({ collapsible }, ...
   mx(!collapsible && 'flex', ...etc);
 
 export const listItemEndcap: ComponentFunction<ListStyleProps> = ({ density }, ...etc) =>
-  mx(density === 'fine' ? getSize(8) : getSize(10), 'shrink-0 flex items-center justify-center', ...etc);
+  mx(
+    density === 'lg' ? getSize(10) : density === 'sm' ? getSize(7) : getSize(8),
+    'shrink-0 flex items-center justify-center',
+    ...etc,
+  );
 
 export const listItemHeading: ComponentFunction<ListStyleProps> = ({ density }, ...etc) =>
   mx(densityBlockSize(density), 'flex items-center overflow-hidden [&>span]:truncate', ...etc);

--- a/packages/ui/ui-theme/src/theme/components/scroll-area.ts
+++ b/packages/ui/ui-theme/src/theme/components/scroll-area.ts
@@ -7,12 +7,19 @@ import { type AllowedAxis, type ComponentFunction, type Theme } from '@dxos/ui-t
 import { mx } from '../../util';
 import { withColumn } from '../primitives/column';
 
+/**
+ * Scrollbar sizing presets keyed by density tier.
+ */
 export const scrollbar = {
-  thin: {
+  sm: {
+    size: 2,
+    padding: 2,
+  },
+  md: {
     size: 4,
     padding: 4,
   },
-  coarse: {
+  lg: {
     size: 8,
     padding: 8,
   },

--- a/packages/ui/ui-theme/src/theme/components/toolbar.ts
+++ b/packages/ui/ui-theme/src/theme/components/toolbar.ts
@@ -18,7 +18,8 @@ export const toolbarLayout =
 export const toolbarRoot: ComponentFunction<ToolbarStyleProps> = ({ density, disabled, layoutManaged }, ...etc) => {
   return mx(
     'bg-toolbar-surface dx-toolbar',
-    density === 'coarse' && 'h-(--dx-rail-size) px-3!',
+    density === 'lg' && 'h-(--dx-rail-size) px-3!',
+    density === 'sm' && 'h-7 px-2!',
     disabled && '*:opacity-20',
     !layoutManaged && toolbarLayout,
     ...etc,

--- a/packages/ui/ui-theme/src/util/mx.ts
+++ b/packages/ui/ui-theme/src/util/mx.ts
@@ -40,7 +40,7 @@ export const mx = extendTailwindMerge<AdditionalClassGroups>({
         validators.isArbitraryNumber,
       ],
 
-      density: ['dx-density-fine', 'dx-density-coarse'],
+      density: ['dx-density-sm', 'dx-density-md', 'dx-density-lg'],
 
       'dx-focus-ring': [
         'dx-focus-ring',

--- a/packages/ui/ui-types/src/density.ts
+++ b/packages/ui/ui-types/src/density.ts
@@ -2,4 +2,13 @@
 // Copyright 2023 DXOS.org
 //
 
-export type Density = 'coarse' | 'fine';
+/**
+ * Density tier for UI surfaces.
+ *
+ * - `lg` — large touch targets (~40px buttons). Use for navigation rails,
+ *   modal headers, primary toolbars where comfortable hit areas matter.
+ * - `md` — default. Standard ~32px controls.
+ * - `sm` — compact ~28px controls. Use in data-dense surfaces (tables,
+ *   side panels, inline forms).
+ */
+export type Density = 'lg' | 'md' | 'sm';


### PR DESCRIPTION
## Summary

- Renames the `Density` type from `'coarse' | 'fine'` (default `'fine'`) to `'lg' | 'md' | 'sm'` (default `'md'`), and introduces a third compact tier (~28px controls).
- Cleans up inconsistent density usage across ~40 files — `fine`/`coarse` mixed pointer-precision vocabulary with density semantics, and several `coarse` references were dead code (matching CSS was commented out).
- No back-compat aliases — every call site is migrated in the same change per the repo's no-shims rule.

## What changed

**Type & defaults**
- `packages/ui/ui-types/src/density.ts`: `Density = 'lg' | 'md' | 'sm'`, doc comment explains each tier.
- `DensityProvider` context default → `'md'`.
- `ThemeProvider.rootDensity` default → `'md'`.
- `mx.ts` `tx` variants → `['dx-density-sm', 'dx-density-md', 'dx-density-lg']`.
- `withLayoutVariants` decorator default → `['md']` (was the almost-certainly-wrong `['coarse']`).

**Theme branches extended to 3 tiers**
- `densityDimensions` / `densityBlockSize` fragments
- `toolbar.ts` — `lg` keeps `h-(--dx-rail-size)`; new `sm` case `h-7 px-2`
- `input.ts` — segment size `size-12 / size-10|8 / size-7`; font sizing per tier
- `list.ts` — endcap `getSize(10) / getSize(8) / getSize(7)`
- `Card.tsx` — `gutter` picks `lg` / `md` / `sm`
- `scroll-area.ts` — `scrollbar` preset now keyed by `sm` (2px) / `md` (4px) / `lg` (8px); dropped `thin`/`coarse` keys and migrated the only remaining `scrollbar.thin` consumer (`Masonry`) to `scrollbar.md` in the same commit (no shim).

**CSS**
- `spacing.css`: uncommented the dead `.dx-density-coarse` block, renamed it `.dx-density-lg`; added new `.dx-density-sm` with smaller `--spacing-form-padding`, `--spacing-icon-button-padding`, `--spacing-scroll-padding`. Renamed `--dx-input-fine` / `--dx-input-coarse` to `--dx-input-md` / `--dx-input-lg`; added `--dx-input-sm`.
- `button.css`: added `[data-density='lg']` and `[data-density='sm']` selectors alongside existing `md`.

**Mechanical codemod** (~25 call sites)
- `density='coarse' → density='lg'`, `density='fine' → density='md'` in: NavTreeItemAction (incl. `fineActionButtonProps` / `coarseActionButtonProps` → `mdActionButtonProps` / `lgActionButtonProps`), L1Panel, AppBar, NavTree.stories, Input.stories, Custom.stories, InvitationAuthenticator, ArrayField, TreeItemToggle, Tooltip, PluginDetail, PluginItem, Home.
- `dx-density-coarse → dx-density-lg`, `dx-density-fine → dx-density-md` in: Theme.stories, StackItemContent, PlankHeading, PlankComponent, ChatPrompt, AppBar, L1Panel, SelectOptionField, FormCellEditor, editor `preview.ts`.
- `data-density: 'fine' → 'md'` in: editor `auto-scroll.ts`, `SelectWidget`, `SuggestionWidget`.

**Dialog change**
- Dropped the hardcoded `dx-density-coarse` class from `dialog.ts` (content + action bar). Dialogs now inherit density from their surrounding context. The class was previously a no-op (its CSS was commented out), so no visual regression is expected.

**Storybook**
- `Custom.stories.tsx`: rewrote the three rows to use `density='lg'` / `'md'` / `'sm'` natively (dropped the `!h-[24px]` manual overrides).
- `Input.stories.tsx`: replaced `DensityCoarse` / `DensityFine` stories with `DensityLg` / `DensityMd` / `DensitySm`.

## Proposed `sm` values

| | lg | md (default) | sm (new) |
|---|---|---|---|
| Button min-h | 2.5rem / 40px | 2rem / 32px | 1.75rem / 28px |
| Button px | px-3 | px-2.5 | px-2 |
| Input segment | size-12 | size-10 / size-8 fine | size-7 (28px) |
| List endcap | size-10 (40px) | size-8 (32px) | size-7 (28px) |
| Toolbar h | `--dx-rail-size` (50px) | (default) | h-7 (28px) |
| Card gutter | 40px | 32px | 16px |
| Scroll padding | 8px | 4px | 2px |
| Form/input padding | trim-md (12px) | trim-sm (8px) | trim-xs (4px) |

Open to feedback on any of these — easy to adjust before merge.

## Out of scope (follow-up)

`DensityProvider` still only provides React context; it does **not** emit a DOM marker. So `.dx-density-{lg,sm}` CSS rules only fire for surfaces that explicitly add the class today (Plank, Stack, NavTree sidebar, AppBar). Components consuming context (Button, Input, List) still TS-branch.

Closing this gap would unify the two mechanisms (CSS-cascade fully replaces TS branching), but it needs a wrapper-element decision — directly conflicts with the project's "no wrapper divs" rule. Worth a separate PR with focused discussion.

## Test plan

- [ ] Storybook visual: `Custom` story shows three rows (lg/md/sm) with correctly-sized buttons.
- [ ] Storybook visual: `Input` `DensityLg`/`DensityMd`/`DensitySm` stories show progressively smaller text inputs.
- [ ] Composer app: NavTree sidebar L1 panel header retains current button sizing (now `density='lg'` instead of `'coarse'`).
- [ ] Composer app: Plank headings retain current density (now `dx-density-lg`).
- [ ] Composer app: Dialogs still look correct after removing the hardcoded `dx-density-coarse` class.
- [ ] Composer app: ChatPrompt, AppBar, ChatThread widgets render unchanged (md density).
- [ ] CI Check workflow passes (build, test, lint, fmt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* Updated the UI density system across all application components
* Changed density options from two-tier (fine/coarse) to three-tier (small/medium/large)
* Modified default density level from fine to medium
* Adjusted button, icon, toolbar, and layout sizing for consistency
* Updated spacing and padding values throughout the application

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->