### PR TITLE
fix(echo,credentials,client-protocol): three proto3/EDGE-routing follow-ups to #11578

### DIFF
--- a/packages/core/compute/compute/src/Operation.ts
+++ b/packages/core/compute/compute/src/Operation.ts
@@ -173,15 +173,17 @@ export const make = <const P extends Types.NoExcessProperties<Props<any, any>, P
 
 /**
  * Marks an operation as intrinsic — provided directly by the DXOS platform runtime rather than
- * deployed as a user function. The `intrinsic:<key>` deployedId routes invocations to the
- * built-in implementation registered with the runtime.
+ * deployed as a user function. The `dxn:<key>` deployedId routes invocations to the built-in
+ * implementation registered with the runtime; the EDGE function service detects the `dxn:`
+ * scheme via `DXN.isDXN` and dispatches to its intrinsic handler instead of looking up a
+ * deployed worker.
  */
 export const intrinsic = <const O extends Operation.Definition.Any>(op: O): O => {
   return {
     ...op,
     meta: {
       ...op.meta,
-      deployedId: `intrinsic:${op.meta.key}`,
+      deployedId: `dxn:${op.meta.key}`,
     },
   };
 };

--- a/packages/core/halo/credentials/src/credentials/signing.ts
+++ b/packages/core/halo/credentials/src/credentials/signing.ts
@@ -14,8 +14,19 @@ import { arrayToBuffer } from '@dxos/util';
  */
 // TODO(nf): rename, this returns not the proof itself, but the payload for verifying against the proof.
 export const getCredentialProofPayload = (credential: Credential): Uint8Array => {
+  // Shallow-copy the credential and override the proof fields that are not part of the signing
+  // payload. The assertion is normalized below; clone its subject so the normalization does not
+  // mutate the caller's credential (which would silently strip `multiUse: false` and other
+  // explicit-default fields from the in-memory object).
+  const originalAssertion = (credential.subject as any)?.assertion;
   const copy = {
     ...credential,
+    subject: originalAssertion
+      ? {
+          ...credential.subject,
+          assertion: { ...originalAssertion },
+        }
+      : credential.subject,
     proof: {
       ...credential.proof,
       value: new Uint8Array(),
@@ -27,13 +38,25 @@ export const getCredentialProofPayload = (credential: Credential): Uint8Array =>
   }
   delete copy.id; // ID is not part of the signature payload.
 
-  // Normalize empty repeated fields in the assertion to avoid proto3 serialization asymmetry.
-  // Proto3 does not encode empty repeated fields, but the codec may restore them as [] after deserialization,
-  // causing a signature mismatch if the original signing payload did not include the field.
+  // Normalize proto3-default fields in the assertion to avoid serialization asymmetry.
+  // Proto3 does not encode default-valued fields (`0` for numbers/enums, `""` for strings,
+  // `false` for booleans, `[]` for repeated), so the deserialized credential is missing those
+  // fields. If the signer included them with default values, the signing-time canonical bytes
+  // would not match the verifying-time bytes and verification would fail.
+  // Strip these shapes so signer and verifier produce identical canonical payloads regardless
+  // of whether the field was explicitly set to its default before encoding.
   const assertion = (copy.subject as any)?.assertion;
   if (assertion) {
     for (const key of Object.keys(assertion)) {
-      if (Array.isArray(assertion[key]) && assertion[key].length === 0) {
+      const value = assertion[key];
+      if (
+        (Array.isArray(value) && value.length === 0) ||
+        value === 0 ||
+        value === '' ||
+        value === false ||
+        value === null ||
+        value === undefined
+      ) {
         delete assertion[key];
       }
     }

--- a/packages/sdk/client-protocol/src/invitations/encoder.ts
+++ b/packages/sdk/client-protocol/src/invitations/encoder.ts
@@ -22,6 +22,13 @@ export class InvitationEncoder {
       decodedInvitation.type = Invitation.Type.INTERACTIVE;
       decodedInvitation.multiUse = true;
     }
+    // Proto3 does not encode default enum values on the wire, so when an invitation was
+    // serialized with `kind: DEVICE` (= 0) the field comes back as `undefined`. Restore the
+    // default explicitly so downstream consumers (`ServiceContext.getInvitationHandler`) can
+    // still dispatch by kind.
+    if (decodedInvitation.kind === undefined) {
+      decodedInvitation.kind = Invitation.Kind.DEVICE;
+    }
     return decodedInvitation;
   }
 


### PR DESCRIPTION
Three independent follow-ups uncovered while integrating #11578's deterministic-ObjectId fix into EDGE.

## Summary

1. **`Operation.intrinsic` deployedId scheme.** EDGE's function-invoker dispatches intrinsic ops by detecting the `dxn:` URI scheme (`DXN.isDXN`); `Operation.intrinsic` was emitting `intrinsic:<key>`, which fell through to the deployed-worker registry and failed every intrinsic call with `Function not deployed` (Fibonacci, AgentPrompt, all assistant-toolkit blueprint ops). Align dxos with EDGE's `dxn:<key>` convention.

2. **Credential signing: proto3-default-valued fields.** After #10888 added `MembershipPolicy membership_policy = 3` to `SpaceGenesis`, every new space failed credential verification with `Invalid credential: Invalid signature`. The signer included `membershipPolicy: 0` in the canonical payload, but proto3 doesn't encode defaults — the deserialized credential is missing the field, signing bytes ≠ verifying bytes. Generalize the existing empty-array workaround in `getCredentialProofPayload` to also strip `0`/`""`/`false`/`null`/`undefined`, plus fix a latent mutation bug that silently stripped `multiUse: false` (and friends) from the caller's in-memory credential.

3. **`InvitationEncoder.decode`: restore default `Kind.DEVICE`.** `Invitation.Kind.DEVICE = 0` is the proto3 enum default, so after `encode → decode` the `kind` field is `undefined`, and `ServiceContext.getInvitationHandler` throws `Unknown invitation kind: undefined` for every device invitation that goes through `sanitizeInvitation`. Restore the default in the decoder.

Each commit is self-contained and corresponds to one of the above.

## Test plan

- [x] `moon run credentials:test` — 54/54 passing (signing.ts mutation bug regression covered by existing `invitation-state-machine.test.ts > expected to have deep property 'multiUse'` assertions; without the deep-copy fix those go red).
- [x] `moon run compute:test` — 21/21 passing.
- [x] `moon run client-services:test` — 112/114 passing (no regressions from baseline).
- [x] Linked into edge via `scripts/link-packages.mjs`, verified:
  - `edge:test/functions.node.test.ts > invoke intrinsic operation` (was failing with `Function not deployed`) ✅
  - `edge:test/ai.node.test.ts > invoke AgentPrompt system operation` (was failing with `Function not deployed`) ✅
  - `space-agent:test` (29/29, was failing with workerd `crypto.getRandomValues` + Invalid signature) ✅
  - `compute-intrinsics:test` (1/1, was failing) ✅


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Enhanced credential assertion handling to prevent unintended mutations during the signing process
- Corrected invitation decoding to properly handle messages with default enum values
- Refined internal operation routing and identification mechanism

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->