### PR TITLE
fix(plugin-integration): fix navigation timeout after OAuth integration setup

### DIFF
--- a/packages/plugins/plugin-integration/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-integration/src/capabilities/app-graph-builder.ts
@@ -17,6 +17,7 @@ import { SETTINGS_SECTION_TYPE, SpaceOperation } from '@dxos/plugin-space';
 import { meta } from '#meta';
 import { IntegrationProvider, type IntegrationProviderEntry } from '#types';
 
+import { INTEGRATIONS_SECTION_ID } from '../constants';
 import { Integration } from '../types';
 
 /** Type for the per-space "Integrations" container node. */
@@ -93,7 +94,7 @@ export default Capability.makeModule(
           }
           return Effect.succeed([
             Node.make({
-              id: 'integrations',
+              id: INTEGRATIONS_SECTION_ID,
               type: INTEGRATIONS_SECTION_TYPE,
               data: null,
               properties: {

--- a/packages/plugins/plugin-integration/src/capabilities/integration-coordinator.ts
+++ b/packages/plugins/plugin-integration/src/capabilities/integration-coordinator.ts
@@ -166,7 +166,9 @@ const finalizePendingEntry = (invoker: Operation.OperationService, entry: Pendin
 
     yield* Effect.all(
       [
-        navigateToNewIntegration(invoker, db, persistedIntegration.id),
+        // Skip navigation when the flow began from a pre-existing target (e.g. a
+        // Mailbox): the user is already on that surface and expects to stay there.
+        existingTarget ? Effect.void : navigateToNewIntegration(invoker, db, persistedIntegration.id),
         provider.getSyncTargets
           ? openSyncTargetsDialogAfterIntegrationCreated(
               invoker,

--- a/packages/plugins/plugin-integration/src/constants.ts
+++ b/packages/plugins/plugin-integration/src/constants.ts
@@ -2,6 +2,8 @@
 // Copyright 2026 DXOS.org
 //
 
+import { SETTINGS_SECTION_ID } from '@dxos/plugin-space/types';
+
 import { meta } from './meta';
 
 /** Surface id for the sync-targets dialog. */
@@ -32,10 +34,15 @@ export const pendingIntegrationStorageKey = (
 /** URL path Edge redirects to after redirect-flow OAuth completes. */
 export const OAUTH_REDIRECT_PATH = '/redirect/oauth' as const;
 
+/** Node id (local segment) for the per-space "Integrations" section. */
+export const INTEGRATIONS_SECTION_ID = 'integrations';
+
 /**
  * Deck navigation subject for a specific integration inside a space — used
  * by `navigateToNewIntegration` to open the freshly created integration
- * after the redirect-flow finalization step.
+ * after the finalization step. The integrations section is nested under the
+ * space's settings section, so the subject must include the `settings`
+ * segment to resolve through the graph.
  */
-export const integrationDeckSubject = (spacePath: string, integrationId: string): `${string}/integrations/${string}` =>
-  `${spacePath}/integrations/${integrationId}`;
+export const integrationDeckSubject = (spacePath: string, integrationId: string): string =>
+  `${spacePath}/${SETTINGS_SECTION_ID}/${INTEGRATIONS_SECTION_ID}/${integrationId}`;

--- a/packages/plugins/plugin-space/package.json
+++ b/packages/plugins/plugin-space/package.json
@@ -95,6 +95,11 @@
       "source": "./src/translations.ts",
       "types": "./dist/types/src/translations.d.ts",
       "default": "./dist/lib/neutral/translations.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/neutral/types/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/settings.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/settings.ts
@@ -10,7 +10,7 @@ import { type Space, isSpace } from '@dxos/client/echo';
 import { GraphBuilder, Node } from '@dxos/plugin-graph';
 
 import { meta } from '#meta';
-import { SETTINGS_SECTION_TYPE } from '#types';
+import { SETTINGS_SECTION_ID, SETTINGS_SECTION_TYPE } from '#types';
 
 //
 // Extension Factory
@@ -31,7 +31,7 @@ export const createSettingsExtensions = Effect.fnUntraced(function* () {
     connector: (space) =>
       Effect.succeed([
         AppNode.makeSection({
-          id: 'settings',
+          id: SETTINGS_SECTION_ID,
           type: SETTINGS_SECTION_TYPE,
           label: ['settings-section.label', { ns: meta.id }],
           icon: 'ph--sliders--regular',

--- a/packages/plugins/plugin-space/src/types/types.ts
+++ b/packages/plugins/plugin-space/src/types/types.ts
@@ -22,6 +22,9 @@ export const SPACE_TYPE = 'org.dxos.type.space';
 /** Type for the per-space virtual "Settings" section that groups settings panels. */
 export const SETTINGS_SECTION_TYPE = `${meta.id}.settings`;
 
+/** Node id (local segment) for the per-space virtual "Settings" section. */
+export const SETTINGS_SECTION_ID = 'settings';
+
 /** Key for the Expando that stores cross-space ordering (must stay stable for persisted data). */
 export const SHARED = 'shared-spaces';
 


### PR DESCRIPTION
## Problem

When connecting an integration (e.g. Gmail from a mailbox), after completing the OAuth flow the app showed a **"Timeout loading content"** error instead of returning the user to where they were.

Root cause (confirmed from repro logs — `Node not found after expansion: root/<space>/integrations/<id>`): the integrations section moved under the space **settings** section, but `integrationDeckSubject` still produced `root/<space>/integrations/<id>`. The deck resolves paths strictly segment-by-segment, so that path never resolves and `PlankError` fires its 5s timeout.

## Fix

- **Correct the path helper** — `integrationDeckSubject` now includes the `settings` segment (`root/<space>/settings/integrations/<id>`). The segment ids are sourced from a new exported `SETTINGS_SECTION_ID` (plugin-space, via a new `./types` subpath export) and a local `INTEGRATIONS_SECTION_ID`, so neither is a drifting magic string.
- **Skip navigation when the flow began from an existing target** — e.g. connecting Gmail from a mailbox's `InitializeMailbox` empty state. The user is already on that surface and expects to stay there, so there's no navigation at all. Only the create-from-scratch case navigates to the new integration node.

## Testing

- Build, lint, and tests pass for `plugin-integration`, `plugin-space`, `plugin-inbox`.
- Full OAuth round-trip requires live Google auth + Edge and was not exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)