### PR TITLE
feat(plugin-sandbox): implement sandbox plugin with blueprint and operations

### DIFF
--- a/packages/plugins/plugin-sandbox/PLUGIN.mdl
+++ b/packages/plugins/plugin-sandbox/PLUGIN.mdl
@@ -1,0 +1,73 @@
+---
+id: org.dxos.plugin.sandbox
+name: SandboxPlugin
+version: 0.1.0
+---
+
+Sandbox plugin for DXOS Composer providing isolated shell environments.
+
+## Types
+
+```mdl
+type Sandbox
+  fields:
+    name?: string
+    baseImage?: string
+    createdAt?: string
+    expiresAt?: string
+```
+
+## Operations
+
+```mdl
+op createSandbox
+  desc: Creates a new sandbox environment persisted as an ECHO object in the space.
+  input:
+    name?: string
+    baseImage?: string
+  output:
+    sandboxId: string    # ECHO object URI of the created sandbox
+  effects: [echo:write, sandbox:create]
+```
+
+```mdl
+op exec
+  desc: Runs a shell command in the sandbox.
+  input:
+    sandbox: Ref<Sandbox>
+    command: string
+    cwd?: string
+    env?: Record<string, string>
+    timeout?: number
+    stdin?: string
+  output:
+    stdout: string
+    stderr: string
+    exitCode: number
+    success: boolean
+  effects: [sandbox:exec]
+```
+
+```mdl
+op uploadFile
+  desc: Uploads a file from ECHO into the sandbox filesystem.
+  input:
+    sandbox: Ref<Sandbox>
+    file: Ref<File>
+    path: string         # absolute path in sandbox
+  output:
+    path: string
+  effects: [echo:read, sandbox:write]
+```
+
+```mdl
+op downloadFile
+  desc: Downloads a file from the sandbox filesystem into ECHO.
+  input:
+    sandbox: Ref<Sandbox>
+    path: string
+    dest?: Ref<File>     # optional existing File to overwrite
+  output:
+    objectId: string     # ECHO object URI of the File
+  effects: [sandbox:read, echo:write]
+```

--- a/packages/plugins/plugin-sandbox/moon.yml
+++ b/packages/plugins/plugin-sandbox/moon.yml
@@ -1,0 +1,17 @@
+layer: library
+language: typescript
+tags:
+  - ts-build
+  - ts-test
+  - pack
+tasks:
+  compile:
+    args:
+      - '--entryPoint=src/index.ts'
+      - '--entryPoint=src/SandboxPlugin.ts'
+      - '--entryPoint=src/blueprints/index.ts'
+      - '--entryPoint=src/capabilities/index.ts'
+      - '--entryPoint=src/meta.ts'
+      - '--entryPoint=src/plugin.ts'
+      - '--entryPoint=src/types/index.ts'
+      - '--platform=neutral'

--- a/packages/plugins/plugin-sandbox/package.json
+++ b/packages/plugins/plugin-sandbox/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@dxos/plugin-sandbox",
+  "version": "0.8.3",
+  "private": true,
+  "description": "DXOS Sandbox plugin for running isolated shell environments",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dxos/dxos"
+  },
+  "license": "FSL-1.1-Apache-2.0",
+  "author": "DXOS.org",
+  "sideEffects": true,
+  "type": "module",
+  "imports": {
+    "#blueprints": {
+      "source": "./src/blueprints/index.ts",
+      "types": "./dist/types/src/blueprints/index.d.ts",
+      "default": "./dist/lib/neutral/blueprints/index.mjs"
+    },
+    "#capabilities": {
+      "source": "./src/capabilities/index.ts",
+      "types": "./dist/types/src/capabilities/index.d.ts",
+      "default": "./dist/lib/neutral/capabilities/index.mjs"
+    },
+    "#meta": {
+      "source": "./src/meta.ts",
+      "types": "./dist/types/src/meta.d.ts",
+      "default": "./dist/lib/neutral/meta.mjs"
+    },
+    "#plugin": {
+      "source": "./src/SandboxPlugin.ts",
+      "types": "./dist/types/src/SandboxPlugin.d.ts",
+      "default": "./dist/lib/neutral/SandboxPlugin.mjs"
+    },
+    "#types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
+    }
+  },
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/types/src/index.d.ts",
+      "default": "./dist/lib/neutral/index.mjs"
+    },
+    "./plugin": {
+      "source": "./src/plugin.ts",
+      "types": "./dist/types/src/plugin.d.ts",
+      "default": "./dist/lib/neutral/plugin.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
+    }
+  },
+  "types": "dist/types/src/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@dxos/app-framework": "workspace:*",
+    "@dxos/app-toolkit": "workspace:*",
+    "@dxos/client": "workspace:*",
+    "@dxos/compute": "workspace:*",
+    "@dxos/echo": "workspace:*",
+    "@dxos/invariant": "workspace:*",
+    "@dxos/keys": "workspace:*",
+    "@dxos/log": "workspace:*",
+    "@dxos/schema": "workspace:*",
+    "@dxos/types": "workspace:*",
+    "@dxos/util": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@dxos/effect": "workspace:*",
+    "@dxos/functions-runtime": "workspace:*",
+    "@dxos/plugin-testing": "workspace:*",
+    "@effect/vitest": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugins/plugin-sandbox/src/SandboxPlugin.ts
+++ b/packages/plugins/plugin-sandbox/src/SandboxPlugin.ts
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+
+import { BlueprintDefinition, OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+import { Sandbox } from '#types';
+
+export const SandboxPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addBlueprintDefinitionModule({ activate: BlueprintDefinition }),
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addSchemaModule({ schema: [Sandbox.Sandbox] }),
+  Plugin.make,
+);
+
+export default SandboxPlugin;

