### PR TITLE
feat(plugin-explorer): SVG boids swarm variant via react-ui-graph projector

### DIFF
--- a/packages/plugins/plugin-explorer/package.json
+++ b/packages/plugins/plugin-explorer/package.json
@@ -112,7 +112,6 @@
     "@dxos/react-ui-components": "workspace:*",
     "@dxos/react-ui-graph": "workspace:*",
     "@dxos/react-ui-mosaic": "workspace:*",
-    "@dxos/react-ui-sfx": "workspace:*",
     "@dxos/react-ui-stack": "workspace:*",
     "@dxos/schema": "workspace:*",
     "@dxos/types": "workspace:*",

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/GraphFlockProjector.ts
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/GraphFlockProjector.ts
@@ -1,0 +1,371 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Timer, timer } from 'd3';
+
+import { type Graph } from '@dxos/graph';
+import { log } from '@dxos/log';
+import { GraphProjector, type GraphProjectorOptions, type GraphLayoutNode } from '@dxos/react-ui-graph';
+
+// Boids flocking simulation rendered through the react-ui-graph SVG renderer.
+// Mirrors the canvas Flock component's tick (alignment / cohesion / separation)
+// but mutates `x/y` on `GraphLayoutNode` instances directly and emits 'positions'
+// each frame so `GraphRenderer.applyPositions` can fast-path SVG transforms,
+// exactly like `GraphForceProjector`.
+//
+// https://en.wikipedia.org/wiki/Boids
+
+const FLOCKMATE_RADIUS = 60;
+const SEPARATION_DISTANCE = 30;
+
+/** Per-frame state stored on a layout node by the projector. */
+export type FlockNode = GraphLayoutNode & {
+  vx?: number;
+  vy?: number;
+  ax?: number;
+  ay?: number;
+  /**
+   * Shallow ring buffer of recent absolute positions (oldest first). One position is
+   * pushed per tick BEFORE integration, so after a tick the most recent entry is the
+   * pre-tick position. Cleared whenever the boid wraps a viewBox edge so the trail
+   * doesn't streak across the canvas.
+   */
+  history?: Array<{ x: number; y: number }>;
+};
+
+export type GraphFlockProjectorOptions = GraphProjectorOptions & {
+  /** Initial spread (px) of new boids around the origin. */
+  spawnRadius?: number;
+  /** Hard cap on per-tick velocity. */
+  maxVelocity?: number;
+  /** Per-force weights — match Flock's normalisation (divided by 100 on apply). */
+  alignment?: number;
+  cohesion?: number;
+  separation?: number;
+  /** Pixel radius (in SVG model coords) of the invisible repel zone tracking the pointer. 0 disables. */
+  cursorRepel?: number;
+  /** Avoidance force weight (divided by 10 on apply, matching canvas Flock). */
+  avoidance?: number;
+  /**
+   * Number of previous positions retained per boid (one per simulation tick). The visible
+   * tail spans roughly `trailLength * maxVelocity` pixels — at 60 fps a value of 30 is
+   * about a half-second streak. Dense per-tick sampling avoids the "snap" artifact a
+   * coarser sample interval introduces when only the head moves between samples.
+   */
+  trailLength?: number;
+};
+
+const DEFAULTS: Required<
+  Pick<
+    GraphFlockProjectorOptions,
+    | 'spawnRadius'
+    | 'maxVelocity'
+    | 'alignment'
+    | 'cohesion'
+    | 'separation'
+    | 'cursorRepel'
+    | 'avoidance'
+    | 'trailLength'
+  >
+> = {
+  spawnRadius: 200,
+  maxVelocity: 1.2,
+  alignment: 3,
+  cohesion: 3,
+  separation: 3,
+  cursorRepel: 120,
+  avoidance: 3,
+  trailLength: 30,
+};
+
+/**
+ * Boids projector. One simulation timer (d3 `timer`) drives the tick; nodes are
+ * the boids, with `vx/vy/ax/ay` carried alongside `x/y`. Edges are kept in the
+ * layout so the renderer still draws them between connected boids, but they do
+ * NOT exert a link force — boid motion is governed purely by alignment, cohesion
+ * and separation, with viewBox-wrap at the SVG bounds.
+ */
+export class GraphFlockProjector<NodeData = any> extends GraphProjector<NodeData, GraphFlockProjectorOptions> {
+  #timer?: Timer;
+  /** Cursor in SVG model coordinates, or null when the pointer is outside the surface. */
+  #cursor: { x: number; y: number } | null = null;
+
+  override findNode(): GraphLayoutNode<NodeData> | undefined {
+    // Boids have no spatial index — drag isn't supported in this variant.
+    return undefined;
+  }
+
+  /**
+   * Tell the projector where the pointer is, in SVG model coordinates (the same space
+   * `node.x/y` live in — center origin, post-zoom). Pass `null` (or omit args) on
+   * pointer-leave to disable cursor avoidance.
+   */
+  setCursor(x?: number | null, y?: number | null): void {
+    if (x == null || y == null) {
+      this.#cursor = null;
+    } else {
+      this.#cursor = { x, y };
+    }
+  }
+
+  protected override onUpdate(graph?: Graph.Any): void {
+    log('onUpdate', { graph: { nodes: graph?.nodes.length, edges: graph?.edges.length } });
+    this.mergeData(graph);
+    this.initializeNodes();
+    // Bind enter/exit once before motion starts; subsequent ticks emit 'positions'.
+    this.emitUpdate('topology');
+  }
+
+  protected override async onStart(): Promise<void> {
+    this.startTimer();
+  }
+
+  protected override async onStop(): Promise<void> {
+    this.stopTimer();
+  }
+
+  protected override onRefresh(): void {
+    if (!this.#timer) {
+      this.startTimer();
+    }
+  }
+
+  #opt<K extends keyof typeof DEFAULTS>(key: K): number {
+    return (this.options[key] as number | undefined) ?? DEFAULTS[key];
+  }
+
+  private initializeNodes(): void {
+    const spawnRadius = this.#opt('spawnRadius');
+    const maxVelocity = this.#opt('maxVelocity');
+    for (const node of this.layout.graph.nodes as FlockNode[]) {
+      if (!node.initialized) {
+        const theta = Math.random() * 2 * Math.PI;
+        const r = Math.random() * spawnRadius;
+        node.x = Math.cos(theta) * r;
+        node.y = Math.sin(theta) * r;
+        // Random initial velocity bounded by maxVelocity.
+        const phi = Math.random() * 2 * Math.PI;
+        const speed = (0.3 + Math.random() * 0.7) * maxVelocity;
+        node.vx = Math.cos(phi) * speed;
+        node.vy = Math.sin(phi) * speed;
+        node.ax = 0;
+        node.ay = 0;
+        node.initialized = true;
+      } else {
+        // Make sure velocity / acceleration exist on nodes inherited from a prior layout.
+        node.vx ??= 0;
+        node.vy ??= 0;
+        node.ax ??= 0;
+        node.ay ??= 0;
+      }
+      // Default render radius — matches the force projector default.
+      node.r ??= 6;
+      // Reset the trail history. On fresh entry (`prev` from force/lattice/...) the field
+      // is undefined; on re-entry from a prior swarm session the layout node is reused and
+      // still carries stale absolute positions which would draw the tail back to wherever
+      // the boid was last time. Seed with the current position so the tail grows from the
+      // boid's actual starting point.
+      node.history = [{ x: node.x ?? 0, y: node.y ?? 0 }];
+    }
+  }
+
+  private startTimer(): void {
+    this.stopTimer();
+    this.#timer = timer(() => this.tick());
+  }
+
+  private stopTimer(): void {
+    this.#timer?.stop();
+    this.#timer = undefined;
+  }
+
+  /**
+   * One simulation step. Modeled on `tick` in Flock.tsx, but operating in the
+   * SVG centered-origin coordinate space and writing to `node.x/y` directly so
+   * the existing `GraphRenderer.applyPositions` reads them unchanged.
+   */
+  private tick(): void {
+    const size = this.context.size;
+    if (!size) {
+      return;
+    }
+    const { width, height } = size;
+    // SVG.Root with `centered: true` (the default) uses a viewBox where origin is
+    // the center and bounds are [-w/2, w/2] x [-h/2, h/2].
+    const halfW = width / 2;
+    const halfH = height / 2;
+
+    const nodes = this.layout.graph.nodes as FlockNode[];
+    const maxVelocity = this.#opt('maxVelocity');
+    // Match Flock's force normalisation so weight semantics line up across variants.
+    const alignmentW = this.#opt('alignment') / 100;
+    const cohesionW = this.#opt('cohesion') / 100;
+    const separationW = this.#opt('separation') / 100;
+    const avoidanceW = this.#opt('avoidance') / 10;
+    const cursorRepel = this.#opt('cursorRepel');
+    const cursor = cursorRepel > 0 ? this.#cursor : null;
+
+    // Two-pass per tick: (1) compute acceleration from neighbours, (2) integrate.
+    for (const b1 of nodes) {
+      let ax = 0;
+      let ay = 0;
+      let alignX = 0;
+      let alignY = 0;
+      let alignActive = false;
+      let cohX = 0;
+      let cohY = 0;
+      let cohActive = false;
+      let sepX = 0;
+      let sepY = 0;
+      let sepActive = false;
+      let avoidX = 0;
+      let avoidY = 0;
+      let avoidActive = false;
+
+      // Cursor repulsion: when the cursor is within the repel zone, push the boid
+      // directly away. Mirrors the canvas Flock's `repel` (treats the cursor as a
+      // FlockObstacle with radius = cursorRepel).
+      if (cursor) {
+        const dx = cursor.x - (b1.x ?? 0);
+        const dy = cursor.y - (b1.y ?? 0);
+        const distSq = dx * dx + dy * dy;
+        if (distSq > 0 && distSq < cursorRepel * cursorRepel) {
+          const dist = Math.sqrt(distSq);
+          // Inverse-distance push, matching the canvas variant's `diff.scaleTo(-1 / distance)`.
+          avoidX = (-dx / dist) * (1 / dist);
+          avoidY = (-dy / dist) * (1 / dist);
+          avoidActive = true;
+        }
+      }
+
+      // Mirror the canvas variant: while a boid is being avoided, ignore flockmate
+      // forces so it commits fully to escaping the cursor.
+      if (!avoidActive) {
+        for (const b2 of nodes) {
+          if (b1 === b2) {
+            continue;
+          }
+
+          const dx = (b2.x ?? 0) - (b1.x ?? 0);
+          const dy = (b2.y ?? 0) - (b1.y ?? 0);
+          const distSq = dx * dx + dy * dy;
+          if (distSq === 0) {
+            continue;
+          }
+          const dist = Math.sqrt(distSq);
+
+          if (dist < SEPARATION_DISTANCE) {
+            // Push away — inverse-distance weighting matches the canvas variant.
+            sepX += (-dx / dist) * (1 / dist);
+            sepY += (-dy / dist) * (1 / dist);
+            sepActive = true;
+          }
+          if (dist < FLOCKMATE_RADIUS) {
+            cohX += dx;
+            cohY += dy;
+            cohActive = true;
+            alignX += b2.vx ?? 0;
+            alignY += b2.vy ?? 0;
+            alignActive = true;
+          }
+        }
+      }
+
+      const applyForce = (fx: number, fy: number, weight: number, active: boolean): void => {
+        if (!active || weight === 0) {
+          return;
+        }
+        // Steer = target_velocity - current_velocity, then truncate to weight.
+        const len = Math.sqrt(fx * fx + fy * fy);
+        if (len === 0) {
+          return;
+        }
+        const sx = (fx * maxVelocity) / len - (b1.vx ?? 0);
+        const sy = (fy * maxVelocity) / len - (b1.vy ?? 0);
+        const slen = Math.sqrt(sx * sx + sy * sy);
+        if (slen > weight) {
+          ax += (sx * weight) / slen;
+          ay += (sy * weight) / slen;
+        } else {
+          ax += sx;
+          ay += sy;
+        }
+      };
+
+      applyForce(alignX, alignY, alignmentW, alignActive);
+      applyForce(cohX, cohY, cohesionW, cohActive);
+      applyForce(sepX, sepY, separationW, sepActive);
+      applyForce(avoidX, avoidY, avoidanceW, avoidActive);
+
+      b1.ax = ax;
+      b1.ay = ay;
+    }
+
+    // Integrate + viewBox-wrap + trail bookkeeping.
+    const trailLength = Math.max(0, Math.round(this.#opt('trailLength')));
+    for (const b of nodes) {
+      let vx = (b.vx ?? 0) + (b.ax ?? 0);
+      let vy = (b.vy ?? 0) + (b.ay ?? 0);
+      const vlen = Math.sqrt(vx * vx + vy * vy);
+      if (vlen > maxVelocity) {
+        vx = (vx * maxVelocity) / vlen;
+        vy = (vy * maxVelocity) / vlen;
+      }
+      b.vx = vx;
+      b.vy = vy;
+
+      // Push the pre-integration position into history every tick. Dense sampling means
+      // the path-end shifts by a sub-pixel amount per frame — the curve evolves
+      // continuously and the tail-end gradient stop tracks smoothly, avoiding the snap
+      // / flicker a sparser sample interval would introduce.
+      if (trailLength > 0) {
+        const history = b.history ?? (b.history = []);
+        history.push({ x: b.x ?? 0, y: b.y ?? 0 });
+        if (history.length > trailLength) {
+          history.splice(0, history.length - trailLength);
+        }
+      }
+
+      let x = (b.x ?? 0) + vx;
+      let y = (b.y ?? 0) + vy;
+      // Wrap at the centered viewBox edges so boids leaving one side reappear on the opposite.
+      // On wrap we clear the trail so the line doesn't streak across the canvas (matches
+      // the canvas Flock's wrap-aware trail rendering, but simpler).
+      let wrapped = false;
+      if (x > halfW) {
+        x -= width;
+        wrapped = true;
+      } else if (x < -halfW) {
+        x += width;
+        wrapped = true;
+      }
+      if (y > halfH) {
+        y -= height;
+        wrapped = true;
+      } else if (y < -halfH) {
+        y += height;
+        wrapped = true;
+      }
+      if (wrapped && b.history) {
+        b.history.length = 0;
+      }
+      b.x = x;
+      b.y = y;
+    }
+
+    // Edge geometry: quadratic Bézier with control at the origin so every edge bends
+    // toward the center — visually echoing the bundle projector's centre-routed
+    // curves while staying cheap to compute. The renderer's `applyPositions` reads
+    // `edge.path` directly when present.
+    for (const edge of this.layout.graph.edges) {
+      const sx = edge.source.x ?? 0;
+      const sy = edge.source.y ?? 0;
+      const tx = edge.target.x ?? 0;
+      const ty = edge.target.y ?? 0;
+      edge.path = `M ${sx} ${sy} Q 0 0 ${tx} ${ty}`;
+    }
+
+    this.emitUpdate('positions');
+  }
+}

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
@@ -2,11 +2,11 @@
 // Copyright 2026 DXOS.org
 //
 
-import { RegistryContext } from '@effect-atom/atom-react';
-import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { curveCatmullRom, line as d3Line } from 'd3';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Obj } from '@dxos/echo';
-import { type ThemedClassName, useThemeContext } from '@dxos/react-ui';
+import { type ThemedClassName } from '@dxos/react-ui';
 import {
   CLUSTER_NODE_TYPE_GROUP,
   CLUSTER_NODE_TYPE_LEAF,
@@ -22,13 +22,13 @@ import {
   SVG,
   type SVGContext,
 } from '@dxos/react-ui-graph';
-import { Flock, type FlockBoid, FlockModel, Vec2 } from '@dxos/react-ui-sfx';
 import { type SpaceGraphEdge, type SpaceGraphModel, type SpaceGraphNode } from '@dxos/schema';
 import { mx } from '@dxos/ui-theme';
 
 import { type TreeNode } from '#components';
 
 import { getNodeFillForObject } from '../../util';
+import { type FlockNode, GraphFlockProjector } from './GraphFlockProjector';
 import { type ExplorerArticleVariant } from './variants';
 
 export type VisualizationProps = ThemedClassName<{
@@ -40,119 +40,117 @@ export type VisualizationProps = ThemedClassName<{
 /**
  * Renders the active visualization variant.
  *
- * For SVG variants (force, cluster, bundle, lattice), one `<SVG.Graph>` instance is
- * kept mounted; only the projector swaps. Each new projector receives the previous
- * layout so node x/y survive the swap and the projector's `animate()` tweens to the
- * new target.
- *
- * The `swarm` variant is canvas-based and uses a `FlockModel`. On entry, boids are
- * seeded from `model.graph.nodes` with positions taken from the latest SVG layout
- * (matched by node id). On exit, the boids' current positions are written back to
- * `lastLayoutRef` so the next SVG projector starts from where the swarm left off.
+ * One `<SVG.Graph>` instance is kept mounted; only the projector swaps when the
+ * variant changes. Each new projector receives the previous layout so node x/y
+ * survive the swap and the projector's `animate()` tweens to the new target. The
+ * `swarm` variant uses `GraphFlockProjector`, which runs the boids tick directly
+ * on `GraphLayoutNode` x/y so the existing renderer's fast-path picks it up
+ * exactly like the force layout.
  */
 export const Visualization = ({ classNames, variant, model, onNodeHover }: VisualizationProps) => {
-  const registry = useContext(RegistryContext);
-  const { themeMode } = useThemeContext();
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const [size, setSize] = useState({ width: 0, height: 0 });
-  // Read the container's effective background so the swarm canvas matches whatever
-  // surface the visualization sits on (bg-base-surface by default, but the consumer
-  // can override via `classNames`). Recomputed on theme toggle. Defaults to the
-  // baseSurface token values used to be hardcoded here, in case the container is
-  // unmounted when the swarm enters.
-  const [flockBackground, setFlockBackground] = useState<string>(themeMode === 'dark' ? '#0a0a0a' : '#fafafa');
-  useEffect(() => {
-    if (containerRef.current) {
-      const bg = getComputedStyle(containerRef.current).backgroundColor;
-      // Skip transparent fallback — Flock needs an opaque color for the trail-fade.
-      if (bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent') {
-        setFlockBackground(bg);
-      }
-    }
-  }, [themeMode, classNames]);
 
   const svgRef = useRef<SVGContext>(null);
   const [projector, setProjector] = useState<GraphProjector<SpaceGraphNode> | undefined>();
   const projectorRef = useRef<GraphProjector<SpaceGraphNode> | undefined>(undefined);
   projectorRef.current = projector;
 
-  // Latest layout we hand to the next SVG projector as `prev` — captured both when
-  // leaving an SVG variant (live projector.layout) and when leaving swarm (boid
-  // positions translated back to center-origin).
+  // Latest layout we hand to the next SVG projector as `prev`. Captured from the live
+  // projector when the variant changes so node x/y survive the swap.
   const lastLayoutRef = useRef<GraphLayout<SpaceGraphNode> | undefined>(undefined);
-
-  // Reactive source of truth for the boid array used by the swarm view.
-  const flockModel = useMemo(() => new FlockModel(registry), [registry]);
 
   // Subscribe to the graph atom — keeps it alive across child unmounts (effect-atom
   // disposes atoms with no subscribers) and triggers re-renders when query results land.
-  const [modelRev, setModelRev] = useState(0);
-  useEffect(() => model?.subscribe(() => setModelRev((r) => r + 1)), [model]);
+  useEffect(() => model?.subscribe(() => undefined), [model]);
 
-  // Track the visualization container size so we can translate between canvas
-  // (top-left origin) and graph (center origin) coordinates when entering or
-  // leaving swarm.
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) {
-      return;
-    }
-
-    const rect = el.getBoundingClientRect();
-    setSize({ width: rect.width, height: rect.height });
-
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) {
-        return;
-      }
-      const { width, height } = entry.contentRect;
-      setSize((prev) => (prev.width === width && prev.height === height ? prev : { width, height }));
-    });
-
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-
-  // Recreate the projector when the variant changes. Two transitions need special handling:
-  //  - leaving an SVG variant: snapshot live projector.layout into lastLayoutRef.
-  //  - leaving swarm: convert current boid positions (canvas-coord) back into a
-  //    center-origin layout in lastLayoutRef so the next projector animates from
-  //    where the boids ended up.
+  // Recreate the projector when the variant changes; snapshot the live layout first so
+  // the next projector animates from where the previous one left off.
   useEffect(() => {
     if (projectorRef.current?.layout) {
       lastLayoutRef.current = projectorRef.current.layout as GraphLayout<SpaceGraphNode>;
-    } else if (flockModel.boids.length > 0 && size.width > 0 && size.height > 0) {
-      lastLayoutRef.current = boidsToLayout(flockModel.boids, size, lastLayoutRef.current);
     }
-
-    if (variant === 'swarm') {
-      setProjector(undefined);
-      return;
-    }
-
     if (!svgRef.current) {
       return;
     }
-
     setProjector(createProjector(variant, svgRef.current, lastLayoutRef.current));
-  }, [variant, flockModel, size.width, size.height]);
-
-  // Seed the flock with boids derived from current graph nodes whenever we enter
-  // swarm (or model data lands while in swarm). Positions are reused from the last
-  // SVG layout where the id matches; otherwise a small random spread around center.
-  useEffect(() => {
-    if (variant !== 'swarm' || !size.width || !size.height) {
-      return;
-    }
-    const nodes = model?.graph.nodes ?? [];
-    if (nodes.length === 0) {
-      return;
-    }
-    flockModel.setBoids(seedBoidsFromNodes(nodes, lastLayoutRef.current, size, flockModel));
-  }, [variant, flockModel, model, modelRev, size.width, size.height]);
+  }, [variant]);
 
   const renderNode = useMemo(() => createRenderNode(variant), [variant]);
