### PR TITLE
refactor(plugin-navtree): standardize L1 panel header IconButton density

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -408,5 +408,5 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "vitest.disableWorkspaceWarning": true,
   "vitest.rootConfig": "vitest.all.config.ts",
-  "typescript.native-preview.tsdk": "/Users/burdon/Code/dxos/dxos/.claude/worktrees/crazy-taussig-af3b75/node_modules/@typescript/native-preview"
+  "typescript.native-preview.tsdk": "${workspaceFolder}/node_modules/@typescript/native-preview"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -408,5 +408,5 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "vitest.disableWorkspaceWarning": true,
   "vitest.rootConfig": "vitest.all.config.ts",
-  "typescript.native-preview.tsdk": "${workspaceFolder}/node_modules/@typescript/native-preview"
+  "typescript.native-preview.tsdk": "/Users/burdon/Code/dxos/dxos/.claude/worktrees/crazy-taussig-af3b75/node_modules/@typescript/native-preview"
 }

--- a/packages/plugins/plugin-integration/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-integration/src/capabilities/app-graph-builder.ts
@@ -6,13 +6,13 @@ import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 
 import { Capability } from '@dxos/app-framework';
-import { AppCapabilities, AppNodeMatcher, createObjectNode } from '@dxos/app-toolkit';
+import { AppCapabilities, createObjectNode } from '@dxos/app-toolkit';
 import { isSpace } from '@dxos/client/echo';
 import { Operation } from '@dxos/compute';
 import { Filter, Obj, Ref } from '@dxos/echo';
 import { AtomQuery } from '@dxos/echo-atom';
-import { GraphBuilder, Node } from '@dxos/plugin-graph';
-import { SpaceOperation } from '@dxos/plugin-space';
+import { GraphBuilder, Node, NodeMatcher } from '@dxos/plugin-graph';
+import { SETTINGS_SECTION_TYPE, SpaceOperation } from '@dxos/plugin-space';
 
 import { meta } from '#meta';
 import { IntegrationProvider, type IntegrationProviderEntry } from '#types';
@@ -77,12 +77,16 @@ export default Capability.makeModule(
           }),
       }),
 
