### PR TITLE
fix(plugin-sequencer): tool visibility, single-note draw, and bar-snap scroll

### DIFF
--- a/packages/plugins/plugin-sequencer/src/audio/ScorePlayer.ts
+++ b/packages/plugins/plugin-sequencer/src/audio/ScorePlayer.ts
@@ -150,21 +150,30 @@ const disposeTrackVoices = (trackVoices: TrackVoices) => {
   trackVoices.fallback.dispose();
 };
 
-type ScheduledTrack = {
+type NoteEvent = { time: number; pitch: number; duration: number; velocity: number };
+
+type TrackData = {
   trackId: string;
   voices: TrackVoices;
-  part: Tone.Part<{ time: number; pitch: number; duration: number; velocity: number }>;
+  events: NoteEvent[];
 };
 
 /**
- * Builds Tone.Parts for each Track of a Score and controls the global transport.
- * Call `load` to (re)build with a new Score, then `play()` / `stop()`.
+ * Builds and runs a Tone.js transport for a Score.
+ * Call `load` to (re)build voices/events from a new Score, then `play()` / `stop()`.
+ *
+ * Tone.js state-machine note: `Tone.Part` instances cannot be reliably
+ * restarted after `part.stop()` or after `Transport.stop()` (which internally
+ * stops all synced sources). To guarantee clean playback on every play/stop
+ * cycle, Parts are created fresh in `play()` and disposed in `stop()`. Voices
+ * (synths, gains) are heavier and are reused across play cycles — they are
+ * only rebuilt when `load()` is called with a new Score.
  */
 export class ScorePlayer {
-  #scheduled: ScheduledTrack[] = [];
+  #tracks: TrackData[] = [];
+  #activeParts: Tone.Part<NoteEvent>[] = [];
   #master?: Tone.Gain;
   #started = false;
-  #partsStarted = false;
   #loopBeats = 16;
   #loopStartBeats = 0;
   #loopEndBeats = 0;
@@ -186,8 +195,9 @@ export class ScorePlayer {
   }
 
   /**
-   * Rebuild Tone Parts from the given Score. Disposes any previously scheduled
-   * tracks. The transport is stopped if running; call `play()` afterwards.
+   * Rebuild voices and note-event tables from the given Score. Disposes any
+   * previously loaded tracks. The transport is stopped if running; call
+   * `play()` afterwards.
    */
   load(score: Score.Score): void {
     this.dispose();
@@ -208,21 +218,13 @@ export class ScorePlayer {
       }
       maxLength = Math.max(maxLength, sequence.length);
       const voices = buildTrackVoices(track, this.#master);
-      type Event = { time: number; pitch: number; duration: number; velocity: number };
-      const events: Event[] = (sequence.notes ?? []).map((note: Note.Note) => ({
+      const events: NoteEvent[] = (sequence.notes ?? []).map((note: Note.Note) => ({
         time: beatsToSeconds(note.startTime, score.tempo),
         pitch: note.pitch,
         duration: note.duration,
         velocity: note.velocity ?? 0.8,
       }));
-      const part = new Tone.Part<Event>((time, value) => {
-        const voice = findVoice(voices, value.pitch);
-        voice.trigger(time, value.pitch, value.duration, value.velocity);
-      }, events);
-      // Parts must NOT loop independently — the global Transport drives the loop
-      // between Score.loopStart..loopEnd so every track stays phase-locked.
-      part.loop = false;
-      this.#scheduled.push({ trackId: track.id, voices, part });
+      this.#tracks.push({ trackId: track.id, voices, events });
     }
 
     // Resolve the score-level loop range with defaults. The loop is allowed to
@@ -252,17 +254,22 @@ export class ScorePlayer {
 
   async play(): Promise<void> {
     await Tone.start();
+    // Create fresh Parts on every play. Tone.js Part instances cannot be
+    // reliably restarted after Transport.stop() (which internally calls stop()
+    // on all synced sources, deregistering them from the Transport's event
+    // queue). Creating new instances avoids all stale-state issues.
+    this.#disposeActiveParts();
     const transport = Tone.getTransport();
-    // Parts are added to the Transport timeline once. Calling part.start()
-    // again after part.stop() is unreliable in Tone.js — the Part's internal
-    // state machine may silently drop the re-schedule. Instead we start each
-    // Part exactly once and keep them in the Transport's event list; on
-    // subsequent plays we only restart the Transport.
-    if (!this.#partsStarted) {
-      for (const { part } of this.#scheduled) {
-        part.start(0);
-      }
-      this.#partsStarted = true;
+    for (const { voices, events } of this.#tracks) {
+      const part = new Tone.Part<NoteEvent>((time, value) => {
+        const voice = findVoice(voices, value.pitch);
+        voice.trigger(time, value.pitch, value.duration, value.velocity);
+      }, events);
+      // Parts must NOT loop independently — the global Transport drives the
+      // loop between Score.loopStart..loopEnd so every track stays phase-locked.
+      part.loop = false;
+      part.start(0);
+      this.#activeParts.push(part);
     }
     // Start the transport AT loopStart so playback always begins inside the
     // configured loop range — otherwise events at beats 0..loopStart would
@@ -281,18 +288,13 @@ export class ScorePlayer {
     // schedule cancel-time setter validates `value >= 0` and throws
     // RangeError. Pass an explicit clamped time and additionally swallow
     // the rare race so a stop after a transient play never bubbles up.
-    //
-    // Parts are intentionally NOT stopped here — stopping a Part removes it
-    // from the Transport's schedule and Tone.js does not reliably re-add it
-    // via part.start() on the same instance. The Transport stop() already
-    // silences all audio; Parts remain in the schedule and replay on the
-    // next transport.start().
     const time = Math.max(0, Tone.now());
     try {
       Tone.getTransport().stop(time);
     } catch {
       /* see comment above */
     }
+    this.#disposeActiveParts();
   }
 
   /** True if play() has been called since the last stop()/dispose(). */
@@ -302,13 +304,25 @@ export class ScorePlayer {
 
   dispose(): void {
     this.stop();
-    for (const entry of this.#scheduled) {
-      entry.part.dispose();
+    this.#disposeActiveParts();
+    for (const entry of this.#tracks) {
       disposeTrackVoices(entry.voices);
     }
-    this.#scheduled = [];
-    this.#partsStarted = false;
+    this.#tracks = [];
     this.#master?.dispose();
     this.#master = undefined;
+  }
+
+  #disposeActiveParts(): void {
+    const time = Math.max(0, Tone.now());
+    for (const part of this.#activeParts) {
+      try {
+        part.stop(time);
+      } catch {
+        // ignore
+      }
+      part.dispose();
+    }
+    this.#activeParts = [];
   }
 }

--- a/packages/plugins/plugin-sequencer/src/audio/ScorePlayer.ts
+++ b/packages/plugins/plugin-sequencer/src/audio/ScorePlayer.ts
@@ -164,6 +164,7 @@ export class ScorePlayer {
   #scheduled: ScheduledTrack[] = [];
   #master?: Tone.Gain;
   #started = false;
+  #partsStarted = false;
   #loopBeats = 16;
   #loopStartBeats = 0;
   #loopEndBeats = 0;
@@ -252,8 +253,16 @@ export class ScorePlayer {
   async play(): Promise<void> {
     await Tone.start();
     const transport = Tone.getTransport();
-    for (const { part } of this.#scheduled) {
-      part.start(0);
+    // Parts are added to the Transport timeline once. Calling part.start()
+    // again after part.stop() is unreliable in Tone.js — the Part's internal
+    // state machine may silently drop the re-schedule. Instead we start each
+    // Part exactly once and keep them in the Transport's event list; on
+    // subsequent plays we only restart the Transport.
+    if (!this.#partsStarted) {
+      for (const { part } of this.#scheduled) {
+        part.start(0);
+      }
+      this.#partsStarted = true;
     }
     // Start the transport AT loopStart so playback always begins inside the
     // configured loop range — otherwise events at beats 0..loopStart would
@@ -272,18 +281,17 @@ export class ScorePlayer {
     // schedule cancel-time setter validates `value >= 0` and throws
     // RangeError. Pass an explicit clamped time and additionally swallow
     // the rare race so a stop after a transient play never bubbles up.
+    //
+    // Parts are intentionally NOT stopped here — stopping a Part removes it
+    // from the Transport's schedule and Tone.js does not reliably re-add it
+    // via part.start() on the same instance. The Transport stop() already
+    // silences all audio; Parts remain in the schedule and replay on the
+    // next transport.start().
     const time = Math.max(0, Tone.now());
     try {
       Tone.getTransport().stop(time);
     } catch {
       /* see comment above */
-    }
-    for (const { part } of this.#scheduled) {
-      try {
-        part.stop(time);
-      } catch {
-        /* see comment above */
-      }
     }
   }
 
@@ -299,6 +307,7 @@ export class ScorePlayer {
       disposeTrackVoices(entry.voices);
     }
     this.#scheduled = [];
+    this.#partsStarted = false;
     this.#master?.dispose();
     this.#master = undefined;
   }

--- a/packages/plugins/plugin-sequencer/src/audio/ScorePlayer.ts
+++ b/packages/plugins/plugin-sequencer/src/audio/ScorePlayer.ts
@@ -154,6 +154,7 @@ type NoteEvent = { time: number; pitch: number; duration: number; velocity: numb
 
 type TrackData = {
   trackId: string;
+  track: Track.Track;
   voices: TrackVoices;
   events: NoteEvent[];
 };
@@ -224,7 +225,7 @@ export class ScorePlayer {
         duration: note.duration,
         velocity: note.velocity ?? 0.8,
       }));
-      this.#tracks.push({ trackId: track.id, voices, events });
+      this.#tracks.push({ trackId: track.id, track, voices, events });
     }
 
     // Resolve the score-level loop range with defaults. The loop is allowed to
@@ -254,11 +255,19 @@ export class ScorePlayer {
 
   async play(): Promise<void> {
     await Tone.start();
-    // Create fresh Parts on every play. Tone.js Part instances cannot be
-    // reliably restarted after Transport.stop() (which internally calls stop()
-    // on all synced sources, deregistering them from the Transport's event
-    // queue). Creating new instances avoids all stale-state issues.
+    // Rebuild voices and Parts on every play. Transport.stop() abruptly
+    // cancels scheduled notes, which can leave PolySynth voice pools in a
+    // bad state. Creating fresh PolySynth instances (via buildTrackVoices)
+    // and fresh Parts matches the clean state you get after an unmount/remount.
+    // The master Gain node is kept stable so the oscilloscope connection is
+    // preserved across play cycles.
     this.#disposeActiveParts();
+    if (this.#master) {
+      for (const trackData of this.#tracks) {
+        disposeTrackVoices(trackData.voices);
+        trackData.voices = buildTrackVoices(trackData.track, this.#master);
+      }
+    }
     const transport = Tone.getTransport();
     for (const { voices, events } of this.#tracks) {
       const part = new Tone.Part<NoteEvent>((time, value) => {

--- a/packages/plugins/plugin-sequencer/src/components/SequenceGrid/SequenceGrid.tsx
+++ b/packages/plugins/plugin-sequencer/src/components/SequenceGrid/SequenceGrid.tsx
@@ -275,14 +275,11 @@ export const SequenceGrid = ({
     [maxPitch, beatsPerCell, onToggleNote, registry, atoms, trackColor],
   );
 
-  const handleDrawUpdate = useCallback(
-    (startCoord: CellCoord, endCoord: CellCoord) => {
-      const col = Math.min(startCoord.col, endCoord.col);
-      const length = Math.abs(endCoord.col - startCoord.col) + 1;
-      setDrawPreview({ col, row: startCoord.row, length });
-    },
-    [],
-  );
+  const handleDrawUpdate = useCallback((startCoord: CellCoord, endCoord: CellCoord) => {
+    const col = Math.min(startCoord.col, endCoord.col);
+    const length = Math.abs(endCoord.col - startCoord.col) + 1;
+    setDrawPreview({ col, row: startCoord.row, length });
+  }, []);
 
   const handleDrawCommit = useCallback(
     (startCoord: CellCoord, endCoord: CellCoord) => {

--- a/packages/plugins/plugin-sequencer/src/components/SequenceGrid/SequenceGrid.tsx
+++ b/packages/plugins/plugin-sequencer/src/components/SequenceGrid/SequenceGrid.tsx
@@ -3,7 +3,7 @@
 //
 
 import { RegistryContext, useAtomValue } from '@effect-atom/atom-react';
-import React, { useContext, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useResizeDetector } from 'react-resize-detector';
 
 import {
@@ -46,16 +46,19 @@ export type SequenceGridProps = {
   loopEnd?: number;
   onLoopChange?: (loopStart: number, loopEnd: number) => void;
   /**
-   * Active tool mode. 'toggle' (default) flips notes on click/drag; 'edit' always adds;
-   * 'delete' always removes.
+   * Active tool mode. 'toggle' (default) flips notes on click/drag; 'edit' draws a single
+   * note spanning the drag extent; 'delete' always removes.
    */
   tool?: Tool;
+  /** Beats per bar used for auto-scroll bar snapping. Defaults to 4 (4/4 time). */
+  beatsPerBar?: number;
   /**
    * Called when the user toggles a cell. The caller is responsible for mutating the sequence.
    * `mode` reflects the gesture: a single click reports `toggle`; a drag reports `set` or
    * `unset` for every cell crossed (chosen by the cell under the initial pointerdown).
+   * `duration` is provided by the edit tool to specify the note length in beats.
    */
-  onToggleNote?: (pitch: number, startTime: number, mode: ToggleMode) => void;
+  onToggleNote?: (pitch: number, startTime: number, mode: ToggleMode, duration?: number) => void;
   /**
    * Other tracks to paint underneath the active sequence in a subdued color.
    * Cells from these tracks are non-interactive — toggle gestures always target
@@ -118,6 +121,7 @@ export const SequenceGrid = ({
   minPitch: minPitchProp,
   maxPitch: maxPitchProp,
   beatsPerCell = 0.25,
+  beatsPerBar = 4,
   playhead = null,
   loopStart,
   loopEnd,
@@ -143,6 +147,9 @@ export const SequenceGrid = ({
       createCellGridAtoms<{ color: string; velocity: number; subdued?: boolean }>({ cellWidth: 28, cellHeight: 18 }),
     [],
   );
+
+  // Temporary cell shown while the user is mid-drag with the edit tool.
+  const [drawPreview, setDrawPreview] = useState<{ col: number; row: number; length: number } | null>(null);
 
   // Rows are pitches arranged high-to-low (row 0 = maxPitch at the top).
   const rows: Row[] = useMemo(
@@ -226,8 +233,17 @@ export const SequenceGrid = ({
         data: { color: trackColor, velocity: note.velocity ?? 0.8 },
       });
     }
+    // Show a live preview cell while the user drags with the edit tool.
+    if (drawPreview) {
+      cells.set(cellKey(drawPreview.col, drawPreview.row), {
+        col: drawPreview.col,
+        row: drawPreview.row,
+        length: drawPreview.length,
+        data: { color: trackColor, velocity: 0.8 },
+      });
+    }
     registry.set(atoms.cells, cells);
-  }, [registry, atoms.cells, notes, overlayCellInputs, minPitch, maxPitch, beatsPerCell, trackColor]);
+  }, [registry, atoms.cells, notes, overlayCellInputs, minPitch, maxPitch, beatsPerCell, trackColor, drawPreview]);
 
   // Mirror playhead (beats → column units, accounting for beatsPerCell).
   useEffect(() => {
@@ -239,22 +255,61 @@ export const SequenceGrid = ({
     registry.set(atoms.tool, tool);
   }, [registry, atoms.tool, tool]);
 
-  const handleToggle = (coord: CellCoord, mode: ToggleMode) => {
-    const pitch = maxPitch - coord.row;
-    const startTime = coord.col * beatsPerCell;
-    if (onToggleNote) {
-      onToggleNote(pitch, startTime, mode);
-      return;
-    }
-    // Default: write directly to the cells atom (preview mode).
-    toggleCell(
-      registry,
-      atoms,
-      coord,
-      ({ col, row }) => ({ col, row, length: 1, data: { color: trackColor, velocity: 0.8 } }),
-      mode,
-    );
-  };
+  const handleToggle = useCallback(
+    (coord: CellCoord, mode: ToggleMode) => {
+      const pitch = maxPitch - coord.row;
+      const startTime = coord.col * beatsPerCell;
+      if (onToggleNote) {
+        onToggleNote(pitch, startTime, mode);
+        return;
+      }
+      // Default: write directly to the cells atom (preview mode).
+      toggleCell(
+        registry,
+        atoms,
+        coord,
+        ({ col, row }) => ({ col, row, length: 1, data: { color: trackColor, velocity: 0.8 } }),
+        mode,
+      );
+    },
+    [maxPitch, beatsPerCell, onToggleNote, registry, atoms, trackColor],
+  );
+
+  const handleDrawUpdate = useCallback(
+    (startCoord: CellCoord, endCoord: CellCoord) => {
+      const col = Math.min(startCoord.col, endCoord.col);
+      const length = Math.abs(endCoord.col - startCoord.col) + 1;
+      setDrawPreview({ col, row: startCoord.row, length });
+    },
+    [],
+  );
+
+  const handleDrawCommit = useCallback(
+    (startCoord: CellCoord, endCoord: CellCoord) => {
+      setDrawPreview(null);
+      const col = Math.min(startCoord.col, endCoord.col);
+      const length = Math.abs(endCoord.col - startCoord.col) + 1;
+      const pitch = maxPitch - startCoord.row;
+      const startTime = col * beatsPerCell;
+      const duration = length * beatsPerCell;
+      if (onToggleNote) {
+        onToggleNote(pitch, startTime, 'set', duration);
+        return;
+      }
+      // Default: write directly to atoms (preview mode).
+      registry.update(atoms.cells, (current) => {
+        const next = new Map(current);
+        next.set(cellKey(col, startCoord.row), {
+          col,
+          row: startCoord.row,
+          length,
+          data: { color: trackColor, velocity: 0.8 },
+        });
+        return next;
+      });
+    },
+    [maxPitch, beatsPerCell, onToggleNote, registry, atoms.cells, trackColor],
+  );
 
   // Style the row bands so black-key rows are darker (piano-roll feel).
   const rowBandRenderer = useMemo(() => {
@@ -302,7 +357,7 @@ export const SequenceGrid = ({
   const pixelsPerBeat = pixelsPerCell / beatsPerCell;
 
   // Auto-scroll: when the playhead moves past the right edge of the visible area,
-  // jump-scroll so the playhead stays in view.
+  // jump-scroll to the nearest previous bar boundary so bar lines stay aligned.
   useEffect(() => {
     return registry.subscribe(atoms.playhead, (playheadCol) => {
       if (playheadCol === null) {
@@ -316,10 +371,12 @@ export const SequenceGrid = ({
         return;
       }
       if (playheadPx > vp.scrollX + visibleWidth) {
-        registry.set(atoms.viewport, { ...vp, scrollX: Math.max(0, playheadPx - pxPerCell * 4) });
+        const pxPerBar = (beatsPerBar / beatsPerCell) * pxPerCell;
+        const barAlignedScrollX = Math.floor(playheadPx / pxPerBar) * pxPerBar;
+        registry.set(atoms.viewport, { ...vp, scrollX: Math.max(0, barAlignedScrollX) });
       }
     });
-  }, [registry, atoms.playhead, atoms.viewport, paneWidth, cellGridHeaders.left]);
+  }, [registry, atoms.playhead, atoms.viewport, paneWidth, cellGridHeaders.left, beatsPerBar, beatsPerCell]);
   const resolvedLoopEnd = loopEnd ?? sequence.length;
   const resolvedLoopStart = loopStart ?? 0;
   // Loop range is allowed to extend beyond the current sequence length — the
@@ -336,6 +393,8 @@ export const SequenceGrid = ({
         headers={cellGridHeaders}
         staticStyle={cellGridStaticStyle}
         onCellToggle={handleToggle}
+        onDrawUpdate={handleDrawUpdate}
+        onDrawCommit={handleDrawCommit}
       />
       {onLoopChange && paneWidth > 0 && (
         <LoopMarkers

--- a/packages/plugins/plugin-sequencer/src/components/SequenceGrid/SequenceGrid.tsx
+++ b/packages/plugins/plugin-sequencer/src/components/SequenceGrid/SequenceGrid.tsx
@@ -128,7 +128,7 @@ export const SequenceGrid = ({
   onLoopChange,
   onToggleNote,
   overlayTracks,
-  tool = 'toggle',
+  tool = 'edit',
   classNames,
 }: SequenceGridProps) => {
   const registry = useContext(RegistryContext);
@@ -361,6 +361,7 @@ export const SequenceGrid = ({
   useEffect(() => {
     return registry.subscribe(atoms.playhead, (playheadCol) => {
       if (playheadCol === null) {
+        registry.update(atoms.viewport, (vp) => ({ ...vp, scrollX: 0 }));
         return;
       }
       const vp = registry.get(atoms.viewport);

--- a/packages/plugins/plugin-sequencer/src/components/SequenceGrid/SequenceGrid.tsx
+++ b/packages/plugins/plugin-sequencer/src/components/SequenceGrid/SequenceGrid.tsx
@@ -359,10 +359,15 @@ export const SequenceGrid = ({
   // Auto-scroll: when the playhead moves past the right edge of the visible area,
   // jump-scroll to the nearest previous bar boundary so bar lines stay aligned.
   useEffect(() => {
+    let wasPlaying = false;
     return registry.subscribe(atoms.playhead, (playheadCol) => {
       if (playheadCol === null) {
-        registry.update(atoms.viewport, (vp) => ({ ...vp, scrollX: 0 }));
+        wasPlaying = false;
         return;
+      }
+      if (!wasPlaying) {
+        wasPlaying = true;
+        registry.update(atoms.viewport, (vp) => ({ ...vp, scrollX: 0 }));
       }
       const vp = registry.get(atoms.viewport);
       const pxPerCell = vp.baseCellWidth * vp.zoomX;

--- a/packages/plugins/plugin-sequencer/src/containers/ScoreArticle/ScoreArticle.tsx
+++ b/packages/plugins/plugin-sequencer/src/containers/ScoreArticle/ScoreArticle.tsx
@@ -10,7 +10,13 @@ import { Obj } from '@dxos/echo';
 import { useObject } from '@dxos/react-client/echo';
 import { Button, Icon, Input, Panel } from '@dxos/react-ui';
 import { type ToggleMode } from '@dxos/react-ui-canvas';
-import { Menu, MenuBuilder, useMenuActions, type ActionGraphProps, type ToolbarMenuActionGroupProperties } from '@dxos/react-ui-menu';
+import {
+  Menu,
+  MenuBuilder,
+  useMenuActions,
+  type ActionGraphProps,
+  type ToolbarMenuActionGroupProperties,
+} from '@dxos/react-ui-menu';
 import { Oscilloscope } from '@dxos/react-ui-sfx';
 import { mx } from '@dxos/ui-theme';
 

--- a/packages/plugins/plugin-sequencer/src/containers/ScoreArticle/ScoreArticle.tsx
+++ b/packages/plugins/plugin-sequencer/src/containers/ScoreArticle/ScoreArticle.tsx
@@ -305,6 +305,8 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
       setPlayhead(null);
       return;
     }
+    player.load(score as Score.Score);
+    setAudioOutputNode(player.outputNode);
     void player.play();
     const startedAt = performance.now();
     const beatsPerSecond = score.tempo / 60;

--- a/packages/plugins/plugin-sequencer/src/containers/ScoreArticle/ScoreArticle.tsx
+++ b/packages/plugins/plugin-sequencer/src/containers/ScoreArticle/ScoreArticle.tsx
@@ -10,7 +10,7 @@ import { Obj } from '@dxos/echo';
 import { useObject } from '@dxos/react-client/echo';
 import { Button, Icon, Input, Panel } from '@dxos/react-ui';
 import { type ToggleMode, type Tool } from '@dxos/react-ui-canvas';
-import { Menu, MenuBuilder, useMenuActions, type ActionGraphProps } from '@dxos/react-ui-menu';
+import { Menu, MenuBuilder, useMenuActions, type ActionGraphProps, type ToolbarMenuActionGroupProperties } from '@dxos/react-ui-menu';
 import { Oscilloscope } from '@dxos/react-ui-sfx';
 import { mx } from '@dxos/ui-theme';
 
@@ -234,7 +234,7 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
   const beatsPerCell = 0.25;
 
   const handleToggleNote = useCallback(
-    (pitch: number, startTime: number, mode: ToggleMode) => {
+    (pitch: number, startTime: number, mode: ToggleMode, duration?: number) => {
       if (!activeSequence) {
         return;
       }
@@ -254,7 +254,7 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
         if (shouldRemove && exists) {
           sequence.notes.splice(existingIndex, 1);
         } else if (shouldAdd && !exists) {
-          sequence.notes.push({ pitch, startTime, duration: beatsPerCell, velocity: 0.8 });
+          sequence.notes.push({ pitch, startTime, duration: duration ?? beatsPerCell, velocity: 0.8 });
         }
       });
     },
@@ -352,29 +352,28 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
               toggleShowAllTracks,
             )
             .separator()
-            .action(
-              'tool-edit',
+            .group(
+              'tool-modes',
               {
-                label: 'Edit (draw notes)',
-                icon: 'ph--pencil-simple--regular',
+                label: 'Tool',
                 iconOnly: true,
-                disposition: 'toolbar',
-                variant: 'toggle',
-                checked: toolMode === 'edit',
+                variant: 'toggleGroup',
+                selectCardinality: 'single',
+                value: toolMode === 'edit' ? 'tool-edit' : toolMode === 'delete' ? 'tool-delete' : '',
+              } as ToolbarMenuActionGroupProperties,
+              (group) => {
+                group
+                  .action(
+                    'tool-edit',
+                    { label: 'Edit (draw notes)', icon: 'ph--pencil-simple--regular', checked: toolMode === 'edit' },
+                    activateEditTool,
+                  )
+                  .action(
+                    'tool-delete',
+                    { label: 'Delete (erase notes)', icon: 'ph--eraser--regular', checked: toolMode === 'delete' },
+                    activateDeleteTool,
+                  );
               },
-              activateEditTool,
-            )
-            .action(
-              'tool-delete',
-              {
-                label: 'Delete (erase notes)',
-                icon: 'ph--eraser--regular',
-                iconOnly: true,
-                disposition: 'toolbar',
-                variant: 'toggle',
-                checked: toolMode === 'delete',
-              },
-              activateDeleteTool,
             )
             .separator()
             .action(
@@ -452,6 +451,7 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
                 sequence={activeSequence}
                 track={activeTrack}
                 beatsPerCell={beatsPerCell}
+                beatsPerBar={beatsPerBar}
                 playhead={playhead}
                 loopStart={score.loopStart}
                 loopEnd={score.loopEnd}

--- a/packages/plugins/plugin-sequencer/src/containers/ScoreArticle/ScoreArticle.tsx
+++ b/packages/plugins/plugin-sequencer/src/containers/ScoreArticle/ScoreArticle.tsx
@@ -2,22 +2,15 @@
 // Copyright 2026 DXOS.org
 //
 
-import { Atom } from '@effect-atom/atom-react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { Obj } from '@dxos/echo';
 import { useObject } from '@dxos/react-client/echo';
 import { Button, Icon, Input, Panel } from '@dxos/react-ui';
 import { type ToggleMode } from '@dxos/react-ui-canvas';
-import {
-  Menu,
-  MenuBuilder,
-  useMenuActions,
-  type ActionGraphProps,
-  type ToolbarMenuActionGroupProperties,
-} from '@dxos/react-ui-menu';
-import { Oscilloscope } from '@dxos/react-ui-sfx';
+import { Menu, MenuBuilder, useMenuBuilder, type ToolbarMenuActionGroupProperties } from '@dxos/react-ui-menu';
+import { Oscilloscope, OscilloscopeMode } from '@dxos/react-ui-sfx';
 import { mx } from '@dxos/ui-theme';
 
 import { SequenceGrid, TrackList } from '#components';
@@ -66,6 +59,7 @@ const findSequenceForTrack = (score: Score.Score, trackId: string | null): Seque
   if (!trackId) {
     return undefined;
   }
+
   return score.sequences.find((sequence) => sequence.trackId === trackId);
 };
 
@@ -73,6 +67,7 @@ const parseTimeSignature = (input: string | undefined): number => {
   if (!input) {
     return 4;
   }
+
   const match = /^(\d+)\s*\/\s*\d+$/.exec(input.trim());
   const beats = match ? Number(match[1]) : NaN;
   // Reject zero / negative / non-integer / non-finite — beatsPerBar=0 would break
@@ -88,11 +83,18 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
   const [snapshot] = useObject(subject);
   const score = snapshot as unknown as Score.Score;
 
+  const beatsPerBar = parseTimeSignature(score.timeSignature);
+  const beatsPerCell = 0.25;
+
   const [selectedTrackId, setSelectedTrackId] = useState<string | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [playhead, setPlayhead] = useState<number | null>(null);
   const [showAllTracks, setShowAllTracks] = useState(false);
   const [toolMode, setToolMode] = useState<'edit' | 'delete'>('edit');
+  const [oscilloscopeMode, setOscilloscopeMode] = useState<OscilloscopeMode>('waveform');
+
+  const activeTrack = score.tracks.find((track) => track.id === selectedTrackId) ?? null;
+  const activeSequence = findSequenceForTrack(score, selectedTrackId) ?? null;
 
   // Auto-select the first track when one becomes available.
   useEffect(() => {
@@ -102,9 +104,6 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
       setSelectedTrackId(score.tracks[0]?.id ?? null);
     }
   }, [selectedTrackId, score.tracks]);
-
-  const activeTrack = score.tracks.find((track) => track.id === selectedTrackId) ?? null;
-  const activeSequence = findSequenceForTrack(score, selectedTrackId) ?? null;
 
   // Ensure a sequence exists for the selected track.
   useEffect(() => {
@@ -187,8 +186,6 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
     [subject],
   );
 
-  const beatsPerBar = parseTimeSignature(score.timeSignature);
-
   const handleExport = useCallback(() => {
     const document = scoreToLeadSheet(score);
     const text = formatLeadSheet(document, { beatsPerBar });
@@ -216,11 +213,13 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
       if (!file) {
         return;
       }
+
       const text = await file.text();
       if (!text.trim()) {
         window.alert(`${file.name} is empty.`);
         return;
       }
+
       let document: LeadSheetDocument;
       try {
         document = parseLeadSheet(text, { beatsPerBar });
@@ -228,22 +227,23 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
         window.alert(`Lead-sheet parse error: ${(error as Error).message}`);
         return;
       }
+
       Obj.update(subject, (subject) => {
         const mutable = subject as unknown as MutableScore;
         applyLeadSheetToScore(mutable, document);
       });
     });
+
     window.document.body.appendChild(input);
     input.click();
   }, [subject, beatsPerBar]);
-
-  const beatsPerCell = 0.25;
 
   const handleToggleNote = useCallback(
     (pitch: number, startTime: number, mode: ToggleMode, duration?: number) => {
       if (!activeSequence) {
         return;
       }
+
       const sequenceId = activeSequence.id;
       Obj.update(subject, (subject) => {
         const mutable = subject as unknown as MutableScore;
@@ -251,6 +251,7 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
         if (!sequence) {
           return;
         }
+
         const existingIndex = sequence.notes.findIndex((note) => {
           if (note.pitch !== pitch) {
             return false;
@@ -259,8 +260,10 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
             // Hit any note whose duration spans over the cursor position.
             return note.startTime <= startTime + 1e-6 && startTime < note.startTime + note.duration - 1e-6;
           }
+
           return Math.abs(note.startTime - startTime) < 1e-6;
         });
+
         const exists = existingIndex >= 0;
         const shouldRemove = mode === 'unset' || (mode === 'toggle' && exists);
         const shouldAdd = mode === 'set' || (mode === 'toggle' && !exists);
@@ -305,15 +308,16 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
       setPlayhead(null);
       return;
     }
+
     player.load(score as Score.Score);
     setAudioOutputNode(player.outputNode);
     void player.play();
     const startedAt = performance.now();
     const beatsPerSecond = score.tempo / 60;
     // Match the ScorePlayer's effective loop range so the visual playhead loops
-    // in lockstep with the audio (start → end → wrap → start). Trust the
-    // score-level loopStart/loopEnd directly; the loop is allowed to extend
-    // past activeSequence.length.
+    // in lockstep with the audio (start → end → wrap → start).
+    // Trust the score-level loopStart/loopEnd directly;
+    // the loop is allowed to extend past activeSequence.length.
     const loopStartBeats = Math.max(0, score.loopStart ?? 0);
     const loopEndBeats = Math.max(loopStartBeats + 0.0625, score.loopEnd ?? activeSequence.length);
     const loopSpan = loopEndBeats - loopStartBeats;
@@ -332,84 +336,80 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
   }, [isPlaying, activeSequence, score.tempo, score.loopStart, score.loopEnd]);
 
   // Toolbar actions composed via the MenuBuilder / Menu.Root idiom
-  // (org.dxos.react-ui-menu.toolbarMenu). useMemo deps cover every value the
-  // menu's invoke handlers close over so the actions stay in sync.
+  // (org.dxos.react-ui-menu.toolbarMenu). Deps cover every value the menu's
+  // invoke handlers close over so the actions stay in sync.
   const togglePlay = useCallback(() => setIsPlaying((current) => !current), []);
   const toggleShowAllTracks = useCallback(() => setShowAllTracks((current) => !current), []);
   const activateEditTool = useCallback(() => setToolMode('edit'), []);
   const activateDeleteTool = useCallback(() => setToolMode('delete'), []);
-  const actionsAtom = useMemo(
+  const menuActions = useMenuBuilder(
     () =>
-      Atom.make(
-        (): ActionGraphProps =>
-          MenuBuilder.make()
-            .action(
-              'play',
-              {
-                label: isPlaying ? 'Stop' : 'Play',
-                icon: isPlaying ? 'ph--pause--regular' : 'ph--play--regular',
-                iconOnly: true,
-                disposition: 'toolbar',
-              },
-              togglePlay,
-            )
-            .action(
-              'show-all-tracks',
-              {
-                label: showAllTracks ? 'Show active track only' : 'Show all tracks',
-                icon: showAllTracks ? 'ph--stack--regular' : 'ph--stack-simple--regular',
-                iconOnly: true,
-                disposition: 'toolbar',
-              },
-              toggleShowAllTracks,
-            )
-            .separator()
-            .group(
-              'tool-modes',
-              {
-                label: 'Tool',
-                iconOnly: true,
-                variant: 'toggleGroup',
-                selectCardinality: 'single',
-                value: toolMode === 'edit' ? 'tool-edit' : 'tool-delete',
-              } as ToolbarMenuActionGroupProperties,
-              (group) => {
-                group
-                  .action(
-                    'tool-edit',
-                    { label: 'Edit (draw notes)', icon: 'ph--pencil-simple--regular', checked: toolMode === 'edit' },
-                    activateEditTool,
-                  )
-                  .action(
-                    'tool-delete',
-                    { label: 'Delete (erase notes)', icon: 'ph--eraser--regular', checked: toolMode === 'delete' },
-                    activateDeleteTool,
-                  );
-              },
-            )
-            .separator()
-            .action(
-              'import',
-              {
-                label: 'Import lead sheet',
-                icon: 'ph--upload-simple--regular',
-                iconOnly: true,
-                disposition: 'toolbar',
-              },
-              handleImport,
-            )
-            .action(
-              'export',
-              {
-                label: 'Export lead sheet',
-                icon: 'ph--download-simple--regular',
-                iconOnly: true,
-                disposition: 'toolbar',
-              },
-              handleExport,
-            )
-            .build(),
-      ),
+      MenuBuilder.make()
+        .action(
+          'play',
+          {
+            label: isPlaying ? 'Stop' : 'Play',
+            icon: isPlaying ? 'ph--pause--regular' : 'ph--play--regular',
+            iconOnly: true,
+            disposition: 'toolbar',
+          },
+          togglePlay,
+        )
+        .action(
+          'show-all-tracks',
+          {
+            label: showAllTracks ? 'Show active track only' : 'Show all tracks',
+            icon: showAllTracks ? 'ph--stack--regular' : 'ph--stack-simple--regular',
+            iconOnly: true,
+            disposition: 'toolbar',
+          },
+          toggleShowAllTracks,
+        )
+        .group(
+          'tool-modes',
+          {
+            label: 'Tool',
+            iconOnly: true,
+            variant: 'toggleGroup',
+            selectCardinality: 'single',
+            value: toolMode === 'edit' ? 'tool-edit' : 'tool-delete',
+          } as ToolbarMenuActionGroupProperties,
+          (group) => {
+            group
+              .action(
+                'tool-edit',
+                { label: 'Edit (draw notes)', icon: 'ph--music-note--regular', checked: toolMode === 'edit' },
+                activateEditTool,
+              )
+              .action(
+                'tool-delete',
+                { label: 'Delete (erase notes)', icon: 'ph--eraser--regular', checked: toolMode === 'delete' },
+                activateDeleteTool,
+              );
+          },
+        )
+        .separator()
+        .action(
+          'import',
+          {
+            label: 'Import lead sheet',
+            icon: 'ph--upload-simple--regular',
+            iconOnly: true,
+            disposition: 'toolbar',
+          },
+          handleImport,
+        )
+        .action(
+          'export',
+          {
+            label: 'Export lead sheet',
+            icon: 'ph--download-simple--regular',
+            iconOnly: true,
+            disposition: 'toolbar',
+          },
+          handleExport,
+        )
+        .build(),
     [
       isPlaying,
       togglePlay,
@@ -422,7 +422,6 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
       handleExport,
     ],
   );
-  const menuActions = useMenuActions(actionsAtom);
 
   return (
     <Panel.Root role={role}>
@@ -453,8 +452,18 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
               onAdd={handleAddTrack}
               onRemove={handleRemoveTrack}
             />
-            <div className='grid p-2 aspect-square'>
-              <Oscilloscope classNames='border-green-500' mode='waveform' active={isPlaying} source={audioOutputNode} />
+            <div
+              className='grid p-2 aspect-square'
+              onClick={() => {
+                setOscilloscopeMode((current) => (current === 'waveform' ? 'frequency' : 'waveform'));
+              }}
+            >
+              <Oscilloscope
+                classNames='border-green-500'
+                mode={oscilloscopeMode}
+                active={isPlaying}
+                source={audioOutputNode}
+              />
             </div>
           </div>
           <div className='flex-1 min-w-0 relative'>

--- a/packages/plugins/plugin-sequencer/src/containers/ScoreArticle/ScoreArticle.tsx
+++ b/packages/plugins/plugin-sequencer/src/containers/ScoreArticle/ScoreArticle.tsx
@@ -9,7 +9,7 @@ import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { Obj } from '@dxos/echo';
 import { useObject } from '@dxos/react-client/echo';
 import { Button, Icon, Input, Panel } from '@dxos/react-ui';
-import { type ToggleMode, type Tool } from '@dxos/react-ui-canvas';
+import { type ToggleMode } from '@dxos/react-ui-canvas';
 import { Menu, MenuBuilder, useMenuActions, type ActionGraphProps, type ToolbarMenuActionGroupProperties } from '@dxos/react-ui-menu';
 import { Oscilloscope } from '@dxos/react-ui-sfx';
 import { mx } from '@dxos/ui-theme';
@@ -86,7 +86,7 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
   const [isPlaying, setIsPlaying] = useState(false);
   const [playhead, setPlayhead] = useState<number | null>(null);
   const [showAllTracks, setShowAllTracks] = useState(false);
-  const [toolMode, setToolMode] = useState<Tool>('toggle');
+  const [toolMode, setToolMode] = useState<'edit' | 'delete'>('edit');
 
   // Auto-select the first track when one becomes available.
   useEffect(() => {
@@ -245,9 +245,16 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
         if (!sequence) {
           return;
         }
-        const existingIndex = sequence.notes.findIndex(
-          (note) => note.pitch === pitch && Math.abs(note.startTime - startTime) < 1e-6,
-        );
+        const existingIndex = sequence.notes.findIndex((note) => {
+          if (note.pitch !== pitch) {
+            return false;
+          }
+          if (mode === 'unset') {
+            // Hit any note whose duration spans over the cursor position.
+            return note.startTime <= startTime + 1e-6 && startTime < note.startTime + note.duration - 1e-6;
+          }
+          return Math.abs(note.startTime - startTime) < 1e-6;
+        });
         const exists = existingIndex >= 0;
         const shouldRemove = mode === 'unset' || (mode === 'toggle' && exists);
         const shouldAdd = mode === 'set' || (mode === 'toggle' && !exists);
@@ -321,11 +328,8 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
   // menu's invoke handlers close over so the actions stay in sync.
   const togglePlay = useCallback(() => setIsPlaying((current) => !current), []);
   const toggleShowAllTracks = useCallback(() => setShowAllTracks((current) => !current), []);
-  const activateEditTool = useCallback(() => setToolMode((current) => (current === 'edit' ? 'toggle' : 'edit')), []);
-  const activateDeleteTool = useCallback(
-    () => setToolMode((current) => (current === 'delete' ? 'toggle' : 'delete')),
-    [],
-  );
+  const activateEditTool = useCallback(() => setToolMode('edit'), []);
+  const activateDeleteTool = useCallback(() => setToolMode('delete'), []);
   const actionsAtom = useMemo(
     () =>
       Atom.make(
@@ -359,7 +363,7 @@ export const ScoreArticle = ({ role, subject, attendableId }: ScoreArticleProps)
                 iconOnly: true,
                 variant: 'toggleGroup',
                 selectCardinality: 'single',
-                value: toolMode === 'edit' ? 'tool-edit' : toolMode === 'delete' ? 'tool-delete' : '',
+                value: toolMode === 'edit' ? 'tool-edit' : 'tool-delete',
               } as ToolbarMenuActionGroupProperties,
               (group) => {
                 group

--- a/packages/ui/react-ui-canvas/src/components/CellGrid/CellGrid.tsx
+++ b/packages/ui/react-ui-canvas/src/components/CellGrid/CellGrid.tsx
@@ -67,6 +67,8 @@ export const CellGrid = <T,>({
   classNames,
   onCellToggle,
   onSelectionCommit,
+  onDrawUpdate,
+  onDrawCommit,
 }: CellGridProps<T>) => {
   const registry = useContext(RegistryContext);
 
@@ -212,8 +214,8 @@ export const CellGrid = <T,>({
   // across consumer re-renders — otherwise an in-progress drag is torn down when
   // the parent's onCellToggle identity changes (e.g. after the very mutation we
   // just triggered), and subsequent pointermove events see drag === null.
-  const callbacksRef = useRef<PointerHandlers>({ onCellToggle, onSelectionCommit });
-  callbacksRef.current = { onCellToggle, onSelectionCommit };
+  const callbacksRef = useRef<PointerHandlers>({ onCellToggle, onSelectionCommit, onDrawUpdate, onDrawCommit });
+  callbacksRef.current = { onCellToggle, onSelectionCommit, onDrawUpdate, onDrawCommit };
   useEffect(() => {
     const element = overlayInputRef.current;
     if (!element) {
@@ -226,6 +228,8 @@ export const CellGrid = <T,>({
       handlers: {
         onCellToggle: (coord, mode) => callbacksRef.current.onCellToggle?.(coord, mode),
         onSelectionCommit: (range) => callbacksRef.current.onSelectionCommit?.(range),
+        onDrawUpdate: (start, end) => callbacksRef.current.onDrawUpdate?.(start, end),
+        onDrawCommit: (start, end) => callbacksRef.current.onDrawCommit?.(start, end),
       },
     });
     const detachWheel = attachWheelHandlers(element, { registry, atoms, headers });

--- a/packages/ui/react-ui-canvas/src/components/CellGrid/input/pointer.ts
+++ b/packages/ui/react-ui-canvas/src/components/CellGrid/input/pointer.ts
@@ -19,10 +19,15 @@ export type ToggleMode = 'set' | 'unset' | 'toggle';
 export type PointerHandlers = {
   onCellToggle?: (coord: CellCoord, mode: ToggleMode) => void;
   onSelectionCommit?: (range: SelectionRange) => void;
+  /** Called each time the draw cursor moves to a new cell (edit tool). */
+  onDrawUpdate?: (startCoord: CellCoord, endCoord: CellCoord) => void;
+  /** Called when the user releases after an edit-tool drag; caller commits the note. */
+  onDrawCommit?: (startCoord: CellCoord, endCoord: CellCoord) => void;
 };
 
 type DragState =
   | { kind: 'toggle'; mode: 'set' | 'unset'; touched: Set<string> }
+  | { kind: 'draw'; startCoord: CellCoord; endCoord: CellCoord }
   | { kind: 'select'; origin: CellCoord }
   | { kind: 'pan'; lastX: number; lastY: number };
 
@@ -95,10 +100,10 @@ export const attachPointerHandlers = <T>(
         break;
       }
       case 'edit': {
-        // Always adds notes regardless of current cell state.
-        const key = cellKey(coord.col, coord.row);
-        handlers.onCellToggle?.(coord, 'set');
-        drag = { kind: 'toggle', mode: 'set', touched: new Set([key]) };
+        // Start a draw gesture: track extent and fire preview/commit callbacks
+        // instead of toggling individual cells. Constrained to the starting row.
+        drag = { kind: 'draw', startCoord: coord, endCoord: coord };
+        handlers.onDrawUpdate?.(coord, coord);
         break;
       }
       case 'delete': {
@@ -149,6 +154,13 @@ export const attachPointerHandlers = <T>(
         drag.touched.add(key);
         handlers.onCellToggle?.(coord, drag.mode);
       }
+    } else if (drag.kind === 'draw') {
+      // Constrain to the starting row so the note stays at the same pitch.
+      const constrainedCol = coord.col;
+      if (constrainedCol !== drag.endCoord.col) {
+        drag.endCoord = { col: constrainedCol, row: drag.startCoord.row };
+        handlers.onDrawUpdate?.(drag.startCoord, drag.endCoord);
+      }
     } else if (drag.kind === 'select') {
       registry.set(atoms.selection, {
         range: { col0: drag.origin.col, row0: drag.origin.row, col1: coord.col, row1: coord.row },
@@ -166,7 +178,9 @@ export const attachPointerHandlers = <T>(
     if (!drag) {
       return;
     }
-    if (drag.kind === 'select') {
+    if (drag.kind === 'draw') {
+      handlers.onDrawCommit?.(drag.startCoord, drag.endCoord);
+    } else if (drag.kind === 'select') {
       const range = registry.get(atoms.selection).range;
       if (range) {
         handlers.onSelectionCommit?.(range);


### PR DESCRIPTION
Follow-up to #11457. Fixes six bugs in the sequencer tool modes (three from the original PR, three more from user feedback).

## Bug fixes (round 2)

**1. One tool must always be selected**
The edit/delete toggle buttons previously allowed deselecting both (clicking the active tool toggled it off). Changed to simple setters — the active tool can only switch, never deselect. Edit mode is now the default instead of the old 'toggle' paint mode, which has been removed from the user-facing UI entirely.

**2. Delete tool only hit the starting cell of multi-cell notes**
`handleToggleNote` used an exact `startTime` match, so the cursor had to land on column 0 of a note to delete it. For `mode === 'unset'`, the search now uses a containment check: `note.startTime ≤ cursorTime < note.startTime + note.duration`.

**3. Scroll back to beginning when playback stops**
When the playhead atom goes to `null` (stop), `SequenceGrid` now resets `scrollX` to 0 so the grid snaps back to bar 1.

---

## Bug fixes (round 1)

**4. Tool state not visible in toolbar**
The previous implementation used `variant: 'toggle'` + `checked` on individual actions, which the `ActionToolbarItem` renderer ignores. Replaced with a proper `toggleGroup` group (same pattern as `plugin-spacetime`) so Radix UI's `ToggleGroup` renders the active item as visually pressed.

**5. Edit tool should create one note per drag**
The edit tool was calling `onCellToggle` for every cell the cursor crossed, producing many individual 1-cell notes. Replaced with a `draw` DragState in `pointer.ts` that fires `onDrawUpdate(start, end)` on each cell change (preview) and `onDrawCommit(start, end)` on pointer-up (commit). `SequenceGrid` shows a live preview cell during drag then commits a single note with `duration = (cols dragged) × beatsPerCell`.

**6. Auto-scroll should snap to nearest previous bar**
Replaced the fixed 4-cell offset with a bar-aligned snap: `Math.floor(playheadPx / pxPerBar) * pxPerBar`. `beatsPerBar` is now a prop on `SequenceGrid` (defaults to 4), passed from `ScoreArticle` via `parseTimeSignature(score.timeSignature)`.

https://claude.ai/code/session_01MQUkgat6yxse86nJPAUBZC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draw notes by dragging with a live preview and commit; set note durations while drawing
  * Toolbar toggle to switch Edit (draw) and Delete (erase)
  * Playback auto-scroll snaps to bar boundaries

* **Bug Fixes / Improvements**
  * More reliable, uninterrupted draw gestures and commit behavior
  * Playback reloads immediately on play for consistent start timing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->