### PR TITLE
fix(tauri): spotlight popover renders blank + exclude sample plugin from tauri

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -385,8 +385,7 @@ const main = async () => {
     logStore,
 
     isDev: !['production', 'staging'].includes(config.values.runtime?.app?.env?.DX_ENVIRONMENT),
-    isLocal:
-      !isTauri && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'),
+    isLocal: !isTauri && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'),
     isPwa,
     isTauri,
     isPopover,

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -385,7 +385,8 @@ const main = async () => {
     logStore,
 
     isDev: !['production', 'staging'].includes(config.values.runtime?.app?.env?.DX_ENVIRONMENT),
-    isLocal: window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1',
+    isLocal:
+      !isTauri && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'),
     isPwa,
     isTauri,
     isPopover,

--- a/packages/plugins/plugin-spotlight/package.json
+++ b/packages/plugins/plugin-spotlight/package.json
@@ -81,6 +81,7 @@
     "@dxos/keys": "workspace:*",
     "@dxos/log": "workspace:*",
     "@dxos/plugin-graph": "workspace:*",
+    "@dxos/plugin-navtree": "workspace:*",
     "@dxos/util": "workspace:*",
     "@effect-atom/atom": "catalog:",
     "@effect-atom/atom-react": "catalog:",

--- a/packages/plugins/plugin-spotlight/src/capabilities/state.tsx
+++ b/packages/plugins/plugin-spotlight/src/capabilities/state.tsx
@@ -8,11 +8,9 @@ import * as Effect from 'effect/Effect';
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
 import { Node } from '@dxos/plugin-graph';
+import { COMMANDS_DIALOG } from '@dxos/plugin-navtree';
 
 import { SpotlightCapabilities } from '#types';
-
-/** Commands dialog surface identifier (from plugin-navtree). */
-const COMMANDS_DIALOG = 'org.dxos.plugin.navtree.commands-dialog';
 
 const defaultState: SpotlightCapabilities.SpotlightState = {
   dialogOpen: true,

--- a/packages/plugins/plugin-spotlight/src/components/SpotlightLayout.tsx
+++ b/packages/plugins/plugin-spotlight/src/components/SpotlightLayout.tsx
@@ -6,13 +6,11 @@ import React from 'react';
 
 import { Surface } from '@dxos/app-framework/ui';
 import { AppSurface } from '@dxos/app-toolkit/ui';
+import { COMMANDS_DIALOG } from '@dxos/plugin-navtree';
 import { Dialog, ErrorFallback, useAsyncEffect } from '@dxos/react-ui';
 import { isTauri } from '@dxos/util';
 
 import { useSpotlightState } from './useSpotlightState';
-
-/** Commands dialog surface identifier (from plugin-navtree). */
-const COMMANDS_DIALOG = 'org.dxos.plugin.navtree.commands-dialog';
 
 /**
  * Spotlight layout renders the commands dialog directly as the main content.

--- a/packages/plugins/plugin-spotlight/tsconfig.json
+++ b/packages/plugins/plugin-spotlight/tsconfig.json
@@ -32,6 +32,9 @@
       "path": "../plugin-graph"
     },
     {
+      "path": "../plugin-navtree"
+    },
+    {
       "path": "../plugin-testing"
     }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15082,6 +15082,9 @@ importers:
       '@dxos/plugin-graph':
         specifier: workspace:*
         version: link:../plugin-graph
+      '@dxos/plugin-navtree':
+        specifier: workspace:*
+        version: link:../plugin-navtree
       '@dxos/util':
         specifier: workspace:*
         version: link:../../common/util


### PR DESCRIPTION
## Summary

- **Blank spotlight popover**: `SpotlightLayout` and `state.tsx` hardcoded a stale, wrong commands-dialog surface id (`'org.dxos.plugin.navtree.commands-dialog'`) while navtree registers its surface under `COMMANDS_DIALOG = DXN.make('…navtree.commandsDialog')`. The values never matched, so the `<Surface>` resolver found no candidate and rendered empty. Fix: import `COMMANDS_DIALOG` from `@dxos/plugin-navtree` directly (single source of truth; adds `@dxos/plugin-navtree` as a workspace dep of `plugin-spotlight`).

- **Sample plugin in Tauri**: `isLocal` was `true` in the desktop app because it serves from `http://localhost`, but the sample plugin should only appear in a local browser dev environment. Guard: `isLocal = !isTauri && (hostname === 'localhost' || …)`.

## Test plan

- [ ] Open the Tauri desktop app, press Alt+Space — commands dialog renders in the spotlight popover (was blank before)
- [ ] Alt+Space → click away → popover dismisses (blur dismissal confirmed working during investigation)
- [ ] Alt+Space → Escape → popover dismisses
- [ ] In a local browser dev build (`localhost:5173`), confirm sample plugin is available
- [ ] In the Tauri desktop build, confirm sample plugin is NOT in the plugin list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated command dialog configuration so multiple plugins share the same dialog behavior

* **Chores**
  * Added integration with a navigation/tree plugin and updated TypeScript project references
  * Tweaked local environment detection to handle Tauri-based launches correctly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->