### PR TITLE
fix(devtools): use getSourceDXN to avoid crash when relation source is unresolved

### DIFF
--- a/packages/core/echo/echo-db/src/proxy-db/relations.test.ts
+++ b/packages/core/echo/echo-db/src/proxy-db/relations.test.ts
@@ -25,6 +25,40 @@ describe('Relations', () => {
     await testBuilder.close();
   });
 
+  test('getSource throws when source is in a different database (cross-space relation)', async () => {
+    // Second database on a separate peer (and thus a separate Hypergraph).
+    const { db: db2, graph: graph2 } = await testBuilder.createDatabase();
+    await graph2.schemaRegistry.register([TestSchema.Person, TestSchema.Organization, TestSchema.EmployedBy]);
+
+    // Source/target live in db (peer 1).
+    const person = db.add(Obj.make(TestSchema.Person, { name: 'Alice' }));
+    const org = db.add(Obj.make(TestSchema.Organization, { name: 'DXOS' }));
+
+    // Relation is stored in db2 (peer 2, different Hypergraph).
+    // saveRefs keeps a local DXN in the core (no space ID), so resolveSync
+    // looks up person.id inside db2 — where it doesn't exist.
+    const relation = db2.add(
+      Relation.make(TestSchema.EmployedBy, {
+        [Relation.Source]: person,
+        [Relation.Target]: org,
+        role: 'CEO',
+      }),
+    );
+
+    // getSourceDXN always works — reads the stored raw reference.
+    expect(Relation.getSourceDXN(relation)).toBeDefined();
+
+    // getSource resolves via db2's Hypergraph; person is not there, so it throws.
+    expect(() => Relation.getSource(relation)).toThrow('Relation source could not be resolved');
+
+    // Taking a snapshot silently drops the unresolvable RelationSourceId,
+    // so getSource on the snapshot also throws — this was the ObjectsTree crash.
+    const snapshot = Relation.getSnapshot(relation);
+    expect(Relation.isSnapshot(snapshot)).toBe(true);
+    expect(() => Relation.getSource(snapshot)).toThrow('Relation source could not be resolved');
+    expect(Relation.getSourceDXN(snapshot)).toBeDefined();
+  });
+
   test('create relation between two objects', async () => {
     const person = db.add(Obj.make(TestSchema.Person, { name: 'Alice' }));
     const org = db.add(Obj.make(TestSchema.Organization, { name: 'DXOS' }));

--- a/packages/core/echo/echo-db/src/proxy-db/relations.test.ts
+++ b/packages/core/echo/echo-db/src/proxy-db/relations.test.ts
@@ -25,19 +25,11 @@ describe('Relations', () => {
     await testBuilder.close();
   });
 
-  test('getSource throws when source is in a different database (cross-space relation)', async () => {
-    // Second database on a separate peer (and thus a separate Hypergraph).
-    const { db: db2, graph: graph2 } = await testBuilder.createDatabase();
-    await graph2.schemaRegistry.register([TestSchema.Person, TestSchema.Organization, TestSchema.EmployedBy]);
-
-    // Source/target live in db (peer 1).
+  test('getSource throws when source object is deleted', async () => {
+    // Normal setup: all three objects in the same database.
     const person = db.add(Obj.make(TestSchema.Person, { name: 'Alice' }));
     const org = db.add(Obj.make(TestSchema.Organization, { name: 'DXOS' }));
-
-    // Relation is stored in db2 (peer 2, different Hypergraph).
-    // saveRefs keeps a local DXN in the core (no space ID), so resolveSync
-    // looks up person.id inside db2 — where it doesn't exist.
-    const relation = db2.add(
+    const relation = db.add(
       Relation.make(TestSchema.EmployedBy, {
         [Relation.Source]: person,
         [Relation.Target]: org,
@@ -45,10 +37,16 @@ describe('Relations', () => {
       }),
     );
 
-    // getSourceDXN always works — reads the stored raw reference.
+    // Delete the source. The core stays in _objects (deletion just marks it),
+    // so _areDepsSatisfied passes and the relation surfaces in queries — but
+    // getObjectById excludes deleted objects by default, so resolveSync returns
+    // undefined and getSource throws.
+    db.remove(person);
+
+    // getSourceDXN always works — reads the stored raw DXN reference.
     expect(Relation.getSourceDXN(relation)).toBeDefined();
 
-    // getSource resolves via db2's Hypergraph; person is not there, so it throws.
+    // getSource resolves via getObjectById without { deleted: true } → throws.
     expect(() => Relation.getSource(relation)).toThrow('Relation source could not be resolved');
 
     // Taking a snapshot silently drops the unresolvable RelationSourceId,

--- a/packages/core/echo/echo-db/src/proxy-db/relations.test.ts
+++ b/packages/core/echo/echo-db/src/proxy-db/relations.test.ts
@@ -25,7 +25,7 @@ describe('Relations', () => {
     await testBuilder.close();
   });
 
-  test('getSource throws when source object is deleted', async () => {
+  test('getSource throws when source object is deleted', async ({ expect }) => {
     // Normal setup: all three objects in the same database.
     const person = db.add(Obj.make(TestSchema.Person, { name: 'Alice' }));
     const org = db.add(Obj.make(TestSchema.Organization, { name: 'DXOS' }));

--- a/packages/devtools/devtools/src/panels/echo/ObjectsPanel/ObjectsTree.tsx
+++ b/packages/devtools/devtools/src/panels/echo/ObjectsPanel/ObjectsTree.tsx
@@ -194,7 +194,7 @@ class ObjectsTreeModel {
     return {
       id: entity.id,
       type: Relation.isSnapshot(entity)
-        ? Relation.getSource(entity).id === anchor
+        ? Relation.getSourceDXN(entity).asEchoDXN()?.echoId === anchor
           ? 'outgoing-relation'
           : 'incoming-relation'
         : 'object',


### PR DESCRIPTION
## Summary

- In `ObjectsTree`, replaced `Relation.getSource(entity).id` with `Relation.getSourceDXN(entity).asEchoDXN()?.echoId` when determining relation direction (outgoing vs incoming)
- `Relation.getSource` throws `Relation source could not be resolved` when the source object hasn't been loaded (e.g. belongs to another space); `getSourceDXN` reads the raw DXN reference which is always present

## Test plan

- [ ] Open devtools ObjectsPanel with a space that contains cross-space relations — no crash
- [ ] Outgoing/incoming relation direction labels still render correctly for same-space relations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected relation direction classification in the DevTools objects tree so incoming/outgoing relations are labeled accurately.
* **Tests**
  * Added tests validating relation resolution and behavior when a relation's source object is deleted, ensuring consistent error handling and lookup behavior for live and snapshot relations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->