### PR TITLE
fix(github): switch claude-code-action workflows to CLAUDE_CODE_OAUTH_TOKEN

### DIFF
--- a/.github/workflows/claude-composer-implement.yml
+++ b/.github/workflows/claude-composer-implement.yml
@@ -56,7 +56,10 @@ jobs:
       - name: Run Claude implementation
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # See claude-composer-triage.yml for the auth caveat — the org-level
+          # ANTHROPIC_API_KEY is rejected; the repo's CLAUDE_CODE_OAUTH_TOKEN
+          # is the currently-working credential.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # `mode: tag` (default) — `agent` mode only accepts
           # `workflow_dispatch`/`schedule` events. With `direct_prompt` set
           # the tag-mode trigger check returns true unconditionally, so the

--- a/.github/workflows/claude-composer-implement.yml
+++ b/.github/workflows/claude-composer-implement.yml
@@ -57,14 +57,15 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # `mode: agent` bypasses the default `@claude` trigger-phrase check
-          # so the action runs unconditionally — the workflow's `if:` gate on
-          # the `needs-implementation` label handles trigger filtering.
-          mode: agent
+          # `mode: tag` (default) — `agent` mode only accepts
+          # `workflow_dispatch`/`schedule` events. With `direct_prompt` set
+          # the tag-mode trigger check returns true unconditionally, so the
+          # workflow's own `if:` gate on the `needs-implementation` label is
+          # what filters which events reach this step.
           max_turns: 15
-          # See claude-composer-triage.yml for the input-name caveat: beta tag
-          # still accepts `direct_prompt` + `max_turns`; HEAD has renamed to
-          # `prompt` + `claude_args`. Swap when beta catches up.
+          # `direct_prompt` carries the implementation instructions. (HEAD of
+          # the action's repo renamed this to `prompt` — swap when @beta
+          # catches up.)
           direct_prompt: |
             This issue has been triaged as actionable. Implement a fix or
             feature in a DRAFT pull request.

--- a/.github/workflows/claude-composer-implement.yml
+++ b/.github/workflows/claude-composer-implement.yml
@@ -57,8 +57,15 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--max-turns 15'
-          prompt: |
+          # `mode: agent` bypasses the default `@claude` trigger-phrase check
+          # so the action runs unconditionally — the workflow's `if:` gate on
+          # the `needs-implementation` label handles trigger filtering.
+          mode: agent
+          max_turns: 15
+          # See claude-composer-triage.yml for the input-name caveat: beta tag
+          # still accepts `direct_prompt` + `max_turns`; HEAD has renamed to
+          # `prompt` + `claude_args`. Swap when beta catches up.
+          direct_prompt: |
             This issue has been triaged as actionable. Implement a fix or
             feature in a DRAFT pull request.
 

--- a/.github/workflows/claude-composer-triage.yml
+++ b/.github/workflows/claude-composer-triage.yml
@@ -45,8 +45,16 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--max-turns 3'
-          prompt: |
+          # `mode: agent` bypasses the default `@claude` trigger-phrase check
+          # so the action runs unconditionally for every dispatched event —
+          # the workflow's own `if:` gates handle the actual filtering.
+          mode: agent
+          max_turns: 3
+          # The `@beta` ref of `claude-code-action` exposes `direct_prompt`
+          # for instructions and `max_turns` as a separate top-level input.
+          # (HEAD of the action's repo recently renamed these to `prompt` and
+          # `claude_args` — when the beta tag catches up, swap the keys.)
+          direct_prompt: |
             You are triaging a GitHub issue filed from the Composer in-app
             feedback form. The body contains a markdown trailer with the
             user-reported type, severity, area (plugin id), and app version.

--- a/.github/workflows/claude-composer-triage.yml
+++ b/.github/workflows/claude-composer-triage.yml
@@ -44,7 +44,11 @@ jobs:
       - name: Run Claude triage
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # The org-level `ANTHROPIC_API_KEY` is currently rejected by Claude
+          # as "Invalid API key" (likely rotated). A `CLAUDE_CODE_OAUTH_TOKEN`
+          # repo secret was added 2026-05-23 as the working alternative; the
+          # action accepts either input.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # `mode: tag` (the default) is required — `mode: agent` only accepts
           # `workflow_dispatch` and `schedule` events per the action's beta
           # source (`src/modes/agent/index.ts`), not `issues:`. In tag mode,

