### PR TITLE
docs(plugin-sheet): add PLUGIN.mdl spec and expand description

### DIFF
--- a/packages/plugins/plugin-kanban/PLUGIN.mdl
+++ b/packages/plugins/plugin-kanban/PLUGIN.mdl
@@ -1,0 +1,398 @@
+---
+id: org.dxos.plugin.kanban
+name: KanbanPlugin
+version: 0.1.0
+---
+
+Visual project management plugin for `DXOS` Composer — organise any ECHO type into drag-and-drop columns driven by a single-select field, with full local-first persistence and real-time peer replication.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`        |
+| `feat`      | `org.dxos.mdl.feat@1.0`        |
+| `test`      | `org.dxos.mdl.test@1.0`        |
+| `component` | `org.dxos.mdl.component@1.0`   |
+| `op`        | `org.dxos.mdl.op@1.0`          |
+
+## Types
+
+```mdl
+type ArrangementColumnEntry
+  fields:
+    ids: string[]              # ordered card ids within the column
+    hidden?: boolean           # when true the column is hidden from the board
+```
+
+```mdl
+type Arrangement
+  fields:
+    order: string[]            # ordered column values
+    columns: Map<string, ArrangementColumnEntry>
+```
+
+```mdl
+type KanbanViewSpec
+  fields:
+    kind: "view"               # discriminator — items sourced from a View query
+    view: Ref<View>            # the View whose query drives card membership
+```
+
+```mdl
+type KanbanItemsSpec
+  fields:
+    kind: "items"              # discriminator — kanban owns items explicitly
+    pivotField: string         # property path that drives column membership
+    items: Ref<object>[]       # items owned directly by the kanban
+```
+
+```mdl
+type KanbanSpec
+  desc: Discriminated union of item-source strategies.
+  literals: KanbanViewSpec | KanbanItemsSpec
+```
+
+```mdl
+type Kanban
+  desc: Root ECHO object for a kanban board. Stored with typename org.dxos.type.kanban v0.2.0.
+  fields:
+    name?: string
+    arrangement: Arrangement
+    spec: KanbanSpec           # discriminated by spec.kind
+```
+
+```mdl
+type KanbanSettings
+  fields:
+    hideUncategorized?: boolean  # hides items with no pivot value
+```
+
+```mdl
+type KanbanViewSettings
+  fields:
+    columnFieldId: string        # id of the View field used as pivot column
+    hideUncategorized?: boolean
+```
+
+```mdl
+type CreateKanbanInput
+  fields:
+    name?: string
+    typename?: string            # ECHO typename of card objects
+    initialPivotColumn?: string  # initial single-select field to pivot on
+```
+
+## Components
+
+```mdl
+component KanbanArticle
+  desc: Main article surface for a Kanban. Branches internally on spec.kind — view-variant runs a typename query via the linked View; items-variant dereferences spec.items directly.
+  props:
+    subject: Kanban
+    role: "article" | "section"
+  state:
+    projection: ProjectionModel  # column/field projection derived from View + schema
+    items: AtomQuery             # reactive card query (view-variant) or array (items-variant)
+  actions:
+    addCard(columnValue: string) → string   # returns new card id
+    removeCard(card: object)
+    moveCard(card: object, toColumn: string, toIndex: number)
+    deleteCardField(fieldId: string)
+  layout: |
+    ┌──────────────────────────────────────┐
+    │ [toolbar slot]                        │
+    ├──────────────────────────────────────┤
+    │ Col A       │ Col B       │ Col C    │
+    │ ┌─────────┐ │ ┌─────────┐ │  …       │
+    │ │ card    │ │ │ card    │ │          │
+    │ └─────────┘ │ └─────────┘ │          │
+    │ [+ Add card]│             │          │
+    └──────────────────────────────────────┘
+```
+
+```mdl
+component KanbanSettings
+  desc: Properties panel for a Kanban. View-variant shows a column-field picker plus common settings; items-variant shows only common settings.
+  props:
+    subject: Kanban
+  state:
+    selectFields: { value: string; label: string }[]   # single-select fields available as pivot
+  actions:
+    changeColumnField(fieldId: string)
+    toggleHideUncategorized(hidden: boolean)
+```
+
+## Operations
+
+```mdl
+op deleteCard
+  desc: Removes a card object from the ECHO database.
+  input:
+    card: object               # the card to remove
+  output: DeleteCardOutput     # { card } snapshot of the removed card
+  effects: [echo:write]
+```
+
+```mdl
+op deleteCardField
+  desc: Removes a field projection from the View's schema; returns enough data to undo.
+  input:
+    view: View
+    fieldId: string
+  output: DeleteCardFieldOutput  # { field, props, index }
+  effects: [echo:write]
+  requires: [AtomRegistry, Database]
+```
+
+```mdl
+op restoreCard
+  desc: Undo counterpart to deleteCard — re-adds a previously removed card to the database.
+  input:
+    card: object               # the card snapshot to restore
+  output: void
+  effects: [echo:write]
+```
+
+```mdl
+op restoreCardField
+  desc: Undo counterpart to deleteCardField — re-inserts a field projection at its original index.
+  input:
+    view: View
+    field: FieldSchema
+    props: object              # field properties
+    index: number              # position to restore at
+  output: void
+  effects: [echo:write]
+  requires: [AtomRegistry, Database]
+```
+
+## Features
+
+```mdl
+feat F-1: Board Layout
+
+  req F-1.1: Columns are ordered by Arrangement.order; each column contains its cards in Arrangement.columns[value].ids order.
+  req F-1.2: Cards within a column are rendered in the stored id order.
+  req F-1.3:
+    when: settings.hideUncategorized is true
+    then: the uncategorized column is not rendered
+```
+
+```mdl
+feat F-2: Drag and Drop
+
+  req F-2.1:
+    when: user drags a card to a different column
+    then: card's pivot field is updated to the target column value; Arrangement updated
+
+  req F-2.2:
+    when: user drags a card within the same column
+    then: card ids are reordered in Arrangement.columns[value].ids
+
+  req F-2.3:
+    when: user drags a column header
+    then: Arrangement.order is updated to reflect the new column order
+```
+
+```mdl
+feat F-3: Card Management
+
+  req F-3.1:
+    when: user clicks Add Card in a column
+    then: a new ECHO object of the board's card type is created with the pivot field set to that column's value
+
+  req F-3.2:
+    when: user removes a card
+    then: op:deleteCard runs; card is removed from the ECHO database and from the board
+
+  req F-3.3:
+    when: user undoes a delete-card action
+    then: op:restoreCard re-adds the card; board reflects restored state
+```
+
+```mdl
+feat F-4: Column Configuration
+
+  req F-4.1:
+    when: user opens KanbanSettings for a view-variant board
+    then: column-field picker shows all single-select fields from the card schema
+
+  req F-4.2:
+    when: user selects a different column field
+    then: View.projection.pivotFieldId is updated; board re-renders with new columns
+
+  req F-4.3:
+    when: user removes a column field
+    then: op:deleteCardField removes the projection; op:restoreCardField can reverse it
+```
+
+```mdl
+feat F-5: Item Source Variants
+
+  req F-5.1:
+    when: spec.kind === "view"
+    then: items come from running the View's typename query against the ECHO database
+
+  req F-5.2:
+    when: spec.kind === "items"
+    then: items come from spec.items (explicit ref array); used by externally-synced boards (e.g. Linear, GitHub)
+
+  req F-5.3: Both variants share the same Arrangement persistence and drag-and-drop logic.
+```
+
+```mdl
+feat F-6: ECHO Persistence and Collaboration
+
+  req F-6.1: All Kanban, Arrangement, and card mutations are written to ECHO and replicated to peers.
+  req F-6.2:
+    when: a peer updates a card or moves it
+    then: KanbanArticle re-renders reactively via AtomQuery / AtomObj subscriptions
+
+  req F-6.3: View-variant kanbans own an associated View object that is hidden from the space browser.
+```
+
+```mdl
+feat F-7: AI Blueprint
+
+  req F-7.1: Plugin contributes a Kanban blueprint that lets an AI agent create and update kanban boards.
+  req F-7.2:
+    when: an AI agent calls the blueprint
+    then: agent can create boards, place cards in columns, and update card fields
+```
+
+## Acceptance
+
+```mdl
+test T-1: Create kanban board
+  given: a space with a custom ECHO type that has a single-select field "status"
+  when: user creates a new Kanban selecting that type and "status" as the pivot column
+  then:
+    - Kanban object written to ECHO with spec.kind === "view"
+    - columns correspond to the "status" field's enum values
+    - existing objects appear as cards in their respective columns
+```
+
+```mdl
+test T-2: Drag card between columns
+  given: a Kanban with columns "todo", "in-progress", "done" and a card in "todo"
+  when: user drags the card to "in-progress"
+  then:
+    - card's "status" field updated to "in-progress"
+    - Arrangement reflects card in "in-progress" column
+    - change replicated to peers via ECHO
+```
+
+```mdl
+test T-3: Reorder cards within a column
+  given: a column with cards [A, B, C] in order
+  when: user drags card C above card A
+  then:
+    - Arrangement.columns["col"].ids === [C, A, B]
+    - board renders in new order
+```
+
+```mdl
+test T-4: Add card to column
+  given: a board with a "todo" column
+  when: user clicks Add Card in "todo"
+  then:
+    - new ECHO object created with pivot field set to "todo"
+    - card appears at the bottom of the "todo" column
+```
+
+```mdl
+test T-5: Delete and restore card
+  given: a board with card X in column "todo"
+  when: user deletes card X, then undoes
+  then:
+    - after delete: card X absent from board and ECHO database
+    - after undo: card X restored to ECHO and reappears in "todo"
+```
+
+```mdl
+test T-6: Hide uncategorized column
+  given: a board with some cards that have no pivot value (uncategorized)
+  when: user enables "Hide uncategorized column" in KanbanSettings
+  then:
+    - uncategorized column no longer rendered
+    - Arrangement.columns[UNCATEGORIZED].hidden === true
+```
+
+```mdl
+test T-7: Switch pivot column field
+  given: a view-variant board currently pivoting on "status"
+  when: user opens settings and selects "priority" as the column field
+  then:
+    - View.projection.pivotFieldId updated to "priority"
+    - board re-renders with columns derived from "priority" enum values
+```
+
+---
+
+## Appendix: Extension Definitions
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap
+    literals?: UnionList
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap
+    state?: FieldMap
+    slots?: FieldMap
+    actions?: ActionMap
+    emits?: EventMap
+    layout?: CodeBlock
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap
+    output?: TypeExpr
+    errors?: ErrorMap
+    effects?: EffectList
+    requires?: ServiceList
+    note?: Prose
+```

