### PR TITLE
fix: trace panel fade z-index escape + AiContext blueprint crash

### DIFF
--- a/packages/core/compute/assistant/src/session/AiContext.ts
+++ b/packages/core/compute/assistant/src/session/AiContext.ts
@@ -155,7 +155,7 @@ export class Binder extends Resource {
       await this._updateBindings(results);
       log('sync complete', {
         blueprints: this._registry.get(this._blueprints).length,
-        blueprintKeys: this._registry.get(this._blueprints).map((bp) => Blueprint.getKey(bp)),
+        blueprintKeys: this._registry.get(this._blueprints).map((bp) => Obj.getMeta(bp).key ?? '<missing>'),
       });
     }
   }
@@ -181,7 +181,17 @@ export class Binder extends Resource {
 
     log('_updateBindings resolved', {
       resolvedBlueprints: resolvedBlueprints.length,
-      resolvedBlueprintKeys: resolvedBlueprints.map((bp) => Blueprint.getKey(bp)),
+      resolvedBlueprintKeys: resolvedBlueprints.map((bp) => Obj.getMeta(bp).key ?? '<missing>'),
+    });
+
+    // Drop blueprints that have no registry key — they cannot be used downstream
+    // (e.g. tool/operation registration calls Blueprint.getKey which throws).
+    const keyedBlueprints = resolvedBlueprints.filter((bp) => {
+      if (Obj.getMeta(bp).key === undefined) {
+        log.warn('dropping blueprint with no meta key', { dxn: Obj.getDXN(bp).toString() });
+        return false;
+      }
+      return true;
     });
 
     // Filter current state to only items still in the reduced binding set,
@@ -196,7 +206,7 @@ export class Binder extends Resource {
     );
     const filteredBlueprints = currentBlueprints.filter((obj) => reducedBlueprintDxns.has(Obj.getDXN(obj)));
     const filteredObjects = currentObjects.filter((obj) => reducedObjectDxns.has(Obj.getDXN(obj)));
-    const mergedBlueprints = this._mergeInto(filteredBlueprints, resolvedBlueprints);
+    const mergedBlueprints = this._mergeInto(filteredBlueprints, keyedBlueprints);
     const mergedObjects = this._mergeInto(filteredObjects, resolvedObjects);
 
     this._registry.set(this._blueprints, mergedBlueprints);

--- a/packages/core/compute/assistant/src/session/AiContext.ts
+++ b/packages/core/compute/assistant/src/session/AiContext.ts
@@ -204,7 +204,9 @@ export class Binder extends Resource {
       DXN.hash,
       [...bindings.objects].map((ref) => ref.dxn),
     );
-    const filteredBlueprints = currentBlueprints.filter((obj) => reducedBlueprintDxns.has(Obj.getDXN(obj)));
+    const filteredBlueprints = currentBlueprints.filter(
+      (bp) => reducedBlueprintDxns.has(Obj.getDXN(bp)) && Obj.getMeta(bp).key !== undefined,
+    );
     const filteredObjects = currentObjects.filter((obj) => reducedObjectDxns.has(Obj.getDXN(obj)));
     const mergedBlueprints = this._mergeInto(filteredBlueprints, keyedBlueprints);
     const mergedObjects = this._mergeInto(filteredObjects, resolvedObjects);

--- a/packages/ui/react-ui/src/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/ui/react-ui/src/components/ScrollContainer/ScrollContainer.tsx
@@ -155,7 +155,7 @@ const ScrollContainerContent = composable<HTMLDivElement, ScrollContainerContent
   ({ children, thin, padding, centered, ...props }, forwardedRef) => {
     return (
       <ScrollArea.Root
-        {...composableProps(props, { classNames: 'relative' })}
+        {...composableProps(props, { classNames: 'relative isolate' })}
         thin={thin}
         padding={padding}
         centered={centered}


### PR DESCRIPTION
## Summary

Two independent UI/runtime bug fixes spotted in the trace-panel + assistant flow.

### 1. `ScrollContainer` fade bled into the R0 toolbar

The fade overlay in `ScrollContainer.Fade` is positioned `absolute z-10`. Its parent (`ScrollContainer.Content` → `ScrollArea.Root`) had `relative overflow-hidden` but **no stacking context**, so the `z-10` was evaluated globally. In `ComplementarySidebar`, R0 (the right vertical toolbar) sits at `absolute z-1 end-0` as an absolute sibling of R1 (the trace-panel content). The fade therefore painted on top of R0 wherever R1 underflowed R0 (e.g. below the `lg` breakpoint where R1 is `w-full`).

Fix: add `isolate` to `ScrollContainer.Content` so the fade's z-index is contained. This is the same pattern already used in `Image.tsx` for the identical class of bug.

### 2. `AiContext` crashed on blueprints missing a meta key

`Blueprint.getKey()` throws `'Blueprint is missing the meta key.'` if `Obj.getMeta(bp).key === undefined`. It was being called from two `log()` calls inside `Binder._updateBindings` / `Binder.sync` — a single keyless blueprint therefore brought down `Binder._open` and the `useContextBinder` effect:

```
Uncaught (in promise) Error: Blueprint is missing the meta key.
    at Module.getKey (Blueprint.ts:110:11)
    at AiContext.ts:186:71
    at Array.map (<anonymous>)
    at Binder._updateBindings (AiContext.ts:186:49)
    at async Binder._open (AiContext.ts:140:5)
```

Fixes:
- Replace `Blueprint.getKey(bp)` in both log sites with `Obj.getMeta(bp).key ?? '<missing>'` so logging is non-throwing.
- Filter keyless blueprints out of the resolved set before merging into the registry, with a `log.warn` that carries the offending DXN so the root cause (something persisting a Blueprint without going through `Blueprint.make()`) can be traced.

The root cause of *how* a Blueprint ended up without a meta key is not addressed here — the warn line should make it discoverable in app logs.

## Test plan

- [x] `moon run react-ui:build` passes
- [x] `moon run assistant:build` passes
- [ ] Refresh the trace panel in Composer — fade no longer paints into the R0 toolbar strip
- [ ] Trigger the prior Blueprint-binding flow that crashed — should now log a warning instead of throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved binding synchronization to rely on registry keys and now filters out resolved items that lack a registry key, with warning logs when items are dropped.

* **Style**
  * Updated scroll container to include an isolation CSS class by default for improved layout and element isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->