### PR TITLE
feat(plugin-trip): editable FlightEditCard with DatePicker

### DIFF
--- a/packages/plugins/plugin-map/src/components/Globe/GlobeControl.tsx
+++ b/packages/plugins/plugin-map/src/components/Globe/GlobeControl.tsx
@@ -18,6 +18,7 @@ import {
   useDrag,
   useGlobeZoomHandler,
   useTour,
+  useWheel,
 } from '@dxos/react-ui-geo';
 import { loadTopology } from '@dxos/react-ui-geo/data';
 import { isNonNullable } from '@dxos/util';
@@ -85,6 +86,7 @@ export const GlobeControl = composable<HTMLDivElement, GlobeControlProps>(
     }, [markers, selected]);
 
     const [moved, setMoved] = useState(false);
+    useWheel(controller);
     useDrag(controller, {
       onUpdate: ({ type }) => {
         if (type === 'move') {

--- a/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.stories.tsx
+++ b/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.stories.tsx
@@ -73,6 +73,7 @@ export const FlightEditable: StoryObj = {
     const segments = useMemo(() => buildSegments(), []);
     const segment = segments[3];
     const handleAction: SegmentCardActionHandler = useCallback((action: SegmentCardAction) => {
+      // eslint-disable-next-line no-console
       console.log(action);
     }, []);
 

--- a/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.stories.tsx
+++ b/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.stories.tsx
@@ -3,7 +3,7 @@
 //
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { Focus, Mosaic } from '@dxos/react-ui-mosaic';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
@@ -12,6 +12,7 @@ import { TripBuilder } from '#testing';
 import { translations } from '#translations';
 
 import { type SegmentCardAction, type SegmentCardActionHandler, SegmentTile } from './SegmentCard';
+import { FlightEditCard } from './SegmentEditCard';
 
 const buildSegments = () =>
   new TripBuilder()
@@ -39,30 +40,67 @@ const DefaultStory = ({ segmentIndex, current }: StoryArgs) => {
     console.log('SegmentCard action', action);
   };
   return (
-    <div className='w-[28rem] border border-subdued-separator'>
-      <Mosaic.Root>
-        <Focus.Group asChild>
-          <Mosaic.Container withFocus currentId={current ? segment.id : undefined}>
-            <SegmentTile data={{ segment, onAction: handleAction }} location='story' current={current} />
-          </Mosaic.Container>
-        </Focus.Group>
-      </Mosaic.Root>
-    </div>
+    <Mosaic.Root>
+      <Focus.Group asChild>
+        <Mosaic.Container withFocus currentId={current ? segment.id : undefined}>
+          <SegmentTile data={{ segment, onAction: handleAction }} location='story' current={current} />
+        </Mosaic.Container>
+      </Focus.Group>
+    </Mosaic.Root>
   );
 };
 
 const meta = {
   title: 'plugins/plugin-trip/components/SegmentCard',
   component: DefaultStory,
-  decorators: [withTheme(), withLayout({ layout: 'centered' })],
-  parameters: { translations },
+  decorators: [withTheme(), withLayout({ layout: 'column', classNames: 'w-(min-card-width)' })],
+  parameters: {
+    translations,
+  },
 } satisfies Meta<typeof DefaultStory>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Flight: Story = { args: { segmentIndex: 0 } };
-export const Accommodation: Story = { args: { segmentIndex: 1 } };
-export const Activity: Story = { args: { segmentIndex: 2 } };
-export const Tentative: Story = { args: { segmentIndex: 3 } };
-export const Current: Story = { args: { segmentIndex: 0, current: true } };
+export const Flight: Story = {
+  args: {
+    segmentIndex: 0,
+  },
+};
+
+export const FlightEditable: StoryObj = {
+  render: () => {
+    const segments = useMemo(() => buildSegments(), []);
+    const segment = segments[3];
+    const handleAction: SegmentCardActionHandler = useCallback((action: SegmentCardAction) => {
+      console.log(action);
+    }, []);
+
+    return <FlightEditCard segment={segment} onAction={handleAction} />;
+  },
+};
+
+export const Accommodation: Story = {
+  args: {
+    segmentIndex: 1,
+  },
+};
+
+export const Activity: Story = {
+  args: {
+    segmentIndex: 2,
+  },
+};
+
+export const Tentative: Story = {
+  args: {
+    segmentIndex: 3,
+  },
+};
+
+export const Current: Story = {
+  args: {
+    segmentIndex: 0,
+    current: true,
+  },
+};

--- a/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentEditCard.tsx
+++ b/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentEditCard.tsx
@@ -3,7 +3,7 @@
 //
 
 import { format } from 'date-fns';
-import React, { type MouseEvent, forwardRef, useCallback, useState } from 'react';
+import React, { type MouseEvent, forwardRef, useCallback, useEffect, useState } from 'react';
 
 import { Obj } from '@dxos/echo';
 import { Card, DatePicker, useTranslation } from '@dxos/react-ui';
@@ -29,6 +29,11 @@ export const FlightEditCard = forwardRef<HTMLDivElement, FlightEditCardProps>(({
 
   const editable = segment.status === 'tentative';
   const [departDate, setDepartDate] = useState<Date | undefined>(() => Segment.parseDate(segment.departAt));
+
+  // Re-sync if the component is reused for a different segment.
+  useEffect(() => {
+    setDepartDate(Segment.parseDate(segment.departAt));
+  }, [segment.id, segment.departAt]);
 
   const handleDepartChange = useCallback(
     (next: Date | undefined) => {

--- a/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentEditCard.tsx
+++ b/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentEditCard.tsx
@@ -1,0 +1,88 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { format } from 'date-fns';
+import React, { type MouseEvent, forwardRef, useCallback, useState } from 'react';
+
+import { Obj } from '@dxos/echo';
+import { Card, DatePicker, useTranslation } from '@dxos/react-ui';
+
+import { meta } from '#meta';
+import { Segment } from '#types';
+
+import { type SegmentCardActionHandler } from './SegmentCard';
+
+type FlightEditCardProps = {
+  segment: Segment.Segment;
+  onAction?: SegmentCardActionHandler;
+};
+
+/**
+ * Editable card variant for a flight Segment. Surfaces only the most important fields:
+ * kind icon + title + delete in the toolbar, route and departure date in the content.
+ * The departure date becomes editable (via DatePicker) when `segment.status === 'tentative'`;
+ * otherwise it renders as static text.
+ */
+export const FlightEditCard = forwardRef<HTMLDivElement, FlightEditCardProps>(({ segment, onAction }, forwardedRef) => {
+  const { t } = useTranslation(meta.id);
+
+  const editable = segment.status === 'tentative';
+  const [departDate, setDepartDate] = useState<Date | undefined>(() => Segment.parseDate(segment.departAt));
+
+  const handleDepartChange = useCallback(
+    (next: Date | undefined) => {
+      setDepartDate(next);
+      Obj.update(segment, (segment) => {
+        segment.departAt = next ? next.toISOString() : undefined;
+      });
+    },
+    [segment],
+  );
+
+  const handleDelete = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      onAction?.({ type: 'delete', segmentId: segment.id });
+    },
+    [onAction, segment.id],
+  );
+
+  const title = Segment.getTitle(segment);
+  const route = Segment.getRoute(segment);
+  const icon = Segment.kindIcon(segment.kind);
+  const isCancelled = segment.status === 'cancelled';
+
+  return (
+    <Card.Root fullWidth ref={forwardedRef} classNames={isCancelled ? 'opacity-40' : undefined}>
+      <Card.Toolbar>
+        <Card.Icon icon={icon} />
+        <Card.Title classNames={isCancelled ? 'line-through' : undefined}>{title}</Card.Title>
+        <Card.ActionIconButton action='delete' onClick={handleDelete} label={t('segment.delete.label')} />
+      </Card.Toolbar>
+      <Card.Content>
+        {route && (
+          <Card.Row>
+            <Card.Text variant='description'>{route}</Card.Text>
+          </Card.Row>
+        )}
+        <Card.Row icon='ph--calendar--regular'>
+          {editable ? (
+            <DatePicker.Root mode='single' value={departDate} onValueChange={handleDepartChange}>
+              <DatePicker.Trigger icon={false} format='PPp' placeholder={t('segment.depart.placeholder')} />
+              <DatePicker.Content>
+                <DatePicker.Calendar />
+              </DatePicker.Content>
+            </DatePicker.Root>
+          ) : (
+            <Card.Text variant='description'>
+              {departDate ? format(departDate, 'PPp') : t('segment.depart.placeholder')}
+            </Card.Text>
+          )}
+        </Card.Row>
+      </Card.Content>
+    </Card.Root>
+  );
+});
+
+FlightEditCard.displayName = 'FlightEditCard';

--- a/packages/plugins/plugin-trip/src/components/TripMapView/TripMapView.tsx
+++ b/packages/plugins/plugin-trip/src/components/TripMapView/TripMapView.tsx
@@ -5,7 +5,15 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { IconButton, composable, composableProps, useThemeContext } from '@dxos/react-ui';
-import { Globe, type GlobeController, globeStyles, useDrag, useGlobeZoomHandler, useTour } from '@dxos/react-ui-geo';
+import {
+  Globe,
+  type GlobeController,
+  globeStyles,
+  useDrag,
+  useGlobeZoomHandler,
+  useTour,
+  useWheel,
+} from '@dxos/react-ui-geo';
 import { loadTopology } from '@dxos/react-ui-geo/data';
 
 import { Segment } from '#types';
@@ -100,6 +108,7 @@ export const TripMapView = composable<HTMLDivElement, TripMapViewProps>(
     }, []);
 
     const handleZoom = useGlobeZoomHandler(controller);
+    useWheel(controller);
     useDrag(controller);
 
     // Build the geo features.

--- a/packages/plugins/plugin-trip/src/testing/builder.ts
+++ b/packages/plugins/plugin-trip/src/testing/builder.ts
@@ -83,10 +83,10 @@ export class TripBuilder {
       typeof arg === 'object'
         ? arg
         : {
-            from: PLACES.SFO,
-            to: PLACES.LHR,
+            from: PLACES.JFK,
+            to: PLACES.CDG,
             daysFromNow: arg ?? 0,
-            airline: { name: 'United Airlines' },
+            airline: { name: 'Air France' },
             cabin: 'economy',
             confirmed: legacyOpts?.confirmed,
           };

--- a/packages/plugins/plugin-trip/src/translations.ts
+++ b/packages/plugins/plugin-trip/src/translations.ts
@@ -34,6 +34,7 @@ export const translations = [
         'segment.accommodation.label': 'Accommodation',
         'segment.activity.label': 'Activity',
         'segment.delete.label': 'Delete segment',
+        'segment.depart.placeholder': 'Pick a departure date',
       },
     },
   },

--- a/packages/ui/react-ui-geo/src/components/Globe/Globe.tsx
+++ b/packages/ui/react-ui-geo/src/components/Globe/Globe.tsx
@@ -241,7 +241,7 @@ const GlobeCanvas = forwardRef<GlobeController, GlobeCanvasProps>(
     const projection = useMemo(() => getProjection(projectionProp), [projectionProp]);
 
     // Layers.
-    // TODO(burdon): Generate on the fly based on what is visible.
+    // TODO(burdon): Generate on-the-fly based on what is visible.
     const layers = useMemo(() => {
       return timer(() => createLayers(topology as Topology, features, styles));
     }, [topology, features, styles]);

--- a/packages/ui/react-ui/src/components/DatePicker/DatePicker.theme.ts
+++ b/packages/ui/react-ui/src/components/DatePicker/DatePicker.theme.ts
@@ -11,7 +11,7 @@ export type DatePickerStyleProps = Partial<{
 
 const trigger: ComponentFunction<DatePickerStyleProps> = ({ hasValue }, ...etc) =>
   mx(
-    'inline-flex items-center gap-2 h-9 px-3 rounded-sm border border-separator',
+    'inline-flex w-fit items-center gap-2 px-2 rounded-sm border border-separator',
     'bg-input-surface text-base-foreground',
     'hover:bg-hover-surface focus-visible:outline-2 focus-visible:outline-primary-500',
     !hasValue && 'text-description',

--- a/packages/ui/react-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/ui/react-ui/src/components/DatePicker/DatePicker.tsx
@@ -144,10 +144,12 @@ export type DatePickerTriggerProps = ThemedClassName<Omit<ComponentPropsWithoutR
   PropsWithChildren<{
     format?: string;
     placeholder?: string;
+    /** Show the leading calendar icon in the default trigger. Defaults to true. */
+    icon?: boolean;
   }>;
 
 const DatePickerTrigger = forwardRef<HTMLButtonElement, DatePickerTriggerProps>(
-  ({ classNames, format: fmt = 'PPP', placeholder, children, ...props }, forwardedRef) => {
+  ({ classNames, format: fmt = 'PPP', placeholder, icon = true, children, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
     const { t } = useTranslation(translationKey);
     const { mode, value } = useDatePickerContext('DatePickerTrigger');
@@ -166,7 +168,7 @@ const DatePickerTrigger = forwardRef<HTMLButtonElement, DatePickerTriggerProps>(
         >
           {children ?? (
             <>
-              <Icon size={4} icon='ph--calendar--regular' />
+              {icon && <Icon size={4} icon='ph--calendar--regular' />}
               {label}
             </>
           )}

--- a/packages/ui/react-ui/src/components/Input/Input.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.tsx
@@ -201,10 +201,28 @@ TextInput.displayName = 'Input.TextInput';
 // Time
 //
 
-type TimeProps = InputSharedProps & ThemedClassName<Omit<TextInputPrimitiveProps, 'type'>>;
+type TimeProps = InputSharedProps &
+  ThemedClassName<Omit<TextInputPrimitiveProps, 'type'>> & {
+    /** Show the native time-picker icon (clock). Defaults to true. */
+    icon?: boolean;
+    /** Show the time-of-day text. Defaults to true. Hide to render an icon-only trigger. */
+    time?: boolean;
+  };
 
 const Time = forwardRef<HTMLInputElement, InputScopedProps<TimeProps>>(
-  ({ __inputScope, classNames, density: densityProp, elevation: elevationProp, variant, ...props }, forwardedRef) => {
+  (
+    {
+      __inputScope,
+      classNames,
+      density: densityProp,
+      elevation: elevationProp,
+      variant,
+      icon = true,
+      time = true,
+      ...props
+    },
+    forwardedRef,
+  ) => {
     const { tx } = useThemeContext();
     const density = useDensityContext(densityProp);
     const elevation = useElevationContext(elevationProp);
@@ -223,6 +241,11 @@ const Time = forwardRef<HTMLInputElement, InputScopedProps<TimeProps>>(
             elevation,
             validationValence,
           },
+          // Force 32px (native time inputs add intrinsic height; the density
+          // `min-h-[2.5rem]` arbitrary value also outranks plain `min-h-8`).
+          '!h-8 !min-h-8 box-border leading-none',
+          !icon && '[&::-webkit-calendar-picker-indicator]:hidden',
+          !time && 'text-transparent',
           classNames,
         )}
         ref={forwardedRef}


### PR DESCRIPTION
## Summary

- Adds `FlightEditCard`, an editable card variant for flight segments. Surfaces only the most important fields (title, route, departure date) and lets the user pick a new departure date via `DatePicker` when `segment.status === 'tentative'`. Mutations go through `Obj.update`.
- Adds a `FlightEditable` Storybook story.
- `DatePicker.Trigger` gains `icon?: boolean` (default `true`) so consumers can suppress the built-in calendar icon when a parent (`Card.Row`) already renders one. Trigger theme is also `w-fit` and no longer hard-codes `h-9`, so it sits naturally inside a `Card.Row`.
- `Input.Time` gains `icon?: boolean` and `time?: boolean` to toggle the native picker indicator and the time-of-day digits, and is forced to 32px (native time inputs were rendering taller due to user-agent intrinsic sizing).
- Pulls in in-progress `Globe` / `TripMapView` tweaks that were live in the working tree.

## Why

First step toward editable segment cards in the trip plugin. Starting with flights, only the departure date is editable, and only while the segment is tentative — the rest of the card stays read-only for this iteration.

## Test plan

- [ ] `moon run plugin-trip:build` ✅
- [ ] `moon run react-ui:build` ✅
- [ ] `moon run plugin-trip:lint react-ui:lint -- --fix` ✅
- [ ] `moon run plugin-trip:test` ✅
- [ ] Storybook: `plugins/plugin-trip/components/SegmentCard` → `FlightEditable` opens the picker and persists the new date
- [ ] Storybook: `ui/react-ui-core/components/Input` → `Time` renders at 32px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wheel-based globe interactions for enhanced map navigation
  * Editable flight segment card with integrated date picker and delete action
  * Optional icon and time display toggles for DatePicker and Time Input

* **Tests**
  * Updated Storybook stories and added an editable flight story
  * Adjusted test builder default flight itinerary

* **Style**
  * Refined DatePicker trigger layout and spacing

* **Localization**
  * Added English placeholder for segment departure date picker

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->