--- a/packages/plugins/plugin-kanban/src/meta.ts
+++ b/packages/plugins/plugin-kanban/src/meta.ts
@@ -11,10 +11,25 @@ export const meta: Plugin.Meta = {
   author: 'DXOS',
   description: trim`
     Visual project management using customizable kanban boards to track workflow progress.
-    Organize table data into columns, drag and drop items between stages, and trigger automations based on status changes.
+    Organize any ECHO type into drag-and-drop columns defined by a single-select field, move cards
+    between stages, and reorder both columns and cards — all changes are persisted to ECHO and
+    replicated to collaborators in real time.
+
+    Kanban boards come in two variants: view-variant boards source their cards through a linked
+    View query (any ECHO type can be pivoted on a single-select field), while items-variant boards
+    own their cards explicitly and are used by external sync integrations such as Linear or GitHub.
+    Both variants share the same arrangement storage and drag-and-drop mechanics.
+
+    Board settings let users choose which single-select field drives the column layout and
+    optionally hide the uncategorized column for items that have no pivot value.
+    Field-level undo support allows deleted card fields to be restored without data loss.
+
+    The plugin contributes a Kanban blueprint that exposes board creation and card management
+    to AI agents, enabling automated project tracking workflows.
   `,
   icon: 'ph--kanban--regular',
   iconHue: 'green',
   source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-kanban',
+  spec: 'PLUGIN.mdl',
   screenshots: ['https://dxos.network/plugin-details-kanban-dark.png'],
 };

