### PR TITLE
ci: simplify composer preview comment to only show pr-XXXX url

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -70,9 +70,4 @@ jobs:
           number: ${{ steps.meta.outputs.pr_number }}
           header: composer-preview
           message: |
-            ### Composer preview
-
-            - Branch alias: ${{ steps.deploy.outputs.alias }}
-            - Deployment: ${{ steps.deploy.outputs.url }}
-
-            Built from ${{ steps.meta.outputs.head_sha }}.
+            ${{ steps.deploy.outputs.alias }}


### PR DESCRIPTION
## Summary

Updates the sticky `composer-preview` comment posted by `preview-deploy.yml` to print **only** the `pr-XXXX` branch-alias URL, instead of the previous multi-line block (heading, branch alias, deployment URL, and built-from SHA).

### Before

```
### Composer preview

- Branch alias: https://pr-11599.composer-app.pages.dev
- Deployment: https://3b321576.composer-app.pages.dev

Built from 0280b5c.
```

### After

```
https://pr-11599.composer-app.pages.dev
```

The stable `pr-XXXX` alias always points at the latest deployment for the PR, so the per-deployment URL and SHA are redundant for the common case.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sz7TguYVPVH7kEBfREhNEw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined preview deployment notifications in pull requests to display only the essential deployment alias, removing detailed deployment metadata to reduce notification clutter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->