### PR TITLE
fix(react-ui-list): truncate tree item titles to prevent navtree horizontal scroll

### DIFF
--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
@@ -95,7 +95,7 @@ const L1PanelContent = ({ path, item, onBack }: Pick<L1PanelProps, 'open' | 'pat
             path={path}
             levelOffset={5}
             draggable
-            gridTemplateColumns='[tree-row-start] 1fr min-content min-content [tree-row-end]'
+            gridTemplateColumns='[tree-row-start] minmax(0, 1fr) min-content min-content [tree-row-end]'
             renderColumns={NavTreeItemColumns}
             blockInstruction={navTreeContext.blockInstruction}
             canDrop={navTreeContext.canDrop}

--- a/packages/ui/react-ui-list/src/components/Tree/Tree.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/Tree.tsx
@@ -35,7 +35,7 @@ export const Tree = <T extends { id: string } = any>({
   path,
   id,
   draggable = false,
-  gridTemplateColumns = '[tree-row-start] 1fr min-content [tree-row-end]',
+  gridTemplateColumns = '[tree-row-start] minmax(0, 1fr) min-content [tree-row-end]',
   levelOffset,
   renderColumns,
   blockInstruction,

--- a/packages/ui/react-ui-list/src/components/Tree/TreeItemHeading.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/TreeItemHeading.tsx
@@ -61,7 +61,7 @@ export const TreeItemHeading = memo(
             data-testid='treeItem.heading'
             variant='ghost'
             classNames={[
-              'grow justify-start gap-2 ps-0.5 hover:bg-transparent dark:hover:bg-transparent',
+              'grow shrink min-w-0 justify-start gap-2 ps-0.5 hover:bg-transparent dark:hover:bg-transparent',
               'disabled:cursor-default disabled:opacity-100',
               className,
             ]}


### PR DESCRIPTION
## Summary

After badges were added to navtree items, long titles pushed rows past the sidebar viewport, causing **horizontal scrolling** instead of truncating. This fixes truncation so the title ellipsis-truncates while badges keep their width.

## Root cause

Two compounding issues — both required to fix it:

1. **Heading button could not shrink.** The `TreeItemHeading` `Button` inherits `flex-shrink: 0` from the `dx-button` base style, so even with its existing `truncate` class the button stayed at content width and overflowed its cell. Added `shrink min-w-0`.
2. **Grid track could not shrink.** The title column used `1fr` (= `minmax(auto, 1fr)`), whose auto-minimum equals the content width, so the track refused to shrink below the full title. Changed to `minmax(0, 1fr)` in both the shared `Tree` default and the navtree `L1Panel`.

## Changes

- `packages/ui/react-ui-list/src/components/Tree/TreeItemHeading.tsx` — add `shrink min-w-0` to the heading button (the primary root cause).
- `packages/ui/react-ui-list/src/components/Tree/Tree.tsx` — default `gridTemplateColumns` track `1fr` → `minmax(0, 1fr)`.
- `packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx` — navtree track `1fr` → `minmax(0, 1fr)`.

## Verification

Verified in Storybook (`ui/react-ui-list/Tree`) at a constrained 200px width with badges + long names. In-browser A/B measurement:

| Config | Horizontal overflow | Labels truncated |
| --- | --- | --- |
| `1fr` + button shrink | 135px | 0 / 84 |
| `minmax(0,1fr)` + button shrink | **0px** | **84 / 84** |

Lint + build pass for `react-ui-list` and `plugin-navtree`. No type casts introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tree component layout behavior to improve content display and prevent text overflow in navigation panels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->