### PR TITLE
fix(echo-pipeline): do not push limit past a child-of FilterStep

### DIFF
--- a/packages/core/echo/echo-db/src/query/query.test.ts
+++ b/packages/core/echo/echo-db/src/query/query.test.ts
@@ -2677,10 +2677,7 @@ describe('Query', () => {
       await db.flush();
 
       const queue = queues.get(Feed.getQueueDxn(feed)!);
-      await queue.append([
-        Obj.make(TestSchema.Task, { title: 'A' }),
-        Obj.make(TestSchema.Task, { title: 'B' }),
-      ]);
+      await queue.append([Obj.make(TestSchema.Task, { title: 'A' }), Obj.make(TestSchema.Task, { title: 'B' })]);
       await db.flush();
 
       const objects = await db

--- a/packages/core/echo/echo-db/src/query/query.test.ts
+++ b/packages/core/echo/echo-db/src/query/query.test.ts
@@ -2661,6 +2661,35 @@ describe('Query', () => {
       expect((objects2[0] as TestSchema.Task).title).toEqual('Task in feed 2');
     });
 
+    test('childOf with limit returns feed items (regression: limit must not be pushed past child-of)', async ({
+      expect,
+    }) => {
+      // Populates the space with enough unrelated objects that, if `.limit(N)` were pushed
+      // into the wildcard SelectStep before the child-of FilterStep, the candidate set sliced
+      // before filtering would not contain any of the feed items and the result would be empty.
+      const peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Task] });
+      const db = await peer.createDatabase();
+      const queues = peer.client.constructQueueFactory(db.spaceId);
+      const feed = db.add(Feed.make({ name: 'limited-feed' }));
+      for (let i = 0; i < 50; i++) {
+        db.add(Obj.make(TestSchema.Expando, { name: `decoy-${i}` }));
+      }
+      await db.flush();
+
+      const queue = queues.get(Feed.getQueueDxn(feed)!);
+      await queue.append([
+        Obj.make(TestSchema.Task, { title: 'A' }),
+        Obj.make(TestSchema.Task, { title: 'B' }),
+      ]);
+      await db.flush();
+
+      const objects = await db
+        .query(Query.select(Filter.childOf(feed)).from(db, { includeFeeds: true }).limit(10))
+        .run();
+      expect(objects).toHaveLength(2);
+      expect(objects.map((obj: any) => obj.title).sort()).toEqual(['A', 'B']);
+    });
+
     test('childOf with Ref argument', async () => {
       const { db } = await builder.createDatabase();
       const parent = db.add(Obj.make(TestSchema.Expando, { name: 'Parent' }));

--- a/packages/core/echo/echo-pipeline/src/query/query-planner.test.ts
+++ b/packages/core/echo/echo-pipeline/src/query/query-planner.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, test } from 'vitest';
 
-import { Filter, Order, Query } from '@dxos/echo';
+import { Filter, Order, Query, Ref } from '@dxos/echo';
 import { type QueryAST } from '@dxos/echo-protocol';
 import { TestSchema } from '@dxos/echo/testing';
 import { DXN, SpaceId } from '@dxos/keys';
@@ -1616,6 +1616,22 @@ describe('QueryPlanner', () => {
       (step) => step._tag === 'FilterStep' && JSON.stringify(step.filter).includes('timestamp'),
     );
     expect(hasTimestampFilter).toBe(true);
+  });
+
+  test('childOf with limit: limit must not be propagated into the SelectStep', () => {
+    // Regression: when a child-of FilterStep sits between SelectStep and LimitStep, pushing
+    // the limit into the SelectStep slices candidates before the filter runs and starves the
+    // result set (e.g. wildcard select grabs 10 random objects, then child-of leaves 0).
+    const parentRef = Ref.fromDXN(DXN.parse('dxn:echo:@:01J7XKZ6E3MZRY7H9TGFR3W6CN'));
+    const query = Query.select(Filter.everything()).select(Filter.childOf(parentRef)).limit(10);
+
+    const plan = planner.createPlan(withSpaceIdOptions(query.ast));
+    const selectStep = plan.steps.find((step) => step._tag === 'SelectStep');
+    expect(selectStep).toBeDefined();
+    expect((selectStep as any).limit).toBeUndefined();
+    const hasLimitStep = plan.steps.some((step) => step._tag === 'LimitStep');
+    const orderWithLimit = plan.steps.some((step) => step._tag === 'OrderStep' && (step as any).limit === 10);
+    expect(hasLimitStep || orderWithLimit).toBe(true);
   });
 });
 

