### PR TITLE
feat(navtree): count badge on navtree items; plugin registry category counts

### DIFF
--- a/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
@@ -81,6 +81,17 @@ export default Capability.makeModule(
 
           return Effect.succeed(
             mailboxes.map((mailbox: Mailbox.Mailbox) => {
+              // Reactively count messages newer than the mailbox's `viewedAt` cursor. Querying the feed here
+              // subscribes the connector to message changes, so the count updates after sync (new messages) and
+              // after the mailbox is viewed (cursor advances, see `Mailbox.markViewed`).
+              // Cast as elsewhere in this file: `AtomRef.make` resolves to `Obj.Snapshot<Feed.Feed>`, which
+              // `Query.from` does not accept; the snapshot is structurally the feed for query purposes.
+              const feed = mailbox.feed ? (get(AtomRef.make(mailbox.feed)) as Feed.Feed | undefined) : undefined;
+              const messages = feed
+                ? get(AtomQuery.make<Message.Message>(space.db, Query.select(Filter.type(Message.Message)).from(feed)))
+                : [];
+              const modifiedCount = Mailbox.getNewMessageCount(mailbox, messages);
+
               return Node.make({
                 id: mailbox.id,
                 type: Type.getTypename(Mailbox.Mailbox),
@@ -91,6 +102,7 @@ export default Capability.makeModule(
                   iconHue: 'rose',
                   role: 'branch',
                   mailbox,
+                  modifiedCount,
                 },
                 nodes: [
                   Node.make({

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -94,6 +94,13 @@ export const MailboxArticle = ({ subject, filter: filterProp, attendableId }: Ma
     [filteredMessages, sortDescending.value],
   );
 
+  // Mark the mailbox as viewed when opened, advancing its `viewedAt` cursor so the navtree new-message
+  // badge clears. Uses the live `subject` (not the `mailbox` snapshot) since this mutates, and is keyed on
+  // the mailbox id so it runs once per opened mailbox rather than on every update.
+  useEffect(() => {
+    Mailbox.markViewed(subject);
+  }, [subject.id]);
+
   // TODO(burdon): Actual test should be if we have synced; not number of messages.
   // Delay showing empty state to prevent flicker as messages are loaded.
   const [isEmpty, setEmpty] = useState<boolean>(false);

--- a/packages/plugins/plugin-inbox/src/types/Mailbox.ts
+++ b/packages/plugins/plugin-inbox/src/types/Mailbox.ts
@@ -56,6 +56,8 @@ export type Tags = Schema.Schema.Type<typeof Tags>;
 /** Mailbox object schema. */
 export const Mailbox = Schema.Struct({
   name: Schema.String.pipe(Schema.optional),
+  // ISO timestamp of when the mailbox was last viewed. Messages with a later `created` time are counted as new.
+  viewedAt: Schema.String.pipe(FormInputAnnotation.set(false), Schema.optional),
   feed: Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false)),
   // Unified tag map covering both Gmail-synced provider labels (`source: 'provider'`,
   // keyed by Gmail's label-id) and user-applied tags (`source: 'user'`, keyed by EntityId).
@@ -91,6 +93,26 @@ export type Mailbox = Type.InstanceType<typeof Mailbox>;
 
 /** Checks if a value is a Mailbox object. */
 export const instanceOf = (value: unknown): value is Mailbox => Obj.instanceOf(Mailbox, value);
+
+/** Number of messages created after the mailbox was last viewed (see {@link markViewed}). */
+export const getNewMessageCount = (
+  mailbox: Mailbox | Obj.Snapshot<Mailbox>,
+  messages: readonly Message.Message[],
+): number => {
+  const viewedAt = mailbox.viewedAt;
+  if (!viewedAt) {
+    return messages.length;
+  }
+  return messages.reduce((count, message) => (message.created > viewedAt ? count + 1 : count), 0);
+};
+
+/** Advances the `viewedAt` cursor to now, clearing the new-message count. */
+export const markViewed = (mailbox: Mailbox): void => {
+  const now = new Date().toISOString();
+  Obj.update(mailbox, (mailbox) => {
+    mailbox.viewedAt = now;
+  });
+};
 
 export const CreateMailboxSchema = Schema.Struct({
   name: Schema.optional(Schema.String.annotations({ title: 'Name' })),

--- a/packages/plugins/plugin-navtree/src/components/NavTree/NavTree.stories.tsx
+++ b/packages/plugins/plugin-navtree/src/components/NavTree/NavTree.stories.tsx
@@ -31,12 +31,8 @@ random.seed(1234);
 
 const StoryState = Capability.make<Atom.Atom<{ tab: string }>>('story-state');
 
-// TODO(burdon): Fix outline (e.g., button in sidebar nav is clipped when focused).
-// TODO(burdon): Consider similar containment of: Table, Sheet, Kanban Column, Form, etc.
-
 const container = 'flex flex-col grow gap-2 p-4 rounded-md';
 
-// TODO(burdon): Factor out PlankHeader.
 const StoryPlankHeading = ({ attendableId }: { attendableId: string }) => {
   const { hasAttention } = useAttention(attendableId);
   console.log('hasAttention', hasAttention);

--- a/packages/plugins/plugin-navtree/src/hooks/useNavTreeModel.ts
+++ b/packages/plugins/plugin-navtree/src/hooks/useNavTreeModel.ts
@@ -57,6 +57,7 @@ const createItemPropsFamily = (graph: ReturnType<typeof useAppGraph>['graph']) =
         icon: node.properties.icon,
         iconHue: node.properties.iconHue,
         testId: node.properties.testId,
+        count: node.properties.count,
       };
     }).pipe(Atom.keepAlive);
   });

--- a/packages/plugins/plugin-navtree/src/hooks/useNavTreeModel.ts
+++ b/packages/plugins/plugin-navtree/src/hooks/useNavTreeModel.ts
@@ -58,6 +58,7 @@ const createItemPropsFamily = (graph: ReturnType<typeof useAppGraph>['graph']) =
         iconHue: node.properties.iconHue,
         testId: node.properties.testId,
         count: node.properties.count,
+        modifiedCount: node.properties.modifiedCount,
       };
     }).pipe(Atom.keepAlive);
   });

--- a/packages/plugins/plugin-navtree/src/testing/app-graph-builder.ts
+++ b/packages/plugins/plugin-navtree/src/testing/app-graph-builder.ts
@@ -171,6 +171,7 @@ export const storybookGraphBuilders = (): BuilderExtensions => {
                 properties: getProperties(`object-${i}`, {
                   label: `Object ${i}`,
                   icon: random.properties.icon(),
+                  ...(i % 3 === 0 && { count: (i + 1) * 2 }),
                 }),
               }),
             );

