### PR TITLE
ci: split storybook tests into their own job

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -42,7 +42,7 @@ To run e2e job:
 | :-- | :-- | :-- | :-- |
 | **Flaky** in Trunk | Trunk UI, or **automatically** via Trunk’s **pass-on-rerun** detection | None—Trunk metadata only | Tests still run; failures still fail the job unless quarantined |
 | **Quarantine** in Trunk | Trunk UI | None | Test still **runs**; its failure does **not** fail the job |
-| **Vitest `tags: ['flaky']`** | Code (per-suite/test option, declared in [`vitest.base.config.ts`](../../vitest.base.config.ts)) | Default `:test` task sets `VITEST_TAGS_FILTER='!flaky && …'` so gated suites **skip** locally | **`test`** job sets `VITEST_TAGS_FILTER='!llm && !sync && !sync-e2e && !functions-e2e && !tracing-e2e'`, so `flaky` tests **run** and Trunk keeps signal |
+| **Vitest `tags: ['flaky']`** | Code (per-suite/test option, declared in [`vitest.base.config.ts`](../../vitest.base.config.ts)) | Default `:test` task sets `VITEST_TAGS_FILTER='!flaky && …'` so gated suites **skip** locally | **`test`** and **`storybook`** jobs set the same `VITEST_TAGS_FILTER='!llm && !sync && !sync-e2e && !functions-e2e && !tracing-e2e'`, so `flaky` tests **run** and Trunk keeps signal |
 
 **Pass-on-rerun:** Trunk marks a test as flaky when it observes a **fail then pass on retry** pattern (same CI job: a failing attempt followed by a passing retry). That is distinct from manually marking a test flaky in the Trunk UI.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,13 +24,14 @@ To run e2e job:
 
 ## Trunk
 
