### PR TITLE
refactor(react-ui): restructure Toast/Message layout using Column primitive

### DIFF
--- a/packages/plugins/plugin-debug/src/components/DebugSettings/DebugSettings.tsx
+++ b/packages/plugins/plugin-debug/src/components/DebugSettings/DebugSettings.tsx
@@ -10,7 +10,7 @@ import { type ConfigProto, SaveConfig, Storage, defs } from '@dxos/config';
 import { log } from '@dxos/log';
 import { type IdbLogStore } from '@dxos/log-store-idb';
 import { useClient } from '@dxos/react-client';
-import { Icon, IconButton, Input, Select, Toast, useFileDownload, useTranslation } from '@dxos/react-ui';
+import { IconButton, Input, Select, Toast, useFileDownload, useTranslation } from '@dxos/react-ui';
 import { Settings as SettingsForm } from '@dxos/react-ui-form';
 import { TRACE_ALL_KEY } from '@dxos/tracing';
 import { setDeep } from '@dxos/util';
@@ -209,13 +209,10 @@ export const DebugSettings = ({ settings, onSettingsChange, logStore, onUpload }
         {/* TODO(burdon): Move to layout? */}
         {toast && (
           <Toast.Root>
-            <Toast.Body>
-              <Toast.Title>
-                <Icon icon='ph--gift--duotone' classNames='inline mr-1' />
-                <span>{toast.title}</span>
-              </Toast.Title>
-              {toast.description && <Toast.Description>{toast.description}</Toast.Description>}
-            </Toast.Body>
+            <Toast.Title icon='ph--gift--duotone'>
+              <span>{toast.title}</span>
+            </Toast.Title>
+            {toast.description && <Toast.Description>{toast.description}</Toast.Description>}
           </Toast.Root>
         )}
 

--- a/packages/plugins/plugin-deck/src/containers/DeckLayout/Toast.tsx
+++ b/packages/plugins/plugin-deck/src/containers/DeckLayout/Toast.tsx
@@ -5,14 +5,7 @@
 import React from 'react';
 
 import { type LayoutOperation } from '@dxos/app-toolkit';
-import {
-  Button,
-  Icon,
-  Toast as NaturalToast,
-  type ToastRootProps,
-  toLocalizedString,
-  useTranslation,
-} from '@dxos/react-ui';
+import { Button, Toast as NaturalToast, type ToastRootProps, toLocalizedString, useTranslation } from '@dxos/react-ui';
 
 import { meta } from '#meta';
 
@@ -25,7 +18,6 @@ export const Toast = ({
   duration,
   actionLabel,
   actionAlt,
-  closeLabel,
   onAction,
   onOpenChange,
 }: LayoutOperation.Toast & Pick<ToastRootProps, 'onOpenChange'>) => {
@@ -33,29 +25,19 @@ export const Toast = ({
 
   return (
     <NaturalToast.Root data-testid={id} defaultOpen duration={duration} onOpenChange={onOpenChange}>
-      <NaturalToast.Body>
-        <NaturalToast.Title classNames='items-center'>
-          {icon && <Icon icon={icon} classNames='inline mr-1' />}
-          {title && <span>{toLocalizedString(title, t)}</span>}
-        </NaturalToast.Title>
-        {description && (
-          <NaturalToast.Description>{description && toLocalizedString(description, t)}</NaturalToast.Description>
-        )}
-      </NaturalToast.Body>
-      <NaturalToast.Actions>
-        {onAction && actionAlt && actionLabel && (
+      <NaturalToast.Title icon={icon} onClose={() => onOpenChange?.(false)}>
+        {title && <span>{toLocalizedString(title, t)}</span>}
+      </NaturalToast.Title>
+      {description && <NaturalToast.Description>{toLocalizedString(description, t)}</NaturalToast.Description>}
+      {onAction && actionAlt && actionLabel && (
+        <NaturalToast.Actions>
           <NaturalToast.Action altText={toLocalizedString(actionAlt, t)} asChild>
             <Button data-testid='toast.action' variant='primary' onClick={() => onAction?.()}>
               {toLocalizedString(actionLabel, t)}
             </Button>
           </NaturalToast.Action>
-        )}
-        {closeLabel && (
-          <NaturalToast.Close asChild>
-            <Button data-testid='toast.close'>{toLocalizedString(closeLabel, t)}</Button>
-          </NaturalToast.Close>
-        )}
-      </NaturalToast.Actions>
+        </NaturalToast.Actions>
+      )}
     </NaturalToast.Root>
   );
 };

--- a/packages/plugins/plugin-space/src/components/AwaitingObject/AwaitingObject.tsx
+++ b/packages/plugins/plugin-space/src/components/AwaitingObject/AwaitingObject.tsx
@@ -61,35 +61,33 @@ export const AwaitingObject = ({ id }: { id: string }) => {
   // TODO(burdon): Why are we not using LayoutOperation.AddToast?
   return (
     <Toast.Root open={open} duration={TOAST_TIMEOUT} onOpenChange={setOpen}>
-      <Toast.Body>
-        <Toast.Title classNames='flex items-center gap-2'>
-          {found ? (
-            <>
-              <Icon icon='ph--check-circle--regular' />
-              <span>{t('found-object.label')}</span>
-            </>
-          ) : waiting ? (
-            <>
-              <Icon icon='ph--circle-notch--regular' classNames='animate-spin' />
-              <span>{t('waiting-for-object.label')}</span>
-            </>
-          ) : (
-            <>
-              <Icon icon='ph--placeholder--regular' />
-              <span>{t('object-not-found.label')}</span>
-            </>
-          )}
-        </Toast.Title>
-        <Toast.Description>
-          {t(
-            found
-              ? 'found-object.description'
-              : waiting
-                ? 'waiting-for-object.description'
-                : 'object-not-found.description',
-          )}
-        </Toast.Description>
-      </Toast.Body>
+      <Toast.Title classNames='flex items-center gap-2'>
+        {found ? (
+          <>
+            <Icon icon='ph--check-circle--regular' />
+            <span>{t('found-object.label')}</span>
+          </>
+        ) : waiting ? (
+          <>
+            <Icon icon='ph--circle-notch--regular' classNames='animate-spin' />
+            <span>{t('waiting-for-object.label')}</span>
+          </>
+        ) : (
+          <>
+            <Icon icon='ph--placeholder--regular' />
+            <span>{t('object-not-found.label')}</span>
+          </>
+        )}
+      </Toast.Title>
+      <Toast.Description>
+        {t(
+          found
+            ? 'found-object.description'
+            : waiting
+              ? 'waiting-for-object.description'
+              : 'object-not-found.description',
+        )}
+      </Toast.Description>
       <Toast.Actions>
         {found ? (
           <>

--- a/packages/plugins/plugin-testing/src/components/Layout/Layout.tsx
+++ b/packages/plugins/plugin-testing/src/components/Layout/Layout.tsx
@@ -12,8 +12,6 @@ import {
   AlertDialog,
   Button,
   Dialog,
-  Icon,
-  IconButton,
   Main,
   Popover,
   type PopoverContentInteractOutsideEvent,
@@ -43,27 +41,19 @@ const StoryToast = ({ toast, onDismiss }: { toast: LayoutOperation.Toast; onDism
         }
       }}
     >
-      <Toast.Body>
-        <Toast.Title classNames='items-center'>
-          {toast.icon && <Icon icon={toast.icon} classNames='inline mr-1' />}
-          {toast.title && <span>{toLocalizedString(toast.title, t)}</span>}
-        </Toast.Title>
-        {toast.description && <Toast.Description>{toLocalizedString(toast.description, t)}</Toast.Description>}
-      </Toast.Body>
-      <Toast.Actions>
-        {toast.onAction && toast.actionAlt && toast.actionLabel && (
+      <Toast.Title icon={toast.icon} onClose={toast.closeLabel ? () => onDismiss(toast.id) : undefined}>
+        {toast.title && <span>{toLocalizedString(toast.title, t)}</span>}
+      </Toast.Title>
+      {toast.description && <Toast.Description>{toLocalizedString(toast.description, t)}</Toast.Description>}
+      {toast.onAction && toast.actionAlt && toast.actionLabel && (
+        <Toast.Actions>
           <Toast.Action altText={toLocalizedString(toast.actionAlt, t)} asChild>
             <Button variant='primary' onClick={() => toast.onAction?.()}>
               {toLocalizedString(toast.actionLabel, t)}
             </Button>
           </Toast.Action>
-        )}
-        {toast.closeLabel && (
-          <Toast.Close asChild>
-            <IconButton icon='ph--x--regular' iconOnly label={toLocalizedString(toast.closeLabel, t)} />
-          </Toast.Close>
-        )}
-      </Toast.Actions>
+        </Toast.Actions>
+      )}
     </Toast.Root>
   );
 };

--- a/packages/ui/react-ui/src/components/Message/Message.theme.ts
+++ b/packages/ui/react-ui/src/components/Message/Message.theme.ts
@@ -11,11 +11,11 @@ export type MessageStyleProps = {
 };
 
 const root: ComponentFunction<MessageStyleProps> = ({ valence }, etc) => {
-  return mx('grid grid-cols-[2rem_1fr_2rem] p-1 rounded-sm', messageValence(valence), etc);
+  return mx('p-1 rounded-sm', messageValence(valence), etc);
 };
 
 const header: ComponentFunction<MessageStyleProps> = (_, etc) => {
-  return mx('col-span-full grid grid-cols-subgrid items-center', etc);
+  return mx('items-center', etc);
 };
 
 const title: ComponentFunction<MessageStyleProps> = (_, etc) => {
@@ -26,8 +26,12 @@ const icon: ComponentFunction<MessageStyleProps> = (_, etc) => {
   return mx('col-start-1 grid place-items-center', etc);
 };
 
+const close: ComponentFunction<MessageStyleProps> = (_, etc) => {
+  return mx('col-start-3', etc);
+};
+
 const content: ComponentFunction<MessageStyleProps> = (_, etc) => {
-  return mx('col-start-2 grid grid-cols-subgrid inline first:font-medium', etc);
+  return mx('col-start-2 first:font-medium', etc);
 };
 
 export const messageTheme: Theme<MessageStyleProps> = {
@@ -35,5 +39,6 @@ export const messageTheme: Theme<MessageStyleProps> = {
   header,
   icon,
   title,
+  close,
   content,
 };

--- a/packages/ui/react-ui/src/components/Message/Message.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.tsx
@@ -16,6 +16,7 @@ import { translationKey } from '#translations';
 import { useElevationContext, useThemeContext } from '../../hooks';
 import { type ThemedClassName } from '../../util';
 import { IconButton } from '../Button';
+import { Column } from '../Column';
 import { Icon } from '../Icon';
 
 const messageIcons: Record<MessageValence, string> = {
@@ -62,20 +63,20 @@ const MessageRoot = forwardRef<HTMLDivElement, MessageRootProps>(
     const titleId = useId('message__title', propsTitleId);
     const descriptionId = useId('message__description', propsDescriptionId);
     const elevation = useElevationContext(propsElevation);
-    const Comp = asChild ? Slot : Primitive.div;
 
     return (
       <MessageProvider {...{ titleId, descriptionId, valence }}>
-        <Comp
+        <Column.Root
+          asChild={asChild}
           role={valence === 'neutral' ? 'paragraph' : 'alert'}
-          {...props}
-          className={tx('message.root', { valence, elevation }, classNames)}
           aria-labelledby={titleId}
           aria-describedby={descriptionId}
+          {...props}
+          classNames={tx('message.root', { valence, elevation }, classNames)}
           ref={forwardedRef}
         >
           {children}
-        </Comp>
+        </Column.Root>
       </MessageProvider>
     );
   },
@@ -94,30 +95,33 @@ type MessageTitleProps = Omit<ThemedClassName<ComponentPropsWithRef<typeof Primi
 
 const MESSAGE_TITLE_NAME = 'Message.Title';
 
-const MessageTitle = forwardRef<HTMLHeadingElement, MessageTitleProps>(
+const MessageTitle = forwardRef<HTMLDivElement, MessageTitleProps>(
   ({ classNames, children, icon: iconProp, onClose }, forwardedRef) => {
     const { t } = useTranslation(translationKey);
     const { tx } = useThemeContext();
     const { titleId, valence } = useMessageContext(MESSAGE_TITLE_NAME);
     const icon = iconProp ?? messageIcons[valence];
     return (
-      <div className={tx('message.header', {}, classNames)} id={titleId} ref={forwardedRef}>
+      <Column.Row classNames={tx('message.header', {}, classNames)} ref={forwardedRef}>
         {icon && (
           <div className={tx('message.icon', { valence })}>
             <Icon icon={icon} />
           </div>
         )}
-        <h2 className={tx('message.title', {}, classNames)}>{children}</h2>
+        <h2 className={tx('message.title', {}, classNames)} id={titleId}>
+          {children}
+        </h2>
         {onClose && (
           <IconButton
             variant='ghost'
             icon='ph--x--regular'
             iconOnly
             label={t('toolbar-close.label')}
+            classNames={tx('message.close', {})}
             onClick={onClose}
           />
         )}
-      </div>
+      </Column.Row>
     );
   },
 );

--- a/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
@@ -17,15 +17,23 @@ type StorybookToastProps = Partial<{
   actionTriggers: ActionTriggerProps[];
   openTrigger: string;
   closeTrigger: ReactNode;
+  defaultOpen: boolean;
 }>;
 
-const DefaultStory = ({ title, description, actionTriggers, openTrigger, closeTrigger }: StorybookToastProps) => {
-  const [open, setOpen] = useState(true);
+const DefaultStory = ({
+  title,
+  description,
+  actionTriggers,
+  openTrigger,
+  closeTrigger,
+  defaultOpen = true,
+}: StorybookToastProps) => {
+  const [open, setOpen] = useState(defaultOpen);
   return (
     <Toast.Provider>
       <Button onClick={() => setOpen(true)}>{openTrigger}</Button>
       <Toast.Viewport />
-      <Toast.Root open={open} onOpenChange={setOpen} defaultOpen>
+      <Toast.Root open={open} onOpenChange={setOpen} defaultOpen={defaultOpen}>
         <Toast.Body>
           <Toast.Title>{title}</Toast.Title>
           <Toast.Description>{description}</Toast.Description>
@@ -56,6 +64,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
+    defaultOpen: true,
     openTrigger: 'Open toast',
     icon: 'ph--sparkle--regular',
     title: 'This is a toast',

--- a/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
@@ -73,16 +73,10 @@ export const Default: Story = {
     title: 'This is a toast',
     description: 'This goes away on its own with a timer.',
     duration: 100_000,
-    actionTriggers: [
-      {
-        altText: 'Press F5 to reload the page',
-        trigger: <Button variant='primary'>Reload</Button>,
-      },
-    ],
   },
 };
 
-export const NoAction: Story = {
+export const WithAction: Story = {
   args: {
     defaultOpen: true,
     openTrigger: 'Open toast',
@@ -90,5 +84,11 @@ export const NoAction: Story = {
     title: 'This is a toast',
     description: 'This goes away on its own with a timer.',
     duration: 100_000,
+    actionTriggers: [
+      {
+        altText: 'Press F5 to reload the page',
+        trigger: <Button variant='primary'>Reload</Button>,
+      },
+    ],
   },
 };

--- a/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
@@ -81,3 +81,14 @@ export const Default: Story = {
     ],
   },
 };
+
+export const NoAction: Story = {
+  args: {
+    defaultOpen: true,
+    openTrigger: 'Open toast',
+    icon: 'ph--sparkle--regular',
+    title: 'This is a toast',
+    description: 'This goes away on its own with a timer.',
+    duration: 100_000,
+  },
+};

--- a/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
@@ -6,26 +6,28 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React, { type ReactNode, useState } from 'react';
 
 import { withTheme } from '../../testing';
-import { Button, IconButton } from '../Button';
+import { Button } from '../Button';
 import { Toast } from './Toast';
 
 type ActionTriggerProps = { altText: string; trigger: ReactNode };
 
 type StorybookToastProps = Partial<{
+  icon: string;
   title: string;
   description: string;
+  duration: number;
   actionTriggers: ActionTriggerProps[];
   openTrigger: string;
-  closeTrigger: ReactNode;
   defaultOpen: boolean;
 }>;
 
 const DefaultStory = ({
+  icon,
   title,
   description,
+  duration,
   actionTriggers,
   openTrigger,
-  closeTrigger,
   defaultOpen = true,
 }: StorybookToastProps) => {
   const [open, setOpen] = useState(defaultOpen);
@@ -33,19 +35,20 @@ const DefaultStory = ({
     <Toast.Provider>
       <Button onClick={() => setOpen(true)}>{openTrigger}</Button>
       <Toast.Viewport />
-      <Toast.Root open={open} onOpenChange={setOpen} defaultOpen={defaultOpen}>
-        <Toast.Body>
-          <Toast.Title>{title}</Toast.Title>
-          <Toast.Description>{description}</Toast.Description>
-        </Toast.Body>
-        <Toast.Actions>
-          <Toast.Close asChild={typeof closeTrigger !== 'string'}>{closeTrigger}</Toast.Close>
-          {(actionTriggers || []).map(({ altText, trigger }: ActionTriggerProps, index: number) => (
-            <Toast.Action key={index} altText={altText} asChild={typeof trigger !== 'string'}>
-              {trigger}
-            </Toast.Action>
-          ))}
-        </Toast.Actions>
+      <Toast.Root open={open} onOpenChange={setOpen} defaultOpen={defaultOpen} duration={duration}>
+        <Toast.Title icon={icon} onClose={() => setOpen(false)}>
+          {title}
+        </Toast.Title>
+        <Toast.Description>{description}</Toast.Description>
+        {actionTriggers && actionTriggers.length > 0 && (
+          <Toast.Actions>
+            {actionTriggers.map(({ altText, trigger }: ActionTriggerProps, index: number) => (
+              <Toast.Action key={index} altText={altText} asChild={typeof trigger !== 'string'}>
+                {trigger}
+              </Toast.Action>
+            ))}
+          </Toast.Actions>
+        )}
       </Toast.Root>
     </Toast.Provider>
   );
@@ -69,13 +72,12 @@ export const Default: Story = {
     icon: 'ph--sparkle--regular',
     title: 'This is a toast',
     description: 'This goes away on its own with a timer.',
-    duration: 10_000,
+    duration: 100_000,
     actionTriggers: [
       {
         altText: 'Press F5 to reload the page',
         trigger: <Button variant='primary'>Reload</Button>,
       },
     ],
-    closeTrigger: <IconButton icon='ph--x--regular' iconOnly label='Close' />,
   },
 };

--- a/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
+++ b/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
@@ -5,9 +5,7 @@
 import { mx, surfaceShadow } from '@dxos/ui-theme';
 import { type ComponentFunction, type Theme } from '@dxos/ui-types';
 
-export type ToastStyleProps = Partial<{
-  srOnly: boolean;
-}>;
+export type ToastStyleProps = {};
 
 const viewport: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
   mx(
@@ -19,7 +17,7 @@ const viewport: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
 
 const root: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
   mx(
-    'dx-modal-surface rounded-md flex p-2 gap-2',
+    'dx-modal-surface rounded-md p-1',
     surfaceShadow({ elevation: 'toast' }),
     'radix-state-open:animate-toast-slide-in-bottom md:radix-state-open:animate-toast-slide-in-right',
     'radix-state-closed:animate-toast-hide',
@@ -30,23 +28,29 @@ const root: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
     ...etc,
   );
 
-const body: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
-  mx('grow flex flex-col gap-1 justify-center pl-2', ...etc);
+const grid: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('gap-y-1', ...etc);
 
-const actions: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
-  mx('shrink-0 flex flex-col gap-1 justify-center', ...etc);
+const header: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('items-center', ...etc);
 
-const title: ComponentFunction<ToastStyleProps> = ({ srOnly }, ...etc) =>
-  mx('shrink-0 font-medium', srOnly && 'sr-only', ...etc);
+const icon: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('col-start-1 grid place-items-center', ...etc);
 
-const description: ComponentFunction<ToastStyleProps> = ({ srOnly }, ...etc) =>
-  mx('text-description', 'shrink-0', srOnly && 'sr-only', ...etc);
+const title: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
+  mx('col-start-2 overflow-hidden truncate font-medium', ...etc);
+
+const close: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('col-start-3', ...etc);
+
+const description: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('col-start-2 text-description', ...etc);
+
+const actions: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('flex gap-2 mbs-1', ...etc);
 
 export const toastTheme: Theme<ToastStyleProps> = {
   viewport,
   root,
-  body,
+  grid,
+  header,
+  icon,
   title,
+  close,
   description,
   actions,
 };

--- a/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
+++ b/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
@@ -28,7 +28,7 @@ const root: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
     ...etc,
   );
 
-const grid: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('gap-y-1', ...etc);
+const grid: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('gap-y-1 pbe-2', ...etc);
 
 const header: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('items-center', ...etc);
 
@@ -41,7 +41,7 @@ const close: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('col-st
 
 const description: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('col-start-2 text-description', ...etc);
 
-const actions: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('flex gap-2 mbs-1 pbe-2', ...etc);
+const actions: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('flex gap-2 mbs-1', ...etc);
 
 export const toastTheme: Theme<ToastStyleProps> = {
   viewport,

--- a/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
+++ b/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
@@ -28,7 +28,7 @@ const root: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
     ...etc,
   );
 
-const grid: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('gap-y-1 pbe-2', ...etc);
+const grid: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('gap-y-1 pbe-1', ...etc);
 
 const header: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('items-center', ...etc);
 

--- a/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
+++ b/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
@@ -41,7 +41,7 @@ const close: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('col-st
 
 const description: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('col-start-2 text-description', ...etc);
 
-const actions: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('flex gap-2 mbs-1', ...etc);
+const actions: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('flex gap-2 mbs-1 pbe-2', ...etc);
 
 export const toastTheme: Theme<ToastStyleProps> = {
   viewport,

--- a/packages/ui/react-ui/src/components/Toast/Toast.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.tsx
@@ -2,18 +2,30 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Primitive } from '@radix-ui/react-primitive';
-import { Slot } from '@radix-ui/react-slot';
 import * as ToastPrimitive from '@radix-ui/react-toast';
 import React, { type ComponentPropsWithRef, forwardRef } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { translationKey } from '#translations';
 
 import { useThemeContext } from '../../hooks';
 import { ElevationProvider } from '../../primitives';
 import { type ThemedClassName } from '../../util';
+import { IconButton } from '../Button';
+import { Column } from '../Column';
+import { Icon } from '../Icon';
+
+//
+// Provider
+//
 
 type ToastProviderProps = ToastPrimitive.ToastProviderProps;
 
 const ToastProvider = ToastPrimitive.Provider;
+
+//
+// Viewport
+//
 
 type ToastViewportProps = ThemedClassName<ToastPrimitive.ToastViewportProps>;
 
@@ -22,54 +34,108 @@ const ToastViewport = forwardRef<HTMLOListElement, ToastViewportProps>(({ classN
   return <ToastPrimitive.Viewport {...props} className={tx('toast.viewport', {}, classNames)} ref={forwardedRef} />;
 });
 
+ToastViewport.displayName = 'Toast.Viewport';
+
+//
+// Root
+//
+
 type ToastRootProps = ThemedClassName<ToastPrimitive.ToastProps>;
 
 const ToastRoot = forwardRef<HTMLLIElement, ToastRootProps>(({ classNames, children, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
   return (
     <ToastPrimitive.Root {...props} className={tx('toast.root', {}, classNames)} ref={forwardedRef}>
-      <ElevationProvider elevation='toast'>{children}</ElevationProvider>
+      <ElevationProvider elevation='toast'>
+        <Column.Root classNames={tx('toast.grid', {})}>{children}</Column.Root>
+      </ElevationProvider>
     </ToastPrimitive.Root>
   );
 });
 
-type ToastBodyProps = ThemedClassName<ComponentPropsWithRef<typeof Primitive.div>>;
+ToastRoot.displayName = 'Toast.Root';
 
-const ToastBody = forwardRef<HTMLDivElement, ToastBodyProps>(({ asChild, classNames, ...props }, forwardedRef) => {
-  const { tx } = useThemeContext();
-  const Comp = asChild ? Slot : Primitive.div;
-  return <Comp {...props} className={tx('toast.body', {}, classNames)} ref={forwardedRef} />;
-});
+//
+// Title
+//
 
-type ToastTitleProps = ThemedClassName<ToastPrimitive.ToastTitleProps>;
+type ToastTitleProps = ThemedClassName<ToastPrimitive.ToastTitleProps> & {
+  icon?: string;
+  onClose?: () => void;
+};
 
 const ToastTitle = forwardRef<HTMLHeadingElement, ToastTitleProps>(
-  ({ asChild, classNames, ...props }, forwardedRef) => {
+  ({ classNames, children, icon, onClose, ...props }, forwardedRef) => {
+    const { t } = useTranslation(translationKey);
     const { tx } = useThemeContext();
-    const Comp = asChild ? Slot : ToastPrimitive.Title;
-    return <Comp {...props} className={tx('toast.title', {}, classNames)} ref={forwardedRef} />;
+    return (
+      <Column.Row classNames={tx('toast.header', {})}>
+        {icon && (
+          <div className={tx('toast.icon', {})}>
+            <Icon icon={icon} />
+          </div>
+        )}
+        <ToastPrimitive.Title {...props} className={tx('toast.title', {}, classNames)} ref={forwardedRef}>
+          {children}
+        </ToastPrimitive.Title>
+        {onClose && (
+          <IconButton
+            variant='ghost'
+            icon='ph--x--regular'
+            iconOnly
+            label={t('toolbar-close.label')}
+            classNames={tx('toast.close', {})}
+            onClick={onClose}
+          />
+        )}
+      </Column.Row>
+    );
   },
 );
+
+ToastTitle.displayName = 'Toast.Title';
+
+//
+// Description
+//
 
 type ToastDescriptionProps = ThemedClassName<ToastPrimitive.ToastDescriptionProps>;
 
 const ToastDescription = forwardRef<HTMLParagraphElement, ToastDescriptionProps>(
-  ({ asChild, classNames, ...props }, forwardedRef) => {
+  ({ classNames, children, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
-    const Comp = asChild ? Slot : ToastPrimitive.Description;
-    return <Comp {...props} className={tx('toast.description', {}, classNames)} ref={forwardedRef} />;
+    return (
+      <ToastPrimitive.Description {...props} className={tx('toast.description', {}, classNames)} ref={forwardedRef}>
+        {children}
+      </ToastPrimitive.Description>
+    );
   },
 );
 
-type ToastActionsProps = ThemedClassName<ComponentPropsWithRef<typeof Primitive.div>>;
+ToastDescription.displayName = 'Toast.Description';
+
+//
+// Actions
+//
+
+type ToastActionsProps = ThemedClassName<ComponentPropsWithRef<'div'>>;
 
 const ToastActions = forwardRef<HTMLDivElement, ToastActionsProps>(
-  ({ asChild, classNames, ...props }, forwardedRef) => {
+  ({ classNames, children, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
-    const Comp = asChild ? Slot : Primitive.div;
-    return <Comp {...props} className={tx('toast.actions', {}, classNames)} ref={forwardedRef} />;
+    return (
+      <Column.Center classNames={tx('toast.actions', {}, classNames)} ref={forwardedRef} {...props}>
+        {children}
+      </Column.Center>
+    );
   },
 );
+
+ToastActions.displayName = 'Toast.Actions';
+
+//
+// Action / Close
+//
 
 type ToastActionProps = ToastPrimitive.ToastActionProps;
 
@@ -79,11 +145,14 @@ type ToastCloseProps = ToastPrimitive.ToastCloseProps;
 
 const ToastClose = ToastPrimitive.Close;
 
+//
+// Toast
+//
+
 export const Toast = {
   Provider: ToastProvider,
   Viewport: ToastViewport,
   Root: ToastRoot,
-  Body: ToastBody,
   Title: ToastTitle,
   Description: ToastDescription,
   Actions: ToastActions,
@@ -95,7 +164,6 @@ export type {
   ToastProviderProps,
   ToastViewportProps,
   ToastRootProps,
-  ToastBodyProps,
   ToastTitleProps,
   ToastDescriptionProps,
   ToastActionsProps,

--- a/packages/ui/react-ui/src/components/Toast/Toast.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { translationKey } from '#translations';
 
 import { useThemeContext } from '../../hooks';
-import { ElevationProvider } from '../../primitives';
+import { DensityProvider, ElevationProvider } from '../../primitives';
 import { type ThemedClassName } from '../../util';
 import { IconButton } from '../Button';
 import { Column } from '../Column';
@@ -72,7 +72,7 @@ const ToastTitle = forwardRef<HTMLHeadingElement, ToastTitleProps>(
       <Column.Row classNames={tx('toast.header', {})}>
         {icon && (
           <div className={tx('toast.icon', {})}>
-            <Icon icon={icon} />
+            <Icon icon={icon} size={5} />
           </div>
         )}
         <ToastPrimitive.Title {...props} className={tx('toast.title', {}, classNames)} ref={forwardedRef}>
@@ -125,7 +125,7 @@ const ToastActions = forwardRef<HTMLDivElement, ToastActionsProps>(
     const { tx } = useThemeContext();
     return (
       <Column.Center classNames={tx('toast.actions', {}, classNames)} ref={forwardedRef} {...props}>
-        {children}
+        <DensityProvider density='sm'>{children}</DensityProvider>
       </Column.Center>
     );
   },


### PR DESCRIPTION
## Summary

Restructures the `Toast` layout to match `Message`, with both components now built on the shared `Column` primitive (3-column grid: `icon | content | action`).

### Changes

- **Column-based layout** for `Toast` and `Message` (`Column.Root` / `Column.Row` / `Column.Center`).
- **`Toast.Title`** now takes an optional `icon` (col 1) and renders a close `IconButton` (col 3) via `onClose`, mirroring `Message.Title`. The body (`Toast.Description`) sits in col 2; optional action(s) render on a separate bottom row (`Toast.Actions`).
- Removed `Toast.Body`; updated all consumers (`plugin-deck`, `plugin-testing`, `plugin-debug`, `plugin-space`) to the new structure.
- Action buttons render at small (`sm`) density via a `DensityProvider` (no consumer changes needed).
- Title icon uses `size={5}`; bottom padding (`pbe-1`) lives on the grid so it applies whether or not action buttons are present.
- Stories: added `defaultOpen` arg, `Default` (no action) and `WithAction` variants; wired `icon`/`duration`/`onClose`.

### Verification

- `react-ui` + all four consumer plugins build (typecheck), lint, and `oxfmt` clean.
- Tests pass for affected packages.
- Verified live in Storybook: Toast and Message share the same 3-column layout (icon→col1, title→col2, close→col3, body→col2); action button at `sm` density; grid bottom padding applied with and without actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Redesigned Toast component with improved icon display and close button integration
  * Updated Message component layout structure for better visual organization

* **Style**
  * Refined theme styling for Toast and Message components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->