### PR TITLE
fix(codec-protobuf): decode empty google.protobuf.Any value bytes

### DIFF
--- a/packages/common/codec-protobuf/src/substitutions/any.test.ts
+++ b/packages/common/codec-protobuf/src/substitutions/any.test.ts
@@ -1,0 +1,32 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { join } from 'node:path';
+
+import * as pb from 'protobufjs';
+import { describe, expect, test } from 'vitest';
+
+import { Schema, anySubstitutions } from '..';
+
+describe('anySubstitutions', () => {
+  test('decodes Any when protobufjs toObject drops empty value bytes', async () => {
+    const anyProto = await pb.load(join(__dirname, '../../test/proto/example/testing/any.proto'));
+    const anotherProto = await pb.load(join(__dirname, '../../test/proto/example/testing/another.proto'));
+
+    const schema = new Schema(anyProto, anySubstitutions);
+    const codec = schema.tryGetCodecForType('example.testing.any.Wrapper');
+    codec.addJson(anotherProto.toJSON());
+
+    const decoded = anySubstitutions['google.protobuf.Any'].decode(
+      { type_url: 'example.testing.another.EmptyMessage' },
+      { messageName: 'example.testing.any.Wrapper', fieldName: 'payload' },
+      schema,
+      {},
+    );
+
+    expect(decoded).to.deep.equal({
+      '@type': 'example.testing.another.EmptyMessage',
+    });
+  });
+});

--- a/packages/common/codec-protobuf/src/substitutions/any.ts
+++ b/packages/common/codec-protobuf/src/substitutions/any.ts
@@ -64,7 +64,7 @@ export const anySubstitutions = {
         };
       }
       const codec = schema.tryGetCodecForType(value.type_url);
-      let data = codec.decode(value.value);
+      let data = codec.decode(value.value ?? new Uint8Array());
 
       if (value.type_url === 'google.protobuf.Struct') {
         data = structSubstitutions['google.protobuf.Struct'].decode(data);

--- a/packages/common/codec-protobuf/test/proto/example/testing/another.proto
+++ b/packages/common/codec-protobuf/test/proto/example/testing/another.proto
@@ -9,3 +9,5 @@ package example.testing.another;
 message AnotherMessage {
   string foo = 1;
 }
+
+message EmptyMessage {}


### PR DESCRIPTION
## Summary

- Default missing `google.protobuf.Any.value` to an empty buffer when decoding substituted types (matches existing `preserveAny` behavior).
- Add regression test for empty `EmptyMessage` packed in `Any`.

## Motivation

Edge `client-invitations.node.test.ts` (`device > no auth`) hangs after mesh auth: `Credential.decode` fails with `illegal buffer` when decoding halo `Auth` credentials. protobufjs 8.4+ omits empty `bytes` fields from `toObject`, so `Any.value` becomes `undefined` and `Auth.decode(undefined)` throws. Edge resolves `^8.0.0` to 8.4.2 while dxos lockfile stays on 8.0.0, exposing the bug.

Related: dxos/dxos#11624 (invitation kind enum fix — separate, in merge queue).

## Test plan

- [x] `moon run codec-protobuf:test -- src/substitutions/any.test.ts`
- [x] Edge linked locally: credential Auth roundtrip + `client-invitations.node.test.ts` device cases (with #11624 linked)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decoding of `google.protobuf.Any` messages to properly handle missing values, preventing undefined data from propagating during codec operations.

* **Tests**
  * Added test suite validating correct decoding behavior for empty `google.protobuf.Any` messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->