### PR TITLE
fix(plugin-space): use translatable fallback for object-deleted undo toast

### DIFF
--- a/packages/plugins/plugin-space/src/capabilities/undo-mappings.ts
+++ b/packages/plugins/plugin-space/src/capabilities/undo-mappings.ts
@@ -44,7 +44,7 @@ export default Capability.makeModule(
           message: (input, _output) => {
             const ns = Entity.getTypename(input.objects[0]);
             return ns && input.objects.length === 1
-              ? ['object-deleted.label', { ns }]
+              ? ['object-deleted.label', { ns: [ns, meta.id] }]
               : ['objects-deleted.label', { ns: meta.id }];
           },
         }),

--- a/packages/sdk/app-framework/src/common/translations.ts
+++ b/packages/sdk/app-framework/src/common/translations.ts
@@ -14,7 +14,7 @@ export const Label = Schema.Union(
       Schema.String,
       Schema.mutable(
         Schema.Struct({
-          ns: Schema.String,
+          ns: Schema.Union(Schema.String, Schema.Array(Schema.String)),
           count: Schema.optional(Schema.Number),
           defaultValue: Schema.optional(Schema.String),
         }),

--- a/packages/sdk/app-framework/src/plugin-process-manager/history/undo-mapping.ts
+++ b/packages/sdk/app-framework/src/plugin-process-manager/history/undo-mapping.ts
@@ -7,7 +7,7 @@ import type { Operation } from '@dxos/compute';
 /**
  * Label type for translatable text (canonical definition in @dxos/app-toolkit).
  */
-type Label = string | [string, { ns: string; count?: number; defaultValue?: string }];
+type Label = string | [string, { ns: string | readonly string[]; count?: number; defaultValue?: string }];
 
 /**
  * Extract the input type from an OperationDefinition.

--- a/packages/ui/react-ui-form/src/components/ObjectPicker/ObjectPicker.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectPicker/ObjectPicker.tsx
@@ -23,7 +23,7 @@ export type RefOption = {
 export type ObjectPickerContentProps = ThemedClassName<{
   options: RefOption[];
   selectedIds?: string[];
-  createOptionLabel?: [string, { ns: string }];
+  createOptionLabel?: [string, { ns: string | readonly string[] }];
   createOptionIcon?: string;
   createSchema?: Schema.Schema.AnyNoContext;
   createInitialValuePath?: string;
@@ -167,7 +167,7 @@ const CreateItem = ({
   onCreateItemSelect,
 }: {
   query: string;
-  createOptionLabel?: [string, { ns: string }];
+  createOptionLabel?: [string, { ns: string | readonly string[] }];
   createOptionIcon: string;
   onCreateItemSelect: (query: string) => void;
 }) => {

--- a/packages/ui/ui-types/src/translations.ts
+++ b/packages/ui/ui-types/src/translations.ts
@@ -5,7 +5,7 @@
 import { type TFunction } from 'i18next';
 
 // TODO(thure): `Parameters<TFunction>` causes typechecking issues because `TFunction` has so many signatures.
-export type Label = string | [string, { ns: string; count?: number; defaultValue?: string }];
+export type Label = string | [string, { ns: string | readonly string[]; count?: number; defaultValue?: string }];
 
 export const isLabel = (o: any): o is Label =>
   typeof o === 'string' ||
@@ -15,7 +15,7 @@ export const isLabel = (o: any): o is Label =>
     !!o[1] &&
     typeof o[1] === 'object' &&
     'ns' in o[1] &&
-    typeof o[1].ns === 'string');
+    (typeof o[1].ns === 'string' || Array.isArray(o[1].ns)));
 
 /**
  * Convert a label to a localized string.


### PR DESCRIPTION
## Summary

- When deleting an object whose typename has no `object-deleted.label` translation registered, the undo toast was displaying the raw i18next key instead of a human-readable string.
- Fix: pass `ns` as `[typename, meta.id]` in the `RemoveObjects` undo mapping so i18next tries the specific type namespace first, then falls back to plugin-space's generic "Object deleted" translation — fully translated, not a hardcoded English string.
- To support array `ns`, broadens `Label.ns` from `string` to `string | readonly string[]` in `@dxos/ui-types`, the app-framework Effect Schema, and the local type mirror in `undo-mapping.ts`. The one downstream callsite in `ObjectPicker.tsx` that declared its own inline `[string, { ns: string }]` type is updated to match; its implementation already passed `ns` straight through to `t()` which accepts arrays.

## Test plan

- [ ] Delete an object of a well-known type (e.g. Task, Project) — undo toast shows the type-specific label ("Task deleted")
- [ ] Delete an object of a custom/unknown type — undo toast shows the generic "Object deleted" label instead of the raw key
- [ ] Delete multiple objects — undo toast shows "Objects deleted"
- [ ] Verify build and type-check pass: `moon run plugin-space:build react-ui-form:build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)