### PR TITLE
refactor(compute): remove Operation.intrinsic helper

### DIFF
--- a/packages/core/compute/assistant-toolkit/src/blueprints/database/functions/definitions.ts
+++ b/packages/core/compute/assistant-toolkit/src/blueprints/database/functions/definitions.ts
@@ -102,7 +102,7 @@ export const Query = Operation.make({
   }),
   output: Schema.Array(Schema.Unknown),
   services: [Database.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const Load = Operation.make({
   meta: {
@@ -123,7 +123,7 @@ export const Load = Operation.make({
   }),
   output: Schema.Unknown,
   services: [Database.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const ObjectCreate = Operation.make({
   meta: {
@@ -143,7 +143,7 @@ export const ObjectCreate = Operation.make({
   }),
   output: Schema.Unknown,
   services: [Database.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const ObjectUpdate = Operation.make({
   meta: {
@@ -162,7 +162,7 @@ export const ObjectUpdate = Operation.make({
   }),
   output: Schema.Unknown,
   services: [Database.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const ObjectDelete = Operation.make({
   meta: {
@@ -178,7 +178,7 @@ export const ObjectDelete = Operation.make({
   }),
   output: Schema.Void,
   services: [Database.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const SchemaAdd = Operation.make({
   meta: {
@@ -199,7 +199,7 @@ export const SchemaAdd = Operation.make({
   }),
   output: Schema.Void,
   services: [Database.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const SchemaList = Operation.make({
   meta: {
@@ -215,7 +215,7 @@ export const SchemaList = Operation.make({
   }),
   output: Schema.Array(Schema.Unknown),
   services: [Database.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const ContextAdd = Operation.make({
   meta: {
@@ -234,7 +234,7 @@ export const ContextAdd = Operation.make({
   }),
   output: Schema.Void,
   services: [AiContext.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const ContextRemove = Operation.make({
   meta: {
@@ -253,7 +253,7 @@ export const ContextRemove = Operation.make({
   }),
   output: Schema.Void,
   services: [AiContext.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const RelationCreate = Operation.make({
   meta: {
@@ -275,7 +275,7 @@ export const RelationCreate = Operation.make({
   }),
   output: Schema.Unknown,
   services: [Database.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const RelationDelete = Operation.make({
   meta: {
@@ -291,7 +291,7 @@ export const RelationDelete = Operation.make({
   }),
   output: Schema.Void,
   services: [Database.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const TagAdd = Operation.make({
   meta: {
@@ -310,7 +310,7 @@ export const TagAdd = Operation.make({
   }),
   output: Schema.Unknown,
   services: [Database.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const TagRemove = Operation.make({
   meta: {
@@ -328,4 +328,4 @@ export const TagRemove = Operation.make({
   }),
   output: Schema.Unknown,
   services: [Database.Service],
-}).pipe(Operation.intrinsic);
+});

--- a/packages/core/compute/assistant-toolkit/src/blueprints/project/functions/definitions.ts
+++ b/packages/core/compute/assistant-toolkit/src/blueprints/project/functions/definitions.ts
@@ -32,7 +32,7 @@ export const AgentWorker = Operation.make({
     Trace.TraceService,
     OpaqueToolkit.OpaqueToolkitProvider,
   ],
-}).pipe(Operation.intrinsic);
+});
 
 export const Qualifier = Operation.make({
   meta: {
@@ -48,7 +48,7 @@ export const Qualifier = Operation.make({
   }),
   output: Schema.Void,
   services: [AiService.AiService, Database.Service, Feed.FeedService],
-}).pipe(Operation.intrinsic);
+});
 
 export const GetContext = Operation.make({
   meta: {
@@ -72,7 +72,7 @@ export const GetContext = Operation.make({
     ),
   }),
   services: [AiContext.Service, Database.Service],
-}).pipe(Operation.intrinsic);
+});
 
 export const AddArtifact = Operation.make({
   meta: {
@@ -91,4 +91,4 @@ export const AddArtifact = Operation.make({
   }),
   output: Schema.Void,
   services: [AiContext.Service, Database.Service],
-}).pipe(Operation.intrinsic);
+});

--- a/packages/core/compute/assistant-toolkit/src/functions/agent/definitions.ts
+++ b/packages/core/compute/assistant-toolkit/src/functions/agent/definitions.ts
@@ -54,4 +54,4 @@ export const AgentPrompt = Operation.make({
     OperationRegistry.Service,
     Trace.TraceService,
   ],
-}).pipe(Operation.intrinsic);
+});

--- a/packages/core/compute/compute/src/Operation.ts
+++ b/packages/core/compute/compute/src/Operation.ts
@@ -173,15 +173,17 @@ export const make = <const P extends Types.NoExcessProperties<Props<any, any>, P
 
 /**
  * Marks an operation as intrinsic — provided directly by the DXOS platform runtime rather than
- * deployed as a user function. The `intrinsic:<key>` deployedId routes invocations to the
- * built-in implementation registered with the runtime.
+ * deployed as a user function. The `dxn:<key>` deployedId routes invocations to the built-in
+ * implementation registered with the runtime; the EDGE function service detects the `dxn:`
+ * scheme via `DXN.isDXN` and dispatches to its intrinsic handler instead of looking up a
+ * deployed worker.
  */
 export const intrinsic = <const O extends Operation.Definition.Any>(op: O): O => {
   return {
     ...op,
     meta: {
       ...op.meta,
-      deployedId: `intrinsic:${op.meta.key}`,
+      deployedId: `dxn:${op.meta.key}`,
     },
   };
 };
@@ -224,27 +226,27 @@ export const withHandler: {
   opOrHandler: Def | Handler<Definition.Input<Def>, Definition.Output<Def>, E, Definition.Services<Def> | Service>,
   handler?: Handler<Definition.Input<Def>, Definition.Output<Def>, E, Definition.Services<Def> | Service>,
 ): WithHandler<Def> => {
-  // If called with just handler (piped usage).
-  if (handler === undefined) {
-    const handlerFn = opOrHandler as Handler<
-      Definition.Input<Def>,
-      Definition.Output<Def>,
-      E,
-      Definition.Services<Def> | Service
-    >;
-    return ((op: Def) => ({
-      ...op,
-      handler: handlerFn,
-    })) as any;
-  }
+    // If called with just handler (piped usage).
+    if (handler === undefined) {
+      const handlerFn = opOrHandler as Handler<
+        Definition.Input<Def>,
+        Definition.Output<Def>,
+        E,
+        Definition.Services<Def> | Service
+      >;
+      return ((op: Def) => ({
+        ...op,
+        handler: handlerFn,
+      })) as any;
+    }
 
-  // If called with both op and handler (direct usage).
-  const op = opOrHandler as Def;
-  return {
-    ...op,
-    handler,
-  } as any;
-};
+    // If called with both op and handler (direct usage).
+    const op = opOrHandler as Def;
+    return {
+      ...op,
+      handler,
+    } as any;
+  };
 
 /**
  * Helper to make the handler type opaque.
@@ -494,7 +496,7 @@ export interface OperationService {
  * ```
  */
 // TODO(dmaretskyi): Rename Operation.Invoker
-export class Service extends Context.Tag('@dxos/operation/Service')<Service, OperationService>() {}
+export class Service extends Context.Tag('@dxos/operation/Service')<Service, OperationService>() { }
 
 //
 // Namespace functions - ergonomic access to Operation.Service methods.

--- a/packages/core/compute/compute/src/Operation.ts
+++ b/packages/core/compute/compute/src/Operation.ts
@@ -136,7 +136,7 @@ export const isOperationWithHandler = (value: unknown): value is WithHandler<Def
   return isOperationDefinition(value) && 'handler' in value;
 };
 
-/**a
+/**
  * Props for creating an Operation definition.
  * Derived from OperationDefinition with executionMode made optional (defaults to 'async').
  */
@@ -169,23 +169,6 @@ export const make = <const P extends Types.NoExcessProperties<Props<any, any>, P
       return Pipeable.pipeArguments(this, arguments);
     },
   } as any;
-};
-
-/**
- * Marks an operation as intrinsic — provided directly by the DXOS platform runtime rather than
- * deployed as a user function. The `dxn:<key>` deployedId routes invocations to the built-in
- * implementation registered with the runtime; the EDGE function service detects the `dxn:`
- * scheme via `DXN.isDXN` and dispatches to its intrinsic handler instead of looking up a
- * deployed worker.
- */
-export const intrinsic = <const O extends Operation.Definition.Any>(op: O): O => {
-  return {
-    ...op,
-    meta: {
-      ...op.meta,
-      deployedId: `dxn:${op.meta.key}`,
-    },
-  };
 };
 
 /**
@@ -226,27 +209,27 @@ export const withHandler: {
   opOrHandler: Def | Handler<Definition.Input<Def>, Definition.Output<Def>, E, Definition.Services<Def> | Service>,
   handler?: Handler<Definition.Input<Def>, Definition.Output<Def>, E, Definition.Services<Def> | Service>,
 ): WithHandler<Def> => {
-    // If called with just handler (piped usage).
-    if (handler === undefined) {
-      const handlerFn = opOrHandler as Handler<
-        Definition.Input<Def>,
-        Definition.Output<Def>,
-        E,
-        Definition.Services<Def> | Service
-      >;
-      return ((op: Def) => ({
-        ...op,
-        handler: handlerFn,
-      })) as any;
-    }
-
-    // If called with both op and handler (direct usage).
-    const op = opOrHandler as Def;
-    return {
+  // If called with just handler (piped usage).
+  if (handler === undefined) {
+    const handlerFn = opOrHandler as Handler<
+      Definition.Input<Def>,
+      Definition.Output<Def>,
+      E,
+      Definition.Services<Def> | Service
+    >;
+    return ((op: Def) => ({
       ...op,
-      handler,
-    } as any;
-  };
+      handler: handlerFn,
+    })) as any;
+  }
+
+  // If called with both op and handler (direct usage).
+  const op = opOrHandler as Def;
+  return {
+    ...op,
+    handler,
+  } as any;
+};
 
 /**
  * Helper to make the handler type opaque.
@@ -496,7 +479,7 @@ export interface OperationService {
  * ```
  */
 // TODO(dmaretskyi): Rename Operation.Invoker
-export class Service extends Context.Tag('@dxos/operation/Service')<Service, OperationService>() { }
+export class Service extends Context.Tag('@dxos/operation/Service')<Service, OperationService>() {}
 
 //
 // Namespace functions - ergonomic access to Operation.Service methods.

--- a/packages/core/compute/compute/src/testing/definitions.ts
+++ b/packages/core/compute/compute/src/testing/definitions.ts
@@ -21,7 +21,7 @@ export const Fibonacci = Operation.make({
   output: Schema.Struct({
     result: Schema.String,
   }),
-}).pipe(Operation.intrinsic);
+});
 
 export const Reply = Operation.make({
   meta: {
@@ -31,7 +31,7 @@ export const Reply = Operation.make({
   },
   input: Schema.Any,
   output: Schema.Any,
-}).pipe(Operation.intrinsic);
+});
 
 export const Sleep = Operation.make({
   meta: {
@@ -46,4 +46,4 @@ export const Sleep = Operation.make({
     }),
   }),
   output: Schema.Void,
-}).pipe(Operation.intrinsic);
+});

--- a/packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.test.ts
+++ b/packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.test.ts
@@ -719,16 +719,15 @@ describe('TriggerDispatcher', () => {
   // can resolve the same space-scoped services their handler declares.
   describe('Service Resolution', () => {
     /**
-     * Operation whose handler depends on {@link Database.Service}. Declared as
-     * `intrinsic` so it routes through the operation handler set we register
-     * via {@link OperationHandlerSet.provide} below.
+     * Operation whose handler depends on {@link Database.Service}. Resolved via the
+     * operation handler set registered with {@link OperationHandlerSet.provide} below.
      */
     const ProbeOp = Operation.make({
       meta: { key: 'test.trigger-dispatcher.probe-database', name: 'Probe Database' },
       input: Schema.Any,
       output: Schema.Struct({ spaceId: Schema.String }),
       services: [Database.Service],
-    }).pipe(Operation.intrinsic);
+    });
 
     const ProbeHandler = ProbeOp.pipe(
       Operation.withHandler(

--- a/packages/sdk/app-toolkit/src/operations.ts
+++ b/packages/sdk/app-toolkit/src/operations.ts
@@ -41,7 +41,7 @@ export namespace LayoutOperation {
       ),
     }),
     output: Schema.Void,
-  }).pipe(Operation.intrinsic);
+  });
 
   export const UpdateComplementary = Operation.make({
     meta: {
@@ -63,7 +63,7 @@ export namespace LayoutOperation {
       ),
     }),
     output: Schema.Void,
-  }).pipe(Operation.intrinsic);
+  });
 
   //
   // Dialog Operations
@@ -102,7 +102,7 @@ export namespace LayoutOperation {
       ),
     }),
     output: Schema.Void,
-  }).pipe(Operation.intrinsic);
+  });
 
   //
   // Popover Operations
@@ -174,7 +174,7 @@ export namespace LayoutOperation {
       ),
     ),
     output: Schema.Void,
-  }).pipe(Operation.intrinsic);
+  });
 
   //
   // Toast Operations
@@ -209,7 +209,7 @@ export namespace LayoutOperation {
     services: [Capability.Service],
     input: Toast,
     output: Schema.Void,
-  }).pipe(Operation.intrinsic);
+  });
 
   //
   // Layout Mode Operations
@@ -236,7 +236,7 @@ export namespace LayoutOperation {
       }),
     ),
     output: Schema.Void,
-  }).pipe(Operation.intrinsic);
+  });
 
   //
   // Workspace Operations