--- a/packages/plugins/plugin-sandbox/src/blueprints/functions/create-sandbox.ts
+++ b/packages/plugins/plugin-sandbox/src/blueprints/functions/create-sandbox.ts
@@ -27,9 +27,7 @@ export default CreateSandbox.pipe(
       const edgeUrl = client.config.values.runtime?.services?.edge?.url ?? '';
       const sandboxClient = new SandboxClient(edgeUrl);
 
-      const record = yield* Effect.promise(() =>
-        sandboxClient.createSandbox(spaceId, sandboxId, { name, baseImage }),
-      );
+      const record = yield* Effect.promise(() => sandboxClient.createSandbox(spaceId, sandboxId, { name, baseImage }));
 
       Obj.update(sandbox, (sandbox) => {
         sandbox.createdAt = record.createdAt;

--- a/packages/plugins/plugin-sandbox/src/blueprints/functions/create-sandbox.ts
+++ b/packages/plugins/plugin-sandbox/src/blueprints/functions/create-sandbox.ts
@@ -1,0 +1,45 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { ClientService } from '@dxos/client';
+import { Operation } from '@dxos/compute';
+import { Database, Obj } from '@dxos/echo';
+import { CollectionModel } from '@dxos/schema';
+
+import { SandboxClient } from '../../services/SandboxClient';
+import * as Sandbox from '../../types/Sandbox';
+import { CreateSandbox } from './definitions';
+
+export default CreateSandbox.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ name, baseImage }) {
+      const { db } = yield* Database.Service;
+      const client = yield* ClientService;
+
+      const sandbox = Sandbox.make({ name, baseImage });
+      yield* CollectionModel.add({ object: sandbox });
+
+      const sandboxId = sandbox.id;
+      const spaceId = db.spaceId;
+      const edgeUrl = client.config.values.runtime?.services?.edge?.url ?? '';
+      const sandboxClient = new SandboxClient(edgeUrl);
+
+      const record = yield* Effect.promise(() =>
+        sandboxClient.createSandbox(spaceId, sandboxId, { name, baseImage }),
+      );
+
+      Obj.update(sandbox, (sandbox) => {
+        sandbox.createdAt = record.createdAt;
+        sandbox.expiresAt = record.expiresAt;
+        if (record.baseImage) {
+          sandbox.baseImage = record.baseImage;
+        }
+      });
+
+      return { sandboxId: Obj.getURI(sandbox) };
+    }),
+  ),
+);

