### PR TITLE
docs(plugin-trello): add PLUGIN.mdl spec and expand description

### DIFF
--- a/packages/plugins/plugin-trello/PLUGIN.mdl
+++ b/packages/plugins/plugin-trello/PLUGIN.mdl
@@ -1,0 +1,376 @@
+---
+id: org.dxos.plugin.trello
+name: TrelloPlugin
+version: 0.1.0
+---
+
+Integrates Trello into DXOS Composer, mirroring boards and cards as local-first
+Kanban objects that stay available alongside everything else in the workspace.
+
+The plugin bridges the Trello REST API with ECHO's object graph using a
+snapshot-driven three-way merge: remote edits to untouched fields flow in,
+local edits to untouched fields flow out, and when both sides change a field
+the remote wins. Every board the user selects is materialized as a
+`Kanban` object keyed by its Trello board id; individual cards become `Expando`
+objects inside the Kanban's `items` array.
+
+Credentials are stored as a colon-separated `apiKey:userToken` string in an
+`AccessToken` object inside the user's `Integration`. The OAuth callback in
+the companion `kms-service` writes this format so the plugin stays
+self-contained and no runtime environment variable is required.
+
+Sync is bidirectional (pull then push) per board. Newly-created local cards
+without a Trello foreign key are pushed with `POST /cards`. Locally-edited
+fields that diverge from the last-pull snapshot are pushed with
+`PUT /cards/{id}`. Board creation and board-rename push are not yet
+implemented in v1.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`       |
+| `feat`      | `org.dxos.mdl.feat@1.0`       |
+| `test`      | `org.dxos.mdl.test@1.0`       |
+| `component` | `org.dxos.mdl.component@1.0`  |
+| `op`        | `org.dxos.mdl.op@1.0`         |
+
+## Types
+
+```mdl
+type TrelloMember
+  fields:
+    id: string
+    username: string
+    fullName: string
+    email?: string
+```
+
+```mdl
+type TrelloBoard
+  fields:
+    id: string
+    name: string
+    closed: boolean
+    url: string
+    shortUrl: string
+    dateLastActivity: string
+```
+
+```mdl
+type TrelloList
+  fields:
+    id: string
+    name: string
+    closed: boolean
+    pos: number
+```
+
+```mdl
+type TrelloCard
+  fields:
+    id: string
+    name: string
+    desc: string
+    closed: boolean
+    idList: string
+    pos: number
+    url: string
+    shortUrl: string
+    dateLastActivity: string
+```
+
+```mdl
+type SyncTarget
+  fields:
+    id: string
+    name: string
+    description?: string
+```
+
+```mdl
+type PullResult
+  fields:
+    added: number
+    updated: number
+    removed: number
+```
+
+```mdl
+type PushResult
+  fields:
+    created: number
+    updated: number
+```
+
+## Operations
+
+```mdl
+op GetTrelloBoards
+  desc: |
+    Discovery only — list Trello boards reachable from the integration's
+    token. Read-only: returns one descriptor per remote board, NEVER creates
+    a local Kanban. Materialization happens lazily in SyncTrelloBoard on first
+    sync of a target, so unselected boards leave no trace in the space.
+  input:
+    integration: Ref<Integration>
+  output: GetSyncTargetsOutput
+  effects: [http]
+```
+
+```mdl
+op SyncTrelloBoard
+  desc: |
+    Bidirectional reconcile of currently-selected Trello targets in an
+    Integration. Pull-then-push per board. Does NOT discover boards or modify
+    integration.targets membership.
+    - Pull: fetch lists + cards, three-way merge each field against the
+      snapshot, soft-delete locally any card absent from the remote response.
+    - Push: POST new local cards without a foreign key; PUT fields that
+      diverged from the last-pull snapshot.
+    Per-target failures write lastError on that target and continue;
+    a toast is emitted on completion regardless of per-target errors.
+  input:
+    integration: Ref<Integration>
+    kanban?: Ref<Kanban>
+  output: SyncTrelloBoardOutput
+  effects: [echo:read, echo:write, http]
+  errors:
+    IntegrationDatabaseMissing: integration ref has no derivable database
+    InvalidTrelloAccessToken: stored token is not in `<key>:<userToken>` format
+```
+
+## Features
+
+```mdl
+feat F-1: Discover Boards
+
+  req F-1.1:
+    when: user opens the integration target picker
+    then: op:GetTrelloBoards lists every open board on the token; no local object is created
+```
+
+```mdl
+feat F-2: Materialize Board
+
+  req F-2.1:
+    when: SyncTrelloBoard runs for the first time against a selected target
+    then: |
+      a Kanban is created in ECHO keyed by the remote board id;
+      the Kanban name matches the Trello board name;
+      the uncategorized column is hidden
+```
+
+```mdl
+feat F-3: Pull Cards
+
+  req F-3.1:
+    when: a card exists on Trello but not locally
+    then: an Expando is created with the Trello foreign key; name, desc, listName seeded from remote
+
+  req F-3.2:
+    when: a card exists both locally and on Trello
+    then: |
+      three-way merge applied per field (name, desc, listName);
+      remote-wins on conflict;
+      snapshot refreshed to remote-current
+
+  req F-3.3:
+    when: a card is closed on Trello or absent from the response
+    then: the local Expando is soft-deleted; its ref in kanban.spec.items is preserved
+
+  req F-3.4:
+    when: pull completes
+    then: kanban.arrangement.order reflects Trello list order sorted by pos
+```
+
+```mdl
+feat F-4: Push Cards
+
+  req F-4.1:
+    when: a local Expando has no Trello foreign key and belongs to a named list
+    then: POST /cards creates the card on Trello; foreign key written back; snapshot seeded
+
+  req F-4.2:
+    when: a local Expando with a foreign key has fields diverged from snapshot
+    then: PUT /cards/{id} sends only the diverged fields (name, desc, idList)
+
+  req F-4.3:
+    when: a locally soft-deleted card is encountered during push
+    then: card is skipped; no Trello API call is made
+```
+
+```mdl
+feat F-5: Authentication
+
+  req F-5.1:
+    when: plugin initializes an API call
+    then: |
+      TrelloCredentials service is resolved from the Integration's AccessToken;
+      token parsed as `<apiKey>:<userToken>`;
+      fails with InvalidTrelloAccessTokenError if the format is wrong
+```
+
+```mdl
+feat F-6: Resilience
+
+  req F-6.1:
+    when: an HTTP request fails with a 429 or 5xx status
+    then: exponential back-off retry with jitter, up to 3 attempts
+
+  req F-6.2:
+    when: a request fails with a 4xx status (excluding 429)
+    then: no retry; error propagated immediately
+
+  req F-6.3:
+    when: a sync target fails
+    then: lastError recorded on that target; remaining targets continue
+```
+
+## Acceptance
+
+```mdl
+test T-1: Discover boards — no local side effects
+  given: a valid Integration with a Trello token
+  when: op:GetTrelloBoards is invoked
+  then:
+    - response contains one SyncTarget per open board
+    - no Kanban or Expando is created in ECHO
+```
+
+```mdl
+test T-2: First sync materializes Kanban
+  given: a target with remoteId set, no local Kanban yet
+  when: op:SyncTrelloBoard runs
+  then:
+    - a Kanban is created in ECHO keyed by remoteId
+    - Kanban.name matches the Trello board name
+    - Kanban.arrangement.order matches Trello list order
+```
+
+```mdl
+test T-3: Pull creates new card
+  given: a remote card with no matching local Expando
+  when: pull phase runs
+  then:
+    - Expando created with source:trello foreign key
+    - name, desc, listName populated from remote
+    - snapshot seeded with remote values
+```
+
+```mdl
+test T-4: Pull applies three-way merge
+  given: local name edited by user, remote desc changed since last pull
+  when: pull phase runs
+  then:
+    - local name preserved (local-wins)
+    - local desc updated from remote (remote-wins)
+    - snapshot refreshed to remote-current on both fields
+```
+
+```mdl
+test T-5: Pull soft-deletes removed card
+  given: local Expando exists with a Trello foreign key
+  when: that card id is absent from the remote response
+  then:
+    - Expando is soft-deleted (Obj.isDeleted === true)
+    - ref in kanban.spec.items is preserved
+```
+
+```mdl
+test T-6: Push creates locally-created card
+  given: local Expando with no foreign key, listName set to an existing Trello list
+  when: push phase runs
+  then:
+    - POST /cards called with correct listId, name, desc
+    - foreign key written back to Expando
+    - snapshot seeded with pushed values
+```
+
+```mdl
+test T-7: Push updates diverged fields
+  given: local Expando with foreign key; name diverged from snapshot; desc unchanged
+  when: push phase runs
+  then:
+    - PUT /cards/{id} sent with name only
+    - snapshot refreshed with pushed name
+```
+
+```mdl
+test T-8: Invalid token fails fast
+  given: Integration AccessToken with a malformed token string (no colon)
+  when: any Trello API call is attempted
+  then: InvalidTrelloAccessTokenError raised; no HTTP request made
+```
+
+---
+
+## Appendix: Extension Definitions
+
+Extension block types used in this document are defined below using
+the core `ext` primitive — the only construct the base language provides.
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap        # name[?]: TypeExpr  (# inline comment)
+    literals?: UnionList     # a | b | c
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap
+    state?: FieldMap
+    slots?: FieldMap
+    actions?: ActionMap
+    emits?: EventMap
+    layout?: CodeBlock
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap
+    output?: TypeExpr
+    errors?: ErrorMap
+    effects?: EffectList
+    requires?: ServiceList
+    note?: Prose
+```

