### PR TITLE
docs(plugin-map-solid): add PLUGIN.mdl spec and expand description

### DIFF
--- a/packages/plugins/plugin-map-solid/PLUGIN.mdl
+++ b/packages/plugins/plugin-map-solid/PLUGIN.mdl
@@ -1,0 +1,258 @@
+---
+id: org.dxos.plugin.map-solid
+name: MapSolidPlugin
+version: 0.1.0
+---
+
+A SolidJS-native map surface plugin for `DXOS` Composer.
+Provides an alternative rendering path for `Map` objects using SolidJS Web Components,
+delivering fine-grained reactivity for high-frequency geospatial updates without a React reconciler.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`       |
+| `feat`      | `org.dxos.mdl.feat@1.0`       |
+| `test`      | `org.dxos.mdl.test@1.0`       |
+| `component` | `org.dxos.mdl.component@1.0`  |
+| `op`        | `org.dxos.mdl.op@1.0`         |
+
+## Types
+
+```mdl
+type MapViewType
+  desc: Rendering mode for the map surface.
+  literals: map | globe
+```
+
+```mdl
+type GeoMarker
+  desc: A resolved geographic pin derived from a dataset row.
+  fields:
+    id: string
+    location:
+      lat: number
+      lng: number
+```
+
+```mdl
+type MapSurfaceData
+  desc: Data payload injected into the dx-map-surface Web Component.
+  fields:
+    subject: Map              # Map ECHO object (imported from plugin-map)
+```
+
+## Components
+
+```mdl
+component MapSurface
+  desc: |
+    SolidJS Web Component (custom element dx-map-surface) that renders a Map object.
+    Registered via solid-element; uses noShadowDOM so host Tailwind styles apply.
+    Reads the linked View to derive GeoMarker pins reactively.
+  props:
+    data?: MapSurfaceData
+  state:
+    type: MapViewType         # local signal, defaults to map
+    markers: GeoMarker[]      # derived from view query
+  actions:
+    toggleView()              # flips type between map and globe
+  layout: |
+    ┌──────────────────────────────┐
+    │  <Show when={type==='map'}>  │
+    │    <MapControl markers />    │
+    │  </Show>                     │
+    │  <Show when={type==='globe'}>│
+    │    <GlobeControl markers />  │
+    │  </Show>                     │
+    └──────────────────────────────┘
+```
+
+```mdl
+component MapControl
+  desc: Leaflet-based 2-D tile map rendered with SolidJS reactive primitives.
+  props:
+    markers: Accessor<GeoMarker[]>
+  actions:
+    onToggle()               # requests switch to globe mode
+```
+
+```mdl
+component GlobeControl
+  desc: 3-D interactive globe rendered with SolidJS reactive primitives.
+  props:
+    markers: Accessor<GeoMarker[]>
+  actions:
+    onToggle()               # requests switch to map mode
+```
+
+## Operations
+
+```mdl
+op resolveSurfaceMarkers
+  desc: |
+    Derives a reactive GeoMarker list from a Map object's linked View.
+    Queries the ECHO database for objects matching the View's schema typename,
+    then extracts the GeoPoint field identified by the View's pivotFieldId.
+  input:
+    map: Map
+  output: GeoMarker[]
+  effects: [echo:read]
+  note: |
+    Rows with absent, null, or non-numeric coordinate values are silently
+    filtered out.  Result updates reactively as the underlying dataset changes.
+```
+
+## Features
+
+```mdl
+feat F-1: SolidJS Surface Registration
+
+  req F-1.1: MapSolidPlugin registers the dx-map-surface custom element on plugin activation.
+  req F-1.2:
+    when: a Map object is opened with role article or section
+    then: the ReactSurface capability routes rendering to dx-map-surface at position first
+  req F-1.3: The surface filter uses Obj.instanceOf(Map.Map) so only genuine Map ECHO objects match.
+```
+
+```mdl
+feat F-2: Reactive Marker Derivation
+
+  req F-2.1:
+    when: the Map's linked View changes
+    then: the typename and schema signals update; the ECHO query re-runs automatically
+  req F-2.2:
+    when: a row is added to the dataset
+    then: a new GeoMarker appears on the surface without a full component remount
+  req F-2.3:
+    when: a row's GeoPoint field is absent or malformed
+    then: that row is excluded from the marker list silently
+```
+
+```mdl
+feat F-3: View Toggle
+
+  req F-3.1:
+    when: the user triggers onToggle on MapControl
+    then: local type signal switches to globe; GlobeControl is shown
+  req F-3.2:
+    when: the user triggers onToggle on GlobeControl
+    then: local type signal switches to map; MapControl is shown
+  req F-3.3: Toggle state is local to each dx-map-surface instance.
+```
+
+```mdl
+feat F-4: No Shadow DOM
+
+  req F-4.1: The custom element calls noShadowDOM() so Tailwind utility classes from the host apply inside the component.
+```
+
+## Acceptance
+
+```mdl
+test T-1: Surface renders for Map object
+  given: a Map ECHO object is added to a space
+  when: the object is opened as an article
+  then: dx-map-surface is rendered; MapControl is visible in map mode
+```
+
+```mdl
+test T-2: Markers appear from linked view
+  given: a Map with a linked View over a schema with a GeoPoint field
+  when: two rows exist in the dataset with valid coordinates
+  then: exactly two GeoMarker pins are displayed on the map
+```
+
+```mdl
+test T-3: Malformed coordinate filtered
+  given: a Map linked to 3 rows; one row has a null GeoPoint
+  when: MapSurface renders
+  then: two markers shown; no error thrown
+```
+
+```mdl
+test T-4: Toggle to globe
+  given: MapSurface is in map mode
+  when: user clicks the toggle control on MapControl
+  then: GlobeControl is rendered; MapControl is hidden
+```
+
+```mdl
+test T-5: Filter rejects non-Map object
+  given: a non-Map ECHO object
+  when: the ReactSurface filter evaluates
+  then: dx-map-surface is not rendered for that object
+```
+
+---
+
+## Appendix: Extension Definitions
+
+Extension block types used in this document are defined below using
+the core `ext` primitive — the only construct the base language provides.
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap
+    literals?: UnionList
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap
+    state?: FieldMap
+    slots?: FieldMap
+    actions?: ActionMap
+    emits?: EventMap
+    layout?: CodeBlock
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap
+    output?: TypeExpr
+    errors?: ErrorMap
+    effects?: EffectList
+    requires?: ServiceList
+    note?: Prose
+```

