### PR TITLE
feat(plugin-sequencer): add edit/delete tool modes and playhead auto-scroll

### DIFF
--- a/packages/plugins/plugin-sequencer/src/components/SequenceGrid/SequenceGrid.tsx
+++ b/packages/plugins/plugin-sequencer/src/components/SequenceGrid/SequenceGrid.tsx
@@ -13,6 +13,7 @@ import {
   type RenderCell,
   type Row,
   type ToggleMode,
+  type Tool,
   createCellGridAtoms,
   toggleCell,
   cellKey,
@@ -44,6 +45,11 @@ export type SequenceGridProps = {
   loopStart?: number;
   loopEnd?: number;
   onLoopChange?: (loopStart: number, loopEnd: number) => void;
+  /**
+   * Active tool mode. 'toggle' (default) flips notes on click/drag; 'edit' always adds;
+   * 'delete' always removes.
+   */
+  tool?: Tool;
   /**
    * Called when the user toggles a cell. The caller is responsible for mutating the sequence.
    * `mode` reflects the gesture: a single click reports `toggle`; a drag reports `set` or
@@ -118,6 +124,7 @@ export const SequenceGrid = ({
   onLoopChange,
   onToggleNote,
   overlayTracks,
+  tool = 'toggle',
   classNames,
 }: SequenceGridProps) => {
   const registry = useContext(RegistryContext);
@@ -227,6 +234,11 @@ export const SequenceGrid = ({
     registry.set(atoms.playhead, playhead === null ? null : playhead / beatsPerCell);
   }, [registry, atoms.playhead, playhead, beatsPerCell]);
 
+  // Sync the active tool into the atoms so the pointer handler uses the right mode.
+  useEffect(() => {
+    registry.set(atoms.tool, tool);
+  }, [registry, atoms.tool, tool]);
+
   const handleToggle = (coord: CellCoord, mode: ToggleMode) => {
     const pitch = maxPitch - coord.row;
     const startTime = coord.col * beatsPerCell;
@@ -288,6 +300,26 @@ export const SequenceGrid = ({
   }, [paneHeight, totalRows, cellGridHeaders.top, registry, atoms.viewport]);
   const pixelsPerCell = viewport.baseCellWidth * viewport.zoomX;
   const pixelsPerBeat = pixelsPerCell / beatsPerCell;
+
+  // Auto-scroll: when the playhead moves past the right edge of the visible area,
+  // jump-scroll so the playhead stays in view.
+  useEffect(() => {
+    return registry.subscribe(atoms.playhead, (playheadCol) => {
+      if (playheadCol === null) {
+        return;
+      }
+      const vp = registry.get(atoms.viewport);
+      const pxPerCell = vp.baseCellWidth * vp.zoomX;
+      const playheadPx = playheadCol * pxPerCell;
+      const visibleWidth = Math.max(0, paneWidth - cellGridHeaders.left);
+      if (visibleWidth <= 0) {
+        return;
+      }
+      if (playheadPx > vp.scrollX + visibleWidth) {
+        registry.set(atoms.viewport, { ...vp, scrollX: Math.max(0, playheadPx - pxPerCell * 4) });
+      }
+    });
+  }, [registry, atoms.playhead, atoms.viewport, paneWidth, cellGridHeaders.left]);
   const resolvedLoopEnd = loopEnd ?? sequence.length;
   const resolvedLoopStart = loopStart ?? 0;
   // Loop range is allowed to extend beyond the current sequence length — the

--- a/packages/plugins/plugin-sequencer/src/containers/ScoreArticle/ScoreArticle.tsx
+++ b/packages/plugins/plugin-sequencer/src/containers/ScoreArticle/ScoreArticle.tsx
@@ -9,7 +9,7 @@ import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { Obj } from '@dxos/echo';
 import { useObject } from '@dxos/react-client/echo';
 import { Button, Icon, Input, Panel } from '@dxos/react-ui';
-import { type ToggleMode } from '@dxos/react-ui-canvas';
+import { type ToggleMode, type Tool } from '@dxos/react-ui-canvas';
 import { Menu, MenuBuilder, useMenuActions, type ActionGraphProps } from '@dxos/react-ui-menu';
 import { Oscilloscope } from '@dxos/react-ui-sfx';
 import { mx } from '@dxos/ui-theme';
@@ -86,6 +86,7 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
   const [isPlaying, setIsPlaying] = useState(false);
   const [playhead, setPlayhead] = useState<number | null>(null);
   const [showAllTracks, setShowAllTracks] = useState(false);
+  const [toolMode, setToolMode] = useState<Tool>('toggle');
 
   // Auto-select the first track when one becomes available.
   useEffect(() => {
@@ -320,6 +321,11 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
   // menu's invoke handlers close over so the actions stay in sync.
   const togglePlay = useCallback(() => setIsPlaying((current) => !current), []);
   const toggleShowAllTracks = useCallback(() => setShowAllTracks((current) => !current), []);
+  const activateEditTool = useCallback(() => setToolMode((current) => (current === 'edit' ? 'toggle' : 'edit')), []);
+  const activateDeleteTool = useCallback(
+    () => setToolMode((current) => (current === 'delete' ? 'toggle' : 'delete')),
+    [],
+  );
   const actionsAtom = useMemo(
     () =>
       Atom.make(
@@ -347,6 +353,31 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
             )
             .separator()
             .action(
+              'tool-edit',
+              {
+                label: 'Edit (draw notes)',
+                icon: 'ph--pencil-simple--regular',
+                iconOnly: true,
+                disposition: 'toolbar',
+                variant: 'toggle',
+                checked: toolMode === 'edit',
+              },
+              activateEditTool,
+            )
+            .action(
+              'tool-delete',
+              {
+                label: 'Delete (erase notes)',
+                icon: 'ph--eraser--regular',
+                iconOnly: true,
+                disposition: 'toolbar',
+                variant: 'toggle',
+                checked: toolMode === 'delete',
+              },
+              activateDeleteTool,
+            )
+            .separator()
+            .action(
               'import',
               {
                 label: 'Import lead sheet',
@@ -368,7 +399,17 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
             )
             .build(),
       ),
-    [isPlaying, togglePlay, showAllTracks, toggleShowAllTracks, handleImport, handleExport],
+    [
+      isPlaying,
+      togglePlay,
+      showAllTracks,
+      toggleShowAllTracks,
+      toolMode,
+      activateEditTool,
+      activateDeleteTool,
+      handleImport,
+      handleExport,
+    ],
   );
   const menuActions = useMenuActions(actionsAtom);
 
@@ -416,6 +457,7 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
                 loopEnd={score.loopEnd}
                 onLoopChange={handleLoopChange}
                 onToggleNote={handleToggleNote}
+                tool={toolMode}
                 overlayTracks={
                   showAllTracks
                     ? score.tracks

--- a/packages/ui/react-ui-canvas/src/components/CellGrid/input/pointer.ts
+++ b/packages/ui/react-ui-canvas/src/components/CellGrid/input/pointer.ts
@@ -94,6 +94,20 @@ export const attachPointerHandlers = <T>(
         drag = { kind: 'toggle', mode, touched: new Set([key]) };
         break;
       }
+      case 'edit': {
+        // Always adds notes regardless of current cell state.
+        const key = cellKey(coord.col, coord.row);
+        handlers.onCellToggle?.(coord, 'set');
+        drag = { kind: 'toggle', mode: 'set', touched: new Set([key]) };
+        break;
+      }
+      case 'delete': {
+        // Always removes notes regardless of current cell state.
+        const key = cellKey(coord.col, coord.row);
+        handlers.onCellToggle?.(coord, 'unset');
+        drag = { kind: 'toggle', mode: 'unset', touched: new Set([key]) };
+        break;
+      }
       case 'select': {
         drag = { kind: 'select', origin: coord };
         registry.set(atoms.selection, {

--- a/packages/ui/react-ui-canvas/src/components/CellGrid/state/types.ts
+++ b/packages/ui/react-ui-canvas/src/components/CellGrid/state/types.ts
@@ -33,7 +33,7 @@ export type Selection = {
   range: SelectionRange | null;
 };
 
-export type Tool = 'toggle' | 'select' | 'resize';
+export type Tool = 'toggle' | 'select' | 'resize' | 'edit' | 'delete';
 
 export type Row = { id: string; label?: string };
 


### PR DESCRIPTION
## Summary

Implements the three features requested in #11453:

- **Auto-scroll during playback**: when the playhead reaches the right edge of the visible grid pane, the view jump-scrolls to keep it in frame (4-cell left margin)
- **Edit tool** (pencil icon in toolbar): drag always adds notes regardless of whether you start on an existing note — useful for painting in new notes without accidentally erasing
- **Delete tool** (eraser icon in toolbar): drag always removes notes — useful for quickly clearing a region without accidentally adding; clicking the active tool button returns to default toggle mode

## Changes

### `packages/ui/react-ui-canvas`
- `state/types.ts`: extend `Tool` union with `'edit' | 'delete'`
- `input/pointer.ts`: add `case 'edit'` (force `mode: 'set'`) and `case 'delete'` (force `mode: 'unset'`) to the pointer-down switch

### `packages/plugins/plugin-sequencer`
- `SequenceGrid`: new `tool?: Tool` prop (default `'toggle'`); synced to the CellGrid atoms via a `useEffect`; auto-scroll `useEffect` subscribes to the playhead atom and updates `scrollX` when the playhead exits the right edge
- `ScoreArticle`: adds `toolMode` state; pencil/eraser toolbar buttons (toggle-style, visually checked when active); passes `tool={toolMode}` to `SequenceGrid`

closes #11453

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQUkgat6yxse86nJPAUBZC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Edit and Delete tool modes for sequencer interactions.
  * Introduced toolbar buttons to toggle between editing tools.
  * Auto-scroll now keeps the playhead in view as it moves during playback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->