--- a/packages/core/echo/echo-pipeline/src/query/query-planner.ts
+++ b/packages/core/echo/echo-pipeline/src/query/query-planner.ts
@@ -821,6 +821,13 @@ export class QueryPlanner {
         selectStepIndex = -1;
         orderStepIndex = -1;
       }
+      // A child-of FilterStep prunes results in-memory after the SelectStep, so pushing the
+      // limit into the SelectStep would slice candidates before the filter runs and starve
+      // the result set (e.g. wildcard select of 10 random objects, then child-of leaves 0).
+      if (step._tag === 'FilterStep' && _filterContainsChildOf(step.filter)) {
+        selectStepIndex = -1;
+        orderStepIndex = -1;
+      }
     }
 
     if (selectStepIndex === -1 && orderStepIndex === -1) {
@@ -901,6 +908,23 @@ const createRelationTraversalStep = (direction: QueryPlan.RelationTraversal['dir
     direction,
   },
 });
+
+/**
+ * Returns true if the filter is `child-of` or composes one via `and` / `or` / `not`.
+ */
+const _filterContainsChildOf = (filter: QueryAST.Filter): boolean => {
+  switch (filter.type) {
+    case 'child-of':
+      return true;
+    case 'not':
+      return _filterContainsChildOf(filter.filter);
+    case 'and':
+    case 'or':
+      return filter.filters.some(_filterContainsChildOf);
+    default:
+      return false;
+  }
+};
 
 /**
  * Recursively flattens nested `and` filters into a single list.

--- a/packages/plugins/plugin-markdown/src/containers/EditableMarkdownCard/EditableMarkdownCard.stories.tsx
+++ b/packages/plugins/plugin-markdown/src/containers/EditableMarkdownCard/EditableMarkdownCard.stories.tsx
@@ -14,9 +14,9 @@ import { corePlugins } from '@dxos/plugin-testing';
 import { random } from '@dxos/random';
 import { useQuery, useSpaces } from '@dxos/react-client/echo';
 import { Card } from '@dxos/react-ui';
+import { translations as editorTranslations } from '@dxos/react-ui-editor/translations';
 import { CardContainer } from '@dxos/react-ui-mosaic/testing';
 import { Loading, withTheme } from '@dxos/react-ui/testing';
-import { translations as editorTranslations } from '@dxos/react-ui-editor/translations';
 import { Text } from '@dxos/schema';
 
 import { translations } from '#translations';


### PR DESCRIPTION
## Summary

Fix queries that combine `Filter.childOf` with `.limit(...)` returning empty results when they shouldn't. This was first observed when querying items inside a subscription feed (`org.dxos.type.subscription.feed`) via the assistant-toolkit `Query` operation: `in: [feedRef]`, `includeQueues: true` returned `[]` even though the feed had items.

### Root cause

The query planner's `_optimizeLimits` pass pushes `LimitStep` down into the preceding `SelectStep` whenever no Union / Traverse / SetDifference step sits between them. For most filters this is fine — the FilterStep that follows the SelectStep is a redundant re-assertion of the selector (e.g. `Filter.type(Task)` produces a `TypeSelector` plus a tautological `FilterStep{type:object, typename:Task}`).

For `Filter.childOf`, however, the plan is:

```
SelectStep(WildcardSelector) → FilterDeletedStep → FilterStep(child-of) → OrderStep → LimitStep
```

Pushing the limit into the wildcard `SelectStep` slices the candidates to N **before** child-of runs, so the in-memory filter then sees N random objects from the space (blueprints, chats, traces…) and almost never any feed items. Result: `[]`.

### Fix

Treat any `FilterStep` whose filter contains `child-of` (recursively through and / or / not) as a blocker for the limit-pushdown optimization. Limit is now applied after the child-of filter, as intended.

### Tests

- `query.test.ts`: new integration test populates a space with 50 unrelated objects, appends 2 tasks to a feed, then runs `Filter.childOf(feed).limit(10)` with `includeFeeds: true`. Expects both tasks to be returned.
- `query-planner.test.ts`: locks in that a `select(everything()).select(childOf(...)).limit(10)` plan does **not** propagate the limit into the SelectStep.

## Test plan

- [x] `moon run echo-pipeline:test` — 225 tests pass
- [x] `moon run echo-db:test` — 573 tests pass (includes new childOf+limit regression test)
- [x] `moon run echo-pipeline:lint` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pn5q6QSdqixfdeNXpFfCCP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where queries using `childOf` filter combined with `limit` would return incorrect or empty results by ensuring limits are applied after filtering rather than before.

* **Tests**
  * Added regression tests to verify `childOf` filter behavior with query limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->