--- a/packages/plugins/plugin-trello/src/meta.ts
+++ b/packages/plugins/plugin-trello/src/meta.ts
@@ -9,8 +9,28 @@ export const meta: Plugin.Meta = {
   id: 'org.dxos.plugin.trello',
   name: 'Trello',
   author: 'DXOS',
+  source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-trello',
+  spec: 'PLUGIN.mdl',
   description: trim`
-    Connect Trello to your workspace so boards and cards stay available alongside everything else you're doing.
+    Integrates Trello into DXOS Composer, mirroring boards and cards as local-first
+    Kanban objects that stay available alongside everything else in the workspace.
+    Each Trello board the user selects is materialized as a Kanban keyed by its remote
+    board id; individual cards become Expando objects inside the Kanban's items list.
+
+    Sync is bidirectional. The pull phase applies a snapshot-driven three-way merge
+    per field: remote edits to untouched fields flow in, local edits to untouched
+    fields are preserved, and on conflict the remote wins. The push phase sends only
+    the fields that diverged from the last-pull snapshot, so unmodified cards produce
+    no network traffic.
+
+    Credentials are stored as a colon-separated apiKey:userToken string in an
+    AccessToken object inside the user's Integration. The OAuth callback in the
+    companion kms-service writes this format so the plugin stays self-contained
+    and no runtime environment variable is required.
+
+    Board creation and board-rename push are not yet implemented in v1; sync
+    focuses on card-level operations with per-target error isolation so a failure
+    on one board does not prevent other boards from syncing.
   `,
   icon: 'ph--kanban--regular',
   iconHue: 'blue',


### PR DESCRIPTION
## Summary

- Adds `PLUGIN.mdl` specification file for `plugin-trello`, covering types, operations, features, acceptance tests, and extension appendix following the MDL format established by `plugin-chess`.
- Expands `meta.ts` description to 4 paragraphs covering the bidirectional sync design, snapshot-driven three-way merge, credential storage format, and v1 scope.
- Adds `source` and `spec: 'PLUGIN.mdl'` fields to `Plugin.Meta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)