### PR TITLE
fix(plugin-trip): mark Segment as a system type to hide it from the types app graph

### DIFF
--- a/packages/plugins/plugin-trip/src/types/Segment.ts
+++ b/packages/plugins/plugin-trip/src/types/Segment.ts
@@ -7,7 +7,6 @@
 import * as Schema from 'effect/Schema';
 
 import { Annotation, DXN, Format, Obj, Ref, Type } from '@dxos/echo';
-import { SystemTypeAnnotation } from '@dxos/echo/internal';
 import { Provider } from '@dxos/types';
 
 import * as Booking from './Booking';
@@ -139,7 +138,7 @@ export const Segment = Schema.Struct({
     icon: 'ph--ticket--regular',
     hue: 'sky',
   }),
-  SystemTypeAnnotation.set(true),
+  Annotation.SystemTypeAnnotation.set(true),
   Type.makeObject(DXN.make('org.dxos.type.trip.segment', '0.1.0')),
 );
 

--- a/packages/plugins/plugin-trip/src/types/Segment.ts
+++ b/packages/plugins/plugin-trip/src/types/Segment.ts
@@ -7,6 +7,7 @@
 import * as Schema from 'effect/Schema';
 
 import { Annotation, DXN, Format, Obj, Ref, Type } from '@dxos/echo';
+import { SystemTypeAnnotation } from '@dxos/echo/internal';
 import { Provider } from '@dxos/types';
 
 import * as Booking from './Booking';
@@ -138,6 +139,7 @@ export const Segment = Schema.Struct({
     icon: 'ph--ticket--regular',
     hue: 'sky',
   }),
+  SystemTypeAnnotation.set(true),
   Type.makeObject(DXN.make('org.dxos.type.trip.segment', '0.1.0')),
 );
 


### PR DESCRIPTION
## Summary

- Adds `SystemTypeAnnotation.set(true)` to the `Segment` schema in `plugin-trip`
- Segments are child objects of a `Trip` and should not appear as top-level types in the types app graph view

## Why

The types app graph (`plugin-space`) filters out any schema annotated with `SystemTypeAnnotation` before building graph nodes. Without this annotation, `Segment` appeared as a standalone type in the types section, which is misleading since segments are always owned by a `Trip` and have no meaningful standalone existence in the UI.

## Reviewer notes

- Pattern matches existing usage in `JournalEntry` (plugin-outliner) and other system types (`Tag`, `Feed`, `View`, `Thread`, etc.)
- The annotation is placed before `Type.makeObject` in the `.pipe()` chain, consistent with the established convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal schema metadata updated to include an additional system annotation on segment metadata.
  * No public API or exported types were changed; consumer-facing behavior remains unchanged.
  * Low-risk internal change focused on metadata; no user-facing features or fixes were introduced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->