### PR TITLE
fix(compute): propagate InvokeOptions through Operation.schedule

### DIFF
--- a/packages/core/compute-runtime/src/ProcessOperationInvoker.ts
+++ b/packages/core/compute-runtime/src/ProcessOperationInvoker.ts
@@ -224,8 +224,10 @@ export const make = (opts: {
     ...args: any[]
   ): Effect.Effect<void> => {
     const input = args[0] as I;
+    const options = args[1] as Operation.InvokeOptions | undefined;
+    const traceMeta = options?.tracing as Trace.Meta | undefined;
     return Effect.gen(function* () {
-      log('scheduling operation', { opKey: op.meta.key });
+      log('scheduling operation', { opKey: op.meta.key, ...options });
       yield* Ref.update(pendingCount, (count) => count + 1);
       // Scheduled operations are explicitly detached from the current process
       // — that's the whole point of `schedule` over `invoke`. Spawning without
@@ -233,7 +235,14 @@ export const make = (opts: {
       // spawning process's child set, doesn't deliver `requestChildEvent`
       // notifications, and the parent's terminal state isn't perturbed by
       // late child exits.
-      const fiber = yield* invokeFiber(op, input, { detached: true }).pipe(
+      const fiber = yield* invokeFiber(op, input, {
+        detached: true,
+        traceMeta,
+        environment: {
+          ...(options?.spaceId !== undefined ? { space: options.spaceId } : {}),
+          ...(options?.conversation !== undefined ? { conversation: options.conversation as DXN.String } : {}),
+        },
+      }).pipe(
         Effect.ensuring(Ref.update(pendingCount, (count) => count - 1)),
         Effect.tapErrorCause((cause) =>
           Effect.sync(() => {

--- a/packages/core/compute/compute/src/Operation.ts
+++ b/packages/core/compute/compute/src/Operation.ts
@@ -453,7 +453,7 @@ export interface OperationService {
    */
   schedule: <I, O>(
     op: Operation.Definition<I, O>,
-    ...args: void extends I ? [input?: I] : [input: I]
+    ...args: void extends I ? [input?: I, options?: InvokeOptions] : [input: I, options?: InvokeOptions]
   ) => Effect.Effect<void>;
 
   /**
@@ -517,9 +517,11 @@ export const invoke = <I, O>(
  */
 export const schedule = <I, O>(
   op: Operation.Definition<I, O>,
-  ...args: void extends I ? [input?: I] : [input: I]
+  ...args: void extends I ? [input?: I, options?: InvokeOptions] : [input: I, options?: InvokeOptions]
 ): Effect.Effect<void, never, Service> =>
-  Effect.flatMap(Service, (ops) => ops.schedule(op, args[0] as I)).pipe(Effect.withSpan('Operation.schedule'));
+  Effect.flatMap(Service, (ops) => ops.schedule(op, ...(args as [I, InvokeOptions?]))).pipe(
+    Effect.withSpan('Operation.schedule'),
+  );
 
 /**
  * Provides additional invocation options to all invocations.
@@ -534,7 +536,8 @@ export const withInvocationOptions = (options: InvokeOptions): Layer.Layer<Servi
           service.invoke(op, input, { ...options, ...invocationOptions })) as any,
         invokePromise: ((op: Operation.Definition.Any, input: any, invocationOptions: InvokeOptions) =>
           service.invokePromise(op, input, { ...options, ...invocationOptions })) as any,
-        schedule: service.schedule,
+        schedule: ((op: Operation.Definition.Any, input: any, invocationOptions: InvokeOptions) =>
+          service.schedule(op, input, { ...options, ...invocationOptions })) as any,
       });
     }),
   );

--- a/packages/core/compute/functions/src/protocol/protocol.ts
+++ b/packages/core/compute/functions/src/protocol/protocol.ts
@@ -337,7 +337,7 @@ const makeOperationServiceLayer = (
           outcome.error ? Effect.die(outcome.error) : Effect.succeed(outcome.data as never),
         ),
       )) as Operation.OperationService['invoke'],
-    schedule: ((op: Operation.Definition.Any, input: unknown) =>
+    schedule: ((op: Operation.Definition.Any, input: unknown, _options?: Operation.InvokeOptions) =>
       Effect.sync(() => {
         invariant(op.meta.deployedId, `Operation '${op.meta.key}' has no deployedId; cannot schedule remotely.`);
         // Fire and forget — schedule is intentionally non-awaiting.

--- a/packages/core/compute/operation/src/OperationInvoker.ts
+++ b/packages/core/compute/operation/src/OperationInvoker.ts
@@ -56,7 +56,9 @@ export interface OperationInvoker {
    */
   schedule: <I, O>(
     op: Operation.Definition<I, O>,
-    ...args: void extends I ? [input?: I] : [input: I]
+    ...args: void extends I
+      ? [input?: I, options?: Operation.InvokeOptions]
+      : [input: I, options?: Operation.InvokeOptions]
   ) => Effect.Effect<void>;
   invokePromise: <I, O>(
     op: Operation.Definition<I, O>,
@@ -148,8 +150,10 @@ class OperationInvokerImpl implements OperationInvokerInternal {
   // Arrow function to preserve `this` context when destructured.
   schedule = <I, O>(
     op: Operation.Definition<I, O>,
-    ...args: void extends I ? [input?: I] : [input: I]
-  ): Effect.Effect<void> => this._followupScheduler.schedule(op, ...(args as [I]));
+    ...args: void extends I
+      ? [input?: I, options?: Operation.InvokeOptions]
+      : [input: I, options?: Operation.InvokeOptions]
+  ): Effect.Effect<void> => this._followupScheduler.schedule(op, ...(args as [I, Operation.InvokeOptions?]));
 
   // Arrow function to preserve `this` context when destructured.
   invoke = <I, O>(

--- a/packages/core/compute/operation/src/scheduler.ts
+++ b/packages/core/compute/operation/src/scheduler.ts
@@ -7,7 +7,7 @@ import * as Fiber from 'effect/Fiber';
 import * as HashSet from 'effect/HashSet';
 import * as Ref from 'effect/Ref';
 
-import type { Operation } from '@dxos/compute';
+import { type Operation } from '@dxos/compute';
 import { log } from '@dxos/log';
 
 /**
@@ -36,7 +36,9 @@ export interface FollowupScheduler {
    */
   schedule: <I, O>(
     op: Operation.Definition<I, O>,
-    ...args: void extends I ? [input?: I] : [input: I]
+    ...args: void extends I
+      ? [input?: I, options?: Operation.InvokeOptions]
+      : [input: I, options?: Operation.InvokeOptions]
   ) => Effect.Effect<void>;
 
   /**
@@ -89,9 +91,11 @@ class FollowupSchedulerImpl implements FollowupScheduler {
   // Arrow function to preserve `this` context when destructured.
   schedule = <I, O>(
     op: Operation.Definition<I, O>,
-    ...args: void extends I ? [input?: I] : [input: I]
+    ...args: void extends I
+      ? [input?: I, options?: Operation.InvokeOptions]
+      : [input: I, options?: Operation.InvokeOptions]
   ): Effect.Effect<void> => {
-    const effect = this._invoke(op, args[0] as I).pipe(
+    const effect = this._invoke(op, args[0] as I, args[1] as Operation.InvokeOptions | undefined).pipe(
       Effect.tap(() => Effect.sync(() => log('followup completed', { key: op.meta.key }))),
       Effect.catchAll((error) =>
         Effect.sync(() => {

--- a/packages/plugins/plugin-assistant/src/processor/processor.ts
+++ b/packages/plugins/plugin-assistant/src/processor/processor.ts
@@ -387,8 +387,12 @@ export class AiChatProcessor {
       return Effect.void;
     }
 
-    // TODO(dmaretskyi): Operation.schedule didn't work.
+    const spaceId = Obj.getDatabase(chat)?.spaceId;
+    if (!spaceId) {
+      return Effect.void;
+    }
+
     log.info('scheduling chat name update', { hasName: !!chat.name, chance });
-    return Operation.schedule(AssistantOperation.UpdateChatName, { chat });
+    return Operation.schedule(AssistantOperation.UpdateChatName, { chat }, { spaceId });
   }
 }


### PR DESCRIPTION
## Summary

Fixes the `installHook.js` runtime error:

```
scheduled operation failed
cause: "ServiceNotAvailable: Service not available: @dxos/echo/Database/Service"
opKey: "org.dxos.plugin.assistant.operation.update-chat-name"
```

`Operation.schedule` did not accept `InvokeOptions`, so scheduled operations always ran without `spaceId`/`conversation` context. The spawned process had no `space` in its environment, leaving `Database.Service` unresolvable for any operation that declared it among its required services. In particular, the assistant's `UpdateChatName` operation declares `services: [Database.Service, Feed.FeedService, AiService.AiService]` and is scheduled at the end of every chat request from `AiChatProcessor`, so it failed every time. (Confirmed by the `// TODO(dmaretskyi): Operation.schedule didn't work.` comment in `processor.ts`.)

## Changes

- **`@dxos/compute` / `Operation.ts`** — `OperationService.schedule`, the exported `Operation.schedule`, and `withInvocationOptions` all now accept and propagate `InvokeOptions`, matching `invoke`.
- **`@dxos/operation` / `scheduler.ts` + `OperationInvoker.ts`** — `FollowupScheduler.schedule` and `OperationInvoker.schedule` thread `InvokeOptions` to the underlying invoke function.
- **`@dxos/compute-runtime` / `ProcessOperationInvoker.ts`** — `schedule` now passes `spaceId`/`conversation`/`tracing` to `invokeFiber` as the spawned process's `environment`, exactly like `invoke` does.
- **`@dxos/functions` / `protocol.ts`** — schedule stub signature widened to accept (ignored) options.
- **`@dxos/plugin-assistant` / `processor.ts`** — `#maybeUpdateChatName()` derives `spaceId` via `Obj.getDatabase(chat).spaceId` and passes `{ spaceId }` to `Operation.schedule(UpdateChatName, ...)` so the handler can resolve `Database.Service` in the space's context. Removes the obsolete TODO.

## Test plan

- [x] `moon run @dxos/compute:build @dxos/operation:build @dxos/compute-runtime:build @dxos/functions:build @dxos/plugin-assistant:build` — pass
- [x] `moon run @dxos/operation:test` (incl. `scheduler.test.ts`, `invoker.test.ts`) — 32/32 pass
- [x] `moon run @dxos/compute:test @dxos/compute-runtime:test` — 32/32 pass (`ProcessManager.test.ts`, `LayerStack.test.ts`)
- [x] Lint clean on all touched packages
- [ ] Manually verify the assistant chat name auto-update no longer logs `scheduled operation failed` and that the chat is renamed after the first request

https://claude.ai/code/session_01XuVgfpgtHQT7BBxkX4GStc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuVgfpgtHQT7BBxkX4GStc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated operation scheduling to accept optional configuration options alongside input parameters.
  * Enhanced tracing metadata and environment context propagation for scheduled operations, including space and conversation identifiers.
  * Aligned operation scheduling API signatures with the invocation API for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->