### PR TITLE
docs(plugin-bluesky): add PLUGIN.mdl spec and expand description

### DIFF
--- a/packages/plugins/plugin-bluesky/PLUGIN.mdl
+++ b/packages/plugins/plugin-bluesky/PLUGIN.mdl
@@ -1,0 +1,408 @@
+---
+id: org.dxos.plugin.bluesky
+name: BlueskyPlugin
+version: 0.1.0
+---
+
+A Composer plugin that integrates the AT Protocol (atproto) and Bluesky social
+network into the local-first workspace. Authenticated via OAuth (atproto
+DPoP-bound tokens managed by the DXOS Edge proxy), the plugin syncs the user's
+own posts, liked posts, bookmarks, and any saved custom feed generators into
+local `Subscription.Feed` objects backed by ECHO queues. Each sync target
+produces a feed of `Subscription.Post` ECHO objects that live in the user's
+space and replicate to peers like any other ECHO data.
+
+Authentication uses the AT Protocol OAuth flow with the `transition:generic`
+scope. The user provides their atproto handle or DID; the plugin resolves the
+user's Personal Data Server (PDS) from the DID document and proxies
+authenticated XRPC requests through the DXOS Edge `/atproto/proxy` endpoint so
+the DPoP signing key never leaves the server.
+
+Sync is pull-only. `GetBlueskyTargets` discovers the available targets (three
+self-targets plus one entry per saved feed generator), and `SyncBlueskyTargets`
+walks XRPC pages for selected targets, stopping at the previously seen post URI
+(`cursor`) on incremental runs. Page budgets are configurable per-target via
+`BlueskyTargetOptions.maxPages` and are capped by a hard safety limit.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`       |
+| `feat`      | `org.dxos.mdl.feat@1.0`       |
+| `test`      | `org.dxos.mdl.test@1.0`       |
+| `component` | `org.dxos.mdl.component@1.0`  |
+| `op`        | `org.dxos.mdl.op@1.0`         |
+
+## Types
+
+```mdl
+type BlueskyTargetOptions
+  desc: Per-target sync options stored in IntegrationTarget.options.
+  fields:
+    maxPages?: number   # XRPC pages walked per sync; capped at MAX_PAGES_HARD_CAP (20)
+```
+
+```mdl
+type FeedViewPost
+  desc: Subset of app.bsky.feed.defs#feedViewPost used by the sync pipeline.
+  fields:
+    post: FeedPost
+    reason?: FeedReason
+```
+
+```mdl
+type FeedPost
+  desc: Core post record decoded from XRPC responses.
+  fields:
+    uri: string         # at://did:plc:.../app.bsky.feed.post/<rkey>
+    cid: string
+    author: FeedAuthor
+    record: FeedRecord
+    indexedAt: string   # ISO 8601
+```
+
+```mdl
+type FeedAuthor
+  fields:
+    did: string
+    handle: string
+    displayName?: string
+    avatar?: string
+```
+
+```mdl
+type FeedRecord
+  fields:
+    text?: string
+    createdAt: string   # ISO 8601
+```
+
+```mdl
+type SavedFeed
+  desc: Saved/pinned feed entry from app.bsky.actor.getPreferences.
+  fields:
+    value: string       # at-uri of the feed generator
+    type: feed | list | timeline
+    pinned?: boolean
+```
+
+```mdl
+type SyncTarget
+  desc: A discovered target the user can select for sync.
+  fields:
+    id: string          # stable remote id (e.g. 'self:posts', 'feed:<at-uri>')
+    name: string
+    description?: string
+```
+
+## Operations
+
+```mdl
+op GetBlueskyTargets
+  desc: >
+    Discovers the available sync targets for the authenticated Bluesky
+    integration: the three built-in self-targets (my posts, my liked posts,
+    my bookmarks) plus one entry per saved feed generator pulled from the
+    user's atproto preferences. Read-only; no ECHO objects are created.
+  input:
+    integration: Ref<Integration>
+  output: GetSyncTargetsOutput
+  effects: [http]
+  errors:
+    IntegrationDatabaseMissing: integration ref has no resolvable ECHO database
+    MissingBlueskyHandle: access token has no account (handle/DID) set
+    PdsResolutionFailed: could not resolve the user's atproto PDS endpoint
+  note: >
+    Saved-feed discovery is best-effort: failures in getPreferences fall back
+    to returning only the three self-targets so the user always has something
+    to pick from.
+```
+
+```mdl
+op SyncBlueskyTargets
+  desc: >
+    Pull-syncs posts for all currently-selected targets in a Bluesky
+    Integration. For each selected target, walks XRPC pages from newest
+    backwards, stopping at the previously seen post URI (target.cursor) or
+    the per-target page budget. On first sync, materializes a
+    Subscription.Feed ECHO object and pins it to target.object. Appended
+    posts become Subscription.Post ECHO objects stored in the feed's queue.
+  input:
+    integration: Ref<Integration>
+  output:
+    appended: number    # total posts appended across all selected targets
+    failed: number      # targets that produced an error this run
+  effects: [http, echo:read, echo:write]
+  errors:
+    IntegrationDatabaseMissing: integration ref has no resolvable ECHO database
+    MissingBlueskyHandle: access token has no account (handle/DID) set
+    PdsResolutionFailed: could not resolve the user's atproto PDS endpoint
+  note: >
+    Per-target failures are collected; a single failing target does not abort
+    the run. Errors are recorded on target.lastError and counted in `failed`.
+    The page budget for self-targets defaults to 5 pages; custom feed
+    generators default to 1 page per sync to avoid runaway pagination on
+    algorithmic feeds. Both are capped at 20 pages regardless of options.
+```
+
+## Features
+
+```mdl
+feat F-1: OAuth Authentication
+
+  req F-1.1: User provides their atproto handle or DID via a pre-flight form.
+  req F-1.2:
+    when: user submits the pre-flight form
+    then: OAuth flow initiated with loginHint = handle; provider = ATPROTO
+  req F-1.3:
+    when: OAuth flow completes
+    then: access token stored in Integration.accessToken with source = 'bsky.app'
+  req F-1.4: Plugin uses redirect-based OAuth flow (no popup) because bsky.social nullifies window.opener.
+  req F-1.5: Requested OAuth scope is 'transition:generic' (read + write across app.bsky.*).
+```
+
+```mdl
+feat F-2: PDS Resolution
+
+  req F-2.1:
+    when: authenticated XRPC required
+    then: plugin resolves the user's PDS from the DID document
+  req F-2.2: did:plc identities are resolved via https://plc.directory/<did>.
+  req F-2.3: did:web identities are resolved via the /.well-known/did.json of the encoded domain.
+  req F-2.4: Resolved PDS endpoint is cached in-process for the lifetime of the sync run.
+  req F-2.5:
+    when: PDS endpoint cannot be resolved
+    then: PdsResolutionFailedError is raised; no silent fallback to bsky.social
+```
+
+```mdl
+feat F-3: Target Discovery
+
+  req F-3.1:
+    when: GetBlueskyTargets is called
+    then: three self-targets returned (my posts, my liked posts, my bookmarks)
+  req F-3.2:
+    when: GetBlueskyTargets is called and getPreferences succeeds
+    then: one additional target returned per saved feed/list in the user's preferences
+  req F-3.3: Home timeline pseudo-entries (type = 'timeline') are excluded from targets.
+  req F-3.4:
+    when: getPreferences fails
+    then: error logged as warning; only self-targets returned (best-effort)
+```
+
+```mdl
+feat F-4: Feed Sync
+
+  req F-4.1: SyncBlueskyTargets iterates over integration.targets; skips targets with no remoteId.
+  req F-4.2:
+    when: a target is synced for the first time
+    then: a new Subscription.Feed ECHO object is created and stored in target.object
+  req F-4.3:
+    when: a target already has a Subscription.Feed in target.object
+    then: the existing feed is reused
+  req F-4.4: Each synced post becomes a Subscription.Post appended to the feed's ECHO queue.
+  req F-4.5:
+    when: sync completes for a target
+    then: target.cursor updated to the URI of the newest post; target.lastSyncAt set
+  req F-4.6:
+    when: no new posts are found
+    then: target.lastSyncAt is still updated; target.cursor unchanged
+  req F-4.7:
+    when: a target sync fails
+    then: error message recorded in target.lastError; remaining targets continue
+```
+
+```mdl
+feat F-5: Page Budget
+
+  req F-5.1: Self-targets default to 5 XRPC pages per sync.
+  req F-5.2: Custom feed generators default to 1 XRPC page per sync.
+  req F-5.3: User can override maxPages per target via BlueskyTargetOptions.
+  req F-5.4: maxPages override is clamped to MAX_PAGES_HARD_CAP (20).
+  req F-5.5:
+    when: target.cursor is reached mid-page
+    then: page walk stops early; only posts newer than cursor are collected
+```
+
+```mdl
+feat F-6: Edge Proxy for Authenticated Requests
+
+  req F-6.1: Public XRPC reads (getAuthorFeed) use the public API and need no auth.
+  req F-6.2: Authenticated reads (getActorLikes, getBookmarks, getFeed, getPreferences) are proxied through Edge.
+  req F-6.3:
+    when: Edge proxy request is made
+    then: request body includes spaceId, accessTokenId, and the target XRPC endpoint with DPoP token
+  req F-6.4:
+    when: a 429 or 5xx response is received
+    then: request retried with exponential back-off (up to 3 attempts, 500 ms base, jitter)
+  req F-6.5:
+    when: a 4xx (other than 429) or ParseError is received
+    then: no retry; error propagated immediately
+```
+
+## Acceptance
+
+```mdl
+test T-1: OAuth and credential storage
+  given: user opens the Bluesky integration setup dialog
+  when: user enters handle 'user.bsky.social' and submits
+  then:
+    - OAuth flow starts with loginHint = 'user.bsky.social'
+    - on completion, Integration.accessToken.account === 'user.bsky.social'
+    - Integration.accessToken.source === 'bsky.app'
+```
+
+```mdl
+test T-2: GetBlueskyTargets returns self-targets
+  given: a valid Bluesky integration with no saved custom feeds
+  when: GetBlueskyTargets is invoked
+  then:
+    - output.targets contains exactly three entries
+    - ids are 'self:posts', 'self:likes', 'self:bookmarks'
+```
+
+```mdl
+test T-3: GetBlueskyTargets includes saved feed generators
+  given: a valid Bluesky integration with two saved feeds in preferences
+  when: GetBlueskyTargets is invoked
+  then:
+    - output.targets contains five entries (three self + two feeds)
+    - feed entries have type 'feed' and ids prefixed with 'feed:'
+```
+
+```mdl
+test T-4: GetBlueskyTargets degrades gracefully on preferences failure
+  given: getPreferences XRPC call returns a network error
+  when: GetBlueskyTargets is invoked
+  then:
+    - warning logged
+    - output.targets contains only the three self-targets
+    - no error thrown to caller
+```
+
+```mdl
+test T-5: First-sync creates Subscription.Feed
+  given: a selected target with no target.object
+  when: SyncBlueskyTargets is invoked and the target returns posts
+  then:
+    - a new Subscription.Feed is created in the integration's ECHO database
+    - target.object is set to a Ref pointing to the new feed
+    - posts are appended to the feed's queue as Subscription.Post objects
+```
+
+```mdl
+test T-6: Incremental sync stops at cursor
+  given: a target with target.cursor = URI of previously seen post
+  when: SyncBlueskyTargets is invoked and the XRPC page contains that URI
+  then:
+    - only posts newer than target.cursor are collected
+    - target.cursor updated to the newest post URI
+```
+
+```mdl
+test T-7: No new posts — cursor unchanged
+  given: a target where all returned posts are older than target.cursor
+  when: SyncBlueskyTargets is invoked
+  then:
+    - appended === 0
+    - target.cursor unchanged
+    - target.lastSyncAt updated
+```
+
+```mdl
+test T-8: Per-target failure is non-fatal
+  given: an integration with two selected targets; the first target's XRPC call returns 500
+  when: SyncBlueskyTargets is invoked
+  then:
+    - failed === 1
+    - second target synced successfully
+    - target.lastError set for the failing target
+```
+
+```mdl
+test T-9: Page budget enforced
+  given: a custom feed target with no maxPages override
+  when: SyncBlueskyTargets is invoked and the feed has 10 pages of posts
+  then:
+    - only 1 page is fetched (DEFAULT_MAX_PAGES.FEED)
+```
+
+```mdl
+test T-10: Hard page cap respected
+  given: a target with target.options.maxPages = 100
+  when: SyncBlueskyTargets is invoked
+  then: at most 20 pages are fetched (MAX_PAGES_HARD_CAP)
+```
+
+---
+
+## Appendix: Extension Definitions
+
+Extension block types used in this document are defined below using
+the core `ext` primitive — the only construct the base language provides.
+
+```mdl
+ext type
+  uri: dxos.spec/ext/type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap        # name[?]: TypeExpr  (# inline comment)
+    literals?: UnionList     # a | b | c
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: dxos.spec/ext/feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self              # feat blocks may contain feat blocks
+```
+
+```mdl
+ext test
+  uri: dxos.spec/ext/test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap            # external inputs (immutable inside component)
+    state?: FieldMap            # internal reactive state
+    slots?: FieldMap            # named ReactNode injection points
+    actions?: ActionMap         # methods the component exposes or handles
+    emits?: EventMap            # events the component raises to its parent
+    layout?: CodeBlock          # ASCII sketch of visual structure (non-normative)
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap            # named input parameters
+    output?: TypeExpr           # return type
+    errors?: ErrorMap           # name: Prose  (when this error occurs)
+    effects?: EffectList        # echo:read | echo:write | http | fs | ...
+    requires?: ServiceList      # injected service dependencies
+    note?: Prose                # implementation guidance (non-normative)
+```

--- a/packages/plugins/plugin-bluesky/src/meta.ts
+++ b/packages/plugins/plugin-bluesky/src/meta.ts
@@ -9,8 +9,33 @@ export const meta: Plugin.Meta = {
   id: 'org.dxos.plugin.bluesky',
   name: 'Bluesky',
   author: 'DXOS',
+  source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-bluesky',
+  spec: 'PLUGIN.mdl',
   description: trim`
