### PR TITLE
fix(echo-pipeline): increase timeouts on documents-loaded-from-disk replication test

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-repo-subduction.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-repo-subduction.test.ts
@@ -152,7 +152,7 @@ describe('AutomergeRepo with Subduction', () => {
       await expect.poll(() => docD.doc()?.text, { timeout: 10_000 }).toEqual('Hello world');
     });
 
-    test('documents loaded from disk get replicated', { timeout: 15_000 }, async () => {
+    test('documents loaded from disk get replicated', { timeout: 30_000 }, async () => {
       const storage = await createLevelAdapter();
       let url: AutomergeUrl | undefined;
 
@@ -171,12 +171,14 @@ describe('AutomergeRepo with Subduction', () => {
 
       const hostHandle = await peer1.find<any>(url as AutomergeUrl);
       await hostHandle.whenReady();
-      await expect.poll(() => hostHandle.doc()?.text, { timeout: 5_000 }).toEqual('foo');
+      // Bumped from 5_000 to 10_000: loading from disk on a loaded CI box can be slow.
+      await expect.poll(() => hostHandle.doc()?.text, { timeout: 10_000 }).toEqual('foo');
       const peer2Handle = await findInStates<any>(peer2, hostHandle.url, FIND_STATES);
-      // Bumped from 5_000 to 10_000: on a loaded CI box, the subduction RequestId
-      // round-trip can hit its internal timeout (~5 s) and only the heal retry succeeds,
-      // pushing past the original 5 s window. See the same fix on `accept/connect syncs`.
-      await expect.poll(() => peer2Handle.doc(), { timeout: 10_000 }).toEqual(hostHandle.doc());
+      // Bumped from 5_000 → 10_000 → 20_000: on a loaded CI box the subduction
+      // RequestId round-trip can hit its internal ~5 s timeout; the heal scheduler
+      // then retries after exponential backoff (up to ~3 s), so a full retry cycle
+      // can take 10–13 s — beyond the previous 10 s poll window.
+      await expect.poll(() => peer2Handle.doc(), { timeout: 20_000 }).toEqual(hostHandle.doc());
     });
 
     test('client creates doc and Repo persists it to disk', async () => {


### PR DESCRIPTION
## Summary

Re-fixes the `AutomergeRepo with Subduction > network > documents loaded from disk get replicated` test, which was re-quarantined by Trunk in CI run `26570006264` on 2026-05-28 — after the previous fix in PR #11430 (merged 2026-05-25).

## Root cause

PR #11430 bumped the peer2 replication poll from 5 s → 10 s and the overall test timeout from the default to 15 s. However, a full heal-scheduler retry cycle takes:

- ~5 s for the subduction `RequestId` internal timeout to fire
- Up to ~3 s of exponential backoff before the first retry
- Some time for the retry itself to succeed

Total worst case: **10–13 s** — right at the edge of the 10 s poll window. Additionally, the peer1 (host) disk-load poll was still at 5 s, leaving no headroom when disk I/O is slow on a loaded CI box. With both polls sharing the 15 s test budget, any overhead (setup, GC, scheduler jitter) pushed the test over the limit.

## Fix

| What | Before | After |
|---|---|---|
| Test overall timeout | 15 000 ms | 30 000 ms |
| peer1 disk-load poll | 5 000 ms | 10 000 ms |
| peer2 replication poll | 10 000 ms | 20 000 ms |

## Pre-existing open PRs checked

- PR #11577 (`fix(plugin-preview): use valid DXN typename in TableLike test schema`) — fixes Card.stories.tsx quarantine, different test
- PR #11447 (`fix(cli): add 60s timeout to chat --help smoke test`) — different test
- PR #11464 (`fix(echo-pipeline): remove timing-sensitive negative assertions`) — different test
- PR #11416 (`fix(client): fix flaky tests for dedicated worker leader election`) — different tests
- PR #11499 (`fix(plugin-assistant): regenerate memoized LLM conversations`) — different tests

No existing open PR was fixing the `documents loaded from disk get replicated` re-quarantine.

https://claude.ai/code/session_01HoUMccBcBKqNfp4jcrnAug

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoUMccBcBKqNfp4jcrnAug)_