### PR TITLE
docs: expand meta.ts descriptions for crm, calls, support, tictactoe

### DIFF
--- a/packages/plugins/plugin-calls/src/meta.ts
+++ b/packages/plugins/plugin-calls/src/meta.ts
@@ -10,8 +10,34 @@ export const meta: Plugin.Meta = {
   name: 'Calls',
   author: 'DXOS',
   description: trim`
-    Video and audio conferencing. Attach a call to any object via its DXN —
-    persistent meeting records, transcripts and summaries are owned by plugin-meeting.
+    Calls adds WebRTC video and audio conferencing to Composer. A call room is
+    derived from the DXN of any host object — typically a Channel — so starting
+    a call requires no extra setup beyond the object that already exists in your
+    space. The live call surface (participant grid, media controls, lobby) runs
+    as a deck companion alongside the chat view so chat and video are
+    independently scrollable and neither displaces the other.
+
+    The plugin owns a CallManager capability that manages the WebRTC session for
+    the lifetime of the client: joining a room, publishing local audio, video,
+    and screenshare tracks to the Cloudflare Calls SFU, pulling remote tracks,
+    and maintaining per-participant state (speaking detection, hand raise, pin).
+    Peer discovery and track negotiation happen over DXOS swarm signalling so
+    calls work without any additional signalling infrastructure.
+
+    A pluggable Extension capability lets other plugins react to call lifecycle
+    events (join, leave, media state changes) without being coupled to
+    plugin-calls. plugin-meeting and plugin-transcription use this contract to
+    start recording and transcription when a call begins and persist the
+    artefacts when it ends. A display-name gate prevents users without a profile
+    from joining; the Lobby component prompts for a name and resumes the join
+    flow automatically on save.
+
+    plugin-calls is fully independent of plugin-thread at runtime: the "Start
+    video call" action is contributed to Channel articles via a graph
+    type-extension, so plugin-thread renders chat-only without error when
+    plugin-calls is absent. The devtools surface exposes live CallState,
+    MediaState, and raw WebRTC stats from @peermetrics/webrtc-stats for
+    diagnostic use.
   `,
   icon: 'ph--video-conference--regular',
   iconHue: 'cyan',

--- a/packages/plugins/plugin-crm/src/meta.ts
+++ b/packages/plugins/plugin-crm/src/meta.ts
@@ -10,8 +10,35 @@ export const meta: Plugin.Meta = {
   name: 'CRM',
   author: 'DXOS',
   description: trim`
-    Contribute a CRM blueprint for researching people and organizations and
-    producing structured Profile documents in your space.
+    CRM adds a blueprint that drives the AI assistant to research people and
+    organizations and produce structured Profile documents stored in your
+    local-first ECHO space. Given a Person, Organization, or email Message as
+    input, the blueprint locates or creates the corresponding ECHO objects,
+    performs web research, and composes a markdown Profile following an editable
+    section template (Overview, Background, Current Role, Organization, Key
+    Links, Notes, Sources).
+
+    The plugin is a thin composition layer: heavy lifting such as web search,
+    document creation, and ECHO database CRUD is delegated to existing
+    blueprints from @dxos/assistant-toolkit (research, web-search, database,
+    markdown). plugin-crm contributes CRM-specific instructions, a ProfileOf
+    ECHO relation that links a Profile document to its subject, a best-effort
+    image-attachment operation that uploads avatars and company logos to the
+    DXOS image service, and a pluggable ResearchSource contract for future
+    extensions.
+
+    Person and Organization records are deduplicated by email address and domain
+    before creation, and a free-mail heuristic prevents personal-email senders
+    (gmail, outlook, icloud, etc.) from being incorrectly attributed to consumer
+    providers. A pure extractContactFromMessage utility parses email signatures
+    into structured ContactExtract output, making contact extraction
+    regression-testable independently of the LLM loop.
+
+    v1 is a library-layer plugin with no UI surfaces. All customisation is done
+    through the blueprint editor: the section template and research instructions
+    are editable prose, and additional research sources (such as a planned
+    LinkedIn integration via the browser extension) register themselves via the
+    ResearchSource contract without modifying the core blueprint.
   `,
   icon: 'ph--address-book--regular',
   iconHue: 'emerald',

--- a/packages/plugins/plugin-support/src/meta.ts
+++ b/packages/plugins/plugin-support/src/meta.ts
@@ -10,9 +10,36 @@ export const meta: Plugin.Meta = {
   name: 'Support',
   author: 'DXOS',
   description: trim`
-    User assistance for Composer: welcome tour, shortcuts, one-shot feedback, and an AI
-    support assistant that can search documentation and capture conversations as
-    local-first ECHO tickets.
+    Support provides three user-assistance paths inside Composer. The
+    conversational path lets users open a Ticket from the navtree and work with
+    the AI assistant to diagnose problems: the assistant searches documentation,
+    proposes solutions, and marks the ticket in-progress or resolved. Tickets
+    are local-first ECHO objects, so the conversation history is replicated
+    across devices and can be reviewed by a human supporter later.
+
+    The one-shot feedback path surfaces a help companion in the deck that lets
+    users send anonymous feedback to the observability backend with a single
+    form submission. The feedback form captures issue type (bug or feature),
+    severity, a short title, a longer description, and an optional plugin area.
+    When the user has authenticated a GitHub integration the issue is filed via
+    the GitHub API; otherwise a prefilled issues/new URL is opened in a new tab
+    so the user can complete submission in their own browser session. Debug logs
+    can be attached to any submission via the LogDownloader capability.
+
+    The support blueprint registers the createTicket, markInProgress,
+    resolveTicket, and searchDocs operations as AI tools. When a Ticket is the
+    active object the blueprint is bound to the chat companion so the assistant
+    can manage the ticket lifecycle without leaving the conversation. The
+    searchDocs operation starts with an in-memory stub and is designed to be
+    replaced by a vector index or remote search endpoint without changing the
+    schema.
+
+    A future iteration will absorb plugin-help (welcome tour, contextual hints,
+    keyboard shortcuts) so all user education lives in a single plugin. The
+    initial scope is a Ticket schema, four ticket operations, a FeedbackForm
+    component, and two surfaces (Ticket article and the --help companion),
+    exercisable end-to-end while documentation search and issue filing
+    integrations land in later phases.
   `,
   icon: 'ph--lifebuoy--regular',
   iconHue: 'rose',

--- a/packages/plugins/plugin-tictactoe/src/meta.ts
+++ b/packages/plugins/plugin-tictactoe/src/meta.ts
@@ -11,8 +11,31 @@ export const meta: Plugin.Meta = {
   name: 'Tic-Tac-Toe',
   author: 'DXOS',
   description: trim`
-    Configurable Tic-Tac-Toe game supporting multiplayer matches and AI opponents
-    with adjustable board sizes and win conditions.
+    Tic-Tac-Toe adds a fully-featured strategy game to Composer. Games are
+    stored as ECHO objects so they replicate in real time across every peer in a
+    shared space — two players can join the same game as X and O from separate
+    devices and see each other's moves with placement animations as they happen.
+    Each move is appended to a semicolon-separated move log, giving a complete
+    audit trail of the match.
+
+    The board is configurable at creation time: dimensions can be 3x3, 4x4, or
+    5x5, and the win condition (consecutive marks required) can be set
+    independently of the board size for a more strategic experience on larger
+    grids. When a winning line is completed the cells are highlighted with a
+    pulse animation; draws are detected automatically when the board fills
+    without a winner.
+
+    A built-in AI engine supports three difficulty levels. Easy plays random
+    valid moves. Medium uses a heuristic that prefers winning, then blocking,
+    then the centre cell. Hard uses minimax with alpha-beta pruning and plays
+    optimally on a 3x3 board. The AI thinking state is shown in the UI during
+    computation so the turn transition feels intentional rather than instant.
+
+    The assistant can also participate via blueprint integration: the create,
+    makeMove, aiMove, and print operations are exposed as tools so the assistant
+    can start a game, analyse the board as ASCII art, play moves, or act as an
+    AI opponent in a conversation. The TicTacToeCard component provides a
+    compact view suitable for embedding in dashboards or space overview panels.
   `,
   icon: 'ph--hash-straight--regular',
   iconHue: 'cyan',


### PR DESCRIPTION
## Summary

- Expanded `meta.ts` description for `plugin-crm` to 4 paragraphs covering blueprint composition, ProfileOf relation, email-signature extraction, and the v1 library-only scope
- Expanded `meta.ts` description for `plugin-calls` to 4 paragraphs covering WebRTC architecture, CallManager capability, pluggable Extension lifecycle, and independence from plugin-thread
- Expanded `meta.ts` description for `plugin-support` to 4 paragraphs covering conversational tickets, one-shot feedback + GitHub issue filing, support blueprint tools, and planned scope
- Expanded `meta.ts` description for `plugin-tictactoe` to 4 paragraphs covering ECHO multiplayer, configurable board, AI difficulty levels, and blueprint integration

All descriptions derived from the existing `PLUGIN.mdl` spec file in each package. `spec: 'PLUGIN.mdl'` field was already present in all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)