### PR TITLE
feat(react-ui-graph): hover highlight for connected edges and nodes

### DIFF
--- a/packages/devtools/cli/bin/dx
+++ b/packages/devtools/cli/bin/dx
@@ -8,7 +8,13 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # NOTE: killall uses the actual executable name, not argv[0], so use pkill instead:
 # pkill -TERM dx
 #
-# `--conditions=source` makes bun prefer the `source` export condition on
-# workspace packages (e.g. @dxos/plugin-registry/cli) so we load directly
-# from TypeScript sources without requiring each dependency to be built first.
-exec -a dx bun run --conditions=source "$DIR/../src/bin.ts" "$@"
+# `--conditions=source` (opt-in via `DX_SOURCE=1`) makes bun prefer the `source`
+# export condition on workspace packages — useful when iterating on TS sources
+# without a build, but broken by third-party packages like `react-aria-components`
+# that advertise a `source` field pointing at a file they don't ship in their
+# npm tarball. Default to the standard resolution path (built dist).
+if [ "${DX_SOURCE:-}" = "1" ]; then
+  exec -a dx bun run --conditions=source "$DIR/../src/bin.ts" "$@"
+else
+  exec -a dx bun run "$DIR/../src/bin.ts" "$@"
+fi

--- a/packages/devtools/cli/src/commands/chat/chat.tsx
+++ b/packages/devtools/cli/src/commands/chat/chat.tsx
@@ -19,7 +19,7 @@ import { CommandConfig, Common, withTypes } from '@dxos/cli-util';
 import { ClientService } from '@dxos/client';
 import { Filter } from '@dxos/echo';
 import { log } from '@dxos/log';
-import { Assistant } from '@dxos/plugin-assistant';
+import { Assistant } from '@dxos/plugin-assistant/types';
 
 import { App, render } from '../../components';
 import { theme } from '../../theme';

--- a/packages/devtools/cli/src/commands/chat/components/Chat.tsx
+++ b/packages/devtools/cli/src/commands/chat/components/Chat.tsx
@@ -12,7 +12,7 @@ import { type Blueprint } from '@dxos/compute';
 import { type Database, Filter, Obj } from '@dxos/echo';
 import { useAtomValue } from '@dxos/effect-atom-solid';
 import { log } from '@dxos/log';
-import { Assistant } from '@dxos/plugin-assistant';
+import { Assistant } from '@dxos/plugin-assistant/types';
 import { isTruthy } from '@dxos/util';
 
 import { AppContext } from '../../../components';

--- a/packages/devtools/cli/src/util/blueprints.ts
+++ b/packages/devtools/cli/src/util/blueprints.ts
@@ -13,8 +13,13 @@ import { AssistantBlueprint } from '@dxos/plugin-assistant';
 import { Chess, ChessBlueprint } from '@dxos/plugin-chess';
 import { ChessOperationHandlerSet } from '@dxos/plugin-chess/plugin';
 import { Game } from '@dxos/plugin-game';
-import { Calendar, CalendarBlueprint, InboxBlueprint, InboxSendBlueprint, Mailbox } from '@dxos/plugin-inbox';
+// Narrow subpath imports so the CLI's `bun run --conditions=source` doesn't pull
+// `@dxos/plugin-inbox`'s React-component sources (which transitively import
+// `react-aria-components` — a package whose `source` export condition advertises
+// a TS file that isn't shipped in its dist, causing Bun resolution to fail).
+import { CalendarBlueprint, InboxBlueprint, InboxSendBlueprint } from '@dxos/plugin-inbox/blueprints';
 import { InboxOperationHandlerSet } from '@dxos/plugin-inbox/plugin';
+import { Calendar, Mailbox } from '@dxos/plugin-inbox/types';
 import { KanbanBlueprint } from '@dxos/plugin-kanban';
 import { KanbanOperationHandlerSet } from '@dxos/plugin-kanban/plugin';
 import { MapBlueprint } from '@dxos/plugin-map';

--- a/packages/devtools/cli/src/util/blueprints.ts
+++ b/packages/devtools/cli/src/util/blueprints.ts
@@ -9,30 +9,34 @@ import { Chat, WebSearchToolkit } from '@dxos/assistant-toolkit';
 import { DatabaseBlueprint, DatabaseHandlers } from '@dxos/assistant-toolkit';
 import { Blueprint, OperationHandlerSet } from '@dxos/compute';
 import { Feed, Tag, type Type } from '@dxos/echo';
-import { AssistantBlueprint } from '@dxos/plugin-assistant';
-import { Chess, ChessBlueprint } from '@dxos/plugin-chess';
+// Narrow subpath imports (`/blueprints` and `/types`) so the CLI's
+// `bun run --conditions=source` only walks plugin source files that are free of
+// React-component imports. The plugin root barrels re-export the whole tree
+// (including React components that transitively pull `react-aria-components` —
+// whose `source` export condition advertises a TS file that isn't shipped in
+// its dist, causing Bun resolution to fail).
+import { AssistantBlueprint } from '@dxos/plugin-assistant/blueprints';
+import { ChessBlueprint } from '@dxos/plugin-chess/blueprints';
 import { ChessOperationHandlerSet } from '@dxos/plugin-chess/plugin';
-import { Game } from '@dxos/plugin-game';
-// Narrow subpath imports so the CLI's `bun run --conditions=source` doesn't pull
-// `@dxos/plugin-inbox`'s React-component sources (which transitively import
-// `react-aria-components` — a package whose `source` export condition advertises
-// a TS file that isn't shipped in its dist, causing Bun resolution to fail).
+import { Chess } from '@dxos/plugin-chess/types';
+import { Game } from '@dxos/plugin-game/types';
 import { CalendarBlueprint, InboxBlueprint, InboxSendBlueprint } from '@dxos/plugin-inbox/blueprints';
 import { InboxOperationHandlerSet } from '@dxos/plugin-inbox/plugin';
 import { Calendar, Mailbox } from '@dxos/plugin-inbox/types';
-import { KanbanBlueprint } from '@dxos/plugin-kanban';
+import { KanbanBlueprint } from '@dxos/plugin-kanban/blueprints';
 import { KanbanOperationHandlerSet } from '@dxos/plugin-kanban/plugin';
-import { MapBlueprint } from '@dxos/plugin-map';
+import { MapBlueprint } from '@dxos/plugin-map/blueprints';
 import { MapOperationHandlerSet } from '@dxos/plugin-map/plugin';
-import { Markdown, MarkdownBlueprint } from '@dxos/plugin-markdown';
+import { MarkdownBlueprint } from '@dxos/plugin-markdown/blueprints';
 import { MarkdownOperationHandlerSet } from '@dxos/plugin-markdown/plugin';
-import { ScriptBlueprint } from '@dxos/plugin-script';
+import { Markdown } from '@dxos/plugin-markdown/types';
+import { ScriptBlueprint } from '@dxos/plugin-script/blueprints';
 import { ScriptOperationHandlerSet } from '@dxos/plugin-script/plugin';
-import { TableBlueprint } from '@dxos/plugin-table';
+import { TableBlueprint } from '@dxos/plugin-table/blueprints';
 import { TableOperationHandlerSet } from '@dxos/plugin-table/plugin';
-import { ThreadBlueprint } from '@dxos/plugin-thread';
+import { ThreadBlueprint } from '@dxos/plugin-thread/blueprints';
 import { ThreadOperationHandlerSet } from '@dxos/plugin-thread/plugin';
-import { TranscriptionBlueprint } from '@dxos/plugin-transcription';
+import { TranscriptionBlueprint } from '@dxos/plugin-transcription/blueprints';
 import { TranscriptionOperationHandlerSet } from '@dxos/plugin-transcription/plugin';
 import { DataTypes } from '@dxos/schema';
 import {

--- a/packages/plugins/plugin-assistant/package.json
+++ b/packages/plugins/plugin-assistant/package.json
@@ -82,6 +82,11 @@
       "types": "./dist/types/src/index.d.ts",
       "default": "./dist/lib/neutral/index.mjs"
     },
