### PR TITLE
fix(app-toolkit): best-effort navigation resolution; don't 404 local objects

### DIFF
--- a/packages/plugins/plugin-deck/src/operations/open.ts
+++ b/packages/plugins/plugin-deck/src/operations/open.ts
@@ -15,7 +15,7 @@ import {
 } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { Context } from '@dxos/context';
-import { Obj } from '@dxos/echo';
+import { Database, EID, Obj } from '@dxos/echo';
 import { log } from '@dxos/log';
 import { AttentionCapabilities } from '@dxos/plugin-attention';
 import { ClientCapabilities } from '@dxos/plugin-client';
@@ -37,12 +37,24 @@ const handler: Operation.WithHandler<typeof LayoutOperation.Open> = LayoutOperat
       // Validate navigation targets, redirecting to 404 if not found.
       const capabilities = yield* Capability.Service;
       const pathResolvers = capabilities.getAll(AppCapabilities.NavigationPathResolver);
-      const checkRemoteExistence = yield* Capability.get(ClientCapabilities.Client).pipe(
-        Effect.map((client) =>
-          createEdgeExistenceChecker((spaceId, body) => client.edge.http.execQuery(new Context(), spaceId, body)),
-        ),
-        Effect.catchAll(() => Effect.succeed(undefined)),
-      );
+      const client = yield* Capability.get(ClientCapabilities.Client).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+      // Existence checkers for the resolved EID: local (loadOption) first, then remote (edge).
+      const checkLocalExistence = client
+        ? (id: EID.EID) => {
+            const spaceId = EID.getSpaceId(id);
+            const space = spaceId ? client.spaces.get(spaceId) : undefined;
+            if (!space) {
+              return Effect.succeed(false);
+            }
+            return Database.loadOption(space.db.makeRef(id)).pipe(
+              Effect.map(Option.isSome),
+              Effect.catchAll(() => Effect.succeed(false)),
+            );
+          }
+        : undefined;
+      const checkRemoteExistence = client
+        ? createEdgeExistenceChecker((spaceId, body) => client.edge.http.execQuery(new Context(), spaceId, body))
+        : undefined;
 
       // Immediate: skip 404 / resolver checks but still expand the path (same as validate’s first step).
       if (input.navigation === 'immediate') {
@@ -55,7 +67,7 @@ const handler: Operation.WithHandler<typeof LayoutOperation.Open> = LayoutOperat
         input.subject.map((subjectId) =>
           input.navigation === 'immediate'
             ? Effect.succeed(subjectId)
-            : validateNavigationTarget({ graph, subjectId, pathResolvers, checkRemoteExistence }),
+            : validateNavigationTarget({ graph, subjectId, pathResolvers, checkLocalExistence, checkRemoteExistence }),
         ),
       );
       input = { ...input, subject: validatedSubjects };

--- a/packages/plugins/plugin-deck/src/operations/open.ts
+++ b/packages/plugins/plugin-deck/src/operations/open.ts
@@ -37,7 +37,9 @@ const handler: Operation.WithHandler<typeof LayoutOperation.Open> = LayoutOperat
       // Validate navigation targets, redirecting to 404 if not found.
       const capabilities = yield* Capability.Service;
       const pathResolvers = capabilities.getAll(AppCapabilities.NavigationPathResolver);
-      const client = yield* Capability.get(ClientCapabilities.Client).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+      const client = yield* Capability.get(ClientCapabilities.Client).pipe(
+        Effect.catchAll(() => Effect.succeed(undefined)),
+      );
       // Existence checkers for the resolved EID: local (loadOption) first, then remote (edge).
       const checkLocalExistence = client
         ? (id: EID.EID) => {

--- a/packages/plugins/plugin-inbox/src/capabilities/navigation-resolver.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/navigation-resolver.ts
@@ -7,15 +7,13 @@ import * as Option from 'effect/Option';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities, getSpaceIdFromPath, getSpacePath, type AppCapabilities as AppCaps } from '@dxos/app-toolkit';
-import { Database, Filter, Key, Obj, Query, Type } from '@dxos/echo';
+import { Database, Key, Type } from '@dxos/echo';
 import { EID, URI } from '@dxos/keys';
-import { ClientCapabilities } from '@dxos/plugin-client';
 import { SETTINGS_ID, SETTINGS_KEY } from '@dxos/plugin-settings';
 import { getLinkedVariant, isLinkedSegment } from '@dxos/react-ui-attention';
-import { Message } from '@dxos/types';
 
 import { meta } from '#meta';