+
+  // Per-tick polyline-points update for boid trails. The base GraphRenderer only writes
+  // transform + edge `d` on `applyPositions`, so we listen to the same emit and rewrite
+  // each `polyline.dx-flock-tail`'s `points` in local node-group coords (head at 0,0,
+  // history deltas trailing behind). Runs after the renderer's listener — by then the
+  // node group's transform already points at the new head, so the local-coord polyline
+  // visually lines up.
+  useEffect(() => {
+    if (variant !== 'swarm' || !(projector instanceof GraphFlockProjector)) {
+      return;
+    }
+    const updateTails = () => {
+      const svg = svgRef.current?.svg;
+      const root = svg?.querySelector('g.dx-graph') as SVGGElement | null;
+      if (!root) {
+        return;
+      }
+      // Edge opacity: 30% in swarm so trails + heads dominate over routing edges. Set
+      // on the `dx-edges` group (inheritable) so we don't fight per-edge enter/exit.
+      const edgesGroup = root.querySelector<SVGGElement>('g.dx-edges');
+      if (edgesGroup) {
+        edgesGroup.style.opacity = '0.3';
+      }
+      // Tail: each boid has one `<path>` traced from head (0,0 in local coords) through
+      // its history (newest → oldest), and one `<linearGradient>` whose axis is aligned
+      // head → oldest. The gradient stops are baked in renderNode; here we just sync the
+      // gradient's vector and the path's `d` to the current frame.
+      const nodeGroups = root.querySelectorAll<SVGGElement>('g.dx-node');
+      nodeGroups.forEach((group) => {
+        const node = (group as any).__data__ as FlockNode | undefined;
+        if (!node) {
+          return;
+        }
+        const path = group.querySelector('path.dx-flock-tail') as SVGPathElement | null;
+        const grad = group.querySelector('linearGradient') as SVGLinearGradientElement | null;
+        if (!path || !grad) {
+          return;
+        }
+        const history = node.history ?? [];
+        if (history.length === 0) {
+          path.setAttribute('d', '');
+          return;
+        }
+        const hx = node.x ?? 0;
+        const hy = node.y ?? 0;
+        // Build local-space points head → most-recent → … → oldest (history is push-at-end
+        // so we walk it backwards), then run them through a Catmull-Rom curve generator so
+        // the trail reads as a smooth arc rather than a polyline. The gradient axis below
+        // is still head → oldest, so the fade stays aligned with travel direction.
+        const points: Array<[number, number]> = [[0, 0]];
+        for (let i = history.length - 1; i >= 0; i--) {
+          points.push([history[i].x - hx, history[i].y - hy]);
+        }
+        path.setAttribute('d', swarmTrailLine(points) ?? '');
+        // Gradient endpoints: head at (0,0), tail at oldest history point (in local coords).
+        // The gradient is a straight-line projection so the fade tracks the boid's overall
+        // direction of travel even when the path itself curves slightly.
+        const oldest = history[0];
+        grad.setAttribute('x2', String(oldest.x - hx));
+        grad.setAttribute('y2', String(oldest.y - hy));
+      });
+    };
+    updateTails();
+    const cleanupListener = projector.updated.on(updateTails);
+    return () => {
+      cleanupListener();
+      // Restore default edge opacity on variant switch so leaving swarm doesn't leak the
+      // 50% style into force / lattice / cluster / bundle.
+      const root = svgRef.current?.svg?.querySelector('g.dx-graph') as SVGGElement | null;
+      const edgesGroup = root?.querySelector<SVGGElement>('g.dx-edges');
+      if (edgesGroup) {
+        edgesGroup.style.opacity = '';
+      }
+    };
+  }, [variant, projector]);
 
   const handleInspect = useCallback(
     (node: GraphLayoutNode<SpaceGraphNode> | null, event: MouseEvent) => {
@@ -165,6 +163,36 @@ export const Visualization = ({ classNames, variant, model, onNodeHover }: Visua
     },
     [onNodeHover],
   );
+
+  // Cursor avoidance for the SVG swarm: forward pointer position (in SVG model coords)
+  // to the projector each move so the boids can steer away. The projector reads it on
+  // its own tick — no React renders triggered by mouse moves.
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (variant !== 'swarm' || !(projector instanceof GraphFlockProjector)) {
+        return;
+      }
+      const svg = svgRef.current?.svg;
+      // Use the dx-graph group's CTM so zoom + viewBox transforms are both undone in one step,
+      // landing the cursor in the same coordinate space the boids live in.
+      const target = svg?.querySelector('g.dx-graph') as SVGGElement | null;
+      const ctm = target?.getScreenCTM();
+      if (!svg || !ctm) {
+        return;
+      }
+      const point = svg.createSVGPoint();
+      point.x = event.clientX;
+      point.y = event.clientY;
+      const modelPoint = point.matrixTransform(ctm.inverse());
+      projector.setCursor(modelPoint.x, modelPoint.y);
+    },
+    [variant, projector],
+  );
+  const handlePointerLeave = useCallback(() => {
+    if (projector instanceof GraphFlockProjector) {
+      projector.setCursor(null);
+    }
+  }, [projector]);
 
   // Cluster-only: clicking a root / group node toggles its subtree open/closed.
   const handleSelect = useCallback(
@@ -183,101 +211,43 @@ export const Visualization = ({ classNames, variant, model, onNodeHover }: Visua
     [variant, projector],
   );
 
+  // Only attach pointer handlers when the SVG swarm is active — other variants don't
+  // need them and we want to avoid the per-move CTM math when it'd be a no-op.
+  const swarmHandlers =
+    variant === 'swarm' ? { onPointerMove: handlePointerMove, onPointerLeave: handlePointerLeave } : undefined;
+
   return (
-    <div ref={containerRef} className={mx('dx-expander relative', classNames)}>
-      {variant === 'swarm' ? (
-        <Flock model={flockModel} coloring='Movement' background={flockBackground} trail={30} />
-      ) : (
-        <SVG.Root ref={svgRef}>
-          <SVG.Zoom extent={[1 / 2, 2]}>
-            <SVG.Graph<SpaceGraphNode, SpaceGraphEdge>
-              model={model}
-              projector={projector}
-              renderNode={renderNode}
-              drag={variant === 'force'}
-              highlightOnHover={variant === 'bundle'}
-              onInspect={handleInspect}
-              onSelect={handleSelect}
-            />
-          </SVG.Zoom>
-        </SVG.Root>
-      )}
+    <div ref={containerRef} className={mx('dx-expander relative', classNames)} {...swarmHandlers}>
+      <SVG.Root ref={svgRef}>
+        <SVG.Zoom extent={[1 / 2, 2]}>
+          <SVG.Graph<SpaceGraphNode, SpaceGraphEdge>
+            model={model}
+            projector={projector}
+            renderNode={renderNode}
+            drag={variant === 'force'}
+            highlightOnHover={variant === 'bundle'}
+            onInspect={handleInspect}
+            onSelect={handleSelect}
+          />
+        </SVG.Zoom>
+        {variant === 'swarm' && <SVG.FPS />}
+      </SVG.Root>
     </div>
   );
-};
-
-/**
- * Build the boid set for entering swarm. For each model node, take the position from
- * `lastLayout` (id-matched), or a random spread around center if the id isn't there.
- * Position reuse keeps in-flight transitions visually continuous.
- */
-const seedBoidsFromNodes = (
-  nodes: readonly SpaceGraphNode[],
-  lastLayout: GraphLayout<SpaceGraphNode> | undefined,
-  { width, height }: { width: number; height: number },
-  flockModel: FlockModel,
-): FlockBoid[] => {
-  const cx = width / 2;
-  const cy = height / 2;
-  const spread = Math.min(width, height) * 0.5;
-  const snapshot = new Map((lastLayout?.graph.nodes ?? []).map((n) => [n.id, n] as const));
-  return nodes.map((node) => {
-    const prev = snapshot.get(node.id);
-    const px = prev?.x ?? (Math.random() - 0.5) * spread;
-    const py = prev?.y ?? (Math.random() - 0.5) * spread;
-    // Preserve existing boid velocity/colour if we already have one for this id —
-    // keeps mid-air boids moving smoothly when the model emits multiple times.
-    const existing = flockModel.findBoid(node.id);
-    return {
-      id: node.id,
-      position: new Vec2(cx + px, cy + py),
-      velocity: existing?.velocity ?? new Vec2(),
-      color: existing?.color,
-      last: existing?.last ?? [],
-    };
-  });
-};
-
-/**
- * Translate canvas-coord boid positions back into a center-origin layout that the
- * next SVG projector can consume as `prev`. Matches nodes from `prevLayout` by id so
- * label / data references are preserved; falls back to creating fresh layout nodes
- * for boids whose ids aren't present in the prior layout.
- */
-const boidsToLayout = (
-  boids: readonly FlockBoid[],
-  { width, height }: { width: number; height: number },
-  prevLayout: GraphLayout<SpaceGraphNode> | undefined,
-): GraphLayout<SpaceGraphNode> => {
-  const cx = width / 2;
-  const cy = height / 2;
-  const previousById = new Map((prevLayout?.graph.nodes ?? []).map((n) => [n.id, n] as const));
-  const nodes: GraphLayoutNode<SpaceGraphNode>[] = boids
-    .filter((b) => b.id !== undefined)
-    .map((boid) => {
-      const id = boid.id!;
-      const prev = previousById.get(id);
-      return {
-        ...(prev ?? { id }),
-        x: boid.position.x - cx,
-        y: boid.position.y - cy,
-      };
-    });
-  return {
-    graph: {
-      nodes,
-      // Edges aren't represented in the swarm — keep whatever the previous layout had so
-      // the next projector still has a topology to bind to via mergeData.
-      edges: prevLayout?.graph.edges ?? [],
-    },
-  };
 };
 
 /** Cross-variant tween duration. Matches the renderer's edge fade timing so node movement and edge enter/exit complete together. */
 const TWEEN_MS = 500;
 
