### PR TITLE
refactor(echo): rename isTypeKindSchema to isTypeKind + filter TypeSchema from navtree

### DIFF
--- a/packages/core/echo/echo-generator/src/generator.ts
+++ b/packages/core/echo/echo-generator/src/generator.ts
@@ -108,11 +108,11 @@ export class SpaceObjectGenerator<T extends string> extends TestObjectGenerator<
   }
 
   private async _maybeRegisterSchema(typename: string, schema: Type.AnyObj): Promise<Type.AnyEntity> {
-    if (Type.isTypeKindSchema(schema)) {
+    if (Type.isTypeKind(schema)) {
       const types = this._space.internal.db.graph.registry.list().filter(Type.isType);
       const version = Type.getVersion(schema);
       const existingSchema = types.find(
-        (t) => Type.isTypeKindSchema(t) && Type.getTypename(t) === typename && Type.getVersion(t) === version,
+        (t) => Type.isTypeKind(t) && Type.getTypename(t) === typename && Type.getVersion(t) === version,
       );
       if (existingSchema != null) {
         return existingSchema;

--- a/packages/core/echo/echo/src/Type.test.ts
+++ b/packages/core/echo/echo/src/Type.test.ts
@@ -44,14 +44,14 @@ describe('Type', () => {
     test('Type.Type is branded as the type entity kind', ({ expect }) => {
       // The Type.Type entity itself is an in-memory object (KindId=Object) that
       // *declares* a type-kind schema (SchemaKindId=Type).
-      expect(Type.isTypeKindSchema(Type.Type)).toBe(true);
+      expect(Type.isTypeKind(Type.Type)).toBe(true);
       expect(Type.isObject(Type.Type)).toBe(false);
       expect(Type.isRelation(Type.Type)).toBe(false);
     });
 
     test('static object/relation types are not type-kind', ({ expect }) => {
-      expect(Type.isTypeKindSchema(TestSchema.Person)).toBe(false);
-      expect(Type.isTypeKindSchema(TestSchema.HasManager)).toBe(false);
+      expect(Type.isTypeKind(TestSchema.Person)).toBe(false);
+      expect(Type.isTypeKind(TestSchema.HasManager)).toBe(false);
     });
 
     test('Type.getMeta(Type.Type) reports key/version of the meta-schema', ({ expect }) => {
@@ -61,7 +61,7 @@ describe('Type', () => {
       const meta = Type.getMeta(Type.Type);
       expect(meta.key).toBe('org.dxos.type.schema');
       expect(meta.version).toBe('0.1.0');
-      expect(Type.isTypeKindSchema(Type.Type)).toBe(true);
+      expect(Type.isTypeKind(Type.Type)).toBe(true);
     });
 
     test('Type.getURI(Type.Type) returns the meta-schema DXN', ({ expect }) => {

--- a/packages/core/echo/echo/src/Type.ts
+++ b/packages/core/echo/echo/src/Type.ts
@@ -331,7 +331,7 @@ export const isRelation = (entity: AnyEntity): entity is AnyRelation => {
  * Type guard: narrows a `Type.AnyEntity` to the type-kind meta-schema
  * (e.g. `Type.Type`). Mirrors {@link isObject} / {@link isRelation}.
  */
-export const isTypeKindSchema = (entity: AnyEntity): entity is Type => {
+export const isTypeKind = (entity: AnyEntity): entity is Type => {
   return internal.getSchemaKind(entity) === internal.EntityKind.Type;
 };
 
@@ -354,7 +354,7 @@ export const expectRelation = (entity: AnyEntity): AnyRelation => {
 
 /** Narrow a `Type.AnyEntity` to the `Type.Type` meta-schema, throwing otherwise. */
 export const expectTypeKind = (entity: AnyEntity): Type => {
-  invariant(isTypeKindSchema(entity), 'Expected a type-kind Type entity.');
+  invariant(isTypeKind(entity), 'Expected a type-kind Type entity.');
   return entity;
 };
 
@@ -480,7 +480,7 @@ const stripTypenamePrefix = (value: string): string => {
  * static meta `Type.Type`, or a persisted `Type.Type` returned by the database.
  *
  * All three branches stamp `[KindId] = Type`, so this is a single brand check.
- * Use {@link isObject} / {@link isRelation} / {@link isTypeKindSchema}
+ * Use {@link isObject} / {@link isRelation} / {@link isTypeKind}
  * when you need to discriminate further; use {@link getDatabase} when you mean
  * "is this a db-attached type" (vs. an in-memory declaration).
  */

--- a/packages/core/echo/echo/src/internal/Entity/type-kind.ts
+++ b/packages/core/echo/echo/src/internal/Entity/type-kind.ts
@@ -29,7 +29,7 @@ export type EchoTypeKindSchema<
  * {@link EchoObjectSchema} / {@link EchoRelationSchema}, but stamps the
  * resulting entity with `[SchemaKindId]: EntityKind.Type` and a matching
  * `TypeAnnotation.kind = 'type'` so meta-schemas surface uniformly through
- * `Type.isTypeKindSchema`, `Filter.type`, etc.
+ * `Type.isTypeKind`, `Filter.type`, etc.
  */
 export const EchoTypeKindSchema: {
   (

--- a/packages/plugins/plugin-debug/src/containers/SpaceGenerator/SpaceGenerator.tsx
+++ b/packages/plugins/plugin-debug/src/containers/SpaceGenerator/SpaceGenerator.tsx
@@ -53,8 +53,8 @@ export const SpaceGenerator = composable<HTMLDivElement, SpaceGeneratorProps>(
     // Query space to get info.
     const updateInfo = useCallback(async () => {
       const allSchema = [...space.db.graph.registry.list().filter(Type.isType)];
-      const echoSchema = allSchema.filter((t) => Type.isTypeKindSchema(t));
-      const staticSchema = allSchema.filter((t) => !Type.isTypeKindSchema(t));
+      const echoSchema = allSchema.filter((t) => Type.isTypeKind(t));
+      const staticSchema = allSchema.filter((t) => !Type.isTypeKind(t));
 
       const objects = await space.db.query(Filter.everything()).run();
       const objectMap = sortKeys(

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.test.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.test.ts
@@ -50,7 +50,7 @@ describe('buildViewIndex', () => {
     const allSchemas = db.graph.registry
       .list()
       .filter(Type.isType)
-      .filter((t) => !Type.isTypeKindSchema(t));
+      .filter((t) => !Type.isTypeKind(t));
     const viewIndex = buildViewIndex(registry.get.bind(registry) as any, { db } as any, allSchemas);
 
     expect(viewIndex.typenamesWithViews.has(Type.getTypename(TestContact))).toBe(true);
@@ -68,7 +68,7 @@ describe('buildViewIndex', () => {
     const allSchemas = db.graph.registry
       .list()
       .filter(Type.isType)
-      .filter((t) => !Type.isTypeKindSchema(t));
+      .filter((t) => !Type.isTypeKind(t));
     const viewIndex = buildViewIndex(registry.get.bind(registry) as any, { db } as any, allSchemas);
 
     expect(viewIndex.typenamesWithViews.has(Type.getTypename(TestContact))).toBe(false);
@@ -87,7 +87,7 @@ describe('buildViewIndex', () => {
     const allSchemas = db.graph.registry
       .list()
       .filter(Type.isType)
-      .filter((t) => !Type.isTypeKindSchema(t));
+      .filter((t) => !Type.isTypeKind(t));
     const viewIndex = buildViewIndex(registry.get.bind(registry) as any, { db } as any, allSchemas);
 
     const views = viewIndex.getViewsForTypename(Type.getTypename(TestContact));
@@ -101,7 +101,7 @@ describe('buildViewIndex', () => {
     const userSchemas = db.graph.registry
       .list()
       .filter(Type.isType)
-      .filter((t) => !Type.isTypeKindSchema(t))
+      .filter((t) => !Type.isTypeKind(t))
       .filter((schema) => !ViewAnnotation.has(schema));
     const viewIndex = buildViewIndex(registry.get.bind(registry) as any, { db } as any, userSchemas);
 

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/types.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/types.ts
@@ -87,6 +87,9 @@ export const createTypeExtensions = Effect.fnUntraced(function* () {
           if (Type.isRelation(type)) {
             return false;
           }
+          if (Type.isTypeKind(type)) {
+            return false;
+          }
           const schema = Type.getSchema(type);
           if (SystemTypeAnnotation.get(schema).pipe(Option.getOrElse(() => false))) {
             return false;

--- a/packages/plugins/plugin-space/src/containers/CreateObjectDialog/CreateObjectDialog.tsx
+++ b/packages/plugins/plugin-space/src/containers/CreateObjectDialog/CreateObjectDialog.tsx
@@ -58,7 +58,7 @@ export const CreateObjectDialog = ({
     ? db.graph.registry
         .list()
         .filter(Type.isType)
-        .filter((t) => !Type.isTypeKindSchema(t))
+        .filter((t) => !Type.isTypeKind(t))
     : undefined;
 
   const entriesByModule = useAtomValue(manager.capabilities.atomByModule(SpaceCapabilities.CreateObjectEntry));

--- a/packages/plugins/plugin-space/src/operations/add-object.ts
+++ b/packages/plugins/plugin-space/src/operations/add-object.ts
@@ -39,7 +39,7 @@ const handler: Operation.WithHandler<typeof SpaceOperation.AddObject> = SpaceOpe
       const types = yield* Effect.promise(() =>
         db.query(Query.select(Filter.type(Type.Type)).from(Scope.registry())).run(),
       );
-      const [runtimeSchema] = types.filter((t) => !Type.isTypeKindSchema(t) && Type.getTypename(t) === typename);
+      const [runtimeSchema] = types.filter((t) => !Type.isTypeKind(t) && Type.getTypename(t) === typename);
       const echoViewPath =
         runtimeSchema !== undefined
           ? ViewAnnotation.get(Type.getSchema(runtimeSchema)).pipe(Option.getOrElse(() => []))

--- a/packages/sdk/app-toolkit/src/type-options.ts
+++ b/packages/sdk/app-toolkit/src/type-options.ts
@@ -33,7 +33,7 @@ export const getTypenames = ({ annotation, db }: { annotation: TypeInputOptions;
       ? db.graph.registry
           .list()
           .filter(Type.isType)
-          .filter((t) => !Type.isTypeKindSchema(t))
+          .filter((t) => !Type.isTypeKind(t))
           .filter((schema) => {
             const effectSchema = Type.getSchema(schema);
             const relation = getTypeAnnotation(effectSchema)?.kind === EntityKind.Relation;
@@ -56,7 +56,7 @@ export const getTypenames = ({ annotation, db }: { annotation: TypeInputOptions;
       ? db.graph.registry
           .list()
           .filter(Type.isType)
-          .filter((t) => Type.isTypeKindSchema(t))
+          .filter((t) => Type.isTypeKind(t))
           .map((schema) => Type.getTypename(schema))
       : [];
 


### PR DESCRIPTION
## Summary

- Renames `Type.isTypeKindSchema` → `Type.isTypeKind` to align with the naming pattern of sibling predicates (`isType`, `isRelation`, `isObject`).
- Adds `Type.isTypeKind(type)` as an explicit filter in the `userSchemas` list inside the types graph-builder extension (`plugin-space`) to prevent the TypeSchema meta-schema from appearing as a user-visible type in the navtree.

## Why

TypeSchema (the built-in meta-schema that describes user-defined types) was appearing in the navtree's **Types** section — with an "All" child node listing the actual type definitions (e.g. "Roast Log"). The existing `SystemTypeAnnotation` check couldn't reliably reach TypeSchema because annotation propagation through `EchoTypeKindSchema` is not guaranteed for entities retrieved from the registry.

`Type.isTypeKind` checks `entity[SchemaKindId]` directly — a structural runtime property always stamped at construction — which is the same approach already used in `add-object.ts` and `app-toolkit/src/type-options.ts` to exclude the meta-schema from user-facing type pickers.

## What changed

| File | Change |
|---|---|
| `echo/src/Type.ts` | Rename `isTypeKindSchema` → `isTypeKind` |
| `echo/src/internal/Entity/type-kind.ts` | Update doc comment reference |
| `echo-generator/src/generator.ts` | Update call sites |
| `plugin-space/.../extensions/types.ts` | Add `isTypeKind` guard to `userSchemas` filter |
| `plugin-space/.../CreateObjectDialog.tsx` | Update call site |
| `plugin-space/.../add-object.ts` | Update call site |
| `app-toolkit/src/type-options.ts` | Update call sites |
| `plugin-debug/.../SpaceGenerator.tsx` | Update call site |
| Test files | Update references |

## Test plan

- [ ] Open a space in Composer, create a user-defined type (e.g. "Roast Log") — TypeSchema should **not** appear as an entry in the Types section of the navtree.
- [ ] User-defined types (Roast Log, People, etc.) still appear correctly under Types.
- [ ] `Type.isTypeKind` returns `true` for the TypeSchema meta-schema and `false` for user-defined type instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to type-guard naming and consistency across the codebase. No changes to end-user functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->