### PR TITLE
feat(plugin-space): add plugin registry shortcut to CreateObjectDialog footer

### DIFF
--- a/packages/plugins/plugin-space/src/containers/CreateObjectDialog/CreateObjectDialog.tsx
+++ b/packages/plugins/plugin-space/src/containers/CreateObjectDialog/CreateObjectDialog.tsx
@@ -9,7 +9,7 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import { Capability } from '@dxos/app-framework';
 import { useOperationInvoker, usePluginManager } from '@dxos/app-framework/ui';
-import { getPersonalSpace, LayoutOperation } from '@dxos/app-toolkit';
+import { getPersonalSpace, LayoutOperation, SettingsOperation } from '@dxos/app-toolkit';
 import { useLayout } from '@dxos/app-toolkit/ui';
 import { Operation } from '@dxos/compute';
 import { Annotation, Collection, Database, Obj, Type } from '@dxos/echo';
@@ -17,7 +17,7 @@ import { runAndForwardErrors } from '@dxos/effect';
 import { invariant } from '@dxos/invariant';
 import { useClient } from '@dxos/react-client';
 import { useSpaces } from '@dxos/react-client/echo';
-import { Dialog, useTranslation } from '@dxos/react-ui';
+import { Dialog, IconButton, useTranslation } from '@dxos/react-ui';
 import { ViewAnnotation } from '@dxos/schema';
 
 import { type CreateObjectOption, CreateObjectPanel, type CreateObjectPanelProps } from '#components';
@@ -178,6 +178,15 @@ export const CreateObjectDialog = ({
           onTypenameChange={setTypename}
         />
       </Dialog.Body>
+      <Dialog.ActionBar>
+        <Dialog.Close asChild>
+          <IconButton
+            icon='ph--squares-four--regular'
+            label={t('open-plugin-registry.label')}
+            onClick={() => void operationInvoker.invokePromise(SettingsOperation.OpenPluginRegistry)}
+          />
+        </Dialog.Close>
+      </Dialog.ActionBar>
     </Dialog.Content>
   );
 };

--- a/packages/plugins/plugin-space/src/translations.ts
+++ b/packages/plugins/plugin-space/src/translations.ts
@@ -219,6 +219,7 @@ export const translations = [
         'no-sync-status.label': 'No space with missing objects.',
         'create-space-dialog.title': 'Create Space',
         'create-object-dialog.title': 'Create {{object}}',
+        'open-plugin-registry.label': 'Open plugin registry',
         'space-input.placeholder': 'Select space',
         'schema-input.placeholder': 'Select type',
         'plugin-subtitle.label': '{{plugin}} Plugin',


### PR DESCRIPTION
## Summary
- Add a footer (`Dialog.ActionBar`) to `CreateObjectDialog` with an `IconButton` (registry icon + label) that closes the dialog and invokes `SettingsOperation.OpenPluginRegistry`.
- Wrap the button in `Dialog.Close asChild` so Radix dismisses the dialog before the operation runs — required so attention can follow when the registry workspace opens.
- Add `open-plugin-registry.label` translation under `meta.id` in `plugin-space`.

## Why
Users who open the create-object dialog and don't see the type they want now have a one-click path to the plugin registry to enable or install one, instead of having to back out and navigate manually.

## Test plan
- [ ] Open the create-object dialog in composer-app and click the registry button in the footer; verify the dialog closes and the plugin registry workspace opens.
- [ ] Confirm the button shows both the registry icon (`ph--squares-four--regular`) and the localized label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now access the plugin registry directly from the object creation dialog via a new action button
  * Enhanced dialog layout with an improved action bar containing close and registry access options
  * Added localization support for the new plugin registry feature

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->