### PR TITLE
test(functions-runtime): store trigger operations in the registry instead of the database

### DIFF
--- a/packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.test.ts
+++ b/packages/core/compute/functions-runtime/src/triggers/trigger-dispatcher.test.ts
@@ -65,6 +65,18 @@ const TestTriggerDispatcherLayer = makeTestTriggerDispatcherLayer({
   startingTime: new Date('2025-09-05T15:01:00.000Z'),
 });
 
+/**
+ * Store an operation definition in the database registry rather than persisting it to the
+ * database. The dispatcher resolves the trigger's function ref transparently from the registry.
+ */
+const registerOperation = (operation: Operation.Definition.Any) =>
+  Effect.gen(function* () {
+    const record = Operation.serialize(operation);
+    const { db } = yield* Database.Service;
+    db.registry.add([record]);
+    return record;
+  });
+
 describe('TriggerDispatcher', () => {
   describe('Time Control', () => {
     it.effect(
@@ -89,8 +101,7 @@ describe('TriggerDispatcher', () => {
     it.effect(
       'should manually invoke trigger',
       Effect.fnUntraced(function* ({ expect }) {
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
         const trigger = Trigger.make({
           function: Ref.make(functionObj),
           enabled: true,
@@ -112,8 +123,7 @@ describe('TriggerDispatcher', () => {
     it.effect(
       'should invoke scheduled timer triggers',
       Effect.fnUntraced(function* ({ expect }) {
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
         const trigger = Trigger.make({
           function: Ref.make(functionObj),
           enabled: true,
@@ -138,8 +148,7 @@ describe('TriggerDispatcher', () => {
     it.effect(
       'should handle disabled triggers',
       Effect.fnUntraced(function* ({ expect }) {
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
 
         const enabledTrigger = Trigger.make({
           function: Ref.make(functionObj),
@@ -173,8 +182,7 @@ describe('TriggerDispatcher', () => {
     it.effect(
       'cron triggers are invoked periodically on schedule',
       Effect.fnUntraced(function* ({ expect }) {
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
 
         // cron every 5 minutes
         const trigger = Trigger.make({
@@ -219,7 +227,8 @@ describe('TriggerDispatcher', () => {
           // Use a Person object as the function ref so trigger invocation fails the
           // `Obj.instanceOf(Operation.PersistentOperation, ...)` invariant.
           const badFn = Obj.make(Person.Person, { fullName: 'not-an-operation' });
-          yield* Database.add(badFn);
+          const { db } = yield* Database.Service;
+          db.registry.add([badFn]);
 
           const trigger = Trigger.make({
             function: Ref.make(badFn) as any,
@@ -269,8 +278,7 @@ describe('TriggerDispatcher', () => {
         // Initially no triggers in database
 
         // Add a trigger dynamically
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
         const trigger = Trigger.make({
           function: Ref.make(functionObj),
           enabled: true,
@@ -289,8 +297,7 @@ describe('TriggerDispatcher', () => {
     it.effect(
       'should support Effect cron expressions',
       Effect.fnUntraced(function* ({ expect }) {
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
 
         const validPatterns = [
           '* * * * *', // Every minute
@@ -320,8 +327,7 @@ describe('TriggerDispatcher', () => {
     it.effect(
       'should handle invalid cron expressions gracefully',
       Effect.fnUntraced(function* ({ expect }) {
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
 
         // Test with an invalid pattern
         const trigger = Trigger.make({
@@ -361,8 +367,7 @@ describe('TriggerDispatcher', () => {
       Effect.fnUntraced(function* ({ expect }) {
         const feed = yield* Database.add(Feed.make());
 
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
         const trigger = Trigger.make({
           function: Ref.make(functionObj),
           enabled: true,
@@ -388,8 +393,7 @@ describe('TriggerDispatcher', () => {
       Effect.fnUntraced(function* ({ expect }) {
         const feed = yield* Database.add(Feed.make());
 
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
         const trigger = Trigger.make({
           function: Ref.make(functionObj),
           enabled: true,
@@ -433,8 +437,7 @@ describe('TriggerDispatcher', () => {
       Effect.fnUntraced(function* ({ expect }) {
         const feed = yield* Database.add(Feed.make());
 
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
         const trigger = Trigger.make({
           function: Ref.make(functionObj),
           enabled: true,
@@ -473,8 +476,7 @@ describe('TriggerDispatcher', () => {
       Effect.fnUntraced(function* ({ expect }) {
         const feed = yield* Database.add(Feed.make());
 
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
         const trigger = Trigger.make({
           function: Ref.make(functionObj),
           enabled: true,
@@ -515,8 +517,7 @@ describe('TriggerDispatcher', () => {
     it.effect(
       'should invoke triggers on object creation',
       Effect.fnUntraced(function* ({ expect }) {
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
 
         // Create a subscription trigger that watches for Person objects
         const trigger = Trigger.make({
@@ -548,8 +549,7 @@ describe('TriggerDispatcher', () => {
     it.effect(
       'should invoke triggers on object updates',
       Effect.fnUntraced(function* ({ expect }) {
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
 
         // Create a person object first
         const person = Obj.make(Person.Person, {
@@ -589,8 +589,7 @@ describe('TriggerDispatcher', () => {
     it.effect.skip(
       'should not invoke triggers for unchanged objects',
       Effect.fnUntraced(function* ({ expect }) {
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
 
         // Create a subscription trigger first
         const trigger = Trigger.make({
@@ -636,8 +635,7 @@ describe('TriggerDispatcher', () => {
     it.effect(
       'should handle multiple object types with filters',
       Effect.fnUntraced(function* ({ expect }) {
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
 
         // Create a subscription trigger that only watches for Task objects
         const trigger = Trigger.make({
@@ -675,8 +673,7 @@ describe('TriggerDispatcher', () => {
     it.effect(
       'should pass correct event data to function',
       Effect.fnUntraced(function* ({ expect }) {
-        const functionObj = Operation.serialize(Reply);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(Reply);
 
         const person = Obj.make(Person.Person, {
           fullName: 'Eva Martinez',
@@ -803,8 +800,7 @@ describe('TriggerDispatcher', () => {
     it.effect(
       'invokeTrigger spawns operations with the dispatcher environment so space-affinity services resolve',
       Effect.fnUntraced(function* ({ expect }) {
-        const functionObj = Operation.serialize(ProbeOp);
-        yield* Database.add(functionObj);
+        const functionObj = yield* registerOperation(ProbeOp);
 
         const trigger = Trigger.make({
           function: Ref.make(functionObj),


### PR DESCRIPTION
## Summary

Migrates the trigger dispatcher test suite to register operation definitions in the ECHO **database registry** (`db.registry.add(...)`) rather than persisting them to the database via `Database.add(...)`.

The `TriggerDispatcher` resolves a trigger's `function` ref by calling `Database.load(trigger.function!)`. Because reference resolution consults the registry transparently, the dispatcher needs **no changes** — the operation record now lives in `db.registry` and the ref still resolves, both for direct `invokeTrigger` calls and for the scheduled path where triggers are re-fetched from a DB query.

## Changes

- Added a `registerOperation(operation)` helper that serializes an operation definition and stores it in `db.registry`, returning the record so callers can still build the trigger's function ref with `Ref.make(...)`.
- Replaced all 16 `Operation.serialize(...)` + `Database.add(...)` pairs across the suite (timer, feed, subscription, cron, dynamic, manual, and service-resolution tests) with the helper.
- Updated the failure-cooldown test's stand-in `Person` ref to register through the registry too, keeping the "resolves to a non-operation → invariant fails" semantics consistent with the rest of the suite.

## Verification

- `trigger-dispatcher.test.ts`: 19 passed, 1 pre-existing skip (matches baseline).
- `functions-runtime:lint` ✓, `functions-runtime:build` ✓, `tsc --noEmit` clean for the file.
- No new type casts introduced.

https://claude.ai/code/session_012BKRQKBh91cY68nGvkyfwz

---
_Generated by [Claude Code](https://claude.ai/code/session_012BKRQKBh91cY68nGvkyfwz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored trigger-related tests to register operations through a standardized database registry pattern, replacing previous persistence methods.
  * Enhanced test consistency across multiple trigger scenarios including timer scheduling, cron scheduling, feed triggers, and database subscriptions.
  * Improved alignment between test infrastructure and runtime operation dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->