### PR TITLE
chore: mark memoized LLM conversation caches as unmergeable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,10 @@ shrinkwrap.yaml              merge=binary
 npm-shrinkwrap.json          merge=binary
 yarn.lock                    merge=binary
 
+# Memoized LLM conversation caches — regenerate with
+# `ALLOW_LLM_GENERATION=1 moon run '#memoized-llm:test'` if conflicts occur.
+*.conversations.json         merge=binary
+
 # Rush's JSON config files use JavaScript-style code comments.  The rule below prevents pedantic
 # syntax highlighters such as GitHub's from highlighting these comments as errors.  Your text editor
 # may also require a special configuration to allow comments in JSON.


### PR DESCRIPTION
## Summary

- Adds `*.conversations.json merge=binary` to `.gitattributes` so git refuses to auto-merge these files on conflict.
- Mirrors the existing treatment of `pnpm-lock.yaml`, `yarn.lock`, etc.

## Why

Auto-merging cached LLM transcripts can produce invalid interleaved JSON that silently breaks tests. Forcing the developer to regenerate is safer than a textual three-way merge.

When a conflict happens, regenerate with:

```bash
ALLOW_LLM_GENERATION=1 moon run '#memoized-llm:test'
```

(see `.agents/skills/regenerate-memoized-llm/SKILL.md`)

## Test plan

- [ ] Confirm `git check-attr merge -- packages/.../foo.conversations.json` reports `merge: binary` after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git configuration for improved handling of conversation cache files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->