### PR TITLE
fix(assistant): filter trace graph processes to current space

### DIFF
--- a/packages/core/compute-runtime/src/ProcessHandle.ts
+++ b/packages/core/compute-runtime/src/ProcessHandle.ts
@@ -134,6 +134,7 @@ export class ProcessHandleImpl<I, O, R> implements ProcessManager.Handle<I, O> {
       parentPid: this.parentId,
       key: this.key,
       params: this.params,
+      space: this.environment.space,
       state: status.state,
       error,
       startedAt: status.startedAt.getTime(),

--- a/packages/core/compute/compute/src/Process.ts
+++ b/packages/core/compute/compute/src/Process.ts
@@ -14,6 +14,7 @@ import * as Scope from 'effect/Scope';
 import type * as Types from 'effect/Types';
 
 import { assertArgument } from '@dxos/invariant';
+import type { SpaceId } from '@dxos/keys';
 import { log } from '@dxos/log';
 import type { ObjectId } from '@dxos/protocols';
 
@@ -380,6 +381,11 @@ export interface Info {
    * Parameters of the process.
    */
   readonly params: Params;
+
+  /**
+   * Space that this process is associated with.
+   */
+  readonly space: SpaceId | undefined;
 
   /**
    * State of the process.

--- a/packages/plugins/plugin-assistant/src/containers/TracePanel/TracePanel.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/TracePanel/TracePanel.tsx
@@ -39,7 +39,8 @@ export const TracePanel = composable<HTMLDivElement, TracePanelProps>(
     const tracePanelDebug = settings.tracePanelDebug ?? false;
     const { branches, commits, spanTree, details } = useExecutionGraph(space);
     const monitor = useCapability(Capabilities.ProcessMonitor);
-    const processes = useAtomValue(monitor?.processTreeAtom ?? atomEmpty);
+    const allProcesses = useAtomValue(monitor?.processTreeAtom ?? atomEmpty);
+    const processes = allProcesses.filter((process) => process.space === space.id);
 
     const [selectedCommit, setSelectedCommit] = useState<Commit | undefined>();
     const handleCommitSelect = useCallback(
@@ -138,7 +139,8 @@ type UseExecutionGraphOptions = {
 
 const useExecutionGraph = (space: Space, { eventLimit }: UseExecutionGraphOptions = {}): ExecutionGraph => {
   const monitor = useCapability(Capabilities.ProcessMonitor);
-  const activeProcesses = useAtomValue(monitor?.processTreeAtom ?? atomEmpty);
+  const allProcesses = useAtomValue(monitor?.processTreeAtom ?? atomEmpty);
+  const activeProcesses = allProcesses.filter((process) => process.space === space.id);
 
   const atom = useMemo(
     () => getExecutionGraph(space, activeProcesses, { eventLimit }),


### PR DESCRIPTION
## Summary

- Adds `space?: SpaceId` to the `Process.Info` interface, populated from the process handle's `environment.space`
- Filters the global `processTreeAtom` in `TracePanel` to only show processes belonging to the active space — both in the `ProcessTree` list and the execution-graph active-process overlay

## Test plan

- [ ] Open Composer with two spaces that each have running agent processes
- [ ] Navigate to the Trace Panel for Space A — verify only Space A's processes appear
- [ ] Navigate to the Trace Panel for Space B — verify only Space B's processes appear
- [ ] Verify processes without a space (e.g. spawned outside a space context) are not shown in any space's trace panel

Closes #11548

https://claude.ai/code/session_019PSNpX6Wk8RnhnRLVwrXsw

---
_Generated by [Claude Code](https://claude.ai/code/session_019PSNpX6Wk8RnhnRLVwrXsw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Processes now track their associated space context
  * Updated trace panel to properly organize and display processes by space association

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->