### PR TITLE
docs(plugin-navtree, plugin-kanban): add PLUGIN.mdl specs and expand descriptions

### DIFF
--- a/packages/plugins/plugin-kanban/PLUGIN.mdl
+++ b/packages/plugins/plugin-kanban/PLUGIN.mdl
@@ -1,0 +1,398 @@
+---
+id: org.dxos.plugin.kanban
+name: KanbanPlugin
+version: 0.1.0
+---
+
+Visual project management plugin for `DXOS` Composer — organise any ECHO type into drag-and-drop columns driven by a single-select field, with full local-first persistence and real-time peer replication.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`        |
+| `feat`      | `org.dxos.mdl.feat@1.0`        |
+| `test`      | `org.dxos.mdl.test@1.0`        |
+| `component` | `org.dxos.mdl.component@1.0`   |
+| `op`        | `org.dxos.mdl.op@1.0`          |
+
+## Types
+
+```mdl
+type ArrangementColumnEntry
+  fields:
+    ids: string[]              # ordered card ids within the column
+    hidden?: boolean           # when true the column is hidden from the board
+```
+
+```mdl
+type Arrangement
+  fields:
+    order: string[]            # ordered column values
+    columns: Map<string, ArrangementColumnEntry>
+```
+
+```mdl
+type KanbanViewSpec
+  fields:
+    kind: "view"               # discriminator — items sourced from a View query
+    view: Ref<View>            # the View whose query drives card membership
+```
+
+```mdl
+type KanbanItemsSpec
+  fields:
+    kind: "items"              # discriminator — kanban owns items explicitly
+    pivotField: string         # property path that drives column membership
+    items: Ref<object>[]       # items owned directly by the kanban
+```
+
+```mdl
+type KanbanSpec
+  desc: Discriminated union of item-source strategies.
+  literals: KanbanViewSpec | KanbanItemsSpec
+```
+
+```mdl
+type Kanban
+  desc: Root ECHO object for a kanban board. Stored with typename org.dxos.type.kanban v0.2.0.
+  fields:
+    name?: string
+    arrangement: Arrangement
+    spec: KanbanSpec           # discriminated by spec.kind
+```
+
+```mdl
+type KanbanSettings
+  fields:
+    hideUncategorized?: boolean  # hides items with no pivot value
+```
+
+```mdl
+type KanbanViewSettings
+  fields:
+    columnFieldId: string        # id of the View field used as pivot column
+    hideUncategorized?: boolean
+```
+
+```mdl
+type CreateKanbanInput
+  fields:
+    name?: string
+    typename?: string            # ECHO typename of card objects
+    initialPivotColumn?: string  # initial single-select field to pivot on
+```
+
+## Components
+
+```mdl
+component KanbanArticle
+  desc: Main article surface for a Kanban. Branches internally on spec.kind — view-variant runs a typename query via the linked View; items-variant dereferences spec.items directly.
+  props:
+    subject: Kanban
+    role: "article" | "section"
+  state:
+    projection: ProjectionModel  # column/field projection derived from View + schema
+    items: AtomQuery             # reactive card query (view-variant) or array (items-variant)
+  actions:
+    addCard(columnValue: string) → string   # returns new card id
+    removeCard(card: object)
+    moveCard(card: object, toColumn: string, toIndex: number)
+    deleteCardField(fieldId: string)
+  layout: |
+    ┌──────────────────────────────────────┐
+    │ [toolbar slot]                        │
+    ├──────────────────────────────────────┤
+    │ Col A       │ Col B       │ Col C    │
+    │ ┌─────────┐ │ ┌─────────┐ │  …       │
+    │ │ card    │ │ │ card    │ │          │
+    │ └─────────┘ │ └─────────┘ │          │
+    │ [+ Add card]│             │          │
+    └──────────────────────────────────────┘
+```
+
+```mdl
+component KanbanSettings
+  desc: Properties panel for a Kanban. View-variant shows a column-field picker plus common settings; items-variant shows only common settings.
+  props:
+    subject: Kanban
+  state:
+    selectFields: { value: string; label: string }[]   # single-select fields available as pivot
+  actions:
+    changeColumnField(fieldId: string)
+    toggleHideUncategorized(hidden: boolean)
+```
+
+## Operations
+
+```mdl
+op deleteCard
+  desc: Removes a card object from the ECHO database.
+  input:
+    card: object               # the card to remove
+  output: DeleteCardOutput     # { card } snapshot of the removed card
+  effects: [echo:write]
+```
+
+```mdl
+op deleteCardField
+  desc: Removes a field projection from the View's schema; returns enough data to undo.
+  input:
+    view: View
+    fieldId: string
+  output: DeleteCardFieldOutput  # { field, props, index }
+  effects: [echo:write]
+  requires: [AtomRegistry, Database]
+```
+
+```mdl
+op restoreCard
+  desc: Undo counterpart to deleteCard — re-adds a previously removed card to the database.
+  input:
+    card: object               # the card snapshot to restore
+  output: void
+  effects: [echo:write]
+```
+
+```mdl
+op restoreCardField
+  desc: Undo counterpart to deleteCardField — re-inserts a field projection at its original index.
+  input:
+    view: View
+    field: FieldSchema
+    props: object              # field properties
+    index: number              # position to restore at
+  output: void
+  effects: [echo:write]
+  requires: [AtomRegistry, Database]
+```
+
+## Features
+
+```mdl
+feat F-1: Board Layout
+
+  req F-1.1: Columns are ordered by Arrangement.order; each column contains its cards in Arrangement.columns[value].ids order.
+  req F-1.2: Cards within a column are rendered in the stored id order.
+  req F-1.3:
+    when: settings.hideUncategorized is true
+    then: the uncategorized column is not rendered
+```
+
+```mdl
+feat F-2: Drag and Drop
+
+  req F-2.1:
+    when: user drags a card to a different column
+    then: card's pivot field is updated to the target column value; Arrangement updated
+
+  req F-2.2:
+    when: user drags a card within the same column
+    then: card ids are reordered in Arrangement.columns[value].ids
+
+  req F-2.3:
+    when: user drags a column header
+    then: Arrangement.order is updated to reflect the new column order
+```
+
+```mdl
+feat F-3: Card Management
+
+  req F-3.1:
+    when: user clicks Add Card in a column
+    then: a new ECHO object of the board's card type is created with the pivot field set to that column's value
+
+  req F-3.2:
+    when: user removes a card
+    then: op:deleteCard runs; card is removed from the ECHO database and from the board
+
+  req F-3.3:
+    when: user undoes a delete-card action
+    then: op:restoreCard re-adds the card; board reflects restored state
+```
+
+```mdl
+feat F-4: Column Configuration
+
+  req F-4.1:
+    when: user opens KanbanSettings for a view-variant board
+    then: column-field picker shows all single-select fields from the card schema
+
+  req F-4.2:
+    when: user selects a different column field
+    then: View.projection.pivotFieldId is updated; board re-renders with new columns
+
+  req F-4.3:
+    when: user removes a column field
+    then: op:deleteCardField removes the projection; op:restoreCardField can reverse it
+```
+
+```mdl
+feat F-5: Item Source Variants
+
+  req F-5.1:
+    when: spec.kind === "view"
+    then: items come from running the View's typename query against the ECHO database
+
+  req F-5.2:
+    when: spec.kind === "items"
+    then: items come from spec.items (explicit ref array); used by externally-synced boards (e.g. Linear, GitHub)
+
+  req F-5.3: Both variants share the same Arrangement persistence and drag-and-drop logic.
+```
+
+```mdl
+feat F-6: ECHO Persistence and Collaboration
+
+  req F-6.1: All Kanban, Arrangement, and card mutations are written to ECHO and replicated to peers.
+  req F-6.2:
+    when: a peer updates a card or moves it
+    then: KanbanArticle re-renders reactively via AtomQuery / AtomObj subscriptions
+
+  req F-6.3: View-variant kanbans own an associated View object that is hidden from the space browser.
+```
+
+```mdl
+feat F-7: AI Blueprint
+
+  req F-7.1: Plugin contributes a Kanban blueprint that lets an AI agent create and update kanban boards.
+  req F-7.2:
+    when: an AI agent calls the blueprint
+    then: agent can create boards, place cards in columns, and update card fields
+```
+
+## Acceptance
+
+```mdl
+test T-1: Create kanban board
+  given: a space with a custom ECHO type that has a single-select field "status"
+  when: user creates a new Kanban selecting that type and "status" as the pivot column
+  then:
+    - Kanban object written to ECHO with spec.kind === "view"
+    - columns correspond to the "status" field's enum values
+    - existing objects appear as cards in their respective columns
+```
+
+```mdl
+test T-2: Drag card between columns
+  given: a Kanban with columns "todo", "in-progress", "done" and a card in "todo"
+  when: user drags the card to "in-progress"
+  then:
+    - card's "status" field updated to "in-progress"
+    - Arrangement reflects card in "in-progress" column
+    - change replicated to peers via ECHO
+```
+
+```mdl
+test T-3: Reorder cards within a column
+  given: a column with cards [A, B, C] in order
+  when: user drags card C above card A
+  then:
+    - Arrangement.columns["col"].ids === [C, A, B]
+    - board renders in new order
+```
+
+```mdl
+test T-4: Add card to column
+  given: a board with a "todo" column
+  when: user clicks Add Card in "todo"
+  then:
+    - new ECHO object created with pivot field set to "todo"
+    - card appears at the bottom of the "todo" column
+```
+
+```mdl
+test T-5: Delete and restore card
+  given: a board with card X in column "todo"
+  when: user deletes card X, then undoes
+  then:
+    - after delete: card X absent from board and ECHO database
+    - after undo: card X restored to ECHO and reappears in "todo"
+```
+
+```mdl
+test T-6: Hide uncategorized column
+  given: a board with some cards that have no pivot value (uncategorized)
+  when: user enables "Hide uncategorized column" in KanbanSettings
+  then:
+    - uncategorized column no longer rendered
+    - Arrangement.columns[UNCATEGORIZED].hidden === true
+```
+
+```mdl
+test T-7: Switch pivot column field
+  given: a view-variant board currently pivoting on "status"
+  when: user opens settings and selects "priority" as the column field
+  then:
+    - View.projection.pivotFieldId updated to "priority"
+    - board re-renders with columns derived from "priority" enum values
+```
+
+---
+
+## Appendix: Extension Definitions
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap
+    literals?: UnionList
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap
+    state?: FieldMap
+    slots?: FieldMap
+    actions?: ActionMap
+    emits?: EventMap
+    layout?: CodeBlock
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap
+    output?: TypeExpr
+    errors?: ErrorMap
+    effects?: EffectList
+    requires?: ServiceList
+    note?: Prose
+```

