### PR TITLE
feat(plugin-assistant): add icons to chat thread block widgets

### DIFF
--- a/packages/core/compute/assistant/src/request/AiRequest.ts
+++ b/packages/core/compute/assistant/src/request/AiRequest.ts
@@ -370,6 +370,7 @@ const enrichToolCallBlock = (
     ...block,
     operationKey: meta.key,
     operationName: meta.name,
+    operationIcon: meta.icon,
   } satisfies ContentBlock.ToolCall;
 };
 

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/ReasoningWidget.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/ReasoningWidget.ts
@@ -46,10 +46,16 @@ export class ReasoningWidget extends WidgetType {
           .attributes({ 'data-trail-container': '' })
           .append(
             Domino.of('div')
-              .classNames('relative z-10 bg-base-surface rounded-sm text-sm text-subdued py-1')
+              .classNames(
+                'relative z-10 bg-base-surface rounded-sm text-sm text-subdued py-1',
+                'grid grid-cols-[24px_1fr] gap-x-0.5 items-start',
+              )
               .append(
                 Domino.of('div')
-                  .classNames('px-2 max-h-[5lh] overflow-y-auto dx-scrollbar-thin')
+                  .classNames('flex h-5 w-full shrink-0 items-center justify-center self-start')
+                  .append(Domino.svg('ph--brain--regular').classNames('shrink-0 size-4 opacity-70')),
+                Domino.of('div')
+                  .classNames('px-2 max-h-[5lh] overflow-y-auto dx-scrollbar-thin min-w-0')
                   .text(this.text)
                   .attributes({ 'data-reasoning-text': '' }),
               ),

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/StatusWidget.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/StatusWidget.ts
@@ -32,7 +32,7 @@ export class StatusWidget extends WidgetType {
               .append(
                 Domino.of('div')
                   .classNames('flex h-5 w-full shrink-0 items-center justify-center self-start')
-                  .append(Domino.of('span').classNames('block size-1.5 shrink-0 rounded-full bg-current opacity-45')),
+                  .append(Domino.svg('ph--info--regular').classNames('shrink-0 size-4 opacity-70')),
                 Domino.of('div')
                   .classNames('relative min-w-0')
                   .append(

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/ToolWidget.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/ToolWidget.tsx
@@ -5,7 +5,7 @@
 import type * as Tool from '@effect/ai/Tool';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { useTranslation } from '@dxos/react-ui';
+import { Icon, useTranslation } from '@dxos/react-ui';
 import { NumericTabs, TextCrawl, TogglePanel, type TogglePanelRootProps } from '@dxos/react-ui-components';
 import { JsonHighlighter } from '@dxos/react-ui-syntax-highlighter';
 import { type ContentBlock, type Message } from '@dxos/types';
@@ -128,7 +128,8 @@ const ToolPanel = ({ items, onChangeOpen }: ToolPanelProps) => {
 
   return (
     <TogglePanel.Root open={open} onChangeOpen={setOpen}>
-      <TogglePanel.Header classNames='text-sm text-placeholder'>
+      <TogglePanel.Header classNames='flex items-center gap-2 text-sm text-placeholder'>
+        <Icon icon='ph--wrench--regular' size={4} classNames='shrink-0 opacity-70' />
         <TextCrawl key='status-roll' lines={items.map((item) => item.title)} autoAdvance greedy />
       </TogglePanel.Header>
       <TogglePanel.Content>

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/ToolWidget.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/ToolWidget.tsx
@@ -42,6 +42,7 @@ export const ToolWidget = ({ view, blocks = [] }: ToolWidgetProps) => {
             lastToolCall = { tool, block };
             return {
               title: tool?.description ?? [t('tool-call.label'), block.name].filter(Boolean).join(' '),
+              icon: block.operationIcon,
               content: {
                 ...block,
                 input: safeParseJson(block.input),
@@ -54,6 +55,7 @@ export const ToolWidget = ({ view, blocks = [] }: ToolWidgetProps) => {
             if (block.error) {
               return {
                 title: t('tool-error.label'),
+                icon: lastToolCall?.block.operationIcon,
                 content: block,
               };
             }
@@ -61,9 +63,11 @@ export const ToolWidget = ({ view, blocks = [] }: ToolWidgetProps) => {
             const title =
               lastToolCall?.tool?.description ??
               [t('tool-result.label'), lastToolCall?.block.name].filter(Boolean).join(' ');
+            const icon = lastToolCall?.block.operationIcon;
             lastToolCall = undefined;
             return {
               title,
+              icon,
               content: {
                 ...block,
                 result: safeParseJson(block.result),
@@ -78,6 +82,7 @@ export const ToolWidget = ({ view, blocks = [] }: ToolWidgetProps) => {
 
             return {
               title: t('stats.label'),
+              icon: lastToolCall.block.operationIcon,
               content: block,
             };
           }
@@ -101,9 +106,13 @@ export const ToolWidget = ({ view, blocks = [] }: ToolWidgetProps) => {
   return <ToolPanel items={items} onChangeOpen={handleChangeOpen} />;
 };
 
+type ToolPanelItem = { title: string; icon?: string; content: any };
+
 type ToolPanelProps = {
-  items: { title: string; content: any }[];
+  items: ToolPanelItem[];
 } & Pick<TogglePanelRootProps, 'onChangeOpen'>;
+
+const DEFAULT_TOOL_ICON = 'ph--wrench--regular';
 
 const ToolPanel = ({ items, onChangeOpen }: ToolPanelProps) => {
   const tabsRef = useRef<HTMLDivElement>(null);
@@ -126,10 +135,15 @@ const ToolPanel = ({ items, onChangeOpen }: ToolPanelProps) => {
     setSelected(index);
   }, []);
 
+  // Prefer the icon from the latest tool call so the header reflects what's currently active.
+  // TextCrawl shows multiple titles, but only one icon slot — using the most recent keeps it in sync
+  // with the visible operation while it streams.
+  const headerIcon = items[items.length - 1]?.icon ?? items[0]?.icon ?? DEFAULT_TOOL_ICON;
+
   return (
     <TogglePanel.Root open={open} onChangeOpen={setOpen}>
       <TogglePanel.Header classNames='flex items-center gap-2 text-sm text-placeholder'>
-        <Icon icon='ph--wrench--regular' size={4} classNames='shrink-0 opacity-70' />
+        <Icon icon={headerIcon} size={4} classNames='shrink-0 opacity-70' />
         <TextCrawl key='status-roll' lines={items.map((item) => item.title)} autoAdvance greedy />
       </TogglePanel.Header>
       <TogglePanel.Content>

--- a/packages/sdk/types/src/types/ContentBlock.ts
+++ b/packages/sdk/types/src/types/ContentBlock.ts
@@ -103,6 +103,12 @@ export const ToolCall = Schema.TaggedStruct('toolCall', {
    */
   operationName: Schema.optional(Schema.String),
 
+  /**
+   * Phosphor icon identifier (`ph--<name>--<variant>`) of the Operation that backs this tool call.
+   * Absent when the tool is not backed by an Operation or the operation has no icon.
+   */
+  operationIcon: Schema.optional(Schema.String),
+
   ...Base.fields,
 });
 


### PR DESCRIPTION
## Summary

Inspired by #11485 (which surfaces operation icons in the trace graph), this PR adds Phosphor icons to the ChatThread block widgets used by the CodeMirror-based markdown chat thread, so tool calls, reasoning, and status blocks render with a recognizable glyph instead of being purely text.

- `ToolWidget` (React): wrench icon in the `TogglePanel.Header` alongside the existing `TextCrawl`.
- `ReasoningWidget` (CodeMirror DOM widget): brain icon in a two-column grid layout next to the streaming reasoning text.
- `StatusWidget` (CodeMirror DOM widget): info icon replacing the previous bare dot indicator.

All three reuse the existing `Domino.svg(...)` / `<Icon ... />` patterns already used elsewhere in the codebase (e.g. `SuggestionWidget`).

## Test plan

- [x] `moon run plugin-assistant:build` — green.
- [x] `moon run plugin-assistant:lint` — clean.
- [x] `moon run plugin-assistant:test` — only the pre-existing `trace-timeline.node.test.ts` memoized-LLM failures remain (unrelated; fixed in #11485). All other suites green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgYmMCJcrCPtizaAyrErER)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reasoning messages now use a two-column layout with a centered visual icon and a scrollable content panel for clearer trails.
  * Status labels use an informational icon for more visible status cues.
  * Tool panels show an icon beside header titles for quicker recognition.
  * Tool actions display associated operation icons to convey context at a glance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->