### PR TITLE
feat(react-ui): xs density, segmented date inputs via react-aria

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -40,6 +40,16 @@
       "port": 9009
     },
     {
+      "name": "storybook-react-alt",
+      "runtimeExecutable": "sh",
+      "runtimeArgs": [
+        "-c",
+        "cd .claude/worktrees/inbox && pnpm --filter @dxos/storybook-react exec storybook dev --port 9012 --no-open --ci"
+      ],
+      "port": 9012,
+      "autoPort": true
+    },
+    {
       "name": "plugin-explorer-storybook",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["--filter", "@dxos/plugin-explorer", "exec", "storybook", "dev", "--port", "9010", "--no-open"],

--- a/packages/common/util/src/string.test.ts
+++ b/packages/common/util/src/string.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, test } from 'vitest';
 
-import { trim } from './string';
+import { inline, trim } from './string';
 
 describe('string', () => {
   test('dedent', async ({ expect }) => {
@@ -15,5 +15,28 @@ describe('string', () => {
     `;
 
     expect(text).to.eq('- 1\n- 2\n  - 3');
+  });
+
+  test('inline collapses whitespace to single spaces', async ({ expect }) => {
+    const classes = inline`
+      rounded-xs outline-none text-end
+      data-[type=year]:min-w-[4ch]
+      data-[focused]:bg-accent-surface  data-[focused]:text-accent-foreground
+    `;
+
+    expect(classes).to.eq(
+      'rounded-xs outline-none text-end data-[type=year]:min-w-[4ch] data-[focused]:bg-accent-surface data-[focused]:text-accent-foreground',
+    );
+  });
+
+  test('inline interpolates values', async ({ expect }) => {
+    const variant = 'data-[focused]:bg-accent-surface';
+    const classes = inline`
+      rounded-xs
+      ${variant}
+      outline-none
+    `;
+
+    expect(classes).to.eq('rounded-xs data-[focused]:bg-accent-surface outline-none');
   });
 });

--- a/packages/common/util/src/string.ts
+++ b/packages/common/util/src/string.ts
@@ -14,6 +14,22 @@ export const capitalize = (str: string): string => {
 };
 
 /**
+ * Collapse a multi-line tagged template literal to a single space-separated string.
+ * Useful for statically concatenating long lists of class names across multiple lines:
+ *
+ * ```ts
+ * const cls = inline`
+ *   rounded-xs outline-none
+ *   data-[focused]:bg-accent-surface
+ * `;
+ * ```
+ */
+export function inline(strings: TemplateStringsArray, ...values: any[]): string {
+  const raw = strings.reduce((out, str, i) => out + str + (i < values.length ? String(values[i]) : ''), '');
+  return raw.replace(/\s+/g, ' ').trim();
+}
+
+/**
  * Remove leading space from multi-line strings.
  */
 export function trim(strings: TemplateStringsArray, ...values: any[]) {

--- a/packages/devtools/devtools/src/components/ObjectsTree.tsx
+++ b/packages/devtools/devtools/src/components/ObjectsTree.tsx
@@ -4,12 +4,12 @@
 
 import { Atom } from '@effect-atom/atom';
 import { useAtomSet, useAtomValue } from '@effect-atom/atom-react';
-import * as Record from 'effect/Record';
 import * as Array from 'effect/Array';
 import { pipe } from 'effect/Function';
 import * as Match from 'effect/Match';
 import * as Option from 'effect/Option';
 import * as Order from 'effect/Order';
+import * as Record from 'effect/Record';
 import * as Schema from 'effect/Schema';
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import React from 'react';

--- a/packages/plugins/plugin-automation/src/components/TriggerEditor/TriggerEditor.tsx
+++ b/packages/plugins/plugin-automation/src/components/TriggerEditor/TriggerEditor.tsx
@@ -2,8 +2,8 @@
 // Copyright 2025 DXOS.org
 //
 
-import { Record } from 'effect';
 import * as Option from 'effect/Option';
+import * as Record from 'effect/Record';
 import React, { useCallback, useMemo } from 'react';
 
 import { Operation, Script, Trigger } from '@dxos/compute';

--- a/packages/plugins/plugin-automation/src/components/TriggerEditor/TriggerEditor.tsx
+++ b/packages/plugins/plugin-automation/src/components/TriggerEditor/TriggerEditor.tsx
@@ -183,7 +183,7 @@ const getObjectIconProps = (object: Entity.Unknown): { icon?: string; iconHue?: 
 const getWorkflowOptions = (graphs: ComputeGraph[]) => {
   return graphs.map((graph) => ({
     label: `compute-${graph.id}`,
-    value: Obj.getDXN(graph).toString(),
+    value: Obj.getURI(graph),
     ...getObjectIconProps(graph),
   }));
 };
@@ -195,7 +195,7 @@ const getFunctionOptions = (scripts: Script.Script[], functions: Operation.Persi
     const { icon: schemaIcon, iconHue } = getObjectIconProps(fn);
     return {
       label: getLabel(fn),
-      value: Obj.getDXN(fn).toString(),
+      value: Obj.getURI(fn),
       icon: fn.icon ?? schemaIcon,
       iconHue,
     };
@@ -228,7 +228,7 @@ const getFeedOptions = (feeds: Feed.Feed[]) => {
       return {
         label: Entity.getLabel(parent) ?? Entity.getTypename(parent) ?? 'Parent',
         secondaryLabel: role ?? getFeedDisplayName(feed),
-        value: Obj.getDXN(feed).toString(),
+        value: Obj.getURI(feed),
         ...getObjectIconProps(displayObject),
       };
     }
@@ -236,7 +236,7 @@ const getFeedOptions = (feeds: Feed.Feed[]) => {
     return {
       label: getFeedDisplayName(feed),
       secondaryLabel: role,
-      value: Obj.getDXN(feed).toString(),
+      value: Obj.getURI(feed),
       ...getObjectIconProps(displayObject),
     };
   });

--- a/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.tsx
+++ b/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.tsx
@@ -46,7 +46,7 @@ type SegmentTileProps = Pick<MosaicTileProps<SegmentTileData>, 'data' | 'locatio
 /**
  * Mosaic tile for a Segment. Follows the Card primitives:
  *   Card.Root
- *     Card.Header  → kind icon + title + delete (Card.CloseIconButton)
+ *     Card.Header  → kind icon + title + delete (Card.ActionIconButton action='close')
  *     Card.Body  → optional Route and Date rows
  *
  * Selection / current state is wired through `Mosaic.Tile asChild` + `Focus.Item`

--- a/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.tsx
+++ b/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.tsx
@@ -46,7 +46,7 @@ type SegmentTileProps = Pick<MosaicTileProps<SegmentTileData>, 'data' | 'locatio
 /**
  * Mosaic tile for a Segment. Follows the Card primitives:
  *   Card.Root
- *     Card.Header  → kind icon + title + delete (Card.ActionIconButton action='close')
+ *     Card.Header  → kind icon + title + delete (Card.ActionIconButton action='delete')
  *     Card.Body  → optional Route and Date rows
  *
  * Selection / current state is wired through `Mosaic.Tile asChild` + `Focus.Item`

--- a/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentEditableCard.tsx
+++ b/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentEditableCard.tsx
@@ -3,7 +3,7 @@
 //
 
 import { format as formatDate } from 'date-fns';
-import React, { type ChangeEvent, type MouseEvent, forwardRef, useCallback } from 'react';
+import React, { type MouseEvent, forwardRef, useCallback } from 'react';
 
 import { Obj } from '@dxos/echo';
 import { Card, Input, useTranslation } from '@dxos/react-ui';
@@ -49,11 +49,11 @@ export const FlightEditableCard = forwardRef<HTMLDivElement, FlightEditableCardP
     const { t } = useTranslation(meta.id);
 
     const handleDepartChange = useCallback(
-      (event: ChangeEvent<HTMLInputElement>) => {
+      (next: string) => {
         Obj.update(segment, (segment) => {
           // Card is only mounted for flight segments (see SegmentEdit registration).
           if (segment.details._tag === 'flight') {
-            segment.details.departAt = localDateTimeToIso(event.target.value);
+            segment.details.departAt = localDateTimeToIso(next);
           }
         });
       },
@@ -91,8 +91,7 @@ export const FlightEditableCard = forwardRef<HTMLDivElement, FlightEditableCardP
               <Input.DateTime
                 aria-label={t('segment.depart.placeholder')}
                 value={isoToLocalDateTime(departAt)}
-                onChange={handleDepartChange}
-                placeholder={t('segment.depart.placeholder')}
+                onValueChange={handleDepartChange}
               />
             </Input.Root>
           </Card.Row>

--- a/packages/ui/react-ui-form/src/components/Form/Form.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/Form.stories.tsx
@@ -11,7 +11,7 @@ import { type AnyProperties } from '@dxos/echo/internal';
 import { log } from '@dxos/log';
 import { useSpaces } from '@dxos/react-client/echo';
 import { withClientProvider } from '@dxos/react-client/testing';
-import { Tooltip, useThemeContext } from '@dxos/react-ui';
+import { Tooltip } from '@dxos/react-ui';
 import { Loading, withLayout, withTheme } from '@dxos/react-ui/testing';
 
 import { translations } from '#translations';
@@ -77,9 +77,6 @@ const DefaultStory = <T extends AnyProperties = AnyProperties>({
   const [values, setValues] = useState<Partial<T>>(valuesProp ?? {});
   const spaces = useSpaces();
   const space = spaces[0];
-  const { themeMode } = useThemeContext();
-  console.log('themeMode', { themeMode });
-
   const handleSave = useCallback<NonNullable<FormRootProps<T>['onSave']>>((values) => {
     log.info('save', { values, meta });
     setValues(values);

--- a/packages/ui/react-ui-form/src/components/Form/Form.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/Form.stories.tsx
@@ -11,7 +11,7 @@ import { type AnyProperties } from '@dxos/echo/internal';
 import { log } from '@dxos/log';
 import { useSpaces } from '@dxos/react-client/echo';
 import { withClientProvider } from '@dxos/react-client/testing';
-import { Tooltip } from '@dxos/react-ui';
+import { Tooltip, useThemeContext } from '@dxos/react-ui';
 import { Loading, withLayout, withTheme } from '@dxos/react-ui/testing';
 
 import { translations } from '#translations';
@@ -77,6 +77,8 @@ const DefaultStory = <T extends AnyProperties = AnyProperties>({
   const [values, setValues] = useState<Partial<T>>(valuesProp ?? {});
   const spaces = useSpaces();
   const space = spaces[0];
+  const { themeMode } = useThemeContext();
+  console.log('themeMode', { themeMode });
 
   const handleSave = useCallback<NonNullable<FormRootProps<T>['onSave']>>((values) => {
     log.info('save', { values, meta });

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -15,7 +15,7 @@ import {
   isDiscriminatedUnion,
   isNestedType,
 } from '@dxos/effect';
-import { IconButton, useTranslation } from '@dxos/react-ui';
+import { IconButton, IconButtonProps, useTranslation } from '@dxos/react-ui';
 
 import { translationKey } from '#translations';
 
@@ -96,14 +96,7 @@ export const ArrayField = ({
             <FormFieldLabel readonly={readonly} label={label} path={createJsonPath(path ?? [])} asChild />
           </div>
           {!readonly && layout !== 'static' && (
-            <IconButton
-              iconOnly
-              density='md'
-              variant='ghost'
-              icon='ph--plus--regular'
-              label={t('add-item.button')}
-              onClick={handleAdd}
-            />
+            <IconBlock icon='ph--plus--regular' label={t('add-item.button')} onClick={handleAdd} />
           )}
         </div>
       )}
@@ -134,10 +127,7 @@ export const ArrayField = ({
           );
 
           return (
-            <div
-              key={index}
-              className='grid grid-cols-[1fr_min-content] gap-form-gap items-center mb-1 last:mb-form-gap'
-            >
+            <div key={index} className='grid grid-cols-[1fr_min-content] items-center mb-1 last:mb-form-gap'>
               {renderItemAsObject ? (
                 <div className='p-1 border border-subdued-separator'>{fieldField}</div>
               ) : (
@@ -145,29 +135,7 @@ export const ArrayField = ({
               )}
 
               {!readonly && layout !== 'static' && (
-                <div className='h-full flex flex-col justify-end'>
-                  {renderItemAsObject ? (
-                    <IconButton
-                      variant='ghost'
-                      icon='ph--x--regular'
-                      iconOnly
-                      label={t('remove-item.button')}
-                      onClick={() => handleDelete(index)}
-                    />
-                  ) : (
-                    // Centers against the inline single-row FormField.
-                    <div className='flex items-center h-[2rem]'>
-                      <IconButton
-                        variant='ghost'
-                        icon='ph--x--regular'
-                        iconOnly
-                        label={t('remove-item.button')}
-                        onClick={() => handleDelete(index)}
-                        classNames='self-center'
-                      />
-                    </div>
-                  )}
-                </div>
+                <IconBlock icon='ph--x--regular' label={t('remove-item.button')} onClick={() => handleDelete(index)} />
               )}
             </div>
           );
@@ -178,6 +146,14 @@ export const ArrayField = ({
 };
 
 ArrayField.displayName = 'Form.ArrayField';
+
+const IconBlock = (props: IconButtonProps) => {
+  return (
+    <div className='flex items-center h-full px-1'>
+      <IconButton variant='ghost' density='xs' square iconOnly {...props} />
+    </div>
+  );
+};
 
 /**
  * Returns the default empty value for a given AST.

--- a/packages/ui/react-ui-form/src/components/Form/fields/DateField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/DateField.tsx
@@ -3,7 +3,7 @@
 //
 
 import { format as formatDate } from 'date-fns';
-import React, { type ChangeEvent, useCallback } from 'react';
+import React, { useCallback } from 'react';
 
 import { Format } from '@dxos/echo';
 import { Input } from '@dxos/react-ui';
@@ -16,10 +16,10 @@ import { type FormFieldComponentProps, FormFieldWrapper } from '../FormFieldComp
  * - `Format.Date`     -> `YYYY-MM-DD`.
  * - `Format.Time`     -> `HH:mm:ss`.
  *
- * Native input value shapes:
- * - `<input type='datetime-local'>` -> `YYYY-MM-DDTHH:mm` in local time.
- * - `<input type='date'>`           -> `YYYY-MM-DD`.
- * - `<input type='time'>`           -> `HH:mm`.
+ * Segmented input value shapes (react-aria-components-backed):
+ * - `Input.DateTime` -> `YYYY-MM-DDTHH:mm` in local time.
+ * - `Input.Date`     -> `YYYY-MM-DD`.
+ * - `Input.Time`     -> `HH:mm`.
  */
 
 /** ISO 8601 → `YYYY-MM-DDTHH:mm` in the user's local timezone. */
@@ -48,24 +48,16 @@ export const DateField = ({
   type,
   format,
   readonly,
-  placeholder,
+  placeholder: _placeholder,
   onValueChange,
-  onBlur,
+  onBlur: _onBlur,
   ...props
 }: FormFieldComponentProps<string>) => {
-  const handleDateOnlyChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => onValueChange(type, event.target.value),
-    [type, onValueChange],
-  );
-
-  const handleTimeChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => onValueChange(type, event.target.value),
-    [type, onValueChange],
-  );
+  const handleSimpleChange = useCallback((next: string) => onValueChange(type, next), [type, onValueChange]);
 
   const handleDateTimeChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const iso = localDateTimeToIso(event.target.value);
+    (next: string) => {
+      const iso = localDateTimeToIso(next);
       onValueChange(type, iso as string);
     },
     [type, onValueChange],
@@ -76,34 +68,16 @@ export const DateField = ({
       {({ value }) => {
         switch (format) {
           case Format.TypeFormat.Date:
-            return (
-              <Input.Date
-                disabled={!!readonly}
-                placeholder={placeholder}
-                value={value ?? ''}
-                onChange={handleDateOnlyChange}
-                onBlur={onBlur}
-              />
-            );
+            return <Input.Date disabled={!!readonly} value={value ?? ''} onValueChange={handleSimpleChange} />;
           case Format.TypeFormat.Time:
-            return (
-              <Input.Time
-                disabled={!!readonly}
-                placeholder={placeholder}
-                value={value ?? ''}
-                onChange={handleTimeChange}
-                onBlur={onBlur}
-              />
-            );
+            return <Input.Time disabled={!!readonly} value={value ?? ''} onValueChange={handleSimpleChange} />;
           case Format.TypeFormat.DateTime:
           default:
             return (
               <Input.DateTime
                 disabled={!!readonly}
-                placeholder={placeholder}
                 value={isoToLocalDateTime(value)}
-                onChange={handleDateTimeChange}
-                onBlur={onBlur}
+                onValueChange={handleDateTimeChange}
               />
             );
         }

--- a/packages/ui/react-ui-form/src/components/Form/fields/DateField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/DateField.tsx
@@ -68,17 +68,25 @@ export const DateField = ({
       {({ value }) => {
         switch (format) {
           case Format.TypeFormat.Date:
-            return <Input.Date disabled={!!readonly} value={value ?? ''} onValueChange={handleSimpleChange} />;
+            return (
+              <div className='grid grid-cols-[1fr_min-content] items-center gap-1'>
+                <Input.Date disabled={!!readonly} value={value ?? ''} onValueChange={handleSimpleChange} />
+                <Input.TriggerIcon />
+              </div>
+            );
           case Format.TypeFormat.Time:
             return <Input.Time disabled={!!readonly} value={value ?? ''} onValueChange={handleSimpleChange} />;
           case Format.TypeFormat.DateTime:
           default:
             return (
-              <Input.DateTime
-                disabled={!!readonly}
-                value={isoToLocalDateTime(value)}
-                onValueChange={handleDateTimeChange}
-              />
+              <div className='grid grid-cols-[1fr_min-content] items-center gap-1'>
+                <Input.DateTime
+                  disabled={!!readonly}
+                  value={isoToLocalDateTime(value)}
+                  onValueChange={handleDateTimeChange}
+                />
+                <Input.TriggerIcon />
+              </div>
             );
         }
       }}

--- a/packages/ui/react-ui-form/src/components/Form/fields/SelectField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/SelectField.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback } from 'react';
 
 import { Icon, Input, Select, type SelectRootProps } from '@dxos/react-ui';
+import { getStyles } from '@dxos/ui-theme';
 
 import { type FormFieldComponentProps, FormFieldLabel } from '../FormFieldComponent';
 
@@ -74,5 +75,3 @@ const getIconHueStyles = (iconHue?: string): string | undefined => {
 
   return styles?.foreground;
 };
-
-import { getStyles } from '@dxos/ui-theme';

--- a/packages/ui/react-ui-form/src/components/Form/fields/SelectField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/SelectField.tsx
@@ -75,4 +75,4 @@ const getIconHueStyles = (iconHue?: string): string | undefined => {
   return styles?.foreground;
 };
 
-import { getStyles, hoverableOpenControlItem } from '@dxos/ui-theme';
+import { getStyles } from '@dxos/ui-theme';

--- a/packages/ui/react-ui/package.json
+++ b/packages/ui/react-ui/package.json
@@ -55,6 +55,7 @@
     "@dxos/util": "workspace:*",
     "@effect-atom/atom-react": "catalog:",
     "@fluentui/react-tabster": "catalog:",
+    "@internationalized/date": "catalog:",
     "@radix-ui/primitive": "catalog:",
     "@radix-ui/react-alert-dialog": "catalog:",
     "@radix-ui/react-avatar": "catalog:",
@@ -91,7 +92,7 @@
     "error-stack-parser": "catalog:",
     "i18next": "catalog:",
     "keyborg": "catalog:",
-    "react-day-picker": "catalog:",
+    "react-aria-components": "catalog:",
     "react-error-boundary": "catalog:",
     "react-i18next": "catalog:",
     "react-remove-scroll": "catalog:"

--- a/packages/ui/react-ui/src/components/Button/IconButton.stories.tsx
+++ b/packages/ui/react-ui/src/components/Button/IconButton.stories.tsx
@@ -24,11 +24,12 @@ const DefaultStory = (props: IconButtonProps) => {
   );
 };
 
-const densities: Density[] = ['lg', 'md', 'sm'];
+const densities: Density[] = ['lg', 'md', 'sm', 'xs'];
 const densityIconSize: Record<Density, IconButtonProps['size']> = {
   lg: 5,
   md: 4,
-  sm: 3,
+  sm: 4,
+  xs: 4,
 };
 
 const DensitiesStory = (props: Omit<IconButtonProps, 'density' | 'size'>) => {
@@ -76,16 +77,16 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: DensitiesStory as any,
   args: {
-    label: 'Bold',
-    icon: 'ph--text-b--regular',
+    label: 'Close',
+    icon: 'ph--x--regular',
   },
 };
 
 export const Ghost: Story = {
   render: DensitiesStory as any,
   args: {
-    label: 'Bold',
-    icon: 'ph--text-b--regular',
+    label: 'Close',
+    icon: 'ph--x--regular',
     variant: 'ghost',
   },
 };

--- a/packages/ui/react-ui/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/ui/react-ui/src/components/Calendar/Calendar.stories.tsx
@@ -4,10 +4,9 @@
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React, { useState } from 'react';
-import { type DateRange } from 'react-day-picker';
 
 import { withLayout, withTheme } from '../../testing';
-import { Calendar } from './Calendar';
+import { Calendar, type DateRange } from './Calendar';
 
 const meta: Meta<typeof Calendar.Root> = {
   title: 'ui/react-ui-core/components/Calendar',
@@ -36,17 +35,9 @@ export const Range: Story = {
   },
 };
 
-export const Multiple: Story = {
-  render: () => {
-    const [dates, setDates] = useState<Date[] | undefined>([]);
-    return <Calendar.Root mode='multiple' selected={dates} onSelect={setDates} />;
-  },
-};
-
-export const WithDisabled: Story = {
+export const WithMinDate: Story = {
   render: () => {
     const [date, setDate] = useState<Date | undefined>();
-    const disabled = { before: new Date() };
-    return <Calendar.Root mode='single' selected={date} onSelect={setDate} disabled={disabled} />;
+    return <Calendar.Root mode='single' selected={date} onSelect={setDate} minValue={new Date()} />;
   },
 };

--- a/packages/ui/react-ui/src/components/Calendar/Calendar.theme.ts
+++ b/packages/ui/react-ui/src/components/Calendar/Calendar.theme.ts
@@ -7,108 +7,68 @@ import { type ComponentFunction, type Theme } from '@dxos/ui-types';
 
 export type CalendarStyleProps = Partial<{}>;
 
-// Slot names match react-day-picker v9 `ClassNames` keys.
-// See https://daypicker.dev/api/type-aliases/ClassNames
+//
+// Theme slots target react-aria-components elements. RAC attaches `data-*` attributes to its
+// rendered nodes (`data-selected`, `data-focused`, `data-disabled`, `data-outside-month`,
+// `data-selection-start`, `data-selection-end`, `data-hovered`, etc.) which we hook into via
+// Tailwind's `data-[…]:` modifiers.
+//
 
 const root: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
-  // `relative` anchors the absolutely-positioned `nav` to the calendar bounds; `w-fit h-fit` keep the root
-  // sized to its content; `self-start` prevents a flex/grid parent from stretching the calendar vertically.
   mx('relative w-fit h-fit self-start p-2 select-none bg-group-surface text-base-foreground', ...etc);
 
-// `<Months>` wraps `<Nav>` and each `<Month>` as flex siblings — keep them stacked so nav sits above the grid.
-const months: ComponentFunction<CalendarStyleProps> = (_p, ...etc) => mx('flex flex-col gap-2', ...etc);
+const nav: ComponentFunction<CalendarStyleProps> = (_p, ...etc) => mx('flex items-center justify-between pb-1', ...etc);
 
-const month: ComponentFunction<CalendarStyleProps> = (_p, ...etc) => mx('flex flex-col gap-2', ...etc);
-
-const month_caption: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
-  mx('flex justify-center items-center relative', ...etc);
-
-const caption_label: ComponentFunction<CalendarStyleProps> = (_p, ...etc) => mx('text-sm font-medium', ...etc);
-
-const nav: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
-  // Flex row: prev chevron, month label (from CalendarNav via useDayPicker), next chevron.
-  mx('flex items-center justify-between', ...etc);
+const caption_label: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
+  mx('flex-1 text-center text-sm font-medium', ...etc);
 
 const button_previous: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
   mx(
-    'h-7 w-7 inline-flex items-center justify-center rounded-sm',
-    'text-description hover:bg-hover-surface aria-disabled:opacity-50',
+    'h-7 w-7 inline-flex items-center justify-center rounded-sm shrink-0',
+    'text-description hover:bg-hover-surface',
+    'data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed',
     ...etc,
   );
 
 const button_next: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
   mx(
-    'h-7 w-7 inline-flex items-center justify-center rounded-sm',
-    'text-description hover:bg-hover-surface aria-disabled:opacity-50',
+    'h-7 w-7 inline-flex items-center justify-center rounded-sm shrink-0',
+    'text-description hover:bg-hover-surface',
+    'data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed',
     ...etc,
   );
 
 const month_grid: ComponentFunction<CalendarStyleProps> = (_p, ...etc) => mx('w-full border-collapse', ...etc);
 
-const weekdays: ComponentFunction<CalendarStyleProps> = (_p, ...etc) => mx('flex pb-1', ...etc);
+const weekdays: ComponentFunction<CalendarStyleProps> = (_p, ...etc) => mx('', ...etc);
 
 const weekday: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
-  mx('w-9 text-xs font-thin text-description', ...etc);
-
-const week: ComponentFunction<CalendarStyleProps> = (_p, ...etc) => mx('flex w-full mt-1', ...etc);
+  mx('w-9 h-7 text-xs font-thin text-description', ...etc);
 
 const day: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
-  mx('relative w-9 h-9 p-0 text-center text-sm', ...etc);
-
-const day_button: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
   mx(
-    'inline-flex items-center justify-center w-9 h-9 rounded-sm',
-    'hover:bg-hover-surface aria-disabled:opacity-50 aria-disabled:pointer-events-none',
-    'focus-visible:outline-2 focus-visible:outline-primary-500',
+    'relative w-9 h-9 p-0 text-center text-sm rounded-sm inline-flex items-center justify-center cursor-pointer',
+    'outline-none',
+    'data-[hovered]:bg-hover-surface',
+    'data-[focus-visible]:outline-2 data-[focus-visible]:outline-primary-500',
+    'data-[selected]:bg-primary-500 data-[selected]:text-primary-fg data-[selected]:hover:bg-primary-500',
+    'data-[outside-month]:text-description/40',
+    'data-[disabled]:text-description/40 data-[disabled]:cursor-not-allowed data-[disabled]:hover:bg-transparent',
+    'data-[unavailable]:line-through data-[unavailable]:text-description/50 data-[unavailable]:cursor-not-allowed',
+    // Range selection visual layer.
+    'data-[selection-start]:rounded-l-sm data-[selection-end]:rounded-r-sm',
+    'data-[selection-start]:bg-primary-500 data-[selection-end]:bg-primary-500',
     ...etc,
   );
 
-const selected: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
-  mx('[&_button]:bg-primary-500 [&_button]:text-primary-fg [&_button]:hover:bg-primary-500', ...etc);
-
-const today: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
-  mx('[&_button]:border [&_button]:border-amber-500', ...etc);
-
-const outside: ComponentFunction<CalendarStyleProps> = (_p, ...etc) => mx('text-description/50', ...etc);
-
-const disabled: ComponentFunction<CalendarStyleProps> = (_p, ...etc) => mx('text-description/40', ...etc);
-
-const range_start: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
-  mx('[&_button]:bg-primary-500 [&_button]:text-primary-fg rounded-l-sm', ...etc);
-
-const range_middle: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
-  mx('bg-primary-500/20 [&_button]:hover:bg-primary-500/30', ...etc);
-
-const range_end: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
-  mx('[&_button]:bg-primary-500 [&_button]:text-primary-fg rounded-r-sm', ...etc);
-
-const hidden: ComponentFunction<CalendarStyleProps> = (_p, ...etc) => mx('invisible', ...etc);
-
-const footer: ComponentFunction<CalendarStyleProps> = (_p, ...etc) =>
-  mx('flex justify-between items-center pt-2 mt-2 border-t border-separator', ...etc);
-
 export const calendarTheme: Theme<CalendarStyleProps> = {
   root,
-  months,
-  month,
-  month_caption,
-  caption_label,
   nav,
+  caption_label,
   button_previous,
   button_next,
   month_grid,
   weekdays,
   weekday,
-  week,
   day,
-  day_button,
-  selected,
-  today,
-  outside,
-  disabled,
-  range_start,
-  range_middle,
-  range_end,
-  hidden,
-  footer,
 };

--- a/packages/ui/react-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/ui/react-ui/src/components/Calendar/Calendar.tsx
@@ -14,6 +14,7 @@ import {
   CalendarGridHeader as RACCalendarGridHeader,
   CalendarHeaderCell as RACCalendarHeaderCell,
   Heading as RACHeading,
+  I18nProvider,
   RangeCalendar as RACRangeCalendar,
   type RangeCalendarProps as RACRangeCalendarProps,
   type DateValue,
@@ -86,12 +87,14 @@ const CalendarShell = ({
 }) => {
   const { tx } = useThemeContext();
   return (
-    <div
-      className={tx('calendar.root', {}, classNames, className) ?? undefined}
-      aria-disabled={isDisabled || undefined}
-    >
-      {children}
-    </div>
+    <I18nProvider locale='en-US'>
+      <div
+        className={tx('calendar.root', {}, classNames, className) ?? undefined}
+        aria-disabled={isDisabled || undefined}
+      >
+        {children}
+      </div>
+    </I18nProvider>
   );
 };
 

--- a/packages/ui/react-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/ui/react-ui/src/components/Calendar/Calendar.tsx
@@ -2,147 +2,192 @@
 // Copyright 2026 DXOS.org
 //
 
-import React, { forwardRef } from 'react';
+import { CalendarDate, parseDate } from '@internationalized/date';
+import React, { forwardRef, type ComponentPropsWithoutRef, type ReactNode } from 'react';
 import {
-  DayPicker,
-  type ClassNames,
-  type CustomComponents,
-  type DayPickerProps,
-  type DayProps,
-  type FooterProps,
-  type NavProps,
-  useDayPicker,
-} from 'react-day-picker';
+  Button as RACButton,
+  Calendar as RACCalendar,
+  CalendarCell as RACCalendarCell,
+  type CalendarProps as RACCalendarProps,
+  CalendarGrid as RACCalendarGrid,
+  CalendarGridBody as RACCalendarGridBody,
+  CalendarGridHeader as RACCalendarGridHeader,
+  CalendarHeaderCell as RACCalendarHeaderCell,
+  Heading as RACHeading,
+  RangeCalendar as RACRangeCalendar,
+  type RangeCalendarProps as RACRangeCalendarProps,
+  type DateValue,
+} from 'react-aria-components';
 
 import { type ClassNameValue } from '@dxos/ui-types';
 
 import { useThemeContext } from '../../hooks';
-import { useTranslation } from '../../primitives';
-import { translationKey } from '../../translations';
-import { composableProps } from '../../util';
-import { IconButton } from '../Button';
+import { Icon } from '../Icon';
 
-// Slot names match react-day-picker v9 `ClassNames` enum values.
-const themeSlots = [
-  'root',
-  'months',
-  'month',
-  'month_caption',
-  'caption_label',
-  'nav',
-  'button_previous',
-  'button_next',
-  'month_grid',
-  'weekdays',
-  'weekday',
-  'week',
-  'day',
-  'day_button',
-  'selected',
-  'today',
-  'outside',
-  'disabled',
-  'range_start',
-  'range_middle',
-  'range_end',
-  'hidden',
-  'footer',
-] as const;
+//
+// Date <-> CalendarDate conversion.
+// External API stays `Date` (and `{from,to}`-style range objects) so existing call sites keep working.
+//
 
-// Distribute `Omit` over the DayPicker discriminated union so each variant preserves its correlated
-// `mode` / `selected` / `onSelect` triple at call sites.
-type DistributiveOmit<U, K extends keyof any> = U extends unknown ? Omit<U, K> : never;
-
-export type CalendarRootProps = DistributiveOmit<DayPickerProps, 'classNames' | 'className'> & {
-  /** Consumer-facing theming override (DXOS convention). Merged with any `className` from a Slot parent. */
-  classNames?: ClassNameValue;
-  /** Forwarded from a Radix Slot parent; merged with `classNames`. */
-  className?: string;
-  /** Slot-level class overrides matching react-day-picker's `ClassNames` shape. Merged on top of theme defaults. */
-  slots?: Partial<ClassNames>;
+const toCalendarDate = (date: Date | undefined): CalendarDate | null => {
+  if (!date) {
+    return null;
+  }
+  return new CalendarDate(date.getFullYear(), date.getMonth() + 1, date.getDate());
 };
 
-const CalendarRoot = forwardRef<HTMLDivElement, CalendarRootProps>(({ slots, components, ...props }, _forwardedRef) => {
-  const { tx } = useThemeContext();
-  const themed: Partial<ClassNames> = {};
-  for (const slot of themeSlots) {
-    themed[slot] = tx(`calendar.${slot}`, {}, slots?.[slot]);
+const fromCalendarDate = (value: DateValue | null | undefined): Date | undefined => {
+  if (!value) {
+    return undefined;
   }
-  // composableProps merges any `className` from a Slot parent with the consumer-facing `classNames` and
-  // the theme default into a single `className` for DayPicker; DayPicker doesn't forward refs.
-  const { className } = composableProps(props, { classNames: tx('calendar.root', {}) });
+  return new Date(value.year, value.month - 1, value.day);
+};
+
+export type DateRange = { from: Date; to?: Date };
+
+//
+// Public API.
+//
+
+type BaseCalendarProps = {
+  classNames?: ClassNameValue;
+  className?: string;
+  isDisabled?: boolean;
+  minValue?: Date;
+  maxValue?: Date;
+  /** Month to render when there's no selection — driven by the consuming picker. */
+  defaultMonth?: Date;
+};
+
+type SingleProps = BaseCalendarProps & {
+  mode?: 'single';
+  selected?: Date;
+  onSelect?: (date: Date | undefined) => void;
+};
+
+type RangeProps = BaseCalendarProps & {
+  mode: 'range';
+  selected?: DateRange;
+  onSelect?: (range: DateRange | undefined) => void;
+};
+
+export type CalendarRootProps = SingleProps | RangeProps;
+
+const CalendarShell = ({
+  classNames,
+  className,
+  isDisabled,
+  children,
+}: {
+  classNames?: ClassNameValue;
+  className?: string;
+  isDisabled?: boolean;
+  children: ReactNode;
+}) => {
+  const { tx } = useThemeContext();
   return (
-    <DayPicker
-      // Spread loses union narrowing inside the function body; restore the type at the DayPicker boundary.
-      {...(props as DayPickerProps)}
-      className={className}
-      classNames={{ ...themed, root: undefined }}
-      components={{
-        MonthCaption: CalendarMonthCaption,
-        Nav: CalendarNav,
-        ...(components ?? {}),
-      }}
-    />
+    <div
+      className={tx('calendar.root', {}, classNames, className) ?? undefined}
+      aria-disabled={isDisabled || undefined}
+    >
+      {children}
+    </div>
+  );
+};
+
+const CalendarChrome = () => {
+  const { tx } = useThemeContext();
+  return (
+    <header className={tx('calendar.nav', {}) ?? undefined}>
+      <RACButton slot='previous' className={tx('calendar.button_previous', {}) ?? undefined}>
+        <Icon size={4} icon='ph--caret-left--regular' />
+      </RACButton>
+      <RACHeading className={tx('calendar.caption_label', {}) ?? undefined} />
+      <RACButton slot='next' className={tx('calendar.button_next', {}) ?? undefined}>
+        <Icon size={4} icon='ph--caret-right--regular' />
+      </RACButton>
+    </header>
+  );
+};
+
+const CalendarGridContent = () => {
+  const { tx } = useThemeContext();
+  return (
+    <RACCalendarGrid className={tx('calendar.month_grid', {}) ?? undefined}>
+      <RACCalendarGridHeader className={tx('calendar.weekdays', {}) ?? undefined}>
+        {(day) => (
+          <RACCalendarHeaderCell className={tx('calendar.weekday', {}) ?? undefined}>{day}</RACCalendarHeaderCell>
+        )}
+      </RACCalendarGridHeader>
+      <RACCalendarGridBody>
+        {(date) => <RACCalendarCell date={date} className={tx('calendar.day', {}) ?? undefined} />}
+      </RACCalendarGridBody>
+    </RACCalendarGrid>
+  );
+};
+
+const CalendarRoot = forwardRef<HTMLDivElement, CalendarRootProps>((props, _forwardedRef) => {
+  const { classNames, className, isDisabled, minValue, maxValue, defaultMonth } = props;
+  const defaultFocused = toCalendarDate(defaultMonth) ?? undefined;
+
+  if (props.mode === 'range') {
+    const racProps: RACRangeCalendarProps<CalendarDate> = {
+      isDisabled,
+      minValue: toCalendarDate(minValue) ?? undefined,
+      maxValue: toCalendarDate(maxValue) ?? undefined,
+      defaultFocusedValue: defaultFocused,
+      value: props.selected?.from
+        ? {
+            start: toCalendarDate(props.selected.from)!,
+            end: toCalendarDate(props.selected.to ?? props.selected.from)!,
+          }
+        : undefined,
+      onChange: (next) => {
+        if (!next) {
+          props.onSelect?.(undefined);
+          return;
+        }
+        const from = fromCalendarDate(next.start);
+        const to = fromCalendarDate(next.end);
+        if (from) {
+          props.onSelect?.({ from, to });
+        }
+      },
+    };
+    return (
+      <CalendarShell classNames={classNames} className={className} isDisabled={isDisabled}>
+        <RACRangeCalendar {...racProps}>
+          <CalendarChrome />
+          <CalendarGridContent />
+        </RACRangeCalendar>
+      </CalendarShell>
+    );
+  }
+
+  const racProps: RACCalendarProps<CalendarDate> = {
+    isDisabled,
+    minValue: toCalendarDate(minValue) ?? undefined,
+    maxValue: toCalendarDate(maxValue) ?? undefined,
+    defaultFocusedValue: defaultFocused,
+    value: toCalendarDate(props.selected),
+    onChange: (next) => props.onSelect?.(fromCalendarDate(next)),
+  };
+  return (
+    <CalendarShell classNames={classNames} className={className} isDisabled={isDisabled}>
+      <RACCalendar {...racProps}>
+        <CalendarChrome />
+        <CalendarGridContent />
+      </RACCalendar>
+    </CalendarShell>
   );
 });
 
 CalendarRoot.displayName = 'Calendar.Root';
 
-//
-// Slot defaults exposed on the namespace.
-// Consumers may pass these (or their own wrappers) via DayPicker's `components` prop.
-//
-
-// The default MonthCaption is rendered inside the nav (see CalendarNav); hide the per-month caption.
-const CalendarMonthCaption: CustomComponents['MonthCaption'] = () => <span hidden />;
-
-const CalendarNav: CustomComponents['Nav'] = ({
-  onPreviousClick,
-  onNextClick,
-  previousMonth,
-  nextMonth,
-  ...rest
-}: NavProps) => {
-  const { t } = useTranslation(translationKey);
-  const { months } = useDayPicker();
-  const displayed = months[0]?.date;
-  return (
-    <nav {...rest}>
-      <IconButton
-        variant='ghost'
-        iconOnly
-        icon='ph--caret-left--regular'
-        label={t('calendar.nav.previous.label')}
-        disabled={!previousMonth}
-        onClick={onPreviousClick}
-      />
-      <span className='text-sm font-medium'>
-        {displayed?.toLocaleString(undefined, { month: 'long', year: 'numeric' })}
-      </span>
-      <IconButton
-        variant='ghost'
-        iconOnly
-        icon='ph--caret-right--regular'
-        label={t('calendar.nav.next.label')}
-        disabled={!nextMonth}
-        onClick={onNextClick}
-      />
-    </nav>
-  );
-};
-
-const CalendarFooter: CustomComponents['Footer'] = ({ ...rest }: FooterProps) => <div {...rest} />;
-
-const CalendarDay: CustomComponents['Day'] = ({ day, modifiers: _modifiers, ...rest }: DayProps) => {
-  return <div {...rest}>{day.date.getDate()}</div>;
-};
-
 export const Calendar = {
   Root: CalendarRoot,
-  Day: CalendarDay,
-  MonthCaption: CalendarMonthCaption,
-  Nav: CalendarNav,
-  Footer: CalendarFooter,
 };
 
-export type { ClassNames as CalendarClassNames, DayPickerProps };
+// Re-export the iso parser for convenience.
+export { parseDate as parseCalendarDate };
+export type { ComponentPropsWithoutRef };

--- a/packages/ui/react-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/ui/react-ui/src/components/Calendar/Calendar.tsx
@@ -158,12 +158,7 @@ const CalendarRoot = forwardRef<HTMLDivElement, CalendarRootProps>((props, forwa
       },
     };
     return (
-      <CalendarShell
-        classNames={classNames}
-        className={className}
-        isDisabled={isDisabled}
-        forwardedRef={forwardedRef}
-      >
+      <CalendarShell classNames={classNames} className={className} isDisabled={isDisabled} forwardedRef={forwardedRef}>
         <RACRangeCalendar {...racProps}>
           <CalendarChrome />
           <CalendarGridContent />
@@ -181,12 +176,7 @@ const CalendarRoot = forwardRef<HTMLDivElement, CalendarRootProps>((props, forwa
     onChange: (next) => props.onSelect?.(fromCalendarDate(next)),
   };
   return (
-    <CalendarShell
-      classNames={classNames}
-      className={className}
-      isDisabled={isDisabled}
-      forwardedRef={forwardedRef}
-    >
+    <CalendarShell classNames={classNames} className={className} isDisabled={isDisabled} forwardedRef={forwardedRef}>
       <RACCalendar {...racProps}>
         <CalendarChrome />
         <CalendarGridContent />

--- a/packages/ui/react-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/ui/react-ui/src/components/Calendar/Calendar.tsx
@@ -14,7 +14,6 @@ import {
   CalendarGridHeader as RACCalendarGridHeader,
   CalendarHeaderCell as RACCalendarHeaderCell,
   Heading as RACHeading,
-  I18nProvider,
   RangeCalendar as RACRangeCalendar,
   type RangeCalendarProps as RACRangeCalendarProps,
   type DateValue,
@@ -89,15 +88,13 @@ const CalendarShell = ({
 }) => {
   const { tx } = useThemeContext();
   return (
-    <I18nProvider locale='en-US'>
-      <div
-        ref={forwardedRef}
-        className={tx('calendar.root', {}, classNames, className) ?? undefined}
-        aria-disabled={isDisabled || undefined}
-      >
-        {children}
-      </div>
-    </I18nProvider>
+    <div
+      ref={forwardedRef}
+      className={tx('calendar.root', {}, classNames, className) ?? undefined}
+      aria-disabled={isDisabled || undefined}
+    >
+      {children}
+    </div>
   );
 };
 

--- a/packages/ui/react-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/ui/react-ui/src/components/Calendar/Calendar.tsx
@@ -78,17 +78,20 @@ const CalendarShell = ({
   classNames,
   className,
   isDisabled,
+  forwardedRef,
   children,
 }: {
   classNames?: ClassNameValue;
   className?: string;
   isDisabled?: boolean;
+  forwardedRef?: React.Ref<HTMLDivElement>;
   children: ReactNode;
 }) => {
   const { tx } = useThemeContext();
   return (
     <I18nProvider locale='en-US'>
       <div
+        ref={forwardedRef}
         className={tx('calendar.root', {}, classNames, className) ?? undefined}
         aria-disabled={isDisabled || undefined}
       >
@@ -129,7 +132,7 @@ const CalendarGridContent = () => {
   );
 };
 
-const CalendarRoot = forwardRef<HTMLDivElement, CalendarRootProps>((props, _forwardedRef) => {
+const CalendarRoot = forwardRef<HTMLDivElement, CalendarRootProps>((props, forwardedRef) => {
   const { classNames, className, isDisabled, minValue, maxValue, defaultMonth } = props;
   const defaultFocused = toCalendarDate(defaultMonth) ?? undefined;
 
@@ -158,7 +161,12 @@ const CalendarRoot = forwardRef<HTMLDivElement, CalendarRootProps>((props, _forw
       },
     };
     return (
-      <CalendarShell classNames={classNames} className={className} isDisabled={isDisabled}>
+      <CalendarShell
+        classNames={classNames}
+        className={className}
+        isDisabled={isDisabled}
+        forwardedRef={forwardedRef}
+      >
         <RACRangeCalendar {...racProps}>
           <CalendarChrome />
           <CalendarGridContent />
@@ -176,7 +184,12 @@ const CalendarRoot = forwardRef<HTMLDivElement, CalendarRootProps>((props, _forw
     onChange: (next) => props.onSelect?.(fromCalendarDate(next)),
   };
   return (
-    <CalendarShell classNames={classNames} className={className} isDisabled={isDisabled}>
+    <CalendarShell
+      classNames={classNames}
+      className={className}
+      isDisabled={isDisabled}
+      forwardedRef={forwardedRef}
+    >
       <RACCalendar {...racProps}>
         <CalendarChrome />
         <CalendarGridContent />

--- a/packages/ui/react-ui/src/components/Card/Card.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.tsx
@@ -70,7 +70,7 @@ const CardRoot = composable<HTMLDivElement, CardRootProps>(
     return (
       <Column.Root
         asChild
-        gutter={density === 'lg' ? 'lg' : density === 'sm' ? 'sm' : 'md'}
+        gutter={density === 'lg' ? 'lg' : density === 'sm' || density === 'xs' ? 'sm' : 'md'}
         classNames={tx('card.root', { border, fullWidth }, className)}
         role={role ?? 'group'}
       >

--- a/packages/ui/react-ui/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/ui/react-ui/src/components/DatePicker/DatePicker.stories.tsx
@@ -5,10 +5,10 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { format } from 'date-fns';
 import React, { useState } from 'react';
-import { type DateRange } from 'react-day-picker';
 
 import { withTheme } from '../../testing';
 import { translations } from '../../translations';
+import { type DateRange } from '../Calendar';
 import { Input } from '../Input';
 import { DatePicker } from './DatePicker';
 
@@ -58,20 +58,6 @@ export const Range: Story = {
   },
 };
 
-export const Multiple: Story = {
-  render: () => {
-    const [value, setValue] = useState<Date[] | undefined>([]);
-    return (
-      <DatePicker.Root mode='multiple' value={value} onValueChange={setValue}>
-        <DatePicker.Trigger />
-        <DatePicker.Content>
-          <DatePicker.Calendar />
-        </DatePicker.Content>
-      </DatePicker.Root>
-    );
-  },
-};
-
 export const SingleWithTime: Story = {
   render: () => {
     const [value, setValue] = useState<Date | undefined>();
@@ -81,7 +67,7 @@ export const SingleWithTime: Story = {
         <DatePicker.Content>
           <DatePicker.Calendar />
           <Input.Root>
-            <Input.Time value={toTime(value)} onChange={(event) => setValue(applyTime(value, event.target.value))} />
+            <Input.Time value={toTime(value)} onValueChange={(next) => setValue(applyTime(value, next))} />
           </Input.Root>
         </DatePicker.Content>
       </DatePicker.Root>
@@ -100,17 +86,13 @@ export const RangeWithTime: Story = {
           <Input.Root>
             <Input.Time
               value={toTime(value?.from)}
-              onChange={(event) =>
-                setValue(value ? { ...value, from: applyTime(value.from, event.target.value) } : undefined)
-              }
+              onValueChange={(next) => setValue(value ? { ...value, from: applyTime(value.from, next) } : undefined)}
             />
           </Input.Root>
           <Input.Root>
             <Input.Time
               value={toTime(value?.to)}
-              onChange={(event) =>
-                setValue(value?.from ? { ...value, to: applyTime(value.to, event.target.value) } : undefined)
-              }
+              onValueChange={(next) => setValue(value?.from ? { ...value, to: applyTime(value.to, next) } : undefined)}
             />
           </Input.Root>
         </DatePicker.Content>

--- a/packages/ui/react-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/ui/react-ui/src/components/DatePicker/DatePicker.tsx
@@ -2,7 +2,6 @@
 // Copyright 2026 DXOS.org
 //
 
-import { CalendarDate, parseDate } from '@internationalized/date';
 import { createContext } from '@radix-ui/react-context';
 import { format as formatDate } from 'date-fns';
 import React, {
@@ -218,7 +217,7 @@ const carryTime = (oldDate: Date | undefined, newDate: Date | undefined): Date |
   return out;
 };
 
-const DatePickerCalendar = (_props: { classNames?: string }) => {
+const DatePickerCalendar = ({ classNames }: { classNames?: string } = {}) => {
   const { mode, value, setValue, withTime, onOpenChange } = useDatePickerContext('DatePickerCalendar');
 
   if (mode === 'single') {
@@ -226,6 +225,7 @@ const DatePickerCalendar = (_props: { classNames?: string }) => {
     return (
       <Calendar.Root
         mode='single'
+        classNames={classNames}
         selected={date}
         onSelect={(next) => {
           const merged = withTime ? carryTime(date, next) : next;
@@ -242,6 +242,7 @@ const DatePickerCalendar = (_props: { classNames?: string }) => {
   return (
     <Calendar.Root
       mode='range'
+      classNames={classNames}
       selected={range}
       onSelect={(next) => {
         if (!next) {
@@ -276,6 +277,3 @@ export const DatePicker = {
 export { useDatePickerContext };
 
 export type { ValueByMode };
-
-// Re-export for convenience.
-export { CalendarDate, parseDate };

--- a/packages/ui/react-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/ui/react-ui/src/components/DatePicker/DatePicker.tsx
@@ -2,36 +2,40 @@
 // Copyright 2026 DXOS.org
 //
 
+import { CalendarDate, parseDate } from '@internationalized/date';
 import { createContext } from '@radix-ui/react-context';
 import { format as formatDate } from 'date-fns';
 import React, {
   type ComponentPropsWithoutRef,
-  PropsWithChildren,
+  type PropsWithChildren,
   type ReactNode,
   forwardRef,
   useCallback,
   useState,
 } from 'react';
-import { type DateRange } from 'react-day-picker';
 
 import { useThemeContext } from '../../hooks';
 import { useTranslation } from '../../primitives';
 import { translationKey } from '../../translations';
 import { type ThemedClassName } from '../../util';
-import { Calendar } from '../Calendar';
+import { Calendar, type DateRange } from '../Calendar';
 import { Icon } from '../Icon';
 import { Popover } from '../Popover';
 
 //
-// Types & context.
+// Public API.
+//
+// Wraps the new react-aria-components-backed `<Calendar>` (single + range) in a Radix Popover,
+// preserving the previous slot-style namespace: `<DatePicker.Root>`, `<DatePicker.Trigger>`,
+// `<DatePicker.Content>`, `<DatePicker.Calendar>`. Multi-select is no longer supported (no
+// in-repo consumers); use `<Calendar.Root>` directly with custom state if needed.
 //
 
-export type DatePickerMode = 'single' | 'range' | 'multiple';
+export type DatePickerMode = 'single' | 'range';
 
 type ValueByMode = {
   single: Date | undefined;
   range: DateRange | undefined;
-  multiple: Date[] | undefined;
 };
 
 type DatePickerContextValue = {
@@ -54,6 +58,7 @@ export type DatePickerRootProps<M extends DatePickerMode = 'single'> = {
   value?: ValueByMode[M];
   defaultValue?: ValueByMode[M];
   onValueChange?: (value: ValueByMode[M]) => void;
+  /** Preserve hour/minute on the selected date(s) when picking a new day. */
   withTime?: boolean;
   open?: boolean;
   defaultOpen?: boolean;
@@ -133,10 +138,6 @@ const formatValue = (mode: DatePickerMode, value: unknown, fmt: string): string 
       }
       return r.to ? `${formatDate(r.from, fmt)} – ${formatDate(r.to, fmt)}` : formatDate(r.from, fmt);
     }
-    case 'multiple': {
-      const arr = value as Date[];
-      return arr.length ? arr.map((date) => formatDate(date, fmt)).join(', ') : undefined;
-    }
   }
 };
 
@@ -202,10 +203,9 @@ const DatePickerContent = forwardRef<HTMLDivElement, DatePickerContentProps>(
 DatePickerContent.displayName = 'DatePickerContent';
 
 //
-// Calendar bound to context (time-of-day preservation).
+// Calendar — single or range, time-of-day preservation, auto-dismiss on completion.
 //
 
-/** Copies the hour/minute from oldDate into a fresh copy of newDate. */
 const carryTime = (oldDate: Date | undefined, newDate: Date | undefined): Date | undefined => {
   if (!newDate) {
     return newDate;
@@ -218,68 +218,44 @@ const carryTime = (oldDate: Date | undefined, newDate: Date | undefined): Date |
   return out;
 };
 
-type DatePickerCalendarProps = {
-  classNames?: ComponentPropsWithoutRef<typeof Calendar.Root>['classNames'];
-  slots?: ComponentPropsWithoutRef<typeof Calendar.Root>['slots'];
-};
+const DatePickerCalendar = (_props: { classNames?: string }) => {
+  const { mode, value, setValue, withTime, onOpenChange } = useDatePickerContext('DatePickerCalendar');
 
-const DatePickerCalendar = (props: DatePickerCalendarProps) => {
-  const { mode, value, setValue, withTime } = useDatePickerContext('DatePickerCalendar');
-
-  const handleSelect = useCallback(
-    (next: ValueByMode[DatePickerMode]) => {
-      if (!withTime) {
-        setValue(next);
-        return;
-      }
-      if (mode === 'single') {
-        setValue(carryTime(value as Date | undefined, next as Date | undefined));
-      } else if (mode === 'range') {
-        const oldRange = value as DateRange | undefined;
-        const newRange = next as DateRange | undefined;
-        setValue(
-          newRange
-            ? { from: carryTime(oldRange?.from, newRange.from)!, to: carryTime(oldRange?.to, newRange.to) }
-            : undefined,
-        );
-      } else {
-        // Multiple — react-day-picker emits the full array; preserve time on existing dates by index.
-        const oldDates = (value as Date[] | undefined) ?? [];
-        const newDates = (next as Date[] | undefined) ?? [];
-        const merged = newDates.map((date, index) => carryTime(oldDates[index], date) ?? date);
-        setValue(merged);
-      }
-    },
-    [withTime, mode, value, setValue],
-  );
-
-  // Branch on mode so each Calendar render targets a single DayPickerProps union member.
   if (mode === 'single') {
+    const date = value as Date | undefined;
     return (
       <Calendar.Root
-        {...props}
         mode='single'
-        selected={value as Date | undefined}
-        onSelect={handleSelect as (date: Date | undefined) => void}
+        selected={date}
+        onSelect={(next) => {
+          const merged = withTime ? carryTime(date, next) : next;
+          setValue(merged);
+          if (next !== undefined) {
+            onOpenChange(false);
+          }
+        }}
       />
     );
   }
-  if (mode === 'range') {
-    return (
-      <Calendar.Root
-        {...props}
-        mode='range'
-        selected={value as DateRange | undefined}
-        onSelect={handleSelect as (range: DateRange | undefined) => void}
-      />
-    );
-  }
+
+  const range = value as DateRange | undefined;
   return (
     <Calendar.Root
-      {...props}
-      mode='multiple'
-      selected={value as Date[] | undefined}
-      onSelect={handleSelect as (dates: Date[] | undefined) => void}
+      mode='range'
+      selected={range}
+      onSelect={(next) => {
+        if (!next) {
+          setValue(undefined);
+          return;
+        }
+        const merged: DateRange = withTime
+          ? { from: carryTime(range?.from, next.from)!, to: carryTime(range?.to, next.to) }
+          : next;
+        setValue(merged);
+        if (merged.from && merged.to) {
+          onOpenChange(false);
+        }
+      }}
     />
   );
 };
@@ -288,8 +264,6 @@ DatePickerCalendar.displayName = 'DatePickerCalendar';
 
 //
 // Public namespace.
-// Time-of-day entry: compose `Input.Time` inside `DatePicker.Content` and wire it to your own state;
-// `DatePicker.Root`'s `withTime` flag preserves hour/minute when the user clicks a new date.
 //
 
 export const DatePicker = {
@@ -302,3 +276,6 @@ export const DatePicker = {
 export { useDatePickerContext };
 
 export type { ValueByMode };
+
+// Re-export for convenience.
+export { CalendarDate, parseDate };

--- a/packages/ui/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.stories.tsx
@@ -198,6 +198,15 @@ export const TimeUncontrolled: Story = {
   },
 };
 
+export const TimeAmPm: Story = {
+  args: {
+    kind: 'time',
+    label: 'Time (12-hour, AM/PM)',
+    defaultValue: '14:00',
+    hourCycle: 12,
+  } as any,
+};
+
 export const TimeDisabled: Story = {
   args: {
     kind: 'time',

--- a/packages/ui/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.stories.tsx
@@ -88,7 +88,7 @@ type Story = StoryObj<DefaultStoryProps & Variant>;
 export const Density: Story = {
   render: () => (
     <div className='flex flex-col gap-4'>
-      {(['lg', 'md', 'sm'] as const).map((density) => (
+      {(['lg', 'md', 'sm', 'xs'] as const).map((density) => (
         <Input.Root key={density}>
           <Input.Label>{`density="${density}"`}</Input.Label>
           <Input.TextInput density={density} placeholder={`This is a density:${density} input`} />
@@ -221,6 +221,32 @@ export const DateTime: Story = {
     label: 'Date & time',
     defaultValue: '2026-06-01T15:30',
   },
+};
+
+export const DateWithPicker: Story = {
+  render: () => (
+    <Input.Root>
+      <Input.Label>Date (with picker)</Input.Label>
+      <div className='flex items-center gap-1'>
+        <Input.Date defaultValue='2026-06-01' />
+        <Input.TriggerIcon />
+      </div>
+      <Input.Description>Click the calendar icon to open the date picker.</Input.Description>
+    </Input.Root>
+  ),
+};
+
+export const DateTimeWithPicker: Story = {
+  render: () => (
+    <Input.Root>
+      <Input.Label>Date & time (with picker)</Input.Label>
+      <div className='flex items-center gap-1'>
+        <Input.DateTime defaultValue='2026-06-01T15:30' />
+        <Input.TriggerIcon />
+      </div>
+      <Input.Description>Click the calendar icon to open the date picker.</Input.Description>
+    </Input.Root>
+  ),
 };
 
 export const Checkbox: Story = {

--- a/packages/ui/react-ui/src/components/Input/Input.theme.ts
+++ b/packages/ui/react-ui/src/components/Input/Input.theme.ts
@@ -125,7 +125,13 @@ const switchThumb: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...etc) =
 const withSegmentsInput: ComponentFunction<InputStyleProps> = (props, ...etc) =>
   mx(
     'font-mono selection:bg-transparent mx-auto',
-    props.density === 'lg' ? 'text-lg' : props.density === 'sm' ? 'text-sm' : 'text-base pointer-fine:text-sm',
+    props.density === 'lg'
+      ? 'text-lg'
+      : props.density === 'sm'
+        ? 'text-sm'
+        : props.density === 'xs'
+          ? 'text-xs'
+          : 'text-base pointer-fine:text-sm',
     props.disabled && 'cursor-not-allowed',
     ...etc,
   );
@@ -137,7 +143,9 @@ const segment: ComponentFunction<InputStyleProps> = (props, ...etc) =>
       ? 'size-12 rounded-xs'
       : props.density === 'sm'
         ? 'size-7 rounded-xs'
-        : 'size-10 pointer-fine:size-8 rounded-xs',
+        : props.density === 'xs'
+          ? 'size-6 rounded-xs'
+          : 'size-10 pointer-fine:size-8 rounded-xs',
     'bg-input-surface text-base-foreground transition-colors border border-separator',
     'data-[focused]:bg-attention-surface data-[focused]:border-focus-ring-subtle',
     'data-[focused]:ring-2 data-[focused]:ring-offset-0 data-[focused]:ring-focus-ring-subtle',
@@ -158,6 +166,14 @@ const descriptionAndValidation: ComponentFunction<InputMetaStyleProps> = (props,
 const validation: ComponentFunction<InputMetaStyleProps> = (props, ...etc) =>
   mx(inputTextLabel, props.srOnly ? 'sr-only' : textValence(props.validationValence), ...etc);
 
+const triggerIcon: ComponentFunction<{}> = (_p, ...etc) =>
+  mx(
+    'shrink-0 inline-flex items-center justify-center size-7 rounded-xs',
+    'bg-input-surface text-subdued hover:text-base-foreground hover:bg-hover-surface',
+    'dx-focus-ring',
+    ...etc,
+  );
+
 export const inputTheme = {
   input,
   textArea,
@@ -171,4 +187,5 @@ export const inputTheme = {
   switchThumb,
   validation,
   descriptionAndValidation,
+  triggerIcon,
 };

--- a/packages/ui/react-ui/src/components/Input/Input.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.tsx
@@ -4,7 +4,18 @@
 
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
-import React, { type ComponentPropsWithRef, type ForwardRefExoticComponent, forwardRef } from 'react';
+import React, {
+  type ComponentPropsWithRef,
+  type ForwardRefExoticComponent,
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import {
   DescriptionAndValidation as DescriptionAndValidationPrimitive,
@@ -33,10 +44,115 @@ import { type Density, type Elevation, type Size } from '@dxos/ui-types';
 import { useDensityContext, useElevationContext, useThemeContext } from '../../hooks';
 import { type ThemedClassName } from '../../util';
 import { Icon } from '../Icon';
+import {
+  SegmentedDate,
+  type SegmentedDateProps,
+  SegmentedDateTime,
+  type SegmentedDateTimeProps,
+  SegmentedTime,
+  type SegmentedTimeProps,
+} from './SegmentedInput';
 
 type InputVariant = 'default' | 'subdued';
 
 type InputSharedProps = Partial<{ density: Density; elevation: Elevation; variant: InputVariant }>;
+
+//
+// Trigger context — lets a sibling `Input.TriggerIcon` open a picker registered by a field inside
+// the same `Input.Root`. Each registered handler is keyed; the most recent registration wins.
+//
+
+type InputTriggerHandler = () => void;
+
+type InputTriggerContextValue = {
+  registerTrigger: (handler: InputTriggerHandler) => () => void;
+  trigger: () => void;
+  hasTrigger: boolean;
+};
+
+const InputTriggerContext = createContext<InputTriggerContextValue | undefined>(undefined);
+
+/**
+ * Field hook. Pass an opener function; while the field is mounted, an `Input.TriggerIcon`
+ * sibling will call this opener on press. Returns a no-op when used outside `Input.Root`.
+ */
+const useInputTrigger = (handler: InputTriggerHandler | undefined) => {
+  const ctx = useContext(InputTriggerContext);
+  useEffect(() => {
+    if (!ctx || !handler) {
+      return;
+    }
+    return ctx.registerTrigger(handler);
+  }, [ctx, handler]);
+};
+
+//
+// Root — wraps the @dxos/react-input primitive root with the trigger registry.
+//
+
+const Root = (props: InputRootProps) => {
+  const handlerRef = useRef<InputTriggerHandler | null>(null);
+  const [hasTrigger, setHasTrigger] = useState(false);
+
+  const registerTrigger = useCallback((handler: InputTriggerHandler) => {
+    handlerRef.current = handler;
+    setHasTrigger(true);
+    return () => {
+      if (handlerRef.current === handler) {
+        handlerRef.current = null;
+        setHasTrigger(false);
+      }
+    };
+  }, []);
+
+  const trigger = useCallback(() => {
+    handlerRef.current?.();
+  }, []);
+
+  const value = useMemo(() => ({ registerTrigger, trigger, hasTrigger }), [registerTrigger, trigger, hasTrigger]);
+
+  return (
+    <InputTriggerContext.Provider value={value}>
+      <InputRoot {...props} />
+    </InputTriggerContext.Provider>
+  );
+};
+
+Root.displayName = 'Input.Root';
+
+//
+// TriggerIcon — sibling button that opens the picker of the registered field. Renders nothing
+// when no field in the surrounding `Input.Root` has registered an opener.
+//
+
+type TriggerIconProps = ThemedClassName<
+  Omit<ComponentPropsWithRef<'button'>, 'children' | 'onClick'> & {
+    icon?: string;
+  }
+>;
+
+const TriggerIcon = forwardRef<HTMLButtonElement, TriggerIconProps>(
+  ({ classNames, icon = 'ph--calendar--regular', ...props }, forwardedRef) => {
+    const ctx = useContext(InputTriggerContext);
+    const { tx } = useThemeContext();
+    if (!ctx?.hasTrigger) {
+      return null;
+    }
+    return (
+      <button
+        type='button'
+        ref={forwardedRef}
+        {...props}
+        onClick={ctx.trigger}
+        className={tx('input.triggerIcon', {}, classNames) ?? undefined}
+      >
+        <Icon size={4} icon={icon} />
+      </button>
+    );
+  },
+);
+
+TriggerIcon.displayName = 'Input.TriggerIcon';
 
 //
 // Label
@@ -198,149 +314,22 @@ const TextInput = forwardRef<HTMLInputElement, InputScopedProps<TextInputProps>>
 TextInput.displayName = 'Input.TextInput';
 
 //
-// Time
+// Date / Time / DateTime — segmented react-aria-components fields with locale-aware ordering,
+// spinbutton semantics, and immutable separators. ISO string API:
+//   - Date     `YYYY-MM-DD`
+//   - Time     `HH:mm`
+//   - DateTime `YYYY-MM-DDTHH:mm`
+// `Date` and `DateTime` accept an optional `iconSide` to render a calendar trigger that opens
+// a popover-mounted DatePicker.
 //
 
-type TimeProps = InputSharedProps &
-  ThemedClassName<Omit<TextInputPrimitiveProps, 'type'>> & {
-    /** Show the native time-picker icon (clock). Defaults to true. */
-    icon?: boolean;
-    /** Show the time-of-day text. Defaults to true. Hide to render an icon-only trigger. */
-    time?: boolean;
-  };
+const Time = SegmentedTime;
+const Date_ = SegmentedDate;
+const DateTime = SegmentedDateTime;
 
-const Time = forwardRef<HTMLInputElement, InputScopedProps<TimeProps>>(
-  (
-    {
-      __inputScope,
-      classNames,
-      density: densityProp,
-      elevation: elevationProp,
-      variant,
-      icon = true,
-      time = true,
-      ...props
-    },
-    forwardedRef,
-  ) => {
-    const { tx } = useThemeContext();
-    const density = useDensityContext(densityProp);
-    const elevation = useElevationContext(elevationProp);
-    const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
-
-    return (
-      <TextInputPrimitive
-        {...props}
-        type='time'
-        className={tx(
-          'input.input',
-          {
-            variant,
-            disabled: props.disabled,
-            density,
-            elevation,
-            validationValence,
-          },
-          // TODO(burdon): Move to theme.
-          // Force 32px (native time inputs add intrinsic height; the density
-          // `min-h-[2.5rem]` arbitrary value also outranks plain `min-h-8`).
-          // '!h-8 !min-h-8 box-border leading-none',
-          !icon && '[&::-webkit-calendar-picker-indicator]:hidden',
-          !time && 'text-transparent',
-          classNames,
-        )}
-        ref={forwardedRef}
-      />
-    );
-  },
-);
-
-Time.displayName = 'Input.Time';
-
-//
-// Date
-//
-
-type DateInputProps = InputSharedProps &
-  ThemedClassName<Omit<TextInputPrimitiveProps, 'type'>> & {
-    /** Show the native calendar-picker icon. Defaults to true. */
-    icon?: boolean;
-  };
-
-const Date_ = forwardRef<HTMLInputElement, InputScopedProps<DateInputProps>>(
-  (
-    { __inputScope, classNames, density: densityProp, elevation: elevationProp, variant, icon = true, ...props },
-    forwardedRef,
-  ) => {
-    const { tx } = useThemeContext();
-    const density = useDensityContext(densityProp);
-    const elevation = useElevationContext(elevationProp);
-    const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
-
-    return (
-      <TextInputPrimitive
-        {...props}
-        type='date'
-        className={tx(
-          'input.input',
-          {
-            variant,
-            disabled: props.disabled,
-            density,
-            elevation,
-            validationValence,
-          },
-          !icon && '[&::-webkit-calendar-picker-indicator]:hidden',
-          classNames,
-        )}
-        ref={forwardedRef}
-      />
-    );
-  },
-);
-
-Date_.displayName = 'Input.Date';
-
-//
-// DateTime (datetime-local)
-//
-
-type DateTimeInputProps = DateInputProps;
-
-// TODO(burdon): Use DatePicker.
-const DateTime = forwardRef<HTMLInputElement, InputScopedProps<DateTimeInputProps>>(
-  (
-    { __inputScope, classNames, density: densityProp, elevation: elevationProp, variant, icon = true, ...props },
-    forwardedRef,
-  ) => {
-    const { tx } = useThemeContext();
-    const density = useDensityContext(densityProp);
-    const elevation = useElevationContext(elevationProp);
-    const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
-
-    return (
-      <TextInputPrimitive
-        {...props}
-        type='datetime-local'
-        className={tx(
-          'input.input',
-          {
-            variant,
-            disabled: props.disabled,
-            density,
-            elevation,
-            validationValence,
-          },
-          !icon && '[&::-webkit-calendar-picker-indicator]:hidden',
-          classNames,
-        )}
-        ref={forwardedRef}
-      />
-    );
-  },
-);
-
-DateTime.displayName = 'Input.DateTime';
+type TimeProps = SegmentedTimeProps;
+type DateInputProps = SegmentedDateProps;
+type DateTimeInputProps = SegmentedDateTimeProps;
 
 //
 // TextArea
@@ -494,7 +483,8 @@ Switch.displayName = 'Input.Switch';
 //
 
 export const Input = {
-  Root: InputRoot,
+  Root,
+  TriggerIcon,
   PinInput,
   TextInput,
   TextArea,
@@ -508,6 +498,8 @@ export const Input = {
   Validation,
   DescriptionAndValidation,
 };
+
+export { useInputTrigger };
 
 export type {
   InputVariant,

--- a/packages/ui/react-ui/src/components/Input/Input.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.tsx
@@ -132,16 +132,18 @@ type TriggerIconProps = ThemedClassName<
 >;
 
 const TriggerIcon = forwardRef<HTMLButtonElement, TriggerIconProps>(
-  ({ classNames, icon = 'ph--calendar--regular', ...props }, forwardedRef) => {
+  ({ classNames, icon = 'ph--calendar--regular', 'aria-label': ariaLabel, ...props }, forwardedRef) => {
     const ctx = useContext(InputTriggerContext);
     const { tx } = useThemeContext();
     if (!ctx?.hasTrigger) {
       return null;
     }
+
     return (
       <button
         type='button'
         ref={forwardedRef}
+        aria-label={ariaLabel ?? 'Open picker'}
         {...props}
         onClick={ctx.trigger}
         className={tx('input.triggerIcon', {}, classNames) ?? undefined}

--- a/packages/ui/react-ui/src/components/Input/Input.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.tsx
@@ -321,8 +321,8 @@ TextInput.displayName = 'Input.TextInput';
 //   - Date     `YYYY-MM-DD`
 //   - Time     `HH:mm`
 //   - DateTime `YYYY-MM-DDTHH:mm`
-// `Date` and `DateTime` accept an optional `iconSide` to render a calendar trigger that opens
-// a popover-mounted DatePicker.
+// Pair `Input.Date` or `Input.DateTime` with a sibling `Input.TriggerIcon` inside an
+// `Input.Root` to expose a calendar popover; `Input.Time` has no picker.
 //
 
 const Time = SegmentedTime;

--- a/packages/ui/react-ui/src/components/Input/SegmentedInput.tsx
+++ b/packages/ui/react-ui/src/components/Input/SegmentedInput.tsx
@@ -141,8 +141,8 @@ const useFieldChrome = ({
   const { tx } = useThemeContext();
   const density = useDensityContext(densityProp);
   const elevation = useElevationContext(elevationProp);
-  const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
-  return { tx, density, elevation, validationValence };
+  const { id: contextId, validationValence, descriptionId, errorMessageId } = useInputContext(INPUT_NAME, __inputScope);
+  return { tx, density, elevation, validationValence, contextId, descriptionId, errorMessageId };
 };
 
 /**
@@ -154,24 +154,30 @@ const PickerWrapper = ({
   pickerValue,
   onPickerChange,
   withTime,
+  disabled = false,
   children,
   calendar,
 }: {
   pickerValue: Date | undefined;
   onPickerChange: (next: Date | undefined) => void;
   withTime: boolean;
+  disabled?: boolean;
   children: React.ReactNode;
   calendar: React.ReactNode;
 }) => {
   const [open, setOpen] = useState(false);
-  const openPicker = useCallback(() => setOpen(true), []);
-  useInputTrigger(openPicker);
+  const openPicker = useCallback(() => {
+    if (!disabled) {
+      setOpen(true);
+    }
+  }, [disabled]);
+  useInputTrigger(disabled ? undefined : openPicker);
   return (
     <DatePicker.Root
       mode='single'
       withTime={withTime}
       value={pickerValue}
-      onValueChange={onPickerChange}
+      onValueChange={disabled ? undefined : onPickerChange}
       open={open}
       onOpenChange={setOpen}
     >
@@ -205,7 +211,7 @@ const SegmentedDate = forwardRef<HTMLDivElement, InputScopedProps<SegmentedDateP
     },
     forwardedRef,
   ) => {
-    const { tx, density, elevation, validationValence } = useFieldChrome({
+    const { tx, density, elevation, validationValence, contextId, descriptionId, errorMessageId } = useFieldChrome({
       __inputScope,
       density: densityProp,
       elevation: elevationProp,
@@ -233,7 +239,11 @@ const SegmentedDate = forwardRef<HTMLDivElement, InputScopedProps<SegmentedDateP
       <DateField {...fieldProps}>
         <DateInput
           ref={forwardedRef}
-          {...(id ? { id } : {})}
+          {...((id ?? contextId) ? { id: id ?? contextId } : {})}
+          {...(descriptionId ? { 'aria-describedby': descriptionId } : {})}
+          {...(validationValence === 'error' && errorMessageId
+            ? { 'aria-invalid': true, 'aria-errormessage': errorMessageId }
+            : {})}
           data-density={density}
           className={tx(
             'input.input',
@@ -253,6 +263,7 @@ const SegmentedDate = forwardRef<HTMLDivElement, InputScopedProps<SegmentedDateP
           pickerValue={parsed ? new Date(parsed.year, parsed.month - 1, parsed.day) : undefined}
           onPickerChange={(next) => setStringValue(next ? formatCalendarDate(toCalendarDate(next)) : '')}
           withTime={false}
+          disabled={disabled}
           calendar={<DatePicker.Calendar />}
         >
           {field}
@@ -288,7 +299,7 @@ const SegmentedTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedTimeP
     },
     forwardedRef,
   ) => {
-    const { tx, density, elevation, validationValence } = useFieldChrome({
+    const { tx, density, elevation, validationValence, contextId, descriptionId, errorMessageId } = useFieldChrome({
       __inputScope,
       density: densityProp,
       elevation: elevationProp,
@@ -361,7 +372,7 @@ const SegmentedDateTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedD
     },
     forwardedRef,
   ) => {
-    const { tx, density, elevation, validationValence } = useFieldChrome({
+    const { tx, density, elevation, validationValence, contextId, descriptionId, errorMessageId } = useFieldChrome({
       __inputScope,
       density: densityProp,
       elevation: elevationProp,
@@ -390,7 +401,11 @@ const SegmentedDateTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedD
       <DateField {...fieldProps}>
         <DateInput
           ref={forwardedRef}
-          {...(id ? { id } : {})}
+          {...((id ?? contextId) ? { id: id ?? contextId } : {})}
+          {...(descriptionId ? { 'aria-describedby': descriptionId } : {})}
+          {...(validationValence === 'error' && errorMessageId
+            ? { 'aria-invalid': true, 'aria-errormessage': errorMessageId }
+            : {})}
           data-density={density}
           className={tx(
             'input.input',
@@ -426,6 +441,7 @@ const SegmentedDateTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedD
             )
           }
           withTime
+          disabled={disabled}
           calendar={<DatePicker.Calendar />}
         >
           {field}

--- a/packages/ui/react-ui/src/components/Input/SegmentedInput.tsx
+++ b/packages/ui/react-ui/src/components/Input/SegmentedInput.tsx
@@ -55,12 +55,54 @@ const toCalendarDate = (date: Date) => new CalendarDate(date.getFullYear(), date
 
 const fieldClass = 'inline-flex items-center gap-px font-mono tabular-nums focus-within:bg-attention-surface';
 
+// React Aria sets `caret-color: transparent` inline on each segment because spinbuttons replace
+// the whole value rather than inserting at a caret position. We override with `!important` so a
+// caret is visible while typing — friendlier UX even though it's slightly misleading mid-segment.
+//
+// `tabular-nums` on the field combined with `min-width` per segment keeps each segment a fixed
+// width regardless of value (so e.g. month `1` and `12` occupy the same space). `text-align: end`
+// right-aligns the digits within that fixed width.
+// TODO(burdon): Move to Input.theme.ts
 const segmentClass =
-  'rounded-xs px-0.5 outline-none ' +
+  'rounded-xs outline-none text-end [caret-color:currentColor]! ' +
+  'data-[type=year]:min-w-[4ch] ' +
+  'data-[type=month]:min-w-[2ch] data-[type=day]:min-w-[2ch] ' +
+  'data-[type=hour]:min-w-[2ch] data-[type=minute]:min-w-[2ch] ' +
   'data-[placeholder]:text-subdued data-[type=literal]:text-subdued ' +
-  'data-[focused]:bg-attention-surface data-[focused]:text-base-foreground ' +
+  'data-[focused]:bg-accent-surface data-[focused]:text-accent-foreground ' +
   'data-[invalid]:text-rose-500 ' +
   'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50';
+
+// Match bidi format characters (LRI/RLI/PDI/LRE/RLE/PDF/LRO/RLO) that React Aria inserts to
+// isolate locale-formatted portions. These are invisible glyphs but the browser still gives
+// them ~4px of width, which pushes the first visible character of time-only fields out of
+// alignment with date fields. Keep them in the DOM (so directional isolation survives) but
+// collapse them to zero width.
+const BIDI_FORMAT_RE = /^[‪-‮⁦-⁩]+$/;
+
+/**
+ * Render a single DateSegment. Locale-specific literals between date and time portions
+ * (e.g. en-US's `", "`) become a plain space; bidi format markers are kept but rendered
+ * zero-width so the visible content lines up at the field's left edge.
+ */
+const renderSegment = (segment: { type: string; text: string }) => {
+  if (segment.type === 'literal') {
+    if (BIDI_FORMAT_RE.test(segment.text)) {
+      // Render as a fixed-width spacer (between date and time portions of a datetime field),
+      // but hide when at the field's edges — opening LRI is the first child of a time-only
+      // field and would push everything right; closing PDI is the last child everywhere.
+      return <span aria-hidden className='select-none w-[2ch] first:hidden last:hidden' />;
+    }
+    if (segment.text.includes(',')) {
+      return (
+        <span aria-hidden className='select-none'>
+          {' '}
+        </span>
+      );
+    }
+  }
+  return <DateSegment segment={segment as any} className={segmentClass} />;
+};
 
 //
 // Shared props.
@@ -76,6 +118,11 @@ type SegmentedInputBaseProps = InputSharedProps &
     autoFocus?: boolean;
     'aria-label'?: string;
   }>;
+
+type SegmentedTimeBearingProps = SegmentedInputBaseProps & {
+  /** `24` (default) renders HH:mm; `12` renders hh:mm with an AM/PM segment. */
+  hourCycle?: 12 | 24;
+};
 
 //
 // Internal helpers.
@@ -178,6 +225,7 @@ const SegmentedDate = forwardRef<HTMLDivElement, InputScopedProps<SegmentedDateP
       autoFocus,
       'aria-label': ariaLabel ?? 'date',
       granularity: 'day',
+      shouldForceLeadingZeros: true,
     };
 
     const field = (
@@ -193,7 +241,7 @@ const SegmentedDate = forwardRef<HTMLDivElement, InputScopedProps<SegmentedDateP
             classNames,
           )}
         >
-          {(segment) => <DateSegment segment={segment} className={segmentClass} />}
+          {renderSegment}
         </DateInput>
       </DateField>
     );
@@ -216,7 +264,7 @@ SegmentedDate.displayName = 'Input.SegmentedDate';
 // SegmentedTime — no picker (no time-only picker primitive available); does not register a trigger.
 //
 
-type SegmentedTimeProps = SegmentedInputBaseProps;
+type SegmentedTimeProps = SegmentedTimeBearingProps;
 
 const SegmentedTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedTimeProps>>(
   (
@@ -232,6 +280,7 @@ const SegmentedTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedTimeP
       disabled,
       autoFocus,
       id,
+      hourCycle = 24,
       'aria-label': ariaLabel,
     },
     forwardedRef,
@@ -257,7 +306,8 @@ const SegmentedTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedTimeP
       autoFocus,
       'aria-label': ariaLabel ?? 'time',
       granularity: 'minute',
-      hourCycle: 24,
+      hourCycle,
+      shouldForceLeadingZeros: true,
     };
 
     return (
@@ -273,7 +323,7 @@ const SegmentedTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedTimeP
             classNames,
           )}
         >
-          {(segment) => <DateSegment segment={segment} className={segmentClass} />}
+          {renderSegment}
         </DateInput>
       </TimeField>
     );
@@ -285,7 +335,7 @@ SegmentedTime.displayName = 'Input.SegmentedTime';
 // SegmentedDateTime.
 //
 
-type SegmentedDateTimeProps = SegmentedInputBaseProps;
+type SegmentedDateTimeProps = SegmentedTimeBearingProps;
 
 const SegmentedDateTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedDateTimeProps>>(
   (
@@ -301,6 +351,7 @@ const SegmentedDateTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedD
       disabled,
       autoFocus,
       id,
+      hourCycle = 24,
       'aria-label': ariaLabel,
     },
     forwardedRef,
@@ -326,7 +377,8 @@ const SegmentedDateTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedD
       autoFocus,
       'aria-label': ariaLabel ?? 'date-time',
       granularity: 'minute',
-      hourCycle: 24,
+      hourCycle,
+      shouldForceLeadingZeros: true,
     };
 
     const field = (
@@ -342,7 +394,7 @@ const SegmentedDateTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedD
             classNames,
           )}
         >
-          {(segment) => <DateSegment segment={segment} className={segmentClass} />}
+          {renderSegment}
         </DateInput>
       </DateField>
     );

--- a/packages/ui/react-ui/src/components/Input/SegmentedInput.tsx
+++ b/packages/ui/react-ui/src/components/Input/SegmentedInput.tsx
@@ -1,0 +1,381 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { CalendarDate, CalendarDateTime, Time, parseDate, parseDateTime, parseTime } from '@internationalized/date';
+import { useControllableState } from '@radix-ui/react-use-controllable-state';
+import React, { forwardRef, useCallback, useState } from 'react';
+import {
+  DateField,
+  type DateFieldProps,
+  DateInput,
+  DateSegment,
+  TimeField,
+  type TimeFieldProps,
+} from 'react-aria-components';
+
+import { INPUT_NAME, type InputScopedProps, useInputContext } from '@dxos/react-input';
+
+import { useDensityContext, useElevationContext, useThemeContext } from '../../hooks';
+import { type ThemedClassName } from '../../util';
+import { DatePicker } from '../DatePicker';
+import { Popover } from '../Popover';
+import { type InputSharedProps, useInputTrigger } from './Input';
+
+//
+// Value <-> @internationalized/date adapters.
+//
+
+const tryParse = <T,>(parser: (input: string) => T, value: string | undefined): T | null => {
+  if (!value) {
+    return null;
+  }
+  try {
+    return parser(value);
+  } catch {
+    return null;
+  }
+};
+
+const pad = (value: number, length = 2) => String(value).padStart(length, '0');
+
+const formatCalendarDate = (date: CalendarDate): string => `${pad(date.year, 4)}-${pad(date.month)}-${pad(date.day)}`;
+
+const formatCalendarDateTime = (datetime: CalendarDateTime): string =>
+  `${pad(datetime.year, 4)}-${pad(datetime.month)}-${pad(datetime.day)}` +
+  `T${pad(datetime.hour)}:${pad(datetime.minute)}`;
+
+const formatTime = (time: Time): string => `${pad(time.hour)}:${pad(time.minute)}`;
+
+const toCalendarDate = (date: Date) => new CalendarDate(date.getFullYear(), date.getMonth() + 1, date.getDate());
+
+//
+// Theming.
+//
+
+const fieldClass = 'inline-flex items-center gap-px font-mono tabular-nums focus-within:bg-attention-surface';
+
+const segmentClass =
+  'rounded-xs px-0.5 outline-none ' +
+  'data-[placeholder]:text-subdued data-[type=literal]:text-subdued ' +
+  'data-[focused]:bg-attention-surface data-[focused]:text-base-foreground ' +
+  'data-[invalid]:text-rose-500 ' +
+  'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50';
+
+//
+// Shared props.
+//
+
+type SegmentedInputBaseProps = InputSharedProps &
+  ThemedClassName<{
+    id?: string;
+    value?: string;
+    defaultValue?: string;
+    onValueChange?: (value: string) => void;
+    disabled?: boolean;
+    autoFocus?: boolean;
+    'aria-label'?: string;
+  }>;
+
+//
+// Internal helpers.
+//
+
+const useFieldChrome = ({
+  __inputScope,
+  density: densityProp,
+  elevation: elevationProp,
+}: {
+  __inputScope?: any;
+  density: InputSharedProps['density'];
+  elevation: InputSharedProps['elevation'];
+}) => {
+  const { tx } = useThemeContext();
+  const density = useDensityContext(densityProp);
+  const elevation = useElevationContext(elevationProp);
+  const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
+  return { tx, density, elevation, validationValence };
+};
+
+/**
+ * Wraps a field with `Popover.Anchor` and a `DatePicker.Root` whose open state is driven by
+ * the surrounding `Input.Root`'s registered trigger. `Input.TriggerIcon` (a sibling under
+ * `Input.Root`) calls the registered handler on press; the popover anchors to this field.
+ */
+const PickerWrapper = ({
+  pickerValue,
+  onPickerChange,
+  withTime,
+  children,
+  calendar,
+}: {
+  pickerValue: Date | undefined;
+  onPickerChange: (next: Date | undefined) => void;
+  withTime: boolean;
+  children: React.ReactNode;
+  calendar: React.ReactNode;
+}) => {
+  const [open, setOpen] = useState(false);
+  const openPicker = useCallback(() => setOpen(true), []);
+  useInputTrigger(openPicker);
+  return (
+    <DatePicker.Root
+      mode='single'
+      withTime={withTime}
+      value={pickerValue}
+      onValueChange={onPickerChange}
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <Popover.Anchor asChild>{children}</Popover.Anchor>
+      <DatePicker.Content>{calendar}</DatePicker.Content>
+    </DatePicker.Root>
+  );
+};
+
+//
+// SegmentedDate.
+//
+
+type SegmentedDateProps = SegmentedInputBaseProps;
+
+const SegmentedDate = forwardRef<HTMLDivElement, InputScopedProps<SegmentedDateProps>>(
+  (
+    {
+      __inputScope,
+      classNames,
+      density: densityProp,
+      elevation: elevationProp,
+      variant,
+      value,
+      defaultValue,
+      onValueChange,
+      disabled,
+      autoFocus,
+      id,
+      'aria-label': ariaLabel,
+    },
+    forwardedRef,
+  ) => {
+    const { tx, density, elevation, validationValence } = useFieldChrome({
+      __inputScope,
+      density: densityProp,
+      elevation: elevationProp,
+    });
+
+    const [stringValue, setStringValue] = useControllableState<string>({
+      prop: value,
+      defaultProp: defaultValue ?? '',
+      onChange: onValueChange,
+    });
+
+    const parsed = tryParse(parseDate, stringValue);
+
+    const fieldProps: DateFieldProps<CalendarDate> = {
+      value: parsed,
+      onChange: (next) => setStringValue(next ? formatCalendarDate(next) : ''),
+      isDisabled: disabled,
+      autoFocus,
+      'aria-label': ariaLabel ?? 'date',
+      granularity: 'day',
+    };
+
+    const field = (
+      <DateField {...fieldProps}>
+        <DateInput
+          ref={forwardedRef}
+          {...(id ? { id } : {})}
+          data-density={density}
+          className={tx(
+            'input.input',
+            { variant, disabled, density, elevation, validationValence },
+            fieldClass,
+            classNames,
+          )}
+        >
+          {(segment) => <DateSegment segment={segment} className={segmentClass} />}
+        </DateInput>
+      </DateField>
+    );
+
+    return (
+      <PickerWrapper
+        pickerValue={parsed ? new Date(parsed.year, parsed.month - 1, parsed.day) : undefined}
+        onPickerChange={(next) => setStringValue(next ? formatCalendarDate(toCalendarDate(next)) : '')}
+        withTime={false}
+        calendar={<DatePicker.Calendar />}
+      >
+        {field}
+      </PickerWrapper>
+    );
+  },
+);
+SegmentedDate.displayName = 'Input.SegmentedDate';
+
+//
+// SegmentedTime — no picker (no time-only picker primitive available); does not register a trigger.
+//
+
+type SegmentedTimeProps = SegmentedInputBaseProps;
+
+const SegmentedTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedTimeProps>>(
+  (
+    {
+      __inputScope,
+      classNames,
+      density: densityProp,
+      elevation: elevationProp,
+      variant,
+      value,
+      defaultValue,
+      onValueChange,
+      disabled,
+      autoFocus,
+      id,
+      'aria-label': ariaLabel,
+    },
+    forwardedRef,
+  ) => {
+    const { tx, density, elevation, validationValence } = useFieldChrome({
+      __inputScope,
+      density: densityProp,
+      elevation: elevationProp,
+    });
+
+    const [stringValue, setStringValue] = useControllableState<string>({
+      prop: value,
+      defaultProp: defaultValue ?? '',
+      onChange: onValueChange,
+    });
+
+    const parsed = tryParse(parseTime, stringValue);
+
+    const fieldProps: TimeFieldProps<Time> = {
+      value: parsed,
+      onChange: (next) => setStringValue(next ? formatTime(next) : ''),
+      isDisabled: disabled,
+      autoFocus,
+      'aria-label': ariaLabel ?? 'time',
+      granularity: 'minute',
+      hourCycle: 24,
+    };
+
+    return (
+      <TimeField {...fieldProps}>
+        <DateInput
+          ref={forwardedRef}
+          {...(id ? { id } : {})}
+          data-density={density}
+          className={tx(
+            'input.input',
+            { variant, disabled, density, elevation, validationValence },
+            fieldClass,
+            classNames,
+          )}
+        >
+          {(segment) => <DateSegment segment={segment} className={segmentClass} />}
+        </DateInput>
+      </TimeField>
+    );
+  },
+);
+SegmentedTime.displayName = 'Input.SegmentedTime';
+
+//
+// SegmentedDateTime.
+//
+
+type SegmentedDateTimeProps = SegmentedInputBaseProps;
+
+const SegmentedDateTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedDateTimeProps>>(
+  (
+    {
+      __inputScope,
+      classNames,
+      density: densityProp,
+      elevation: elevationProp,
+      variant,
+      value,
+      defaultValue,
+      onValueChange,
+      disabled,
+      autoFocus,
+      id,
+      'aria-label': ariaLabel,
+    },
+    forwardedRef,
+  ) => {
+    const { tx, density, elevation, validationValence } = useFieldChrome({
+      __inputScope,
+      density: densityProp,
+      elevation: elevationProp,
+    });
+
+    const [stringValue, setStringValue] = useControllableState<string>({
+      prop: value,
+      defaultProp: defaultValue ?? '',
+      onChange: onValueChange,
+    });
+
+    const parsed = tryParse(parseDateTime, stringValue);
+
+    const fieldProps: DateFieldProps<CalendarDateTime> = {
+      value: parsed,
+      onChange: (next) => setStringValue(next ? formatCalendarDateTime(next) : ''),
+      isDisabled: disabled,
+      autoFocus,
+      'aria-label': ariaLabel ?? 'date-time',
+      granularity: 'minute',
+      hourCycle: 24,
+    };
+
+    const field = (
+      <DateField {...fieldProps}>
+        <DateInput
+          ref={forwardedRef}
+          {...(id ? { id } : {})}
+          data-density={density}
+          className={tx(
+            'input.input',
+            { variant, disabled, density, elevation, validationValence },
+            fieldClass,
+            classNames,
+          )}
+        >
+          {(segment) => <DateSegment segment={segment} className={segmentClass} />}
+        </DateInput>
+      </DateField>
+    );
+
+    return (
+      <PickerWrapper
+        pickerValue={
+          parsed ? new Date(parsed.year, parsed.month - 1, parsed.day, parsed.hour, parsed.minute) : undefined
+        }
+        onPickerChange={(next) =>
+          setStringValue(
+            next
+              ? formatCalendarDateTime(
+                  new CalendarDateTime(
+                    next.getFullYear(),
+                    next.getMonth() + 1,
+                    next.getDate(),
+                    next.getHours(),
+                    next.getMinutes(),
+                  ),
+                )
+              : '',
+          )
+        }
+        withTime
+        calendar={<DatePicker.Calendar />}
+      >
+        {field}
+      </PickerWrapper>
+    );
+  },
+);
+SegmentedDateTime.displayName = 'Input.SegmentedDateTime';
+
+export { SegmentedDate, SegmentedTime, SegmentedDateTime };
+export type { SegmentedDateProps, SegmentedTimeProps, SegmentedDateTimeProps };

--- a/packages/ui/react-ui/src/components/Input/SegmentedInput.tsx
+++ b/packages/ui/react-ui/src/components/Input/SegmentedInput.tsx
@@ -10,7 +10,6 @@ import {
   type DateFieldProps,
   DateInput,
   DateSegment,
-  I18nProvider,
   TimeField,
   type TimeFieldProps,
 } from 'react-aria-components';
@@ -258,17 +257,15 @@ const SegmentedDate = forwardRef<HTMLDivElement, InputScopedProps<SegmentedDateP
     );
 
     return (
-      <I18nProvider locale='en-US'>
-        <PickerWrapper
-          pickerValue={parsed ? new Date(parsed.year, parsed.month - 1, parsed.day) : undefined}
-          onPickerChange={(next) => setStringValue(next ? formatCalendarDate(toCalendarDate(next)) : '')}
-          withTime={false}
-          disabled={disabled}
-          calendar={<DatePicker.Calendar />}
-        >
-          {field}
-        </PickerWrapper>
-      </I18nProvider>
+      <PickerWrapper
+        pickerValue={parsed ? new Date(parsed.year, parsed.month - 1, parsed.day) : undefined}
+        onPickerChange={(next) => setStringValue(next ? formatCalendarDate(toCalendarDate(next)) : '')}
+        withTime={false}
+        disabled={disabled}
+        calendar={<DatePicker.Calendar />}
+      >
+        {field}
+      </PickerWrapper>
     );
   },
 );
@@ -325,23 +322,25 @@ const SegmentedTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedTimeP
     };
 
     return (
-      <I18nProvider locale='en-US'>
-        <TimeField {...fieldProps}>
-          <DateInput
-            ref={forwardedRef}
-            {...(id ? { id } : {})}
-            data-density={density}
-            className={tx(
-              'input.input',
-              { variant, disabled, density, elevation, validationValence },
-              fieldClass,
-              classNames,
-            )}
-          >
-            {renderSegment}
-          </DateInput>
-        </TimeField>
-      </I18nProvider>
+      <TimeField {...fieldProps}>
+        <DateInput
+          ref={forwardedRef}
+          {...((id ?? contextId) ? { id: id ?? contextId } : {})}
+          {...(descriptionId ? { 'aria-describedby': descriptionId } : {})}
+          {...(validationValence === 'error' && errorMessageId
+            ? { 'aria-invalid': true, 'aria-errormessage': errorMessageId }
+            : {})}
+          data-density={density}
+          className={tx(
+            'input.input',
+            { variant, disabled, density, elevation, validationValence },
+            fieldClass,
+            classNames,
+          )}
+        >
+          {renderSegment}
+        </DateInput>
+      </TimeField>
     );
   },
 );
@@ -420,33 +419,31 @@ const SegmentedDateTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedD
     );
 
     return (
-      <I18nProvider locale='en-US'>
-        <PickerWrapper
-          pickerValue={
-            parsed ? new Date(parsed.year, parsed.month - 1, parsed.day, parsed.hour, parsed.minute) : undefined
-          }
-          onPickerChange={(next) =>
-            setStringValue(
-              next
-                ? formatCalendarDateTime(
-                    new CalendarDateTime(
-                      next.getFullYear(),
-                      next.getMonth() + 1,
-                      next.getDate(),
-                      next.getHours(),
-                      next.getMinutes(),
-                    ),
-                  )
-                : '',
-            )
-          }
-          withTime
-          disabled={disabled}
-          calendar={<DatePicker.Calendar />}
-        >
-          {field}
-        </PickerWrapper>
-      </I18nProvider>
+      <PickerWrapper
+        pickerValue={
+          parsed ? new Date(parsed.year, parsed.month - 1, parsed.day, parsed.hour, parsed.minute) : undefined
+        }
+        onPickerChange={(next) =>
+          setStringValue(
+            next
+              ? formatCalendarDateTime(
+                  new CalendarDateTime(
+                    next.getFullYear(),
+                    next.getMonth() + 1,
+                    next.getDate(),
+                    next.getHours(),
+                    next.getMinutes(),
+                  ),
+                )
+              : '',
+          )
+        }
+        withTime
+        disabled={disabled}
+        calendar={<DatePicker.Calendar />}
+      >
+        {field}
+      </PickerWrapper>
     );
   },
 );

--- a/packages/ui/react-ui/src/components/Input/SegmentedInput.tsx
+++ b/packages/ui/react-ui/src/components/Input/SegmentedInput.tsx
@@ -10,6 +10,7 @@ import {
   type DateFieldProps,
   DateInput,
   DateSegment,
+  I18nProvider,
   TimeField,
   type TimeFieldProps,
 } from 'react-aria-components';
@@ -247,14 +248,16 @@ const SegmentedDate = forwardRef<HTMLDivElement, InputScopedProps<SegmentedDateP
     );
 
     return (
-      <PickerWrapper
-        pickerValue={parsed ? new Date(parsed.year, parsed.month - 1, parsed.day) : undefined}
-        onPickerChange={(next) => setStringValue(next ? formatCalendarDate(toCalendarDate(next)) : '')}
-        withTime={false}
-        calendar={<DatePicker.Calendar />}
-      >
-        {field}
-      </PickerWrapper>
+      <I18nProvider locale='en-US'>
+        <PickerWrapper
+          pickerValue={parsed ? new Date(parsed.year, parsed.month - 1, parsed.day) : undefined}
+          onPickerChange={(next) => setStringValue(next ? formatCalendarDate(toCalendarDate(next)) : '')}
+          withTime={false}
+          calendar={<DatePicker.Calendar />}
+        >
+          {field}
+        </PickerWrapper>
+      </I18nProvider>
     );
   },
 );
@@ -311,21 +314,23 @@ const SegmentedTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedTimeP
     };
 
     return (
-      <TimeField {...fieldProps}>
-        <DateInput
-          ref={forwardedRef}
-          {...(id ? { id } : {})}
-          data-density={density}
-          className={tx(
-            'input.input',
-            { variant, disabled, density, elevation, validationValence },
-            fieldClass,
-            classNames,
-          )}
-        >
-          {renderSegment}
-        </DateInput>
-      </TimeField>
+      <I18nProvider locale='en-US'>
+        <TimeField {...fieldProps}>
+          <DateInput
+            ref={forwardedRef}
+            {...(id ? { id } : {})}
+            data-density={density}
+            className={tx(
+              'input.input',
+              { variant, disabled, density, elevation, validationValence },
+              fieldClass,
+              classNames,
+            )}
+          >
+            {renderSegment}
+          </DateInput>
+        </TimeField>
+      </I18nProvider>
     );
   },
 );
@@ -400,30 +405,32 @@ const SegmentedDateTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedD
     );
 
     return (
-      <PickerWrapper
-        pickerValue={
-          parsed ? new Date(parsed.year, parsed.month - 1, parsed.day, parsed.hour, parsed.minute) : undefined
-        }
-        onPickerChange={(next) =>
-          setStringValue(
-            next
-              ? formatCalendarDateTime(
-                  new CalendarDateTime(
-                    next.getFullYear(),
-                    next.getMonth() + 1,
-                    next.getDate(),
-                    next.getHours(),
-                    next.getMinutes(),
-                  ),
-                )
-              : '',
-          )
-        }
-        withTime
-        calendar={<DatePicker.Calendar />}
-      >
-        {field}
-      </PickerWrapper>
+      <I18nProvider locale='en-US'>
+        <PickerWrapper
+          pickerValue={
+            parsed ? new Date(parsed.year, parsed.month - 1, parsed.day, parsed.hour, parsed.minute) : undefined
+          }
+          onPickerChange={(next) =>
+            setStringValue(
+              next
+                ? formatCalendarDateTime(
+                    new CalendarDateTime(
+                      next.getFullYear(),
+                      next.getMonth() + 1,
+                      next.getDate(),
+                      next.getHours(),
+                      next.getMinutes(),
+                    ),
+                  )
+                : '',
+            )
+          }
+          withTime
+          calendar={<DatePicker.Calendar />}
+        >
+          {field}
+        </PickerWrapper>
+      </I18nProvider>
     );
   },
 );

--- a/packages/ui/react-ui/src/components/Input/index.ts
+++ b/packages/ui/react-ui/src/components/Input/index.ts
@@ -3,4 +3,5 @@
 //
 
 export * from './Input';
+export * from './SegmentedInput';
 export * from './constants';

--- a/packages/ui/react-ui/src/components/List/List.theme.ts
+++ b/packages/ui/react-ui/src/components/List/List.theme.ts
@@ -17,7 +17,7 @@ const item: ComponentFunction<ListStyleProps> = ({ collapsible }, ...etc) => mx(
 
 const itemEndcap: ComponentFunction<ListStyleProps> = ({ density }, ...etc) =>
   mx(
-    density === 'lg' ? getSize(10) : density === 'sm' ? getSize(7) : getSize(8),
+    density === 'lg' ? getSize(10) : density === 'sm' ? getSize(7) : density === 'xs' ? getSize(6) : getSize(8),
     'shrink-0 flex items-center justify-center',
     ...etc,
   );

--- a/packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts
+++ b/packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts
@@ -19,6 +19,7 @@ const root: ComponentFunction<ToolbarStyleProps> = ({ density, disabled, layoutM
     'bg-toolbar-surface dx-toolbar',
     density === 'lg' && 'h-(--dx-rail-size) px-3!',
     density === 'sm' && 'h-7 px-2!',
+    density === 'xs' && 'h-6 px-1.5!',
     disabled && '*:opacity-20',
     !layoutManaged && layout,
     ...etc,

--- a/packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts
+++ b/packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts
@@ -19,7 +19,7 @@ const root: ComponentFunction<ToolbarStyleProps> = ({ density, disabled, layoutM
     'bg-toolbar-surface dx-toolbar',
     density === 'lg' && 'h-(--dx-rail-size) px-3!',
     density === 'sm' && 'h-7 px-2!',
-    density === 'xs' && 'h-6 px-1.5!',
+    density === 'xs' && 'h-6 px-1!',
     disabled && '*:opacity-20',
     !layoutManaged && layout,
     ...etc,

--- a/packages/ui/react-ui/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/react-ui/src/components/Toolbar/Toolbar.tsx
@@ -298,21 +298,6 @@ const ToolbarActionIconButton = forwardRef<HTMLButtonElement, ToolbarActionIconB
 ToolbarActionIconButton.displayName = 'Toolbar.ActionIconButton';
 
 //
-// CloseIconButton
-//
-
-type ToolbarCloseIconButtonProps = { onClick?: MouseEventHandler<HTMLButtonElement>; label?: string };
-
-/** @deprecated Use `Toolbar.ActionIconButton action='close'`. */
-const ToolbarCloseIconButton = forwardRef<HTMLButtonElement, ToolbarCloseIconButtonProps>(
-  ({ onClick, label }, forwardedRef) => (
-    <ToolbarActionIconButton action='close' onClick={onClick} label={label} ref={forwardedRef} />
-  ),
-);
-
-ToolbarCloseIconButton.displayName = 'Toolbar.CloseIconButton';
-
-//
 // Menu
 //
 
@@ -377,8 +362,6 @@ export const Toolbar = {
   Separator: ToolbarSeparator,
   DragHandle: ToolbarDragHandle,
   ActionIconButton: ToolbarActionIconButton,
-  /** @deprecated Use `Toolbar.ActionIconButton action='close'`. */
-  CloseIconButton: ToolbarCloseIconButton,
   Menu: ToolbarMenu,
 };
 
@@ -396,7 +379,6 @@ export type {
   ToolbarDragHandleProps,
   ToolbarActionIconButtonAction,
   ToolbarActionIconButtonProps,
-  ToolbarCloseIconButtonProps,
   ToolbarMenuItem,
   ToolbarMenuProps,
 };

--- a/packages/ui/react-ui/src/testing/decorators/withTheme.tsx
+++ b/packages/ui/react-ui/src/testing/decorators/withTheme.tsx
@@ -25,7 +25,7 @@ export const withTheme =
     return (
       <ThemeProvider
         tx={tx}
-        themeMode={theme as ThemeMode}
+        themeMode={(theme as ThemeMode) || 'dark'}
         resourceExtensions={translations}
         noCache={noCache}
         platform={platform}

--- a/packages/ui/react-ui/src/testing/decorators/withTheme.tsx
+++ b/packages/ui/react-ui/src/testing/decorators/withTheme.tsx
@@ -4,6 +4,7 @@
 
 import { type Decorator } from '@storybook/react';
 import React from 'react';
+import { I18nProvider } from 'react-aria-components';
 
 import { type ThemeMode } from '@dxos/ui-types';
 
@@ -13,6 +14,10 @@ import { defaultTx } from '../../theme';
 
 /**
  * Adds theme decorator.
+ *
+ * `I18nProvider` is included so react-aria-components-backed widgets (DateField, Calendar, …)
+ * have a guaranteed locale in headless test environments where `navigator.language` may be
+ * empty.
  */
 export const withTheme =
   ({ tx = defaultTx, noCache, platform }: Partial<ThemeContextValue> = {}): Decorator =>
@@ -23,16 +28,18 @@ export const withTheme =
     } = context;
 
     return (
-      <ThemeProvider
-        tx={tx}
-        themeMode={(theme as ThemeMode) || 'dark'}
-        resourceExtensions={translations}
-        noCache={noCache}
-        platform={platform}
-      >
-        <Tooltip.Provider>
-          <Story />
-        </Tooltip.Provider>
-      </ThemeProvider>
+      <I18nProvider locale='en-US'>
+        <ThemeProvider
+          tx={tx}
+          themeMode={(theme as ThemeMode) || 'dark'}
+          resourceExtensions={translations}
+          noCache={noCache}
+          platform={platform}
+        >
+          <Tooltip.Provider>
+            <Story />
+          </Tooltip.Provider>
+        </ThemeProvider>
+      </I18nProvider>
     );
   };

--- a/packages/ui/ui-theme/src/css/components/button.css
+++ b/packages/ui/ui-theme/src/css/components/button.css
@@ -83,6 +83,12 @@
   .dx-button[data-density='sm'] {
     @apply min-h-[1.75rem] px-2;
   }
+  .dx-button[data-density='xs'] {
+    @apply min-h-[1.5rem] px-1.5 text-xs;
+  }
+  .dx-button[data-density='xs'].aspect-square {
+    @apply size-6 px-0;
+  }
   @media (pointer: fine) {
     .dx-button[data-density='md'] {
       @apply min-h-[2rem] px-2.5;

--- a/packages/ui/ui-theme/src/css/components/button.css
+++ b/packages/ui/ui-theme/src/css/components/button.css
@@ -84,7 +84,7 @@
     @apply min-h-[1.75rem] px-2;
   }
   .dx-button[data-density='xs'] {
-    @apply min-h-[1.5rem] px-1.5 text-xs;
+    @apply min-h-[1.5rem] px-1 text-xs;
   }
   .dx-button[data-density='xs'].aspect-square {
     @apply size-6 px-0;

--- a/packages/ui/ui-theme/src/css/theme/spacing.css
+++ b/packages/ui/ui-theme/src/css/theme/spacing.css
@@ -59,6 +59,15 @@
     --spacing-icon-button-padding: var(--spacing-trim-xs);
     --spacing-scroll-padding: 2px;
   }
+
+  /**
+   * Density: xs — ultra-compact (~24px controls).
+   */
+  .dx-density-xs {
+    --spacing-form-padding: var(--spacing-trim-xs);
+    --spacing-icon-button-padding: var(--spacing-trim-xs);
+    --spacing-scroll-padding: 2px;
+  }
 }
 
 /**

--- a/packages/ui/ui-theme/src/fragments/density.ts
+++ b/packages/ui/ui-theme/src/fragments/density.ts
@@ -7,10 +7,12 @@ import { type Density } from '@dxos/ui-types';
 const lgBlockSize = 'min-h-[2.5rem]';
 const mdBlockSize = 'min-h-[2.5rem] pointer-fine:min-h-[2rem]';
 const smBlockSize = 'min-h-[1.75rem]';
+const xsBlockSize = 'min-h-[1.5rem]';
 
 const lgDimensions = `${lgBlockSize} px-3`;
 const mdDimensions = `${mdBlockSize} px-2`;
 const smDimensions = `${smBlockSize} px-1.5`;
+const xsDimensions = `${xsBlockSize} px-1`;
 
 export const densityDimensions = (density: Density = 'md') => {
   switch (density) {
@@ -18,6 +20,8 @@ export const densityDimensions = (density: Density = 'md') => {
       return lgDimensions;
     case 'sm':
       return smDimensions;
+    case 'xs':
+      return xsDimensions;
     case 'md':
     default:
       return mdDimensions;
@@ -30,6 +34,8 @@ export const densityBlockSize = (density: Density = 'md') => {
       return lgBlockSize;
     case 'sm':
       return smBlockSize;
+    case 'xs':
+      return xsBlockSize;
     case 'md':
     default:
       return mdBlockSize;

--- a/packages/ui/ui-types/src/density.ts
+++ b/packages/ui/ui-types/src/density.ts
@@ -10,5 +10,9 @@
  * - `md` — default. Standard ~32px controls.
  * - `sm` — compact ~28px controls. Use in data-dense surfaces (tables,
  *   side panels, inline forms).
+ * - `xs` — ultra-compact ~24px controls. Reserve for chrome that is not the
+ *   primary hit target (status bars, inline chips, pointer-fine grids).
+ *   Below the WCAG 2.5.5 (Level AAA) 24×24 minimum once padding is included;
+ *   avoid for touch surfaces.
  */
-export type Density = 'lg' | 'md' | 'sm';
+export type Density = 'lg' | 'md' | 'sm' | 'xs';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ catalogs:
     '@huggingface/transformers':
       specifier: ^3.8.1
       version: 3.8.1
+    '@internationalized/date':
+      specifier: ^3.12.1
+      version: 3.12.1
     '@ipld/car':
       specifier: ^5.3.3
       version: 5.4.1
@@ -1515,12 +1518,12 @@ catalogs:
     re-resizable:
       specifier: ^6.9.17
       version: 6.9.17
+    react-aria-components:
+      specifier: ^1.17.0
+      version: 1.17.0
     react-charts:
       specifier: beta
       version: 3.0.0-beta.57
-    react-day-picker:
-      specifier: ^9.4.0
-      version: 9.14.0
     react-drag-drop-files:
       specifier: ^2.3.8
       version: 2.3.8
@@ -2333,7 +2336,7 @@ importers:
         version: 6.1.1(typescript@6.0.3)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wait-on:
         specifier: 'catalog:'
         version: 8.0.3
@@ -3855,7 +3858,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/common/effect-zod:
     dependencies:
@@ -3874,7 +3877,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/common/errors: {}
 
@@ -4574,7 +4577,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/common/web-context-solid:
     dependencies:
@@ -4651,7 +4654,7 @@ importers:
         version: 0.29.0(effect@3.20.0)(vitest@4.1.7)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/core/compute/ai:
     dependencies:
@@ -5015,7 +5018,7 @@ importers:
         version: 3.20.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/core/compute/compute-hyperformula:
     dependencies:
@@ -5492,7 +5495,7 @@ importers:
         version: 0.33.2(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -5529,7 +5532,7 @@ importers:
         version: 3.20.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/core/echo/echo:
     dependencies:
@@ -5963,7 +5966,7 @@ importers:
         version: 1.8.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -6068,7 +6071,7 @@ importers:
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/core/echo/feed:
     dependencies:
@@ -7018,7 +7021,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/devtools/cli-util:
     dependencies:
@@ -7076,7 +7079,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/devtools/devtools:
     dependencies:
@@ -9271,7 +9274,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/plugins/plugin-crx:
     dependencies:
@@ -9326,7 +9329,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/plugins/plugin-debug:
     dependencies:
@@ -16496,7 +16499,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/reflect/introspect:
     dependencies:
@@ -16539,7 +16542,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/reflect/introspect-mcp:
     dependencies:
@@ -16560,7 +16563,7 @@ importers:
         version: link:../../common/util
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -16579,7 +16582,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/reflect/introspect-tools:
     dependencies:
@@ -16604,7 +16607,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/sdk/app-framework:
     dependencies:
@@ -18618,6 +18621,9 @@ importers:
       '@fluentui/react-tabster':
         specifier: 'catalog:'
         version: 9.26.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@internationalized/date':
+        specifier: 'catalog:'
+        version: 3.12.1
       '@radix-ui/primitive':
         specifier: 'catalog:'
         version: 1.1.1
@@ -18726,9 +18732,9 @@ importers:
       keyborg:
         specifier: 'catalog:'
         version: 2.6.0
-      react-day-picker:
+      react-aria-components:
         specifier: 'catalog:'
-        version: 9.14.0(react@19.2.6)
+        version: 1.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-error-boundary:
         specifier: 'catalog:'
         version: 4.0.13(react@19.2.6)
@@ -20443,7 +20449,7 @@ importers:
         version: link:../ui-theme
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -20790,7 +20796,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/ui/react-ui-menu:
     dependencies:
@@ -22471,7 +22477,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   tools/vite-plugin-log/example:
     devDependencies:
@@ -24137,9 +24143,6 @@ packages:
   '@dabh/diagnostics@2.0.3':
     resolution: {integrity: sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==}
 
-  '@date-fns/tz@1.5.0':
-    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
-
   '@dependents/detective-less@5.0.1':
     resolution: {integrity: sha512-Y6+WUMsTFWE5jb20IFP4YGa5IrGY/+a/FbOSjDF/wz9gepU2hwCYSXRHP/vPwBvwcY3SVMASt4yXxbXNXigmZQ==}
     engines: {node: '>=18'}
@@ -25092,8 +25095,17 @@ packages:
   '@internationalized/date@3.10.0':
     resolution: {integrity: sha512-oxDR/NTEJ1k+UFVQElaNIk65E/Z83HK1z1WI3lQyhTtnNg4R5oVXaPzK3jcpKG8UHKDVuDQHzn+wsxSz8RP3aw==}
 
+  '@internationalized/date@3.12.1':
+    resolution: {integrity: sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==}
+
   '@internationalized/number@3.6.5':
     resolution: {integrity: sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==}
+
+  '@internationalized/number@3.6.6':
+    resolution: {integrity: sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==}
+
+  '@internationalized/string@3.2.8':
+    resolution: {integrity: sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==}
 
   '@ioredis/commands@1.2.0':
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
@@ -25415,6 +25427,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -28346,6 +28359,11 @@ packages:
       react-native:
         optional: true
 
+  '@react-types/shared@3.34.0':
+    resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
+    peerDependencies:
+      react: ~19.2.3
+
   '@redis/bloom@1.2.0':
     resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
     peerDependencies:
@@ -29694,10 +29712,6 @@ packages:
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
-
-  '@tabby_ai/hijri-converter@1.0.5':
-    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
-    engines: {node: '>=16.0.0'}
 
   '@tailwindcss/forms@0.5.11':
     resolution: {integrity: sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA==}
@@ -32413,6 +32427,9 @@ packages:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
 
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
   clipboardy@3.0.0:
     resolution: {integrity: sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -33103,14 +33120,8 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  date-fns-jalali@4.1.0-0:
-    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
-
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
-
-  date-fns@4.3.0:
-    resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
 
   dayjs@1.11.10:
     resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
@@ -38195,6 +38206,18 @@ packages:
       react: ~19.2.3
       react-dom: ~19.2.3
 
+  react-aria-components@1.17.0:
+    resolution: {integrity: sha512-0EyisMgvsFJ2aML3crDYv2tW5vT2Ryf8PGzY/g63JjDdCbLshlwazhS8JNtPF1vkTkungJJ6sVJbKyX+YKSoFA==}
+    peerDependencies:
+      react: ~19.2.3
+      react-dom: ~19.2.3
+
+  react-aria@3.48.0:
+    resolution: {integrity: sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==}
+    peerDependencies:
+      react: ~19.2.3
+      react-dom: ~19.2.3
+
   react-base16-styling@0.9.1:
     resolution: {integrity: sha512-1s0CY1zRBOQ5M3T61wetEpvQmsYSNtWEcdYzyZNxKa8t7oDvaOn9d21xrGezGAHFWLM7SHcktPuPTrvoqxSfKw==}
 
@@ -38209,12 +38232,6 @@ packages:
     peerDependencies:
       react: ~19.2.3
       react-dom: ~19.2.3
-
-  react-day-picker@9.14.0:
-    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      react: ~19.2.3
 
   react-docgen-typescript@2.2.2:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
@@ -38392,6 +38409,11 @@ packages:
   react-router@6.30.3:
     resolution: {integrity: sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==}
     engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ~19.2.3
+
+  react-stately@3.46.0:
+    resolution: {integrity: sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==}
     peerDependencies:
       react: ~19.2.3
 
@@ -40941,6 +40963,7 @@ packages:
       '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
+      vite: '>=8.0.0'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -43543,7 +43566,7 @@ snapshots:
       cjs-module-lexer: 1.3.1
       esbuild: 0.28.0
       miniflare: 4.20260521.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wrangler: 4.68.1(@cloudflare/workers-types@4.20260303.0)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -43963,8 +43986,6 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@date-fns/tz@1.5.0': {}
-
   '@dependents/detective-less@5.0.1':
     dependencies:
       gonzales-pe: 4.3.0
@@ -44250,7 +44271,7 @@ snapshots:
   '@effect/vitest@0.29.0(effect@3.20.0)(vitest@4.1.7)':
     dependencies:
       effect: 3.20.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@effect/wa-sqlite@0.1.2': {}
 
@@ -44827,7 +44848,19 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.17
 
+  '@internationalized/date@3.12.1':
+    dependencies:
+      '@swc/helpers': 0.5.17
+
   '@internationalized/number@3.6.5':
+    dependencies:
+      '@swc/helpers': 0.5.17
+
+  '@internationalized/number@3.6.6':
+    dependencies:
+      '@swc/helpers': 0.5.17
+
+  '@internationalized/string@3.2.8':
     dependencies:
       '@swc/helpers': 0.5.17
 
@@ -45301,7 +45334,7 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.2)
       ajv: 8.18.0
@@ -48277,6 +48310,10 @@ snapshots:
       - '@types/react'
       - immer
 
+  '@react-types/shared@3.34.0(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+
   '@redis/bloom@1.2.0(@redis/client@1.5.7)':
     dependencies:
       '@redis/client': 1.5.7
@@ -49291,7 +49328,7 @@ snapshots:
       '@vitest/browser': 4.1.7(patch_hash=6c3dc337ee70b919eca34fd4b7144f3f075cb1e9285392c3ac13108c217939a5)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.7)
       '@vitest/browser-playwright': 4.1.7(playwright@1.57.0)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.7)
       '@vitest/runner': 4.1.7
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -49595,8 +49632,6 @@ snapshots:
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
-
-  '@tabby_ai/hijri-converter@1.0.5': {}
 
   '@tailwindcss/forms@0.5.11(tailwindcss@4.2.0)':
     dependencies:
@@ -50748,7 +50783,7 @@ snapshots:
       '@vitest/mocker': 4.1.7(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -50764,7 +50799,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -50784,7 +50819,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
       '@vitest/browser': 4.1.7(patch_hash=6c3dc337ee70b919eca34fd4b7144f3f075cb1e9285392c3ac13108c217939a5)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.7)
 
@@ -50848,7 +50883,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -51772,7 +51807,7 @@ snapshots:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@cloudflare/ai-chat': 0.0.6(agents@0.3.10)(ai@6.0.97(zod@4.3.6))(react@19.2.6)(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 6.0.97(zod@4.3.6)
       cron-schedule: 6.0.0
       escape-html: 1.0.3
@@ -52965,6 +53000,8 @@ snapshots:
       slice-ansi: 5.0.0
       string-width: 7.2.0
 
+  client-only@0.0.1: {}
+
   clipboardy@3.0.0:
     dependencies:
       arch: 2.2.0
@@ -53727,11 +53764,7 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  date-fns-jalali@4.1.0-0: {}
-
   date-fns@3.6.0: {}
-
-  date-fns@4.3.0: {}
 
   dayjs@1.11.10: {}
 
@@ -54159,10 +54192,6 @@ snapshots:
   draco3d@1.5.7: {}
 
   dset@3.1.4: {}
-
-  dts-resolver@2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
-    optionalDependencies:
-      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   dts-resolver@2.1.3(oxc-resolver@11.9.0):
     optionalDependencies:
@@ -60093,6 +60122,31 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
+  react-aria-components@1.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@swc/helpers': 0.5.17
+      client-only: 0.0.1
+      react: 19.2.6
+      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
+      react-stately: 3.46.0(react@19.2.6)
+
+  react-aria@3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@internationalized/string': 3.2.8
+      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@swc/helpers': 0.5.17
+      aria-hidden: 1.2.4
+      clsx: 2.1.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-stately: 3.46.0(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
+
   react-base16-styling@0.9.1:
     dependencies:
       '@babel/runtime': 7.27.1
@@ -60126,14 +60180,6 @@ snapshots:
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-
-  react-day-picker@9.14.0(react@19.2.6):
-    dependencies:
-      '@date-fns/tz': 1.5.0
-      '@tabby_ai/hijri-converter': 1.0.5
-      date-fns: 4.3.0
-      date-fns-jalali: 4.1.0-0
-      react: 19.2.6
 
   react-docgen-typescript@2.2.2(typescript@6.0.3):
     dependencies:
@@ -60346,6 +60392,16 @@ snapshots:
     dependencies:
       '@remix-run/router': 1.23.2
       react: 19.2.6
+
+  react-stately@3.46.0(react@19.2.6):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@internationalized/string': 3.2.8
+      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@swc/helpers': 0.5.17
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)
 
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.6):
     dependencies:
@@ -60922,24 +60978,6 @@ snapshots:
       sprintf-js: 1.1.3
 
   robust-predicates@3.0.1: {}
-
-  rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
-    dependencies:
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-      ast-kit: 2.2.0
-      birpc: 3.0.0
-      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
-      get-tsconfig: 4.13.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260421.2
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - oxc-resolver
 
   rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
     dependencies:
@@ -62616,34 +62654,6 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
-    dependencies:
-      ansis: 4.2.0
-      cac: 6.7.14
-      chokidar: 5.0.0
-      diff: 8.0.3
-      empathic: 2.0.0
-      hookable: 5.5.3
-      obug: 2.1.1
-      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      rolldown-plugin-dts: 0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
-      semver: 7.7.4
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tree-kill: 1.2.2
-      unconfig-core: 7.4.2
-      unrun: 0.2.19(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@ts-macro/tsc'
-      - '@typescript/native-preview'
-      - oxc-resolver
-      - synckit
-      - vue-tsc
-
   tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
@@ -63434,7 +63444,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -63465,18 +63475,7 @@ snapshots:
       happy-dom: 20.7.0
       jsdom: 29.1.1(canvas@3.2.0)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   void-elements@3.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -105,6 +105,7 @@ catalog:
   '@fontsource/poiret-one': ^5.0.20
   '@hazae41/symbol-dispose-polyfill': ^1.0.2
   '@huggingface/transformers': ^3.8.1
+  '@internationalized/date': ^3.12.1
   '@ipld/car': ^5.3.3
   '@jitl/quickjs-wasmfile-release-sync': ^0.31.0
   '@lezer/common': ^1.5.2
@@ -547,6 +548,7 @@ catalog:
   randombytes: ^2.1.0
   re-resizable: ^6.9.17
   react: ~19.2.3
+  react-aria-components: ^1.17.0
   react-charts: beta
   react-day-picker: ^9.4.0
   react-dom: ~19.2.3

--- a/vitest.base.config.ts
+++ b/vitest.base.config.ts
@@ -74,7 +74,10 @@ const createStorybookProject = (dirname: string) =>
       browser: {
         enabled: true,
         headless: true,
-        provider: playwright(),
+        // Pin the browser timezone so `Intl.DateTimeFormat().resolvedOptions().timeZone`
+        // does not resolve to `Etc/Unknown` in headless CI containers — react-aria's
+        // calendar feeds that value back into `Intl.DateTimeFormat`, which throws.
+        provider: playwright({ contextOptions: { timezoneId: 'America/Los_Angeles' } }),
         instances: [{ browser: 'chromium' }],
       },
       setupFiles: [new URL('./tools/storybook-react/.storybook/vitest.setup.ts', import.meta.url).pathname],


### PR DESCRIPTION
## Summary

- Adds a new `xs` density tier (24×24 controls) across `react-ui` components.
- Replaces the native `<input type='date'|'time'|'datetime-local'>` implementations of `Input.Date` / `Input.Time` / `Input.DateTime` with segmented fields backed by `react-aria-components` + `@internationalized/date`. The outer API stays as ISO strings, so call sites that read/write `YYYY-MM-DD` / `HH:mm` / `YYYY-MM-DDTHH:mm` keep working.
- Replaces the internals of `Calendar` and `DatePicker` (previously `react-day-picker`) with `react-aria-components`. Drops the `react-day-picker` dependency.
- Adds a compositional `Input.TriggerIcon` so that a sibling under `Input.Root` can open a field's picker (replaces the per-field `iconSide` prop).
- Removes the deprecated `Toolbar.CloseIconButton` (no consumers).
- Fixes `withTheme` storybook decorator passing empty-string `themeMode` on first render.

## New `xs` density

`Density = 'lg' | 'md' | 'sm' | 'xs'`. Component themes get explicit `xs` branches:

| | lg | md | sm | xs |
|---|---|---|---|---|
| Min-height | 40px | 32px | 28px | **24px** |
| Horizontal padding | px-3 | px-2 | px-1.5 | **px-1** |

CSS for `Input.input` and `.dx-button[data-density='xs']` are extended; `.dx-button[data-density='xs'].aspect-square` clamps `IconButton` to a true 24×24 square. `Input.SegmentedX` fields propagate `data-density` so the field surface picks up the tier.

WCAG 2.5.5 (Level AAA) recommends 24×24 minimum touch targets; the doc-comment on the `Density` type calls out that `xs` is for chrome/pointer-fine contexts, not primary hit targets.

## Segmented `Input.Date` / `Input.Time` / `Input.DateTime`

- Each segment is `role='spinbutton'` with `aria-valuenow` / `aria-valuetext`, full keyboard nav (arrows increment, type to overwrite, Backspace at start jumps back), and immutable literal separators.
- Locale-aware: en-US renders `MM/DD/YYYY`; switch via `<I18nProvider locale=…>` at the app root.
- Paste an ISO timestamp on any segment and all segments populate.
- Value model preserved: `value` / `defaultValue` are ISO strings; **`onChange(event)` is replaced with `onValueChange(value: string)`** (the only breaking change in this PR — `react-ui-form`'s `DateField` updated accordingly).
- `icon` and `time` props (which toggled the native browser picker indicator) are gone — replaced with the compositional pattern below.

## `Input.TriggerIcon` (compositional)

```tsx
<Input.Root>
  <Input.Label>Date</Input.Label>
  <div className='flex items-center gap-1'>
    <Input.Date defaultValue='2026-06-01' />
    <Input.TriggerIcon />
  </div>
</Input.Root>
```

`Input.Root` provides an internal context. A field calls `useInputTrigger(openHandler)` to register itself; `Input.TriggerIcon` renders nothing unless a field has registered, otherwise on press it fires the handler — currently used by `Input.Date` and `Input.DateTime` to open the popover-mounted DatePicker. The popover anchors to the field via `Popover.Anchor`.

## `Calendar` / `DatePicker` swap to react-aria-components

- `Calendar.Root` now wraps RAC's `<Calendar>` and `<RangeCalendar>`; keeps the public `mode='single'|'range'` API and takes `Date` objects at the boundary. Multi-select dropped (no in-repo consumers).
- `DatePicker.Root/Trigger/Content/Calendar` keep the slot-style namespace and are rewired to use the new RAC-backed `<Calendar>` inside the existing Radix `Popover`.
- New `defaultMonth?: Date` prop on `Calendar.Root` (threaded into RAC's `defaultFocusedValue`) so the picker opens on the value's month, not the current month.
- Picker auto-dismisses on selection: `single` mode on any pick, `range` mode once both ends are set, `multiple` would stay open (mode removed).
- `react-day-picker` dependency removed; `date-fns` still in use for the format string on `DatePicker.Trigger`.

## Notes for reviewers

- **Breaking**: `Input.Date|Time|DateTime` use `onValueChange(string)` instead of `onChange(event)`; `placeholder` / `onBlur` props are no longer plumbed (no RAC equivalent — call out if you need them and we can expose `<Label>` / `<Description>` slots from RAC). `iconSide` removed in favor of `Input.TriggerIcon`.
- New deps: `react-aria-components`, `@internationalized/date` (~30kb gz combined, both Adobe-maintained, tree-shakeable).
- The translations key `date-picker.placeholder.multiple.label` is now unused; left in place pending a separate i18n cleanup.

## Test plan

- [ ] Build CI passes (`react-ui`, `react-ui-form`, downstream).
- [ ] Storybook: `Input` → `Date`, `Time`, `DateTime`, `DateWithPicker`, `DateTimeWithPicker` all render; segments are keyboard-navigable; TriggerIcon opens the picker on the value's month and dismisses on select.
- [ ] Storybook: `Calendar` → `Single`, `Range`, `WithMinDate`.
- [ ] Storybook: `DatePicker` → `Single`, `Range`, `SingleWithTime`, `RangeWithTime`.
- [ ] Storybook: `IconButton` densities — lg / md / sm / **xs** render at 40 / 32 / 28 / **24** px.
- [ ] Forms with `Format.Date|Time|DateTime` fields still round-trip through `react-ui-form/DateField`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ultra-compact "xs" density added across UI, themes, and spacing
  * Input trigger/icon and segmented date/time inputs with picker integration
  * New and expanded Storybook demos for densities, time formats, and pickers

* **Refactoring**
  * Calendar rebuilt on a new picker engine with simplified theming
  * Date/time handling refactored to segmented controls and shared trigger plumbing

* **Breaking Changes**
  * Removed Toolbar.CloseIconButton — use action-style close/delete
  * DatePicker no longer supports "multiple" selection mode

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->