### PR TITLE
test(composer-app): repair e2e tests after exemplar-space and navtree changes

### DIFF
--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -259,10 +259,6 @@ export class AppManager {
 
   async createObject({ type, name, nth }: { type: string; name?: string; nth?: number }): Promise<void> {
     if (nth !== undefined) {
-      // The inline primary-action column was removed from navtree items; object actions now live
-      // in the actions dropdown menu, so reveal it on hover, open it, and select the create action.
-      // The actions testId is suffixed with the tree depth (`...actionsLevel${level}`), so match
-      // any level to support nested objects.
       const object = this.getObjectLinks().nth(nth);
       await object.hover();
       await object

--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -265,7 +265,10 @@ export class AppManager {
       // any level to support nested objects.
       const object = this.getObjectLinks().nth(nth);
       await object.hover();
-      await object.getByTestId(/navtree\.treeItem\.actionsLevel\d+/).first().click();
+      await object
+        .getByTestId(/navtree\.treeItem\.actionsLevel\d+/)
+        .first()
+        .click();
       await this.page.keyboard.press('ArrowDown');
       await this.page.getByTestId('spacePlugin.createObject').last().focus();
       await this.page.keyboard.press('Enter');

--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -21,8 +21,9 @@ const modifier = isMac ? 'Meta' : 'Control';
 
 export const INITIAL_URL = 'http://localhost:4173';
 
-// Personal space + exemplar space seeded on every new identity.
-export const INITIAL_SPACE_COUNT = 2;
+// Only the personal space is seeded on every new identity. The exemplar space is skipped on
+// localhost (see WelcomePlugin `generateExemplarSpace`), which is where e2e tests run.
+export const INITIAL_SPACE_COUNT = 1;
 
 export class AppManager {
   page!: Page;
@@ -258,9 +259,16 @@ export class AppManager {
 
   async createObject({ type, name, nth }: { type: string; name?: string; nth?: number }): Promise<void> {
     if (nth !== undefined) {
+      // The inline primary-action column was removed from navtree items; object actions now live
+      // in the actions dropdown menu, so reveal it on hover, open it, and select the create action.
+      // The actions testId is suffixed with the tree depth (`...actionsLevel${level}`), so match
+      // any level to support nested objects.
       const object = this.getObjectLinks().nth(nth);
       await object.hover();
-      await object.getByTestId('spacePlugin.createObject').click();
+      await object.getByTestId(/navtree\.treeItem\.actionsLevel\d+/).first().click();
+      await this.page.keyboard.press('ArrowDown');
+      await this.page.getByTestId('spacePlugin.createObject').last().focus();
+      await this.page.keyboard.press('Enter');
     } else {
       await this.currentWorkspace.getByTestId('spacePlugin.createObject').first().click();
     }

--- a/packages/apps/composer-app/src/playwright/halo.spec.ts
+++ b/packages/apps/composer-app/src/playwright/halo.spec.ts
@@ -39,7 +39,7 @@ test.describe('HALO tests', () => {
     await host.createSpace();
 
     await expect(host.getSpaceItems()).toHaveCount(INITIAL_SPACE_COUNT + 1);
-    // By the time host.createSpace() completes (>500ms), the exemplar has loaded on the guest too.
+    // The guest has only its own personal space until it joins the host's identity.
     await expect(guest.getSpaceItems()).toHaveCount(INITIAL_SPACE_COUNT);
 
     await host.openUserDevices();


### PR DESCRIPTION
## Problem

Composer e2e tests began failing on `main` this afternoon. `e2e` was green at `df45442` (17:29) and red immediately after. Bisecting from CI logs revealed **two independent regressions**:

1. **Space count** — [#11605](https://github.com/dxos/dxos/pull/11605) "skip exemplar space creation on localhost" (commit `5a93d4e`). E2e runs against `localhost:4173`, so the exemplar space is now skipped and a fresh identity has **1** seeded space, not 2. This broke the `basic` (create space, reset device) and `halo` (join new identity) count assertions.
2. **navtree create action** — [#11608](https://github.com/dxos/dxos/pull/11608) "remove primary action column from navtree items" (commit `d3fb65a`). An object's inline `spacePlugin.createObject` button is gone; per-item actions now live in the `…` dropdown menu. The `collections` tests (delete, deletion undo) hung waiting for the removed inline button.

Bisect confirmation from CI: at `5a93d4e`, `collections` still **passed** (only `basic`/`halo` failed); `collections` broke later (at/before `3c0dd46`) via the navtree refactor.

## Fix (test-only)

- `INITIAL_SPACE_COUNT` 2 → 1, with updated comments explaining the localhost exemplar-skip.
- `createObject({ nth })` now hovers the row, opens the actions dropdown (mirroring `deleteObject`), and selects the create action. The actions testId is suffixed with tree depth (`navtree.treeItem.actionsLevel${level}`), so a **level-agnostic** RegExp matcher is used — required because the deeper nested create in `deletion undo` lands at `actionsLevel3`, not `actionsLevel2`.
- Updated a stale exemplar-space comment in `halo.spec.ts`.

## Verification

Built the production preview and ran the affected specs locally (`DX_PWA=false`): `basic`, `halo`, and `collections` all pass on chromium (`collections` 5/5). Triggered the **Check** workflow with `e2e=true` to validate across all browsers in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object creation flow to use keyboard navigation in specific scenarios.

* **Chores**
  * Updated test infrastructure for space initialization.
  * Refined test setup configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->