### PR TITLE
fix(plugin-trip,plugin-inbox): dedupe trips by normalized PNR and gate extraction on AiService

### DIFF
--- a/packages/plugins/plugin-inbox/src/components/Message/useExtractorActions.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Message/useExtractorActions.tsx
@@ -10,6 +10,7 @@ import { log } from '@dxos/log';
 import { getSpace } from '@dxos/react-client/echo';
 import { type Message } from '@dxos/types';
 
+import { isAiServiceUnavailable } from '../../operations/extractor/ai-gate';
 import { InboxCapabilities, InboxOperation } from '../../types';
 
 export type ExtractorMenuItem = {
@@ -49,7 +50,18 @@ export const useExtractorActions = (message: Message.Message): ExtractorMenuItem
       }
       return invoker
         .invokePromise(InboxOperation.ExtractMessage, { db: space.db, source: message, extractorId })
-        .catch((err) => log.warn('extract message failed', { err, extractorId }));
+        .catch((err) => {
+          // Distinguish the startup race where the assistant plugin's `AiService` LayerSpec is not
+          // yet in the process-manager runtime: surface an actionable message instead of an opaque
+          // failure. Retrying once the assistant has loaded resolves it.
+          if (isAiServiceUnavailable(err)) {
+            log.warn('extract message skipped: AI service not ready — try again once the assistant has loaded', {
+              extractorId,
+            });
+          } else {
+            log.warn('extract message failed', { err, extractorId });
+          }
+        });
     };
 
     const perExtractor: ExtractorMenuItem[] = matching.map((extractor) => ({

--- a/packages/plugins/plugin-inbox/src/operations/extractor/ai-gate.test.ts
+++ b/packages/plugins/plugin-inbox/src/operations/extractor/ai-gate.test.ts
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { AiService } from '@dxos/ai';
+import { ServiceNotAvailableError } from '@dxos/compute';
+
+import { isAiServiceUnavailable } from './ai-gate';
+
+describe('isAiServiceUnavailable', () => {
+  test('true for a ServiceNotAvailableError naming the AiService tag (structured context)', ({ expect }) => {
+    const error = new ServiceNotAvailableError(AiService.AiService.key);
+    expect(isAiServiceUnavailable(error)).toBe(true);
+  });
+
+  test('true for an error whose message carries the AiService key (context lost across the boundary)', ({
+    expect,
+  }) => {
+    // The process-invocation boundary can flatten a structured error to a plain Error; the gate
+    // must still recognise it from the formatted message the LayerStack produces.
+    const error = new Error(
+      `ServiceNotAvailable: Service not available: ${AiService.AiService.key} (affinity=process) [space=<missing>]`,
+    );
+    expect(isAiServiceUnavailable(error)).toBe(true);
+  });
+
+  test('false for a ServiceNotAvailableError for a different service', ({ expect }) => {
+    const error = new ServiceNotAvailableError('@dxos/echo/Database');
+    expect(isAiServiceUnavailable(error)).toBe(false);
+  });
+
+  test('false for an unrelated error', ({ expect }) => {
+    expect(isAiServiceUnavailable(new Error('boom'))).toBe(false);
+  });
+
+  test('false for non-error values', ({ expect }) => {
+    expect(isAiServiceUnavailable(undefined)).toBe(false);
+    expect(isAiServiceUnavailable('nope')).toBe(false);
+  });
+});

--- a/packages/plugins/plugin-inbox/src/operations/extractor/ai-gate.test.ts
+++ b/packages/plugins/plugin-inbox/src/operations/extractor/ai-gate.test.ts
@@ -15,9 +15,7 @@ describe('isAiServiceUnavailable', () => {
     expect(isAiServiceUnavailable(error)).toBe(true);
   });
 
-  test('true for an error whose message carries the AiService key (context lost across the boundary)', ({
-    expect,
-  }) => {
+  test('true for an error whose message carries the AiService key (context lost across the boundary)', ({ expect }) => {
     // The process-invocation boundary can flatten a structured error to a plain Error; the gate
     // must still recognise it from the formatted message the LayerStack produces.
     const error = new Error(
@@ -38,5 +36,11 @@ describe('isAiServiceUnavailable', () => {
   test('false for non-error values', ({ expect }) => {
     expect(isAiServiceUnavailable(undefined)).toBe(false);
     expect(isAiServiceUnavailable('nope')).toBe(false);
+  });
+
+  test('does not throw when context is null', ({ expect }) => {
+    // The predicate runs inside catch handlers — a deref on a null `context` would convert the
+    // intended soft skip into an unhandled failure.
+    expect(isAiServiceUnavailable({ context: null, message: 'unrelated' })).toBe(false);
   });
 });

--- a/packages/plugins/plugin-inbox/src/operations/extractor/ai-gate.ts
+++ b/packages/plugins/plugin-inbox/src/operations/extractor/ai-gate.ts
@@ -1,0 +1,32 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { AiService } from '@dxos/ai';
+
+/**
+ * Recognise a failure caused by `@dxos/ai/AiService` being absent from the process-manager
+ * `LayerStack`. The extract operations declare `AiService` in their `services`, so the process
+ * invoker resolves it eagerly at spawn time; if the assistant plugin's `AiService` `LayerSpec`
+ * was not contributed before the runtime built its stack, the spawn dies with a
+ * `ServiceNotAvailableError` naming the tag — before the handler ever runs.
+ *
+ * The check is intentionally lenient: it matches the structured `context.service` field
+ * (`ServiceNotAvailableError`) and falls back to the formatted message, since the structured error
+ * can be flattened to a plain `Error` as it crosses the operation-invocation boundary.
+ */
+export const isAiServiceUnavailable = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const key = AiService.AiService.key;
+
+  const context = (error as { context?: { service?: unknown } }).context;
+  if (context !== undefined && context.service === key) {
+    return true;
+  }
+
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' && message.includes(key);
+};

--- a/packages/plugins/plugin-inbox/src/operations/extractor/ai-gate.ts
+++ b/packages/plugins/plugin-inbox/src/operations/extractor/ai-gate.ts
@@ -22,8 +22,8 @@ export const isAiServiceUnavailable = (error: unknown): boolean => {
 
   const key = AiService.AiService.key;
 
-  const context = (error as { context?: { service?: unknown } }).context;
-  if (context !== undefined && context.service === key) {
+  const context = (error as { context?: { service?: unknown } | null }).context;
+  if (context != null && typeof context === 'object' && context.service === key) {
     return true;
   }
 

--- a/packages/plugins/plugin-inbox/src/operations/google/gmail/sync.ts
+++ b/packages/plugins/plugin-inbox/src/operations/google/gmail/sync.ts
@@ -25,6 +25,7 @@ import { Message } from '@dxos/types';
 import { GoogleMail } from '../../../apis';
 import { InboxResolver, GoogleCredentials } from '../../../services';
 import { InboxCapabilities, InboxOperation, Mailbox } from '../../../types';
+import { isAiServiceUnavailable } from '../../extractor/ai-gate';
 import { mapMessage } from './mapper';
 
 type DateChunk = {
@@ -362,7 +363,15 @@ const streamGmailMessagesToFeed = Effect.fn(function* (
                   extractorId: best.extractor.id,
                 }).pipe(
                   Effect.catchAll((err) => {
-                    log.warn('auto-on-arrival extract failed', { err, messageId: message.id });
+                    // The AI service can be momentarily absent from the process-manager LayerStack
+                    // during startup (the assistant plugin's `AiService` LayerSpec races the
+                    // runtime build). Treat that as a deferrable skip — a later sync (or app load,
+                    // once the stack carries the spec) re-attempts — rather than a hard failure.
+                    if (isAiServiceUnavailable(err)) {
+                      log.info('auto-on-arrival extract skipped: AI service not ready', { messageId: message.id });
+                    } else {
+                      log.warn('auto-on-arrival extract failed', { err, messageId: message.id });
+                    }
                     return Effect.void;
                   }),
                 );

--- a/packages/plugins/plugin-trip/src/operations/extractor/trip-extractor.test.ts
+++ b/packages/plugins/plugin-trip/src/operations/extractor/trip-extractor.test.ts
@@ -68,6 +68,18 @@ const SECOND_LEG_PAYLOAD = {
   confirmationCode: 'ABC123',
 };
 
+// The SAME booking as UNITED_PAYLOAD, but a second email's LLM pass returns the PNR with
+// different casing/whitespace ("abc 123" vs "ABC123"). Two related emails for one booking must
+// still resolve to a single Trip — the confirmation-code dedup has to be representation-insensitive.
+const SECOND_LEG_PNR_VARIANT_PAYLOAD = {
+  number: 'AF-9',
+  origin: { code: 'JFK', name: 'New York' },
+  destination: { code: 'LAX', name: 'Los Angeles' },
+  departAt: '2026-06-10T12:00:00.000Z',
+  arriveAt: '2026-06-10T15:00:00.000Z',
+  confirmationCode: 'abc 123',
+};
+
 describe('TripMessageExtractor', () => {
   let builder: EchoTestBuilder;
   let db: EchoDatabase;
@@ -245,6 +257,33 @@ describe('TripMessageExtractor', () => {
     // The Trip date range widens to cover the appended leg (depart 2026-06-01, arrive 2026-06-10).
     expect(trips[0].start).toBe('2026-06-01T15:30:00.000Z');
     expect(trips[0].end).toBe('2026-06-10T15:00:00.000Z');
+  });
+
+  test('extract — a second email whose PNR differs only in case/whitespace appends to the same Trip', async ({
+    expect,
+  }) => {
+    // Email 1 creates a Trip under PNR "ABC123"; persist it.
+    const first = await extract(unitedConfirmationRaw, UNITED_PAYLOAD);
+    for (const obj of first.created) {
+      db.add(obj);
+    }
+    await db.flush();
+    const trip = first.created.find((obj) => Obj.instanceOf(Trip.Trip, obj)) as Trip.Trip;
+
+    // Email 2: the SAME booking, but the LLM returned the PNR as "abc 123". This is one booking
+    // across two emails — it must append to the existing Trip, not spawn a duplicate.
+    const second = await extract(unitedConfirmationRaw, SECOND_LEG_PNR_VARIANT_PAYLOAD);
+    expect(second.created.some((obj) => Obj.instanceOf(Trip.Trip, obj))).toBe(false);
+    expect(second.updated).toHaveLength(1);
+    expect((second.updated![0] as Trip.Trip).id).toBe(trip.id);
+
+    for (const obj of second.created) {
+      db.add(obj);
+    }
+    await db.flush();
+    const trips = await db.query(Filter.type(Trip.Trip)).run();
+    expect(trips).toHaveLength(1);
+    expect(trips[0].segments).toHaveLength(2);
   });
 });
 

--- a/packages/plugins/plugin-trip/src/operations/extractor/trip-extractor.ts
+++ b/packages/plugins/plugin-trip/src/operations/extractor/trip-extractor.ts
@@ -124,6 +124,14 @@ const findExistingFlight = (
 };
 
 /**
+ * Normalise a confirmation code (PNR) for comparison. Airline record locators are case-insensitive
+ * alphanumerics; an LLM pass over a second email may return the same code with different casing or
+ * stray whitespace (e.g. "abc 123" vs "ABC123"). Comparing the normalised form keeps two emails for
+ * one booking on a single Trip instead of spawning a duplicate.
+ */
+const normalizeConfirmationCode = (code: string): string => code.replace(/\s+/g, '').toUpperCase();
+
+/**
  * Find an existing Booking with this confirmation code (PNR). Flights booked under one
  * reservation share a code, so a follow-up segment attaches to that Booking's Trip rather than
  * spawning a new one. The Booking is parented to its Trip via `Obj.setParent`.
@@ -135,8 +143,14 @@ const findExistingBookingByConfirmation = (
   if (!confirmationCode) {
     return Effect.succeed(undefined);
   }
+  const normalized = normalizeConfirmationCode(confirmationCode);
   return Effect.promise(() => db.query(Filter.type(Booking.Booking)).run()).pipe(
-    Effect.map((bookings) => bookings.find((booking) => booking.confirmationCode === confirmationCode)),
+    Effect.map((bookings) =>
+      bookings.find(
+        (booking) =>
+          booking.confirmationCode !== undefined && normalizeConfirmationCode(booking.confirmationCode) === normalized,
+      ),
+    ),
     Effect.catchAllDefect(() => Effect.succeed(undefined)),
   );
 };


### PR DESCRIPTION
## Summary

Fixes two bugs in plugin-trip's message extraction (surfaced via the inbox extract dispatcher).

### Bug 1 — duplicate Trip for the same booking
Two related emails for one booking spawned **separate Trips** when the LLM returned the PNR with different casing/whitespace (e.g. `abc 123` vs `ABC123`). The same-booking dedup (`findExistingBookingByConfirmation`) compared the confirmation code with exact, case/whitespace-sensitive `===`.

**Fix:** normalize the PNR (strip whitespace + uppercase) on both sides of the lookup so two emails for one booking resolve to a single Trip.

### Bug 2 — `ServiceNotAvailable: @dxos/ai/AiService`
Extraction intermittently failed with a cryptic `operation invocation failed` whose cause was `ServiceNotAvailable: @dxos/ai/AiService (affinity=process) [space=<missing>]`.

Root cause: the process-manager runtime collects `LayerSpec`s **once** (`Capability.getAll` → `new LayerStack(...)` → `ManagedRuntime.make`) and is never rebuilt. An extraction spawned before the assistant plugin's `AiService` `LayerSpec` is contributed dies at service resolution — before the handler runs. Intermittent because it depends on plugin load/activation ordering.

**Fix (gate):** `isAiServiceUnavailable` recognises this failure (structured `context.service`, with a flattened-message fallback). Both call sites — auto-on-arrival sync and the manual extractor menu — now fail soft: a deferrable skip with an actionable log instead of an opaque failure.

> **Limitation / follow-up:** because the stack is built once, the gate turns the crash into a clean outcome and lets auto-sync retry on a *later app load*, but it does **not** make extraction succeed within a session that lost the boot race. The durable fix is activation-ordering or reactive `LayerSpec` collection in the process-manager runtime — intentionally out of scope here.

## Tests
- `trip-extractor.test.ts`: new failing→passing test for PNR case/whitespace dedup (21 pass).
- `ai-gate.test.ts`: 5 tests for the `isAiServiceUnavailable` predicate (structured + flattened error, negatives).
- Full plugin-inbox (55 pass / 13 skip) and plugin-trip suites green; lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clearer guidance when AI service is unavailable during message extraction, prompting retry once the assistant is ready.
  * Improved confirmation-code normalization so matching ignores casing and whitespace.

* **Bug Fixes**
  * Prevented duplicate travel bookings caused by formatting variations in confirmation codes.

* **Tests**
  * Added tests for AI-service availability detection and for deduplication of confirmation codes across variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->