### PR TITLE
feat(plugin-file): add read-file tool returning a File content block

### DIFF
--- a/packages/plugins/plugin-file/moon.yml
+++ b/packages/plugins/plugin-file/moon.yml
@@ -10,6 +10,7 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--entryPoint=src/FilePlugin.tsx'
       - '--entryPoint=src/FilePlugin.node.ts'
+      - '--entryPoint=src/blueprints/index.ts'
       - '--entryPoint=src/capabilities/index.ts'
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/containers/index.ts'

--- a/packages/plugins/plugin-file/package.json
+++ b/packages/plugins/plugin-file/package.json
@@ -14,6 +14,11 @@
   "sideEffects": true,
   "type": "module",
   "imports": {
+    "#blueprints": {
+      "source": "./src/blueprints/index.ts",
+      "types": "./dist/types/src/blueprints/index.d.ts",
+      "default": "./dist/lib/neutral/blueprints/index.mjs"
+    },
     "#capabilities": {
       "source": "./src/capabilities/index.ts",
       "types": "./dist/types/src/capabilities/index.d.ts",

--- a/packages/plugins/plugin-file/src/FilePlugin.tsx
+++ b/packages/plugins/plugin-file/src/FilePlugin.tsx
@@ -8,6 +8,7 @@ import { ClientEvents } from '@dxos/plugin-client';
 import { MarkdownEvents } from '@dxos/plugin-markdown';
 
 import {
+  BlueprintDefinition,
   CreateObject,
   FileUploader,
   InlineBackend,
@@ -21,6 +22,7 @@ import { translations } from '#translations';
 import { File } from '#types';
 
 export const FilePlugin = Plugin.define(meta).pipe(
+  AppPlugin.addBlueprintDefinitionModule({ activate: BlueprintDefinition }),
   AppPlugin.addCreateObjectModule({ activate: CreateObject }),
   AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
   AppPlugin.addSchemaModule({ schema: [File.File] }),

--- a/packages/plugins/plugin-file/src/blueprints/file-blueprint.ts
+++ b/packages/plugins/plugin-file/src/blueprints/file-blueprint.ts
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Blueprint, Template } from '@dxos/compute';
+import { trim } from '@dxos/util';
+
+import { FileOperation } from '../types';
+
+export const BLUEPRINT_KEY = 'org.dxos.blueprint.file';
+
+const make = () =>
+  Blueprint.make({
+    key: BLUEPRINT_KEY,
+    name: 'File',
+    description: 'Read the contents of files (images, videos, PDFs) as File content blocks.',
+    tools: Blueprint.toolDefinitions({
+      operations: [FileOperation.Read],
+    }),
+    instructions: Template.make({
+      source: trim`
+        {{! File }}
+
+        You can read the contents of files.
+        Calling the read tool returns the file contents as a File content block (a data URL for
+        inline files, the original URL for external files). The model receives the file natively
+        and can describe, transcribe, or otherwise reason over its contents.
+      `,
+    }),
+  });
+
+const blueprint: Blueprint.Definition = {
+  key: BLUEPRINT_KEY,
+  make,
+};
+
+export default blueprint;

--- a/packages/plugins/plugin-file/src/blueprints/index.ts
+++ b/packages/plugins/plugin-file/src/blueprints/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export { default as FileBlueprint, BLUEPRINT_KEY } from './file-blueprint';

--- a/packages/plugins/plugin-file/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-file/src/capabilities/blueprint-definition.ts
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capability } from '@dxos/app-framework';
+import { AppCapabilities } from '@dxos/app-toolkit';
+// eslint-disable-next-line unused-imports/no-unused-imports
+import type { Blueprint } from '@dxos/compute';
+
+import { FileBlueprint } from '#blueprints';
+
+const blueprintDefinition = Capability.makeModule<
+  [],
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+>(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, FileBlueprint)]));
+
+export default blueprintDefinition;

--- a/packages/plugins/plugin-file/src/capabilities/index.ts
+++ b/packages/plugins/plugin-file/src/capabilities/index.ts
@@ -3,8 +3,11 @@
 //
 
 import { Capability } from '@dxos/app-framework';
+// eslint-disable-next-line unused-imports/no-unused-imports
+import type { Blueprint } from '@dxos/compute';
 import { OperationHandlerSet } from '@dxos/compute';
 
+export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const FileUploader = Capability.lazy('FileUploader', () => import('./file-uploader'));
 export const InlineBackend = Capability.lazy('InlineBackend', () => import('./inline-backend'));

--- a/packages/plugins/plugin-file/src/index.ts
+++ b/packages/plugins/plugin-file/src/index.ts
@@ -2,5 +2,6 @@
 // Copyright 2026 DXOS.org
 //
 