@@ -255,7 +255,7 @@ export namespace LayoutOperation {
       subject: Schema.String.annotations({ description: 'The id of the workspace to switch to.' }),
     }),
     output: Schema.Void,
-  }).pipe(Operation.intrinsic);
+  });
 
   export const RevertWorkspace = Operation.make({
     meta: {
@@ -318,7 +318,7 @@ export namespace LayoutOperation {
       ),
     }),
     output: Schema.Array(Schema.String).annotations({ description: 'The resolved navigation paths that were opened.' }),
-  }).pipe(Operation.intrinsic);
+  });
 
   export const Close = Operation.make({
     meta: {
@@ -333,7 +333,7 @@ export namespace LayoutOperation {
       subject: Schema.Array(Schema.String.annotations({ description: 'Ids of the items to close.' })),
     }),
     output: Schema.Void,
-  }).pipe(Operation.intrinsic);
+  });
 
   export const Set = Operation.make({
     meta: {
@@ -368,7 +368,7 @@ export namespace LayoutOperation {
       ref: Schema.optional(Schema.String.annotations({ description: 'A reference id for the scroll target.' })),
     }),
     output: Schema.Void,
-  }).pipe(Operation.intrinsic);
+  });
 
   export const Expose = Operation.make({
     meta: {


### PR DESCRIPTION
## Summary

- Removes `Operation.intrinsic` from `@dxos/compute` — platform operations no longer set a synthetic `deployedId` (`intrinsic:` / `dxn:`); they resolve locally via `meta.key` through the operation handler set.
- Strips `.pipe(Operation.intrinsic)` from layout, assistant-toolkit, and test operation definitions.
- Fixes a stray `/**a` JSDoc typo in `Operation.ts`.

## Rationale

Built-in operations are registered with `OperationHandlerSet` and invoked by key. The `intrinsic` helper only stamped `deployedId` for remote EDGE routing; that indirection is unnecessary now that local dispatch is the canonical path for platform operations.

## Test plan

- [x] `pnpm format`
- [x] `moon run compute:build app-toolkit:build assistant-toolkit:build functions-runtime:build`
- [x] `moon run compute:test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized how built-in operations are identified and how handlers are registered across the system to improve consistency and reliability.
* **Tests**
  * Aligned tests with the updated dispatch/handler behavior to ensure correct operation resolution.
* **Documentation**
  * Clarified inline documentation and fixed formatting to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->