### PR TITLE
ci(preview): link composer PR previews to a GitHub Environment

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -14,6 +14,8 @@ permissions:
   contents: read
   pull-requests: write
   actions: read
+  deployments: write
+  statuses: write
 
 jobs:
   deploy:
@@ -43,9 +45,43 @@ jobs:
             echo "Invalid head SHA: $HEAD_SHA" >&2
             exit 1
           fi
+          BRANCH_ALIAS="pr-$PR_NUMBER"
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
-          echo "branch_alias=pr-$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "branch_alias=$BRANCH_ALIAS" >> $GITHUB_OUTPUT
+          echo "environment_name=composer-preview-pr-$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "environment_url=https://$BRANCH_ALIAS.composer-app.pages.dev" >> $GITHUB_OUTPUT
+
+      # Create a GitHub Deployment against the PR head SHA. This is what makes
+      # the deployment appear on the PR (Deployments sidebar / "View deployment"
+      # button) — the built-in `environment:` job key would attach to the base
+      # branch SHA because this workflow is triggered via workflow_run.
+      - name: Create GitHub Deployment
+        id: deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: '${{ steps.meta.outputs.head_sha }}',
+              environment: '${{ steps.meta.outputs.environment_name }}',
+              description: 'Composer preview for PR #${{ steps.meta.outputs.pr_number }}',
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              production_environment: false,
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: data.id,
+              state: 'in_progress',
+              environment: '${{ steps.meta.outputs.environment_name }}',
+              environment_url: '${{ steps.meta.outputs.environment_url }}',
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+            core.setOutput('deployment_id', data.id);
 
       - name: Install wrangler
         run: npm install --global wrangler@3
@@ -62,7 +98,36 @@ jobs:
             | tee deploy.log
           URL=$(grep -Eo 'https://[a-z0-9-]+\.composer-app\.pages\.dev' deploy.log | head -n1)
           echo "url=$URL" >> $GITHUB_OUTPUT
-          echo "alias=https://${{ steps.meta.outputs.branch_alias }}.composer-app.pages.dev" >> $GITHUB_OUTPUT
+          echo "alias=${{ steps.meta.outputs.environment_url }}" >> $GITHUB_OUTPUT
+
+      - name: Update Deployment status (success)
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.deployment_id }},
+              state: 'success',
+              environment: '${{ steps.meta.outputs.environment_name }}',
+              environment_url: '${{ steps.meta.outputs.environment_url }}',
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+      - name: Update Deployment status (failure)
+        if: failure() && steps.deployment.outputs.deployment_id != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.deployment_id }},
+              state: 'failure',
+              environment: '${{ steps.meta.outputs.environment_name }}',
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
 
       - name: Comment preview URL on PR
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
## Summary

Make composer PR preview deploys show up on the PR as a GitHub Environment (Deployments sidebar / "View deployment" button), in addition to the existing sticky comment.

## Why this isn't just `environment:` on the job

The Preview Deploy workflow runs via `workflow_run` so it can use secrets safely. That means its checkout ref is the **base branch**, not the PR head. The built-in `environment:` job key creates the deployment record against the workflow's ref, which would attach the deployment to `main` rather than the PR — so it would never appear on the PR.

To attach to the PR, the deployment must be created via the API with `ref` = PR head SHA. This PR adds `actions/github-script` calls that do exactly that:

- Create a deployment with `ref` = PR head SHA (read from the trusted artifact metadata) and `environment` = `composer-preview-pr-<N>`.
- Mark `in_progress` before wrangler runs, then `success` or `failure` after.
- `transient_environment: true` so old PR environments auto-deactivate when the PR is closed/merged.
- Adds `deployments: write` and `statuses: write` permissions.

The existing sticky PR comment is preserved.

## Test plan

- [ ] Open a PR from a branch in `dxos/dxos`; verify Preview Build succeeds and Preview Deploy creates a deployment.
- [ ] Confirm the PR shows a Deployments entry (sidebar + "View deployment" button) linking to `https://pr-<N>.composer-app.pages.dev`.
- [ ] Confirm the sticky `composer-preview` comment still posts.
- [ ] Close/merge the PR and confirm the transient environment is marked inactive.


---
_Generated by [Claude Code](https://claude.ai/code/session_011URoAgGqWjpQ7AfLUcQhV4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved preview deployment status tracking with explicit success and failure state reporting
  * Enhanced deployment environment metadata extraction for better visibility in pull requests
  * Refined deployment workflow to capture comprehensive status updates throughout the deployment process

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->