-    Connect Bluesky / atproto to your workspace so your timeline, likes, and saved feeds sync into local Feed objects.
+    Integrates the AT Protocol (atproto) and Bluesky social network into the
+    DXOS Composer workspace. Users authenticate via the atproto OAuth flow —
+    DPoP-bound tokens are managed by the DXOS Edge proxy so credentials never
+    leave the server — and the plugin syncs their posts, liked posts, bookmarks,
+    and saved custom feed generators into local Subscription.Feed objects backed
+    by ECHO queues.
+
+    Each sync target produces Subscription.Post ECHO objects that live in the
+    user's space and replicate to peers like any other local-first data. Sync is
+    pull-only and cursor-based: on incremental runs the plugin walks XRPC pages
+    from newest backwards and stops when it reaches the last-seen post URI,
+    keeping bandwidth low for active users.
+
+    Target discovery lists the three built-in self-targets (my posts, my liked
+    posts, my bookmarks) plus one entry per saved feed generator from the user's
+    atproto preferences. Per-target page budgets are configurable via
+    BlueskyTargetOptions.maxPages and are capped by a hard safety limit to
+    prevent runaway pagination on algorithmic feeds.
+
+    Authenticated XRPC calls (likes, bookmarks, saved feeds, custom feed
+    generators) are proxied through the DXOS Edge /atproto/proxy endpoint so
+    the stored DPoP signing key can attach the required proof headers before
+    forwarding to the user's Personal Data Server (PDS). Public reads such as
+    the author feed bypass the proxy and call the Bluesky public API directly.
   `,
   icon: 'ph--butterfly--regular',
   iconHue: 'sky',


### PR DESCRIPTION
## Summary

- Add `PLUGIN.mdl` spec to `plugin-bluesky` covering types (`BlueskyTargetOptions`, `FeedViewPost`, `FeedPost`, `FeedAuthor`, `FeedRecord`, `SavedFeed`, `SyncTarget`), the two operations (`GetBlueskyTargets`, `SyncBlueskyTargets`), six feature blocks (OAuth auth, PDS resolution, target discovery, feed sync, page budgets, Edge proxy), and ten acceptance tests.
- Expand `meta.ts` description from one line to four paragraphs covering AT Protocol / Bluesky integration, cursor-based pull sync into ECHO `Subscription.Feed` objects, target discovery including saved custom feed generators, and authenticated XRPC proxied through the DXOS Edge `/atproto/proxy` endpoint.
- Add `source` and `spec: 'PLUGIN.mdl'` fields to the plugin meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)