### PR TITLE
docs(plugin-github): add PLUGIN.mdl spec and expand description

### DIFF
--- a/packages/plugins/plugin-github/PLUGIN.mdl
+++ b/packages/plugins/plugin-github/PLUGIN.mdl
@@ -1,0 +1,488 @@
+---
+id: org.dxos.plugin.github
+name: GitHubPlugin
+version: 0.1.0
+---
+
+Bidirectional GitHub integration for DXOS Composer.
+
+Connects one or more GitHub OAuth integrations to a space and keeps
+organizations, people, repositories, issues, and pull requests
+synchronized with ECHO.  Users select repositories as sync targets; owning
+organizations and their members are pulled automatically.  Local edits to
+issue title, description, and open/closed status are pushed back to GitHub
+via snapshot-diff reconciliation.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`       |
+| `feat`      | `org.dxos.mdl.feat@1.0`       |
+| `test`      | `org.dxos.mdl.test@1.0`       |
+| `component` | `org.dxos.mdl.component@1.0`  |
+| `op`        | `org.dxos.mdl.op@1.0`         |
+
+## Types
+
+```mdl
+type SyncTargetDescriptor
+  desc: Lightweight descriptor returned by GetGitHubRepositories; never stored in ECHO directly.
+  fields:
+    id: string            # stringified GitHub numeric repo id
+    name: string          # full_name e.g. "acme/anvil"
+    description?: string
+```
+
+```mdl
+type SyncOptions
+  desc: Per-target sync tuning knobs stored on Integration.targets[i].options.
+  fields:
+    maxDaysBack?: number  # pull issues/PRs updated within this many days; omit for full history
+```
+
+```mdl
+type GitHubUser
+  desc: Subset of the GitHub REST user object consumed by the sync service.
+  fields:
+    id: number
+    login: string
+    name?: string
+    email?: string
+    avatar_url?: string
+    html_url?: string
+```
+
+```mdl
+type GitHubOrg
+  desc: Subset of the GitHub REST org object.
+  fields:
+    id: number
+    login: string
+    name?: string
+    description?: string
+    blog?: string
+    avatar_url?: string
+    html_url?: string
+```
+
+```mdl
+type GitHubRepo
+  desc: Subset of the GitHub REST repo object.
+  fields:
+    id: number
+    name: string
+    full_name: string
+    description?: string
+    html_url?: string
+    archived?: boolean
+    owner: GitHubUser    # owner.login used to derive org lookup
+```
+
+```mdl
+type GitHubIssue
+  desc: Subset of the GitHub REST issue object; PRs appear here with a non-null pull_request field.
+  fields:
+    id: number
+    number: number
+    title: string
+    body?: string
+    state: open | closed
+    assignees?: GitHubUser[]
+    labels?: GitHubLabel[]
+    pull_request?: GitHubPullRef  # non-null → this item is a PR
+    created_at?: string
+    updated_at?: string
+    closed_at?: string
+```
+
+```mdl
+type GitHubLabel
+  fields:
+    name: string
+```
+
+```mdl
+type GitHubPullRef
+  desc: Minimal PR marker stored inline on a GitHubIssue.
+  fields:
+    url: string
+    merged_at?: string
+```
+
+```mdl
+type GitHubComment
+  fields:
+    id: number
+    body?: string
+    user?: GitHubUser
+    created_at?: string
+    updated_at?: string
+    html_url?: string
+```
+
+```mdl
+type ProjectSnapshot
+  desc: Fields recorded on Integration.snapshots after each pull; used to detect local divergence on push.
+  fields:
+    name: string          # recorded but push is intentionally disabled
+    description: string
+```
+
+```mdl
+type TaskSnapshot
+  desc: Fields recorded on Integration.snapshots after each pull; used to detect local divergence on push.
+  fields:
+    title: string
+    description: string
+    status: todo | done   # collapsed from GitHub open/closed
+```
+
+```mdl
+type SyncResult
+  desc: Counters returned by SyncGitHubRepositories.
+  fields:
+    pulled:
+      organizations: number
+      people: number
+      projects: number
+      tasks: number
+      comments: number
+```
+
+## Operations
+
+Discovery operations — read-only, no local writes.
+
+```mdl
+op GetGitHubRepositories
+  desc: |
+    List GitHub repositories reachable from an integration token.
+    Read-only: no local objects are created.  Orgs are NOT listed here;
+    they are auto-pulled during SyncGitHubRepositories.
+  input:
+    integration: Ref<Integration>
+  output: GetSyncTargetsOutput
+  effects: [http]
+  errors:
+    Unauthorized: token missing or revoked
+    NetworkError: transient HTTP failure after retries
+```
+
+Effectful sync operations — pull from GitHub, push diverged fields back.
+
+```mdl
+op SyncGitHubRepositories
+  desc: |
+    Reconcile selected GitHub repositories plus their owning organizations,
+    members, issues, PRs, and (future) comments with ECHO.
+    Pull direction: upserts Organization, Person, Project, Task via foreign-key.
+    Push direction: snapshot-diffs Project.description and Task title /
+    description / status and PATCHes diverged fields back to GitHub.
+    PR status is pull-only (push is intentionally disabled).
+    Updates Integration.targets[i].lastSyncAt / lastError per target.
+  input:
+    integration: Ref<Integration>
+    repository?: Ref<Project>   # optional: narrow to a single target repo
+  output: SyncResult
+  effects: [echo:read, echo:write, http]
+  errors:
+    Unauthorized: token missing or revoked
+    NetworkError: transient HTTP failure after retries
+    RepositoryNotAccessible: token cannot see one or more selected repos
+  note: |
+    Parallelism: up to 4 repos concurrently (REPO_CONCURRENCY); up to 4
+    issues per repo (ISSUE_CONCURRENCY).  Person upserts are serialized via
+    a semaphore + login-keyed cache to prevent duplicates across fibers.
+    Pagination: up to 10 pages per paginated endpoint (1 000 items max).
+```
+
+## Features
+
+```mdl
+feat F-1: OAuth Integration
+
+  req F-1.1:
+    when: user connects a GitHub integration
+    then: plugin-integration OAuth flow redirects to GitHub for authorization
+
+  req F-1.2:
+    when: OAuth callback completes
+    then: accessToken stored in ECHO; fetchUser called to set accessToken.account to user login
+
+  req F-1.3: Integration source is "github.com"; provider id is "github".
+```
+
+```mdl
+feat F-2: Repository Discovery
+
+  req F-2.1:
+    when: user opens the integration target picker
+    then: GetGitHubRepositories returns all repos visible to the token sorted by full_name (case-insensitive)
+
+  req F-2.2: No local ECHO objects are created during discovery.
+
+  req F-2.3: Owner, collaborator, and org-member repo affiliations are included.
+```
+
+```mdl
+feat F-3: Pull — Organizations and People
+
+  req F-3.1:
+    when: a selected repo is owned by a GitHub organization
+    then: that org is upserted as an Organization in ECHO (name, description, website, image)
+
+  req F-3.2:
+    when: org is synced
+    then: org members are upserted as Person objects linked to the Organization
+
+  req F-3.3: Personal-account repos (owner is not an org) skip org/member pull without error.
+
+  req F-3.4: A single org is pulled at most once per sync pass regardless of how many repos it owns.
+```
+
+```mdl
+feat F-4: Pull — Repositories as Projects
+
+  req F-4.1:
+    when: a selected repo does not yet have a local mirror
+    then: Project created in ECHO with foreign key [source: "github.com", id: String(repo.id)]
+
+  req F-4.2:
+    when: a selected repo already has a local mirror
+    then: Project fields updated via three-way merge against the stored snapshot
+
+  req F-4.3:
+    when: Integration.targets[i].object is missing or points at a different Project
+    then: target.object is rewired to the upserted Project
+```
+
+```mdl
+feat F-5: Pull — Issues and PRs as Tasks
+
+  req F-5.1:
+    when: issue/PR does not yet have a local mirror
+    then: Task created with fields title, description, status (open→todo, closed→done), assignee, project ref
+
+  req F-5.2:
+    when: issue/PR already has a local mirror
+    then: Task fields updated via three-way merge against stored snapshot
+
+  req F-5.3: PRs are treated identically to issues on pull; pull_request field marks them as PRs.
+
+  req F-5.4:
+    when: maxDaysBack is set on a target
+    then: only issues/PRs updated within that window are fetched from GitHub
+```
+
+```mdl
+feat F-6: Push — Local Edits Back to GitHub
+
+  req F-6.1:
+    when: Project.description diverges from the last pulled snapshot
+    then: PATCH /repos/{owner}/{repo} sends the new description
+
+  req F-6.2:
+    when: Task.title or Task.description diverges from snapshot
+    then: PATCH /repos/{owner}/{repo}/issues/{number} sends the updated fields
+
+  req F-6.3:
+    when: Task.status diverges from snapshot and the issue is not a PR
+    then: PATCH sends state: open or closed accordingly
+
+  req F-6.4:
+    when: PR status diverges locally
+    then: divergence is logged; push is skipped (PRs are pull-only for status)
+
+  req F-6.5: Project.name (repo rename) divergence is logged but never pushed.
+```
+
+```mdl
+feat F-7: Error Handling and Resilience
+
+  req F-7.1:
+    when: a per-target sync fails
+    then: lastError is set on that target; other targets continue
+
+  req F-7.2:
+    when: a repo is inaccessible to the integration token
+    then: lastError is set to "Repository not accessible to integration token"
+
+  req F-7.3:
+    when: an HTTP request returns 429 or 5xx
+    then: request is retried with exponential backoff + jitter (max 3 retries, 500 ms base)
+
+  req F-7.4:
+    when: sync succeeds
+    then: LayoutOperation.AddToast fires a success notification
+
+  req F-7.5:
+    when: sync fails
+    then: LayoutOperation.AddToast fires an error notification with a human-readable message
+```
+
+## Acceptance
+
+```mdl
+test T-1: Token account populated on connect
+  given: user completes GitHub OAuth
+  when: onTokenCreated fires
+  then:
+    - GET /user is called with the new token
+    - accessToken.account === user.login
+```
+
+```mdl
+test T-2: Repository discovery is read-only
+  given: valid GitHub integration
+  when: GetGitHubRepositories is invoked
+  then:
+    - list of SyncTargetDescriptor returned sorted by full_name
+    - no Organization, Person, Project, or Task objects are created in ECHO
+```
+
+```mdl
+test T-3: First sync — create Project and Tasks
+  given: integration with one selected repo (no prior local mirror)
+  when: SyncGitHubRepositories runs
+  then:
+    - Project created with foreign key for the repo
+    - one Task created per issue/PR
+    - open issues map to status todo; closed issues map to status done
+    - ProjectSnapshot and TaskSnapshot written for each object
+```
+
+```mdl
+test T-4: Incremental pull — remote-wins merge
+  given: integration with a previously synced repo; remote title changed
+  when: SyncGitHubRepositories runs
+  then:
+    - Task.title updated to remote value
+    - TaskSnapshot.title updated to match
+```
+
+```mdl
+test T-5: Push issue edit
+  given: Task.description differs from TaskSnapshot.description; issue is not a PR
+  when: SyncGitHubRepositories runs
+  then:
+    - PATCH /repos/{owner}/{repo}/issues/{number} called with new body
+    - TaskSnapshot.description updated to sent value
+```
+
+```mdl
+test T-6: PR status not pushed
+  given: Task (backed by a PR) status differs from snapshot
+  when: SyncGitHubRepositories runs
+  then:
+    - no PATCH issued for that task's status
+    - divergence logged at warn level
+```
+
+```mdl
+test T-7: Inaccessible repo error surfaced
+  given: integration target whose repo id is not in fetchUserRepos response
+  when: SyncGitHubRepositories runs
+  then:
+    - target.lastError === "Repository not accessible to integration token"
+    - other targets continue and complete normally
+```
+
+```mdl
+test T-8: Org deduplication
+  given: two selected repos with the same owner org
+  when: SyncGitHubRepositories runs
+  then:
+    - fetchOrg called once for that owner
+    - exactly one Organization upserted
+```
+
+```mdl
+test T-9: Personal-account owner skips org pull
+  given: selected repo owned by a GitHub user (not an org)
+  when: SyncGitHubRepositories runs
+  then:
+    - org lookup returns 404
+    - no Organization created; sync continues without error
+```
+
+```mdl
+test T-10: maxDaysBack filters issue window
+  given: target with maxDaysBack = 7
+  when: SyncGitHubRepositories runs
+  then:
+    - fetchRepoIssues called with since = (now − 7 days).toISOString()
+    - issues older than the window are not fetched
+```
+
+---
+
+## Appendix: Extension Definitions
+
+Extension block types used in this document are defined below using
+the core `ext` primitive — the only construct the base language provides.
+
+```mdl
+ext type
+  uri: dxos.spec/ext/type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap        # name[?]: TypeExpr  (# inline comment)
+    literals?: UnionList     # a | b | c
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: dxos.spec/ext/feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self              # feat blocks may contain feat blocks
+```
+
+```mdl
+ext test
+  uri: dxos.spec/ext/test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap            # external inputs (immutable inside component)
+    state?: FieldMap            # internal reactive state
+    slots?: FieldMap            # named ReactNode injection points
+    actions?: ActionMap         # methods the component exposes or handles
+    emits?: EventMap            # events the component raises to its parent
+    layout?: CodeBlock          # ASCII sketch of visual structure (non-normative)
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap            # named input parameters
+    output?: TypeExpr           # return type
+    errors?: ErrorMap           # name: Prose  (when this error occurs)
+    effects?: EffectList        # echo:read | echo:write | http | fs | ...
+    requires?: ServiceList      # injected service dependencies
+    note?: Prose                # implementation guidance (non-normative)
+```

--- a/packages/plugins/plugin-github/src/meta.ts
+++ b/packages/plugins/plugin-github/src/meta.ts
@@ -9,9 +9,28 @@ export const meta: Plugin.Meta = {
   id: 'org.dxos.plugin.github',
   name: 'GitHub',
   author: 'DXOS',
+  source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-github',
+  spec: 'PLUGIN.mdl',
   description: trim`
