### PR TITLE
fix(plugin-feed): fix RSS sync cursor so only new posts are appended

### DIFF
--- a/packages/plugins/plugin-feed/src/operations/sync-feed.ts
+++ b/packages/plugins/plugin-feed/src/operations/sync-feed.ts
@@ -46,8 +46,14 @@ const handler: Operation.WithHandler<typeof FeedOperation.SyncFeed> = FeedOperat
         const { feed: feedMeta, posts } = await fetcher(url, { corsProxy });
         const cursor = subscriptionFeed.cursor;
 
-        // Filter posts newer than the cursor.
-        const newPosts = cursor ? posts.filter((post) => post.guid !== cursor) : posts;
+        // Posts from the fetcher are sorted newest-first. The cursor is the guid
+        // of the newest post from the previous sync. Slice everything before the
+        // cursor position so that only genuinely new posts are appended.
+        // If the cursor is not found (e.g. it rolled off the fetched window) fall
+        // back to including all posts — some may be duplicates but new posts will
+        // not be missed.
+        const cursorIndex = cursor ? posts.findIndex((post) => post.guid === cursor) : -1;
+        const newPosts = cursorIndex >= 0 ? posts.slice(0, cursorIndex) : posts;
 
         // Append new posts to the ECHO feed.
         // NOTE: The `Subscription.Subscription.keep` bound is currently NOT enforced


### PR DESCRIPTION
## Summary

- Fixes a cursor filter bug in `sync-feed.ts` where `posts.filter(p => p.guid !== cursor)` only excluded the single post matching the cursor guid, causing all older posts to be re-appended as duplicates on every subsequent sync.
- Replaces the filter with `findIndex` + `slice`: the cursor position is located in the newest-first posts array and only the slice before it (i.e. strictly newer posts) is appended.
- When the cursor post is no longer present in the fetched window (rolled off), all fetched posts are included as a fallback so new posts are never missed.

## Root Cause

The old filter logic:
```ts
const newPosts = cursor ? posts.filter((post) => post.guid !== cursor) : posts;
```

Since `posts` are sorted newest-first and `cursor` is the guid of the most recently synced post, the filter kept everything **except** the cursor post. This meant every subsequent sync re-appended all older posts as duplicates, and new posts were never properly isolated.

The fix:
```ts
const cursorIndex = cursor ? posts.findIndex((post) => post.guid === cursor) : -1;
const newPosts = cursorIndex >= 0 ? posts.slice(0, cursorIndex) : posts;
```

## Test plan

- [x] All existing `plugin-feed` tests pass (43 tests)
- [x] Lint passes

Closes #11550

https://claude.ai/code/session_01E47efzT3ALEwSqqVRqDnBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01E47efzT3ALEwSqqVRqDnBW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved feed synchronization reliability when identifying new posts, with enhanced fallback handling for edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->