### PR TITLE
feat(composer): skip exemplar space creation on localhost

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -385,6 +385,7 @@ const main = async () => {
     logStore,
 
     isDev: !['production', 'staging'].includes(config.values.runtime?.app?.env?.DX_ENVIRONMENT),
+    isLocal: window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1',
     isPwa,
     isTauri,
     isPopover,

--- a/packages/apps/composer-app/src/plugin-defs.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.tsx
@@ -244,7 +244,7 @@ export const getPlugins = ({
     ThreadPlugin(),
     IntegrationPlugin(),
     TranscriptionPlugin(),
-    WelcomePlugin(),
+    WelcomePlugin({ generateExemplarSpace: !isLocal }),
 
     // TODO(wittjosiah): Consider factoring these out as standalone plugins published through the registry.
     BlueskyPlugin(),

--- a/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
@@ -2,42 +2,24 @@
 // Copyright 2025 DXOS.org
 //
 
-import * as Effect from 'effect/Effect';
-
-import { ActivationEvent, ActivationEvents, Capability, Plugin } from '@dxos/app-framework';
+import { ActivationEvent, ActivationEvents, Plugin } from '@dxos/app-framework';
 import { AppActivationEvents, AppPlugin } from '@dxos/app-toolkit';
 import { ClientEvents } from '@dxos/plugin-client';
 import { SpaceEvents } from '@dxos/plugin-space';
 
-import {
-  AppGraphBuilder,
-  DefaultContent,
-  Onboarding,
-  ReactSurface,
-  WelcomeCapabilities,
-  type WelcomeOptions,
-} from './capabilities';
+import { AppGraphBuilder, DefaultContent, Onboarding, ReactSurface, type WelcomeOptions } from './capabilities';
 import { meta } from './meta';
 import { translations } from './translations';
 
 export const WelcomePlugin = Plugin.define<WelcomeOptions>(meta).pipe(
-  Plugin.addModule((options) => ({
-    id: 'options',
-    activatesOn: ActivationEvents.Startup,
-    activate: Capability.makeModule(
-      Effect.fnUntraced(function* () {
-        return Capability.contributes(WelcomeCapabilities.Options, options);
-      }),
-    ),
-  })),
   AppPlugin.addAppGraphModule({ activate: AppGraphBuilder }),
   AppPlugin.addSurfaceModule({ activate: ReactSurface }),
   AppPlugin.addTranslationsModule({ translations }),
-  Plugin.addModule({
+  Plugin.addModule((options) => ({
     id: 'default-content',
     activatesOn: SpaceEvents.PersonalSpaceReady,
-    activate: DefaultContent,
-  }),
+    activate: () => DefaultContent(options),
+  })),
   Plugin.addModule({
     id: 'onboarding',
     activatesOn: ActivationEvent.allOf(

--- a/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
@@ -20,33 +20,33 @@ import {
 import { meta } from './meta';
 import { translations } from './translations';
 
-export const WelcomePlugin = (options: WelcomeOptions) =>
-  Plugin.define(meta).pipe(
-    Plugin.addModule({
-      id: 'options',
-      activate: Capability.makeModule(
-        Effect.fnUntraced(function* () {
-          return Capability.contributes(WelcomeCapabilities.Options, options);
-        }),
-      ),
-    }),
-    AppPlugin.addAppGraphModule({ activate: AppGraphBuilder }),
-    AppPlugin.addSurfaceModule({ activate: ReactSurface }),
-    AppPlugin.addTranslationsModule({ translations }),
-    Plugin.addModule({
-      id: 'default-content',
-      activatesOn: SpaceEvents.PersonalSpaceReady,
-      activate: DefaultContent,
-    }),
-    Plugin.addModule({
-      id: 'onboarding',
-      activatesOn: ActivationEvent.allOf(
-        AppActivationEvents.AppGraphReady,
-        ActivationEvents.ProcessManagerReady,
-        AppActivationEvents.LayoutReady,
-        ClientEvents.ClientReady,
-      ),
-      activate: Onboarding,
-    }),
-    Plugin.make,
-  );
+export const WelcomePlugin = Plugin.define<WelcomeOptions>(meta).pipe(
+  Plugin.addModule((options) => ({
+    id: 'options',
+    activatesOn: ActivationEvents.Startup,
+    activate: Capability.makeModule(
+      Effect.fnUntraced(function* () {
+        return Capability.contributes(WelcomeCapabilities.Options, options);
+      }),
+    ),
+  })),
+  AppPlugin.addAppGraphModule({ activate: AppGraphBuilder }),
+  AppPlugin.addSurfaceModule({ activate: ReactSurface }),
+  AppPlugin.addTranslationsModule({ translations }),
+  Plugin.addModule({
+    id: 'default-content',
+    activatesOn: SpaceEvents.PersonalSpaceReady,
+    activate: DefaultContent,
+  }),
+  Plugin.addModule({
+    id: 'onboarding',
+    activatesOn: ActivationEvent.allOf(
+      AppActivationEvents.AppGraphReady,
+      ActivationEvents.ProcessManagerReady,
+      AppActivationEvents.LayoutReady,
+      ClientEvents.ClientReady,
+    ),
+    activate: Onboarding,
+  }),
+  Plugin.make,
+);

--- a/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
@@ -2,33 +2,42 @@
 // Copyright 2025 DXOS.org
 //
 
-import { ActivationEvent, ActivationEvents, Plugin } from '@dxos/app-framework';
+import * as Effect from 'effect/Effect';
+
+import { ActivationEvent, ActivationEvents, Capability, Plugin } from '@dxos/app-framework';
 import { AppActivationEvents, AppPlugin } from '@dxos/app-toolkit';
 import { ClientEvents } from '@dxos/plugin-client';
 import { SpaceEvents } from '@dxos/plugin-space';
 
-import { AppGraphBuilder, DefaultContent, Onboarding, ReactSurface } from './capabilities';
+import { AppGraphBuilder, DefaultContent, Onboarding, ReactSurface, WelcomeCapabilities, type WelcomeOptions } from './capabilities';
 import { meta } from './meta';
 import { translations } from './translations';
 
-export const WelcomePlugin = Plugin.define(meta).pipe(
-  AppPlugin.addAppGraphModule({ activate: AppGraphBuilder }),
-  AppPlugin.addSurfaceModule({ activate: ReactSurface }),
-  AppPlugin.addTranslationsModule({ translations }),
-  Plugin.addModule({
-    id: 'default-content',
-    activatesOn: SpaceEvents.PersonalSpaceReady,
-    activate: DefaultContent,
-  }),
-  Plugin.addModule({
-    id: 'onboarding',
-    activatesOn: ActivationEvent.allOf(
-      AppActivationEvents.AppGraphReady,
-      ActivationEvents.ProcessManagerReady,
-      AppActivationEvents.LayoutReady,
-      ClientEvents.ClientReady,
-    ),
-    activate: Onboarding,
-  }),
-  Plugin.make,
-);
+export const WelcomePlugin = (options: WelcomeOptions) =>
+  Plugin.define(meta).pipe(
+    Plugin.addModule({
+      id: 'options',
+      activate: Capability.makeModule(Effect.fnUntraced(function* () {
+        return Capability.contributes(WelcomeCapabilities.Options, options);
+      })),
+    }),
+    AppPlugin.addAppGraphModule({ activate: AppGraphBuilder }),
+    AppPlugin.addSurfaceModule({ activate: ReactSurface }),
+    AppPlugin.addTranslationsModule({ translations }),
+    Plugin.addModule({
+      id: 'default-content',
+      activatesOn: SpaceEvents.PersonalSpaceReady,
+      activate: DefaultContent,
+    }),
+    Plugin.addModule({
+      id: 'onboarding',
+      activatesOn: ActivationEvent.allOf(
+        AppActivationEvents.AppGraphReady,
+        ActivationEvents.ProcessManagerReady,
+        AppActivationEvents.LayoutReady,
+        ClientEvents.ClientReady,
+      ),
+      activate: Onboarding,
+    }),
+    Plugin.make,
+  );

--- a/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
@@ -9,7 +9,14 @@ import { AppActivationEvents, AppPlugin } from '@dxos/app-toolkit';
 import { ClientEvents } from '@dxos/plugin-client';
 import { SpaceEvents } from '@dxos/plugin-space';
 
-import { AppGraphBuilder, DefaultContent, Onboarding, ReactSurface, WelcomeCapabilities, type WelcomeOptions } from './capabilities';
+import {
+  AppGraphBuilder,
+  DefaultContent,
+  Onboarding,
+  ReactSurface,
+  WelcomeCapabilities,
+  type WelcomeOptions,
+} from './capabilities';
 import { meta } from './meta';
 import { translations } from './translations';
 
@@ -17,9 +24,11 @@ export const WelcomePlugin = (options: WelcomeOptions) =>
   Plugin.define(meta).pipe(
     Plugin.addModule({
       id: 'options',
-      activate: Capability.makeModule(Effect.fnUntraced(function* () {
-        return Capability.contributes(WelcomeCapabilities.Options, options);
-      })),
+      activate: Capability.makeModule(
+        Effect.fnUntraced(function* () {
+          return Capability.contributes(WelcomeCapabilities.Options, options);
+        }),
+      ),
     }),
     AppPlugin.addAppGraphModule({ activate: AppGraphBuilder }),
     AppPlugin.addSurfaceModule({ activate: ReactSurface }),

--- a/packages/apps/composer-app/src/plugins/welcome/capabilities/capabilities.ts
+++ b/packages/apps/composer-app/src/plugins/welcome/capabilities/capabilities.ts
@@ -7,6 +7,11 @@ import { Capability } from '@dxos/app-framework';
 import { meta } from '../meta';
 import { type OnboardingManager } from '../onboarding-manager';
 
+export type WelcomeOptions = {
+  generateExemplarSpace: boolean;
+};
+
 export namespace WelcomeCapabilities {
   export const Onboarding = Capability.make<OnboardingManager>(`${meta.id}.capability.onboarding`);
+  export const Options = Capability.make<WelcomeOptions>(`${meta.id}.capability.options`);
 }

--- a/packages/apps/composer-app/src/plugins/welcome/capabilities/capabilities.ts
+++ b/packages/apps/composer-app/src/plugins/welcome/capabilities/capabilities.ts
@@ -13,5 +13,4 @@ export type WelcomeOptions = {
 
 export namespace WelcomeCapabilities {
   export const Onboarding = Capability.make<OnboardingManager>(`${meta.id}.capability.onboarding`);
-  export const Options = Capability.make<WelcomeOptions>(`${meta.id}.capability.options`);
 }

--- a/packages/apps/composer-app/src/plugins/welcome/capabilities/default-content.ts
+++ b/packages/apps/composer-app/src/plugins/welcome/capabilities/default-content.ts
@@ -11,6 +11,8 @@ import { Graph, Node } from '@dxos/plugin-graph';
 import { SpaceCapabilities, SpaceEvents } from '@dxos/plugin-space';
 import { SpaceArchive } from '@dxos/protocols/proto/dxos/client/services';
 
+import { WelcomeCapabilities } from './capabilities';
+
 import EXEMPLAR_SPACE_JSON from '../content/exemplar-space.dx.json?raw';
 
 const PERSONAL_SPACE_ICON = 'house-line';
@@ -27,6 +29,7 @@ export default Capability.makeModule(
     const operationInvoker = yield* Capability.get(Capabilities.OperationInvoker);
     const { graph } = yield* Capability.get(AppCapabilities.AppGraph);
     const client = yield* Capability.get(ClientCapabilities.Client);
+    const { generateExemplarSpace } = yield* Capability.get(WelcomeCapabilities.Options);
 
     const personalSpace = getPersonalSpace(client);
     if (!personalSpace) {
@@ -53,36 +56,36 @@ export default Capability.makeModule(
       );
     }
 
-    // Import the bundled Bramble Coffee Roasters exemplar space on first launch.
-    // The immutable EXEMPLAR_SPACE_TAG guards re-import — if a space with that tag already
-    // exists we use it as-is, even if the user has renamed or partially deleted content.
-    const existingExemplar = client.spaces.get().find((space) => space.tags.includes(EXEMPLAR_SPACE_TAG));
-    const exemplarSpace =
-      existingExemplar ??
-      (yield* Effect.tryPromise(async () => {
-        const archive: SpaceArchive = {
-          filename: EXEMPLAR_SPACE_ARCHIVE_FILENAME,
-          contents: new TextEncoder().encode(EXEMPLAR_SPACE_JSON),
-          format: SpaceArchive.Format.JSON,
-        };
-        return client.spaces.import(archive, { tags: [EXEMPLAR_SPACE_TAG] });
-      }));
-    yield* Effect.tryPromise(() => exemplarSpace!.waitUntilReady());
+    if (generateExemplarSpace) {
+      // Import the bundled Bramble Coffee Roasters exemplar space on first launch.
+      // The immutable EXEMPLAR_SPACE_TAG guards re-import — if a space with that tag already
+      // exists we use it as-is, even if the user has renamed or partially deleted content.
+      const existingExemplar = client.spaces.get().find((space) => space.tags.includes(EXEMPLAR_SPACE_TAG));
+      const exemplarSpace =
+        existingExemplar ??
+        (yield* Effect.tryPromise(async () => {
+          const archive: SpaceArchive = {
+            filename: EXEMPLAR_SPACE_ARCHIVE_FILENAME,
+            contents: new TextEncoder().encode(EXEMPLAR_SPACE_JSON),
+            format: SpaceArchive.Format.JSON,
+          };
+          return client.spaces.import(archive, { tags: [EXEMPLAR_SPACE_TAG] });
+        }));
+      yield* Effect.tryPromise(() => exemplarSpace!.waitUntilReady());
 
-    // Stamp the migration version so the exemplar space is treated as already migrated,
-    // the same way create.ts and identity-created.ts do for newly created spaces.
-    if (Migrations.versionProperty) {
-      Obj.update(exemplarSpace.properties, (properties) => {
-        properties[Migrations.versionProperty!] = Migrations.targetVersion;
-      });
+      // Stamp the migration version so the exemplar space is treated as already migrated,
+      // the same way create.ts and identity-created.ts do for newly created spaces.
+      if (Migrations.versionProperty) {
+        Obj.update(exemplarSpace.properties, (properties) => {
+          properties[Migrations.versionProperty!] = Migrations.targetVersion;
+        });
+      }
+
+      // Eagerly expand the graph so the exemplar space's content is visible in the navtree
+      // as soon as the user opens it, without waiting for a lazy expansion pass.
+      graph.pipe(Graph.expand(Node.RootId, 'child'), Graph.expand(personalSpace.id, 'child'), Graph.expand(exemplarSpace.id, 'child'));
+    } else {
+      graph.pipe(Graph.expand(Node.RootId, 'child'), Graph.expand(personalSpace.id, 'child'));
     }
-
-    // Eagerly expand the graph so the exemplar space's content is visible in the navtree
-    // as soon as the user opens it, without waiting for a lazy expansion pass.
-    graph.pipe(
-      Graph.expand(Node.RootId, 'child'),
-      Graph.expand(personalSpace.id, 'child'),
-      Graph.expand(exemplarSpace.id, 'child'),
-    );
   }),
 );

--- a/packages/apps/composer-app/src/plugins/welcome/capabilities/default-content.ts
+++ b/packages/apps/composer-app/src/plugins/welcome/capabilities/default-content.ts
@@ -11,9 +11,8 @@ import { Graph, Node } from '@dxos/plugin-graph';
 import { SpaceCapabilities, SpaceEvents } from '@dxos/plugin-space';
 import { SpaceArchive } from '@dxos/protocols/proto/dxos/client/services';
 
-import { WelcomeCapabilities } from './capabilities';
-
 import EXEMPLAR_SPACE_JSON from '../content/exemplar-space.dx.json?raw';
+import { WelcomeCapabilities } from './capabilities';
 
 const PERSONAL_SPACE_ICON = 'house-line';
 const PERSONAL_SPACE_ICON_HUE = 'violet';
@@ -83,7 +82,11 @@ export default Capability.makeModule(
 
       // Eagerly expand the graph so the exemplar space's content is visible in the navtree
       // as soon as the user opens it, without waiting for a lazy expansion pass.
-      graph.pipe(Graph.expand(Node.RootId, 'child'), Graph.expand(personalSpace.id, 'child'), Graph.expand(exemplarSpace.id, 'child'));
+      graph.pipe(
+        Graph.expand(Node.RootId, 'child'),
+        Graph.expand(personalSpace.id, 'child'),
+        Graph.expand(exemplarSpace.id, 'child'),
+      );
     } else {
       graph.pipe(Graph.expand(Node.RootId, 'child'), Graph.expand(personalSpace.id, 'child'));
     }

--- a/packages/apps/composer-app/src/plugins/welcome/capabilities/default-content.ts
+++ b/packages/apps/composer-app/src/plugins/welcome/capabilities/default-content.ts
@@ -12,14 +12,14 @@ import { SpaceCapabilities, SpaceEvents } from '@dxos/plugin-space';
 import { SpaceArchive } from '@dxos/protocols/proto/dxos/client/services';
 
 import EXEMPLAR_SPACE_JSON from '../content/exemplar-space.dx.json?raw';
-import { WelcomeCapabilities } from './capabilities';
+import { type WelcomeOptions } from './capabilities';
 
 const PERSONAL_SPACE_ICON = 'house-line';
 const PERSONAL_SPACE_ICON_HUE = 'violet';
 const EXEMPLAR_SPACE_ARCHIVE_FILENAME = 'exemplar-space.dx.json';
 
 export default Capability.makeModule(
-  Effect.fnUntraced(function* () {
+  Effect.fnUntraced(function* ({ generateExemplarSpace }: WelcomeOptions) {
     const { Collection, Obj, Type } = yield* Effect.tryPromise(() => import('@dxos/echo'));
     const { Migrations } = yield* Effect.tryPromise(() => import('@dxos/migrations'));
     const { ClientCapabilities } = yield* Effect.tryPromise(() => import('@dxos/plugin-client'));
@@ -28,7 +28,6 @@ export default Capability.makeModule(
     const operationInvoker = yield* Capability.get(Capabilities.OperationInvoker);
     const { graph } = yield* Capability.get(AppCapabilities.AppGraph);
     const client = yield* Capability.get(ClientCapabilities.Client);
-    const { generateExemplarSpace } = yield* Capability.get(WelcomeCapabilities.Options);
 
     const personalSpace = getPersonalSpace(client);
     if (!personalSpace) {

--- a/packages/apps/composer-app/src/plugins/welcome/capabilities/index.ts
+++ b/packages/apps/composer-app/src/plugins/welcome/capabilities/index.ts
@@ -4,8 +4,10 @@
 
 import { Capability } from '@dxos/app-framework';
 
+import { type WelcomeOptions } from './capabilities';
+
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
-export const DefaultContent = Capability.lazy('DefaultContent', () => import('./default-content'));
+export const DefaultContent = Capability.lazy<WelcomeOptions>('DefaultContent', () => import('./default-content'));
 export const Onboarding = Capability.lazy('Onboarding', () => import('./onboarding'));
 export const ReactSurface = Capability.lazy('ReactSurface', () => import('./react-surface'));
 


### PR DESCRIPTION
## Summary

- `WelcomePlugin` is now a function that accepts a `WelcomeOptions` object (`{ generateExemplarSpace: boolean }`)
- `isLocal` is computed in `main.tsx` from `window.location.hostname` and added to `PluginConfig`
- `plugin-defs.tsx` passes `WelcomePlugin({ generateExemplarSpace: !isLocal })` so the exemplar space is skipped on localhost/127.0.0.1
- The options are contributed as `WelcomeCapabilities.Options` capability and consumed by `default-content.ts`, replacing the previous inline `window.location` check

## Why

Creating a new identity on localhost (dev environment) previously always imported the Bramble Coffee Roasters exemplar space, cluttering dev workflows. The exemplar is useful for demos and production onboarding but noise locally.

## Test plan

- [ ] Create a new identity on localhost — no exemplar space should appear
- [ ] Create a new identity on a non-local deployment — exemplar space should be created as before
- [ ] Existing identities with the exemplar space tag are unaffected (tag guard still in place)