### PR TITLE
fix(plugin-deck,plugin-explorer,plugin-trip): card preview fixes + trip extraction

### DIFF
--- a/packages/plugins/plugin-deck/src/containers/DeckLayout/Popover.tsx
+++ b/packages/plugins/plugin-deck/src/containers/DeckLayout/Popover.tsx
@@ -74,6 +74,9 @@ export const PopoverContent = () => {
   const objectMenuItems = useObjectMenuItems(popoverSubject);
   const title = state.popoverTitle ? toLocalizedString(state.popoverTitle, t) : 'Unknown';
   const icon = isObjectPopover ? (Obj.getIcon(popoverSubject)?.icon ?? 'ph--circle-dashed--regular') : undefined;
+  const content = state.popoverContent;
+  // A base popover renders a plugin-provided component; everything else falls through to the card.
+  const isBasePopover = state.popoverKind === 'base' && !!content && 'component' in content;
 
   const handleClose = useCallback(() => {
     setOpen(false);
@@ -112,13 +115,17 @@ export const PopoverContent = () => {
         onEscapeKeyDown={handleInteractOutside}
       >
         <Popover.Viewport>
-          {/* Base popover */}
-          {state.popoverKind === 'base' && state.popoverContent && 'component' in state.popoverContent && (
-            <Surface.Surface type={AppSurface.Popover} data={state.popoverContent} limit={1} />
-          )}
-
-          {/* Card popover */}
-          {state.popoverKind === 'card' && (
+          {isBasePopover && content && 'component' in content ? (
+            /* Base popover: a plugin-provided component (e.g. editor link preview). */
+            <Surface.Surface type={AppSurface.Popover} data={content} limit={1} />
+          ) : (
+            /*
+             * Card popover (default). Rendered for any open popover that isn't an explicit
+             * base-component popover so the popover can never collapse to a bare 1px frame: the
+             * header (icon + title + menu) always renders, and the body falls back to a fixed-
+             * height "no preview" row when no subject resolves a card Surface (e.g. system-type
+             * objects like a raw Feed that have no registered card and no renderable fields).
+             */
             <Menu.Root>
               <Card.Root border={false} classNames='dx-card-popover'>
                 <Card.Header>
@@ -139,8 +146,14 @@ export const PopoverContent = () => {
                   </Card.IconBlock>
                 </Card.Header>
 
-                {state.popoverContent && 'subject' in state.popoverContent && (
-                  <Surface.Surface type={AppSurface.Card} data={state.popoverContent} limit={1} />
+                {content && 'subject' in content ? (
+                  <Surface.Surface type={AppSurface.Card} data={content} limit={1} />
+                ) : (
+                  <Card.Body classNames='min-bs-8'>
+                    <Card.Row>
+                      <Card.Text variant='description'>{t('popover-no-preview.message')}</Card.Text>
+                    </Card.Row>
+                  </Card.Body>
                 )}
               </Card.Root>
             </Menu.Root>

--- a/packages/plugins/plugin-deck/src/containers/DeckLayout/Popover.tsx
+++ b/packages/plugins/plugin-deck/src/containers/DeckLayout/Popover.tsx
@@ -122,8 +122,6 @@ export const PopoverContent = () => {
             <Menu.Root>
               <Card.Root border={false} classNames='dx-card-popover'>
                 <Card.Header>
-                  {/* Disabled drag handle keeps the toolbar slot layout consistent with regular cards. */}
-                  <Card.DragHandle />
                   <Card.IconBlock padding>{icon && <Card.Icon icon={icon} />}</Card.IconBlock>
                   <Card.Title>{title}</Card.Title>
                   {/* TODO(wittjosiah): Reconcile with Card.Menu. */}

--- a/packages/plugins/plugin-deck/src/translations.ts
+++ b/packages/plugins/plugin-deck/src/translations.ts
@@ -53,6 +53,7 @@ export const translations = [
         'close-all.label': 'Close all planks',
         'close-navigation-sidebar.button': 'Close',
         'companion-plank-heading-fallback.label': 'Related',
+        'popover-no-preview.message': 'No preview available.',
       },
     },
   },

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/ExplorerArticle.tsx
@@ -50,16 +50,18 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
     }
   }, []);
 
+  // Dismiss the preview popover. The dxn/label/trigger fields are placeholders ignored on
+  // `state: false`.
+  const handleDismiss = useCallback(() => {
+    document.defaultView?.dispatchEvent(
+      new DxAnchorActivate({ dxn: '', label: '', trigger: document.body, state: false }),
+    );
+  }, []);
+
   const handleHover = useCallback((node: TreeNode | null, event?: MouseEvent) => {
-    // Pointer left the node/label: dispatch a close event so the preview popover
-    // dismisses (the dxn/label/trigger fields are placeholders ignored on `state: false`).
-    if (!node) {
-      document.defaultView?.dispatchEvent(
-        new DxAnchorActivate({ dxn: '', label: '', trigger: document.body, state: false }),
-      );
-      return;
-    }
-    if (!event) {
+    // Pointer left the node/label: keep the popover open so it can be hovered/interacted with.
+    // The popover is dismissed only on an explicit click on the component surface (handleDismiss).
+    if (!node || !event) {
       return;
     }
     const obj = node.data;
@@ -105,7 +107,13 @@ export const ExplorerArticle = ({ role, subject, variant }: ExplorerArticleProps
         </Panel.Toolbar>
       )}
       <Panel.Content>
-        <Visualization classNames='bg-base-surface' variant={selected} model={model} onNodeHover={handleHover} />
+        <Visualization
+          classNames='bg-base-surface'
+          variant={selected}
+          model={model}
+          onNodeHover={handleHover}
+          onSurfaceClick={handleDismiss}
+        />
       </Panel.Content>
     </Panel.Root>
   );

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerArticle/Visualization.tsx
@@ -40,12 +40,21 @@ export type VisualizationProps = ThemedClassName<{
   variant: ExplorerArticleVariant;
   model: SpaceGraphModel;
   onNodeHover?: (node: TreeNode | null, event?: MouseEvent) => void;
+  /** Called when the user clicks the visualization surface (e.g. to dismiss a node preview). */
+  onSurfaceClick?: () => void;
 }>;
 
 /**
  * Renders the active visualization variant.
  */
-export const Visualization = ({ classNames, debug = true, variant, model, onNodeHover }: VisualizationProps) => {
+export const Visualization = ({
+  classNames,
+  debug = true,
+  variant,
+  model,
+  onNodeHover,
+  onSurfaceClick,
+}: VisualizationProps) => {
   const svgRef = useRef<SVGContext>(null);
   const [projector, setProjector] = useState<GraphProjector<SpaceGraphNode> | undefined>();
   const projectorRef = useRef<GraphProjector<SpaceGraphNode> | undefined>(undefined);
@@ -113,7 +122,7 @@ export const Visualization = ({ classNames, debug = true, variant, model, onNode
     variant === 'swarm' ? { onPointerMove: handlePointerMove, onPointerLeave: handlePointerLeave } : undefined;
 
   return (
-    <div className={mx('dx-expander relative', classNames)}>
+    <div className={mx('dx-expander relative', classNames)} onClick={onSurfaceClick}>
       <SVG.Root ref={svgRef}>
         <SVG.Zoom extent={[1 / 2, 2]}>
           <SVG.Graph<SpaceGraphNode, SpaceGraphEdge>

--- a/packages/plugins/plugin-inbox/src/capabilities/MessageExtractor.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/MessageExtractor.ts
@@ -81,6 +81,8 @@ export class ExtractError {
  */
 export interface MessageExtractor {
   readonly id: string;
+  /** Short, human-readable title for menus/toolbars (e.g. "Trip", "Contact"). */
+  readonly title: string;
   readonly description: string;
   readonly kinds: readonly string[];
   match(message: Message.Message): MatchResult;

--- a/packages/plugins/plugin-inbox/src/components/Message/Message.stories.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Message/Message.stories.tsx
@@ -139,6 +139,7 @@ export const TrackingPixel: Story = {
 // dispatcher uses `extract` directly so pointing it at any real definition is fine here.
 const FakeTripExtractor: MessageExtractor.MessageExtractor = {
   id: 'story.extractor.fake-trip',
+  title: 'Trip',
   description: 'Story: extract travel itinerary',
   kinds: ['flight'],
   match: (message) => {

--- a/packages/plugins/plugin-inbox/src/components/Message/useExtractorActions.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Message/useExtractorActions.tsx
@@ -59,7 +59,7 @@ export const useExtractorActions = (message: Message.Message): ExtractorMenuItem
 
     const perExtractor: ExtractorMenuItem[] = matching.map((extractor) => ({
       id: extractor.id,
-      label: extractor.description,
+      label: extractor.title,
       onSelect: () => {
         void runOne(extractor.id);
       },

--- a/packages/plugins/plugin-inbox/src/operations/extractor/contact-extractor.ts
+++ b/packages/plugins/plugin-inbox/src/operations/extractor/contact-extractor.ts
@@ -47,6 +47,7 @@ export default handler;
  */
 export const ContactMessageExtractor: MessageExtractor.MessageExtractor = {
   id: ID,
+  title: 'Contact',
   description: 'Create contact from message sender',
   kinds: ['contact'],
   match: matchMessage,

--- a/packages/plugins/plugin-inbox/src/operations/extractor/extract-message.test.ts
+++ b/packages/plugins/plugin-inbox/src/operations/extractor/extract-message.test.ts
@@ -27,6 +27,7 @@ const stubExtractor = (opts: {
   extract?: () => Effect.Effect<MessageExtractor.ExtractResult, MessageExtractor.ExtractError>;
 }): MessageExtractor.MessageExtractor => ({
   id: opts.id,
+  title: opts.id,
   description: opts.id,
   kinds: [],
   match: () => ({ matched: opts.matched, confidence: opts.confidence }),

--- a/packages/plugins/plugin-inbox/src/operations/extractor/extract-message.ts
+++ b/packages/plugins/plugin-inbox/src/operations/extractor/extract-message.ts
@@ -83,6 +83,35 @@ const handler: Operation.WithHandler<typeof InboxOperation.ExtractMessage> = Inb
       //     so the trip extractor's Trip + Booking + Segment trio surfaces as one Trip chip,
       //     not three.
       const shouldRelate = chosen.createRelation !== false;
+      const hasTags = !!result.tags && result.tags.length > 0;
+
+      // Resolve the owning mailbox AND the live message object. The `message` arg may be a
+      // deserialized snapshot (this operation runs in a separate process), and both
+      // `ExtractedFrom` relation endpoints and tag `Ref`s require live ECHO proxies — a
+      // snapshot as a relation Target throws "target must be an ECHO object". The owning
+      // mailbox's feed holds the live object, so resolve it by querying each mailbox's feed
+      // for the message id. Falls back to the passed `message` (unit tests add it to the db
+      // directly, so it's already a proxy) and the first mailbox in the space.
+      let owningMailbox: Mailbox.Mailbox | undefined;
+      let sourceMessage = message;
+      if (shouldRelate || hasTags) {
+        const mailboxes = yield* Effect.promise(() => db.query(Filter.type(Mailbox.Mailbox)).run());
+        const resolved = yield* Effect.promise(async () => {
+          for (const candidate of mailboxes) {
+            const feed = await candidate.feed?.tryLoad();
+            if (!feed) {
+              continue;
+            }
+            const found = await db.query(Query.select(Filter.id(message.id)).from(feed)).run();
+            if (found.length > 0) {
+              return { mailbox: candidate, message: found[0] };
+            }
+          }
+          return { mailbox: mailboxes[0], message: undefined };
+        });
+        owningMailbox = resolved.mailbox;
+        sourceMessage = resolved.message ?? message;
+      }
 
       // Persist created objects, then attach an ExtractedFrom relation for each top-level
       // one when the extractor opts in.
@@ -93,7 +122,7 @@ const handler: Operation.WithHandler<typeof InboxOperation.ExtractMessage> = Inb
         }
         const rel = ExtractedFrom.make({
           [Relation.Source]: obj,
-          [Relation.Target]: message,
+          [Relation.Target]: sourceMessage,
           extractorId: chosen.id,
           extractedAt,
           confidence: chosenConfidence,
@@ -109,7 +138,7 @@ const handler: Operation.WithHandler<typeof InboxOperation.ExtractMessage> = Inb
         }
         const rel = ExtractedFrom.make({
           [Relation.Source]: obj,
-          [Relation.Target]: message,
+          [Relation.Target]: sourceMessage,
           extractorId: chosen.id,
           extractedAt,
           confidence: chosenConfidence,
@@ -122,30 +151,10 @@ const handler: Operation.WithHandler<typeof InboxOperation.ExtractMessage> = Inb
         db.add(rel);
       }
 
-      // Apply tags to the source message. The Mailbox containing this message owns the
-      // tag map; resolve the owning mailbox by querying each mailbox's feed for the
-      // message id (feed-stored Messages are immutable so the back-ref is the feed query).
-      // Falls back to the first mailbox in the space for environments where the message
-      // hasn't yet been appended to any feed (e.g. unit tests).
-      if (result.tags && result.tags.length > 0) {
-        const mailboxes = yield* Effect.promise(() => db.query(Filter.type(Mailbox.Mailbox)).run());
-        const owningMailbox = yield* Effect.promise(async () => {
-          for (const candidate of mailboxes) {
-            const feed = await candidate.feed?.tryLoad();
-            if (!feed) {
-              continue;
-            }
-            const found = await db.query(Query.select(Filter.id(message.id)).from(feed)).run();
-            if (found.length > 0) {
-              return candidate;
-            }
-          }
-          return mailboxes[0];
-        });
-        if (owningMailbox) {
-          for (const tag of result.tags) {
-            Mailbox.applyTag(owningMailbox, tag, message);
-          }
+      // Apply tags to the source message via the owning mailbox's tag map.
+      if (hasTags && owningMailbox) {
+        for (const tag of result.tags!) {
+          Mailbox.applyTag(owningMailbox, tag, sourceMessage);
         }
       }
 

--- a/packages/plugins/plugin-inbox/src/operations/extractor/summarize-extractor.ts
+++ b/packages/plugins/plugin-inbox/src/operations/extractor/summarize-extractor.ts
@@ -121,6 +121,7 @@ const extract = (input: MessageExtractor.ExtractInput) =>
 
 export const SummarizeMessageExtractor: MessageExtractor.MessageExtractor = {
   id: SUMMARIZE_ID,
+  title: 'Summary',
   description: 'Summarize a long email body into a Markdown document via the AI service.',
   kinds: ['document', 'summary'],
   match: matchMessage,

--- a/packages/plugins/plugin-trip/src/operations/extractor/trip-extractor.test.ts
+++ b/packages/plugins/plugin-trip/src/operations/extractor/trip-extractor.test.ts
@@ -10,6 +10,7 @@ import { Filter, Obj } from '@dxos/echo';
 import { type EchoDatabase } from '@dxos/echo-db';
 import { EchoTestBuilder } from '@dxos/echo-db/testing';
 import { runAndForwardErrors } from '@dxos/effect';
+import { Organization } from '@dxos/types';
 
 import { Booking, Segment, Trip } from '../../types';
 import gateChangeRaw from './testing/files/gate-change.txt?raw';
@@ -37,7 +38,9 @@ describe('TripMessageExtractor', () => {
 
   beforeEach(async () => {
     builder = await new EchoTestBuilder().open();
-    const result = await builder.createDatabase({ types: [Booking.Booking, Segment.Segment, Trip.Trip] });
+    const result = await builder.createDatabase({
+      types: [Booking.Booking, Segment.Segment, Trip.Trip, Organization.Organization],
+    });
     db = result.db;
   });
 
@@ -172,4 +175,91 @@ describe('TripMessageExtractor', () => {
     expect(bookings).toHaveLength(1);
     expect(segments).toHaveLength(1);
   });
+
+  test('extract — provider domain comes from the sender, name from the airline prefix', async ({ expect }) => {
+    // Regression: the provider was hardcoded to united.com regardless of the actual airline.
+    const result = await TripMessageExtractor.extract({ db, message: parseFixtureMessage(AIR_FRANCE_RAW) })
+      .pipe(provideOperationServiceStub)
+      .pipe(runAndForwardErrors);
+
+    const booking = result.created.find((obj) => Obj.instanceOf(Booking.Booking, obj)) as Booking.Booking;
+    expect(booking.provider?.domain).toBe('airfrance.com');
+    expect(booking.provider?.name).toBe('Air France');
+
+    const segment = result.created.find((obj) => Obj.instanceOf(Segment.Segment, obj)) as Segment.Segment;
+    if (segment.details._tag !== 'flight') {
+      throw new Error('expected flight details');
+    }
+    expect(segment.details.provider?.domain).toBe('airfrance.com');
+    // The Segment references the Booking created from the same email.
+    expect(segment.booking?.target?.id).toBe(booking.id);
+  });
+
+  test('extract — links the provider to a matching Organization', async ({ expect }) => {
+    const org = db.add(Organization.make({ name: 'Air France', website: 'https://airfrance.com' }));
+    await db.flush();
+
+    const result = await TripMessageExtractor.extract({ db, message: parseFixtureMessage(AIR_FRANCE_RAW) })
+      .pipe(provideOperationServiceStub)
+      .pipe(runAndForwardErrors);
+
+    const booking = result.created.find((obj) => Obj.instanceOf(Booking.Booking, obj)) as Booking.Booking;
+    expect(booking.provider?.ref?.target?.id).toBe(org.id);
+  });
+
+  test('extract — a different flight is appended to the most-recently-created Trip', async ({ expect }) => {
+    // Email 1 creates a Trip; persist it so the second extract can discover it.
+    const first = await TripMessageExtractor.extract({ db, message: parseFixtureMessage(unitedConfirmationRaw) })
+      .pipe(provideOperationServiceStub)
+      .pipe(runAndForwardErrors);
+    for (const obj of first.created) {
+      db.add(obj);
+    }
+    await db.flush();
+    const trip = first.created.find((obj) => Obj.instanceOf(Trip.Trip, obj)) as Trip.Trip;
+
+    // Email 2: a different flight (new number) → no segment match → append to the existing Trip.
+    const second = await TripMessageExtractor.extract({ db, message: parseFixtureMessage(SECOND_FLIGHT_RAW) })
+      .pipe(provideOperationServiceStub)
+      .pipe(runAndForwardErrors);
+
+    // No new Trip; the existing one is returned as `updated` so the dispatcher links the message.
+    expect(second.created.some((obj) => Obj.instanceOf(Trip.Trip, obj))).toBe(false);
+    expect(second.created).toHaveLength(2);
+    expect(second.updated).toHaveLength(1);
+    expect((second.updated![0] as Trip.Trip).id).toBe(trip.id);
+
+    // After both emails there is a single Trip referencing two segments.
+    for (const obj of second.created) {
+      db.add(obj);
+    }
+    await db.flush();
+    const trips = await db.query(Filter.type(Trip.Trip)).run();
+    expect(trips).toHaveLength(1);
+    expect(trips[0].segments).toHaveLength(2);
+  });
 });
+
+const AIR_FRANCE_RAW = [
+  'From: noreply@airfrance.com',
+  'Subject: Flight confirmation',
+  '',
+  'Flight: AF-7',
+  'From: CDG (Paris)',
+  'To: JFK (New York)',
+  'Depart: 2026-07-01 10:00',
+  'Arrive: 2026-07-01 13:00',
+  'Confirmation: AF999',
+].join('\n');
+
+const SECOND_FLIGHT_RAW = [
+  'From: noreply@united.com',
+  'Subject: Flight confirmation',
+  '',
+  'Flight: AF-2',
+  'From: LHR (London Heathrow)',
+  'To: SFO (San Francisco)',
+  'Depart: 2026-06-10 12:00',
+  'Arrive: 2026-06-10 15:00',
+  'Confirmation: XYZ789',
+].join('\n');

--- a/packages/plugins/plugin-trip/src/operations/extractor/trip-extractor.test.ts
+++ b/packages/plugins/plugin-trip/src/operations/extractor/trip-extractor.test.ts
@@ -237,6 +237,9 @@ describe('TripMessageExtractor', () => {
     const trips = await db.query(Filter.type(Trip.Trip)).run();
     expect(trips).toHaveLength(1);
     expect(trips[0].segments).toHaveLength(2);
+    // The Trip date range widens to cover the appended segment (depart 2026-06-10).
+    expect(trips[0].start).toBe('2026-06-01T15:30:00.000Z');
+    expect(trips[0].end).toBe('2026-06-10T15:00:00.000Z');
   });
 });
 

--- a/packages/plugins/plugin-trip/src/operations/extractor/trip-extractor.ts
+++ b/packages/plugins/plugin-trip/src/operations/extractor/trip-extractor.ts
@@ -328,6 +328,16 @@ const extractFromMessage = (
     const existingTrip = yield* findLatestTrip(db);
     if (existingTrip) {
       Trip.addSegment(existingTrip, segment);
+      // `Trip.addSegment` only pushes the segment ref; widen the Trip's date range so it
+      // covers the appended segment (ISO timestamps compare lexically).
+      Obj.update(existingTrip, (existingTrip) => {
+        if (candidate.departAt && (!existingTrip.start || candidate.departAt < existingTrip.start)) {
+          existingTrip.start = candidate.departAt;
+        }
+        if (candidate.arriveAt && (!existingTrip.end || candidate.arriveAt > existingTrip.end)) {
+          existingTrip.end = candidate.arriveAt;
+        }
+      });
       // Booking + Segment are parented to the Trip so the dispatcher skips a per-artifact edge.
       Obj.setParent(booking, existingTrip);
       return {

--- a/packages/plugins/plugin-trip/src/operations/extractor/trip-extractor.ts
+++ b/packages/plugins/plugin-trip/src/operations/extractor/trip-extractor.ts
@@ -5,9 +5,10 @@
 import * as Effect from 'effect/Effect';
 
 import { Operation } from '@dxos/compute';
-import { Filter, Obj, type Database } from '@dxos/echo';
+import { Filter, Obj, Ref, type Database } from '@dxos/echo';
+import { log } from '@dxos/log';
 import { type MessageExtractor } from '@dxos/plugin-inbox';
-import { type ContentBlock, type Message } from '@dxos/types';
+import { type ContentBlock, type Message, Organization, type Provider } from '@dxos/types';
 
 import { Booking, Segment, Trip, TripOperation } from '../../types';
 
@@ -30,7 +31,10 @@ import { Booking, Segment, Trip, TripOperation } from '../../types';
  * Create-or-update: existing flight segments in `ctx.database` are looked up
  * by `(number, departAt date)`. A match is mutated in place (returned in
  * `updated`) and a fresh `Booking` is NOT emitted; otherwise a new `Booking`
- * + `Segment` pair is created.
+ * + `Segment` pair is created and appended to the most-recently-created Trip
+ * (a new Trip is created only when none exists). The flight provider (airline)
+ * is derived from the sender domain + flight-number prefix and linked to a
+ * matching Organization when one is found.
  */
 export const ID = 'org.dxos.plugin.trip.extractor.trip';
 
@@ -292,17 +296,19 @@ const extractFromMessage = (
       };
     }
 
-    // No prior segment — create a Trip + Booking + flight Segment trio. The Trip is the
-    // top-level container surfaced as a tag on the source message; Booking + Segment hang
-    // off the Trip.
+    // No prior segment — create a Booking + flight Segment. The provider (airline) is derived
+    // from the sender domain + flight-number prefix and linked to a matching Organization.
+    const provider = yield* resolveProvider(db, candidate, message);
+
     const booking = Booking.make({
-      provider: { name: 'Air France', domain: 'united.com' },
+      provider,
       confirmationCode: candidate.confirmationCode,
       source: 'email',
       rawPayload: body,
     });
 
     const segment = Segment.make({
+      booking: Ref.make(booking),
       details: {
         _tag: 'flight',
         origin: candidate.origin,
@@ -310,13 +316,32 @@ const extractFromMessage = (
         departAt: candidate.departAt,
         arriveAt: candidate.arriveAt,
         number: candidate.number,
-        provider: { name: 'Air France', domain: 'united.com' },
+        provider,
         gateFrom: candidate.gateFrom,
         terminalFrom: candidate.terminalFrom,
         seat: candidate.seat,
       },
     });
 
+    // Decision: for now, append the segment to the most-recently-created Trip rather than
+    // spawning a new Trip per email; only create a new Trip when none exists yet.
+    const existingTrip = yield* findLatestTrip(db);
+    if (existingTrip) {
+      Trip.addSegment(existingTrip, segment);
+      // Booking + Segment are parented to the Trip so the dispatcher skips a per-artifact edge.
+      Obj.setParent(booking, existingTrip);
+      return {
+        created: [booking, segment],
+        // The Trip is mutated in place; surface it as `updated` so the dispatcher links THIS
+        // message to the Trip (top-level → one ExtractedFrom edge → Trip chip on the message).
+        updated: [existingTrip],
+        relations: [],
+        tags: [{ label: 'travel', hue: 'sky' }],
+      };
+    }
+
+    // First trip — create the Trip + Booking + flight Segment trio. The Trip is the top-level
+    // container surfaced as a tag on the source message; Booking + Segment hang off the Trip.
     const trip = Trip.make({
       name: tripNameFor(candidate),
       start: candidate.departAt,
@@ -337,6 +362,91 @@ const extractFromMessage = (
       tags: [{ label: 'travel', hue: 'sky' }],
     };
   });
+
+/** IATA airline prefix → display name. Extend as needed; falls back to the sender domain. */
+const AIRLINE_NAMES: Record<string, string> = {
+  AA: 'American Airlines',
+  AF: 'Air France',
+  BA: 'British Airways',
+  DL: 'Delta Air Lines',
+  IB: 'Iberia',
+  KL: 'KLM',
+  LH: 'Lufthansa',
+  TP: 'TAP Air Portugal',
+  UA: 'United Airlines',
+};
+
+/** Leading two-letter IATA code of a flight number (e.g. "AF0003" → "AF"). */
+const airlineCodeOf = (flightNumber: string | undefined): string | undefined =>
+  flightNumber?.match(/^([A-Za-z]{2})/)?.[1]?.toUpperCase();
+
+/** Domain part of the sender's email (e.g. "noreply@airfrance.com" → "airfrance.com"). */
+const senderDomainOf = (message: Message.Message): string | undefined =>
+  message.sender.email?.split('@')[1]?.toLowerCase();
+
+/** Title-case a domain's second-level label as a provider-name fallback (airfrance.com → Airfrance). */
+const domainToName = (domain: string): string => {
+  const label = domain.split('.')[0] ?? domain;
+  return label.charAt(0).toUpperCase() + label.slice(1);
+};
+
+/** Whether an Organization website matches the sender domain (host equality or sub-domain either way). */
+const matchesDomain = (website: string | undefined, domain: string): boolean => {
+  if (!website) {
+    return false;
+  }
+  try {
+    const host = new URL(website.startsWith('http') ? website : `https://${website}`).hostname.toLowerCase();
+    return host === domain || host.endsWith(`.${domain}`) || domain.endsWith(`.${host}`);
+  } catch (err) {
+    log.warn('parsing organization website', { website, err });
+    return false;
+  }
+};
+
+/**
+ * Builds the flight provider: `domain` from the sender's email, `name` from the airline-prefix
+ * map (sender-domain fallback), and a `ref` to an existing Organization when one matches by
+ * website domain or name.
+ */
+const resolveProvider = (
+  db: Database.Database,
+  candidate: Candidate,
+  message: Message.Message,
+): Effect.Effect<Provider.Provider, never> =>
+  Effect.gen(function* () {
+    const domain = senderDomainOf(message);
+    const code = airlineCodeOf(candidate.number);
+    const name = (code && AIRLINE_NAMES[code]) ?? (domain ? domainToName(domain) : undefined);
+    if (!domain && !name) {
+      return {};
+    }
+
+    const orgs = yield* Effect.promise(() => db.query(Filter.type(Organization.Organization)).run()).pipe(
+      Effect.catchAllDefect(() => Effect.succeed([] as Organization.Organization[])),
+    );
+    const match = orgs.find(
+      (org) =>
+        (!!domain && matchesDomain(org.website, domain)) || (!!name && org.name?.toLowerCase() === name.toLowerCase()),
+    );
+
+    return {
+      ...(name ? { name } : {}),
+      ...(domain ? { domain } : {}),
+      ...(match ? { ref: Ref.make(match) } : {}),
+    };
+  });
+
+/**
+ * Returns the most-recently-created Trip in the space, or undefined when none exist.
+ * TODO(burdon): No stable createdAt accessor on instances yet — relies on natural (insertion)
+ * query order. Replace with an explicit createdAt ordering when available.
+ */
+const findLatestTrip = (db: Database.Database): Effect.Effect<Trip.Trip | undefined, never> =>
+  Effect.promise(() => db.query(Filter.type(Trip.Trip)).run()).pipe(
+    Effect.map((trips) => trips.at(-1)),
+    Effect.catchAllDefect(() => Effect.succeed(undefined)),
+  );
 
 const tripNameFor = (candidate: Candidate): string => {
   const origin = candidate.origin?.code ?? '?';
@@ -362,7 +472,7 @@ const findExistingFlight = (
   );
 };
 
-const extract = ({
+export const extract = ({
   db,
   message,
 }: MessageExtractor.ExtractInput): Effect.Effect<MessageExtractor.ExtractResult, never> =>
@@ -382,6 +492,7 @@ export default handler;
 /** Heuristic v1 extractor — recognises United-style flight confirmations. */
 export const TripMessageExtractor: MessageExtractor.MessageExtractor = {
   id: ID,
+  title: 'Trip',
   description: 'Recognises airline booking confirmations and produces Bookings + flight Segments.',
   kinds: ['flight'],
   match: matchMessage,

--- a/packages/stories/stories-inbox/src/containers/MessageArticle.stories.tsx
+++ b/packages/stories/stories-inbox/src/containers/MessageArticle.stories.tsx
@@ -61,6 +61,7 @@ const MockDeckOperationsPlugin = Plugin.define({ id: 'story.mock-deck-operations
  */
 const ImportantMessageExtractor: MessageExtractor.MessageExtractor = {
   id: 'story.extractor.important',
+  title: 'Important',
   description: 'Mark message as important',
   kinds: ['tag'],
   match: () => ({ matched: true, confidence: 0.05 }),

--- a/packages/stories/stories-inbox/src/containers/MessageArticle.stories.tsx
+++ b/packages/stories/stories-inbox/src/containers/MessageArticle.stories.tsx
@@ -287,11 +287,11 @@ export const ExtractTripWithPlay: Story = {
     await userEvent.click(extractTrigger as HTMLElement);
 
     // Assert the summarize extractor is registered and matches the seeded body. The dropdown
-    // entry uses the extractor's `description` text. If the body falls below the 200-char
+    // entry uses the extractor's short `title` ("Summary"). If the body falls below the 200-char
     // threshold or the InboxPlugin's Startup module stops contributing the extractor, this
     // assertion fails before "Run all" even fires — so the test catches a missing wire-up
     // rather than passing for the wrong reason on the trip-only assertions below.
-    const summarizeItem = await waitFor(() => body.queryByText(/summarize a long email body/i));
+    const summarizeItem = await waitFor(() => body.queryByText(/^summary$/i));
     void expect(summarizeItem).toBeInTheDocument();
 
     // The `Run all (N)` label includes the count of matching extractors. With contact + trip

--- a/packages/stories/stories-inbox/src/containers/MessageArticle.stories.tsx
+++ b/packages/stories/stories-inbox/src/containers/MessageArticle.stories.tsx
@@ -287,12 +287,16 @@ export const ExtractTripWithPlay: Story = {
     await userEvent.click(extractTrigger as HTMLElement);
 
     // Assert the summarize extractor is registered and matches the seeded body. The dropdown
-    // entry uses the extractor's short `title` ("Summary"). If the body falls below the 200-char
-    // threshold or the InboxPlugin's Startup module stops contributing the extractor, this
-    // assertion fails before "Run all" even fires — so the test catches a missing wire-up
-    // rather than passing for the wrong reason on the trip-only assertions below.
-    const summarizeItem = await waitFor(() => body.queryByText(/^summary$/i));
-    void expect(summarizeItem).toBeInTheDocument();
+    // entry uses the extractor's short `title` ("Summary"). Use queryAllByText (the label text
+    // can match both the menu item and its inner text node) and require at least one match. If
+    // the body falls below the 200-char threshold or the InboxPlugin's Startup module stops
+    // contributing the extractor, this assertion fails before "Run all" even fires — so the test
+    // catches a missing wire-up rather than passing for the wrong reason on the trip assertions.
+    const summarizeItems = await waitFor(
+      () => body.queryAllByText(/^summary$/i),
+      (items) => items.length > 0,
+    );
+    void expect(summarizeItems.length).toBeGreaterThan(0);
 
     // The `Run all (N)` label includes the count of matching extractors. With contact + trip
     // + summarize + important all matching, the label must read "Run all (4)".


### PR DESCRIPTION
## Summary

Two related fix sets in one branch.

### Card preview (plugin-deck / plugin-explorer)
1. **DragHandle wrap** — the card popover header rendered both a `Card.DragHandle` (added in #11575) and the type icon, forcing the actions menu to wrap. Removed the stray drag handle; header is now icon + title + menu.
2. **Popover dismissal** — the node preview popover was dismissed on pointer-leave, so it couldn't be hovered/interacted with. It now persists on leave and is dismissed only on an explicit click on the visualization surface (`onSurfaceClick`).
3. **Zero-height ("1px line") preview** — for some nodes (e.g. a raw `Feed`) the popover rendered a bare ~1px frame: the card was only rendered when `popoverKind === 'card'`, and in production `Surface` renders nothing (not a fallback) when no card surface matches. The card is now the default branch for any open popover that isn't an explicit base-component popover, and always renders the header + a fixed-height "No preview available." body so it can never collapse.

### Trip extraction (plugin-inbox / plugin-trip)
1. **`ExtractMessage` relation crash** (`TypeError: target must be an ECHO object`) — the operation runs in a separate process, so the `message` arg arrives as a deserialized snapshot, but `ExtractedFrom` relation endpoints (and tag `Ref`s) require live ECHO proxies. Resolve the live message from its owning mailbox feed before creating relations/tags; fall back to the passed message. This also unblocks the trip relation, the message-header chip, and the travel tag (which previously never ran because the crash aborted the handler).
2. **Wrong provider domain** — the trip extractor hardcoded `{ name: 'Air France', domain: 'united.com' }`. Now derives `domain` from the sender email, `name` from the flight-number IATA prefix (sender-domain fallback), and links `provider.ref` to a matching `Organization` when one exists.
3. **A new Trip per email** — a new flight Segment is now appended to the most-recently-created Trip (a new Trip is created only when none exists); the reused Trip is returned as `updated` so the dispatcher still links the message to it.
4. **Extractor titles** — added a `title` field to `MessageExtractor` (Trip / Contact / Summary) and use it for the message extractor menu instead of the long description.

## Verification
- Affected packages build + lint clean.
- `plugin-inbox` (60) and `plugin-trip` (15, incl. new provider/org-link/trip-reuse cases) tests pass.
- The card DragHandle (①) and FormCard popover sizing were checked in Storybook (`plugin-preview/cards/Card`, real `dx-card-popover` host).
- **Needs runtime confirmation:** the trip relation fix's production queue→relation path can't be exercised in unit tests (needs feed-stored messages); please verify the crash is gone in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message extractors now show short, human-readable titles in menus.
  * Trip extraction improved: better provider detection, groups related flights into existing trips, and links providers to organizations.

* **Bug Fixes**
  * Refined popover preview rendering with a clear "No preview available." message.
  * Visualization surface clicks no longer inadvertently dismiss previews.

* **Tests**
  * Expanded trip extractor tests covering additional flight and organization scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->