--- a/.github/workflows/claude-composer-triage.yml
+++ b/.github/workflows/claude-composer-triage.yml
@@ -45,15 +45,18 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # `mode: agent` bypasses the default `@claude` trigger-phrase check
-          # so the action runs unconditionally for every dispatched event —
-          # the workflow's own `if:` gates handle the actual filtering.
-          mode: agent
+          # `mode: tag` (the default) is required — `mode: agent` only accepts
+          # `workflow_dispatch` and `schedule` events per the action's beta
+          # source (`src/modes/agent/index.ts`), not `issues:`. In tag mode,
+          # supplying a non-empty `direct_prompt` triggers the action
+          # unconditionally (see `checkContainsTrigger` in the action source),
+          # so the workflow's own `if:` gate on the Composer label is what
+          # filters which events get here, and `direct_prompt` then forces
+          # the run.
           max_turns: 3
-          # The `@beta` ref of `claude-code-action` exposes `direct_prompt`
-          # for instructions and `max_turns` as a separate top-level input.
-          # (HEAD of the action's repo recently renamed these to `prompt` and
-          # `claude_args` — when the beta tag catches up, swap the keys.)
+          # `direct_prompt` carries the triage instructions. (HEAD of the
+          # action's repo renamed this to `prompt` — swap when @beta catches
+          # up.)
           direct_prompt: |
             You are triaging a GitHub issue filed from the Composer in-app
             feedback form. The body contains a markdown trailer with the

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -36,4 +36,8 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # The org-level ANTHROPIC_API_KEY is currently rejected as "Invalid
+          # API key" by Claude; the repo's CLAUDE_CODE_OAUTH_TOKEN secret
+          # (added 2026-05-23) is the working credential. The action accepts
+          # either input.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Third (and hopefully last) installment fixing the Composer triage/implement workflows. PRs #11452 and #11454 corrected the input keys and trigger mode; this one fixes the credential.

## Symptom

Run [26347705864](https://github.com/dxos/dxos/actions/runs/26347705864) on issue #2325 (after #11454 merged) reached the new expected path:
\`\`\`
Direct prompt provided, triggering action
\`\`\`
and then immediately failed with:
\`\`\`json
{
  "result": "Invalid API key · Fix external API key",
  "is_error": true,
  "apiKeySource": "ANTHROPIC_API_KEY",
  "total_cost_usd": 0
}
\`\`\`

## Root cause

\`gh secret list --org dxos | grep ANTHROPIC\` shows \`ANTHROPIC_API_KEY\` is present at the org level, but Claude rejects it. \`gh secret list --repo dxos/dxos\` shows a brand-new \`CLAUDE_CODE_OAUTH_TOKEN\` secret added 2026-05-23T23:15:14Z — clearly the migration credential. The org API key has been rotated/revoked but the workflows still reference it.

## Fix

\`anthropics/claude-code-action@beta\` accepts either \`anthropic_api_key:\` *or* \`claude_code_oauth_token:\`. Switching all three Composer-side workflows to the OAuth token:

- \`.github/workflows/claude-composer-triage.yml\`
- \`.github/workflows/claude-composer-implement.yml\`
- \`.github/workflows/claude-mention.yml\` *(silently broken too — \`@claude\` mentions would have failed the same way, just less visibly)*

## Test plan

- [ ] Merge.
- [ ] Toggle the \`Composer\` label on issue #2325 (remove then re-add). The triage workflow run logs should show \`Direct prompt provided, triggering action\` followed by a successful Claude session (not \`Invalid API key\`).
- [ ] Confirm Claude posts a triage verdict comment on the issue.
- [ ] If actionable: re-label with \`needs-implementation\` and confirm the implement workflow opens a draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow authentication configuration to use updated credential methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->