### PR TITLE
fix(plugin-code): preserve file selection when resolvedFiles is temporarily empty

### DIFF
--- a/packages/plugins/plugin-code/src/containers/CodeArticle/CodeArticle.tsx
+++ b/packages/plugins/plugin-code/src/containers/CodeArticle/CodeArticle.tsx
@@ -200,8 +200,11 @@ export const CodeArticle = forwardRef<HTMLDivElement, CodeArticleProps>(
       if (!selectedPath && resolvedFiles.length > 0) {
         setSelectedPath(resolvedFiles[0].path);
       }
-      if (selectedPath && !resolvedFiles.some((file) => file.path === selectedPath)) {
-        setSelectedPath(resolvedFiles[0]?.path);
+      // Guard with resolvedFiles.length > 0: if the list is temporarily empty
+      // (e.g. a transient ECHO update clears project.files before repopulating it)
+      // we preserve the current selection rather than resetting it to undefined.
+      if (selectedPath && resolvedFiles.length > 0 && !resolvedFiles.some((file) => file.path === selectedPath)) {
+        setSelectedPath(resolvedFiles[0].path);
       }
     }, [resolvedFiles, selectedPath]);
 


### PR DESCRIPTION
## Summary

- Guards the `selectedPath` reset in `CodeArticle` with `resolvedFiles.length > 0` to prevent losing the user's file selection during transient ECHO reactive updates.

## Root Cause

The `selectedPath` effect had this logic:

```ts
if (selectedPath && !resolvedFiles.some((file) => file.path === selectedPath)) {
  setSelectedPath(resolvedFiles[0]?.path);
}
```

When ECHO emits a reactive update (e.g. after a build operation modifies `project.files`), `project.files` can momentarily return `undefined`. This causes:

1. `fileRefs` → `[]` (empty, via `project.files ?? []`)
2. `Promise.all([])` resolves immediately → `setResolvedFiles([])`
3. `resolvedFiles` is now `[]`, so `!resolvedFiles.some(...)` is always `true`
4. `setSelectedPath(undefined)` is called — the user's selection is lost
5. The editor disappears

The fix adds `resolvedFiles.length > 0 &&` to the guard so that a momentarily empty list is treated as "still loading" rather than "file deleted". When the file list comes back (non-empty) and the previously-selected file is genuinely gone, the reset still fires correctly.

## Test plan

- [ ] Open a CodeProject that has files scaffolded/built
- [ ] Click on a file in the file tree — editor should show and remain visible
- [ ] Trigger a build or scaffold — the selection should be preserved after ECHO updates settle
- [ ] Delete a file that was selected — selection should move to the first remaining file

closes #11554

https://claude.ai/code/session_019PCb15hpnVrvtGo7pkAsWp

---
_Generated by [Claude Code](https://claude.ai/code/session_019PCb15hpnVrvtGo7pkAsWp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file selection preservation in the code editor. When the file list updates, your currently selected file is now retained. If the selected file is no longer available, the editor automatically defaults to the first file in the updated list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->