+    "./blueprints": {
+      "source": "./src/blueprints/index.ts",
+      "types": "./dist/types/src/blueprints/index.d.ts",
+      "default": "./dist/lib/neutral/blueprints/index.mjs"
+    },
     "./components": {
       "source": "./src/components/index.ts",
       "types": "./dist/types/src/components/index.d.ts",
@@ -106,6 +111,11 @@
       "source": "./src/translations.ts",
       "types": "./dist/types/src/translations.d.ts",
       "default": "./dist/lib/neutral/translations.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-assistant/src/containers/AgentArticle/AgentArticle.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/AgentArticle/AgentArticle.stories.tsx
@@ -30,9 +30,17 @@ import { AgentArticle } from './AgentArticle';
 random.seed(1);
 
 type DefaultStoryProps = {
-  spec?: TypeSpec[];
   inputs?: boolean;
 };
+
+// Hoisted out of `args` because Storybook's CSF arg traversal walks every value
+// and tries to mutate `.id` on each entry — which throws on ECHO `Type.Type`
+// entities (Type.makeObject returns an immutable proxy). Keeping the spec here
+// dodges the traversal entirely.
+const defaultSpec: TypeSpec[] = [
+  { type: Organization.Organization, count: 10 },
+  { type: Person.Person, count: 10 },
+];
 
 const DefaultStory = (_: DefaultStoryProps) => {
   const [space] = useSpaces();
@@ -49,7 +57,7 @@ const meta = {
   render: DefaultStory,
   decorators: [
     withTheme(),
-    withPluginManager<DefaultStoryProps>(({ args: { spec = [], inputs } }) => ({
+    withPluginManager<DefaultStoryProps>(({ args: { inputs } }) => ({
       plugins: [
         ...corePlugins(),
         ClientPlugin({
@@ -61,7 +69,7 @@ const meta = {
               yield* Effect.promise(() => space.waitUntilReady());
 
               const factory = createObjectFactory(space.db, random as any);
-              const artifacts = yield* Effect.promise(() => factory(spec));
+              const artifacts = yield* Effect.promise(() => factory(defaultSpec));
 
               const inputQueue = space.queues.create();
               if (inputs) {
@@ -110,10 +118,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     inputs: true,
-    spec: [
-      { type: Organization.Organization, count: 10 },
-      { type: Person.Person, count: 10 },
-    ],
   },
 };
 

--- a/packages/plugins/plugin-chess/package.json
+++ b/packages/plugins/plugin-chess/package.json
@@ -71,6 +71,11 @@
       "types": "./dist/types/src/index.d.ts",
       "default": "./dist/lib/neutral/index.mjs"
     },
+    "./blueprints": {
+      "source": "./src/blueprints/index.ts",
+      "types": "./dist/types/src/blueprints/index.d.ts",
+      "default": "./dist/lib/neutral/blueprints/index.mjs"
+    },
     "./plugin": {
       "source": "./src/plugin.ts",
       "types": "./dist/types/src/plugin.d.ts",
@@ -85,6 +90,11 @@
       "source": "./src/translations.ts",
       "types": "./dist/types/src/translations.d.ts",
       "default": "./dist/lib/neutral/translations.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-client/src/operations/recover-identity.ts
+++ b/packages/plugins/plugin-client/src/operations/recover-identity.ts
@@ -6,7 +6,7 @@ import * as Effect from 'effect/Effect';
 
 import { LayoutOperation } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
-import { type JoinPanelProps } from '@dxos/shell/react';
+import type { JoinPanelProps } from '@dxos/shell/react';
 
 import { JOIN_DIALOG } from '../constants';
 import { RecoverIdentity } from './definitions';

--- a/packages/plugins/plugin-deck/src/containers/DeckLayout/Popover.tsx
+++ b/packages/plugins/plugin-deck/src/containers/DeckLayout/Popover.tsx
@@ -118,6 +118,7 @@ export const PopoverContent = () => {
         side={state.popoverSide}
         sticky='always'
         hideWhenDetached
+        onOpenAutoFocus={(event) => event.preventDefault()}
         onInteractOutside={handleInteractOutside}
         onEscapeKeyDown={handleInteractOutside}
       >
@@ -132,6 +133,8 @@ export const PopoverContent = () => {
             <Menu.Root>
               <Card.Root border={false} classNames='dx-card-popover'>
                 <Card.Header>
+                  {/* Disabled drag handle keeps the toolbar slot layout consistent with regular cards. */}
+                  <Card.DragHandle />
                   <Card.IconBlock padding>{icon && <Card.Icon icon={icon} />}</Card.IconBlock>
                   <Card.Title>{title}</Card.Title>
                   {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
@@ -139,6 +142,7 @@ export const PopoverContent = () => {
                     <Menu.Trigger asChild disabled={!objectMenuItems.length}>
                       <Toolbar.IconButton
                         variant='ghost'
+                        density='sm'
                         icon='ph--dots-three-vertical--regular'
                         iconOnly
                         label='Actions'

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
@@ -59,7 +59,15 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
   }, []);
 
   const handleHover = useCallback((node: TreeNode | null, event?: MouseEvent) => {
-    if (!node || !event) {
+    // Pointer left the node/label: dispatch a close event so the preview popover
+    // dismisses (the dxn/label/trigger fields are placeholders ignored on `state: false`).
+    if (!node) {
+      document.defaultView?.dispatchEvent(
+        new DxAnchorActivate({ dxn: '', label: '', trigger: document.body, state: false }),
+      );
+      return;
+    }
+    if (!event) {
       return;
     }
     const obj = node.data;
@@ -105,7 +113,7 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
         </Panel.Toolbar>
       )}
       <Panel.Content>
-        <Visualization variant={selected} model={model} onNodeHover={handleHover} />
+        <Visualization classNames='bg-base-surface' variant={selected} model={model} onNodeHover={handleHover} />
       </Panel.Content>
     </Panel.Root>
   );

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
@@ -183,6 +183,7 @@ export const Visualization = ({ variant, model, onNodeHover }: VisualizationProp
               projector={projector}
               renderNode={renderNode}
               drag={variant === 'force'}
+              highlightOnHover={variant === 'bundle'}
               onInspect={handleInspect}
               onSelect={handleSelect}
             />

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
@@ -6,7 +6,7 @@ import { RegistryContext } from '@effect-atom/atom-react';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Obj } from '@dxos/echo';
-import { useThemeContext } from '@dxos/react-ui';
+import { type ThemedClassName, useThemeContext } from '@dxos/react-ui';
 import {
   CLUSTER_NODE_TYPE_GROUP,
   CLUSTER_NODE_TYPE_LEAF,
@@ -24,17 +24,18 @@ import {
 } from '@dxos/react-ui-graph';
 import { Flock, type FlockBoid, FlockModel, Vec2 } from '@dxos/react-ui-sfx';
 import { type SpaceGraphEdge, type SpaceGraphModel, type SpaceGraphNode } from '@dxos/schema';
+import { mx } from '@dxos/ui-theme';
 
 import { type TreeNode } from '#components';
 
 import { getNodeFillForObject } from '../../util';
 import { type ExplorerArticleVariant } from './variants';
 
-export type VisualizationProps = {
+export type VisualizationProps = ThemedClassName<{
   variant: ExplorerArticleVariant;
   model: SpaceGraphModel;
   onNodeHover?: (node: TreeNode | null, event?: MouseEvent) => void;
-};
+}>;
 
 /**
  * Renders the active visualization variant.
@@ -49,15 +50,26 @@ export type VisualizationProps = {
  * (matched by node id). On exit, the boids' current positions are written back to
  * `lastLayoutRef` so the next SVG projector starts from where the swarm left off.
  */
-export const Visualization = ({ variant, model, onNodeHover }: VisualizationProps) => {
+export const Visualization = ({ classNames, variant, model, onNodeHover }: VisualizationProps) => {
   const registry = useContext(RegistryContext);
   const { themeMode } = useThemeContext();
-  // Match the visible app background so the swarm canvas reads as continuous
-  // with the rest of the UI. Page bg comes from --color-baseSurface tokens
-  // (dark = neutral-950 ≈ #0a0a0a, light = neutral-50 ≈ #fafafa).
-  const flockBackground = themeMode === 'dark' ? '#0a0a0a' : '#fafafa';
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [size, setSize] = useState({ width: 0, height: 0 });
+  // Read the container's effective background so the swarm canvas matches whatever
+  // surface the visualization sits on (bg-base-surface by default, but the consumer
+  // can override via `classNames`). Recomputed on theme toggle. Defaults to the
+  // baseSurface token values used to be hardcoded here, in case the container is
+  // unmounted when the swarm enters.
+  const [flockBackground, setFlockBackground] = useState<string>(themeMode === 'dark' ? '#0a0a0a' : '#fafafa');
+  useEffect(() => {
+    if (containerRef.current) {
+      const bg = getComputedStyle(containerRef.current).backgroundColor;
+      // Skip transparent fallback — Flock needs an opaque color for the trail-fade.
+      if (bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent') {
+        setFlockBackground(bg);
+      }
+    }
+  }, [themeMode, classNames]);
 
   const svgRef = useRef<SVGContext>(null);
   const [projector, setProjector] = useState<GraphProjector<SpaceGraphNode> | undefined>();
@@ -172,9 +184,9 @@ export const Visualization = ({ variant, model, onNodeHover }: VisualizationProp
   );
 
   return (
-    <div ref={containerRef} className='dx-expander relative'>
+    <div ref={containerRef} className={mx('dx-expander relative', classNames)}>
       {variant === 'swarm' ? (
-        <Flock model={flockModel} coloring='Movement' background={flockBackground} />
+        <Flock model={flockModel} coloring='Movement' background={flockBackground} trail={30} />
       ) : (
         <SVG.Root ref={svgRef}>
           <SVG.Zoom extent={[1 / 2, 2]}>
@@ -429,7 +441,7 @@ const appendRadialLeafLabel = (
     .attr('x', flipped ? -(r + 4) : r + 4)
     .attr('text-anchor', flipped ? 'end' : 'start')
     .attr('opacity', 0)
-    .style('pointer-events', 'none')
+    .style('cursor', 'pointer')
     .text(label)
     .transition()
     .delay(TWEEN_MS)

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/variants.ts
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/variants.ts
@@ -14,12 +14,12 @@ export const VARIANTS: { value: ExplorerArticleVariant; icon: string; label: str
   {
     value: 'cluster',
     icon: 'ph--asterisk-simple--regular',
-    label: 'Radial cluster',
+    label: 'Radial',
   },
   {
     value: 'bundle',
     icon: 'ph--circles-three-plus--regular',
-    label: 'Edge bundling',
+    label: 'Connections',
   },
   {
     value: 'lattice',

--- a/packages/plugins/plugin-game/package.json
+++ b/packages/plugins/plugin-game/package.json
@@ -72,6 +72,11 @@
       "source": "./src/translations.ts",
       "types": "./dist/types/src/translations.d.ts",
       "default": "./dist/lib/neutral/translations.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-inbox/package.json
+++ b/packages/plugins/plugin-inbox/package.json
@@ -81,6 +81,11 @@
       "types": "./dist/types/src/index.d.ts",
       "default": "./dist/lib/neutral/index.mjs"
     },
+    "./blueprints": {
+      "source": "./src/blueprints/index.ts",
+      "types": "./dist/types/src/blueprints/index.d.ts",
+      "default": "./dist/lib/neutral/blueprints/index.mjs"
+    },
     "./plugin": {
       "source": "./src/plugin.ts",
       "types": "./dist/types/src/plugin.d.ts",
@@ -95,6 +100,11 @@
       "source": "./src/translations.ts",
       "types": "./dist/types/src/translations.d.ts",
       "default": "./dist/lib/neutral/translations.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-kanban/package.json
+++ b/packages/plugins/plugin-kanban/package.json
@@ -77,6 +77,11 @@
       "types": "./dist/types/src/index.d.ts",
       "default": "./dist/lib/neutral/index.mjs"
     },
+    "./blueprints": {
+      "source": "./src/blueprints/index.ts",
+      "types": "./dist/types/src/blueprints/index.d.ts",
+      "default": "./dist/lib/neutral/blueprints/index.mjs"
+    },
     "./plugin": {
       "source": "./src/plugin.ts",
       "types": "./dist/types/src/plugin.d.ts",
@@ -86,6 +91,11 @@
       "source": "./src/translations.ts",
       "types": "./dist/types/src/translations.d.ts",
       "default": "./dist/lib/neutral/translations.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-map/package.json
+++ b/packages/plugins/plugin-map/package.json
@@ -76,6 +76,11 @@
       "types": "./dist/types/src/index.d.ts",
       "default": "./dist/lib/neutral/index.mjs"
     },
+    "./blueprints": {
+      "source": "./src/blueprints/index.ts",
+      "types": "./dist/types/src/blueprints/index.d.ts",
+      "default": "./dist/lib/neutral/blueprints/index.mjs"
+    },
     "./plugin": {
       "source": "./src/plugin.ts",
       "types": "./dist/types/src/plugin.d.ts",
@@ -90,6 +95,11 @@
       "source": "./src/translations.ts",
       "types": "./dist/types/src/translations.d.ts",
       "default": "./dist/lib/neutral/translations.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-markdown/package.json
+++ b/packages/plugins/plugin-markdown/package.json
@@ -85,6 +85,11 @@
       "types": "./dist/types/src/index.d.ts",
       "default": "./dist/lib/neutral/index.mjs"
     },
+    "./blueprints": {
+      "source": "./src/blueprints/index.ts",
+      "types": "./dist/types/src/blueprints/index.d.ts",
+      "default": "./dist/lib/neutral/blueprints/index.mjs"
+    },
     "./plugin": {
       "source": "./src/plugin.ts",
       "types": "./dist/types/src/plugin.d.ts",
@@ -99,6 +104,11 @@
       "source": "./src/translations.ts",
       "types": "./dist/types/src/translations.d.ts",
       "default": "./dist/lib/neutral/translations.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-preview/src/capabilities/preview-popover.ts
+++ b/packages/plugins/plugin-preview/src/capabilities/preview-popover.ts
@@ -45,8 +45,23 @@ export default Capability.makeModule(
       title: titleProp,
       side,
       props,
+      state,
     }: DxAnchorActivate) => {
       const { invokePromise } = capabilities.get(Capabilities.OperationInvoker);
+
+      // Explicit close: callers pass `state: false` on pointer-leave to dismiss
+      // the popover. Operation schema requires anchor + kind, so use placeholders;
+      // they're overwritten in ephemeral state but only `state` is read by the UI.
+      if (state === false) {
+        await invokePromise(LayoutOperation.UpdatePopover, {
+          variant: 'virtual',
+          anchor: trigger,
+          kind: 'base',
+          state: false,
+        });
+        return;
+      }
+
       const client = capabilities.get(ClientCapabilities.Client);
       const registry = capabilities.get(Capabilities.AtomRegistry);
       // Layout is optional: in standalone harnesses (Storybook, tests) no plugin contributes

--- a/packages/plugins/plugin-preview/src/capabilities/preview-popover.ts
+++ b/packages/plugins/plugin-preview/src/capabilities/preview-popover.ts
@@ -37,6 +37,10 @@ export default Capability.makeModule(
     const capabilities = yield* Capability.Service;
 
     // TODO(wittjosiah): Factor out lookup handlers to other plugins to make not ECHO-specific.
+    // Monotonic activation token: each invocation captures its own sequence; only the
+    // most recent activation is allowed to commit popover state. Prevents a slow
+    // open (async lookup) from clobbering a later close that fires while it's in flight.
+    let activationSequence = 0;
     const handleAnchorActivate = async ({
       dxn,
       label,
@@ -47,6 +51,7 @@ export default Capability.makeModule(
       props,
       state,
     }: DxAnchorActivate) => {
+      const sequence = ++activationSequence;
       const { invokePromise } = capabilities.get(Capabilities.OperationInvoker);
 
       // Explicit close: callers pass `state: false` on pointer-leave to dismiss
@@ -76,6 +81,11 @@ export default Capability.makeModule(
       }
       const result = await handlePreviewLookup(client, space, { dxn, label });
       if (!result) {
+        return;
+      }
+      // A newer activation (open or close) arrived while the lookup was in flight; bail
+      // out so we don't clobber the latest state.
+      if (sequence !== activationSequence) {
         return;
       }
 

--- a/packages/plugins/plugin-preview/src/stories/testing.tsx
+++ b/packages/plugins/plugin-preview/src/stories/testing.tsx
@@ -131,7 +131,7 @@ const TableLike = Schema.Struct({
     Schema.mutable,
     Annotation.FormInputAnnotation.set(false),
   ),
-}).pipe(Type.makeObject(DXN.make('org.dxos.test.table-like', '0.1.0')));
+}).pipe(Type.makeObject(DXN.make('org.dxos.test.tableLike', '0.1.0')));
 type TableLike = Type.InstanceType<typeof TableLike>;
 
 /**

--- a/packages/plugins/plugin-script/package.json
+++ b/packages/plugins/plugin-script/package.json
@@ -81,6 +81,11 @@
       "types": "./dist/types/src/index.d.ts",
       "default": "./dist/lib/neutral/index.mjs"
     },
+    "./blueprints": {
+      "source": "./src/blueprints/index.ts",
+      "types": "./dist/types/src/blueprints/index.d.ts",
+      "default": "./dist/lib/neutral/blueprints/index.mjs"
+    },
     "./containers": {
       "source": "./src/containers/index.ts",
       "types": "./dist/types/src/containers/index.d.ts",
@@ -100,6 +105,11 @@
       "source": "./src/translations.ts",
       "types": "./dist/types/src/translations.d.ts",
       "default": "./dist/lib/neutral/translations.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-simple-layout/src/components/Popover/Popover.tsx
+++ b/packages/plugins/plugin-simple-layout/src/components/Popover/Popover.tsx
@@ -97,6 +97,7 @@ export const PopoverContent = () => {
         sticky='always'
         hideWhenDetached
         collisionBoundary={collisionBoundaries}
+        onOpenAutoFocus={(event) => event.preventDefault()}
         onInteractOutside={handleInteractOutside}
         onEscapeKeyDown={handleInteractOutside}
       >
@@ -107,8 +108,8 @@ export const PopoverContent = () => {
           {state.popoverKind === 'card' && (
             <Card.Root border={false} classNames='dx-card-popover'>
               <Card.Header>
-                {/* TODO(wittjosiah): Cleaner way to handle no drag handle in toolbar? */}
-                <span />
+                {/* Disabled drag handle keeps the toolbar slot layout consistent with regular cards. */}
+                <Card.DragHandle />
                 {state.popoverTitle ? <Card.Title>{toLocalizedString(state.popoverTitle, t)}</Card.Title> : <span />}
                 <Card.ActionIconButton action='close' onClick={handleClose} />
               </Card.Header>

--- a/packages/plugins/plugin-table/package.json
+++ b/packages/plugins/plugin-table/package.json
@@ -66,6 +66,11 @@
       "types": "./dist/types/src/index.d.ts",
       "default": "./dist/lib/neutral/index.mjs"
     },
+    "./blueprints": {
+      "source": "./src/blueprints/index.ts",
+      "types": "./dist/types/src/blueprints/index.d.ts",
+      "default": "./dist/lib/neutral/blueprints/index.mjs"
+    },
     "./plugin": {
       "source": "./src/plugin.ts",
       "types": "./dist/types/src/plugin.d.ts",
@@ -80,6 +85,11 @@
       "source": "./src/translations.ts",
       "types": "./dist/types/src/translations.d.ts",
       "default": "./dist/lib/neutral/translations.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-testing/src/components/Layout/Layout.tsx
+++ b/packages/plugins/plugin-testing/src/components/Layout/Layout.tsx
@@ -180,6 +180,7 @@ export const Layout = ({ children }: PropsWithChildren<{}>) => {
             <Popover.Portal>
               <Popover.Content
                 side={layout.popoverSide}
+                onOpenAutoFocus={(event) => event.preventDefault()}
                 onInteractOutside={handleInteractOutside}
                 onEscapeKeyDown={handleInteractOutside}
                 sticky='always'
@@ -189,8 +190,8 @@ export const Layout = ({ children }: PropsWithChildren<{}>) => {
                   {layout.popoverKind === 'card' && (
                     <Card.Root>
                       <Card.Header>
-                        {/* TODO(wittjosiah): Cleaner way to handle no drag handle in toolbar? */}
-                        <span />
+                        {/* Disabled drag handle keeps the toolbar slot layout consistent with regular cards. */}
+                        <Card.DragHandle />
                         {layout.popoverTitle ? (
                           <Card.Title>{toLocalizedString(layout.popoverTitle, t)}</Card.Title>
                         ) : (

--- a/packages/plugins/plugin-thread/package.json
+++ b/packages/plugins/plugin-thread/package.json
@@ -81,6 +81,11 @@
       "types": "./dist/types/src/index.d.ts",
       "default": "./dist/lib/neutral/index.mjs"
     },
+    "./blueprints": {
+      "source": "./src/blueprints/index.ts",
+      "types": "./dist/types/src/blueprints/index.d.ts",
+      "default": "./dist/lib/neutral/blueprints/index.mjs"
+    },
     "./plugin": {
       "source": "./src/plugin.ts",
       "types": "./dist/types/src/plugin.d.ts",
@@ -90,6 +95,11 @@
       "source": "./src/translations.ts",
       "types": "./dist/types/src/translations.d.ts",
       "default": "./dist/lib/neutral/translations.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-transcription/package.json
+++ b/packages/plugins/plugin-transcription/package.json
@@ -76,6 +76,11 @@
       "types": "./dist/types/src/index.d.ts",
       "default": "./dist/lib/neutral/index.mjs"
     },
+    "./blueprints": {
+      "source": "./src/blueprints/index.ts",
+      "types": "./dist/types/src/blueprints/index.d.ts",
+      "default": "./dist/lib/neutral/blueprints/index.mjs"
+    },
     "./components": {
       "source": "./src/components/index.ts",
       "types": "./dist/types/src/components/index.d.ts",
@@ -95,6 +100,11 @@
       "source": "./src/translations.ts",
       "types": "./dist/types/src/translations.d.ts",
       "default": "./dist/lib/neutral/translations.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/ui/react-ui-graph/src/components/Graph/Graph.tsx
+++ b/packages/ui/react-ui-graph/src/components/Graph/Graph.tsx
@@ -27,7 +27,7 @@ export type GraphController = {
 };
 
 export type GraphProps<Node extends Graph$.Node.Any = any, Edge extends Graph$.Edge.Any = any> = ThemedClassName<
-  Pick<GraphRendererOptions<Node>, 'labels' | 'subgraphs' | 'attributes' | 'renderNode'> & {
+  Pick<GraphRendererOptions<Node>, 'labels' | 'subgraphs' | 'attributes' | 'renderNode' | 'highlightOnHover'> & {
     model?: GraphModel.ReactiveGraphModel<Node, Edge>;
     projector?: GraphProjector<Node>;
     renderer?: GraphRenderer<Node>;
@@ -95,6 +95,7 @@ const GraphInner = <Node extends Graph$.Node.Any = any, Edge extends Graph$.Edge
     props.subgraphs,
     props.attributes,
     props.renderNode,
+    props.highlightOnHover,
   ]);
 
   // External API.

--- a/packages/ui/react-ui-graph/src/graph/renderer/graph-renderer.ts
+++ b/packages/ui/react-ui-graph/src/graph/renderer/graph-renderer.ts
@@ -655,7 +655,7 @@ const applyHoverHighlight = (root: SVGGElement | null, focusedId: string | null)
         groupSel.style('opacity', null);
         shape.style('stroke', 'var(--color-orange-400)').style('stroke-width', '2.5px');
       } else {
-        groupSel.style('opacity', '0.15');
+        groupSel.style('opacity', '0.5');
         shape.style('stroke', null).style('stroke-width', null);
       }
     });

--- a/packages/ui/react-ui-graph/src/graph/renderer/graph-renderer.ts
+++ b/packages/ui/react-ui-graph/src/graph/renderer/graph-renderer.ts
@@ -633,7 +633,7 @@ const applyHoverHighlight = (root: SVGGElement | null, focusedId: string | null)
       } else if (edge.target.id === focusedId) {
         path.style('stroke', 'var(--color-sky-500)').style('stroke-width', '1.5px').style('opacity', null);
       } else {
-        path.style('stroke', null).style('stroke-width', null).style('opacity', '0.08');
+        path.style('stroke', null).style('stroke-width', null).style('opacity', '0.8');
       }
     });
 
@@ -655,7 +655,7 @@ const applyHoverHighlight = (root: SVGGElement | null, focusedId: string | null)
         groupSel.style('opacity', null);
         shape.style('stroke', 'var(--color-orange-400)').style('stroke-width', '2.5px');
       } else {
-        groupSel.style('opacity', '0.5');
+        groupSel.style('opacity', '0.4');
         shape.style('stroke', null).style('stroke-width', null);
       }
     });

--- a/packages/ui/react-ui-graph/src/graph/renderer/graph-renderer.ts
+++ b/packages/ui/react-ui-graph/src/graph/renderer/graph-renderer.ts
@@ -642,6 +642,12 @@ const applyHoverHighlight = (root: SVGGElement | null, focusedId: string | null)
     .each(function (node) {
       const groupSel = select(this);
       const shape = groupSel.select<SVGGraphicsElement>('circle, rect');
+      // Hidden nodes (e.g. cluster-collapsed leaves) are kept invisible via the
+      // group's `opacity` attribute — set by `updateNode`. style.opacity would
+      // override that attribute, so leave hidden nodes alone.
+      if (node.hidden) {
+        return;
+      }
       if (!on) {
         groupSel.style('opacity', null);
         shape.style('stroke', null).style('stroke-width', null);

--- a/packages/ui/react-ui-graph/src/graph/renderer/graph-renderer.ts
+++ b/packages/ui/react-ui-graph/src/graph/renderer/graph-renderer.ts
@@ -61,6 +61,13 @@ export type GraphRendererOptions<NodeData = any, EdgeData = any> = RendererOptio
    */
   renderNode?: RenderNode<NodeData>;
   transition?: () => any;
+  /**
+   * On node pointerenter, color outgoing edges orange, incoming edges sky-blue, dim
+   * unrelated edges, and stroke connected nodes / dim unrelated ones. Cleared on
+   * pointerleave. Designed for the bundle variant; harmless for variants where the
+   * topology doesn't carry meaningful direction.
+   */
+  highlightOnHover?: boolean;
   onNodeClick?: (node: GraphLayoutNode<NodeData>, event: MouseEvent) => void;
   onNodePointerEnter?: (node: GraphLayoutNode<NodeData>, event: MouseEvent) => void;
   /** Fires on pointerleave from a node hit-target. Pair with `onNodePointerEnter` to clear hover state. */
@@ -362,14 +369,20 @@ const createNode: D3Callable = <Data>(group: D3Selection, options: GraphRenderer
   }
 
   // Hover.
-  if (options.onNodePointerEnter || options.onNodePointerLeave) {
+  if (options.onNodePointerEnter || options.onNodePointerLeave || options.highlightOnHover) {
     hitTarget.on('pointerenter', function (event: PointerEvent) {
       const node = select<any, GraphLayoutNode<Data>>(useCustom ? this : this.parentElement).datum();
       options.onNodePointerEnter?.(node, event);
+      if (options.highlightOnHover) {
+        applyHoverHighlight((this as Element).closest('g.dx-graph') as SVGGElement | null, node.id);
+      }
     });
     hitTarget.on('pointerleave', function (event: PointerEvent) {
       const node = select<any, GraphLayoutNode<Data>>(useCustom ? this : this.parentElement).datum();
       options.onNodePointerLeave?.(node, event);
+      if (options.highlightOnHover) {
+        applyHoverHighlight((this as Element).closest('g.dx-graph') as SVGGElement | null, null);
+      }
     });
 
     group.attr('data-hover', 'handled');
@@ -576,6 +589,76 @@ const updateEdge: D3Callable = <NodeData = any, EdgeData = any>(
 
     return createLine(getCircumferencePoints([source.x, source.y], [target.x, target.y], source.r, target.r));
   });
+};
+
+/**
+ * Hover-driven directional highlight: when `focusedId` is set, paint outgoing edges
+ * orange, incoming edges sky-blue, dim unrelated edges, stroke connected nodes, and
+ * dim unrelated nodes. When `focusedId` is null, clear every inline override so the
+ * graph returns to its default styling.
+ */
+const applyHoverHighlight = (root: SVGGElement | null, focusedId: string | null) => {
+  if (!root) {
+    return;
+  }
+  const r = select(root);
+  const on = focusedId != null;
+
+  const outgoing = new Set<string>();
+  const incoming = new Set<string>();
+  if (on) {
+    r.select('g.dx-edges')
+      .selectAll<SVGGElement, GraphLayoutEdge>('g.dx-edge')
+      .each((edge) => {
+        if (edge.source.id === focusedId) {
+          outgoing.add(edge.target.id);
+        }
+        if (edge.target.id === focusedId) {
+          incoming.add(edge.source.id);
+        }
+      });
+  }
+
+  r.select('g.dx-edges')
+    .selectAll<SVGGElement, GraphLayoutEdge>('g.dx-edge')
+    .each(function (edge) {
+      // Visible edge path — exclude the wider transparent click target when present.
+      const path = select(this).select<SVGPathElement>('path:not(.dx-click)');
+      if (!on) {
+        path.style('stroke', null).style('stroke-width', null).style('opacity', null);
+        return;
+      }
+      if (edge.source.id === focusedId) {
+        path.style('stroke', 'var(--color-orange-500)').style('stroke-width', '1.5px').style('opacity', null);
+      } else if (edge.target.id === focusedId) {
+        path.style('stroke', 'var(--color-sky-500)').style('stroke-width', '1.5px').style('opacity', null);
+      } else {
+        path.style('stroke', null).style('stroke-width', null).style('opacity', '0.08');
+      }
+    });
+
+  r.select('g.dx-nodes')
+    .selectAll<SVGGElement, GraphLayoutNode>('g.dx-node')
+    .each(function (node) {
+      const groupSel = select(this);
+      const shape = groupSel.select<SVGGraphicsElement>('circle, rect');
+      if (!on) {
+        groupSel.style('opacity', null);
+        shape.style('stroke', null).style('stroke-width', null);
+        return;
+      }
+      const connected = outgoing.has(node.id) || incoming.has(node.id);
+      if (node.id === focusedId) {
+        groupSel.style('opacity', null);
+        shape.style('stroke', null).style('stroke-width', null);
+      } else if (connected) {
+        groupSel.style('opacity', null);
+        shape.style('stroke', 'var(--color-orange-400)').style('stroke-width', '2.5px');
+      } else {
+        groupSel.style('opacity', '0.15');
+        shape.style('stroke', null).style('stroke-width', null);
+      }
+    });
 };
 
 // TODO(burdon): Factor out.

--- a/packages/ui/react-ui-graph/src/stories/experimental.stories.tsx
+++ b/packages/ui/react-ui-graph/src/stories/experimental.stories.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 
 const meta: Meta = {
-  title: 'plugins/plugin-explorer/containers/ExplorerArticle/experimental',
+  title: 'ui/react-ui-graph/experimental',
   decorators: [withTheme(), withLayout({ layout: 'fullscreen' })],
   parameters: {
     layout: 'fullscreen',

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -140,24 +140,21 @@ const stepBoid = (
 };
 
 /**
- * Wrap-aware. Boids wrap on canvas edges, so consecutive trail positions can be
- * arbitrarily far apart — left edge to right edge — and lineTo'ing across that gap
- * would paint a streak across the whole canvas. Any segment longer than this is
- * treated as a wrap and broken into a fresh sub-path. Threshold is generous: max
- * physical velocity is < 1px/frame, so anything > a few pixels is a wrap.
- */
-const WRAP_GAP_SQ = 100 * 100;
-
-/**
  * Render a boid as a tapered, faded polyline + a solid head. Three stroke passes
  * cover ~thirds of the trail with decreasing lineWidth (head fatter than tail) and
  * decreasing alpha (head opaque, tail faint). This is ~10× cheaper than drawing
  * each trail position as its own arc, and gives a continuous curve instead of a
  * dotted streak when boids move fast.
+ *
+ * Wrap-aware: boids wrap on canvas edges, so consecutive trail positions can be
+ * up to (width, height) apart. Any segment that jumps further than half the
+ * canvas in either axis is treated as a wrap and broken into a fresh sub-path —
+ * otherwise the line would streak across the entire canvas.
  */
 const renderBoid = (
   b: FlockBoid,
   context: CanvasRenderingContext2D,
+  { width, height }: Dimensions,
   { radius, coloring }: Pick<TickConfig, 'radius' | 'coloring'>,
 ) => {
   const trail = b.trail ?? [];
@@ -191,9 +188,9 @@ const renderBoid = (
       context.beginPath();
       context.moveTo(trail[pass.from].x, trail[pass.from].y);
       for (let i = pass.from + 1; i <= pass.to; i++) {
-        const dx = trail[i].x - trail[i - 1].x;
-        const dy = trail[i].y - trail[i - 1].y;
-        if (dx * dx + dy * dy > WRAP_GAP_SQ) {
+        const dx = Math.abs(trail[i].x - trail[i - 1].x);
+        const dy = Math.abs(trail[i].y - trail[i - 1].y);
+        if (dx > width / 2 || dy > height / 2) {
           // Edge-wrap detected — start a fresh sub-path at this position so we
           // don't draw a line across the entire canvas to the wrapped point.
           context.moveTo(trail[i].x, trail[i].y);
@@ -318,7 +315,7 @@ const tick = (
   });
 
   boids.forEach((boid) => stepBoid(boid, { width, height }, config));
-  boids.forEach((boid) => renderBoid(boid, context, config));
+  boids.forEach((boid) => renderBoid(boid, context, { width, height }, config));
 };
 
 const generateFlockObstacles = (dimensions: Dimensions, numObstacles: number): FlockObstacle[] => {
@@ -378,7 +375,11 @@ export type FlockProps = ThemedClassName<{
   coloring?: FlockColoring;
   /** Per-boid render radius in pixels. */
   radius?: number;
-  /** Vapor trail factor, 0..20. */
+  /**
+   * Number of recent positions kept per boid; the rendered trail length, in frames.
+   * One position is recorded per simulation tick, so e.g. `trail={30}` is roughly a
+   * 0.5-second tail at 60 fps. Clamped to `Math.max(1, Math.round(trail))`.
+   */
   trail?: number;
   maxVelocity?: number;
   alignment?: number;
@@ -451,10 +452,18 @@ export const Flock = ({
 
   // Track the model's boid array via subscribe → setBoids. Per-tick position
   // mutations don't emit on the atom (by design), so this only fires on
-  // `model.setBoids(...)` and the initial sync.
+  // `model.setBoids(...)` and the initial sync. Reset each boid's renderer-owned
+  // trail so a `setBoids` that reuses boid identities doesn't carry stale
+  // segments from the previous scene into the next.
   useEffect(() => {
-    setBoids(model.boids);
-    return model.subscribe(() => setBoids(model.boids));
+    const sync = () => {
+      for (const boid of model.boids) {
+        boid.trail = [];
+      }
+      setBoids(model.boids);
+    };
+    sync();
+    return model.subscribe(sync);
   }, [model]);
 
   // Populate the model once the container dimensions are known and the model is

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -101,7 +101,8 @@ const coloringFunction: Record<FlockColoring, (boid: FlockBoid) => string> = {
 };
 
 type TickConfig = {
-  trail: number;
+  /** Number of recent positions kept per boid; the rendered trail length, in frames. */
+  trailLength: number;
   maxVelocity: number;
   alignment: number;
   cohesion: number;
@@ -109,15 +110,13 @@ type TickConfig = {
   avoidance: number;
   radius: number;
   coloring: FlockColoring;
-  /** Pre-computed `rgba(0, 0, 0, 1-trail)` string used by the destination-out fade. */
-  fadeStyle: string;
 };
 
-const updateBoid = (
+/** Integrate position + wrap on canvas edges + record into the trail ring buffer. */
+const stepBoid = (
   b: FlockBoid,
-  context: CanvasRenderingContext2D,
   { width, height }: Dimensions,
-  { radius, coloring, maxVelocity }: Pick<TickConfig, 'radius' | 'coloring' | 'maxVelocity'>,
+  { maxVelocity, trailLength }: Pick<TickConfig, 'maxVelocity' | 'trailLength'>,
 ) => {
   b.position.add(b.velocity.add(b.acceleration!).truncate(maxVelocity));
 
@@ -133,9 +132,81 @@ const updateBoid = (
     b.position.x += width;
   }
 
+  const trail = b.trail ?? (b.trail = []);
+  trail.unshift({ x: b.position.x, y: b.position.y });
+  if (trail.length > trailLength) {
+    trail.length = trailLength;
+  }
+};
+
+/**
+ * Wrap-aware. Boids wrap on canvas edges, so consecutive trail positions can be
+ * arbitrarily far apart — left edge to right edge — and lineTo'ing across that gap
+ * would paint a streak across the whole canvas. Any segment longer than this is
+ * treated as a wrap and broken into a fresh sub-path. Threshold is generous: max
+ * physical velocity is < 1px/frame, so anything > a few pixels is a wrap.
+ */
+const WRAP_GAP_SQ = 100 * 100;
+
+/**
+ * Render a boid as a tapered, faded polyline + a solid head. Three stroke passes
+ * cover ~thirds of the trail with decreasing lineWidth (head fatter than tail) and
+ * decreasing alpha (head opaque, tail faint). This is ~10× cheaper than drawing
+ * each trail position as its own arc, and gives a continuous curve instead of a
+ * dotted streak when boids move fast.
+ */
+const renderBoid = (
+  b: FlockBoid,
+  context: CanvasRenderingContext2D,
+  { radius, coloring }: Pick<TickConfig, 'radius' | 'coloring'>,
+) => {
+  const trail = b.trail ?? [];
+  if (trail.length === 0) {
+    return;
+  }
+  const color = coloringFunction[coloring](b);
+
+  // Trail body — drawn first so the head sits on top.
+  if (trail.length >= 2) {
+    context.strokeStyle = color;
+    context.lineCap = 'round';
+    context.lineJoin = 'round';
+    const tl = trail.length;
+    const mid1 = Math.max(1, Math.floor(tl * 0.33));
+    const mid2 = Math.max(mid1 + 1, Math.floor(tl * 0.66));
+    const passes: Array<{ from: number; to: number; width: number; alpha: number }> = [
+      { from: 0, to: mid1, width: radius * 1.5, alpha: 0.7 },
+      { from: mid1, to: mid2, width: radius, alpha: 0.4 },
+      { from: mid2, to: tl - 1, width: radius * 0.5, alpha: 0.15 },
+    ];
+    for (const pass of passes) {
+      if (pass.to <= pass.from) {
+        continue;
+      }
+      context.lineWidth = pass.width;
+      context.globalAlpha = pass.alpha;
+      context.beginPath();
+      context.moveTo(trail[pass.from].x, trail[pass.from].y);
+      for (let i = pass.from + 1; i <= pass.to; i++) {
+        const dx = trail[i].x - trail[i - 1].x;
+        const dy = trail[i].y - trail[i - 1].y;
+        if (dx * dx + dy * dy > WRAP_GAP_SQ) {
+          // Edge-wrap detected — start a fresh sub-path at this position so we
+          // don't draw a line across the entire canvas to the wrapped point.
+          context.moveTo(trail[i].x, trail[i].y);
+        } else {
+          context.lineTo(trail[i].x, trail[i].y);
+        }
+      }
+      context.stroke();
+    }
+    context.globalAlpha = 1;
+  }
+
+  // Head — full-radius arc on top of the trail.
+  context.fillStyle = color;
   context.beginPath();
-  context.fillStyle = coloringFunction[coloring](b);
-  context.arc(b.position.x, b.position.y, radius, 0, 2 * Math.PI);
+  context.arc(trail[0].x, trail[0].y, radius, 0, 2 * Math.PI);
   context.fill();
 };
 
@@ -160,23 +231,16 @@ const tick = (
   cursor: FlockObstacle | null,
   config: TickConfig,
 ) => {
-  const { maxVelocity, alignment, cohesion, separation, fadeStyle } = config;
+  const { maxVelocity, alignment, cohesion, separation } = config;
 
-  // Trail fade via `destination-out`: each frame multiplies every pixel's α by
-  // `trail` on the GPU compositor — no pixel-buffer roundtrip, ~free per frame.
-  // Canvas's round-half-to-even leaves a stall floor at low α (where x * trail
-  // rounds back to x), so we use an aggressive trail factor (default 0.70, max
-  // 0.80 at slider trail=20) to push that floor down to α ≈ 2/255 — visually
-  // indistinguishable from the
-  // CSS background that shows through. RGB is untouched, so boid colours stay
-  // intact while the alpha channel decays toward transparent.
+  // Render-from-history approach: clear the canvas each frame and redraw each boid's
+  // trail from its in-memory position ring buffer. Avoids u8 alpha/RGB rounding
+  // stalls (which manifested as faint residual dots on dark backgrounds in the
+  // earlier accumulating-canvas approach).
   const context = canvas.getContext('2d')!;
-  context.globalCompositeOperation = 'destination-out';
-  context.fillStyle = fadeStyle;
-  context.fillRect(0, 0, width, height);
-  context.globalCompositeOperation = 'source-over';
+  context.clearRect(0, 0, width, height);
 
-  // Obstacles re-paint at full alpha every frame so they don't decay with the trail.
+  // Obstacles re-paint every frame on the cleared canvas.
   renderObstacles(context, obstacles);
 
   // Calculate forces.
@@ -250,7 +314,8 @@ const tick = (
     }
   });
 
-  boids.forEach((boid) => updateBoid(boid, context, { width, height }, config));
+  boids.forEach((boid) => stepBoid(boid, { width, height }, config));
+  boids.forEach((boid) => renderBoid(boid, context, config));
 };
 
 const generateFlockObstacles = (dimensions: Dimensions, numObstacles: number): FlockObstacle[] => {
@@ -416,22 +481,19 @@ export const Flock = ({
   }, [width, height, numObstacles]);
 
   // The trail/physics config bundled for tick; memoed so the interval effect
-  // below doesn't re-key on every parent render. fadeStyle's RGB is ignored
-  // under `destination-out`; only its alpha matters.
+  // below doesn't re-key on every parent render.
   const tickConfig = useMemo<TickConfig>(() => {
-    // Map slider 0..20 → factor 0.60..0.80. Even at the max the stall sits
-    // around α=2 (≈0.8% visible) which the CSS bg masks out.
-    const trailFactor = (60 + trail) / 100;
     return {
       coloring,
       radius,
       maxVelocity,
-      trail: trailFactor,
+      // `trail` is now the literal number of recent positions kept and rendered per
+      // boid (one position per frame). At 60fps a value of 30 → ~0.5s visible tail.
+      trailLength: Math.max(1, Math.round(trail)),
       alignment: alignment / 100,
       cohesion: cohesion / 100,
       separation: separation / 100,
       avoidance: avoidance / 10,
-      fadeStyle: `rgba(0, 0, 0, ${1 - trailFactor})`,
     };
   }, [coloring, radius, maxVelocity, trail, alignment, cohesion, separation, avoidance]);
 

--- a/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
+++ b/packages/ui/react-ui-sfx/src/components/Flock/Flock.tsx
@@ -172,12 +172,15 @@ const renderBoid = (
     context.lineCap = 'round';
     context.lineJoin = 'round';
     const tl = trail.length;
-    const mid1 = Math.max(1, Math.floor(tl * 0.33));
-    const mid2 = Math.max(mid1 + 1, Math.floor(tl * 0.66));
+    const last = tl - 1;
+    // Clamp to valid indices so small trails (e.g. tl=2 during the initial transient)
+    // don't index past `tl - 1`. Skipped passes fall out below via `pass.to <= pass.from`.
+    const mid1 = Math.min(last, Math.max(0, Math.floor(tl * 0.33)));
+    const mid2 = Math.min(last, Math.max(mid1, Math.floor(tl * 0.66)));
     const passes: Array<{ from: number; to: number; width: number; alpha: number }> = [
       { from: 0, to: mid1, width: radius * 1.5, alpha: 0.7 },
       { from: mid1, to: mid2, width: radius, alpha: 0.4 },
-      { from: mid2, to: tl - 1, width: radius * 0.5, alpha: 0.15 },
+      { from: mid2, to: last, width: radius * 0.5, alpha: 0.15 },
     ];
     for (const pass of passes) {
       if (pass.to <= pass.from) {

--- a/packages/ui/react-ui-sfx/src/components/Flock/FlockModel.ts
+++ b/packages/ui/react-ui-sfx/src/components/Flock/FlockModel.ts
@@ -25,6 +25,12 @@ export type FlockBoid = {
   color?: string;
   /** Recent acceleration magnitudes; consumed by Movement / Grey colorings. */
   last?: number[];
+  /**
+   * Ring buffer of recent positions (newest at index 0). Rendered with decreasing
+   * alpha to draw the visible trail. Cleared and refilled by the renderer per tick,
+   * so consumers don't need to seed it. Allocated lazily.
+   */
+  trail?: Array<{ x: number; y: number }>;
 };
 
 /**

--- a/packages/ui/ui-types/src/anchor.ts
+++ b/packages/ui/ui-types/src/anchor.ts
@@ -12,6 +12,12 @@ export type DxAnchorActivateProps = {
   title?: string;
   side?: 'top' | 'right' | 'bottom' | 'left';
   props?: Record<string, unknown>;
+  /**
+   * Set to `false` to close any open popover. When omitted (or `true`), the event opens a
+   * popover anchored to `trigger`. `dxn` / `label` / `trigger` may be placeholders when
+   * `state` is `false` — the close path ignores them.
+   */
+  state?: boolean;
 };
 
 /**
@@ -25,6 +31,7 @@ export class DxAnchorActivate extends Event {
   public readonly title?: string;
   public readonly side?: 'top' | 'right' | 'bottom' | 'left';
   public readonly props?: Record<string, unknown>;
+  public readonly state?: boolean;
 
   constructor(props: DxAnchorActivateProps) {
     super(DX_ANCHOR_ACTIVATE);
@@ -35,5 +42,6 @@ export class DxAnchorActivate extends Event {
     this.title = props.title;
     this.side = props.side;
     this.props = props.props;
+    this.state = props.state;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2336,7 +2336,7 @@ importers:
         version: 6.1.1(typescript@6.0.3)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       wait-on:
         specifier: 'catalog:'
         version: 8.0.3
@@ -3858,7 +3858,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/common/effect-zod:
     dependencies:
@@ -3877,7 +3877,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/common/errors: {}
 
@@ -4577,7 +4577,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/common/web-context-solid:
     dependencies:
@@ -4654,7 +4654,7 @@ importers:
         version: 0.29.0(effect@3.20.0)(vitest@4.1.7)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core/compute/ai:
     dependencies:
@@ -5018,7 +5018,7 @@ importers:
         version: 3.20.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core/compute/compute-hyperformula:
     dependencies:
@@ -5495,7 +5495,7 @@ importers:
         version: 0.33.2(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -5532,7 +5532,7 @@ importers:
         version: 3.20.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core/echo/echo:
     dependencies:
@@ -5966,7 +5966,7 @@ importers:
         version: 1.8.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3)
+        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -6071,7 +6071,7 @@ importers:
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core/echo/feed:
     dependencies:
@@ -7021,7 +7021,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/devtools/cli-util:
     dependencies:
@@ -7079,7 +7079,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/devtools/devtools:
     dependencies:
@@ -9274,7 +9274,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/plugins/plugin-crx:
     dependencies:
@@ -9329,7 +9329,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/plugins/plugin-debug:
     dependencies:
@@ -16499,7 +16499,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/reflect/introspect:
     dependencies:
@@ -16542,7 +16542,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/reflect/introspect-mcp:
     dependencies:
@@ -16563,7 +16563,7 @@ importers:
         version: link:../../common/util
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -16582,7 +16582,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/reflect/introspect-tools:
     dependencies:
@@ -16607,7 +16607,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/sdk/app-framework:
     dependencies:
@@ -20449,7 +20449,7 @@ importers:
         version: link:../ui-theme
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -20796,7 +20796,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/ui/react-ui-menu:
     dependencies:
@@ -22477,7 +22477,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   tools/vite-plugin-log/example:
     devDependencies:
@@ -25427,7 +25427,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -40963,7 +40962,6 @@ packages:
       '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
-      vite: '>=8.0.0'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -43566,7 +43564,7 @@ snapshots:
       cjs-module-lexer: 1.3.1
       esbuild: 0.28.0
       miniflare: 4.20260521.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       wrangler: 4.68.1(@cloudflare/workers-types@4.20260303.0)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -44271,7 +44269,7 @@ snapshots:
   '@effect/vitest@0.29.0(effect@3.20.0)(vitest@4.1.7)':
     dependencies:
       effect: 3.20.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@effect/wa-sqlite@0.1.2': {}
 
@@ -45334,7 +45332,7 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.2)
       ajv: 8.18.0
@@ -49328,7 +49326,7 @@ snapshots:
       '@vitest/browser': 4.1.7(patch_hash=6c3dc337ee70b919eca34fd4b7144f3f075cb1e9285392c3ac13108c217939a5)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.7)
       '@vitest/browser-playwright': 4.1.7(playwright@1.57.0)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.7)
       '@vitest/runner': 4.1.7
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -50783,7 +50781,7 @@ snapshots:
       '@vitest/mocker': 4.1.7(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -50799,7 +50797,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -50819,7 +50817,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       '@vitest/browser': 4.1.7(patch_hash=6c3dc337ee70b919eca34fd4b7144f3f075cb1e9285392c3ac13108c217939a5)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.7)
 
@@ -50883,7 +50881,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -51807,7 +51805,7 @@ snapshots:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@cloudflare/ai-chat': 0.0.6(agents@0.3.10)(ai@6.0.97(zod@4.3.6))(react@19.2.6)(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
       ai: 6.0.97(zod@4.3.6)
       cron-schedule: 6.0.0
       escape-html: 1.0.3
@@ -54192,6 +54190,10 @@ snapshots:
   draco3d@1.5.7: {}
 
   dset@3.1.4: {}
+
+  dts-resolver@2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
+    optionalDependencies:
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   dts-resolver@2.1.3(oxc-resolver@11.9.0):
     optionalDependencies:
@@ -60979,6 +60981,24 @@ snapshots:
 
   robust-predicates@3.0.1: {}
 
+  rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
+    dependencies:
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      ast-kit: 2.2.0
+      birpc: 3.0.0
+      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
+      get-tsconfig: 4.13.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260421.2
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
     dependencies:
       '@babel/generator': 7.28.5
@@ -62654,6 +62674,34 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
+    dependencies:
+      ansis: 4.2.0
+      cac: 6.7.14
+      chokidar: 5.0.0
+      diff: 8.0.3
+      empathic: 2.0.0
+      hookable: 5.5.3
+      obug: 2.1.1
+      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rolldown-plugin-dts: 0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+      semver: 7.7.4
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+      unconfig-core: 7.4.2
+      unrun: 0.2.19(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - synckit
+      - vue-tsc
+
   tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
@@ -63444,7 +63492,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.7.0)(jsdom@29.1.1(canvas@3.2.0))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -63475,7 +63523,18 @@ snapshots:
       happy-dom: 20.7.0
       jsdom: 29.1.1(canvas@3.2.0)
     transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   void-elements@3.1.0: {}
 


### PR DESCRIPTION
## Summary

- Lifts the bundle-layout hover highlight into `GraphRenderer` behind a new `highlightOnHover` option so it actually runs in Composer's Explorer view.
- Enables it for the `bundle` variant via a one-line addition to `Visualization.tsx`.
- Applies the toolbar label rename (`Radial cluster` → `Radial`, `Edge bundling` → `Connections`) that the prior PR's description claimed but never landed.

## Background

[#11557](https://github.com/dxos/dxos/pull/11557) wired hover highlighting into `HierarchicalEdgeBundling.tsx`, but that component is only used by storybook stories — the in-app Explorer view goes through `ExplorerArticle` → `Visualization` → `<SVG.Graph projector={GraphBundleProjector}>` from `@dxos/react-ui-graph`, so the hover code never ran in the app. The PR's `variants.ts` rename and `graph.css` additions described in the body were also missing from the merge commit.

## Changes

- `packages/ui/react-ui-graph/src/graph/renderer/graph-renderer.ts`
  - New `highlightOnHover` option on `GraphRendererOptions`.
  - New `applyHoverHighlight(root, focusedId)` helper. On pointerenter: outgoing edges → `var(--color-orange-500)` @ 1.5px, incoming edges → `var(--color-sky-500)` @ 1.5px, unrelated edges → opacity 0.08, connected node shapes get an orange stroke, unrelated node groups dim to opacity 0.15. On pointerleave: every inline override is cleared.
- `packages/ui/react-ui-graph/src/components/Graph/Graph.tsx`
  - Exposes `highlightOnHover` via the `Pick<GraphRendererOptions, …>` prop set and adds it to the renderer-memo deps.
- `packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx`
  - Passes `highlightOnHover={variant === 'bundle'}` to `<SVG.Graph>`.
- `packages/plugins/plugin-explorer/src/containers/ExplorerArticle/variants.ts`
  - Renames `'Radial cluster'` → `'Radial'`, `'Edge bundling'` → `'Connections'`.

## Test plan

- [x] `moon run react-ui-graph:build` / `moon run plugin-explorer:build` green
- [x] `moon run react-ui-graph:lint plugin-explorer:lint` green
- [x] `moon run react-ui-graph:test plugin-explorer:test` green
- [x] Storybook `ExplorerArticle / Bundle`: hover source leaf → outgoing edges turn orange, target node stays opaque, unrelated edges dim to 0.08, unrelated nodes dim to 0.15
- [x] Hover target leaf → incoming edge turns sky-blue
- [x] pointerleave restores all inline styles (0 styled edges, 0 dimmed nodes)
- [x] Toolbar labels read "Radial" and "Connections"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hover highlighting in graph views to emphasize connected nodes/edges (active for "Connections" variant).
  * Visible motion trails for flocking visuals; trail length controls the rendered frames.

* **Style**
  * Renamed variants: "Radial cluster" → "Radial"; "Edge bundling" → "Connections".

* **Bug Fixes**
  * Stabilized popover toolbar layout and suppressed unwanted auto-focus on open.

* **Behavior**
  * Preview/popover now reliably dismisses when closed (pointer-leave/explicit close).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->