### PR TITLE
docs(plugin-native): add PLUGIN.mdl spec and expand description

### DIFF
--- a/packages/plugins/plugin-kanban/PLUGIN.mdl
+++ b/packages/plugins/plugin-kanban/PLUGIN.mdl
@@ -1,0 +1,398 @@
+---
+id: org.dxos.plugin.kanban
+name: KanbanPlugin
+version: 0.1.0
+---
+
+Visual project management plugin for `DXOS` Composer — organise any ECHO type into drag-and-drop columns driven by a single-select field, with full local-first persistence and real-time peer replication.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`        |
+| `feat`      | `org.dxos.mdl.feat@1.0`        |
+| `test`      | `org.dxos.mdl.test@1.0`        |
+| `component` | `org.dxos.mdl.component@1.0`   |
+| `op`        | `org.dxos.mdl.op@1.0`          |
+
+## Types
+
+```mdl
+type ArrangementColumnEntry
+  fields:
+    ids: string[]              # ordered card ids within the column
+    hidden?: boolean           # when true the column is hidden from the board
+```
+
+```mdl
+type Arrangement
+  fields:
+    order: string[]            # ordered column values
+    columns: Map<string, ArrangementColumnEntry>
+```
+
+```mdl
+type KanbanViewSpec
+  fields:
+    kind: "view"               # discriminator — items sourced from a View query
+    view: Ref<View>            # the View whose query drives card membership
+```
+
+```mdl
+type KanbanItemsSpec
+  fields:
+    kind: "items"              # discriminator — kanban owns items explicitly
+    pivotField: string         # property path that drives column membership
+    items: Ref<object>[]       # items owned directly by the kanban
+```
+
+```mdl
+type KanbanSpec
+  desc: Discriminated union of item-source strategies.
+  literals: KanbanViewSpec | KanbanItemsSpec
+```
+
+```mdl
+type Kanban
+  desc: Root ECHO object for a kanban board. Stored with typename org.dxos.type.kanban v0.2.0.
+  fields:
+    name?: string
+    arrangement: Arrangement
+    spec: KanbanSpec           # discriminated by spec.kind
+```
+
+```mdl
+type KanbanSettings
+  fields:
+    hideUncategorized?: boolean  # hides items with no pivot value
+```
+
+```mdl
+type KanbanViewSettings
+  fields:
+    columnFieldId: string        # id of the View field used as pivot column
+    hideUncategorized?: boolean
+```
+
+```mdl
+type CreateKanbanInput
+  fields:
+    name?: string
+    typename?: string            # ECHO typename of card objects
+    initialPivotColumn?: string  # initial single-select field to pivot on
+```
+
+## Components
+
+```mdl
+component KanbanArticle
+  desc: Main article surface for a Kanban. Branches internally on spec.kind — view-variant runs a typename query via the linked View; items-variant dereferences spec.items directly.
+  props:
+    subject: Kanban
+    role: "article" | "section"
+  state:
+    projection: ProjectionModel  # column/field projection derived from View + schema
+    items: AtomQuery             # reactive card query (view-variant) or array (items-variant)
+  actions:
+    addCard(columnValue: string) → string   # returns new card id
+    removeCard(card: object)
+    moveCard(card: object, toColumn: string, toIndex: number)
+    deleteCardField(fieldId: string)
+  layout: |
+    ┌──────────────────────────────────────┐
+    │ [toolbar slot]                        │
+    ├──────────────────────────────────────┤
+    │ Col A       │ Col B       │ Col C    │
+    │ ┌─────────┐ │ ┌─────────┐ │  …       │
+    │ │ card    │ │ │ card    │ │          │
+    │ └─────────┘ │ └─────────┘ │          │
+    │ [+ Add card]│             │          │
+    └──────────────────────────────────────┘
+```
+
+```mdl
+component KanbanSettings
+  desc: Properties panel for a Kanban. View-variant shows a column-field picker plus common settings; items-variant shows only common settings.
+  props:
+    subject: Kanban
+  state:
+    selectFields: { value: string; label: string }[]   # single-select fields available as pivot
+  actions:
+    changeColumnField(fieldId: string)
+    toggleHideUncategorized(hidden: boolean)
+```
+
+## Operations
+
+```mdl
+op deleteCard
+  desc: Removes a card object from the ECHO database.
+  input:
+    card: object               # the card to remove
+  output: DeleteCardOutput     # { card } snapshot of the removed card
+  effects: [echo:write]
+```
+
+```mdl
+op deleteCardField
+  desc: Removes a field projection from the View's schema; returns enough data to undo.
+  input:
+    view: View
+    fieldId: string
+  output: DeleteCardFieldOutput  # { field, props, index }
+  effects: [echo:write]
+  requires: [AtomRegistry, Database]
+```
+
+```mdl
+op restoreCard
+  desc: Undo counterpart to deleteCard — re-adds a previously removed card to the database.
+  input:
+    card: object               # the card snapshot to restore
+  output: void
+  effects: [echo:write]
+```
+
+```mdl
+op restoreCardField
+  desc: Undo counterpart to deleteCardField — re-inserts a field projection at its original index.
+  input:
+    view: View
+    field: FieldSchema
+    props: object              # field properties
+    index: number              # position to restore at
+  output: void
+  effects: [echo:write]
+  requires: [AtomRegistry, Database]
+```
+
+## Features
+
+```mdl
+feat F-1: Board Layout
+
+  req F-1.1: Columns are ordered by Arrangement.order; each column contains its cards in Arrangement.columns[value].ids order.
+  req F-1.2: Cards within a column are rendered in the stored id order.
+  req F-1.3:
+    when: settings.hideUncategorized is true
+    then: the uncategorized column is not rendered
+```
+
+```mdl
+feat F-2: Drag and Drop
+
+  req F-2.1:
+    when: user drags a card to a different column
+    then: card's pivot field is updated to the target column value; Arrangement updated
+
+  req F-2.2:
+    when: user drags a card within the same column
+    then: card ids are reordered in Arrangement.columns[value].ids
+
+  req F-2.3:
+    when: user drags a column header
+    then: Arrangement.order is updated to reflect the new column order
+```
+
+```mdl
+feat F-3: Card Management
+
+  req F-3.1:
+    when: user clicks Add Card in a column
+    then: a new ECHO object of the board's card type is created with the pivot field set to that column's value
+
+  req F-3.2:
+    when: user removes a card
+    then: op:deleteCard runs; card is removed from the ECHO database and from the board
+
+  req F-3.3:
+    when: user undoes a delete-card action
+    then: op:restoreCard re-adds the card; board reflects restored state
+```
+
+```mdl
+feat F-4: Column Configuration
+
+  req F-4.1:
+    when: user opens KanbanSettings for a view-variant board
+    then: column-field picker shows all single-select fields from the card schema
+
+  req F-4.2:
+    when: user selects a different column field
+    then: View.projection.pivotFieldId is updated; board re-renders with new columns
+
+  req F-4.3:
+    when: user removes a column field
+    then: op:deleteCardField removes the projection; op:restoreCardField can reverse it
+```
+
+```mdl
+feat F-5: Item Source Variants
+
+  req F-5.1:
+    when: spec.kind === "view"
+    then: items come from running the View's typename query against the ECHO database
+
+  req F-5.2:
+    when: spec.kind === "items"
+    then: items come from spec.items (explicit ref array); used by externally-synced boards (e.g. Linear, GitHub)
+
+  req F-5.3: Both variants share the same Arrangement persistence and drag-and-drop logic.
+```
+
+```mdl
+feat F-6: ECHO Persistence and Collaboration
+
+  req F-6.1: All Kanban, Arrangement, and card mutations are written to ECHO and replicated to peers.
+  req F-6.2:
+    when: a peer updates a card or moves it
+    then: KanbanArticle re-renders reactively via AtomQuery / AtomObj subscriptions
+
+  req F-6.3: View-variant kanbans own an associated View object that is hidden from the space browser.
+```
+
+```mdl
+feat F-7: AI Blueprint
+
+  req F-7.1: Plugin contributes a Kanban blueprint that lets an AI agent create and update kanban boards.
+  req F-7.2:
+    when: an AI agent calls the blueprint
+    then: agent can create boards, place cards in columns, and update card fields
+```
+
+## Acceptance
+
+```mdl
+test T-1: Create kanban board
+  given: a space with a custom ECHO type that has a single-select field "status"
+  when: user creates a new Kanban selecting that type and "status" as the pivot column
+  then:
+    - Kanban object written to ECHO with spec.kind === "view"
+    - columns correspond to the "status" field's enum values
+    - existing objects appear as cards in their respective columns
+```
+
+```mdl
+test T-2: Drag card between columns
+  given: a Kanban with columns "todo", "in-progress", "done" and a card in "todo"
+  when: user drags the card to "in-progress"
+  then:
+    - card's "status" field updated to "in-progress"
+    - Arrangement reflects card in "in-progress" column
+    - change replicated to peers via ECHO
+```
+
+```mdl
+test T-3: Reorder cards within a column
+  given: a column with cards [A, B, C] in order
+  when: user drags card C above card A
+  then:
+    - Arrangement.columns["col"].ids === [C, A, B]
+    - board renders in new order
+```
+
+```mdl
+test T-4: Add card to column
+  given: a board with a "todo" column
+  when: user clicks Add Card in "todo"
+  then:
+    - new ECHO object created with pivot field set to "todo"
+    - card appears at the bottom of the "todo" column
+```
+
+```mdl
+test T-5: Delete and restore card
+  given: a board with card X in column "todo"
+  when: user deletes card X, then undoes
+  then:
+    - after delete: card X absent from board and ECHO database
+    - after undo: card X restored to ECHO and reappears in "todo"
+```
+
+```mdl
+test T-6: Hide uncategorized column
+  given: a board with some cards that have no pivot value (uncategorized)
+  when: user enables "Hide uncategorized column" in KanbanSettings
+  then:
+    - uncategorized column no longer rendered
+    - Arrangement.columns[UNCATEGORIZED].hidden === true
+```
+
+```mdl
+test T-7: Switch pivot column field
+  given: a view-variant board currently pivoting on "status"
+  when: user opens settings and selects "priority" as the column field
+  then:
+    - View.projection.pivotFieldId updated to "priority"
+    - board re-renders with columns derived from "priority" enum values
+```
+
+---
+
+## Appendix: Extension Definitions
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap
+    literals?: UnionList
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap
+    state?: FieldMap
+    slots?: FieldMap
+    actions?: ActionMap
+    emits?: EventMap
+    layout?: CodeBlock
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap
+    output?: TypeExpr
+    errors?: ErrorMap
+    effects?: EffectList
+    requires?: ServiceList
+    note?: Prose
+```