--- a/packages/plugins/plugin-sandbox/src/blueprints/functions/definitions.ts
+++ b/packages/plugins/plugin-sandbox/src/blueprints/functions/definitions.ts
@@ -1,0 +1,121 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+
+import { ClientService } from '@dxos/client';
+import { Operation } from '@dxos/compute';
+import { Database, Ref } from '@dxos/echo';
+import { File } from '@dxos/types';
+
+import * as Sandbox from '../../types/Sandbox';
+
+const SandboxRef = Ref.Ref(Sandbox.Sandbox).annotations({
+  description: 'The sandbox object ID.',
+});
+
+export const CreateSandbox = Operation.make({
+  meta: {
+    key: 'org.dxos.function.sandbox.create',
+    name: 'CreateSandbox',
+    description: 'Creates a new sandbox environment in the current space. The sandbox is a persistent isolated container.',
+    icon: 'ph--terminal--regular',
+  },
+  input: Schema.Struct({
+    name: Schema.optional(Schema.String).annotations({
+      description: 'Display name for the sandbox.',
+    }),
+    baseImage: Schema.optional(Schema.String).annotations({
+      description: 'Base container image to use. Defaults to the service default.',
+    }),
+  }),
+  output: Schema.Struct({
+    sandboxId: Schema.String.annotations({
+      description: 'The ECHO object ID of the created sandbox (also used as the sandbox service ID).',
+    }),
+  }),
+  services: [Database.Service, ClientService],
+});
+
+export const Exec = Operation.make({
+  meta: {
+    key: 'org.dxos.function.sandbox.exec',
+    name: 'Exec',
+    description: 'Runs a shell command in the sandbox and returns stdout, stderr, and exit code.',
+    icon: 'ph--terminal-window--regular',
+  },
+  input: Schema.Struct({
+    sandbox: SandboxRef,
+    command: Schema.String.annotations({
+      description: 'Shell command to run.',
+    }),
+    cwd: Schema.optional(Schema.String).annotations({
+      description: 'Working directory for the command (absolute path).',
+    }),
+    env: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.String })).annotations({
+      description: 'Additional environment variables.',
+    }),
+    timeout: Schema.optional(Schema.Number).annotations({
+      description: 'Timeout in milliseconds.',
+    }),
+    stdin: Schema.optional(Schema.String).annotations({
+      description: 'Data to pass on standard input.',
+    }),
+  }),
+  output: Schema.Struct({
+    stdout: Schema.String,
+    stderr: Schema.String,
+    exitCode: Schema.Number,
+    success: Schema.Boolean,
+  }),
+  services: [Database.Service, ClientService],
+});
+
+export const UploadFile = Operation.make({
+  meta: {
+    key: 'org.dxos.function.sandbox.upload-file',
+    name: 'UploadFile',
+    description: 'Uploads a file from ECHO into the sandbox filesystem.',
+    icon: 'ph--upload--regular',
+  },
+  input: Schema.Struct({
+    sandbox: SandboxRef,
+    file: Ref.Ref(File.File).annotations({
+      description: 'The ECHO File object to upload.',
+    }),
+    path: Schema.String.annotations({
+      description: 'Absolute path in the sandbox where the file should be written.',
+    }),
+  }),
+  output: Schema.Struct({
+    path: Schema.String.annotations({
+      description: 'The path where the file was written in the sandbox.',
+    }),
+  }),
+  services: [Database.Service, ClientService],
+});
+
+export const DownloadFile = Operation.make({
+  meta: {
+    key: 'org.dxos.function.sandbox.download-file',
+    name: 'DownloadFile',
+    description: 'Downloads a file from the sandbox filesystem into ECHO.',
+    icon: 'ph--download--regular',
+  },
+  input: Schema.Struct({
+    sandbox: SandboxRef,
+    path: Schema.String.annotations({
+      description: 'Absolute path of the file in the sandbox.',
+    }),
+    dest: Schema.optional(Ref.Ref(File.File)).annotations({
+      description: 'Existing ECHO File object to overwrite. If omitted, a new File object is created.',
+    }),
+  }),
+  output: Schema.Struct({
+    objectId: Schema.String.annotations({
+      description: 'The ECHO object ID of the File containing the downloaded content.',
+    }),
+  }),
+  services: [Database.Service, ClientService],
+});

--- a/packages/plugins/plugin-sandbox/src/blueprints/functions/definitions.ts
+++ b/packages/plugins/plugin-sandbox/src/blueprints/functions/definitions.ts
@@ -19,7 +19,8 @@ export const CreateSandbox = Operation.make({
   meta: {
     key: 'org.dxos.function.sandbox.create',
     name: 'CreateSandbox',
-    description: 'Creates a new sandbox environment in the current space. The sandbox is a persistent isolated container.',
+    description:
+      'Creates a new sandbox environment in the current space. The sandbox is a persistent isolated container.',
     icon: 'ph--terminal--regular',
   },
   input: Schema.Struct({

--- a/packages/plugins/plugin-sandbox/src/blueprints/functions/download-file.ts
+++ b/packages/plugins/plugin-sandbox/src/blueprints/functions/download-file.ts
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { ClientService } from '@dxos/client';
+import { Operation } from '@dxos/compute';
+import { Database, Obj } from '@dxos/echo';
+import { CollectionModel } from '@dxos/schema';
+import { File } from '@dxos/types';
+
+import { SandboxClient } from '../../services/SandboxClient';
+import { DownloadFile } from './definitions';
+
+export default DownloadFile.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ sandbox, path, dest }) {
+      const { db } = yield* Database.Service;
+      const client = yield* ClientService;
+
+      const loadedSandbox = yield* Database.load(sandbox);
+      const sandboxId = loadedSandbox.id;
+      const spaceId = db.spaceId;
+      const edgeUrl = client.config.values.runtime?.services?.edge?.url ?? '';
+      const sandboxClient = new SandboxClient(edgeUrl);
+
+      const content = yield* Effect.promise(() => sandboxClient.readFile(spaceId, sandboxId, path));
+
+      const bytes = new TextEncoder().encode(content);
+      const fileName = path.split('/').at(-1) ?? path;
+
+      if (dest) {
+        const loadedDest = yield* Database.load(dest);
+        Obj.update(loadedDest, (loadedDest) => {
+          loadedDest.name = fileName;
+          loadedDest.size = bytes.byteLength;
+          loadedDest.data = File.inlineData(bytes);
+          loadedDest.timestamp = new Date().toISOString();
+        });
+        return { objectId: Obj.getURI(loadedDest) };
+      }
+
+      const fileObj = File.make({
+        name: fileName,
+        type: 'text/plain',
+        size: bytes.byteLength,
+        data: File.inlineData(bytes),
+        timestamp: new Date().toISOString(),
+      });
+      yield* CollectionModel.add({ object: fileObj });
+
+      return { objectId: Obj.getURI(fileObj) };
+    }),
+  ),
+);

