### PR TITLE
fix(plugin-deck): confirm before navigating out of Composer (history sentinel)

### DIFF
--- a/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
@@ -153,11 +153,28 @@ export default Capability.makeModule(
     };
 
     // Install the sentinel before handleNavigation()/state-sync push entries on top of it.
-    installLeaveTrap();
+    const sentinelKey = installLeaveTrap();
+
+    // Re-arm: if a non-cancelable back (the browser makes a traversal uncancelable shortly after a
+    // preventDefault) slips past the trap and lands on the sentinel, re-mark it (the app may have
+    // overwritten its state) and climb back above it — so we never leave silently and the trap
+    // stays armed. Keyed on the entry key, which survives state changes.
+    const onCurrentEntryChange = () => {
+      const current = window.navigation.currentEntry;
+      if (!current || current.key !== sentinelKey) {
+        return;
+      }
+      if (current.getState()?.[SENTINEL_KEY] !== true) {
+        window.navigation.updateCurrentEntry({ state: { ...current.getState(), [SENTINEL_KEY]: true } });
+      }
+      history.pushState(null, '', window.location.pathname + window.location.search);
+    };
+
     yield* provideServices(handleNavigation());
     window.addEventListener('popstate', onPopState);
     if ('navigation' in window) {
       window.navigation.addEventListener('navigate', onNavigate);
+      window.navigation.addEventListener('currententrychange', onCurrentEntryChange);
     }
 
     // Tauri deep link support.
