### PR TITLE
docs(plugin-mermaid): add PLUGIN.mdl spec and expand description

### DIFF
--- a/packages/plugins/plugin-mermaid/PLUGIN.mdl
+++ b/packages/plugins/plugin-mermaid/PLUGIN.mdl
@@ -1,0 +1,260 @@
+---
+id: org.dxos.plugin.mermaid
+name: MermaidPlugin
+version: 0.1.0
+---
+
+A CodeMirror extension plugin for DXOS Composer that renders Mermaid diagram
+definitions as live SVG previews inside the markdown editor.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                           |
+|-------------|-------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`      |
+| `feat`      | `org.dxos.mdl.feat@1.0`      |
+| `test`      | `org.dxos.mdl.test@1.0`      |
+| `component` | `org.dxos.mdl.component@1.0` |
+| `op`        | `org.dxos.mdl.op@1.0`        |
+
+## Types
+
+```mdl
+type DiagramKind
+  literals: flowchart | sequenceDiagram | classDiagram | stateDiagram | erDiagram | gantt | pie | gitGraph | mindmap | timeline
+```
+
+```mdl
+type DiagramTheme
+  literals: default | neutral | dark | forest | base
+```
+
+```mdl
+type RenderResult
+  fields:
+    svg: string          # rendered SVG markup
+    id: string           # unique widget id used by the Mermaid API
+```
+
+```mdl
+type RenderError
+  fields:
+    message: string      # human-readable parse or render error text
+    source: string       # the Mermaid source that caused the error
+```
+
+## Components
+
+```mdl
+component MermaidWidget
+  desc: |
+    An inline CodeMirror widget that replaces a ```mermaid fenced code block
+    with its rendered SVG diagram. The source code block is hidden while the
+    cursor is outside it; moving the cursor inside restores the raw text for
+    editing.
+  props:
+    id: string             # unique widget id (mermaid-<offset>)
+    source: string         # raw Mermaid diagram source
+    label?: string         # first token of source used as a diagram-type badge
+    darkMode: boolean      # mirrors the editor dark-theme facet
+  state:
+    svg?: string           # last successfully rendered SVG
+    error?: string         # last render error message; shown in place of diagram
+  layout: |
+    ┌────────────────────────────────┐
+    │  [rendered SVG diagram]        │
+    │                       [label] │
+    └────────────────────────────────┘
+    (on error)
+    ┌────────────────────────────────┐
+    │  error text                    │
+    └────────────────────────────────┘
+```
+
+## Operations
+
+```mdl
+op renderDiagram
+  desc: Parses a Mermaid source string and renders it to SVG via the Mermaid JS API.
+  input:
+    id: string             # unique element id required by the Mermaid render API
+    source: string         # raw Mermaid diagram definition
+    darkMode?: boolean     # sets darkMode / theme on the Mermaid config
+  output: RenderResult
+  errors:
+    ParseError: source does not conform to Mermaid syntax
+    RenderError: SVG generation failed after successful parse
+```
+
+## Features
+
+```mdl
+feat F-1: Diagram Rendering
+
+  req F-1.1:
+    when: a fenced code block with language tag `mermaid` is present in the document
+    then: the block is replaced by a rendered SVG diagram widget
+
+  req F-1.2:
+    when: the cursor moves inside the fenced code block
+    then: raw source text is revealed for editing and the widget is hidden
+
+  req F-1.3:
+    when: the cursor moves outside the fenced code block
+    then: the widget is restored and the raw text is hidden
+
+  req F-1.4:
+    when: the editor is in read-only mode
+    then: widgets are always shown regardless of cursor position
+```
+
+```mdl
+feat F-2: Error Handling
+
+  req F-2.1:
+    when: Mermaid fails to parse the source
+    then: an inline error message is shown in place of the diagram
+
+  req F-2.2:
+    when: a previously failing source is corrected
+    then: the widget re-renders and displays the valid diagram
+```
+
+```mdl
+feat F-3: Theme Integration
+
+  req F-3.1:
+    when: the editor's dark-theme facet is true
+    then: the Mermaid diagram is initialized with darkMode enabled
+
+  req F-3.2: The rendered widget uses the editor's group-surface background token.
+```
+
+```mdl
+feat F-4: Markdown Editor Integration
+
+  req F-4.1:
+    when: the MermaidPlugin is loaded
+    then: it registers the mermaid CodeMirror extension via MarkdownCapabilities.Extensions
+
+  req F-4.2: The plugin activates on MarkdownEvents.SetupExtensions.
+```
+
+## Acceptance
+
+```mdl
+test T-1: Valid flowchart renders
+  given: a document containing a ```mermaid fenced block with a valid flowchart definition
+  then:
+    - the raw code block lines are hidden
+    - an SVG widget is injected immediately after the block
+    - no error text is visible
+```
+
+```mdl
+test T-2: Cursor-in/out toggle
+  given: a rendered Mermaid widget is visible
+  when: the cursor moves inside the fenced code block
+  then:
+    - the cm-mermaid-hidden class is removed from the block lines
+    - the widget is no longer rendered in the viewport
+
+  when: the cursor moves back outside the block
+  then:
+    - block lines are hidden again
+    - widget is rendered again
+```
+
+```mdl
+test T-3: Invalid syntax shows error
+  given: a document containing a ```mermaid block with invalid syntax
+  then:
+    - no SVG is rendered
+    - an inline error message is shown with class cm-mermaid-error
+```
+
+```mdl
+test T-4: Read-only always shows widget
+  given: the editor is in read-only mode
+  when: any cursor position
+  then: widgets are rendered and raw source lines remain hidden
+```
+
+```mdl
+test T-5: Plugin activates on markdown event
+  given: MermaidPlugin and ProcessManagerPlugin are loaded
+  when: MarkdownEvents.SetupExtensions fires
+  then: the markdown module is in the active module list
+```
+
+---
+
+## Appendix: Extension Definitions
+
+Extension block types used in this document are defined below using
+the core `ext` primitive — the only construct the base language provides.
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap        # name[?]: TypeExpr  (# inline comment)
+    literals?: UnionList     # a | b | c
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap
+    state?: FieldMap
+    slots?: FieldMap
+    actions?: ActionMap
+    emits?: EventMap
+    layout?: CodeBlock
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap
+    output?: TypeExpr
+    errors?: ErrorMap
+    effects?: EffectList
+    requires?: ServiceList
+    note?: Prose
+```

--- a/packages/plugins/plugin-mermaid/src/meta.ts
+++ b/packages/plugins/plugin-mermaid/src/meta.ts
@@ -11,8 +11,23 @@ export const meta: Plugin.Meta = {
   author: 'DXOS',
   description: trim`
     Generate diagrams from simple text-based definitions using Mermaid syntax.