--- a/packages/plugins/plugin-navtree/src/testing/app-graph-builder.ts
+++ b/packages/plugins/plugin-navtree/src/testing/app-graph-builder.ts
@@ -172,6 +172,7 @@ export const storybookGraphBuilders = (): BuilderExtensions => {
                   label: `Object ${i}`,
                   icon: random.properties.icon(),
                   ...(i % 3 === 0 && { count: (i + 1) * 2 }),
+                  ...(i % 3 === 1 && { modifiedCount: i + 1 }),
                 }),
               }),
             );

--- a/packages/plugins/plugin-navtree/src/types/schema.ts
+++ b/packages/plugins/plugin-navtree/src/types/schema.ts
@@ -43,8 +43,10 @@ export type NodeProperties = SharedProperties & {
   error?: string;
   modified?: boolean;
   palette?: string;
-  /** Optional item count rendered as a badge before the action column. */
+  /** Optional item count rendered as a neutral badge after the label. */
   count?: number;
+  /** Optional count of new/modified items; when greater than zero it shows as a rose badge in place of `count`. */
+  modifiedCount?: number;
 };
 
 export type ActionProperties = SharedProperties & {

--- a/packages/plugins/plugin-navtree/src/types/schema.ts
+++ b/packages/plugins/plugin-navtree/src/types/schema.ts
@@ -43,6 +43,8 @@ export type NodeProperties = SharedProperties & {
   error?: string;
   modified?: boolean;
   palette?: string;
+  /** Optional item count rendered as a badge before the action column. */
+  count?: number;
 };
 
 export type ActionProperties = SharedProperties & {

--- a/packages/plugins/plugin-registry/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-registry/src/capabilities/app-graph-builder.ts
@@ -11,6 +11,7 @@ import { GraphBuilder, Node, NodeMatcher } from '@dxos/plugin-graph';
 
 import { REGISTRY_ID, REGISTRY_KEY, registryCategoryId, meta } from '#meta';
 
+import { getCategoryPredicate, getRemotePluginIds } from '../categories';
 import { LOAD_PLUGIN_DIALOG } from '../containers';
 
 /**
@@ -60,8 +61,19 @@ export default Capability.makeModule(
       GraphBuilder.createExtension({
         id: 'registry',
         match: NodeMatcher.whenRoot,
-        connector: () =>
-          Effect.succeed([
+        connector: (_node, get) => {
+          const manager = capabilities.get(Capabilities.PluginManager);
+          const plugins = get(manager.plugins);
+          const filterContext = {
+            core: get(manager.core),
+            enabled: get(manager.enabled),
+            remoteIds: getRemotePluginIds(),
+          };
+          const categoryCount = (category: string) =>
+            plugins.filter(getCategoryPredicate(category, filterContext)).length;
+          const registryCount = get(manager.pluginRegistry.plugins).entries.length;
+
+          return Effect.succeed([
             Node.make({
               id: REGISTRY_ID,
               type: meta.id,
@@ -82,6 +94,7 @@ export default Capability.makeModule(
                     icon: 'ph--squares-four--regular',
                     key: REGISTRY_KEY,
                     testId: 'pluginRegistry.bundled',
+                    count: categoryCount(registryCategoryId('bundled')),
                   },
                 }),
                 Node.make({
@@ -93,6 +106,7 @@ export default Capability.makeModule(
                     icon: 'ph--check--regular',
                     key: REGISTRY_KEY,
                     testId: 'pluginRegistry.installed',
+                    count: categoryCount(registryCategoryId('installed')),
                   },
                 }),
                 Node.make({
@@ -104,6 +118,7 @@ export default Capability.makeModule(
                     icon: 'ph--star--regular',
                     key: REGISTRY_KEY,
                     testId: 'pluginRegistry.recommended',
+                    count: categoryCount(registryCategoryId('recommended')),
                   },
                 }),
                 Node.make({
@@ -115,6 +130,7 @@ export default Capability.makeModule(
                     icon: 'ph--flask--regular',
                     key: REGISTRY_KEY,
                     testId: 'pluginRegistry.labs',
+                    count: categoryCount(registryCategoryId('labs')),
                   },
                 }),
                 Node.make({
@@ -126,11 +142,13 @@ export default Capability.makeModule(
                     icon: 'ph--users-three--regular',
                     key: REGISTRY_KEY,
                     testId: 'pluginRegistry.registry',
+                    count: registryCount,
                   },
                 }),
               ],
             }),
-          ]),
+          ]);
+        },
       }),
       GraphBuilder.createExtension({
         id: 'actions',

--- a/packages/plugins/plugin-registry/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-registry/src/capabilities/react-surface.tsx
@@ -21,6 +21,7 @@ import {
 } from '#containers';
 import { DISABLE_DEPENDENTS_DIALOG, meta, registryCategoryId } from '#meta';
 
+import { type PluginPredicate, getCategoryPredicate } from '../categories';
 import { useAutoTags, useRegistryPlugins, useRemotePluginIds } from '../hooks';
 
 export default Capability.makeModule(() =>
@@ -30,16 +31,7 @@ export default Capability.makeModule(() =>
         id: 'bundled',
         filter: AppSurface.literal(AppSurface.Article, registryCategoryId('bundled')),
         component: () => {
-          const manager = usePluginManager();
-          const remoteIds = useRemotePluginIds();
-          const core = useMemo(() => manager.getCore(), [manager]);
-          const predicate = useMemo<PluginPredicate>(
-            () =>
-              ({ meta }) =>
-                !core.includes(meta.id) && !remoteIds.has(meta.id),
-            [core, remoteIds],
-          );
-
+          const predicate = useCategoryPredicate(registryCategoryId('bundled'));
           return <FilteredRegistryArticle id={registryCategoryId('bundled')} filter={predicate} />;
         },
       }),
@@ -47,16 +39,7 @@ export default Capability.makeModule(() =>
         id: 'installed',
         filter: AppSurface.literal(AppSurface.Article, registryCategoryId('installed')),
         component: () => {
-          const manager = usePluginManager();
-          const core = useMemo(() => manager.getCore(), [manager]);
-          const enabled = useMemo(() => manager.getEnabled(), [manager]);
-          const predicate = useMemo<PluginPredicate>(
-            () =>
-              ({ meta }) =>
-                !core.includes(meta.id) && enabled.includes(meta.id),
-            [core, enabled],
-          );
-
+          const predicate = useCategoryPredicate(registryCategoryId('installed'));
           return <FilteredRegistryArticle id={registryCategoryId('installed')} filter={predicate} />;
         },
       }),
@@ -64,16 +47,7 @@ export default Capability.makeModule(() =>
         id: 'recommended',
         filter: AppSurface.literal(AppSurface.Article, registryCategoryId('recommended')),
         component: () => {
-          const manager = usePluginManager();
-          const remoteIds = useRemotePluginIds();
-          const core = useMemo(() => manager.getCore(), [manager]);
-          const predicate = useMemo<PluginPredicate>(
-            () =>
-              ({ meta }) =>
-                !core.includes(meta.id) && !remoteIds.has(meta.id) && !meta.tags?.includes('labs'),
-            [core, remoteIds],
-          );
-
+          const predicate = useCategoryPredicate(registryCategoryId('recommended'));
           return <FilteredRegistryArticle id={registryCategoryId('recommended')} filter={predicate} />;
         },
       }),
@@ -81,13 +55,7 @@ export default Capability.makeModule(() =>
         id: 'labs',
         filter: AppSurface.literal(AppSurface.Article, registryCategoryId('labs')),
         component: () => {
-          const predicate = useMemo<PluginPredicate>(
-            () =>
-              ({ meta }) =>
-                meta.tags?.includes('labs') ?? false,
-            [],
-          );
-
+          const predicate = useCategoryPredicate(registryCategoryId('labs'));
           return <FilteredRegistryArticle id={registryCategoryId('labs')} filter={predicate} />;
         },
       }),
@@ -127,7 +95,20 @@ export default Capability.makeModule(() =>
   ),
 );
 
-type PluginPredicate = (plugin: Plugin.Plugin) => boolean;
+/**
+ * Resolves the {@link PluginPredicate} for a registry category against the live plugin list.
+ * Shared with the graph builder via {@link getCategoryPredicate} so the category lists and their counts agree.
+ */
+const useCategoryPredicate = (category: string): PluginPredicate => {
+  const manager = usePluginManager();
+  const remoteIds = useRemotePluginIds();
+  const core = useMemo(() => manager.getCore(), [manager]);
+  const enabled = useMemo(() => manager.getEnabled(), [manager]);
+  return useMemo(
+    () => getCategoryPredicate(category, { core, enabled, remoteIds }),
+    [category, core, enabled, remoteIds],
+  );
+};
 
 /**
  * Renders the {@link RegistryArticle} surface filtered by an arbitrary

--- a/packages/plugins/plugin-registry/src/categories.ts
+++ b/packages/plugins/plugin-registry/src/categories.ts
@@ -1,0 +1,44 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Plugin, UrlLoader } from '@dxos/app-framework';
+
+import { registryCategoryId } from './meta';
+
+export type PluginPredicate = (plugin: Plugin.Plugin) => boolean;
+
+export type CategoryFilterContext = {
+  /** Core (bundled-by-default) plugin ids. */
+  core: readonly string[];
+  /** Enabled plugin ids. */
+  enabled: readonly string[];
+  /** Plugin ids loaded from a remote URL (not bundled). */
+  remoteIds: ReadonlySet<string>;
+};
+
+/**
+ * Predicate selecting the plugins shown in a registry category, computed against the live plugin list.
+ * The `registry` category is sourced from the catalog rather than the local plugin list and is not handled here.
+ */
+export const getCategoryPredicate = (
+  category: string,
+  { core, enabled, remoteIds }: CategoryFilterContext,
+): PluginPredicate => {
+  switch (category) {
+    case registryCategoryId('bundled'):
+      return ({ meta }) => !core.includes(meta.id) && !remoteIds.has(meta.id);
+    case registryCategoryId('installed'):
+      return ({ meta }) => !core.includes(meta.id) && enabled.includes(meta.id);
+    case registryCategoryId('recommended'):
+      return ({ meta }) => !core.includes(meta.id) && !remoteIds.has(meta.id) && !meta.tags?.includes('labs');
+    case registryCategoryId('labs'):
+      return ({ meta }) => meta.tags?.includes('labs') ?? false;
+    default:
+      return () => false;
+  }
+};
+
+/** Set of plugin ids known to originate from a remote URL (not bundled). */
+export const getRemotePluginIds = (): ReadonlySet<string> =>
+  new Set(UrlLoader.getRemoteEntries().map((entry) => entry.id));

--- a/packages/plugins/plugin-registry/src/components/PluginList/PluginItem.tsx
+++ b/packages/plugins/plugin-registry/src/components/PluginList/PluginItem.tsx
@@ -148,7 +148,7 @@ export const PluginItem = ({
         />
       </div>
 
-      <div className={mx(gridRows)}>
+      <div className={mx(gridRows, 'min-w-0')}>
         <div className='flex items-center gap-2 overflow-hidden cursor-pointer' onClick={handleClick}>
           <span className='text-lg truncate'>{name ?? id}</span>
           {failure && <PluginFailureBadge failure={failure} />}

--- a/packages/plugins/plugin-registry/src/hooks/useAutoTags.ts
+++ b/packages/plugins/plugin-registry/src/hooks/useAutoTags.ts
@@ -6,6 +6,8 @@ import { useMemo } from 'react';
 
 import { type Registry, UrlLoader } from '@dxos/app-framework';
 
+import { getRemotePluginIds } from '../categories';
+
 /**
  * Auto-tags that are derived at display time rather than persisted to `Plugin.Meta`.
  * - `registry`: plugin id appears in the registry catalog manifest.
@@ -47,5 +49,4 @@ export const useAutoTags = (registryEntries: readonly Registry.Plugin[]): AutoTa
  * Returns the set of plugin ids known to originate from a remote URL (not bundled).
  * Used to filter the Official/Recommended sections so third-party plugins are excluded.
  */
-export const useRemotePluginIds = (): ReadonlySet<string> =>
-  useMemo(() => new Set(UrlLoader.getRemoteEntries().map((entry) => entry.id)), []);
+export const useRemotePluginIds = (): ReadonlySet<string> => useMemo(() => getRemotePluginIds(), []);

--- a/packages/ui/react-ui-list/src/components/Tree/Tree.stories.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/Tree.stories.tsx
@@ -93,6 +93,7 @@ const DefaultStory = ({ draggable }: { draggable?: boolean }) => {
             icon: parent.icon,
             ...((parent.items?.length ?? 0) > 0 && {
               parentOf: parent.items!.map(({ id }) => id),
+              count: parent.items!.length,
             }),
           };
         }).pipe(Atom.keepAlive);

--- a/packages/ui/react-ui-list/src/components/Tree/Tree.stories.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/Tree.stories.tsx
@@ -94,6 +94,8 @@ const DefaultStory = ({ draggable }: { draggable?: boolean }) => {
             ...((parent.items?.length ?? 0) > 0 && {
               parentOf: parent.items!.map(({ id }) => id),
               count: parent.items!.length,
+              // Demonstrate the rose "new/modified" badge on a subset of branches (replaces the neutral count).
+              ...(parent.name.length % 3 === 0 && { modifiedCount: (parent.name.length % 5) + 1 }),
             }),
           };
         }).pipe(Atom.keepAlive);

