### PR TITLE
refactor(react-ui-graph): factor variant-specific hooks out of plugin-explorer Visualization

### DIFF
--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
@@ -8,7 +8,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Obj } from '@dxos/echo';
 import { type ThemedClassName } from '@dxos/react-ui';
 import {
-  CLUSTER_NODE_TYPE_GROUP,
   CLUSTER_NODE_TYPE_LEAF,
   CLUSTER_NODE_TYPE_ROOT,
   GraphBundleProjector,
@@ -19,10 +18,14 @@ import {
   GraphLatticeProjector,
   type GraphProjector,
   GraphSwarmProjector,
+  type ModelPoint,
   type RenderNode,
   SVG,
   type SVGContext,
   type SwarmNode,
+  appendRadialGroupLabel,
+  appendRadialLeafLabel,
+  appendRootLabel,
 } from '@dxos/react-ui-graph';
 import { type SpaceGraphEdge, type SpaceGraphModel, type SpaceGraphNode } from '@dxos/schema';
 import { mx } from '@dxos/ui-theme';
@@ -43,8 +46,6 @@ export type VisualizationProps = ThemedClassName<{
  * Renders the active visualization variant.
  */
 export const Visualization = ({ classNames, debug = true, variant, model, onNodeHover }: VisualizationProps) => {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
   const svgRef = useRef<SVGContext>(null);
   const [projector, setProjector] = useState<GraphProjector<SpaceGraphNode> | undefined>();
   const projectorRef = useRef<GraphProjector<SpaceGraphNode> | undefined>(undefined);
@@ -68,91 +69,31 @@ export const Visualization = ({ classNames, debug = true, variant, model, onNode
       return;
     }
 
-    setProjector(createProjector(variant, svgRef.current, lastLayoutRef.current));
+    setProjector(createProjector(svgRef.current, variant, lastLayoutRef.current));
   }, [variant]);
 
   const renderNode = useMemo(() => createRenderNode(variant), [variant]);
 
-  // TODO(burdon): Factor out layout-specific logic.
+  // Per-tick swarm tail update. Receives the dx-node `<g>` after its transform is set,
+  // so the polyline points + gradient axis can live in node-local coordinates.
+  const applyNode = useMemo(() => (variant === 'swarm' ? applyNodeSwarm : undefined), [variant]);
 
-  // Per-tick polyline-points update for boid trails. The base GraphRenderer only writes
-  // transform + edge `d` on `applyPositions`, so we listen to the same emit and rewrite
-  // each `polyline.dx-swarm-tail`'s `points` in local node-group coords (head at 0,0,
-  // history deltas trailing behind). Runs after the renderer's listener — by then the
-  // node group's transform already points at the new head, so the local-coord polyline
-  // visually lines up.
-  useEffect(() => {
-    if (variant !== 'swarm' || !(projector instanceof GraphSwarmProjector)) {
-      return;
+  // Cursor avoidance for the SVG swarm. The Graph component hands us pre-transformed
+  // SVG model coordinates — same space the boids live in.
+  const handlePointerMove = useCallback(
+    (point: ModelPoint) => {
+      if (projector instanceof GraphSwarmProjector) {
+        projector.setCursor(point.x, point.y);
+      }
+    },
+    [projector],
+  );
+
+  const handlePointerLeave = useCallback(() => {
+    if (projector instanceof GraphSwarmProjector) {
+      projector.setCursor(null);
     }
-
-    const updateTails = () => {
-      const svg = svgRef.current?.svg;
-      const root = svg?.querySelector('g.dx-graph') as SVGGElement | null;
-      if (!root) {
-        return;
-      }
-
-      // Edge opacity: 30% in swarm so trails + heads dominate over routing edges. Set
-      // on the `dx-edges` group (inheritable) so we don't fight per-edge enter/exit.
-      const edgesGroup = root.querySelector<SVGGElement>('g.dx-edges');
-      if (edgesGroup) {
-        edgesGroup.style.opacity = '0.3';
-      }
-      // Tail: each boid has one `<path>` traced from head (0,0 in local coords) through
-      // its history (newest → oldest), and one `<linearGradient>` whose axis is aligned
-      // head → oldest. The gradient stops are baked in renderNode; here we just sync the
-      // gradient's vector and the path's `d` to the current frame.
-      const nodeGroups = root.querySelectorAll<SVGGElement>('g.dx-node');
-      nodeGroups.forEach((group) => {
-        const node = (group as any).__data__ as SwarmNode | undefined;
-        if (!node) {
-          return;
-        }
-        const path = group.querySelector('path.dx-swarm-tail') as SVGPathElement | null;
-        const grad = group.querySelector('linearGradient') as SVGLinearGradientElement | null;
-        if (!path || !grad) {
-          return;
-        }
-        const history = node.history ?? [];
-        if (history.length === 0) {
-          path.setAttribute('d', '');
-          return;
-        }
-
-        const hx = node.x ?? 0;
-        const hy = node.y ?? 0;
-        // Build local-space points head → most-recent → … → oldest (history is push-at-end
-        // so we walk it backwards), then run them through a Catmull-Rom curve generator so
-        // the trail reads as a smooth arc rather than a polyline. The gradient axis below
-        // is still head → oldest, so the fade stays aligned with travel direction.
-        const points: Array<[number, number]> = [[0, 0]];
-        for (let i = history.length - 1; i >= 0; i--) {
-          points.push([history[i].x - hx, history[i].y - hy]);
-        }
-        path.setAttribute('d', swarmTrailLine(points) ?? '');
-        // Gradient endpoints: head at (0,0), tail at oldest history point (in local coords).
-        // The gradient is a straight-line projection so the fade tracks the boid's overall
-        // direction of travel even when the path itself curves slightly.
-        const oldest = history[0];
-        grad.setAttribute('x2', String(oldest.x - hx));
-        grad.setAttribute('y2', String(oldest.y - hy));
-      });
-    };
-
-    updateTails();
-    const cleanupListener = projector.updated.on(updateTails);
-    return () => {
-      cleanupListener();
-      // Restore default edge opacity on variant switch so leaving swarm doesn't leak the
-      // 50% style into force / lattice / cluster / bundle.
-      const root = svgRef.current?.svg?.querySelector('g.dx-graph') as SVGGElement | null;
-      const edgesGroup = root?.querySelector<SVGGElement>('g.dx-edges');
-      if (edgesGroup) {
-        edgesGroup.style.opacity = '';
-      }
-    };
-  }, [variant, projector]);
+  }, [projector]);
 
   const handleInspect = useCallback(
     (node: GraphLayoutNode<SpaceGraphNode> | null, event: MouseEvent) => {
@@ -166,71 +107,25 @@ export const Visualization = ({ classNames, debug = true, variant, model, onNode
     [onNodeHover],
   );
 
-  // Cursor avoidance for the SVG swarm: forward pointer position (in SVG model coords)
-  // to the projector each move so the boids can steer away. The projector reads it on
-  // its own tick — no React renders triggered by mouse moves.
-  const handlePointerMove = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>) => {
-      if (variant !== 'swarm' || !(projector instanceof GraphSwarmProjector)) {
-        return;
-      }
-      const svg = svgRef.current?.svg;
-      // Use the dx-graph group's CTM so zoom + viewBox transforms are both undone in one step,
-      // landing the cursor in the same coordinate space the boids live in.
-      const target = svg?.querySelector('g.dx-graph') as SVGGElement | null;
-      const ctm = target?.getScreenCTM();
-      if (!svg || !ctm) {
-        return;
-      }
-      const point = svg.createSVGPoint();
-      point.x = event.clientX;
-      point.y = event.clientY;
-      const modelPoint = point.matrixTransform(ctm.inverse());
-      projector.setCursor(modelPoint.x, modelPoint.y);
-    },
-    [variant, projector],
-  );
-
-  const handlePointerLeave = useCallback(() => {
-    if (projector instanceof GraphSwarmProjector) {
-      projector.setCursor(null);
-    }
-  }, [projector]);
-
-  // Cluster-only: clicking a root / group node toggles its subtree open/closed.
-  const handleSelect = useCallback(
-    (node: GraphLayoutNode<SpaceGraphNode>) => {
-      if (
-        variant !== 'cluster' ||
-        !node ||
-        (node.type !== CLUSTER_NODE_TYPE_ROOT && node.type !== CLUSTER_NODE_TYPE_GROUP)
-      ) {
-        return;
-      }
-
-      const cluster = projector as GraphClusterProjector<SpaceGraphNode> | undefined;
-      cluster?.toggleCollapsed(node.id);
-    },
-    [variant, projector],
-  );
-
   // Only attach pointer handlers when the SVG swarm is active — other variants don't
   // need them and we want to avoid the per-move CTM math when it'd be a no-op.
-  const swarmHandlers =
+  const swarmPointerProps =
     variant === 'swarm' ? { onPointerMove: handlePointerMove, onPointerLeave: handlePointerLeave } : undefined;
 
   return (
-    <div ref={containerRef} className={mx('dx-expander relative', classNames)} {...swarmHandlers}>
+    <div className={mx('dx-expander relative', classNames)}>
       <SVG.Root ref={svgRef}>
         <SVG.Zoom extent={[1 / 2, 2]}>
           <SVG.Graph<SpaceGraphNode, SpaceGraphEdge>
             model={model}
             projector={projector}
             renderNode={renderNode}
+            applyNode={applyNode}
+            edgeOpacity={variant === 'swarm' ? 0.3 : undefined}
             drag={variant === 'force'}
             highlightOnHover={variant === 'bundle'}
             onInspect={handleInspect}
-            onSelect={handleSelect}
+            {...swarmPointerProps}
           />
         </SVG.Zoom>
         {debug && <SVG.FPS />}
@@ -242,6 +137,9 @@ export const Visualization = ({ classNames, debug = true, variant, model, onNode
 /** Cross-variant tween duration. Matches the renderer's edge fade timing so node movement and edge enter/exit complete together. */
 const TWEEN_MS = 500;
 
+/** Fade-in duration applied to labels after the layout tween completes. */
+const LABEL_FADE_MS = 200;
+
 /**
  * Catmull-Rom curve generator (α=0.5, "centripetal") for swarm boid trails.
  * Passes through every point and avoids the looping/overshoot artifacts a plain
@@ -249,9 +147,44 @@ const TWEEN_MS = 500;
  */
 const swarmTrailLine = d3Line<[number, number]>().curve(curveCatmullRom.alpha(0.5));
 
+/**
+ * Per-tick swarm tail update. The dx-node `<g>` transform has just been written, so we work
+ * in node-local coordinates: head at (0,0), history deltas trailing behind. The single
+ * `<path>` is stroked with a per-boid `<linearGradient>` whose endpoints we sync to the
+ * tail axis so the fade tracks the direction of travel.
+ */
+const applyNodeSwarm = (group: SVGGElement, node: GraphLayoutNode<SpaceGraphNode>): void => {
+  const swarm = node as SwarmNode;
+  const path = group.querySelector('path.dx-swarm-tail') as SVGPathElement | null;
+  const grad = group.querySelector('linearGradient') as SVGLinearGradientElement | null;
+  if (!path || !grad) {
+    return;
+  }
+  const history = swarm.history ?? [];
+  if (history.length === 0) {
+    path.setAttribute('d', '');
+    return;
+  }
+
+  const hx = swarm.x ?? 0;
+  const hy = swarm.y ?? 0;
+  // Build local-space points head → most-recent → … → oldest (history is push-at-end so
+  // we walk it backwards), then run them through a Catmull-Rom curve generator so the
+  // trail reads as a smooth arc rather than a polyline. The gradient axis below is still
+  // head → oldest, so the fade stays aligned with travel direction.
+  const points: Array<[number, number]> = [[0, 0]];
+  for (let i = history.length - 1; i >= 0; i--) {
+    points.push([history[i].x - hx, history[i].y - hy]);
+  }
+  path.setAttribute('d', swarmTrailLine(points) ?? '');
+  const oldest = history[0];
+  grad.setAttribute('x2', String(oldest.x - hx));
+  grad.setAttribute('y2', String(oldest.y - hy));
+};
+
 const createProjector = (
-  variant: ExplorerArticleVariant,
   ctx: SVGContext,
+  variant: ExplorerArticleVariant,
   prev?: GraphLayout<SpaceGraphNode>,
 ): GraphProjector<SpaceGraphNode> => {
   switch (variant) {
@@ -313,13 +246,6 @@ const createProjector = (
   }
 };
 
-/** Group leaves by typename so same-type leaves cluster together — used by both the
- * cluster (visible structural nodes) and bundle (invisible routing anchors) projectors. */
-const typenameGroupOf = (node: GraphLayoutNode<SpaceGraphNode>): string | undefined => {
-  const obj = node.data?.data?.object;
-  return obj ? (Obj.getTypename(obj) ?? '(untyped)') : undefined;
-};
-
 const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGraphNode> | undefined => {
   switch (variant) {
     case 'force':
@@ -350,8 +276,8 @@ const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGrap
           .append('linearGradient')
           .attr('id', gradId)
           // userSpaceOnUse so x1/y1/x2/y2 are interpreted in the dx-node's local coord space
-          // (head at 0,0). The listener overwrites them per tick to align with the path's
-          // head → tail axis.
+          // (head at 0,0). The applyNode hook overwrites them per tick to align with the
+          // path's head → tail axis.
           .attr('gradientUnits', 'userSpaceOnUse')
           .attr('x1', 0)
           .attr('y1', 0)
@@ -399,12 +325,20 @@ const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGrap
           .attr('r', r)
           .style('cursor', 'pointer')
           .style('fill', obj ? getNodeFillForObject(obj) : 'var(--color-neutral-500)');
+        const labelOptions = { delay: TWEEN_MS, duration: LABEL_FADE_MS };
         if (node.type === CLUSTER_NODE_TYPE_LEAF) {
-          appendRadialLeafLabel(group, node, obj, r);
+          const text = labelForLeaf(node, obj);
+          if (text) {
+            appendRadialLeafLabel(group, node, text, r, labelOptions);
+          }
         } else if (node.type === CLUSTER_NODE_TYPE_ROOT) {
-          appendRootLabel(group, node, r);
-        } else if (node.type === CLUSTER_NODE_TYPE_GROUP) {
-          appendRadialGroupLabel(group, node, r);
+          if (node.label) {
+            appendRootLabel(group, node.label, r, labelOptions);
+          }
+        } else {
+          if (node.label) {
+            appendRadialGroupLabel(group, node, node.label, r, labelOptions);
+          }
         }
       };
 
@@ -418,103 +352,21 @@ const createRenderNode = (variant: ExplorerArticleVariant): RenderNode<SpaceGrap
           .attr('r', r)
           .style('cursor', 'pointer')
           .style('fill', obj ? getNodeFillForObject(obj) : 'var(--color-neutral-500)');
-        appendRadialLeafLabel(group, node, obj, r);
+        const text = labelForLeaf(node, obj);
+        if (text) {
+          appendRadialLeafLabel(group, node, text, r, { delay: TWEEN_MS, duration: LABEL_FADE_MS });
+        }
       };
   }
 };
 
-/** Fade-in duration applied to labels after the layout tween completes. */
-const LABEL_FADE_MS = 200;
-
 /**
- * Append a radial leaf label outside the ring, oriented outward. Compute orientation
- * from the TARGET position (tx/ty) — at enter time node.x/y is still at the previous
- * projector's coordinates, so using current x/y would orient the label by the
- * pre-transition layout (wrong) and the rotation wouldn't update during the tween.
+ * Group leaves by typename so same-type leaves cluster together — used by both the
+ * cluster (visible structural nodes) and bundle (invisible routing anchors) projectors.
  */
-const appendRadialLeafLabel = (
-  group: Parameters<RenderNode<SpaceGraphNode>>[0],
-  node: GraphLayoutNode<SpaceGraphNode>,
-  obj: Obj.Unknown | undefined,
-  r: number,
-): void => {
-  const label = (obj && Obj.getLabel(obj)) ?? node.data?.data?.label ?? node.id;
-  if (!label) {
-    return;
-  }
-
-  const targetX = (node as any).tx ?? node.x ?? 0;
-  const targetY = (node as any).ty ?? node.y ?? 0;
-  const angleDeg = (Math.atan2(targetY, targetX) * 180) / Math.PI;
-  const flipped = angleDeg > 90 || angleDeg < -90;
-  group
-    .append('text')
-    .classed('dx-cluster-label', true)
-    .attr('dy', '0.32em')
-    .attr('transform', `rotate(${flipped ? angleDeg + 180 : angleDeg})`)
-    .attr('x', flipped ? -(r + 4) : r + 4)
-    .attr('text-anchor', flipped ? 'end' : 'start')
-    .attr('opacity', 0)
-    .style('cursor', 'pointer')
-    .text(label)
-    .transition()
-    .delay(TWEEN_MS)
-    .duration(LABEL_FADE_MS)
-    .attr('opacity', 1);
-};
-
-const appendRadialGroupLabel = (
-  group: Parameters<RenderNode<SpaceGraphNode>>[0],
-  node: GraphLayoutNode<SpaceGraphNode>,
-  r: number,
-): void => {
-  if (!node.label) {
-    return;
-  }
-
-  const targetX = (node as any).tx ?? node.x ?? 0;
-  const targetY = (node as any).ty ?? node.y ?? 0;
-  const angleDeg = (Math.atan2(targetY, targetX) * 180) / Math.PI;
-  const flipped = angleDeg > 90 || angleDeg < -90;
-  group
-    .append('text')
-    .classed('dx-cluster-label', true)
-    .classed('dx-cluster-label-group', true)
-    .attr('dy', '0.32em')
-    .attr('transform', `rotate(${flipped ? angleDeg + 180 : angleDeg})`)
-    .attr('x', flipped ? r + 4 : -(r + 4))
-    .attr('text-anchor', flipped ? 'start' : 'end')
-    .attr('opacity', 0)
-    .style('pointer-events', 'none')
-    .text(node.label)
-    .transition()
-    .delay(TWEEN_MS)
-    .duration(LABEL_FADE_MS)
-    .attr('opacity', 1);
-};
-
-const appendRootLabel = (
-  group: Parameters<RenderNode<SpaceGraphNode>>[0],
-  node: GraphLayoutNode<SpaceGraphNode>,
-  r: number,
-): void => {
-  if (!node.label) {
-    return;
-  }
-
-  group
-    .append('text')
-    .classed('dx-cluster-label', true)
-    .classed('dx-cluster-label-root', true)
-    .attr('text-anchor', 'middle')
-    .attr('y', -(r + 6))
-    .attr('opacity', 0)
-    .style('pointer-events', 'none')
-    .text(node.label)
-    .transition()
-    .delay(TWEEN_MS)
-    .duration(LABEL_FADE_MS)
-    .attr('opacity', 1);
+const typenameGroupOf = (node: GraphLayoutNode<SpaceGraphNode>): string | undefined => {
+  const obj = node.data?.data?.object;
+  return obj ? (Obj.getTypename(obj) ?? '(untyped)') : undefined;
 };
 
 /** Drop the package prefix from a typename for display: `org.dxos.type.Person` → `Person`. */
@@ -522,3 +374,7 @@ const shortTypename = (typename: string): string => {
   const last = typename.split('.').pop() ?? typename;
   return last.charAt(0).toUpperCase() + last.slice(1);
 };
+
+/** Resolve a leaf's display label from its ECHO object, falling back to node-level metadata. */
+const labelForLeaf = (node: GraphLayoutNode<SpaceGraphNode>, obj: Obj.Unknown | undefined): string | undefined =>
+  (obj && Obj.getLabel(obj)) ?? node.data?.data?.label ?? node.id;

--- a/packages/ui/react-ui-graph/src/components/Graph/Graph.tsx
+++ b/packages/ui/react-ui-graph/src/components/Graph/Graph.tsx
@@ -26,8 +26,14 @@ export type GraphController = {
   findNode: (id: string) => SVGGElement | null;
 };
 
+/** Cursor position expressed in the same SVG model coordinates that node `x/y` live in (centered origin, post-zoom). */
+export type ModelPoint = { x: number; y: number };
+
 export type GraphProps<Node extends Graph$.Node.Any = any, Edge extends Graph$.Edge.Any = any> = ThemedClassName<
-  Pick<GraphRendererOptions<Node>, 'labels' | 'subgraphs' | 'attributes' | 'renderNode' | 'highlightOnHover'> & {
+  Pick<
+    GraphRendererOptions<Node>,
+    'labels' | 'subgraphs' | 'attributes' | 'renderNode' | 'highlightOnHover' | 'applyNode' | 'edgeOpacity'
+  > & {
     model?: GraphModel.ReactiveGraphModel<Node, Edge>;
     projector?: GraphProjector<Node>;
     renderer?: GraphRenderer<Node>;
@@ -39,6 +45,15 @@ export type GraphProps<Node extends Graph$.Node.Any = any, Edge extends Graph$.E
      * Use the `null` signal to clear hover-driven previews / highlights.
      */
     onInspect?: (node: GraphLayoutNode<Node> | null, event: MouseEvent) => void;
+    /**
+     * Pointer-move in SVG model coordinates (the same space `node.x/y` live in — centered
+     * origin, post-zoom). The CTM lookup is done against the dx-graph group, so zoom + viewBox
+     * are both undone in one step. Pair with `onPointerLeave` to clear cursor-driven state.
+     * When either handler is set the renderer's `<svg>` is given `pointer-events: all` so
+     * events fire across empty canvas, not just over painted nodes.
+     */
+    onPointerMove?: (point: ModelPoint, event: PointerEvent) => void;
+    onPointerLeave?: (event: PointerEvent) => void;
   }
 >;
 
@@ -52,6 +67,8 @@ const GraphInner = <Node extends Graph$.Node.Any = any, Edge extends Graph$.Edge
     arrows,
     onSelect,
     onInspect,
+    onPointerMove,
+    onPointerLeave,
     ...props
   }: GraphProps<Node, Edge>,
   forwardedRef: Ref<GraphController>,
@@ -72,7 +89,14 @@ const GraphInner = <Node extends Graph$.Node.Any = any, Edge extends Graph$.Edge
         // TODO(burdon): Replace drag when projector is updated.
         drag: drag ? createGraphDrag(context, projector) : undefined,
         arrows: { end: arrows },
-        onNodeClick: onSelect,
+        // Projector intercept first so built-in interactions (e.g. cluster collapse) can
+        // run without consumers wiring them. Returning true suppresses the user handler.
+        onNodeClick: (node, event) => {
+          if (projector.handleNodeClick(node, event)) {
+            return;
+          }
+          onSelect?.(node, event);
+        },
         onNodePointerEnter: onInspect ? (node, event) => onInspect(node, event) : undefined,
         // Pair pointerenter with leave so consumers can clear hover-driven previews.
         // The callback receives `null` on leave (event still carries the source).
@@ -96,6 +120,8 @@ const GraphInner = <Node extends Graph$.Node.Any = any, Edge extends Graph$.Edge
     props.attributes,
     props.renderNode,
     props.highlightOnHover,
+    props.applyNode,
+    props.edgeOpacity,
   ]);
 
   // External API.
@@ -154,6 +180,47 @@ const GraphInner = <Node extends Graph$.Node.Any = any, Edge extends Graph$.Edge
       void projector.stop();
     };
   }, [projector]);
+
+  // Model-space pointer events. Attached to the SVG element so they fire across the entire
+  // canvas (with pointer-events: all), not just over painted nodes. The dx-graph group's CTM
+  // undoes both the centered viewBox and any active zoom in one step, landing the cursor in
+  // the same coordinate space the projector reads.
+  useEffect(() => {
+    if (!onPointerMove && !onPointerLeave) {
+      return;
+    }
+    const svg = context.svg;
+    if (!svg) {
+      return;
+    }
+    const previousPointerEvents = svg.style.pointerEvents;
+    svg.style.pointerEvents = 'all';
+    const handleMove = (event: PointerEvent) => {
+      if (!onPointerMove) {
+        return;
+      }
+      const target = graphRef.current;
+      const ctm = target?.getScreenCTM();
+      if (!target || !ctm) {
+        return;
+      }
+      const point = svg.createSVGPoint();
+      point.x = event.clientX;
+      point.y = event.clientY;
+      const modelPoint = point.matrixTransform(ctm.inverse());
+      onPointerMove({ x: modelPoint.x, y: modelPoint.y }, event);
+    };
+    const handleLeave = (event: PointerEvent) => {
+      onPointerLeave?.(event);
+    };
+    svg.addEventListener('pointermove', handleMove);
+    svg.addEventListener('pointerleave', handleLeave);
+    return () => {
+      svg.removeEventListener('pointermove', handleMove);
+      svg.removeEventListener('pointerleave', handleLeave);
+      svg.style.pointerEvents = previousPointerEvents;
+    };
+  }, [context, onPointerMove, onPointerLeave]);
 
   return <g ref={graphRef} className={mx('dx-graph', classNames)} />;
 };

--- a/packages/ui/react-ui-graph/src/graph/projector/graph-cluster-projector.ts
+++ b/packages/ui/react-ui-graph/src/graph/projector/graph-cluster-projector.ts
@@ -95,6 +95,18 @@ export class GraphClusterProjector<
   // would permanently lose the hidden leaves and they couldn't reappear on expand.
   #dataNodes: GraphLayoutNode<NodeData>[] = [];
 
+  /**
+   * Built-in click semantics: clicking a synthetic root / group node toggles its subtree.
+   * Leaf clicks fall through to the consumer's `onSelect` (returns `false`).
+   */
+  override handleNodeClick(node: GraphLayoutNode<NodeData>, _event: MouseEvent): boolean {
+    if (node.type !== CLUSTER_NODE_TYPE_ROOT && node.type !== CLUSTER_NODE_TYPE_GROUP) {
+      return false;
+    }
+    this.toggleCollapsed(node.id);
+    return true;
+  }
+
   /** Toggle collapse state for a synthetic node id. Triggers a topology re-emit. */
   toggleCollapsed(id: string): void {
     if (this.#collapsed.has(id)) {

--- a/packages/ui/react-ui-graph/src/graph/projector/graph-projector.ts
+++ b/packages/ui/react-ui-graph/src/graph/projector/graph-projector.ts
@@ -102,5 +102,16 @@ export abstract class GraphProjector<NodeData = any, Options extends GraphProjec
     this.reset();
   }
 
+  /**
+   * Optional projector-owned click intercept. The Graph component invokes this BEFORE
+   * forwarding to the consumer's `onSelect`, so projectors can implement built-in
+   * interactions (e.g. cluster collapse) without each consumer wiring them. Returning
+   * `true` indicates the click was handled — consumer's `onSelect` is suppressed.
+   * Default no-op returns `false` so consumer handlers still run.
+   */
+  handleNodeClick(_node: GraphLayoutNode<NodeData>, _event: MouseEvent): boolean {
+    return false;
+  }
+
   abstract findNode(x: number, y: number, radius: number): GraphLayoutNode<NodeData> | undefined;
 }

--- a/packages/ui/react-ui-graph/src/graph/renderer/graph-renderer.ts
+++ b/packages/ui/react-ui-graph/src/graph/renderer/graph-renderer.ts
@@ -60,6 +60,19 @@ export type GraphRendererOptions<NodeData = any, EdgeData = any> = RendererOptio
    * whatever this callback creates instead. Use for lattice rects, custom icons, etc.
    */
   renderNode?: RenderNode<NodeData>;
+  /**
+   * Per-tick per-node callback invoked from `applyPositions` AFTER the dx-node group's
+   * transform is updated. Use it to keep node-local SVG (trail paths, gradient axes,
+   * per-frame decorations) in sync with the node's current position. The group is the
+   * dx-node `<g>` (head at 0,0 in local coords); the node is the live layout node.
+   * Runs only on the positions fast-path; full `render` calls don't invoke it.
+   */
+  applyNode?: (group: SVGGElement, node: GraphLayoutNode<NodeData>) => void;
+  /**
+   * Opacity applied to the `dx-edges` group. Set < 1 to dim edges relative to nodes
+   * (e.g. swarm trails over routing edges). Default is the inherited group opacity.
+   */
+  edgeOpacity?: number;
   transition?: () => any;
   /**
    * On node pointerenter, color outgoing edges orange, incoming edges sky-blue, dim
@@ -188,7 +201,8 @@ export class GraphRenderer<NodeData = any, EdgeData = any> extends Renderer<
       .selectAll('g.dx-edges')
       .data([{ id: 'edges' }], (d: any) => d.id)
       .join('g')
-      .classed('dx-edges', true);
+      .classed('dx-edges', true)
+      .style('opacity', this.options.edgeOpacity != null ? String(this.options.edgeOpacity) : null);
 
     const nodeGroup = root
       .selectAll('g.dx-nodes')
@@ -277,10 +291,20 @@ export class GraphRenderer<NodeData = any, EdgeData = any> extends Renderer<
     const root = select(this.root);
 
     // Transforms only — no attribute callback, no label measurement.
+    const applyNode = this.options.applyNode;
     root
       .select('g.dx-nodes')
       .selectAll<SVGGElement, GraphLayoutNode<NodeData>>('g.dx-node')
-      .attr('transform', (d) => (d.x != null && d.y != null ? `translate(${d.x},${d.y})` : null));
+      .attr('transform', (d) => (d.x != null && d.y != null ? `translate(${d.x},${d.y})` : null))
+      .each(
+        applyNode
+          ? function (d) {
+              // Per-tick consumer hook (e.g. swarm trail). Group transform is already up to date,
+              // so node-local coords land in the same frame as the head position.
+              applyNode(this, d);
+            }
+          : () => {},
+      );
 
     // Edge geometry — either precomputed (`edge.path`) or derived from endpoint positions.
     root

--- a/packages/ui/react-ui-graph/src/graph/renderer/index.ts
+++ b/packages/ui/react-ui-graph/src/graph/renderer/index.ts
@@ -3,5 +3,6 @@
 //
 
 export * from './graph-renderer';
+export * from './labels';
 export * from './linker';
 export * from './renderer';

--- a/packages/ui/react-ui-graph/src/graph/renderer/labels.ts
+++ b/packages/ui/react-ui-graph/src/graph/renderer/labels.ts
@@ -1,0 +1,138 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type D3Selection } from '../../util';
+import { type GraphLayoutNode } from '../types';
+
+export type LabelOptionsBase = {
+  /**
+   * Delay before fading the label in (ms). Default 0. Pair with the projector's tween
+   * duration so labels appear after the layout settles.
+   */
+  delay?: number;
+  /** Fade-in duration (ms). Default 200. */
+  duration?: number;
+  /** Radial offset from the node center (px). Default 4. */
+  offset?: number;
+  /** Additional CSS class(es) to set on the text element. */
+  className?: string;
+};
+
+const DEFAULT_DURATION = 200;
+const DEFAULT_OFFSET = 4;
+
+/** Read the target (post-tween) position from a node. Falls back to current x/y on entry. */
+const getTarget = (node: GraphLayoutNode): { x: number; y: number } => {
+  const tx = (node as any).tx;
+  const ty = (node as any).ty;
+  return { x: tx ?? node.x ?? 0, y: ty ?? node.y ?? 0 };
+};
+
+/**
+ * Append a radial leaf label outside the node ring, oriented outward toward the TARGET
+ * position so the label rotates with the layout tween rather than the pre-tween position.
+ * Used by cluster + bundle variants for typename-grouped leaves.
+ */
+export const appendRadialLeafLabel = (
+  group: D3Selection<SVGGElement>,
+  node: GraphLayoutNode,
+  label: string,
+  r: number,
+  options: LabelOptionsBase = {},
+): void => {
+  if (!label) {
+    return;
+  }
+  const { delay = 0, duration = DEFAULT_DURATION, offset = DEFAULT_OFFSET, className = 'dx-cluster-label' } = options;
+  const { x: targetX, y: targetY } = getTarget(node);
+  const angleDeg = (Math.atan2(targetY, targetX) * 180) / Math.PI;
+  const flipped = angleDeg > 90 || angleDeg < -90;
+  group
+    .append('text')
+    .attr('class', className)
+    .attr('dy', '0.32em')
+    .attr('transform', `rotate(${flipped ? angleDeg + 180 : angleDeg})`)
+    .attr('x', flipped ? -(r + offset) : r + offset)
+    .attr('text-anchor', flipped ? 'end' : 'start')
+    .attr('opacity', 0)
+    .style('cursor', 'pointer')
+    .text(label)
+    .transition()
+    .delay(delay)
+    .duration(duration)
+    .attr('opacity', 1);
+};
+
+/**
+ * Append a radial group label inside the node ring (anchored toward center), oriented along
+ * the TARGET radial direction. Mirrors `appendRadialLeafLabel` but anchored on the opposite
+ * side so leaf and group labels don't collide.
+ */
+export const appendRadialGroupLabel = (
+  group: D3Selection<SVGGElement>,
+  node: GraphLayoutNode,
+  label: string,
+  r: number,
+  options: LabelOptionsBase = {},
+): void => {
+  if (!label) {
+    return;
+  }
+  const {
+    delay = 0,
+    duration = DEFAULT_DURATION,
+    offset = DEFAULT_OFFSET,
+    className = 'dx-cluster-label dx-cluster-label-group',
+  } = options;
+  const { x: targetX, y: targetY } = getTarget(node);
+  const angleDeg = (Math.atan2(targetY, targetX) * 180) / Math.PI;
+  const flipped = angleDeg > 90 || angleDeg < -90;
+  group
+    .append('text')
+    .attr('class', className)
+    .attr('dy', '0.32em')
+    .attr('transform', `rotate(${flipped ? angleDeg + 180 : angleDeg})`)
+    .attr('x', flipped ? r + offset : -(r + offset))
+    .attr('text-anchor', flipped ? 'start' : 'end')
+    .attr('opacity', 0)
+    .style('pointer-events', 'none')
+    .text(label)
+    .transition()
+    .delay(delay)
+    .duration(duration)
+    .attr('opacity', 1);
+};
+
+/**
+ * Append a centered root label above the node. Used by the cluster variant for the synthetic
+ * root circle so the database / collection name reads from above the ring.
+ */
+export const appendRootLabel = (
+  group: D3Selection<SVGGElement>,
+  label: string,
+  r: number,
+  options: LabelOptionsBase = {},
+): void => {
+  if (!label) {
+    return;
+  }
+  const {
+    delay = 0,
+    duration = DEFAULT_DURATION,
+    offset = 6,
+    className = 'dx-cluster-label dx-cluster-label-root',
+  } = options;
+  group
+    .append('text')
+    .attr('class', className)
+    .attr('text-anchor', 'middle')
+    .attr('y', -(r + offset))
+    .attr('opacity', 0)
+    .style('pointer-events', 'none')
+    .text(label)
+    .transition()
+    .delay(delay)
+    .duration(duration)
+    .attr('opacity', 1);
+};


