### PR TITLE
docs: expand meta.ts descriptions for thread, feed, gallery, sequencer

### DIFF
--- a/packages/plugins/plugin-feed/src/meta.ts
+++ b/packages/plugins/plugin-feed/src/meta.ts
@@ -10,7 +10,35 @@ export const meta: Plugin.Meta = {
   name: 'Feed',
   author: 'DXOS',
   description: trim`
-    Manage and display RSS and open protocol feed subscriptions.
+    FeedPlugin brings syndicated content into DXOS Composer by syncing RSS feeds
+    and ATproto (Bluesky) feeds as ECHO objects stored in the user's space.
+    Subscribed feeds are polled incrementally using a cursor so only new posts
+    are fetched on each sync, and feed metadata (name, icon, description) is
+    persisted alongside the posts for offline access.
+
+    Magazines are agent-curated collections drawn from one or more feeds. The
+    user writes a natural-language brief describing what the Magazine should
+    gather; pressing the Curate button triggers a deterministic sync of all
+    referenced feeds followed by a curation pass that derives a short snippet
+    and hero image from each post's description and appends matching posts to
+    the collection. A Masonry grid renders the curated tiles with images, titles,
+    author metadata, and read-state dimming.
+
+    A parallel agent path lets a conversational assistant curate a Magazine with
+    higher fidelity. The MagazineBlueprint exposes three fine-grained tools —
+    ListCandidatePosts, FetchArticleContent, and AddPostToMagazine — that the
+    agent calls in sequence, reading the full article body and selecting the best
+    hero image before committing a post to the collection. The deterministic
+    button path and the agent path coexist: the button gives an immediate result
+    without requiring an LLM, while the agent path delivers instruction-driven
+    selection when a chat session is active.
+
+    Clicking a tile opens the PostArticle detail surface via the deck's layout
+    dispatch, routing to the appropriate location (complementary drawer, sibling
+    plank, or deck companion) based on the current layout mode. The schema also
+    scaffolds a future tagging feature — posts carry an optional tags array and
+    the tile renders a tag row when tags are present — enabling navigation and
+    feed-discovery flows in a later revision.
   `,
   icon: 'ph--rss--regular',
   iconHue: 'orange',

--- a/packages/plugins/plugin-gallery/src/meta.ts
+++ b/packages/plugins/plugin-gallery/src/meta.ts
@@ -10,8 +10,30 @@ export const meta: Plugin.Meta = {
   name: 'Gallery',
   author: 'DXOS',
   description: trim`
-    A simple image gallery. Drop in images and browse them in a masonry grid;
-    present in fullscreen.
+    GalleryPlugin is a lightweight image gallery for DXOS Composer. A Gallery is
+    an ECHO object that stores an ordered array of images, where each image
+    carries a URL (either an external https:// address or a wnfs:// URL backed by
+    the WNFS file-uploader plugin), an optional MIME type, file name, caption,
+    and pixel dimensions. Galleries are first-class workspace objects and appear
+    in the navtree alongside documents and other content types.
+
+    Adding images is handled through the toolbar's Add button, which opens a file
+    picker restricted to image MIME types. Selected files are uploaded via the
+    registered FileUploader capability (WNFS) and the resulting URL is appended
+    to the gallery. The Add button is automatically disabled when no FileUploader
+    capability is present, so the plugin degrades gracefully in environments
+    without file-storage support.
+
+    Images are displayed as cards in a responsive Masonry grid. Each card renders
+    the image as a poster with a delete affordance that removes the image from the
+    gallery on confirmation. A fullscreen Show mode fills the viewport with the
+    masonry layout via plugin-deck's solo--fullscreen adjustment, opening the
+    GalleryShow companion surface for distraction-free presentation.
+
+    The plugin also exposes a describeImage operation that generates a textual
+    description for any image and writes it to the image's description field,
+    providing a foundation for AI-assisted alt-text and caption generation as
+    the platform's image-to-text capabilities mature.
   `,
   icon: 'ph--images--regular',
   iconHue: 'rose',

--- a/packages/plugins/plugin-sequencer/src/meta.ts
+++ b/packages/plugins/plugin-sequencer/src/meta.ts
@@ -10,9 +10,34 @@ export const meta: Plugin.Meta = {
   name: 'Sequencer',
   author: 'DXOS',
   description: trim`
-    Music sequencer / step-grid editor. A Score owns a set of tracks and per-track
-    Sequence objects whose Notes are edited on a 2D piano-roll style grid (pitch
-    on the y-axis, time on the x-axis).
+    SequencerPlugin is a collaborative music step-grid editor embedded in DXOS
+    Composer. A Score is a first-class ECHO object that owns a roster of tracks
+    and a collection of Sequence objects. Each Sequence holds an array of Notes
+    with MIDI pitch (0–127), start time and duration in beats, velocity, and an
+    opaque data bag for per-note metadata added by patches or extensions. Scores
+    also carry tempo (BPM), time signature, and display name so they integrate
+    naturally with the workspace navtree.
+
+    The editing surface is a 2D piano-roll grid rendered by the canvas-based
+    CellGrid component from @dxos/react-ui-canvas. Pitch runs on the y-axis
+    (high pitches at the top, matching standard piano-roll convention) and time
+    runs on the x-axis at a configurable beats-per-cell resolution (default
+    16th notes). Clicking an empty cell adds a note; clicking a filled cell
+    removes it; dragging paints notes across multiple cells in a single gesture.
+    Pitch labels and the beat ruler stay frozen during scroll and zoom so
+    orientation is always clear.
+
+    The TrackList panel on the left lets users add and remove tracks, toggle
+    mute per track, and select which track's sequence is shown in the grid.
+    Removing a track cascades to delete all sequences that reference it.
+    Selecting a track that has no sequence yet automatically creates an empty
+    one, so the grid is always ready to edit.
+
+    Playback advances a visual playhead across the active sequence at the
+    score's tempo and loops at the end of the sequence length. The play/stop
+    controls live in the ScoreArticle toolbar alongside the tempo control.
+    Phase 2 of the roadmap adds sequence arrangement, a sound engine for
+    audible playback, and richer sequence editing workflows.
   `,
   icon: 'ph--music-notes--regular',
   iconHue: 'fuchsia',

--- a/packages/plugins/plugin-thread/src/meta.ts
+++ b/packages/plugins/plugin-thread/src/meta.ts
@@ -10,12 +10,37 @@ export const meta: Plugin.Meta = {
   name: 'Threads',
   author: 'DXOS',
   description: trim`
-    Multi-modal communication platform supporting text chat, voice, and video conferencing.
-    Create threaded conversations and add contextual comments directly on any workspace object.
+    ThreadPlugin renders comment threads anchored to ECHO objects and provides a
+    persistent chat channel attached to every workspace. Threads can be created
+    inline on any Markdown document, letting collaborators leave contextual
+    comments and hold focused discussions without leaving the document surface.
+
+    Each thread carries an optional AI agent configuration that controls how the
+    built-in assistant participates in the conversation. Threads can be set to
+    off, mention-only (the agent responds only when @-mentioned by name), or
+    auto mode (the agent replies to every new user message). The agent identity —
+    display name, DID, and avatar — is resolved at runtime from a pluggable
+    Effect capability so host applications can substitute their own assistant
+    persona.
+
+    When the agent is enabled, it executes one LLM turn per trigger via the
+    AgentRunner capability. The runner has access to edit tools that can splice
+    a replacement range into the anchored document span or replace the entire
+    document content, so the assistant can propose inline edits in addition to
+    posting chat replies. A self-loop guard prevents the agent from responding
+    to its own messages, and resolved threads are excluded from triggering.
+
+    The toggle UI appears as a per-thread icon button in the CommentsPanel
+    header. Clicking it opens a popover with three radio options (off / mention /
+    auto) and a read-only label showing the active agent name. All state changes
+    go through the SetAgentConfig operation rather than direct schema writes,
+    keeping mutation logic in one place and making the feature testable with
+    stub runners in storybook.
   `,
   icon: 'ph--video-conference--regular',
   iconHue: 'rose',
   source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-thread',
+  spec: 'PLUGIN.mdl',
 };
 
 export const THREAD_ITEM = `${meta.id}.item`;


### PR DESCRIPTION
## Summary

- **plugin-thread**: Expanded from 2-line placeholder to 4 paragraphs covering comment threads anchored to ECHO objects, per-thread AI agent configuration (off/mention/auto modes), AgentRunner capability with inline document edit tools, and the toggle UI in CommentsPanel. Added missing `spec: 'PLUGIN.mdl'`.
- **plugin-feed**: Expanded from 1-line description to 4 paragraphs covering RSS/ATproto feed sync, Magazine collections with Masonry grid, the dual curation paths (deterministic button vs. agent blueprint with ListCandidatePosts/FetchArticleContent/AddPostToMagazine tools), and the master-detail PostArticle layout dispatch.
- **plugin-gallery**: Expanded from 2-line description to 4 paragraphs covering the Gallery ECHO type, WNFS-backed image upload with graceful degradation, Masonry grid with delete affordance, fullscreen Show mode, and the describeImage operation.
- **plugin-sequencer**: Expanded from 3-line description to 4 paragraphs covering the Score/Track/Sequence/Note ECHO type hierarchy, the piano-roll CellGrid editor, TrackList management with cascade delete, and playback with looping playhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)