### PR TITLE
fix(github): correct anthropics/claude-code-action input keys

### DIFF
--- a/.github/workflows/claude-composer-implement.yml
+++ b/.github/workflows/claude-composer-implement.yml
@@ -57,8 +57,15 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--max-turns 15'
-          prompt: |
+          # `mode: agent` bypasses the default `@claude` trigger-phrase check
+          # so the action runs unconditionally — the workflow's `if:` gate on
+          # the `needs-implementation` label handles trigger filtering.
+          mode: agent
+          max_turns: 15
+          # See claude-composer-triage.yml for the input-name caveat: beta tag
+          # still accepts `direct_prompt` + `max_turns`; HEAD has renamed to
+          # `prompt` + `claude_args`. Swap when beta catches up.
+          direct_prompt: |
             This issue has been triaged as actionable. Implement a fix or
             feature in a DRAFT pull request.
 

--- a/.github/workflows/claude-composer-triage.yml
+++ b/.github/workflows/claude-composer-triage.yml
@@ -45,8 +45,16 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--max-turns 3'
-          prompt: |
+          # `mode: agent` bypasses the default `@claude` trigger-phrase check
+          # so the action runs unconditionally for every dispatched event —
+          # the workflow's own `if:` gates handle the actual filtering.
+          mode: agent
+          max_turns: 3
+          # The `@beta` ref of `claude-code-action` exposes `direct_prompt`
+          # for instructions and `max_turns` as a separate top-level input.
+          # (HEAD of the action's repo recently renamed these to `prompt` and
+          # `claude_args` — when the beta tag catches up, swap the keys.)
+          direct_prompt: |
             You are triaging a GitHub issue filed from the Composer in-app
             feedback form. The body contains a markdown trailer with the
             user-reported type, severity, area (plugin id), and app version.


### PR DESCRIPTION
## Summary

The `claude-composer-triage.yml` and `claude-composer-implement.yml` workflows landed in #11449 with input keys that the `@beta` ref of `anthropics/claude-code-action` doesn't accept — the action's runtime validator emits `Unexpected input(s) 'claude_args', 'prompt', valid inputs are [..., 'direct_prompt', ..., 'max_turns', ...]` and silently falls back to default tag-mode (waits for an `@claude` mention, finds none, exits clean).

The first real submission — issue #2325 ("Sequencer tools") — completed [run 26347218224](https://github.com/dxos/dxos/actions/runs/26347218224) successfully on paper but never actually called Claude, hence no triage comment.

## Fix

In **both** workflows, in the `Run Claude triage` / `Run Claude implementation` step:

- `prompt:` → `direct_prompt:`
- `claude_args: '--max-turns N'` → `max_turns: N` (top-level input)
- Added `mode: agent` so the action bypasses trigger-phrase detection (the action.yml description for this mode is *"for automation with no trigger checking"* — exactly our case). The workflows' own `if:` gates handle filtering (`Composer` label for triage, `needs-implementation` label for implement).

Inline comments in both files flag that the input names will need to be swapped back to `prompt` + `claude_args` once the `@beta` tag tracks the recent HEAD-of-repo rename in `anthropics/claude-code-action`.

## Why this slipped past the original PR

Workflow files on a non-default branch are inert for `issues:` triggers — GitHub only dispatches those events from the default branch. So nothing exercised the workflow until #11449 merged, by which point review was done.

## Test plan

- [ ] Re-trigger the workflow on issue #2325 (re-add the `Composer` label, or open a new test issue with the label). Confirm the triage workflow either posts a triage verdict comment or, if it still fails, the annotations now show different errors than the `Unexpected input` ones.
- [ ] If the test issue triages cleanly, follow up by labelling it `needs-implementation` and confirm the implement workflow opens a draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to use the latest Claude code action version with improved agent mode settings for automated implementation and triage tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->