### PR TITLE
docs(plugin-presenter): add PLUGIN.mdl spec and expand description

### DIFF
--- a/packages/plugins/plugin-presenter/PLUGIN.mdl
+++ b/packages/plugins/plugin-presenter/PLUGIN.mdl
@@ -1,0 +1,309 @@
+---
+id: org.dxos.plugin.presenter
+name: PresenterPlugin
+version: 0.1.0
+---
+
+A presentation plugin for DXOS Composer that turns existing workspace objects — markdown documents and collections — into interactive slideshows with fullscreen mode and keyboard navigation.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`       |
+| `feat`      | `org.dxos.mdl.feat@1.0`       |
+| `test`      | `org.dxos.mdl.test@1.0`       |
+| `component` | `org.dxos.mdl.component@1.0`  |
+| `op`        | `org.dxos.mdl.op@1.0`         |
+
+## Types
+
+```mdl
+type PresentationTarget
+  literals: document | collection
+  desc: The kind of workspace object being presented.
+```
+
+```mdl
+type SlideIndex
+  fields:
+    current: number             # zero-based index of the active slide
+    count: number               # total number of slides in the presentation
+```
+
+```mdl
+type PresentationSettings
+  fields:
+    presentCollections?: boolean  # when true, Collections may also be presented as slideshows (experimental)
+```
+
+## Components
+
+```mdl
+component DocumentPresenterContainer
+  desc: |
+    Full-screen Reveal.js player for a single Markdown document.
+    Parses the document content into slides using horizontal/vertical `---` separators.
+    Renders in a Panel that fills the available viewport.
+  props:
+    document: Markdown.Document
+  slots:
+    (none)
+  actions:
+    exit()                      # navigates back to the originating document view
+  layout: |
+    ┌─────────────────────────────┐
+    │                             │
+    │        RevealPlayer         │
+    │  (full-screen slide canvas) │
+    │                             │
+    └─────────────────────────────┘
+```
+
+```mdl
+component CollectionPresenterArticle
+  desc: |
+    Slideshow player for a Collection.
+    Renders one slide per object in the collection's ordered items array.
+    The active slide is delegated to the AppSurface.Slide surface, so each
+    item's own plugin renders it (e.g. MarkdownSlide for documents).
+  props:
+    subject: Collection.Collection
+    role?: string
+  state:
+    slide: number               # zero-based index of the current slide
+    running: boolean            # whether keyboard navigation is active (from PresenterContext)
+  slots:
+    (none)
+  actions:
+    setSlide(index: number)
+    exit()
+  layout: |
+    ┌─────────────────────────────┐
+    │                             │
+    │       Surface (slide N)     │  ← AppSurface.Slide surface
+    │                             │
+    ├────────────────┬────────────┤
+    │   [Pager]      │ [PageNum]  │
+    └────────────────┴────────────┘
+```
+
+```mdl
+component MarkdownSlide
+  desc: |
+    Renders a single Markdown document as a slide panel inside a Collection presentation.
+    Used as the AppSurface.Slide surface implementation for Markdown.Document objects.
+  props:
+    document: Markdown.Document
+  layout: |
+    ┌─────────────────────────────┐
+    │  Panel                      │
+    │   └─ Slide (markdown)       │
+    └─────────────────────────────┘
+```
+
+## Operations
+
+```mdl
+op TogglePresentation
+  desc: |
+    Toggles presentation mode for a Markdown document or Collection.
+    Opens the presenter companion node in solo-fullscreen layout via the Deck plugin.
+    If the deck is not already in fullscreen, switches to solo--fullscreen before opening.
+  input:
+    object: Markdown.Document | Collection.Collection
+    state?: boolean             # explicit on/off override; omit to toggle
+  output: void
+  effects: [layout:navigate, deck:solo-fullscreen]
+  requires: [DeckCapabilities.State, DeckOperation.Adjust, LayoutOperation.Open]
+  note: |
+    Resolves the presenter companion node path as `<objectPath>/presenter`.
+    Keyboard shortcut: Shift+Cmd+P (macOS), Shift+Alt+P (Windows/Linux).
+```
+
+## Features
+
+```mdl
+feat F-1: Presentation Mode
+
+  req F-1.1: Every Markdown document in the workspace has a companion "Presenter" node in the app graph.
+  req F-1.2:
+    when: settings.presentCollections is true
+    then: every Collection also has a companion Presenter node
+  req F-1.3:
+    when: user activates TogglePresentation on a document or collection
+    then: Composer opens the presenter node in solo-fullscreen mode
+  req F-1.4:
+    when: user presses Shift+Cmd+P (macOS) or Shift+Alt+P (Windows)
+    then: TogglePresentation is invoked for the focused object
+```
+
+```mdl
+feat F-2: Document Slideshow (Reveal.js)
+
+  req F-2.1:
+    when: DocumentPresenterContainer mounts with a Markdown.Document
+    then: RevealPlayer parses the document content and renders slides
+  req F-2.2: Horizontal slides are separated by `---`; vertical slides by `----`.
+  req F-2.3:
+    when: user presses Escape or the exit action is triggered
+    then: presenter navigates back to the originating document view
+```
+
+```mdl
+feat F-3: Collection Slideshow
+
+  req F-3.1:
+    when: CollectionPresenterArticle mounts with a Collection
+    then: slide 0 is shown, corresponding to collection.objects[0]
+  req F-3.2:
+    when: user navigates to slide N via the Pager
+    then: the AppSurface.Slide surface renders collection.objects[N]
+  req F-3.3: PageNumber displays the current slide index and total count.
+  req F-3.4:
+    when: user presses Escape or the exit action is triggered
+    then: presenter navigates back to the collection view
+```
+
+```mdl
+feat F-4: Plugin Settings
+
+  req F-4.1: PresenterSettings panel is registered for the plugin settings surface.
+  req F-4.2:
+    when: user enables "Present collections (experimental)"
+    then: settings.presentCollections is set to true and Collection nodes gain Presenter companions
+```
+
+## Acceptance
+
+```mdl
+test T-1: Document presenter opens in fullscreen
+  given: a Markdown document exists in the workspace
+  when: user invokes TogglePresentation (keyboard or action menu)
+  then:
+    - Composer switches to solo-fullscreen layout
+    - DocumentPresenterContainer is shown with the document content
+    - RevealPlayer is visible with at least one slide
+```
+
+```mdl
+test T-2: Slide navigation via Reveal.js
+  given: a Markdown document with three `---`-separated sections
+  when: DocumentPresenterContainer renders the document
+  then:
+    - three horizontal slides are produced
+    - arrow-key navigation advances and retreats between slides
+```
+
+```mdl
+test T-3: Exit returns to document view
+  given: DocumentPresenterContainer is open in fullscreen
+  when: user presses Escape
+  then: Composer navigates back to the document article view
+```
+
+```mdl
+test T-4: Collection slideshow renders per-item surfaces
+  given: a Collection with two Markdown documents and settings.presentCollections = true
+  when: CollectionPresenterArticle mounts
+  then:
+    - slide 0 shows MarkdownSlide for collection.objects[0]
+    - Pager shows count = 2
+```
+
+```mdl
+test T-5: Collection slide advance
+  given: CollectionPresenterArticle at slide 0 with a three-item collection
+  when: user clicks the next-slide control in Pager
+  then:
+    - slide index advances to 1
+    - AppSurface.Slide renders collection.objects[1]
+    - PageNumber shows "2 / 3"
+```
+
+```mdl
+test T-6: Collections hidden when setting disabled
+  given: settings.presentCollections is false (default)
+  when: app graph is built for a Collection node
+  then: no Presenter companion node is created for the collection
+```
+
+```mdl
+test T-7: Keyboard shortcut registered
+  given: a Markdown document node is focused in the app graph
+  then:
+    - action with key TogglePresentation is present on the node
+    - keyBinding shows Shift+Cmd+P on macOS
+```
+
+---
+
+## Appendix: Extension Definitions
+
+Extension block types used in this document are defined below using
+the core `ext` primitive — the only construct the base language provides.
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap
+    literals?: UnionList
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap
+    state?: FieldMap
+    slots?: FieldMap
+    actions?: ActionMap
+    emits?: EventMap
+    layout?: CodeBlock
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap
+    output?: TypeExpr
+    errors?: ErrorMap
+    effects?: EffectList
+    requires?: ServiceList
+    note?: Prose
+```