### PR DESCRIPTION
## Summary

plugin-explorer's `Visualization` component glued together five projection variants from react-ui-graph but had to leak ~170 lines of variant-specific plumbing into the consumer: a per-tick DOM walk to update swarm trails, hand-rolled CTM math to convert pointer coords into SVG model space, an awkward switch + projector cast for cluster click-to-collapse, and local copies of radial label helpers. This refactor adds four small APIs to `react-ui-graph` so each of those responsibilities lives behind the projector / renderer boundary instead.

### New react-ui-graph APIs

- **`GraphRendererOptions.applyNode`** — per-tick per-node callback invoked from `applyPositions` *after* the dx-node `<g>` transform is written. Consumers can update node-local SVG (trail paths, gradient axes, per-frame decorations) without walking the DOM from outside. Runs only on the positions fast-path.
- **`GraphRendererOptions.edgeOpacity`** — opacity applied to the `dx-edges` group. Replaces direct mutation of group `style.opacity` from the consumer side.
- **`GraphProps.onPointerMove` / `onPointerLeave`** — emits pre-transformed SVG model coordinates (centered origin, post-zoom). While either handler is wired, the renderer's `<svg>` is given `pointer-events: all` so events fire across empty canvas, not just over painted nodes. Listeners are torn down and the original `pointer-events` style restored on cleanup.
- **`GraphProjector.handleNodeClick`** — optional projector-owned click intercept invoked by `Graph` *before* the user's `onSelect`. Returning `true` suppresses the user handler. `GraphClusterProjector` overrides this to own root/group collapse semantics.
- **Reusable label helpers** — `appendRadialLeafLabel`, `appendRadialGroupLabel`, `appendRootLabel` moved into `react-ui-graph/src/graph/renderer/labels.ts` and exported from the package barrel.

