### PR TITLE
docs(plugin-linear): add PLUGIN.mdl spec and expand description

### DIFF
--- a/packages/plugins/plugin-linear/PLUGIN.mdl
+++ b/packages/plugins/plugin-linear/PLUGIN.mdl
@@ -1,0 +1,425 @@
+---
+id: org.dxos.plugin.linear
+name: LinearPlugin
+version: 0.1.0
+---
+
+Integrates Linear into DXOS Composer, mirroring teams, projects, and issues as
+local-first objects that stay available alongside everything else in the workspace.
+
+The plugin bridges the Linear GraphQL API with ECHO's object graph using a
+snapshot-driven three-way merge: remote edits to untouched fields flow in,
+local edits to untouched fields are preserved, and on conflict the remote wins.
+The user selects Linear teams; the plugin then pulls all projects for each team
+as `Project` objects and all issues as `Task` objects keyed by their Linear ids.
+
+Sync is bidirectional (pull then push) per team. The pull phase upserts projects
+and tasks, refreshing a snapshot for each object. The push phase walks every
+locally-mirrored object and sends only the fields that diverged from the snapshot,
+so read-only syncs produce no network traffic. Workflow states are fetched lazily
+and only when a status-change push is needed. Creating new local issues on Linear
+is not supported in v1 — push covers edits to already-synced objects only.
+
+Credentials are stored as a Bearer token in an `AccessToken` object inside the
+user's `Integration`. Linear OAuth produces a single opaque token; no API-key
+pairing is required. Priority and workflow-state mappings use Linear's stable
+numeric codes and category constants, not workspace-customisable display names.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`       |
+| `feat`      | `org.dxos.mdl.feat@1.0`       |
+| `test`      | `org.dxos.mdl.test@1.0`       |
+| `component` | `org.dxos.mdl.component@1.0`  |
+| `op`        | `org.dxos.mdl.op@1.0`         |
+
+## Types
+
+```mdl
+type Viewer
+  fields:
+    id: string
+    name: string
+    email?: string
+```
+
+```mdl
+type Team
+  fields:
+    id: string
+    key: string
+    name: string
+    description?: string
+```
+
+```mdl
+type Project
+  fields:
+    id: string
+    name: string
+    description?: string
+```
+
+```mdl
+type StateType
+  literals: triage | backlog | unstarted | started | completed | canceled
+```
+
+```mdl
+type IssueState
+  fields:
+    id: string
+    name: string
+    type: StateType
+```
+
+```mdl
+type Issue
+  fields:
+    id: string
+    identifier: string
+    title: string
+    description?: string
+    priority?: number
+    estimate?: number
+    state: IssueState
+    assignee?: IssueAssignee
+    project?: ProjectRef
+    createdAt?: string
+    updatedAt?: string
+```
+
+```mdl
+type WorkflowState
+  fields:
+    id: string
+    name: string
+    type: StateType
+```
+
+```mdl
+type SyncTarget
+  fields:
+    id: string
+    name: string
+    description?: string
+```
+
+```mdl
+type SyncOptions
+  fields:
+    maxDaysBack?: number      # pull issues updated within this many days; omit to sync everything
+```
+
+```mdl
+type PullResult
+  fields:
+    teams: number
+    projects: number
+    tasks: number
+```
+
+## Operations
+
+```mdl
+op GetLinearTeams
+  desc: |
+    Discovery only — list Linear teams reachable from the integration's token.
+    Returns one descriptor per team across the user's workspace, sorted by key.
+    Read-only: NEVER materializes local objects. Materialization happens lazily
+    in SyncLinearTeams on first sync of a target.
+  input:
+    integration: Ref<Integration>
+  output: GetSyncTargetsOutput
+  effects: [http]
+```
+
+```mdl
+op SyncLinearTeams
+  desc: |
+    Reconcile Linear data for currently-selected team targets in an Integration.
+    Pull-then-push per team.
+    - Pull: upsert each team's projects as Project objects and issues as Task
+      objects, applying snapshot-driven three-way merge per field.
+    - Push: diff every locally-mirrored Project/Task against its snapshot and
+      PATCH diverged fields back to Linear. Workflow states are fetched lazily.
+    Creating new Local issues on Linear is NOT supported in v1.
+    Per-target failures record lastError on that target and continue.
+    A toast is emitted on completion regardless of per-target outcomes.
+  input:
+    integration: Ref<Integration>
+    team?: Ref<Project>
+  output: SyncLinearTeamsOutput
+  effects: [echo:read, echo:write, http]
+  errors:
+    IntegrationDatabaseMissing: integration ref has no derivable database
+    LinearGraphQLError: Linear returned GraphQL-level errors or success=false
+```
+
+## Features
+
+```mdl
+feat F-1: Discover Teams
+
+  req F-1.1:
+    when: user opens the integration target picker
+    then: op:GetLinearTeams returns one SyncTarget per reachable team, sorted by key; no local object is created
+```
+
+```mdl
+feat F-2: Pull Projects
+
+  req F-2.1:
+    when: SyncLinearTeams runs and a remote project has no matching local Project
+    then: a Project is created in ECHO keyed by the remote project id; name and description populated
+
+  req F-2.2:
+    when: SyncLinearTeams runs and a remote project has a matching local Project
+    then: |
+      three-way merge applied per field (name, description);
+      remote-wins on conflict;
+      snapshot refreshed to remote-current
+```
+
+```mdl
+feat F-3: Pull Issues
+
+  req F-3.1:
+    when: SyncLinearTeams runs and a remote issue has no matching local Task
+    then: a Task is created in ECHO keyed by the remote issue id; title, description, status, priority, estimate, project populated
+
+  req F-3.2:
+    when: SyncLinearTeams runs and a remote issue has a matching local Task
+    then: |
+      three-way merge applied per field (title, description, status, priority, estimate);
+      remote-wins on conflict;
+      snapshot refreshed to remote-current
+
+  req F-3.3:
+    when: SyncOptions.maxDaysBack is set
+    then: only issues with updatedAt >= (now − maxDaysBack days) are fetched
+
+  req F-3.4:
+    when: a remote issue belongs to a project
+    then: Task.project ref is set to the corresponding local Project
+```
+
+```mdl
+feat F-4: Push Projects
+
+  req F-4.1:
+    when: a local Project has name or description diverged from its snapshot
+    then: Linear.projectUpdate called with only the diverged fields; snapshot refreshed
+
+  req F-4.2:
+    when: a local Project is soft-deleted
+    then: push skipped for that object
+```
+
+```mdl
+feat F-5: Push Issues
+
+  req F-5.1:
+    when: a local Task has title or description diverged from its snapshot
+    then: Linear.issueUpdate called with only the diverged fields
+
+  req F-5.2:
+    when: a local Task has status diverged from its snapshot
+    then: |
+      workflow states fetched (lazy, once per team);
+      Linear.issueUpdate called with stateId resolved from the desired StateType;
+      if no matching state found, status push skipped and a warning logged
+
+  req F-5.3:
+    when: a local Task has priority diverged from its snapshot
+    then: Linear.issueUpdate called with the numeric priority (1–4); null sent to clear
+
+  req F-5.4:
+    when: a local Task has estimate diverged from its snapshot
+    then: Linear.issueUpdate called with estimate; null sent to clear
+```
+
+```mdl
+feat F-6: Priority Mapping
+
+  req F-6.1: Linear priority 1 (Urgent) maps to Task.priority 'urgent'.
+  req F-6.2: Linear priority 2 (High) maps to Task.priority 'high'.
+  req F-6.3: Linear priority 3 (Medium) maps to Task.priority 'medium'.
+  req F-6.4: Linear priority 4 (Low) maps to Task.priority 'low'.
+  req F-6.5: Linear priority 0 (None) maps to Task.priority undefined.
+```
+
+```mdl
+feat F-7: Status Mapping
+
+  req F-7.1: StateType started maps to Task.status 'in-progress'.
+  req F-7.2: StateType completed or canceled maps to Task.status 'done'.
+  req F-7.3: StateType triage, backlog, or unstarted maps to Task.status 'todo'.
+  req F-7.4: On push, Task.status 'todo' resolves to StateType 'unstarted'.
+  req F-7.5: On push, Task.status 'in-progress' resolves to StateType 'started'.
+  req F-7.6: On push, Task.status 'done' resolves to StateType 'completed'.
+```
+
+```mdl
+feat F-8: Resilience
+
+  req F-8.1:
+    when: an HTTP request or GraphQL transport fails with a 429 or 5xx status
+    then: exponential back-off retry with jitter, up to 3 attempts
+
+  req F-8.2:
+    when: a request fails with a 4xx status (excluding 429) or returns GraphQL errors
+    then: no retry; error propagated immediately
+
+  req F-8.3:
+    when: a sync target fails
+    then: lastError recorded on that target; remaining targets continue
+```
+
+## Acceptance
+
+```mdl
+test T-1: Discover teams — no local side effects
+  given: a valid Integration with a Linear token
+  when: op:GetLinearTeams is invoked
+  then:
+    - response contains one SyncTarget per reachable team sorted by key
+    - no Project or Task is created in ECHO
+```
+
+```mdl
+test T-2: Pull creates new project
+  given: a remote project with no matching local Project
+  when: SyncLinearTeams pull phase runs
+  then:
+    - Project created in ECHO keyed by remote project id
+    - name and description populated from remote
+    - snapshot seeded with remote values
+```
+
+```mdl
+test T-3: Pull creates new task
+  given: a remote issue with no matching local Task
+  when: SyncLinearTeams pull phase runs
+  then:
+    - Task created in ECHO keyed by remote issue id
+    - title, description, status, priority, estimate populated
+    - Task.project set to the corresponding local Project when remote issue.project is set
+```
+
+```mdl
+test T-4: Pull applies three-way merge
+  given: local Task title edited by user, remote description changed since last pull
+  when: SyncLinearTeams pull phase runs
+  then:
+    - local title preserved (local-wins)
+    - local description updated from remote (remote-wins)
+    - snapshot refreshed to remote-current on both fields
+```
+
+```mdl
+test T-5: Push updates diverged project name
+  given: local Project with name diverged from snapshot
+  when: SyncLinearTeams push phase runs
+  then:
+    - Linear.projectUpdate called with name only
+    - snapshot refreshed with pushed name
+```
+
+```mdl
+test T-6: Push updates diverged task status
+  given: local Task with status 'done', snapshot status 'todo'
+  when: SyncLinearTeams push phase runs
+  then:
+    - workflow states fetched for the team
+    - Linear.issueUpdate called with stateId for StateType 'completed'
+    - snapshot refreshed with new status
+```
+
+```mdl
+test T-7: maxDaysBack limits issue fetch
+  given: SyncOptions.maxDaysBack === 7
+  when: SyncLinearTeams runs
+  then: GraphQL filter includes updatedAt >= (now − 7 days); older issues not fetched
+```
+
+```mdl
+test T-8: Push skips soft-deleted objects
+  given: local Task is soft-deleted; foreign key present in snapshot
+  when: SyncLinearTeams push phase runs
+  then: Linear.issueUpdate is NOT called for that Task
+```
+
+---
+
+## Appendix: Extension Definitions
+
+Extension block types used in this document are defined below using
+the core `ext` primitive — the only construct the base language provides.
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap        # name[?]: TypeExpr  (# inline comment)
+    literals?: UnionList     # a | b | c
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap
+    state?: FieldMap
+    slots?: FieldMap
+    actions?: ActionMap
+    emits?: EventMap
+    layout?: CodeBlock
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap
+    output?: TypeExpr
+    errors?: ErrorMap
+    effects?: EffectList
+    requires?: ServiceList
+    note?: Prose
+```

