### PR TITLE
feat(plugin-outliner): hide create outline graph action

### DIFF
--- a/packages/plugins/plugin-outliner/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-outliner/src/capabilities/app-graph-builder.ts
@@ -3,16 +3,11 @@
 //
 
 import * as Effect from 'effect/Effect';
-import * as Option from 'effect/Option';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities, LayoutOperation } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
-import { Obj, Relation, Type } from '@dxos/echo';
-import { SystemTypeAnnotation } from '@dxos/echo/internal';
-import { invariant } from '@dxos/invariant';
 import { GraphBuilder, Node, NodeMatcher } from '@dxos/plugin-graph';
-import { HasSubject } from '@dxos/types';
 
 import { QUICK_ENTRY_DIALOG, meta } from '#meta';
 import { OutlineOperation } from '#types';
@@ -20,52 +15,6 @@ import { OutlineOperation } from '#types';
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
     const extensions = yield* Effect.all([
-      GraphBuilder.createExtension({
-        id: 'root',
-        match: (node) => {
-          if (!Obj.isObject(node.data)) {
-            return Option.none();
-          }
-
-          const type = Obj.getType(node.data);
-          const system = Option.fromNullable(type).pipe(
-            Option.flatMap((type) => SystemTypeAnnotation.get(Type.getSchema(type))),
-            Option.getOrElse(() => false),
-          );
-          if (system) {
-            return Option.none();
-          }
-
-          return Option.some(node.data);
-        },
-        actions: (object) => {
-          const db = Obj.getDatabase(object);
-          return Effect.succeed([
-            Node.makeAction({
-              id: OutlineOperation.CreateOutline.meta.key,
-              properties: {
-                label: ['create-outline.label', { ns: meta.id }],
-                icon: 'ph--tree-structure--regular',
-                disposition: 'list-item',
-              },
-              data: Effect.fnUntraced(function* () {
-                invariant(db);
-                const result = yield* Operation.invoke(OutlineOperation.CreateOutline, {});
-                if (result?.object) {
-                  db.add(result.object);
-                  db.add(
-                    Relation.make(HasSubject.HasSubject, {
-                      [Relation.Source]: result.object,
-                      [Relation.Target]: object,
-                      completedAt: new Date().toISOString(),
-                    }),
-                  );
-                }
-              }),
-            }),
-          ]);
-        },
-      }),
       GraphBuilder.createExtension({
         id: 'quick-entry',
         match: NodeMatcher.whenRoot,


### PR DESCRIPTION
## Summary

- Removes the "Create outline" action from the context menu of every non-system object in the app graph builder.

The `root` graph extension in `plugin-outliner` was contributing a "Create outline" action to every non-system ECHO object's context menu. This removes that extension entirely, keeping only the quick-entry (quick journal entry) action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified and cleaned up internal module dependencies in the plugin-outliner package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->