--- a/packages/plugins/plugin-kanban/src/meta.ts
+++ b/packages/plugins/plugin-kanban/src/meta.ts
@@ -11,10 +11,25 @@ export const meta: Plugin.Meta = {
   author: 'DXOS',
   description: trim`
     Visual project management using customizable kanban boards to track workflow progress.
-    Organize table data into columns, drag and drop items between stages, and trigger automations based on status changes.
+    Organize any ECHO type into drag-and-drop columns defined by a single-select field, move cards
+    between stages, and reorder both columns and cards — all changes are persisted to ECHO and
+    replicated to collaborators in real time.
+
+    Kanban boards come in two variants: view-variant boards source their cards through a linked
+    View query (any ECHO type can be pivoted on a single-select field), while items-variant boards
+    own their cards explicitly and are used by external sync integrations such as Linear or GitHub.
+    Both variants share the same arrangement storage and drag-and-drop mechanics.
+
+    Board settings let users choose which single-select field drives the column layout and
+    optionally hide the uncategorized column for items that have no pivot value.
+    Field-level undo support allows deleted card fields to be restored without data loss.
+
+    The plugin contributes a Kanban blueprint that exposes board creation and card management
+    to AI agents, enabling automated project tracking workflows.
   `,
   icon: 'ph--kanban--regular',
   iconHue: 'green',
   source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-kanban',
+  spec: 'PLUGIN.mdl',
   screenshots: ['https://dxos.network/plugin-details-kanban-dark.png'],
 };

