### PR TITLE
docs(plugin-search): add PLUGIN.mdl spec and expand description

### DIFF
--- a/packages/plugins/plugin-search/PLUGIN.mdl
+++ b/packages/plugins/plugin-search/PLUGIN.mdl
@@ -1,0 +1,291 @@
+---
+id: org.dxos.plugin.search
+name: SearchPlugin
+version: 0.1.0
+---
+
+A full-text search and web-search plugin for `DXOS` Composer that lets users locate objects
+across all spaces and pull in structured data from the web.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`       |
+| `feat`      | `org.dxos.mdl.feat@1.0`       |
+| `test`      | `org.dxos.mdl.test@1.0`       |
+| `component` | `org.dxos.mdl.component@1.0`  |
+| `op`        | `org.dxos.mdl.op@1.0`         |
+
+## Types
+
+```mdl
+type SearchQuery
+  fields:
+    text: string              # raw query string entered by the user
+    spaceId?: string          # optional scope; omit to search all spaces
+```
+
+```mdl
+type MatchField
+  fields:
+    key: string               # field name that matched (e.g. "title", "body")
+    value: string             # full field value containing the match
+```
+
+```mdl
+type SearchResult
+  fields:
+    objectId: string          # ECHO object DXN
+    typeName: string          # schema typename of the matched object
+    fields: MatchField[]      # list of fields where the query matched
+```
+
+```mdl
+type WebSearchResult
+  fields:
+    url: string
+    title: string
+    snippet: string
+    publishedDate?: string
+```
+
+## Components
+
+```mdl
+component SearchDialog
+  desc: |
+    Modal command-palette style dialog invoked globally via the OpenSearch operation.
+    Renders a search input at the top; results populate below in real time.
+  props:
+    space: Space              # current active space to scope the search
+  state:
+    query: string             # live query text
+    results: SearchResult[]   # objects matching the current query
+    pending: boolean          # true while debounced search is in-flight
+  slots:
+    empty?: ReactNode         # shown when query is non-empty but results are empty
+  actions:
+    submitQuery(text: string)
+    clearQuery()
+    selectResult(result: SearchResult)
+  emits:
+    onSelect(result: SearchResult)
+  layout: |
+    ┌─────────────────────────────┐
+    │  🔍 [search input]          │
+    ├─────────────────────────────┤
+    │  result row                 │
+    │  result row                 │
+    │  result row                 │
+    │  [empty slot]               │
+    └─────────────────────────────┘
+```
+
+```mdl
+component SearchArticle
+  desc: |
+    Inline search panel mounted in the deck companion (sidebar) and in the
+    search-input role.  Shares the same SearchContextProvider as SearchDialog
+    so the active query filters objects across the whole Composer deck.
+  props:
+    space: Space
+  state:
+    query: string
+    results: SearchResult[]
+  actions:
+    submitQuery(text: string)
+    clearQuery()
+  layout: |
+    ┌─────────────────────────────┐
+    │ [search input]              │
+    ├─────────────────────────────┤
+    │ result list                 │
+    └─────────────────────────────┘
+```
+
+## Operations
+
+```mdl
+op OpenSearch
+  desc: |
+    Opens the global SearchDialog by dispatching a LayoutOperation.UpdateDialog
+    event. No input parameters required; the dialog manages its own query state.
+  input: void
+  output: void
+  effects: [layout:dialog]
+  note: Registered as SearchOperation.OpenSearch; triggered from the command palette.
+```
+
+## Features
+
+```mdl
+feat F-1: Local Object Search
+
+  req F-1.1: User can open SearchDialog from anywhere in Composer via the OpenSearch operation.
+
+  req F-1.2:
+    when: user types into the search input
+    then: query is debounced (400 ms) then matched against all ECHO objects in the active space
+
+  req F-1.3:
+    when: an object's field value matches the query regex
+    then: result entry shown with the object type, matched field key, and field value snippet
+
+  req F-1.4:
+    when: query is empty or cleared
+    then: results list is empty; no search is executed
+```
+
+```mdl
+feat F-2: Global Filter Integration
+
+  req F-2.1:
+    when: SearchContextProvider is mounted
+    then: active query is propagated to GlobalFilterProvider so all views using
+          useGlobalFilteredObjects automatically show only matching objects
+
+  req F-2.2:
+    when: query is cleared
+    then: GlobalFilterProvider returns all objects unfiltered
+```
+
+```mdl
+feat F-3: Deck Companion Search Panel
+
+  req F-3.1:
+    when: user opens the deck companion panel with role deck-companion--search
+    then: SearchArticle is rendered scoped to the active Space
+
+  req F-3.2:
+    when: user types in SearchArticle
+    then: results update in real time using the same debounced filter as SearchDialog
+```
+
+```mdl
+feat F-4: Web Search (Exa)
+
+  req F-4.1:
+    when: the Exa API key is configured
+    then: external web-search is available and returns WebSearchResult objects
+
+  req F-4.2:
+    when: web search returns results
+    then: results are ranked by relevance and returned with url, title, and snippet
+```
+
+## Acceptance
+
+```mdl
+test T-1: OpenSearch operation opens dialog
+  given: user is in Composer with an active space
+  when: user triggers the OpenSearch operation (e.g. ⌘K)
+  then:
+    - SearchDialog is visible
+    - search input has focus
+```
+
+```mdl
+test T-2: Query returns matching objects
+  given: space contains a document with title "Meeting Notes"
+  when: user types "meeting" into SearchDialog
+  then:
+    - result row for the document appears
+    - matched field key is "title"
+    - field value contains "Meeting Notes"
+```
+
+```mdl
+test T-3: Empty query shows no results
+  given: SearchDialog is open
+  when: user clears the query string
+  then: results list is empty; pending is false
+```
+
+```mdl
+test T-4: GlobalFilter propagation
+  given: SearchContextProvider is mounted in the deck
+  when: user types "budget" in SearchArticle
+  then: all views using useGlobalFilteredObjects show only objects matching "budget"
+```
+
+```mdl
+test T-5: Non-matching query shows empty state
+  given: space has no objects matching "xyzzy"
+  when: user types "xyzzy"
+  then:
+    - results list is empty
+    - empty slot is rendered
+```
+
+---
+
+## Appendix: Extension Definitions
+
+Extension block types used in this document are defined below using
+the core `ext` primitive — the only construct the base language provides.
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap        # name[?]: TypeExpr  (# inline comment)
+    literals?: UnionList     # a | b | c
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self              # feat blocks may contain feat blocks
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap            # external inputs (immutable inside component)
+    state?: FieldMap            # internal reactive state
+    slots?: FieldMap            # named ReactNode injection points
+    actions?: ActionMap         # methods the component exposes or handles
+    emits?: EventMap            # events the component raises to its parent
+    layout?: CodeBlock          # ASCII sketch of visual structure (non-normative)
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap            # named input parameters
+    output?: TypeExpr           # return type
+    errors?: ErrorMap           # name: Prose  (when this error occurs)
+    effects?: EffectList        # echo:read | echo:write | http | fs | ...
+    requires?: ServiceList      # injected service dependencies
+    note?: Prose                # implementation guidance (non-normative)
+```

