### PR TITLE
feat(react-ui-form): DateField for Format.Date/DateTime/Time

### DIFF
--- a/packages/core/echo/echo/src/internal/Format/date.ts
+++ b/packages/core/echo/echo/src/internal/Format/date.ts
@@ -104,7 +104,6 @@ export const DateOnly = /* Schema.transformOrFail(Schema.String, SimpleDate, {
 }) */ Schema.String.pipe(
   FormatAnnotation.set(TypeFormat.Date),
   Schema.annotations({
-    title: 'Date',
     description: 'Valid date in ISO format',
   }),
 );
@@ -134,7 +133,6 @@ export const TimeOnly = /* Schema.transformOrFail(Schema.String, SimpleTime, {
 }) */ Schema.String.pipe(
   FormatAnnotation.set(TypeFormat.Time),
   Schema.annotations({
-    title: 'Time',
     description: 'Valid time in ISO format',
   }),
 );
@@ -179,7 +177,6 @@ export const DateTime = /* Schema.transformOrFail(Schema.String, SimpleDateTime,
 }) */ Schema.String.pipe(
   FormatAnnotation.set(TypeFormat.DateTime),
   Schema.annotations({
-    title: 'DateTime',
     description: 'Valid date and time in ISO format',
   }),
 );
@@ -191,7 +188,6 @@ export const DateTime = /* Schema.transformOrFail(Schema.String, SimpleDateTime,
 export const Duration = Schema.String.pipe(
   FormatAnnotation.set(TypeFormat.Duration),
   Schema.annotations({
-    title: 'Duration',
     description: 'Duration in ISO 8601 format',
     [SchemaAST.ExamplesAnnotationId]: ['1h', '3D'],
   }),

--- a/packages/core/echo/echo/src/internal/Format/index.ts
+++ b/packages/core/echo/echo/src/internal/Format/index.ts
@@ -2,11 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-export type { SimpleDate, SimpleDateTime, SimpleTime } from './date';
+export * from './date';
+export * from './format';
 export { CurrencyAnnotationId, DecimalPrecision, Currency } from './number';
 export { GeoPoint, GeoLocation } from './object';
-
-export * from './format';
 export * from './select';
 export * from './string';
 export * from './types';

--- a/packages/plugins/plugin-trip/src/types/Segment.ts
+++ b/packages/plugins/plugin-trip/src/types/Segment.ts
@@ -6,19 +6,25 @@
 
 import * as Schema from 'effect/Schema';
 
-import { Annotation, Obj, Ref, Type } from '@dxos/echo';
+import { Annotation, Format, Obj, Ref, Type } from '@dxos/echo';
 import { Provider } from '@dxos/types';
 
 import * as Booking from './Booking';
 import { Place } from './Place';
 
-// ---------------------------------------------------------------------------
+//
 // Kind enum
-// ---------------------------------------------------------------------------
+//
 
 export const Kind = Schema.Literal('flight', 'train', 'boat', 'road', 'accommodation', 'activity');
 export type Kind = Schema.Schema.Type<typeof Kind>;
 
+/**
+ * tentative: user-authored placeholder.
+ * proposed:  extractor/agent suggestion awaiting user accept.
+ * confirmed: backed by a real Booking.
+ * cancelled: kept for history; rendered de-emphasised.
+ */
 export const Status = Schema.Literal('tentative', 'proposed', 'confirmed', 'cancelled');
 export type Status = Schema.Schema.Type<typeof Status>;
 
@@ -28,9 +34,9 @@ export type RoadSubKind = Schema.Schema.Type<typeof RoadSubKind>;
 export const Cabin = Schema.Literal('economy', 'premium', 'business', 'first');
 export type Cabin = Schema.Schema.Type<typeof Cabin>;
 
-// ---------------------------------------------------------------------------
+//
 // Segment ECHO type
