### PR TITLE
feat: extend pkg-lint to validate imports source paths and wire into CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Check publish config
         run: pnpm run check-publish-config
 
+      - name: Check package.json paths
+        run: pnpm run pkg-lint
+
       - name: Check formatting
         run: pnpm run format-check
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lockfile": "vite-node scripts/lockfile.ts",
     "moonx": "./scripts/moonx",
     "pkg-inspect": "./scripts/pkg-inspect.mjs",
+    "pkg-lint": "node scripts/pkg-lint.mjs",
     "pre-ci": "./scripts/pre-ci.mjs",
     "prepare": "[ \"$HUSKY\" != \"0\" ] && husky install || true",
     "query-logs": "node scripts/query-logs.mjs",

--- a/packages/plugins/plugin-assistant/package.json
+++ b/packages/plugins/plugin-assistant/package.json
@@ -57,7 +57,7 @@
       "source": {
         "workerd": "./src/AssistantPlugin.workerd.ts",
         "node": "./src/AssistantPlugin.node.ts",
-        "default": "./src/AssistantPlugin.tsx"
+        "default": "./src/AssistantPlugin.ts"
       },
       "types": "./dist/types/src/AssistantPlugin.d.ts",
       "workerd": "./dist/lib/neutral/AssistantPlugin.workerd.mjs",

--- a/packages/plugins/plugin-wnfs/package.json
+++ b/packages/plugins/plugin-wnfs/package.json
@@ -18,16 +18,6 @@
       "types": "./dist/types/src/capabilities/index.d.ts",
       "default": "./dist/lib/neutral/capabilities/index.mjs"
     },
-    "#components": {
-      "source": "./src/components/index.ts",
-      "types": "./dist/types/src/components/index.d.ts",
-      "default": "./dist/lib/neutral/components/index.mjs"
-    },
-    "#containers": {
-      "source": "./src/containers/index.ts",
-      "types": "./dist/types/src/containers/index.d.ts",
-      "default": "./dist/lib/neutral/containers/index.mjs"
-    },
     "#helpers": {
       "source": "./src/helpers/index.ts",
       "types": "./dist/types/src/helpers/index.d.ts",
@@ -37,11 +27,6 @@
       "source": "./src/meta.ts",
       "types": "./dist/types/src/meta.d.ts",
       "default": "./dist/lib/neutral/meta.mjs"
-    },
-    "#operations": {
-      "source": "./src/operations/index.ts",
-      "types": "./dist/types/src/operations/index.d.ts",
-      "default": "./dist/lib/neutral/operations/index.mjs"
     },
     "#plugin": {
       "source": {

--- a/packages/sdk/config/package.json
+++ b/packages/sdk/config/package.json
@@ -52,19 +52,19 @@
       }
     },
     "./esbuild-plugin": {
-      "source": "./src/esbuild-plugin/index.ts",
+      "source": "./src/plugin/esbuild-plugin.ts",
       "types": "./dist/types/src/esbuild-plugin/index.d.ts",
       "import": "./dist/plugin/node-esm/esbuild-plugin.mjs",
       "require": "./dist/plugin/node/esbuild-plugin.cjs"
     },
     "./rollup-plugin": {
-      "source": "./src/rollup-plugin/index.ts",
+      "source": "./src/plugin/rollup-plugin.ts",
       "types": "./dist/types/src/rollup-plugin/index.d.ts",
       "import": "./dist/plugin/node-esm/rollup-plugin.mjs",
       "require": "./dist/plugin/node/rollup-plugin.cjs"
     },
     "./vite-plugin": {
-      "source": "./src/vite-plugin/index.ts",
+      "source": "./src/plugin/vite-plugin.ts",
       "types": "./dist/types/src/vite-plugin/index.d.ts",
       "import": "./dist/plugin/node-esm/vite-plugin.mjs",
       "require": "./dist/plugin/node/vite-plugin.cjs"

--- a/scripts/pkg-lint.mjs
+++ b/scripts/pkg-lint.mjs
@@ -19,6 +19,8 @@ const packages = await $`pnpm -r ls --depth=-1 --json`.json();
 
 const repoRoot = await $`git rev-parse --show-toplevel`.text().then((text) => text.trim());
 
+let hasErrors = false;
+
 for (const { name, path: pkgPath } of packages) {
   let diagnostics = [];
 
@@ -96,10 +98,54 @@ for (const { name, path: pkgPath } of packages) {
     addDiagnostic('conventional', 'type-module', 'package.json is "type": "module"');
   }
 
-  // Package has imports field - info.
-  if ('imports' in pkgJson) {
-    const importCount = Object.keys(pkgJson.imports).length;
-    addDiagnostic('info', 'imports-field', `package.json has "imports" field with ${importCount} entries`);
+  // Check imports source paths.
+  const pkgImports = pkgJson.imports ?? {};
+  for (const [importPath, importValue] of Object.entries(pkgImports)) {
+    if (typeof importValue === 'string') {
+      // Simple string import — skip dist paths (pre-built artifacts).
+      if (!importValue.startsWith('./dist/')) {
+        const srcPath = join(pkgPath, importValue);
+        if (!existsSync(srcPath)) {
+          addDiagnostic('error', 'import-source-missing', `import "${importPath}": file does not exist: ${importValue}`);
+        } else {
+          addDiagnostic('conventional', 'import-source-exists', `import "${importPath}": file exists`);
+        }
+      }
+    } else if (importValue && typeof importValue === 'object') {
+      const { source } = importValue;
+      if (typeof source === 'string') {
+        const srcPath = join(pkgPath, source);
+        if (!existsSync(srcPath)) {
+          addDiagnostic(
+            'error',
+            'import-source-missing',
+            `import "${importPath}": source file does not exist: ${source}`,
+          );
+        } else {
+          addDiagnostic('conventional', 'import-source-exists', `import "${importPath}": source file exists`);
+        }
+      } else if (source && typeof source === 'object') {
+        // Nested conditions (e.g., { workerd: "...", node: "...", default: "..." }).
+        for (const [condition, condValue] of Object.entries(source)) {
+          if (typeof condValue === 'string') {
+            const srcPath = join(pkgPath, condValue);
+            if (!existsSync(srcPath)) {
+              addDiagnostic(
+                'error',
+                'import-source-missing',
+                `import "${importPath}": source[${condition}] does not exist: ${condValue}`,
+              );
+            } else {
+              addDiagnostic(
+                'conventional',
+                'import-source-exists',
+                `import "${importPath}": source[${condition}] exists`,
+              );
+            }
+          }
+        }
+      }
+    }
   }
 
   // Package has peerDependencies - info.
@@ -353,4 +399,12 @@ for (const { name, path: pkgPath } of packages) {
     }
     console.log();
   }
+
+  if (diagnostics.some((d) => d.severity === 'error')) {
+    hasErrors = true;
+  }
+}
+
+if (hasErrors) {
+  process.exit(1);
 }

--- a/scripts/pkg-lint.mjs
+++ b/scripts/pkg-lint.mjs
@@ -106,7 +106,11 @@ for (const { name, path: pkgPath } of packages) {
       if (!importValue.startsWith('./dist/')) {
         const srcPath = join(pkgPath, importValue);
         if (!existsSync(srcPath)) {
-          addDiagnostic('error', 'import-source-missing', `import "${importPath}": file does not exist: ${importValue}`);
+          addDiagnostic(
+            'error',
+            'import-source-missing',
+            `import "${importPath}": file does not exist: ${importValue}`,
+          );
         } else {
           addDiagnostic('conventional', 'import-source-exists', `import "${importPath}": file exists`);
         }

--- a/tools/toolbox/package.json
+++ b/tools/toolbox/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "source": "./dist/src/index.ts",
+      "source": "./src/index.ts",
       "types": "./dist/src/index.d.ts",
       "default": "./dist/src/index.js"
     }

--- a/tools/vite-plugin-icons/package.json
+++ b/tools/vite-plugin-icons/package.json
@@ -15,7 +15,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "source": "./dist/src/index.ts",
+      "source": "./src/index.ts",
       "types": "./dist/src/index.d.ts",
       "default": "./dist/src/index.js"
     }

--- a/tools/vite-plugin-import-source/package.json
+++ b/tools/vite-plugin-import-source/package.json
@@ -15,7 +15,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "source": "./dist/src/index.ts",
+      "source": "./src/index.ts",
       "types": "./dist/src/index.d.ts",
       "default": "./dist/src/index.js"
     }