--- a/packages/plugins/plugin-search/src/meta.ts
+++ b/packages/plugins/plugin-search/src/meta.ts
@@ -10,11 +10,26 @@ export const meta: Plugin.Meta = {
   name: 'Search',
   author: 'DXOS',
   description: trim`
-    Full-text search engine for finding content across all spaces and object types.
-    Quickly locate documents, tables, and other objects with instant results and relevance ranking.
+    Full-text search engine for finding content across all spaces and object types in DXOS Composer.
+    The plugin provides a global command-palette style dialog (invoked via the OpenSearch operation)
+    that debounces user input and matches it against every field of every ECHO object in the active
+    space, returning ranked results with field-level match context.
+
+    A persistent SearchArticle panel can be pinned in the deck companion sidebar so the query stays
+    visible while navigating documents. Both surfaces share a SearchContextProvider that drives the
+    GlobalFilterProvider, allowing any view that uses useGlobalFilteredObjects to automatically show
+    only the objects matching the current query.
+
+    Web search is available through the Exa integration: when an API key is configured, the plugin
+    can fetch and rank external web results alongside local objects. The results are structured with
+    URL, title, and snippet fields ready for use in Composer documents.
+
+    All search operations are registered through the standard DXOS operations system and can be
+    wired into keyboard shortcuts, command palettes, and AI assistants via the OperationHandlerSet.
   `,
   icon: 'ph--magnifying-glass--regular',
   source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-search',
+  spec: 'PLUGIN.mdl',
   tags: ['labs'],
 };
 


### PR DESCRIPTION
## Summary

- Add `PLUGIN.mdl` specification for `plugin-search` covering types (`SearchQuery`, `MatchField`, `SearchResult`, `WebSearchResult`), components (`SearchDialog`, `SearchArticle`), the `OpenSearch` operation, features (F-1 through F-4), and five acceptance tests
- Expand `src/meta.ts` description from 2 lines to 4 paragraphs covering local object search, global filter integration, deck companion panel, and Exa web search
- Add `spec: 'PLUGIN.mdl'` field to `meta.ts` to link the plugin to its spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive search plugin with full-text search capabilities
  * Integrated optional web search functionality via Exa
  * Introduced SearchDialog and SearchArticle UI components for search interface
  * Implemented global filter propagation across search results
  * Added acceptance test coverage for search functionality including dialog, empty state, and filter scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->