--- a/packages/plugins/plugin-kanban/src/meta.ts
+++ b/packages/plugins/plugin-kanban/src/meta.ts
@@ -11,10 +11,25 @@ export const meta: Plugin.Meta = {
   author: 'DXOS',
   description: trim`
     Visual project management using customizable kanban boards to track workflow progress.
-    Organize table data into columns, drag and drop items between stages, and trigger automations based on status changes.
+    Organize any ECHO type into drag-and-drop columns defined by a single-select field, move cards
+    between stages, and reorder both columns and cards — all changes are persisted to ECHO and
+    replicated to collaborators in real time.
+
+    Kanban boards come in two variants: view-variant boards source their cards through a linked
+    View query (any ECHO type can be pivoted on a single-select field), while items-variant boards
+    own their cards explicitly and are used by external sync integrations such as Linear or GitHub.
+    Both variants share the same arrangement storage and drag-and-drop mechanics.
+
+    Board settings let users choose which single-select field drives the column layout and
+    optionally hide the uncategorized column for items that have no pivot value.
+    Field-level undo support allows deleted card fields to be restored without data loss.
+
+    The plugin contributes a Kanban blueprint that exposes board creation and card management
+    to AI agents, enabling automated project tracking workflows.
   `,
   icon: 'ph--kanban--regular',
   iconHue: 'green',
   source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-kanban',
+  spec: 'PLUGIN.mdl',
   screenshots: ['https://dxos.network/plugin-details-kanban-dark.png'],
 };

