### PR TITLE
docs(plugin-game): add PLUGIN.mdl spec and expand description

### DIFF
--- a/packages/plugins/plugin-game/PLUGIN.mdl
+++ b/packages/plugins/plugin-game/PLUGIN.mdl
@@ -1,0 +1,334 @@
+---
+id: org.dxos.plugin.game
+name: GamePlugin
+version: 0.1.0
+---
+
+A generic game host plugin for `DXOS` Composer that provides shared infrastructure for
+multi-player, local-first turn-based games. Variant plugins (e.g. plugin-chess,
+plugin-tictactoe) contribute a `GameVariant` capability and game-specific surfaces;
+plugin-game supplies the `Game` ECHO type, create flow, and dispatch scaffolding.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`       |
+| `feat`      | `org.dxos.mdl.feat@1.0`       |
+| `test`      | `org.dxos.mdl.test@1.0`       |
+| `component` | `org.dxos.mdl.component@1.0`  |
+| `op`        | `org.dxos.mdl.op@1.0`         |
+
+## Types
+
+```mdl
+type Player
+  fields:
+    role: string          # variant-defined (e.g. "white", "x"); required
+    identity?: string     # DID of a human player; absent for AI / empty seats
+    name?: string         # display label for AI or guest players
+```
+
+```mdl
+type Game
+  fields:
+    name?: string
+    players?: Player[]    # populated during or after creation
+    variant: Ref<Unknown> # reference to variant-specific state object (e.g. Chess.State)
+  typename: org.dxos.type.game
+  version: 0.1.0
+```
+
+```mdl
+type GameVariant
+  desc: |
+    Contribution interface from a variant plugin. Registered via
+    `Capability.contributes(GameCapabilities.Variant, variant)`.
+  fields:
+    id: string                  # stable variant id; matches the variant state typename
+    label: string               # human-readable name shown in the picker
+    icon?: string               # Phosphor icon name
+    variantSchema: Schema       # Effect/Schema for the ECHO state object
+    inputSchema?: Schema        # optional form schema shown after variant is selected
+    roles: string[]             # player roles (e.g. ["white", "black"])
+    createVariant: Effect       # factory that builds the variant ECHO state object
+    card?: ComponentType        # optional Card surface component
+    article?: ComponentType     # optional Article/Section surface component
+```
+
+## Components
+
+```mdl
+component CreateGamePanel
+  desc: |
+    Two-stage creation panel. Stage 1 shows a searchable variant picker.
+    Stage 2 (optional) shows a form rendered from the variant's inputSchema.
+  props:
+    target: Space | Obj
+    onCreateObject: (args: { variantId: string; input?: Record }) => void
+    variants?: GameVariant[]    # override; defaults to GameCapabilities.Variant
+  state:
+    selectedId?: string         # id of the variant chosen in stage 1
+  actions:
+    selectVariant(id: string)
+    submitForm(input: Record)
+  layout: |
+    ┌─────────────────────────┐
+    │ Stage 1: Variant Picker │
+    │  ┌───────────────────┐  │
+    │  │ Search input      │  │
+    │  ├───────────────────┤  │
+    │  │ variant row       │  │
+    │  │ variant row       │  │
+    │  └───────────────────┘  │
+    ├─────────────────────────┤
+    │ Stage 2: Input Form     │
+    │  (rendered from schema) │
+    │  [Submit]               │
+    └─────────────────────────┘
+```
+
+```mdl
+component GameArticle
+  desc: |
+    Article / Section surface for Game objects. Resolves the variant via
+    `game.variant` ref, finds the matching `GameVariant` by typename, and
+    delegates rendering to `variant.article`.
+  props:
+    game: Game
+    role?: string
+    attendableId?: string
+  state:
+    variant: Unknown            # live variant state object from the Ref
+    match?: GameVariant         # resolved GameVariant from capabilities
+  layout: |
+    ┌─────────────────────────┐
+    │ [variant.article]       │
+    │  (fallback: unsupported │
+    │   variant message)      │
+    └─────────────────────────┘
+```
+
+```mdl
+component GameCard
+  desc: |
+    Card surface for Game objects. Follows the same variant-resolution
+    logic as GameArticle and delegates to `variant.card`.
+  props:
+    game: Game
+    role?: string
+  state:
+    variant: Unknown
+    match?: GameVariant
+```
+
+## Operations
+
+```mdl
+op createGame
+  desc: |
+    Creates a variant state object via `variant.createVariant`, adds it
+    to the space as a hidden object, then wraps it in a top-level Game.
+    If the second write fails the variant state object is rolled back.
+  input:
+    variantId: string
+    input?: Record              # variant-specific form values
+    target: Space | Obj
+    targetNodeId?: string
+  output: Game
+  errors:
+    UnknownVariant: no registered GameVariant matches variantId
+  effects: [echo:write]
+  requires: [GameCapabilities.Variant, SpaceOperation.AddObject, SpaceOperation.RemoveObjects]
+  note: |
+    Invoked by CreateObjectEntry.createObject.
+    Variant state is added with `hidden: true` so it does not appear
+    as a top-level item in the user's space graph.
+```
+
+## Features
+
+```mdl
+feat F-1: Variant Registration
+
+  req F-1.1:
+    when: a variant plugin loads
+    then: it contributes a GameVariant via `Capability.contributes(GameCapabilities.Variant, …)`
+
+  req F-1.2:
+    when: GameCapabilities.Variant contributions are queried
+    then: all registered variants are returned as an ordered list
+```
+
+```mdl
+feat F-2: Game Creation
+
+  req F-2.1:
+    when: user opens the create-object flow for type `org.dxos.type.game`
+    then: CreateGamePanel is shown with a searchable list of available variants
+
+  req F-2.2:
+    when: user selects a variant with no inputSchema
+    then: op:createGame is invoked immediately with empty input
+
+  req F-2.3:
+    when: user selects a variant that has an inputSchema
+    then: a form rendered from the schema is shown; op:createGame is invoked on submit
+
+  req F-2.4:
+    when: op:createGame completes
+    then: a Game object appears in the space graph; variant state is hidden
+```
+
+```mdl
+feat F-3: Game Article / Card Rendering
+
+  req F-3.1:
+    when: Composer navigates to a Game object
+    then: GameArticle resolves `game.variant` and delegates to the matching `variant.article`
+
+  req F-3.2:
+    when: a Game object is shown in a Card layout
+    then: GameCard resolves `game.variant` and delegates to `variant.card`
+
+  req F-3.3:
+    when: no matching variant is found for the loaded state object
+    then: GameArticle renders an "Unsupported game variant" fallback message
+
+  req F-3.4:
+    when: the variant ref is not yet loaded
+    then: neither GameArticle nor GameCard renders (returns null)
+```
+
+## Acceptance
+
+```mdl
+test T-1: Variant picker shows all contributions
+  given: two variant plugins have contributed GameVariants
+  when: the user opens the create-game panel
+  then:
+    - CreateGamePanel lists both variants
+    - variants are sorted alphabetically
+```
+
+```mdl
+test T-2: Create game without form
+  given: a variant with no inputSchema is selected
+  when: user clicks the variant item
+  then:
+    - onCreateObject is called immediately with { variantId }
+    - no form is shown
+```
+
+```mdl
+test T-3: Create game with form
+  given: a variant with an inputSchema is selected
+  when: user fills and submits the form
+  then:
+    - onCreateObject is called with { variantId, input: <form values> }
+```
+
+```mdl
+test T-4: Atomic game creation
+  given: a valid variantId and target space
+  when: op:createGame is invoked
+  then:
+    - variant state object added to space (hidden)
+    - Game object added with game.variant pointing to the state object
+    - both writes are visible to other peers via ECHO replication
+```
+
+```mdl
+test T-5: Rollback on second write failure
+  given: variant state is successfully written
+  when: the second write (Game object) fails
+  then:
+    - RemoveObjects is invoked for the variant state
+    - no orphaned state object remains in the space
+```
+
+```mdl
+test T-6: Unknown variant rejected
+  given: op:createGame is invoked with an unregistered variantId
+  when: the handler runs
+  then: UnknownVariant error is returned; no ECHO writes occur
+```
+
+```mdl
+test T-7: Unsupported variant fallback
+  given: a Game whose variant typename has no registered GameVariant
+  when: GameArticle renders
+  then: "Unsupported game variant" message is shown instead of crashing
+```
+
+---
+
+## Appendix: Extension Definitions
+
+Extension block types used in this document are defined below using
+the core `ext` primitive — the only construct the base language provides.
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap        # name[?]: TypeExpr  (# inline comment)
+    literals?: UnionList     # a | b | c
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self              # feat blocks may contain feat blocks
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap            # external inputs (immutable inside component)
+    state?: FieldMap            # internal reactive state
+    slots?: FieldMap            # named ReactNode injection points
+    actions?: ActionMap         # methods the component exposes or handles
+    emits?: EventMap            # events the component raises to its parent
+    layout?: CodeBlock          # ASCII sketch of visual structure (non-normative)
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap            # named input parameters
+    output?: TypeExpr           # return type
+    errors?: ErrorMap           # name: Prose  (when this error occurs)
+    effects?: EffectList        # echo:read | echo:write | http | fs | ...
+    requires?: ServiceList      # injected service dependencies
+    note?: Prose                # implementation guidance (non-normative)
+```

