### PR TITLE
docs(plans): add echo-db usage audit categorized by usage kind

### DIFF
--- a/packages/common/graph/package.json
+++ b/packages/common/graph/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@dxos/echo": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/random": "workspace:*",
     "effect": "catalog:"
   },

--- a/packages/common/graph/tsconfig.json
+++ b/packages/common/graph/tsconfig.json
@@ -22,9 +22,6 @@
       "path": "../../core/echo/echo"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../async"
     },
     {

--- a/packages/core/compute/ai/package.json
+++ b/packages/core/compute/ai/package.json
@@ -47,7 +47,6 @@
     "@dxos/context": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/echo": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/effect": "workspace:*",
     "@dxos/errors": "workspace:*",
     "@dxos/graph": "workspace:*",

--- a/packages/core/compute/ai/tsconfig.json
+++ b/packages/core/compute/ai/tsconfig.json
@@ -52,9 +52,6 @@
       "path": "../../echo/echo"
     },
     {
-      "path": "../../echo/echo-db"
-    },
-    {
       "path": "../../protocols"
     }
   ]

--- a/packages/core/compute/assistant-toolkit/package.json
+++ b/packages/core/compute/assistant-toolkit/package.json
@@ -34,7 +34,6 @@
     "@dxos/client-protocol": "workspace:*",
     "@dxos/compute": "workspace:*",
     "@dxos/echo": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/echo-protocol": "workspace:*",
     "@dxos/effect": "workspace:*",
     "@dxos/errors": "workspace:*",

--- a/packages/core/compute/assistant-toolkit/tsconfig.json
+++ b/packages/core/compute/assistant-toolkit/tsconfig.json
@@ -57,9 +57,6 @@
       "path": "../../echo/echo"
     },
     {
-      "path": "../../echo/echo-db"
-    },
-    {
       "path": "../../echo/echo-protocol"
     },
     {

--- a/packages/core/compute/compute-hyperformula/package.json
+++ b/packages/core/compute/compute-hyperformula/package.json
@@ -54,7 +54,6 @@
   },
   "devDependencies": {
     "@dxos/echo": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/random": "workspace:*",
     "@tldraw/indices": "catalog:",
     "@types/lodash.defaultsdeep": "catalog:"

--- a/packages/core/compute/compute-hyperformula/tsconfig.json
+++ b/packages/core/compute/compute-hyperformula/tsconfig.json
@@ -52,9 +52,6 @@
       "path": "../../echo/echo"
     },
     {
-      "path": "../../echo/echo-db"
-    },
-    {
       "path": "../compute"
     }
   ]

--- a/packages/core/compute/operation/package.json
+++ b/packages/core/compute/operation/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@dxos/echo": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/test-utils": "workspace:*",
     "@effect/vitest": "catalog:",
     "effect": "catalog:",

--- a/packages/core/compute/operation/tsconfig.json
+++ b/packages/core/compute/operation/tsconfig.json
@@ -20,9 +20,6 @@
       "path": "../../echo/echo"
     },
     {
-      "path": "../../echo/echo-db"
-    },
-    {
       "path": "../compute"
     }
   ]

--- a/packages/core/echo/echo-db/src/query/index.ts
+++ b/packages/core/echo/echo-db/src/query/index.ts
@@ -2,7 +2,6 @@
 // Copyright 2020 DXOS.org
 //
 
-export { Filter, Query } from '@dxos/echo';
 export * from './graph-query-context';
 export * from './query-context';
 export * from './query-result';

--- a/packages/plugins/plugin-automation/package.json
+++ b/packages/plugins/plugin-automation/package.json
@@ -120,7 +120,6 @@
     "@dxos/debug": "workspace:*",
     "@dxos/echo": "workspace:*",
     "@dxos/echo-atom": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/echo-react": "workspace:*",
     "@dxos/edge-client": "workspace:*",
     "@dxos/effect": "workspace:*",

