### PR TITLE
docs: expand meta.ts descriptions for sidekick and code

### DIFF
--- a/packages/plugins/plugin-code/src/meta.ts
+++ b/packages/plugins/plugin-code/src/meta.ts
@@ -10,8 +10,38 @@ export const meta: Plugin.Meta = {
   name: 'Code',
   author: 'DXOS',
   description: trim`
-    Composer plugin for AI-assisted plugin development.
-    Authors DEUS specs and dispatches a build agent that generates Composer plugins.
+    Code is the plugin-authoring workbench for DXOS Composer. It pairs a
+    structured DEUS spec document (a .mdl file describing types, components,
+    operations, and acceptance tests) with a CodeProject that holds the
+    TypeScript source tree produced from that spec. Both objects live in ECHO,
+    so edits are CRDT-merged and fully reactive — the same space can be shared
+    with collaborators or an AI agent without any special sync infrastructure.
+
+    The Coder blueprint drives the authoring loop: the assistant refines the
+    spec with the user, then calls the introspect-mcp server to look up live
+    DXOS and Composer APIs before writing source files. A full file-CRUD
+    operation set (scaffold, list, read, write, delete, reset, helloWorld) is
+    exposed as blueprint tools, letting the agent build up a project
+    incrementally and correct mistakes without leaving the chat. An Anthropic
+    API key can be stored securely as an AccessToken in the user's HALO space
+    via the plugin's settings panel.
+
+    The CodeArticle surface renders a two-pane layout: a hierarchical FileTree
+    on the left derived from the project's SourceFile paths, and a
+    react-ui-editor CodeMirror instance on the right that selects the
+    appropriate language mode (TypeScript, Markdown, or plain text) based on
+    the selected file's extension. The SpecArticle surfaces the .mdl document
+    with dedicated syntax highlighting, linting, and completion extensions so
+    the spec itself is pleasant to read and edit by hand.
+
+    An in-browser build pipeline transpiles the project's TypeScript sources
+    using a virtual TypeScript environment for single-file projects, and
+    esbuild-wasm for multi-file bundles. The buildProject operation returns
+    typed diagnostics; runBuild evaluates the emitted JavaScript in a
+    console-capturing wrapper and returns stdout and stderr, giving the agent
+    a fast verify-and-fix loop without requiring any external build service.
+    Remote dispatch to an EDGE build agent is wired as a stub and will be
+    activated in a subsequent phase.
   `,
   icon: 'ph--code--regular',
   iconHue: 'indigo',

--- a/packages/plugins/plugin-deck/src/meta.ts
+++ b/packages/plugins/plugin-deck/src/meta.ts
@@ -9,9 +9,24 @@ export const meta: Plugin.Meta = {
   id: 'org.dxos.plugin.deck',
   name: 'Layout',
   author: 'DXOS',
+  spec: 'PLUGIN.mdl',
   description: trim`
-    Flexible layout system for arranging workspace views in tabs, splits, and panels.
-    Customize your workspace organization with drag-and-drop layout management.
+    The Deck plugin is the core layout engine for DXOS Composer. It manages the multi-plank
+    workspace (the "deck"), sidebar panels, dialogs, popovers, and toast notifications, giving
+    users a flexible, persistent workspace they can arrange to match their workflow.
+
+    In multi mode, subjects are opened as resizable "planks" arranged side by side. Users can
+    navigate with stack semantics — opening from a pivot truncates planks to the right and
+    appends the new one — or switch to solo or fullscreen mode for focused, distraction-free
+    viewing.
+
+    Layout state (active planks, sidebar visibility, plank sizes, companion pane) is persisted
+    across sessions via KVS/localStorage. URL routing is handled by the plugin so that any
+    workspace configuration can be bookmarked or shared as a deep link.
+
+    All layout changes are expressed through typed LayoutOperations (Open, Close, SetLayoutMode,
+    UpdateSidebar, UpdateDialog, UpdatePopover, etc.) that any plugin in the system can dispatch,
+    keeping the layout logic centralised and easy to extend.
   `,
   icon: 'ph--layout--regular',
   tags: ['system'],

--- a/packages/plugins/plugin-sidekick/src/meta.ts
+++ b/packages/plugins/plugin-sidekick/src/meta.ts
@@ -10,8 +10,35 @@ export const meta: Plugin.Meta = {
   name: 'Sidekick',
   author: 'DXOS',
   description: trim`
-    Personal companion agent that monitors activity, maintains profiles of people
-    and the user, keeps a daily journal, and helps manage communications.
+    Sidekick is a personal companion agent for DXOS Composer that acts as a
+    persistent, document-aware assistant living inside your workspace. On first
+    activation it creates a dedicated Agent instance backed by the Sidekick
+    blueprint, sets up a Chat channel for ongoing conversation (with optional
+    voice input via plugin-transcription), provisions a daily Journal, and
+    generates a frank written profile of the user — goals, character, and
+    current priorities — that it refines over time through dialogue.
+
+    For every Person in the space, Sidekick automatically creates and maintains
+    a linked markdown Profile document. As new information arrives through
+    email, chat, or other sources, the agent updates the relevant profiles and
+    suggests relationship category tags such as colleague, investor, friend, or
+    customer. A permission matrix lets the user decide, per contact, whether
+    the agent may auto-respond on their behalf or should only draft messages
+    for manual review.
+
+    The primary surface is the SidekickArticle dashboard, which presents a
+    Day Ahead summary derived from today's Journal entry, an aggregated Action
+    Items checklist of open tasks from recent entries, a People grid with
+    per-contact update badges, the user's own profile excerpt, and the
+    per-contact permission toggles. The agent records important decisions,
+    key conversations, and action items into dated Journal entries using
+    markdown task lists, keeping the dashboard current without manual input.
+
+    Phase 2 extends the plugin with email monitoring and draft generation for
+    authorized contacts, background research on tracked persons, and proactive
+    comment-thread responses. Future phases add calendar integration for
+    day-ahead enrichment, local ML transcription, multi-space person
+    deduplication, and agent-to-agent communication.
   `,
   icon: 'ph--brain--regular',
   iconHue: 'violet',


### PR DESCRIPTION
## Summary

- **plugin-sidekick**: expands the 2-line description to 4 paragraphs covering agent initialization (Chat, Journal, user profile), person profile management and permission matrix, the SidekickArticle dashboard layout, and the Phase 2/3 feature roadmap
- **plugin-code**: expands the 2-line description to 4 paragraphs covering the ECHO-backed Spec/CodeProject model, the Coder blueprint authoring loop with introspect-mcp integration, the two-pane CodeArticle UI (FileTree + language-aware editor), and the in-browser TypeScript/esbuild build pipeline
- **plugin-deck**: includes a pre-existing description expansion (multi-plank layout engine, LayoutOperations, URL routing, KVS persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)