--- a/packages/plugins/plugin-navtree/PLUGIN.mdl
+++ b/packages/plugins/plugin-navtree/PLUGIN.mdl
@@ -1,0 +1,376 @@
+---
+id: org.dxos.plugin.navtree
+name: NavTreePlugin
+version: 0.1.0
+---
+
+Hierarchical navigation sidebar for `DXOS` Composer — renders the application graph as a collapsible tree, manages workspace tabs, exposes keyboard-driven command search, and handles drag-and-drop rearrangement of spaces, folders, and objects.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`       |
+| `feat`      | `org.dxos.mdl.feat@1.0`       |
+| `test`      | `org.dxos.mdl.test@1.0`       |
+| `component` | `org.dxos.mdl.component@1.0`  |
+| `op`        | `org.dxos.mdl.op@1.0`         |
+
+## Types
+
+```mdl
+type NavTreeItemState
+  fields:
+    open: boolean          # whether the tree node is expanded
+    current: boolean       # whether the node is in the active layout
+```
+
+```mdl
+type KeyBinding
+  fields:
+    macos?: string
+    windows?: string
+    linux?: string
+    ios?: string
+    unknown?: string
+```
+
+```mdl
+type NodeProperties
+  fields:
+    label: Label
+    icon?: string
+    iconHue?: string
+    role?: string
+    error?: string
+    modified?: boolean
+    palette?: string
+    disabled?: boolean
+    testId?: string
+    position?: Position
+    className?: string
+    keyBinding?: string | KeyBinding
+    persistenceClass?: string
+    persistenceKey?: string
+```
+
+## Components
+
+```mdl
+component NavTree
+  desc: Root navigation tree that renders workspace tabs at the top level and a collapsible subtree for the active workspace.
+  props:
+    id: string             # root node id (Node.RootId)
+    root: Node             # root of the application graph
+    tab: string            # currently active workspace tab id
+    open: boolean          # whether the navigation sidebar is open
+  state:
+    model: NavTreeModel    # live tree model built from graph connections
+  slots:
+    itemEnd?: ReactNode    # per-item trailing content (e.g. action badges)
+  actions:
+    openChange(item: Node, path: string[], open: boolean)
+    tabChange(node: Node)
+    select(item: Node, path: string[], option: boolean)
+    back()
+    itemHover(item: Node)
+  layout: |
+    ┌─────────────────────────┐
+    │ workspace tabs          │
+    │  [tab] [tab] [tab]      │
+    ├─────────────────────────┤
+    │ collapsible tree        │
+    │  ▾ Space                │
+    │    ▾ Folder             │
+    │      • Object           │
+    │      • Object           │
+    │    • Object             │
+    └─────────────────────────┘
+```
+
+```mdl
+component NavTreeContainer
+  desc: Smart container that wires the NavTree to the app graph, layout state, and drag-and-drop monitor.
+  props:
+    tab: string
+    popoverAnchorId?: string
+  state:
+    layout: LayoutState    # active items, sidebar open/closed, mode
+    model: NavTreeModel
+  actions:
+    handleSelect(item: Node, path: string[], option: boolean)
+    handleOpenChange(item: Node, path: string[], open: boolean)
+    handleTabChange(node: Node)
+    handleBack()
+    handleDrop(source: TreeData, target: TreeData, instruction: Instruction)
+  emits:
+    onNavigate(subject: string | string[])
+  layout: |
+    ┌──────────────────────────┐
+    │ NavTreeContext.Provider  │
+    │  └─ NavTree              │
+    └──────────────────────────┘
+```
+
+```mdl
+component CommandsDialogContent
+  desc: Full-screen command palette dialog — surfaces all graph actions, searchable by label.
+  props:
+    onClose?: () => void
+  state:
+    query: string
+    results: Node[]
+  actions:
+    search(query: string) → Node[]
+    execute(node: Node)
+  layout: |
+    ┌──────────────────────────┐
+    │ [search input]           │
+    ├──────────────────────────┤
+    │ result list              │
+    │  icon  label  shortcut   │
+    │  icon  label             │
+    │  …                       │
+    └──────────────────────────┘
+```
+
+```mdl
+component CommandsTrigger
+  desc: Search-input surface slot component — opens the commands dialog on click or ⌘K / Ctrl+K.
+  slots:
+    (none)
+  actions:
+    openCommandsDialog()
+```
+
+## Operations
+
+```mdl
+op expose
+  desc: Expands tree nodes along the path to a subject and marks each as open so the item becomes visible in the NavTree.
+  input:
+    subject: string        # attendable DXN or node id
+  output: void
+  effects: [echo:read]
+  note: |
+    Resolves the full ancestor path via expandAttendableId, calls Graph.expand per node,
+    then sets each path segment open in NavTreeCapabilities.State.
+```
+
+## Features
+
+```mdl
+feat F-1: Sidebar Navigation
+
+  req F-1.1: NavTree renders all root-level graph connections as workspace tabs.
+  req F-1.2:
+    when: user selects a workspace tab
+    then: LayoutOperation.SwitchWorkspace is invoked; subtree for that workspace is expanded
+  req F-1.3:
+    when: sidebar is closed and user selects a workspace tab
+    then: sidebar opens (state transitions to expanded)
+  req F-1.4:
+    when: same active tab is clicked while sidebar is expanded
+    then: sidebar collapses (state transitions to collapsed or closed on mobile)
+```
+
+```mdl
+feat F-2: Tree Expand / Collapse
+
+  req F-2.1: Tree items with children show an expand/collapse toggle.
+  req F-2.2:
+    when: user expands a node
+    then: open state persisted to localStorage keyed by path; Graph.expand called for the node
+  req F-2.3:
+    when: plugin initialises after layout is ready
+    then: all paths previously marked open are re-expanded from localStorage
+  req F-2.4:
+    when: op:expose is called
+    then: all ancestors of the subject are expanded and marked open
+```
+
+```mdl
+feat F-3: Item Selection
+
+  req F-3.1:
+    when: user selects a non-current item
+    then: LayoutOperation.Open (single mode) or LayoutOperation.Set (multi mode) is invoked
+  req F-3.2:
+    when: user option-clicks a currently active item
+    then: LayoutOperation.Close is invoked for that item
+  req F-3.3:
+    when: user clicks a currently active item without option key
+    then: LayoutOperation.ScrollIntoView is invoked
+  req F-3.4:
+    when: item has a default disposition action
+    then: that action is run after navigation
+  req F-3.5:
+    when: navigation succeeds on mobile
+    then: sidebar is closed automatically
+```
+
+```mdl
+feat F-4: Drag and Drop
+
+  req F-4.1: NavTree items can be dragged to rearrange within the same parent.
+  req F-4.2: NavTree items can be dragged to copy or transfer to a different parent.
+  req F-4.3:
+    when: drop instruction is rearrange
+    then: onRearrange callback on the parent node is called with the new order
+  req F-4.4:
+    when: drop instruction is copy
+    then: onCopy callback on the target node is called
+  req F-4.5:
+    when: drop instruction is transfer
+    then: onTransferStart and onTransferEnd callbacks are called on source and target parents
+  req F-4.6:
+    when: target node reports blockInstruction for an instruction type
+    then: that instruction is blocked and the drop is not applied
+```
+
+```mdl
+feat F-5: Keyboard Shortcuts
+
+  req F-5.1: NavTree plugin registers keyboard shortcuts for all graph actions that declare a keyBinding property.
+  req F-5.2: Graph is traversed on change (debounced 500 ms) to bind newly added shortcuts.
+  req F-5.3: The commands dialog is opened via ⌘K (macOS) / Ctrl+K (Windows/Linux).
+  req F-5.4:
+    when: plugin deactivates
+    then: Keyboard.singleton is destroyed and all shortcuts are unregistered
+```
+
+```mdl
+feat F-6: State Persistence
+
+  req F-6.1: Per-path open/current state is stored in an atom family keyed by path string.
+  req F-6.2: Open state (not current) is persisted to localStorage on every change.
+  req F-6.3: Current state reflects active layout items and is never persisted.
+  req F-6.4:
+    when: layout.active changes
+    then: removed items are marked not-current; newly active items are marked current
+```
+
+## Acceptance
+
+```mdl
+test T-1: Workspace tab switch
+  given: two workspace tabs exist in the graph
+  when: user clicks the second workspace tab
+  then:
+    - LayoutOperation.SwitchWorkspace is invoked with the tab's node id
+    - sidebar transitions to expanded
+    - subtree for the selected workspace is expanded
+```
+
+```mdl
+test T-2: Tree node expand persists
+  given: NavTree is rendered with a collapsed folder node
+  when: user expands the folder
+  then:
+    - folder node state.open === true
+    - localStorage entry updated for the folder's path
+    - Graph.expand called for the folder node id
+```
+
+```mdl
+test T-3: Expose navigates to nested item
+  given: a deeply nested object id is active in the layout
+  when: op:expose is called with that object id
+  then:
+    - all ancestor paths are marked open
+    - Graph.expand is called for each ancestor
+```
+
+```mdl
+test T-4: Select item in single mode
+  given: layout.mode === single, item not currently active
+  when: user selects a tree item
+  then: LayoutOperation.Open is invoked with the item id
+```
+
+```mdl
+test T-5: Command palette opens on keyboard shortcut
+  given: NavTree is active
+  when: user presses ⌘K (macOS) or Ctrl+K (Windows)
+  then:
+    - CommandsDialogContent is shown in the layout dialog slot
+    - search input is focused
+```
+
+```mdl
+test T-6: Drag-and-drop rearrange
+  given: two sibling items in the same folder
+  when: user drags the first item below the second
+  then:
+    - onRearrange callback is called with the reordered array
+    - tree re-renders with the new order
+```
+
+---
+
+## Appendix: Extension Definitions
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap
+    literals?: UnionList
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap
+    state?: FieldMap
+    slots?: FieldMap
+    actions?: ActionMap
+    emits?: EventMap
+    layout?: CodeBlock
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap
+    output?: TypeExpr
+    errors?: ErrorMap
+    effects?: EffectList
+    requires?: ServiceList
+    note?: Prose
+```

