### PR TITLE
feat(node-std): add workerd condition for Cloudflare Workers Node.js compat

### DIFF
--- a/packages/common/node-std/package.json
+++ b/packages/common/node-std/package.json
@@ -18,50 +18,62 @@
       "node": "./dist/lib/browser/_/config.mjs"
     },
     "./assert": {
+      "workerd": "./src/node/assert.js",
       "browser": "./dist/lib/browser/assert.mjs",
       "node": "./src/node/assert.js"
     },
     "./buffer": {
+      "workerd": "./src/node/buffer.js",
       "browser": "./dist/lib/browser/buffer.mjs",
       "node": "./src/node/buffer.js"
     },
     "./crypto": {
+      "workerd": "./src/node/crypto.js",
       "browser": "./dist/lib/browser/crypto.mjs",
       "node": "./src/node/crypto.js"
     },
     "./events": {
+      "workerd": "./src/node/events.js",
       "browser": "./dist/lib/browser/events.mjs",
       "node": "./src/node/events.js"
     },
     "./fs": {
+      "workerd": "./dist/lib/browser/fs.mjs",
       "browser": "./dist/lib/browser/fs.mjs",
       "node": "./src/node/fs.js"
     },
     "./fs/promises": {
+      "workerd": "./dist/lib/browser/fs/promises.mjs",
       "browser": "./dist/lib/browser/fs/promises.mjs",
       "node": "./src/node/fs/promises.js"
     },
     "./globals": {
+      "workerd": "./src/node/globals.js",
       "browser": "./dist/lib/browser/globals.mjs",
       "node": "./src/node/globals.js"
     },
     "./inject-globals": {
+      "workerd": "./src/node/inject-globals.js",
       "browser": "./dist/lib/browser/inject-globals.mjs",
       "node": "./src/node/inject-globals.js"
     },
     "./path": {
+      "workerd": "./src/node/path.js",
       "browser": "./dist/lib/browser/path.mjs",
       "node": "./src/node/path.js"
     },
     "./process": {
+      "workerd": "./src/node/process.js",
       "browser": "./dist/lib/browser/process.mjs",
       "node": "./src/node/process.js"
     },
     "./stream": {
+      "workerd": "./src/node/stream.js",
       "browser": "./dist/lib/browser/stream.mjs",
       "node": "./src/node/stream.js"
     },
     "./util": {
+      "workerd": "./src/node/util.js",
       "browser": "./dist/lib/browser/util.mjs",
       "node": "./src/node/util.js"
     }

--- a/packages/core/compute/functions-runtime/scripts/build-modules.mjs
+++ b/packages/core/compute/functions-runtime/scripts/build-modules.mjs
@@ -68,6 +68,8 @@ await build({
   format: 'esm',
   platform: 'browser',
   conditions: ['workerd', 'worker', 'browser'],
+  // node:* modules are provided by workerd's Node.js compat layer at runtime.
+  external: ['node:*'],
   metafile: true,
   logLevel: 'error',
   plugins: [rawImportPlugin()],

--- a/packages/core/compute/functions-runtime/src/native/bundler.ts
+++ b/packages/core/compute/functions-runtime/src/native/bundler.ts
@@ -59,14 +59,9 @@ export const bundleFunction = async (options: BundleOptions): Promise<BundleResu
       '.wasm': 'copy',
     },
     external: [
-      'node:async_hooks',
+      'node:*',
       'cloudflare:workers',
       'functions-service:user-script',
-      'node:async_hooks',
-      'node:buffer',
-      'node:crypto',
-      'node:diagnostics_channel',
-      'node:events',
     ],
     plugins: [
       httpPlugin,

--- a/packages/core/compute/functions-runtime/src/native/bundler.ts
+++ b/packages/core/compute/functions-runtime/src/native/bundler.ts
@@ -58,11 +58,7 @@ export const bundleFunction = async (options: BundleOptions): Promise<BundleResu
     loader: {
       '.wasm': 'copy',
     },
-    external: [
-      'node:*',
-      'cloudflare:workers',
-      'functions-service:user-script',
-    ],
+    external: ['node:*', 'cloudflare:workers', 'functions-service:user-script'],
     plugins: [
       httpPlugin,
       {

--- a/packages/experimental/env-tests/src/build.test.ts
+++ b/packages/experimental/env-tests/src/build.test.ts
@@ -22,7 +22,7 @@ describe('build tests', () => {
         '@dxos/log',
       ],
       conditions: ['workerd', 'worker', 'browser'],
-      external: ['*.wasm', 'node:async_hook'],
+      external: ['*.wasm', 'node:*'],
       forbid: [
         // Place patterns that must not appear in the bundle here, e.g. packages known to not be compatible with workerd.
         // NOTE: Patterns are matched against .pnpm store: ../../../node_modules/.pnpm/parjs@1.3.9/node_modules/parjs/dist/internal/parsers/string-len.js

--- a/packages/plugins/plugin-markdown/src/containers/EditableMarkdownCard/EditableMarkdownCard.stories.tsx
+++ b/packages/plugins/plugin-markdown/src/containers/EditableMarkdownCard/EditableMarkdownCard.stories.tsx
@@ -14,9 +14,9 @@ import { corePlugins } from '@dxos/plugin-testing';
 import { random } from '@dxos/random';
 import { useQuery, useSpaces } from '@dxos/react-client/echo';
 import { Card } from '@dxos/react-ui';
+import { translations as editorTranslations } from '@dxos/react-ui-editor/translations';
 import { CardContainer } from '@dxos/react-ui-mosaic/testing';
 import { Loading, withTheme } from '@dxos/react-ui/testing';
-import { translations as editorTranslations } from '@dxos/react-ui-editor/translations';
 import { Text } from '@dxos/schema';
 
 import { translations } from '#translations';


### PR DESCRIPTION
## Summary

- Adds a `workerd` export condition to `@dxos/node-std` for all modules
- Supported modules (`assert`, `buffer`, `crypto`, `events`, `path`, `process`, `stream`, `util`, `globals`, `inject-globals`) route to `./src/node/*.js`, which use `node:*` imports resolved by Cloudflare's Node.js compatibility layer
- Unsupported modules (`fs`, `fs/promises`) fall back to the existing browser stubs, since Workers has no filesystem access

## Why

Without explicit `workerd` entries, Cloudflare's bundler matches the `browser` condition and bundles polyfills instead of using the native `node:*` compat modules. The `workerd` condition (resolved before `browser` in the Cloudflare toolchain) fixes this.

See: https://developers.cloudflare.com/workers/runtime-apis/nodejs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new runtime-specific export condition for many Node standard modules to improve edge/workers compatibility.
  * For fs and fs/promises, the runtime now resolves to the browser ESM implementation.
  * Build tooling updated to treat all node:* imports as external so they remain provided at runtime.
  * Tests/build scripts updated to treat node:* imports as external during bundling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->