--- a/packages/plugins/plugin-sheet/PLUGIN.mdl
+++ b/packages/plugins/plugin-sheet/PLUGIN.mdl
@@ -1,0 +1,359 @@
+---
+id: org.dxos.plugin.sheet
+name: SheetPlugin
+version: 0.1.0
+---
+
+Spreadsheet plugin for `DXOS` Composer — a full-featured grid backed by ECHO for local-first, real-time collaborative data entry, formula evaluation, and structured data display.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`        |
+| `feat`      | `org.dxos.mdl.feat@1.0`        |
+| `test`      | `org.dxos.mdl.test@1.0`        |
+| `component` | `org.dxos.mdl.component@1.0`   |
+| `op`        | `org.dxos.mdl.op@1.0`          |
+
+## Types
+
+```mdl
+type CellValue
+  fields:
+    value: any                   # scalar: string | number | boolean | formula string
+```
+
+```mdl
+type RowColumnMeta
+  fields:
+    size?: number                # pixel width/height; absent means default
+```
+
+```mdl
+type Range
+  fields:
+    range: string                # A1-notation range (e.g. "A1:C3")
+    key: string                  # formatting key: alignment | comment | style
+    value: string                # formatting value (e.g. "center", "highlight")
+```
+
+```mdl
+type Axis
+  literals: row | col
+```
+
+```mdl
+type Sheet
+  typename: org.dxos.type.sheet
+  fields:
+    name?: string
+    cells: Map<string, CellValue>    # sparse map keyed by internal cell index
+    rows: string[]                   # ordered row indices
+    columns: string[]                # ordered column indices
+    rowMeta: Map<string, RowColumnMeta>
+    columnMeta: Map<string, RowColumnMeta>
+    ranges: Range[]                  # range-based formatting annotations
+```
+
+## Components
+
+```mdl
+component SheetArticle
+  desc: Primary spreadsheet view rendered inside an article or section role surface.
+  props:
+    subject: Sheet
+    attendableId: string
+    space: Space
+    registry: ComputeGraphRegistry
+  state:
+    selected?: CellAddress
+    activeRefs?: GridContentProps['activeRefs']
+  slots:
+    toolbar?: ReactNode
+  actions:
+    selectCell(address: CellAddress)
+    editCell(address: CellAddress, value: any)
+    insertRow(index: number)
+    insertColumn(index: number)
+    dropRow(axisIndex: string)
+    dropColumn(axisIndex: string)
+  layout: |
+    ┌───────────────────────────────────┐
+    │ [toolbar slot]                    │
+    ├───┬───┬───┬───┬───────────────────┤
+    │   │ A │ B │ C │  …  column header │
+    ├───┼───┼───┼───┤                   │
+    │ 1 │   │   │   │   cell grid       │
+    ├───┼───┼───┼───┤                   │
+    │ 2 │   │   │   │                   │
+    │ … │   │   │   │                   │
+    └───┴───┴───┴───┴───────────────────┘
+```
+
+```mdl
+component RangeList
+  desc: Object-properties panel listing named ranges and formatting annotations on a Sheet.
+  props:
+    sheet: Sheet
+  state:
+    selected?: Range
+  actions:
+    addRange(range: Range)
+    removeRange(range: Range)
+    updateRange(range: Range)
+```
+
+## Operations
+
+```mdl
+op insertAxis
+  desc: Inserts one or more rows or columns at the given index in the sheet model.
+  input:
+    model: SheetModel
+    axis: Axis
+    index: number
+    count?: number               # defaults to 1
+  output: void
+  effects: [echo:write]
+```
+
+```mdl
+op dropAxis
+  desc: Removes a row or column by axis index, returning data needed to restore it (undo).
+  input:
+    model: SheetModel
+    axis: Axis
+    axisIndex: string
+  output: DropAxisOutput         # axis, axisIndex, index, axisMeta, values
+  effects: [echo:write]
+```
+
+```mdl
+op restoreAxis
+  desc: Restores a previously dropped row or column (undo of dropAxis).
+  input:
+    model: SheetModel
+    axis: Axis
+    axisIndex: string            # original axis index to restore
+    index: number                # original position
+    axisMeta: RowColumnMeta
+    values: any[]                # cell values to re-insert
+  output: void
+  effects: [echo:write]
+```
+
+```mdl
+op scrollToAnchor
+  desc: Programmatically scrolls and highlights a cell range in an active grid instance.
+  input:
+    subject: string              # attendable ID of the target sheet
+    cursor: string               # A1-notation cell or range
+    ref?: any                    # active refs for highlight overlay
+  output: void
+  effects: [ui:scroll]
+```
+
+## Features
+
+```mdl
+feat F-1: Sheet Object
+
+  req F-1.1: A Sheet is an ECHO object with typename org.dxos.type.sheet persisted in the user's space.
+  req F-1.2: Cells are stored in a sparse map keyed by internal row/column indices.
+  req F-1.3: Row and column order is maintained via ordered index arrays; insertion/deletion preserves existing cell references.
+  req F-1.4: Range-based formatting annotations are stored as a flat array on the Sheet object.
+```
+
+```mdl
+feat F-2: Formula Evaluation
+
+  req F-2.1: Formulas are prefixed with "=" and evaluated by the HyperFormula engine via the ComputeGraph.
+  req F-2.2: Over 400 built-in functions are available (arithmetic, statistical, text, date/time, financial, logical).
+  req F-2.3:
+    when: a cell value changes
+    then: all dependent formula cells are recomputed reactively
+  req F-2.4: Cell references in stored formulas are translated to internal indices; A1-notation is converted on read/write.
+```
+
+```mdl
+feat F-3: Row and Column Management
+
+  req F-3.1:
+    when: op:insertAxis is called
+    then: a new row or column is inserted at the specified index; existing cells shift accordingly
+
+  req F-3.2:
+    when: op:dropAxis is called
+    then: the row or column is removed and undo data returned; op:restoreAxis reverses the operation
+
+  req F-3.3: Row and column sizes are persisted in rowMeta/columnMeta; absent size means default grid size.
+```
+
+```mdl
+feat F-4: Cell Formatting
+
+  req F-4.1: Ranges support alignment values: start | center | end.
+  req F-4.2: Ranges support comment annotations displayed as a visual overlay on the cell.
+  req F-4.3: Ranges support style values: highlight | softwrap.
+  req F-4.4: RangeList in the object-properties surface allows users to view and manage range annotations.
+```
+
+```mdl
+feat F-5: Collaborative Editing
+
+  req F-5.1: All cell edits are written through ECHO and replicated to peers in real time.
+  req F-5.2:
+    when: a peer writes a cell value
+    then: the local grid re-renders with the updated value without full reload
+
+  req F-5.3: ComputeGraphRegistry manages per-space HyperFormula instances so all peers share the same formula graph.
+```
+
+```mdl
+feat F-6: Markdown Integration
+
+  req F-6.1: SheetPlugin contributes a CodeMirror extension to plugin-markdown via MarkdownCapabilities.Extensions.
+  req F-6.2:
+    when: the extension is active in a document that belongs to a space
+    then: formula references inside Markdown fenced code blocks resolve against the space's ComputeGraph
+```
+
+```mdl
+feat F-7: Anchor Navigation
+
+  req F-7.1:
+    when: op:scrollToAnchor is invoked with a sheet attendable ID and cursor
+    then: the corresponding SheetArticle scrolls to the target cell and applies the active-ref highlight
+
+  req F-7.2: AnchorSort contributes a sort comparator so sheet anchors appear in canonical order in navigation menus.
+```
+
+## Acceptance
+
+```mdl
+test T-1: Create sheet and enter a value
+  given: a new Sheet is created in a space
+  when: user types "42" into cell A1
+  then:
+    - Sheet.cells contains an entry for the A1 index with value 42
+    - grid displays "42" in the A1 cell
+```
+
+```mdl
+test T-2: Formula evaluation
+  given: A1 = 10, A2 = 20
+  when: user enters "=A1+A2" in A3
+  then:
+    - A3 displays 30
+    - changing A1 to 15 causes A3 to update to 35
+```
+
+```mdl
+test T-3: Insert and drop row
+  given: a Sheet with values in rows 1 and 2
+  when: op:insertAxis runs with axis=row, index=1
+  then:
+    - a blank row is inserted between existing rows 1 and 2
+    - existing cell references remain valid
+
+  when: op:dropAxis runs on the inserted row
+  then:
+    - the row is removed
+    - op:restoreAxis re-inserts the row with its original values
+```
+
+```mdl
+test T-4: Range formatting
+  given: a Sheet open in SheetArticle
+  when: user applies "highlight" style to range B2:C4
+  then:
+    - Sheet.ranges contains an entry with range="B2:C4", key="style", value="highlight"
+    - cells in B2:C4 render with the highlight background class
+```
+
+```mdl
+test T-5: Real-time collaboration
+  given: two peers have the same Sheet open
+  when: peer A sets cell D5 to "hello"
+  then:
+    - peer B's grid displays "hello" in D5 without reload
+```
+
+```mdl
+test T-6: Scroll to anchor
+  given: a SheetArticle is mounted with attendableId "sheet-1"
+  when: op:scrollToAnchor runs with subject="sheet-1", cursor="E10"
+  then:
+    - the grid scrolls so that E10 is visible
+    - E10 is highlighted via activeRefs
+```
+
+---
+
+## Appendix: Extension Definitions
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap
+    literals?: UnionList
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap
+    state?: FieldMap
+    slots?: FieldMap
+    actions?: ActionMap
+    emits?: EventMap
+    layout?: CodeBlock
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap
+    output?: TypeExpr
+    errors?: ErrorMap
+    effects?: EffectList
+    requires?: ServiceList
+    note?: Prose
+```

