### PR TITLE
refactor: migrate invariant type assertions to assertArgument

### DIFF
--- a/packages/common/keys/src/public-key.ts
+++ b/packages/common/keys/src/public-key.ts
@@ -14,7 +14,7 @@ import {
   inspectCustom,
   truncateKey,
 } from '@dxos/debug';
-import { invariant } from '@dxos/invariant';
+import { assertArgument, invariant } from '@dxos/invariant';
 
 import { randomBytes } from './random-bytes';
 
@@ -149,7 +149,7 @@ export class PublicKey implements Equatable {
    * @deprecated All keys should be represented as instances of PublicKey.
    */
   static bufferize(str: string): Buffer {
-    invariant(typeof str === 'string', 'Invalid type');
+    assertArgument(typeof str === 'string', 'str', 'Invalid type');
     const buffer = Buffer.from(str, 'hex');
     // invariant(buffer.length === PUBLIC_KEY_LENGTH || buffer.length === SECRET_KEY_LENGTH,
     //   `Invalid key length: ${buffer.length}`);

--- a/packages/common/protobuf-compiler/src/module-specifier.ts
+++ b/packages/common/protobuf-compiler/src/module-specifier.ts
@@ -5,7 +5,7 @@
 import { createRequire } from 'node:module';
 import { isAbsolute, relative, resolve } from 'path';
 
-import { invariant } from '@dxos/invariant';
+import { assertArgument } from '@dxos/invariant';
 
 const require = createRequire(import.meta.url);
 
@@ -26,7 +26,7 @@ export class ModuleSpecifier {
     public readonly name: string,
     public readonly contextPath: string,
   ) {
-    invariant(isAbsolute(contextPath));
+    assertArgument(isAbsolute(contextPath), 'contextPath');
   }
 
   isAbsolute(): boolean {

--- a/packages/common/protobuf-compiler/src/module-specifier.ts
+++ b/packages/common/protobuf-compiler/src/module-specifier.ts
@@ -26,7 +26,7 @@ export class ModuleSpecifier {
     public readonly name: string,
     public readonly contextPath: string,
   ) {
-    assertArgument(isAbsolute(contextPath), 'contextPath');
+    assertArgument(isAbsolute(contextPath), 'contextPath', 'must be an absolute path');
   }
 
   isAbsolute(): boolean {

--- a/packages/core/compute/compute/src/Template.ts
+++ b/packages/core/compute/compute/src/Template.ts
@@ -9,7 +9,7 @@ import * as Schema from 'effect/Schema';
 
 import { Database, Ref } from '@dxos/echo';
 import type { EntityNotFoundError } from '@dxos/echo/Err';
-import { invariant } from '@dxos/invariant';
+import { assertArgument, invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 import { Text } from '@dxos/schema';
 import Handlebars from '@dxos/vendor-kbn-handlebars';
@@ -75,7 +75,7 @@ export const make = ({ id, source, inputs = [] }: MakeProps = {}): Template => (
  * Process Handlebars template.
  */
 export const process = <Options extends {}>(source: string, variables: Partial<Options> = {}): string => {
-  invariant(typeof source === 'string');
+  assertArgument(typeof source === 'string', 'source');
   let section = 0;
   const handlebars = Handlebars.create();
   handlebars.registerHelper('section', () => String(++section));

--- a/packages/core/echo/echo-db/src/core-db/object-core.ts
+++ b/packages/core/echo/echo-db/src/core-db/object-core.ts
@@ -16,7 +16,7 @@ import {
 } from '@dxos/echo-protocol';
 import { EntityKind, type EntityMeta } from '@dxos/echo/internal';
 import { isProxy } from '@dxos/echo/internal';
-import { invariant } from '@dxos/invariant';
+import { assertArgument, invariant } from '@dxos/invariant';
 import { DXN, EID, EntityId, SpaceId, type URI } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { defer, getDeep, setDeep, throwUnhandledError } from '@dxos/util';
@@ -199,7 +199,7 @@ export class ObjectCore {
   }
 
   getDocAccessor(path: KeyPath = []): DocAccessor {
-    invariant(isValidKeyPath(path));
+    assertArgument(isValidKeyPath(path), 'path');
     const self = this;
     return {
       handle: {

--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.ts
@@ -1350,7 +1350,7 @@ const metaNotEmpty = (meta: EntityMeta) =>
  */
 // TODO(burdon): Call and remove subscriptions.
 export const destroyObject = <T extends Obj.Unknown>(proxy: T) => {
-  invariant(isEchoObject(proxy));
+  assertArgument(isEchoObject(proxy), 'proxy');
   const target: ProxyTarget = getProxyTarget(proxy);
   const internals: ObjectInternals = target[symbolInternals];
   for (const unsubscribe of internals.subscriptions) {

--- a/packages/core/echo/echo-db/src/proxy-db/database.ts
+++ b/packages/core/echo/echo-db/src/proxy-db/database.ts
@@ -26,7 +26,7 @@ import {
   setRefResolver,
 } from '@dxos/echo/internal';
 import { getProxyTarget, isProxy } from '@dxos/echo/internal';
-import { invariant } from '@dxos/invariant';
+import { assertArgument, invariant } from '@dxos/invariant';
 import { type PublicKey, type SpaceId, type URI } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { type QueryService } from '@dxos/protocols/proto/dxos/echo/query';
@@ -441,7 +441,7 @@ export class EchoDatabaseImpl extends Resource implements EchoDatabase {
    * Remove reactive object.
    */
   remove<T extends Entity.Unknown = Entity.Unknown>(obj: T): void {
-    invariant(isEchoObject(obj));
+    assertArgument(isEchoObject(obj), 'obj');
     return this._coreDatabase.removeCore(getObjectCore(obj));
   }
 

--- a/packages/core/echo/echo-db/src/text.ts
+++ b/packages/core/echo/echo-db/src/text.ts
@@ -6,7 +6,7 @@ import { next as A } from '@automerge/automerge';
 
 import { type Obj } from '@dxos/echo';
 import { isProxy } from '@dxos/echo/internal';
-import { invariant } from '@dxos/invariant';
+import { assertArgument, invariant } from '@dxos/invariant';
 import { getDeep } from '@dxos/util';
 
 import { type DocAccessor, type KeyPath, isValidKeyPath } from './core-db';
@@ -87,7 +87,7 @@ export const getRangeFromCursor = (accessor: DocAccessor, cursor: string) => {
  * @returns The updated object.
  */
 export const updateText = <T extends Obj.Unknown>(obj: T, path: KeyPath, newText: string): T => {
-  invariant(isProxy(obj));
+  assertArgument(isProxy(obj), 'obj');
   invariant(path === undefined || isValidKeyPath(path));
   const accessor = createDocAccessor(obj, path);
   accessor.handle.change((doc) => {

--- a/packages/core/echo/echo/src/Type.ts
+++ b/packages/core/echo/echo/src/Type.ts
@@ -9,7 +9,7 @@ import type * as Types from 'effect/Types';
 
 import { raise } from '@dxos/debug';
 import { type EncodedReference } from '@dxos/echo-protocol';
-import { invariant } from '@dxos/invariant';
+import { assertArgument, invariant } from '@dxos/invariant';
 import { DXN, EID, type EntityId, type URI } from '@dxos/keys';
 
 import type * as Database from './Database';
@@ -342,19 +342,19 @@ export const isTypeKind = (entity: AnyEntity): entity is Type => {
  * `Filter.type`, or other object-only APIs.
  */
 export const assertObject = (entity: AnyEntity): AnyObj => {
-  invariant(isObject(entity), 'Expected an object-kind Type entity.');
+  assertArgument(isObject(entity), 'entity', 'Expected an object-kind Type entity.');
   return entity;
 };
 
 /** Narrow a `Type.AnyEntity` to `AnyRelation`, throwing otherwise. */
 export const expectRelation = (entity: AnyEntity): AnyRelation => {
-  invariant(isRelation(entity), 'Expected a relation-kind Type entity.');
+  assertArgument(isRelation(entity), 'entity', 'Expected a relation-kind Type entity.');
   return entity;
 };
 
 /** Narrow a `Type.AnyEntity` to the `Type.Type` meta-schema, throwing otherwise. */
 export const expectTypeKind = (entity: AnyEntity): Type => {
-  invariant(isTypeKind(entity), 'Expected a type-kind Type entity.');
+  assertArgument(isTypeKind(entity), 'entity', 'Expected a type-kind Type entity.');
   return entity;
 };
 
@@ -538,7 +538,7 @@ export function getMeta(entity: AnyEntity | internal.Mutable<AnyEntity> | Mutabl
   // The `Mutable` overload accepts the narrowed view passed to `Type.update`
   // callbacks; at runtime that draft IS the underlying persisted Type entity,
   // so the same `MetaId` lookup works.
-  invariant(isType(entity), 'Expected a Type entity.');
+  assertArgument(isType(entity), 'entity', 'Expected a Type entity.');
   // Both persisted and in-memory type entities carry runtime `EntityMeta` via
   // `[MetaId]`, so the lookup is uniform.
   return internal.getMetaChecked(entity);
@@ -623,7 +623,7 @@ export function getSchema(type: AnyEntity): Schema.Schema.AnyNoContext {
   if (staticSchema != null) {
     return staticSchema;
   }
-  invariant(isType(type), 'Expected a Type entity.');
+  assertArgument(isType(type), 'type', 'Expected a Type entity.');
   // Persisted `Type.Type` entity — build the Effect Schema from its stored
   // jsonSchema and re-attach the TypeIdentifierAnnotation so the rebuilt
   // schema's URI (via getSchemaURI) matches the entity's local EID.

--- a/packages/core/echo/echo/src/internal/Annotation/annotations.ts
+++ b/packages/core/echo/echo/src/internal/Annotation/annotations.ts
@@ -190,7 +190,7 @@ export const getTypename = (obj: AnyProperties): string | undefined => {
  */
 // TODO(dmaretskyi): Rename setTypeDXN.
 export const setTypename = (obj: any, typename: URI.URI): void => {
-  invariant(typeof typename === 'string', 'Invalid type.');
+  assertArgument(typeof typename === 'string', 'typename', 'Invalid type.');
   Object.defineProperty(obj, TypeId, {
     value: typename,
     writable: false,

--- a/packages/core/echo/echo/src/internal/common/proxy/typed-handler.ts
+++ b/packages/core/echo/echo/src/internal/common/proxy/typed-handler.ts
@@ -8,7 +8,7 @@ import { type InspectOptionsStylized } from 'node:util';
 
 import { Event } from '@dxos/async';
 import { inspectCustom } from '@dxos/debug';
-import { invariant } from '@dxos/invariant';
+import { assertArgument, invariant } from '@dxos/invariant';
 
 import { getSchemaURI } from '../../Annotation';
 import { toEffectSchema } from '../../JsonSchema/json-schema';
@@ -143,7 +143,7 @@ export class TypedReactiveHandler implements ReactiveHandler<ProxyTarget> {
   private constructor() {}
 
   init(target: ProxyTarget): void {
-    invariant(typeof target === 'object' && target !== null);
+    assertArgument(typeof target === 'object' && target !== null, 'target');
     invariant(SchemaId in target, 'Schema is not defined for the target');
 
     // Only set EventId on root objects (those without an owner).

--- a/packages/core/mesh/network-manager/src/network-manager.ts
+++ b/packages/core/mesh/network-manager/src/network-manager.ts
@@ -159,10 +159,10 @@ export class SwarmNetworkManager {
       label,
     }: SwarmOptions,
   ): Promise<SwarmConnection> {
-    invariant(PublicKey.isPublicKey(topic));
+    assertArgument(PublicKey.isPublicKey(topic), 'topic');
     invariant(topology);
     invariant(this._peerInfo);
-    assertArgument(typeof protocol === 'function', 'protocol');
+    assertArgument(typeof protocol === 'function', 'protocolProvider');
     if (this._swarms.has(topic)) {
       throw new Error(`Already connected to swarm: ${PublicKey.from(topic)}`);
     }

--- a/packages/core/mesh/network-manager/src/network-manager.ts
+++ b/packages/core/mesh/network-manager/src/network-manager.ts
@@ -4,7 +4,7 @@
 
 import { Event, synchronized } from '@dxos/async';
 import { Context } from '@dxos/context';
-import { invariant } from '@dxos/invariant';
+import { assertArgument, invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { Messenger, type PeerInfo, type SignalManager } from '@dxos/messaging';
@@ -162,7 +162,7 @@ export class SwarmNetworkManager {
     invariant(PublicKey.isPublicKey(topic));
     invariant(topology);
     invariant(this._peerInfo);
-    invariant(typeof protocol === 'function');
+    assertArgument(typeof protocol === 'function', 'protocol');
     if (this._swarms.has(topic)) {
       throw new Error(`Already connected to swarm: ${PublicKey.from(topic)}`);
     }

--- a/packages/core/mesh/teleport/src/teleport.ts
+++ b/packages/core/mesh/teleport/src/teleport.ts
@@ -7,7 +7,7 @@ import { type Duplex } from 'node:stream';
 import { type Event, runInContextAsync, scheduleTask, synchronized } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { failUndefined } from '@dxos/debug';
-import { invariant } from '@dxos/invariant';
+import { assertArgument, invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { log, logInfo } from '@dxos/log';
 import { RpcClosedError, TimeoutError } from '@dxos/protocols';
@@ -60,9 +60,9 @@ export class Teleport {
   }
 
   constructor({ initiator, localPeerId, remotePeerId, ...rest }: TeleportProps) {
-    invariant(typeof initiator === 'boolean');
-    invariant(PublicKey.isPublicKey(localPeerId));
-    invariant(PublicKey.isPublicKey(remotePeerId));
+    assertArgument(typeof initiator === 'boolean', 'initiator');
+    assertArgument(PublicKey.isPublicKey(localPeerId), 'localPeerId');
+    assertArgument(PublicKey.isPublicKey(remotePeerId), 'remotePeerId');
     this.initiator = initiator;
     this.localPeerId = localPeerId;
     this.remotePeerId = remotePeerId;

--- a/packages/plugins/plugin-sheet/src/model/sheet-model.ts
+++ b/packages/plugins/plugin-sheet/src/model/sheet-model.ts
@@ -24,7 +24,7 @@ import {
 import { Resource } from '@dxos/context';
 import { Obj } from '@dxos/echo';
 import { Format, TypeEnum } from '@dxos/echo/internal';
-import { invariant } from '@dxos/invariant';
+import { assertArgument, invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 
@@ -489,7 +489,7 @@ export class SheetModel extends Resource {
    * Map from indices to A1 notation.
    */
   mapFormulaIndicesToRefs(formula: string): string {
-    invariant(isFormula(formula));
+    assertArgument(isFormula(formula), 'formula');
     return formula.replace(/([a-zA-Z0-9]+)@([a-zA-Z0-9]+)/g, (idx) => {
       return addressToA1Notation(addressFromIndex(this._sheet, idx));
     });

--- a/packages/plugins/plugin-sheet/src/types/util.ts
+++ b/packages/plugins/plugin-sheet/src/types/util.ts
@@ -12,7 +12,7 @@ import {
 } from '@dxos/compute-hyperformula';
 import { randomBytes } from '@dxos/crypto';
 import { type Obj } from '@dxos/echo';
-import { invariant } from '@dxos/invariant';
+import { assertArgument } from '@dxos/invariant';
 
 import { type Sheet } from '../types';
 
@@ -122,7 +122,7 @@ export const compareIndexPositions = (sheet: Sheet.Sheet, indexA: string, indexB
  * Map from A1 notation to indices.
  */
 export const mapFormulaRefsToIndices = (sheet: Sheet.Sheet, formula: string): string => {
-  invariant(isFormula(formula));
+  assertArgument(isFormula(formula), 'formula');
   return formula.replace(/([a-zA-Z]+)([0-9]+)/g, (match) => {
     return addressToIndex(sheet, addressFromA1Notation(match));
   });
@@ -132,7 +132,7 @@ export const mapFormulaRefsToIndices = (sheet: Sheet.Sheet, formula: string): st
  * Map from indices to A1 notation.
  */
 export const mapFormulaIndicesToRefs = (sheet: Sheet.Sheet, formula: string): string => {
-  invariant(isFormula(formula));
+  assertArgument(isFormula(formula), 'formula');
   return formula.replace(/([a-zA-Z0-9]+)@([a-zA-Z0-9]+)/g, (idx) => {
     return addressToA1Notation(addressFromIndex(sheet, idx));
   });


### PR DESCRIPTION
## Summary

- Replaces `invariant(isXxx(arg), 'message')` with `assertArgument(isXxx(arg), 'arg', 'message')` across 14 files where `invariant` was being used to validate the type of a function argument
- `assertArgument` throws a `TypeError: Invalid argument \`arg\`: message` which better communicates *caller* errors vs. internal invariant violations
- Only migrates direct argument checks — internal state checks, protocol decoding, and derived-variable checks are left as `invariant`

## Files changed

- `Type.ts` — `assertObject`, `expectRelation`, `expectTypeKind`, `getMeta`, `getSchema`
- `database.ts` — `EchoDatabaseImpl.remove`
- `echo-handler.ts` — `destroyObject`
- `annotations.ts` — `setTypename`
- `public-key.ts` — `PublicKey.bufferize`
- `module-specifier.ts` — `ModuleSpecifier` constructor
- `object-core.ts` — `ObjectCore.getDocAccessor`
- `text.ts` — `updateText`
- `typed-handler.ts` — `TypedReactiveHandler.init`
- `teleport.ts` — `Teleport` constructor (3 params)
- `network-manager.ts` — `SwarmNetworkManager.join`
- `sheet-model.ts` — `SheetModel.mapFormulaIndicesToRefs`
- `util.ts` (plugin-sheet) — `mapFormulaRefsToIndices`, `mapFormulaIndicesToRefs`
- `Template.ts` — `process`

https://claude.ai/code/session_0191x9Zwv78h3ruWadsnnJKb

---
_Generated by [Claude Code](https://claude.ai/code/session_0191x9Zwv78h3ruWadsnnJKb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized runtime argument validation across core modules and plugins by replacing older assertion calls with a unified argument-assertion utility.  
  * No public APIs or behaviors changed; backward compatible and transparent to end users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->