### PR TITLE
refactor(compute): migrate TriggerDispatcher from QueueService to Feed.FeedService

### DIFF
--- a/packages/core/compute/assistant-toolkit/src/blueprints/project/blueprint.test.ts
+++ b/packages/core/compute/assistant-toolkit/src/blueprints/project/blueprint.test.ts
@@ -191,7 +191,7 @@ describe('Agent', () => {
         );
 
         const dispatcher = yield* TriggerDispatcher;
-        const invocations = yield* dispatcher.invokeScheduledTriggers({ kinds: ['queue'], untilExhausted: true });
+        const invocations = yield* dispatcher.invokeScheduledTriggers({ kinds: ['feed'], untilExhausted: true });
         expect(invocations.every((invocation) => Exit.isSuccess(invocation.result))).toBe(true);
 
         console.log(yield* Effect.promise(() => dumpAgent(agent)));

--- a/packages/core/compute/assistant-toolkit/src/blueprints/project/functions/qualifier.ts
+++ b/packages/core/compute/assistant-toolkit/src/blueprints/project/functions/qualifier.ts
@@ -73,7 +73,7 @@ export default Qualifier.pipe(
 
         if (isRelevant) {
           const feedTarget = yield* Database.load(queue);
-          if ('queue' in event && event.item) {
+          if ('feed' in event && event.item) {
             const obj = event.item;
             yield* Feed.append(feedTarget, [obj]);
           } else if ('subject' in event && Ref.isRef(event.subject)) {

--- a/packages/core/compute/compute/src/Trigger.ts
+++ b/packages/core/compute/compute/src/Trigger.ts
@@ -9,15 +9,13 @@ import * as SchemaAST from 'effect/SchemaAST';
 
 import { Annotation, Feed, Obj, QueryAST, Ref, Type, type Query } from '@dxos/echo';
 import { OptionsAnnotationId, SystemTypeAnnotation } from '@dxos/echo/internal';
-import { failedInvariant } from '@dxos/invariant';
-import { DXN } from '@dxos/keys';
 
 /**
  * Type discriminator for TriggerType.
  * Every spec has a type field of type TriggerKind that we can use to understand which type we're working with.
  * https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions
  */
-export const Kinds = ['email', 'queue', 'subscription', 'timer', 'webhook'] as const;
+export const Kinds = ['email', 'feed', 'subscription', 'timer', 'webhook'] as const;
 export type Kind = (typeof Kinds)[number];
 
 const kindLiteralAnnotations = { title: 'Kind' };
@@ -32,29 +30,20 @@ export type EmailSpec = Schema.Schema.Type<typeof EmailSpec>;
  */
 export const specEmail = (): EmailSpec => ({ kind: 'email' });
 
-// TODO(burdon): Change to Feed.
 // TODO(wittjosiah): Remove. Migrate to Subscription triggers once EDGE supports them for feed queries.
-export const QueueSpec = Schema.Struct({
-  kind: Schema.Literal('queue').annotations(kindLiteralAnnotations),
-
-  // TODO(dmaretskyi): Rename to `feed` and change to a reference.
-  queue: DXN.Schema,
+export const FeedSpec = Schema.Struct({
+  kind: Schema.Literal('feed').annotations(kindLiteralAnnotations),
+  feed: Schema.optional(Ref.Ref(Feed.Feed).annotations({ title: 'Feed' })),
 });
-export type QueueSpec = Schema.Schema.Type<typeof QueueSpec>;
+export type FeedSpec = Schema.Schema.Type<typeof FeedSpec>;
 
 /**
- * Construct a Queue trigger spec from a queue DXN string.
+ * Construct a Feed trigger spec from a Feed object.
  */
-export const specQueue = (queueDXN: string): QueueSpec => ({
-  kind: 'queue',
-  queue: queueDXN,
+export const specFeed = (feed: Feed.Feed): FeedSpec => ({
+  kind: 'feed',
+  feed: Ref.make(feed),
 });
-
-/**
- * Construct a Queue trigger spec from a Feed object.
- */
-export const specFeed = (feed: Feed.Feed): QueueSpec =>
-  specQueue(Feed.getQueueDxn(feed)?.toString() ?? failedInvariant(new Error('Could not extract DXN from feed')));
 
 /**
  * Subscription.
@@ -143,7 +132,7 @@ export const specWebhook = (opts?: { method?: string; port?: number }): WebhookS
 /**
  * Trigger schema.
  */
-export const Spec = Schema.Union(EmailSpec, QueueSpec, SubscriptionSpec, TimerSpec, WebhookSpec).annotations({
+export const Spec = Schema.Union(EmailSpec, FeedSpec, SubscriptionSpec, TimerSpec, WebhookSpec).annotations({
   title: 'Trigger',
 });
 export type Spec = Schema.Schema.Type<typeof Spec>;

--- a/packages/core/compute/compute/src/TriggerEvent.ts
+++ b/packages/core/compute/compute/src/TriggerEvent.ts
@@ -6,7 +6,7 @@
 
 import * as Schema from 'effect/Schema';
 
-import { DXN, Obj, Ref } from '@dxos/echo';
+import { Feed, Obj, Ref } from '@dxos/echo';
 
 // TODO(wittjosiah): Review this type.
 //   - Should be discriminated union.
@@ -23,12 +23,12 @@ export const EmailEvent = Schema.Struct({
 });
 export type EmailEvent = Schema.Schema.Type<typeof EmailEvent>;
 
-export const QueueEvent = Schema.Struct({
-  queue: DXN.Schema,
+export const FeedEvent = Schema.Struct({
+  feed: Ref.Ref(Feed.Feed),
   item: Schema.Any,
   cursor: Schema.String,
 });
-export type QueueEvent = Schema.Schema.Type<typeof QueueEvent>;
+export type FeedEvent = Schema.Schema.Type<typeof FeedEvent>;
 
 export const SubscriptionEvent = Schema.Struct({
   /**
@@ -60,5 +60,5 @@ export const WebhookEvent = Schema.Struct({
 });
 export type WebhookEvent = Schema.Schema.Type<typeof WebhookEvent>;
 
-export const TriggerEvent = Schema.Union(EmailEvent, QueueEvent, SubscriptionEvent, TimerEvent, WebhookEvent);
+export const TriggerEvent = Schema.Union(EmailEvent, FeedEvent, SubscriptionEvent, TimerEvent, WebhookEvent);
 export type TriggerEvent = Schema.Schema.Type<typeof TriggerEvent>;

--- a/packages/core/compute/functions-runtime/src/object-template.test.ts
+++ b/packages/core/compute/functions-runtime/src/object-template.test.ts
@@ -15,8 +15,8 @@ interface TestContext {
     id: string;
     concurrency: number;
     spec: {
-      kind: 'queue';
-      queue: string;
+      kind: 'feed';
+      feed: string;
     };
   };
   function: {

--- a/packages/core/compute/functions-runtime/src/triggers/__snapshots__/jsonata.test.ts.snap
+++ b/packages/core/compute/functions-runtime/src/triggers/__snapshots__/jsonata.test.ts.snap
@@ -7,7 +7,6 @@ exports[`jsonata > evaluates expression with trigger event > input as expression
     "name": "John",
     "value": "nested",
   },
-  "queue": "dxn:queue:data:BA25QRC2FEWCSAMRP4RZL65LWJ7352CKE:01J00J9B45YHYSGZQTQMSKMGJ6",
   "ref": {
     "/": "dxn:echo:@:01KD35WMWTEEE1WQQPYEGD1X2B",
   },
@@ -22,7 +21,6 @@ exports[`jsonata > evaluates expression with trigger event > input templating 1`
     "name": "John",
     "value": "nested",
   },
-  "queue": "dxn:queue:data:BA25QRC2FEWCSAMRP4RZL65LWJ7352CKE:01J00J9B45YHYSGZQTQMSKMGJ6",
   "ref": {
     "/": "dxn:echo:@:01KD35WMWTEEE1WQQPYEGD1X2B",
     "target": {

--- a/packages/core/compute/functions-runtime/src/triggers/feed-position.test.ts
+++ b/packages/core/compute/functions-runtime/src/triggers/feed-position.test.ts
@@ -8,13 +8,13 @@ import { Obj } from '@dxos/echo';
 import { FeedProtocol } from '@dxos/protocols';
 import { Person } from '@dxos/types';
 
-import { filterReadyQueueItems, getQueuePosition } from './queue-position';
+import { filterReadyFeedItems, getFeedPosition } from './feed-position';
 
-describe('queue-position', () => {
-  describe('getQueuePosition', () => {
+describe('feed-position', () => {
+  describe('getFeedPosition', () => {
     test('returns undefined when the key is absent', ({ expect }) => {
       const obj = Obj.make(Person.Person, { fullName: 'Alice' });
-      expect(getQueuePosition(obj)).toBeUndefined();
+      expect(getFeedPosition(obj)).toBeUndefined();
     });
 
     test('returns the position id when the key is present', ({ expect }) => {
@@ -22,11 +22,11 @@ describe('queue-position', () => {
       Obj.update(person, (person) => {
         Obj.getMeta(person).keys.push({ source: FeedProtocol.KEY_QUEUE_POSITION, id: '42' });
       });
-      expect(getQueuePosition(person)).toBe('42');
+      expect(getFeedPosition(person)).toBe('42');
     });
   });
 
-  describe('filterReadyQueueItems', () => {
+  describe('filterReadyFeedItems', () => {
     const stamp = <T extends Obj.Any>(obj: T, position: string): T => {
       Obj.update(obj, (obj) => {
         Obj.getMeta(obj).keys.push({ source: FeedProtocol.KEY_QUEUE_POSITION, id: position });
@@ -39,9 +39,9 @@ describe('queue-position', () => {
       const bob = Obj.make(Person.Person, { fullName: 'Bob' });
       const carol = stamp(Obj.make(Person.Person, { fullName: 'Carol' }), '2');
 
-      const ready = filterReadyQueueItems([alice, bob, carol], undefined);
-      expect(ready.map(({ item }) => item)).toEqual([alice, carol]);
-      expect(ready.map(({ position }) => position)).toEqual(['0', '2']);
+      const ready = filterReadyFeedItems([alice, bob, carol], undefined);
+      expect(ready.map(({ item }: { item: Obj.Any; position: string }) => item)).toEqual([alice, carol]);
+      expect(ready.map(({ position }: { item: Obj.Any; position: string }) => position)).toEqual(['0', '2']);
     });
 
     test('skips items at or below the cursor', ({ expect }) => {
@@ -49,15 +49,15 @@ describe('queue-position', () => {
       const bob = stamp(Obj.make(Person.Person, { fullName: 'Bob' }), '1');
       const carol = stamp(Obj.make(Person.Person, { fullName: 'Carol' }), '2');
 
-      const ready = filterReadyQueueItems([alice, bob, carol], '1');
-      expect(ready.map(({ position }) => position)).toEqual(['2']);
+      const ready = filterReadyFeedItems([alice, bob, carol], '1');
+      expect(ready.map(({ position }: { item: Obj.Any; position: string }) => position)).toEqual(['2']);
     });
 
     test('returns all stamped items when cursor is undefined', ({ expect }) => {
       const alice = stamp(Obj.make(Person.Person, { fullName: 'Alice' }), '0');
       const bob = stamp(Obj.make(Person.Person, { fullName: 'Bob' }), '1');
 
-      const ready = filterReadyQueueItems([alice, bob], undefined);
+      const ready = filterReadyFeedItems([alice, bob], undefined);
       expect(ready).toHaveLength(2);
     });
 
@@ -65,7 +65,7 @@ describe('queue-position', () => {
       const alice = stamp(Obj.make(Person.Person, { fullName: 'Alice' }), '0');
       const bob = stamp(Obj.make(Person.Person, { fullName: 'Bob' }), '1');
 
-      const ready = filterReadyQueueItems([alice, bob], 'not-a-number');
+      const ready = filterReadyFeedItems([alice, bob], 'not-a-number');
       expect(ready).toEqual([]);
     });
 
@@ -74,8 +74,8 @@ describe('queue-position', () => {
       const bob = stamp(Obj.make(Person.Person, { fullName: 'Bob' }), '2abc');
       const carol = stamp(Obj.make(Person.Person, { fullName: 'Carol' }), '3');
 
-      const ready = filterReadyQueueItems([alice, bob, carol], '0');
-      expect(ready.map(({ position }) => position)).toEqual(['3']);
+      const ready = filterReadyFeedItems([alice, bob, carol], '0');
+      expect(ready.map(({ position }: { item: Obj.Any; position: string }) => position)).toEqual(['3']);
     });
   });
 });

--- a/packages/core/compute/functions-runtime/src/triggers/feed-position.ts
+++ b/packages/core/compute/functions-runtime/src/triggers/feed-position.ts
@@ -6,14 +6,14 @@ import { Entity } from '@dxos/echo';
 import { FeedProtocol } from '@dxos/protocols';
 
 /**
- * Read the queue position id stamped onto a queue object by `QueueService.append`.
+ * Read the position id stamped onto a feed item by the storage layer.
  * Returns `undefined` if the object has no position key (e.g. stale data, or a write that
- * bypassed the queue service).
+ * bypassed the feed service).
  */
-export const getQueuePosition = (object: Entity.Unknown): string | undefined =>
+export const getFeedPosition = (object: Entity.Unknown): string | undefined =>
   Entity.getKeys(object, FeedProtocol.KEY_QUEUE_POSITION).at(0)?.id;
 
-const parseQueuePosition = (position: string): number | undefined => {
+const parseFeedPosition = (position: string): number | undefined => {
   if (!/^\d+$/.test(position)) {
     return undefined;
   }
@@ -22,26 +22,26 @@ const parseQueuePosition = (position: string): number | undefined => {
 };
 
 /**
- * Filter queue objects to only those past the given cursor, pairing each with its position.
+ * Filter feed items to only those past the given cursor, pairing each with its position.
  * Objects without a position key are skipped defensively so that a single malformed entry
  * does not stall trigger dispatch. A malformed cursor rejects all items so a corrupted
  * checkpoint cannot cause unbounded re-dispatch.
  */
-export const filterReadyQueueItems = <T extends Entity.Unknown>(
+export const filterReadyFeedItems = <T extends Entity.Unknown>(
   objects: readonly T[],
   cursor: string | undefined,
 ): { item: T; position: string }[] => {
-  const cursorPos = cursor !== undefined ? parseQueuePosition(cursor) : undefined;
+  const cursorPos = cursor !== undefined ? parseFeedPosition(cursor) : undefined;
   if (cursor !== undefined && cursorPos === undefined) {
     return [];
   }
   const ready: { item: T; position: string }[] = [];
   for (const item of objects) {
-    const position = getQueuePosition(item);
+    const position = getFeedPosition(item);
     if (position === undefined) {
       continue;
     }
-    const itemPos = parseQueuePosition(position);
+    const itemPos = parseFeedPosition(position);
     if (itemPos === undefined) {
       continue;
     }

--- a/packages/core/compute/functions-runtime/src/triggers/jsonata.test.ts
+++ b/packages/core/compute/functions-runtime/src/triggers/jsonata.test.ts
@@ -6,8 +6,9 @@ import jsonata from 'jsonata';
 import { assert, describe, test } from 'vitest';
 
 import { Trigger, TriggerEvent } from '@dxos/compute';
-import { Obj, Ref } from '@dxos/echo';
+import { Feed, Obj, Ref } from '@dxos/echo';
 import { TestSchema } from '@dxos/echo/testing';
+import { DXN } from '@dxos/keys';
 import { trim } from '@dxos/util';
 
 describe('jsonata', () => {
@@ -51,9 +52,11 @@ describe('jsonata', () => {
   });
 
   describe('evaluates expression with trigger event', () => {
-    const queueDXN = 'dxn:queue:data:BA25QRC2FEWCSAMRP4RZL65LWJ7352CKE:01J00J9B45YHYSGZQTQMSKMGJ6';
+    const feedRef: Ref.Ref<Feed.Feed> = Ref.fromDXN(
+      DXN.parse('dxn:echo:BA25QRC2FEWCSAMRP4RZL65LWJ7352CKE:01J00J9B45YHYSGZQTQMSKMGJ6'),
+    );
     const event: TriggerEvent.TriggerEvent = {
-      queue: queueDXN,
+      feed: feedRef,
       item: {
         name: 'John',
       },
@@ -62,7 +65,7 @@ describe('jsonata', () => {
 
     const obj = Obj.make(TestSchema.Expando, { id: '01KD35WMWTEEE1WQQPYEGD1X2B', name: 'DXOS' });
     const trigger = Trigger.make({
-      spec: Trigger.specQueue(queueDXN),
+      spec: { kind: 'feed', feed: feedRef },
       input: {
         nested: {
           value: 'nested',
@@ -100,7 +103,6 @@ describe('jsonata', () => {
     test('input as expression', async ({ expect }) => {
       const input = trim`
       {
-        "queue": event.queue,
         "cursor": event.cursor,
         "nested": {
           "value": "nested",
@@ -115,7 +117,6 @@ describe('jsonata', () => {
       const expression = jsonata(input);
       const result = await expression.evaluate({ trigger, event });
       expect(result).toMatchSnapshot({
-        queue: event.queue,
         cursor: event.cursor,
         nested: {
           value: 'nested',
@@ -130,7 +131,6 @@ describe('jsonata', () => {
 
     test('input templating', async ({ expect }) => {
       const input = {
-        queue: '{{event.queue}}',
         cursor: '{{event.cursor}}',
         nested: {
           value: 'nested',
@@ -146,7 +146,6 @@ describe('jsonata', () => {
       const expression = jsonata(transformedInput);
       const result = await expression.evaluate({ trigger, event });
       expect(result).toMatchSnapshot({
-        queue: event.queue,
         cursor: event.cursor,
         nested: {
           value: 'nested',

--- a/packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.test.ts
+++ b/packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.test.ts
@@ -347,9 +347,9 @@ describe('TriggerDispatcher', () => {
     );
   });
 
-  describe('Queue Triggers', () => {
+  describe('Feed Triggers', () => {
     it.effect(
-      'should invoke scheduled queue triggers',
+      'should invoke scheduled feed triggers',
       Effect.fnUntraced(function* ({ expect }) {
         const feed = yield* Database.add(Feed.make());
 
@@ -368,7 +368,7 @@ describe('TriggerDispatcher', () => {
         ]);
 
         const dispatcher = yield* TriggerDispatcher;
-        const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['queue'] });
+        const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['feed'] });
         expect(results.length).toBe(1);
         expect(results[0].triggerId).toBe(trigger.id);
         expect(Exit.isSuccess(results[0].result)).toBe(true);
@@ -400,21 +400,21 @@ describe('TriggerDispatcher', () => {
         const dispatcher = yield* TriggerDispatcher;
 
         {
-          const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['queue'] });
+          const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['feed'] });
           expect(results.length).toBe(1);
           expect(results[0].triggerId).toBe(trigger.id);
           expect(Exit.isSuccess(results[0].result)).toBe(true);
         }
 
         {
-          const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['queue'] });
+          const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['feed'] });
           expect(results.length).toBe(1);
           expect(results[0].triggerId).toBe(trigger.id);
           expect(Exit.isSuccess(results[0].result)).toBe(true);
         }
 
         {
-          const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['queue'] });
+          const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['feed'] });
           expect(results.length).toBe(0);
         }
       }, Effect.provide(TestTriggerDispatcherLayer)),
@@ -444,7 +444,7 @@ describe('TriggerDispatcher', () => {
         yield* Feed.append(feed, [person]);
 
         const dispatcher = yield* TriggerDispatcher;
-        const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['queue'] });
+        const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['feed'] });
         expect(results.length).toBe(1);
         expect(results[0].triggerId).toBe(trigger.id);
         const exit = results[0].result;
@@ -483,20 +483,20 @@ describe('TriggerDispatcher', () => {
         const dispatcher = yield* TriggerDispatcher;
 
         {
-          const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['queue'] });
+          const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['feed'] });
           expect(results.length).toBe(2);
           expect(results.every((r) => Exit.isSuccess(r.result))).toBe(true);
         }
 
         {
-          const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['queue'] });
+          const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['feed'] });
           expect(results.length).toBe(1);
           expect(results[0].triggerId).toBe(trigger.id);
           expect(Exit.isSuccess(results[0].result)).toBe(true);
         }
 
         {
-          const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['queue'] });
+          const results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['feed'] });
           expect(results.length).toBe(0);
         }
       }, Effect.provide(TestTriggerDispatcherLayer)),

--- a/packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.ts
+++ b/packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.ts
@@ -23,15 +23,14 @@ import * as Struct from 'effect/Struct';
 
 import { Process, Trigger, TriggerEvent, Operation } from '@dxos/compute';
 import { ProcessManager } from '@dxos/compute-runtime';
-import { Database, DXN, Filter, Obj, Query } from '@dxos/echo';
+import { Database, Feed, Filter, Obj, Query } from '@dxos/echo';
 import { causeToError } from '@dxos/effect';
-import { QueueService } from '@dxos/functions';
 import { failedInvariant, invariant } from '@dxos/invariant';
 import { ObjectId } from '@dxos/keys';
 import { log } from '@dxos/log';
 
 import { createInvocationPayload } from './input-builder';
-import { filterReadyQueueItems } from './queue-position';
+import { filterReadyFeedItems } from './feed-position';
 import { type TriggerState, TriggerStateStore } from './trigger-state-store';
 
 export type TimeControl = 'natural' | 'manual';
@@ -83,9 +82,9 @@ export interface TriggerExecutionResult {
   result: Exit.Exit<unknown>;
 
   /**
-   * Only for queue triggers.
+   * Only for feed triggers.
    */
-  queueCursor?: string;
+  feedCursor?: string;
 }
 
 /**
@@ -101,7 +100,7 @@ type TriggerDispatcherServices =
   | Registry.AtomRegistry
   | ProcessManager.Service
   | TriggerStateStore
-  | QueueService
+  | Feed.FeedService
   | Database.Service;
 
 export type InvocationsState = {
@@ -154,7 +153,7 @@ export class TriggerDispatcher extends Context.Tag('@dxos/functions/TriggerDispa
     /**
      * Invoke all scheduled triggers who are due.
      * @param opts.kinds - The kinds of triggers to invoke.
-     * @param opts.untilExhausted - Invoke until no more triggers are due. By default only one queue/subscription item is processed at a time.
+     * @param opts.untilExhausted - Invoke until no more triggers are due. By default only one feed/subscription item is processed at a time.
      */
     invokeScheduledTriggers(opts?: {
       kinds?: Trigger.Kind[];
@@ -376,7 +375,7 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
       const triggerExecutionResult: TriggerExecutionResult = {
         triggerId: trigger.id,
         result,
-        queueCursor: trigger.spec?.kind === 'queue' && 'cursor' in event ? event.cursor : undefined,
+        feedCursor: trigger.spec?.kind === 'feed' && 'cursor' in event ? event.cursor : undefined,
       };
       if (Exit.isSuccess(result)) {
         log('trigger execution success', {
@@ -406,7 +405,7 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
     }).pipe(Effect.provide(this._services));
 
   invokeScheduledTriggers = ({
-    kinds = ['timer', 'queue', 'subscription'],
+    kinds = ['timer', 'feed', 'subscription'],
     untilExhausted = false,
   } = {}): Effect.Effect<TriggerExecutionResult[]> =>
     Effect.gen(this, function* () {
@@ -446,24 +445,29 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
               );
             }
             break;
-          case 'queue': {
+          case 'feed': {
             for (const trigger of this._triggers) {
               const spec = trigger.spec;
-              if (spec?.kind !== 'queue') {
+              if (spec?.kind !== 'feed') {
                 continue;
               }
               if (this._isInCooldown(trigger.id)) {
                 log('skipping trigger in cooldown', { triggerId: trigger.id });
                 continue;
               }
-              const cursor = Obj.getKeys(trigger, KEY_QUEUE_CURSOR).at(0)?.id;
-              const queue = yield* QueueService.getQueue(DXN.parse(spec.queue));
+              const feedRef = spec.feed;
+              if (!feedRef) {
+                log('skipping feed trigger with no feed reference', { triggerId: trigger.id });
+                continue;
+              }
+              const cursor = Obj.getKeys(trigger, KEY_FEED_CURSOR).at(0)?.id;
+              const feed = yield* Database.load(feedRef).pipe(Effect.orDie);
 
               const concurrency = Math.min(trigger.concurrency ?? 1, this._maxConcurrency);
 
               // TODO(dmaretskyi): Include cursor & limit in the query.
-              const chunks = yield* Effect.promise(() => queue.queryObjects()).pipe(
-                Effect.map((objects) => filterReadyQueueItems(objects, cursor)),
+              const chunks = yield* Feed.runQuery(feed, Filter.everything()).pipe(
+                Effect.map((objects) => filterReadyFeedItems(objects, cursor)),
                 Effect.map(Array.chunksOf(concurrency)),
               );
 
@@ -474,10 +478,10 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
                     this.invokeTrigger({
                       trigger,
                       event: {
-                        queue: spec.queue,
+                        feed: feedRef,
                         item,
                         cursor: position,
-                      } satisfies TriggerEvent.QueueEvent,
+                      } satisfies TriggerEvent.FeedEvent,
                     }),
                   { concurrency: 'unbounded' },
                 );
@@ -491,10 +495,10 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
                 );
                 if (Option.isSome(lastSuccessfulInvocation)) {
                   Obj.update(trigger, (trigger) => {
-                    Obj.deleteKeys(trigger, KEY_QUEUE_CURSOR);
+                    Obj.deleteKeys(trigger, KEY_FEED_CURSOR);
                     Obj.getMeta(trigger).keys.push({
-                      source: KEY_QUEUE_CURSOR,
-                      id: lastSuccessfulInvocation.value.queueCursor ?? failedInvariant(),
+                      source: KEY_FEED_CURSOR,
+                      id: lastSuccessfulInvocation.value.feedCursor ?? failedInvariant(),
                     });
                   });
                   yield* Database.flush();
@@ -502,7 +506,7 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
                   break;
                 }
 
-                // We only invoke one trigger for each queue at a time.
+                // We only invoke one trigger for each feed at a time.
                 if (!untilExhausted) {
                   break;
                 }
@@ -678,6 +682,6 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
 }
 
 /**
- * Key for the current queue cursor for queue triggers.
+ * Key for the current cursor for feed triggers.
  */
-export const KEY_QUEUE_CURSOR = 'org.dxos.key.local-trigger-dispatcher.queue-cursor';
+export const KEY_FEED_CURSOR = 'org.dxos.key.local-trigger-dispatcher.feed-cursor';

--- a/packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.ts
+++ b/packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.ts
@@ -29,8 +29,8 @@ import { failedInvariant, invariant } from '@dxos/invariant';
 import { ObjectId } from '@dxos/keys';
 import { log } from '@dxos/log';
 
-import { createInvocationPayload } from './input-builder';
 import { filterReadyFeedItems } from './feed-position';
+import { createInvocationPayload } from './input-builder';
 import { type TriggerState, TriggerStateStore } from './trigger-state-store';
 
 export type TimeControl = 'natural' | 'manual';
@@ -404,10 +404,9 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
       return triggerExecutionResult;
     }).pipe(Effect.provide(this._services));
 
-  invokeScheduledTriggers = ({
-    kinds = ['timer', 'feed', 'subscription'],
-    untilExhausted = false,
-  } = {}): Effect.Effect<TriggerExecutionResult[]> =>
+  invokeScheduledTriggers = ({ kinds = ['timer', 'feed', 'subscription'], untilExhausted = false } = {}): Effect.Effect<
+    TriggerExecutionResult[]
+  > =>
     Effect.gen(this, function* () {
       yield* this.refreshTriggers();
       const invocations: TriggerExecutionResult[] = [];

--- a/packages/plugins/plugin-assistant/src/testing/trace-timeline.node.test.ts
+++ b/packages/plugins/plugin-assistant/src/testing/trace-timeline.node.test.ts
@@ -196,7 +196,7 @@ describe('Trace timeline', () => {
 
           const dispatcher = yield* TriggerDispatcher;
           yield* dispatcher
-            .invokeScheduledTriggers({ kinds: ['queue'], untilExhausted: true })
+            .invokeScheduledTriggers({ kinds: ['feed'], untilExhausted: true })
             .pipe(Effect.flatMap(Effect.forEach((result) => result.result)));
 
           const messages = yield* queryTraceMessages;

--- a/packages/plugins/plugin-automation/src/capabilities/layer-specs.ts
+++ b/packages/plugins/plugin-automation/src/capabilities/layer-specs.ts
@@ -13,7 +13,6 @@ import { ClientService } from '@dxos/client';
 import { Blueprint, LayerSpec, OperationHandlerSet, OperationRegistry } from '@dxos/compute';
 import { ProcessManager } from '@dxos/compute-runtime';
 import { Database, Feed } from '@dxos/echo';
-import { QueueService } from '@dxos/functions';
 import {
   AgentService,
   FeedTraceSink,
@@ -192,7 +191,7 @@ const TriggerDispatcherSpec = LayerSpec.make(
     affinity: 'space',
     requires: [
       Database.Service,
-      QueueService,
+      Feed.FeedService,
       TriggerStateStore,
       ProcessManager.ProcessManagerService,
       Registry.AtomRegistry,

--- a/packages/plugins/plugin-automation/src/commands/trigger/create/queue.ts
+++ b/packages/plugins/plugin-automation/src/commands/trigger/create/queue.ts
@@ -14,18 +14,18 @@ import { CommandConfig } from '@dxos/cli-util';
 import { flushAndSync, print, spaceLayer, withTypes } from '@dxos/cli-util';
 import { Common } from '@dxos/cli-util';
 import { Operation, Trigger } from '@dxos/compute';
-import { Database, Filter, JsonSchema, Ref } from '@dxos/echo';
+import { Database, Feed as FeedNs, Filter, JsonSchema, Ref } from '@dxos/echo';
 
-import { Enabled, Input, Queue } from '../options';
+import { Enabled, Feed, Input } from '../options';
 import { printTrigger, promptForSchemaInput, selectFunction, selectFeed } from '../util';
 
 export const queue = Command.make(
-  'queue',
+  'feed',
   {
     spaceId: Common.spaceId.pipe(Options.optional),
     enabled: Enabled,
     functionId: Common.functionId.pipe(Options.optional),
-    queue: Queue.pipe(Options.optional),
+    feed: Feed.pipe(Options.optional),
     input: Input.pipe(Options.optional),
   },
   (options) =>
@@ -42,9 +42,9 @@ export const queue = Command.make(
         return yield* Effect.fail(new Error(`Function not found: ${functionId}`));
       }
 
-      const queueDXN = yield* Option.match(options.queue, {
+      const feed = yield* Option.match(options.feed, {
         onNone: () => selectFeed(),
-        onSome: (dxn) => Effect.succeed(dxn.toString()),
+        onSome: (dxn) => Database.resolve(dxn, FeedNs.Feed),
       });
 
       const input = yield* Option.match(options.input, {
@@ -65,7 +65,7 @@ export const queue = Command.make(
       const trigger = Trigger.make({
         function: Ref.make(fn),
         enabled,
-        spec: Trigger.specQueue(queueDXN),
+        spec: Trigger.specFeed(feed),
         input,
       });
 
@@ -80,7 +80,7 @@ export const queue = Command.make(
       yield* flushAndSync({ indexes: true });
     }),
 ).pipe(
-  Command.withDescription('Create a queue trigger.'),
+  Command.withDescription('Create a feed trigger.'),
   Command.provide(({ spaceId }) => spaceLayer(spaceId, true)),
   Command.provideEffectDiscard(() => withTypes(Operation.PersistentOperation, Trigger.Trigger)),
 );

--- a/packages/plugins/plugin-automation/src/commands/trigger/options.ts
+++ b/packages/plugins/plugin-automation/src/commands/trigger/options.ts
@@ -42,7 +42,7 @@ export const Cron = Options.text('cron').pipe(
 );
 
 //
-// Queue
+// Feed
 //
 
 // TODO(dmaretskyi): Extract
@@ -53,7 +53,7 @@ const DXNSchema = Schema.String.pipe(
   }),
 );
 
-export const Queue = Options.text('queue').pipe(
-  Options.withDescription('The DXN of the queue for the queue trigger.'),
+export const Feed = Options.text('feed').pipe(
+  Options.withDescription('The DXN of the feed for the feed trigger.'),
   Options.withSchema(DXNSchema),
 );

--- a/packages/plugins/plugin-automation/src/commands/trigger/update/queue.ts
+++ b/packages/plugins/plugin-automation/src/commands/trigger/update/queue.ts
@@ -13,36 +13,36 @@ import { CommandConfig } from '@dxos/cli-util';
 import { flushAndSync, print, spaceLayer, withTypes } from '@dxos/cli-util';
 import { Common } from '@dxos/cli-util';
 import { Operation, Trigger } from '@dxos/compute';
-import { DXN, Database, Filter, JsonSchema, Obj, Ref } from '@dxos/echo';
+import { DXN, Database, Feed as FeedNs, Filter, JsonSchema, Obj, Ref } from '@dxos/echo';
 
-import { Enabled, Input, Queue, TriggerId } from '../options';
+import { Enabled, Feed, Input, TriggerId } from '../options';
 import { printTrigger, promptForSchemaInput, selectFunction, selectFeed, selectTrigger } from '../util';
 
 export const queue = Command.make(
-  'queue',
+  'feed',
   {
     spaceId: Common.spaceId.pipe(Options.optional),
     id: TriggerId.pipe(Options.optional),
     enabled: Enabled,
     functionId: Common.functionId.pipe(Options.optional),
-    queue: Queue.pipe(Options.optional),
+    feed: Feed.pipe(Options.optional),
     input: Input.pipe(Options.optional),
   },
   (options) =>
     Effect.gen(function* () {
       const { json } = yield* CommandConfig;
       const triggerId = yield* Option.match(options.id, {
-        onNone: () => selectTrigger('queue'),
+        onNone: () => selectTrigger('feed'),
         onSome: (id) => Effect.succeed(id),
       });
       const dxn = DXN.fromLocalObjectId(triggerId);
       const trigger = yield* Database.resolve(dxn, Trigger.Trigger);
-      if (trigger.spec?.kind !== 'queue') {
+      if (trigger.spec?.kind !== 'feed') {
         return yield* Effect.fail(new Error(`Invalid trigger type: ${trigger.spec?.kind}`));
       }
 
       const currentFn = yield* updateFunction(trigger, options.functionId);
-      yield* updateQueue(trigger, options.queue);
+      yield* updateFeed(trigger, options.feed);
       yield* updateInput(trigger, currentFn, options.input);
       yield* updateEnabled(trigger, options.id, options.enabled);
 
@@ -55,7 +55,7 @@ export const queue = Command.make(
       yield* flushAndSync({ indexes: true });
     }),
 ).pipe(
-  Command.withDescription('Update a queue trigger.'),
+  Command.withDescription('Update a feed trigger.'),
   Command.provide(({ spaceId }) => spaceLayer(spaceId, true)),
   Command.provideEffectDiscard(() => withTypes(Operation.PersistentOperation, Trigger.Trigger)),
 );
@@ -106,32 +106,28 @@ const updateFunction = Effect.fn(function* (trigger: Trigger.Trigger, functionId
 });
 
 /**
- * Handles updating the queue DXN for a queue trigger.
- * Prompts for confirmation if queue is not provided, then updates the queue if confirmed.
+ * Handles updating the feed reference for a feed trigger.
+ * Prompts for confirmation if feed is not provided, then updates the feed if confirmed.
  */
-const updateQueue = Effect.fn(function* (trigger: Trigger.Trigger, queueOption: Option.Option<DXN>) {
-  const currentQueue = trigger.spec?.kind === 'queue' ? trigger.spec.queue : undefined;
-  const currentQueueStr = currentQueue
-    ? typeof currentQueue === 'string'
-      ? currentQueue
-      : String(currentQueue)
-    : undefined;
-  const shouldChangeQueue = yield* Option.match(queueOption, {
+const updateFeed = Effect.fn(function* (trigger: Trigger.Trigger, feedOption: Option.Option<DXN>) {
+  const currentFeed = trigger.spec?.kind === 'feed' ? trigger.spec.feed : undefined;
+  const currentFeedStr = currentFeed ? currentFeed.dxn.toString() : undefined;
+  const shouldChangeFeed = yield* Option.match(feedOption, {
     onNone: () =>
       Prompt.confirm({
-        message: `Change the queue${currentQueueStr ? ` (current: ${currentQueueStr})` : ''}?`,
+        message: `Change the feed${currentFeedStr ? ` (current: ${currentFeedStr})` : ''}?`,
         initial: false,
       }).pipe(Prompt.run),
     onSome: () => Effect.succeed(true),
   });
-  if (shouldChangeQueue) {
-    const queueDXN = yield* Option.match(queueOption, {
+  if (shouldChangeFeed) {
+    const feed = yield* Option.match(feedOption, {
       onNone: () => selectFeed(),
-      onSome: (dxn) => Effect.succeed(dxn.toString()),
+      onSome: (dxn) => Database.resolve(dxn, FeedNs.Feed),
     });
     Obj.update(trigger, (trigger) => {
-      if (trigger.spec?.kind === 'queue') {
-        trigger.spec.queue = queueDXN;
+      if (trigger.spec?.kind === 'feed') {
+        trigger.spec.feed = Ref.make(feed);
       }
     });
   }

--- a/packages/plugins/plugin-automation/src/commands/trigger/util.ts
+++ b/packages/plugins/plugin-automation/src/commands/trigger/util.ts
@@ -79,8 +79,8 @@ const printSpec = <T extends Trigger.Spec>(spec: T): FormBuilder.FormBuilder => 
       return printSubscription(spec);
     case 'webhook':
       return printWebhook(spec);
-    case 'queue':
-      return printQueue(spec);
+    case 'feed':
+      return printFeed(spec);
     default:
       return FormBuilder.make({}).pipe(FormBuilder.set('unknown', 'Unknown spec type'));
   }
@@ -94,7 +94,8 @@ const printSubscription = (spec: Trigger.SubscriptionSpec) =>
 const printWebhook = (spec: Trigger.WebhookSpec) =>
   FormBuilder.make({}).pipe(FormBuilder.set('method', spec.method), FormBuilder.set('port', spec.port));
 
-const printQueue = (spec: Trigger.QueueSpec) => FormBuilder.make({}).pipe(FormBuilder.set('queue', spec.queue));
+const printFeed = (spec: Trigger.FeedSpec) =>
+  FormBuilder.make({}).pipe(FormBuilder.set('feed', spec.feed ? spec.feed.dxn.toString() : '(none)'));
 
 /**
  * Prompts for input values based on an Effect schema.
@@ -339,7 +340,7 @@ export const selectTrigger = Effect.fn(function* (kind?: Trigger.Kind) {
 /**
  * Selects a feed interactively from available feeds in the database.
  * Queries schemas with FeedAnnotation, then queries objects of those types,
- * and extracts queue DXNs from the objects' feed properties.
+ * and returns the chosen Feed object.
  */
 export const selectFeed = Effect.fn(function* () {
   // Query schema registry for schemas with FeedAnnotation.
@@ -355,10 +356,10 @@ export const selectFeed = Effect.fn(function* () {
     return yield* Effect.fail(new Error('No schemas with Feed annotation found'));
   }
 
-  // Collect all objects with feeds.
-  const feedChoices: Array<{ title: string; value: string; description?: string }> = [];
+  // Collect all Feed objects referenced by host objects.
+  const feedChoices: Array<{ title: string; value: Feed.Feed; description?: string }> = [];
 
-  // Process each feed schema, loading the Feed object to extract queue DXN.
+  // Process each feed schema, resolving the Feed object reference.
   for (const schema of feedSchemas) {
     yield* Effect.gen(function* () {
       const typename = Type.getTypename(schema);
@@ -376,17 +377,12 @@ export const selectFeed = Effect.fn(function* () {
           continue;
         }
 
-        const feedDXN = Feed.getQueueDxn(feedObj);
-        if (!feedDXN) {
-          continue;
-        }
-
         const label = Obj.getLabel(obj) ?? obj.id;
         const description = Obj.getTypename(obj);
 
         feedChoices.push({
           title: label,
-          value: feedDXN.toString(),
+          value: feedObj,
           description,
         });
       }
@@ -394,15 +390,15 @@ export const selectFeed = Effect.fn(function* () {
   }
 
   if (feedChoices.length === 0) {
-    return yield* Effect.fail(new Error('No objects with queue properties found'));
+    return yield* Effect.fail(new Error('No objects with feed properties found'));
   }
 
   const selected = yield* Prompt.select({
-    message: 'Select a queue:',
+    message: 'Select a feed:',
     choices: feedChoices,
   });
 
-  return String(selected);
+  return selected as Feed.Feed;
 });
 
 /**

--- a/packages/plugins/plugin-automation/src/components/AutomationPanel/AutomationPanel.tsx
+++ b/packages/plugins/plugin-automation/src/components/AutomationPanel/AutomationPanel.tsx
@@ -15,7 +15,7 @@ import { type ComputeEnvironment } from '@dxos/client-protocol';
 import { Operation, Script, ServiceResolver, Trigger, TriggerEvent } from '@dxos/compute';
 import { Context } from '@dxos/context';
 import { Filter, Obj, Query, Tag } from '@dxos/echo';
-import { KEY_QUEUE_CURSOR, TriggerDispatcher } from '@dxos/functions-runtime';
+import { KEY_FEED_CURSOR, TriggerDispatcher } from '@dxos/functions-runtime';
 import { FunctionsServiceClient } from '@dxos/functions-runtime/edge';
 import { log } from '@dxos/log';
 import { type Client, useClient } from '@dxos/react-client';
@@ -134,7 +134,7 @@ export const AutomationPanel = ({ space, object, initialTrigger, onDone }: Autom
 
   const handleResetCursor = async (trigger: Trigger.Trigger) => {
     Obj.update(trigger, (trigger) => {
-      Obj.deleteKeys(trigger, KEY_QUEUE_CURSOR);
+      Obj.deleteKeys(trigger, KEY_FEED_CURSOR);
     });
     await space.db.flush({ indexes: true });
   };
@@ -210,7 +210,7 @@ const TriggerListItem = ({
   const client = useClient();
   const copyAction = getCopyAction(client, trigger);
   const { t } = useTranslation(meta.id);
-  const cursor = Obj.getKeys(trigger, KEY_QUEUE_CURSOR).at(0)?.id;
+  const cursor = Obj.getKeys(trigger, KEY_FEED_CURSOR).at(0)?.id;
   const [snapshot, updateTrigger] = useObject(trigger);
 
   const enabled = snapshot.enabled ?? false;
@@ -246,7 +246,7 @@ const TriggerListItem = ({
       };
     }
 
-    if (trigger.spec?.kind === 'queue' && onResetCursor) {
+    if (trigger.spec?.kind === 'feed' && onResetCursor) {
       return {
         disabled: !cursor,
         icon: 'ph--arrow-clockwise--regular',

--- a/packages/plugins/plugin-automation/src/components/TriggerEditor/SpecSelector.tsx
+++ b/packages/plugins/plugin-automation/src/components/TriggerEditor/SpecSelector.tsx
@@ -25,8 +25,8 @@ export const SpecSelector = (props: SpecSelectorProps) => {
             return Trigger.specTimer('');
           case 'subscription':
             return Trigger.specSubscription(Query.select(Filter.nothing()));
-          case 'queue':
-            return Trigger.specQueue('dxn:queue:default');
+          case 'feed':
+            return { kind: 'feed' } satisfies Trigger.FeedSpec;
           case 'email':
             return Trigger.specEmail();
           case 'webhook':
@@ -53,7 +53,7 @@ export const SpecSelector = (props: SpecSelectorProps) => {
     websocket: t('trigger-type.websocket.label'),
     subscription: t('trigger-type.subscription.label'),
     email: t('trigger-type.email.label'),
-    queue: t('trigger-type.queue.label'),
+    feed: t('trigger-type.feed.label'),
   };
 
   const options = useMemo(

--- a/packages/plugins/plugin-automation/src/components/TriggerEditor/TriggerEditor.tsx
+++ b/packages/plugins/plugin-automation/src/components/TriggerEditor/TriggerEditor.tsx
@@ -119,8 +119,35 @@ const useCustomInputs = ({ db, readonlySpec, types, tags }: UseCustomInputsProps
       // Spec selector.
       'spec.kind': (props) => <SpecSelector {...props} readonly={readonlySpec} />,
 
-      // Queue feed selector with parent labels.
-      'spec.queue': (props) => <SelectField {...props} options={getFeedQueueOptions(feeds)} />,
+      // Feed selector with parent labels.
+      'spec.feed': (props) => {
+        const getValue = useCallback(() => {
+          const formValue = props.getValue();
+          if (Ref.isRef(formValue)) {
+            return formValue.dxn.toString() as string;
+          }
+          return undefined;
+        }, [props]);
+
+        const handleOnValueChange = useCallback(
+          (_type: any, dxnString: string) => {
+            const dxn = DXN.parse(dxnString);
+            if (dxn) {
+              props.onValueChange(props.type, Ref.fromDXN(dxn));
+            }
+          },
+          [props.type, props.onValueChange],
+        );
+
+        return (
+          <SelectField
+            {...props}
+            getValue={getValue as any}
+            onValueChange={handleOnValueChange}
+            options={getFeedOptions(feeds)}
+          />
+        );
+      },
 
       // TODO(wittjosiah): Copied from ViewEditor.
       // Query input editor.
@@ -155,14 +182,10 @@ const getFunctionOptions = (scripts: Script.Script[], functions: Operation.Persi
   return functions.map((fn) => ({ label: getLabel(fn), value: `dxn:echo:@:${fn.id}` }));
 };
 
-const getFeedQueueOptions = (feeds: Feed.Feed[]) => {
-  return feeds.flatMap((feed) => {
-    const queueDXN = Feed.getQueueDxn(feed);
-    if (!queueDXN) {
-      return [];
-    }
+const getFeedOptions = (feeds: Feed.Feed[]) => {
+  return feeds.map((feed) => {
     const parent = Obj.getParent(feed);
     const label = parent ? Entity.getLabel(parent) : Entity.getLabel(feed);
-    return [{ label: label ?? feed.id, value: queueDXN.toString() }];
+    return { label: label ?? feed.id, value: Obj.getDXN(feed).toString() };
   });
 };

--- a/packages/plugins/plugin-automation/src/operations/create-trigger-from-template.ts
+++ b/packages/plugins/plugin-automation/src/operations/create-trigger-from-template.ts
@@ -6,8 +6,7 @@ import * as Effect from 'effect/Effect';
 
 import { LayoutOperation, getSpacePath } from '@dxos/app-toolkit';
 import { Operation, Script, Trigger } from '@dxos/compute';
-import { Filter, Obj, Ref } from '@dxos/echo';
-import { type DXN } from '@dxos/keys';
+import { type Feed, Filter, Obj, Ref } from '@dxos/echo';
 import { SpaceOperation } from '@dxos/plugin-space';
 
 import { meta } from '#meta';
@@ -44,9 +43,9 @@ const handler: Operation.WithHandler<typeof AutomationOperation.CreateTriggerFro
             });
             break;
           }
-          case 'queue': {
+          case 'feed': {
             Obj.update(trigger, (trigger) => {
-              trigger.spec = Trigger.specQueue((template.queueDXN as DXN).toString());
+              trigger.spec = Trigger.specFeed(template.feed as Feed.Feed);
             });
             break;
           }

--- a/packages/plugins/plugin-automation/src/translations.ts
+++ b/packages/plugins/plugin-automation/src/translations.ts
@@ -42,7 +42,7 @@ export const translations = [
         'trigger-type.websocket.label': 'Websocket',
         'trigger-type.subscription.label': 'Subscription',
         'trigger-type.email.label': 'Email',
-        'trigger-type.queue.label': 'Feed',
+        'trigger-type.feed.label': 'Feed',
 
         'trigger-payload-prop-name.placeholder': 'New payload property name',
         'import-function-button.label': 'Loading...',

--- a/packages/plugins/plugin-automation/src/types/schema.ts
+++ b/packages/plugins/plugin-automation/src/types/schema.ts
@@ -10,7 +10,7 @@ import { meta } from '#meta';
 
 export const TriggerTemplate = Schema.Union(
   Schema.Struct({ type: Schema.Literal('timer'), cron: Schema.String }),
-  Schema.Struct({ type: Schema.Literal('queue'), queueDXN: Schema.Any }),
+  Schema.Struct({ type: Schema.Literal('feed'), feed: Schema.Any }),
 );
 
 export namespace AutomationAction {

--- a/packages/stories/stories-assistant/src/stories/Chat.stories.tsx
+++ b/packages/stories/stories-assistant/src/stories/Chat.stories.tsx
@@ -768,7 +768,7 @@ export const WithResearchQueue: Story = {
         Trigger.make({
           function: Ref.make(Operation.serialize(AgentPrompt)),
           enabled: true,
-          spec: Trigger.specQueue(Feed.getQueueDxn(feed)!.toString()),
+          spec: Trigger.specFeed(feed),
           input: {
             prompt: Ref.make(researchPrompt),
             input: '{{event.item}}',

--- a/packages/ui/react-ui-canvas-compute/src/shapes/Trigger.tsx
+++ b/packages/ui/react-ui-canvas-compute/src/shapes/Trigger.tsx
@@ -9,7 +9,7 @@ import { Trigger, TriggerEvent } from '@dxos/compute';
 import { VoidInput } from '@dxos/conductor';
 import { Filter, Obj, Query, Ref } from '@dxos/echo';
 import { type Mutable } from '@dxos/echo/internal';
-import { DXN, SpaceId } from '@dxos/keys';
+import { type SpaceId } from '@dxos/keys';
 import { useSpaces } from '@dxos/react-client/echo';
 import { Select, type SelectRootProps } from '@dxos/react-ui';
 import { type ShapeComponentProps, type ShapeDef } from '@dxos/react-ui-canvas-editor';
@@ -121,9 +121,8 @@ const createTriggerSpec = (props: { triggerKind?: Trigger.Kind; spaceId?: SpaceI
       return Trigger.specSubscription(Query.select(Filter.nothing()));
     case 'email':
       return Trigger.specEmail();
-    case 'queue': {
-      const dxn = new DXN(DXN.kind.QUEUE, ['data', props.spaceId ?? SpaceId.random(), Obj.ID.random()]).toString();
-      return Trigger.specQueue(dxn);
+    case 'feed': {
+      return { kind: 'feed' } satisfies Trigger.FeedSpec;
     }
   }
 };
@@ -134,7 +133,7 @@ const getOutputSchema = (kind: Trigger.Kind) => {
     ['subscription']: TriggerEvent.SubscriptionEvent,
     ['timer']: TriggerEvent.TimerEvent,
     ['webhook']: TriggerEvent.WebhookEvent,
-    ['queue']: TriggerEvent.QueueEvent,
+    ['feed']: TriggerEvent.FeedEvent,
   };
   return kindToSchema[kind];
 };

--- a/plans/queue-to-feed-migration/MIGRATION_PLAN.md
+++ b/plans/queue-to-feed-migration/MIGRATION_PLAN.md
@@ -6,11 +6,13 @@
 
 **Phase 2 COMPLETE**: Migrated `AiConversation` and `AiContextBinder` to use `Feed` object and `feedRuntime` instead of `Queue`.
 
+**Phase 3 COMPLETE**: Migrated `TriggerDispatcher` to `Feed.FeedService` and renamed the `'queue'` trigger kind (spec, event, helpers, cursor key) to `'feed'`. `Trigger.specQueue` was removed; `Trigger.QueueSpec`/`TriggerEvent.QueueEvent` are now `Trigger.FeedSpec`/`TriggerEvent.FeedEvent`; spec storage changed from a queue DXN string to `Ref.Ref(Feed.Feed)`.
+
 ## Decisions (from PR review)
 
 Based on feedback from @dmaretskyi:
 
-1. **Trigger Dispatcher**: Do NOT migrate - let it continue using QueueService
+1. **Trigger Dispatcher**: ~~Do NOT migrate - let it continue using QueueService~~ Migrated in Phase 3 (decision reversed).
 2. **Service Container**: Deprecated - updates are fine but not critical
 3. **AiConversation**: Should be changed to take a `Feed` object instead of `Queue`
 4. **ContextQueueService**: Deprecated - doesn't need migration
@@ -118,11 +120,7 @@ Only migrate handlers that don't need Queue-specific methods (sync/refresh/subsc
 
 The following should continue using QueueService:
 
-1. **Trigger Dispatcher** (`packages/core/functions-runtime/src/triggers/trigger-dispatcher.ts`)
-   - Uses queue DXN strings in trigger specs
-   - Complex cursor/position tracking logic
-
-2. **Code paths using Queue methods**: `sync()`, `refresh()`, `subscribe()`
+1. **Code paths using Queue methods**: `sync()`, `refresh()`, `subscribe()`
 
 ## Escape Hatch
 


### PR DESCRIPTION
## Summary

- Migrate `TriggerDispatcher` off the deprecated `QueueService` and onto the canonical `Feed.FeedService` (load Feed via `Database.load`, query items with `Feed.runQuery`). Resolves the TODO in `Trigger.ts` to change the trigger spec from a queue DXN string to a `Ref<Feed>`.
- Rename the `'queue'` trigger kind throughout to `'feed'`, with consistent renames across spec, event, helpers, and cursor key:
  - `Trigger.QueueSpec` / `specQueue` → `Trigger.FeedSpec` / `specFeed` (`specQueue` removed, no compat shim)
  - `TriggerEvent.QueueEvent` → `TriggerEvent.FeedEvent`; event field `queue: DXN` → `feed: Ref<Feed>`
  - `KEY_QUEUE_CURSOR` → `KEY_FEED_CURSOR` (source string `…queue-cursor` → `…feed-cursor`); `queueCursor` → `feedCursor`
  - `queue-position.{ts,test.ts}` → `feed-position.{ts,test.ts}` (`filterReadyQueueItems` → `filterReadyFeedItems`)
- Updated all call sites in `plugin-automation`, `react-ui-canvas-compute`, `stories-assistant`, and `assistant-toolkit` blueprints. Tests already used `Trigger.specFeed(feed)` / `Feed.append(feed, …)` — they now also use `kinds: ['feed']`.
- `TriggerDispatcherServices` drops `QueueService`, gains `Feed.FeedService`. The plugin-automation layer-spec was updated accordingly.
- The previous decision in `plans/queue-to-feed-migration/MIGRATION_PLAN.md` to skip this dispatcher was reversed; the plan is updated to reflect Phase 3 completion.

## Test plan

- [x] `moon run compute:build functions-runtime:build plugin-automation:build assistant-toolkit:build react-ui-canvas-compute:build conductor:build stories-assistant:build plugin-assistant:build`
- [x] `moon run functions-runtime:test` (57 passed)
- [x] `moon run plugin-automation:test`
- [x] `moon run :lint -- --fix`
- [ ] Manual: in Composer, create a feed trigger via the automation panel, append a Feed item, verify the function fires and the cursor is recorded under `org.dxos.key.local-trigger-dispatcher.feed-cursor`.

https://claude.ai/code/session_01MQj2dYW3BAsfjF3TVs2CEB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQj2dYW3BAsfjF3TVs2CEB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Migrated trigger system to use feed-based architecture, replacing queue-based triggers.
  * Updated CLI commands for creating and updating triggers (now use `feed` designation).

* **Tests**
  * Updated test suite to validate feed trigger behavior and cursor handling.

* **Documentation**
  * Updated migration guidance to reflect completed feed trigger migration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->