+export * from './blueprints';
 export * from './meta';
 export * from './types';

--- a/packages/plugins/plugin-file/src/operations/index.ts
+++ b/packages/plugins/plugin-file/src/operations/index.ts
@@ -4,4 +4,7 @@
 
 import { OperationHandlerSet } from '@dxos/compute';
 
-export const FileOperationHandlerSet = OperationHandlerSet.lazy(() => import('./create'));
+export const FileOperationHandlerSet = OperationHandlerSet.lazy(
+  () => import('./create'),
+  () => import('./read'),
+);

--- a/packages/plugins/plugin-file/src/operations/read.ts
+++ b/packages/plugins/plugin-file/src/operations/read.ts
@@ -1,0 +1,33 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Operation } from '@dxos/compute';
+import { Database } from '@dxos/echo';
+
+import { FileOperation } from '../types';
+
+const handler: Operation.WithHandler<typeof FileOperation.Read> = FileOperation.Read.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ file }) {
+      const obj = yield* Database.load(file);
+      const url =
+        obj.data._tag === 'inline'
+          ? `data:${obj.type};base64,${Buffer.from(obj.data.bytes).toString('base64')}`
+          : obj.data.url;
+
+      return {
+        content: {
+          _tag: 'file' as const,
+          url,
+          name: obj.name,
+          mediaType: obj.type,
+        },
+      };
+    }),
+  ),
+);
+
+export default handler;

--- a/packages/plugins/plugin-file/src/types/FileOperation.ts
+++ b/packages/plugins/plugin-file/src/types/FileOperation.ts
@@ -30,7 +30,8 @@ export const Read = Operation.make({
   meta: {
     key: `${FILE_OPERATION}.read`,
     name: 'Read File',
-    description: 'Reads the contents of a file and returns them as a File content block (data URL for inline files, original URL for external files).',
+    description:
+      'Reads the contents of a file and returns them as a File content block (data URL for inline files, original URL for external files).',
     icon: 'ph--file-arrow-down--regular',
   },
   input: Schema.Struct({

--- a/packages/plugins/plugin-file/src/types/FileOperation.ts
+++ b/packages/plugins/plugin-file/src/types/FileOperation.ts
@@ -8,8 +8,8 @@ import * as Schema from 'effect/Schema';
 
 import { Capability } from '@dxos/app-framework';
 import { Operation } from '@dxos/compute';
-import { Database, Type } from '@dxos/echo';
-import { File } from '@dxos/types';
+import { Database, Ref, Type } from '@dxos/echo';
+import { ContentBlock, File } from '@dxos/types';
 
 import { meta } from '#meta';
 
@@ -24,4 +24,22 @@ export const Create = Operation.make({
   output: Schema.Struct({
     object: Type.getSchema(File.File),
   }),
+});
+
+export const Read = Operation.make({
+  meta: {
+    key: `${FILE_OPERATION}.read`,
+    name: 'Read File',
+    description: 'Reads the contents of a file and returns them as a File content block (data URL for inline files, original URL for external files).',
+    icon: 'ph--file-arrow-down--regular',
+  },
+  input: Schema.Struct({
+    file: Ref.Ref(File.File).annotations({
+      description: 'The file to read.',
+    }),
+  }),
+  output: Schema.Struct({
+    content: ContentBlock.File,
+  }),
+  services: [Database.Service],
 });


### PR DESCRIPTION
## Summary

- Adds a new `Read` operation to `@dxos/plugin-file` (registered as the `org.dxos.plugin.file.operation.read` tool).
- Loads a `File` ECHO object by `Ref` and returns its contents as a `ContentBlock.File`:
  - Inline files → `data:<mediaType>;base64,<bytes>` URL.
  - External files → original URL passed through.
- This shape matches the file content block format that `@effect/ai`'s `Prompt.FilePart` and Anthropic's API consume natively (the existing `AiPreprocessor` already maps a `'file'` `ContentBlock` to a `Prompt.FilePart` with a `URL` data field).

## Test plan

- [x] `moon run plugin-file:build` succeeds.
- [x] `moon run plugin-file:lint` succeeds.
- [x] `moon run plugin-file:test` — existing tests still pass (6/6).
- [ ] Manual: invoke the `Read` tool from an assistant blueprint against a File object and verify the model receives the file content.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tydrisx7K5JjG2zd2Wdfnz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File read operation added — retrieve stored files with automatic handling of inline (data:) and remote URLs.
  * File blueprint introduced and registered — enables describing/transcribing file contents and integrates into plugin capabilities.
  * Plugin now exposes file blueprints through its public API and build/package mappings updated to include blueprint entry points.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->