### PR TITLE
feat(plugin-explorer): add flock visualization variant

### DIFF
--- a/packages/common/graph/src/GraphModel.ts
+++ b/packages/common/graph/src/GraphModel.ts
@@ -433,7 +433,6 @@ export class ReactiveGraphModel<
 
     // Prime the atom by reading before subscribing to avoid double-fire on first mutation.
     this._registry.get(this._graphAtom);
-
     return this._registry.subscribe(this._graphAtom, () => {
       cb(this, this.graph);
     });

--- a/packages/plugins/plugin-debug/src/containers/GithubPanel/GithubComponent.stories.tsx
+++ b/packages/plugins/plugin-debug/src/containers/GithubPanel/GithubComponent.stories.tsx
@@ -13,7 +13,7 @@ import { GithubComponent } from './GithubComponent';
 
 const DefaultStory = () => (
   <GithubComponent.Root>
-    <div className='grid grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden bs-full is-full'>
+    <div className='grid grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden h-full is-full'>
       <GithubComponent.Header />
       <GithubComponent.Content />
       <GithubComponent.StatusBar />

--- a/packages/plugins/plugin-debug/src/containers/GithubPanel/GithubPanel.tsx
+++ b/packages/plugins/plugin-debug/src/containers/GithubPanel/GithubPanel.tsx
@@ -8,7 +8,7 @@ import { GithubComponent } from './GithubComponent';
 
 export const GithubPanel = () => (
   <GithubComponent.Root>
-    <div className='h-full grid grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden bs-full is-full'>
+    <div className='h-full grid grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden h-full is-full'>
       <GithubComponent.Header />
       <GithubComponent.Content />
       <GithubComponent.StatusBar />

--- a/packages/plugins/plugin-explorer/package.json
+++ b/packages/plugins/plugin-explorer/package.json
@@ -112,6 +112,7 @@
     "@dxos/react-ui-components": "workspace:*",
     "@dxos/react-ui-graph": "workspace:*",
     "@dxos/react-ui-mosaic": "workspace:*",
+    "@dxos/react-ui-sfx": "workspace:*",
     "@dxos/react-ui-stack": "workspace:*",
     "@dxos/schema": "workspace:*",
     "@dxos/types": "workspace:*",

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.stories.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.stories.tsx
@@ -135,12 +135,8 @@ export const Lattice: Story = {
   },
 };
 
-/**
- * Flock: boids-style canvas animation seeded from the most recent layout — each node from
- * the model becomes a boid starting at its current x/y position.
- */
-export const Flock: Story = {
+export const Swarm: Story = {
   args: {
-    variant: 'flock',
+    variant: 'swarm',
   },
 };

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.stories.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.stories.tsx
@@ -134,3 +134,13 @@ export const Lattice: Story = {
     variant: 'lattice',
   },
 };
+
+/**
+ * Flock: boids-style canvas animation seeded from the most recent layout — each node from
+ * the model becomes a boid starting at its current x/y position.
+ */
+export const Flock: Story = {
+  args: {
+    variant: 'flock',
+  },
+};

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
@@ -26,7 +26,7 @@ import {
   type SVGContext,
 } from '@dxos/react-ui-graph';
 import { Flock, type FlockSeed } from '@dxos/react-ui-sfx';
-import { type SpaceGraphEdge, type SpaceGraphNode } from '@dxos/schema';
+import { SpaceGraphModel, type SpaceGraphEdge, type SpaceGraphNode } from '@dxos/schema';
 // Side-effect import: ExplorerArticle drives `SVG.Graph` directly (previously the CSS
 // was pulled in transitively via `ForceGraph.tsx`, which we no longer use). Without it
 // the `g.dx-edge path` rules — including `fill: none` — never reach the bundle and SVG
@@ -153,7 +153,7 @@ const isVariant = (value: unknown): value is ExplorerArticleVariant =>
 
 type VisualizationProps = {
   variant: ExplorerArticleVariant;
-  model: NonNullable<ReturnType<typeof useGraphModel>>;
+  model: NonNullable<SpaceGraphModel>;
   onNodeHover?: (node: TreeNode | null, event?: MouseEvent) => void;
 };
 
@@ -201,12 +201,15 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
     setProjector(createProjector(variant as Exclude<ExplorerArticleVariant, 'swarm'>, svgRef.current, prev));
   }, [variant]);
 
-  // Keep the model's reactive graph atom alive across SVG.Graph unmount cycles.
-  // The atom auto-disposes when its last subscriber unsubscribes (effect-atom
-  // default), which means the SVG variant ↔ swarm swap would wipe model.graph
-  // to its initial empty value while the canvas was mounted. A no-op subscription
-  // pinned to the model's lifetime keeps the atom retained.
-  useEffect(() => model?.subscribe(() => {}), [model]);
+  // Subscribe to the model's reactive graph atom. Two purposes:
+  //  1. Keep-alive: effect-atom auto-disposes atoms when no subscribers remain
+  //     (its documented default). Without this, swarm ↔ SVG variant swaps would
+  //     wipe model.graph to its initial empty value while the canvas is mounted.
+  //  2. Re-render: when model data first arrives (asynchronously from the ECHO
+  //     query), bump local state so flockSeeds re-memos and Flock receives the
+  //     new node positions.
+  const [modelRev, setModelRev] = useState(0);
+  useEffect(() => model?.subscribe(() => setModelRev((r) => r + 1)), [model]);
 
   const renderNode = useMemo(() => createRenderNode(variant), [variant]);
 
@@ -247,9 +250,7 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
     return ({ width, height }: { width: number; height: number }): FlockSeed[] => {
       const cx = width / 2;
       const cy = height / 2;
-      const snapshot = new Map(
-        (lastLayoutRef.current?.graph.nodes ?? []).map((node) => [node.id, node] as const),
-      );
+      const snapshot = new Map((lastLayoutRef.current?.graph.nodes ?? []).map((node) => [node.id, node] as const));
       const modelNodes = model?.graph.nodes ?? [];
       if (modelNodes.length) {
         const spread = Math.min(width, height) * 0.5;
@@ -272,7 +273,7 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
       }
       return [];
     };
-  }, [model, variant]);
+  }, [model, variant, modelRev]);
 
   if (variant === 'swarm') {
     return (
@@ -295,6 +296,7 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
       onSelect={handleSelect}
     />
   );
+
   return (
     <SVG.Root ref={svgRef}>{variant === 'force' ? <SVG.Zoom extent={[1 / 2, 2]}>{inner}</SVG.Zoom> : inner}</SVG.Root>
   );
@@ -453,6 +455,7 @@ const appendRadialLeafLabel = (
   if (!label) {
     return;
   }
+
   const targetX = (node as any).tx ?? node.x ?? 0;
   const targetY = (node as any).ty ?? node.y ?? 0;
   const angleDeg = (Math.atan2(targetY, targetX) * 180) / Math.PI;
@@ -487,6 +490,7 @@ const appendRadialGroupLabel = (
   if (!node.label) {
     return;
   }
+
   const targetX = (node as any).tx ?? node.x ?? 0;
   const targetY = (node as any).ty ?? node.y ?? 0;
   const angleDeg = (Math.atan2(targetY, targetX) * 180) / Math.PI;
@@ -522,6 +526,7 @@ const appendRootLabel = (
   if (!node.label) {
     return;
   }
+
   group
     .append('text')
     .classed('dx-cluster-label', true)

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
@@ -36,7 +36,7 @@ import '@dxos/react-ui-graph/styles/graph.css';
 import { type TreeNode } from '#components';
 import { useGraphModel } from '#hooks';
 
-import { getNodeFillForObject } from '../../util/node-color';
+import { getNodeFillForObject } from '../../util';
 
 /** Visualization variants exposed by `ExplorerArticle`. */
 export type ExplorerArticleVariant = 'force' | 'cluster' | 'bundle' | 'lattice' | 'swarm';
@@ -78,9 +78,12 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
   const model = useGraphModel(db, filter);
 
   const builder = useMemo(() => new QueryBuilder(), []);
-  const handleChange = useCallback<NonNullable<QueryEditorProps['onChange']>>((value) => {
-    setFilter(builder.build(value).filter);
-  }, []);
+  const handleChange = useCallback<NonNullable<QueryEditorProps['onChange']>>(
+    (value) => {
+      setFilter(builder.build(value).filter);
+    },
+    [builder],
+  );
 
   // The `variant` prop is the initial value; user can toggle via the toolbar tabs.
   const [selected, setSelected] = useState<ExplorerArticleVariant>(isVariant(variant) ? variant : 'force');
@@ -89,6 +92,7 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
       setSelected(variant);
     }
   }, [variant]);
+
   const handleVariantChange = useCallback((value: string) => {
     if (isVariant(value)) {
       setSelected(value);
@@ -275,35 +279,32 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
     };
   }, [model, variant, modelRev]);
 
-  if (variant === 'swarm') {
-    return (
-      <div className='dx-expander relative'>
-        <Flock seeds={flockSeeds} coloring='Movement' />
-      </div>
-    );
+  switch (variant) {
+    case 'swarm':
+      return (
+        <div className='dx-expander relative'>
+          <Flock seeds={flockSeeds} coloring='Movement' />
+        </div>
+      );
+    default:
+      return (
+        <SVG.Root ref={svgRef}>
+          <SVG.Zoom extent={[1 / 2, 2]}>
+            <SVG.Graph<SpaceGraphNode, SpaceGraphEdge>
+              model={model}
+              projector={projector}
+              renderNode={renderNode}
+              drag={variant === 'force'}
+              onInspect={handleInspect}
+              onSelect={handleSelect}
+            />
+          </SVG.Zoom>
+        </SVG.Root>
+      );
   }
-
-  // Force needs SVG.Zoom (drag interaction). Cluster/lattice don't, AND including the zoom
-  // wrapper makes their curve edges render incorrectly in some contexts (see iteration
-  // history in graph-cluster-projector.ts). So mount with vs. without zoom conditionally.
-  const inner = (
-    <SVG.Graph<SpaceGraphNode, SpaceGraphEdge>
-      model={model}
-      projector={projector}
-      renderNode={renderNode}
-      drag={variant === 'force'}
-      onInspect={handleInspect}
-      onSelect={handleSelect}
-    />
-  );
-
-  return (
-    <SVG.Root ref={svgRef}>{variant === 'force' ? <SVG.Zoom extent={[1 / 2, 2]}>{inner}</SVG.Zoom> : inner}</SVG.Root>
-  );
 };
 
-/** Cross-variant tween duration. Matches the renderer's edge fade timing so node
- * movement and edge enter/exit complete together. */
+// Cross-variant tween duration. Matches the renderer's edge fade timing so node.
 const TWEEN_MS = 500;
 
 const createProjector = (
@@ -315,6 +316,7 @@ const createProjector = (
     case 'force':
       // Force has no `duration` — its own simulation drives motion via ticks.
       return new GraphForceProjector<SpaceGraphNode>(ctx, undefined, undefined, prev);
+
     case 'lattice':
       return new GraphLatticeProjector<SpaceGraphNode>(
         ctx,
@@ -334,6 +336,7 @@ const createProjector = (
         undefined,
         prev,
       );
+
     case 'cluster':
       return new GraphClusterProjector<SpaceGraphNode>(
         ctx,
@@ -350,6 +353,7 @@ const createProjector = (
         undefined,
         prev,
       );
+
     case 'bundle':
       return new GraphBundleProjector<SpaceGraphNode>(
         ctx,
@@ -374,6 +378,7 @@ const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGrap
   switch (variant) {
     case 'swarm':
       return undefined;
+
     case 'force':
       return (group, node) => {
         const r = node.r ?? 6;
@@ -383,6 +388,7 @@ const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGrap
           .style('cursor', 'pointer')
           .style('fill', getNodeFillForObject(node.data?.data?.object as Obj.Unknown | undefined));
       };
+
     case 'lattice':
       return (group, node) => {
         const r = node.r ?? 6;
@@ -398,6 +404,7 @@ const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGrap
           .style('cursor', 'pointer')
           .style('fill', getNodeFillForObject(node.data?.data?.object as Obj.Unknown | undefined));
       };
+
     case 'cluster':
       return (group, node) => {
         const obj = node.data?.data?.object as Obj.Unknown | undefined;
@@ -417,6 +424,7 @@ const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGrap
           appendRadialGroupLabel(group, node, r);
         }
       };
+
     case 'bundle':
       // Bundle layout renders ONLY leaves (root/group are invisible routing anchors).
       // Every node here is a leaf — same circle + radial label shape as cluster.

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
@@ -193,8 +193,7 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
       setProjector(undefined);
       return;
     }
-    const prev =
-      (projectorRef.current?.layout as GraphLayout<SpaceGraphNode> | undefined) ?? lastLayoutRef.current;
+    const prev = (projectorRef.current?.layout as GraphLayout<SpaceGraphNode> | undefined) ?? lastLayoutRef.current;
     setProjector(createProjector(variant as Exclude<ExplorerArticleVariant, 'flock'>, svgRef.current, prev));
   }, [variant]);
 

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
@@ -201,6 +201,13 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
     setProjector(createProjector(variant as Exclude<ExplorerArticleVariant, 'swarm'>, svgRef.current, prev));
   }, [variant]);
 
+  // Keep the model's reactive graph atom alive across SVG.Graph unmount cycles.
+  // The atom auto-disposes when its last subscriber unsubscribes (effect-atom
+  // default), which means the SVG variant ↔ swarm swap would wipe model.graph
+  // to its initial empty value while the canvas was mounted. A no-op subscription
+  // pinned to the model's lifetime keeps the atom retained.
+  useEffect(() => model?.subscribe(() => {}), [model]);
+
   const renderNode = useMemo(() => createRenderNode(variant), [variant]);
 
   const handleInspect = useCallback(
@@ -233,29 +240,37 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
     [variant, projector],
   );
 
-  // Build the boid seeds from the snapshot of the last graph layout. Graph coordinates
-  // are center-origin; the Flock canvas uses top-left origin, so translate by the
-  // container center. Fall back to a random spread inside the container when there's no
-  // prior layout (e.g. the user lands directly on flock).
+  // Build boid seeds from the current model graph, falling back to the last SVG layout
+  // for positions where available. Graph coordinates are center-origin; the Flock canvas
+  // uses top-left origin, so translate by the container center.
   const flockSeeds = useMemo(() => {
     return ({ width, height }: { width: number; height: number }): FlockSeed[] => {
-      const nodes = lastLayoutRef.current?.graph.nodes;
-      const modelNodes = model?.graph.nodes ?? [];
-      const count = nodes?.length ?? modelNodes.length;
       const cx = width / 2;
       const cy = height / 2;
-      if (nodes && nodes.length) {
-        return nodes.map((node) => ({
-          x: cx + (node.x ?? 0),
-          y: cy + (node.y ?? 0),
-        }));
+      const snapshot = new Map(
+        (lastLayoutRef.current?.graph.nodes ?? []).map((node) => [node.id, node] as const),
+      );
+      const modelNodes = model?.graph.nodes ?? [];
+      if (modelNodes.length) {
+        const spread = Math.min(width, height) * 0.5;
+        return modelNodes.map((node) => {
+          const prev = snapshot.get(node.id);
+          if (prev && prev.x != null && prev.y != null) {
+            return { x: cx + prev.x, y: cy + prev.y };
+          }
+          return {
+            x: cx + (Math.random() - 0.5) * spread,
+            y: cy + (Math.random() - 0.5) * spread,
+          };
+        });
       }
 
-      // No prior layout — spread points around the center so the flock still has bodies.
-      return Array.from({ length: count }, () => ({
-        x: cx + (Math.random() - 0.5) * Math.min(width, height) * 0.5,
-        y: cy + (Math.random() - 0.5) * Math.min(width, height) * 0.5,
-      }));
+      // No model nodes yet — fall back to the snapshot if present, else a small random spread.
+      const snapshotNodes = lastLayoutRef.current?.graph.nodes ?? [];
+      if (snapshotNodes.length) {
+        return snapshotNodes.map((node) => ({ x: cx + (node.x ?? 0), y: cy + (node.y ?? 0) }));
+      }
+      return [];
     };
   }, [model, variant]);
 

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
@@ -39,7 +39,7 @@ import { useGraphModel } from '#hooks';
 import { getNodeFillForObject } from '../../util/node-color';
 
 /** Visualization variants exposed by `ExplorerArticle`. */
-export type ExplorerArticleVariant = 'force' | 'cluster' | 'bundle' | 'lattice' | 'flock';
+export type ExplorerArticleVariant = 'force' | 'cluster' | 'bundle' | 'lattice' | 'swarm';
 
 const VARIANTS: { value: ExplorerArticleVariant; icon: string; label: string }[] = [
   {
@@ -63,9 +63,9 @@ const VARIANTS: { value: ExplorerArticleVariant; icon: string; label: string }[]
     label: 'Lattice',
   },
   {
-    value: 'flock',
-    icon: 'ph--bird--regular',
-    label: 'Flock',
+    value: 'swarm',
+    icon: 'ph--fish--regular',
+    label: 'Swarm',
   },
 ];
 
@@ -107,6 +107,7 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
     if (!dxn) {
       return;
     }
+
     const target = event.target as HTMLElement;
     target.dispatchEvent(
       new DxAnchorActivate({
@@ -148,7 +149,7 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
 };
 
 const isVariant = (value: unknown): value is ExplorerArticleVariant =>
-  value === 'force' || value === 'cluster' || value === 'bundle' || value === 'lattice' || value === 'flock';
+  value === 'force' || value === 'cluster' || value === 'bundle' || value === 'lattice' || value === 'swarm';
 
 type VisualizationProps = {
   variant: ExplorerArticleVariant;
@@ -181,20 +182,23 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
   // layout to the constructor so existing node x/y persist across the swap, then
   // the new projector's animate() tweens to its target positions.
   useEffect(() => {
-    if (!svgRef.current) {
-      return;
+    // Snapshot the latest layout BEFORE checking svgRef. When swapping from an SVG
+    // variant to swarm, the SVG.Root unmounts during commit (so svgRef.current is
+    // null by the time this effect runs), but projectorRef still references the
+    // previous projector whose layout we want to hand to the Flock.
+    if (projectorRef.current?.layout) {
+      lastLayoutRef.current = projectorRef.current.layout as GraphLayout<SpaceGraphNode>;
     }
-    if (variant === 'flock') {
-      // Capture the latest layout before unmounting the SVG projector; the canvas-based
-      // Flock takes over rendering.
-      if (projectorRef.current?.layout) {
-        lastLayoutRef.current = projectorRef.current.layout as GraphLayout<SpaceGraphNode>;
-      }
+    if (variant === 'swarm') {
       setProjector(undefined);
       return;
     }
-    const prev = (projectorRef.current?.layout as GraphLayout<SpaceGraphNode> | undefined) ?? lastLayoutRef.current;
-    setProjector(createProjector(variant as Exclude<ExplorerArticleVariant, 'flock'>, svgRef.current, prev));
+    if (!svgRef.current) {
+      return;
+    }
+
+    const prev = lastLayoutRef.current;
+    setProjector(createProjector(variant as Exclude<ExplorerArticleVariant, 'swarm'>, svgRef.current, prev));
   }, [variant]);
 
   const renderNode = useMemo(() => createRenderNode(variant), [variant]);
@@ -206,6 +210,7 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
         onNodeHover?.(null);
         return;
       }
+
       onNodeHover?.({ id: node.id, data: node.data?.data?.object }, event);
     },
     [onNodeHover],
@@ -221,6 +226,7 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
       ) {
         return;
       }
+
       const cluster = projector as GraphClusterProjector<SpaceGraphNode> | undefined;
       cluster?.toggleCollapsed(node.id);
     },
@@ -244,6 +250,7 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
           y: cy + (node.y ?? 0),
         }));
       }
+
       // No prior layout — spread points around the center so the flock still has bodies.
       return Array.from({ length: count }, () => ({
         x: cx + (Math.random() - 0.5) * Math.min(width, height) * 0.5,
@@ -252,10 +259,10 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
     };
   }, [model, variant]);
 