--- a/packages/plugins/plugin-game/src/meta.ts
+++ b/packages/plugins/plugin-game/src/meta.ts
@@ -9,11 +9,24 @@ export const meta: Plugin.Meta = {
   id: 'org.dxos.plugin.game',
   name: 'Game',
   author: 'DXOS',
+  spec: 'PLUGIN.mdl',
   description: trim`
-    Generic game plugin. Provides a base Game type with shared players and a
-    referenced variant state. Variant plugins (chess, tic-tac-toe, etc.) contribute
-    a GameVariant capability that defines their state schema, create form, and
-    surface components.
+    Generic game host plugin that provides shared infrastructure for local-first,
+    multi-player turn-based games inside DXOS Composer. The plugin owns the base
+    \`Game\` ECHO type — which stores players and a reference to variant-specific
+    state — and drives the two-stage game-creation flow (variant picker + optional
+    input form).
+
+    Game variants (chess, tic-tac-toe, and others) are contributed by separate
+    plugins via the \`GameCapabilities.Variant\` capability. Each variant supplies
+    its own state schema, player roles, create factory, and surface components
+    (Article and Card). Plugin-game resolves the correct variant at runtime and
+    delegates rendering, keeping the host layer fully decoupled from game logic.
+
+    Variant state objects are stored as hidden ECHO objects alongside the top-level
+    \`Game\`, ensuring they replicate to all peers but do not appear as independent
+    items in the user's space graph. The entire creation flow is atomic: if the
+    Game write fails, the variant state is rolled back automatically.
   `,
   icon: 'ph--sword--regular',
   iconHue: 'indigo',


### PR DESCRIPTION
## Summary

- Add `PLUGIN.mdl` spec for `plugin-game` documenting the `Game`/`Player`/`GameVariant` types, `CreateGamePanel`/`GameArticle`/`GameCard` components, the `createGame` operation, feature requirements, and acceptance tests.
- Expand `meta.ts` description to 3 paragraphs covering the host/variant architecture, capability-driven dispatch, and atomic ECHO creation flow.
- Add `spec: 'PLUGIN.mdl'` field to `meta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)