### PR TITLE
fix(assistant-toolkit): resolve list-schema tool failure for types with Uint8Array fields

### DIFF
--- a/packages/core/compute/assistant-toolkit/src/blueprints/database/functions/schema-list.ts
+++ b/packages/core/compute/assistant-toolkit/src/blueprints/database/functions/schema-list.ts
@@ -6,6 +6,7 @@ import * as Effect from 'effect/Effect';
 
 import { Routine, Blueprint, Operation } from '@dxos/compute';
 import { Database, Feed, JsonSchema, Type, View } from '@dxos/echo';
+import { log } from '@dxos/log';
 
 import { SchemaList } from './definitions';
 
@@ -20,13 +21,20 @@ export default SchemaList.pipe(
       const schema = yield* Effect.promise(() => db.schemaRegistry.query({ location: ['database', 'runtime'] }).run());
       return schema
         .filter((schema) => !excludedTypenames.includes(Type.getTypename(schema)))
-        .map((schema) => {
-          const meta = Type.getMeta(schema);
-          return {
-            typename: Type.getTypename(schema),
-            jsonSchema: JsonSchema.toJsonSchema(schema),
-            kind: meta?.sourceSchema ? 'relation' : 'record',
-          };
+        .flatMap((schema) => {
+          try {
+            const meta = Type.getMeta(schema);
+            return [
+              {
+                typename: Type.getTypename(schema),
+                jsonSchema: JsonSchema.toJsonSchema(schema),
+                kind: meta?.sourceSchema ? 'relation' : 'record',
+              },
+            ];
+          } catch (err) {
+            log.warn('Failed to generate JSON schema for type', { typename: Type.getTypename(schema), err });
+            return [];
+          }
         });
     }),
   ),

--- a/packages/sdk/types/src/types/File.ts
+++ b/packages/sdk/types/src/types/File.ts
@@ -16,7 +16,9 @@ import { FormInputAnnotation } from '@dxos/echo/internal';
  */
 export const FileDataSchema = Schema.Union(
   Schema.TaggedStruct('inline', {
-    bytes: Schema.Uint8ArrayFromSelf,
+    bytes: Schema.Uint8ArrayFromSelf.annotations({
+      jsonSchema: { type: 'string', contentEncoding: 'base64' },
+    }),
   }),
   Schema.TaggedStruct('external', {
     url: Schema.String,


### PR DESCRIPTION
## Summary

Fixes #11564. The `schema-list` operation (`org.dxos.function.database.schema-list`) was crashing with:

```
Missing annotation at path: ["data"]["bytes"]
details: Generating a JSON Schema for this schema requires a "jsonSchema" annotation
schema (Declaration): Uint8ArrayFromSelf
```

Root cause: `FileDataSchema` in `packages/sdk/types/src/types/File.ts` uses `Schema.Uint8ArrayFromSelf` for the inline bytes field. Effect's JSON Schema generator requires a `jsonSchema` annotation for Declaration-type schemas like `Uint8ArrayFromSelf` — without it, `toJsonSchema()` throws and the entire tool call fails.

### Changes

- **`packages/sdk/types/src/types/File.ts`**: Add `jsonSchema: { type: 'string', contentEncoding: 'base64' }` annotation to the `bytes` field on `FileDataSchema`. This is the standard JSON Schema representation for binary data (RFC 7159 / draft-07).

- **`packages/core/compute/assistant-toolkit/src/blueprints/database/functions/schema-list.ts`**: Wrap `toJsonSchema()` in a try/catch so any future schema that can't be serialized is skipped with a warning instead of crashing the entire tool call. This makes the tool resilient against similar issues in user-defined or third-party schema types.

closes #11564

---
_Generated by [Claude Code](https://claude.ai/code/session_017wAAJnGiuLHnWz1JsBnrUT)_