--- a/packages/plugins/plugin-sandbox/src/blueprints/functions/exec.ts
+++ b/packages/plugins/plugin-sandbox/src/blueprints/functions/exec.ts
@@ -1,0 +1,33 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { ClientService } from '@dxos/client';
+import { Operation } from '@dxos/compute';
+import { Database } from '@dxos/echo';
+
+import { SandboxClient } from '../../services/SandboxClient';
+import { Exec } from './definitions';
+
+export default Exec.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ sandbox, command, cwd, env, timeout, stdin }) {
+      const { db } = yield* Database.Service;
+      const client = yield* ClientService;
+
+      const loaded = yield* Database.load(sandbox);
+      const sandboxId = loaded.id;
+      const spaceId = db.spaceId;
+      const edgeUrl = client.config.values.runtime?.services?.edge?.url ?? '';
+      const sandboxClient = new SandboxClient(edgeUrl);
+
+      const result = yield* Effect.promise(() =>
+        sandboxClient.exec(spaceId, sandboxId, { command, cwd, env, timeout, stdin }),
+      );
+
+      return result;
+    }),
+  ),
+);

--- a/packages/plugins/plugin-sandbox/src/blueprints/functions/index.ts
+++ b/packages/plugins/plugin-sandbox/src/blueprints/functions/index.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { OperationHandlerSet } from '@dxos/compute';
+
+export * from './definitions';
+
+export const SandboxHandlers = OperationHandlerSet.lazy(
+  () => import('./create-sandbox'),
+  () => import('./exec'),
+  () => import('./upload-file'),
+  () => import('./download-file'),
+);

--- a/packages/plugins/plugin-sandbox/src/blueprints/functions/upload-file.ts
+++ b/packages/plugins/plugin-sandbox/src/blueprints/functions/upload-file.ts
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { ClientService } from '@dxos/client';
+import { Operation } from '@dxos/compute';
+import { Database } from '@dxos/echo';
+
+import { SandboxClient } from '../../services/SandboxClient';
+import { UploadFile } from './definitions';
+
+export default UploadFile.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ sandbox, file, path }) {
+      const { db } = yield* Database.Service;
+      const client = yield* ClientService;
+
+      const loadedSandbox = yield* Database.load(sandbox);
+      const loadedFile = yield* Database.load(file);
+
+      const content = fileToString(loadedFile);
+      const sandboxId = loadedSandbox.id;
+      const spaceId = db.spaceId;
+      const edgeUrl = client.config.values.runtime?.services?.edge?.url ?? '';
+      const sandboxClient = new SandboxClient(edgeUrl);
+
+      yield* Effect.promise(() => sandboxClient.writeFile(spaceId, sandboxId, path, content));
+
+      return { path };
+    }),
+  ),
+);
+
+const fileToString = (file: { data?: { _tag: string; bytes?: Uint8Array; url?: string } }): string => {
+  if (!file.data) {
+    return '';
+  }
+  if (file.data._tag === 'inline' && file.data.bytes) {
+    return new TextDecoder().decode(file.data.bytes);
+  }
+  if (file.data._tag === 'external' && file.data.url) {
+    return file.data.url;
+  }
+  return '';
+};

--- a/packages/plugins/plugin-sandbox/src/blueprints/index.ts
+++ b/packages/plugins/plugin-sandbox/src/blueprints/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export { default as SandboxBlueprint } from './sandbox-blueprint';

--- a/packages/plugins/plugin-sandbox/src/blueprints/sandbox-blueprint.ts
+++ b/packages/plugins/plugin-sandbox/src/blueprints/sandbox-blueprint.ts
@@ -1,0 +1,35 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Blueprint, Template } from '@dxos/compute';
+import { trim } from '@dxos/util';
+
+import * as Sandbox from '../types/Sandbox';
+import { CreateSandbox, Exec, UploadFile, DownloadFile } from './functions';
+
+const make = () =>
+  Blueprint.make({
+    key: Sandbox.BLUEPRINT_KEY,
+    name: 'Sandbox',
+    agentCanEnable: true,
+    tools: Blueprint.toolDefinitions({
+      operations: [CreateSandbox, Exec, UploadFile, DownloadFile],
+    }),
+    instructions: Template.make({
+      source: trim`
+        You can create and manage sandbox environments — isolated containers for running shell commands.
+        Each sandbox is persisted as an ECHO object in the space and identified by its object ID.
+        You can create sandboxes, run shell commands inside them, upload files from ECHO into a sandbox,
+        and download files from a sandbox back into ECHO.
+        The sandbox service is lazily initialized: the container starts on first use.
+      `,
+    }),
+  });
+
+const blueprint: Blueprint.Definition = {
+  key: Sandbox.BLUEPRINT_KEY,
+  make,
+};
+
+export default blueprint;

--- a/packages/plugins/plugin-sandbox/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-sandbox/src/capabilities/blueprint-definition.ts
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capability } from '@dxos/app-framework';
+import { AppCapabilities } from '@dxos/app-toolkit';
+// eslint-disable-next-line unused-imports/no-unused-imports
+import type { Blueprint } from '@dxos/compute';
+
+import { SandboxBlueprint } from '#blueprints';
+
+const blueprintDefinition = Capability.makeModule<
+  [],
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+>(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, SandboxBlueprint)]));
+
+export default blueprintDefinition;