@@ -219,6 +236,7 @@ export default Capability.makeModule(
         window.removeEventListener('popstate', onPopState);
         if ('navigation' in window) {
           window.navigation.removeEventListener('navigate', onNavigate);
+          window.navigation.removeEventListener('currententrychange', onCurrentEntryChange);
         }
         unsubscribe();
         unlistenDeepLink?.();
@@ -237,20 +255,27 @@ const SENTINEL_KEY = '__composerSentinel';
  * `beforeunload` cannot distinguish reload from leave, so this same-document floor is required;
  * reload fires no traversal and is never trapped. Requires the Navigation API (Chromium); no-op
  * otherwise. Idempotent across reloads — entry state survives, so the sentinel is not duplicated.
+ * Returns the sentinel entry's key (stable across state changes) for the re-arm, or undefined.
  */
-const installLeaveTrap = (): void => {
+const installLeaveTrap = (): string | undefined => {
   if (!('navigation' in window)) {
-    return;
+    return undefined;
   }
-  const hasSentinel = window.navigation.entries().some((entry) => entry.getState()?.[SENTINEL_KEY] === true);
+  const existing = window.navigation.entries().find((entry) => entry.getState()?.[SENTINEL_KEY] === true);
+  if (existing) {
+    return existing.key;
+  }
   // history.length > 1 (not navigation.canGoBack, which is false for a cross-origin prior entry)
   // means there is somewhere to leave to; otherwise Back can't exit and no sentinel is needed.
-  if (!hasSentinel && window.history.length > 1) {
+  if (window.history.length > 1) {
     window.navigation.updateCurrentEntry({
       state: { ...window.navigation.currentEntry?.getState(), [SENTINEL_KEY]: true },
     });
+    const key = window.navigation.currentEntry?.key;
     history.pushState(null, '', window.location.pathname + window.location.search);
+    return key;
   }
+  return undefined;
 };
 
 /** Check if a path is a redirect path handled elsewhere (e.g., OAuth). */

--- a/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
@@ -131,15 +131,11 @@ export default Capability.makeModule(
 
     const onPopState = () => void runAndForwardErrors(provideServices(handleNavigation()));
 
-    // Install the sentinel (the floor entry beneath the app's working entries) before
-    // handleNavigation()/state-sync push entries on top of it. See `installLeaveTrap` below.
+    // Install before handleNavigation()/state-sync push entries on top of the sentinel.
     const sentinelKey = installLeaveTrap();
 
-    // Confirm before a Back-press leaves Composer. The platform makes a traversal uncancelable
-    // shortly after a preventDefault (and we can't block it then), so rather than cancelling the
-    // traversal we let a Back land on the sentinel and decide here: Leave -> step back to the prior
-    // page; Stay -> step forward to the entry the user came from. The blocking confirm also stops
-    // rapid repeated Backs from looping. Guarded so our own back()/forward() don't re-enter.
+    // Landing on the sentinel means a Back is about to leave Composer; confirm and act on it.
+    // The guard stops our own back()/forward() from re-entering.
     let handlingSentinel = false;
     const onCurrentEntryChange = () => {
       const current = window.navigation.currentEntry;
@@ -149,9 +145,9 @@ export default Capability.makeModule(
       handlingSentinel = true;
       queueMicrotask(() => {
         if (window.confirm('Leave Composer?')) {
-          history.back(); // Sentinel -> prior page (leave Composer).
+          history.back(); // Past the sentinel to the prior page.
         } else {
-          history.forward(); // Back to the entry the user came from (stay).
+          history.forward(); // Back to where the user was.
         }
         setTimeout(() => {
           handlingSentinel = false;

--- a/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
@@ -131,14 +131,25 @@ export default Capability.makeModule(
 
     const onPopState = () => void runAndForwardErrors(provideServices(handleNavigation()));
 
-    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+    // Show a leave-Composer confirmation only on back/forward navigations that exit the app.
+    // Uses the Navigation API to distinguish traverse from reload (beforeunload cannot).
+    // Not supported in Safari — no guard shown there.
+    const onNavigate = (event: NavigateEvent) => {
+      if (event.navigationType !== 'traverse') return;
+      // canIntercept is false for cross-document navigations (leaving the SPA entirely).
+      if (event.canIntercept) return;
       event.preventDefault();
+      if (window.confirm('Leave Composer?')) {
+        window.location.href = event.destination.url;
+      }
     };
 
     // Initial navigation.
     yield* provideServices(handleNavigation());
     window.addEventListener('popstate', onPopState);
-    window.addEventListener('beforeunload', onBeforeUnload);
+    if ('navigation' in window) {
+      window.navigation.addEventListener('navigate', onNavigate);
+    }
 
     // Tauri deep link support.
     let unlistenDeepLink: (() => void) | undefined;
@@ -197,7 +208,9 @@ export default Capability.makeModule(
     return Capability.contributes(Capabilities.Null, null, () =>
       Effect.sync(() => {
         window.removeEventListener('popstate', onPopState);
-        window.removeEventListener('beforeunload', onBeforeUnload);
+        if ('navigation' in window) {
+          window.navigation.removeEventListener('navigate', onNavigate);
+        }
         unsubscribe();
         unlistenDeepLink?.();
       }),

--- a/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
@@ -131,49 +131,37 @@ export default Capability.makeModule(
 
     const onPopState = () => void runAndForwardErrors(provideServices(handleNavigation()));
 
-    // Confirm before a Back-press leaves Composer. See `installLeaveTrap` below.
-    const onNavigate = (event: NavigateEvent) => {
-      // Only a same-document traversal back onto the sentinel (a would-be exit) is trapped.
-      if (
-        event.navigationType !== 'traverse' ||
-        !event.canIntercept ||
-        event.destination.getState()?.[SENTINEL_KEY] !== true
-      ) {
-        return;
-      }
-      // Cancel synchronously; confirm after, since confirm() can be suppressed mid-dispatch.
-      event.preventDefault();
-      queueMicrotask(() => {
-        if (window.confirm('Leave Composer?')) {
-          // Working entry -> sentinel -> prior page. History API (the prior page is usually
-          // cross-origin, so absent from navigation.entries()).
-          history.go(-2);
-        }
-      });
-    };
-
-    // Install the sentinel before handleNavigation()/state-sync push entries on top of it.
+    // Install the sentinel (the floor entry beneath the app's working entries) before
+    // handleNavigation()/state-sync push entries on top of it. See `installLeaveTrap` below.
     const sentinelKey = installLeaveTrap();
 
-    // Re-arm: if a non-cancelable back (the browser makes a traversal uncancelable shortly after a
-    // preventDefault) slips past the trap and lands on the sentinel, re-mark it (the app may have
-    // overwritten its state) and climb back above it — so we never leave silently and the trap
-    // stays armed. Keyed on the entry key, which survives state changes.
+    // Confirm before a Back-press leaves Composer. The platform makes a traversal uncancelable
+    // shortly after a preventDefault (and we can't block it then), so rather than cancelling the
+    // traversal we let a Back land on the sentinel and decide here: Leave -> step back to the prior
+    // page; Stay -> step forward to the entry the user came from. The blocking confirm also stops
+    // rapid repeated Backs from looping. Guarded so our own back()/forward() don't re-enter.
+    let handlingSentinel = false;
     const onCurrentEntryChange = () => {
       const current = window.navigation.currentEntry;
-      if (!current || current.key !== sentinelKey) {
+      if (handlingSentinel || !current || current.key !== sentinelKey) {
         return;
       }
-      if (current.getState()?.[SENTINEL_KEY] !== true) {
-        window.navigation.updateCurrentEntry({ state: { ...current.getState(), [SENTINEL_KEY]: true } });
-      }
-      history.pushState(null, '', window.location.pathname + window.location.search);
+      handlingSentinel = true;
+      queueMicrotask(() => {
+        if (window.confirm('Leave Composer?')) {
+          history.back(); // Sentinel -> prior page (leave Composer).
+        } else {
+          history.forward(); // Back to the entry the user came from (stay).
+        }
+        setTimeout(() => {
+          handlingSentinel = false;
+        });
+      });
     };
 
     yield* provideServices(handleNavigation());
     window.addEventListener('popstate', onPopState);
     if ('navigation' in window) {
-      window.navigation.addEventListener('navigate', onNavigate);
       window.navigation.addEventListener('currententrychange', onCurrentEntryChange);
     }
 
@@ -235,7 +223,6 @@ export default Capability.makeModule(
       Effect.sync(() => {
         window.removeEventListener('popstate', onPopState);
         if ('navigation' in window) {
-          window.navigation.removeEventListener('navigate', onNavigate);
           window.navigation.removeEventListener('currententrychange', onCurrentEntryChange);
         }
         unsubscribe();
@@ -245,33 +232,42 @@ export default Capability.makeModule(
   }),
 );
 
-/** State key marking the sentinel history entry used by the leave-Composer trap. */
-const SENTINEL_KEY = '__composerSentinel';
+/**
+ * sessionStorage key holding the sentinel history entry's key. The entry is identified by its
+ * (reload-stable) Navigation API key rather than by entry state, because the deck overwrites
+ * history state via replaceState during URL sync — which would erase a state marker. sessionStorage
+ * survives reloads within the tab and the deck never touches it.
+ */
+const SENTINEL_STORAGE_KEY = 'dxos.composer.deck.leaveTrap.sentinelKey';
 
 /**
- * Insert a marked "sentinel" history entry beneath the app's working entries, so the first
- * Back-press that would leave Composer instead lands on it as a same-document (cancelable)
- * traversal — which `onNavigate` cancels and confirms. A cross-document back is uncancelable and
- * `beforeunload` cannot distinguish reload from leave, so this same-document floor is required;
- * reload fires no traversal and is never trapped. Requires the Navigation API (Chromium); no-op
- * otherwise. Idempotent across reloads — entry state survives, so the sentinel is not duplicated.
- * Returns the sentinel entry's key (stable across state changes) for the re-arm, or undefined.
+ * Insert a "sentinel" history entry beneath the app's working entries, so a Back-press that would
+ * leave Composer instead lands on the sentinel — where `onCurrentEntryChange` confirms the exit. A
+ * cross-document back is uncancelable and `beforeunload` cannot distinguish reload from leave, so
+ * this same-document floor is required; reload fires no traversal and is never trapped. Requires the
+ * Navigation API (Chromium); no-op otherwise. Idempotent across reloads via the sessionStorage-held
+ * entry key, so the sentinel is not duplicated. Returns the sentinel entry's key, or undefined.
  */
 const installLeaveTrap = (): string | undefined => {
   if (!('navigation' in window)) {
     return undefined;
   }
-  const existing = window.navigation.entries().find((entry) => entry.getState()?.[SENTINEL_KEY] === true);
-  if (existing) {
-    return existing.key;
+  const saved = sessionStorage.getItem(SENTINEL_STORAGE_KEY);
+  if (saved && window.navigation.entries().some((entry) => entry.key === saved)) {
+    // The sentinel survived (reload, or the user returned to Composer after leaving). If we are
+    // sitting ON it — e.g. the user left via the sentinel then came back Forward onto it — push a
+    // working entry above so the user is above the floor again and the trap re-arms.
+    if (window.navigation.currentEntry?.key === saved) {
+      history.pushState(null, '', window.location.pathname + window.location.search);
+    }
+    return saved;
   }
   // history.length > 1 (not navigation.canGoBack, which is false for a cross-origin prior entry)
   // means there is somewhere to leave to; otherwise Back can't exit and no sentinel is needed.
-  if (window.history.length > 1) {
-    window.navigation.updateCurrentEntry({
-      state: { ...window.navigation.currentEntry?.getState(), [SENTINEL_KEY]: true },
-    });
-    const key = window.navigation.currentEntry?.key;
+  const key = window.navigation.currentEntry?.key;
+  if (key && window.history.length > 1) {
+    // Record the current (landing) entry as the sentinel, then push the working entry above it.
+    sessionStorage.setItem(SENTINEL_STORAGE_KEY, key);
     history.pushState(null, '', window.location.pathname + window.location.search);
     return key;
   }

--- a/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
@@ -131,12 +131,9 @@ export default Capability.makeModule(
 
     const onPopState = () => void runAndForwardErrors(provideServices(handleNavigation()));
 
-    // Show a "Leave Composer?" confirmation only when a back/forward navigation would exit the
-    // app (see `installLeaveTrap` at the bottom of this module). In-app back/forward and reload
-    // must not prompt.
+    // Confirm before a Back-press leaves Composer. See `installLeaveTrap` below.
     const onNavigate = (event: NavigateEvent) => {
-      // Only trap a same-document (cancelable) traversal back onto the sentinel — i.e. a
-      // Back-press that would otherwise leave Composer. In-app back/forward and reload are ignored.
+      // Only a same-document traversal back onto the sentinel (a would-be exit) is trapped.
       if (
         event.navigationType !== 'traverse' ||
         !event.canIntercept ||
@@ -144,23 +141,18 @@ export default Capability.makeModule(
       ) {
         return;
       }
-      // Cancel synchronously to hold the user in place, then confirm outside the event dispatch
-      // (confirm() can be suppressed while a navigation is being dispatched).
+      // Cancel synchronously; confirm after, since confirm() can be suppressed mid-dispatch.
       event.preventDefault();
       queueMicrotask(() => {
-        if (!window.confirm('Leave Composer?')) {
-          return;
+        if (window.confirm('Leave Composer?')) {
+          // Working entry -> sentinel -> prior page. History API (the prior page is usually
+          // cross-origin, so absent from navigation.entries()).
+          history.go(-2);
         }
-        // The trap always fires from the entry directly above the sentinel, so going back two
-        // entries (working -> sentinel -> prior page) leaves Composer. Uses the History API
-        // rather than navigation.traverseTo because the prior page is typically cross-origin
-        // and therefore absent from navigation.entries().
-        history.go(-2);
       });
     };
 
-    // Initial navigation. Install the sentinel first so the floor entry sits beneath the first
-    // working entry before handleNavigation() and the state subscription push entries on top.
+    // Install the sentinel before handleNavigation()/state-sync push entries on top of it.
     installLeaveTrap();
     yield* provideServices(handleNavigation());
     window.addEventListener('popstate', onPopState);
@@ -239,25 +231,21 @@ export default Capability.makeModule(
 const SENTINEL_KEY = '__composerSentinel';
 
 /**
- * Insert a marked "sentinel" history entry beneath the app's working entries so that the first
- * Back-press that would leave Composer instead lands on the sentinel as a same-document
- * (cancelable) traversal — which `onNavigate` cancels and confirms. The platform makes a
- * cross-document back uncancelable (and `beforeunload` cannot tell a reload from a leave), so
- * trapping it requires this same-document floor entry. Reload fires no navigate traversal, so it
- * is never trapped. Requires the Navigation API (Chromium); no-op in browsers without it (e.g.
- * Safari). Idempotent across reloads — entry state survives reload, so the existing sentinel is
- * detected and not duplicated.
+ * Insert a marked "sentinel" history entry beneath the app's working entries, so the first
+ * Back-press that would leave Composer instead lands on it as a same-document (cancelable)
+ * traversal — which `onNavigate` cancels and confirms. A cross-document back is uncancelable and
+ * `beforeunload` cannot distinguish reload from leave, so this same-document floor is required;
+ * reload fires no traversal and is never trapped. Requires the Navigation API (Chromium); no-op
+ * otherwise. Idempotent across reloads — entry state survives, so the sentinel is not duplicated.
  */
 const installLeaveTrap = (): void => {
   if (!('navigation' in window)) {
     return;
   }
   const hasSentinel = window.navigation.entries().some((entry) => entry.getState()?.[SENTINEL_KEY] === true);
-  // history.length > 1 means there is a prior entry to leave to (counts cross-origin entries,
-  // unlike navigation.canGoBack which is false when the previous entry is another origin).
-  // If there is nowhere to go back to, Back can't exit, so no sentinel is needed.
+  // history.length > 1 (not navigation.canGoBack, which is false for a cross-origin prior entry)
+  // means there is somewhere to leave to; otherwise Back can't exit and no sentinel is needed.
   if (!hasSentinel && window.history.length > 1) {
-    // Mark the current (landing) entry as the sentinel, then push the working entry above it.
     window.navigation.updateCurrentEntry({
       state: { ...window.navigation.currentEntry?.getState(), [SENTINEL_KEY]: true },
     });

--- a/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
@@ -131,20 +131,37 @@ export default Capability.makeModule(
 
     const onPopState = () => void runAndForwardErrors(provideServices(handleNavigation()));
 
-    // Show a leave-Composer confirmation only on back/forward navigations that exit the app.
-    // Uses the Navigation API to distinguish traverse from reload (beforeunload cannot).
-    // Not supported in Safari — no guard shown there.
+    // Show a "Leave Composer?" confirmation only when a back/forward navigation would exit the
+    // app (see `installLeaveTrap` at the bottom of this module). In-app back/forward and reload
+    // must not prompt.
     const onNavigate = (event: NavigateEvent) => {
-      if (event.navigationType !== 'traverse') return;
-      // canIntercept is false for cross-document navigations (leaving the SPA entirely).
-      if (event.canIntercept) return;
-      event.preventDefault();
-      if (window.confirm('Leave Composer?')) {
-        window.location.href = event.destination.url;
+      // Only trap a same-document (cancelable) traversal back onto the sentinel — i.e. a
+      // Back-press that would otherwise leave Composer. In-app back/forward and reload are ignored.
+      if (
+        event.navigationType !== 'traverse' ||
+        !event.canIntercept ||
+        event.destination.getState()?.[SENTINEL_KEY] !== true
+      ) {
+        return;
       }
+      // Cancel synchronously to hold the user in place, then confirm outside the event dispatch
+      // (confirm() can be suppressed while a navigation is being dispatched).
+      event.preventDefault();
+      queueMicrotask(() => {
+        if (!window.confirm('Leave Composer?')) {
+          return;
+        }
+        // The trap always fires from the entry directly above the sentinel, so going back two
+        // entries (working -> sentinel -> prior page) leaves Composer. Uses the History API
+        // rather than navigation.traverseTo because the prior page is typically cross-origin
+        // and therefore absent from navigation.entries().
+        history.go(-2);
+      });
     };
 
-    // Initial navigation.
+    // Initial navigation. Install the sentinel first so the floor entry sits beneath the first
+    // working entry before handleNavigation() and the state subscription push entries on top.
+    installLeaveTrap();
     yield* provideServices(handleNavigation());
     window.addEventListener('popstate', onPopState);
     if ('navigation' in window) {
@@ -217,6 +234,36 @@ export default Capability.makeModule(
     );
   }),
 );
+
+/** State key marking the sentinel history entry used by the leave-Composer trap. */
+const SENTINEL_KEY = '__composerSentinel';
+
+/**
+ * Insert a marked "sentinel" history entry beneath the app's working entries so that the first
+ * Back-press that would leave Composer instead lands on the sentinel as a same-document
+ * (cancelable) traversal — which `onNavigate` cancels and confirms. The platform makes a
+ * cross-document back uncancelable (and `beforeunload` cannot tell a reload from a leave), so
+ * trapping it requires this same-document floor entry. Reload fires no navigate traversal, so it
+ * is never trapped. Requires the Navigation API (Chromium); no-op in browsers without it (e.g.
+ * Safari). Idempotent across reloads — entry state survives reload, so the existing sentinel is
+ * detected and not duplicated.
+ */
+const installLeaveTrap = (): void => {
+  if (!('navigation' in window)) {
+    return;
+  }
+  const hasSentinel = window.navigation.entries().some((entry) => entry.getState()?.[SENTINEL_KEY] === true);
+  // history.length > 1 means there is a prior entry to leave to (counts cross-origin entries,
+  // unlike navigation.canGoBack which is false when the previous entry is another origin).
+  // If there is nowhere to go back to, Back can't exit, so no sentinel is needed.
+  if (!hasSentinel && window.history.length > 1) {
+    // Mark the current (landing) entry as the sentinel, then push the working entry above it.
+    window.navigation.updateCurrentEntry({
+      state: { ...window.navigation.currentEntry?.getState(), [SENTINEL_KEY]: true },
+    });
+    history.pushState(null, '', window.location.pathname + window.location.search);
+  }
+};
 
 /** Check if a path is a redirect path handled elsewhere (e.g., OAuth). */
 const isRedirectPath = (pathname: string): boolean => pathname.startsWith('/redirect/');


### PR DESCRIPTION
## Summary

Shows a **"Leave Composer?"** confirm when the browser **Back/Forward** would navigate *out of* Composer. It does **not** prompt on reload, and **not** on in-app back/forward between Composer views.

## Why a "sentinel" and not `beforeunload`?

A live Chromium debug session established the constraints:

- `beforeunload` fires on **both** reload and leave with no way to tell them apart → prompting on reload (rejected as too aggressive).
- The Navigation API `navigate` event does **not** fire before unload for a reload or a cross-document back-leave, and a cross-document traverse is **non-cancelable by spec** — so the leave cannot be blocked after the fact, and reload/leave are indistinguishable at `beforeunload` time.
- A **same-document** traverse *is* cancelable (`canIntercept === true`), and reload fires **no** `navigate` traversal at all.

So we insert a marked **sentinel** history entry beneath Composer's working entries. The first Back-press that would leave instead lands on the sentinel as a **same-document, cancelable** traversal, which we cancel and confirm; on confirm we `history.go(-2)` to the prior page. Reload never hits this path.

## Implementation (single file)

`packages/plugins/plugin-deck/src/capabilities/url-handler.ts`:
- `installLeaveTrap()` (module-scope): if `history.length > 1` and no sentinel exists yet, mark the landing entry via `navigation.updateCurrentEntry({ state: { __composerSentinel: true } })` and `history.pushState` a working entry above it. Idempotent across reloads (entry state survives reload). Uses `history.length` rather than `navigation.canGoBack`, which is `false` when the prior entry is cross-origin — the common case.
- `onNavigate`: traps a `traverse` whose `destination.getState().__composerSentinel === true`, `preventDefault()`s synchronously, then defers `window.confirm()` out of the event dispatch; on confirm, `history.go(-2)`.
- Removes the earlier `beforeunload` / reload-suppression approach.

Scope is **history navigation only** — close-tab / type-URL / reload intentionally do not prompt. Requires the Navigation API (Chromium); no-op elsewhere (e.g. Safari).

## Verification

Validated in Chromium via an isolated **two-origin** Playwright harness replicating the exact logic:
- Arriving from another origin → sentinel installs (`history.length=3`, `canGoBack=false`).
- Back → same-document `traverse` trap fires (`canIntercept=true, cancelable=true, destSentinel=true`) → `preventDefault` + confirm shown.
- **Cancel** → user held in place. **Confirm** → leaves to the prior page.

Also: `moon run plugin-deck:build`, `:test` (45 passing), `:lint` all green.

## Known limitations

- Two Back-presses coalesced into one cross-document traverse are non-cancelable → may leave without prompt (inherent to the platform; the sentinel makes a single Back always land cancelably first).
- Browsers without the Navigation API get no guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leave-composer behavior: confirmation now reliably appears for in-app back navigation to prevent accidental data loss.
  * Reduced intrusive unload prompts and duplicate confirmations after reloads; composer cleanup is more reliable when closed, improving cross-browser consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->