### Visualization.tsx changes

- ~70-line `useEffect` that DOM-walked `g.dx-graph` per tick to update tail paths, gradient endpoints, and edge opacity → replaced with `applyNode={applyNodeSwarm}` plus `edgeOpacity={variant === 'swarm' ? 0.3 : undefined}`.
- `handlePointerMove` / `handlePointerLeave` with manual `getScreenCTM` math on the wrapping `<div>` → replaced with `onPointerMove={point => projector.setCursor(point.x, point.y)}` directly on `<SVG.Graph>`.
- Cluster-only `handleSelect` with variant check + `as GraphClusterProjector` cast → projector owns the interaction via `handleNodeClick`.
- Local `appendRadialLeafLabel` / `appendRadialGroupLabel` / `appendRootLabel` → imported from `@dxos/react-ui-graph`.

Net change in plugin-explorer: ~525 → ~357 lines.

## Verified

- `moon run react-ui-graph:build plugin-explorer:build`
- `moon run react-ui-graph:lint plugin-explorer:lint`
- `moon run react-ui-graph:test plugin-explorer:test`
- All five variants exercised in plugin-explorer storybook:
  - **Force**: 63 nodes, 17 edges, normal edge opacity.
  - **Swarm**: 63 boids with 63 trail paths and 63 per-boid `<linearGradient>` defs; `g.dx-edges` opacity = `0.3`; `<svg>` has `pointer-events: all`. Tail `d` updated each tick; on variant change away from swarm, both `edgeOpacity` and `<svg> pointer-events` are cleared by the renderer / Graph cleanup paths.
  - **Cluster**: 70 nodes (1 root + 6 groups + 63 leaves), 1 root label "Database", 6 group labels, 63 leaf labels. Clicking the Person group (via `GraphClusterProjector.handleNodeClick`) fades 21 leaves to `opacity: 0`.
  - **Lattice**: 63 rounded rects.
  - **Bundle**: 63 leaves with leaf labels; structural anchors invisible.
- No console errors at any point.

## Test plan

- [ ] `moon run react-ui-graph:build` succeeds
- [ ] `moon run plugin-explorer:build` succeeds
- [ ] `moon run :lint` clean
- [ ] `moon run :test` clean
- [ ] Manually load each ExplorerArticle story (Force / Swarm / Cluster / Bundle / Lattice) and switch between them — node positions should carry over across variant changes, and swarm-specific styling (dimmed edges, `pointer-events: all`) should not leak into other variants.
- [ ] In Swarm story, moving the cursor across the canvas should make boids steer away.
- [ ] In Cluster story, clicking a group / root circle toggles its subtree visibility; clicking a leaf does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added click-based expansion and collapse for cluster hierarchy nodes.
  * Introduced pointer event callbacks for improved cursor position tracking within the graph.

* **Refactor**
  * Extracted label rendering utilities to shared module for reusability.
  * Refactored swarm-specific updates to use per-tick hooks for improved performance.
  * Enhanced edge opacity control options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->