### PR TITLE
docs: minimize user round-trips in agent workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,12 @@
 
 - When collaborating closely with the User, determine if the user's role can be automated.
 - Be precise about what you are asking the user to do and actively manage the process.
+- **IMPORTANT**: Model the user as a very expensive, intermittent resource and minimize round-trips to them. The wasteful pattern to avoid: the user waits a long time for the agent to finish, only to be asked to test or supply something the agent could have anticipated.
+  - At task start, analyze ALL human dependencies up-front (test credentials, assets, design decisions, accounts, manual verification steps).
+  - Gather/build/scaffold anything obtainable autonomously BEFORE asking the user for anything.
+  - Request all needed resources from the user in ONE batch, alongside a very concise plan; get a single go-ahead.
+  - Then execute the remainder of the task uninterrupted; do not bounce back for things that could have been front-loaded.
+  - If you hit an unforeseen human dependency mid-task, park it and continue all other reachable work; only surface an immediate ask when you are fully blocked and cannot make progress otherwise. Batch parked asks for the next checkpoint.
 
 ## PR Naming Convention
 


### PR DESCRIPTION
## Summary

Adds guidance to `AGENTS.md` (the file `CLAUDE.md` symlinks to) under **Interacting The User**: model the user as a very expensive, intermittent resource and minimize round-trips.

The wasteful pattern this targets: the user waits a long time for the agent to finish, only to be asked to test or supply something the agent could have anticipated.

## Guidance added

- Analyze ALL human dependencies up-front at task start.
- Gather/build/scaffold anything obtainable autonomously before asking the user.
- Request needed resources in ONE batch alongside a concise plan; get a single go-ahead.
- Then execute the remainder uninterrupted.
- Park unforeseen mid-task dependencies; surface an immediate ask only when fully blocked, and batch parked asks.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal workflow guidance for resource management and structured interaction processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->