### PR TITLE
fix(repo): use workspaceFolder for typescript.native-preview.tsdk

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -408,5 +408,5 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "vitest.disableWorkspaceWarning": true,
   "vitest.rootConfig": "vitest.all.config.ts",
-  "typescript.native-preview.tsdk": "/Users/burdon/Code/dxos/dxos/node_modules/@typescript/native-preview"
+  "typescript.native-preview.tsdk": "${workspaceFolder}/node_modules/@typescript/native-preview"
 }


### PR DESCRIPTION
## Summary
Follow-up to #11474. The hardcoded `/Users/burdon/...` path in `.vscode/settings.json` won't resolve for any other contributor or CI. Replace with VS Code's `${workspaceFolder}` variable.

Flagged by CodeRabbit on the prior PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code workspace configuration to use workspace-relative paths instead of absolute paths, improving portability across team environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->