--- a/packages/ui/react-ui-list/src/components/Tree/TreeContext.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/TreeContext.tsx
@@ -22,6 +22,8 @@ export type TreeItemDataProps = {
   iconHue?: string;
   disabled?: boolean;
   testId?: string;
+  /** Optional item count rendered as a badge directly after the label. */
+  count?: number;
 };
 
 export interface TreeModel<T extends { id: string } = any> {

--- a/packages/ui/react-ui-list/src/components/Tree/TreeContext.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/TreeContext.tsx
@@ -22,8 +22,10 @@ export type TreeItemDataProps = {
   iconHue?: string;
   disabled?: boolean;
   testId?: string;
-  /** Optional item count rendered as a badge directly after the label. */
+  /** Optional item count rendered as a neutral badge directly after the label. */
   count?: number;
+  /** Optional count of new/modified items; when greater than zero it shows as a rose badge in place of `count`. */
+  modifiedCount?: number;
 };
 
 export interface TreeModel<T extends { id: string } = any> {

--- a/packages/ui/react-ui-list/src/components/Tree/TreeItem.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/TreeItem.tsx
@@ -119,6 +119,7 @@ const RawTreeItem = <T extends { id: string } = any>({
     iconHue,
     disabled,
     testId,
+    count,
   } = useAtomValue(itemPropsAtom(path));
   const childIds = useAtomValue(childIdsAtom(item.id));
   const open = useAtomValue(itemOpenAtom(path));
@@ -336,6 +337,7 @@ const RawTreeItem = <T extends { id: string } = any>({
               className={headingClassName}
               icon={icon}
               iconHue={iconHue}
+              count={count}
               onSelect={handleSelect}
               ref={buttonRef}
             />

--- a/packages/ui/react-ui-list/src/components/Tree/TreeItem.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/TreeItem.tsx
@@ -120,6 +120,7 @@ const RawTreeItem = <T extends { id: string } = any>({
     disabled,
     testId,
     count,
+    modifiedCount,
   } = useAtomValue(itemPropsAtom(path));
   const childIds = useAtomValue(childIdsAtom(item.id));
   const open = useAtomValue(itemOpenAtom(path));
@@ -338,6 +339,7 @@ const RawTreeItem = <T extends { id: string } = any>({
               icon={icon}
               iconHue={iconHue}
               count={count}
+              modifiedCount={modifiedCount}
               onSelect={handleSelect}
               ref={buttonRef}
             />

--- a/packages/ui/react-ui-list/src/components/Tree/TreeItemHeading.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/TreeItemHeading.tsx
@@ -4,7 +4,7 @@
 
 import React, { type KeyboardEvent, type MouseEvent, forwardRef, memo, useCallback } from 'react';
 
-import { Button, Icon, type Label, toLocalizedString, useTranslation } from '@dxos/react-ui';
+import { Button, Icon, type Label, Tag, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { TextTooltip } from '@dxos/react-ui-text-tooltip';
 import { getStyles } from '@dxos/ui-theme';
 
@@ -17,12 +17,14 @@ export type TreeItemHeadingProps = {
   iconHue?: string;
   disabled?: boolean;
   current?: boolean;
+  /** Optional item count rendered as a badge directly after the label. */
+  count?: number;
   onSelect?: (option: boolean) => void;
 };
 
 export const TreeItemHeading = memo(
   forwardRef<HTMLButtonElement, TreeItemHeadingProps>(
-    ({ label, className, icon, iconHue, disabled, current, onSelect }, forwardedRef) => {
+    ({ label, className, icon, iconHue, disabled, current, count, onSelect }, forwardedRef) => {
       const { t } = useTranslation();
       const styles = iconHue ? getStyles(iconHue) : undefined;
 
@@ -57,7 +59,7 @@ export const TreeItemHeading = memo(
             data-testid='treeItem.heading'
             variant='ghost'
             classNames={[
-              'grow gap-2 ps-0.5 hover:bg-transparent dark:hover:bg-transparent',
+              'grow justify-start gap-2 ps-0.5 hover:bg-transparent dark:hover:bg-transparent',
               'disabled:cursor-default disabled:opacity-100',
               className,
             ]}
@@ -69,9 +71,14 @@ export const TreeItemHeading = memo(
             {icon && (
               <Icon size={5} icon={icon ?? 'ph--circle-dashed--regular'} classNames={['my-1', styles?.foreground]} />
             )}
-            <span className='flex-1 w-0 truncate text-start font-normal' data-tooltip>
+            <span className='min-w-0 truncate text-start font-normal' data-tooltip>
               {toLocalizedString(label, t)}
             </span>
+            {typeof count === 'number' && (
+              <Tag palette='neutral' classNames='shrink-0 text-center [min-inline-size:1.5rem] tabular-nums'>
+                {count}
+              </Tag>
+            )}
           </Button>
         </TextTooltip>
       );

--- a/packages/ui/react-ui-list/src/components/Tree/TreeItemHeading.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/TreeItemHeading.tsx
@@ -17,14 +17,16 @@ export type TreeItemHeadingProps = {
   iconHue?: string;
   disabled?: boolean;
   current?: boolean;
-  /** Optional item count rendered as a badge directly after the label. */
+  /** Optional item count rendered as a neutral badge directly after the label. */
   count?: number;
+  /** Optional count of new/modified items; when greater than zero it replaces {@link count} with a rose badge. */
+  modifiedCount?: number;
   onSelect?: (option: boolean) => void;
 };
 
 export const TreeItemHeading = memo(
   forwardRef<HTMLButtonElement, TreeItemHeadingProps>(
-    ({ label, className, icon, iconHue, disabled, current, count, onSelect }, forwardedRef) => {
+    ({ label, className, icon, iconHue, disabled, current, count, modifiedCount, onSelect }, forwardedRef) => {
       const { t } = useTranslation();
       const styles = iconHue ? getStyles(iconHue) : undefined;
 
@@ -74,14 +76,34 @@ export const TreeItemHeading = memo(
             <span className='min-w-0 truncate text-start font-normal' data-tooltip>
               {toLocalizedString(label, t)}
             </span>
-            {typeof count === 'number' && (
-              <Tag palette='neutral' classNames='shrink-0 text-center [min-inline-size:1.5rem] tabular-nums'>
-                {count}
-              </Tag>
-            )}
+            <CountBadge count={count} modifiedCount={modifiedCount} />
           </Button>
         </TextTooltip>
       );
     },
   ),
 );
+
+/**
+ * Renders the count badge after a tree item label.
+ * A positive `modifiedCount` (e.g. new/unread items) shows as a rose badge in place of the neutral total `count`.
+ */
+const CountBadge = ({ count, modifiedCount }: Pick<TreeItemHeadingProps, 'count' | 'modifiedCount'>) => {
+  if (typeof modifiedCount === 'number' && modifiedCount > 0) {
+    return (
+      <Tag palette='rose' classNames='shrink-0 text-center [min-inline-size:1.5rem] tabular-nums'>
+        {modifiedCount}
+      </Tag>
+    );
+  }
+
+  if (typeof count === 'number') {
+    return (
+      <Tag palette='neutral' classNames='shrink-0 text-center [min-inline-size:1.5rem] tabular-nums'>
+        {count}
+      </Tag>
+    );
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Summary

Adds an optional **item count badge** to navtree items, rendered directly after the item label, and uses it to show **plugin counts per registry category**. Also fixes a registry plugin-tile overflow.

### Generic count badge
- `count?: number` added to the generic `react-ui-list` `TreeItemDataProps`.
- `TreeItemHeading` renders a neutral `Tag` immediately after the title — the title truncates first (`min-w-0`), the badge hugs it (`shrink-0`, `tabular-nums`, fixed `min-inline-size` so digit-count changes don't shift). Restored `justify-start` on the heading button so removing the title's `flex-1` didn't expose the button's default `justify-center` (which centered every row).
- Threaded through `TreeItem` → navtree `useNavTreeModel` maps `node.properties.count`, so any graph node can set a count.

### Plugin registry category counts
- Each category node (Bundled, Enabled, Recommended, Labs, Registry) now sets a reactive `count` in the app-graph builder. Bundled/Enabled/Recommended/Labs filter the live plugin list; Registry uses the catalog entry count.
- The category filter predicates were extracted into a shared `categories.ts` (`getCategoryPredicate`, `getRemotePluginIds`) used by **both** the `react-surface` category lists and the graph-builder counts, so the lists and their counts cannot drift. `useRemotePluginIds` now reuses the shared helper.

### Tile overflow fix
- `min-w-0` on the plugin tile's content column. It defaulted to `min-width: auto`, so a long description/tag row expanded the `1fr` grid track past the card and pushed the enable switch outside. The switch now stays inside; the description clamps cleanly.

## Testing
- `build`, `lint`, `test` green for `react-ui-list`, `plugin-navtree`, `plugin-registry`.
- Verified visually in a worktree Storybook: count badge hugs the title and rows stay left-aligned (`react-ui-list` Tree + navtree stories); plugin tile switch sits inside the card with the description clamped.
- Note: category-count badges render in `composer-app` (the navtree storybook builder doesn't load the registry plugin).

## Reviewer notes
- Stories updated to exercise the feature: `react-ui-list` Tree shows each branch's child count; navtree testing builder sets a sample `count` on object nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Count and "modified" badges added to tree and nav items; registry categories show live counts.
  * Mailboxes track viewed time so new-message badges clear after opening.

* **Improvements**
  * Consistent category filtering/counts across registry UI.
  * Better truncation/overflow handling in list rows and item headings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->