### PR TITLE
docs(plugin-integration): add PLUGIN.mdl spec and expand description

### DIFF
--- a/packages/plugins/plugin-integration/PLUGIN.mdl
+++ b/packages/plugins/plugin-integration/PLUGIN.mdl
@@ -1,0 +1,514 @@
+---
+id: org.dxos.plugin.integration
+name: IntegrationPlugin
+version: 0.1.0
+---
+
+A Composer plugin that manages connections to external services. It stores
+OAuth credentials and API tokens as `AccessToken` objects in ECHO, organises
+them into `Integration` records that carry one or more sync targets, and
+orchestrates the full lifecycle: provider registration, credential acquisition
+(OAuth popup, redirect-flow, or custom token form), target selection, and
+incremental sync. Other plugins register themselves as
+`IntegrationProvider` capability entries; the plugin renders a generic UI
+that adapts automatically to however many providers are currently loaded.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`       |
+| `feat`      | `org.dxos.mdl.feat@1.0`       |
+| `test`      | `org.dxos.mdl.test@1.0`       |
+| `component` | `org.dxos.mdl.component@1.0`  |
+| `op`        | `org.dxos.mdl.op@1.0`         |
+
+## Types
+
+```mdl
+type IntegrationTarget
+  desc: >
+    One sync target row on an Integration. Binds a remote foreign id
+    (e.g. Trello board id, Gmail label) to an optional local ECHO object
+    and carries incremental sync bookmarks.
+  fields:
+    object?: Ref<Unknown>         # local ECHO root created on first sync
+    remoteId?: string             # remote foreign id before materialization
+    name?: string                 # display label cached from discovery
+    cursor?: string               # provider-opaque sync bookmark
+    lastSyncAt?: DateTime         # ISO timestamp of last successful sync
+    lastError?: string            # last sync failure message
+    options?: Record<string, any> # provider-specific per-target options (opaque)
+```
+
+```mdl
+type Integration
+  desc: >
+    ECHO-persisted record binding an AccessToken to one or more sync targets.
+    The `providerId` field selects the registered IntegrationProvider entry;
+    multiple providers may share the same OAuth source (e.g. `google.com`)
+    while behaving differently.
+  typename: org.dxos.type.integration
+  fields:
+    name?: string                 # user-facing label (e.g. "Work Trello")
+    providerId?: string           # capability id of the owning IntegrationProvider
+    accessToken: Ref<AccessToken> # stored OAuth/API credential
+    targets: IntegrationTarget[]  # remote ↔ local bindings
+    snapshots?: Record<string, any>  # last-seen remote state keyed by remoteId (merge base)
+```
+
+```mdl
+type RemoteTarget
+  desc: Wire shape returned by a provider's getSyncTargets operation.
+  fields:
+    id: string                    # remote service identifier
+    name: string                  # user-readable label
+    description?: string          # optional secondary line
+    metadata?: Record<string, unknown>  # provider-specific display extras
+```
+
+```mdl
+type IntegrationOAuthSpec
+  desc: OAuth flow descriptor contributed on an IntegrationProvider entry.
+  fields:
+    provider: OAuthProvider       # Edge-known provider key
+    scopes: string[]              # requested OAuth scopes
+    useRedirectFlow?: boolean     # open new tab instead of popup (for providers that nullify window.opener)
+```
+
+```mdl
+type CredentialFormResult
+  literals: complete | oauth
+  desc: >
+    Discriminated result from a provider's credential-form submission.
+    `complete` — form produced a fully built AccessToken + Integration (non-OAuth).
+    `oauth` — form produced a loginHint; coordinator opens the OAuth popup.
+```
+
+```mdl
+type IntegrationProviderEntry
+  desc: >
+    One row contributed to the IntegrationProvider capability registry.
+    Describes how to authenticate, discover remote targets, and sync for a
+    specific external service.
+  fields:
+    id: string                           # unique capability/provider id
+    source: string                       # matches AccessToken.source (e.g. "trello.com")
+    label?: string                       # user-facing name; defaults to id
+    oauth?: IntegrationOAuthSpec         # set for OAuth providers
+    credentialForm?: CredentialForm      # pre-flight input for non-OAuth or OAuth with a hint
+    getSyncTargets?: Op<GetSyncTargetsInput, GetSyncTargetsOutput>  # discovery operation
+    sync?: Op<IntegrationSyncInput, any> # incremental sync operation
+    optionsSchema?: Schema               # per-target options rendered in the Integration UI
+    onTokenCreated?: Hook                # side-effect run once after OAuth succeeds
+```
+
+## Components
+
+```mdl
+component IntegrationArticle
+  desc: >
+    Main surface for a persisted Integration. Shows provider identity,
+    connected targets with their last-sync timestamps and error states, and
+    action buttons (add targets, re-authenticate, delete).
+  props:
+    subject: Integration          # the Integration being viewed
+    attendableId?: string         # Deck attendable for toolbar wiring
+  slots:
+    toolbar?: ReactNode
+  actions:
+    openSyncTargetsDialog()
+    deleteIntegration()
+  layout: |
+    ┌─────────────────────────────────┐
+    │ [toolbar slot]                  │
+    ├─────────────────────────────────┤
+    │ Provider logo + name + account  │
+    ├─────────────────────────────────┤
+    │ Target list                     │
+    │  ┌─────────────────────────┐    │
+    │  │ target row (name, sync) │    │
+    │  └─────────────────────────┘    │
+    ├─────────────────────────────────┤
+    │ [Add targets] [Delete]          │
+    └─────────────────────────────────┘
+```
+
+```mdl
+component IntegrationAuthButton
+  desc: >
+    Inline auth trigger contributed via role "integration--auth". Rendered
+    by other plugins (e.g. plugin-inbox) to bootstrap an Integration for a
+    specific provider without navigating away. Passes an optional
+    `existingTarget` ref so the new Integration is pre-wired to an existing
+    local object.
+  props:
+    providerId: string
+    db: Database
+    existingTarget?: Ref<Unknown>
+  actions:
+    startAuth()
+```
+
+```mdl
+component SyncTargetsChecklist
+  desc: >
+    Dialog opened after OAuth completes (or on demand) that lists available
+    remote targets returned by the provider's getSyncTargets operation. User
+    checks/unchecks items; submit calls op:SetIntegrationTargets.
+  props:
+    integration: Integration
+    availableTargets: RemoteTarget[]
+    existingTarget?: Ref<Unknown>
+  state:
+    selected: string[]            # checked remoteId set
+  actions:
+    toggleTarget(remoteId: string)
+    confirm()
+  layout: |
+    ┌──────────────────────────────┐
+    │ "Select targets to sync"     │
+    ├──────────────────────────────┤
+    │ ☑ target A                   │
+    │ ☐ target B                   │
+    │ ☑ target C                   │
+    ├──────────────────────────────┤
+    │               [Cancel] [OK]  │
+    └──────────────────────────────┘
+```
+
+```mdl
+component CustomTokenDialog
+  desc: >
+    Generic provider-form dialog. Renders either a provider's custom
+    `credentialForm` schema or a fallback raw-token input for non-OAuth
+    providers. On submit dispatches IntegrationCoordinator.submitCredentialForm.
+  props:
+    db: Database
+    spaceId: SpaceId
+    providerId: string
+    providerLabel: string
+  state:
+    values: Record<string, any>   # live form values
+  actions:
+    submit(values)
+    cancel()
+```
+
+## Operations
+
+```mdl
+op CreateIntegration
+  desc: Creates a new Integration bound to an existing AccessToken.
+  input:
+    accessToken: Ref<AccessToken>
+    name?: string
+  output: Integration
+  effects: [echo:write]
+  note: Derives the target Database from the accessToken ref's object graph.
+```
+
+```mdl
+op SetIntegrationTargets
+  desc: >
+    Reconciles an Integration's targets array to match a user-chosen selection.
+    Existing targets whose remoteId appears in `selected` are preserved with
+    their cursor/options intact. Targets not in the new selection are removed.
+    Auto-created targets with no remoteId (e.g. Gmail's single Mailbox) are
+    never touched. The first newly-added target receives `existingTarget` as
+    its local object ref when supplied.
+  input:
+    integration: Ref<Integration>
+    selected: { remoteId: string; name?: string }[]
+    existingTarget?: Ref<Unknown>
+  output: { added: number; removed: number }
+  effects: [echo:write]
+```
+
+## Features
+
+```mdl
+feat F-1: Provider Registration
+
+  req F-1.1: Any plugin may contribute one or more IntegrationProviderEntry rows via the IntegrationProvider capability.
+  req F-1.2: The integration UI queries IntegrationProvider at render time; adding or removing a provider plugin updates the list without a build step.
+  req F-1.3:
+    when: a provider declares oauth
+    then: the coordinator routes through the Edge OAuth service using provider.oauth.provider and provider.oauth.scopes
+  req F-1.4:
+    when: a provider declares credentialForm
+    then: the coordinator opens CustomTokenDialog before starting any OAuth flow
+  req F-1.5:
+    when: a provider declares getSyncTargets
+    then: the coordinator opens SyncTargetsChecklist after OAuth completes
+```
+
+```mdl
+feat F-2: OAuth Popup Flow
+
+  req F-2.1:
+    when: user triggers auth for an OAuth provider (no credentialForm or loginHint already supplied)
+    then: coordinator calls Edge /oauth/initiate and opens a popup window to the returned authUrl
+  req F-2.2:
+    when: Edge posts a success message to window.opener
+    then: coordinator finalizes the pending entry (persists AccessToken + Integration, runs onTokenCreated)
+  req F-2.3:
+    when: Edge posts a failure message
+    then: pending entry is discarded; no ECHO writes occur
+  req F-2.4: In-memory pending entries are keyed by AccessToken.id; a localStorage snapshot is written for redirect-flow recovery.
+```
+
+```mdl
+feat F-3: OAuth Redirect Flow
+
+  req F-3.1:
+    when: provider declares oauth.useRedirectFlow = true
+    then: authUrl is opened in a new browser tab instead of a popup
+  req F-3.2: A PendingSnapshot keyed by accessTokenId is written to localStorage before opening the new tab.
+  req F-3.3:
+    when: Edge redirects the new tab to /redirect/oauth with accessToken params
+    then: the NavigationHandler calls IntegrationCoordinator.finalizeRedirectFlow
+  req F-3.4:
+    when: finalizeRedirectFlow runs
+    then: PendingSnapshot is read from localStorage, AccessToken + Integration are rebuilt, standard finalize path runs
+  req F-3.5: After finalize the PendingSnapshot is deleted from localStorage.
+```
+
+```mdl
+feat F-4: Custom / Non-OAuth Credentials
+
+  req F-4.1:
+    when: provider has no oauth field
+    then: coordinator opens CustomTokenDialog (generic raw-token form or provider's credentialForm)
+  req F-4.2:
+    when: credentialForm.onSubmit returns kind=complete
+    then: AccessToken + Integration from the result are persisted directly via createCustomIntegration
+  req F-4.3:
+    when: credentialForm.onSubmit returns kind=oauth with a loginHint
+    then: coordinator re-enters createIntegration with the supplied loginHint and starts the OAuth popup
+```
+
+```mdl
+feat F-5: Target Selection
+
+  req F-5.1:
+    when: a provider has getSyncTargets and OAuth just completed
+    then: coordinator invokes getSyncTargets and opens SyncTargetsChecklist with the result
+  req F-5.2:
+    when: user confirms a selection in SyncTargetsChecklist
+    then: op:SetIntegrationTargets is called; added and removed counts are returned
+  req F-5.3: Targets whose remoteId is already present in Integration.targets are preserved with their existing cursor and options.
+  req F-5.4:
+    when: existingTarget is supplied and at least one new target is added
+    then: the first new target's object ref is set to existingTarget
+```
+
+```mdl
+feat F-6: Integration Persistence and Navigation
+
+  req F-6.1:
+    when: finalize completes
+    then: AccessToken and Integration are written to ECHO; AccessToken.parent is set to the Integration
+  req F-6.2:
+    when: Integration is persisted
+    then: Composer navigates to the Integration article in the active Deck
+  req F-6.3:
+    when: onTokenCreated is declared by the provider
+    then: it is called once after AccessToken + Integration are persisted, before navigation
+  req F-6.4: onTokenCreated failures are caught and logged; they do not abort the finalize flow.
+```
+
+```mdl
+feat F-7: Integration Article UI
+
+  req F-7.1: IntegrationArticle is rendered for any ECHO object of type org.dxos.type.integration via the AppSurface.Article role.
+  req F-7.2: The article lists all Integration.targets with their name, lastSyncAt, and lastError fields.
+  req F-7.3:
+    when: user clicks "Add targets"
+    then: SyncTargetsChecklist opens using the provider's getSyncTargets operation
+  req F-7.4:
+    when: user clicks "Delete"
+    then: the Integration and its AccessToken are removed from ECHO
+```
+
+```mdl
+feat F-8: Provider Picker in Create Form
+
+  req F-8.1: The Integration create-object form schema carries IntegrationProviderAnnotationId on its providerId field.
+  req F-8.2:
+    when: a form-input Surface encounters IntegrationProviderAnnotationId
+    then: it renders a SelectField populated from registered IntegrationProvider entries
+  req F-8.3: The dropdown updates live when provider plugins are loaded or unloaded.
+```
+
+## Acceptance
+
+```mdl
+test T-1: OAuth popup flow creates Integration
+  given: a provider registered with oauth scopes; user is in a space
+  when: user triggers createIntegration for that provider
+  then:
+    - Edge /oauth/initiate called with provider + scopes + spaceId
+    - popup window opened at authUrl
+    - no ECHO writes occur yet
+```
+
+```mdl
+test T-2: OAuth callback finalizes Integration
+  given: pending entry in memory for accessTokenId X
+  when: Edge postMessage arrives with tag=success, accessTokenId=X, accessToken=TOKEN
+  then:
+    - AccessToken persisted with token=TOKEN
+    - Integration persisted with accessToken ref pointing to the AccessToken
+    - Composer navigates to the new Integration article
+```
+
+```mdl
+test T-3: OAuth failure discards pending entry
+  given: pending entry in memory for accessTokenId X
+  when: Edge postMessage arrives with tag=failure
+  then:
+    - pending entry removed
+    - no ECHO writes occur
+    - no navigation occurs
+```
+
+```mdl
+test T-4: Redirect flow recovery
+  given: provider with useRedirectFlow=true; PendingSnapshot written to localStorage for accessTokenId Y
+  when: NavigationHandler calls finalizeRedirectFlow({ accessTokenId: Y, accessToken: TOKEN })
+  then:
+    - snapshot read from localStorage
+    - AccessToken and Integration rebuilt from snapshot
+    - finalize path runs; ECHO writes succeed
+    - localStorage entry deleted
+```
+
+```mdl
+test T-5: Custom token flow
+  given: provider with credentialForm that returns kind=complete on submit
+  when: user submits the credential form with valid values
+  then:
+    - AccessToken + Integration from credentialForm.onSubmit persisted to ECHO
+    - Composer navigates to the new Integration article
+```
+
+```mdl
+test T-6: SetIntegrationTargets adds and removes
+  given: Integration with targets [{remoteId: "A"}, {remoteId: "B"}]
+  when: op:SetIntegrationTargets called with selected=[{remoteId: "B"}, {remoteId: "C"}]
+  then:
+    - target A removed (removed=1)
+    - target B preserved with its existing cursor intact
+    - target C added (added=1)
+    - output = { added: 1, removed: 1 }
+```
+
+```mdl
+test T-7: Auto-created target preserved by SetIntegrationTargets
+  given: Integration with target [{object: ref(Mailbox), remoteId: undefined}]
+  when: op:SetIntegrationTargets called with selected=[]
+  then:
+    - auto-created target preserved unchanged
+    - output = { added: 0, removed: 0 }
+```
+
+```mdl
+test T-8: existingTarget wired to first new target
+  given: Integration with no targets; existingTarget ref supplied
+  when: op:SetIntegrationTargets called with selected=[{remoteId: "X", name: "Inbox"}]
+  then:
+    - new target added with object=existingTarget, remoteId="X", name="Inbox"
+    - existingTarget.name set to "Inbox" if previously empty
+```
+
+```mdl
+test T-9: Provider picker reflects live registry
+  given: create-object form for Integration type is open
+  when: a second IntegrationProvider capability entry is contributed at runtime
+  then:
+    - SelectField options list now includes the new provider
+    - no page reload required
+```
+
+```mdl
+test T-10: onTokenCreated failure does not abort finalize
+  given: provider with onTokenCreated that throws an Error
+  when: finalize runs after OAuth success
+  then:
+    - error is logged with log.warn
+    - AccessToken and Integration are still persisted
+    - navigation to Integration article still occurs
+```
+
+---
+
+## Appendix: Extension Definitions
+
+Extension block types used in this document are defined below using
+the core `ext` primitive — the only construct the base language provides.
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap        # name[?]: TypeExpr  (# inline comment)
+    literals?: UnionList     # a | b | c
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self              # feat blocks may contain feat blocks
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap            # external inputs (immutable inside component)
+    state?: FieldMap            # internal reactive state
+    slots?: FieldMap            # named ReactNode injection points
+    actions?: ActionMap         # methods the component exposes or handles
+    emits?: EventMap            # events the component raises to its parent
+    layout?: CodeBlock          # ASCII sketch of visual structure (non-normative)
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap            # named input parameters
+    output?: TypeExpr           # return type
+    errors?: ErrorMap           # name: Prose  (when this error occurs)
+    effects?: EffectList        # echo:read | echo:write | http | fs | ...
+    requires?: ServiceList      # injected service dependencies
+    note?: Prose                # implementation guidance (non-normative)
+```

--- a/packages/plugins/plugin-integration/src/meta.ts
+++ b/packages/plugins/plugin-integration/src/meta.ts
@@ -10,8 +10,32 @@ export const meta: Plugin.Meta = {
   name: 'Integrations',
   author: 'DXOS',
   description: trim`
-    Manage integrations with external services.
-    Connect your space to external services and manage your integrations here.
+    Manages connections to external services for DXOS Composer workspaces.
+    OAuth credentials and API tokens are stored as AccessToken objects in ECHO
+    and organised into Integration records that each carry one or more sync
+    targets (a remote foreign id paired with a local ECHO root object).
+
+    Other plugins register themselves as IntegrationProvider capability entries,
+    describing their OAuth scopes, target-discovery operation, incremental sync
+    operation, and optional credential form. The plugin renders a generic UI
+    that adapts automatically to however many providers are currently loaded:
+    a provider-picker dropdown in the create form, a sync-target checklist after
+    authentication, and an Integration article that shows per-target sync status.
+
+    Authentication supports three paths: an OAuth popup flow (default), a
+    redirect flow for providers that nullify window.opener (e.g. AT Protocol),
+    and a custom-token or pre-flight form for non-OAuth credentials. Pending
+    OAuth state is kept in memory and mirrored to localStorage so the redirect
+    path can recover across tab boundaries.
+
+    ECHO writes happen only after authentication succeeds: AccessToken and
+    Integration are persisted together, the provider's onTokenCreated hook
+    fires, and Composer navigates to the new Integration article. The
+    SetIntegrationTargets operation reconciles target selections
+    non-destructively, preserving existing sync cursors and options for
+    targets that remain selected.
   `,
   tags: ['system'],
+  source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-integration',
+  spec: 'PLUGIN.mdl',
 };


### PR DESCRIPTION
## Summary

- Add `PLUGIN.mdl` to `plugin-integration` covering types (`Integration`, `IntegrationTarget`, `IntegrationProviderEntry`, `RemoteTarget`, `IntegrationOAuthSpec`), four UI components (`IntegrationArticle`, `IntegrationAuthButton`, `SyncTargetsChecklist`, `CustomTokenDialog`), two ECHO operations (`CreateIntegration`, `SetIntegrationTargets`), eight feature groups (provider registration, OAuth popup/redirect/custom flows, target selection, persistence, article UI, provider picker), and ten acceptance tests
- Expand `meta.ts` description from two sentences to four paragraphs covering OAuth lifecycle, provider capability registration, target selection, and ECHO write semantics
- Add `source` URL and `spec: 'PLUGIN.mdl'` pointer to `meta.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)