--- a/packages/plugins/plugin-presenter/src/meta.ts
+++ b/packages/plugins/plugin-presenter/src/meta.ts
@@ -10,10 +10,27 @@ export const meta: Plugin.Meta = {
   name: 'Presenter',
   author: 'DXOS',
   description: trim`
-    Transform markdown documents into interactive presentation slideshows.
-    Navigate between slides with keyboard controls and present content in full-screen mode.
+    Transform existing workspace objects into interactive presentation slideshows without
+    duplicating content. Markdown documents are split into slides on horizontal \`---\`
+    separators and rendered with Reveal.js, giving authors a familiar authoring surface
+    with full Markdown syntax. Collections can optionally be presented slide-by-slide,
+    with each member object rendered by its own plugin surface.
+
+    Activate presentation mode for any supported object via the action menu or the
+    Shift+Cmd+P (macOS) / Shift+Alt+P (Windows/Linux) keyboard shortcut. The presenter
+    opens in a solo fullscreen layout managed by the Deck plugin, keeping the rest of the
+    workspace undisturbed.
+
+    Navigation controls and a page-number indicator are shown during collection
+    slideshows. Pressing Escape exits fullscreen and returns to the originating document
+    or collection view. All navigation is keyboard-accessible.
+
+    Collaboration is inherent: because slides are backed by live ECHO objects, edits made
+    by any peer in the workspace are immediately reflected in an open presentation without
+    any manual refresh.
   `,
   icon: 'ph--presentation--regular',
   iconHue: 'indigo',
   source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-presenter',
+  spec: 'PLUGIN.mdl',
 };