--- a/packages/plugins/plugin-native/PLUGIN.mdl
+++ b/packages/plugins/plugin-native/PLUGIN.mdl
@@ -1,0 +1,284 @@
+---
+id: org.dxos.plugin.native
+name: NativePlugin
+version: 0.1.0
+---
+
+A Tauri-based native platform integration plugin for DXOS Composer that enables desktop-specific
+capabilities on macOS, Linux, and Windows. It manages Spotlight window integration, over-the-air
+application updates, and an Ollama sidecar process for local AI model inference.
+
+## Extensions
+
+The following extension dialects are used in this document.
+Each extension is defined in the Appendix or resolved via its URI.
+
+| Term        | URI                            |
+|-------------|--------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`       |
+| `feat`      | `org.dxos.mdl.feat@1.0`       |
+| `test`      | `org.dxos.mdl.test@1.0`       |
+| `component` | `org.dxos.mdl.component@1.0`  |
+| `op`        | `org.dxos.mdl.op@1.0`         |
+
+## Types
+
+```mdl
+type Settings
+  fields:
+    # No user-visible settings fields yet; reserved for future configuration.
+```
+
+```mdl
+type UpdateStatus
+  literals: unsupported | idle | checking | up-to-date | available | downloading | ready | failed
+```
+
+```mdl
+type UpdateState
+  fields:
+    kind: UpdateStatus
+    version?: string          # set when kind = available
+    checkedAt?: number        # epoch ms; set when kind = up-to-date
+    downloaded?: number       # bytes received; set when kind = downloading
+    contentLength?: number    # total bytes; set when kind = downloading
+    error?: string            # set when kind = failed
+```
+
+## Components
+
+```mdl
+component NativeSettings
+  desc: |
+    Settings panel section rendered inside the global Settings dialog under the
+    App (native) plugin entry.  Shows the current update status and exposes
+    Check / Update Now / Relaunch actions depending on the UpdateState.
+  props:
+    settings: Settings
+    onSettingsChange(patch: Partial<Settings>)
+  state:
+    pending: null | 'check' | 'install' | 'relaunch'
+    status: UpdateState          # derived from UpdateManager capability
+  actions:
+    checkForUpdate()
+    installUpdate()
+    relaunchApp()
+  layout: |
+    ┌─────────────────────────────────────────┐
+    │  Updates                                │
+    ├─────────────────────────────────────────┤
+    │  [status description]   [Check / Update]│
+    └─────────────────────────────────────────┘
+```
+
+## Operations
+
+```mdl
+op CheckForUpdate
+  desc: |
+    Initiates an OTA update check via the Tauri updater plugin.
+    Updates the UpdateManager status atom as the check progresses.
+  input: void
+  output: void
+  effects: [http]
+  note: No-op on unsupported platforms; guarded by SUPPORTS_OTA list.
+```
+
+```mdl
+op InstallUpdate
+  desc: |
+    Downloads and installs a pending update, streaming progress events to the
+    UpdateManager status atom. Does not relaunch the app automatically.
+  input: void
+  output: void
+  effects: [http, fs]
+  note: Only valid when UpdateManager status kind = available.
+```
+
+```mdl
+op RelaunchApp
+  desc: |
+    Relaunches the Tauri app process to apply the installed update.
+  input: void
+  output: void
+  effects: [process]
+```
+
+## Features
+
+```mdl
+feat F-1: Spotlight Window Integration
+
+  req F-1.1:
+    when: the main Composer window receives a spotlight:invoke Tauri event with operation = 'open'
+    then: the LayoutOperation.Open intent is dispatched with the provided payload
+
+  req F-1.2:
+    when: the main Composer window receives a spotlight:invoke event with operation = 'switch-workspace'
+    then: the LayoutOperation.SwitchWorkspace intent is dispatched with the provided payload
+
+  req F-1.3:
+    when: a spotlight:invoke event is handled successfully
+    then: the main Composer window is shown and brought to focus
+
+  req F-1.4:
+    when: a spotlight:invoke event carries an unrecognised operation
+    then: a warning is logged and no intent is dispatched
+```
+
+```mdl
+feat F-2: Over-the-Air Updates
+
+  req F-2.1:
+    when: the Updater module activates on a supported platform (macOS, Linux, Windows) in production
+    then: a background Effect fiber is started that checks for updates immediately and repeats hourly
+
+  req F-2.2:
+    when: an update is available and successfully downloaded
+    then: a toast notification is shown with a Relaunch action; the status atom transitions to ready
+
+  req F-2.3:
+    when: the Tauri updater check throws
+    then: the status atom transitions to failed with a human-readable error string
+
+  req F-2.4:
+    when: the app is running in a dev-server build (port ≠ TAURI_LOCALHOST_PORT)
+    then: the updater is disabled and status remains unsupported
+
+  req F-2.5:
+    when: the Updater module is torn down
+    then: the background update-check fiber is interrupted cleanly
+```
+
+```mdl
+feat F-3: Ollama Sidecar
+
+  req F-3.1:
+    when: the AssistantEvents.SetupAiServiceProviders event fires
+    then: the Ollama sidecar binary is spawned via Tauri shell on localhost port 21434
+
+  req F-3.2:
+    when: the Ollama sidecar is running
+    then: it is registered as an AiModelResolver under AppCapabilities.AiModelResolver
+
+  req F-3.3:
+    when: the Ollama capability is torn down
+    then: the sidecar process is killed and the managed runtime is disposed
+```
+
+## Acceptance
+
+```mdl
+test T-1: Spotlight open dispatches LayoutOperation.Open
+  given: Composer is running and SpotlightListener is active
+  when: a spotlight:invoke Tauri event arrives with operation = 'open' and payload { spaceId: 'abc' }
+  then:
+    - LayoutOperation.Open is invoked with { spaceId: 'abc' }
+    - main window is visible and focused
+```
+
+```mdl
+test T-2: Unknown spotlight operation is silently dropped
+  given: SpotlightListener is active
+  when: a spotlight:invoke event arrives with operation = 'foobar'
+  then:
+    - no intent is dispatched
+    - a warning log entry is emitted with the unknown operation name
+```
+
+```mdl
+test T-3: Update check transitions status atom
+  given: Updater module is active on a supported platform
+  when: CheckForUpdate is called
+  then:
+    - status transitions to checking while the HTTP call is in-flight
+    - status transitions to up-to-date if no update is available
+    - status transitions to available with a version string if an update exists
+```
+
+```mdl
+test T-4: Failed update check transitions to failed status
+  given: Updater module is active
+  when: the Tauri updater plugin throws an error during check
+  then:
+    - status transitions to failed
+    - status.error contains a human-readable description
+```
+
+```mdl
+test T-5: Dev-server build disables updater
+  given: the app is served on a port other than TAURI_LOCALHOST_PORT
+  when: the Updater module activates
+  then:
+    - status is set to unsupported immediately
+    - no HTTP update check is performed
+```
+
+---
+
+## Appendix: Extension Definitions
+
+Extension block types used in this document are defined below using
+the core `ext` primitive — the only construct the base language provides.
+
+```mdl
+ext type
+  uri: org.dxos.mdl.type@1.0
+  desc: A named data structure with typed fields and optional literals.
+  fields:
+    desc?: Prose
+    fields?: FieldMap        # name[?]: TypeExpr  (# inline comment)
+    literals?: UnionList     # a | b | c
+    extends?: TypeRef[]
+```
+
+```mdl
+ext feat
+  uri: org.dxos.mdl.feat@1.0
+  desc: A named feature grouping one or more requirements.
+  fields:
+    desc?: Prose
+    req: RequirementList
+  nesting: self              # feat blocks may contain feat blocks
+```
+
+```mdl
+ext test
+  uri: org.dxos.mdl.test@1.0
+  desc: An acceptance scenario expressed as given / when / then steps.
+  fields:
+    given?: Step | Step[]
+    when?: Step | Step[]
+    then: Step | Step[]
+    tags?: TagList
+```
+
+```mdl
+ext component
+  uri: org.dxos.mdl.component@1.0
+  desc: A UI component with props, internal state, slots, actions, and events.
+  fields:
+    desc?: Prose
+    props?: FieldMap            # external inputs (immutable inside component)
+    state?: FieldMap            # internal reactive state
+    slots?: FieldMap            # named ReactNode injection points
+    actions?: ActionMap         # methods the component exposes or handles
+    emits?: EventMap            # events the component raises to its parent
+    layout?: CodeBlock          # ASCII sketch of visual structure (non-normative)
+```
+
+```mdl
+ext op
+  uri: org.dxos.mdl.op@1.0
+  desc: |
+    A named operation with typed inputs, outputs, and declared errors.
+    Pure ops have no effects or requires. Effectful ops declare both.
+  fields:
+    desc?: Prose
+    input?: FieldMap            # named input parameters
+    output?: TypeExpr           # return type
+    errors?: ErrorMap           # name: Prose  (when this error occurs)
+    effects?: EffectList        # echo:read | echo:write | http | fs | ...
+    requires?: ServiceList      # injected service dependencies
+    note?: Prose                # implementation guidance (non-normative)
+```

--- a/packages/plugins/plugin-native/src/meta.ts
+++ b/packages/plugins/plugin-native/src/meta.ts
@@ -10,9 +10,21 @@ export const meta: Plugin.Meta = {
   id: 'org.dxos.plugin.native',
   name: 'App',
   author: 'DXOS',
+  spec: 'PLUGIN.mdl',
   description: trim`
-    Native platform integration providing desktop-specific features and system-level capabilities.
-    Access native file dialogs, notifications, and OS integrations.
+    Tauri-based native platform integration for DXOS Composer on macOS, Linux, and Windows.
+
+    Provides Spotlight window integration that forwards spotlight:invoke Tauri events to
+    Composer operations, letting the OS-level launcher open spaces and switch workspaces
+    without the main window being focused first.
+
+    Manages over-the-air application updates via the Tauri updater plugin, automatically
+    checking for new releases in the background, streaming download progress, and surfacing
+    a toast notification with a one-click Relaunch action when an update is ready.
+
+    Spawns an Ollama sidecar process on localhost for local AI model inference, registering
+    it as an AiModelResolver so Assistant features can resolve model requests without any
+    external server dependency.
   `,
   icon: 'ph--app-window--regular',
   tags: ['system'],


### PR DESCRIPTION
## Summary

- Add `PLUGIN.mdl` spec for `plugin-native` documenting types, components, operations, features, and acceptance tests
- Covers three capabilities: Spotlight window integration, over-the-air updates via Tauri updater, and Ollama sidecar for local AI inference
- Expand `meta.ts` description to 4 paragraphs with `spec: 'PLUGIN.mdl'` reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)