### PR TITLE
refactor(echo): rename SystemTypeAnnotation → HiddenAnnotation

### DIFF
--- a/.agent/workflows/types/Function.ts
+++ b/.agent/workflows/types/Function.ts
@@ -5,7 +5,7 @@
 import * as Schema from 'effect/Schema';
 
 import { DXN, Annotation, JsonSchema, Obj, Type } from '@dxos/echo';
-import { SystemTypeAnnotation } from '@dxos/echo/internal';
+import { HiddenAnnotation } from '@dxos/echo/internal';
 
 import { Script } from './Script';
 
@@ -52,7 +52,7 @@ export const Function = Schema.Struct({
 }).pipe(
   Type.makeObject(DXN.make('org.dxos.type.function', '0.1.0')),
   Annotation.LabelAnnotation.set(['name']),
-  SystemTypeAnnotation.set(true),
+  HiddenAnnotation.set(true),
 );
 
 export interface Function extends Schema.Schema.Type<typeof Function> {}

--- a/.agent/workflows/types/Trigger.ts
+++ b/.agent/workflows/types/Trigger.ts
@@ -6,7 +6,7 @@ import * as Schema from 'effect/Schema';
 import * as SchemaAST from 'effect/SchemaAST';
 
 import { DXN, Obj, QueryAST, Ref, Type } from '@dxos/echo';
-import { OptionsAnnotationId, SystemTypeAnnotation } from '@dxos/echo/internal';
+import { OptionsAnnotationId, HiddenAnnotation } from '@dxos/echo/internal';
 import { EID } from '@dxos/keys';
 import { Expando } from '@dxos/schema';
 
@@ -138,7 +138,7 @@ const TriggerSchema = Schema.Struct({
    * }
    */
   input: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.Any })),
-}).pipe(Type.makeObject(DXN.make('org.dxos.type.trigger', '0.1.0')), SystemTypeAnnotation.set(true));
+}).pipe(Type.makeObject(DXN.make('org.dxos.type.trigger', '0.1.0')), HiddenAnnotation.set(true));
 
 export interface Trigger extends Schema.Schema.Type<typeof TriggerSchema> {}
 export const Trigger: Type.Obj<Trigger> = TriggerSchema as any;