-      // Per-space integrations folder; kept empty until an Integration exists.
+      // Integrations folder nested under the space settings section; kept empty until an Integration exists.
       // Separate listing extension so graph reacts when targets are deleted.
       GraphBuilder.createExtension({
         id: 'integrations-section',
-        match: AppNodeMatcher.whenSpace,
-        connector: (space, get) => {
+        match: NodeMatcher.whenNodeType(SETTINGS_SECTION_TYPE),
+        connector: (node, get) => {
+          const space = isSpace(node.properties.space) ? node.properties.space : undefined;
+          if (!space) {
+            return Effect.succeed([]);
+          }
           const integrations = get(AtomQuery.make(space.db, Filter.type(Integration.Integration)));
           if (integrations.length === 0) {
             return Effect.succeed([]);

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L0Menu.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L0Menu.tsx
@@ -327,7 +327,15 @@ export const L0Menu = ({
       <Menu.Root onAction={handleAction}>
         <Menu.Trigger asChild data-testid='spacePlugin.addSpace'>
           <div className='grid place-items-center'>
-            <IconButton variant='ghost' icon='ph--list--regular' iconOnly label={t('app-menu.label')} />
+            <IconButton
+              density='lg'
+              variant='ghost'
+              size={5}
+              icon='ph--list--regular'
+              iconOnly
+              square
+              label={t('app-menu.label')}
+            />
           </div>
         </Menu.Trigger>
         <Menu.Content group={parent} items={menuActions} />

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
@@ -198,6 +198,7 @@ const MenuActions = ({
         variant='ghost'
         icon={menuActions[0].properties?.icon ?? 'ph--circle-dashed--regular'}
         iconOnly
+        size={4}
         label={toLocalizedString(menuActions[0].properties?.label, t)}
         data-testid={menuActions[0].properties?.testId}
         onClick={() => onAction(menuActions[0] as Node.Action)}
@@ -213,6 +214,7 @@ const MenuActions = ({
           variant='ghost'
           icon='ph--dots-three-vertical--regular'
           iconOnly
+          size={4}
           label={t('tree-item-actions.label')}
           data-testid='navtree.treeItem.actionsLevel0'
         />

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
@@ -125,21 +125,21 @@ const L1PanelHeader = ({ item, path, onBack }: Pick<L1PanelProps, 'item' | 'path
   return (
     <div
       data-tauri-drag-region
-      className='flex w-full items-center border-b border-subdued-separator dx-app-drag dx-density-lg pe-1'
+      className='grid grid-cols-[28px_1fr_28px_28px] w-full items-center border-b border-subdued-separator dx-app-drag dx-density-lg pe-1'
     >
       {backCapableWorkspace ? (
         <IconButton
-          density='lg'
-          classNames={['shrink-0 px-2 pointer-fine:px-1', hoverableControlItem, hoverableOpenControlItem]}
+          classNames={[hoverableControlItem, hoverableOpenControlItem]}
           variant='ghost'
           icon='ph--caret-left--regular'
           iconOnly
+          size={4}
           label={t('button-back.button')}
           data-testid='treeView.primaryTreeButton'
           onClick={() => onBack?.()}
         />
       ) : (
-        <div data-tauri-drag-region className='w-6' />
+        <div />
       )}
       <h2 data-tauri-drag-region className='flex-1 truncate min-w-0'>
         {title}
@@ -194,7 +194,6 @@ const MenuActions = ({
   if (menuActions.length === 1) {
     return (
       <IconButton
-        density='lg'
         classNames={['shrink-0 px-2 pointer-fine:px-1', hoverableControlItem, hoverableOpenControlItem]}
         variant='ghost'
         icon={menuActions[0].properties?.icon ?? 'ph--circle-dashed--regular'}
@@ -210,7 +209,6 @@ const MenuActions = ({
     <Menu.Root caller={NAV_TREE_ITEM} onAction={onAction}>
       <Menu.Trigger asChild>
         <IconButton
-          density='lg'
           classNames={['shrink-0 px-2 pointer-fine:px-1', hoverableControlItem, hoverableOpenControlItem]}
           variant='ghost'
           icon='ph--dots-three-vertical--regular'

--- a/packages/ui/react-ui-components/src/components/Timeline/Timeline.tsx
+++ b/packages/ui/react-ui-components/src/components/Timeline/Timeline.tsx
@@ -79,7 +79,7 @@ export type TimelineProps = ThemedClassName<{
  * GitGraph-style timeline.
  */
 // TODO(burdon): Virtualize.
-export const Timeline = React.memo(
+export const Timeline = memo(
   composable<HTMLDivElement, TimelineProps>(
     (
       {
@@ -370,6 +370,7 @@ export const Timeline = React.memo(
     },
   ),
 );
+
 Timeline.displayName = 'Timeline';
 
 const CommitIcon = memo(({ commit }: { commit: Commit }) => {

--- a/packages/ui/react-ui/src/components/Button/IconButton.stories.tsx
+++ b/packages/ui/react-ui/src/components/Button/IconButton.stories.tsx
@@ -5,6 +5,8 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
+import { type Density } from '@dxos/ui-types';
+
 import { withTheme } from '../../testing';
 import { Tooltip } from '../Tooltip';
 import { Button } from './Button';
@@ -17,6 +19,41 @@ const DefaultStory = (props: IconButtonProps) => {
         <IconButton {...props} />
         <IconButton iconOnly {...props} />
         <Button>{props.label}</Button>
+      </div>
+    </Tooltip.Provider>
+  );
+};
+
+const densities: Density[] = ['lg', 'md', 'sm'];
+const densityIconSize: Record<Density, IconButtonProps['size']> = {
+  lg: 5,
+  md: 4,
+  sm: 3,
+};
+
+const DensitiesStory = (props: Omit<IconButtonProps, 'density' | 'size'>) => {
+  return (
+    <Tooltip.Provider>
+      <div className='grid grid-cols-[auto_1fr_1fr_1fr] gap-4 items-center'>
+        <div />
+        <div className='text-xs text-subdued uppercase'>iconOnly</div>
+        <div className='text-xs text-subdued uppercase'>label + icon</div>
+        <div className='text-xs text-subdued uppercase'>Button (reference)</div>
+        {densities.map((density) => (
+          <React.Fragment key={density}>
+            <div className='text-xs font-mono'>density={density}</div>
+            <IconButton
+              square
+              classNames='w-fit'
+              density={density}
+              size={densityIconSize[density]}
+              iconOnly
+              {...props}
+            />
+            <IconButton classNames='w-fit' density={density} size={densityIconSize[density]} {...props} />
+            <Button density={density}>{props.label}</Button>
+          </React.Fragment>
+        ))}
       </div>
     </Tooltip.Provider>
   );
@@ -37,8 +74,18 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  render: DensitiesStory as any,
   args: {
     label: 'Bold',
     icon: 'ph--text-b--regular',
+  },
+};
+
+export const Ghost: Story = {
+  render: DensitiesStory as any,
+  args: {
+    label: 'Bold',
+    icon: 'ph--text-b--regular',
+    variant: 'ghost',
   },
 };


### PR DESCRIPTION
## Summary

- **plugin-integration**: nest the `integrations` section under the space `SETTINGS_SECTION_TYPE` (alongside automation/functions) instead of attaching it directly to the space root.
- **plugin-navtree L1 header**: standardize the back / single-action / dots-menu IconButtons to inherit density from the surrounding `DensityProvider` (density `md`), so they match the primary action contributed via `NavTreeItemAction` (which already reads density from context). Previously the bare IconButtons hard-coded `density='lg'` while the primary action rendered at `md` (`size=4`), producing visibly inconsistent button sizes in the header row.
- **plugin-navtree L0 rail**: bump the app-menu IconButton (`data-testid='spacePlugin.addSpace'`) to `density='lg'` so it matches the rail scale.
- **react-ui IconButton.stories**: add a `Densities` story (lg/md/sm × iconOnly/label+icon, with a `Button` reference column) and a `Ghost` variant for visual review.
- **react-ui-components Timeline**: drop stray `React.memo` qualifier in favour of the already-imported `memo` name.

## Test plan

- [ ] `moon run plugin-integration:build plugin-navtree:build react-ui:build` — green.
- [ ] `moon run plugin-integration:lint plugin-navtree:lint react-ui:lint react-ui-components:lint` — green.
- [ ] In Composer: open a non-personal space → confirm the `Integrations` section appears under Settings only when at least one Integration exists.
- [ ] In Composer: open the L1 panel for a space and for Settings → confirm the back, add (`+`), download (`cloud-arrow-down`), and dots-menu buttons all render at the same size.
- [ ] Storybook: open `ui/react-ui-core/components/IconButton` → check `Densities` and `Ghost` stories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved app navigation menu button sizing and visual presentation.
  * Refined panel header layout and button styling for better visual consistency.

* **Behavior**
  * Integrations area now only appears within the space settings section; if no space is present the integrations list will be empty.

* **Documentation**
  * Storybook updated to showcase multiple button density variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->