### PR TITLE
feat(echo): add QueryResultEffect API for Database.query

### DIFF
--- a/packages/core/echo/echo-db/src/query/query-effect.test.ts
+++ b/packages/core/echo/echo-db/src/query/query-effect.test.ts
@@ -1,0 +1,91 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
+import { describe, test } from 'vitest';
+
+import { Event } from '@dxos/async';
+import { Database, Filter, Obj, Query } from '@dxos/echo';
+import { TestSchema } from '@dxos/echo/testing';
+import { runAndForwardErrors } from '@dxos/effect';
+
+import { TestDatabaseLayer } from '../testing';
+
+const TestLayer = TestDatabaseLayer({ types: [TestSchema.Person] });
+
+describe('Database.query (Effect API)', () => {
+  test('run returns matching objects', async ({ expect }) => {
+    await Effect.gen(function* () {
+      const alice = Obj.make(TestSchema.Person, { name: 'alice' });
+      const bob = Obj.make(TestSchema.Person, { name: 'bob' });
+      yield* Database.add(alice);
+      yield* Database.add(bob);
+      yield* Database.flush();
+
+      const results = yield* Database.query(Filter.type(TestSchema.Person)).run;
+      expect(results).toHaveLength(2);
+      expect(results.map((person) => person.name).sort()).toEqual(['alice', 'bob']);
+    }).pipe(Effect.provide(TestLayer), runAndForwardErrors);
+  });
+
+  test('run accepts Query AST', async ({ expect }) => {
+    await Effect.gen(function* () {
+      yield* Database.add(Obj.make(TestSchema.Person, { name: 'alice' }));
+      yield* Database.flush();
+
+      const results = yield* Database.query(Query.select(Filter.type(TestSchema.Person, { name: 'alice' }))).run;
+      expect(results).toHaveLength(1);
+      expect(results[0]?.name).toBe('alice');
+    }).pipe(Effect.provide(TestLayer), runAndForwardErrors);
+  });
+
+  test('first returns Option', async ({ expect }) => {
+    await Effect.gen(function* () {
+      const alice = Obj.make(TestSchema.Person, { name: 'alice' });
+      yield* Database.add(alice);
+      yield* Database.flush();
+
+      const first = yield* Database.query(Filter.type(TestSchema.Person, { name: 'alice' })).first;
+      expect(Option.isSome(first)).toBe(true);
+      expect(Option.getOrThrow(first).name).toBe('alice');
+
+      const missing = yield* Database.query(Filter.type(TestSchema.Person, { name: 'missing' })).first;
+      expect(Option.isNone(missing)).toBe(true);
+    }).pipe(Effect.provide(TestLayer), runAndForwardErrors);
+  });
+
+  test('evaluating the effect yields a QueryResult', async ({ expect }) => {
+    await Effect.gen(function* () {
+      const alice = Obj.make(TestSchema.Person, { name: 'alice' });
+      yield* Database.add(alice);
+      yield* Database.flush();
+
+      const queryResult = yield* Database.query(Filter.type(TestSchema.Person));
+      const results = queryResult.runSync();
+      expect(results).toHaveLength(1);
+      expect(results[0]?.name).toBe('alice');
+    }).pipe(Effect.provide(TestLayer), runAndForwardErrors);
+  });
+
+  test('subscribe fires with current results when fire: true', async ({ expect }) => {
+    await Effect.gen(function* () {
+      const alice = Obj.make(TestSchema.Person, { name: 'alice' });
+      const bob = Obj.make(TestSchema.Person, { name: 'bob' });
+      yield* Database.add(alice);
+      yield* Database.add(bob);
+      yield* Database.flush();
+
+      const queryResult = yield* Database.query(Filter.type(TestSchema.Person));
+      const called = new Event();
+      const calledOnce = called.waitForCount(1);
+      const unsubscribe = queryResult.subscribe(() => called.emit(), { fire: true });
+
+      yield* Effect.promise(() => calledOnce);
+      expect(queryResult.results).toHaveLength(2);
+      expect(queryResult.results.map((person) => person.name).sort()).toEqual(['alice', 'bob']);
+      unsubscribe();
+    }).pipe(Effect.provide(TestLayer), runAndForwardErrors);
+  });
+});

--- a/packages/core/echo/echo/src/Database.ts
+++ b/packages/core/echo/echo/src/Database.ts
@@ -4,6 +4,7 @@
 
 // @import-as-namespace
 
+import * as Effectable from 'effect/Effectable';
 import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