--- a/packages/plugins/plugin-sketch/PLUGIN.mdl
+++ b/packages/plugins/plugin-sketch/PLUGIN.mdl
@@ -1,0 +1,312 @@
+---
+id: org.dxos.plugin.sketch
+name: SketchPlugin
+version: 0.1.0
+---
+
+A collaborative whiteboard plugin for `DXOS` Composer — powered by tldraw, persisted in ECHO, and available as a first-class workspace object.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`        |
+| `feat`      | `org.dxos.mdl.feat@1.0`        |
+| `test`      | `org.dxos.mdl.test@1.0`        |
+| `component` | `org.dxos.mdl.component@1.0`   |
+| `op`        | `org.dxos.mdl.op@1.0`          |
+
+## Types
+
+```mdl
+type Canvas
+  desc: Low-level drawing document backed by a tldraw store.
+  fields:
+    schema?: string              # external schema reference (default: tldraw.com/2)
+    content: Map<string, any>    # tldraw store snapshot — shapes, bindings, assets
+```
+
+```mdl
+type Sketch
+  desc: User-facing whiteboard object that wraps a Canvas.
+  fields:
+    name?: string
+    canvas: Ref<Canvas>          # reference to the tldraw content store
+```
+
+```mdl
+type SketchGrid
+  literals: mesh | dotted
+```
+
+```mdl
+type Settings
+  fields:
+    showGrid?: boolean           # display a background grid on the canvas
+    gridType?: SketchGrid        # mesh or dotted pattern
+```
+
+## Components
+
+```mdl
+component SketchArticle
+  desc: Full-screen whiteboard surface for a Sketch object. Renders inside article, section, and slide roles.
+  props:
+    subject: Sketch
+    settings: Settings
+    attendableId: string
+    role: article | section | slide
+  state:
+    editor?: Editor              # tldraw Editor instance
+    hasAttention: boolean
+  slots:
+    toolbar?: ReactNode          # injected tldraw toolbar actions
+  actions:
+    createThread()               # opens a comment thread anchored to a selection
+  layout: |
+    ┌─────────────────────────────────┐
+    │ tldraw toolbar (when attended)  │
+    ├─────────────────────────────────┤
+    │                                 │
+    │   infinite canvas (tldraw)      │
+    │   shapes / freehand / text      │
+    │                                 │
+    │   [comment thread anchors]      │
+    │                                 │
+    └─────────────────────────────────┘
+```
+
+```mdl
+component SketchSettings
+  desc: Settings panel for the Sketch plugin — controls grid visibility and type.
+  props:
+    settings: Settings
+    onSettingsChange?: (updater: (s: Settings) => Settings) => void
+```
+
+## Operations
+
+```mdl
+op createSketch
+  desc: Creates a new Sketch with an associated Canvas and adds it to the target space or collection.
+  input:
+    name?: string
+    schema?: string              # tldraw schema version (default: tldraw.com/2)
+    content?: Map<string, any>   # optional initial tldraw store snapshot
+  output: Sketch
+  effects: [echo:write]
+```
+
+## Features
+
+```mdl
+feat F-1: Whiteboard Canvas
+
+  req F-1.1: Each Sketch owns exactly one Canvas; the Canvas holds the full tldraw store snapshot.
+  req F-1.2: Canvas content is stored as a plain record in ECHO — no binary blobs.
+  req F-1.3: All tldraw shape types (freehand, geometric, text, arrow, image) are supported.
+```
+
+```mdl
+feat F-2: ECHO Persistence
+
+  req F-2.1:
+    when: user makes any edit in the whiteboard
+    then: Canvas.content is updated in ECHO within the debounce window
+
+  req F-2.2:
+    when: Sketch is opened after a page reload
+    then: tldraw store is hydrated from Canvas.content; no drawing is lost
+
+  req F-2.3: Canvas is a separate ECHO object from Sketch so it can be replicated independently.
+```
+
+```mdl
+feat F-3: Real-time Collaboration
+
+  req F-3.1:
+    when: two or more peers open the same Sketch
+    then: edits by each peer appear on the other's canvas via ECHO replication
+
+  req F-3.2:
+    when: a peer is offline and makes edits
+    then: changes merge with remote state on reconnection using ECHO CRDT semantics
+```
+
+```mdl
+feat F-4: Roles and Presentation
+
+  req F-4.1:
+    when: role is article
+    then: full tldraw toolbar shown when the sketch has attention; hidden otherwise
+
+  req F-4.2:
+    when: role is slide
+    then: canvas is read-only; zoom capped at 1.5×
+
+  req F-4.3:
+    when: role is section
+    then: canvas auto-zooms to fit content; no toolbar shown
+```
+
+```mdl
+feat F-5: Comment Threads
+
+  req F-5.1:
+    when: user activates the thread tool in the toolbar
+    then: a new comment thread is created anchored to the current selection
+
+  req F-5.2: Thread anchor positions are stored alongside the drawing so they survive reloads.
+```
+
+```mdl
+feat F-6: Grid Settings
+
+  req F-6.1:
+    when: Settings.showGrid is true
+    then: a background grid rendered beneath drawing content
+
+  req F-6.2:
+    when: Settings.gridType is mesh
+    then: a square-mesh grid is shown
+
+  req F-6.3:
+    when: Settings.gridType is dotted
+    then: a dotted grid is shown
+```
+
+```mdl
+feat F-7: Create Sketch Operation
+
+  req F-7.1: Plugin contributes op:createSketch to the operation registry.
+  req F-7.2:
+    when: op:createSketch is invoked
+    then: a Sketch + Canvas pair is created and returned; the Sketch is added to the target collection
+```
+
+## Acceptance
+
+```mdl
+test T-1: Create and open sketch
+  given: a Composer space is active
+  when: op:createSketch runs with name "My Diagram"
+  then:
+    - a Sketch object is created with name "My Diagram"
+    - Sketch.canvas references a new Canvas with empty content
+    - Sketch appears in the space object list
+```
+
+```mdl
+test T-2: Drawing persists across reload
+  given: a Sketch is open and the user draws a freehand stroke
+  when: the page is reloaded and the Sketch is reopened
+  then:
+    - the stroke is visible on the canvas
+    - Canvas.content is non-empty
+```
+
+```mdl
+test T-3: Collaborative edit
+  given: two peers have the same Sketch open
+  when: peer A draws a rectangle
+  then:
+    - peer B sees the rectangle appear within the ECHO sync window
+    - no data loss if both peers edit simultaneously
+```
+
+```mdl
+test T-4: Read-only slide role
+  given: a Sketch is rendered in role slide
+  then:
+    - tldraw toolbar is not shown
+    - all drawing tools are disabled
+    - zoom is capped at 1.5×
+```
+
+```mdl
+test T-5: Grid toggle
+  given: SketchSettings panel is open
+  when: user enables the grid and selects "dotted"
+  then:
+    - Settings.showGrid === true
+    - Settings.gridType === dotted
+    - dotted grid appears on the canvas immediately
+```
+
+```mdl
+test T-6: Attention-aware toolbar
+  given: a Sketch is open in article role alongside other articles
+  when: user clicks on the sketch to give it attention
+  then: tldraw toolbar becomes visible
+  when: user clicks away, removing attention
+  then: tldraw toolbar is hidden
+```
+
+---
+
+## Appendix: Extension Definitions
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap
+    literals?: UnionList
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap
+    state?: FieldMap
+    slots?: FieldMap
+    actions?: ActionMap
+    emits?: EventMap
+    layout?: CodeBlock
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap
+    output?: TypeExpr
+    errors?: ErrorMap
+    effects?: EffectList
+    requires?: ServiceList
+    note?: Prose
+```

