### PR TITLE
fix(cli): add 60s timeout to chat --help smoke test

### DIFF
--- a/packages/devtools/cli/src/commands/chat/chat-prompt.test.ts
+++ b/packages/devtools/cli/src/commands/chat/chat-prompt.test.ts
@@ -18,8 +18,8 @@ import { runDx, withIsolatedHome } from '../../testing';
  */
 
 describe('dx chat --prompt (non-interactive)', () => {
-  test('chat --help advertises --prompt and --json composes with it', ({ expect }) => {
-    const { stdout, status } = runDx(['chat', '--help']);
+  test('chat --help advertises --prompt and --json composes with it', { timeout: 60_000 }, ({ expect }) => {
+    const { stdout, status } = runDx(['chat', '--help'], { timeout: 60_000 });
     expect(status).toBe(0);
     expect(stdout).toMatch(/--prompt/);
     expect(stdout).toMatch(/non-interactively/);


### PR DESCRIPTION
## Summary

Fixes the `dx chat --prompt (non-interactive) > chat --help advertises --prompt and --json composes with it` test that was flagged as failing (non-quarantined) by Trunk in CI run `26319111250`.

- Adds `{ timeout: 60_000 }` to the vitest test options
- Passes `{ timeout: 60_000 }` to the `runDx` call

## Root cause

`dx chat --help` triggers full plugin activation via `createCliApp` → `manager.activate(ActivationEvents.Startup)`, which includes `ClientPlugin.initialize()`. The client initialization waits up to 10 s for a `SystemService` status response. On a loaded CI box, bun's source-mode TypeScript loading adds further overhead, pushing total time past the 30 s default `spawnSync` timeout in `runDx`, causing `status: null` and the assertion `expected null to be +0` to fail.

The sibling test in the same file (`chat --prompt without a HALO identity exits cleanly`) already uses `{ timeout: 60_000 }` on both the vitest test and the `runDx` call — this fix applies the same pattern to the first test.

## Pre-existing open PR

PR #11430 (`fix(echo-pipeline): bump timeout on documents-loaded-from-disk replication test`) covers the quarantined `AutomergeRepo with Subduction > network > documents loaded from disk get replicated` test. That test is already handled and is a separate change.

https://claude.ai/code/session_01X98xJXWokfMVrHwCRpCfRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01X98xJXWokfMVrHwCRpCfRC)_