--- a/packages/core/compute/assistant-toolkit/src/types/Plan.ts
+++ b/packages/core/compute/assistant-toolkit/src/types/Plan.ts
@@ -44,7 +44,7 @@ export type Task = Schema.Schema.Type<typeof Task>;
  */
 export const Plan = Schema.Struct({
   tasks: Schema.Array(Task),
-}).pipe(Annotation.SystemTypeAnnotation.set(true), Type.makeObject(DXN.make('org.dxos.type.plan', '0.1.0')));
+}).pipe(Annotation.HiddenAnnotation.set(true), Type.makeObject(DXN.make('org.dxos.type.plan', '0.1.0')));
 export type Plan = Type.InstanceType<typeof Plan>;
 export const generateTaskId = (plan: Plan): TaskId => {
   const existingIds = plan.tasks

--- a/packages/core/compute/compute/src/Operation.ts
+++ b/packages/core/compute/compute/src/Operation.ts
@@ -320,7 +320,7 @@ export const PersistentOperation = Schema$.Struct({
 }).pipe(
   Annotation.LabelAnnotation.set(['name']),
   Annotation.IconAnnotation.set({ icon: 'ph--function--regular', hue: 'blue' }),
-  Annotation.SystemTypeAnnotation.set(true),
+  Annotation.HiddenAnnotation.set(true),
   // TODO(dmaretskyi): Keep typename as 'org.dxos.type.function' (not 'operation') to maintain
   //  backward compatibility with existing data and avoid requiring data migration.
   Type.makeObject(DXN.make('org.dxos.type.function', '0.2.0')),

--- a/packages/core/compute/compute/src/Trigger.ts
+++ b/packages/core/compute/compute/src/Trigger.ts
@@ -8,7 +8,7 @@ import * as Schema from 'effect/Schema';
 import * as SchemaAST from 'effect/SchemaAST';
 
 import { DXN, Annotation, Feed, Obj, QueryAST, Ref, Type, type Query } from '@dxos/echo';
-import { OptionsAnnotationId, SystemTypeAnnotation } from '@dxos/echo/internal';
+import { OptionsAnnotationId, HiddenAnnotation } from '@dxos/echo/internal';
 
 /**
  * Type discriminator for TriggerType.
@@ -185,7 +185,7 @@ const TriggerSchema = Schema.Struct({
   input: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.Any })),
 }).pipe(
   Annotation.IconAnnotation.set({ icon: 'ph--lightning--regular', hue: 'yellow' }),
-  SystemTypeAnnotation.set(true),
+  HiddenAnnotation.set(true),
   Type.makeObject(DXN.make('org.dxos.type.trigger', '0.1.0')),
 );
 

--- a/packages/core/echo/echo/src/Annotation.ts
+++ b/packages/core/echo/echo/src/Annotation.ts
@@ -10,7 +10,7 @@ export {
   GeneratorAnnotation,
   LabelAnnotation,
   ReferenceAnnotation,
-  SystemTypeAnnotation,
+  HiddenAnnotation,
   TypeAnnotation,
   getDescriptionWithSchema,
   getLabelWithSchema,

--- a/packages/core/echo/echo/src/Feed.ts
+++ b/packages/core/echo/echo/src/Feed.ts
@@ -43,7 +43,7 @@ export const Feed = Schema.Struct({
    */
   namespace: Schema.optional(Schema.Literal('data', 'trace')),
 }).pipe(
-  internal.SystemTypeAnnotation.set(true),
+  internal.HiddenAnnotation.set(true),
   Annotation.IconAnnotation.set({
     icon: 'ph--rows--regular',
     hue: 'yellow',

--- a/packages/core/echo/echo/src/Tag.ts
+++ b/packages/core/echo/echo/src/Tag.ts
@@ -20,7 +20,7 @@ export const Tag = Schema.Struct({
   hue: Schema.optional(Schema.String), // TODO(burdon): Color name?
 }).pipe(
   internal.LabelAnnotation.set(['label']),
-  internal.SystemTypeAnnotation.set(true),
+  internal.HiddenAnnotation.set(true),
   Type.makeObject(DXN.make('org.dxos.type.tag', '0.1.0')),
 );
 

--- a/packages/core/echo/echo/src/View.ts
+++ b/packages/core/echo/echo/src/View.ts
@@ -75,7 +75,7 @@ const ViewSchema = Schema.Struct({
    */
   projection: Projection,
 }).pipe(
-  internal.SystemTypeAnnotation.set(true),
+  internal.HiddenAnnotation.set(true),
   Annotation.IconAnnotation.set({
     icon: 'ph--funnel--regular',
     hue: 'green',

--- a/packages/core/echo/echo/src/internal/Annotation/annotations.ts
+++ b/packages/core/echo/echo/src/internal/Annotation/annotations.ts
@@ -280,10 +280,10 @@ export const SchemaMetaSymbol = Symbol.for('@dxos/schema/SchemaMeta');
 export type SchemaMeta = TypeMeta & { id: string };
 
 /**
- * Identifies a schema as a schema for a hidden system type.
+ * Identifies a schema as hidden from user-facing surfaces (like dotfiles — visible only via an advanced setting).
  */
-export const SystemTypeAnnotationId = Symbol.for('@dxos/schema/annotation/SystemType');
-export const SystemTypeAnnotation = createAnnotationHelper<boolean>(SystemTypeAnnotationId);
+export const HiddenAnnotationId = Symbol.for('@dxos/schema/annotation/Hidden');
+export const HiddenAnnotation = createAnnotationHelper<boolean>(HiddenAnnotationId);
 
 /**
  * Identifies label property or JSON path expression.

--- a/packages/plugins/plugin-assistant/src/hooks/useFilteredTypes.ts
+++ b/packages/plugins/plugin-assistant/src/hooks/useFilteredTypes.ts
@@ -6,7 +6,7 @@ import * as Option from 'effect/Option';
 import { useEffect, useState } from 'react';
 
 import { type Database, Type } from '@dxos/echo';
-import { EntityKind, SystemTypeAnnotation, getTypeAnnotation } from '@dxos/echo/internal';
+import { EntityKind, HiddenAnnotation, getTypeAnnotation } from '@dxos/echo/internal';
 
 const getFilteredTypes = (db: Database.Database): Type.AnyEntity[] =>
   Array.from(
@@ -15,7 +15,7 @@ const getFilteredTypes = (db: Database.Database): Type.AnyEntity[] =>
         .list()
         .filter(Type.isType)
         .filter((schema) => getTypeAnnotation(Type.getSchema(schema))?.kind !== EntityKind.Relation)
-        .filter((schema) => !SystemTypeAnnotation.get(Type.getSchema(schema)).pipe(Option.getOrElse(() => false))),
+        .filter((schema) => !HiddenAnnotation.get(Type.getSchema(schema)).pipe(Option.getOrElse(() => false))),
     ),
   );
 

--- a/packages/plugins/plugin-chess/src/types/Chess.ts
+++ b/packages/plugins/plugin-chess/src/types/Chess.ts
@@ -7,7 +7,7 @@ import * as Schema from 'effect/Schema';
 
 import { BlueprintsAnnotation } from '@dxos/app-toolkit';
 import { DXN, Annotation, Obj, Type } from '@dxos/echo';
-import { FormInputAnnotation, SystemTypeAnnotation } from '@dxos/echo/internal';
+import { FormInputAnnotation, HiddenAnnotation } from '@dxos/echo/internal';
 import { log } from '@dxos/log';
 
 export const BLUEPRINT_KEY = 'org.dxos.blueprint.chess';
@@ -30,10 +30,10 @@ export const State = Schema.Struct({
   }),
   BlueprintsAnnotation.set([BLUEPRINT_KEY]),
   // Implementation detail of the unified `Game` schema. The user-facing object is `Game`;
-  // this state is only ever referenced via `Game.variant`. SystemType keeps it out of the
+  // this state is only ever referenced via `Game.variant`. HiddenAnnotation keeps it out of the
   // navtree's typed branches so an orphaned state object doesn't reappear after the
   // wrapping Game is deleted.
-  SystemTypeAnnotation.set(true),
+  HiddenAnnotation.set(true),
   Type.makeObject(DXN.make('org.dxos.type.chess.state', '0.1.0')),
 );
 

--- a/packages/plugins/plugin-markdown/src/hooks/useLinkQuery.ts
+++ b/packages/plugins/plugin-markdown/src/hooks/useLinkQuery.ts
@@ -6,7 +6,7 @@ import * as Option from 'effect/Option';
 import { useCallback, useMemo } from 'react';
 
 import { Annotation, type Database, Filter, Obj, Query, Type } from '@dxos/echo';
-import { EntityKind, SystemTypeAnnotation, getTypeAnnotation } from '@dxos/echo/internal';
+import { EntityKind, HiddenAnnotation, getTypeAnnotation } from '@dxos/echo/internal';
 import { type Label, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { type EditorMenuGroup, type EditorMenuItem } from '@dxos/react-ui-editor';
 import { insertAtCursor, insertAtLineStart } from '@dxos/ui-editor';
@@ -21,7 +21,7 @@ export const useLinkQuery = (db: Database.Database | undefined) => {
       Filter.or(
         ...(db ? db.graph.registry.list().filter(Type.isType) : [])
           .filter((schema) => getTypeAnnotation(Type.getSchema(schema))?.kind !== EntityKind.Relation)
-          .filter((schema) => !SystemTypeAnnotation.get(Type.getSchema(schema)).pipe(Option.getOrElse(() => false)))
+          .filter((schema) => !HiddenAnnotation.get(Type.getSchema(schema)).pipe(Option.getOrElse(() => false)))
           .map((schema) => Filter.typename(Type.getTypename(schema))),
       ),
     [db],

--- a/packages/plugins/plugin-outliner/src/types/Journal.ts
+++ b/packages/plugins/plugin-outliner/src/types/Journal.ts
@@ -7,7 +7,7 @@ import * as Schema from 'effect/Schema';
 
 import { DXN, Annotation, Obj, Ref, Type } from '@dxos/echo';
 import { updateText } from '@dxos/echo-db';
-import { SystemTypeAnnotation } from '@dxos/echo/internal';
+import { HiddenAnnotation } from '@dxos/echo/internal';
 import { Text } from '@dxos/schema';
 
 import { getDateString, parseDateString } from './util';
@@ -16,7 +16,7 @@ export const JournalEntry = Schema.Struct({
   id: Schema.String,
   date: Schema.String,
   content: Ref.Ref(Text.Text),
-}).pipe(SystemTypeAnnotation.set(true), Type.makeObject(DXN.make('org.dxos.type.journalEntry', '0.1.0')));
+}).pipe(HiddenAnnotation.set(true), Type.makeObject(DXN.make('org.dxos.type.journalEntry', '0.1.0')));
 
 export type JournalEntry = Type.InstanceType<typeof JournalEntry>;
 

--- a/packages/plugins/plugin-sketch/src/types/Sketch.ts
+++ b/packages/plugins/plugin-sketch/src/types/Sketch.ts
@@ -7,7 +7,7 @@
 import * as Schema from 'effect/Schema';
 
 import { DXN, Annotation, Obj, Ref, Type } from '@dxos/echo';
-import { FormInputAnnotation, SystemTypeAnnotation } from '@dxos/echo/internal';
+import { FormInputAnnotation, HiddenAnnotation } from '@dxos/echo/internal';
 
 export const TLDRAW_SCHEMA = 'tldraw.com/2';
 
@@ -16,7 +16,7 @@ export const Canvas = Schema.Struct({
   // TODO(wittjosiah): Remove once the schema is fully internalized.
   schema: Schema.String.pipe(Schema.optional),
   content: Schema.Record({ key: Schema.String, value: Schema.Any }),
-}).pipe(SystemTypeAnnotation.set(true), Type.makeObject(DXN.make('org.dxos.type.canvas', '0.1.0')));
+}).pipe(HiddenAnnotation.set(true), Type.makeObject(DXN.make('org.dxos.type.canvas', '0.1.0')));
 export type Canvas = Type.InstanceType<typeof Canvas>;
 
 export const Sketch = Schema.Struct({

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/types.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/types.ts
@@ -13,7 +13,7 @@ import { type Space, SpaceState, isSpace } from '@dxos/client/echo';
 import { Operation } from '@dxos/compute';
 import { Annotation, Collection, Filter, Obj, Query, Scope, Type } from '@dxos/echo';
 import { AtomObj, AtomQuery } from '@dxos/echo-atom';
-import { SystemTypeAnnotation } from '@dxos/echo/internal';
+import { HiddenAnnotation } from '@dxos/echo/internal';
 import { ClientCapabilities } from '@dxos/plugin-client';
 import { CreateAtom, GraphBuilder, Node } from '@dxos/plugin-graph';
 import { ViewAnnotation } from '@dxos/schema';
@@ -91,7 +91,7 @@ export const createTypeExtensions = Effect.fnUntraced(function* () {
             return false;
           }
           const schema = Type.getSchema(type);
-          if (SystemTypeAnnotation.get(schema).pipe(Option.getOrElse(() => false))) {
+          if (HiddenAnnotation.get(schema).pipe(Option.getOrElse(() => false))) {
             return false;
           }
           if (Type.getTypename(type) === Type.getTypename(Collection.Collection)) {

--- a/packages/plugins/plugin-space/src/commands/database/add.ts
+++ b/packages/plugins/plugin-space/src/commands/database/add.ts
@@ -17,7 +17,7 @@ import { SpaceProperties } from '@dxos/client/echo';
 // eslint-disable-next-line unused-imports/no-unused-imports
 import type { Operation } from '@dxos/compute';
 import { Collection, Database, Filter, Obj, Query, Scope, Type } from '@dxos/echo';
-import { EntityKind, SystemTypeAnnotation, getTypeAnnotation } from '@dxos/echo/internal';
+import { EntityKind, HiddenAnnotation, getTypeAnnotation } from '@dxos/echo/internal';
 
 import { SpaceCapabilities } from '#types';
 
@@ -86,7 +86,7 @@ const selectTypename = Effect.fn(function* (
   const { db } = yield* Database.Service;
   const allTypes = yield* Database.runQuery(Query.select(Filter.type(Type.Type)).from(Scope.space(), Scope.registry()));
   const types = allTypes
-    .filter((schema) => !SystemTypeAnnotation.get(Type.getSchema(schema)).pipe(Option.getOrElse(() => false)))
+    .filter((schema) => !HiddenAnnotation.get(Type.getSchema(schema)).pipe(Option.getOrElse(() => false)))
     .filter((schema) => getTypeAnnotation(Type.getSchema(schema))?.kind !== EntityKind.Relation)
     .filter((schema) => !!resolve(Type.getTypename(schema)));
 

--- a/packages/plugins/plugin-tictactoe/src/types/TicTacToe.ts
+++ b/packages/plugins/plugin-tictactoe/src/types/TicTacToe.ts
@@ -5,7 +5,7 @@
 import * as Schema from 'effect/Schema';
 
 import { DXN, Annotation, Obj, Type } from '@dxos/echo';
-import { FormInputAnnotation, SystemTypeAnnotation } from '@dxos/echo/internal';
+import { FormInputAnnotation, HiddenAnnotation } from '@dxos/echo/internal';
 
 export const Level = Schema.Literal('easy', 'medium', 'hard');
 export type Level = Schema.Schema.Type<typeof Level>;
@@ -42,7 +42,7 @@ export const State = Schema.Struct({
   // Implementation detail of the unified `Game` schema (see plugin-chess/Chess.ts for the
   // same reasoning). Keeps the state out of the navtree's typed branches so an orphaned
   // state doesn't reappear after the wrapping Game is deleted.
-  SystemTypeAnnotation.set(true),
+  HiddenAnnotation.set(true),
   Type.makeObject(DXN.make('org.dxos.type.tictactoe.state', '0.1.0')),
 );
 

--- a/packages/plugins/plugin-trip/src/types/Segment.ts
+++ b/packages/plugins/plugin-trip/src/types/Segment.ts
@@ -138,7 +138,7 @@ export const Segment = Schema.Struct({
     icon: 'ph--ticket--regular',
     hue: 'sky',
   }),
-  Annotation.SystemTypeAnnotation.set(true),
+  Annotation.HiddenAnnotation.set(true),
   Type.makeObject(DXN.make('org.dxos.type.trip.segment', '0.1.0')),
 );
 

--- a/packages/sdk/app-toolkit/src/type-options.ts
+++ b/packages/sdk/app-toolkit/src/type-options.ts
@@ -6,11 +6,11 @@ import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 
 import { type Database, Type } from '@dxos/echo';
-import { EntityKind, SystemTypeAnnotation, createAnnotationHelper, getTypeAnnotation } from '@dxos/echo/internal';
+import { EntityKind, HiddenAnnotation, createAnnotationHelper, getTypeAnnotation } from '@dxos/echo/internal';
 
 export const TypeInputOptions = Schema.Struct({
   location: Schema.Array(Schema.Literal('database', 'runtime')),
-  kind: Schema.Array(Schema.Literal('system', 'user')),
+  kind: Schema.Array(Schema.Literal('hidden', 'user')),
 });
 
 export type TypeInputOptions = Schema.Schema.Type<typeof TypeInputOptions>;
@@ -25,7 +25,7 @@ export const TypeInputOptionsAnnotation = createAnnotationHelper<TypeInputOption
 export const getTypenames = ({ annotation, db }: { annotation: TypeInputOptions; db?: Database.Database }) => {
   const includeRuntime = annotation.location.includes('runtime');
   const includeDatabase = annotation.location.includes('database');
-  const includeSystemType = annotation.kind.includes('system');
+  const includeHiddenType = annotation.kind.includes('hidden');
   const includeUserType = annotation.kind.includes('user');
 
   const runtimeTypenames =
@@ -38,12 +38,12 @@ export const getTypenames = ({ annotation, db }: { annotation: TypeInputOptions;
             const effectSchema = Type.getSchema(schema);
             const relation = getTypeAnnotation(effectSchema)?.kind === EntityKind.Relation;
             if (relation) {
-              return includeSystemType;
+              return includeHiddenType;
             }
 
-            const system = SystemTypeAnnotation.get(effectSchema).pipe(Option.getOrElse(() => false));
-            if (system) {
-              return includeSystemType;
+            const hidden = HiddenAnnotation.get(effectSchema).pipe(Option.getOrElse(() => false));
+            if (hidden) {
+              return includeHiddenType;
             }
 
             return includeUserType;

--- a/packages/sdk/app-toolkit/src/ui/hooks/useObjectMenuItems.ts
+++ b/packages/sdk/app-toolkit/src/ui/hooks/useObjectMenuItems.ts
@@ -16,7 +16,7 @@ import { getObjectPathFromObject } from '../../paths';
 
 const OPEN_ICON = 'ph--arrow-square-out--regular';
 
-/** True when subject is an Echo object and its schema does not have the system annotation. */
+/** True when subject is an Echo object and its schema does not have the hidden annotation. */
 const canNavigateToSubject = (subject: unknown): subject is Obj.Unknown => {
   if (!subject || !Obj.isObject(subject)) {
     return false;
@@ -27,7 +27,7 @@ const canNavigateToSubject = (subject: unknown): subject is Obj.Unknown => {
   }
 
   const type = Obj.getType(subject);
-  return !(type != null && Option.getOrElse(Annotation.SystemTypeAnnotation.get(Type.getSchema(type)), () => false));
+  return !(type != null && Option.getOrElse(Annotation.HiddenAnnotation.get(Type.getSchema(type)), () => false));
 };
 
 /**

--- a/packages/sdk/app-toolkit/src/ui/hooks/useObjectMenuItems.ts
+++ b/packages/sdk/app-toolkit/src/ui/hooks/useObjectMenuItems.ts
@@ -32,7 +32,7 @@ const canNavigateToSubject = (subject: unknown): subject is Obj.Unknown => {
 
 /**
  * Returns an onClick handler that opens the subject in the layout, or undefined if the subject is not navigable
- * (e.g. not an Echo object or has system annotation). Use with Card.Title for object cards.
+ * (e.g. not an Echo object or has hidden annotation). Use with Card.Title for object cards.
  */
 export const useObjectNavigate = (subject: unknown): (() => void) | undefined => {
   const { invokePromise } = useOperationInvoker();

--- a/packages/sdk/client-protocol/src/types/SpaceProperties.ts
+++ b/packages/sdk/client-protocol/src/types/SpaceProperties.ts
@@ -55,7 +55,7 @@ export type SpacePropertiesSchema = Schema.Schema.Type<typeof SpacePropertiesSch
 // TODO(burdon): Pipe Schem.optional, or partial to entire struct to make everything optional?
 // TODO(burdon): Is separate schema def required for forms? Can it be extracted from SpaceProperties?
 export const SpaceProperties = SpacePropertiesSchema.pipe(
-  Annotation.SystemTypeAnnotation.set(true),
+  Annotation.HiddenAnnotation.set(true),
   Type.makeObject(DXN.make('org.dxos.type.spaceProperties', '0.1.0')),
 );
 

--- a/packages/sdk/schema/src/types/Expando.ts
+++ b/packages/sdk/schema/src/types/Expando.ts
@@ -12,7 +12,7 @@ import { DXN, Annotation, Obj, Type } from '@dxos/echo';
  * Expando object is an object with an arbitrary set of properties.
  */
 export const Expando = Schema.Struct({}, { key: Schema.String, value: Schema.Any }).pipe(
-  Annotation.SystemTypeAnnotation.set(true),
+  Annotation.HiddenAnnotation.set(true),
   Type.makeObject(DXN.make('org.dxos.type.expando', '0.1.0')),
 );
 

--- a/packages/sdk/schema/src/types/Text.ts
+++ b/packages/sdk/schema/src/types/Text.ts
@@ -13,7 +13,7 @@ export const Text = Schema.Struct({
   content: Schema.String,
 }).pipe(
   Annotation.LabelAnnotation.set(['name']),
-  Annotation.SystemTypeAnnotation.set(true),
+  Annotation.HiddenAnnotation.set(true),
   Annotation.IconAnnotation.set({
     icon: 'ph--text-t--regular',
     hue: 'green',

--- a/packages/sdk/types/src/types/AccessToken.ts
+++ b/packages/sdk/types/src/types/AccessToken.ts
@@ -7,7 +7,7 @@
 import * as Schema from 'effect/Schema';
 
 import { DXN, Annotation, Obj, Type } from '@dxos/echo';
-import { Format, LabelAnnotation, SystemTypeAnnotation } from '@dxos/echo/internal';
+import { Format, LabelAnnotation, HiddenAnnotation } from '@dxos/echo/internal';
 
 export const AccessToken = Schema.Struct({
   source: Format.Hostname.annotations({
@@ -35,7 +35,7 @@ export const AccessToken = Schema.Struct({
     icon: 'ph--key--regular',
     hue: 'yellow',
   }),
-  SystemTypeAnnotation.set(true),
+  HiddenAnnotation.set(true),
   Schema.annotations({
     description: 'A credential or token for accessing a service.',
   }),

--- a/packages/sdk/types/src/types/Thread.ts
+++ b/packages/sdk/types/src/types/Thread.ts
@@ -7,7 +7,7 @@
 import * as Schema from 'effect/Schema';
 
 import { DXN, Obj, Ref, Type } from '@dxos/echo';
-import { SystemTypeAnnotation } from '@dxos/echo/internal';
+import { HiddenAnnotation } from '@dxos/echo/internal';
 
 import * as Message from './Message';
 
@@ -43,7 +43,7 @@ export const Thread = Schema.Struct({
   status: ThreadStatus.pipe(Schema.optional),
   messages: Schema.Array(Ref.Ref(Message.Message)),
   agent: Schema.optional(AgentConfig),
-}).pipe(SystemTypeAnnotation.set(true), Type.makeObject(DXN.make('org.dxos.type.thread', '0.2.0')));
+}).pipe(HiddenAnnotation.set(true), Type.makeObject(DXN.make('org.dxos.type.thread', '0.2.0')));
 
 export type Thread = Type.InstanceType<typeof Thread>;
 export const make = ({

--- a/packages/sdk/types/src/types/Transcript.ts
+++ b/packages/sdk/types/src/types/Transcript.ts
@@ -7,7 +7,7 @@
 import * as Schema from 'effect/Schema';
 
 import { DXN, Annotation, Feed, Obj, Ref, Type } from '@dxos/echo';
-import { SystemTypeAnnotation } from '@dxos/echo/internal';
+import { HiddenAnnotation } from '@dxos/echo/internal';
 
 /**
  * Root transcript object created when the user starts a transcription.
@@ -24,7 +24,7 @@ export const Transcript = Schema.Struct({
    */
   feed: Ref.Ref(Feed.Feed),
 }).pipe(
-  SystemTypeAnnotation.set(true),
+  HiddenAnnotation.set(true),
   Annotation.IconAnnotation.set({
     icon: 'ph--subtitles--regular',
     hue: 'sky',


### PR DESCRIPTION
## Summary

- Renames `SystemTypeAnnotation` / `SystemTypeAnnotationId` to `HiddenAnnotation` / `HiddenAnnotationId` across 27 files
- Updates the annotation symbol from `@dxos/schema/annotation/SystemType` → `@dxos/schema/annotation/Hidden`
- Updates `TypeInputOptions` kind literal from `'system'` → `'hidden'`

## Why

The old name "SystemType" was misleading on two counts:

1. **"System"** implies low-level framework internals, but the annotation is used for anything that should be invisible to users by default — like dotfiles on a filesystem. Types like `Thread`, `Transcript`, `Canvas`, `TicTacToe.State`, and `Chess.State` are hidden not because they're "system" types, but because they're implementation details or supporting types the user never needs to see directly.

2. **"Type"** implied specificity to Type-kind entities, when the annotation applies to any schema-defined object kind.

`HiddenAnnotation` captures the intent precisely: annotated schemas are hidden from user-facing surfaces (type selectors, navtree, link queries, object menu navigation). Showing them requires explicitly opting in — like a "show hidden files" setting.

## Scope

Schema-level annotation only (all instances of a hidden type are hidden). Per-instance hiding is out of scope.

## Test plan

- [x] `moon run echo:test` — all 353 tests pass
- [x] `moon run echo:build app-toolkit:build plugin-space:build plugin-markdown:build plugin-assistant:build plugin-chess:build plugin-sketch:build plugin-tictactoe:build plugin-outliner:build plugin-trip:build` — 335 tasks completed, no errors
- [x] No remaining references to `SystemTypeAnnotation` or `SystemTypeAnnotationId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized how certain internal types are marked as hidden across the app. As a result, type lists, selection dialogs, navigation menus, link queries, and other UI surfaces consistently exclude hidden types unless explicitly requested, improving clarity and consistency in type selection and navigation throughout the product.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->