-    Connect GitHub to your workspace so organizations, repos, issues, and pull requests
-    stay available alongside everything else you're doing.
+    Connect GitHub to your Composer workspace so organizations, repositories,
+    issues, and pull requests stay available alongside everything else you're
+    working on.
+
+    Authenticate with a GitHub OAuth App or GitHub App and select the
+    repositories you want to track.  On each sync pass the plugin pulls
+    organizations and their members into ECHO as Organization and Person
+    objects, and mirrors every repository as a Project and every issue or
+    pull request as a Task — with open mapping to "todo" and closed mapping
+    to "done".
+
+    Edits made locally to issue title, description, or open/closed status
+    are pushed back to GitHub via a snapshot-diff reconciliation step, so
+    changes flow in both directions.  Pull request status is deliberately
+    pull-only to avoid accidental closes; repo renames are similarly guarded.
+
+    All GitHub data is stored in ECHO and replicated to other peers in the
+    space, giving the whole team a shared, local-first view of the project
+    without requiring each member to hold their own GitHub token.
   `,
   icon: 'ph--github-logo--regular',
   iconHue: 'neutral',


### PR DESCRIPTION
## Summary

- Add `PLUGIN.mdl` specification for `plugin-github` covering types, operations, features, and acceptance tests
- Operations documented: `GetGitHubRepositories` (discovery, read-only) and `SyncGitHubRepositories` (bidirectional pull/push sync)
- Features documented: OAuth integration, repository discovery, pull of orgs/people/repos/issues, push of local edits, error handling and resilience
- Expand `meta.ts` description from one sentence to four paragraphs covering GitHub integration, bidirectional sync mechanics, OAuth, and ECHO storage
- Add `source` and `spec: 'PLUGIN.mdl'` fields to `Plugin.Meta`

## Test plan

- [ ] Verify `PLUGIN.mdl` renders correctly in any MDL viewer
- [ ] Confirm `meta.ts` compiles without type errors (`moon run plugin-github:build`)
- [ ] Confirm `source` and `spec` fields are accepted by `Plugin.Meta` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)