--- a/packages/plugins/plugin-map-solid/src/meta.ts
+++ b/packages/plugins/plugin-map-solid/src/meta.ts
@@ -10,11 +10,23 @@ export const meta: Plugin.Meta = {
   name: 'Maps (Solid)',
   author: 'DXOS',
   description: trim`
-    Map surface for SolidJS.
+    SolidJS-native map surface plugin that renders ECHO Map objects as interactive tile maps or 3-D globes.
+    Implements the map surface as a SolidJS Web Component (dx-map-surface), providing fine-grained reactivity
+    for high-frequency geospatial updates without the overhead of a React reconciler.
+
+    The component derives geographic markers reactively from the Map's linked View: as rows are added or
+    updated in the underlying ECHO dataset, pins appear or move on the map without a full remount.
+    Two rendering modes are available — a standard 2-D tile map and an interactive 3-D globe —
+    toggled locally per surface instance.
+
+    The custom element uses noShadowDOM so host Tailwind utility classes apply inside the component,
+    ensuring consistent styling with the rest of the Composer shell.
+    This plugin is designed to complement plugin-map, which owns the Map ECHO schema and object-creation flow.
   `,
   icon: 'ph--compass--regular',
   iconHue: 'green',
-  source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-map',
+  source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-map-solid',
+  spec: 'PLUGIN.mdl',
   tags: ['labs'],
   screenshots: ['https://dxos.network/plugin-details-map-dark.png'],
 };


### PR DESCRIPTION
## Summary

- Adds `PLUGIN.mdl` spec file for `plugin-map-solid` with type, component, operation, feature, and acceptance-test sections
- Updates `meta.ts` with a 4-paragraph description covering SolidJS Web Component rendering, reactive marker derivation, view toggle, and the relationship to `plugin-map`
- Adds `spec: 'PLUGIN.mdl'` field and corrects the `source` URL to point at `plugin-map-solid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)