-import { DraftMessage, Mailbox } from '#types';
+import { Mailbox } from '#types';
 
 import { getMailboxAllMailPath, getMailboxesSectionId } from '../paths';
 
@@ -56,10 +54,9 @@ export default Capability.makeModule(
         ];
       })) as AppCapabilities.NavigationTargetResolver;
 
-    // Resolve mailbox paths (root/<spaceId>/mailboxes/<mailboxId>/...) to DXNs.
-    // For message paths (~<messageId>), validates the message exists in the mailbox feed or as a draft in the DB.
-    // For mailbox paths, validates the mailbox exists.
-    const client = yield* Capability.get(ClientCapabilities.Client);
+    // Parse mailbox paths (root/<spaceId>/mailboxes/<mailboxId>/...) into EIDs (structure only;
+    // existence is checked by the caller). A message path (.../~<messageId>) resolves to the message;
+    // any other mailbox path resolves to the mailbox itself.
     const pathResolver: AppCaps.NavigationPathResolver = (qualifiedPath) => {
       const segments = qualifiedPath.split('/');
       const spaceId = getSpaceIdFromPath(qualifiedPath);
@@ -69,53 +66,9 @@ export default Capability.makeModule(
         return Effect.succeed(Option.none());
       }
 
-      const space = client.spaces.get(spaceId);
-      if (!space) {
-        return Effect.succeed(Option.none());
-      }
-
-      const mailboxEchoId = EID.make({ spaceId: spaceId, entityId: mailboxId as Key.EntityId });
-      const mailboxRef = space.db.makeRef(mailboxEchoId);
-
-      const isMessagePath = isLinkedSegment(qualifiedPath);
-      const messageId = isMessagePath ? getLinkedVariant(qualifiedPath) : undefined;
-
-      return Database.loadOption(mailboxRef).pipe(
-        Effect.flatMap((mailboxOption) => {
-          if (Option.isNone(mailboxOption) || !Mailbox.instanceOf(mailboxOption.value)) {
-            return Effect.succeed(Option.none<EID.EID>());
-          }
-
-          // For non-message paths, the mailbox existing is sufficient.
-          if (!messageId || !Key.EntityId.isValid(messageId)) {
-            return Effect.succeed(Option.some(mailboxEchoId));
-          }
-
-          // For message paths, verify the message exists in the feed or as a mailbox-scoped draft.
-          const mailbox = mailboxOption.value as Mailbox.Mailbox;
-          const mailboxUriString = Obj.getURI(mailbox);
-
-          return Effect.tryPromise(async () => {
-            // TODO(wittjosiah): This is awkward, clean it up.
-            if (mailbox.feed) {
-              const feed = await mailbox.feed.load();
-              const messages = await space.db.query(Query.select(Filter.id(messageId)).from(feed)).run();
-              if (messages.length > 0) {
-                return Option.some(EID.parse(Obj.getURI(messages[0])));
-              }
-            }
-
-            const fromDb = (await space.db.query(Query.select(Filter.id(messageId))).first()) as
-              | Message.Message
-              | undefined;
-            if (fromDb && DraftMessage.belongsTo(fromDb, mailboxUriString)) {
-              return Option.some(EID.parse(Obj.getURI(fromDb)));
-            }
-
-            return Option.none<EID.EID>();
-          }).pipe(Effect.catchAll(() => Effect.succeed(Option.none<EID.EID>())));
-        }),
-      );
+      const messageId = isLinkedSegment(qualifiedPath) ? getLinkedVariant(qualifiedPath) : undefined;
+      const objectId = messageId && Key.EntityId.isValid(messageId) ? messageId : mailboxId;
+      return Effect.succeed(Option.some(EID.make({ spaceId, entityId: objectId as Key.EntityId })));
     };
 
     return [

--- a/packages/plugins/plugin-simple-layout/src/operations/open.ts
+++ b/packages/plugins/plugin-simple-layout/src/operations/open.ts
@@ -1,6 +1,7 @@
 // Copyright 2025 DXOS.org
 
 import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
 
 import { Capability } from '@dxos/app-framework';
 import {
@@ -11,6 +12,7 @@ import {
 } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { Context } from '@dxos/context';
+import { Database, EID } from '@dxos/echo';
 import { log } from '@dxos/log';
 import { ClientCapabilities } from '@dxos/plugin-client';
 
@@ -27,12 +29,24 @@ const handler: Operation.WithHandler<typeof LayoutOperation.Open> = LayoutOperat
       // Validate navigation target, redirecting to 404 if not found.
       const capabilities = yield* Capability.Service;
       const pathResolvers = capabilities.getAll(AppCapabilities.NavigationPathResolver);
-      const checkRemoteExistence = yield* Capability.get(ClientCapabilities.Client).pipe(
-        Effect.map((client) =>
-          createEdgeExistenceChecker((spaceId, body) => client.edge.http.execQuery(new Context(), spaceId, body)),
-        ),
-        Effect.catchAll(() => Effect.succeed(undefined)),
-      );
+      const client = yield* Capability.get(ClientCapabilities.Client).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+      // Existence checkers for the resolved EID: local (loadOption) first, then remote (edge).
+      const checkLocalExistence = client
+        ? (uri: EID.EID) => {
+            const spaceId = EID.getSpaceId(uri);
+            const space = spaceId ? client.spaces.get(spaceId) : undefined;
+            if (!space) {
+              return Effect.succeed(false);
+            }
+            return Database.loadOption(space.db.makeRef(uri)).pipe(
+              Effect.map(Option.isSome),
+              Effect.catchAll(() => Effect.succeed(false)),
+            );
+          }
+        : undefined;
+      const checkRemoteExistence = client
+        ? createEdgeExistenceChecker((spaceId, body) => client.edge.http.execQuery(new Context(), spaceId, body))
+        : undefined;
 
       const validatedId =
         input.navigation === 'immediate'
@@ -41,6 +55,7 @@ const handler: Operation.WithHandler<typeof LayoutOperation.Open> = LayoutOperat
               graph,
               subjectId: id,
               pathResolvers,
+              checkLocalExistence,
               checkRemoteExistence,
             });
 