-// ---------------------------------------------------------------------------
+//
 
 /**
  * A travel segment. Single ECHO object type with union properties — `kind`
@@ -40,20 +46,18 @@ export type Cabin = Schema.Schema.Type<typeof Cabin>;
  */
 export const Segment = Schema.Struct({
   // Core (all variants).
-  /**
-   * tentative: user-authored placeholder.
-   * proposed:  extractor/agent suggestion awaiting user accept.
-   * confirmed: backed by a real Booking.
-   * cancelled: kept for history; rendered de-emphasised.
-   */
   status: Status,
   kind: Kind,
+
   origin: Schema.optional(Place),
   destination: Schema.optional(Place),
-  departAt: Schema.optional(Schema.String),
-  arriveAt: Schema.optional(Schema.String),
+  departAt: Schema.optional(Format.DateTime),
+  arriveAt: Schema.optional(Format.DateTime),
   booking: Schema.optional(Ref.Ref(Booking.Booking)),
   notes: Schema.optional(Schema.String),
+
+  // TOOD(burdon): Harmonize flight/train/vesselNumber, airline/operator, common fields, etc.
+  // TODO(burdon): Annotations for IATA codes, etc. (See Amadeus for examples.)
 
   // Flight.
   airline: Schema.optional(Provider.Provider),
@@ -68,7 +72,6 @@ export const Segment = Schema.Struct({
   // Train (shares operator + seat with road/accommodation/etc).
   operator: Schema.optional(Provider.Provider),
   trainNumber: Schema.optional(Schema.String),
-  cabinClass: Schema.optional(Schema.String), // renamed from `class` (reserved word).
   coach: Schema.optional(Schema.String),
 
   // Boat (operator + cabin shared).
@@ -81,8 +84,8 @@ export const Segment = Schema.Struct({
   // Accommodation.
   propertyName: Schema.optional(Schema.String),
   roomType: Schema.optional(Schema.String),
-  checkIn: Schema.optional(Schema.String),
-  checkOut: Schema.optional(Schema.String),
+  checkIn: Schema.optional(Format.DateTime),
+  checkOut: Schema.optional(Format.DateTime),
 
   // Activity.
   title: Schema.optional(Schema.String),
@@ -119,9 +122,9 @@ export const makeDefault = (kind: Kind): Segment => {
   }
 };
 
-// ---------------------------------------------------------------------------
+//
 // Helpers
-// ---------------------------------------------------------------------------
+//
 
 /** Parses an ISO string to a Date; returns undefined if missing or invalid. */
 export const parseDate = (iso?: string): Date | undefined => {

--- a/packages/plugins/plugin-trip/src/types/Trip.ts
+++ b/packages/plugins/plugin-trip/src/types/Trip.ts
@@ -6,7 +6,7 @@
 
 import * as Schema from 'effect/Schema';
 
-import { Annotation, Obj, Ref, Type } from '@dxos/echo';
+import { Annotation, Format, Obj, Ref, Type } from '@dxos/echo';
 import { LabelAnnotation } from '@dxos/echo/internal';
 
 import * as Segment from './Segment';
@@ -19,9 +19,9 @@ import * as Segment from './Segment';
 export const Trip = Schema.Struct({
   name: Schema.optional(Schema.String),
   summary: Schema.optional(Schema.String),
-  startDate: Schema.optional(Schema.String),
-  endDate: Schema.optional(Schema.String),
-  segments: Schema.Array(Ref.Ref(Segment.Segment)),
+  start: Schema.optional(Format.DateTime),
+  end: Schema.optional(Format.DateTime),
+  segments: Schema.Array(Ref.Ref(Segment.Segment)).pipe(Annotation.FormInputAnnotation.set(false)),
 }).pipe(
   Type.object({
     typename: 'org.dxos.type.trip',

--- a/packages/ui/react-ui-form/src/components/Form/Form.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/Form.stories.tsx
@@ -51,6 +51,9 @@ const Person = Schema.Struct({
   status: Schema.optional(Schema.Literal('active', 'inactive').annotations({ title: 'Status' })),
   notes: Schema.optional(Format.Text.annotations({ title: 'Notes' })),
   location: Schema.optional(Format.GeoPoint.annotations({ title: 'Location' })),
+  birthday: Schema.optional(Format.DateOnly.annotations({ title: 'Birthday' })),
+  meetingAt: Schema.optional(Format.DateTime.annotations({ title: 'Next meeting' })),
+  reminderAt: Schema.optional(Format.TimeOnly.annotations({ title: 'Reminder time' })),
   tasks: Schema.optional(Schema.Array(Schema.String).annotations({ title: 'Tasks' })),
   locations: Schema.optional(Schema.Array(Format.GeoPoint).annotations({ title: 'Locations' })),
   identities: Schema.optional(
@@ -156,6 +159,9 @@ const values: Partial<Person> = {
   name: 'Alice',
   location: [40.7128, -74.006],
   tasks: ['task 1', 'task 2'],
+  birthday: '1990-05-12',
+  meetingAt: '2026-06-01T15:30:00.000Z',
+  reminderAt: '09:00:00',
 };
 
 export const Default: Story<ExcludeId<typeof Person>> = {

--- a/packages/ui/react-ui-form/src/components/Form/FormField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormField.tsx
@@ -29,6 +29,7 @@ import { getRefProps } from '../../util';
 import {
   ArrayField,
   BooleanField,
+  DateField,
   GeoPointField,
   MarkdownField,
   NumberField,
@@ -294,9 +295,12 @@ const getFormField = ({ type, format }: FormFieldComponentProps): FormFieldCompo
 
   const formatField = Match.value(format).pipe(
     Match.withReturnType<FormFieldComponent | undefined>(),
+    Match.when(Format.TypeFormat.Date, () => DateField),
+    Match.when(Format.TypeFormat.DateTime, () => DateField),
     Match.when(Format.TypeFormat.GeoPoint, () => GeoPointField),
     Match.when(Format.TypeFormat.Markdown, () => MarkdownField),
     Match.when(Format.TypeFormat.Text, () => TextAreaField),
+    Match.when(Format.TypeFormat.Time, () => DateField),
     Match.orElse(() => undefined),
   );
   if (formatField) {

--- a/packages/ui/react-ui-form/src/components/Form/fields/DateField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/DateField.tsx
@@ -33,8 +33,15 @@ const parseDateOnly = (value: string | undefined): Date | undefined => {
   if (!match) {
     return undefined;
   }
-  const [, year, month, day] = match;
-  return new Date(Number(year), Number(month) - 1, Number(day));
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+  // Reject impossible calendar dates (e.g. 2026-02-31) which Date() would otherwise silently shift.
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return undefined;
+  }
+  return date;
 };
 
 const encodeDateOnly = (date: Date | undefined): string | undefined =>

--- a/packages/ui/react-ui-form/src/components/Form/fields/DateField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/DateField.tsx
@@ -78,14 +78,7 @@ export const DateField = ({
     <FormFieldWrapper<string> readonly={readonly} {...props}>
       {({ value }) => {
         if (isTimeOnly) {
-          return (
-            <Input.Time
-              disabled={!!readonly}
-              value={value ?? ''}
-              onChange={handleTimeChange}
-              onBlur={onBlur}
-            />
-          );
+          return <Input.Time disabled={!!readonly} value={value ?? ''} onChange={handleTimeChange} onBlur={onBlur} />;
         }
 
         const date = isDateOnly ? parseDateOnly(value) : parseDateTime(value);

--- a/packages/ui/react-ui-form/src/components/Form/fields/DateField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/DateField.tsx
@@ -6,7 +6,7 @@ import { format as formatDate } from 'date-fns';
 import React, { type ChangeEvent, useCallback } from 'react';
 
 import { Format } from '@dxos/echo';
-import { DatePicker, Input } from '@dxos/react-ui';
+import { Input } from '@dxos/react-ui';
 
 import { type FormFieldComponentProps, FormFieldWrapper } from '../FormFieldComponent';
 
@@ -15,45 +15,33 @@ import { type FormFieldComponentProps, FormFieldWrapper } from '../FormFieldComp
  * - `Format.DateTime` -> ISO 8601 (`2018-11-13T20:20:39.000Z`).
  * - `Format.Date`     -> `YYYY-MM-DD`.
  * - `Format.Time`     -> `HH:mm:ss`.
+ *
+ * Native input value shapes:
+ * - `<input type='datetime-local'>` -> `YYYY-MM-DDTHH:mm` in local time.
+ * - `<input type='date'>`           -> `YYYY-MM-DD`.
+ * - `<input type='time'>`           -> `HH:mm`.
  */
 
-const parseDateTime = (value: string | undefined): Date | undefined => {
+/** ISO 8601 → `YYYY-MM-DDTHH:mm` in the user's local timezone. */
+const isoToLocalDateTime = (value: string | undefined): string => {
   if (!value) {
-    return undefined;
+    return '';
   }
   const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? undefined : date;
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return formatDate(date, "yyyy-MM-dd'T'HH:mm");
 };
 
-const parseDateOnly = (value: string | undefined): Date | undefined => {
+/** `YYYY-MM-DDTHH:mm` (local) → ISO 8601 with timezone. */
+const localDateTimeToIso = (value: string): string | undefined => {
   if (!value) {
     return undefined;
   }
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  if (!match) {
-    return undefined;
-  }
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  const date = new Date(year, month - 1, day);
-  // Reject impossible calendar dates (e.g. 2026-02-31) which Date() would otherwise silently shift.
-  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
-    return undefined;
-  }
-  return date;
-};
-
-const encodeDateOnly = (date: Date | undefined): string | undefined =>
-  date ? formatDate(date, 'yyyy-MM-dd') : undefined;
-
-const encodeDateTime = (date: Date | undefined): string | undefined => date?.toISOString();
-
-const applyHoursMinutes = (date: Date | undefined, hhmm: string): Date => {
-  const [h, m] = hhmm.split(':').map((part) => Number.parseInt(part, 10));
-  const next = date ? new Date(date) : new Date();
-  next.setHours(Number.isFinite(h) ? h : 0, Number.isFinite(m) ? m : 0, 0, 0);
-  return next;
+  // Treat the input as local time. `new Date('YYYY-MM-DDTHH:mm')` parses as local.
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
 };
 
 export const DateField = ({
@@ -65,49 +53,60 @@ export const DateField = ({
   onBlur,
   ...props
 }: FormFieldComponentProps<string>) => {
-  const isDateOnly = format === Format.TypeFormat.Date;
-  const isTimeOnly = format === Format.TypeFormat.Time;
+  const handleDateOnlyChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => onValueChange(type, event.target.value),
+    [type, onValueChange],
+  );
 
   const handleTimeChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => onValueChange(type, event.target.value),
     [type, onValueChange],
   );
 
-  const handleDateChange = useCallback(
-    (next: Date | undefined) => {
-      const encoded = isDateOnly ? encodeDateOnly(next) : encodeDateTime(next);
-      onValueChange(type, encoded as string);
+  const handleDateTimeChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const iso = localDateTimeToIso(event.target.value);
+      onValueChange(type, iso as string);
     },
-    [type, isDateOnly, onValueChange],
+    [type, onValueChange],
   );
 
   return (
     <FormFieldWrapper<string> readonly={readonly} {...props}>
       {({ value }) => {
-        if (isTimeOnly) {
-          return <Input.Time disabled={!!readonly} value={value ?? ''} onChange={handleTimeChange} onBlur={onBlur} />;
+        switch (format) {
+          case Format.TypeFormat.Date:
+            return (
+              <Input.Date
+                disabled={!!readonly}
+                placeholder={placeholder}
+                value={value ?? ''}
+                onChange={handleDateOnlyChange}
+                onBlur={onBlur}
+              />
+            );
+          case Format.TypeFormat.Time:
+            return (
+              <Input.Time
+                disabled={!!readonly}
+                placeholder={placeholder}
+                value={value ?? ''}
+                onChange={handleTimeChange}
+                onBlur={onBlur}
+              />
+            );
+          case Format.TypeFormat.DateTime:
+          default:
+            return (
+              <Input.DateTime
+                disabled={!!readonly}
+                placeholder={placeholder}
+                value={isoToLocalDateTime(value)}
+                onChange={handleDateTimeChange}
+                onBlur={onBlur}
+              />
+            );
         }
-
-        const date = isDateOnly ? parseDateOnly(value) : parseDateTime(value);
-        const triggerFormat = isDateOnly ? 'PPP' : 'PPp';
-        const withTime = !isDateOnly;
-
-        return (
-          <DatePicker.Root mode='single' withTime={withTime} value={date} onValueChange={handleDateChange}>
-            <DatePicker.Trigger disabled={!!readonly} placeholder={placeholder} format={triggerFormat} />
-            <DatePicker.Content>
-              <DatePicker.Calendar />
-              {withTime && (
-                <Input.Root>
-                  <Input.Time
-                    value={date ? formatDate(date, 'HH:mm') : ''}
-                    onChange={(event) => handleDateChange(applyHoursMinutes(date, event.target.value))}
-                  />
-                </Input.Root>
-              )}
-            </DatePicker.Content>
-          </DatePicker.Root>
-        );
       }}
     </FormFieldWrapper>
   );

--- a/packages/ui/react-ui-form/src/components/Form/fields/DateField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/DateField.tsx
@@ -1,0 +1,114 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { format as formatDate } from 'date-fns';
+import React, { type ChangeEvent, useCallback } from 'react';
+
+import { Format } from '@dxos/echo';
+import { DatePicker, Input } from '@dxos/react-ui';
+
+import { type FormFieldComponentProps, FormFieldWrapper } from '../FormFieldComponent';
+
+/**
+ * Stored value shapes:
+ * - `Format.DateTime` -> ISO 8601 (`2018-11-13T20:20:39.000Z`).
+ * - `Format.Date`     -> `YYYY-MM-DD`.
+ * - `Format.Time`     -> `HH:mm:ss`.
+ */
+
+const parseDateTime = (value: string | undefined): Date | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+};
+
+const parseDateOnly = (value: string | undefined): Date | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    return undefined;
+  }
+  const [, year, month, day] = match;
+  return new Date(Number(year), Number(month) - 1, Number(day));
+};
+
+const encodeDateOnly = (date: Date | undefined): string | undefined =>
+  date ? formatDate(date, 'yyyy-MM-dd') : undefined;
+
+const encodeDateTime = (date: Date | undefined): string | undefined => date?.toISOString();
+
+const applyHoursMinutes = (date: Date | undefined, hhmm: string): Date => {
+  const [h, m] = hhmm.split(':').map((part) => Number.parseInt(part, 10));
+  const next = date ? new Date(date) : new Date();
+  next.setHours(Number.isFinite(h) ? h : 0, Number.isFinite(m) ? m : 0, 0, 0);
+  return next;
+};
+
+export const DateField = ({
+  type,
+  format,
+  readonly,
+  placeholder,
+  onValueChange,
+  onBlur,
+  ...props
+}: FormFieldComponentProps<string>) => {
+  const isDateOnly = format === Format.TypeFormat.Date;
+  const isTimeOnly = format === Format.TypeFormat.Time;
+
+  const handleTimeChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => onValueChange(type, event.target.value),
+    [type, onValueChange],
+  );
+
+  const handleDateChange = useCallback(
+    (next: Date | undefined) => {
+      const encoded = isDateOnly ? encodeDateOnly(next) : encodeDateTime(next);
+      onValueChange(type, encoded as string);
+    },
+    [type, isDateOnly, onValueChange],
+  );
+
+  return (
+    <FormFieldWrapper<string> readonly={readonly} {...props}>
+      {({ value }) => {
+        if (isTimeOnly) {
+          return (
+            <Input.Time
+              disabled={!!readonly}
+              value={value ?? ''}
+              onChange={handleTimeChange}
+              onBlur={onBlur}
+            />
+          );
+        }
+
+        const date = isDateOnly ? parseDateOnly(value) : parseDateTime(value);
+        const triggerFormat = isDateOnly ? 'PPP' : 'PPp';
+        const withTime = !isDateOnly;
+
+        return (
+          <DatePicker.Root mode='single' withTime={withTime} value={date} onValueChange={handleDateChange}>
+            <DatePicker.Trigger disabled={!!readonly} placeholder={placeholder} format={triggerFormat} />
+            <DatePicker.Content>
+              <DatePicker.Calendar />
+              {withTime && (
+                <Input.Root>
+                  <Input.Time
+                    value={date ? formatDate(date, 'HH:mm') : ''}
+                    onChange={(event) => handleDateChange(applyHoursMinutes(date, event.target.value))}
+                  />
+                </Input.Root>
+              )}
+            </DatePicker.Content>
+          </DatePicker.Root>
+        );
+      }}
+    </FormFieldWrapper>
+  );
+};

--- a/packages/ui/react-ui-form/src/components/Form/fields/index.ts
+++ b/packages/ui/react-ui-form/src/components/Form/fields/index.ts
@@ -4,6 +4,7 @@
 
 export * from './ArrayField';
 export * from './BooleanField';
+export * from './DateField';
 export * from './GeoPointField';
 export * from './MarkdownField';
 export * from './NumberField';

--- a/packages/ui/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.stories.tsx
@@ -3,7 +3,7 @@
 //
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import React, { useRef } from 'react';
+import React from 'react';
 
 import { type MessageValence } from '@dxos/ui-types';
 

--- a/packages/ui/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.stories.tsx
@@ -10,6 +10,8 @@ import { type MessageValence } from '@dxos/ui-types';
 import { withLayoutVariants, withTheme } from '../../testing';
 import {
   type CheckboxProps,
+  type DateInputProps,
+  type DateTimeInputProps,
   Input,
   type PinInputProps,
   type SwitchProps,
@@ -23,6 +25,8 @@ type VariantMap = {
   pin: PinInputProps;
   textarea: TextAreaProps;
   time: TimeProps;
+  date: DateInputProps;
+  datetime: DateTimeInputProps;
   checkbox: CheckboxProps;
   switch: SwitchProps;
 };
@@ -57,6 +61,8 @@ const DefaultStory = ({
       {kind === 'pin' && <Input.PinInput {...props} />}
       {kind === 'textarea' && <Input.TextArea {...props} />}
       {kind === 'time' && <Input.Time {...props} />}
+      {kind === 'date' && <Input.Date {...props} />}
+      {kind === 'datetime' && <Input.DateTime {...props} />}
       {kind === 'checkbox' && <Input.Checkbox {...props} />}
       {kind === 'switch' && <Input.Switch {...props} />}
 
@@ -198,6 +204,22 @@ export const TimeDisabled: Story = {
     label: 'Time (disabled)',
     defaultValue: '12:00',
     disabled: true,
+  },
+};
+
+export const Date: Story = {
+  args: {
+    kind: 'date',
+    label: 'Date',
+    defaultValue: '1990-05-12',
+  },
+};
+
+export const DateTime: Story = {
+  args: {
+    kind: 'datetime',
+    label: 'Date & time',
+    defaultValue: '2026-06-01T15:30',
   },
 };
 

--- a/packages/ui/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.stories.tsx
@@ -3,7 +3,7 @@
 //
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 
 import { type MessageValence } from '@dxos/ui-types';
 
@@ -271,47 +271,6 @@ export const TextInputTypes: Story = {
           <Input.TextInput type={type} placeholder={placeholder} />
         </Input.Root>
       ))}
-    </div>
-  ),
-};
-
-/**
- * Single `datetime-local` input that auto-focuses and re-invokes
- * `showPicker()` on every focus so the native picker pops open as soon
- * as the story mounts. Browsers don't expose a way to lock the picker
- * permanently open — this is the closest approximation for visual
- * inspection of the native picker UI.
- */
-const DateTimeLocalPickerOpen = () => {
-  const ref = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) {
-      return;
-    }
-    const open = () => {
-      try {
-        el.showPicker?.();
-      } catch {
-        // Some browsers reject showPicker() if not user-initiated; ignore.
-      }
-    };
-    el.addEventListener('focus', open);
-    el.focus();
-    return () => el.removeEventListener('focus', open);
-  }, []);
-  return (
-    <Input.Root>
-      <Input.Label>{'type="datetime-local"'}</Input.Label>
-      <Input.TextInput ref={ref} type='datetime-local' />
-    </Input.Root>
-  );
-};
-
-export const DateTimeLocalPicker: Story = {
-  render: () => (
-    <div className='min-w-[24rem]'>
-      <DateTimeLocalPickerOpen />
     </div>
   ),
 };

--- a/packages/ui/react-ui/src/components/Input/Input.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.tsx
@@ -259,6 +259,90 @@ const Time = forwardRef<HTMLInputElement, InputScopedProps<TimeProps>>(
 Time.displayName = 'Input.Time';
 
 //
+// Date
+//
+
+type DateInputProps = InputSharedProps &
+  ThemedClassName<Omit<TextInputPrimitiveProps, 'type'>> & {
+    /** Show the native calendar-picker icon. Defaults to true. */
+    icon?: boolean;
+  };
+
+const Date_ = forwardRef<HTMLInputElement, InputScopedProps<DateInputProps>>(
+  (
+    { __inputScope, classNames, density: densityProp, elevation: elevationProp, variant, icon = true, ...props },
+    forwardedRef,
+  ) => {
+    const { tx } = useThemeContext();
+    const density = useDensityContext(densityProp);
+    const elevation = useElevationContext(elevationProp);
+    const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
+
+    return (
+      <TextInputPrimitive
+        {...props}
+        type='date'
+        className={tx(
+          'input.input',
+          {
+            variant,
+            disabled: props.disabled,
+            density,
+            elevation,
+            validationValence,
+          },
+          !icon && '[&::-webkit-calendar-picker-indicator]:hidden',
+          classNames,
+        )}
+        ref={forwardedRef}
+      />
+    );
+  },
+);
+
+Date_.displayName = 'Input.Date';
+
+//
+// DateTime (datetime-local)
+//
+
+type DateTimeInputProps = DateInputProps;
+
+const DateTime = forwardRef<HTMLInputElement, InputScopedProps<DateTimeInputProps>>(
+  (
+    { __inputScope, classNames, density: densityProp, elevation: elevationProp, variant, icon = true, ...props },
+    forwardedRef,
+  ) => {
+    const { tx } = useThemeContext();
+    const density = useDensityContext(densityProp);
+    const elevation = useElevationContext(elevationProp);
+    const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
+
+    return (
+      <TextInputPrimitive
+        {...props}
+        type='datetime-local'
+        className={tx(
+          'input.input',
+          {
+            variant,
+            disabled: props.disabled,
+            density,
+            elevation,
+            validationValence,
+          },
+          !icon && '[&::-webkit-calendar-picker-indicator]:hidden',
+          classNames,
+        )}
+        ref={forwardedRef}
+      />
+    );
+  },
+);
+
+DateTime.displayName = 'Input.DateTime';
+
+//
 // TextArea
 //
 
@@ -415,6 +499,8 @@ export const Input = {
   TextInput,
   TextArea,
   Time,
+  Date: Date_,
+  DateTime,
   Checkbox,
   Switch,
   Label,
@@ -431,6 +517,8 @@ export type {
   TextInputProps,
   TextAreaProps,
   TimeProps,
+  DateInputProps,
+  DateTimeInputProps,
   CheckboxProps,
   SwitchProps,
   LabelProps,

--- a/packages/ui/react-ui/src/components/Input/Input.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.tsx
@@ -227,6 +227,7 @@ const Time = forwardRef<HTMLInputElement, InputScopedProps<TimeProps>>(
     const density = useDensityContext(densityProp);
     const elevation = useElevationContext(elevationProp);
     const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
+    console.log('time', props.value);
 
     return (
       <TextInputPrimitive
@@ -241,9 +242,10 @@ const Time = forwardRef<HTMLInputElement, InputScopedProps<TimeProps>>(
             elevation,
             validationValence,
           },
+          // TODO(burdon): Move to theme.
           // Force 32px (native time inputs add intrinsic height; the density
           // `min-h-[2.5rem]` arbitrary value also outranks plain `min-h-8`).
-          '!h-8 !min-h-8 box-border leading-none',
+          // '!h-8 !min-h-8 box-border leading-none',
           !icon && '[&::-webkit-calendar-picker-indicator]:hidden',
           !time && 'text-transparent',
           classNames,

--- a/packages/ui/react-ui/src/components/Input/Input.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.tsx
@@ -307,6 +307,7 @@ Date_.displayName = 'Input.Date';
 
 type DateTimeInputProps = DateInputProps;
 
+// TODO(burdon): Use DatePicker.
 const DateTime = forwardRef<HTMLInputElement, InputScopedProps<DateTimeInputProps>>(
   (
     { __inputScope, classNames, density: densityProp, elevation: elevationProp, variant, icon = true, ...props },

--- a/packages/ui/react-ui/src/components/Input/Input.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.tsx
@@ -227,7 +227,6 @@ const Time = forwardRef<HTMLInputElement, InputScopedProps<TimeProps>>(
     const density = useDensityContext(densityProp);
     const elevation = useElevationContext(elevationProp);
     const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
-    console.log('time', props.value);
 
     return (
       <TextInputPrimitive


### PR DESCRIPTION
## Summary

- New `DateField` in `@dxos/react-ui-form` that renders the appropriate input for each date-flavored `TypeFormat`:
  - `Format.DateTime` → `DatePicker` with `withTime` (full ISO 8601 round-trip).
  - `Format.Date` (`DateOnly`) → `DatePicker` without time (`YYYY-MM-DD`).
  - `Format.Time` (`TimeOnly`) → native `Input.Time` (`HH:mm:ss`).
- `getFormField` (in `FormField.tsx`) maps `TypeFormat.Date` / `DateTime` / `Time` to `DateField`, so any schema property annotated with one of these formats picks up the right control automatically.
- `@dxos/echo` `Format` namespace now re-exports the date schemas (`DateOnly`, `TimeOnly`, `DateTime`, `Duration`) — previously only the `Simple*` types were public.
- `plugin-trip` `Segment.ts`: migrated `departAt`, `arriveAt`, `checkIn`, `checkOut` from `Schema.String` to `Format.DateTime` so any generated form over a `Segment` gets date pickers; dropped the unused `cabinClass` field and tidied separator comments.
- Added `birthday` / `meetingAt` / `reminderAt` fields to the `Person` schema in `Form.stories.tsx` for visual coverage.

## Why

After `Format.DateTime` was added to `Segment` fields, the generated forms were still rendering plain text inputs because the form's format → component map had no entries for the date formats. `DateField` closes that gap and gives every consumer of `Form.Root` proper date editing for free.

## Test plan

- [x] `moon run react-ui-form:build` — clean.
- [x] Storybook `ui/react-ui-form/Form > Default`:
  - Birthday → renders `DatePicker` showing `May 12th, 1990`; clicking opens the calendar grid.
  - Next meeting → renders `DatePicker` with time, showing `Jun 1, 2026, 11:30 AM`.
  - Reminder time → renders `<input type='time'>` with value `09:00:00`.
- [ ] CI Check workflow green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Date, DateTime and Time inputs, a reusable DateField form component, and Storybook stories for Date/DateTime.
  * Example form fields added: birthday (date), meetingAt (date-time), reminderAt (time).

* **Refactor**
  * Trip and segment schemas updated to use typed date/time fields and a typed cabin field; segment list input disabled in forms.
  * Internal format exports and format metadata adjusted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->