### PR TITLE
feat(echo)!: workerd-safe Type entities via deterministic ObjectIds

### DIFF
--- a/packages/common/keys/src/object-id.test.ts
+++ b/packages/common/keys/src/object-id.test.ts
@@ -1,0 +1,73 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, test, vi } from 'vitest';
+
+import { ObjectId } from './object-id';
+
+describe('ObjectId', () => {
+  describe('isValid', () => {
+    test('accepts a randomly-generated id', ({ expect }) => {
+      const id = ObjectId.random();
+      expect(ObjectId.isValid(id)).toBe(true);
+    });
+
+    test('rejects malformed strings', ({ expect }) => {
+      expect(ObjectId.isValid('')).toBe(false);
+      expect(ObjectId.isValid('not-a-ulid')).toBe(false);
+      // Wrong leading char (must be 0-7).
+      expect(ObjectId.isValid('8AAAAAAAAAAAAAAAAAAAAAAAAA')).toBe(false);
+    });
+  });
+
+  describe('deterministic', () => {
+    test('returns the same id for the same seeds', ({ expect }) => {
+      const first = ObjectId.deterministic('org.dxos.type.person', '0.1.0');
+      const second = ObjectId.deterministic('org.dxos.type.person', '0.1.0');
+      expect(first).toBe(second);
+    });
+
+    test('returns different ids for different seeds', ({ expect }) => {
+      const person = ObjectId.deterministic('org.dxos.type.person', '0.1.0');
+      const organization = ObjectId.deterministic('org.dxos.type.organization', '0.1.0');
+      expect(person).not.toBe(organization);
+    });
+
+    test('returns different ids when version differs', ({ expect }) => {
+      const v1 = ObjectId.deterministic('org.dxos.type.person', '0.1.0');
+      const v2 = ObjectId.deterministic('org.dxos.type.person', '0.2.0');
+      expect(v1).not.toBe(v2);
+    });
+
+    test('output passes ObjectId.isValid', ({ expect }) => {
+      const id = ObjectId.deterministic('org.dxos.type.person', '0.1.0');
+      expect(ObjectId.isValid(id)).toBe(true);
+    });
+
+    test('accepts numeric seeds', ({ expect }) => {
+      const id = ObjectId.deterministic('prefix', 42, 'suffix');
+      expect(ObjectId.isValid(id)).toBe(true);
+    });
+
+    test('does not call crypto.getRandomValues', ({ expect }) => {
+      // Workerd forbids `crypto.getRandomValues()` in global scope; deterministic() must therefore
+      // never reach for the platform RNG. Verify by spying on the global.
+      const spy = vi.spyOn(globalThis.crypto, 'getRandomValues');
+      try {
+        ObjectId.deterministic('org.dxos.type.person', '0.1.0');
+        expect(spy).not.toHaveBeenCalled();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    test('seed-component separator avoids collisions across adjacent inputs', ({ expect }) => {
+      // ('ab', 'c') vs ('a', 'bc') must hash differently — guards against naive
+      // concatenation that would conflate adjacent string seeds.
+      const left = ObjectId.deterministic('ab', 'c');
+      const right = ObjectId.deterministic('a', 'bc');
+      expect(left).not.toBe(right);
+    });
+  });
+});

--- a/packages/common/keys/src/object-id.test.ts
+++ b/packages/common/keys/src/object-id.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-import { describe, expect, test, vi } from 'vitest';
+import { describe, test, vi } from 'vitest';
 
 import { ObjectId } from './object-id';
 

--- a/packages/common/keys/src/object-id.ts
+++ b/packages/common/keys/src/object-id.ts
@@ -5,6 +5,9 @@
 import * as Schema from 'effect/Schema';
 import { type PRNG, type ULIDFactory, monotonicFactory } from 'ulidx';
 
+// Crockford Base32 alphabet used by ULID. Excludes I, L, O, U.
+const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
 // TODO(dmaretskyi): Make brand.
 // export const ObjectIdBrand: unique symbol = Symbol('@dxos/echo/ObjectId');
 // export const ObjectIdSchema = Schema.ULID.pipe(S.brand(ObjectIdBrand));
@@ -30,6 +33,29 @@ export interface ObjectIdClass extends Schema.SchemaClass<ObjectId, string> {
    * Generates a random ObjectId.
    */
   random(): ObjectId;
+
+  /**
+   * Derives a deterministic ULID-format ObjectId from arbitrary seed values.
+   *
+   * The same inputs always produce the same id, across processes, isolates, and workers.
+   * Unlike `random()`, this method does not call `crypto.getRandomValues()` and is therefore
+   * safe to call at module top-level — required for Cloudflare workerd, which forbids random
+   * generation in global scope.
+   *
+   * Intended for stable identity of declarative artefacts (e.g. `Type.Type` entities derived
+   * from a `(typename, version)` pair, fixtures, well-known objects). NOT a substitute for
+   * `random()` when global uniqueness is required: callers must guarantee seed uniqueness
+   * themselves; identical seeds yield identical ids and therefore collide.
+   *
+   * The result always passes `ObjectId.isValid(...)`.
+   *
+   * @param seed - One or more seed values; coerced to strings and joined.
+   *
+   * ```ts
+   * ObjectId.deterministic('org.dxos.type.person', '0.1.0'); // stable across runs
+   * ```
+   */
+  deterministic(...seed: (string | number)[]): ObjectId;
 
   /**
    * WARNING: To be used only within tests.
@@ -89,6 +115,28 @@ export const ObjectId: ObjectIdClass = class extends ObjectIdSchema {
 
   static random(): ObjectId {
     return this.#factory(this.#seedTime) as ObjectId;
+  }
+
+  static deterministic(...seed: (string | number)[]): ObjectId {
+    const input = seed.map((value) => String(value)).join('\0');
+    // FNV-1a 32-bit ×2 → 64 bits of derived entropy, packed into the 80-bit ULID random component.
+    let h1 = 0x811c9dc5 >>> 0;
+    let h2 = 0x1b873593 >>> 0;
+    for (let i = 0; i < input.length; i++) {
+      const code = input.charCodeAt(i);
+      h1 = Math.imul(h1 ^ code, 0x01000193) >>> 0;
+      h2 = Math.imul(h2 ^ ((code << 13) | (code >>> 3)), 0x01000193) >>> 0;
+    }
+    // 10 chars for the time component, all '0' — pins to the ULID epoch (timestamp 0) so the leading
+    // char is in [0-7]. The randomness lives entirely in the 16-char random component below.
+    const time = ALPHABET[0].repeat(10);
+    let bits = (BigInt(h1) << 32n) | BigInt(h2);
+    let rand = '';
+    for (let i = 0; i < 16; i++) {
+      rand = ALPHABET[Number(bits & 0x1fn)] + rand;
+      bits >>= 5n;
+    }
+    return (time + rand) as ObjectId;
   }
 
   static dangerouslyDisableRandomness() {

--- a/packages/core/echo/echo/src/Type.test.ts
+++ b/packages/core/echo/echo/src/Type.test.ts
@@ -5,6 +5,8 @@
 import * as Schema from 'effect/Schema';
 import { describe, test } from 'vitest';
 
+import { DXN, ObjectId } from '@dxos/keys';
+
 import * as Entity from './Entity';
 import * as JsonSchema from './JsonSchema';
 import * as Obj from './Obj';
@@ -192,6 +194,64 @@ describe('Type', () => {
     test('Type.getURI returns the DXN for static types', ({ expect }) => {
       expect(Type.getURI(TestSchema.Person).toString()).toBe('dxn:com.example.type.person:0.1.0');
       expect(Type.getURI(TestSchema.HasManager).toString()).toBe('dxn:com.example.type.hasManager:0.1.0');
+    });
+  });
+
+  describe('deterministic id default', () => {
+    // The default id is `ObjectId.deterministic(typename, version)` — required so that
+    // `Type.makeObject(...)` never calls `crypto.getRandomValues()` at module-evaluation
+    // time (forbidden by Cloudflare workerd in global scope).
+    const personDxn = DXN.make('com.example.type.deterministic.person', '0.1.0');
+    const worksForDxn = DXN.make('com.example.type.deterministic.worksFor', '0.1.0');
+
+    test('Type.makeObject with the same DXN twice yields entities with identical ids', ({ expect }) => {
+      const a = Schema.Struct({ name: Schema.String }).pipe(Type.makeObject(personDxn));
+      const b = Schema.Struct({ name: Schema.String }).pipe(Type.makeObject(personDxn));
+      expect(a.id).toBe(b.id);
+      expect(a.id).toBe(ObjectId.deterministic('com.example.type.deterministic.person', '0.1.0'));
+    });
+
+    test('different versions produce different ids', ({ expect }) => {
+      const v1 = Schema.Struct({ name: Schema.String }).pipe(
+        Type.makeObject(DXN.make('com.example.type.deterministic.person', '0.1.0')),
+      );
+      const v2 = Schema.Struct({ name: Schema.String }).pipe(
+        Type.makeObject(DXN.make('com.example.type.deterministic.person', '0.2.0')),
+      );
+      expect(v1.id).not.toBe(v2.id);
+    });
+
+    test('Type.makeObject({ id }) override is honoured', ({ expect }) => {
+      const explicit = ObjectId.random();
+      const entity = Schema.Struct({ name: Schema.String }).pipe(Type.makeObject(personDxn, { id: explicit }));
+      expect(entity.id).toBe(explicit);
+      // And the default still kicks in when no override is supplied.
+      const defaultEntity = Schema.Struct({ name: Schema.String }).pipe(Type.makeObject(personDxn));
+      expect(defaultEntity.id).not.toBe(explicit);
+    });
+
+    test('Type.makeRelation defaults id to deterministic(typename, version)', ({ expect }) => {
+      const a = Schema.Struct({ since: Schema.Number }).pipe(
+        Type.makeRelation({ dxn: worksForDxn, source: TestSchema.Person, target: TestSchema.Organization }),
+      );
+      const b = Schema.Struct({ since: Schema.Number }).pipe(
+        Type.makeRelation({ dxn: worksForDxn, source: TestSchema.Person, target: TestSchema.Organization }),
+      );
+      expect(a.id).toBe(b.id);
+      expect(a.id).toBe(ObjectId.deterministic('com.example.type.deterministic.worksFor', '0.1.0'));
+    });
+
+    test('Type.makeRelation({ id }) override is honoured', ({ expect }) => {
+      const explicit = ObjectId.random();
+      const entity = Schema.Struct({ since: Schema.Number }).pipe(
+        Type.makeRelation({
+          dxn: worksForDxn,
+          source: TestSchema.Person,
+          target: TestSchema.Organization,
+          id: explicit,
+        }),
+      );
+      expect(entity.id).toBe(explicit);
     });
   });
 });

--- a/packages/core/echo/echo/src/Type.ts
+++ b/packages/core/echo/echo/src/Type.ts
@@ -109,6 +109,12 @@ export type AnyObj = Obj<unknown>;
  * NOT a `Schema.Schema`. Use `Type.InstanceType<typeof Foo>` for the instance
  * type and `Type.getSchema(Foo)` to obtain the underlying Effect Schema.
  *
+ * The entity's id defaults to `ObjectId.deterministic(typename, version)` so
+ * constructing a type never reaches `crypto.getRandomValues()` — required for
+ * Cloudflare workerd, which forbids RNG calls in global (module-evaluation)
+ * scope. Pass `{ id }` to override (e.g. with `ObjectId.random()` from a
+ * request handler).
+ *
  * @example
  * ```ts
  * const Person = Schema.Struct({
@@ -117,7 +123,10 @@ export type AnyObj = Obj<unknown>;
  * ```
  */
 export const makeObject: {
-  (dxn: DXN.DXN): <Self extends Schema.Schema.Any>(self: Self) => Obj<Schema.Schema.Type<Self>>;
+  (
+    dxn: DXN.DXN,
+    options?: { id?: ObjectId },
+  ): <Self extends Schema.Schema.Any>(self: Self) => Obj<Schema.Schema.Type<Self>>;
 } = internal.EchoObjectSchema as any;
 
 //
@@ -272,6 +281,11 @@ export const makeRelation: {
     dxn: DXN.DXN;
     source: Obj<SourceInstance, any> | internal.UnknownTypeSchema<SourceInstance, typeof EntityModule.Kind.Object>;
     target: Obj<TargetInstance, any> | internal.UnknownTypeSchema<TargetInstance, typeof EntityModule.Kind.Object>;
+    /**
+     * Override the entity id. Defaults to `ObjectId.deterministic(typename, version)`;
+     * see `Type.makeObject` for the workerd motivation.
+     */
+    id?: ObjectId;
   }): <Self extends Schema.Schema.Any>(
     self: Self,
   ) => Relation<

--- a/packages/core/echo/echo/src/internal/Entity/entity.ts
+++ b/packages/core/echo/echo/src/internal/Entity/entity.ts
@@ -30,6 +30,23 @@ import { JsonSchemaType } from '../JsonSchema';
 export type EchoTypeSchemaProps<T, ExtraFields = {}> = Types.Simplify<AnyEntity & ToMutable<T> & ExtraFields>;
 
 /**
+ * Options accepted by every `Type.makeObject` / `Type.makeRelation` / type-kind
+ * factory. Defaults are derived from `(typename, version)` so callers normally
+ * pass nothing.
+ */
+export type EchoTypeOptions = {
+  /**
+   * Override the entity id stamped on the in-memory `Type.Type` value.
+   *
+   * Defaults to `ObjectId.deterministic(typename, version)` — stable across processes
+   * and workerd-safe (no `crypto.getRandomValues()` at module-evaluation time).
+   * Pass an explicit id (typically `ObjectId.random()`) to opt out of the
+   * deterministic default.
+   */
+  id?: ObjectId;
+};
+
+/**
  * In-memory `Type.Type` entity shape produced by `Type.makeObject(dxn)` /
  * `Type.makeRelation({...})`. A live reactive `TypeSchema` instance —
  * identical to a persisted `Type.Type` except for database attachment.
@@ -198,6 +215,7 @@ export const makeEchoTypeSchema = <
   version: string,
   kind: K,
   computeJsonSchema: () => JsonSchemaType,
+  explicitId?: ObjectId,
 ): EchoTypeSchema<Self, {}, K, Fields> => {
   // Source Effect Schema describing the user's type — cached for `Type.getSchema`.
   const sourceSchema = Schema.make<
@@ -211,9 +229,19 @@ export const makeEchoTypeSchema = <
   // in-memory declarations until persisted.
   const meta: ObjectMeta = { keys: [], key: typename, version };
 
+  // Default to a deterministic id derived from `(typename, version)` so that
+  // constructing a `Type.Type` entity never reaches `crypto.getRandomValues()`.
+  // Cloudflare workerd forbids RNG calls in global scope, and the ~hundreds of
+  // `Type.makeObject(...)` call sites across the monorepo execute at module top.
+  // `setIdOnTarget` (see `proxy/make-object.ts`) short-circuits on a pre-supplied
+  // valid id, so this also bypasses the `ObjectId.random()` path inside `makeObject`.
+  // Callers can override via `Type.makeObject(dxn, { id })` when they want a fresh
+  // random id (e.g. inside a request handler where workerd does allow RNG).
+  const id = explicitId ?? ObjectId.deterministic(typename, version);
+
   // Materialise as a live reactive meta-schema instance. `jsonSchema` is attached
   // below as a getter (not passed here as data) for two reasons; see that accessor.
-  const entity = makeObject(persistentEntitySchema, {} as any, meta);
+  const entity = makeObject(persistentEntitySchema, { id } as any, meta);
 
   const target = getProxyTarget(entity)!;
   // `jsonSchema` is always available, but computed once on first read rather than at

--- a/packages/core/echo/echo/src/internal/Entity/object.ts
+++ b/packages/core/echo/echo/src/internal/Entity/object.ts
@@ -11,7 +11,7 @@ import { DXN } from '@dxos/keys';
 import { type TypeAnnotation, TypeAnnotationId, makeTypeJsonSchemaAnnotation } from '../Annotation';
 import { EntityKind } from '../common/types';
 import { toJsonSchema } from '../JsonSchema';
-import { type EchoTypeSchema, makeEchoTypeSchema } from './entity';
+import { type EchoTypeOptions, type EchoTypeSchema, makeEchoTypeSchema } from './entity';
 
 /**
  * Object schema type with kind marker.
@@ -28,10 +28,11 @@ export type EchoObjectSchema<
 export const EchoObjectSchema: {
   (
     dxn: DXN.DXN,
+    options?: EchoTypeOptions,
   ): <Self extends Schema.Schema.Any, Fields extends Schema.Struct.Fields = Schema.Struct.Fields>(
     self: Self & { fields?: Fields },
   ) => EchoObjectSchema<Self, Fields>;
-} = (dxn) => {
+} = (dxn, options) => {
   const typename = DXN.getName(dxn);
   const version = DXN.getVersion(dxn);
   invariant(version, `Type.makeObject requires a versioned DXN: ${dxn}`);
@@ -58,8 +59,14 @@ export const EchoObjectSchema: {
       }),
     });
 
-    return makeEchoTypeSchema<Self, EntityKind.Object, Fields>(fields, ast, typename, version, EntityKind.Object, () =>
-      toJsonSchema(Schema.make(ast)),
+    return makeEchoTypeSchema<Self, EntityKind.Object, Fields>(
+      fields,
+      ast,
+      typename,
+      version,
+      EntityKind.Object,
+      () => toJsonSchema(Schema.make(ast)),
+      options?.id,
     );
   };
 };

--- a/packages/core/echo/echo/src/internal/Entity/relation.ts
+++ b/packages/core/echo/echo/src/internal/Entity/relation.ts
@@ -7,7 +7,7 @@ import * as SchemaAST from 'effect/SchemaAST';
 
 import { raise } from '@dxos/debug';
 import { assertArgument, invariant } from '@dxos/invariant';
-import { DXN } from '@dxos/keys';
+import { DXN, type ObjectId } from '@dxos/keys';
 
 // Type-only imports (erased at runtime — no import cycle); `internal` may depend
 // on the top-level `Obj` / `Type` API at the type level only.
@@ -82,6 +82,13 @@ export type EchoRelationSchemaOptions<TSource extends RelationEndpoint, TTarget 
   dxn: DXN.DXN;
   source: TSource;
   target: TTarget;
+  /**
+   * Override the entity id stamped on the in-memory `Type.Type` value.
+   *
+   * Defaults to `ObjectId.deterministic(typename, version)` — stable across processes
+   * and workerd-safe (no `crypto.getRandomValues()` at module-evaluation time).
+   */
+  id?: ObjectId;
 };
 
 /**
@@ -102,6 +109,7 @@ export const EchoRelationSchema = <Source extends RelationEndpoint, Target exten
   dxn,
   source,
   target,
+  id: explicitId,
 }: EchoRelationSchemaOptions<Source, Target>) => {
   // `source` / `target` are `Type.Type` entities (slot-backed) or the branded
   // `Obj.Unknown` schema (used directly); resolve each to its Effect Schema for
@@ -159,6 +167,7 @@ export const EchoRelationSchema = <Source extends RelationEndpoint, Target exten
       version,
       EntityKind.Relation,
       () => toJsonSchema(Schema.make(ast)),
+      explicitId,
     );
   };
 };

--- a/packages/core/echo/echo/src/internal/Entity/type-kind.ts
+++ b/packages/core/echo/echo/src/internal/Entity/type-kind.ts
@@ -11,7 +11,7 @@ import { DXN } from '@dxos/keys';
 import { type TypeAnnotation, TypeAnnotationId, makeTypeJsonSchemaAnnotation } from '../Annotation';
 import { EntityKind } from '../common/types';
 import { toJsonSchema } from '../JsonSchema';
-import { type EchoTypeSchema, makeEchoTypeSchema } from './entity';
+import { type EchoTypeOptions, type EchoTypeSchema, makeEchoTypeSchema } from './entity';
 
 /**
  * Type-kind schema marker — produced by {@link EchoTypeKindSchema}.
@@ -34,10 +34,11 @@ export type EchoTypeKindSchema<
 export const EchoTypeKindSchema: {
   (
     dxn: DXN.DXN,
+    options?: EchoTypeOptions,
   ): <Self extends Schema.Schema.Any, Fields extends Schema.Struct.Fields = Schema.Struct.Fields>(
     self: Self & { fields?: Fields },
   ) => EchoTypeKindSchema<Self, Fields>;
-} = (dxn) => {
+} = (dxn, options) => {
   const typename = DXN.getName(dxn);
   const version = DXN.getVersion(dxn);
   invariant(version, `Type-kind schemas require a versioned DXN: ${dxn}`);
@@ -60,8 +61,14 @@ export const EchoTypeKindSchema: {
       }),
     });
 
-    return makeEchoTypeSchema<Self, EntityKind.Type, Fields>(fields, ast, typename, version, EntityKind.Type, () =>
-      toJsonSchema(Schema.make(ast)),
+    return makeEchoTypeSchema<Self, EntityKind.Type, Fields>(
+      fields,
+      ast,
+      typename,
+      version,
+      EntityKind.Type,
+      () => toJsonSchema(Schema.make(ast)),
+      options?.id,
     );
   };
 };


### PR DESCRIPTION
## Motivation

Cloudflare workerd forbids `crypto.getRandomValues()` in global (module-evaluation) scope. Since #11458 made `Type.makeObject(...)` / `Type.makeRelation(...)` return real `Type.Type` entities, every static type declaration walks `makeObject` → `setIdOnTarget` → `ObjectId.random()` → `crypto.getRandomValues()` at module load. The ~hundreds of `Type.makeObject(...)` call sites across this monorepo and downstream consumers (e.g. `@dxos/edge`) all crash at worker startup with:

```
Disallowed operation called within global scope. Asynchronous I/O ... and generating random values are not allowed within global scope.
```

## Approach

Pre-supply a deterministic id when building the in-memory `Type.Type` entity so the hot path never reaches `ObjectId.random()`. `setIdOnTarget` already short-circuits on a pre-supplied valid id, so no other code paths change.

## Changes

Three Conventional Commits:

1. `feat(keys): ObjectId.deterministic(...seed)` — new static on `ObjectId` that derives a valid ULID-format id from arbitrary `(string | number)` seeds. Pure (no RNG), safe to call at module top-level. Implementation: two FNV-1a 32-bit hashes packed into the ULID random component; time component pinned to the ULID epoch so the leading char stays in `[0-7]`.

2. `feat(echo): default Type entity id to ObjectId.deterministic(typename, version)` — single behavioural change inside `makeEchoTypeSchema`: `makeObject(persistentEntitySchema, {} as any, meta)` becomes `makeObject(persistentEntitySchema, { id: explicitId ?? ObjectId.deterministic(typename, version) } as any, meta)`.

3. `feat(echo): allow Type.makeObject(dxn, { id }) override` — exposes the new id parameter through `EchoObjectSchema`, `EchoRelationSchema`, `EchoTypeKindSchema`, and the public `Type.makeObject` / `Type.makeRelation` re-exports.

## Backwards compatibility

All existing single-arg `Type.makeObject(dxn)` / object-only `Type.makeRelation({ dxn, source, target })` call sites are untouched (the new parameter is optional). Tests pass without modification across `keys`, `echo`, and `echo-db`.

## Persistence note (please review)

When `db.add(typeEntity)` runs inside a handler, the entity's pre-set deterministic id is kept (`setIdOnTarget` short-circuits on a valid existing id). That means every space that registers e.g. `Person@0.1.0` sees the same `echo:/<id>` for the type entity. This is likely a feature (cross-space type identity), but worth flagging — if per-space type ids are desired, the DB-attachment path needs to mint a fresh `ObjectId.random()` at attach time (running inside a handler, where workerd does allow RNG).

## Verification

- `moon run keys:test` — 65 passed (9 new in `object-id.test.ts`)
- `moon run echo:test` — 351 passed (6 new in `Type.test.ts`)
- `moon run echo-db:test` — 577 passed
- `moon run :build` — clean across the monorepo

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic ID generation from seed inputs, producing stable, ULID-formatted IDs without relying on runtime RNG.
  * Entity/object/relation factories now accept an optional ID override, with a deterministic ID used by default.

* **Tests**
  * Added tests verifying deterministic ID behavior, validity checks, determinism across seeds/versions, and override semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->