-  if (variant === 'flock') {
+  if (variant === 'swarm') {
     return (
-      <div className='relative is-full bs-full'>
-        <Flock seeds={flockSeeds} coloring='Rainbow' />
+      <div className='dx-expander relative'>
+        <Flock seeds={flockSeeds} coloring='Movement' />
       </div>
     );
   }
@@ -283,7 +290,7 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
 const TWEEN_MS = 500;
 
 const createProjector = (
-  variant: Exclude<ExplorerArticleVariant, 'flock'>,
+  variant: Exclude<ExplorerArticleVariant, 'swarm'>,
   ctx: SVGContext,
   prev?: GraphLayout<SpaceGraphNode>,
 ): GraphProjector<SpaceGraphNode> => {
@@ -348,7 +355,7 @@ const typenameGroupOf = (node: GraphLayoutNode<SpaceGraphNode>): string | undefi
 
 const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGraphNode> | undefined => {
   switch (variant) {
-    case 'flock':
+    case 'swarm':
       return undefined;
     case 'force':
       return (group, node) => {

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
@@ -25,6 +25,7 @@ import {
   SVG,
   type SVGContext,
 } from '@dxos/react-ui-graph';
+import { Flock, type FlockSeed } from '@dxos/react-ui-sfx';
 import { type SpaceGraphEdge, type SpaceGraphNode } from '@dxos/schema';
 // Side-effect import: ExplorerArticle drives `SVG.Graph` directly (previously the CSS
 // was pulled in transitively via `ForceGraph.tsx`, which we no longer use). Without it
@@ -38,7 +39,7 @@ import { useGraphModel } from '#hooks';
 import { getNodeFillForObject } from '../../util/node-color';
 
 /** Visualization variants exposed by `ExplorerArticle`. */
-export type ExplorerArticleVariant = 'force' | 'cluster' | 'bundle' | 'lattice';
+export type ExplorerArticleVariant = 'force' | 'cluster' | 'bundle' | 'lattice' | 'flock';
 
 const VARIANTS: { value: ExplorerArticleVariant; icon: string; label: string }[] = [
   {
@@ -60,6 +61,11 @@ const VARIANTS: { value: ExplorerArticleVariant; icon: string; label: string }[]
     value: 'lattice',
     icon: 'ph--grid-four--regular',
     label: 'Lattice',
+  },
+  {
+    value: 'flock',
+    icon: 'ph--bird--regular',
+    label: 'Flock',
   },
 ];
 
@@ -142,7 +148,7 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
 };
 
 const isVariant = (value: unknown): value is ExplorerArticleVariant =>
-  value === 'force' || value === 'cluster' || value === 'bundle' || value === 'lattice';
+  value === 'force' || value === 'cluster' || value === 'bundle' || value === 'lattice' || value === 'flock';
 
 type VisualizationProps = {
   variant: ExplorerArticleVariant;
@@ -151,18 +157,25 @@ type VisualizationProps = {
 };
 
 /**
- * One persistent `<SVG.Graph>` mount for all four variants. When the variant
+ * One persistent `<SVG.Graph>` mount for all four SVG variants. When the variant
  * changes, a new projector is instantiated and seeded with the previous
  * projector's layout so node x/y survive the swap — the new projector's
  * `animate()` then tweens each node from its current position to the new
  * target, and per-frame edge generators (cluster, bundle) keep curves glued
  * to the moving endpoints.
+ *
+ * The `flock` variant is a separate canvas-based render that seeds boids from
+ * the most recent projector layout so the swap into/out of flock preserves
+ * each node's last position.
  */
 const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
   const svgRef = useRef<SVGContext>(null);
   const [projector, setProjector] = useState<GraphProjector<SpaceGraphNode> | undefined>();
   const projectorRef = useRef<GraphProjector<SpaceGraphNode> | undefined>(undefined);
   projectorRef.current = projector;
+  // Snapshot of the last SVG projector layout taken just before entering flock,
+  // so the boids can start exactly where the nodes were.
+  const lastLayoutRef = useRef<GraphLayout<SpaceGraphNode> | undefined>(undefined);
 
   // Recreate the projector when the variant changes. Pass the previous projector's
   // layout to the constructor so existing node x/y persist across the swap, then
@@ -171,8 +184,18 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
     if (!svgRef.current) {
       return;
     }
-    const prev = projectorRef.current?.layout as GraphLayout<SpaceGraphNode> | undefined;
-    setProjector(createProjector(variant, svgRef.current, prev));
+    if (variant === 'flock') {
+      // Capture the latest layout before unmounting the SVG projector; the canvas-based
+      // Flock takes over rendering.
+      if (projectorRef.current?.layout) {
+        lastLayoutRef.current = projectorRef.current.layout as GraphLayout<SpaceGraphNode>;
+      }
+      setProjector(undefined);
+      return;
+    }
+    const prev =
+      (projectorRef.current?.layout as GraphLayout<SpaceGraphNode> | undefined) ?? lastLayoutRef.current;
+    setProjector(createProjector(variant as Exclude<ExplorerArticleVariant, 'flock'>, svgRef.current, prev));
   }, [variant]);
 
   const renderNode = useMemo(() => createRenderNode(variant), [variant]);
@@ -205,6 +228,39 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
     [variant, projector],
   );
 
+  // Build the boid seeds from the snapshot of the last graph layout. Graph coordinates
+  // are center-origin; the Flock canvas uses top-left origin, so translate by the
+  // container center. Fall back to a random spread inside the container when there's no
+  // prior layout (e.g. the user lands directly on flock).
+  const flockSeeds = useMemo(() => {
+    return ({ width, height }: { width: number; height: number }): FlockSeed[] => {
+      const nodes = lastLayoutRef.current?.graph.nodes;
+      const modelNodes = model?.graph.nodes ?? [];
+      const count = nodes?.length ?? modelNodes.length;
+      const cx = width / 2;
+      const cy = height / 2;
+      if (nodes && nodes.length) {
+        return nodes.map((node) => ({
+          x: cx + (node.x ?? 0),
+          y: cy + (node.y ?? 0),
+        }));
+      }
+      // No prior layout — spread points around the center so the flock still has bodies.
+      return Array.from({ length: count }, () => ({
+        x: cx + (Math.random() - 0.5) * Math.min(width, height) * 0.5,
+        y: cy + (Math.random() - 0.5) * Math.min(width, height) * 0.5,
+      }));
+    };
+  }, [model, variant]);
+
+  if (variant === 'flock') {
+    return (
+      <div className='relative is-full bs-full'>
+        <Flock seeds={flockSeeds} coloring='Rainbow' />
+      </div>
+    );
+  }
+
   // Force needs SVG.Zoom (drag interaction). Cluster/lattice don't, AND including the zoom
   // wrapper makes their curve edges render incorrectly in some contexts (see iteration
   // history in graph-cluster-projector.ts). So mount with vs. without zoom conditionally.
@@ -228,7 +284,7 @@ const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
 const TWEEN_MS = 500;
 
 const createProjector = (
-  variant: ExplorerArticleVariant,
+  variant: Exclude<ExplorerArticleVariant, 'flock'>,
   ctx: SVGContext,
   prev?: GraphLayout<SpaceGraphNode>,
 ): GraphProjector<SpaceGraphNode> => {
@@ -293,6 +349,8 @@ const typenameGroupOf = (node: GraphLayoutNode<SpaceGraphNode>): string | undefi
 
 const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGraphNode> | undefined => {
   switch (variant) {
+    case 'flock':
+      return undefined;
     case 'force':
       return (group, node) => {
         const r = node.r ?? 6;

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { type Filter, Obj, type View } from '@dxos/echo';
@@ -10,71 +10,31 @@ import { QueryBuilder } from '@dxos/echo-query';
 import { useObject } from '@dxos/react-client/echo';
 import { DxAnchorActivate, Icon, Panel, Toolbar } from '@dxos/react-ui';
 import { QueryEditor, type QueryEditorProps } from '@dxos/react-ui-components';
-import {
-  CLUSTER_NODE_TYPE_GROUP,
-  CLUSTER_NODE_TYPE_LEAF,
-  CLUSTER_NODE_TYPE_ROOT,
-  GraphBundleProjector,
-  GraphClusterProjector,
-  GraphForceProjector,
-  type GraphLayout,
-  type GraphLayoutNode,
-  GraphLatticeProjector,
-  type GraphProjector,
-  type RenderNode,
-  SVG,
-  type SVGContext,
-} from '@dxos/react-ui-graph';
-import { Flock, type FlockSeed } from '@dxos/react-ui-sfx';
-import { SpaceGraphModel, type SpaceGraphEdge, type SpaceGraphNode } from '@dxos/schema';
-// Side-effect import: ExplorerArticle drives `SVG.Graph` directly (previously the CSS
-// was pulled in transitively via `ForceGraph.tsx`, which we no longer use). Without it
-// the `g.dx-edge path` rules — including `fill: none` — never reach the bundle and SVG
+// Side-effect import: Visualization drives `SVG.Graph` directly. Without the CSS the
+// `g.dx-edge path` rules — including `fill: none` — never reach the bundle and SVG
 // defaults (stroke: none, fill: black) make every edge invisible.
 import '@dxos/react-ui-graph/styles/graph.css';
 
 import { type TreeNode } from '#components';
 import { useGraphModel } from '#hooks';
 
-import { getNodeFillForObject } from '../../util';
+import { type ExplorerArticleVariant, VARIANTS, isVariant } from './variants';
+import { Visualization } from './Visualization';
 
-/** Visualization variants exposed by `ExplorerArticle`. */
-export type ExplorerArticleVariant = 'force' | 'cluster' | 'bundle' | 'lattice' | 'swarm';
-
-const VARIANTS: { value: ExplorerArticleVariant; icon: string; label: string }[] = [
-  {
-    value: 'force',
-    icon: 'ph--graph--regular',
-    label: 'Force-directed',
-  },
-  {
-    value: 'cluster',
-    icon: 'ph--asterisk-simple--regular',
-    label: 'Radial cluster',
-  },
-  {
-    value: 'bundle',
-    icon: 'ph--circles-three-plus--regular',
-    label: 'Edge bundling',
-  },
-  {
-    value: 'lattice',
-    icon: 'ph--grid-four--regular',
-    label: 'Lattice',
-  },
-  {
-    value: 'swarm',
-    icon: 'ph--fish--regular',
-    label: 'Swarm',
-  },
-];
+export type { ExplorerArticleVariant } from './variants';
 
 export type ExplorerArticleProps = AppSurface.ObjectArticleProps<View.View>;
 
+/**
+ * Thin wrapper: owns the query editor, the variant toggle, and the DxAnchor preview
+ * dispatch. The actual rendering — SVG projector swaps and the swarm canvas — lives in
+ * `Visualization`.
+ */
 export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps) => {
   const [view] = useObject(subject);
-  const db = view && Obj.getDatabase(view);
   const [filter, setFilter] = useState<Filter.Any>();
+
+  const db = view && Obj.getDatabase(view);
   const model = useGraphModel(db, filter);
 
   const builder = useMemo(() => new QueryBuilder(), []);
@@ -85,7 +45,6 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
     [builder],
   );
 
-  // The `variant` prop is the initial value; user can toggle via the toolbar tabs.
   const [selected, setSelected] = useState<ExplorerArticleVariant>(isVariant(variant) ? variant : 'force');
   useEffect(() => {
     if (isVariant(variant)) {
@@ -99,7 +58,7 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
     }
   }, []);
 
-  const handleHoverPreview = useCallback((node: TreeNode | null, event?: MouseEvent) => {
+  const handleHover = useCallback((node: TreeNode | null, event?: MouseEvent) => {
     if (!node || !event) {
       return;
     }
@@ -116,9 +75,9 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
     target.dispatchEvent(
       new DxAnchorActivate({
         dxn,
-        label: Obj.getLabel(obj) ?? dxn,
-        trigger: target,
         kind: 'card',
+        trigger: target,
+        label: Obj.getLabel(obj) ?? dxn,
       }),
     );
   }, []);
@@ -146,412 +105,8 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
         </Panel.Toolbar>
       )}
       <Panel.Content>
-        <Visualization variant={selected} model={model} onNodeHover={handleHoverPreview} />
+        <Visualization variant={selected} model={model} onNodeHover={handleHover} />
       </Panel.Content>
     </Panel.Root>
   );
-};
-
-const isVariant = (value: unknown): value is ExplorerArticleVariant =>
-  value === 'force' || value === 'cluster' || value === 'bundle' || value === 'lattice' || value === 'swarm';
-
-type VisualizationProps = {
-  variant: ExplorerArticleVariant;
-  model: NonNullable<SpaceGraphModel>;
-  onNodeHover?: (node: TreeNode | null, event?: MouseEvent) => void;
-};
-
-/**
- * One persistent `<SVG.Graph>` mount for all four SVG variants. When the variant
- * changes, a new projector is instantiated and seeded with the previous
- * projector's layout so node x/y survive the swap — the new projector's
- * `animate()` then tweens each node from its current position to the new
- * target, and per-frame edge generators (cluster, bundle) keep curves glued
- * to the moving endpoints.
- *
- * The `flock` variant is a separate canvas-based render that seeds boids from
- * the most recent projector layout so the swap into/out of flock preserves
- * each node's last position.
- */
-const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
-  const svgRef = useRef<SVGContext>(null);
-  const [projector, setProjector] = useState<GraphProjector<SpaceGraphNode> | undefined>();
-  const projectorRef = useRef<GraphProjector<SpaceGraphNode> | undefined>(undefined);
-  projectorRef.current = projector;
-  // Snapshot of the last SVG projector layout taken just before entering flock,
-  // so the boids can start exactly where the nodes were.
-  const lastLayoutRef = useRef<GraphLayout<SpaceGraphNode> | undefined>(undefined);
-
-  // Recreate the projector when the variant changes. Pass the previous projector's
-  // layout to the constructor so existing node x/y persist across the swap, then
-  // the new projector's animate() tweens to its target positions.
-  useEffect(() => {
-    // Snapshot the latest layout BEFORE checking svgRef. When swapping from an SVG
-    // variant to swarm, the SVG.Root unmounts during commit (so svgRef.current is
-    // null by the time this effect runs), but projectorRef still references the
-    // previous projector whose layout we want to hand to the Flock.
-    if (projectorRef.current?.layout) {
-      lastLayoutRef.current = projectorRef.current.layout as GraphLayout<SpaceGraphNode>;
-    }
-    if (variant === 'swarm') {
-      setProjector(undefined);
-      return;
-    }
-    if (!svgRef.current) {
-      return;
-    }
-
-    const prev = lastLayoutRef.current;
-    setProjector(createProjector(variant as Exclude<ExplorerArticleVariant, 'swarm'>, svgRef.current, prev));
-  }, [variant]);
-
-  // Subscribe to the model's reactive graph atom. Two purposes:
-  //  1. Keep-alive: effect-atom auto-disposes atoms when no subscribers remain
-  //     (its documented default). Without this, swarm ↔ SVG variant swaps would
-  //     wipe model.graph to its initial empty value while the canvas is mounted.
-  //  2. Re-render: when model data first arrives (asynchronously from the ECHO
-  //     query), bump local state so flockSeeds re-memos and Flock receives the
-  //     new node positions.
-  const [modelRev, setModelRev] = useState(0);
-  useEffect(() => model?.subscribe(() => setModelRev((r) => r + 1)), [model]);
-
-  const renderNode = useMemo(() => createRenderNode(variant), [variant]);
-
-  const handleInspect = useCallback(
-    (node: GraphLayoutNode<SpaceGraphNode> | null, event: MouseEvent) => {
-      // null = pointerleave: forward to the shared hover handler so it can clear any preview.
-      if (!node) {
-        onNodeHover?.(null);
-        return;
-      }
-
-      onNodeHover?.({ id: node.id, data: node.data?.data?.object }, event);
-    },
-    [onNodeHover],
-  );
-
-  // Cluster-only: clicking a root / group node toggles its subtree open/closed.
-  const handleSelect = useCallback(
-    (node: GraphLayoutNode<SpaceGraphNode>) => {
-      if (
-        variant !== 'cluster' ||
-        !node ||
-        (node.type !== CLUSTER_NODE_TYPE_ROOT && node.type !== CLUSTER_NODE_TYPE_GROUP)
-      ) {
-        return;
-      }
-
-      const cluster = projector as GraphClusterProjector<SpaceGraphNode> | undefined;
-      cluster?.toggleCollapsed(node.id);
-    },
-    [variant, projector],
-  );
-
-  // Build boid seeds from the current model graph, falling back to the last SVG layout
-  // for positions where available. Graph coordinates are center-origin; the Flock canvas
-  // uses top-left origin, so translate by the container center.
-  const flockSeeds = useMemo(() => {
-    return ({ width, height }: { width: number; height: number }): FlockSeed[] => {
-      const cx = width / 2;
-      const cy = height / 2;
-      const snapshot = new Map((lastLayoutRef.current?.graph.nodes ?? []).map((node) => [node.id, node] as const));
-      const modelNodes = model?.graph.nodes ?? [];
-      if (modelNodes.length) {
-        const spread = Math.min(width, height) * 0.5;
-        return modelNodes.map((node) => {
-          const prev = snapshot.get(node.id);
-          if (prev && prev.x != null && prev.y != null) {
-            return { x: cx + prev.x, y: cy + prev.y };
-          }
-          return {
-            x: cx + (Math.random() - 0.5) * spread,
-            y: cy + (Math.random() - 0.5) * spread,
-          };
-        });
-      }
-
-      // No model nodes yet — fall back to the snapshot if present, else a small random spread.
-      const snapshotNodes = lastLayoutRef.current?.graph.nodes ?? [];
-      if (snapshotNodes.length) {
-        return snapshotNodes.map((node) => ({ x: cx + (node.x ?? 0), y: cy + (node.y ?? 0) }));
-      }
-      return [];
-    };
-  }, [model, variant, modelRev]);
-
-  switch (variant) {
-    case 'swarm':
-      return (
-        <div className='dx-expander relative'>
-          <Flock seeds={flockSeeds} coloring='Movement' />
-        </div>
-      );
-    default:
-      return (
-        <SVG.Root ref={svgRef}>
-          <SVG.Zoom extent={[1 / 2, 2]}>
-            <SVG.Graph<SpaceGraphNode, SpaceGraphEdge>
-              model={model}
-              projector={projector}
-              renderNode={renderNode}
-              drag={variant === 'force'}
-              onInspect={handleInspect}
-              onSelect={handleSelect}
-            />
-          </SVG.Zoom>
-        </SVG.Root>
-      );
-  }
-};
-
-// Cross-variant tween duration. Matches the renderer's edge fade timing so node.
-const TWEEN_MS = 500;
-
-const createProjector = (
-  variant: Exclude<ExplorerArticleVariant, 'swarm'>,
-  ctx: SVGContext,
-  prev?: GraphLayout<SpaceGraphNode>,
-): GraphProjector<SpaceGraphNode> => {
-  switch (variant) {
-    case 'force':
-      // Force has no `duration` — its own simulation drives motion via ticks.
-      return new GraphForceProjector<SpaceGraphNode>(ctx, undefined, undefined, prev);
-
-    case 'lattice':
-      return new GraphLatticeProjector<SpaceGraphNode>(
-        ctx,
-        {
-          duration: TWEEN_MS,
-          // Plugin-explorer overrides the projector's force-matched default (6)
-          // with a smaller node so the lattice reads as a dense matrix.
-          radius: 4,
-          // Cluster by typename first so same-type rects sit together; break ties by label.
-          sortBy: (node: GraphLayoutNode<SpaceGraphNode>) => {
-            const obj = node.data?.data?.object;
-            const typename = obj ? (Obj.getTypename(obj) ?? '(untyped)') : '(untyped)';
-            const label = (obj && Obj.getLabel(obj)) ?? node.data?.data?.label ?? node.id;
-            return `${typename} ${label}`;
-          },
-        },
-        undefined,
-        prev,
-      );
-
-    case 'cluster':
-      return new GraphClusterProjector<SpaceGraphNode>(
-        ctx,
-        {
-          duration: TWEEN_MS,
-          groupOf: typenameGroupOf,
-          rootLabel: 'Database',
-          groupLabel: shortTypename,
-          // All three node kinds share the same radius — leaves, groups, and root read
-          // as members of the same circle rather than ranked by size.
-          rootRadius: 4,
-          groupRadius: 4,
-        },
-        undefined,
-        prev,
-      );
-
-    case 'bundle':
-      return new GraphBundleProjector<SpaceGraphNode>(
-        ctx,
-        {
-          duration: TWEEN_MS,
-          groupOf: typenameGroupOf,
-        },
-        undefined,
-        prev,
-      );
-  }
-};
-
-/** Group leaves by typename so same-type leaves cluster together — used by both the
- * cluster (visible structural nodes) and bundle (invisible routing anchors) projectors. */
-const typenameGroupOf = (node: GraphLayoutNode<SpaceGraphNode>): string | undefined => {
-  const obj = node.data?.data?.object;
-  return obj ? (Obj.getTypename(obj) ?? '(untyped)') : undefined;
-};
-
-const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGraphNode> | undefined => {
-  switch (variant) {
-    case 'swarm':
-      return undefined;
-
-    case 'force':
-      return (group, node) => {
-        const r = node.r ?? 6;
-        group
-          .append('circle')
-          .attr('r', r)
-          .style('cursor', 'pointer')
-          .style('fill', getNodeFillForObject(node.data?.data?.object as Obj.Unknown | undefined));
-      };
-
-    case 'lattice':
-      return (group, node) => {
-        const r = node.r ?? 6;
-        const size = r * 2;
-        group
-          .append('rect')
-          .attr('x', -r)
-          .attr('y', -r)
-          .attr('width', size)
-          .attr('height', size)
-          .attr('rx', r * 0.3)
-          .attr('ry', r * 0.3)
-          .style('cursor', 'pointer')
-          .style('fill', getNodeFillForObject(node.data?.data?.object as Obj.Unknown | undefined));
-      };
-
-    case 'cluster':
-      return (group, node) => {
-        const obj = node.data?.data?.object as Obj.Unknown | undefined;
-        const r = node.r ?? 4;
-        // Synthetic root / group nodes have no underlying ECHO object; render them as
-        // smaller, neutral circles so the hierarchy reads as "structure + leaves".
-        group
-          .append('circle')
-          .attr('r', r)
-          .style('cursor', 'pointer')
-          .style('fill', obj ? getNodeFillForObject(obj) : 'var(--color-neutral-500)');
-        if (node.type === CLUSTER_NODE_TYPE_LEAF) {
-          appendRadialLeafLabel(group, node, obj, r);
-        } else if (node.type === CLUSTER_NODE_TYPE_ROOT) {
-          appendRootLabel(group, node, r);
-        } else if (node.type === CLUSTER_NODE_TYPE_GROUP) {
-          appendRadialGroupLabel(group, node, r);
-        }
-      };
-
-    case 'bundle':
-      // Bundle layout renders ONLY leaves (root/group are invisible routing anchors).
-      // Every node here is a leaf — same circle + radial label shape as cluster.
-      return (group, node) => {
-        const obj = node.data?.data?.object as Obj.Unknown | undefined;
-        const r = node.r ?? 4;
-        group
-          .append('circle')
-          .attr('r', r)
-          .style('cursor', 'pointer')
-          .style('fill', obj ? getNodeFillForObject(obj) : 'var(--color-neutral-500)');
-        appendRadialLeafLabel(group, node, obj, r);
-      };
-  }
-};
-
-/** Fade-in duration applied to labels after the layout tween completes. */
-const LABEL_FADE_MS = 200;
-
-/**
- * Append a radial leaf label outside the ring, oriented outward. Compute orientation
- * from the TARGET position (tx/ty) — at enter time node.x/y is still at the previous
- * projector's coordinates, so using current x/y would orient the label by the
- * pre-transition layout (wrong) and the rotation wouldn't update during the tween.
- *
- * Label appears with opacity 0 and fades in after a `TWEEN_MS` delay so the text isn't
- * sliding across the screen mid-tween — leaves first, labels after.
- */
-const appendRadialLeafLabel = (
-  group: Parameters<RenderNode<SpaceGraphNode>>[0],
-  node: GraphLayoutNode<SpaceGraphNode>,
-  obj: Obj.Unknown | undefined,
-  r: number,
-): void => {
-  const label = (obj && Obj.getLabel(obj)) ?? node.data?.data?.label ?? node.id;
-  if (!label) {
-    return;
-  }
-
-  const targetX = (node as any).tx ?? node.x ?? 0;
-  const targetY = (node as any).ty ?? node.y ?? 0;
-  const angleDeg = (Math.atan2(targetY, targetX) * 180) / Math.PI;
-  // Flip text 180° on the left half of the layout so it still reads left-to-right.
-  const flipped = angleDeg > 90 || angleDeg < -90;
-  group
-    .append('text')
-    .classed('dx-cluster-label', true)
-    .attr('dy', '0.32em')
-    .attr('transform', `rotate(${flipped ? angleDeg + 180 : angleDeg})`)
-    .attr('x', flipped ? -(r + 4) : r + 4)
-    .attr('text-anchor', flipped ? 'end' : 'start')
-    .attr('opacity', 0)
-    .style('pointer-events', 'none')
-    .text(label)
-    .transition()
-    .delay(TWEEN_MS)
-    .duration(LABEL_FADE_MS)
-    .attr('opacity', 1);
-};
-
-/**
- * Append a radial label INSIDE the ring (toward origin) for a synthetic group node.
- * Same rotation/flip rules as the leaf label, but offset and anchor inverted so the
- * text reads from the group circle back toward the center rather than outward.
- */
-const appendRadialGroupLabel = (
-  group: Parameters<RenderNode<SpaceGraphNode>>[0],
-  node: GraphLayoutNode<SpaceGraphNode>,
-  r: number,
-): void => {
-  if (!node.label) {
-    return;
-  }
-
-  const targetX = (node as any).tx ?? node.x ?? 0;
-  const targetY = (node as any).ty ?? node.y ?? 0;
-  const angleDeg = (Math.atan2(targetY, targetX) * 180) / Math.PI;
-  const flipped = angleDeg > 90 || angleDeg < -90;
-  group
-    .append('text')
-    .classed('dx-cluster-label', true)
-    .classed('dx-cluster-label-group', true)
-    .attr('dy', '0.32em')
-    .attr('transform', `rotate(${flipped ? angleDeg + 180 : angleDeg})`)
-    // Inverse of the leaf offset / anchor — push the text inward, toward the origin.
-    .attr('x', flipped ? r + 4 : -(r + 4))
-    .attr('text-anchor', flipped ? 'start' : 'end')
-    .attr('opacity', 0)
-    .style('pointer-events', 'none')
-    .text(node.label)
-    .transition()
-    .delay(TWEEN_MS)
-    .duration(LABEL_FADE_MS)
-    .attr('opacity', 1);
-};
-
-/**
- * Append a centered label below the root node. Root sits at origin where there's no
- * meaningful radial direction; render the label as a plain horizontal caption with
- * the standard halo style.
- */
-const appendRootLabel = (
-  group: Parameters<RenderNode<SpaceGraphNode>>[0],
-  node: GraphLayoutNode<SpaceGraphNode>,
-  r: number,
-): void => {
-  if (!node.label) {
-    return;
-  }
-
-  group
-    .append('text')
-    .classed('dx-cluster-label', true)
-    .classed('dx-cluster-label-root', true)
-    .attr('text-anchor', 'middle')
-    .attr('y', -(r + 6))
-    .attr('opacity', 0)
-    .style('pointer-events', 'none')
-    .text(node.label)
-    .transition()
-    .delay(TWEEN_MS)
-    .duration(LABEL_FADE_MS)
-    .attr('opacity', 1);
-};
-
-/** Drop the package prefix from a typename for display: `org.dxos.type.Person` → `Person`. */
-const shortTypename = (typename: string): string => {
-  const last = typename.split('.').pop() ?? typename;
-  return last.charAt(0).toUpperCase() + last.slice(1);
 };

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
@@ -6,6 +6,7 @@ import { RegistryContext } from '@effect-atom/atom-react';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Obj } from '@dxos/echo';
+import { useThemeContext } from '@dxos/react-ui';
 import {
   CLUSTER_NODE_TYPE_GROUP,
   CLUSTER_NODE_TYPE_LEAF,
@@ -50,6 +51,11 @@ export type VisualizationProps = {
  */
 export const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
   const registry = useContext(RegistryContext);
+  const { themeMode } = useThemeContext();
+  // Match the visible app background so the swarm canvas reads as continuous
+  // with the rest of the UI. Page bg comes from --color-baseSurface tokens
+  // (dark = neutral-950 ≈ #0a0a0a, light = neutral-50 ≈ #fafafa).
+  const flockBackground = themeMode === 'dark' ? '#0a0a0a' : '#fafafa';
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [size, setSize] = useState({ width: 0, height: 0 });
 
@@ -168,7 +174,7 @@ export const Visualization = ({ variant, model, onNodeHover }: VisualizationProp
   return (
     <div ref={containerRef} className='dx-expander relative'>
       {variant === 'swarm' ? (
-        <Flock model={flockModel} coloring='Movement' />
+        <Flock model={flockModel} coloring='Movement' background={flockBackground} />
       ) : (
         <SVG.Root ref={svgRef}>
           <SVG.Zoom extent={[1 / 2, 2]}>

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
@@ -1,0 +1,491 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { RegistryContext } from '@effect-atom/atom-react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+
+import { Obj } from '@dxos/echo';
+import {
+  CLUSTER_NODE_TYPE_GROUP,
+  CLUSTER_NODE_TYPE_LEAF,
+  CLUSTER_NODE_TYPE_ROOT,
+  GraphBundleProjector,
+  GraphClusterProjector,
+  GraphForceProjector,
+  type GraphLayout,
+  type GraphLayoutNode,
+  GraphLatticeProjector,
+  type GraphProjector,
+  type RenderNode,
+  SVG,
+  type SVGContext,
+} from '@dxos/react-ui-graph';
+import { Flock, type FlockBoid, FlockModel, Vec2 } from '@dxos/react-ui-sfx';
+import { type SpaceGraphEdge, type SpaceGraphModel, type SpaceGraphNode } from '@dxos/schema';
+
+import { type TreeNode } from '#components';
+
+import { getNodeFillForObject } from '../../util';
+import { type ExplorerArticleVariant } from './variants';
+
+export type VisualizationProps = {
+  variant: ExplorerArticleVariant;
+  model: SpaceGraphModel;
+  onNodeHover?: (node: TreeNode | null, event?: MouseEvent) => void;
+};
+
+/**
+ * Renders the active visualization variant.
+ *
+ * For SVG variants (force, cluster, bundle, lattice), one `<SVG.Graph>` instance is
+ * kept mounted; only the projector swaps. Each new projector receives the previous
+ * layout so node x/y survive the swap and the projector's `animate()` tweens to the
+ * new target.
+ *
+ * The `swarm` variant is canvas-based and uses a `FlockModel`. On entry, boids are
+ * seeded from `model.graph.nodes` with positions taken from the latest SVG layout
+ * (matched by node id). On exit, the boids' current positions are written back to
+ * `lastLayoutRef` so the next SVG projector starts from where the swarm left off.
+ */
+export const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
+  const registry = useContext(RegistryContext);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  const svgRef = useRef<SVGContext>(null);
+  const [projector, setProjector] = useState<GraphProjector<SpaceGraphNode> | undefined>();
+  const projectorRef = useRef<GraphProjector<SpaceGraphNode> | undefined>(undefined);
+  projectorRef.current = projector;
+
+  // Latest layout we hand to the next SVG projector as `prev` — captured both when
+  // leaving an SVG variant (live projector.layout) and when leaving swarm (boid
+  // positions translated back to center-origin).
+  const lastLayoutRef = useRef<GraphLayout<SpaceGraphNode> | undefined>(undefined);
+
+  // Reactive source of truth for the boid array used by the swarm view.
+  const flockModel = useMemo(() => new FlockModel(registry), [registry]);
+
+  // Subscribe to the graph atom — keeps it alive across child unmounts (effect-atom
+  // disposes atoms with no subscribers) and triggers re-renders when query results land.
+  const [modelRev, setModelRev] = useState(0);
+  useEffect(() => model?.subscribe(() => setModelRev((r) => r + 1)), [model]);
+
+  // Track the visualization container size so we can translate between canvas
+  // (top-left origin) and graph (center origin) coordinates when entering or
+  // leaving swarm.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) {
+      return;
+    }
+
+    const rect = el.getBoundingClientRect();
+    setSize({ width: rect.width, height: rect.height });
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) {
+        return;
+      }
+      const { width, height } = entry.contentRect;
+      setSize((prev) => (prev.width === width && prev.height === height ? prev : { width, height }));
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Recreate the projector when the variant changes. Two transitions need special handling:
+  //  - leaving an SVG variant: snapshot live projector.layout into lastLayoutRef.
+  //  - leaving swarm: convert current boid positions (canvas-coord) back into a
+  //    center-origin layout in lastLayoutRef so the next projector animates from
+  //    where the boids ended up.
+  useEffect(() => {
+    if (projectorRef.current?.layout) {
+      lastLayoutRef.current = projectorRef.current.layout as GraphLayout<SpaceGraphNode>;
+    } else if (flockModel.boids.length > 0 && size.width > 0 && size.height > 0) {
+      lastLayoutRef.current = boidsToLayout(flockModel.boids, size, lastLayoutRef.current);
+    }
+
+    if (variant === 'swarm') {
+      setProjector(undefined);
+      return;
+    }
+
+    if (!svgRef.current) {
+      return;
+    }
+
+    setProjector(createProjector(variant, svgRef.current, lastLayoutRef.current));
+  }, [variant, flockModel, size.width, size.height]);
+
+  // Seed the flock with boids derived from current graph nodes whenever we enter
+  // swarm (or model data lands while in swarm). Positions are reused from the last
+  // SVG layout where the id matches; otherwise a small random spread around center.
+  useEffect(() => {
+    if (variant !== 'swarm' || !size.width || !size.height) {
+      return;
+    }
+    const nodes = model?.graph.nodes ?? [];
+    if (nodes.length === 0) {
+      return;
+    }
+    flockModel.setBoids(seedBoidsFromNodes(nodes, lastLayoutRef.current, size, flockModel));
+  }, [variant, flockModel, model, modelRev, size.width, size.height]);
+
+  const renderNode = useMemo(() => createRenderNode(variant), [variant]);
+
+  const handleInspect = useCallback(
+    (node: GraphLayoutNode<SpaceGraphNode> | null, event: MouseEvent) => {
+      // null = pointerleave: forward to the shared hover handler so it can clear any preview.
+      if (!node) {
+        onNodeHover?.(null);
+        return;
+      }
+      onNodeHover?.({ id: node.id, data: node.data?.data?.object }, event);
+    },
+    [onNodeHover],
+  );
+
+  // Cluster-only: clicking a root / group node toggles its subtree open/closed.
+  const handleSelect = useCallback(
+    (node: GraphLayoutNode<SpaceGraphNode>) => {
+      if (
+        variant !== 'cluster' ||
+        !node ||
+        (node.type !== CLUSTER_NODE_TYPE_ROOT && node.type !== CLUSTER_NODE_TYPE_GROUP)
+      ) {
+        return;
+      }
+
+      const cluster = projector as GraphClusterProjector<SpaceGraphNode> | undefined;
+      cluster?.toggleCollapsed(node.id);
+    },
+    [variant, projector],
+  );
+
+  return (
+    <div ref={containerRef} className='dx-expander relative'>
+      {variant === 'swarm' ? (
+        <Flock model={flockModel} coloring='Movement' />
+      ) : (
+        <SVG.Root ref={svgRef}>
+          <SVG.Zoom extent={[1 / 2, 2]}>
+            <SVG.Graph<SpaceGraphNode, SpaceGraphEdge>
+              model={model}
+              projector={projector}
+              renderNode={renderNode}
+              drag={variant === 'force'}
+              onInspect={handleInspect}
+              onSelect={handleSelect}
+            />
+          </SVG.Zoom>
+        </SVG.Root>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Build the boid set for entering swarm. For each model node, take the position from
+ * `lastLayout` (id-matched), or a random spread around center if the id isn't there.
+ * Position reuse keeps in-flight transitions visually continuous.
+ */
+const seedBoidsFromNodes = (
+  nodes: readonly SpaceGraphNode[],
+  lastLayout: GraphLayout<SpaceGraphNode> | undefined,
+  { width, height }: { width: number; height: number },
+  flockModel: FlockModel,
+): FlockBoid[] => {
+  const cx = width / 2;
+  const cy = height / 2;
+  const spread = Math.min(width, height) * 0.5;
+  const snapshot = new Map((lastLayout?.graph.nodes ?? []).map((n) => [n.id, n] as const));
+  return nodes.map((node) => {
+    const prev = snapshot.get(node.id);
+    const px = prev?.x ?? (Math.random() - 0.5) * spread;
+    const py = prev?.y ?? (Math.random() - 0.5) * spread;
+    // Preserve existing boid velocity/colour if we already have one for this id —
+    // keeps mid-air boids moving smoothly when the model emits multiple times.
+    const existing = flockModel.findBoid(node.id);
+    return {
+      id: node.id,
+      position: new Vec2(cx + px, cy + py),
+      velocity: existing?.velocity ?? new Vec2(),
+      color: existing?.color,
+      last: existing?.last ?? [],
+    };
+  });
+};
+
+/**
+ * Translate canvas-coord boid positions back into a center-origin layout that the
+ * next SVG projector can consume as `prev`. Matches nodes from `prevLayout` by id so
+ * label / data references are preserved; falls back to creating fresh layout nodes
+ * for boids whose ids aren't present in the prior layout.
+ */
+const boidsToLayout = (
+  boids: readonly FlockBoid[],
+  { width, height }: { width: number; height: number },
+  prevLayout: GraphLayout<SpaceGraphNode> | undefined,
+): GraphLayout<SpaceGraphNode> => {
+  const cx = width / 2;
+  const cy = height / 2;
+  const previousById = new Map((prevLayout?.graph.nodes ?? []).map((n) => [n.id, n] as const));
+  const nodes: GraphLayoutNode<SpaceGraphNode>[] = boids
+    .filter((b) => b.id !== undefined)
+    .map((boid) => {
+      const id = boid.id!;
+      const prev = previousById.get(id);
+      return {
+        ...(prev ?? { id }),
+        x: boid.position.x - cx,
+        y: boid.position.y - cy,
+      };
+    });
+  return {
+    graph: {
+      nodes,
+      // Edges aren't represented in the swarm — keep whatever the previous layout had so
+      // the next projector still has a topology to bind to via mergeData.
+      edges: prevLayout?.graph.edges ?? [],
+    },
+  };
+};
+
+/** Cross-variant tween duration. Matches the renderer's edge fade timing so node movement and edge enter/exit complete together. */
+const TWEEN_MS = 500;
+
+const createProjector = (
+  variant: Exclude<ExplorerArticleVariant, 'swarm'>,
+  ctx: SVGContext,
+  prev?: GraphLayout<SpaceGraphNode>,
+): GraphProjector<SpaceGraphNode> => {
+  switch (variant) {
+    case 'force':
+      // Force has no `duration` — its own simulation drives motion via ticks.
+      return new GraphForceProjector<SpaceGraphNode>(ctx, undefined, undefined, prev);
+
+    case 'lattice':
+      return new GraphLatticeProjector<SpaceGraphNode>(
+        ctx,
+        {
+          duration: TWEEN_MS,
+          // Plugin-explorer overrides the projector's force-matched default (6)
+          // with a smaller node so the lattice reads as a dense matrix.
+          radius: 4,
+          // Cluster by typename first so same-type rects sit together; break ties by label.
+          sortBy: (node: GraphLayoutNode<SpaceGraphNode>) => {
+            const obj = node.data?.data?.object;
+            const typename = obj ? (Obj.getTypename(obj) ?? '(untyped)') : '(untyped)';
+            const label = (obj && Obj.getLabel(obj)) ?? node.data?.data?.label ?? node.id;
+            return `${typename} ${label}`;
+          },
+        },
+        undefined,
+        prev,
+      );
+
+    case 'cluster':
+      return new GraphClusterProjector<SpaceGraphNode>(
+        ctx,
+        {
+          duration: TWEEN_MS,
+          groupOf: typenameGroupOf,
+          rootLabel: 'Database',
+          groupLabel: shortTypename,
+          // All three node kinds share the same radius — leaves, groups, and root read
+          // as members of the same circle rather than ranked by size.
+          rootRadius: 4,
+          groupRadius: 4,
+        },
+        undefined,
+        prev,
+      );
+
+    case 'bundle':
+      return new GraphBundleProjector<SpaceGraphNode>(
+        ctx,
+        {
+          duration: TWEEN_MS,
+          groupOf: typenameGroupOf,
+        },
+        undefined,
+        prev,
+      );
+  }
+};
+
+/** Group leaves by typename so same-type leaves cluster together — used by both the
+ * cluster (visible structural nodes) and bundle (invisible routing anchors) projectors. */
+const typenameGroupOf = (node: GraphLayoutNode<SpaceGraphNode>): string | undefined => {
+  const obj = node.data?.data?.object;
+  return obj ? (Obj.getTypename(obj) ?? '(untyped)') : undefined;
+};
+
+const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGraphNode> | undefined => {
+  switch (variant) {
+    case 'swarm':
+      return undefined;
+
+    case 'force':
+      return (group, node) => {
+        const r = node.r ?? 6;
+        group
+          .append('circle')
+          .attr('r', r)
+          .style('cursor', 'pointer')
+          .style('fill', getNodeFillForObject(node.data?.data?.object as Obj.Unknown | undefined));
+      };
+
+    case 'lattice':
+      return (group, node) => {
+        const r = node.r ?? 6;
+        const sz = r * 2;
+        group
+          .append('rect')
+          .attr('x', -r)
+          .attr('y', -r)
+          .attr('width', sz)
+          .attr('height', sz)
+          .attr('rx', r * 0.3)
+          .attr('ry', r * 0.3)
+          .style('cursor', 'pointer')
+          .style('fill', getNodeFillForObject(node.data?.data?.object as Obj.Unknown | undefined));
+      };
+
+    case 'cluster':
+      return (group, node) => {
+        const obj = node.data?.data?.object as Obj.Unknown | undefined;
+        const r = node.r ?? 4;
+        // Synthetic root / group nodes have no underlying ECHO object; render them as
+        // smaller, neutral circles so the hierarchy reads as "structure + leaves".
+        group
+          .append('circle')
+          .attr('r', r)
+          .style('cursor', 'pointer')
+          .style('fill', obj ? getNodeFillForObject(obj) : 'var(--color-neutral-500)');
+        if (node.type === CLUSTER_NODE_TYPE_LEAF) {
+          appendRadialLeafLabel(group, node, obj, r);
+        } else if (node.type === CLUSTER_NODE_TYPE_ROOT) {
+          appendRootLabel(group, node, r);
+        } else if (node.type === CLUSTER_NODE_TYPE_GROUP) {
+          appendRadialGroupLabel(group, node, r);
+        }
+      };
+
+    case 'bundle':
+      // Bundle layout renders ONLY leaves (root/group are invisible routing anchors).
+      return (group, node) => {
+        const obj = node.data?.data?.object as Obj.Unknown | undefined;
+        const r = node.r ?? 4;
+        group
+          .append('circle')
+          .attr('r', r)
+          .style('cursor', 'pointer')
+          .style('fill', obj ? getNodeFillForObject(obj) : 'var(--color-neutral-500)');
+        appendRadialLeafLabel(group, node, obj, r);
+      };
+  }
+};
+
+/** Fade-in duration applied to labels after the layout tween completes. */
+const LABEL_FADE_MS = 200;
+
+/**
+ * Append a radial leaf label outside the ring, oriented outward. Compute orientation
+ * from the TARGET position (tx/ty) — at enter time node.x/y is still at the previous
+ * projector's coordinates, so using current x/y would orient the label by the
+ * pre-transition layout (wrong) and the rotation wouldn't update during the tween.
+ */
+const appendRadialLeafLabel = (
+  group: Parameters<RenderNode<SpaceGraphNode>>[0],
+  node: GraphLayoutNode<SpaceGraphNode>,
+  obj: Obj.Unknown | undefined,
+  r: number,
+): void => {
+  const label = (obj && Obj.getLabel(obj)) ?? node.data?.data?.label ?? node.id;
+  if (!label) {
+    return;
+  }
+
+  const targetX = (node as any).tx ?? node.x ?? 0;
+  const targetY = (node as any).ty ?? node.y ?? 0;
+  const angleDeg = (Math.atan2(targetY, targetX) * 180) / Math.PI;
+  const flipped = angleDeg > 90 || angleDeg < -90;
+  group
+    .append('text')
+    .classed('dx-cluster-label', true)
+    .attr('dy', '0.32em')
+    .attr('transform', `rotate(${flipped ? angleDeg + 180 : angleDeg})`)
+    .attr('x', flipped ? -(r + 4) : r + 4)
+    .attr('text-anchor', flipped ? 'end' : 'start')
+    .attr('opacity', 0)
+    .style('pointer-events', 'none')
+    .text(label)
+    .transition()
+    .delay(TWEEN_MS)
+    .duration(LABEL_FADE_MS)
+    .attr('opacity', 1);
+};
+
+const appendRadialGroupLabel = (
+  group: Parameters<RenderNode<SpaceGraphNode>>[0],
+  node: GraphLayoutNode<SpaceGraphNode>,
+  r: number,
+): void => {
+  if (!node.label) {
+    return;
+  }
+
+  const targetX = (node as any).tx ?? node.x ?? 0;
+  const targetY = (node as any).ty ?? node.y ?? 0;
+  const angleDeg = (Math.atan2(targetY, targetX) * 180) / Math.PI;
+  const flipped = angleDeg > 90 || angleDeg < -90;
+  group
+    .append('text')
+    .classed('dx-cluster-label', true)
+    .classed('dx-cluster-label-group', true)
+    .attr('dy', '0.32em')
+    .attr('transform', `rotate(${flipped ? angleDeg + 180 : angleDeg})`)
+    .attr('x', flipped ? r + 4 : -(r + 4))
+    .attr('text-anchor', flipped ? 'start' : 'end')
+    .attr('opacity', 0)
+    .style('pointer-events', 'none')
+    .text(node.label)
+    .transition()
+    .delay(TWEEN_MS)
+    .duration(LABEL_FADE_MS)
+    .attr('opacity', 1);
+};
+
+const appendRootLabel = (
+  group: Parameters<RenderNode<SpaceGraphNode>>[0],
+  node: GraphLayoutNode<SpaceGraphNode>,
+  r: number,
+): void => {
+  if (!node.label) {
+    return;
+  }
+
+  group
+    .append('text')
+    .classed('dx-cluster-label', true)
+    .classed('dx-cluster-label-root', true)
+    .attr('text-anchor', 'middle')
+    .attr('y', -(r + 6))
+    .attr('opacity', 0)
+    .style('pointer-events', 'none')
+    .text(node.label)
+    .transition()
+    .delay(TWEEN_MS)
+    .duration(LABEL_FADE_MS)
+    .attr('opacity', 1);
+};
+
+/** Drop the package prefix from a typename for display: `org.dxos.type.Person` → `Person`. */
+const shortTypename = (typename: string): string => {
+  const last = typename.split('.').pop() ?? typename;
+  return last.charAt(0).toUpperCase() + last.slice(1);
+};

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/variants.ts
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/variants.ts
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+/** Visualization variants exposed by `ExplorerArticle`. */
+export type ExplorerArticleVariant = 'force' | 'cluster' | 'bundle' | 'lattice' | 'swarm';
+
+export const VARIANTS: { value: ExplorerArticleVariant; icon: string; label: string }[] = [
+  {
+    value: 'force',
+    icon: 'ph--graph--regular',
+    label: 'Force-directed',
+  },
+  {
+    value: 'cluster',
+    icon: 'ph--asterisk-simple--regular',
+    label: 'Radial cluster',
+  },
+  {
+    value: 'bundle',
+    icon: 'ph--circles-three-plus--regular',
+    label: 'Edge bundling',
+  },
+  {
+    value: 'lattice',
+    icon: 'ph--grid-four--regular',
+    label: 'Lattice',
+  },
+  {
+    value: 'swarm',
+    icon: 'ph--fish--regular',
+    label: 'Swarm',
+  },
+];
+
+export const isVariant = (value: unknown): value is ExplorerArticleVariant =>
+  value === 'force' || value === 'cluster' || value === 'bundle' || value === 'lattice' || value === 'swarm';

--- a/packages/plugins/plugin-explorer/tsconfig.json
+++ b/packages/plugins/plugin-explorer/tsconfig.json
@@ -86,6 +86,9 @@
       "path": "../../ui/react-ui-mosaic"
     },
     {
+      "path": "../../ui/react-ui-sfx"
+    },
+    {
       "path": "../../ui/react-ui-stack"
     },
     {

--- a/packages/plugins/plugin-support/src/containers/DiscordPanel/DiscordComponent.stories.tsx
+++ b/packages/plugins/plugin-support/src/containers/DiscordPanel/DiscordComponent.stories.tsx
@@ -13,7 +13,7 @@ import { DiscordComponent } from './DiscordComponent';
 
 const DefaultStory = () => (
   <DiscordComponent.Root>
-    <div className='grid grid-rows-[auto_auto_minmax(0,1fr)_auto] overflow-hidden bs-full is-full'>
+    <div className='grid grid-rows-[auto_auto_minmax(0,1fr)_auto] overflow-hidden h-full is-full'>
       <DiscordComponent.Header />
       <DiscordComponent.Channels />
       <DiscordComponent.Content />

--- a/packages/plugins/plugin-support/src/containers/DiscordPanel/DiscordPanel.tsx
+++ b/packages/plugins/plugin-support/src/containers/DiscordPanel/DiscordPanel.tsx
@@ -8,7 +8,7 @@ import { DiscordComponent } from './DiscordComponent';
 
 export const DiscordPanel = () => (
   <DiscordComponent.Root>
-    <div className='h-full grid grid-rows-[auto_auto_minmax(0,1fr)_auto] overflow-hidden bs-full is-full'>
+    <div className='h-full grid grid-rows-[auto_auto_minmax(0,1fr)_auto] overflow-hidden h-full is-full'>
       <DiscordComponent.Header />
       <DiscordComponent.Channels />
       <DiscordComponent.Content />

--- a/packages/plugins/plugin-table/src/containers/TableCard/TableCard.tsx
+++ b/packages/plugins/plugin-table/src/containers/TableCard/TableCard.tsx
@@ -55,14 +55,17 @@ export const TableCard = ({ role, subject: object }: TableCardProps) => {
 
   return (
     <Card.Body>
-      <TableComponent.Root ref={tableRef}>
-        <TableComponent.Content
-          key={Obj.getDXN(object).toString()}
-          model={model}
-          presentation={presentation}
-          schema={schema}
-        />
-      </TableComponent.Root>
+      <Card.Row fullWidth>
+        <TableComponent.Root ref={tableRef}>
+          <TableComponent.Content
+            key={Obj.getDXN(object).toString()}
+            model={model}
+            presentation={presentation}
+            schema={schema}
+            classNames='scale-75'
+          />
+        </TableComponent.Root>
+      </Card.Row>
     </Card.Body>
   );
 };

--- a/packages/plugins/plugin-thread/src/components/Chat/Chat.tsx
+++ b/packages/plugins/plugin-thread/src/components/Chat/Chat.tsx
@@ -154,7 +154,7 @@ export const Chat = composable<HTMLDivElement, ChatProps>(
 
     return orientation === 'bottom' ? (
       <ChannelLayout
-        {...composableProps(props, { classNames: 'flex flex-col bs-full min-h-0' })}
+        {...composableProps(props, { classNames: 'flex flex-col h-full min-h-0' })}
         id={id}
         ref={forwardedRef}
         state={renderState}

--- a/packages/ui/react-ui-sfx/package.json
+++ b/packages/ui/react-ui-sfx/package.json
@@ -36,6 +36,7 @@
     "@dxos/log": "workspace:*",
     "@dxos/node-std": "workspace:*",
     "@dxos/util": "workspace:*",
+    "@effect-atom/atom-react": "catalog:",
     "@react-three/drei": "catalog:",
     "@react-three/fiber": "catalog:",
     "d3": "catalog:",

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.stories.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.stories.tsx
@@ -2,13 +2,15 @@
 // Copyright 2026 DXOS.org
 //
 
+import { RegistryContext } from '@effect-atom/atom-react';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useControls } from 'leva';
-import React from 'react';
+import React, { useContext, useMemo } from 'react';
 
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 
 import { Flock, type FlockColoring, type FlockStartingPosition } from './Flock';
+import { FlockModel } from './FlockModel';
 
 const StoryFlock = () => {
   const {
@@ -45,8 +47,15 @@ const StoryFlock = () => {
     avoidance: { label: 'Avoidance', value: 3, min: 0, max: 10, step: 0.1 },
   });
 
+  const registry = useContext(RegistryContext);
+  // One model per mount; remounts on `num` / `startingPosition` change so the
+  // controls visibly reset (Flock seeds itself from num/startingPosition when
+  // the model is empty).
+  const model = useMemo(() => new FlockModel(registry), [registry, num, startingPosition]);
+
   return (
     <Flock
+      model={model}
       num={num}
       numObstacles={numObstacles}
       startingPosition={startingPosition}

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.stories.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.stories.tsx
@@ -3,317 +3,14 @@
 //
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import * as d3 from 'd3';
 import { useControls } from 'leva';
-import React, { useEffect, useRef, useState } from 'react';
-import { useResizeDetector } from 'react-resize-detector';
+import React from 'react';
 
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 
-import { Vec2 } from '../../util';
+import { Flock, type FlockColoring, type FlockStartingPosition } from './Flock';
 
-// Boids flocking.
-// https://en.wikipedia.org/wiki/Boids
-// https://bl.ocks.org/veltman/995d3a677418100ac43877f3ed1cc728
-
-const flockmateRadius = 60;
-const separationDistance = 30;
-
-type Boid = {
-  position: Vec2;
-  velocity: Vec2;
-  acceleration?: Vec2;
-  color?: string;
-  last?: number[];
-};
-
-type Obstacle = {
-  position: Vec2;
-  radius: number;
-};
-
-type Dimensions = { width: number; height: number };
-
-type StartingPosition = 'Random' | 'Circle' | 'CircleRandom' | 'Sine' | 'Phyllotaxis';
-type Coloring = 'Movement' | 'Grey' | 'Rainbow';
-
-type Config = {
-  num: number;
-  numObstacles: number;
-  startingPosition: StartingPosition;
-  coloring: Coloring;
-  radius: number;
-  trail: number;
-  maxVelocity: number;
-  alignment: number;
-  cohesion: number;
-  separation: number;
-  avoidance: number;
-};
-
-const randomVelocity = ({ maxVelocity }: { maxVelocity: number }) =>
-  new Vec2(1 - Math.random() * 2, 1 - Math.random() * 2).scale(maxVelocity);
-
-const radialVelocity = (p: number, { maxVelocity }: { maxVelocity: number }) =>
-  new Vec2(Math.sin(2 * Math.PI * p), Math.cos(2 * Math.PI * p)).scale(maxVelocity);
-
-const initializeRandom = (
-  { num, maxVelocity }: { num: number; maxVelocity: number },
-  { width, height }: Dimensions,
-): Boid[] =>
-  d3.range(num).map(() => ({
-    position: new Vec2(Math.random() * width, Math.random() * height),
-    velocity: randomVelocity({ maxVelocity }),
-  }));
-
-const initializePhyllotaxis = (
-  { num, maxVelocity }: { num: number; maxVelocity: number },
-  { width, height }: Dimensions,
-): Boid[] =>
-  d3.range(num).map((_d, i) => {
-    const theta = Math.PI * i * (Math.sqrt(5) - 1);
-    const r = (Math.sqrt(i) * 200) / Math.sqrt(num);
-    return {
-      position: new Vec2(width / 2 + r * Math.cos(theta), height / 2 - r * Math.sin(theta)),
-      velocity: radialVelocity(i / num, { maxVelocity }),
-    };
-  });
-
-const initializeSine = (
-  { num, maxVelocity }: { num: number; maxVelocity: number },
-  { width, height }: Dimensions,
-): Boid[] =>
-  d3.range(num).map((i) => {
-    const angle = (2 * Math.PI * i) / num;
-    const x = (width * i) / num;
-    const y = height / 2 + (Math.sin(angle) * height) / 4;
-    return {
-      position: new Vec2(x, y),
-      velocity: radialVelocity(i / num, { maxVelocity }),
-    };
-  });
-
-const initializeCircle = (
-  { num, maxVelocity }: { num: number; maxVelocity: number },
-  { width, height }: Dimensions,
-): Boid[] =>
-  d3.range(num).map((i) => {
-    const angle = (i * 2 * Math.PI) / num;
-    const x = 200 * Math.sin(angle);
-    const y = 200 * Math.cos(angle);
-    return {
-      position: new Vec2(x + width / 2, y + height / 2),
-      velocity: new Vec2(-x, -y).scale(maxVelocity),
-    };
-  });
-
-const initializeCircleRandom = (
-  { num, maxVelocity }: { num: number; maxVelocity: number },
-  { width, height }: Dimensions,
-): Boid[] =>
-  d3.range(num).map((i) => {
-    const angle = (i * 2 * Math.PI) / num;
-    const x = 200 * Math.sin(angle);
-    const y = 200 * Math.cos(angle);
-    return {
-      position: new Vec2(x + width / 2, y + height / 2),
-      velocity: randomVelocity({ maxVelocity }),
-    };
-  });
-
-const initializeFunction: Record<
-  StartingPosition,
-  (
-    cfg: {
-      num: number;
-      maxVelocity: number;
-    },
-    dim: Dimensions,
-  ) => Boid[]
-> = {
-  Random: initializeRandom,
-  Phyllotaxis: initializePhyllotaxis,
-  Sine: initializeSine,
-  Circle: initializeCircle,
-  CircleRandom: initializeCircleRandom,
-};
-
-// https://github.com/d3/d3-scale-chromatic
-const coloringFunction: Record<Coloring, (boid: Boid) => string> = {
-  Rainbow: (b) => b.color ?? '#000',
-  Grey: (b) => d3.interpolateGreys(0.25 + d3.mean(b.last ?? [0])!),
-  Movement: (b) => d3.interpolateSpectral(d3.mean(b.last ?? [0])!),
-};
-
-const updateBoid = (
-  b: Boid,
-  context: CanvasRenderingContext2D,
-  { width, height }: Dimensions,
-  { radius, coloring, maxVelocity }: Pick<Config, 'radius' | 'coloring' | 'maxVelocity'>,
-) => {
-  b.position.add(b.velocity.add(b.acceleration!).truncate(maxVelocity));
-
-  if (b.position.y > height) {
-    b.position.y -= height;
-  } else if (b.position.y < 0) {
-    b.position.y += height;
-  }
-
-  if (b.position.x > width) {
-    b.position.x -= width;
-  } else if (b.position.x < 0) {
-    b.position.x += width;
-  }
-
-  context.beginPath();
-  context.fillStyle = coloringFunction[coloring](b);
-  context.arc(b.position.x, b.position.y, radius, 0, 2 * Math.PI);
-  context.fill();
-};
-
-const renderObstacles = (context: CanvasRenderingContext2D, obstacles: Obstacle[]) => {
-  context.fillStyle = 'darkred';
-  context.filter = 'blur(40px)';
-
-  obstacles.forEach((obstacle) => {
-    context.beginPath();
-    context.arc(obstacle.position.x, obstacle.position.y, obstacle.radius, 0, 2 * Math.PI);
-    context.fill();
-  });
-
-  context.filter = 'blur(0)';
-};
-
-type TickConfig = Pick<
-  Config,
-  'trail' | 'maxVelocity' | 'alignment' | 'cohesion' | 'separation' | 'avoidance' | 'radius' | 'coloring'
->;
-
-const tick = (
-  boids: Boid[],
-  obstacles: Obstacle[],
-  canvas: HTMLCanvasElement,
-  offscreenCanvas: HTMLCanvasElement,
-  { width, height }: Dimensions,
-  config: TickConfig,
-) => {
-  const { trail, maxVelocity, alignment, cohesion, separation } = config;
-
-  // Vapor trail.
-  const offscreenContext = offscreenCanvas.getContext('2d')!;
-  offscreenContext.globalAlpha = trail;
-  offscreenContext.clearRect(0, 0, width, height);
-  offscreenContext.drawImage(canvas, 0, 0, width, height);
-
-  renderObstacles(offscreenContext, obstacles);
-
-  const context = canvas.getContext('2d')!;
-  context.clearRect(0, 0, width, height);
-  context.drawImage(offscreenCanvas, 0, 0, width, height);
-
-  // Update physics.
-  boids.forEach((b1) => {
-    const forces: Record<'alignment' | 'cohesion' | 'separation' | 'avoidance', Vec2> = {
-      alignment: new Vec2(),
-      cohesion: new Vec2(),
-      separation: new Vec2(),
-      avoidance: new Vec2(),
-    };
-
-    // Avoidance.
-    let avoid = false;
-    obstacles.forEach((o) => {
-      const diff = o.position.clone().subtract(b1.position);
-      const distance = diff.length();
-      if (distance < o.radius) {
-        forces.avoidance.add(diff.clone().scaleTo(-1 / distance));
-        forces.avoidance.active = true;
-        avoid = true;
-      }
-    });
-
-    // Flocking (compare with others).
-    if (!avoid) {
-      boids.forEach((b2) => {
-        if (b1 === b2) {
-          return;
-        }
-
-        const diff = b2.position.clone().subtract(b1.position);
-        const distance = diff.length();
-
-        if (distance && distance < separationDistance) {
-          forces.separation.add(diff.clone().scaleTo(-1 / distance));
-          forces.separation.active = true;
-        }
-
-        if (distance < flockmateRadius) {
-          forces.cohesion.add(diff);
-          forces.cohesion.active = true;
-          forces.alignment.add(b2.velocity);
-          forces.alignment.active = true;
-        }
-      });
-    }
-
-    // Compute forces.
-    b1.acceleration = new Vec2();
-    (Object.keys(forces) as Array<keyof typeof forces>).forEach((key) => {
-      const force = forces[key];
-      const weight = config[key];
-      if (force.active && weight) {
-        force.scaleTo(maxVelocity).subtract(b1.velocity).truncate(weight);
-        b1.acceleration!.add(force);
-      }
-    });
-
-    const { coloring } = config;
-    if (coloring === 'Movement') {
-      const last = b1.last ?? (b1.last = []);
-      const sum = alignment + cohesion + separation;
-      last.push(sum > 0 ? b1.acceleration.length() / sum : 0);
-      if (last.length > 20) {
-        last.shift();
-      }
-    }
-  });
-
-  // Update and render boids.
-  boids.forEach((boid) => updateBoid(boid, context, { width, height }, config));
-};
-
-const generateObstacles = ({ width, height }: Dimensions, { numObstacles }: { numObstacles: number }): Obstacle[] => {
-  const obstacles: Obstacle[] = [];
-  for (let i = 0; i < numObstacles; i++) {
-    obstacles.push({
-      position: new Vec2(Math.random() * width, Math.random() * height),
-      radius: 20 + Math.random() * 50,
-    });
-  }
-  return obstacles;
-};
-
-const generateBoids = (
-  dimensions: Dimensions,
-  config: { num: number; maxVelocity: number; startingPosition: StartingPosition },
-): Boid[] => {
-  const { num, startingPosition } = config;
-  const boids = initializeFunction[startingPosition](config, dimensions);
-  boids.forEach((b, i) => {
-    b.color = d3.interpolateRainbow(i / num);
-    b.last = [];
-  });
-
-  return boids;
-};
-
-const Flock = () => {
-  const canvas = useRef<HTMLCanvasElement>(null);
-  const buffer = useRef<HTMLCanvasElement>(null);
-  const { ref: containerRef, width = 0, height = 0 } = useResizeDetector<HTMLDivElement>();
-  const [obstacles, setObstacles] = useState<Obstacle[]>([]);
-  const [boids, setBoids] = useState<Boid[]>([]);
-
+const StoryFlock = () => {
   const {
     num,
     numObstacles,
@@ -327,29 +24,17 @@ const Flock = () => {
     separation,
     avoidance,
   } = useControls({
-    num: {
-      label: 'Count',
-      value: 100,
-      min: 10,
-      max: 1000,
-      step: 10,
-    },
-    numObstacles: {
-      label: 'Obstacles',
-      value: 0,
-      min: 0,
-      max: 10,
-      step: 1,
-    },
+    num: { label: 'Count', value: 100, min: 10, max: 1000, step: 10 },
+    numObstacles: { label: 'Obstacles', value: 0, min: 0, max: 10, step: 1 },
     startingPosition: {
       label: 'Start',
-      value: 'CircleRandom' as StartingPosition,
-      options: ['Random', 'Circle', 'CircleRandom', 'Sine', 'Phyllotaxis'] as StartingPosition[],
+      value: 'CircleRandom' as FlockStartingPosition,
+      options: ['Random', 'Circle', 'CircleRandom', 'Sine', 'Phyllotaxis'] as FlockStartingPosition[],
     },
     coloring: {
       label: 'Coloring',
-      value: 'Movement' as Coloring,
-      options: ['Movement', 'Grey', 'Rainbow'] as Coloring[],
+      value: 'Movement' as FlockColoring,
+      options: ['Movement', 'Grey', 'Rainbow'] as FlockColoring[],
     },
     radius: { label: 'Size', value: 2, min: 1, max: 20, step: 0.5 },
     trail: { label: 'Trail', value: 10, min: 0, max: 20, step: 1 },
@@ -360,73 +45,31 @@ const Flock = () => {
     avoidance: { label: 'Avoidance', value: 3, min: 0, max: 10, step: 0.1 },
   });
 
-  useEffect(() => {
-    if (width && height) {
-      setObstacles(generateObstacles({ width, height }, { numObstacles }));
-      setBoids(generateBoids({ width, height }, { num, startingPosition, maxVelocity }));
-    }
-  }, [width, height, num, numObstacles, startingPosition, maxVelocity]);
-
-  useEffect(() => {
-    if (!canvas.current || !buffer.current || !width || !height) {
-      return;
-    }
-
-    const interval = d3.interval(() => {
-      tick(
-        boids,
-        obstacles,
-        canvas.current!,
-        buffer.current!,
-        {
-          width,
-          height,
-        },
-        {
-          coloring,
-          radius,
-          maxVelocity,
-          trail: (80 + trail) / 100,
-          alignment: alignment / 100,
-          cohesion: cohesion / 100,
-          separation: separation / 100,
-          avoidance: avoidance / 10,
-        },
-      );
-    });
-
-    return () => interval.stop();
-  }, [
-    boids,
-    obstacles,
-    width,
-    height,
-    radius,
-    coloring,
-    trail,
-    maxVelocity,
-    alignment,
-    cohesion,
-    separation,
-    avoidance,
-  ]);
-
   return (
-    <div ref={containerRef} className='absolute inset-0'>
-      <canvas ref={canvas} width={width} height={height} />
-      <canvas ref={buffer} width={width} height={height} style={{ display: 'none' }} />
-    </div>
+    <Flock
+      num={num}
+      numObstacles={numObstacles}
+      startingPosition={startingPosition}
+      coloring={coloring}
+      radius={radius}
+      trail={trail}
+      maxVelocity={maxVelocity}
+      alignment={alignment}
+      cohesion={cohesion}
+      separation={separation}
+      avoidance={avoidance}
+    />
   );
 };
 
 const meta = {
   title: 'ui/react-ui-sfx/Flock',
-  component: Flock,
+  component: StoryFlock,
   decorators: [withTheme(), withLayout({ layout: 'fullscreen' })],
   parameters: {
     layout: 'fullscreen',
   },
-} satisfies Meta<typeof Flock>;
+} satisfies Meta<typeof StoryFlock>;
 
 export default meta;
 

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -169,11 +169,11 @@ const renderObstacles = (context: CanvasRenderingContext2D, obstacles: FlockObst
 };
 
 const tick = (
-  boids: FlockBoid[],
-  obstacles: FlockObstacle[],
   canvas: HTMLCanvasElement,
   offscreenCanvas: HTMLCanvasElement,
   { width, height }: Dimensions,
+  boids: FlockBoid[],
+  obstacles: FlockObstacle[],
   config: TickConfig,
 ) => {
   const { trail, maxVelocity, alignment, cohesion, separation } = config;
@@ -201,7 +201,9 @@ const tick = (
     obstacles.forEach((o) => {
       const diff = o.position.clone().subtract(b1.position);
       const distance = diff.length();
-      if (distance < o.radius) {
+      // Guard against distance === 0: scaleTo divides by length and would
+      // poison the simulation with Infinity/NaN if a boid lands on an obstacle.
+      if (distance > 0 && distance < o.radius) {
         forces.avoidance.add(diff.clone().scaleTo(-1 / distance));
         forces.avoidance.active = true;
         avoid = true;
@@ -241,8 +243,10 @@ const tick = (
       }
     });
 
+    // Movement and Grey both read from `b1.last` to colorize; record the same history
+    // for both so Grey isn't stuck at an empty array (which yields NaN colors).
     const { coloring } = config;
-    if (coloring === 'Movement') {
+    if (coloring === 'Movement' || coloring === 'Grey') {
       const last = b1.last ?? (b1.last = []);
       const sum = alignment + cohesion + separation;
       last.push(sum > 0 ? b1.acceleration.length() / sum : 0);
@@ -345,6 +349,7 @@ export const Flock = ({
     if (!container) {
       return;
     }
+
     const rect = container.getBoundingClientRect();
     setSize({ width: rect.width, height: rect.height });
     const observer = new ResizeObserver((entries) => {
@@ -379,23 +384,16 @@ export const Flock = ({
     }
 
     const interval = d3.interval(() => {
-      tick(
-        boids,
-        obstacles,
-        canvas.current!,
-        buffer.current!,
-        { width, height },
-        {
-          coloring,
-          radius,
-          maxVelocity,
-          trail: (80 + trail) / 100,
-          alignment: alignment / 100,
-          cohesion: cohesion / 100,
-          separation: separation / 100,
-          avoidance: avoidance / 10,
-        },
-      );
+      tick(canvas.current!, buffer.current!, { width, height }, boids, obstacles, {
+        coloring,
+        radius,
+        maxVelocity,
+        trail: (80 + trail) / 100,
+        alignment: alignment / 100,
+        cohesion: cohesion / 100,
+        separation: separation / 100,
+        avoidance: avoidance / 10,
+      });
     });
 
     return () => interval.stop();

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -17,6 +17,8 @@ import { Vec2 } from '../../util';
 const FLOCKMATE_RADIUS = 60;
 const SEPARATION_DISTANCE = 30;
 
+export type Dimensions = { width: number; height: number };
+
 export type FlockBoid = {
   position: Vec2;
   velocity: Vec2;
@@ -29,8 +31,6 @@ export type FlockObstacle = {
   position: Vec2;
   radius: number;
 };
-
-type Dimensions = { width: number; height: number };
 
 export type FlockStartingPosition = 'Random' | 'Circle' | 'CircleRandom' | 'Sine' | 'Phyllotaxis';
 export type FlockColoring = 'Movement' | 'Grey' | 'Rainbow';
@@ -170,7 +170,6 @@ const renderObstacles = (context: CanvasRenderingContext2D, obstacles: FlockObst
 
 const tick = (
   canvas: HTMLCanvasElement,
-  offscreenCanvas: HTMLCanvasElement,
   { width, height }: Dimensions,
   boids: FlockBoid[],
   obstacles: FlockObstacle[],
@@ -178,16 +177,16 @@ const tick = (
 ) => {
   const { trail, maxVelocity, alignment, cohesion, separation } = config;
 
-  const offscreenContext = offscreenCanvas.getContext('2d')!;
-  offscreenContext.globalAlpha = trail;
-  offscreenContext.clearRect(0, 0, width, height);
-  offscreenContext.drawImage(canvas, 0, 0, width, height);
-
-  renderObstacles(offscreenContext, obstacles);
-
+  // Trail fade: paint semi-transparent black over the previous frame so older
+  // pixels darken additively toward true #000. The alternative (alpha-blitting
+  // onto a cleared buffer) stalls at α ≈ 3–4 / 255 due to integer rounding,
+  // leaving a permanent ~#0f residue over a dark page.
   const context = canvas.getContext('2d')!;
-  context.clearRect(0, 0, width, height);
-  context.drawImage(offscreenCanvas, 0, 0, width, height);
+  context.fillStyle = `rgba(0, 0, 0, ${1 - trail})`;
+  context.fillRect(0, 0, width, height);
+
+  // Obstacles re-paint at full alpha every frame so they don't decay with the trail.
+  renderObstacles(context, obstacles);
 
   boids.forEach((b1) => {
     const forces: Record<'alignment' | 'cohesion' | 'separation' | 'avoidance', Vec2> = {
@@ -218,7 +217,6 @@ const tick = (
 
         const diff = b2.position.clone().subtract(b1.position);
         const distance = diff.length();
-
         if (distance && distance < SEPARATION_DISTANCE) {
           forces.separation.add(diff.clone().scaleTo(-1 / distance));
           forces.separation.active = true;
@@ -259,7 +257,7 @@ const tick = (
   boids.forEach((boid) => updateBoid(boid, context, { width, height }, config));
 };
 
-export const generateFlockObstacles = (dimensions: Dimensions, numObstacles: number): FlockObstacle[] => {
+const generateFlockObstacles = (dimensions: Dimensions, numObstacles: number): FlockObstacle[] => {
   const obstacles: FlockObstacle[] = [];
   for (let i = 0; i < numObstacles; i++) {
     obstacles.push({
@@ -270,7 +268,7 @@ export const generateFlockObstacles = (dimensions: Dimensions, numObstacles: num
   return obstacles;
 };
 
-export const generateFlockBoids = (
+const generateFlockBoids = (
   dimensions: Dimensions,
   config: { num: number; maxVelocity: number; startingPosition: FlockStartingPosition },
 ): FlockBoid[] => {
@@ -328,7 +326,7 @@ export const Flock = ({
   numObstacles = 0,
   coloring = 'Movement',
   radius = 2,
-  trail = 15,
+  trail = 10,
   maxVelocity = 0.5,
   alignment = 3,
   cohesion = 3,
@@ -336,10 +334,6 @@ export const Flock = ({
   avoidance = 3,
 }: FlockProps) => {
   const canvas = useRef<HTMLCanvasElement>(null);
-  const buffer = useRef<HTMLCanvasElement>(null);
-  // Direct ResizeObserver — `react-resize-detector` was flaky in our Storybook
-  // environment (initial measurement sometimes never fired). Matches the
-  // pattern used by SVG.Root.
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [{ width, height }, setSize] = useState<Dimensions>({ width: 0, height: 0 });
   const [obstacles, setObstacles] = useState<FlockObstacle[]>([]);
@@ -379,16 +373,16 @@ export const Flock = ({
   }, [width, height, num, numObstacles, startingPosition, maxVelocity, seeds]);
 
   useEffect(() => {
-    if (!canvas.current || !buffer.current || !width || !height) {
+    if (!canvas.current || !width || !height) {
       return;
     }
 
     const interval = d3.interval(() => {
-      tick(canvas.current!, buffer.current!, { width, height }, boids, obstacles, {
+      tick(canvas.current!, { width, height }, boids, obstacles, {
         coloring,
         radius,
         maxVelocity,
-        trail: (80 + trail) / 100,
+        trail: (85 + trail) / 100,
         alignment: alignment / 100,
         cohesion: cohesion / 100,
         separation: separation / 100,
@@ -415,7 +409,6 @@ export const Flock = ({
   return (
     <div className={mx('dx-expander absolute inset-0', classNames)} ref={setContainer}>
       <canvas ref={canvas} width={width} height={height} />
-      <canvas ref={buffer} width={width} height={height} style={{ display: 'none' }} />
     </div>
   );
 };

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -109,6 +109,28 @@ type TickConfig = {
   avoidance: number;
   radius: number;
   coloring: FlockColoring;
+  /** Pre-computed `rgba(r, g, b, 1-trail)` string used by the fade fillRect. */
+  fadeStyle: string;
+};
+
+/**
+ * Resolve any CSS color string to an `{ r, g, b }` triple by letting the browser
+ * normalise it (named colors, hex, rgb(), hsl()…). Returns null on unparseable input.
+ */
+const parseColorRgb = (color: string): { r: number; g: number; b: number } | null => {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const probe = document.createElement('div');
+  probe.style.color = color;
+  document.body.appendChild(probe);
+  const computed = getComputedStyle(probe).color;
+  document.body.removeChild(probe);
+  const match = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(computed);
+  if (!match) {
+    return null;
+  }
+  return { r: +match[1], g: +match[2], b: +match[3] };
 };
 
 const updateBoid = (
@@ -158,13 +180,14 @@ const tick = (
   cursor: FlockObstacle | null,
   config: TickConfig,
 ) => {
-  const { trail, maxVelocity, alignment, cohesion, separation } = config;
+  const { maxVelocity, alignment, cohesion, separation, fadeStyle } = config;
 
-  // Trail fade: paint semi-transparent black over the canvas. GPU-only path, no
-  // pixel-buffer roundtrip. Leaves a small rounding-residue at low RGB but the
-  // canvas is initialised opaque so α stays 255 and no page background bleeds.
+  // Trail fade: paint a semi-transparent rectangle in the background color over the
+  // canvas. GPU-only path, no pixel-buffer roundtrip. Leaves a small rounding-residue
+  // near the bg color but the canvas is initialised opaque to the same color so α
+  // stays 255 and the page can't bleed through.
   const context = canvas.getContext('2d')!;
-  context.fillStyle = `rgba(0, 0, 0, ${1 - trail})`;
+  context.fillStyle = fadeStyle;
   context.fillRect(0, 0, width, height);
 
   // Obstacles re-paint at full alpha every frame so they don't decay with the trail.
@@ -310,6 +333,12 @@ export type FlockProps = ThemedClassName<{
   avoidance?: number;
   /** Pixel radius of the invisible repel zone tracking the pointer. 0 disables. */
   cursorRepel?: number;
+  /**
+   * Canvas background CSS color. The canvas is initialised opaquely to this color
+   * and each frame's trail fade is drawn in this color (so old boid pixels decay
+   * toward it). Any color the browser can parse — hex, rgb(), named — is fine.
+   */
+  background?: string;
 }>;
 
 /**
@@ -333,6 +362,7 @@ export const Flock = ({
   separation = 3,
   avoidance = 3,
   cursorRepel = 120,
+  background = '#000',
 }: FlockProps) => {
   const canvas = useRef<HTMLCanvasElement>(null);
   // Cursor in canvas-local coordinates, or null while the pointer is outside.
@@ -400,31 +430,34 @@ export const Flock = ({
   }, [width, height, numObstacles]);
 
   // The trail/physics config bundled for tick; memoed so the interval effect
-  // below doesn't re-key on every parent render.
-  const tickConfig = useMemo<TickConfig>(
-    () => ({
+  // below doesn't re-key on every parent render. The fade style is pre-computed
+  // from `background` and the current trail so tick doesn't reparse each frame.
+  const tickConfig = useMemo<TickConfig>(() => {
+    const trailFactor = (80 + trail) / 100;
+    const rgb = parseColorRgb(background) ?? { r: 0, g: 0, b: 0 };
+    return {
       coloring,
       radius,
       maxVelocity,
-      trail: (80 + trail) / 100,
+      trail: trailFactor,
       alignment: alignment / 100,
       cohesion: cohesion / 100,
       separation: separation / 100,
       avoidance: avoidance / 10,
-    }),
-    [coloring, radius, maxVelocity, trail, alignment, cohesion, separation, avoidance],
-  );
+      fadeStyle: `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${1 - trailFactor})`,
+    };
+  }, [coloring, radius, maxVelocity, trail, alignment, cohesion, separation, avoidance, background]);
 
   useEffect(() => {
     if (!canvas.current || !width || !height) {
       return;
     }
 
-    // Initialise the canvas to opaque black so the per-frame fillRect fade
-    // (rgba(0,0,0,1-trail) source-over) keeps α=255 and the page background
-    // can't bleed through asymptotic-α gaps.
+    // Initialise the canvas opaquely to the configured background so the
+    // per-frame fillRect fade keeps α=255 and the page can't bleed through
+    // asymptotic-α gaps.
     const ctx = canvas.current.getContext('2d')!;
-    ctx.fillStyle = '#000';
+    ctx.fillStyle = background;
     ctx.fillRect(0, 0, width, height);
 
     const interval = d3.interval(() => {
@@ -434,7 +467,7 @@ export const Flock = ({
     });
 
     return () => interval.stop();
-  }, [boids, obstacles, width, height, tickConfig, cursorRepel]);
+  }, [boids, obstacles, width, height, tickConfig, cursorRepel, background]);
 
   const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
     const rect = event.currentTarget.getBoundingClientRect();

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -3,11 +3,12 @@
 //
 
 import * as d3 from 'd3';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { type ThemedClassName } from '@dxos/react-ui';
 import { mx } from '@dxos/ui-theme';
 
+import { type FlockBoid, FlockModel } from './FlockModel';
 import { Vec2 } from '../../util';
 
 // Boids flocking.
@@ -19,14 +20,6 @@ const SEPARATION_DISTANCE = 30;
 
 export type Dimensions = { width: number; height: number };
 
-export type FlockBoid = {
-  position: Vec2;
-  velocity: Vec2;
-  acceleration?: Vec2;
-  color?: string;
-  last?: number[];
-};
-
 export type FlockObstacle = {
   position: Vec2;
   radius: number;
@@ -34,17 +27,6 @@ export type FlockObstacle = {
 
 export type FlockStartingPosition = 'Random' | 'Circle' | 'CircleRandom' | 'Sine' | 'Phyllotaxis';
 export type FlockColoring = 'Movement' | 'Grey' | 'Rainbow';
-
-export type FlockSeed = {
-  /** Absolute x position in container coordinates (origin top-left). */
-  x: number;
-  /** Absolute y position in container coordinates (origin top-left). */
-  y: number;
-  /** Optional initial velocity. Defaults to a random velocity scaled by `maxVelocity`. */
-  vx?: number;
-  vy?: number;
-  color?: string;
-};
 
 const randomVelocity = (maxVelocity: number): Vec2 =>
   new Vec2(1 - Math.random() * 2, 1 - Math.random() * 2).scale(maxVelocity);
@@ -171,7 +153,7 @@ const renderObstacles = (context: CanvasRenderingContext2D, obstacles: FlockObst
 const tick = (
   canvas: HTMLCanvasElement,
   { width, height }: Dimensions,
-  boids: FlockBoid[],
+  boids: readonly FlockBoid[],
   obstacles: FlockObstacle[],
   cursor: FlockObstacle | null,
   config: TickConfig,
@@ -274,7 +256,12 @@ const generateFlockObstacles = (dimensions: Dimensions, numObstacles: number): F
   return obstacles;
 };
 
-const generateFlockBoids = (
+/**
+ * Generate the default boid set when a caller doesn't supply a populate callback.
+ * Honors `num`, `startingPosition`, and `maxVelocity`; assigns a rainbow color
+ * and an empty history.
+ */
+const generateDefaultBoids = (
   dimensions: Dimensions,
   config: { num: number; maxVelocity: number; startingPosition: FlockStartingPosition },
 ): FlockBoid[] => {
@@ -284,28 +271,31 @@ const generateFlockBoids = (
     b.color = d3.interpolateRainbow(i / num);
     b.last = [];
   });
-
   return boids;
 };
 
-const seedsToBoids = (seeds: readonly FlockSeed[], maxVelocity: number): FlockBoid[] =>
-  seeds.map((seed, i) => ({
-    position: new Vec2(seed.x, seed.y),
-    velocity: seed.vx != null && seed.vy != null ? new Vec2(seed.vx, seed.vy) : randomVelocity(maxVelocity),
-    color: seed.color ?? d3.interpolateRainbow(seeds.length > 0 ? i / seeds.length : 0),
-    last: [],
-  }));
-
 export type FlockProps = ThemedClassName<{
   /**
-   * Resolve the initial boid seeds given the container's dimensions. Called whenever the
-   * container resizes or the callback identity changes. When omitted, boids are generated
-   * from `num` and `startingPosition`.
+   * Reactive source of truth for the boid array. Flock subscribes via `model.subscribe`
+   * and restarts the simulation whenever `setBoids` replaces the array. Per-tick
+   * position changes are mutated in place on the same boid objects — external readers
+   * (e.g. an explorer that handed in boids with ids) sample those positions any time
+   * via `model.boids` / `model.findBoid`.
+   *
+   * When the model starts empty, Flock generates a default boid set from `num` and
+   * `startingPosition` once the container is first measured, and writes it into the
+   * model. The `populate` callback overrides that default population.
    */
-  seeds?: (dimensions: Dimensions) => readonly FlockSeed[];
-  /** Used only when `seeds` is not provided. */
+  model: FlockModel;
+  /**
+   * Optional initial-population callback. Called once when the container is first
+   * measured AND the model is empty. Use this to position boids using canvas
+   * dimensions (top-left origin) — typically when seeding from an external layout.
+   */
+  populate?: (dimensions: Dimensions) => readonly FlockBoid[];
+  /** Used only when `populate` is not provided. */
   num?: number;
-  /** Used only when `seeds` is not provided. */
+  /** Used only when `populate` is not provided. */
   startingPosition?: FlockStartingPosition;
   numObstacles?: number;
   coloring?: FlockColoring;
@@ -323,13 +313,14 @@ export type FlockProps = ThemedClassName<{
 }>;
 
 /**
- * Canvas-rendered boids flocking simulation. When `seeds` is provided, each boid starts at
- * the supplied position so callers can hand off positions from another layout.
- * Without `seeds`, boids are generated from `num` and `startingPosition`.
+ * Canvas-rendered boids flocking simulation. The boid array is owned by `model`
+ * (a `FlockModel`); Flock subscribes to it and mutates per-boid `position`,
+ * `velocity`, and `acceleration` in place each tick.
  */
 export const Flock = ({
   classNames,
-  seeds,
+  model,
+  populate,
   num = 100,
   startingPosition = 'CircleRandom',
   numObstacles = 0,
@@ -350,7 +341,9 @@ export const Flock = ({
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [{ width, height }, setSize] = useState<Dimensions>({ width: 0, height: 0 });
   const [obstacles, setObstacles] = useState<FlockObstacle[]>([]);
-  const [boids, setBoids] = useState<FlockBoid[]>([]);
+  // Local snapshot of `model.boids` — the simulation reads from this so that
+  // changing the model identity via `setBoids` triggers a clean restart.
+  const [boids, setBoids] = useState<readonly FlockBoid[]>(() => model.boids);
 
   useEffect(() => {
     if (!container) {
@@ -372,18 +365,55 @@ export const Flock = ({
     return () => observer.disconnect();
   }, [container]);
 
+  // Track the model's boid array via subscribe → setBoids. Per-tick position
+  // mutations don't emit on the atom (by design), so this only fires on
+  // `model.setBoids(...)` and the initial sync.
+  useEffect(() => {
+    setBoids(model.boids);
+    return model.subscribe(() => setBoids(model.boids));
+  }, [model]);
+
+  // Populate the model once the container dimensions are known and the model is
+  // empty. Subsequent resizes don't repopulate — the caller owns that decision.
+  const populatedRef = useRef(false);
+  useEffect(() => {
+    if (!width || !height || populatedRef.current) {
+      return;
+    }
+    if (model.boids.length > 0) {
+      populatedRef.current = true;
+      return;
+    }
+    const seeded = populate
+      ? populate({ width, height })
+      : generateDefaultBoids({ width, height }, { num, maxVelocity, startingPosition });
+    model.setBoids(seeded);
+    populatedRef.current = true;
+  }, [model, width, height, populate, num, maxVelocity, startingPosition]);
+
+  // Obstacles are derived from container size + count; regenerate on either change.
   useEffect(() => {
     if (!width || !height) {
       return;
     }
-
     setObstacles(generateFlockObstacles({ width, height }, numObstacles));
-    setBoids(
-      seeds
-        ? seedsToBoids(seeds({ width, height }), maxVelocity)
-        : generateFlockBoids({ width, height }, { num, startingPosition, maxVelocity }),
-    );
-  }, [width, height, num, numObstacles, startingPosition, maxVelocity, seeds]);
+  }, [width, height, numObstacles]);
+
+  // The trail/physics config bundled for tick; memoed so the interval effect
+  // below doesn't re-key on every parent render.
+  const tickConfig = useMemo<TickConfig>(
+    () => ({
+      coloring,
+      radius,
+      maxVelocity,
+      trail: (80 + trail) / 100,
+      alignment: alignment / 100,
+      cohesion: cohesion / 100,
+      separation: separation / 100,
+      avoidance: avoidance / 10,
+    }),
+    [coloring, radius, maxVelocity, trail, alignment, cohesion, separation, avoidance],
+  );
 
   useEffect(() => {
     if (!canvas.current || !width || !height) {
@@ -398,35 +428,13 @@ export const Flock = ({
     ctx.fillRect(0, 0, width, height);
 
     const interval = d3.interval(() => {
-      const cursor = cursorRepel > 0 && cursorRef.current ? { position: cursorRef.current, radius: cursorRepel } : null;
-      tick(canvas.current!, { width, height }, boids, obstacles, cursor, {
-        coloring,
-        radius,
-        maxVelocity,
-        trail: (80 + trail) / 100,
-        alignment: alignment / 100,
-        cohesion: cohesion / 100,
-        separation: separation / 100,
-        avoidance: avoidance / 10,
-      });
+      const cursor =
+        cursorRepel > 0 && cursorRef.current ? { position: cursorRef.current, radius: cursorRepel } : null;
+      tick(canvas.current!, { width, height }, boids, obstacles, cursor, tickConfig);
     });
 
     return () => interval.stop();
-  }, [
-    boids,
-    obstacles,
-    width,
-    height,
-    radius,
-    coloring,
-    trail,
-    maxVelocity,
-    alignment,
-    cohesion,
-    separation,
-    avoidance,
-    cursorRepel,
-  ]);
+  }, [boids, obstacles, width, height, tickConfig, cursorRepel]);
 
   const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
     const rect = event.currentTarget.getBoundingClientRect();

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -8,8 +8,8 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { type ThemedClassName } from '@dxos/react-ui';
 import { mx } from '@dxos/ui-theme';
 
-import { type FlockBoid, FlockModel } from './FlockModel';
 import { Vec2 } from '../../util';
+import { type FlockBoid, FlockModel } from './FlockModel';
 
 // Boids flocking.
 // https://en.wikipedia.org/wiki/Boids
@@ -112,7 +112,6 @@ type TickConfig = {
   /** Pre-computed `rgba(r, g, b, 1-trail)` string used by the fade fillRect. */
   fadeStyle: string;
 };
-
 
 const updateBoid = (
   b: FlockBoid,
@@ -445,8 +444,7 @@ export const Flock = ({
     ctx.clearRect(0, 0, width, height);
 
     const interval = d3.interval(() => {
-      const cursor =
-        cursorRepel > 0 && cursorRef.current ? { position: cursorRef.current, radius: cursorRepel } : null;
+      const cursor = cursorRepel > 0 && cursorRef.current ? { position: cursorRef.current, radius: cursorRepel } : null;
       tick(canvas.current!, { width, height }, boids, obstacles, cursor, tickConfig);
     });
 

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -113,25 +113,6 @@ type TickConfig = {
   fadeStyle: string;
 };
 
-/**
- * Resolve any CSS color string to an `{ r, g, b }` triple by letting the browser
- * normalise it (named colors, hex, rgb(), hsl()…). Returns null on unparseable input.
- */
-const parseColorRgb = (color: string): { r: number; g: number; b: number } | null => {
-  if (typeof document === 'undefined') {
-    return null;
-  }
-  const probe = document.createElement('div');
-  probe.style.color = color;
-  document.body.appendChild(probe);
-  const computed = getComputedStyle(probe).color;
-  document.body.removeChild(probe);
-  const match = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(computed);
-  if (!match) {
-    return null;
-  }
-  return { r: +match[1], g: +match[2], b: +match[3] };
-};
 
 const updateBoid = (
   b: FlockBoid,
@@ -182,13 +163,18 @@ const tick = (
 ) => {
   const { maxVelocity, alignment, cohesion, separation, fadeStyle } = config;
 
-  // Trail fade: paint a semi-transparent rectangle in the background color over the
-  // canvas. GPU-only path, no pixel-buffer roundtrip. Leaves a small rounding-residue
-  // near the bg color but the canvas is initialised opaque to the same color so α
-  // stays 255 and the page can't bleed through.
+  // Trail fade via `destination-out`: each frame multiplies every pixel's α by
+  // `trail` and leaves RGB untouched. Boid color decays through alpha rather than
+  // through RGB blending, which sidesteps the rounding stall that plagues color-over-
+  // color fades — bright channels (e.g. 255) would round back to 255 every frame when
+  // blended against a light bg, leaving permanent boid-colored streaks. The canvas's
+  // CSS `background-color` shows through transparent pixels, so the visual bg is
+  // whatever the parent set on the canvas element.
   const context = canvas.getContext('2d')!;
+  context.globalCompositeOperation = 'destination-out';
   context.fillStyle = fadeStyle;
   context.fillRect(0, 0, width, height);
+  context.globalCompositeOperation = 'source-over';
 
   // Obstacles re-paint at full alpha every frame so they don't decay with the trail.
   renderObstacles(context, obstacles);
@@ -430,11 +416,10 @@ export const Flock = ({
   }, [width, height, numObstacles]);
 
   // The trail/physics config bundled for tick; memoed so the interval effect
-  // below doesn't re-key on every parent render. The fade style is pre-computed
-  // from `background` and the current trail so tick doesn't reparse each frame.
+  // below doesn't re-key on every parent render. fadeStyle's RGB is ignored under
+  // `destination-out`; only its alpha matters.
   const tickConfig = useMemo<TickConfig>(() => {
     const trailFactor = (80 + trail) / 100;
-    const rgb = parseColorRgb(background) ?? { r: 0, g: 0, b: 0 };
     return {
       coloring,
       radius,
@@ -444,21 +429,20 @@ export const Flock = ({
       cohesion: cohesion / 100,
       separation: separation / 100,
       avoidance: avoidance / 10,
-      fadeStyle: `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${1 - trailFactor})`,
+      fadeStyle: `rgba(0, 0, 0, ${1 - trailFactor})`,
     };
-  }, [coloring, radius, maxVelocity, trail, alignment, cohesion, separation, avoidance, background]);
+  }, [coloring, radius, maxVelocity, trail, alignment, cohesion, separation, avoidance]);
 
   useEffect(() => {
     if (!canvas.current || !width || !height) {
       return;
     }
 
-    // Initialise the canvas opaquely to the configured background so the
-    // per-frame fillRect fade keeps α=255 and the page can't bleed through
-    // asymptotic-α gaps.
+    // Start the canvas transparent so the CSS background-color on the element
+    // shows through wherever the simulation hasn't drawn (or has faded back to
+    // α=0). No opaque init needed under the destination-out fade.
     const ctx = canvas.current.getContext('2d')!;
-    ctx.fillStyle = background;
-    ctx.fillRect(0, 0, width, height);
+    ctx.clearRect(0, 0, width, height);
 
     const interval = d3.interval(() => {
       const cursor =
@@ -467,7 +451,7 @@ export const Flock = ({
     });
 
     return () => interval.stop();
-  }, [boids, obstacles, width, height, tickConfig, cursorRepel, background]);
+  }, [boids, obstacles, width, height, tickConfig, cursorRepel]);
 
   const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
     const rect = event.currentTarget.getBoundingClientRect();
@@ -491,7 +475,7 @@ export const Flock = ({
       onPointerMove={handlePointerMove}
       onPointerLeave={handlePointerLeave}
     >
-      <canvas ref={canvas} width={width} height={height} />
+      <canvas ref={canvas} width={width} height={height} style={{ backgroundColor: background }} />
     </div>
   );
 };

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -4,7 +4,6 @@
 
 import * as d3 from 'd3';
 import React, { useEffect, useRef, useState } from 'react';
-import { useResizeDetector } from 'react-resize-detector';
 
 import { type ThemedClassName } from '@dxos/react-ui';
 import { mx } from '@dxos/ui-theme';
@@ -314,8 +313,8 @@ export type FlockProps = ThemedClassName<{
 
 /**
  * Canvas-rendered boids flocking simulation. When `seeds` is provided, each boid starts at
- * the supplied position so callers can hand off positions from another layout. Without
- * `seeds`, boids are generated from `num` and `startingPosition`.
+ * the supplied position so callers can hand off positions from another layout.
+ * Without `seeds`, boids are generated from `num` and `startingPosition`.
  */
 export const Flock = ({
   classNames,
@@ -325,8 +324,8 @@ export const Flock = ({
   numObstacles = 0,
   coloring = 'Movement',
   radius = 2,
-  trail = 10,
-  maxVelocity = 2,
+  trail = 15,
+  maxVelocity = 0.5,
   alignment = 3,
   cohesion = 3,
   separation = 3,
@@ -334,14 +333,38 @@ export const Flock = ({
 }: FlockProps) => {
   const canvas = useRef<HTMLCanvasElement>(null);
   const buffer = useRef<HTMLCanvasElement>(null);
-  const { ref: containerRef, width = 0, height = 0 } = useResizeDetector<HTMLDivElement>();
+  // Direct ResizeObserver — `react-resize-detector` was flaky in our Storybook
+  // environment (initial measurement sometimes never fired). Matches the
+  // pattern used by SVG.Root.
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const [{ width, height }, setSize] = useState<Dimensions>({ width: 0, height: 0 });
   const [obstacles, setObstacles] = useState<FlockObstacle[]>([]);
   const [boids, setBoids] = useState<FlockBoid[]>([]);
+
+  useEffect(() => {
+    if (!container) {
+      return;
+    }
+    const rect = container.getBoundingClientRect();
+    setSize({ width: rect.width, height: rect.height });
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) {
+        return;
+      }
+
+      const { width: w, height: h } = entry.contentRect;
+      setSize((prev) => (prev.width === w && prev.height === h ? prev : { width: w, height: h }));
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [container]);
 
   useEffect(() => {
     if (!width || !height) {
       return;
     }
+
     setObstacles(generateFlockObstacles({ width, height }, numObstacles));
     setBoids(
       seeds
@@ -392,7 +415,7 @@ export const Flock = ({
   ]);
 
   return (
-    <div ref={containerRef} className={mx('absolute inset-0', classNames)}>
+    <div className={mx('dx-expander absolute inset-0', classNames)} ref={setContainer}>
       <canvas ref={canvas} width={width} height={height} />
       <canvas ref={buffer} width={width} height={height} style={{ display: 'none' }} />
     </div>

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -173,6 +173,7 @@ const tick = (
   { width, height }: Dimensions,
   boids: FlockBoid[],
   obstacles: FlockObstacle[],
+  cursor: FlockObstacle | null,
   config: TickConfig,
 ) => {
   const { trail, maxVelocity, alignment, cohesion, separation } = config;
@@ -182,13 +183,21 @@ const tick = (
   // faster but leaves a sticky rounding band around RGB=9 — Chrome's
   // premultiplied source-over rounds up just often enough that pixels never
   // decay all the way to 0. Floor on a CPU pass guarantees monotonic decay.
+  // The context is created with willReadFrequently in the consumer so this
+  // read+write doesn't force a GPU→CPU sync per frame.
   const context = canvas.getContext('2d')!;
   const img = context.getImageData(0, 0, width, height);
   const data = img.data;
+  // 256-entry LUT so the inner loop is a Uint8Array index, not a float multiply
+  // per channel. With ~1.5M iterations at 60 Hz this matters.
+  const lut = new Uint8Array(256);
+  for (let v = 0; v < 256; v++) {
+    lut[v] = (v * trail) | 0;
+  }
   for (let i = 0; i < data.length; i += 4) {
-    data[i] = (data[i] * trail) | 0;
-    data[i + 1] = (data[i + 1] * trail) | 0;
-    data[i + 2] = (data[i + 2] * trail) | 0;
+    data[i] = lut[data[i]];
+    data[i + 1] = lut[data[i + 1]];
+    data[i + 2] = lut[data[i + 2]];
   }
   context.putImageData(img, 0, 0);
 
@@ -205,17 +214,21 @@ const tick = (
     };
 
     let avoid = false;
-    obstacles.forEach((o) => {
+    const repel = (o: FlockObstacle) => {
       const diff = o.position.clone().subtract(b1.position);
       const distance = diff.length();
       // Guard against distance === 0: scaleTo divides by length and would
-      // poison the simulation with Infinity/NaN if a boid lands on an obstacle.
+      // poison the simulation with Infinity/NaN if a boid lands on the source.
       if (distance > 0 && distance < o.radius) {
         forces.avoidance.add(diff.clone().scaleTo(-1 / distance));
         forces.avoidance.active = true;
         avoid = true;
       }
-    });
+    };
+    obstacles.forEach(repel);
+    if (cursor) {
+      repel(cursor);
+    }
 
     if (!avoid) {
       boids.forEach((b2) => {
@@ -321,6 +334,8 @@ export type FlockProps = ThemedClassName<{
   cohesion?: number;
   separation?: number;
   avoidance?: number;
+  /** Pixel radius of the invisible repel zone tracking the pointer. 0 disables. */
+  cursorRepel?: number;
 }>;
 
 /**
@@ -342,8 +357,12 @@ export const Flock = ({
   cohesion = 3,
   separation = 3,
   avoidance = 3,
+  cursorRepel = 120,
 }: FlockProps) => {
   const canvas = useRef<HTMLCanvasElement>(null);
+  // Cursor in canvas-local coordinates, or null while the pointer is outside.
+  // Tracked via ref so mouse moves don't re-render or restart the simulation.
+  const cursorRef = useRef<Vec2 | null>(null);
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [{ width, height }, setSize] = useState<Dimensions>({ width: 0, height: 0 });
   const [obstacles, setObstacles] = useState<FlockObstacle[]>([]);
@@ -387,17 +406,24 @@ export const Flock = ({
       return;
     }
 
-    // Initialise the canvas to opaque black once. Without this, the very first
-    // pixels start at α=0 (transparent) and the per-frame source-over fillRect
-    // asymptotes to α ≈ 246/255 in 8-bit storage — letting the page background
-    // bleed ~3.5 % through. Starting opaque means fillRect maintains α=255
-    // (final.α = src.α + dest.α(1−src.α) = 1−trail + trail·1 = 1).
-    const initCtx = canvas.current.getContext('2d')!;
-    initCtx.fillStyle = '#000';
-    initCtx.fillRect(0, 0, width, height);
+    // The trail fade in tick() does getImageData + putImageData every frame.
+    // Without willReadFrequently, Chrome backs the canvas with a GPU texture and
+    // each read forces a GPU → CPU sync — single-digit ms per frame, enough to
+    // tank a 60 Hz simulation (boids visibly ~10× slower). The hint asks the
+    // browser to keep a CPU-resident copy, cutting that cost dramatically.
+    const ctx = canvas.current.getContext('2d', { willReadFrequently: true })!;
+
+    // Initialise the canvas to opaque black so the CPU-pass fade preserves
+    // α=255 forever (no page bleed through asymptotic-α gaps).
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, width, height);
 
     const interval = d3.interval(() => {
-      tick(canvas.current!, { width, height }, boids, obstacles, {
+      const cursor =
+        cursorRepel > 0 && cursorRef.current
+          ? { position: cursorRef.current, radius: cursorRepel }
+          : null;
+      tick(canvas.current!, { width, height }, boids, obstacles, cursor, {
         coloring,
         radius,
         maxVelocity,
@@ -423,10 +449,31 @@ export const Flock = ({
     cohesion,
     separation,
     avoidance,
+    cursorRepel,
   ]);
 
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    if (cursorRef.current) {
+      cursorRef.current.x = x;
+      cursorRef.current.y = y;
+    } else {
+      cursorRef.current = new Vec2(x, y);
+    }
+  };
+  const handlePointerLeave = () => {
+    cursorRef.current = null;
+  };
+
   return (
-    <div className={mx('dx-expander absolute inset-0', classNames)} ref={setContainer}>
+    <div
+      className={mx('dx-expander absolute inset-0', classNames)}
+      ref={setContainer}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={handlePointerLeave}
+    >
       <canvas ref={canvas} width={width} height={height} />
     </div>
   );

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -178,28 +178,12 @@ const tick = (
 ) => {
   const { trail, maxVelocity, alignment, cohesion, separation } = config;
 
-  // Trail fade: multiply each RGB channel by `trail` with floor (`| 0`). Going
-  // through the canvas compositor (fillRect rgba(0,0,0,1-trail) source-over) is
-  // faster but leaves a sticky rounding band around RGB=9 — Chrome's
-  // premultiplied source-over rounds up just often enough that pixels never
-  // decay all the way to 0. Floor on a CPU pass guarantees monotonic decay.
-  // The context is created with willReadFrequently in the consumer so this
-  // read+write doesn't force a GPU→CPU sync per frame.
+  // Trail fade: paint semi-transparent black over the canvas. GPU-only path, no
+  // pixel-buffer roundtrip. Leaves a small rounding-residue at low RGB but the
+  // canvas is initialised opaque so α stays 255 and no page background bleeds.
   const context = canvas.getContext('2d')!;
-  const img = context.getImageData(0, 0, width, height);
-  const data = img.data;
-  // 256-entry LUT so the inner loop is a Uint8Array index, not a float multiply
-  // per channel. With ~1.5M iterations at 60 Hz this matters.
-  const lut = new Uint8Array(256);
-  for (let v = 0; v < 256; v++) {
-    lut[v] = (v * trail) | 0;
-  }
-  for (let i = 0; i < data.length; i += 4) {
-    data[i] = lut[data[i]];
-    data[i + 1] = lut[data[i + 1]];
-    data[i + 2] = lut[data[i + 2]];
-  }
-  context.putImageData(img, 0, 0);
+  context.fillStyle = `rgba(0, 0, 0, ${1 - trail})`;
+  context.fillRect(0, 0, width, height);
 
   // Obstacles re-paint at full alpha every frame so they don't decay with the trail.
   renderObstacles(context, obstacles);
@@ -406,15 +390,10 @@ export const Flock = ({
       return;
     }
 
-    // The trail fade in tick() does getImageData + putImageData every frame.
-    // Without willReadFrequently, Chrome backs the canvas with a GPU texture and
-    // each read forces a GPU → CPU sync — single-digit ms per frame, enough to
-    // tank a 60 Hz simulation (boids visibly ~10× slower). The hint asks the
-    // browser to keep a CPU-resident copy, cutting that cost dramatically.
-    const ctx = canvas.current.getContext('2d', { willReadFrequently: true })!;
-
-    // Initialise the canvas to opaque black so the CPU-pass fade preserves
-    // α=255 forever (no page bleed through asymptotic-α gaps).
+    // Initialise the canvas to opaque black so the per-frame fillRect fade
+    // (rgba(0,0,0,1-trail) source-over) keeps α=255 and the page background
+    // can't bleed through asymptotic-α gaps.
+    const ctx = canvas.current.getContext('2d')!;
     ctx.fillStyle = '#000';
     ctx.fillRect(0, 0, width, height);
 

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -165,7 +165,7 @@ const renderObstacles = (context: CanvasRenderingContext2D, obstacles: FlockObst
     context.fill();
   });
 
-  context.filter = 'blur(10px)';
+  context.filter = 'blur(0)';
 };
 
 const tick = (
@@ -398,10 +398,7 @@ export const Flock = ({
     ctx.fillRect(0, 0, width, height);
 
     const interval = d3.interval(() => {
-      const cursor =
-        cursorRepel > 0 && cursorRef.current
-          ? { position: cursorRef.current, radius: cursorRepel }
-          : null;
+      const cursor = cursorRepel > 0 && cursorRef.current ? { position: cursorRef.current, radius: cursorRepel } : null;
       tick(canvas.current!, { width, height }, boids, obstacles, cursor, {
         coloring,
         radius,

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -1,0 +1,400 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as d3 from 'd3';
+import React, { useEffect, useRef, useState } from 'react';
+import { useResizeDetector } from 'react-resize-detector';
+
+import { type ThemedClassName } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+import { Vec2 } from '../../util';
+
+// Boids flocking.
+// https://en.wikipedia.org/wiki/Boids
+// https://bl.ocks.org/veltman/995d3a677418100ac43877f3ed1cc728
+
+const FLOCKMATE_RADIUS = 60;
+const SEPARATION_DISTANCE = 30;
+
+export type FlockBoid = {
+  position: Vec2;
+  velocity: Vec2;
+  acceleration?: Vec2;
+  color?: string;
+  last?: number[];
+};
+
+export type FlockObstacle = {
+  position: Vec2;
+  radius: number;
+};
+
+type Dimensions = { width: number; height: number };
+
+export type FlockStartingPosition = 'Random' | 'Circle' | 'CircleRandom' | 'Sine' | 'Phyllotaxis';
+export type FlockColoring = 'Movement' | 'Grey' | 'Rainbow';
+
+export type FlockSeed = {
+  /** Absolute x position in container coordinates (origin top-left). */
+  x: number;
+  /** Absolute y position in container coordinates (origin top-left). */
+  y: number;
+  /** Optional initial velocity. Defaults to a random velocity scaled by `maxVelocity`. */
+  vx?: number;
+  vy?: number;
+  color?: string;
+};
+
+const randomVelocity = (maxVelocity: number): Vec2 =>
+  new Vec2(1 - Math.random() * 2, 1 - Math.random() * 2).scale(maxVelocity);
+
+const radialVelocity = (p: number, maxVelocity: number): Vec2 =>
+  new Vec2(Math.sin(2 * Math.PI * p), Math.cos(2 * Math.PI * p)).scale(maxVelocity);
+
+const initializeRandom = (num: number, maxVelocity: number, { width, height }: Dimensions): FlockBoid[] =>
+  d3.range(num).map(() => ({
+    position: new Vec2(Math.random() * width, Math.random() * height),
+    velocity: randomVelocity(maxVelocity),
+  }));
+
+const initializePhyllotaxis = (num: number, maxVelocity: number, { width, height }: Dimensions): FlockBoid[] =>
+  d3.range(num).map((_d, i) => {
+    const theta = Math.PI * i * (Math.sqrt(5) - 1);
+    const r = (Math.sqrt(i) * 200) / Math.sqrt(num);
+    return {
+      position: new Vec2(width / 2 + r * Math.cos(theta), height / 2 - r * Math.sin(theta)),
+      velocity: radialVelocity(i / num, maxVelocity),
+    };
+  });
+
+const initializeSine = (num: number, maxVelocity: number, { width, height }: Dimensions): FlockBoid[] =>
+  d3.range(num).map((i) => {
+    const angle = (2 * Math.PI * i) / num;
+    const x = (width * i) / num;
+    const y = height / 2 + (Math.sin(angle) * height) / 4;
+    return {
+      position: new Vec2(x, y),
+      velocity: radialVelocity(i / num, maxVelocity),
+    };
+  });
+
+const initializeCircle = (num: number, maxVelocity: number, { width, height }: Dimensions): FlockBoid[] =>
+  d3.range(num).map((i) => {
+    const angle = (i * 2 * Math.PI) / num;
+    const x = 200 * Math.sin(angle);
+    const y = 200 * Math.cos(angle);
+    return {
+      position: new Vec2(x + width / 2, y + height / 2),
+      velocity: new Vec2(-x, -y).scale(maxVelocity),
+    };
+  });
+
+const initializeCircleRandom = (num: number, maxVelocity: number, { width, height }: Dimensions): FlockBoid[] =>
+  d3.range(num).map((i) => {
+    const angle = (i * 2 * Math.PI) / num;
+    const x = 200 * Math.sin(angle);
+    const y = 200 * Math.cos(angle);
+    return {
+      position: new Vec2(x + width / 2, y + height / 2),
+      velocity: randomVelocity(maxVelocity),
+    };
+  });
+
+const startingInitializers: Record<
+  FlockStartingPosition,
+  (num: number, maxVelocity: number, dim: Dimensions) => FlockBoid[]
+> = {
+  Random: initializeRandom,
+  Phyllotaxis: initializePhyllotaxis,
+  Sine: initializeSine,
+  Circle: initializeCircle,
+  CircleRandom: initializeCircleRandom,
+};
+
+const coloringFunction: Record<FlockColoring, (boid: FlockBoid) => string> = {
+  Rainbow: (b) => b.color ?? '#000',
+  Grey: (b) => d3.interpolateGreys(0.25 + d3.mean(b.last ?? [0])!),
+  Movement: (b) => d3.interpolateSpectral(d3.mean(b.last ?? [0])!),
+};
+
+type TickConfig = {
+  trail: number;
+  maxVelocity: number;
+  alignment: number;
+  cohesion: number;
+  separation: number;
+  avoidance: number;
+  radius: number;
+  coloring: FlockColoring;
+};
+
+const updateBoid = (
+  b: FlockBoid,
+  context: CanvasRenderingContext2D,
+  { width, height }: Dimensions,
+  { radius, coloring, maxVelocity }: Pick<TickConfig, 'radius' | 'coloring' | 'maxVelocity'>,
+) => {
+  b.position.add(b.velocity.add(b.acceleration!).truncate(maxVelocity));
+
+  if (b.position.y > height) {
+    b.position.y -= height;
+  } else if (b.position.y < 0) {
+    b.position.y += height;
+  }
+
+  if (b.position.x > width) {
+    b.position.x -= width;
+  } else if (b.position.x < 0) {
+    b.position.x += width;
+  }
+
+  context.beginPath();
+  context.fillStyle = coloringFunction[coloring](b);
+  context.arc(b.position.x, b.position.y, radius, 0, 2 * Math.PI);
+  context.fill();
+};
+
+const renderObstacles = (context: CanvasRenderingContext2D, obstacles: FlockObstacle[]) => {
+  context.fillStyle = 'darkred';
+  context.filter = 'blur(40px)';
+
+  obstacles.forEach((obstacle) => {
+    context.beginPath();
+    context.arc(obstacle.position.x, obstacle.position.y, obstacle.radius, 0, 2 * Math.PI);
+    context.fill();
+  });
+
+  context.filter = 'blur(0)';
+};
+
+const tick = (
+  boids: FlockBoid[],
+  obstacles: FlockObstacle[],
+  canvas: HTMLCanvasElement,
+  offscreenCanvas: HTMLCanvasElement,
+  { width, height }: Dimensions,
+  config: TickConfig,
+) => {
+  const { trail, maxVelocity, alignment, cohesion, separation } = config;
+
+  const offscreenContext = offscreenCanvas.getContext('2d')!;
+  offscreenContext.globalAlpha = trail;
+  offscreenContext.clearRect(0, 0, width, height);
+  offscreenContext.drawImage(canvas, 0, 0, width, height);
+
+  renderObstacles(offscreenContext, obstacles);
+
+  const context = canvas.getContext('2d')!;
+  context.clearRect(0, 0, width, height);
+  context.drawImage(offscreenCanvas, 0, 0, width, height);
+
+  boids.forEach((b1) => {
+    const forces: Record<'alignment' | 'cohesion' | 'separation' | 'avoidance', Vec2> = {
+      alignment: new Vec2(),
+      cohesion: new Vec2(),
+      separation: new Vec2(),
+      avoidance: new Vec2(),
+    };
+
+    let avoid = false;
+    obstacles.forEach((o) => {
+      const diff = o.position.clone().subtract(b1.position);
+      const distance = diff.length();
+      if (distance < o.radius) {
+        forces.avoidance.add(diff.clone().scaleTo(-1 / distance));
+        forces.avoidance.active = true;
+        avoid = true;
+      }
+    });
+
+    if (!avoid) {
+      boids.forEach((b2) => {
+        if (b1 === b2) {
+          return;
+        }
+
+        const diff = b2.position.clone().subtract(b1.position);
+        const distance = diff.length();
+
+        if (distance && distance < SEPARATION_DISTANCE) {
+          forces.separation.add(diff.clone().scaleTo(-1 / distance));
+          forces.separation.active = true;
+        }
+
+        if (distance < FLOCKMATE_RADIUS) {
+          forces.cohesion.add(diff);
+          forces.cohesion.active = true;
+          forces.alignment.add(b2.velocity);
+          forces.alignment.active = true;
+        }
+      });
+    }
+
+    b1.acceleration = new Vec2();
+    (Object.keys(forces) as Array<keyof typeof forces>).forEach((key) => {
+      const force = forces[key];
+      const weight = config[key];
+      if (force.active && weight) {
+        force.scaleTo(maxVelocity).subtract(b1.velocity).truncate(weight);
+        b1.acceleration!.add(force);
+      }
+    });
+
+    const { coloring } = config;
+    if (coloring === 'Movement') {
+      const last = b1.last ?? (b1.last = []);
+      const sum = alignment + cohesion + separation;
+      last.push(sum > 0 ? b1.acceleration.length() / sum : 0);
+      if (last.length > 20) {
+        last.shift();
+      }
+    }
+  });
+
+  boids.forEach((boid) => updateBoid(boid, context, { width, height }, config));
+};
+
+export const generateFlockObstacles = (dimensions: Dimensions, numObstacles: number): FlockObstacle[] => {
+  const obstacles: FlockObstacle[] = [];
+  for (let i = 0; i < numObstacles; i++) {
+    obstacles.push({
+      position: new Vec2(Math.random() * dimensions.width, Math.random() * dimensions.height),
+      radius: 20 + Math.random() * 50,
+    });
+  }
+  return obstacles;
+};
+
+export const generateFlockBoids = (
+  dimensions: Dimensions,
+  config: { num: number; maxVelocity: number; startingPosition: FlockStartingPosition },
+): FlockBoid[] => {
+  const { num, startingPosition, maxVelocity } = config;
+  const boids = startingInitializers[startingPosition](num, maxVelocity, dimensions);
+  boids.forEach((b, i) => {
+    b.color = d3.interpolateRainbow(i / num);
+    b.last = [];
+  });
+  return boids;
+};
+
+const seedsToBoids = (seeds: readonly FlockSeed[], maxVelocity: number): FlockBoid[] =>
+  seeds.map((seed, i) => ({
+    position: new Vec2(seed.x, seed.y),
+    velocity: seed.vx != null && seed.vy != null ? new Vec2(seed.vx, seed.vy) : randomVelocity(maxVelocity),
+    color: seed.color ?? d3.interpolateRainbow(seeds.length > 0 ? i / seeds.length : 0),
+    last: [],
+  }));
+
+export type FlockProps = ThemedClassName<{
+  /**
+   * Resolve the initial boid seeds given the container's dimensions. Called whenever the
+   * container resizes or the callback identity changes. When omitted, boids are generated
+   * from `num` and `startingPosition`.
+   */
+  seeds?: (dimensions: Dimensions) => readonly FlockSeed[];
+  /** Used only when `seeds` is not provided. */
+  num?: number;
+  /** Used only when `seeds` is not provided. */
+  startingPosition?: FlockStartingPosition;
+  numObstacles?: number;
+  coloring?: FlockColoring;
+  /** Per-boid render radius in pixels. */
+  radius?: number;
+  /** Vapor trail factor, 0..20. */
+  trail?: number;
+  maxVelocity?: number;
+  alignment?: number;
+  cohesion?: number;
+  separation?: number;
+  avoidance?: number;
+}>;
+
+/**
+ * Canvas-rendered boids flocking simulation. When `seeds` is provided, each boid starts at
+ * the supplied position so callers can hand off positions from another layout. Without
+ * `seeds`, boids are generated from `num` and `startingPosition`.
+ */
+export const Flock = ({
+  classNames,
+  seeds,
+  num = 100,
+  startingPosition = 'CircleRandom',
+  numObstacles = 0,
+  coloring = 'Movement',
+  radius = 2,
+  trail = 10,
+  maxVelocity = 2,
+  alignment = 3,
+  cohesion = 3,
+  separation = 3,
+  avoidance = 3,
+}: FlockProps) => {
+  const canvas = useRef<HTMLCanvasElement>(null);
+  const buffer = useRef<HTMLCanvasElement>(null);
+  const { ref: containerRef, width = 0, height = 0 } = useResizeDetector<HTMLDivElement>();
+  const [obstacles, setObstacles] = useState<FlockObstacle[]>([]);
+  const [boids, setBoids] = useState<FlockBoid[]>([]);
+
+  useEffect(() => {
+    if (!width || !height) {
+      return;
+    }
+    setObstacles(generateFlockObstacles({ width, height }, numObstacles));
+    setBoids(
+      seeds
+        ? seedsToBoids(seeds({ width, height }), maxVelocity)
+        : generateFlockBoids({ width, height }, { num, startingPosition, maxVelocity }),
+    );
+  }, [width, height, num, numObstacles, startingPosition, maxVelocity, seeds]);
+
+  useEffect(() => {
+    if (!canvas.current || !buffer.current || !width || !height) {
+      return;
+    }
+
+    const interval = d3.interval(() => {
+      tick(
+        boids,
+        obstacles,
+        canvas.current!,
+        buffer.current!,
+        { width, height },
+        {
+          coloring,
+          radius,
+          maxVelocity,
+          trail: (80 + trail) / 100,
+          alignment: alignment / 100,
+          cohesion: cohesion / 100,
+          separation: separation / 100,
+          avoidance: avoidance / 10,
+        },
+      );
+    });
+
+    return () => interval.stop();
+  }, [
+    boids,
+    obstacles,
+    width,
+    height,
+    radius,
+    coloring,
+    trail,
+    maxVelocity,
+    alignment,
+    cohesion,
+    separation,
+    avoidance,
+  ]);
+
+  return (
+    <div ref={containerRef} className={mx('absolute inset-0', classNames)}>
+      <canvas ref={canvas} width={width} height={height} />
+      <canvas ref={buffer} width={width} height={height} style={{ display: 'none' }} />
+    </div>
+  );
+};

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -165,7 +165,7 @@ const renderObstacles = (context: CanvasRenderingContext2D, obstacles: FlockObst
     context.fill();
   });
 
-  context.filter = 'blur(0)';
+  context.filter = 'blur(10px)';
 };
 
 const tick = (
@@ -177,17 +177,25 @@ const tick = (
 ) => {
   const { trail, maxVelocity, alignment, cohesion, separation } = config;
 
-  // Trail fade: paint semi-transparent black over the previous frame so older
-  // pixels darken additively toward true #000. The alternative (alpha-blitting
-  // onto a cleared buffer) stalls at α ≈ 3–4 / 255 due to integer rounding,
-  // leaving a permanent ~#0f residue over a dark page.
+  // Trail fade: multiply each RGB channel by `trail` with floor (`| 0`). Going
+  // through the canvas compositor (fillRect rgba(0,0,0,1-trail) source-over) is
+  // faster but leaves a sticky rounding band around RGB=9 — Chrome's
+  // premultiplied source-over rounds up just often enough that pixels never
+  // decay all the way to 0. Floor on a CPU pass guarantees monotonic decay.
   const context = canvas.getContext('2d')!;
-  context.fillStyle = `rgba(0, 0, 0, ${1 - trail})`;
-  context.fillRect(0, 0, width, height);
+  const img = context.getImageData(0, 0, width, height);
+  const data = img.data;
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = (data[i] * trail) | 0;
+    data[i + 1] = (data[i + 1] * trail) | 0;
+    data[i + 2] = (data[i + 2] * trail) | 0;
+  }
+  context.putImageData(img, 0, 0);
 
   // Obstacles re-paint at full alpha every frame so they don't decay with the trail.
   renderObstacles(context, obstacles);
 
+  // Calculate forces.
   boids.forEach((b1) => {
     const forces: Record<'alignment' | 'cohesion' | 'separation' | 'avoidance', Vec2> = {
       alignment: new Vec2(),
@@ -265,6 +273,7 @@ const generateFlockObstacles = (dimensions: Dimensions, numObstacles: number): F
       radius: 20 + Math.random() * 50,
     });
   }
+
   return obstacles;
 };
 
@@ -278,6 +287,7 @@ const generateFlockBoids = (
     b.color = d3.interpolateRainbow(i / num);
     b.last = [];
   });
+
   return boids;
 };
 
@@ -326,7 +336,7 @@ export const Flock = ({
   numObstacles = 0,
   coloring = 'Movement',
   radius = 2,
-  trail = 10,
+  trail = 15,
   maxVelocity = 0.5,
   alignment = 3,
   cohesion = 3,
@@ -377,12 +387,21 @@ export const Flock = ({
       return;
     }
 
+    // Initialise the canvas to opaque black once. Without this, the very first
+    // pixels start at α=0 (transparent) and the per-frame source-over fillRect
+    // asymptotes to α ≈ 246/255 in 8-bit storage — letting the page background
+    // bleed ~3.5 % through. Starting opaque means fillRect maintains α=255
+    // (final.α = src.α + dest.α(1−src.α) = 1−trail + trail·1 = 1).
+    const initCtx = canvas.current.getContext('2d')!;
+    initCtx.fillStyle = '#000';
+    initCtx.fillRect(0, 0, width, height);
+
     const interval = d3.interval(() => {
       tick(canvas.current!, { width, height }, boids, obstacles, {
         coloring,
         radius,
         maxVelocity,
-        trail: (85 + trail) / 100,
+        trail: (80 + trail) / 100,
         alignment: alignment / 100,
         cohesion: cohesion / 100,
         separation: separation / 100,

--- a/packages/ui/react-ui-sfx/src/components/Flock/FlockModel.ts
+++ b/packages/ui/react-ui-sfx/src/components/Flock/FlockModel.ts
@@ -1,0 +1,78 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Atom, type Registry } from '@effect-atom/atom-react';
+
+import { Vec2 } from '../../util';
+
+/**
+ * One body in the flocking simulation.
+ *
+ * `id` is optional but enables identity-based reads — callers that seed boids from a
+ * domain model (e.g. graph nodes) can later look up a boid's mutated position by id.
+ *
+ * `position`, `velocity`, and `acceleration` are mutated in place by the simulation
+ * each tick — this is hot-loop code, so the Vec2 instances are reused rather than
+ * replaced. The `boids` atom only emits when the array identity changes (i.e. on
+ * `setBoids`), not on per-tick position drift.
+ */
+export type FlockBoid = {
+  id?: string;
+  position: Vec2;
+  velocity: Vec2;
+  acceleration?: Vec2;
+  color?: string;
+  /** Recent acceleration magnitudes; consumed by Movement / Grey colorings. */
+  last?: number[];
+};
+
+/**
+ * Reactive container for the boid array used by the `Flock` component.
+ *
+ * Two readers:
+ *  - `Flock` subscribes via {@link subscribe} and starts a fresh simulation whenever
+ *    {@link setBoids} replaces the array.
+ *  - External code (e.g. an explorer that hands boids ids matching graph nodes) reads
+ *    {@link boids} or {@link findBoid} to sample the latest mutated positions — useful
+ *    when handing positions back to another visualisation on layout swap.
+ */
+export class FlockModel {
+  readonly #boidsAtom: Atom.Writable<readonly FlockBoid[]>;
+
+  constructor(
+    private readonly _registry: Registry.Registry,
+    initial: readonly FlockBoid[] = [],
+  ) {
+    this.#boidsAtom = Atom.make<readonly FlockBoid[]>(initial);
+  }
+
+  /** The effect-atom for direct subscription via the registry. */
+  get boidsAtom(): Atom.Writable<readonly FlockBoid[]> {
+    return this.#boidsAtom;
+  }
+
+  /** Current boids. Positions reflect the last simulation tick (mutated in place). */
+  get boids(): readonly FlockBoid[] {
+    return this._registry.get(this.#boidsAtom);
+  }
+
+  /** Replace the boid array atomically — Flock restarts its simulation on emit. */
+  setBoids(boids: readonly FlockBoid[]): this {
+    this._registry.set(this.#boidsAtom, boids);
+    return this;
+  }
+
+  /** First boid whose `id` matches, or `undefined`. */
+  findBoid(id: string): FlockBoid | undefined {
+    return this.boids.find((b) => b.id === id);
+  }
+
+  /**
+   * Subscribe to array-identity changes (setBoids). The callback is NOT invoked on
+   * per-tick position mutations — those would flood for no benefit.
+   */
+  subscribe(cb: () => void): () => void {
+    return this._registry.subscribe(this.#boidsAtom, cb);
+  }
+}

--- a/packages/ui/react-ui-sfx/src/components/Flock/index.ts
+++ b/packages/ui/react-ui-sfx/src/components/Flock/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './Flock';

--- a/packages/ui/react-ui-sfx/src/components/Flock/index.ts
+++ b/packages/ui/react-ui-sfx/src/components/Flock/index.ts
@@ -3,3 +3,4 @@
 //
 
 export * from './Flock';
+export * from './FlockModel';

--- a/packages/ui/react-ui-sfx/src/components/index.ts
+++ b/packages/ui/react-ui-sfx/src/components/index.ts
@@ -3,6 +3,7 @@
 //
 
 export * from './Chaos';
+export * from './Flock';
 export * from './Morph';
 export * from './Matrix';
 export * from './Oscilloscope';

--- a/packages/ui/react-ui-sfx/src/index.ts
+++ b/packages/ui/react-ui-sfx/src/index.ts
@@ -4,3 +4,4 @@
 
 export * from './components';
 export * from './hooks';
+export * from './util';

--- a/plans/burdon/plugin-refactor/findings.md
+++ b/plans/burdon/plugin-refactor/findings.md
@@ -23,7 +23,7 @@ Only `KanbanColumn.tsx` had issues.
 
 ### react-ui-mosaic changes (`Board/Column.tsx`)
 
-- Added `Board.Column.Grid` — encapsulates the `group/column grid bs-full overflow-hidden` wrapper div; callers pass grid-rows via `classNames`.
+- Added `Board.Column.Grid` — encapsulates the `group/column grid h-full overflow-hidden` wrapper div; callers pass grid-rows via `classNames`.
 - Baked `border-be border-separator` into `Board.Column.Header` (all callers passed it).
 - Baked `border-bs border-separator` + `rounded-b-sm` into `Board.Column.Footer`.
 - Added `onAdd` prop to `Board.Column.Footer` — falls back to `model.onItemCreate` when not provided.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10686,6 +10686,9 @@ importers:
       '@dxos/invariant':
         specifier: workspace:*
         version: link:../../common/invariant
+      '@dxos/keyboard':
+        specifier: workspace:*
+        version: link:../../common/keyboard
       '@dxos/keys':
         specifier: workspace:*
         version: link:../../common/keys

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2333,7 +2333,7 @@ importers:
         version: 6.1.1(typescript@6.0.3)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wait-on:
         specifier: 'catalog:'
         version: 8.0.3
@@ -3855,7 +3855,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/common/effect-zod:
     dependencies:
@@ -3874,7 +3874,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/common/errors: {}
 
@@ -4574,7 +4574,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/common/web-context-solid:
     dependencies:
@@ -4651,7 +4651,7 @@ importers:
         version: 0.29.0(effect@3.20.0)(vitest@4.1.7)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/core/compute/ai:
     dependencies:
@@ -5015,7 +5015,7 @@ importers:
         version: 3.20.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/core/compute/compute-hyperformula:
     dependencies:
@@ -5492,7 +5492,7 @@ importers:
         version: 0.33.2(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -5529,7 +5529,7 @@ importers:
         version: 3.20.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/core/echo/echo:
     dependencies:
@@ -5963,7 +5963,7 @@ importers:
         version: 1.8.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -6068,7 +6068,7 @@ importers:
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/core/echo/feed:
     dependencies:
@@ -7018,7 +7018,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/devtools/cli-util:
     dependencies:
@@ -7076,7 +7076,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/devtools/devtools:
     dependencies:
@@ -9268,7 +9268,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/plugins/plugin-crx:
     dependencies:
@@ -9323,7 +9323,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/plugins/plugin-debug:
     dependencies:
@@ -16469,7 +16469,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/reflect/introspect:
     dependencies:
@@ -16512,7 +16512,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/reflect/introspect-mcp:
     dependencies:
@@ -16533,7 +16533,7 @@ importers:
         version: link:../../common/util
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -16552,7 +16552,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/reflect/introspect-tools:
     dependencies:
@@ -16577,7 +16577,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/sdk/app-framework:
     dependencies:
@@ -20413,7 +20413,7 @@ importers:
         version: link:../ui-theme
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -20760,7 +20760,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/ui/react-ui-menu:
     dependencies:
@@ -21083,6 +21083,9 @@ importers:
       '@dxos/util':
         specifier: workspace:*
         version: link:../../common/util
+      '@effect-atom/atom-react':
+        specifier: 'catalog:'
+        version: 0.5.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)(react@19.2.6)(scheduler@0.27.0)
       '@react-three/drei':
         specifier: 'catalog:'
         version: 10.7.7(@react-three/fiber@9.5.0(@types/react@19.2.14)(immer@10.1.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.178.0))(@types/react@19.2.14)(@types/three@0.165.0)(immer@10.1.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.178.0)
@@ -22435,7 +22438,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   tools/vite-plugin-log/example:
     devDependencies:
@@ -25379,6 +25382,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -40905,6 +40909,7 @@ packages:
       '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
+      vite: '>=8.0.0'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -43507,7 +43512,7 @@ snapshots:
       cjs-module-lexer: 1.3.1
       esbuild: 0.28.0
       miniflare: 4.20260521.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wrangler: 4.68.1(@cloudflare/workers-types@4.20260303.0)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -44214,7 +44219,7 @@ snapshots:
   '@effect/vitest@0.29.0(effect@3.20.0)(vitest@4.1.7)':
     dependencies:
       effect: 3.20.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@effect/wa-sqlite@0.1.2': {}
 
@@ -45265,7 +45270,7 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.2)
       ajv: 8.18.0
@@ -49255,7 +49260,7 @@ snapshots:
       '@vitest/browser': 4.1.7(patch_hash=6c3dc337ee70b919eca34fd4b7144f3f075cb1e9285392c3ac13108c217939a5)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.7)
       '@vitest/browser-playwright': 4.1.7(playwright@1.57.0)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.7)
       '@vitest/runner': 4.1.7
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -50712,7 +50717,7 @@ snapshots:
       '@vitest/mocker': 4.1.7(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -50728,7 +50733,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -50748,7 +50753,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
       '@vitest/browser': 4.1.7(patch_hash=6c3dc337ee70b919eca34fd4b7144f3f075cb1e9285392c3ac13108c217939a5)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.7)
 
@@ -50812,7 +50817,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -51736,7 +51741,7 @@ snapshots:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@cloudflare/ai-chat': 0.0.6(agents@0.3.10)(ai@6.0.97(zod@4.3.6))(react@19.2.6)(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 6.0.97(zod@4.3.6)
       cron-schedule: 6.0.0
       escape-html: 1.0.3
@@ -54123,10 +54128,6 @@ snapshots:
   draco3d@1.5.7: {}
 
   dset@3.1.4: {}
-
-  dts-resolver@2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
-    optionalDependencies:
-      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   dts-resolver@2.1.3(oxc-resolver@11.9.0):
     optionalDependencies:
@@ -60887,24 +60888,6 @@ snapshots:
 
   robust-predicates@3.0.1: {}
 
-  rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
-    dependencies:
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-      ast-kit: 2.2.0
-      birpc: 3.0.0
-      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
-      get-tsconfig: 4.13.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260421.2
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - oxc-resolver
-
   rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
     dependencies:
       '@babel/generator': 7.28.5
@@ -62580,34 +62563,6 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
-    dependencies:
-      ansis: 4.2.0
-      cac: 6.7.14
-      chokidar: 5.0.0
-      diff: 8.0.3
-      empathic: 2.0.0
-      hookable: 5.5.3
-      obug: 2.1.1
-      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      rolldown-plugin-dts: 0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
-      semver: 7.7.4
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tree-kill: 1.2.2
-      unconfig-core: 7.4.2
-      unrun: 0.2.19(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@ts-macro/tsc'
-      - '@typescript/native-preview'
-      - oxc-resolver
-      - synckit
-      - vue-tsc
-
   tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
@@ -63398,7 +63353,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -63429,18 +63384,7 @@ snapshots:
       happy-dom: 20.7.0
       jsdom: 29.1.1(canvas@3.2.0)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   void-elements@3.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9898,6 +9898,9 @@ importers:
       '@dxos/react-ui-mosaic':
         specifier: workspace:*
         version: link:../../ui/react-ui-mosaic
+      '@dxos/react-ui-sfx':
+        specifier: workspace:*
+        version: link:../../ui/react-ui-sfx
       '@dxos/react-ui-stack':
         specifier: workspace:*
         version: link:../../ui/react-ui-stack

--- a/tools/vscode-file-templates/templates/RadixComponent.tsx.tpl
+++ b/tools/vscode-file-templates/templates/RadixComponent.tsx.tpl
@@ -42,7 +42,7 @@ type ${name}ViewportProps = ThemedClassName<PropsWithChildren<{}>>;
 
 const ${name}Viewport = ({ classNames, children }: ${name}ViewportProps) => {
   const context = use${name}Context(${NAME}_VIEWPORT_NAME);
-  return <div role='none' className={mx('flex bs-full is-full overflow-y-auto', classNames)}>{children}</div>;
+  return <div role='none' className={mx('flex h-full is-full overflow-y-auto', classNames)}>{children}</div>;
 };
 
 ${name}Viewport.displayName = ${NAME}_VIEWPORT_NAME;


### PR DESCRIPTION
## Summary
- Adds a 5th layout type, **Flock**, to `ExplorerArticle` alongside `force` / `cluster` / `bundle` / `lattice`.
- Each node from the existing graph model becomes a boid; positions are seeded from the most recent SVG projector layout (translated from center-origin to top-left), so switching into Flock continues from wherever the prior layout left off.
- Extracts the boids simulation from `react-ui-sfx`'s Flock story into a reusable `Flock` component (canvas + d3 interval, no leva). The story now wraps the component while keeping the leva controls for SFX tuning.

## Why
- Wanted a more expressive variant for visualising the graph as a living swarm.
- The extraction makes the simulation reusable from anywhere in the workspace without dragging leva or storybook-only wiring along.

## Notes for reviewer
- New variant uses icon `ph--bird--regular`.
- `Visualization` snapshots the last graph projector layout via `lastLayoutRef` before mounting the Flock canvas; on swap back to an SVG variant the layout is fed in as `prev` so the SVG projector tweens back from the boids' last frame.
- `seeds` is a callback receiving container dimensions so callers can compute absolute pixel positions (top-left origin). When absent, the component falls back to its previous random `startingPosition` initializer.
- `@dxos/react-ui-sfx` was added as a dep to `plugin-explorer`; also exposes `util` (for `Vec2`) at the package root.

## Test plan
- [ ] `moon run storybook-react:serve` → open `plugins/plugin-explorer/containers/ExplorerArticle` → cycle Force → Cluster → Flock; verify boids appear where nodes were and start flocking.
- [ ] Swap back from Flock → other variants; layout should resume from the latest boid positions.
- [ ] `ui/react-ui-sfx/Flock` story still renders with leva controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "swarm" visualization to Explorer — a canvas-based boids/flock mode that seeds from the current layout and preserves node positions when switching back.
  * Introduced a reusable Flock component for canvas-based flocking effects, supporting multiple starting patterns, coloring modes, and responsive behavior.

* **Documentation / Examples**
  * Storybook updated with a new "Swarm" story for Explorer and a driven Flock story with interactive controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->