### PR TITLE
docs: expand meta.ts descriptions for doctor, trip, generator, crx

### DIFF
--- a/packages/plugins/plugin-crx/src/meta.ts
+++ b/packages/plugins/plugin-crx/src/meta.ts
@@ -10,9 +10,38 @@ export const meta: Plugin.Meta = {
   name: 'CRX',
   author: 'DXOS',
   description: trim`
-    Coordinates with the composer-crx browser extension. Owns the settings
-    surface and receives clippings from the extension, materializing them as
-    Person, Organization, or Note objects in the active space.
+    CRX is the Composer side of the composer-crx browser extension bridge. The
+    extension lets users pick any DOM subtree on any web page and send it to
+    Composer as a typed clip. plugin-crx registers a window event listener for
+    the composer:clip CustomEvent, validates and decodes the clip envelope, maps
+    it to an ECHO object in the active space, and dispatches a composer:clip:ack
+    acknowledgement back to the extension with the outcome. The extension
+    discovers the Composer tab via chrome.tabs.query; the plugin owns all
+    Composer-side logic including envelope validation, object mapping, and user
+    feedback.
+
+    Three clip kinds are supported. A person clip creates a Person object with
+    fullName populated from page heuristics (h1 heading, og:title, or the first
+    line of the selection), an image from og:image, the picked text as notes,
+    and the page URL as a link. An organization clip creates an Organization
+    with name from og:title or h1, description from og:description, and the
+    page URL as website. A note clip creates a Markdown document with a small
+    prelude (title, source link, timestamp) followed by the rendered selection
+    text. All mappings are best-effort: missing fields are left unset rather
+    than blocking creation.
+
+    Envelope validation runs a version check (only version 1 is accepted) and
+    full schema decoding before any object is created. Invalid payloads,
+    unsupported versions, and unknown kinds each return a distinct stable error
+    code in the ack event so the extension can surface a precise error message
+    to the user. If the active space cannot be resolved no object is created and
+    the ack carries a noSpace error.
+
+    The settings surface contributes two toggles: an enabled master switch that
+    prevents the bridge from processing any clips when off, and an
+    autoOpenAfterClip option that navigates Composer to the newly created object
+    after a successful clip. Settings are persisted to the app-framework
+    settings store and available to other plugins via a plugin-scoped capability.
   `,
   icon: 'ph--browser--regular',
   iconHue: 'neutral',

--- a/packages/plugins/plugin-doctor/src/meta.ts
+++ b/packages/plugins/plugin-doctor/src/meta.ts
@@ -10,8 +10,33 @@ export const meta: Plugin.Meta = {
   name: 'Doctor',
   author: 'DXOS',
   description: trim`
-    Self-introspection blueprint that lets the assistant query Composer's own
-    NDJSON log store to diagnose problems and explain unexpected behavior.
+    Doctor adds a self-introspection blueprint to Composer. When the blueprint
+    is loaded the assistant gains access to the queryComposerLogs tool, which
+    reads the browser tab's own NDJSON log store (populated by
+    @dxos/log-store-idb) directly from IndexedDB — no log file download or
+    external service required. The assistant can use this tool to investigate
+    unexpected behaviour, count error occurrences, or explain what happened
+    during a specific time window without leaving the chat.
+
+    The query operation supports the same filtering vocabulary as the
+    scripts/query-logs.mjs CLI: LOG_FILTER tokens (e.g. dxos.echo, !dxos.net),
+    message and raw-JSON regular expressions, time bounds (ISO or epoch ms),
+    and level allow-lists (T/D/V/I/W/E). Results can be projected to a subset
+    of fields via the select parameter to keep responses concise, and output
+    can be formatted as JSON, JSONL, or a human-readable pretty string matching
+    the CLI's formatLine output.
+
+    Aggregate queries are supported via groupBy and aggregate parameters.
+    Setting groupBy to level, message, file, or a context path returns a ranked
+    frequency table; aggregate=sample includes representative entries per
+    bucket; aggregate=firstLast adds the earliest and latest timestamps so the
+    assistant can identify when a recurring message started or stopped.
+
+    Hard caps clamp limit and topK to 1000 and sampleSize to 25. The IDB
+    cursor exits early once the requested number of un-filtered rows is
+    collected, so cheap tail queries are fast even on a large log store. The
+    truncated flag signals when results were capped so the assistant can
+    prompt the user to narrow the query.
   `,
   icon: 'ph--first-aid-kit--regular',
   iconHue: 'rose',

--- a/packages/plugins/plugin-generator/src/meta.ts
+++ b/packages/plugins/plugin-generator/src/meta.ts
@@ -10,8 +10,34 @@ export const meta: Plugin.Meta = {
   name: 'Generator',
   author: 'DXOS',
   description: trim`
-    AI video and audio generation. Author a markdown prompt and dispatch
-    it to a pluggable provider (default: HeyGen) to produce playable media.
+    Generator adds AI-driven media production to Composer. A Generation object
+    pairs a markdown prompt (stored as a linked Text ref so it replicates to
+    peers) with a media kind (video or audio) and optional provider-specific
+    avatar and voice identifiers. The article surface presents an inline
+    markdown editor above a video or audio player that appears as soon as the
+    generation completes, so the full author-to-playback workflow lives in a
+    single view.
+
+    Media is produced by a pluggable GenerationProvider abstraction. The
+    default implementation calls the HeyGen API: it submits the prompt via
+    POST /v2/video/generate then polls the status endpoint until the job
+    completes or fails, returning the final media URL. The provider interface
+    also exposes listAvatars and listVoices so the UI can populate pickers from
+    live provider data. The abstraction is intentionally provider-agnostic:
+    backends such as Veo, Sora, or ElevenLabs can be added without changing the
+    Generation data model or the article surface.
+
+    The API key is stored in local plugin settings (scoped to the plugin id in
+    KVS) and read reactively so toggling a key in the settings panel enables or
+    disables the Generate button without a page reload. When the key is missing
+    the generate operation returns a structured MissingApiKey error that the
+    article surfaces inline; when the provider returns an error the article
+    shows it in the status bar without modifying the stored URL.
+
+    Generation objects are full ECHO citizens: they are queryable from Table
+    views, replicable to collaborators in the same space, and addressable by
+    DXN. The underlying Text prompt replicates independently so multiple users
+    can edit the prompt while the generation result is still pending.
   `,
   icon: 'ph--film-reel--regular',
   iconHue: 'fuchsia',

--- a/packages/plugins/plugin-trip/src/meta.ts
+++ b/packages/plugins/plugin-trip/src/meta.ts
@@ -10,9 +10,36 @@ export const meta: Plugin.Meta = {
   name: 'Trip',
   author: 'DXOS',
   description: trim`
-    Travel itinerary planning plugin. Organise trips as ordered
-    sequences of typed segments (flights, trains, boats, hotels, activities)
-    each linked to a booking record.
+    Trip manages travel itineraries as local-first ECHO objects. A Trip is an
+    ordered list of typed Segments — Flight, Train, Boat, Road, Lodging, and
+    Activity — each of which may be linked to a Booking that carries the
+    confirmation code, provider, passengers, price, and attached e-ticket
+    files. Trips are browsable as Articles with a calendar mini-view and a
+    SegmentStack companion surface, and can be embedded inside Markdown
+    documents or queried by the existing Table and Map views without additional
+    configuration.
+
+    Phase 2 adds inbox integration via a generic MessageExtractor contract in
+    plugin-inbox. plugin-trip registers a TravelMessageExtractor that matches
+    flight and hotel confirmation emails, parses them into Booking and Segment
+    objects, and appends them to the relevant Trip in the user's space. The
+    extractor runs in three modes: manually from a message action menu,
+    agent-assisted via the inbox blueprint tool, and automatically on message
+    arrival when opted in per Mailbox. All three modes funnel through the same
+    ExtractMessage operation so behaviour is consistent regardless of how
+    extraction was triggered.
+
+    Booking and Segment provenance is tracked via ExtractedFrom ECHO relations
+    that link each extracted object back to the source Message. Account objects
+    record loyalty programme memberships and are deduplicated by provider domain
+    and account number so the same frequent-flyer number is not created twice
+    across separate confirmation emails from the same carrier.
+
+    A TripCalendarSource contract (follow-up phase) will project Segments as
+    CalendarEventLike values directly into calendar views without materialising
+    separate CalendarEvent objects. Planned future work includes agent-backed
+    extraction for providers without a deterministic parser, additional carrier
+    coverage, and a SegmentRequest shape for multi-leg search input.
   `,
   icon: 'ph--airplane-takeoff--regular',
   iconHue: 'sky',


### PR DESCRIPTION
## Summary

- Expanded `meta.ts` description for `plugin-doctor` to 4 paragraphs covering the self-introspection blueprint, log query filtering vocabulary, aggregate/groupBy modes, and hard caps with early-exit cursor behaviour
- Expanded `meta.ts` description for `plugin-trip` to 4 paragraphs covering the Trip/Segment/Booking data model, Phase 2 inbox integration via MessageExtractor, ExtractedFrom provenance relations, and planned TripCalendarSource
- Expanded `meta.ts` description for `plugin-generator` to 4 paragraphs covering Generation objects, pluggable GenerationProvider with HeyGen default, API key settings, and ECHO replication of prompts
- Expanded `meta.ts` description for `plugin-crx` to 4 paragraphs covering the extension bridge architecture, three clip kind mappings, envelope validation error codes, and settings toggles

All descriptions derived from the existing `PLUGIN.mdl` spec file in each package. `spec: 'PLUGIN.mdl'` field was already present in all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)