-    Create flowcharts, sequence diagrams, and other visualizations that stay in sync with your documentation.
+    Create flowcharts, sequence diagrams, class diagrams, state diagrams, entity-relationship
+    diagrams, Gantt charts, pie charts, Git graphs, mindmaps, and timelines — all from
+    plain-text source embedded directly in your documents.
+
+    The plugin integrates with the markdown editor as a CodeMirror extension.
+    Any fenced code block tagged with the \`mermaid\` language identifier is automatically
+    detected and replaced with a live SVG preview rendered by the Mermaid JS library.
+    The raw source is revealed for editing whenever the cursor moves inside the block,
+    then the rendered diagram is restored when the cursor moves away, providing a seamless
+    live-preview experience without leaving the editor.
+
+    Diagram rendering adapts to the editor's current color scheme: dark-mode documents
+    use Mermaid's dark theme while light-mode documents use the neutral theme.
+    Parse and render errors are shown inline in place of the diagram so that
+    invalid syntax is immediately visible without disrupting the rest of the document.
   `,
   icon: 'ph--anchor-simple--regular',
   source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-mermaid',
+  spec: 'PLUGIN.mdl',
 };


### PR DESCRIPTION
## Summary

- Add `PLUGIN.mdl` specification for `plugin-mermaid` covering types (`DiagramKind`, `DiagramTheme`, `RenderResult`, `RenderError`), the `MermaidWidget` component, the `renderDiagram` operation, four feature groups, and five acceptance tests.
- Expand `meta.ts` description from two lines to a full four-paragraph `trim\`` block covering supported diagram types, CodeMirror extension integration, live-preview cursor behaviour, and dark-mode / error-handling behaviour.
- Add `spec: 'PLUGIN.mdl'` field to the plugin meta after the `source:` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Mermaid plugin for DXOS Composer enabling live diagram rendering from Mermaid syntax in markdown files
* Supports SVG rendering with dark/light theme adaptation and cursor-based visibility toggle
* Includes inline error handling for invalid diagram syntax with clear error messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->