### PR TITLE
fix(plugin-deck): show leave-site confirmation when navigating out of Composer

### DIFF
--- a/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
@@ -131,9 +131,14 @@ export default Capability.makeModule(
 
     const onPopState = () => void runAndForwardErrors(provideServices(handleNavigation()));
 
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+    };
+
     // Initial navigation.
     yield* provideServices(handleNavigation());
     window.addEventListener('popstate', onPopState);
+    window.addEventListener('beforeunload', onBeforeUnload);
 
     // Tauri deep link support.
     let unlistenDeepLink: (() => void) | undefined;
@@ -192,6 +197,7 @@ export default Capability.makeModule(
     return Capability.contributes(Capabilities.Null, null, () =>
       Effect.sync(() => {
         window.removeEventListener('popstate', onPopState);
+        window.removeEventListener('beforeunload', onBeforeUnload);
         unsubscribe();
         unlistenDeepLink?.();
       }),


### PR DESCRIPTION
## Summary

- Adds a `beforeunload` event listener in the deck URL handler ([`plugin-deck/src/capabilities/url-handler.ts`](packages/plugins/plugin-deck/src/capabilities/url-handler.ts))
- When the user navigates away from Composer via browser back/forward (or closes the tab / types a new URL), the browser shows its native "Leave site?" confirmation dialog
- The listener is removed during plugin disposal to avoid leaks

## Notes for reviewer

- Only `plugin-deck` is modified — `plugin-simple-layout` is used only in the mobile app and doesn't need this guard
- Modern browsers no longer allow custom messages in `beforeunload` dialogs; `event.preventDefault()` is the standard way to trigger the generic browser prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handler to ensure proper state management during page navigation and reload events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->