@@ -321,16 +322,18 @@ export const flush = (opts?: FlushOptions) =>
  * Creates a `QueryResult` object that can be subscribed to.
  */
 export const query: {
-  <Q extends Query.Any>(query: Q): Effect.Effect<QueryResult.QueryResult<Query.Type<Q>>, never, Service>;
-  <F extends Filter.Any>(filter: F): Effect.Effect<QueryResult.QueryResult<Filter.Type<F>>, never, Service>;
+  <Q extends Query.Any>(query: Q): QueryResult.QueryResultEffect<Query.Type<Q>, never, Service>;
+  <F extends Filter.Any>(filter: F): QueryResult.QueryResultEffect<Filter.Type<F>, never, Service>;
 } = (queryOrFilter: Query.Any | Filter.Any) =>
   Service.pipe(
     Effect.map(({ db }) => db.query(queryOrFilter as any) as QueryResult.QueryResult<any>),
     Effect.withSpan('Database.query'),
+    makeQueryResultEffect,
   );
 
 /**
  * Executes the query once and returns the results.
+ * @deprecated Use `yield* query(...).run` instead.
  */
 export const runQuery: {
   <Q extends Query.Any>(query: Q): Effect.Effect<Query.Type<Q>[], never, Service>;
@@ -343,6 +346,7 @@ export const runQuery: {
 
 /**
  * Executes the query once and returns the first result as or None.
+ * @deprecated Use `yield* query(...).first` instead.
  */
 export const runQueryFirst: {
   <Q extends Query.Any>(query: Q): Effect.Effect<Option.Option<Query.Type<Q>>, never, Service>;
@@ -354,3 +358,20 @@ export const runQueryFirst: {
     ),
     Effect.withSpan('Database.runQueryFirst'),
   );
+
+const makeQueryResultEffect = <T>(
+  eff: Effect.Effect<QueryResult.QueryResult<T>, never, Service>,
+): QueryResult.QueryResultEffect<T, never, Service> => {
+  return {
+    run: Effect.flatMap(eff, (result) => promiseWithCauseCapture(() => result.run())),
+    first: Effect.flatMap(eff, (result) =>
+      promiseWithCauseCapture(async () => Option.fromNullable(await result.firstOrUndefined())),
+    ),
+
+    // Effect internals
+    ...Effectable.CommitPrototype,
+    commit() {
+      return eff;
+    },
+  } as any;
+};

--- a/packages/core/echo/echo/src/Database.ts
+++ b/packages/core/echo/echo/src/Database.ts
@@ -4,9 +4,9 @@
 
 // @import-as-namespace
 
-import * as Effectable from 'effect/Effectable';
 import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
+import * as Effectable from 'effect/Effectable';
 import * as Layer from 'effect/Layer';
 import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';

--- a/packages/core/echo/echo/src/QueryResult.ts
+++ b/packages/core/echo/echo/src/QueryResult.ts
@@ -2,6 +2,9 @@
 // Copyright 2025 DXOS.org
 //
 
+import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
+
 import { type CleanupFn } from '@dxos/async';
 
 import type * as Entity from './Entity';
@@ -103,4 +106,12 @@ export interface QueryResult<T> {
    * Subscribes to changes in query results.
    */
   subscribe(callback?: (query: QueryResult<T>) => void, opts?: SubscriptionOptions): CleanupFn;
+}
+
+/**
+ * Effect that returns a QueryResult when evaluated, but also has shorthand methods for running the query or getting the first result.
+ */
+export interface QueryResultEffect<T, E, R> extends Effect.Effect<QueryResult<T>, E, R> {
+  run: Effect.Effect<T[], E, R>;
+  first: Effect.Effect<Option.Option<T>, E, R>;
 }


### PR DESCRIPTION
## Summary

- Add `QueryResultEffect` type with `.run` and `.first` shorthand effects on `Database.query`.
- Mark `Database.runQuery` / `Database.runQueryFirst` as deprecated in favor of the new API.
- Add smoke tests in `echo-db` using `TestDatabaseLayer`.

## Test plan

- [x] `moon run echo-db:test -- src/query/query-effect.test.ts`
- [x] `moon run echo:lint echo-db:lint -- --fix`
- [x] `moon run echo:build echo-db:build`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query results now provide `run()` and `first()` methods for simplified data access.
  * `runQuery` and `runQueryFirst` functions are deprecated; use the new methods via `query(...).run()` and `query(...).first()` instead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->