### PR TITLE
fix(plugin-preview): use valid DXN typename in TableLike test schema

### DIFF
--- a/packages/plugins/plugin-preview/src/stories/testing.tsx
+++ b/packages/plugins/plugin-preview/src/stories/testing.tsx
@@ -131,7 +131,7 @@ const TableLike = Schema.Struct({
     Schema.mutable,
     Annotation.FormInputAnnotation.set(false),
   ),
-}).pipe(Type.makeObject(DXN.make('org.dxos.test.table-like', '0.1.0')));
+}).pipe(Type.makeObject(DXN.make('org.dxos.test.tableLike', '0.1.0')));
 type TableLike = Type.InstanceType<typeof TableLike>;
 
 /**


### PR DESCRIPTION
## Closing — fix already in main

The `tableLike` rename was already applied to `origin/main` independently (likely as part of another PR that landed while this one was being prepared). After rebasing on the latest main, this branch has no unique commits.

The root cause was confirmed: `DXN.make('org.dxos.test.table-like', '0.1.0')` threw at module load time because the DXN validator rejects hyphens in the final dot-segment. The fix (`tableLike`) is now live in main.

https://claude.ai/code/session_01Q3gbx76wcbwB66gwv57Aj2