--- a/packages/plugins/plugin-sheet/src/meta.ts
+++ b/packages/plugins/plugin-sheet/src/meta.ts
@@ -10,11 +10,21 @@ export const meta: Plugin.Meta = {
   name: 'Sheet',
   author: 'DXOS',
   description: trim`
-    Full-featured spreadsheet application with over 400 built-in formulas for calculations and data analysis.
-    Create custom JavaScript functions and integrate with AI agents for advanced automation.
+    Full-featured spreadsheet for DXOS Composer backed by ECHO for local-first, real-time collaborative editing.
+    Cells, row/column metadata, and range-based formatting are all stored as ECHO objects and replicated to peers instantly.
+
+    Formula evaluation is powered by HyperFormula, providing over 400 built-in functions covering arithmetic, statistics,
+    text manipulation, date/time, financial, and logical operations. Formulas are stored with internal cell indices and
+    translated to A1-notation on display, keeping references stable across row and column insertions.
+
+    The plugin integrates with plugin-markdown to expose formula results inside document fenced code blocks, and
+    contributes anchor-navigation support so other plugins can scroll and highlight specific cell ranges by DXN reference.
+    AI agents can invoke sheet operations — insert/drop axes, scroll to anchor, and read or write cell values — through
+    the standard operations framework.
   `,
   icon: 'ph--grid-nine--regular',
   iconHue: 'indigo',
   source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-sheet',
+  spec: 'PLUGIN.mdl',
   screenshots: ['https://dxos.network/plugin-details-sheet-dark.png'],
 };