--- a/packages/plugins/plugin-automation/tsconfig.json
+++ b/packages/plugins/plugin-automation/tsconfig.json
@@ -75,9 +75,6 @@
       "path": "../../core/echo/echo-atom"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../../core/echo/echo-react"
     },
     {

--- a/packages/plugins/plugin-chess/package.json
+++ b/packages/plugins/plugin-chess/package.json
@@ -103,7 +103,6 @@
     "@dxos/compute": "workspace:*",
     "@dxos/display-name": "workspace:*",
     "@dxos/echo": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/echo-react": "workspace:*",
     "@dxos/invariant": "workspace:*",
     "@dxos/log": "workspace:*",

--- a/packages/plugins/plugin-chess/tsconfig.json
+++ b/packages/plugins/plugin-chess/tsconfig.json
@@ -48,9 +48,6 @@
       "path": "../../core/echo/echo"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../../core/echo/echo-react"
     },
     {

--- a/packages/plugins/plugin-meeting/package.json
+++ b/packages/plugins/plugin-meeting/package.json
@@ -88,7 +88,6 @@
     "@dxos/display-name": "workspace:*",
     "@dxos/echo": "workspace:*",
     "@dxos/echo-atom": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/edge-client": "workspace:*",
     "@dxos/effect": "workspace:*",
     "@dxos/invariant": "workspace:*",

--- a/packages/plugins/plugin-meeting/tsconfig.json
+++ b/packages/plugins/plugin-meeting/tsconfig.json
@@ -74,9 +74,6 @@
       "path": "../../core/echo/echo-atom"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../../core/mesh/edge-client"
     },
     {

--- a/packages/plugins/plugin-preview/package.json
+++ b/packages/plugins/plugin-preview/package.json
@@ -99,7 +99,6 @@
     "@effect-atom/atom-react": "catalog:"
   },
   "devDependencies": {
-    "@dxos/echo-db": "workspace:*",
     "@dxos/echo-react": "workspace:*",
     "@dxos/plugin-testing": "workspace:*",
     "@dxos/random": "workspace:*",

--- a/packages/plugins/plugin-preview/tsconfig.json
+++ b/packages/plugins/plugin-preview/tsconfig.json
@@ -45,9 +45,6 @@
       "path": "../../core/echo/echo"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../../core/echo/echo-react"
     },
     {

--- a/packages/plugins/plugin-support/package.json
+++ b/packages/plugins/plugin-support/package.json
@@ -103,7 +103,6 @@
     "@dxos/debug": "workspace:*",
     "@dxos/echo": "workspace:*",
     "@dxos/echo-atom": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/echo-react": "workspace:*",
     "@dxos/effect": "workspace:*",
     "@dxos/invariant": "workspace:*",

--- a/packages/plugins/plugin-support/tsconfig.json
+++ b/packages/plugins/plugin-support/tsconfig.json
@@ -51,9 +51,6 @@
       "path": "../../core/echo/echo-atom"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../../core/echo/echo-react"
     },
     {

--- a/packages/plugins/plugin-transcription/package.json
+++ b/packages/plugins/plugin-transcription/package.json
@@ -117,7 +117,6 @@
     "@dxos/debug": "workspace:*",
     "@dxos/display-name": "workspace:*",
     "@dxos/echo": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/effect": "workspace:*",
     "@dxos/functions-runtime": "workspace:*",
     "@dxos/invariant": "workspace:*",

--- a/packages/plugins/plugin-transcription/tsconfig.json
+++ b/packages/plugins/plugin-transcription/tsconfig.json
@@ -75,9 +75,6 @@
       "path": "../../core/echo/echo"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../../core/protocols"
     },
     {

--- a/packages/plugins/plugin-trip/package.json
+++ b/packages/plugins/plugin-trip/package.json
@@ -89,7 +89,7 @@
     "@dxos/app-toolkit": "workspace:*",
     "@dxos/compute": "workspace:*",
     "@dxos/echo": "workspace:*",
-    "@dxos/echo-db": "workspace:^0.8.3",
+    "@dxos/echo-db": "workspace:*",
     "@dxos/effect": "workspace:*",
     "@dxos/log": "workspace:*",
     "@dxos/plugin-attention": "workspace:*",

--- a/packages/plugins/plugin-trip/tsconfig.json
+++ b/packages/plugins/plugin-trip/tsconfig.json
@@ -36,6 +36,9 @@
       "path": "../../core/echo/echo"
     },
     {
+      "path": "../../core/echo/echo-db"
+    },
+    {
       "path": "../../sdk/app-framework"
     },
     {

--- a/packages/sdk/app-graph/package.json
+++ b/packages/sdk/app-graph/package.json
@@ -50,7 +50,6 @@
     "main-thread-scheduling": "catalog:"
   },
   "devDependencies": {
-    "@dxos/echo-db": "workspace:*",
     "@dxos/random": "workspace:*",
     "@dxos/react-client": "workspace:*",
     "@dxos/react-ui": "workspace:*",

--- a/packages/sdk/app-graph/tsconfig.json
+++ b/packages/sdk/app-graph/tsconfig.json
@@ -43,9 +43,6 @@
       "path": "../../core/echo/echo-atom"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../../ui/react-ui"
     },
     {

--- a/packages/sdk/client/src/echo/import.ts
+++ b/packages/sdk/client/src/echo/import.ts
@@ -3,9 +3,8 @@
 //
 
 import { SpaceProperties } from '@dxos/client-protocol';
-import { DXN, Type } from '@dxos/echo';
-import { Filter, type SerializedSpace, Serializer, decodeDXNFromJSON } from '@dxos/echo-db';
-import { type EchoDatabase } from '@dxos/echo-db';
+import { DXN, Filter, Type } from '@dxos/echo';
+import { type EchoDatabase, type SerializedSpace, Serializer, decodeDXNFromJSON } from '@dxos/echo-db';
 
 export type ImportSpaceOptions = {
   /** Type names to filter out during import (e.g., SpaceProperties typename). */

--- a/packages/sdk/client/src/echo/space-list.ts
+++ b/packages/sdk/client/src/echo/space-list.ts
@@ -16,8 +16,8 @@ import {
 import { type Config } from '@dxos/config';
 import { Context } from '@dxos/context';
 import { failUndefined, inspectObject } from '@dxos/debug';
-import { type Database, Obj } from '@dxos/echo';
-import { type EchoClient, Filter, Query } from '@dxos/echo-db';
+import { type Database, Filter, Obj, Query } from '@dxos/echo';
+import { type EchoClient } from '@dxos/echo-db';
 import { failedInvariant, invariant } from '@dxos/invariant';
 import { PublicKey, SpaceId } from '@dxos/keys';
 import { log } from '@dxos/log';

--- a/packages/sdk/client/src/echo/space-proxy.ts
+++ b/packages/sdk/client/src/echo/space-proxy.ts
@@ -33,12 +33,11 @@ import {
   todo,
   warnAfterTimeout,
 } from '@dxos/debug';
-import { Obj } from '@dxos/echo';
+import { Filter, Obj } from '@dxos/echo';
 import {
   type EchoClient,
   type EchoDatabase,
   type EchoDatabaseImpl,
-  Filter,
   type QueueFactory,
   type SpaceSyncState,
 } from '@dxos/echo-db';

--- a/packages/sdk/client/src/tests/client.test.ts
+++ b/packages/sdk/client/src/tests/client.test.ts
@@ -7,8 +7,7 @@ import { afterEach, beforeEach, describe, expect, onTestFinished, test } from 'v
 
 import { Trigger, asyncTimeout } from '@dxos/async';
 import { Config } from '@dxos/config';
-import { Obj } from '@dxos/echo';
-import { Filter } from '@dxos/echo-db';
+import { Filter, Obj } from '@dxos/echo';
 import { Ref } from '@dxos/echo/internal';
 import { type Runtime } from '@dxos/protocols/proto/dxos/config';
 import { isNode } from '@dxos/util';

--- a/packages/sdk/client/src/tests/indexing.test.ts
+++ b/packages/sdk/client/src/tests/indexing.test.ts
@@ -7,8 +7,7 @@ import { describe, expect, onTestFinished, test } from 'vitest';
 
 import { Trigger, TriggerState, asyncTimeout } from '@dxos/async';
 import { type ClientServicesProvider, type Space, SpaceProperties } from '@dxos/client-protocol';
-import { type Entity, Obj, type QueryResult } from '@dxos/echo';
-import { Filter } from '@dxos/echo-db';
+import { type Entity, Filter, Obj, type QueryResult } from '@dxos/echo';
 import { Ref } from '@dxos/echo/internal';
 import { TestSchema as TestSchema$ } from '@dxos/echo/testing';
 import { type PublicKey } from '@dxos/keys';

--- a/packages/sdk/react-edge-client/package.json
+++ b/packages/sdk/react-edge-client/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@dxos/client": "workspace:*",
     "@dxos/debug": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/edge-client": "workspace:*",
     "@dxos/invariant": "workspace:*",
     "@dxos/log": "workspace:*",

--- a/packages/sdk/react-edge-client/tsconfig.json
+++ b/packages/sdk/react-edge-client/tsconfig.json
@@ -24,9 +24,6 @@
       "path": "../../common/util"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../../core/mesh/edge-client"
     },
     {

--- a/packages/stories/stories-ui/package.json
+++ b/packages/stories/stories-ui/package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "@dxos/app-framework": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/plugin-client": "workspace:*",
     "@dxos/plugin-testing": "workspace:*",
     "@dxos/random": "workspace:*",

--- a/packages/stories/stories-ui/tsconfig.json
+++ b/packages/stories/stories-ui/tsconfig.json
@@ -37,9 +37,6 @@
       "path": "../../core/echo/echo"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../../plugins/plugin-client"
     },
     {

--- a/packages/ui/react-ui-canvas-compute/package.json
+++ b/packages/ui/react-ui-canvas-compute/package.json
@@ -38,7 +38,6 @@
     "@dxos/context": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/echo": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/edge-client": "workspace:*",
     "@dxos/effect": "workspace:*",
     "@dxos/functions": "workspace:*",

--- a/packages/ui/react-ui-canvas-compute/tsconfig.json
+++ b/packages/ui/react-ui-canvas-compute/tsconfig.json
@@ -72,9 +72,6 @@
       "path": "../../core/echo/echo"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../../core/mesh/edge-client"
     },
     {

--- a/packages/ui/react-ui-stack/package.json
+++ b/packages/ui/react-ui-stack/package.json
@@ -64,7 +64,6 @@
     "@dxos/app-graph": "workspace:*",
     "@dxos/client": "workspace:*",
     "@dxos/echo": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/random": "workspace:*",
     "@dxos/react-client": "workspace:*",
     "@dxos/react-ui": "workspace:*",

--- a/packages/ui/react-ui-stack/tsconfig.json
+++ b/packages/ui/react-ui-stack/tsconfig.json
@@ -31,9 +31,6 @@
       "path": "../../core/echo/echo"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../../sdk/app-framework"
     },
     {

--- a/packages/ui/react-ui-thread/package.json
+++ b/packages/ui/react-ui-thread/package.json
@@ -42,7 +42,6 @@
   },
   "devDependencies": {
     "@dxos/echo": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/keys": "workspace:*",
     "@dxos/log": "workspace:*",
     "@dxos/random": "workspace:*",

--- a/packages/ui/react-ui-thread/tsconfig.json
+++ b/packages/ui/react-ui-thread/tsconfig.json
@@ -30,9 +30,6 @@
       "path": "../../core/echo/echo"
     },
     {
-      "path": "../../core/echo/echo-db"
-    },
-    {
       "path": "../react-ui"
     },
     {

--- a/plans/echo-db-dependency-reduction.md
+++ b/plans/echo-db-dependency-reduction.md
@@ -45,45 +45,141 @@ Also remove the `sdk/client` barrel re-export of `Filter` (currently re-exported
 
 ---
 
-## 2. Automerge / text editing: expose via `@dxos/echo` and a dedicated text package
+## 2. Automerge / text editing: what consumers actually need and how to hide automerge
 
-### Problem
+### What each consumer uses from the current API
 
-`createDocAccessor`, `DocAccessor`, `updateText`, and six cursor helpers (`toCursor`, `fromCursor`,
-`toCursorRange`, `getTextInRange`, `getRangeFromCursor`, `IDocHandle`) are used in ~40 files across
-UI, plugins, and editor packages. They are currently implemented in `echo-db` but have nothing
-inherently DB-internal about them—they are automerge document utilities.
+The ~40 import sites fall into three distinct layers with very different needs:
 
-### Proposal
+#### Layer A — CodeMirror sync (`ui-editor/src/extensions/automerge/`)
 
-**2a. `Obj.updateText` → move to `@dxos/echo`**
+These files implement the automerge ↔ CodeMirror bridge and **legitimately depend on automerge**:
 
-`updateText(obj, path, newText)` is a one-liner that goes through `createDocAccessor` and calls
-`A.updateText`. It operates at the `Obj` level with no DB-internal knowledge. Move it into the `Obj`
-namespace in `@dxos/echo` as `Obj.updateText`. The two existing callers
+| File                  | Automerge API used                                                        |
+| --------------------- | ------------------------------------------------------------------------- |
+| `automerge.ts`        | `A.getHeads(doc)` to track revision heads; `accessor.handle.doc()`        |
+| `sync.ts`             | `A.getHeads`, `A.diff`, `A.equals` to compute patches between revisions   |
+| `update-automerge.ts` | `handle.changeAt(heads, fn)`, `A.splice` to apply editor edits to the doc |
+| `cursor.ts`           | `A.getCursor`, `A.getCursorPosition` for stable position encoding         |
+
+These must import `@automerge/automerge` directly. No amount of abstraction eliminates that — they
+are implementing the CRDT sync protocol. They should declare the dependency explicitly rather than
+inheriting it through `@dxos/echo-db`.
+
+#### Layer B — Sketch / TLDraw adapter (`plugin-sketch/src/util/base-adapter.ts`, `actions.ts`)
+
+The sketch adapter drives TLDraw from an automerge document that stores a `Record<string, TLRecord>`
+map. It uses:
+
+- `accessor.handle.doc()` — reads the raw map to initialize the TLDraw store
+- `accessor.handle.change(fn)` — mutates the map (add/delete/update shapes)
+- `accessor.handle.addListener/removeListener` — reacts to remote changes
+
+The callback in `handle.change(fn)` receives the automerge doc but only uses `getDeep(doc, path)`
+to navigate into it — **no automerge API functions are called inside the callback itself**. The
+mutation is plain JS object manipulation (`map[record.id] = encode(record)`).
+
+This means sketch's dependency on automerge is superficial: it needs the raw doc only because
+`IDocHandle` returns `Doc<T>` rather than `unknown`. If `doc()` returned `unknown`, all the sketch
+code works unchanged after a trivial `as any` or a typed helper.
+
+#### Layer C — Plugin code (all remaining ~30 files)
+
+Plugins like `plugin-markdown`, `plugin-thread`, `plugin-script`, `plugin-code`, `plugin-generator`,
+`plugin-sheet`, `plugin-assistant`, etc. use `createDocAccessor` and the cursor helpers. Their
+actual needs:
+
+| What they do           | Current API                                                         | Automerge leakage                              |
+| ---------------------- | ------------------------------------------------------------------- | ---------------------------------------------- |
+| Pass to editor         | `{ text: createDocAccessor(obj, ['content']) }`                     | `DocAccessor` type contains `IDocHandle`       |
+| Read text content      | `DocAccessor.getValue<string>(accessor)`                            | None — wraps `getDeep(handle.doc(), path)`     |
+| Update text atomically | `accessor.handle.change((doc) => A.updateText(doc, path, newText))` | `A.updateText` leaks                           |
+| Stable cursor position | `toCursorRange(accessor, from, to): string`                         | Return type is `A.Cursor` (alias for `string`) |
+| Decode cursor          | `getRangeFromCursor(accessor, cursor: string)`                      | None                                           |
+| Text in range          | `getTextInRange(accessor, start, end)`                              | None                                           |
+
+The **only** automerge leakage to layer C is:
+
+1. The `IDocHandle` type on `DocAccessor.handle` (exposes `Doc<T>`, `ChangeFn<T>`, `Heads`)
+2. The `A.Cursor` type alias on the return of `toCursor` (it's just `string` at runtime)
+3. `updateText` calling `A.updateText` inside `handle.change` (not visible to callers)
+
+### How to eliminate automerge from layer C and B
+
+**`A.Cursor` → `string`**
+
+`A.Cursor` is `string` in automerge. Changing the return type of `toCursor` from `A.Cursor` to
+`string` is a no-op at runtime and removes the only type-level automerge leak in the cursor API.
+`fromCursor` already accepts `A.Cursor` which is `string`, so its signature is already clean.
+
+**`IDocHandle` → opaque handle interface with no automerge types**
+
+Change the `IDocHandle` interface to not expose automerge types:
+
+```ts
+// Before — leaks Doc<T>, ChangeFn<T>, Heads from automerge
+interface IDocHandle<T = any> {
+  doc(): Doc<T> | undefined;
+  change(callback: ChangeFn<T>, options?: ChangeOptions<T>): void;
+  changeAt(heads: Heads, callback: ChangeFn<T>): Heads | undefined;
+  addListener(event: 'change', listener: () => void): void;
+  removeListener(event: 'change', listener: () => void): void;
+}
+
+// After — no automerge types at all
+interface IDocHandle<T = any> {
+  doc(): T | undefined;
+  change(callback: (doc: T) => void): void;
+  changeAt(heads: unknown, callback: (doc: T) => void): unknown;
+  addListener(event: 'change', listener: () => void): void;
+  removeListener(event: 'change', listener: () => void): void;
+}
+```
+
+The editor layer (`ui-editor`, the legitimate automerge consumer) holds the concrete
+`AutomergeRepo.DocHandle` which satisfies this interface. It can call
+`A.getHeads(handle.doc() as A.Doc<unknown>)` — a single cast at the boundary, contained in the
+editor package.
+
+The sketch adapter works unchanged: its `handle.change(fn)` callback uses plain JS object
+manipulation, not automerge API functions.
+
+**`Obj.updateText` → move to `@dxos/echo`**
+
+`updateText(obj, path, newText)` calls `A.updateText` inside `handle.change`. Plugin callers don't
+see the automerge call — they just call `updateText(obj, path, text)`. Moving to `Obj.updateText`
+in `@dxos/echo` (which can depend on `echo-db` internally or have `echo-db` expose the
+implementation) removes the import from plugin code entirely. The two current callers
 (`plugin-outliner/Journal.ts`, `plugin-native-filesystem/markdown-documents.ts`) switch to
-`import { Obj } from '@dxos/echo'` and call `Obj.updateText(...)`.
+`Obj.updateText(obj, ['content'], newText)`.
 
-**2b. `createDocAccessor` + `DocAccessor` + cursor helpers → new `@dxos/echo-text` package**
+**`createDocAccessor` → `Obj.getDocAccessor` or a stable re-export**
 
-These are automerge handle accessors and cursor math. They are widely used in UI and editor code and
-have no business being imported from an internal DB package. Extract to a new
-`packages/core/echo/echo-text` (or `packages/ui/ui-editor-automerge`) package that depends only on
-`@dxos/echo` and `@automerge/automerge`.
+`createDocAccessor(obj, path)` only needs `echo-db` internals (`getObjectCore`, `symbolPath`). It
+cannot move to `@dxos/echo` without creating a circular dependency — `echo` has no knowledge of the
+CRDT layer. Options:
 
-Exports: `DocAccessor`, `IDocHandle`, `createDocAccessor`, `toCursor`, `fromCursor`,
-`toCursorRange`, `getTextInRange`, `getRangeFromCursor`.
+- **Stay in `echo-db`, re-export as a stable surface** (lowest friction). Plugins continue to import
+  `createDocAccessor` from `@dxos/echo-db`. With the `IDocHandle` interface cleaned up, the
+  automerge types are no longer visible to callers. The function itself is a stable bridge between
+  the `Obj` proxy layer and the CRDT handle layer.
+- **New package `@dxos/echo-crdt`** containing `createDocAccessor`, `DocAccessor`, `IDocHandle`,
+  and the cursor helpers. Both `echo-db` and `ui-editor` depend on it. Plugin packages import from
+  `@dxos/echo-crdt`. This is the cleanest long-term shape but requires a new package.
 
-All ~40 import sites switch from `@dxos/echo-db` to the new package. `echo-db` can then re-export
-from it for its own internal use and remove the implementations.
+### Summary: what needs to change
 
-Alternatively (simpler, lower risk): publish these as a stable sub-path
-`@dxos/echo-db/text` using an exports condition, treating them as a promoted stable surface while
-keeping the code in place. The editor/UI packages import from `@dxos/echo-db/text` rather than the
-default barrel, signalling intent without a package split.
+| Item                                             | Action                                               | Automerge removed from callers? |
+| ------------------------------------------------ | ---------------------------------------------------- | ------------------------------- |
+| `A.Cursor` return type on `toCursor`             | Change to `string`                                   | Yes                             |
+| `Doc<T>`, `ChangeFn<T>`, `Heads` on `IDocHandle` | Change to `unknown`/generic                          | Yes                             |
+| `updateText` → `Obj.updateText`                  | Move to `@dxos/echo`                                 | Yes (2 callers)                 |
+| `createDocAccessor`                              | Keep in `echo-db`, clean interface is enough         | Yes (types are clean)           |
+| `ui-editor` automerge extensions                 | Import `@automerge/automerge` directly               | n/a (expected)                  |
+| `plugin-sketch` adapter                          | No change needed; `handle.change(fn)` stays abstract | Yes                             |
 
-**Effort:** 2a is ~2 hours. 2b (new package) is ~1 day including wiring moon/tsconfig. Sub-path
-approach is ~2 hours.
+**Effort:** Interface cleanup (~2h), `Obj.updateText` move (~1h), `ui-editor` direct automerge dep
+(~30min). No new packages required in this path.
 
 ---
 
@@ -116,18 +212,16 @@ already in scope when these operations run.
 These include `useChatProcessor.ts`, `useContextBinder.ts`, `run-prompt-in-new-chat.ts`,
 `create-chat.ts`, `feed-logger.ts`, `cli/processor.ts`, `cli-util/space.ts`,
 `devtools/WorkflowDebugPanel.tsx`, `stories-assistant/*`. They run outside the LayerSpec Effect
-context and need to construct a runtime snapshot.
+context and need to construct a runtime snapshot explicitly.
 
-Fix: Expose `feedServiceLayer` as a getter on the `Space` type (parallel to `space.db` and
-`space.queues`). Implementation: the space builds it lazily from `space.queues` the first time. All
-category B call sites replace `createFeedServiceLayer(space.queues)` with `space.feedServiceLayer`.
+These sites exist because the operations are triggered imperatively (React hooks, CLI commands)
+rather than through the Effect layer system. The right fix is not to expose a pre-built layer on
+`Space` — `Space` shouldn't know about Effect layers. Instead, the callers should be migrated into
+the Effect operation system so they are invoked through the LayerSpec context like category A.
+Until that migration happens, these sites keep their explicit `createFeedServiceLayer(space.queues)`
+calls.
 
-Once both categories are fixed, `createFeedServiceLayer` becomes internal to `echo-db` (only used
-by `plugin-client`'s `DatabaseLayerSpec` and `TestDatabaseLayer`). Its public export can be removed
-from the `echo-db` barrel.
-
-**Effort:** Category A is ~half a day. Category B (adding `space.feedServiceLayer`) requires touching
-the `Space` class in `client-protocol` or `client` — ~half a day. Total: ~1 day.
+**Effort:** Category A is ~half a day per the investigation below.
 
 ---
 

--- a/plans/echo-db-dependency-reduction.md
+++ b/plans/echo-db-dependency-reduction.md
@@ -1,0 +1,217 @@
+# `@dxos/echo-db` Dependency Reduction Plan
+
+Based on the [usage audit](./echo-db-usage-audit.md). Goal: shrink the footprint of `@dxos/echo-db`
+so that high-level consumers (plugins, apps, SDK users) import from stable, purpose-specific packages
+(`@dxos/echo`, a new text package, the client SDK) rather than directly from the internal DB layer.
+
+Usages kept as-is: test infrastructure (`EchoTestBuilder`, `TestDatabaseLayer`), internal database
+wiring (`EchoClient`, `EchoDatabaseImpl`, `CoreDatabase`), object internals (`ObjectCore`,
+`getObjectCore`, `migrateDocument`), and serialization (`Serializer`, `SerializedSpace`).
+
+---
+
+## 1. Move `Filter` / `Query` imports to `@dxos/echo` (easy, mechanical)
+
+### Problem
+
+`Filter` and `Query` are already defined in `@dxos/echo`. `echo-db` merely re-exports them from
+`packages/core/echo/echo-db/src/query/index.ts`:
+
+```ts
+export { Filter, Query } from '@dxos/echo';
+```
+
+Yet 7 call sites still import them from `@dxos/echo-db`.
+
+### Change
+
+Delete the re-export. Update all 7 import sites to use `@dxos/echo` directly.
+
+| File                                                     | Current                | After               |
+| -------------------------------------------------------- | ---------------------- | ------------------- |
+| `packages/sdk/client/src/echo/space-list.ts`             | `from '@dxos/echo-db'` | `from '@dxos/echo'` |
+| `packages/sdk/client/src/echo/space-proxy.ts`            | `from '@dxos/echo-db'` | `from '@dxos/echo'` |
+| `packages/sdk/client/src/echo/import.ts`                 | `from '@dxos/echo-db'` | `from '@dxos/echo'` |
+| `packages/sdk/client/src/tests/client.test.ts`           | `from '@dxos/echo-db'` | `from '@dxos/echo'` |
+| `packages/sdk/client/src/tests/indexing.test.ts`         | `from '@dxos/echo-db'` | `from '@dxos/echo'` |
+| `packages/plugins/plugin-discord/src/operations/sync.ts` | `from '@dxos/echo-db'` | `from '@dxos/echo'` |
+| `packages/devtools/cli/src/commands/chat/processor.ts`   | `from '@dxos/echo-db'` | `from '@dxos/echo'` |
+
+Also remove the `sdk/client` barrel re-export of `Filter` (currently re-exported through
+`client/src/echo/index.ts` via `echo-db`). Verify `Filter` is already available on the public
+`@dxos/client` surface through `@dxos/echo`.
+
+**Effort:** ~1 hour. No logic changes.
+
+---
+
+## 2. Automerge / text editing: expose via `@dxos/echo` and a dedicated text package
+
+### Problem
+
+`createDocAccessor`, `DocAccessor`, `updateText`, and six cursor helpers (`toCursor`, `fromCursor`,
+`toCursorRange`, `getTextInRange`, `getRangeFromCursor`, `IDocHandle`) are used in ~40 files across
+UI, plugins, and editor packages. They are currently implemented in `echo-db` but have nothing
+inherently DB-internal about them—they are automerge document utilities.
+
+### Proposal
+
+**2a. `Obj.updateText` → move to `@dxos/echo`**
+
+`updateText(obj, path, newText)` is a one-liner that goes through `createDocAccessor` and calls
+`A.updateText`. It operates at the `Obj` level with no DB-internal knowledge. Move it into the `Obj`
+namespace in `@dxos/echo` as `Obj.updateText`. The two existing callers
+(`plugin-outliner/Journal.ts`, `plugin-native-filesystem/markdown-documents.ts`) switch to
+`import { Obj } from '@dxos/echo'` and call `Obj.updateText(...)`.
+
+**2b. `createDocAccessor` + `DocAccessor` + cursor helpers → new `@dxos/echo-text` package**
+
+These are automerge handle accessors and cursor math. They are widely used in UI and editor code and
+have no business being imported from an internal DB package. Extract to a new
+`packages/core/echo/echo-text` (or `packages/ui/ui-editor-automerge`) package that depends only on
+`@dxos/echo` and `@automerge/automerge`.
+
+Exports: `DocAccessor`, `IDocHandle`, `createDocAccessor`, `toCursor`, `fromCursor`,
+`toCursorRange`, `getTextInRange`, `getRangeFromCursor`.
+
+All ~40 import sites switch from `@dxos/echo-db` to the new package. `echo-db` can then re-export
+from it for its own internal use and remove the implementations.
+
+Alternatively (simpler, lower risk): publish these as a stable sub-path
+`@dxos/echo-db/text` using an exports condition, treating them as a promoted stable surface while
+keeping the code in place. The editor/UI packages import from `@dxos/echo-db/text` rather than the
+default barrel, signalling intent without a package split.
+
+**Effort:** 2a is ~2 hours. 2b (new package) is ~1 day including wiring moon/tsconfig. Sub-path
+approach is ~2 hours.
+
+---
+
+## 3. Centralize `createFeedServiceLayer` — eliminate per-call-site construction
+
+### Problem
+
+`createFeedServiceLayer(space.queues)` is called at 22 sites. It always takes the same argument
+(`space.queues`) and always produces the same `Feed.FeedService` layer. The function is already
+provided in one central place: `plugin-client`'s `DatabaseLayerSpec` contributes `Feed.FeedService`
+to the space-scoped Effect layer graph.
+
+The 22 sites split into two categories:
+
+**Category A — Effect operations that already run inside a LayerSpec context (13 files)**
+
+These include `plugin-discord/sync.ts`, `plugin-slack/sync.ts`, `plugin-thread/append-channel-message.ts`,
+`plugin-inbox/*`, `plugin-pipeline/stories`, etc. They manually call
+`Effect.provide(createFeedServiceLayer(space.queues))` inside operation handlers, even though the
+operation runtime will have `Feed.FeedService` available in context when operations are invoked via
+the LayerSpec system.
+
+Fix: Remove the `Effect.provide(createFeedServiceLayer(...))` wrappers. Declare `Feed.FeedService`
+as a requirement in the operation's Effect type signature instead (it will be satisfied by the
+ambient layer). Verify with the existing `DatabaseLayerSpec` that `Feed.FeedService` is indeed
+already in scope when these operations run.
+
+**Category B — Imperative hooks and non-Effect code (9 files)**
+
+These include `useChatProcessor.ts`, `useContextBinder.ts`, `run-prompt-in-new-chat.ts`,
+`create-chat.ts`, `feed-logger.ts`, `cli/processor.ts`, `cli-util/space.ts`,
+`devtools/WorkflowDebugPanel.tsx`, `stories-assistant/*`. They run outside the LayerSpec Effect
+context and need to construct a runtime snapshot.
+
+Fix: Expose `feedServiceLayer` as a getter on the `Space` type (parallel to `space.db` and
+`space.queues`). Implementation: the space builds it lazily from `space.queues` the first time. All
+category B call sites replace `createFeedServiceLayer(space.queues)` with `space.feedServiceLayer`.
+
+Once both categories are fixed, `createFeedServiceLayer` becomes internal to `echo-db` (only used
+by `plugin-client`'s `DatabaseLayerSpec` and `TestDatabaseLayer`). Its public export can be removed
+from the `echo-db` barrel.
+
+**Effort:** Category A is ~half a day. Category B (adding `space.feedServiceLayer`) requires touching
+the `Space` class in `client-protocol` or `client` — ~half a day. Total: ~1 day.
+
+---
+
+## 4. Drop `@dxos/echo-db` from package.json where not needed
+
+### 4a. Zero-source-import packages — drop immediately (no code change needed)
+
+18 packages declare `@dxos/echo-db` as a dependency but have zero TypeScript source imports. These
+are almost certainly transitive copies or stale entries from scaffolding.
+
+| Package                   | Notes                                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------------ |
+| `react-ui-stack`          | No source usage                                                                            |
+| `react-ui-thread`         | No source usage                                                                            |
+| `react-ui-canvas-compute` | No source usage                                                                            |
+| `stories-ui`              | No source usage                                                                            |
+| `app-graph`               | No source usage                                                                            |
+| `react-edge-client`       | No source usage                                                                            |
+| `operation`               | No source usage                                                                            |
+| `ai`                      | No source usage                                                                            |
+| `assistant-toolkit`       | No source usage                                                                            |
+| `graph`                   | No source usage                                                                            |
+| `plugin-automation`       | No source usage                                                                            |
+| `plugin-chess`            | No source usage                                                                            |
+| `plugin-support`          | No source usage                                                                            |
+| `plugin-meeting`          | No source usage                                                                            |
+| `plugin-preview`          | No source usage                                                                            |
+| `plugin-transcription`    | No source usage                                                                            |
+| `compute-hyperformula`    | No source usage                                                                            |
+| `app-framework`           | String reference in vite plugin package list (not an import); move to a constant or inline |
+
+Action: remove `"@dxos/echo-db": "workspace:*"` from each. Run `moon run :build` to confirm nothing
+breaks.
+
+**Effort:** ~30 minutes.
+
+### 4b. Packages that only import `Filter` / `Query` — drop after step 1
+
+Check after completing step 1: several packages (e.g. `sdk/client`) may keep the dependency for
+other symbols. Audit and remove where `Filter`/`Query` were the only reason.
+
+### 4c. Packages that only import `createFeedServiceLayer` — drop after step 3
+
+After centralizing to `space.feedServiceLayer`: `plugin-discord`, `plugin-slack`, `plugin-thread`,
+`plugin-inbox`, `plugin-pipeline`, `plugin-assistant` (hooks and operations), `devtools`, `cli`,
+`cli-util`, `stories-assistant` can all drop the `@dxos/echo-db` dependency (they will either use
+the Effect context or `space.feedServiceLayer`).
+
+### 4d. Packages that only import `createDocAccessor` / editor symbols — drop after step 2
+
+After step 2: all editor and plugin packages that use `createDocAccessor`/`DocAccessor`/cursor
+helpers will import from `@dxos/echo-text` (or the sub-path) instead.
+
+This covers the largest group: `react-ui-editor`, `ui-editor`, `react-ui-form`, `plugin-markdown`,
+`plugin-script`, `plugin-sketch`, `plugin-code`, `plugin-sheet`, `plugin-generator`,
+`plugin-thread`, `plugin-outliner`, `plugin-assistant`, `echo-generator`, `testbench-app`,
+`stories-assistant`, `blade-runner`.
+
+### 4e. `plugin-trip` version pin
+
+`plugin-trip` incorrectly pins `"@dxos/echo-db": "workspace:^0.8.3"` instead of `workspace:*`.
+Fix regardless of other steps.
+
+---
+
+## Summary: expected dependency footprint after all steps
+
+| Package                                 | Uses remaining                                                                                                                                      | Still needs echo-db?    |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `sdk/client`                            | `EchoClient`, `SpaceSyncState`, `QueryResultImpl`, `Serializer`, `decodeDXNFromJSON`, `createSubscription`, `ObjectMigration`, `SubscriptionHandle` | Yes (core SDK layer)    |
+| `sdk/client-protocol`                   | `type QueueFactory`, `type SpaceSyncState`                                                                                                          | Yes (type-only)         |
+| `sdk/client-services`                   | `type SerializedSpace/Feed`                                                                                                                         | Yes (space export)      |
+| `sdk/migrations`                        | `ObjectCore`, `migrateDocument`, `DocHandleProxy`, `RepoProxy`                                                                                      | Yes (internal)          |
+| `plugin-client`                         | `createFeedServiceLayer` (in DatabaseLayerSpec)                                                                                                     | Yes (one central place) |
+| `sdk/schema`                            | `RuntimeSchemaRegistry`, `DatabaseSchemaRegistry`                                                                                                   | Yes                     |
+| `echo-atom`, `echo-react`, `echo-solid` | `createObject`, `EchoTestBuilder`                                                                                                                   | Yes (test infra)        |
+| `echo-generator`                        | `getObjectCore`                                                                                                                                     | Yes                     |
+| `devtools`                              | `checkoutVersion`, `getEditHistory`, `type SpaceSyncState`                                                                                          | Yes                     |
+| `blade-runner`, `proto-guard`           | `Serializer`, `EchoTestBuilder`, replication types                                                                                                  | Yes (e2e)               |
+| `conductor`, `functions-runtime*`       | `TestDatabaseLayer`, `makeFeedService` (testing)                                                                                                    | Yes (test infra)        |
+| `compute-runtime`                       | `TestDatabaseLayer`                                                                                                                                 | Yes (test infra)        |
+| `plugin-space`                          | `EchoDatabaseImpl`, `Serializer`                                                                                                                    | Yes                     |
+| `functions-runtime-cloudflare`          | `EchoClient`, `CoreDatabase`, `EchoDatabaseImpl`                                                                                                    | Yes                     |
+| `functions`                             | `EchoClient`, `EchoDatabaseImpl`                                                                                                                    | Yes                     |
+| 18 zero-import packages                 | —                                                                                                                                                   | **Drop immediately**    |
+| ~16 editor/plugin packages              | `createDocAccessor` only                                                                                                                            | **Drop after step 2**   |
+| ~10 feed-layer packages                 | `createFeedServiceLayer` only                                                                                                                       | **Drop after step 3**   |

--- a/plans/echo-db-usage-audit.md
+++ b/plans/echo-db-usage-audit.md
@@ -1,0 +1,286 @@
+# `@dxos/echo-db` Usage Audit
+
+Audit of all imports and dependency declarations for `@dxos/echo-db` across the monorepo, grouped by usage kind.
+
+---
+
+## 1. Document Text Editing (Automerge / CRDT)
+
+Symbols: `createDocAccessor`, `DocAccessor`, `updateText`, `getTextInRange`, `getRangeFromCursor`, `toCursor`, `fromCursor`, `toCursorRange`, `IDocHandle`
+
+These provide the bridge between ECHO objects and automerge documents, used heavily by editor and plugin code.
+
+| File | Symbols |
+|------|---------|
+| `packages/ui/ui-editor/src/extensions/automerge/automerge.ts` | `DocAccessor` |
+| `packages/ui/ui-editor/src/extensions/automerge/cursor.ts` | `type DocAccessor`, `fromCursor`, `toCursor` |
+| `packages/ui/ui-editor/src/extensions/automerge/sync.ts` | `type IDocHandle` |
+| `packages/ui/ui-editor/src/extensions/automerge/update-automerge.ts` | `type IDocHandle` |
+| `packages/ui/ui-editor/src/extensions/automerge/automerge.test.tsx` | `type IDocHandle` |
+| `packages/ui/ui-editor/src/extensions/factories.ts` | `type DocAccessor` |
+| `packages/ui/react-ui-editor/src/components/Editor/Editor.stories.tsx` | `createDocAccessor`, `createObject` |
+| `packages/ui/react-ui-editor/src/stories/Automerge.stories.tsx` | `DocAccessor`, `createDocAccessor` |
+| `packages/ui/react-ui-form/src/components/Form/fields/MarkdownField.tsx` | `createDocAccessor` |
+| `packages/plugins/plugin-markdown/src/capabilities/anchor-sort.ts` | `createDocAccessor`, `getRangeFromCursor` |
+| `packages/plugins/plugin-markdown/src/capabilities/comment-config.ts` | `createDocAccessor`, `getTextInRange` |
+| `packages/plugins/plugin-markdown/src/hooks/useExtensions.tsx` | `createDocAccessor` |
+| `packages/plugins/plugin-markdown/src/operations/update-markdown.ts` | `DocAccessor`, `createDocAccessor` |
+| `packages/plugins/plugin-native-filesystem/src/capabilities/state/markdown-documents.ts` | `updateText` |
+| `packages/plugins/plugin-outliner/src/components/Outline/Outline.tsx` | `createDocAccessor` |
+| `packages/plugins/plugin-outliner/src/types/Journal.ts` | `updateText` |
+| `packages/plugins/plugin-thread/src/capabilities/agent-runner.ts` | `createDocAccessor`, `getRangeFromCursor`, `toCursorRange`, `updateText` |
+| `packages/plugins/plugin-thread/src/extensions/threads.ts` | `createDocAccessor`, `getTextInRange` |
+| `packages/plugins/plugin-thread/src/operations/create-proposals.ts` | `createDocAccessor` |
+| `packages/plugins/plugin-script/src/blueprints/functions/update.ts` | `DocAccessor`, `createDocAccessor` |
+| `packages/plugins/plugin-script/src/components/NotebookStack/NotebookCell.tsx` | `createDocAccessor` |
+| `packages/plugins/plugin-script/src/components/QueryEditor/QueryEditor.stories.tsx` | `createDocAccessor` |
+| `packages/plugins/plugin-script/src/components/TypescriptEditor/TypescriptEditor.stories.tsx` | `createDocAccessor` |
+| `packages/plugins/plugin-script/src/containers/ScriptArticle/ScriptArticle.tsx` | `createDocAccessor` |
+| `packages/plugins/plugin-script/src/templates/commentary.ts` | `createDocAccessor` |
+| `packages/plugins/plugin-sketch/src/components/actions.ts` | `createDocAccessor` |
+| `packages/plugins/plugin-sketch/src/hooks/useStoreAdapter.ts` | `createDocAccessor` |
+| `packages/plugins/plugin-sketch/src/util/base-adapter.ts` | `type DocAccessor` |
+| `packages/plugins/plugin-code/src/containers/CodeArticle/CodeArticle.tsx` | `createDocAccessor` |
+| `packages/plugins/plugin-code/src/containers/SpecArticle/SpecArticle.tsx` | `createDocAccessor` |
+| `packages/plugins/plugin-generator/src/components/PromptEditor/PromptEditor.tsx` | `createDocAccessor` |
+| `packages/plugins/plugin-sheet/src/components/SheetContent/SheetCellEditor.stories.tsx` | `createDocAccessor` |
+| `packages/plugins/plugin-sheet/src/components/SheetContent/util.ts` | `createDocAccessor` |
+| `packages/plugins/plugin-assistant/src/components/TemplateEditor/TemplateEditor.tsx` | `createDocAccessor` |
+| `packages/core/compute/assistant/src/util/diff.ts` | `DocAccessor`, `toCursorRange` |
+| `packages/core/compute/assistant/src/util/diff.test.ts` | `createDocAccessor` |
+| `packages/core/echo/echo-generator/src/data.ts` | `createDocAccessor` |
+| `packages/apps/testbench-app/src/components/ItemList.tsx` | `createDocAccessor` |
+| `packages/stories/stories-assistant/src/components/TasksModule.tsx` | `createDocAccessor` |
+| `packages/e2e/blade-runner/src/replicants/echo-replicant.ts` | `createDocAccessor` |
+
+---
+
+## 2. Feed / Effect Service Layer
+
+Symbols: `createFeedServiceLayer`, `makeFeedService`, `type Queue`, `type QueueFactory`
+
+Used to wire up the Effect-based `Feed.FeedService` for async messaging and operation queues.
+
+| File | Symbols |
+|------|---------|
+| `packages/core/compute/functions/src/protocol/protocol.ts` | `createFeedServiceLayer`, `type QueueFactory` |
+| `packages/core/compute-runtime/src/testing/layer.ts` | `makeFeedService`, `type QueueFactory` |
+| `packages/core/compute/functions-runtime/src/testing/services.ts` | `makeFeedService`, `type QueueFactory` |
+| `packages/devtools/devtools/src/panels/edge/WorkflowPanel/WorkflowDebugPanel.tsx` | `makeFeedService` |
+| `packages/devtools/cli-util/src/util/space.ts` | `createFeedServiceLayer` |
+| `packages/devtools/cli/src/commands/chat/processor.ts` | `createFeedServiceLayer` |
+| `packages/plugins/plugin-client/src/capabilities/layer-specs.ts` | `createFeedServiceLayer` |
+| `packages/plugins/plugin-assistant/src/hooks/useChatProcessor.ts` | `createFeedServiceLayer` |
+| `packages/plugins/plugin-assistant/src/hooks/useContextBinder.ts` | `createFeedServiceLayer` |
+| `packages/plugins/plugin-assistant/src/operations/create-chat.ts` | `createFeedServiceLayer` |
+| `packages/plugins/plugin-assistant/src/operations/run-prompt-in-new-chat.ts` | `createFeedServiceLayer` |
+| `packages/plugins/plugin-assistant/src/feed-logger.ts` | `type Queue` |
+| `packages/plugins/plugin-discord/src/operations/sync.ts` | `createFeedServiceLayer` |
+| `packages/plugins/plugin-slack/src/operations/sync.ts` | `createFeedServiceLayer` |
+| `packages/plugins/plugin-thread/src/containers/ChannelArticle/ChannelArticle.stories.tsx` | `createFeedServiceLayer` |
+| `packages/plugins/plugin-thread/src/operations/append-channel-message.ts` | `createFeedServiceLayer` |
+| `packages/plugins/plugin-inbox/src/containers/CalendarArticle/CalendarArticle.stories.tsx` | `createFeedServiceLayer` |
+| `packages/plugins/plugin-inbox/src/testing/data.ts` | `createFeedServiceLayer` |
+| `packages/plugins/plugin-pipeline/src/containers/PipelineArticle/PipelineArticle.stories.tsx` | `createFeedServiceLayer` |
+| `packages/stories/stories-assistant/src/stories/Projects.stories.tsx` | `createFeedServiceLayer` |
+| `packages/stories/stories-assistant/src/testing/ModuleContainer.tsx` | `createFeedServiceLayer` |
+| `packages/stories/stories-assistant/src/testing/testing.tsx` | `createFeedServiceLayer` |
+
+---
+
+## 3. Database / Client Interfaces
+
+Symbols: `EchoClient`, `type EchoDatabase`, `EchoDatabaseImpl`, `type CoreDatabase`, `type SpaceSyncState`
+
+Core database and client type surface used in the SDK, runtime adapters, and devtools.
+
+| File | Symbols |
+|------|---------|
+| `packages/sdk/client/src/client/client.ts` | `EchoClient` |
+| `packages/sdk/client/src/echo/space-list.ts` | `type EchoClient`, `Filter`, `Query` |
+| `packages/sdk/client/src/echo/space-proxy.ts` | `type EchoClient`, `type EchoDatabase`, `type EchoDatabaseImpl`, `type QueueFactory`, `type SpaceSyncState` |
+| `packages/sdk/client/src/echo/util.ts` | `type SpaceSyncState` |
+| `packages/sdk/client-protocol/src/space.ts` | `type EchoDatabase`, `type QueueFactory`, `type SpaceSyncState` |
+| `packages/core/compute/functions/src/protocol/protocol.ts` | `EchoClient`, `type EchoDatabaseImpl` |
+| `packages/core/compute/functions-runtime-cloudflare/src/functions-client.ts` | `EchoClient` |
+| `packages/core/compute/functions-runtime-cloudflare/src/space-proxy.ts` | `type CoreDatabase`, `type EchoClient`, `type EchoDatabaseImpl` |
+| `packages/core/compute-runtime/src/testing/layer.ts` | `type EchoDatabaseImpl` |
+| `packages/plugins/plugin-space/src/operations/snapshot.ts` | `EchoDatabaseImpl` |
+| `packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SyncStateInfo.tsx` | `type SpaceSyncState` |
+| `packages/sdk/client/test/e2e/edge-recovery.test.ts` | `type SpaceSyncState` |
+| `packages/sdk/client/test/e2e/sync.test.ts` | `type SpaceSyncState` |
+| `packages/e2e/blade-runner/src/replicants/echo-replicant.ts` | `type EchoDatabaseImpl` |
+
+---
+
+## 4. Query / Filtering
+
+Symbols: `Filter`, `Query`, `type QueryResult`, `QueryResultImpl`, `type QueryContext`
+
+| File | Symbols |
+|------|---------|
+| `packages/sdk/client/src/echo/space-list.ts` | `Filter`, `Query` |
+| `packages/sdk/client/src/echo/import.ts` | `Filter` |
+| `packages/sdk/client/src/tests/client.test.ts` | `Filter` |
+| `packages/sdk/client/src/tests/indexing.test.ts` | `Filter` |
+| `packages/sdk/client/src/edge/client-edge-api.ts` | `type QueryContext`, `QueryResultImpl` |
+| `packages/e2e/blade-runner/src/replicants/echo-replicant.ts` | `type QueryResult` |
+| `packages/e2e/blade-runner/src/spec/query.ts` | `type QueryResult` |
+
+---
+
+## 5. Object Creation & Internal Access
+
+Symbols: `createObject`, `getObjectCore`, `ObjectCore`
+
+| File | Symbols |
+|------|---------|
+| `packages/core/echo/echo-atom/src/atom.test.ts` | `createObject` |
+| `packages/core/echo/echo-atom/src/batching.test.ts` | `createObject` |
+| `packages/core/echo/echo-atom/src/reactivity.test.ts` | `createObject` |
+| `packages/core/echo/echo-react/src/useObject.test.tsx` | `createObject` |
+| `packages/core/echo/echo-solid/src/useObject.test.tsx` | `createObject` |
+| `packages/plugins/plugin-script/src/testing/test-notebook.ts` | `createObject` |
+| `packages/plugins/plugin-sketch/src/components/Sketch/Sketch.stories.tsx` | `createObject` |
+| `packages/ui/react-ui-editor/src/components/Editor/Editor.stories.tsx` | `createObject` |
+| `packages/core/echo/echo-generator/src/generator.test.ts` | `getObjectCore` |
+| `packages/plugins/plugin-sheet/src/serializer.ts` | `getObjectCore` |
+| `packages/plugins/plugin-sketch/src/util/serializer.ts` | `getObjectCore` |
+| `packages/sdk/client/src/tests/spaces.test.ts` | `getObjectCore` |
+| `packages/sdk/migrations/src/migration-builder.ts` | `ObjectCore` |
+
+---
+
+## 6. Schema Registry
+
+Symbols: `RuntimeSchemaRegistry`, `DatabaseSchemaRegistry`
+
+| File | Symbols |
+|------|---------|
+| `packages/core/echo/echo-atom/src/query-atom.test.ts` | `RuntimeSchemaRegistry` |
+| `packages/sdk/schema/src/projection/projection.test.ts` | `DatabaseSchemaRegistry`, `RuntimeSchemaRegistry` |
+| `packages/sdk/schema/src/types/View.test.ts` | `RuntimeSchemaRegistry` |
+
+---
+
+## 7. Object Versioning / History
+
+Symbols: `type ObjectVersion`, `ObjectVersion`, `getVersion`, `checkoutVersion`, `getEditHistory`
+
+Used by the AI assistant for artifact diffs and the devtools for version history.
+
+| File | Symbols |
+|------|---------|
+| `packages/core/compute/assistant/src/request/artifact-diff.ts` | `type ObjectVersion` |
+| `packages/core/compute/assistant/src/request/format.ts` | `ObjectVersion` |
+| `packages/core/compute/assistant/src/request/version-pin.ts` | `type ObjectVersion`, `getVersion` |
+| `packages/devtools/devtools/src/panels/echo/ObjectsPanel/ObjectsPanel.tsx` | `checkoutVersion`, `getEditHistory` |
+
+---
+
+## 8. Serialization / Space Export
+
+Symbols: `Serializer`, `type SerializedSpace`, `type SerializedFeed`, `decodeDXNFromJSON`
+
+| File | Symbols |
+|------|---------|
+| `packages/sdk/client/src/echo/import.ts` | `type SerializedSpace`, `Serializer`, `decodeDXNFromJSON` |
+| `packages/sdk/client/src/tests/spaces.test.ts` | `Serializer` |
+| `packages/sdk/client-services/src/packlets/space-export/serialized-space-reader.ts` | `type SerializedSpace` |
+| `packages/sdk/client-services/src/packlets/space-export/serialized-space-writer.ts` | `type SerializedFeed`, `type SerializedSpace` |
+| `packages/sdk/client-services/src/packlets/space-export/space-archive.test.ts` | `type SerializedSpace` |
+| `packages/plugins/plugin-space/src/operations/snapshot.ts` | `Serializer` |
+| `packages/devtools/devtools/src/panels/echo/SpaceListPanel/backup.ts` | `type SerializedSpace` |
+| `packages/apps/testbench-app/src/util/backup.ts` | `type SerializedSpace`, `Serializer` |
+| `packages/e2e/proto-guard/src/space-json-dump.ts` | `Serializer` |
+| `packages/devtools/cli-util/src/util/space.ts` | (via `createFeedServiceLayer`) |
+
+---
+
+## 9. Document Migration (Automerge internals)
+
+Symbols: `migrateDocument`, `type DocHandleProxy`, `type RepoProxy`
+
+Only used by the SDK migrations package.
+
+| File | Symbols |
+|------|---------|
+| `packages/sdk/migrations/src/migration-builder.ts` | `type DocHandleProxy`, `ObjectCore`, `type RepoProxy`, `migrateDocument` |
+
+---
+
+## 10. Re-exports (SDK barrel)
+
+`packages/sdk/client/src/echo/index.ts` re-exports the following from `@dxos/echo-db` under the public `@dxos/client` surface:
+
+- `createFeedServiceLayer`
+- `createObject`
+- `createSubscription`
+- `type ObjectMigration`
+- `type Selection`
+- `type SubscriptionHandle`
+
+---
+
+## 11. Test Utilities (`@dxos/echo-db/testing`)
+
+Symbols: `EchoTestBuilder`, `TestDatabaseLayer`, `EchoTestPeer`, `TestReplicator`, `TestReplicatorConnection`, `createDataAssertion`
+
+| File | Symbols |
+|------|---------|
+| `packages/core/echo/echo-atom/src/atom.test.ts` | `EchoTestBuilder` |
+| `packages/core/echo/echo-atom/src/query-atom.test.ts` | `EchoTestBuilder` |
+| `packages/core/echo/echo-atom/src/ref-atom.test.ts` | `EchoTestBuilder` |
+| `packages/core/echo/echo-solid/src/useQuery.test.tsx` | `EchoTestBuilder` |
+| `packages/core/echo/echo-solid/src/useSchema.test.tsx` | `EchoTestBuilder` |
+| `packages/core/compute/assistant/src/util/diff.test.ts` | `EchoTestBuilder` |
+| `packages/core/compute/conductor/src/compiler/fiber-compiler.test.ts` | `TestDatabaseLayer` |
+| `packages/core/compute/conductor/src/nodes/gpt/gpt.test.ts` | `EchoTestBuilder` |
+| `packages/core/compute/conductor/src/sequence/Sequence.test.ts` | `EchoTestBuilder` |
+| `packages/core/compute/conductor/src/tests/gpt.test.ts` | `TestDatabaseLayer` |
+| `packages/core/compute/conductor/src/tests/streaming.test.ts` | `TestDatabaseLayer` |
+| `packages/core/compute/conductor/src/types/compute.test.ts` | `TestDatabaseLayer` |
+| `packages/core/compute/conductor/src/workflow/workflow.test.ts` | `TestDatabaseLayer` |
+| `packages/core/compute/functions-runtime/src/assistant-session-tests/session.test.ts` | `TestDatabaseLayer` |
+| `packages/core/compute/functions-runtime/src/services/function-invocation-service.test.ts` | `TestDatabaseLayer` |
+| `packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.test.ts` | `TestDatabaseLayer` |
+| `packages/core/compute-runtime/src/testing/layer.ts` | `EchoTestBuilder` |
+| `packages/sdk/schema/src/projection/projection.test.ts` | `EchoTestBuilder` |
+| `packages/sdk/schema/src/types/View.test.ts` | `EchoTestBuilder` |
+| `packages/sdk/types/src/testing/generator.test.ts` | `EchoTestBuilder` |
+| `packages/plugins/plugin-feed/src/operations/curate-magazine.test.ts` | `EchoTestBuilder` |
+| `packages/plugins/plugin-github/src/operations/sync.test.ts` | `EchoTestBuilder` |
+| `packages/plugins/plugin-inbox/src/operations/extract-message.test.ts` | `EchoTestBuilder` |
+| `packages/plugins/plugin-integration/src/operations/set-integration-targets.test.ts` | `EchoTestBuilder` |
+| `packages/plugins/plugin-kanban/src/types/migrations.test.ts` | `EchoTestBuilder` |
+| `packages/plugins/plugin-linear/src/operations/sync.test.ts` | `EchoTestBuilder` |
+| `packages/plugins/plugin-outliner/src/types/Journal.test.ts` | `EchoTestBuilder` |
+| `packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.test.ts` | `EchoTestBuilder` |
+| `packages/plugins/plugin-trello/src/operations/handlers.test.ts` | `EchoTestBuilder` |
+| `packages/plugins/plugin-trello/src/operations/sync.test.ts` | `EchoTestBuilder` |
+| `packages/plugins/plugin-trip/src/operations/extractor/TravelMessageExtractor.test.ts` | `EchoTestBuilder` |
+| `packages/plugins/plugin-trip/src/types/Trip.test.ts` | `EchoTestBuilder` |
+| `packages/e2e/blade-runner/src/redis/redis.node.test.ts` | `EchoTestBuilder`, `TestReplicator`, `TestReplicatorConnection`, `createDataAssertion` |
+| `packages/e2e/blade-runner/src/replicants/echo-replicant.ts` | `EchoTestPeer` |
+
+---
+
+## 12. Dependency Declarations (package.json)
+
+71 packages declare `@dxos/echo-db` as a dependency. All use `workspace:*` except `plugin-trip` which pins `workspace:^0.8.3`.
+
+**By domain:**
+
+| Domain | Packages |
+|--------|---------|
+| Echo core | `echo-atom`, `echo-db` (self), `echo-generator`, `echo-react`, `echo-solid` |
+| Compute | `ai`, `assistant`, `assistant-toolkit`, `compute-hyperformula`, `compute-runtime`, `conductor`, `functions`, `functions-runtime`, `functions-runtime-cloudflare`, `operation` |
+| SDK | `app-framework`, `app-graph`, `client`, `client-protocol`, `client-services`, `migrations`, `react-edge-client`, `schema`, `types` |
+| Plugins | `plugin-assistant` (×2), `plugin-automation`, `plugin-chess`, `plugin-client`, `plugin-code`, `plugin-discord`, `plugin-feed`, `plugin-generator`, `plugin-github`, `plugin-inbox`, `plugin-integration`, `plugin-kanban`, `plugin-linear`, `plugin-markdown`, `plugin-meeting`, `plugin-native-filesystem`, `plugin-outliner`, `plugin-pipeline`, `plugin-preview`, `plugin-script`, `plugin-sheet`, `plugin-sketch`, `plugin-slack`, `plugin-space`, `plugin-support`, `plugin-thread`, `plugin-transcription`, `plugin-trello`, `plugin-trip` |
+| UI | `react-ui-canvas-compute`, `react-ui-editor`, `react-ui-form`, `react-ui-stack`, `react-ui-thread`, `ui-editor` |
+| Devtools | `cli`, `cli-util`, `devtools` |
+| Apps | `composer-app`, `testbench-app` |
+| Stories | `stories-assistant` (×2), `stories-ui` |
+| Common | `graph` |
+| E2E | `blade-runner`, `proto-guard` |
+| Experimental | `env-tests` |

--- a/plans/echo-db-usage-audit.md
+++ b/plans/echo-db-usage-audit.md
@@ -10,48 +10,48 @@ Symbols: `createDocAccessor`, `DocAccessor`, `updateText`, `getTextInRange`, `ge
 
 These provide the bridge between ECHO objects and automerge documents, used heavily by editor and plugin code.
 
-| File | Symbols |
-|------|---------|
-| `packages/ui/ui-editor/src/extensions/automerge/automerge.ts` | `DocAccessor` |
-| `packages/ui/ui-editor/src/extensions/automerge/cursor.ts` | `type DocAccessor`, `fromCursor`, `toCursor` |
-| `packages/ui/ui-editor/src/extensions/automerge/sync.ts` | `type IDocHandle` |
-| `packages/ui/ui-editor/src/extensions/automerge/update-automerge.ts` | `type IDocHandle` |
-| `packages/ui/ui-editor/src/extensions/automerge/automerge.test.tsx` | `type IDocHandle` |
-| `packages/ui/ui-editor/src/extensions/factories.ts` | `type DocAccessor` |
-| `packages/ui/react-ui-editor/src/components/Editor/Editor.stories.tsx` | `createDocAccessor`, `createObject` |
-| `packages/ui/react-ui-editor/src/stories/Automerge.stories.tsx` | `DocAccessor`, `createDocAccessor` |
-| `packages/ui/react-ui-form/src/components/Form/fields/MarkdownField.tsx` | `createDocAccessor` |
-| `packages/plugins/plugin-markdown/src/capabilities/anchor-sort.ts` | `createDocAccessor`, `getRangeFromCursor` |
-| `packages/plugins/plugin-markdown/src/capabilities/comment-config.ts` | `createDocAccessor`, `getTextInRange` |
-| `packages/plugins/plugin-markdown/src/hooks/useExtensions.tsx` | `createDocAccessor` |
-| `packages/plugins/plugin-markdown/src/operations/update-markdown.ts` | `DocAccessor`, `createDocAccessor` |
-| `packages/plugins/plugin-native-filesystem/src/capabilities/state/markdown-documents.ts` | `updateText` |
-| `packages/plugins/plugin-outliner/src/components/Outline/Outline.tsx` | `createDocAccessor` |
-| `packages/plugins/plugin-outliner/src/types/Journal.ts` | `updateText` |
-| `packages/plugins/plugin-thread/src/capabilities/agent-runner.ts` | `createDocAccessor`, `getRangeFromCursor`, `toCursorRange`, `updateText` |
-| `packages/plugins/plugin-thread/src/extensions/threads.ts` | `createDocAccessor`, `getTextInRange` |
-| `packages/plugins/plugin-thread/src/operations/create-proposals.ts` | `createDocAccessor` |
-| `packages/plugins/plugin-script/src/blueprints/functions/update.ts` | `DocAccessor`, `createDocAccessor` |
-| `packages/plugins/plugin-script/src/components/NotebookStack/NotebookCell.tsx` | `createDocAccessor` |
-| `packages/plugins/plugin-script/src/components/QueryEditor/QueryEditor.stories.tsx` | `createDocAccessor` |
-| `packages/plugins/plugin-script/src/components/TypescriptEditor/TypescriptEditor.stories.tsx` | `createDocAccessor` |
-| `packages/plugins/plugin-script/src/containers/ScriptArticle/ScriptArticle.tsx` | `createDocAccessor` |
-| `packages/plugins/plugin-script/src/templates/commentary.ts` | `createDocAccessor` |
-| `packages/plugins/plugin-sketch/src/components/actions.ts` | `createDocAccessor` |
-| `packages/plugins/plugin-sketch/src/hooks/useStoreAdapter.ts` | `createDocAccessor` |
-| `packages/plugins/plugin-sketch/src/util/base-adapter.ts` | `type DocAccessor` |
-| `packages/plugins/plugin-code/src/containers/CodeArticle/CodeArticle.tsx` | `createDocAccessor` |
-| `packages/plugins/plugin-code/src/containers/SpecArticle/SpecArticle.tsx` | `createDocAccessor` |
-| `packages/plugins/plugin-generator/src/components/PromptEditor/PromptEditor.tsx` | `createDocAccessor` |
-| `packages/plugins/plugin-sheet/src/components/SheetContent/SheetCellEditor.stories.tsx` | `createDocAccessor` |
-| `packages/plugins/plugin-sheet/src/components/SheetContent/util.ts` | `createDocAccessor` |
-| `packages/plugins/plugin-assistant/src/components/TemplateEditor/TemplateEditor.tsx` | `createDocAccessor` |
-| `packages/core/compute/assistant/src/util/diff.ts` | `DocAccessor`, `toCursorRange` |
-| `packages/core/compute/assistant/src/util/diff.test.ts` | `createDocAccessor` |
-| `packages/core/echo/echo-generator/src/data.ts` | `createDocAccessor` |
-| `packages/apps/testbench-app/src/components/ItemList.tsx` | `createDocAccessor` |
-| `packages/stories/stories-assistant/src/components/TasksModule.tsx` | `createDocAccessor` |
-| `packages/e2e/blade-runner/src/replicants/echo-replicant.ts` | `createDocAccessor` |
+| File                                                                                          | Symbols                                                                  |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `packages/ui/ui-editor/src/extensions/automerge/automerge.ts`                                 | `DocAccessor`                                                            |
+| `packages/ui/ui-editor/src/extensions/automerge/cursor.ts`                                    | `type DocAccessor`, `fromCursor`, `toCursor`                             |
+| `packages/ui/ui-editor/src/extensions/automerge/sync.ts`                                      | `type IDocHandle`                                                        |
+| `packages/ui/ui-editor/src/extensions/automerge/update-automerge.ts`                          | `type IDocHandle`                                                        |
+| `packages/ui/ui-editor/src/extensions/automerge/automerge.test.tsx`                           | `type IDocHandle`                                                        |
+| `packages/ui/ui-editor/src/extensions/factories.ts`                                           | `type DocAccessor`                                                       |
+| `packages/ui/react-ui-editor/src/components/Editor/Editor.stories.tsx`                        | `createDocAccessor`, `createObject`                                      |
+| `packages/ui/react-ui-editor/src/stories/Automerge.stories.tsx`                               | `DocAccessor`, `createDocAccessor`                                       |
+| `packages/ui/react-ui-form/src/components/Form/fields/MarkdownField.tsx`                      | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-markdown/src/capabilities/anchor-sort.ts`                            | `createDocAccessor`, `getRangeFromCursor`                                |
+| `packages/plugins/plugin-markdown/src/capabilities/comment-config.ts`                         | `createDocAccessor`, `getTextInRange`                                    |
+| `packages/plugins/plugin-markdown/src/hooks/useExtensions.tsx`                                | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-markdown/src/operations/update-markdown.ts`                          | `DocAccessor`, `createDocAccessor`                                       |
+| `packages/plugins/plugin-native-filesystem/src/capabilities/state/markdown-documents.ts`      | `updateText`                                                             |
+| `packages/plugins/plugin-outliner/src/components/Outline/Outline.tsx`                         | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-outliner/src/types/Journal.ts`                                       | `updateText`                                                             |
+| `packages/plugins/plugin-thread/src/capabilities/agent-runner.ts`                             | `createDocAccessor`, `getRangeFromCursor`, `toCursorRange`, `updateText` |
+| `packages/plugins/plugin-thread/src/extensions/threads.ts`                                    | `createDocAccessor`, `getTextInRange`                                    |
+| `packages/plugins/plugin-thread/src/operations/create-proposals.ts`                           | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-script/src/blueprints/functions/update.ts`                           | `DocAccessor`, `createDocAccessor`                                       |
+| `packages/plugins/plugin-script/src/components/NotebookStack/NotebookCell.tsx`                | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-script/src/components/QueryEditor/QueryEditor.stories.tsx`           | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-script/src/components/TypescriptEditor/TypescriptEditor.stories.tsx` | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-script/src/containers/ScriptArticle/ScriptArticle.tsx`               | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-script/src/templates/commentary.ts`                                  | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-sketch/src/components/actions.ts`                                    | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-sketch/src/hooks/useStoreAdapter.ts`                                 | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-sketch/src/util/base-adapter.ts`                                     | `type DocAccessor`                                                       |
+| `packages/plugins/plugin-code/src/containers/CodeArticle/CodeArticle.tsx`                     | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-code/src/containers/SpecArticle/SpecArticle.tsx`                     | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-generator/src/components/PromptEditor/PromptEditor.tsx`              | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-sheet/src/components/SheetContent/SheetCellEditor.stories.tsx`       | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-sheet/src/components/SheetContent/util.ts`                           | `createDocAccessor`                                                      |
+| `packages/plugins/plugin-assistant/src/components/TemplateEditor/TemplateEditor.tsx`          | `createDocAccessor`                                                      |
+| `packages/core/compute/assistant/src/util/diff.ts`                                            | `DocAccessor`, `toCursorRange`                                           |
+| `packages/core/compute/assistant/src/util/diff.test.ts`                                       | `createDocAccessor`                                                      |
+| `packages/core/echo/echo-generator/src/data.ts`                                               | `createDocAccessor`                                                      |
+| `packages/apps/testbench-app/src/components/ItemList.tsx`                                     | `createDocAccessor`                                                      |
+| `packages/stories/stories-assistant/src/components/TasksModule.tsx`                           | `createDocAccessor`                                                      |
+| `packages/e2e/blade-runner/src/replicants/echo-replicant.ts`                                  | `createDocAccessor`                                                      |
 
 ---
 
@@ -61,30 +61,30 @@ Symbols: `createFeedServiceLayer`, `makeFeedService`, `type Queue`, `type QueueF
 
 Used to wire up the Effect-based `Feed.FeedService` for async messaging and operation queues.
 
-| File | Symbols |
-|------|---------|
-| `packages/core/compute/functions/src/protocol/protocol.ts` | `createFeedServiceLayer`, `type QueueFactory` |
-| `packages/core/compute-runtime/src/testing/layer.ts` | `makeFeedService`, `type QueueFactory` |
-| `packages/core/compute/functions-runtime/src/testing/services.ts` | `makeFeedService`, `type QueueFactory` |
-| `packages/devtools/devtools/src/panels/edge/WorkflowPanel/WorkflowDebugPanel.tsx` | `makeFeedService` |
-| `packages/devtools/cli-util/src/util/space.ts` | `createFeedServiceLayer` |
-| `packages/devtools/cli/src/commands/chat/processor.ts` | `createFeedServiceLayer` |
-| `packages/plugins/plugin-client/src/capabilities/layer-specs.ts` | `createFeedServiceLayer` |
-| `packages/plugins/plugin-assistant/src/hooks/useChatProcessor.ts` | `createFeedServiceLayer` |
-| `packages/plugins/plugin-assistant/src/hooks/useContextBinder.ts` | `createFeedServiceLayer` |
-| `packages/plugins/plugin-assistant/src/operations/create-chat.ts` | `createFeedServiceLayer` |
-| `packages/plugins/plugin-assistant/src/operations/run-prompt-in-new-chat.ts` | `createFeedServiceLayer` |
-| `packages/plugins/plugin-assistant/src/feed-logger.ts` | `type Queue` |
-| `packages/plugins/plugin-discord/src/operations/sync.ts` | `createFeedServiceLayer` |
-| `packages/plugins/plugin-slack/src/operations/sync.ts` | `createFeedServiceLayer` |
-| `packages/plugins/plugin-thread/src/containers/ChannelArticle/ChannelArticle.stories.tsx` | `createFeedServiceLayer` |
-| `packages/plugins/plugin-thread/src/operations/append-channel-message.ts` | `createFeedServiceLayer` |
-| `packages/plugins/plugin-inbox/src/containers/CalendarArticle/CalendarArticle.stories.tsx` | `createFeedServiceLayer` |
-| `packages/plugins/plugin-inbox/src/testing/data.ts` | `createFeedServiceLayer` |
-| `packages/plugins/plugin-pipeline/src/containers/PipelineArticle/PipelineArticle.stories.tsx` | `createFeedServiceLayer` |
-| `packages/stories/stories-assistant/src/stories/Projects.stories.tsx` | `createFeedServiceLayer` |
-| `packages/stories/stories-assistant/src/testing/ModuleContainer.tsx` | `createFeedServiceLayer` |
-| `packages/stories/stories-assistant/src/testing/testing.tsx` | `createFeedServiceLayer` |
+| File                                                                                          | Symbols                                       |
+| --------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `packages/core/compute/functions/src/protocol/protocol.ts`                                    | `createFeedServiceLayer`, `type QueueFactory` |
+| `packages/core/compute-runtime/src/testing/layer.ts`                                          | `makeFeedService`, `type QueueFactory`        |
+| `packages/core/compute/functions-runtime/src/testing/services.ts`                             | `makeFeedService`, `type QueueFactory`        |
+| `packages/devtools/devtools/src/panels/edge/WorkflowPanel/WorkflowDebugPanel.tsx`             | `makeFeedService`                             |
+| `packages/devtools/cli-util/src/util/space.ts`                                                | `createFeedServiceLayer`                      |
+| `packages/devtools/cli/src/commands/chat/processor.ts`                                        | `createFeedServiceLayer`                      |
+| `packages/plugins/plugin-client/src/capabilities/layer-specs.ts`                              | `createFeedServiceLayer`                      |
+| `packages/plugins/plugin-assistant/src/hooks/useChatProcessor.ts`                             | `createFeedServiceLayer`                      |
+| `packages/plugins/plugin-assistant/src/hooks/useContextBinder.ts`                             | `createFeedServiceLayer`                      |
+| `packages/plugins/plugin-assistant/src/operations/create-chat.ts`                             | `createFeedServiceLayer`                      |
+| `packages/plugins/plugin-assistant/src/operations/run-prompt-in-new-chat.ts`                  | `createFeedServiceLayer`                      |
+| `packages/plugins/plugin-assistant/src/feed-logger.ts`                                        | `type Queue`                                  |
+| `packages/plugins/plugin-discord/src/operations/sync.ts`                                      | `createFeedServiceLayer`                      |
+| `packages/plugins/plugin-slack/src/operations/sync.ts`                                        | `createFeedServiceLayer`                      |
+| `packages/plugins/plugin-thread/src/containers/ChannelArticle/ChannelArticle.stories.tsx`     | `createFeedServiceLayer`                      |
+| `packages/plugins/plugin-thread/src/operations/append-channel-message.ts`                     | `createFeedServiceLayer`                      |
+| `packages/plugins/plugin-inbox/src/containers/CalendarArticle/CalendarArticle.stories.tsx`    | `createFeedServiceLayer`                      |
+| `packages/plugins/plugin-inbox/src/testing/data.ts`                                           | `createFeedServiceLayer`                      |
+| `packages/plugins/plugin-pipeline/src/containers/PipelineArticle/PipelineArticle.stories.tsx` | `createFeedServiceLayer`                      |
+| `packages/stories/stories-assistant/src/stories/Projects.stories.tsx`                         | `createFeedServiceLayer`                      |
+| `packages/stories/stories-assistant/src/testing/ModuleContainer.tsx`                          | `createFeedServiceLayer`                      |
+| `packages/stories/stories-assistant/src/testing/testing.tsx`                                  | `createFeedServiceLayer`                      |
 
 ---
 
@@ -94,22 +94,22 @@ Symbols: `EchoClient`, `type EchoDatabase`, `EchoDatabaseImpl`, `type CoreDataba
 
 Core database and client type surface used in the SDK, runtime adapters, and devtools.
 
-| File | Symbols |
-|------|---------|
-| `packages/sdk/client/src/client/client.ts` | `EchoClient` |
-| `packages/sdk/client/src/echo/space-list.ts` | `type EchoClient`, `Filter`, `Query` |
-| `packages/sdk/client/src/echo/space-proxy.ts` | `type EchoClient`, `type EchoDatabase`, `type EchoDatabaseImpl`, `type QueueFactory`, `type SpaceSyncState` |
-| `packages/sdk/client/src/echo/util.ts` | `type SpaceSyncState` |
-| `packages/sdk/client-protocol/src/space.ts` | `type EchoDatabase`, `type QueueFactory`, `type SpaceSyncState` |
-| `packages/core/compute/functions/src/protocol/protocol.ts` | `EchoClient`, `type EchoDatabaseImpl` |
-| `packages/core/compute/functions-runtime-cloudflare/src/functions-client.ts` | `EchoClient` |
-| `packages/core/compute/functions-runtime-cloudflare/src/space-proxy.ts` | `type CoreDatabase`, `type EchoClient`, `type EchoDatabaseImpl` |
-| `packages/core/compute-runtime/src/testing/layer.ts` | `type EchoDatabaseImpl` |
-| `packages/plugins/plugin-space/src/operations/snapshot.ts` | `EchoDatabaseImpl` |
-| `packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SyncStateInfo.tsx` | `type SpaceSyncState` |
-| `packages/sdk/client/test/e2e/edge-recovery.test.ts` | `type SpaceSyncState` |
-| `packages/sdk/client/test/e2e/sync.test.ts` | `type SpaceSyncState` |
-| `packages/e2e/blade-runner/src/replicants/echo-replicant.ts` | `type EchoDatabaseImpl` |
+| File                                                                          | Symbols                                                                                                     |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `packages/sdk/client/src/client/client.ts`                                    | `EchoClient`                                                                                                |
+| `packages/sdk/client/src/echo/space-list.ts`                                  | `type EchoClient`, `Filter`, `Query`                                                                        |
+| `packages/sdk/client/src/echo/space-proxy.ts`                                 | `type EchoClient`, `type EchoDatabase`, `type EchoDatabaseImpl`, `type QueueFactory`, `type SpaceSyncState` |
+| `packages/sdk/client/src/echo/util.ts`                                        | `type SpaceSyncState`                                                                                       |
+| `packages/sdk/client-protocol/src/space.ts`                                   | `type EchoDatabase`, `type QueueFactory`, `type SpaceSyncState`                                             |
+| `packages/core/compute/functions/src/protocol/protocol.ts`                    | `EchoClient`, `type EchoDatabaseImpl`                                                                       |
+| `packages/core/compute/functions-runtime-cloudflare/src/functions-client.ts`  | `EchoClient`                                                                                                |
+| `packages/core/compute/functions-runtime-cloudflare/src/space-proxy.ts`       | `type CoreDatabase`, `type EchoClient`, `type EchoDatabaseImpl`                                             |
+| `packages/core/compute-runtime/src/testing/layer.ts`                          | `type EchoDatabaseImpl`                                                                                     |
+| `packages/plugins/plugin-space/src/operations/snapshot.ts`                    | `EchoDatabaseImpl`                                                                                          |
+| `packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SyncStateInfo.tsx` | `type SpaceSyncState`                                                                                       |
+| `packages/sdk/client/test/e2e/edge-recovery.test.ts`                          | `type SpaceSyncState`                                                                                       |
+| `packages/sdk/client/test/e2e/sync.test.ts`                                   | `type SpaceSyncState`                                                                                       |
+| `packages/e2e/blade-runner/src/replicants/echo-replicant.ts`                  | `type EchoDatabaseImpl`                                                                                     |
 
 ---
 
@@ -117,15 +117,15 @@ Core database and client type surface used in the SDK, runtime adapters, and dev
 
 Symbols: `Filter`, `Query`, `type QueryResult`, `QueryResultImpl`, `type QueryContext`
 
-| File | Symbols |
-|------|---------|
-| `packages/sdk/client/src/echo/space-list.ts` | `Filter`, `Query` |
-| `packages/sdk/client/src/echo/import.ts` | `Filter` |
-| `packages/sdk/client/src/tests/client.test.ts` | `Filter` |
-| `packages/sdk/client/src/tests/indexing.test.ts` | `Filter` |
-| `packages/sdk/client/src/edge/client-edge-api.ts` | `type QueryContext`, `QueryResultImpl` |
-| `packages/e2e/blade-runner/src/replicants/echo-replicant.ts` | `type QueryResult` |
-| `packages/e2e/blade-runner/src/spec/query.ts` | `type QueryResult` |
+| File                                                         | Symbols                                |
+| ------------------------------------------------------------ | -------------------------------------- |
+| `packages/sdk/client/src/echo/space-list.ts`                 | `Filter`, `Query`                      |
+| `packages/sdk/client/src/echo/import.ts`                     | `Filter`                               |
+| `packages/sdk/client/src/tests/client.test.ts`               | `Filter`                               |
+| `packages/sdk/client/src/tests/indexing.test.ts`             | `Filter`                               |
+| `packages/sdk/client/src/edge/client-edge-api.ts`            | `type QueryContext`, `QueryResultImpl` |
+| `packages/e2e/blade-runner/src/replicants/echo-replicant.ts` | `type QueryResult`                     |
+| `packages/e2e/blade-runner/src/spec/query.ts`                | `type QueryResult`                     |
 
 ---
 
@@ -133,21 +133,21 @@ Symbols: `Filter`, `Query`, `type QueryResult`, `QueryResultImpl`, `type QueryCo
 
 Symbols: `createObject`, `getObjectCore`, `ObjectCore`
 
-| File | Symbols |
-|------|---------|
-| `packages/core/echo/echo-atom/src/atom.test.ts` | `createObject` |
-| `packages/core/echo/echo-atom/src/batching.test.ts` | `createObject` |
-| `packages/core/echo/echo-atom/src/reactivity.test.ts` | `createObject` |
-| `packages/core/echo/echo-react/src/useObject.test.tsx` | `createObject` |
-| `packages/core/echo/echo-solid/src/useObject.test.tsx` | `createObject` |
-| `packages/plugins/plugin-script/src/testing/test-notebook.ts` | `createObject` |
-| `packages/plugins/plugin-sketch/src/components/Sketch/Sketch.stories.tsx` | `createObject` |
-| `packages/ui/react-ui-editor/src/components/Editor/Editor.stories.tsx` | `createObject` |
-| `packages/core/echo/echo-generator/src/generator.test.ts` | `getObjectCore` |
-| `packages/plugins/plugin-sheet/src/serializer.ts` | `getObjectCore` |
-| `packages/plugins/plugin-sketch/src/util/serializer.ts` | `getObjectCore` |
-| `packages/sdk/client/src/tests/spaces.test.ts` | `getObjectCore` |
-| `packages/sdk/migrations/src/migration-builder.ts` | `ObjectCore` |
+| File                                                                      | Symbols         |
+| ------------------------------------------------------------------------- | --------------- |
+| `packages/core/echo/echo-atom/src/atom.test.ts`                           | `createObject`  |
+| `packages/core/echo/echo-atom/src/batching.test.ts`                       | `createObject`  |
+| `packages/core/echo/echo-atom/src/reactivity.test.ts`                     | `createObject`  |
+| `packages/core/echo/echo-react/src/useObject.test.tsx`                    | `createObject`  |
+| `packages/core/echo/echo-solid/src/useObject.test.tsx`                    | `createObject`  |
+| `packages/plugins/plugin-script/src/testing/test-notebook.ts`             | `createObject`  |
+| `packages/plugins/plugin-sketch/src/components/Sketch/Sketch.stories.tsx` | `createObject`  |
+| `packages/ui/react-ui-editor/src/components/Editor/Editor.stories.tsx`    | `createObject`  |
+| `packages/core/echo/echo-generator/src/generator.test.ts`                 | `getObjectCore` |
+| `packages/plugins/plugin-sheet/src/serializer.ts`                         | `getObjectCore` |
+| `packages/plugins/plugin-sketch/src/util/serializer.ts`                   | `getObjectCore` |
+| `packages/sdk/client/src/tests/spaces.test.ts`                            | `getObjectCore` |
+| `packages/sdk/migrations/src/migration-builder.ts`                        | `ObjectCore`    |
 
 ---
 
@@ -155,11 +155,11 @@ Symbols: `createObject`, `getObjectCore`, `ObjectCore`
 
 Symbols: `RuntimeSchemaRegistry`, `DatabaseSchemaRegistry`
 
-| File | Symbols |
-|------|---------|
-| `packages/core/echo/echo-atom/src/query-atom.test.ts` | `RuntimeSchemaRegistry` |
+| File                                                    | Symbols                                           |
+| ------------------------------------------------------- | ------------------------------------------------- |
+| `packages/core/echo/echo-atom/src/query-atom.test.ts`   | `RuntimeSchemaRegistry`                           |
 | `packages/sdk/schema/src/projection/projection.test.ts` | `DatabaseSchemaRegistry`, `RuntimeSchemaRegistry` |
-| `packages/sdk/schema/src/types/View.test.ts` | `RuntimeSchemaRegistry` |
+| `packages/sdk/schema/src/types/View.test.ts`            | `RuntimeSchemaRegistry`                           |
 
 ---
 
@@ -169,11 +169,11 @@ Symbols: `type ObjectVersion`, `ObjectVersion`, `getVersion`, `checkoutVersion`,
 
 Used by the AI assistant for artifact diffs and the devtools for version history.
 
-| File | Symbols |
-|------|---------|
-| `packages/core/compute/assistant/src/request/artifact-diff.ts` | `type ObjectVersion` |
-| `packages/core/compute/assistant/src/request/format.ts` | `ObjectVersion` |
-| `packages/core/compute/assistant/src/request/version-pin.ts` | `type ObjectVersion`, `getVersion` |
+| File                                                                       | Symbols                             |
+| -------------------------------------------------------------------------- | ----------------------------------- |
+| `packages/core/compute/assistant/src/request/artifact-diff.ts`             | `type ObjectVersion`                |
+| `packages/core/compute/assistant/src/request/format.ts`                    | `ObjectVersion`                     |
+| `packages/core/compute/assistant/src/request/version-pin.ts`               | `type ObjectVersion`, `getVersion`  |
 | `packages/devtools/devtools/src/panels/echo/ObjectsPanel/ObjectsPanel.tsx` | `checkoutVersion`, `getEditHistory` |
 
 ---
@@ -182,18 +182,18 @@ Used by the AI assistant for artifact diffs and the devtools for version history
 
 Symbols: `Serializer`, `type SerializedSpace`, `type SerializedFeed`, `decodeDXNFromJSON`
 
-| File | Symbols |
-|------|---------|
-| `packages/sdk/client/src/echo/import.ts` | `type SerializedSpace`, `Serializer`, `decodeDXNFromJSON` |
-| `packages/sdk/client/src/tests/spaces.test.ts` | `Serializer` |
-| `packages/sdk/client-services/src/packlets/space-export/serialized-space-reader.ts` | `type SerializedSpace` |
-| `packages/sdk/client-services/src/packlets/space-export/serialized-space-writer.ts` | `type SerializedFeed`, `type SerializedSpace` |
-| `packages/sdk/client-services/src/packlets/space-export/space-archive.test.ts` | `type SerializedSpace` |
-| `packages/plugins/plugin-space/src/operations/snapshot.ts` | `Serializer` |
-| `packages/devtools/devtools/src/panels/echo/SpaceListPanel/backup.ts` | `type SerializedSpace` |
-| `packages/apps/testbench-app/src/util/backup.ts` | `type SerializedSpace`, `Serializer` |
-| `packages/e2e/proto-guard/src/space-json-dump.ts` | `Serializer` |
-| `packages/devtools/cli-util/src/util/space.ts` | (via `createFeedServiceLayer`) |
+| File                                                                                | Symbols                                                   |
+| ----------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `packages/sdk/client/src/echo/import.ts`                                            | `type SerializedSpace`, `Serializer`, `decodeDXNFromJSON` |
+| `packages/sdk/client/src/tests/spaces.test.ts`                                      | `Serializer`                                              |
+| `packages/sdk/client-services/src/packlets/space-export/serialized-space-reader.ts` | `type SerializedSpace`                                    |
+| `packages/sdk/client-services/src/packlets/space-export/serialized-space-writer.ts` | `type SerializedFeed`, `type SerializedSpace`             |
+| `packages/sdk/client-services/src/packlets/space-export/space-archive.test.ts`      | `type SerializedSpace`                                    |
+| `packages/plugins/plugin-space/src/operations/snapshot.ts`                          | `Serializer`                                              |
+| `packages/devtools/devtools/src/panels/echo/SpaceListPanel/backup.ts`               | `type SerializedSpace`                                    |
+| `packages/apps/testbench-app/src/util/backup.ts`                                    | `type SerializedSpace`, `Serializer`                      |
+| `packages/e2e/proto-guard/src/space-json-dump.ts`                                   | `Serializer`                                              |
+| `packages/devtools/cli-util/src/util/space.ts`                                      | (via `createFeedServiceLayer`)                            |
 
 ---
 
@@ -203,8 +203,8 @@ Symbols: `migrateDocument`, `type DocHandleProxy`, `type RepoProxy`
 
 Only used by the SDK migrations package.
 
-| File | Symbols |
-|------|---------|
+| File                                               | Symbols                                                                  |
+| -------------------------------------------------- | ------------------------------------------------------------------------ |
 | `packages/sdk/migrations/src/migration-builder.ts` | `type DocHandleProxy`, `ObjectCore`, `type RepoProxy`, `migrateDocument` |
 
 ---
@@ -226,42 +226,42 @@ Only used by the SDK migrations package.
 
 Symbols: `EchoTestBuilder`, `TestDatabaseLayer`, `EchoTestPeer`, `TestReplicator`, `TestReplicatorConnection`, `createDataAssertion`
 
-| File | Symbols |
-|------|---------|
-| `packages/core/echo/echo-atom/src/atom.test.ts` | `EchoTestBuilder` |
-| `packages/core/echo/echo-atom/src/query-atom.test.ts` | `EchoTestBuilder` |
-| `packages/core/echo/echo-atom/src/ref-atom.test.ts` | `EchoTestBuilder` |
-| `packages/core/echo/echo-solid/src/useQuery.test.tsx` | `EchoTestBuilder` |
-| `packages/core/echo/echo-solid/src/useSchema.test.tsx` | `EchoTestBuilder` |
-| `packages/core/compute/assistant/src/util/diff.test.ts` | `EchoTestBuilder` |
-| `packages/core/compute/conductor/src/compiler/fiber-compiler.test.ts` | `TestDatabaseLayer` |
-| `packages/core/compute/conductor/src/nodes/gpt/gpt.test.ts` | `EchoTestBuilder` |
-| `packages/core/compute/conductor/src/sequence/Sequence.test.ts` | `EchoTestBuilder` |
-| `packages/core/compute/conductor/src/tests/gpt.test.ts` | `TestDatabaseLayer` |
-| `packages/core/compute/conductor/src/tests/streaming.test.ts` | `TestDatabaseLayer` |
-| `packages/core/compute/conductor/src/types/compute.test.ts` | `TestDatabaseLayer` |
-| `packages/core/compute/conductor/src/workflow/workflow.test.ts` | `TestDatabaseLayer` |
-| `packages/core/compute/functions-runtime/src/assistant-session-tests/session.test.ts` | `TestDatabaseLayer` |
-| `packages/core/compute/functions-runtime/src/services/function-invocation-service.test.ts` | `TestDatabaseLayer` |
-| `packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.test.ts` | `TestDatabaseLayer` |
-| `packages/core/compute-runtime/src/testing/layer.ts` | `EchoTestBuilder` |
-| `packages/sdk/schema/src/projection/projection.test.ts` | `EchoTestBuilder` |
-| `packages/sdk/schema/src/types/View.test.ts` | `EchoTestBuilder` |
-| `packages/sdk/types/src/testing/generator.test.ts` | `EchoTestBuilder` |
-| `packages/plugins/plugin-feed/src/operations/curate-magazine.test.ts` | `EchoTestBuilder` |
-| `packages/plugins/plugin-github/src/operations/sync.test.ts` | `EchoTestBuilder` |
-| `packages/plugins/plugin-inbox/src/operations/extract-message.test.ts` | `EchoTestBuilder` |
-| `packages/plugins/plugin-integration/src/operations/set-integration-targets.test.ts` | `EchoTestBuilder` |
-| `packages/plugins/plugin-kanban/src/types/migrations.test.ts` | `EchoTestBuilder` |
-| `packages/plugins/plugin-linear/src/operations/sync.test.ts` | `EchoTestBuilder` |
-| `packages/plugins/plugin-outliner/src/types/Journal.test.ts` | `EchoTestBuilder` |
-| `packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.test.ts` | `EchoTestBuilder` |
-| `packages/plugins/plugin-trello/src/operations/handlers.test.ts` | `EchoTestBuilder` |
-| `packages/plugins/plugin-trello/src/operations/sync.test.ts` | `EchoTestBuilder` |
-| `packages/plugins/plugin-trip/src/operations/extractor/TravelMessageExtractor.test.ts` | `EchoTestBuilder` |
-| `packages/plugins/plugin-trip/src/types/Trip.test.ts` | `EchoTestBuilder` |
-| `packages/e2e/blade-runner/src/redis/redis.node.test.ts` | `EchoTestBuilder`, `TestReplicator`, `TestReplicatorConnection`, `createDataAssertion` |
-| `packages/e2e/blade-runner/src/replicants/echo-replicant.ts` | `EchoTestPeer` |
+| File                                                                                         | Symbols                                                                                |
+| -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `packages/core/echo/echo-atom/src/atom.test.ts`                                              | `EchoTestBuilder`                                                                      |
+| `packages/core/echo/echo-atom/src/query-atom.test.ts`                                        | `EchoTestBuilder`                                                                      |
+| `packages/core/echo/echo-atom/src/ref-atom.test.ts`                                          | `EchoTestBuilder`                                                                      |
+| `packages/core/echo/echo-solid/src/useQuery.test.tsx`                                        | `EchoTestBuilder`                                                                      |
+| `packages/core/echo/echo-solid/src/useSchema.test.tsx`                                       | `EchoTestBuilder`                                                                      |
+| `packages/core/compute/assistant/src/util/diff.test.ts`                                      | `EchoTestBuilder`                                                                      |
+| `packages/core/compute/conductor/src/compiler/fiber-compiler.test.ts`                        | `TestDatabaseLayer`                                                                    |
+| `packages/core/compute/conductor/src/nodes/gpt/gpt.test.ts`                                  | `EchoTestBuilder`                                                                      |
+| `packages/core/compute/conductor/src/sequence/Sequence.test.ts`                              | `EchoTestBuilder`                                                                      |
+| `packages/core/compute/conductor/src/tests/gpt.test.ts`                                      | `TestDatabaseLayer`                                                                    |
+| `packages/core/compute/conductor/src/tests/streaming.test.ts`                                | `TestDatabaseLayer`                                                                    |
+| `packages/core/compute/conductor/src/types/compute.test.ts`                                  | `TestDatabaseLayer`                                                                    |
+| `packages/core/compute/conductor/src/workflow/workflow.test.ts`                              | `TestDatabaseLayer`                                                                    |
+| `packages/core/compute/functions-runtime/src/assistant-session-tests/session.test.ts`        | `TestDatabaseLayer`                                                                    |
+| `packages/core/compute/functions-runtime/src/services/function-invocation-service.test.ts`   | `TestDatabaseLayer`                                                                    |
+| `packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.test.ts`            | `TestDatabaseLayer`                                                                    |
+| `packages/core/compute-runtime/src/testing/layer.ts`                                         | `EchoTestBuilder`                                                                      |
+| `packages/sdk/schema/src/projection/projection.test.ts`                                      | `EchoTestBuilder`                                                                      |
+| `packages/sdk/schema/src/types/View.test.ts`                                                 | `EchoTestBuilder`                                                                      |
+| `packages/sdk/types/src/testing/generator.test.ts`                                           | `EchoTestBuilder`                                                                      |
+| `packages/plugins/plugin-feed/src/operations/curate-magazine.test.ts`                        | `EchoTestBuilder`                                                                      |
+| `packages/plugins/plugin-github/src/operations/sync.test.ts`                                 | `EchoTestBuilder`                                                                      |
+| `packages/plugins/plugin-inbox/src/operations/extract-message.test.ts`                       | `EchoTestBuilder`                                                                      |
+| `packages/plugins/plugin-integration/src/operations/set-integration-targets.test.ts`         | `EchoTestBuilder`                                                                      |
+| `packages/plugins/plugin-kanban/src/types/migrations.test.ts`                                | `EchoTestBuilder`                                                                      |
+| `packages/plugins/plugin-linear/src/operations/sync.test.ts`                                 | `EchoTestBuilder`                                                                      |
+| `packages/plugins/plugin-outliner/src/types/Journal.test.ts`                                 | `EchoTestBuilder`                                                                      |
+| `packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.test.ts` | `EchoTestBuilder`                                                                      |
+| `packages/plugins/plugin-trello/src/operations/handlers.test.ts`                             | `EchoTestBuilder`                                                                      |
+| `packages/plugins/plugin-trello/src/operations/sync.test.ts`                                 | `EchoTestBuilder`                                                                      |
+| `packages/plugins/plugin-trip/src/operations/extractor/TravelMessageExtractor.test.ts`       | `EchoTestBuilder`                                                                      |
+| `packages/plugins/plugin-trip/src/types/Trip.test.ts`                                        | `EchoTestBuilder`                                                                      |
+| `packages/e2e/blade-runner/src/redis/redis.node.test.ts`                                     | `EchoTestBuilder`, `TestReplicator`, `TestReplicatorConnection`, `createDataAssertion` |
+| `packages/e2e/blade-runner/src/replicants/echo-replicant.ts`                                 | `EchoTestPeer`                                                                         |
 
 ---
 
@@ -271,16 +271,16 @@ Symbols: `EchoTestBuilder`, `TestDatabaseLayer`, `EchoTestPeer`, `TestReplicator
 
 **By domain:**
 
-| Domain | Packages |
-|--------|---------|
-| Echo core | `echo-atom`, `echo-db` (self), `echo-generator`, `echo-react`, `echo-solid` |
-| Compute | `ai`, `assistant`, `assistant-toolkit`, `compute-hyperformula`, `compute-runtime`, `conductor`, `functions`, `functions-runtime`, `functions-runtime-cloudflare`, `operation` |
-| SDK | `app-framework`, `app-graph`, `client`, `client-protocol`, `client-services`, `migrations`, `react-edge-client`, `schema`, `types` |
-| Plugins | `plugin-assistant` (×2), `plugin-automation`, `plugin-chess`, `plugin-client`, `plugin-code`, `plugin-discord`, `plugin-feed`, `plugin-generator`, `plugin-github`, `plugin-inbox`, `plugin-integration`, `plugin-kanban`, `plugin-linear`, `plugin-markdown`, `plugin-meeting`, `plugin-native-filesystem`, `plugin-outliner`, `plugin-pipeline`, `plugin-preview`, `plugin-script`, `plugin-sheet`, `plugin-sketch`, `plugin-slack`, `plugin-space`, `plugin-support`, `plugin-thread`, `plugin-transcription`, `plugin-trello`, `plugin-trip` |
-| UI | `react-ui-canvas-compute`, `react-ui-editor`, `react-ui-form`, `react-ui-stack`, `react-ui-thread`, `ui-editor` |
-| Devtools | `cli`, `cli-util`, `devtools` |
-| Apps | `composer-app`, `testbench-app` |
-| Stories | `stories-assistant` (×2), `stories-ui` |
-| Common | `graph` |
-| E2E | `blade-runner`, `proto-guard` |
-| Experimental | `env-tests` |
+| Domain       | Packages                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Echo core    | `echo-atom`, `echo-db` (self), `echo-generator`, `echo-react`, `echo-solid`                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Compute      | `ai`, `assistant`, `assistant-toolkit`, `compute-hyperformula`, `compute-runtime`, `conductor`, `functions`, `functions-runtime`, `functions-runtime-cloudflare`, `operation`                                                                                                                                                                                                                                                                                                                                                                    |
+| SDK          | `app-framework`, `app-graph`, `client`, `client-protocol`, `client-services`, `migrations`, `react-edge-client`, `schema`, `types`                                                                                                                                                                                                                                                                                                                                                                                                               |
+| Plugins      | `plugin-assistant` (×2), `plugin-automation`, `plugin-chess`, `plugin-client`, `plugin-code`, `plugin-discord`, `plugin-feed`, `plugin-generator`, `plugin-github`, `plugin-inbox`, `plugin-integration`, `plugin-kanban`, `plugin-linear`, `plugin-markdown`, `plugin-meeting`, `plugin-native-filesystem`, `plugin-outliner`, `plugin-pipeline`, `plugin-preview`, `plugin-script`, `plugin-sheet`, `plugin-sketch`, `plugin-slack`, `plugin-space`, `plugin-support`, `plugin-thread`, `plugin-transcription`, `plugin-trello`, `plugin-trip` |
+| UI           | `react-ui-canvas-compute`, `react-ui-editor`, `react-ui-form`, `react-ui-stack`, `react-ui-thread`, `ui-editor`                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Devtools     | `cli`, `cli-util`, `devtools`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Apps         | `composer-app`, `testbench-app`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Stories      | `stories-assistant` (×2), `stories-ui`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Common       | `graph`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| E2E          | `blade-runner`, `proto-guard`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Experimental | `env-tests`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3987,9 +3987,6 @@ importers:
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../core/echo/echo
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/random':
         specifier: workspace:*
         version: link:../random
@@ -4670,9 +4667,6 @@ importers:
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../echo/echo
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../echo/echo-db
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../../common/effect
@@ -4900,9 +4894,6 @@ importers:
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../echo/echo
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../echo/echo-db
       '@dxos/echo-protocol':
         specifier: workspace:*
         version: link:../../echo/echo-protocol
@@ -5059,9 +5050,6 @@ importers:
         specifier: 'catalog:'
         version: 4.6.1
     devDependencies:
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../echo/echo-db
       '@dxos/random':
         specifier: workspace:*
         version: link:../../../common/random
@@ -5515,9 +5503,6 @@ importers:
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../echo/echo
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../echo/echo-db
       '@dxos/test-utils':
         specifier: workspace:*
         version: link:../../../common/test-utils
@@ -8261,9 +8246,6 @@ importers:
       '@dxos/echo-atom':
         specifier: workspace:*
         version: link:../../core/echo/echo-atom
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/echo-react':
         specifier: workspace:*
         version: link:../../core/echo/echo-react
@@ -8772,9 +8754,6 @@ importers:
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../core/echo/echo
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/echo-react':
         specifier: workspace:*
         version: link:../../core/echo/echo-react
@@ -11766,9 +11745,6 @@ importers:
       '@dxos/echo-atom':
         specifier: workspace:*
         version: link:../../core/echo/echo-atom
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/edge-client':
         specifier: workspace:*
         version: link:../../core/mesh/edge-client
@@ -12913,9 +12889,6 @@ importers:
         specifier: 'catalog:'
         version: 0.5.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)(react@19.2.6)(scheduler@0.27.0)
     devDependencies:
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/plugin-testing':
         specifier: workspace:*
         version: link:../plugin-testing
@@ -14952,9 +14925,6 @@ importers:
       '@dxos/echo-atom':
         specifier: workspace:*
         version: link:../../core/echo/echo-atom
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/echo-react':
         specifier: workspace:*
         version: link:../../core/echo/echo-react
@@ -15700,9 +15670,6 @@ importers:
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../core/echo/echo
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../common/effect
@@ -16061,7 +16028,7 @@ importers:
         specifier: workspace:*
         version: link:../../core/echo/echo
       '@dxos/echo-db':
-        specifier: workspace:^0.8.3
+        specifier: workspace:*
         version: link:../../core/echo/echo-db
       '@dxos/effect':
         specifier: workspace:*
@@ -16754,9 +16721,6 @@ importers:
         specifier: 'catalog:'
         version: 14.2.0
     devDependencies:
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/random':
         specifier: workspace:*
         version: link:../../common/random
@@ -17644,9 +17608,6 @@ importers:
       '@dxos/debug':
         specifier: workspace:*
         version: link:../../common/debug
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/edge-client':
         specifier: workspace:*
         version: link:../../core/mesh/edge-client
@@ -18299,9 +18260,6 @@ importers:
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/plugin-client':
         specifier: workspace:*
         version: link:../../plugins/plugin-client
@@ -19127,9 +19085,6 @@ importers:
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../core/echo/echo
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/edge-client':
         specifier: workspace:*
         version: link:../../core/mesh/edge-client
@@ -21265,9 +21220,6 @@ importers:
       '@dxos/client':
         specifier: workspace:*
         version: link:../../sdk/client
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/random':
         specifier: workspace:*
         version: link:../../common/random
@@ -21615,9 +21567,6 @@ importers:
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../core/echo/echo
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/keys':
         specifier: workspace:*
         version: link:../../common/keys


### PR DESCRIPTION
## Summary

- Adds `plans/echo-db-usage-audit.md` — a comprehensive audit of all `@dxos/echo-db` usages across the monorepo
- Categorizes 12 usage kinds: document text editing, feed/Effect service layer, database/client interfaces, query/filtering, object creation, schema registry, versioning/history, serialization, document migration, SDK re-exports, test utilities, and package dependency declarations
- Covers ~110 source files and 71 packages that depend on `@dxos/echo-db`

https://claude.ai/code/session_018FboH2NP1cqWSTNEHPuXnC

---
_Generated by [Claude Code](https://claude.ai/code/session_018FboH2NP1cqWSTNEHPuXnC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive usage audit for the ECHO DB package and a staged dependency-reduction migration plan.
* **Chores**
  * Removed the ECHO DB dependency from multiple package manifests and updated TypeScript project references.
* **Bug Fixes / API**
  * Adjusted query re-exports to rely on local query modules (minor public export surface change).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->