### PR TITLE
chore(plugin-feed): publish to pkg.pr.new

### DIFF
--- a/packages/plugins/plugin-feed/package.json
+++ b/packages/plugins/plugin-feed/package.json
@@ -140,5 +140,8 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-feed/package.json
+++ b/packages/plugins/plugin-feed/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-feed",
   "version": "0.8.3",
-  "private": true,
   "description": "Feed plugin for RSS and open protocol subscriptions.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",


### PR DESCRIPTION
## Summary

Removes `"private": true` from `@dxos/plugin-feed/package.json` so the package is included in the pkg.pr.new publish run on every push to `main`.

## Why

A downstream consumer (`compute-intrinsics`) depends on `@dxos/plugin-feed` and needs to install snapshots from pkg.pr.new — but `.github/workflows/scripts/pkg-pr-new-publish.sh` filters by `!pkg.private`, so the plugin was silently skipped.

The `private` gate in CLAUDE.md is about npm registry publishing (which requires a trusted publisher); pkg.pr.new has no such requirement, so this change is safe. Comparable plugins (`plugin-graph`, `plugin-deck`, `plugin-space`, `plugin-client`) already have no `private` field.

## Test plan

- [ ] After merge, confirm the next `pkg-pr-new` workflow run on `main` lists `@dxos/plugin-feed` among the published packages.
- [ ] Confirm compute-intrinsics can resolve `@dxos/plugin-feed` from the pkg.pr.new snapshot URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made the plugin-feed package publicly publishable, enabling it to be distributed and installed from the public package registry. This is a packaging/configuration change only and does not alter runtime behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->