### PR TITLE
fix(github): drop mode: agent from Composer workflows

### DIFF
--- a/.github/workflows/claude-composer-implement.yml
+++ b/.github/workflows/claude-composer-implement.yml
@@ -57,14 +57,15 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # `mode: agent` bypasses the default `@claude` trigger-phrase check
-          # so the action runs unconditionally — the workflow's `if:` gate on
-          # the `needs-implementation` label handles trigger filtering.
-          mode: agent
+          # `mode: tag` (default) — `agent` mode only accepts
+          # `workflow_dispatch`/`schedule` events. With `direct_prompt` set
+          # the tag-mode trigger check returns true unconditionally, so the
+          # workflow's own `if:` gate on the `needs-implementation` label is
+          # what filters which events reach this step.
           max_turns: 15
-          # See claude-composer-triage.yml for the input-name caveat: beta tag
-          # still accepts `direct_prompt` + `max_turns`; HEAD has renamed to
-          # `prompt` + `claude_args`. Swap when beta catches up.
+          # `direct_prompt` carries the implementation instructions. (HEAD of
+          # the action's repo renamed this to `prompt` — swap when @beta
+          # catches up.)
           direct_prompt: |
             This issue has been triaged as actionable. Implement a fix or
             feature in a DRAFT pull request.

--- a/.github/workflows/claude-composer-implement.yml
+++ b/.github/workflows/claude-composer-implement.yml
@@ -57,8 +57,15 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--max-turns 15'
-          prompt: |
+          # `mode: agent` bypasses the default `@claude` trigger-phrase check
+          # so the action runs unconditionally — the workflow's `if:` gate on
+          # the `needs-implementation` label handles trigger filtering.
+          mode: agent
+          max_turns: 15
+          # See claude-composer-triage.yml for the input-name caveat: beta tag
+          # still accepts `direct_prompt` + `max_turns`; HEAD has renamed to
+          # `prompt` + `claude_args`. Swap when beta catches up.
+          direct_prompt: |
             This issue has been triaged as actionable. Implement a fix or
             feature in a DRAFT pull request.
 

--- a/.github/workflows/claude-composer-triage.yml
+++ b/.github/workflows/claude-composer-triage.yml
@@ -45,8 +45,16 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--max-turns 3'
-          prompt: |
+          # `mode: agent` bypasses the default `@claude` trigger-phrase check
+          # so the action runs unconditionally for every dispatched event —
+          # the workflow's own `if:` gates handle the actual filtering.
+          mode: agent
+          max_turns: 3
+          # The `@beta` ref of `claude-code-action` exposes `direct_prompt`
+          # for instructions and `max_turns` as a separate top-level input.
+          # (HEAD of the action's repo recently renamed these to `prompt` and
+          # `claude_args` — when the beta tag catches up, swap the keys.)
+          direct_prompt: |
             You are triaging a GitHub issue filed from the Composer in-app
             feedback form. The body contains a markdown trailer with the
             user-reported type, severity, area (plugin id), and app version.

--- a/.github/workflows/claude-composer-triage.yml
+++ b/.github/workflows/claude-composer-triage.yml
@@ -45,15 +45,18 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # `mode: agent` bypasses the default `@claude` trigger-phrase check
-          # so the action runs unconditionally for every dispatched event —
-          # the workflow's own `if:` gates handle the actual filtering.
-          mode: agent
+          # `mode: tag` (the default) is required — `mode: agent` only accepts
+          # `workflow_dispatch` and `schedule` events per the action's beta
+          # source (`src/modes/agent/index.ts`), not `issues:`. In tag mode,
+          # supplying a non-empty `direct_prompt` triggers the action
+          # unconditionally (see `checkContainsTrigger` in the action source),
+          # so the workflow's own `if:` gate on the Composer label is what
+          # filters which events get here, and `direct_prompt` then forces
+          # the run.
           max_turns: 3
-          # The `@beta` ref of `claude-code-action` exposes `direct_prompt`
-          # for instructions and `max_turns` as a separate top-level input.
-          # (HEAD of the action's repo recently renamed these to `prompt` and
-          # `claude_args` — when the beta tag catches up, swap the keys.)
+          # `direct_prompt` carries the triage instructions. (HEAD of the
+          # action's repo renamed this to `prompt` — swap when @beta catches
+          # up.)
           direct_prompt: |
             You are triaging a GitHub issue filed from the Composer in-app
             feedback form. The body contains a markdown trailer with the


### PR DESCRIPTION
## Summary

PR #11452 added `mode: agent` to the Composer triage + implement workflows expecting it to bypass trigger detection on `issues:` events. It doesn't — at the `@beta` ref, `agent` mode is gated to **only** `workflow_dispatch` and `schedule` events.

Confirmed via the action's source [`src/modes/agent/index.ts`](https://github.com/anthropics/claude-code-action/blob/beta/src/modes/agent/index.ts) and [`src/github/context.ts`](https://github.com/anthropics/claude-code-action/blob/beta/src/github/context.ts):

```ts
const AUTOMATION_EVENT_NAMES = ["workflow_dispatch", "schedule"] as const;
// agentMode.shouldTrigger(context) returns isAutomationContext(context)
// — false for issues:, so the action exits with "No trigger found".
```

Run [26347485296](https://github.com/dxos/dxos/actions/runs/26347485296) on issue #2325 after #11452 merged showed this exact path:
```
Mode: agent
Trigger result: false
No trigger found, skipping remaining steps
```

## Fix

Drop `mode: agent`. Default `mode: tag` is correct for `issues:` events. In tag mode, `checkContainsTrigger` returns true unconditionally when `direct_prompt` is non-empty:

```ts
// src/github/validation/trigger.ts (beta ref)
if (directPrompt) {
  console.log("Direct prompt provided, triggering action");
  return true;
}
```

So the workflow's own `if:` gate on the label is what filters which events reach the action; once the action runs, `direct_prompt` forces it to invoke Claude.

## Test plan

- [ ] Once merged, re-fire the triage workflow on an issue (add/remove `Composer` label, or open a new test issue). Check the run logs for `Direct prompt provided, triggering action` instead of `No trigger found`.
- [ ] Confirm Claude posts a triage verdict comment on the issue.
- [ ] If actionable: label with `needs-implementation` → confirm implement workflow opens a draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to enhance automation for code composition and development processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->