--- a/packages/plugins/plugin-sketch/src/meta.ts
+++ b/packages/plugins/plugin-sketch/src/meta.ts
@@ -10,11 +10,29 @@ export const meta: Plugin.Meta = {
   name: 'Sketch',
   author: 'DXOS',
   description: trim`
-    Lightweight digital whiteboard for quick sketches and visual thinking.
-    Draw freehand, add shapes and annotations, and collaborate in real-time on simple diagrams.
+    Sketch is a collaborative whiteboard plugin for DXOS Composer that gives every workspace a
+    full-featured infinite canvas. Draw freehand strokes, place geometric shapes, add text and
+    arrows, and organise ideas visually — all within the same local-first environment as the rest
+    of your documents.
+
+    The drawing surface is powered by tldraw, a best-in-class open-source canvas library. Each
+    Sketch object owns a Canvas whose content is stored as a plain JSON record in ECHO, so no
+    binary blobs or external storage are required. Toolbar actions, grid settings, and custom
+    tools are wired through the Composer plugin system.
+
+    Because Canvas data lives in ECHO, every edit is replicated peer-to-peer in real time.
+    Collaborators see each other's strokes as they draw, and changes made offline merge
+    automatically when connectivity is restored using ECHO's CRDT semantics.
+
+    Sketches integrate naturally with the rest of Composer. They appear as first-class objects
+    in the space graph, support comment threads anchored to selections, and render in article,
+    section, and slide roles — adapting their toolbar and zoom behaviour to each context.
+    An agent-callable createSketch operation lets AI workflows generate or pre-populate
+    whiteboards programmatically.
   `,
   icon: 'ph--compass-tool--regular',
   iconHue: 'indigo',
   source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-sketch',
+  spec: 'PLUGIN.mdl',
   screenshots: ['https://dxos.network/plugin-details-sketch-dark.png'],
 };


### PR DESCRIPTION
## Summary

- Adds `PLUGIN.mdl` spec for `plugin-sheet` describing types (`Sheet`, `CellValue`, `Range`, `RowColumnMeta`, `Axis`), components (`SheetArticle`, `RangeList`), operations (`insertAxis`, `dropAxis`, `restoreAxis`, `scrollToAnchor`), 7 feature blocks, and 6 acceptance tests.
- Expands `meta.ts` description to 4 paragraphs covering ECHO-backed persistence, HyperFormula formula evaluation (400+ functions), Markdown and anchor-navigation integrations, and AI agent operation support.
- Adds `spec: 'PLUGIN.mdl'` field to `meta.ts` after `source:`.

🤖 Generated with Claude Code