### PR DESCRIPTION
## Summary

- `scripts/pkg-lint.mjs` now walks the `imports` field the same way it already walks `exports` — checking every `source` path for existence, including nested condition objects (`{ workerd, node, default }`). Exits non-zero on any `error`-severity finding, so CI will catch future regressions.
- `pnpm run pkg-lint` wired into the **Check** CI workflow alongside `check-cycles` and `check-publish-config`.
- Fixed all pre-existing broken paths the new check found:

| Package | Fix |
|---|---|
| `plugin-assistant` | `#plugin.source.default` was `.tsx`, file is `.ts` |
| `plugin-wnfs` | Removed stale `#components`, `#containers`, `#operations` entries whose source dirs don't exist |
| `@dxos/config` | `./esbuild-plugin`, `./rollup-plugin`, `./vite-plugin` exports pointed to non-existent subdirs; corrected to `src/plugin/*.ts` |
| `toolbox`, `vite-plugin-icons`, `vite-plugin-import-source` | `source` condition said `./dist/src/index.ts`; corrected to `./src/index.ts` |

## Test plan

- [ ] `pnpm run pkg-lint` exits 0 locally
- [ ] CI Check workflow passes (new "Check package.json paths" step should be green)
- [ ] Intentional dist-only imports (e.g. `echo-query`'s `#query-lite: "./dist/query-lite/index.js"`) are not flagged

https://claude.ai/code/session_01H6rA1ERywhnJcZqQ97gCBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6rA1ERywhnJcZqQ97gCBp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated package configuration validation in the CI pipeline to check package import path integrity.
  * Added `pkg-lint` script for validating that referenced file paths exist in package configurations.

* **Chores**
  * Updated package export configurations across multiple packages to reference correct source paths.
  * Streamlined package import mappings by removing unused entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->