### PR TITLE
feat(echo-protocol): export PERSONAL_SPACE_TAG; add SpaceProxy.getGenesisCredential

### DIFF
--- a/packages/core/echo/echo-protocol/src/index.ts
+++ b/packages/core/echo/echo-protocol/src/index.ts
@@ -11,3 +11,4 @@ export * from './query';
 export * from './reference';
 export * from './space-doc-version';
 export * from './space-id';
+export * from './space-tags';

--- a/packages/core/echo/echo-protocol/src/space-tags.ts
+++ b/packages/core/echo/echo-protocol/src/space-tags.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+/**
+ * Well-known space tags. Tags are immutable strings attached at SpaceGenesis time and surfaced
+ * via the `SpaceGenesis` credential assertion's `tags` field. They classify the role of a space
+ * (e.g. personal, exemplar) so that infrastructure can route to or recognize specific spaces
+ * without inspecting their contents.
+ */
+
+/** Space tag for the personal space. */
+export const PERSONAL_SPACE_TAG = 'org.dxos.space.personal';
+
+/** Space tag for the bundled exemplar/sample space. */
+export const EXEMPLAR_SPACE_TAG = 'org.dxos.space.exemplar';

--- a/packages/sdk/app-toolkit/package.json
+++ b/packages/sdk/app-toolkit/package.json
@@ -55,6 +55,7 @@
     "@dxos/client": "workspace:*",
     "@dxos/compute": "workspace:*",
     "@dxos/echo": "workspace:*",
+    "@dxos/echo-protocol": "workspace:*",
     "@dxos/effect": "workspace:*",
     "@dxos/invariant": "workspace:*",
     "@dxos/log": "workspace:*",

--- a/packages/sdk/app-toolkit/src/personal-space.ts
+++ b/packages/sdk/app-toolkit/src/personal-space.ts
@@ -4,12 +4,9 @@
 
 import { type Space } from '@dxos/client/echo';
 import { Obj } from '@dxos/echo';
+import { EXEMPLAR_SPACE_TAG, PERSONAL_SPACE_TAG } from '@dxos/echo-protocol';
 
-/** Space tag for the personal space. */
-export const PERSONAL_SPACE_TAG = 'org.dxos.space.personal';
-
-/** Space tag for the bundled exemplar/sample space. */
-export const EXEMPLAR_SPACE_TAG = 'org.dxos.space.exemplar';
+export { PERSONAL_SPACE_TAG, EXEMPLAR_SPACE_TAG };
 
 // TODO(wittjosiah): Remove once all profiles have tagged personal spaces (tags cannot be added retroactively).
 const DEFAULT_SPACE_KEY = '__DEFAULT__';

--- a/packages/sdk/app-toolkit/tsconfig.json
+++ b/packages/sdk/app-toolkit/tsconfig.json
@@ -36,6 +36,9 @@
       "path": "../../core/echo/echo"
     },
     {
+      "path": "../../core/echo/echo-protocol"
+    },
+    {
       "path": "../../ui/react-ui"
     },
     {

--- a/packages/sdk/client/src/echo/space-proxy.ts
+++ b/packages/sdk/client/src/echo/space-proxy.ts
@@ -689,6 +689,17 @@ export class SpaceProxy implements Space, CustomInspectable {
     return credentials.filter((credential) => checkCredentialType(credential, 'dxos.halo.credentials.Epoch'));
   }
 
+  /**
+   * Returns this space's `SpaceGenesis` credential, the self-signed root that establishes the
+   * space's identity, key, and immutable `tags`. Used by infrastructure (e.g. OAuth recovery
+   * registration) that needs to attest a space's identity out-of-band by verifying a
+   * client-supplied signed credential.
+   */
+  async getGenesisCredential(): Promise<Credential | undefined> {
+    const credentials = await this._getCredentials();
+    return credentials.find((credential) => checkCredentialType(credential, 'dxos.halo.credentials.SpaceGenesis'));
+  }
+
   private async _migrate(): Promise<void> {
     await this._createEpoch({
       migration: CreateEpochRequest.Migration.MIGRATE_REFERENCES_TO_DXN,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16824,6 +16824,9 @@ importers:
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../core/echo/echo
+      '@dxos/echo-protocol':
+        specifier: workspace:*
+        version: link:../../core/echo/echo-protocol
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../common/effect


### PR DESCRIPTION
## Summary

- Move `PERSONAL_SPACE_TAG` and `EXEMPLAR_SPACE_TAG` from `@dxos/app-toolkit` to `@dxos/echo-protocol` so non-client packages (e.g. edge OAuth recovery) can verify space-tag assertions without pulling in the full client.
- `@dxos/app-toolkit` re-exports for back-compat; all existing imports keep working.
- Add public `SpaceProxy.getGenesisCredential()` so callers can attest a space's identity by handing infrastructure the self-signed root credential.

## Motivation

Edge OAuth recovery (edge#592) needs to verify, at registration time, that a space is the user's personal space. The plan is for the client to pass the space's `SpaceGenesis` credential in-band on the OAuth initiate request; the server verifies the signature chains to the claimed identity and that the credential carries `PERSONAL_SPACE_TAG`. That requires (a) the tag constant in a package edge can depend on, and (b) a way for the client to fetch the genesis credential.

## Test plan

- [x] `moon run echo-protocol:build app-toolkit:build client:build` clean
- [ ] Verify pkg.pr.new build publishes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new method to retrieve genesis credentials from spaces, enabling applications to access comprehensive space creation metadata and detailed credential information for improved management.

* **Refactor**
  * Standardized well-known space tag constants for consistent and reliable identification of personal and exemplar spaces across the entire SDK and application ecosystem.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->