-[Trunk](https://trunk.io) ingests JUnit from the **Check** workflow ([`check.yml`](check.yml)) for flaky-test detection and quarantine. The **`test`** and **`e2e`** jobs wrap their `moon` steps with `trunk-io/analytics-uploader@v1` (`org-slug: dxos`, `quarantine: true`, `TRUNK_TOKEN`). Uploaded XML feeds Trunk for flaky labeling and quarantine decisions.
+[Trunk](https://trunk.io) ingests JUnit from the **Check** workflow ([`check.yml`](check.yml)) for flaky-test detection and quarantine. The **`test`**, **`storybook`**, and **`e2e`** jobs wrap their `moon` steps with `trunk-io/analytics-uploader@v1` (`org-slug: dxos`, `quarantine: true`, `TRUNK_TOKEN`). Uploaded XML feeds Trunk for flaky labeling and quarantine decisions.
 
 ### Jobs and artifacts
 
 | Job | What runs | JUnit paths Trunk reads |
 | :-- | :-- | :-- |
-| `test` | Vitest, browser Vitest, Storybook (`:test`, `:test-browser`, `:test-storybook` via uploader; same workflow triggers as the rest of **Check**). | `test-results/**/results.xml` |
+| `test` | Vitest + browser Vitest (`:test`, `:test-browser` via uploader; same workflow triggers as the rest of **Check**). | `test-results/**/results.xml` |
+| `storybook` | Storybook tests (`:test-storybook` via uploader). Runs on its own runner in parallel with `test`. | `test-results/**/results.xml` |
 | `e2e` | Playwright e2e (`:e2e` via uploader). Job runs only for `main` / `rc-*` / `hotfix-*` / `release-please-*` refs, or `workflow_dispatch` with `e2e` (see [`check.yml`](check.yml)). | `test-results/playwright/report/*.xml` |
 
 **unit/browser/storybook** go through Trunk on typical PRs; **e2e** only when the `e2e` job runs (not on ordinary topic-branch PRs). Exact `moon` commands and `env` are in [`check.yml`](check.yml).

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -486,7 +486,7 @@ jobs:
           access-token: ${{ secrets.GITHUB_TOKEN }}
 
   report:
-    needs: test
+    needs: [test, storybook]
     if: always() && github.event_name == 'schedule'
     runs-on: depot-ubuntu-24.04-8
     container:
@@ -501,3 +501,8 @@ jobs:
         with:
           name: test-24.11.1
           result: ${{ needs.test.result }}
+      - name: Send storybook report
+        uses: ./.github/actions/test-report
+        with:
+          name: storybook-24.11.1
+          result: ${{ needs.storybook.result }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -172,12 +172,12 @@ jobs:
           org-slug: dxos
           token: ${{ secrets.TRUNK_TOKEN }}
           quarantine: true
-          run: moon run :test :test-browser :test-storybook --affected remote -- --no-file-parallelism
+          run: moon run :test :test-browser --affected remote -- --no-file-parallelism
 
       # Fallback for fork PRs and local runs where TRUNK_TOKEN is unavailable.
       - name: Test Affected (no analytics)
         if: ${{ steps.extract_branch.outputs.branch != 'main' && env.TRUNK_TOKEN == '' }}
-        run: moon run :test :test-browser :test-storybook --affected remote -- --no-file-parallelism
+        run: moon run :test :test-browser --affected remote -- --no-file-parallelism
 
       - name: Test All
         if: ${{ steps.extract_branch.outputs.branch == 'main' && env.TRUNK_TOKEN != '' }}
@@ -187,12 +187,12 @@ jobs:
           org-slug: dxos
           token: ${{ secrets.TRUNK_TOKEN }}
           quarantine: true
-          run: moon exec --on-failure continue :test :test-browser :test-storybook -- --no-file-parallelism
+          run: moon exec --on-failure continue :test :test-browser -- --no-file-parallelism
 
       # Fallback for forks running against their own main where TRUNK_TOKEN is unavailable.
       - name: Test All (no analytics)
         if: ${{ steps.extract_branch.outputs.branch == 'main' && env.TRUNK_TOKEN == '' }}
-        run: moon exec --on-failure continue :test :test-browser :test-storybook -- --no-file-parallelism
+        run: moon exec --on-failure continue :test :test-browser -- --no-file-parallelism
 
       - name: Upload Test Results
         if: always()
@@ -210,6 +210,115 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository
         with:
           name: moon-test-report-${{ matrix.node-version }}
+          path: .moon/cache/runReport.json
+          retention-days: 1
+          if-no-files-found: ignore
+
+      - uses: codecov/codecov-action@v5
+        if: ${{ matrix.node-version == '24.11.1' && env.VITEST_COVERAGE == 'true' }}
+        with:
+          directory: ./coverage
+          fail_ci_if_error: false
+          handle_no_reports_found: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+  # Storybook tests run on their own runner, in parallel with `test`, so the (large)
+  # set of :test-storybook tasks no longer serializes behind unit/browser tests in the
+  # `test` job. File parallelism stays disabled here too — overloaded runners flake — so
+  # the win is concurrency across machines, not within one.
+  storybook:
+    strategy:
+      matrix:
+        node-version: ['24.11.1']
+    runs-on: depot-ubuntu-24.04-8
+    container:
+      image: ghcr.io/dxos/gh-actions:${{ matrix.node-version }}
+      credentials:
+        username: dxos-bot
+        password: ${{ github.token }}
+    timeout-minutes: 30
+    env:
+      NODE_VERSION: ${{ matrix.node-version }}
+      # Opt in to flaky-tagged suites (Trunk pass-on-rerun keeps signal),
+      # while still excluding the heavier opt-in tag families.
+      VITEST_TAGS_FILTER: '!llm && !sync && !sync-e2e && !functions-e2e && !tracing-e2e'
+      VITEST_ENV: 'node'
+      VITEST_COVERAGE: ${{ secrets.CODECOV_TOKEN != '' && 'true' || 'false' }}
+      VITEST_XML_REPORT: 'true'
+      # NOTE: Storybook tests spawn a process for chromium. Limiting to 4 provides headroom for those processes.
+      MOON_CONCURRENCY: 4
+      # Exposed so step conditions can branch on token presence without referencing
+      # secrets directly (secrets are not allowed in if: expressions).
+      TRUNK_TOKEN: ${{ secrets.TRUNK_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          lfs: true
+          persist-credentials: false
+
+      - name: Extract branch
+        id: extract_branch
+        uses: ./.github/actions/branch
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Install Playwright
+        run: pnpm run install-playwright
+
+      - name: Clean stale test results
+        run: rm -rf test-results
+
+      - name: Test Storybook Affected
+        if: ${{ steps.extract_branch.outputs.branch != 'main' && env.TRUNK_TOKEN != '' }}
+        uses: trunk-io/analytics-uploader@v1
+        with:
+          junit-paths: 'test-results/**/results.xml'
+          org-slug: dxos
+          token: ${{ secrets.TRUNK_TOKEN }}
+          quarantine: true
+          run: moon run :test-storybook --affected remote -- --no-file-parallelism
+
+      # Fallback for fork PRs and local runs where TRUNK_TOKEN is unavailable.
+      - name: Test Storybook Affected (no analytics)
+        if: ${{ steps.extract_branch.outputs.branch != 'main' && env.TRUNK_TOKEN == '' }}
+        run: moon run :test-storybook --affected remote -- --no-file-parallelism
+
+      - name: Test Storybook All
+        if: ${{ steps.extract_branch.outputs.branch == 'main' && env.TRUNK_TOKEN != '' }}
+        uses: trunk-io/analytics-uploader@v1
+        with:
+          junit-paths: 'test-results/**/results.xml'
+          org-slug: dxos
+          token: ${{ secrets.TRUNK_TOKEN }}
+          quarantine: true
+          run: moon exec --on-failure continue :test-storybook -- --no-file-parallelism
+
+      # Fallback for forks running against their own main where TRUNK_TOKEN is unavailable.
+      - name: Test Storybook All (no analytics)
+        if: ${{ steps.extract_branch.outputs.branch == 'main' && env.TRUNK_TOKEN == '' }}
+        run: moon exec --on-failure continue :test-storybook -- --no-file-parallelism
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: vitest-report-storybook-${{ matrix.node-version }}
+          path: test-results
+          retention-days: 7
+
+      - name: Upload moon run report
+        uses: actions/upload-artifact@v7
+        if: >-
+          (success() || failure()) &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          name: moon-storybook-report-${{ matrix.node-version }}
           path: .moon/cache/runReport.json
           retention-days: 1
           if-no-files-found: ignore
@@ -325,7 +434,7 @@ jobs:
           result: ${{ job.status }}
 
   check-report:
-    needs: [check, test]
+    needs: [check, test, storybook]
     # Only post on same-repo PRs — fork PRs get read-only tokens regardless of
     # declared permissions, and non-PR runs have no PR to comment on.
     if: >-
@@ -360,6 +469,19 @@ jobs:
 
       - uses: 'moonrepo/run-report-action@v1'
         if: steps.download-test-report.outcome == 'success'
+        with:
+          access-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download storybook moon report
+        id: download-storybook-report
+        continue-on-error: true
+        uses: actions/download-artifact@v5
+        with:
+          name: moon-storybook-report-24.11.1
+          path: .moon/cache
+
+      - uses: 'moonrepo/run-report-action@v1'
+        if: steps.download-storybook-report.outcome == 'success'
         with:
           access-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Storybook tests (`:test-storybook`) were the dominant cost inside the `test` job. On a representative affected PR, `:test-storybook` accounts for ~70 of the moon tasks and roughly half of the test job's task-time, all running serially behind `:test` / `:test-browser` under `--no-file-parallelism`.

This PR moves Storybook tests onto a dedicated **`storybook`** job that runs **in parallel with `test`** on its own runner. The PR wall clock for the test path becomes `max(test, storybook)` instead of one long serialized job.

We deliberately **do not** raise file parallelism — `--no-file-parallelism` and `MOON_CONCURRENCY: 4` stay as-is in both jobs, since overloaded runners flake. The win here is concurrency *across machines*, not within one.

## Changes

- **`test` job**: drop `:test-storybook` from all four run commands (affected / all × analytics / no-analytics); it now runs `:test :test-browser` only.
- **New `storybook` job**: mirrors the `test` job's container, env, Setup, Playwright install, Trunk uploader, and fork/`main` fallbacks. Runs `:test-storybook --affected remote -- --no-file-parallelism` (and `moon exec ... :test-storybook` on `main`). Uses distinct artifact names (`vitest-report-storybook-*`, `moon-storybook-report-*`) to avoid collisions with the `test` job's uploads.
- **`check-report`**: add `storybook` to `needs` and download + render its moon run report alongside the check/test reports.
- **`.github/workflows/README.md`**: update the jobs/artifacts table to reflect the split.

## Notes / follow-up

- Branch protection: if the repo requires specific status checks for merge, the new **`storybook`** job will need to be added to the required-checks list so it gates merges (the old combined `test` check no longer covers storybook).
- Behavior is otherwise preserved: same tag filters, same Trunk quarantine, same `--no-file-parallelism`, same coverage upload path.

https://claude.ai/code/session_01WApBcxczFhJcb1G7AWqPp2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WApBcxczFhJcb1G7AWqPp2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized CI pipeline to separate Storybook tests into a dedicated job, improving test execution organization and reporting accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->