### PR TITLE
fix(github): gate Composer workflows behind claude-pilot label (upstream bug)

### DIFF
--- a/.github/workflows/claude-composer-implement.yml
+++ b/.github/workflows/claude-composer-implement.yml
@@ -26,7 +26,10 @@ jobs:
     # PILOT GATE — see `claude-composer-triage.yml` for the rationale. The
     # implement step inherits the same upstream-bug exposure, so it stays
     # gated behind `claude-pilot` until anthropics/claude-code-action#1351
-    # is resolved. Remove this line in lockstep with the triage workflow.
+    # is resolved. To re-enable, delete the
+    # `contains(github.event.issue.labels.*.name, 'claude-pilot') &&` line
+    # from the `if:` block below (and this comment), in lockstep with the
+    # matching change in `claude-composer-triage.yml`.
     if: >
       github.event.label.name == 'needs-implementation' &&
       contains(github.event.issue.labels.*.name, 'Composer') &&

--- a/.github/workflows/claude-composer-implement.yml
+++ b/.github/workflows/claude-composer-implement.yml
@@ -23,9 +23,14 @@ concurrency:
 
 jobs:
   implement:
+    # PILOT GATE — see `claude-composer-triage.yml` for the rationale. The
+    # implement step inherits the same upstream-bug exposure, so it stays
+    # gated behind `claude-pilot` until anthropics/claude-code-action#1351
+    # is resolved. Remove this line in lockstep with the triage workflow.
     if: >
       github.event.label.name == 'needs-implementation' &&
       contains(github.event.issue.labels.*.name, 'Composer') &&
+      contains(github.event.issue.labels.*.name, 'claude-pilot') &&
       !contains(github.event.issue.labels.*.name, 'claude-implementing')
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/claude-composer-triage.yml
+++ b/.github/workflows/claude-composer-triage.yml
@@ -29,7 +29,9 @@ jobs:
     # (https://github.com/anthropics/claude-code-action/issues/1351). Until
     # that upstream fix lands, only issues explicitly labeled `claude-pilot`
     # will trigger triage — so we don't keep burning ~$0.10 per filed issue
-    # for a guaranteed crash. Remove this line once #1351 ships.
+    # for a guaranteed crash. To re-enable, delete the
+    # `contains(github.event.issue.labels.*.name, 'claude-pilot') &&` line
+    # from the `if:` block below (and this comment), once #1351 ships.
     if: >
       contains(github.event.issue.labels.*.name, 'Composer') &&
       contains(github.event.issue.labels.*.name, 'claude-pilot') &&

--- a/.github/workflows/claude-composer-triage.yml
+++ b/.github/workflows/claude-composer-triage.yml
@@ -23,8 +23,16 @@ jobs:
   triage:
     # Only run on Composer-labeled issues — never every issue. Avoid retriggering
     # on labels we (or the implement workflow) add ourselves, or on bot events.
+    #
+    # PILOT GATE: requires the `claude-pilot` label in addition to `Composer`.
+    # The action currently crashes mid-run on its own progress-spinner GIF
+    # (https://github.com/anthropics/claude-code-action/issues/1351). Until
+    # that upstream fix lands, only issues explicitly labeled `claude-pilot`
+    # will trigger triage — so we don't keep burning ~$0.10 per filed issue
+    # for a guaranteed crash. Remove this line once #1351 ships.
     if: >
       contains(github.event.issue.labels.*.name, 'Composer') &&
+      contains(github.event.issue.labels.*.name, 'claude-pilot') &&
       !contains(github.event.issue.labels.*.name, 'needs-implementation') &&
       !contains(github.event.issue.labels.*.name, 'needs-info') &&
       !contains(github.event.issue.labels.*.name, 'claude-implementing') &&


### PR DESCRIPTION
## Summary

Disables the Composer triage + implement workflows until upstream bug [anthropics/claude-code-action#1351](https://github.com/anthropics/claude-code-action/issues/1351) is fixed, by requiring an additional \`claude-pilot\` label.

## Why

After PRs #11449, #11452, #11454, #11455 fixed every layer of the workflow we control (input keys, trigger mode, OAuth credential), runs reach Claude correctly and execute multiple turns — then crash with HTTP 400 because the action injects its own GIF spinner into the prompt and saves it back as a \`.png\`. Every run burns ~$0.10 in tokens for a guaranteed failure with no triage output.

Repro chain documented in #1351. The bug is closed-loop within the action — users can't work around it by editing their issues.

## Change

Added a single \`contains(github.event.issue.labels.*.name, 'claude-pilot')\` clause to both workflows' \`if:\` gates. Inline comments point at #1351 and note the one-line revert path.

\`\`\`yaml
if: >
  contains(github.event.issue.labels.*.name, 'Composer') &&
  contains(github.event.issue.labels.*.name, 'claude-pilot') &&   # ← gated
  ...
\`\`\`

While #1351 is open, no issue triggers the action unless someone explicitly opts it in by adding \`claude-pilot\`. The Composer feedback form continues to file issues normally; they just sit in the queue until the upstream fix lands or a human applies the pilot label.

## Re-enabling

When [#1351](https://github.com/anthropics/claude-code-action/issues/1351) is fixed:

1. Delete the two \`contains(... 'claude-pilot') &&\` lines (one per workflow).
2. Optionally remove the explanatory comment blocks.
3. Optionally provision and bulk-apply \`claude-pilot\` to a few existing Composer issues to test before going wide.

## Test plan

- [ ] Merge.
- [ ] Confirm by labeling a test issue with \`Composer\` only (no \`claude-pilot\`): the workflow should be skipped (no runs in the Actions tab).
- [ ] Optionally add \`claude-pilot\` to that issue to verify the gate works in reverse: the workflow fires (and still crashes on #1351, until that lands).
- [ ] Subscribe to #1351 for notification when fix is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a temporary "PILOT GATE" to Composer automation: triage and implementation steps will only run when a claude-pilot label is present. Explanatory comments were added describing the gate, its temporary nature (due to an upstream issue), and how to re-enable the steps by removing the gate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->