### PR TITLE
fix(plugin-space): stop spurious space migration action

### DIFF
--- a/packages/plugins/plugin-navtree/src/components/NavTree/NavTree.stories.tsx
+++ b/packages/plugins/plugin-navtree/src/components/NavTree/NavTree.stories.tsx
@@ -161,9 +161,8 @@ export const Default: Story = {
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
 
-    // Find the element with treegrid role and click on its parent.
-    // Allow extra time for the plugin manager and graph to mount in slower CI environments.
-    const treegridElement = await canvas.findByRole('treegrid', undefined, { timeout: 10_000 });
+    // Find the element with treegrid role and click on its parent
+    const treegridElement = await canvas.findByRole('treegrid');
     const treegridParent = treegridElement.parentElement;
     if (treegridParent) {
       await userEvent.click(treegridParent);

--- a/packages/plugins/plugin-navtree/src/components/NavTree/NavTree.stories.tsx
+++ b/packages/plugins/plugin-navtree/src/components/NavTree/NavTree.stories.tsx
@@ -161,8 +161,9 @@ export const Default: Story = {
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
 
-    // Find the element with treegrid role and click on its parent
-    const treegridElement = await canvas.findByRole('treegrid');
+    // Find the element with treegrid role and click on its parent.
+    // Allow extra time for the plugin manager and graph to mount in slower CI environments.
+    const treegridElement = await canvas.findByRole('treegrid', undefined, { timeout: 10_000 });
     const treegridParent = treegridElement.parentElement;
     if (treegridParent) {
       await userEvent.click(treegridParent);

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.test.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.test.ts
@@ -10,6 +10,7 @@ import { type Space, SpaceState } from '@dxos/client/echo';
 import { DXN, Filter, Obj, Query, Ref, Type, View } from '@dxos/echo';
 import { type EchoDatabase } from '@dxos/echo-db';
 import { EchoTestBuilder } from '@dxos/echo-db/testing';
+import { invariant } from '@dxos/invariant';
 import { Migrations } from '@dxos/migrations';
 import { ViewAnnotation } from '@dxos/schema';
 
@@ -121,6 +122,7 @@ describe('checkPendingMigration', () => {
 
   let savedNamespace: string | undefined;
   let savedMigrations: typeof Migrations.migrations;
+  let versionProperty: string;
 
   beforeEach(() => {
     savedNamespace = Migrations.namespace;
@@ -129,6 +131,8 @@ describe('checkPendingMigration', () => {
       { version: '1970-01-01', next: async () => {} },
       { version: TARGET, next: async () => {} },
     ]);
+    invariant(Migrations.versionProperty, 'Migrations.versionProperty must be set after define().');
+    versionProperty = Migrations.versionProperty;
   });
 
   afterEach(() => {
@@ -137,12 +141,12 @@ describe('checkPendingMigration', () => {
   });
 
   test('SPACE_REQUIRES_MIGRATION is pending regardless of version property', ({ expect }) => {
-    const space = makeFakeSpace(SpaceState.SPACE_REQUIRES_MIGRATION, { [Migrations.versionProperty!]: TARGET });
+    const space = makeFakeSpace(SpaceState.SPACE_REQUIRES_MIGRATION, { [versionProperty]: TARGET });
     expect(checkPendingMigration(space)).toBe(true);
   });
 
   test('READY with version matching target is not pending', ({ expect }) => {
-    const space = makeFakeSpace(SpaceState.SPACE_READY, { [Migrations.versionProperty!]: TARGET });
+    const space = makeFakeSpace(SpaceState.SPACE_READY, { [versionProperty]: TARGET });
     expect(checkPendingMigration(space)).toBe(false);
   });
 
@@ -152,7 +156,7 @@ describe('checkPendingMigration', () => {
   });
 
   test('READY with stale version is pending', ({ expect }) => {
-    const space = makeFakeSpace(SpaceState.SPACE_READY, { [Migrations.versionProperty!]: '1970-01-01' });
+    const space = makeFakeSpace(SpaceState.SPACE_READY, { [versionProperty]: '1970-01-01' });
     expect(checkPendingMigration(space)).toBe(true);
   });
 });

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.test.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.test.ts
@@ -6,12 +6,14 @@ import * as Registry from '@effect-atom/atom/Registry';
 import * as Schema from 'effect/Schema';
 import { afterEach, beforeEach, describe, test } from 'vitest';
 
+import { type Space, SpaceState } from '@dxos/client/echo';
 import { DXN, Filter, Obj, Query, Ref, Type, View } from '@dxos/echo';
 import { type EchoDatabase } from '@dxos/echo-db';
 import { EchoTestBuilder } from '@dxos/echo-db/testing';
+import { Migrations } from '@dxos/migrations';
 import { ViewAnnotation } from '@dxos/schema';
 
-import { buildViewIndex } from './shared';
+import { buildViewIndex, checkPendingMigration } from './shared';
 
 const TestContact = Schema.Struct({
   name: Schema.String,
@@ -107,5 +109,50 @@ describe('buildViewIndex', () => {
 
     expect(viewIndex.typenamesWithViews.size).toBe(0);
     expect(viewIndex.getViewsForTypename(Type.getTypename(TestContact))).toHaveLength(0);
+  });
+});
+
+describe('checkPendingMigration', () => {
+  const TARGET = '1970-01-02';
+
+  // Minimal fake exercising only the fields checkPendingMigration reads (state, properties).
+  const makeFakeSpace = (state: SpaceState, properties: Record<string, unknown>): Space =>
+    ({ state: { get: () => state }, properties }) as unknown as Space;
+
+  let savedNamespace: string | undefined;
+  let savedMigrations: typeof Migrations.migrations;
+
+  beforeEach(() => {
+    savedNamespace = Migrations.namespace;
+    savedMigrations = Migrations.migrations;
+    Migrations.define('test', [
+      { version: '1970-01-01', next: async () => {} },
+      { version: TARGET, next: async () => {} },
+    ]);
+  });
+
+  afterEach(() => {
+    Migrations.namespace = savedNamespace;
+    Migrations.migrations = savedMigrations;
+  });
+
+  test('SPACE_REQUIRES_MIGRATION is pending regardless of version property', ({ expect }) => {
+    const space = makeFakeSpace(SpaceState.SPACE_REQUIRES_MIGRATION, { [Migrations.versionProperty!]: TARGET });
+    expect(checkPendingMigration(space)).toBe(true);
+  });
+
+  test('READY with version matching target is not pending', ({ expect }) => {
+    const space = makeFakeSpace(SpaceState.SPACE_READY, { [Migrations.versionProperty!]: TARGET });
+    expect(checkPendingMigration(space)).toBe(false);
+  });
+
+  test('READY with undefined version is pending (legacy property-migration preserved)', ({ expect }) => {
+    const space = makeFakeSpace(SpaceState.SPACE_READY, {});
+    expect(checkPendingMigration(space)).toBe(true);
+  });
+
+  test('READY with stale version is pending', ({ expect }) => {
+    const space = makeFakeSpace(SpaceState.SPACE_READY, { [Migrations.versionProperty!]: '1970-01-01' });
+    expect(checkPendingMigration(space)).toBe(true);
   });
 });

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
@@ -230,6 +230,12 @@ export const createSpaceExtensions = Effect.fnUntraced(function* () {
           return Effect.succeed([]);
         }
 
+        // Recompute actions when a migration completes (state transition or versionProperty stamp).
+        get(CreateAtom.fromObservable(space.state));
+        if (space.state.get() === SpaceState.SPACE_READY) {
+          get(AtomObj.make(space.properties));
+        }
+
         return Effect.succeed(
           constructSpaceActions({
             space,

--- a/packages/plugins/plugin-space/src/capabilities/identity-created.ts
+++ b/packages/plugins/plugin-space/src/capabilities/identity-created.ts
@@ -17,7 +17,10 @@ export default Capability.makeModule(
     const client = yield* Capability.get(ClientCapabilities.Client);
 
     const personalSpace = yield* Effect.tryPromise(() =>
-      client.spaces.create({}, { tags: [PERSONAL_SPACE_TAG], membershipPolicy: MembershipPolicy.LOCKED }),
+      client.spaces.create(
+        Migrations.versionProperty ? { [Migrations.versionProperty]: Migrations.targetVersion } : {},
+        { tags: [PERSONAL_SPACE_TAG], membershipPolicy: MembershipPolicy.LOCKED },
+      ),
     );
     yield* Effect.tryPromise(() => personalSpace.waitUntilReady());
 
@@ -25,9 +28,6 @@ export default Capability.makeModule(
     yield* Effect.tryPromise(() => personalSpace.internal.setEdgeReplicationPreference(EdgeReplicationSetting.ENABLED));
     Obj.update(personalSpace.properties, (properties) => {
       properties[Type.getTypename(Collection.Collection)] = Ref.make(Collection.make());
-      if (Migrations.versionProperty) {
-        properties[Migrations.versionProperty] = Migrations.targetVersion;
-      }
     });
   }),
 );

--- a/packages/plugins/plugin-space/src/operations/create.ts
+++ b/packages/plugins/plugin-space/src/operations/create.ts
@@ -22,7 +22,14 @@ const handler: Operation.WithHandler<typeof SpaceOperation.Create> = SpaceOperat
       const client = yield* Capability.get(ClientCapabilities.Client);
       const hue = hue_ ?? hues[Math.floor(Math.random() * hues.length)];
       const icon = icon_ ?? iconValues[Math.floor(Math.random() * iconValues.length)];
-      const space = yield* Effect.promise(() => client.spaces.create({ name, hue, icon }));
+      const space = yield* Effect.promise(() =>
+        client.spaces.create({
+          name,
+          hue,
+          icon,
+          ...(Migrations.versionProperty ? { [Migrations.versionProperty]: Migrations.targetVersion } : {}),
+        }),
+      );
       if (edgeReplication) {
         yield* Effect.promise(() => space.internal.setEdgeReplicationPreference(EdgeReplicationSetting.ENABLED));
       }
@@ -31,9 +38,6 @@ const handler: Operation.WithHandler<typeof SpaceOperation.Create> = SpaceOperat
       const collection = Obj.make(Collection.Collection, { objects: [] });
       Obj.update(space.properties, (obj) => {
         obj[Type.getTypename(Collection.Collection)] = Ref.make(collection);
-        if (Migrations.versionProperty) {
-          obj[Migrations.versionProperty] = Migrations.targetVersion;
-        }
       });
 
       yield* Plugin.activate(SpaceEvents.SpaceCreated);


### PR DESCRIPTION
## Problem

A space's **"Migrate" (database migration)** button could show up as the *primary* action (replacing "Add object") on a space, and after running it the button wouldn't go away. It was intermittent and reproduced even for newly created identities.

## Root causes

**1. Race on space creation.** Both creation paths ([create.ts](https://github.com/dxos/dxos/blob/main/packages/plugins/plugin-space/src/operations/create.ts), [identity-created.ts](https://github.com/dxos/dxos/blob/main/packages/plugins/plugin-space/src/capabilities/identity-created.ts)) stamped the migration version property *after* `waitUntilReady()` via a follow-up `Obj.update`. Between the space becoming READY and that stamp landing, `space.properties[versionProperty]` was `undefined`, so `checkPendingMigration` returned true (`undefined !== targetVersion`) and the Migrate action was shown.

**2. Missing reactivity.** The space-node `actions` graph extension only reactively subscribed to the Client and EphemeralState atoms; it read `space.state` and `space.properties` as *untracked* plain reads. When a migration completed (state transition or version-property write), the extension never re-ran, so the `spaceActionsCache` kept serving the stale Migrate action until a full reload. This is the "won't disappear after running it" symptom.

## Fix

1. **Atomic stamp** — pass the version through the `client.spaces.create(meta)` argument, which is written and flushed *before* the space is observable as READY. Closes the race by construction (no transient undefined window). The `SpaceProperties` index signature accepts the key with no cast.
2. **Restore reactivity** — the `actions` extension now subscribes to `space.state` and (when READY) `space.properties`, mirroring the proven sibling connector extension. The action list recomputes and `spaceActionsCache` invalidates the moment a migration completes.

`checkPendingMigration` is intentionally left unchanged so genuine legacy property-migrations still register as pending.

## Tests

Added `checkPendingMigration` unit tests covering `SPACE_REQUIRES_MIGRATION` → pending, READY+matching → not pending, READY+stale → pending, and **READY+undefined → still pending** (guards the legacy invariant).

## Verification

- `moon run plugin-space:build` — green
- `moon run plugin-space:lint -- --fix` — clean
- `moon run plugin-space:test` — green (incl. new tests)
- Cast audit: only the test fake (`as unknown as Space`), zero casts in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests validating space migration state handling across multiple scenarios.

* **Bug Fixes**
  * Improved space state reactivity so actions refresh when migration-related transitions or version changes occur.
  * Fixed space creation to include migration/version metadata at initialization rather than via a subsequent update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->