--- a/packages/plugins/plugin-navtree/src/meta.ts
+++ b/packages/plugins/plugin-navtree/src/meta.ts
@@ -9,9 +9,21 @@ export const meta: Plugin.Meta = {
   id: 'org.dxos.plugin.navtree',
   name: 'Navtree',
   author: 'DXOS',
+  spec: 'PLUGIN.mdl',
   description: trim`
-    Hierarchical navigation tree for browsing spaces, folders, and objects.
-    Provides sidebar navigation with collapsible sections and quick access to workspace content.
+    NavTreePlugin renders the application graph as a collapsible hierarchical tree in the Composer sidebar.
+    It manages workspace tabs at the root level and provides expand/collapse navigation for spaces, folders,
+    and objects, with open/current state persisted to localStorage across sessions.
+
+    The plugin wires drag-and-drop rearrangement and cross-parent transfer of tree items via Pragmatic DnD,
+    and registers graph-action keyboard shortcuts (including the ⌘K / Ctrl+K command palette) through a
+    global Keyboard singleton that tracks context as the user navigates.
+
+    An operation handler for LayoutOperation.Expose expands ancestor paths on demand so that any
+    programmatically activated item is scrolled into view in the tree.
+
+    A commands dialog surfaces all discoverable graph actions as a searchable palette, making it the primary
+    keyboard-first entry point for power users.
   `,
   tags: ['system'],
 };


### PR DESCRIPTION
## Summary

### plugin-navtree
- Add `PLUGIN.mdl` spec covering types, components, operations, features, and acceptance tests  
- Expand `meta.ts` description to 4 paragraphs (tree rendering, drag-and-drop, Expose operation, command palette)
- Add `spec: 'PLUGIN.mdl'` reference

### plugin-kanban
- Add `PLUGIN.mdl` spec with types (KanbanSpec, Kanban, etc.), components (KanbanArticle, KanbanSettings), operations, features (board layout, drag-and-drop, card management, ECHO persistence, AI blueprint), and acceptance tests
- Expand `meta.ts` description to 4 paragraphs
- Add `spec: 'PLUGIN.mdl'` reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)