--- a/packages/plugins/plugin-sandbox/src/capabilities/index.ts
+++ b/packages/plugins/plugin-sandbox/src/capabilities/index.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Capability } from '@dxos/app-framework';
+// eslint-disable-next-line unused-imports/no-unused-imports
+import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+
+export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
+  'OperationHandler',
+  () => import('./operation-handler'),
+);

--- a/packages/plugins/plugin-sandbox/src/capabilities/operation-handler.ts
+++ b/packages/plugins/plugin-sandbox/src/capabilities/operation-handler.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capabilities, Capability } from '@dxos/app-framework';
+import type { OperationHandlerSet } from '@dxos/compute';
+
+import { SandboxHandlers } from '../blueprints/functions';
+
+export default Capability.makeModule<OperationHandlerSet.OperationHandlerSet>(
+  Effect.fnUntraced(function* () {
+    return Capability.contributes(Capabilities.OperationHandler, SandboxHandlers);
+  }),
+);

--- a/packages/plugins/plugin-sandbox/src/index.ts
+++ b/packages/plugins/plugin-sandbox/src/index.ts
@@ -1,0 +1,7 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './blueprints';
+export * from './meta';
+export * from './types';

--- a/packages/plugins/plugin-sandbox/src/meta.ts
+++ b/packages/plugins/plugin-sandbox/src/meta.ts
@@ -1,0 +1,23 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Plugin } from '@dxos/app-framework';
+import { trim } from '@dxos/util';
+
+export const meta: Plugin.Meta = {
+  id: 'org.dxos.plugin.sandbox',
+  name: 'Sandbox',
+  author: 'DXOS',
+  spec: 'PLUGIN.mdl',
+  description: trim`
+    Sandbox plugin for DXOS Composer that provides isolated shell environments.
+    Each sandbox is a persistent container identified by an ECHO object in the space.
+    An AI Sandbox assistant provides tools to create sandboxes, run shell commands,
+    and transfer files between ECHO and the sandbox filesystem.
+  `,
+  icon: 'ph--terminal--regular',
+  iconHue: 'green',
+  source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-sandbox',
+  tags: ['labs'],
+};

--- a/packages/plugins/plugin-sandbox/src/plugin.ts
+++ b/packages/plugins/plugin-sandbox/src/plugin.ts
@@ -1,0 +1,9 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const SandboxPlugin = Plugin.lazy(meta, () => import('#plugin'));