--- a/packages/plugins/plugin-sketch/src/meta.ts
+++ b/packages/plugins/plugin-sketch/src/meta.ts
@@ -10,11 +10,29 @@ export const meta: Plugin.Meta = {
   name: 'Sketch',
   author: 'DXOS',
   description: trim`
-    Lightweight digital whiteboard for quick sketches and visual thinking.
-    Draw freehand, add shapes and annotations, and collaborate in real-time on simple diagrams.
+    Sketch is a collaborative whiteboard plugin for DXOS Composer that gives every workspace a
+    full-featured infinite canvas. Draw freehand strokes, place geometric shapes, add text and
+    arrows, and organise ideas visually — all within the same local-first environment as the rest
+    of your documents.
+
+    The drawing surface is powered by tldraw, a best-in-class open-source canvas library. Each
+    Sketch object owns a Canvas whose content is stored as a plain JSON record in ECHO, so no
+    binary blobs or external storage are required. Toolbar actions, grid settings, and custom
+    tools are wired through the Composer plugin system.
+
+    Because Canvas data lives in ECHO, every edit is replicated peer-to-peer in real time.
+    Collaborators see each other's strokes as they draw, and changes made offline merge
+    automatically when connectivity is restored using ECHO's CRDT semantics.
+
+    Sketches integrate naturally with the rest of Composer. They appear as first-class objects
+    in the space graph, support comment threads anchored to selections, and render in article,
+    section, and slide roles — adapting their toolbar and zoom behaviour to each context.
+    An agent-callable createSketch operation lets AI workflows generate or pre-populate
+    whiteboards programmatically.
   `,
   icon: 'ph--compass-tool--regular',
   iconHue: 'indigo',
   source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-sketch',
+  spec: 'PLUGIN.mdl',
   screenshots: ['https://dxos.network/plugin-details-sketch-dark.png'],
 };


### PR DESCRIPTION
## Summary

- Add `PLUGIN.mdl` spec for `plugin-presenter` covering types (`PresentationTarget`, `SlideIndex`, `PresentationSettings`), components (`DocumentPresenterContainer`, `CollectionPresenterArticle`, `MarkdownSlide`), the `TogglePresentation` operation, features (F-1 through F-4), and acceptance tests (T-1 through T-7)
- Expand `meta.ts` description from 2 lines to 4 paragraphs covering authoring model, activation shortcuts, navigation controls, and real-time collaboration via ECHO
- Add `spec: 'PLUGIN.mdl'` field to the plugin meta

🤖 Generated with [Claude Code](https://claude.com/claude-code)