### PR TITLE
fix(protocols)!: reserve Invitation.Kind.INVALID=0 so DEVICE survives encode

### DIFF
--- a/packages/core/protocols/src/proto/dxos/client/invitation.proto
+++ b/packages/core/protocols/src/proto/dxos/client/invitation.proto
@@ -85,8 +85,12 @@ message Invitation {
   }
 
   enum Kind {
-    DEVICE = 0;
-    SPACE = 1;
+    /// Unset / unknown. Must not be used for new invitations.
+    INVALID = 0;
+
+    DEVICE = 1;
+
+    SPACE = 2;
   }
 
   enum AuthMethod {

--- a/packages/sdk/client-protocol/src/invitations/encoder.test.ts
+++ b/packages/sdk/client-protocol/src/invitations/encoder.test.ts
@@ -58,4 +58,20 @@ describe('Invitation utils', () => {
     expect(decoded.identityKey).to.not.exist;
     expect(decoded).to.deep.eq(invitation);
   });
+
+  test('encodes and decodes a device invitation', () => {
+    const invitation: Invitation = {
+      invitationId: PublicKey.random().toHex(),
+      type: Invitation.Type.INTERACTIVE,
+      kind: Invitation.Kind.DEVICE,
+      authMethod: Invitation.AuthMethod.NONE,
+      state: Invitation.State.INIT,
+      swarmKey: PublicKey.random(),
+      created: CREATED,
+      lifetime: 86400,
+    };
+    const encoded = InvitationEncoder.encode(invitation);
+    const decoded = InvitationEncoder.decode(encoded);
+    expect(decoded).to.deep.eq(invitation);
+  });
 });


### PR DESCRIPTION
## Summary

- Add `Invitation.Kind.INVALID = 0` and renumber `DEVICE = 1`, `SPACE = 2` so proto3 encode/decode round-trips preserve device invitation kind (previously `DEVICE = 0` was omitted on the wire).
- Add encoder test covering device invitation encode/decode round-trip.

## Motivation

Edge `client-invitations.node.test.ts` device cases hang at 30s: `performInvitation` → `sanitizeInvitation` → `InvitationEncoder` drops `kind` when it is enum value 0, guest accept throws `Unknown invitation kind: undefined`, and completion triggers never fire.

## Breaking change

Wire/persistence shape for invitation codes changes: old codes with omitted/`0` kind meant DEVICE; new codes use `1` for DEVICE and `2` for SPACE. No migration layer (per design decision).

## Test plan

- [x] `moon run client-protocol:test -- packages/sdk/client-protocol/src/invitations/encoder.test.ts`
- [x] `moon run client-services:test -- packages/sdk/client-services/src/packlets/invitations/device-invitation-protocol.test.ts`
- [ ] Edge linked locally: `client-invitations.node.test.ts` device cases


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated invitation protocol definitions by adjusting invitation-kind numeric assignments.

* **Tests**
  * Added test coverage ensuring invitation encoding/decoding preserves data integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->