--- a/packages/plugins/plugin-linear/src/meta.ts
+++ b/packages/plugins/plugin-linear/src/meta.ts
@@ -9,9 +9,29 @@ export const meta: Plugin.Meta = {
   id: 'org.dxos.plugin.linear',
   name: 'Linear',
   author: 'DXOS',
+  source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-linear',
+  spec: 'PLUGIN.mdl',
   description: trim`
-    Connect Linear so projects, issues, and comment threads stay available
-    in your workspace alongside everything else you're doing.
+    Integrates Linear into DXOS Composer, mirroring teams, projects, and issues as
+    local-first objects that stay available alongside everything else in the workspace.
+    The user selects Linear teams; the plugin pulls each team's projects as Project
+    objects and its issues as Task objects keyed by their remote ids.
+
+    Sync is bidirectional. The pull phase applies a snapshot-driven three-way merge
+    per field: remote edits to untouched fields flow in, local edits to untouched
+    fields are preserved, and on conflict the remote wins. The push phase diffs every
+    locally-mirrored object against its snapshot and sends only the diverged fields,
+    so read-only syncs produce no network traffic. Workflow states are fetched lazily
+    and only when a status-change push is detected.
+
+    Priority and status values are mapped through Linear's stable numeric codes and
+    category constants rather than workspace-customisable display names, so renamed
+    states continue to work. SyncOptions.maxDaysBack can limit how far back issues
+    are pulled to keep initial syncs fast for large teams.
+
+    Creating new local issues on Linear is not supported in v1; push covers edits to
+    already-synced objects only. Per-target errors are isolated so a failure on one
+    team does not prevent other teams from syncing.
   `,
   icon: 'ph--list-checks--regular',
   iconHue: 'neutral',


### PR DESCRIPTION
## Summary

- Adds `PLUGIN.mdl` specification file for `plugin-linear`, covering types, operations, features (including priority/status mapping), acceptance tests, and extension appendix following the MDL format established by `plugin-chess`.
- Expands `meta.ts` description to 4 paragraphs covering bidirectional sync design, snapshot-driven three-way merge, priority/status mapping approach, and v1 scope.
- Adds `source` and `spec: 'PLUGIN.mdl'` fields to `Plugin.Meta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)