--- a/packages/plugins/plugin-sandbox/src/services/SandboxClient.ts
+++ b/packages/plugins/plugin-sandbox/src/services/SandboxClient.ts
@@ -1,0 +1,104 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export type SandboxRecord = {
+  id: string;
+  spaceId: string;
+  name?: string;
+  baseImage: string;
+  createdAt: string;
+  expiresAt: string;
+};
+
+export type ExecResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  success: boolean;
+};
+
+export type FileEntry = {
+  name: string;
+  type: 'file' | 'directory';
+  size?: number;
+};
+
+/**
+ * HTTP client for the sandbox REST service.
+ * Base path: /api/sandbox
+ */
+export class SandboxClient {
+  constructor(private readonly _baseUrl: string) {}
+
+  async createSandbox(
+    spaceId: string,
+    sandboxId: string,
+    options?: { name?: string; baseImage?: string; expiresIn?: number },
+  ): Promise<SandboxRecord> {
+    const resp = await fetch(`${this._baseUrl}/api/sandbox/spaces/${spaceId}/sandboxes/${sandboxId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(options ?? {}),
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => resp.statusText);
+      throw new Error(`Failed to create sandbox (${resp.status}): ${text}`);
+    }
+    const data = await resp.json();
+    return data.sandbox as SandboxRecord;
+  }
+
+  async getSandbox(spaceId: string, sandboxId: string): Promise<SandboxRecord> {
+    const resp = await fetch(`${this._baseUrl}/api/sandbox/spaces/${spaceId}/sandboxes/${sandboxId}`);
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => resp.statusText);
+      throw new Error(`Failed to get sandbox (${resp.status}): ${text}`);
+    }
+    const data = await resp.json();
+    return data.sandbox as SandboxRecord;
+  }
+
+  async exec(
+    spaceId: string,
+    sandboxId: string,
+    options: { command: string; cwd?: string; env?: Record<string, string>; timeout?: number; stdin?: string },
+  ): Promise<ExecResult> {
+    const resp = await fetch(`${this._baseUrl}/api/sandbox/spaces/${spaceId}/sandboxes/${sandboxId}/exec`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(options),
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => resp.statusText);
+      throw new Error(`Failed to exec command (${resp.status}): ${text}`);
+    }
+    return resp.json() as Promise<ExecResult>;
+  }
+
+  async readFile(spaceId: string, sandboxId: string, path: string): Promise<string> {
+    const url = new URL(`${this._baseUrl}/api/sandbox/spaces/${spaceId}/sandboxes/${sandboxId}/files`);
+    url.searchParams.set('path', path);
+    const resp = await fetch(url.toString());
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => resp.statusText);
+      throw new Error(`Failed to read file (${resp.status}): ${text}`);
+    }
+    const data = await resp.json();
+    return data.content as string;
+  }
+
+  async writeFile(spaceId: string, sandboxId: string, path: string, content: string): Promise<void> {
+    const url = new URL(`${this._baseUrl}/api/sandbox/spaces/${spaceId}/sandboxes/${sandboxId}/files`);
+    url.searchParams.set('path', path);
+    const resp = await fetch(url.toString(), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => resp.statusText);
+      throw new Error(`Failed to write file (${resp.status}): ${text}`);
+    }
+  }
+}

--- a/packages/plugins/plugin-sandbox/src/services/index.ts
+++ b/packages/plugins/plugin-sandbox/src/services/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export { SandboxClient } from './SandboxClient';
+export type { SandboxRecord, ExecResult, FileEntry } from './SandboxClient';

--- a/packages/plugins/plugin-sandbox/src/testing/SandboxPlugin.test.ts
+++ b/packages/plugins/plugin-sandbox/src/testing/SandboxPlugin.test.ts
@@ -1,0 +1,99 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, it } from '@effect/vitest';
+import * as Effect from 'effect/Effect';
+
+import { Blueprint, Operation } from '@dxos/compute';
+import { Collection, Database, Feed, Ref } from '@dxos/echo';
+import { TestContextService } from '@dxos/effect/testing';
+import { AssistantTestLayer } from '@dxos/functions-runtime/testing';
+import { ObjectId } from '@dxos/keys';
+import { File } from '@dxos/types';
+
+import { SandboxHandlers, CreateSandbox, Exec, UploadFile, DownloadFile } from '../blueprints/functions';
+import SandboxBlueprint from '../blueprints/sandbox-blueprint';
+import * as Sandbox from '../types/Sandbox';
+
+ObjectId.dangerouslyDisableRandomness();
+
+const TestLayer = AssistantTestLayer({
+  operationHandlers: SandboxHandlers,
+  types: [Sandbox.Sandbox, File.File, Collection.Collection, Blueprint.Blueprint, Feed.Feed],
+  blueprints: [SandboxBlueprint.make()],
+});
+
+// Requires a running sandbox service and real edge URL. Disabled by default.
+describe.skip('SandboxPlugin', () => {
+  it.effect(
+    'create sandbox',
+    (ctx) =>
+      Effect.gen(function* () {
+        const result = yield* Operation.invoke(CreateSandbox, { name: 'test-sandbox' });
+        expect(result.sandboxId).toBeTruthy();
+      }).pipe(
+        Effect.provide(TestLayer),
+        Effect.provideService(TestContextService, ctx),
+      ),
+    60_000,
+  );
+
+  it.effect(
+    'exec command',
+    (ctx) =>
+      Effect.gen(function* () {
+        const sandbox = Sandbox.make({ name: 'exec-test' });
+        yield* Database.add(sandbox);
+
+        const result = yield* Operation.invoke(Exec, {
+          sandbox: Ref.make(sandbox),
+          command: 'echo hello world',
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.success).toBe(true);
+        expect(result.stdout.trim()).toBe('hello world');
+      }).pipe(
+        Effect.provide(TestLayer),
+        Effect.provideService(TestContextService, ctx),
+      ),
+    60_000,
+  );
+
+  it.effect(
+    'upload and download file',
+    (ctx) =>
+      Effect.gen(function* () {
+        const sandbox = Sandbox.make({ name: 'file-test' });
+        yield* Database.add(sandbox);
+
+        const content = 'Hello from ECHO!';
+        const bytes = new TextEncoder().encode(content);
+        const fileObj = File.make({
+          name: 'test.txt',
+          type: 'text/plain',
+          size: bytes.byteLength,
+          data: File.inlineData(bytes),
+        });
+        yield* Database.add(fileObj);
+
+        yield* Operation.invoke(UploadFile, {
+          sandbox: Ref.make(sandbox),
+          file: Ref.make(fileObj),
+          path: '/workspace/test.txt',
+        });
+
+        const downloadResult = yield* Operation.invoke(DownloadFile, {
+          sandbox: Ref.make(sandbox),
+          path: '/workspace/test.txt',
+        });
+
+        expect(downloadResult.objectId).toBeTruthy();
+      }).pipe(
+        Effect.provide(TestLayer),
+        Effect.provideService(TestContextService, ctx),
+      ),
+    60_000,
+  );
+});

--- a/packages/plugins/plugin-sandbox/src/testing/SandboxPlugin.test.ts
+++ b/packages/plugins/plugin-sandbox/src/testing/SandboxPlugin.test.ts
@@ -32,10 +32,7 @@ describe.skip('SandboxPlugin', () => {
       Effect.gen(function* () {
         const result = yield* Operation.invoke(CreateSandbox, { name: 'test-sandbox' });
         expect(result.sandboxId).toBeTruthy();
-      }).pipe(
-        Effect.provide(TestLayer),
-        Effect.provideService(TestContextService, ctx),
-      ),
+      }).pipe(Effect.provide(TestLayer), Effect.provideService(TestContextService, ctx)),
     60_000,
   );
 
@@ -54,10 +51,7 @@ describe.skip('SandboxPlugin', () => {
         expect(result.exitCode).toBe(0);
         expect(result.success).toBe(true);
         expect(result.stdout.trim()).toBe('hello world');
-      }).pipe(
-        Effect.provide(TestLayer),
-        Effect.provideService(TestContextService, ctx),
-      ),
+      }).pipe(Effect.provide(TestLayer), Effect.provideService(TestContextService, ctx)),
     60_000,
   );
 
@@ -90,10 +84,7 @@ describe.skip('SandboxPlugin', () => {
         });
 
         expect(downloadResult.objectId).toBeTruthy();
-      }).pipe(
-        Effect.provide(TestLayer),
-        Effect.provideService(TestContextService, ctx),
-      ),
+      }).pipe(Effect.provide(TestLayer), Effect.provideService(TestContextService, ctx)),
     60_000,
   );
 });

--- a/packages/plugins/plugin-sandbox/src/types/Sandbox.ts
+++ b/packages/plugins/plugin-sandbox/src/types/Sandbox.ts
@@ -1,0 +1,35 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as Schema from 'effect/Schema';
+
+import { Annotation, DXN, Obj, Type } from '@dxos/echo';
+
+export const BLUEPRINT_KEY = 'org.dxos.blueprint.sandbox';
+
+/**
+ * ECHO object representing a persistent sandbox environment.
+ * The object id is used as the sandbox id in the sandbox service.
+ */
+export const Sandbox = Schema.Struct({
+  name: Schema.optional(Schema.String),
+  baseImage: Schema.optional(Schema.String),
+  createdAt: Schema.optional(Schema.String),
+  expiresAt: Schema.optional(Schema.String),
+}).pipe(
+  Annotation.IconAnnotation.set({
+    icon: 'ph--terminal--regular',
+    hue: 'green',
+  }),
+  Type.makeObject(DXN.make('org.dxos.type.sandbox', '0.1.0')),
+);
+
+export type Sandbox = Type.InstanceType<typeof Sandbox>;
+
+/**
+ * Constructs a `Sandbox` ECHO object from the given props.
+ */
+export const make = (props: Obj.MakeProps<typeof Sandbox>): Sandbox => Obj.make(Sandbox, props);

--- a/packages/plugins/plugin-sandbox/src/types/index.ts
+++ b/packages/plugins/plugin-sandbox/src/types/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * as Sandbox from './Sandbox';

--- a/packages/plugins/plugin-sandbox/tsconfig.json
+++ b/packages/plugins/plugin-sandbox/tsconfig.json
@@ -1,0 +1,62 @@
+{
+  "extends": [
+    "../../../tsconfig.base.json"
+  ],
+  "compilerOptions": {
+    "types": [
+      "@dxos/typings",
+      "node"
+    ]
+  },
+  "exclude": [
+    "*.t.ts",
+    "vite.config.ts"
+  ],
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../common/effect"
+    },
+    {
+      "path": "../../common/invariant"
+    },
+    {
+      "path": "../../common/keys"
+    },
+    {
+      "path": "../../common/log"
+    },
+    {
+      "path": "../../common/util"
+    },
+    {
+      "path": "../../core/compute/compute"
+    },
+    {
+      "path": "../../core/compute/functions-runtime"
+    },
+    {
+      "path": "../../core/echo/echo"
+    },
+    {
+      "path": "../../sdk/app-framework"
+    },
+    {
+      "path": "../../sdk/app-toolkit"
+    },
+    {
+      "path": "../../sdk/client"
+    },
+    {
+      "path": "../../sdk/schema"
+    },
+    {
+      "path": "../../sdk/types"
+    },
+    {
+      "path": "../plugin-testing"
+    }
+  ]
+}

--- a/packages/plugins/plugin-sandbox/vitest.config.ts
+++ b/packages/plugins/plugin-sandbox/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5495,7 +5495,7 @@ importers:
         version: 0.33.2(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -5966,7 +5966,7 @@ importers:
         version: 1.8.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -13190,6 +13190,61 @@ importers:
         specifier: '>=8.0.0'
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/plugins/plugin-sandbox:
+    dependencies:
+      '@dxos/app-framework':
+        specifier: workspace:*
+        version: link:../../sdk/app-framework
+      '@dxos/app-toolkit':
+        specifier: workspace:*
+        version: link:../../sdk/app-toolkit
+      '@dxos/client':
+        specifier: workspace:*
+        version: link:../../sdk/client
+      '@dxos/compute':
+        specifier: workspace:*
+        version: link:../../core/compute/compute
+      '@dxos/echo':
+        specifier: workspace:*
+        version: link:../../core/echo/echo
+      '@dxos/invariant':
+        specifier: workspace:*
+        version: link:../../common/invariant
+      '@dxos/keys':
+        specifier: workspace:*
+        version: link:../../common/keys
+      '@dxos/log':
+        specifier: workspace:*
+        version: link:../../common/log
+      '@dxos/schema':
+        specifier: workspace:*
+        version: link:../../sdk/schema
+      '@dxos/types':
+        specifier: workspace:*
+        version: link:../../sdk/types
+      '@dxos/util':
+        specifier: workspace:*
+        version: link:../../common/util
+      effect:
+        specifier: 3.20.0
+        version: 3.20.0
+    devDependencies:
+      '@dxos/effect':
+        specifier: workspace:*
+        version: link:../../common/effect
+      '@dxos/functions-runtime':
+        specifier: workspace:*
+        version: link:../../core/compute/functions-runtime
+      '@dxos/plugin-testing':
+        specifier: workspace:*
+        version: link:../plugin-testing
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.29.0(effect@3.20.0)(vitest@4.1.7)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(patch_hash=a7bf6a3d21c2bc782d60d0f0f916d76f304c0eb6fbf2827e8d981408c7b5120e)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/plugins/plugin-script:
     dependencies:
       '@automerge/automerge':
@@ -16563,7 +16618,7 @@ importers:
         version: link:../../common/util
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -20449,7 +20504,7 @@ importers:
         version: link:../ui-theme
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -25427,6 +25482,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -45332,7 +45388,7 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.2)
       ajv: 8.18.0
@@ -51805,7 +51861,7 @@ snapshots:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@cloudflare/ai-chat': 0.0.6(agents@0.3.10)(ai@6.0.97(zod@4.3.6))(react@19.2.6)(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 6.0.97(zod@4.3.6)
       cron-schedule: 6.0.0
       escape-html: 1.0.3
@@ -54190,10 +54246,6 @@ snapshots:
   draco3d@1.5.7: {}
 
   dset@3.1.4: {}
-
-  dts-resolver@2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
-    optionalDependencies:
-      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   dts-resolver@2.1.3(oxc-resolver@11.9.0):
     optionalDependencies:
@@ -60981,24 +61033,6 @@ snapshots:
 
   robust-predicates@3.0.1: {}
 
-  rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
-    dependencies:
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-      ast-kit: 2.2.0
-      birpc: 3.0.0
-      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
-      get-tsconfig: 4.13.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260421.2
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - oxc-resolver
-
   rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
     dependencies:
       '@babel/generator': 7.28.5
@@ -62673,34 +62707,6 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
-
-  tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
-    dependencies:
-      ansis: 4.2.0
-      cac: 6.7.14
-      chokidar: 5.0.0
-      diff: 8.0.3
-      empathic: 2.0.0
-      hookable: 5.5.3
-      obug: 2.1.1
-      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      rolldown-plugin-dts: 0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
-      semver: 7.7.4
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tree-kill: 1.2.2
-      unconfig-core: 7.4.2
-      unrun: 0.2.19(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@ts-macro/tsc'
-      - '@typescript/native-preview'
-      - oxc-resolver
-      - synckit
-      - vue-tsc
 
   tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3):
     dependencies:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -755,6 +755,11 @@
         },
         {
           "type": "json",
+          "path": "packages/plugins/plugin-sandbox/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/plugins/plugin-script/package.json",
           "jsonpath": "$.version"
         },

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -439,6 +439,9 @@
       "path": "packages/plugins/plugin-sample/tsconfig.json"
     },
     {
+      "path": "packages/plugins/plugin-sandbox/tsconfig.json"
+    },
+    {
       "path": "packages/plugins/plugin-script/tsconfig.json"
     },
     {


### PR DESCRIPTION
## Summary

Implements `@dxos/plugin-sandbox` (DX-951), a plugin that provides isolated shell environments for Composer spaces.

- **`Sandbox` ECHO type** (`org.dxos.type.sandbox@0.1.0`) — stored in the space, its object id doubles as the sandbox id in the sandbox service
- **`SandboxBlueprint`** — AI toolkit with four tools wired to the sandbox REST API (`/api/sandbox`):
  - `CreateSandbox` — creates an ECHO Sandbox object and lazily registers it with the service via idempotent PUT
  - `Exec` — runs a shell command in the sandbox (stdout, stderr, exitCode)
  - `UploadFile` — writes an ECHO `File` object's content into a sandbox path
  - `DownloadFile` — reads a file from the sandbox and creates (or overwrites) an ECHO `File` object
- **`SandboxClient`** — thin fetch-based HTTP client mapping to the REST spec
- **Capability modules** — `BlueprintDefinition` and `OperationHandler` wired through `AppPlugin`
- **Tests** — three integration tests behind `describe.skip` (manual flag); disabled by default, require a live sandbox service

The edge URL is derived from `client.config.values.runtime?.services?.edge?.url`, consistent with how `plugin-script` locates the edge service.

## Test plan

- [ ] Build passes: `moon run plugin-sandbox:build`
- [ ] Lint passes: `moon run plugin-sandbox:lint`
- [ ] Tests skipped cleanly: `moon run plugin-sandbox:test` (3 skipped)
- [ ] Manual: enable tests against a live sandbox service by removing `describe.skip`

closes DX-951

https://claude.ai/code/session_01XRHi5Mz99vZoVSLqA2pV1G

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRHi5Mz99vZoVSLqA2pV1G)_