--- a/packages/plugins/plugin-simple-layout/src/operations/open.ts
+++ b/packages/plugins/plugin-simple-layout/src/operations/open.ts
@@ -29,7 +29,9 @@ const handler: Operation.WithHandler<typeof LayoutOperation.Open> = LayoutOperat
       // Validate navigation target, redirecting to 404 if not found.
       const capabilities = yield* Capability.Service;
       const pathResolvers = capabilities.getAll(AppCapabilities.NavigationPathResolver);
-      const client = yield* Capability.get(ClientCapabilities.Client).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+      const client = yield* Capability.get(ClientCapabilities.Client).pipe(
+        Effect.catchAll(() => Effect.succeed(undefined)),
+      );
       // Existence checkers for the resolved EID: local (loadOption) first, then remote (edge).
       const checkLocalExistence = client
         ? (uri: EID.EID) => {

--- a/packages/plugins/plugin-space/src/capabilities/navigation-resolver.ts
+++ b/packages/plugins/plugin-space/src/capabilities/navigation-resolver.ts
@@ -15,7 +15,6 @@ import {
 } from '@dxos/app-toolkit';
 import { Database, Entity, Key } from '@dxos/echo';
 import { EID } from '@dxos/keys';
-import { ClientCapabilities } from '@dxos/plugin-client';
 import { SETTINGS_ID, SETTINGS_KEY } from '@dxos/plugin-settings';
 
 import { meta } from '#meta';
@@ -61,11 +60,10 @@ export default Capability.makeModule(
         ];
       })) as AppCaps.NavigationTargetResolver;
 
-    // Resolve object paths to DXNs.
+    // Parse object paths into EIDs (structure only; existence is checked by the caller).
     // Handles canonical type paths (root/<spaceId>/types/<typename>/all/<objectId>)