+/**
+ * Catmull-Rom curve generator (α=0.5, "centripetal") for swarm boid trails.
+ * Passes through every point and avoids the looping/overshoot artifacts a plain
+ * cardinal spline produces when consecutive history samples land close together.
+ */
+const swarmTrailLine = d3Line<[number, number]>().curve(curveCatmullRom.alpha(0.5));
+
 const createProjector = (
-  variant: Exclude<ExplorerArticleVariant, 'swarm'>,
+  variant: ExplorerArticleVariant,
   ctx: SVGContext,
   prev?: GraphLayout<SpaceGraphNode>,
 ): GraphProjector<SpaceGraphNode> => {
@@ -285,6 +255,10 @@ const createProjector = (
     case 'force':
       // Force has no `duration` — its own simulation drives motion via ticks.
       return new GraphForceProjector<SpaceGraphNode>(ctx, undefined, undefined, prev);
+
+    case 'swarm':
+      // Boids in SVG: a per-tick projector mirroring force's emit-positions pattern.
+      return new GraphFlockProjector<SpaceGraphNode>(ctx, undefined, undefined, prev);
 
     case 'lattice':
       return new GraphLatticeProjector<SpaceGraphNode>(
@@ -346,7 +320,44 @@ const typenameGroupOf = (node: GraphLayoutNode<SpaceGraphNode>): string | undefi
 const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGraphNode> | undefined => {
   switch (variant) {
     case 'swarm':
-      return undefined;
+      // Match the force variant's shape so identity-by-id transitions read continuously.
+      // The tail is a SINGLE `<path>` traced through head + history points; its stroke
+      // uses a per-boid `<linearGradient>` that fades head → tail. Done this way (rather
+      // than as N overlapping `<line>` segments) so coincident segment endpoints don't
+      // compound their alpha and read as a striped trail.
+      return (group, node) => {
+        const fill = getNodeFillForObject(node.data?.data?.object as Obj.Unknown | undefined);
+        const r = node.r ?? 6;
+        const strokeWidth = Math.max(1, r * 0.6);
+        // Gradient id must be unique document-wide. node.id is the DXN, which contains
+        // characters (`:`, `/`, etc.) that aren't valid in NCName-style ids, so sanitize.
+        const gradId = `dx-flock-grad-${String(node.id).replace(/[^\w-]/g, '_')}`;
+        const grad = group
+          .append('defs')
+          .append('linearGradient')
+          .attr('id', gradId)
+          // userSpaceOnUse so x1/y1/x2/y2 are interpreted in the dx-node's local coord space
+          // (head at 0,0). The listener overwrites them per tick to align with the path's
+          // head → tail axis.
+          .attr('gradientUnits', 'userSpaceOnUse')
+          .attr('x1', 0)
+          .attr('y1', 0)
+          .attr('x2', 0)
+          .attr('y2', 0);
+        grad.append('stop').attr('offset', 0).attr('stop-color', fill).attr('stop-opacity', 0.7);
+        grad.append('stop').attr('offset', 1).attr('stop-color', fill).attr('stop-opacity', 0);
+        // Path first so the head circle sits on top.
+        group
+          .append('path')
+          .classed('dx-flock-tail', true)
+          .attr('fill', 'none')
+          .attr('stroke', `url(#${gradId})`)
+          .attr('stroke-width', strokeWidth)
+          .attr('stroke-linecap', 'round')
+          .attr('stroke-linejoin', 'round')
+          .attr('pointer-events', 'none');
+        group.append('circle').attr('r', r).style('cursor', 'pointer').style('fill', fill);
+      };
 
     case 'force':
       return (group, node) => {

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/variants.ts
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/variants.ts
@@ -28,7 +28,7 @@ export const VARIANTS: { value: ExplorerArticleVariant; icon: string; label: str
   },
   {
     value: 'swarm',
-    icon: 'ph--fish--regular',
+    icon: 'ph--microscope--regular',
     label: 'Swarm',
   },
 ];

--- a/packages/plugins/plugin-explorer/tsconfig.json
+++ b/packages/plugins/plugin-explorer/tsconfig.json
@@ -86,9 +86,6 @@
       "path": "../../ui/react-ui-mosaic"
     },
     {
-      "path": "../../ui/react-ui-sfx"
-    },
-    {
       "path": "../../ui/react-ui-stack"
     },
     {

--- a/packages/ui/react-ui-graph/src/components/SVG/FPS.tsx
+++ b/packages/ui/react-ui-graph/src/components/SVG/FPS.tsx
@@ -1,0 +1,91 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React, { useEffect, useState } from 'react';
+
+import { type ThemedClassName } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+import { useSvgContext } from '../../hooks';
+
+export type FPSCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+export type FPSProps = ThemedClassName<{
+  /** Which corner of the SVG viewport to anchor the readout to. */
+  corner?: FPSCorner;
+  /** Pixels of padding from the chosen corner. */
+  margin?: number;
+}>;
+
+const PADDING = 8;
+
+/**
+ * Frame-rate readout — drops into an `<SVG.Root>` alongside `<SVG.Graph>` to display a
+ * rolling 1-second average of the browser's repaint rate. Self-contained: runs its own
+ * `requestAnimationFrame` loop, so the number reflects actual render rate independent of
+ * whichever projector is driving the graph.
+ *
+ * Anchored to a corner of the SVG viewBox via the `<text>`'s `text-anchor` and `dy`
+ * attributes — re-renders on `context.resized` so the position tracks container resizes.
+ */
+export const FPS = ({ classNames, corner = 'top-right', margin = PADDING }: FPSProps) => {
+  const context = useSvgContext();
+  const [size, setSize] = useState(context.size);
+  const [fps, setFps] = useState<number | null>(null);
+
+  // Keep `size` in sync with the SVG context so the corner anchor follows container resizes.
+  useEffect(() => {
+    setSize(context.size);
+    return context.resized.on((ctx) => setSize(ctx.size));
+  }, [context]);
+
+  // Independent rAF loop — measures the browser's actual repaint rate, not any specific
+  // projector's tick rate. Rolling 1-second window so the number is responsive but stable.
+  useEffect(() => {
+    let frames = 0;
+    let windowStart = performance.now();
+    let rafId = 0;
+    const loop = (now: number) => {
+      frames++;
+      const elapsed = now - windowStart;
+      if (elapsed >= 1000) {
+        setFps((frames * 1000) / elapsed);
+        frames = 0;
+        windowStart = now;
+      }
+      rafId = requestAnimationFrame(loop);
+    };
+    rafId = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafId);
+  }, []);
+
+  if (!size) {
+    return null;
+  }
+
+  // The SVG.Root viewBox is centered ([-w/2, w/2] × [-h/2, h/2]); offset from the chosen
+  // corner inward by `margin` and pick the corresponding text-anchor / dominant-baseline.
+  const halfW = size.width / 2;
+  const halfH = size.height / 2;
+  const left = corner === 'top-left' || corner === 'bottom-left';
+  const top = corner === 'top-left' || corner === 'top-right';
+  const x = left ? -halfW + margin : halfW - margin;
+  const y = top ? -halfH + margin : halfH - margin;
+  const textAnchor = left ? 'start' : 'end';
+  const dominantBaseline = top ? 'hanging' : 'alphabetic';
+
+  return (
+    <g className='dx-fps' style={{ pointerEvents: 'none' }}>
+      <text
+        x={x}
+        y={y}
+        textAnchor={textAnchor}
+        dominantBaseline={dominantBaseline}
+        className={mx('font-mono text-xs fill-neutral-500 tabular-nums', classNames)}
+      >
+        {fps == null ? '— fps' : `${fps.toFixed(0)} fps`}
+      </text>
+    </g>
+  );
+};

--- a/packages/ui/react-ui-graph/src/components/SVG/SVG.tsx
+++ b/packages/ui/react-ui-graph/src/components/SVG/SVG.tsx
@@ -8,6 +8,7 @@ import { type ThemedClassName } from '@dxos/react-ui';
 
 import { Graph, type GraphProps as SVGGraphProps } from '../Graph';
 import { Mesh, type MeshProps as SVGMeshProps } from '../Mesh';
+import { FPS, type FPSProps as SVGFPSProps } from './FPS';
 import { Grid, type GridProps as SVGGridProps } from './Grid';
 import { Markers, type MarkersProps as SVGMarkersProps } from './Markers';
 import { Root, type RootProps as SVGRootProps } from './Root';
@@ -22,6 +23,7 @@ type SVG = {
   Mesh: typeof Mesh;
   Zoom: typeof Zoom;
   Graph: typeof Graph;
+  FPS: typeof FPS;
 };
 
 export const SVG: SVG = {
@@ -31,6 +33,7 @@ export const SVG: SVG = {
   Mesh,
   Zoom,
   Graph,
+  FPS,
 };
 
-export type { SVGRootProps, SVGGridProps, SVGMarkersProps, SVGZoomProps, SVGGraphProps, SVGMeshProps };
+export type { SVGRootProps, SVGGridProps, SVGMarkersProps, SVGZoomProps, SVGGraphProps, SVGMeshProps, SVGFPSProps };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5483,7 +5483,7 @@ importers:
         version: 0.33.2(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -5951,7 +5951,7 @@ importers:
         version: 1.8.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3)
+        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -9886,9 +9886,6 @@ importers:
       '@dxos/react-ui-mosaic':
         specifier: workspace:*
         version: link:../../ui/react-ui-mosaic
-      '@dxos/react-ui-sfx':
-        specifier: workspace:*
-        version: link:../../ui/react-ui-sfx
       '@dxos/react-ui-stack':
         specifier: workspace:*
         version: link:../../ui/react-ui-stack
@@ -16585,7 +16582,7 @@ importers:
         version: link:../../common/util
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -20459,7 +20456,7 @@ importers:
         version: link:../ui-theme
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -25431,7 +25428,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -45337,7 +45333,7 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.2)
       ajv: 8.18.0
@@ -51810,7 +51806,7 @@ snapshots:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@cloudflare/ai-chat': 0.0.6(agents@0.3.10)(ai@6.0.97(zod@4.3.6))(react@19.2.6)(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
       ai: 6.0.97(zod@4.3.6)
       cron-schedule: 6.0.0
       escape-html: 1.0.3
@@ -54195,6 +54191,10 @@ snapshots:
   draco3d@1.5.7: {}
 
   dset@3.1.4: {}
+
+  dts-resolver@2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
+    optionalDependencies:
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   dts-resolver@2.1.3(oxc-resolver@11.9.0):
     optionalDependencies:
@@ -60982,6 +60982,24 @@ snapshots:
 
   robust-predicates@3.0.1: {}
 
+  rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
+    dependencies:
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      ast-kit: 2.2.0
+      birpc: 3.0.0
+      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
+      get-tsconfig: 4.13.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260421.2
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
     dependencies:
       '@babel/generator': 7.28.5
@@ -62656,6 +62674,34 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
+    dependencies:
+      ansis: 4.2.0
+      cac: 6.7.14
+      chokidar: 5.0.0
+      diff: 8.0.3
+      empathic: 2.0.0
+      hookable: 5.5.3
+      obug: 2.1.1
+      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rolldown-plugin-dts: 0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+      semver: 7.7.4
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+      unconfig-core: 7.4.2
+      unrun: 0.2.19(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - synckit
+      - vue-tsc
 
   tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
## Summary
- New `GraphFlockProjector` extending `GraphProjector` runs the boids tick directly on `GraphLayoutNode.x/y` and emits `'positions'` per frame, so the existing `GraphRenderer.applyPositions` fast-path picks it up like the force projector. Boids alignment/cohesion/separation + cursor avoidance + viewBox-wrap, with center-routed quadratic-Bézier edges and Catmull-Rom-curved trails using a head→tail `<linearGradient>` stroke.
- Replaces the canvas Flock used by the old `swarm` variant; removes the `@dxos/react-ui-sfx` dependency from `plugin-explorer`.
- Adds `SVG.FPS` to `@dxos/react-ui-graph` — a reusable, self-measuring (rolling 1 s rAF window) frame-rate readout anchored to a viewBox corner; opt-in alongside other SVG elements.

## Test plan
- [x] `moon run react-ui-graph:build plugin-explorer:build` clean
- [x] `moon run react-ui-graph:lint plugin-explorer:lint` clean
- [x] `moon run plugin-explorer:test react-ui-graph:test` pass
- [ ] Verify in Composer / storybook: swarm renders, boids flock, edges route through center, trails fade smoothly head→tail, cursor repels nearby boids, FPS reads ~60 in foreground tab
- [ ] Cross-variant transitions (force ↔ swarm ↔ cluster) preserve node positions and don't leak edge opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented boids-style flocking simulation for swarm visualization with enhanced animated motion and realistic particle behavior.
  * Added FPS performance counter component for SVG graphs to monitor rendering performance.

* **Updates**
  * Changed swarm variant icon from fish to microscope symbol.
  * Removed unused UI dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->