-    // and collection paths (root/<spaceId>/collections/<collectionId>/<objectId>).
-    // Validates that the object actually exists in the space before returning a DXN.
-    const client = yield* Capability.get(ClientCapabilities.Client);
+    // and collection paths (root/<spaceId>/collections/<collectionId>/<objectId>): the space id
+    // is the first segment and the object id the last.
     const pathResolver: AppCaps.NavigationPathResolver = (qualifiedPath) => {
       const segments = qualifiedPath.split('/');
       const spaceId = getSpaceIdFromPath(qualifiedPath);
@@ -73,17 +71,7 @@ export default Capability.makeModule(
       if (!spaceId || !objectId || !Key.EntityId.isValid(objectId)) {
         return Effect.succeed(Option.none());
       }
-
-      const space = client.spaces.get(spaceId);
-      if (!space) {
-        return Effect.succeed(Option.none());
-      }
-
-      const echoUri = EID.make({ spaceId: spaceId, entityId: objectId as Key.EntityId });
-      const ref = space.db.makeRef(echoUri);
-      return Database.loadOption(ref).pipe(
-        Effect.map((option) => (Option.isSome(option) ? Option.some(echoUri) : Option.none<EID.EID>())),
-      );
+      return Effect.succeed(Option.some(EID.make({ spaceId, entityId: objectId as Key.EntityId })));
     };
 
     return [

--- a/packages/sdk/app-toolkit/src/not-found.ts
+++ b/packages/sdk/app-toolkit/src/not-found.ts
@@ -19,10 +19,10 @@ export const NOT_FOUND_NODE_TYPE = 'org.dxos.type.not-found';
 export const NOT_FOUND_PATH = `${Node.RootId}/${NOT_FOUND_NODE_ID}`;
 
 /**
- * Callback to check if an object exists on a remote service (e.g., edge).
- * Takes a DXN identifying the object. Returns an Effect resolving to true if the object exists remotely.
+ * Callback to check whether the object identified by an EID exists in some store (local or remote).
+ * Returns an Effect resolving to true if the object exists there.
  */
-export type RemoteExistenceChecker = (echoUri: EID.EID) => Effect.Effect<boolean>;
+export type ExistenceChecker = (echoUri: EID.EID) => Effect.Effect<boolean>;
 
 /**
  * Expand a qualified graph path by expanding each ancestor prefix.
@@ -44,20 +44,21 @@ export const expandPath = (graph: Graph.ExpandableGraph, qualifiedId: string): v
  * Validate a navigation target by expanding the graph path and checking existence.
  * Returns the original subjectId if valid, or NOT_FOUND_PATH if the target doesn't exist.
  *
- * Path resolvers (NavigationPathResolver) are used to determine if the path is valid
- * and to extract a DXN for remote validation. If no resolver recognizes the path, it's 404.
- *
- * When a remote existence checker is provided (e.g., backed by edge), objects that exist
- * remotely but haven't replicated locally will be considered valid (replication will load them).
- * Without a checker (offline), objects not in the local graph are treated as not found.
+ * Resolution is three independent steps: a path resolver parses the path into an EID (structure
+ * only — it does not validate the full container path), then existence is checked against that EID
+ * locally and, failing that, remotely. The path is considered valid if the object exists in either
+ * store — we render it best-effort even if intermediate path segments (collection, feed, etc.) no
+ * longer describe where it lives. If no resolver recognizes the path, it's a 404. When no existence
+ * checker is available, a resolved EID is trusted.
  */
 export const validateNavigationTarget = (params: {
   graph: Graph.ExpandableGraph;
   subjectId: string;
   pathResolvers: AppCapabilities.NavigationPathResolver[];
-  checkRemoteExistence?: RemoteExistenceChecker;
+  checkLocalExistence?: ExistenceChecker;
+  checkRemoteExistence?: ExistenceChecker;
 }): Effect.Effect<string> => {
-  const { graph, subjectId, pathResolvers, checkRemoteExistence } = params;
+  const { graph, subjectId, pathResolvers, checkLocalExistence, checkRemoteExistence } = params;
 
   // Skip validation for system paths.
   if (subjectId === NOT_FOUND_PATH || subjectId === Node.RootId || isPinnedWorkspace(subjectId)) {
@@ -67,15 +68,15 @@ export const validateNavigationTarget = (params: {
   // Expand the graph path to trigger loading.
   expandPath(graph, subjectId);
 
-  // Check if node exists after expansion.
+  // Fast path: the object is already a node in the local graph.
   const nodeAfterExpand = Graph.getNode(graph, subjectId);
   if (Option.isSome(nodeAfterExpand)) {
     return Effect.succeed(subjectId);
   }
 
-  // Node not found locally. Ask path resolvers to identify the DXN for this path.
   return Effect.gen(function* () {
-    const dxn = yield* Effect.reduce(pathResolvers, Option.none<EID.EID>(), (acc, resolver) =>
+    // Parse the path into an EID. If no resolver recognizes the path, there's nothing to open.
+    const id = yield* Effect.reduce(pathResolvers, Option.none<EID.EID>(), (acc, resolver) =>
       Option.isSome(acc)
         ? Effect.succeed(acc)
         : resolver(subjectId).pipe(
@@ -85,35 +86,46 @@ export const validateNavigationTarget = (params: {
             }),
           ),
     );
-
-    if (Option.isNone(dxn)) {
+    if (Option.isNone(id)) {
       return NOT_FOUND_PATH;
     }
 
-    // Path resolver validated this path. Check remote existence for additional confirmation if available.
-    if (checkRemoteExistence) {
-      const exists = yield* checkRemoteExistence(dxn.value).pipe(
-        Effect.catchAll((error) => {
-          log.warn('remote existence check failed', { subjectId, error });
-          return Effect.succeed(false);
-        }),
-      );
-      if (!exists) {
-        return NOT_FOUND_PATH;
-      }
+    // Check existence cheapest-first: local (fast) then remote (network, only when not local).
+    // Local existence alone is sufficient — an object present locally is valid even if it hasn't
+    // replicated to edge; remote existence rescues objects that exist remotely but not yet locally.
+    const exists = (checker?: ExistenceChecker) =>
+      checker
+        ? checker(id.value).pipe(
+            Effect.catchAll((error) => {
+              log.warn('existence check failed', { subjectId, error });
+              return Effect.succeed(false);
+            }),
+          )
+        : Effect.succeed(false);
+
+    if (yield* exists(checkLocalExistence)) {
+      return subjectId;
+    }
+    if (yield* exists(checkRemoteExistence)) {
+      return subjectId;
     }
 
-    return subjectId;
+    // With no checkers available we cannot confirm existence; trust the resolved path.
+    if (!checkLocalExistence && !checkRemoteExistence) {
+      return subjectId;
+    }
+
+    return NOT_FOUND_PATH;
   });
 };
 
 /**
- * Create a RemoteExistenceChecker backed by an edge execQuery function.
+ * Create an ExistenceChecker backed by an edge execQuery function (remote existence).
  * The execQuery parameter should match the EdgeHttpClient.execQuery signature.
  */
 export const createEdgeExistenceChecker = (
   execQuery: (spaceId: Key.SpaceId, body: { query: string; reactivity: number }) => Promise<{ results?: unknown[] }>,
-): RemoteExistenceChecker => {
+): ExistenceChecker => {
   return (echoUri) => {
     const spaceId = EID.getSpaceId(echoUri);
     const objectId = EID.getEntityId(echoUri);


### PR DESCRIPTION
## Summary

On first/cold load, navigating to an object frequently redirected to **not-found** even though the object existed locally (it would resolve fine after a reload). Root cause: the path resolvers conflated two concerns — *parse the path into an id* **and** *check local existence* — so a resolver only returned an id when the object was already loaded locally. `validateNavigationTarget` then required the **edge remote-existence** check to pass, which:

- **404'd local-only objects** (present locally but not on edge), and
- could **never rescue remote-only objects** (the resolver returned `none` before the remote check ran).

## Change

Split navigation resolution into three independent steps:

1. **Parse** — `NavigationPathResolver` now maps `path → id` *structurally only* (space id + object id), without validating the container path or checking existence. (Per-plugin resolvers are kept; space & inbox just parse now.)
2. **Local existence** — `checkLocalExistence` (`Database.loadOption`), checked first (cheap).
3. **Remote existence** — `checkRemoteExistence` (edge), checked only if not local.

`validateNavigationTarget` treats the target as valid if the object exists in **either** store (`local OR remote`), cheapest-first. A target is rendered **best-effort** whenever a valid id parses and the object exists somewhere — even if intermediate path segments (collection, feed, mailbox view) no longer describe where it lives.

Net effect:
- **Local existence alone is now sufficient** → fixes the cold-load 404 for local objects.
- **Remote existence is reachable** → rescues replication-pending objects as originally intended.

## Files

- `app-toolkit/src/not-found.ts` — `validateNavigationTarget` cascade + generalized `ExistenceChecker` (was `RemoteExistenceChecker`) + `checkLocalExistence` param.
- `plugin-space` / `plugin-inbox` `navigation-resolver.ts` — path resolvers reduced to structural parsing.
- `plugin-deck` / `plugin-simple-layout` `operations/open.ts` — construct `checkLocalExistence` (loadOption) alongside the edge checker.

## Verification

`moon run :build/:lint/:test` for the five affected packages — all green (app-toolkit 66, plugin-deck 45, plugin-space, plugin-inbox, plugin-simple-layout). No casts.

## Notes

- Message paths (`mailboxes/<id>/~<msgId>`) now resolve to the message id structurally; the previous feed/draft membership verification is intentionally dropped in favor of best-effort existence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Navigation validation system enhanced to support both local and remote existence checking, preferring local checks first.
  * Path resolution in navigation resolvers simplified to structural parsing; existence verification delegated to validation layer.
  * Navigation validation API updated with unified existence checker interface across plugins.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->