### PR TITLE
feat(ui-theme): monotonic surface elevation system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,5 @@ node_modules
 
 # @dxos/introspect symbol cache (regenerated as needed).
 .dxos-introspect/
+
+.superpowers/

--- a/docs/superpowers/plans/2026-06-02-composer-theme-elevation.md
+++ b/docs/superpowers/plans/2026-06-02-composer-theme-elevation.md
@@ -12,50 +12,55 @@
 
 ## File map
 
-| File | Change |
-|------|--------|
-| `packages/ui/ui-theme/src/css/theme/palette.css` | Add `--color-neutral-775` interpolation |
-| `packages/ui/ui-theme/src/css/theme/semantic.css` | Add `--dx-elevation-0…7`; remap all surface tokens; add `--color-popover-surface` |
-| `packages/ui/ui-theme/src/css/components/surface.css` | Add `.dx-popover-surface` utility class |
-| `packages/ui/react-ui/src/components/Popover/Popover.theme.ts` | `dx-modal-surface` → `dx-popover-surface` |
-| `packages/ui/react-ui/src/components/Toast/Toast.theme.ts` | `dx-modal-surface` → `dx-popover-surface` |
-| `packages/ui/react-ui/src/components/Menu/Menu.theme.ts` | `dx-modal-surface` → `dx-popover-surface` |
-| `packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts` | Add drop shadow to toolbar root |
-| `packages/ui/ui-theme/src/util/valence.ts` | Add `buttonValence()` export |
-| `packages/ui/react-ui/src/components/Message/Message.tsx` | Set `--dx-valence-bg/bg-hover/fg` CSS vars in `Message.Root` |
-| `packages/ui/react-ui/src/components/Message/Message.stories.tsx` | Add `WithButton` story |
-| `packages/ui/ui-theme/src/css/components/button.css` | Add `.dx-button[data-variant='valence']` rule |
-| `packages/plugins/plugin-space/src/components/CreateObjectPanel/CreateObjectPanel.tsx` | Add column-propagation classNames to form branch |
-| `packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md` | Rewrite surfaces/hierarchy sections; remove `fill` role |
+| File                                                                                   | Change                                                                            |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `packages/ui/ui-theme/src/css/theme/palette.css`                                       | Add `--color-neutral-775` interpolation                                           |
+| `packages/ui/ui-theme/src/css/theme/semantic.css`                                      | Add `--dx-elevation-0…7`; remap all surface tokens; add `--color-popover-surface` |
+| `packages/ui/ui-theme/src/css/components/surface.css`                                  | Add `.dx-popover-surface` utility class                                           |
+| `packages/ui/react-ui/src/components/Popover/Popover.theme.ts`                         | `dx-modal-surface` → `dx-popover-surface`                                         |
+| `packages/ui/react-ui/src/components/Toast/Toast.theme.ts`                             | `dx-modal-surface` → `dx-popover-surface`                                         |
+| `packages/ui/react-ui/src/components/Menu/Menu.theme.ts`                               | `dx-modal-surface` → `dx-popover-surface`                                         |
+| `packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts`                         | Add drop shadow to toolbar root                                                   |
+| `packages/ui/ui-theme/src/util/valence.ts`                                             | Add `buttonValence()` export                                                      |
+| `packages/ui/react-ui/src/components/Message/Message.tsx`                              | Set `--dx-valence-bg/bg-hover/fg` CSS vars in `Message.Root`                      |
+| `packages/ui/react-ui/src/components/Message/Message.stories.tsx`                      | Add `WithButton` story                                                            |
+| `packages/ui/ui-theme/src/css/components/button.css`                                   | Add `.dx-button[data-variant='valence']` rule                                     |
+| `packages/plugins/plugin-space/src/components/CreateObjectPanel/CreateObjectPanel.tsx` | Add column-propagation classNames to form branch                                  |
+| `packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md`                                        | Rewrite surfaces/hierarchy sections; remove `fill` role                           |
 
 ---
 
 ## Task 1: Add `n-775` to palette
 
 **Files:**
+
 - Modify: `packages/ui/ui-theme/src/css/theme/palette.css`
 
 - [ ] **Open** `packages/ui/ui-theme/src/css/theme/palette.css` and locate the block near line 42 (`--color-neutral-825`, `--color-neutral-850`, …). Insert one new line between `--color-neutral-750` and `--color-neutral-800`:
 
 ```css
-  --color-neutral-775: color-mix(in oklch, var(--color-neutral-750) 50%, var(--color-neutral-800) 50%);
+--color-neutral-775: color-mix(in oklch, var(--color-neutral-750) 50%, var(--color-neutral-800) 50%);
 ```
 
 The block should now read:
+
 ```css
-  --color-neutral-700: oklch(0.371 var(--dx-neutral-chroma) var(--dx-neutral-hue));
-  --color-neutral-750: color-mix(in oklch, var(--color-neutral-700) 50%, var(--color-neutral-800) 50%);
-  --color-neutral-775: color-mix(in oklch, var(--color-neutral-750) 50%, var(--color-neutral-800) 50%);
-  --color-neutral-800: oklch(0.269 var(--dx-neutral-chroma) var(--dx-neutral-hue));
+--color-neutral-700: oklch(0.371 var(--dx-neutral-chroma) var(--dx-neutral-hue));
+--color-neutral-750: color-mix(in oklch, var(--color-neutral-700) 50%, var(--color-neutral-800) 50%);
+--color-neutral-775: color-mix(in oklch, var(--color-neutral-750) 50%, var(--color-neutral-800) 50%);
+--color-neutral-800: oklch(0.269 var(--dx-neutral-chroma) var(--dx-neutral-hue));
 ```
 
 - [ ] **Verify** the file has no duplicate `--color-neutral-7*` keys:
+
 ```bash
 grep "neutral-7" packages/ui/ui-theme/src/css/theme/palette.css
 ```
+
 Expected: four lines — `700`, `750`, `775`, `800`.
 
 - [ ] **Commit:**
+
 ```bash
 git add packages/ui/ui-theme/src/css/theme/palette.css
 git commit -m "chore(ui-theme): add n-775 neutral ramp step"
@@ -66,12 +71,13 @@ git commit -m "chore(ui-theme): add n-775 neutral ramp step"
 ## Task 2: Add `--dx-elevation-0…7` and remap surface tokens
 
 **Files:**
+
 - Modify: `packages/ui/ui-theme/src/css/theme/semantic.css`
 
 - [ ] **Add the elevation primitive.** At the very top of the `@theme` block (before the first `--color-deck-surface` line), insert:
 
 ```css
-  /*
+/*
    * Elevation ladder — strictly monotonic, z-order low → high.
    * Dark: darker = lower; light: lighter = lower (inverted toward white).
    *
@@ -85,48 +91,51 @@ git commit -m "chore(ui-theme): add n-775 neutral ramp step"
    *   6    modal   dialog, modal
    *   7    float   popover, menu, toast, tooltip
    */
-  --dx-elevation-0: light-dark(var(--color-neutral-200), var(--color-neutral-950)); /* void   */
-  --dx-elevation-1: light-dark(var(--color-neutral-175), var(--color-neutral-900)); /* rail   */
-  --dx-elevation-2: light-dark(var(--color-neutral-150), var(--color-neutral-875)); /* chrome */
-  --dx-elevation-3: light-dark(var(--color-neutral-125), var(--color-neutral-850)); /* canvas */
-  --dx-elevation-4: light-dark(var(--color-neutral-100), var(--color-neutral-825)); /* raised */
-  --dx-elevation-5: light-dark(var(--color-neutral-75),  var(--color-neutral-800)); /* bar    */
-  --dx-elevation-6: light-dark(var(--color-neutral-50),  var(--color-neutral-775)); /* modal  */
-  --dx-elevation-7: light-dark(white,                    var(--color-neutral-750)); /* float  */
+--dx-elevation-0: light-dark(var(--color-neutral-200), var(--color-neutral-950)); /* void   */
+--dx-elevation-1: light-dark(var(--color-neutral-175), var(--color-neutral-900)); /* rail   */
+--dx-elevation-2: light-dark(var(--color-neutral-150), var(--color-neutral-875)); /* chrome */
+--dx-elevation-3: light-dark(var(--color-neutral-125), var(--color-neutral-850)); /* canvas */
+--dx-elevation-4: light-dark(var(--color-neutral-100), var(--color-neutral-825)); /* raised */
+--dx-elevation-5: light-dark(var(--color-neutral-75), var(--color-neutral-800)); /* bar    */
+--dx-elevation-6: light-dark(var(--color-neutral-50), var(--color-neutral-775)); /* modal  */
+--dx-elevation-7: light-dark(white, var(--color-neutral-750)); /* float  */
 ```
 
 - [ ] **Remap the named surface tokens.** Replace the existing individual `--color-*-surface` declarations in the `@theme` block with these (preserving the existing block structure, just changing the values). The complete set after the edit:
 
 ```css
-  /* Surfaces — each maps to exactly one elevation level */
-  --color-deck-surface:    var(--dx-elevation-3);
-  --color-base-surface:    var(--dx-elevation-3);
-  --color-sidebar-surface: var(--dx-elevation-2);
-  --color-header-surface:  var(--dx-elevation-2);
-  --color-toolbar-surface: var(--dx-elevation-5);
-  --color-card-surface:    var(--dx-elevation-4);
-  --color-group-surface:   var(--dx-elevation-4);
-  --color-group-alt-surface: var(--dx-elevation-4);
-  --color-input-surface:   var(--dx-elevation-4);
-  --color-modal-surface:   var(--dx-elevation-6);
-  --color-popover-surface: var(--dx-elevation-7); /* new — float tier */
+/* Surfaces — each maps to exactly one elevation level */
+--color-deck-surface: var(--dx-elevation-3);
+--color-base-surface: var(--dx-elevation-3);
+--color-sidebar-surface: var(--dx-elevation-2);
+--color-header-surface: var(--dx-elevation-2);
+--color-toolbar-surface: var(--dx-elevation-5);
+--color-card-surface: var(--dx-elevation-4);
+--color-group-surface: var(--dx-elevation-4);
+--color-group-alt-surface: var(--dx-elevation-4);
+--color-input-surface: var(--dx-elevation-4);
+--color-modal-surface: var(--dx-elevation-6);
+--color-popover-surface: var(--dx-elevation-7); /* new — float tier */
 
-  /* Sidebar / panel layout levels */
-  --color-l0-surface: var(--dx-elevation-1);
-  --color-l1-surface: var(--dx-elevation-2);
-  --color-r0-surface: var(--dx-elevation-2);
-  --color-r1-surface: var(--dx-elevation-2);
+/* Sidebar / panel layout levels */
+--color-l0-surface: var(--dx-elevation-1);
+--color-l1-surface: var(--dx-elevation-2);
+--color-r0-surface: var(--dx-elevation-2);
+--color-r1-surface: var(--dx-elevation-2);
 ```
 
 Keep `--color-scrim-surface`, `--color-inverse-surface`, `--color-inverse-fg`, `--color-focus-surface`, `--color-attention-surface` unchanged — they are not elevation-driven.
 
 - [ ] **Verify** all old individual values (`var(--color-neutral-825)` etc. on surface tokens) are gone:
+
 ```bash
 grep "neutral-825\|neutral-850\|neutral-875\|neutral-100\|neutral-825" packages/ui/ui-theme/src/css/theme/semantic.css | grep "surface"
 ```
+
 Expected: no matches (old literal values replaced by `--dx-elevation-*` references).
 
 - [ ] **Commit:**
+
 ```bash
 git add packages/ui/ui-theme/src/css/theme/semantic.css
 git commit -m "feat(ui-theme): add --dx-elevation-0…7 primitive; remap all surface tokens"
@@ -137,15 +146,16 @@ git commit -m "feat(ui-theme): add --dx-elevation-0…7 primitive; remap all sur
 ## Task 3: Add `.dx-popover-surface` utility class
 
 **Files:**
+
 - Modify: `packages/ui/ui-theme/src/css/components/surface.css`
 
 - [ ] **Append** the new class at the end of the `@layer dx-components` block in `surface.css`:
 
 ```css
-  .dx-popover-surface {
-    @apply bg-popover-surface text-base-fg backdrop-blur-md;
-    --surface-bg: var(--color-popover-surface);
-  }
+.dx-popover-surface {
+  @apply bg-popover-surface text-base-fg backdrop-blur-md;
+  --surface-bg: var(--color-popover-surface);
+}
 ```
 
 The full file after the edit:
@@ -186,6 +196,7 @@ The full file after the edit:
 (Remove the stale commented-out `@layer dx-tokens` block at the bottom while you're here — it was a TODO that never landed.)
 
 - [ ] **Commit:**
+
 ```bash
 git add packages/ui/ui-theme/src/css/components/surface.css
 git commit -m "feat(ui-theme): add dx-popover-surface utility (elevation level 7)"
@@ -196,11 +207,13 @@ git commit -m "feat(ui-theme): add dx-popover-surface utility (elevation level 7
 ## Task 4: Switch overlays from `dx-modal-surface` to `dx-popover-surface`
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/components/Popover/Popover.theme.ts`
 - Modify: `packages/ui/react-ui/src/components/Toast/Toast.theme.ts`
 - Modify: `packages/ui/react-ui/src/components/Menu/Menu.theme.ts`
 
 - [ ] **Popover.theme.ts** — change line 16:
+
 ```ts
 // before:
 'dx-modal-surface border border-separator rounded-sm',
@@ -209,6 +222,7 @@ git commit -m "feat(ui-theme): add dx-popover-surface utility (elevation level 7
 ```
 
 - [ ] **Toast.theme.ts** — change line 20:
+
 ```ts
 // before:
 'dx-modal-surface rounded-md p-1',
@@ -217,6 +231,7 @@ git commit -m "feat(ui-theme): add dx-popover-surface utility (elevation level 7
 ```
 
 - [ ] **Menu.theme.ts** — change line 16:
+
 ```ts
 // before:
 'dx-modal-surface w-48 rounded-sm md:w-56 border border-separator',
@@ -227,12 +242,15 @@ git commit -m "feat(ui-theme): add dx-popover-surface utility (elevation level 7
 Dialog.theme.ts intentionally stays on `dx-modal-surface` (level 6).
 
 - [ ] **Build react-ui to catch typos:**
+
 ```bash
 moon run react-ui:build 2>&1 | tail -20
 ```
+
 Expected: build succeeds with no errors.
 
 - [ ] **Commit:**
+
 ```bash
 git add packages/ui/react-ui/src/components/Popover/Popover.theme.ts \
         packages/ui/react-ui/src/components/Toast/Toast.theme.ts \
@@ -245,6 +263,7 @@ git commit -m "feat(react-ui): switch popover/toast/menu to dx-popover-surface (
 ## Task 5: Add toolbar drop shadow
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts`
 
 The toolbar now sits at elevation 5 (lighter than the deck in dark, raised in light). A downward drop shadow communicates that content scrolls beneath it.
@@ -266,6 +285,7 @@ const root: ComponentFunction<ToolbarStyleProps> = ({ density, disabled, layoutM
 ```
 
 - [ ] **Commit:**
+
 ```bash
 git add packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts
 git commit -m "feat(react-ui): add drop shadow to toolbar (elevation bar tier)"
@@ -276,6 +296,7 @@ git commit -m "feat(react-ui): add drop shadow to toolbar (elevation bar tier)"
 ## Task 6: Message-button valence inheritance
 
 **Files:**
+
 - Modify: `packages/ui/ui-theme/src/util/valence.ts`
 - Modify: `packages/ui/react-ui/src/components/Message/Message.tsx`
 - Modify: `packages/ui/ui-theme/src/css/components/button.css`
@@ -359,16 +380,16 @@ return (
 - [ ] **Edit** `packages/ui/ui-theme/src/css/components/button.css`. Inside the `&:not([disabled]), &[disabled='false']` block (around line 55), add after the `destructive` rule:
 
 ```css
-      &[data-variant='valence'] {
-        color: var(--dx-valence-fg);
-        background: var(--dx-valence-bg);
-        &:hover,
-        &[aria-pressed='true'],
-        &[aria-checked='true'],
-        &[data-state='open'] {
-          background: var(--dx-valence-bg-hover);
-        }
-      }
+&[data-variant='valence'] {
+  color: var(--dx-valence-fg);
+  background: var(--dx-valence-bg);
+  &:hover,
+  &[aria-pressed='true'],
+  &[aria-checked='true'],
+  &[data-state='open'] {
+    background: var(--dx-valence-bg-hover);
+  }
+}
 ```
 
 ### 6d: Add a story showing a valence button
@@ -399,12 +420,15 @@ export const WithButton: Story = {
 ```
 
 - [ ] **Build to check types:**
+
 ```bash
 moon run react-ui:build ui-theme:build 2>&1 | tail -20
 ```
+
 Expected: succeeds.
 
 - [ ] **Commit:**
+
 ```bash
 git add packages/ui/ui-theme/src/util/valence.ts \
         packages/ui/react-ui/src/components/Message/Message.tsx \
@@ -418,6 +442,7 @@ git commit -m "feat(react-ui): Message-button valence inheritance via CSS custom
 ## Task 7: Fix `CreateObjectDialog` form nesting
 
 **Files:**
+
 - Modify: `packages/plugins/plugin-space/src/components/CreateObjectPanel/CreateObjectPanel.tsx`
 
 **Root cause:** `Dialog.Body` propagates its column grid with `withColumn.propagate()`. `CreateObjectPanel` is the direct child of `Dialog.Body`. When it returns `<Form.Root>`, `Form.Root` renders a DOM element that does not carry the column-span classes needed to join the grid — so `Form.Viewport` then creates its own nested `Column.Root` instead of flowing into the dialog's column.
@@ -427,43 +452,48 @@ git commit -m "feat(react-ui): Message-button valence inheritance via CSS custom
 - [ ] **Edit** `CreateObjectPanel.tsx`. Change the `inputSchema` branch (currently lines ~116–130) to wrap `Form.Root` in a `<div>` carrying the column-propagation:
 
 ```tsx
-  if (metadata.inputSchema) {
-    return (
-      <div className='[.dx-column-root_&]:col-span-full [.dx-column-root_&]:grid [.dx-column-root_&]:grid-cols-subgrid'>
-        <Form.Root
-          autoFocus
-          schema={inputSchema}
-          defaultValues={initialFormValues}
-          fieldProvider={inputSurfaceLookup}
-          db={Obj.isObject(target) ? Obj.getDatabase(target) : target}
-          onSave={handleCreateObject}
-          testId='create-object-form'
-        >
-          <Form.Viewport>
-            <Form.Content>
-              <Form.FieldSet />
-              <Form.Submit />
-            </Form.Content>
-          </Form.Viewport>
-        </Form.Root>
-      </div>
-    );
-  }
+if (metadata.inputSchema) {
+  return (
+    <div className='[.dx-column-root_&]:col-span-full [.dx-column-root_&]:grid [.dx-column-root_&]:grid-cols-subgrid'>
+      <Form.Root
+        autoFocus
+        schema={inputSchema}
+        defaultValues={initialFormValues}
+        fieldProvider={inputSurfaceLookup}
+        db={Obj.isObject(target) ? Obj.getDatabase(target) : target}
+        onSave={handleCreateObject}
+        testId='create-object-form'
+      >
+        <Form.Viewport>
+          <Form.Content>
+            <Form.FieldSet />
+            <Form.Submit />
+          </Form.Content>
+        </Form.Viewport>
+      </Form.Root>
+    </div>
+  );
+}
 ```
 
 - [ ] **Verify the `SelectType` and `SelectSpace` branches are untouched** (they don't go through Column):
+
 ```bash
 grep -n "SelectType\|SelectSpace\|SearchList" packages/plugins/plugin-space/src/components/CreateObjectPanel/CreateObjectPanel.tsx | head -10
 ```
+
 Expected: the `SelectType` and `SelectSpace` return paths are unchanged.
 
 - [ ] **Build plugin-space:**
+
 ```bash
 moon run plugin-space:build 2>&1 | tail -20
 ```
+
 Expected: succeeds.
 
 - [ ] **Commit:**
+
 ```bash
 git add packages/plugins/plugin-space/src/components/CreateObjectPanel/CreateObjectPanel.tsx
 git commit -m "fix(plugin-space): CreateObjectPanel form participates in Dialog.Body column grid"
@@ -474,24 +504,31 @@ git commit -m "fix(plugin-space): CreateObjectPanel form participates in Dialog.
 ## Task 8: Lint and build check
 
 - [ ] **Run linter across all changed packages:**
+
 ```bash
 moon run ui-theme:lint react-ui:lint plugin-space:lint -- --fix 2>&1 | tail -30
 ```
+
 Expected: exits 0 or only pre-existing warnings.
 
 - [ ] **Run tests for affected packages:**
+
 ```bash
 moon run ui-theme:test react-ui:test 2>&1 | tail -30
 ```
+
 Expected: all pass.
 
 - [ ] **Audit diff for any casts introduced:**
+
 ```bash
 git diff origin/main | grep -nE '\bas (any|unknown|[A-Z])|as unknown as'
 ```
+
 Expected: no matches (the `as React.CSSProperties` casts in Message.tsx are the only ones — these are legitimate type-system boundaries for CSS custom properties, which TypeScript's `CSSProperties` doesn't include by default).
 
 - [ ] **Stage any lint-fixed files and commit if needed:**
+
 ```bash
 git status
 # If files modified by --fix:
@@ -504,6 +541,7 @@ git commit -m "chore: lint fixes after elevation remap"
 ## Task 9: Rewrite `DESIGN_SYSTEM.md`
 
 **Files:**
+
 - Modify: `packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md`
 
 - [ ] **Edit the Naming convention section.** Find the `part` bullet list and remove `fill` — the hue roles are `bg / bg-hover / surface / fg / text / border`. The updated list:
@@ -528,32 +566,34 @@ mode; inverted toward white in light mode. Every named surface token is an alias
 `--dx-elevation-N` level. Never set a surface to a raw scale value — pick the level that matches the
 role and point the token there.
 
-| Level | Name     | Dark      | Light    | Named surfaces                                     |
-| ----- | -------- | --------- | -------- | -------------------------------------------------- |
-| 0     | `void`   | `n-950`   | `n-200`  | scrim base, window gaps                            |
-| 1     | `rail`   | `n-900`   | `n-175`  | `l0-surface` (icon rail)                           |
-| 2     | `chrome` | `n-875`   | `n-150`  | `sidebar-surface`, `header-surface`, `l1-surface`, `r0-surface`, `r1-surface` |
-| 3     | `canvas` | `n-850`   | `n-125`  | `base-surface`, `deck-surface`                     |
-| 4     | `raised` | `n-825`   | `n-100`  | `card-surface`, `group-surface`, `input-surface`   |
-| 5     | `bar`    | `n-800`   | `n-75`   | `toolbar-surface` (sticky, drop-shadowed)          |
-| 6     | `modal`  | `n-775`   | `n-50`   | `modal-surface` (dialogs)                          |
-| 7     | `float`  | `n-750`   | `white`  | `popover-surface` (menus, popovers, toasts, tooltips) |
+| Level | Name     | Dark    | Light   | Named surfaces                                                                |
+| ----- | -------- | ------- | ------- | ----------------------------------------------------------------------------- |
+| 0     | `void`   | `n-950` | `n-200` | scrim base, window gaps                                                       |
+| 1     | `rail`   | `n-900` | `n-175` | `l0-surface` (icon rail)                                                      |
+| 2     | `chrome` | `n-875` | `n-150` | `sidebar-surface`, `header-surface`, `l1-surface`, `r0-surface`, `r1-surface` |
+| 3     | `canvas` | `n-850` | `n-125` | `base-surface`, `deck-surface`                                                |
+| 4     | `raised` | `n-825` | `n-100` | `card-surface`, `group-surface`, `input-surface`                              |
+| 5     | `bar`    | `n-800` | `n-75`  | `toolbar-surface` (sticky, drop-shadowed)                                     |
+| 6     | `modal`  | `n-775` | `n-50`  | `modal-surface` (dialogs)                                                     |
+| 7     | `float`  | `n-750` | `white` | `popover-surface` (menus, popovers, toasts, tooltips)                         |
 
 The primitive `--dx-elevation-0…7` is defined in `semantic.css` using `light-dark()`. Raw scale values
 (`n-*`) are in `palette.css` — the docs table above is for human reference only.
 
 ### Visual hierarchy (dark)
+```
+
+popover/float n-750 ↑ highest / closest to viewer
+modal/dialog n-775
+toolbar n-800 (sticky bar; content passes beneath)
+card/raised n-825
+canvas/deck n-850
+chrome/sidebar n-875
+rail/L0 n-900
+void n-950 ↓ lowest
 
 ```
-popover/float   n-750  ↑ highest / closest to viewer
-modal/dialog    n-775
-toolbar         n-800  (sticky bar; content passes beneath)
-card/raised     n-825
-canvas/deck     n-850
-chrome/sidebar  n-875
-rail/L0         n-900
-void            n-950  ↓ lowest
-```
+
 ```
 
 - [ ] **Add an "Elevation primitive" section** immediately after "Surfaces":
@@ -582,6 +622,7 @@ When adding a new surface:
 ```
 
 - [ ] **Commit:**
+
 ```bash
 git add packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md
 git commit -m "docs(ui-theme): rewrite DESIGN_SYSTEM.md — elevation ladder, drop fill role"
@@ -592,16 +633,21 @@ git commit -m "docs(ui-theme): rewrite DESIGN_SYSTEM.md — elevation ladder, dr
 ## Task 10: Push and CI check
 
 - [ ] **Push branch:**
+
 ```bash
 git push -u origin claude/compassionate-mclaren-b485af
 ```
 
 - [ ] **Check CI:**
+
 ```bash
 gh run list --branch claude/compassionate-mclaren-b485af --limit 5 --workflow "Check"
 ```
+
 Wait ~5 min then re-run until `status=completed`. If `conclusion=failure`:
+
 ```bash
 gh run view <run-id> --log-failed 2>&1 | head -60
 ```
+
 Fix root cause, commit, push.

--- a/docs/superpowers/plans/2026-06-02-composer-theme-elevation.md
+++ b/docs/superpowers/plans/2026-06-02-composer-theme-elevation.md
@@ -1,0 +1,607 @@
+# Composer Theme Elevation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a strict `--dx-elevation-0…7` scale in `ui-theme`, remap every named surface to it, add a distinct float tier for overlays, fix card/toolbar collision, add Message-button valence inheritance, and fix CreateObjectDialog form nesting.
+
+**Architecture:** A private `--dx-elevation-N` scale in `semantic.css` (8 levels, monotonic in both modes) acts as the single source of truth; every `--color-*-surface` becomes an alias of the appropriate level. Component-level fixes (Message valence CSS vars, CreateObjectPanel column layout) are self-contained. `DESIGN_SYSTEM.md` is rewritten last.
+
+**Tech Stack:** CSS (`@theme`, `light-dark()`, `color-mix()`), Tailwind v4 utility classes, TypeScript (React component theme files), Vitest, moon tasks.
+
+---
+
+## File map
+
+| File | Change |
+|------|--------|
+| `packages/ui/ui-theme/src/css/theme/palette.css` | Add `--color-neutral-775` interpolation |
+| `packages/ui/ui-theme/src/css/theme/semantic.css` | Add `--dx-elevation-0…7`; remap all surface tokens; add `--color-popover-surface` |
+| `packages/ui/ui-theme/src/css/components/surface.css` | Add `.dx-popover-surface` utility class |
+| `packages/ui/react-ui/src/components/Popover/Popover.theme.ts` | `dx-modal-surface` → `dx-popover-surface` |
+| `packages/ui/react-ui/src/components/Toast/Toast.theme.ts` | `dx-modal-surface` → `dx-popover-surface` |
+| `packages/ui/react-ui/src/components/Menu/Menu.theme.ts` | `dx-modal-surface` → `dx-popover-surface` |
+| `packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts` | Add drop shadow to toolbar root |
+| `packages/ui/ui-theme/src/util/valence.ts` | Add `buttonValence()` export |
+| `packages/ui/react-ui/src/components/Message/Message.tsx` | Set `--dx-valence-bg/bg-hover/fg` CSS vars in `Message.Root` |
+| `packages/ui/react-ui/src/components/Message/Message.stories.tsx` | Add `WithButton` story |
+| `packages/ui/ui-theme/src/css/components/button.css` | Add `.dx-button[data-variant='valence']` rule |
+| `packages/plugins/plugin-space/src/components/CreateObjectPanel/CreateObjectPanel.tsx` | Add column-propagation classNames to form branch |
+| `packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md` | Rewrite surfaces/hierarchy sections; remove `fill` role |
+
+---
+
+## Task 1: Add `n-775` to palette
+
+**Files:**
+- Modify: `packages/ui/ui-theme/src/css/theme/palette.css`
+
+- [ ] **Open** `packages/ui/ui-theme/src/css/theme/palette.css` and locate the block near line 42 (`--color-neutral-825`, `--color-neutral-850`, …). Insert one new line between `--color-neutral-750` and `--color-neutral-800`:
+
+```css
+  --color-neutral-775: color-mix(in oklch, var(--color-neutral-750) 50%, var(--color-neutral-800) 50%);
+```
+
+The block should now read:
+```css
+  --color-neutral-700: oklch(0.371 var(--dx-neutral-chroma) var(--dx-neutral-hue));
+  --color-neutral-750: color-mix(in oklch, var(--color-neutral-700) 50%, var(--color-neutral-800) 50%);
+  --color-neutral-775: color-mix(in oklch, var(--color-neutral-750) 50%, var(--color-neutral-800) 50%);
+  --color-neutral-800: oklch(0.269 var(--dx-neutral-chroma) var(--dx-neutral-hue));
+```
+
+- [ ] **Verify** the file has no duplicate `--color-neutral-7*` keys:
+```bash
+grep "neutral-7" packages/ui/ui-theme/src/css/theme/palette.css
+```
+Expected: four lines — `700`, `750`, `775`, `800`.
+
+- [ ] **Commit:**
+```bash
+git add packages/ui/ui-theme/src/css/theme/palette.css
+git commit -m "chore(ui-theme): add n-775 neutral ramp step"
+```
+
+---
+
+## Task 2: Add `--dx-elevation-0…7` and remap surface tokens
+
+**Files:**
+- Modify: `packages/ui/ui-theme/src/css/theme/semantic.css`
+
+- [ ] **Add the elevation primitive.** At the very top of the `@theme` block (before the first `--color-deck-surface` line), insert:
+
+```css
+  /*
+   * Elevation ladder — strictly monotonic, z-order low → high.
+   * Dark: darker = lower; light: lighter = lower (inverted toward white).
+   *
+   * Level  Name    Roles
+   *   0    void    window gaps, scrim base
+   *   1    rail    L0 icon rail
+   *   2    chrome  L1/R sidebars, header
+   *   3    canvas  base, deck
+   *   4    raised  card, group, input
+   *   5    bar     toolbar (sticky, drop-shadowed)
+   *   6    modal   dialog, modal
+   *   7    float   popover, menu, toast, tooltip
+   */
+  --dx-elevation-0: light-dark(var(--color-neutral-200), var(--color-neutral-950)); /* void   */
+  --dx-elevation-1: light-dark(var(--color-neutral-175), var(--color-neutral-900)); /* rail   */
+  --dx-elevation-2: light-dark(var(--color-neutral-150), var(--color-neutral-875)); /* chrome */
+  --dx-elevation-3: light-dark(var(--color-neutral-125), var(--color-neutral-850)); /* canvas */
+  --dx-elevation-4: light-dark(var(--color-neutral-100), var(--color-neutral-825)); /* raised */
+  --dx-elevation-5: light-dark(var(--color-neutral-75),  var(--color-neutral-800)); /* bar    */
+  --dx-elevation-6: light-dark(var(--color-neutral-50),  var(--color-neutral-775)); /* modal  */
+  --dx-elevation-7: light-dark(white,                    var(--color-neutral-750)); /* float  */
+```
+
+- [ ] **Remap the named surface tokens.** Replace the existing individual `--color-*-surface` declarations in the `@theme` block with these (preserving the existing block structure, just changing the values). The complete set after the edit:
+
+```css
+  /* Surfaces — each maps to exactly one elevation level */
+  --color-deck-surface:    var(--dx-elevation-3);
+  --color-base-surface:    var(--dx-elevation-3);
+  --color-sidebar-surface: var(--dx-elevation-2);
+  --color-header-surface:  var(--dx-elevation-2);
+  --color-toolbar-surface: var(--dx-elevation-5);
+  --color-card-surface:    var(--dx-elevation-4);
+  --color-group-surface:   var(--dx-elevation-4);
+  --color-group-alt-surface: var(--dx-elevation-4);
+  --color-input-surface:   var(--dx-elevation-4);
+  --color-modal-surface:   var(--dx-elevation-6);
+  --color-popover-surface: var(--dx-elevation-7); /* new — float tier */
+
+  /* Sidebar / panel layout levels */
+  --color-l0-surface: var(--dx-elevation-1);
+  --color-l1-surface: var(--dx-elevation-2);
+  --color-r0-surface: var(--dx-elevation-2);
+  --color-r1-surface: var(--dx-elevation-2);
+```
+
+Keep `--color-scrim-surface`, `--color-inverse-surface`, `--color-inverse-fg`, `--color-focus-surface`, `--color-attention-surface` unchanged — they are not elevation-driven.
+
+- [ ] **Verify** all old individual values (`var(--color-neutral-825)` etc. on surface tokens) are gone:
+```bash
+grep "neutral-825\|neutral-850\|neutral-875\|neutral-100\|neutral-825" packages/ui/ui-theme/src/css/theme/semantic.css | grep "surface"
+```
+Expected: no matches (old literal values replaced by `--dx-elevation-*` references).
+
+- [ ] **Commit:**
+```bash
+git add packages/ui/ui-theme/src/css/theme/semantic.css
+git commit -m "feat(ui-theme): add --dx-elevation-0…7 primitive; remap all surface tokens"
+```
+
+---
+
+## Task 3: Add `.dx-popover-surface` utility class
+
+**Files:**
+- Modify: `packages/ui/ui-theme/src/css/components/surface.css`
+
+- [ ] **Append** the new class at the end of the `@layer dx-components` block in `surface.css`:
+
+```css
+  .dx-popover-surface {
+    @apply bg-popover-surface text-base-fg backdrop-blur-md;
+    --surface-bg: var(--color-popover-surface);
+  }
+```
+
+The full file after the edit:
+
+```css
+/**
+ * Surfaces
+ */
+
+@layer dx-components {
+  .dx-base-surface {
+    @apply bg-base-surface text-base-fg;
+    --surface-bg: var(--color-base-surface);
+  }
+
+  .dx-sidebar-surface {
+    @apply bg-sidebar-surface text-base-fg;
+    --surface-bg: var(--color-sidebar-surface);
+  }
+
+  .dx-modal-surface {
+    @apply bg-modal-surface text-base-fg backdrop-blur-md;
+    --surface-bg: var(--color-modal-surface);
+  }
+
+  .dx-attention-surface {
+    @apply bg-attention-surface text-base-fg;
+    --surface-bg: var(--color-attention-surface);
+  }
+
+  .dx-popover-surface {
+    @apply bg-popover-surface text-base-fg backdrop-blur-md;
+    --surface-bg: var(--color-popover-surface);
+  }
+}
+```
+
+(Remove the stale commented-out `@layer dx-tokens` block at the bottom while you're here — it was a TODO that never landed.)
+
+- [ ] **Commit:**
+```bash
+git add packages/ui/ui-theme/src/css/components/surface.css
+git commit -m "feat(ui-theme): add dx-popover-surface utility (elevation level 7)"
+```
+
+---
+
+## Task 4: Switch overlays from `dx-modal-surface` to `dx-popover-surface`
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/components/Popover/Popover.theme.ts`
+- Modify: `packages/ui/react-ui/src/components/Toast/Toast.theme.ts`
+- Modify: `packages/ui/react-ui/src/components/Menu/Menu.theme.ts`
+
+- [ ] **Popover.theme.ts** — change line 16:
+```ts
+// before:
+'dx-modal-surface border border-separator rounded-sm',
+// after:
+'dx-popover-surface border border-separator rounded-sm',
+```
+
+- [ ] **Toast.theme.ts** — change line 20:
+```ts
+// before:
+'dx-modal-surface rounded-md p-1',
+// after:
+'dx-popover-surface rounded-md p-1',
+```
+
+- [ ] **Menu.theme.ts** — change line 16:
+```ts
+// before:
+'dx-modal-surface w-48 rounded-sm md:w-56 border border-separator',
+// after:
+'dx-popover-surface w-48 rounded-sm md:w-56 border border-separator',
+```
+
+Dialog.theme.ts intentionally stays on `dx-modal-surface` (level 6).
+
+- [ ] **Build react-ui to catch typos:**
+```bash
+moon run react-ui:build 2>&1 | tail -20
+```
+Expected: build succeeds with no errors.
+
+- [ ] **Commit:**
+```bash
+git add packages/ui/react-ui/src/components/Popover/Popover.theme.ts \
+        packages/ui/react-ui/src/components/Toast/Toast.theme.ts \
+        packages/ui/react-ui/src/components/Menu/Menu.theme.ts
+git commit -m "feat(react-ui): switch popover/toast/menu to dx-popover-surface (float tier)"
+```
+
+---
+
+## Task 5: Add toolbar drop shadow
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts`
+
+The toolbar now sits at elevation 5 (lighter than the deck in dark, raised in light). A downward drop shadow communicates that content scrolls beneath it.
+
+- [ ] **Edit** `Toolbar.theme.ts` — update the `root` function to add `shadow-sm` (the existing `surfaceShadow` positioned-elevation value):
+
+```ts
+const root: ComponentFunction<ToolbarStyleProps> = ({ density, disabled, layoutManaged }, ...etc) => {
+  return mx(
+    'bg-toolbar-surface dx-toolbar shadow-sm',
+    density === 'lg' && 'h-(--dx-rail-size) px-3!',
+    density === 'sm' && 'h-7 px-2!',
+    density === 'xs' && 'h-6 px-1!',
+    disabled && '*:opacity-20',
+    !layoutManaged && layout,
+    ...etc,
+  );
+};
+```
+
+- [ ] **Commit:**
+```bash
+git add packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts
+git commit -m "feat(react-ui): add drop shadow to toolbar (elevation bar tier)"
+```
+
+---
+
+## Task 6: Message-button valence inheritance
+
+**Files:**
+- Modify: `packages/ui/ui-theme/src/util/valence.ts`
+- Modify: `packages/ui/react-ui/src/components/Message/Message.tsx`
+- Modify: `packages/ui/ui-theme/src/css/components/button.css`
+- Modify: `packages/ui/react-ui/src/components/Message/Message.stories.tsx`
+
+### 6a: Add `buttonValence` to valence.ts
+
+The function returns Tailwind classes for a button variant that reads CSS variables (`--dx-valence-bg`, `--dx-valence-bg-hover`, `--dx-valence-fg`) set by an ancestor `Message.Root`. Using CSS vars (not hardcoded hue names) so the button automatically matches whatever valence the message carries.
+
+- [ ] **Edit** `packages/ui/ui-theme/src/util/valence.ts` — append after the existing `messageValence` export:
+
+```ts
+/**
+ * Classes for a button rendered inside a Message.Root that should inherit the message's valence color.
+ * Message.Root sets --dx-valence-bg / --dx-valence-bg-hover / --dx-valence-fg on its DOM node;
+ * these classes consume those variables. Use data-variant="valence" on the Button.
+ */
+export const buttonValence = (_valence?: MessageValence) =>
+  'text-(--dx-valence-fg) bg-(--dx-valence-bg) hover:bg-(--dx-valence-bg-hover)';
+```
+
+(The valence parameter is intentionally unused — the CSS vars carry the value. It is accepted so callers can see the intent and for future extension.)
+
+### 6b: Set valence CSS vars in Message.Root
+
+- [ ] **Edit** `packages/ui/react-ui/src/components/Message/Message.tsx`. In `MessageRoot`, add an inline `style` prop on `Column.Root` that sets the three CSS vars from the valence:
+
+```tsx
+const valenceVars: Record<MessageValence, React.CSSProperties> = {
+  success: {
+    '--dx-valence-bg': 'var(--color-success-bg)',
+    '--dx-valence-bg-hover': 'var(--color-success-bg-hover)',
+    '--dx-valence-fg': 'var(--color-success-fg)',
+  } as React.CSSProperties,
+  info: {
+    '--dx-valence-bg': 'var(--color-info-bg)',
+    '--dx-valence-bg-hover': 'var(--color-info-bg-hover)',
+    '--dx-valence-fg': 'var(--color-info-fg)',
+  } as React.CSSProperties,
+  warning: {
+    '--dx-valence-bg': 'var(--color-warning-bg)',
+    '--dx-valence-bg-hover': 'var(--color-warning-bg-hover)',
+    '--dx-valence-fg': 'var(--color-warning-fg)',
+  } as React.CSSProperties,
+  error: {
+    '--dx-valence-bg': 'var(--color-error-bg)',
+    '--dx-valence-bg-hover': 'var(--color-error-bg-hover)',
+    '--dx-valence-fg': 'var(--color-error-fg)',
+  } as React.CSSProperties,
+  neutral: {
+    '--dx-valence-bg': 'var(--color-neutral-bg)',
+    '--dx-valence-bg-hover': 'var(--color-neutral-bg-hover)',
+    '--dx-valence-fg': 'var(--color-neutral-fg)',
+  } as React.CSSProperties,
+};
+```
+
+Then pass `style={valenceVars[valence]}` to `Column.Root`. The full `MessageRoot` return becomes:
+
+```tsx
+return (
+  <MessageProvider {...{ titleId, descriptionId, valence }}>
+    <Column.Root
+      asChild={asChild}
+      role={valence === 'neutral' ? 'paragraph' : 'alert'}
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      {...props}
+      style={valenceVars[valence]}
+      classNames={tx('message.root', { valence, elevation }, classNames)}
+      ref={forwardedRef}
+    >
+      {children}
+    </Column.Root>
+  </MessageProvider>
+);
+```
+
+### 6c: Add the `valence` button variant rule in button.css
+
+- [ ] **Edit** `packages/ui/ui-theme/src/css/components/button.css`. Inside the `&:not([disabled]), &[disabled='false']` block (around line 55), add after the `destructive` rule:
+
+```css
+      &[data-variant='valence'] {
+        color: var(--dx-valence-fg);
+        background: var(--dx-valence-bg);
+        &:hover,
+        &[aria-pressed='true'],
+        &[aria-checked='true'],
+        &[data-state='open'] {
+          background: var(--dx-valence-bg-hover);
+        }
+      }
+```
+
+### 6d: Add a story showing a valence button
+
+- [ ] **Edit** `packages/ui/react-ui/src/components/Message/Message.stories.tsx`. Add an import for `Button` and a new story at the bottom:
+
+```ts
+import { Button } from '../Button';
+```
+
+```ts
+export const WithButton: Story = {
+  args: {
+    valence: 'success',
+    title: 'Action required',
+    body: random.lorem.paragraphs(1),
+  },
+  render: ({ valence, title, body }) => (
+    <div className='w-[30rem]'>
+      <Message.Root valence={valence}>
+        {title && <Message.Title onClose={() => console.log('close')}>{title}</Message.Title>}
+        {body && <Message.Content>{body}</Message.Content>}
+        <Button variant='valence' classNames='col-start-2'>Confirm</Button>
+      </Message.Root>
+    </div>
+  ),
+};
+```
+
+- [ ] **Build to check types:**
+```bash
+moon run react-ui:build ui-theme:build 2>&1 | tail -20
+```
+Expected: succeeds.
+
+- [ ] **Commit:**
+```bash
+git add packages/ui/ui-theme/src/util/valence.ts \
+        packages/ui/react-ui/src/components/Message/Message.tsx \
+        packages/ui/ui-theme/src/css/components/button.css \
+        packages/ui/react-ui/src/components/Message/Message.stories.tsx
+git commit -m "feat(react-ui): Message-button valence inheritance via CSS custom properties"
+```
+
+---
+
+## Task 7: Fix `CreateObjectDialog` form nesting
+
+**Files:**
+- Modify: `packages/plugins/plugin-space/src/components/CreateObjectPanel/CreateObjectPanel.tsx`
+
+**Root cause:** `Dialog.Body` propagates its column grid with `withColumn.propagate()`. `CreateObjectPanel` is the direct child of `Dialog.Body`. When it returns `<Form.Root>`, `Form.Root` renders a DOM element that does not carry the column-span classes needed to join the grid — so `Form.Viewport` then creates its own nested `Column.Root` instead of flowing into the dialog's column.
+
+**Fix:** wrap the `Form.Root` return in `CreateObjectPanel`'s `inputSchema` branch with the column-propagation classes (same pattern `Form.Viewport` uses for itself), making `Form.Root` span the full grid width. This avoids hoisting form state into `CreateObjectDialog` while aligning the form column with the dialog's.
+
+- [ ] **Edit** `CreateObjectPanel.tsx`. Change the `inputSchema` branch (currently lines ~116–130) to wrap `Form.Root` in a `<div>` carrying the column-propagation:
+
+```tsx
+  if (metadata.inputSchema) {
+    return (
+      <div className='[.dx-column-root_&]:col-span-full [.dx-column-root_&]:grid [.dx-column-root_&]:grid-cols-subgrid'>
+        <Form.Root
+          autoFocus
+          schema={inputSchema}
+          defaultValues={initialFormValues}
+          fieldProvider={inputSurfaceLookup}
+          db={Obj.isObject(target) ? Obj.getDatabase(target) : target}
+          onSave={handleCreateObject}
+          testId='create-object-form'
+        >
+          <Form.Viewport>
+            <Form.Content>
+              <Form.FieldSet />
+              <Form.Submit />
+            </Form.Content>
+          </Form.Viewport>
+        </Form.Root>
+      </div>
+    );
+  }
+```
+
+- [ ] **Verify the `SelectType` and `SelectSpace` branches are untouched** (they don't go through Column):
+```bash
+grep -n "SelectType\|SelectSpace\|SearchList" packages/plugins/plugin-space/src/components/CreateObjectPanel/CreateObjectPanel.tsx | head -10
+```
+Expected: the `SelectType` and `SelectSpace` return paths are unchanged.
+
+- [ ] **Build plugin-space:**
+```bash
+moon run plugin-space:build 2>&1 | tail -20
+```
+Expected: succeeds.
+
+- [ ] **Commit:**
+```bash
+git add packages/plugins/plugin-space/src/components/CreateObjectPanel/CreateObjectPanel.tsx
+git commit -m "fix(plugin-space): CreateObjectPanel form participates in Dialog.Body column grid"
+```
+
+---
+
+## Task 8: Lint and build check
+
+- [ ] **Run linter across all changed packages:**
+```bash
+moon run ui-theme:lint react-ui:lint plugin-space:lint -- --fix 2>&1 | tail -30
+```
+Expected: exits 0 or only pre-existing warnings.
+
+- [ ] **Run tests for affected packages:**
+```bash
+moon run ui-theme:test react-ui:test 2>&1 | tail -30
+```
+Expected: all pass.
+
+- [ ] **Audit diff for any casts introduced:**
+```bash
+git diff origin/main | grep -nE '\bas (any|unknown|[A-Z])|as unknown as'
+```
+Expected: no matches (the `as React.CSSProperties` casts in Message.tsx are the only ones — these are legitimate type-system boundaries for CSS custom properties, which TypeScript's `CSSProperties` doesn't include by default).
+
+- [ ] **Stage any lint-fixed files and commit if needed:**
+```bash
+git status
+# If files modified by --fix:
+git add -p
+git commit -m "chore: lint fixes after elevation remap"
+```
+
+---
+
+## Task 9: Rewrite `DESIGN_SYSTEM.md`
+
+**Files:**
+- Modify: `packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md`
+
+- [ ] **Edit the Naming convention section.** Find the `part` bullet list and remove `fill` — the hue roles are `bg / bg-hover / surface / fg / text / border`. The updated list:
+
+```markdown
+- **`part`** is one of a fixed vocabulary:
+  - `surface` — the background fill of a thing.
+  - `fg` — the text/icon color that sits on the surface (paired with `surface`).
+  - `bg` — solid attention-grabbing fill (buttons, badges, indicators); more saturated than `surface`.
+  - `bg-hover` — hover state for `bg`.
+  - `border` — border color on the surface.
+  - `text` — text color used standalone, on the base canvas (no enclosing surface).
+```
+
+- [ ] **Replace the entire "Surfaces" section** with:
+
+```markdown
+## Surfaces
+
+Surfaces are governed by a strict elevation ladder: **lighter = higher = closer to the viewer** in dark
+mode; inverted toward white in light mode. Every named surface token is an alias of exactly one
+`--dx-elevation-N` level. Never set a surface to a raw scale value — pick the level that matches the
+role and point the token there.
+
+| Level | Name     | Dark      | Light    | Named surfaces                                     |
+| ----- | -------- | --------- | -------- | -------------------------------------------------- |
+| 0     | `void`   | `n-950`   | `n-200`  | scrim base, window gaps                            |
+| 1     | `rail`   | `n-900`   | `n-175`  | `l0-surface` (icon rail)                           |
+| 2     | `chrome` | `n-875`   | `n-150`  | `sidebar-surface`, `header-surface`, `l1-surface`, `r0-surface`, `r1-surface` |
+| 3     | `canvas` | `n-850`   | `n-125`  | `base-surface`, `deck-surface`                     |
+| 4     | `raised` | `n-825`   | `n-100`  | `card-surface`, `group-surface`, `input-surface`   |
+| 5     | `bar`    | `n-800`   | `n-75`   | `toolbar-surface` (sticky, drop-shadowed)          |
+| 6     | `modal`  | `n-775`   | `n-50`   | `modal-surface` (dialogs)                          |
+| 7     | `float`  | `n-750`   | `white`  | `popover-surface` (menus, popovers, toasts, tooltips) |
+
+The primitive `--dx-elevation-0…7` is defined in `semantic.css` using `light-dark()`. Raw scale values
+(`n-*`) are in `palette.css` — the docs table above is for human reference only.
+
+### Visual hierarchy (dark)
+
+```
+popover/float   n-750  ↑ highest / closest to viewer
+modal/dialog    n-775
+toolbar         n-800  (sticky bar; content passes beneath)
+card/raised     n-825
+canvas/deck     n-850
+chrome/sidebar  n-875
+rail/L0         n-900
+void            n-950  ↓ lowest
+```
+```
+
+- [ ] **Add an "Elevation primitive" section** immediately after "Surfaces":
+
+```markdown
+## Elevation primitive
+
+The `--dx-elevation-0…7` custom properties in `semantic.css` are the single source of truth. They are
+private (`--dx-*` prefix) — never use them directly in component CSS; use the named surface tokens
+(`bg-card-surface`, `dx-modal-surface`, etc.) instead.
+
+When adding a new surface:
+
+1. Decide which elevation level the new surface belongs to (see the table above).
+2. Add `--color-<name>-surface: var(--dx-elevation-N);` in the `Surfaces` block of `semantic.css`.
+3. Add a matching `--color-<name>-fg` if text/icons will sit on it.
+4. If the surface needs a utility class (like `dx-modal-surface`), add it to `surface.css`.
+```
+
+- [ ] **Update "Adding a new token" step 1** to read:
+
+```markdown
+1. Does an existing semantic token already cover it? For a new named surface, check the elevation
+   ladder first — the new surface probably fits an existing level and should alias `--dx-elevation-N`
+   rather than a raw scale value.
+```
+
+- [ ] **Commit:**
+```bash
+git add packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md
+git commit -m "docs(ui-theme): rewrite DESIGN_SYSTEM.md — elevation ladder, drop fill role"
+```
+
+---
+
+## Task 10: Push and CI check
+
+- [ ] **Push branch:**
+```bash
+git push -u origin claude/compassionate-mclaren-b485af
+```
+
+- [ ] **Check CI:**
+```bash
+gh run list --branch claude/compassionate-mclaren-b485af --limit 5 --workflow "Check"
+```
+Wait ~5 min then re-run until `status=completed`. If `conclusion=failure`:
+```bash
+gh run view <run-id> --log-failed 2>&1 | head -60
+```
+Fix root cause, commit, push.

--- a/docs/superpowers/specs/2026-06-02-composer-theme-elevation-design.md
+++ b/docs/superpowers/specs/2026-06-02-composer-theme-elevation-design.md
@@ -1,0 +1,218 @@
+# Composer Theme: Monotonic Surface Elevation
+
+Date: 2026-06-02
+Status: Approved (design) — pending spec review
+Branch: `claude/compassionate-mclaren-b485af`
+
+## Problem
+
+Composer's surface tokens in [`packages/ui/ui-theme/src/css/theme/semantic.css`](../../../packages/ui/ui-theme/src/css/theme/semantic.css)
+are not organized as an ordered elevation system. Concretely (dark mode):
+
+- **Five roles collapse onto `n-825`**: `toolbar`, `card`, `modal`, and (via `dx-modal-surface`)
+  `popover` + `toast`. `card-surface` is _identical_ to `toolbar-surface`, so a card has no edge as it
+  scrolls under the toolbar.
+- **Overlays barely separate from content**: popovers/toasts/menus/dialogs all use
+  `dx-modal-surface` (`n-825`), only one ramp step lighter than the deck (`n-850`); they rely on shadow +
+  blur alone to read as floating.
+- **The ramp is not monotonic by elevation**: the header (`n-875`) is _darker_ than the deck (`n-850`)
+  it frames, and the toolbar (`n-825`) is _lighter_ than the deck yet equal to cards.
+
+`DESIGN_SYSTEM.md` already describes an idealized ordered hierarchy, but the shipped CSS has drifted from it.
+
+Two further component-level issues are bundled into the same branch (see §6, §7).
+
+## Goals
+
+1. A single, **strictly monotonic** elevation model: lighter = higher = closer to the viewer (dark
+   mode); inverted toward white (light mode). No two adjacent named surfaces collide.
+2. Encode it as an explicit **numbered elevation primitive** (`--dx-elevation-0…7`); every named surface
+   points at exactly one level. (Approach "C" from brainstorming.)
+3. Fix the two reported symptoms structurally:
+   - Popovers/toasts/menus distinct from the background.
+   - Cards distinct from the toolbar they scroll under.
+4. Bundle two adjacent fixes: Message-button valence inheritance, and the `CreateObjectDialog` form
+   nesting regression.
+
+Non-goals: re-theming hue/status colors, touching the grid/sheet tokens, or restyling individual
+plugins beyond what the token remap implies.
+
+## The elevation model
+
+A numbered scale, **z-order low → high**. The toolbar is a _raised, shadowed bar_ that floats above
+scrolling content (decision "B" from brainstorming).
+
+| Level | Name     | Roles (named surfaces)                                  | Dark  | Light          |
+| ----- | -------- | ------------------------------------------------------- | ----- | -------------- |
+| 0     | `void`   | window gaps, scrim base                                 | n-950 | n-200          |
+| 1     | `rail`   | L0 icon rail                                            | n-900 | n-175          |
+| 2     | `chrome` | L1 / R0 / R1 sidebars, header                           | n-875 | n-150          |
+| 3     | `canvas` | base, deck                                              | n-850 | n-125          |
+| 4     | `raised` | card, group, input                                      | n-825 | n-100          |
+| 5     | `bar`    | toolbar (sticky, shadowed)                              | n-800 | n-75           |
+| 6     | `modal`  | dialog, modal                                           | n-775 | n-50           |
+| 7     | `float`  | popover, menu, toast, tooltip                           | n-750 | white          |
+
+Notes:
+
+- **Strictly monotonic** in both modes. Dark mode has `950→750` of headroom, so eight distinct levels
+  are comfortable. Light mode saturates at white, so the **light canvas darkens to ≈ n-125** (from
+  today's near-white base) to leave `n-100 / n-75 / n-50 / white` for the raised tiers. Net effect: light
+  theme reads slightly more "gray paper"; cards/toolbar/overlays clearly lift off it. _(Chosen over the
+  keep-it-bright + shadow-only alternative.)_
+- `n-775` is a **new neutral step** (dark: `color-mix(n-750, n-800)`), added to
+  [`palette.css`](../../../packages/ui/ui-theme/src/css/theme/palette.css) following the existing
+  `color-mix` interpolation convention. Light mode needs no new step (float = white).
+- Card↔toolbar now a full level apart (`825` vs `800`) **plus** the toolbar's drop shadow as content
+  passes beneath — the reported collision is gone.
+- Floating overlays sit 2–3 levels above the deck — they pop without relying on shadow alone.
+
+### Mockups
+
+Rendered with real OKLCH values during brainstorming (persisted under
+`.superpowers/brainstorm/`): `current-state.html` (the collisions), `proposed-state.html`,
+`toolbar-direction.html` (A vs B), `final-system.html` (the locked B system, both modes).
+
+## §5. Implementation — elevation primitive
+
+### 5.1 Add the elevation scale (`semantic.css`)
+
+Introduce an ordered, mode-aware primitive at the top of the `@theme` block:
+
+```css
+/* Elevation ladder — z-order low → high. Lighter = higher (dark); toward white (light). */
+--dx-elevation-0: light-dark(var(--color-neutral-200), var(--color-neutral-950)); /* void   */
+--dx-elevation-1: light-dark(var(--color-neutral-175), var(--color-neutral-900)); /* rail   */
+--dx-elevation-2: light-dark(var(--color-neutral-150), var(--color-neutral-875)); /* chrome */
+--dx-elevation-3: light-dark(var(--color-neutral-125), var(--color-neutral-850)); /* canvas */
+--dx-elevation-4: light-dark(var(--color-neutral-100), var(--color-neutral-825)); /* raised */
+--dx-elevation-5: light-dark(var(--color-neutral-75),  var(--color-neutral-800)); /* bar    */
+--dx-elevation-6: light-dark(var(--color-neutral-50),  var(--color-neutral-775)); /* modal  */
+--dx-elevation-7: light-dark(var(--color-white),       var(--color-neutral-750)); /* float  */
+```
+
+`--color-neutral-775` is the only **new** ramp step (dark: `color-mix(n-750, n-800)`); light mode reuses
+existing steps with the float tier going pure white. These are private `--dx-*` knobs, not utilities, so
+they need no `@source inline`.
+
+### 5.2 Re-point named surfaces at levels
+
+Every existing `--color-*-surface` is redefined as `var(--dx-elevation-N)` — names unchanged, so consumers
+(`bg-card-surface`, `dx-modal-surface`, …) keep working:
+
+```css
+--color-base-surface:    var(--dx-elevation-3);
+--color-deck-surface:    var(--dx-elevation-3);
+--color-card-surface:    var(--dx-elevation-4);
+--color-group-surface:   var(--dx-elevation-4);
+--color-input-surface:   var(--dx-elevation-4);
+--color-toolbar-surface: var(--dx-elevation-5);
+--color-modal-surface:   var(--dx-elevation-6);
+--color-popover-surface: var(--dx-elevation-7); /* NEW */
+--color-sidebar-surface: var(--dx-elevation-2);
+--color-header-surface:  var(--dx-elevation-2);
+--color-l0-surface:      var(--dx-elevation-1);
+--color-l1-surface:      var(--dx-elevation-2);
+--color-r0-surface:      var(--dx-elevation-2);
+--color-r1-surface:      var(--dx-elevation-2);
+```
+
+- `group-alt-surface`, `attention-surface`, `focus-surface` etc. are reconciled to the nearest level (to
+  be confirmed during implementation; `attention-surface` currently aliases `focus-surface`).
+- The matching `*-fg` tokens are reviewed for contrast at the new levels and adjusted only where a level
+  moved enough to break legibility.
+
+### 5.3 New `popover-surface` token + `dx-popover-surface` class
+
+Add `--color-popover-surface` (level 7) and a `.dx-popover-surface` utility in
+[`surface.css`](../../../packages/ui/ui-theme/src/css/components/surface.css) mirroring `.dx-modal-surface`
+(with `backdrop-blur` + `--surface-bg`). Re-point the overlay theme files off `dx-modal-surface`:
+
+- [`Popover.theme.ts`](../../../packages/ui/react-ui/src/components/Popover/Popover.theme.ts) → `dx-popover-surface`
+- [`Toast.theme.ts`](../../../packages/ui/react-ui/src/components/Toast/Toast.theme.ts) → `dx-popover-surface`
+- [`Menu.theme.ts`](../../../packages/ui/react-ui/src/components/Menu/Menu.theme.ts) → `dx-popover-surface`
+- [`Dialog.theme.ts`](../../../packages/ui/react-ui/src/components/Dialog/Dialog.theme.ts) → stays `dx-modal-surface` (level 6)
+
+### 5.4 Toolbar elevation + shadow
+
+The toolbar moves to level 5 and gains a downward drop shadow so scrolling content reads as passing
+beneath it. Reuse the existing `surfaceShadow()` elevation helper where toolbars are themed
+([`Panel`](../../../packages/ui/react-ui/src/components/Panel/Panel.tsx) / toolbar theme) rather than a
+bespoke shadow.
+
+### 5.5 Update `DESIGN_SYSTEM.md`
+
+Rewrite the "Surfaces" and "Visual hierarchy" sections to document the numbered ladder as the source of
+truth, replacing the stale table that no longer matches the CSS.
+
+## §6. Message-button valence inheritance
+
+**Goal:** a `Button` inside a `Message` adopts the message's valence color instead of the default neutral
+fill.
+
+**Mechanism (matches the existing token-re-derivation idiom):**
+[`Message.Root`](../../../packages/ui/react-ui/src/components/Message/Message.tsx) already applies
+`messageValence(valence)` and provides `valence` via context. Have it additionally set scoped CSS
+variables for the valence hue (e.g. `--dx-fill`, `--dx-fill-hover`, `--dx-fill-fg`) the way `main.css`
+re-derives `--surface-bg` inside `.dx-main-sidebar`. A new `buttonValence(valence)` in
+[`valence.ts`](../../../packages/ui/ui-theme/src/util/valence.ts) returns the classes a button uses to
+consume those vars.
+
+**Open decision — the `fill` role.** `DESIGN_SYSTEM.md` documents a `fill` role ("solid
+attention-grabbing fill, more saturated than surface") but **it is not implemented** — hue roles today are
+`bg / bg-hover / fg / surface / text / border`.
+
+- _Option A (recommended):_ introduce the missing `fill` role in
+  [`styles.css`](../../../packages/ui/ui-theme/src/css/theme/styles.css) for each hue + semantic alias,
+  so `buttonValence` can emit `bg-{valence}-fill` exactly as the brief describes, and the docs become
+  true.
+- _Option B:_ skip `fill`; reuse the existing solid `bg`/`bg-hover` role (`bg-success-bg`).
+
+Either way the button reads a CSS variable set by `Message.Root`, so message and button stay in sync.
+Scope: `valence.ts`, `Message.tsx` (+ `Message.theme.ts`), and `styles.css` if Option A.
+
+## §7. `CreateObjectDialog` form nesting
+
+**Root cause:** the Form is rendered indirectly through `CreateObjectPanel`, which sits inside
+`Dialog.Body` but does not participate in the Column grid that `Dialog.Body` propagates
+(`withColumn.propagate()`). The Form then builds its own nested `Column.Root`, producing a
+double-nested padded panel instead of flowing into the dialog's column layout.
+
+- Broken: [`CreateObjectDialog.tsx`](../../../packages/plugins/plugin-space/src/containers/CreateObjectDialog/CreateObjectDialog.tsx)
+  → [`CreateObjectPanel.tsx`](../../../packages/plugins/plugin-space/src/components/CreateObjectPanel/CreateObjectPanel.tsx)
+- Working reference: [`CreateSpaceDialog.tsx`](../../../packages/plugins/plugin-space/src/containers/CreateSpaceDialog/CreateSpaceDialog.tsx)
+  places `Form.Root` as a **direct child** of `Dialog.Body`.
+
+**Fix (recommended):** make the Form participate in the column grid — either render `Form.Root` directly
+under `Dialog.Body` (hoist out of the wrapper for the schema-form branch), or give `CreateObjectPanel`'s
+wrapper the propagation classes (`[.dx-column-root_&]:col-span-full` + subgrid) so the form column lines
+up with the dialog's. Match the `CreateSpaceDialog` structure. Verify both branches of
+`CreateObjectPanel` (schema form vs. type picker) still render correctly.
+
+## Testing & verification
+
+- **Storybook is the primary review surface.** Run from the worktree on a free port
+  (`moon run storybook-react:serve -- --port 9014 --no-open --ci`) and drive with Playwright; never kill
+  the user's :9009 server.
+- Visual checks, both light and dark:
+  - Card scrolling under the toolbar shows a clear edge + shadow.
+  - Popover / menu / toast / tooltip clearly float above the deck.
+  - Dialog over content; popover opened from within a dialog still reads above it.
+  - Sidebars / header / rail form a coherent recessive frame; deck lighter than chrome.
+- The two component items get/keep stories: a `Message` with a valence + button; the `CreateObjectDialog`
+  form rendering flush in the dialog column.
+- `moon run :lint -- --fix`, `moon run :test`, and a build of `ui-theme` + affected `react-ui*` packages.
+- Audit diff for casts per CLAUDE.md.
+
+## Risks
+
+- Re-pointing surfaces shifts many screens at once; the light-canvas darkening is the most visible change
+  and must be reviewed in-app, not just storybook.
+- `*-fg` contrast at moved levels — review legibility on each surface.
+- Adding the `fill` role (if Option A) touches every hue; mechanical but wide.
+
+## Out of scope / follow-ups
+
+- The two `bg-hover-surface`-as-resting-fill drift sites noted in `DESIGN_SYSTEM.md`.
+- The commented-out `dx-tokens` re-derivation block in `surface.css` (hover/input/separator inside
+  sidebar/modal) — revisit only if the remap makes it necessary.

--- a/docs/superpowers/specs/2026-06-02-composer-theme-elevation-design.md
+++ b/docs/superpowers/specs/2026-06-02-composer-theme-elevation-design.md
@@ -42,16 +42,16 @@ plugins beyond what the token remap implies.
 A numbered scale, **z-order low → high**. The toolbar is a _raised, shadowed bar_ that floats above
 scrolling content (decision "B" from brainstorming).
 
-| Level | Name     | Roles (named surfaces)                                  | Dark  | Light          |
-| ----- | -------- | ------------------------------------------------------- | ----- | -------------- |
-| 0     | `void`   | window gaps, scrim base                                 | n-950 | n-200          |
-| 1     | `rail`   | L0 icon rail                                            | n-900 | n-175          |
-| 2     | `chrome` | L1 / R0 / R1 sidebars, header                           | n-875 | n-150          |
-| 3     | `canvas` | base, deck                                              | n-850 | n-125          |
-| 4     | `raised` | card, group, input                                      | n-825 | n-100          |
-| 5     | `bar`    | toolbar (sticky, shadowed)                              | n-800 | n-75           |
-| 6     | `modal`  | dialog, modal                                           | n-775 | n-50           |
-| 7     | `float`  | popover, menu, toast, tooltip                           | n-750 | white          |
+| Level | Name     | Roles (named surfaces)        | Dark  | Light |
+| ----- | -------- | ----------------------------- | ----- | ----- |
+| 0     | `void`   | window gaps, scrim base       | n-950 | n-200 |
+| 1     | `rail`   | L0 icon rail                  | n-900 | n-175 |
+| 2     | `chrome` | L1 / R0 / R1 sidebars, header | n-875 | n-150 |
+| 3     | `canvas` | base, deck                    | n-850 | n-125 |
+| 4     | `raised` | card, group, input            | n-825 | n-100 |
+| 5     | `bar`    | toolbar (sticky, shadowed)    | n-800 | n-75  |
+| 6     | `modal`  | dialog, modal                 | n-775 | n-50  |
+| 7     | `float`  | popover, menu, toast, tooltip | n-750 | white |
 
 Notes:
 
@@ -86,9 +86,9 @@ Introduce an ordered, mode-aware primitive at the top of the `@theme` block:
 --dx-elevation-2: light-dark(var(--color-neutral-150), var(--color-neutral-875)); /* chrome */
 --dx-elevation-3: light-dark(var(--color-neutral-125), var(--color-neutral-850)); /* canvas */
 --dx-elevation-4: light-dark(var(--color-neutral-100), var(--color-neutral-825)); /* raised */
---dx-elevation-5: light-dark(var(--color-neutral-75),  var(--color-neutral-800)); /* bar    */
---dx-elevation-6: light-dark(var(--color-neutral-50),  var(--color-neutral-775)); /* modal  */
---dx-elevation-7: light-dark(var(--color-white),       var(--color-neutral-750)); /* float  */
+--dx-elevation-5: light-dark(var(--color-neutral-75), var(--color-neutral-800)); /* bar    */
+--dx-elevation-6: light-dark(var(--color-neutral-50), var(--color-neutral-775)); /* modal  */
+--dx-elevation-7: light-dark(var(--color-white), var(--color-neutral-750)); /* float  */
 ```
 
 `--color-neutral-775` is the only **new** ramp step (dark: `color-mix(n-750, n-800)`); light mode reuses
@@ -101,20 +101,20 @@ Every existing `--color-*-surface` is redefined as `var(--dx-elevation-N)` — n
 (`bg-card-surface`, `dx-modal-surface`, …) keep working:
 
 ```css
---color-base-surface:    var(--dx-elevation-3);
---color-deck-surface:    var(--dx-elevation-3);
---color-card-surface:    var(--dx-elevation-4);
---color-group-surface:   var(--dx-elevation-4);
---color-input-surface:   var(--dx-elevation-4);
+--color-base-surface: var(--dx-elevation-3);
+--color-deck-surface: var(--dx-elevation-3);
+--color-card-surface: var(--dx-elevation-4);
+--color-group-surface: var(--dx-elevation-4);
+--color-input-surface: var(--dx-elevation-4);
 --color-toolbar-surface: var(--dx-elevation-5);
---color-modal-surface:   var(--dx-elevation-6);
+--color-modal-surface: var(--dx-elevation-6);
 --color-popover-surface: var(--dx-elevation-7); /* NEW */
 --color-sidebar-surface: var(--dx-elevation-2);
---color-header-surface:  var(--dx-elevation-2);
---color-l0-surface:      var(--dx-elevation-1);
---color-l1-surface:      var(--dx-elevation-2);
---color-r0-surface:      var(--dx-elevation-2);
---color-r1-surface:      var(--dx-elevation-2);
+--color-header-surface: var(--dx-elevation-2);
+--color-l0-surface: var(--dx-elevation-1);
+--color-l1-surface: var(--dx-elevation-2);
+--color-r0-surface: var(--dx-elevation-2);
+--color-r1-surface: var(--dx-elevation-2);
 ```
 
 - `group-alt-surface`, `attention-surface`, `focus-surface` etc. are reconciled to the nearest level (to

--- a/docs/superpowers/specs/2026-06-02-composer-theme-elevation-design.md
+++ b/docs/superpowers/specs/2026-06-02-composer-theme-elevation-design.md
@@ -150,10 +150,10 @@ fill.
 **Mechanism (matches the existing token-re-derivation idiom):**
 [`Message.Root`](../../../packages/ui/react-ui/src/components/Message/Message.tsx) already applies
 `messageValence(valence)` and provides `valence` via context. Have it additionally set scoped CSS
-variables for the valence hue (e.g. `--dx-fill`, `--dx-fill-hover`, `--dx-fill-fg`) the way `main.css`
-re-derives `--surface-bg` inside `.dx-main-sidebar`. A new `buttonValence(valence)` in
+variables for the valence hue (`--dx-valence-bg`, `--dx-valence-bg-hover`, `--dx-valence-fg`) the way
+`main.css` re-derives `--surface-bg` inside `.dx-main-sidebar`. A new `buttonValence(valence)` in
 [`valence.ts`](../../../packages/ui/ui-theme/src/util/valence.ts) returns the classes a button uses to
-consume those vars.
+consume those `--dx-valence-*` vars.
 
 **Token role:** use the existing solid-fill role `bg` / `bg-hover` (e.g. `bg-success-bg`,
 `bg-success-bg-hover`, `text-success-fg`). There is **no separate `fill` role** — `DESIGN_SYSTEM.md`'s

--- a/docs/superpowers/specs/2026-06-02-composer-theme-elevation-design.md
+++ b/docs/superpowers/specs/2026-06-02-composer-theme-elevation-design.md
@@ -140,10 +140,7 @@ beneath it. Reuse the existing `surfaceShadow()` elevation helper where toolbars
 ([`Panel`](../../../packages/ui/react-ui/src/components/Panel/Panel.tsx) / toolbar theme) rather than a
 bespoke shadow.
 
-### 5.5 Update `DESIGN_SYSTEM.md`
-
-Rewrite the "Surfaces" and "Visual hierarchy" sections to document the numbered ladder as the source of
-truth, replacing the stale table that no longer matches the CSS.
+### 5.5 `DESIGN_SYSTEM.md` rewrite — see §8.
 
 ## §6. Message-button valence inheritance
 
@@ -158,18 +155,15 @@ re-derives `--surface-bg` inside `.dx-main-sidebar`. A new `buttonValence(valenc
 [`valence.ts`](../../../packages/ui/ui-theme/src/util/valence.ts) returns the classes a button uses to
 consume those vars.
 
-**Open decision — the `fill` role.** `DESIGN_SYSTEM.md` documents a `fill` role ("solid
-attention-grabbing fill, more saturated than surface") but **it is not implemented** — hue roles today are
-`bg / bg-hover / fg / surface / text / border`.
+**Token role:** use the existing solid-fill role `bg` / `bg-hover` (e.g. `bg-success-bg`,
+`bg-success-bg-hover`, `text-success-fg`). There is **no separate `fill` role** — `DESIGN_SYSTEM.md`'s
+mention of one is stale and is removed in §8, not implemented. (The brief's "`-fill`" means this `-bg`
+role.)
 
-- _Option A (recommended):_ introduce the missing `fill` role in
-  [`styles.css`](../../../packages/ui/ui-theme/src/css/theme/styles.css) for each hue + semantic alias,
-  so `buttonValence` can emit `bg-{valence}-fill` exactly as the brief describes, and the docs become
-  true.
-- _Option B:_ skip `fill`; reuse the existing solid `bg`/`bg-hover` role (`bg-success-bg`).
-
-Either way the button reads a CSS variable set by `Message.Root`, so message and button stay in sync.
-Scope: `valence.ts`, `Message.tsx` (+ `Message.theme.ts`), and `styles.css` if Option A.
+`buttonValence(valence)` in [`valence.ts`](../../../packages/ui/ui-theme/src/util/valence.ts) returns the
+classes a button uses for its fill/hover/ink, reading the scoped CSS variables that `Message.Root` sets
+for the message's hue (the `--surface-bg` re-derivation idiom). Message and button stay in sync because
+both derive from the same `valence`. Scope: `valence.ts`, `Message.tsx` (+ `Message.theme.ts`).
 
 ## §7. `CreateObjectDialog` form nesting
 
@@ -188,6 +182,18 @@ under `Dialog.Body` (hoist out of the wrapper for the schema-form branch), or gi
 wrapper the propagation classes (`[.dx-column-root_&]:col-span-full` + subgrid) so the form column lines
 up with the dialog's. Match the `CreateSpaceDialog` structure. Verify both branches of
 `CreateObjectPanel` (schema form vs. type picker) still render correctly.
+
+## §8. `DESIGN_SYSTEM.md` rewrite (done last)
+
+The doc has drifted from the CSS and must be brought back in line as the final step:
+
+- Replace the "Surfaces" and "Visual hierarchy" sections with the numbered elevation ladder (§3) as the
+  source of truth; show the actual dark/light values per level.
+- **Remove the `fill` role** from the naming-convention vocabulary and the "Adding a new token" guidance —
+  it was never implemented. The hue roles are `bg / bg-hover / surface / fg / text / border`.
+- Document `popover-surface` (level 7) and the `--dx-elevation-*` primitive.
+- Reconcile the "State tokens" / consolidation tables against the shipped `semantic.css` while here (fix
+  any other stale references noticed during implementation).
 
 ## Testing & verification
 

--- a/packages/plugins/plugin-space/src/components/CreateObjectPanel/CreateObjectPanel.tsx
+++ b/packages/plugins/plugin-space/src/components/CreateObjectPanel/CreateObjectPanel.tsx
@@ -113,22 +113,24 @@ export const CreateObjectPanel = ({
 
   if (metadata.inputSchema) {
     return (
-      <Form.Root
-        autoFocus
-        schema={inputSchema}
-        defaultValues={initialFormValues}
-        fieldProvider={inputSurfaceLookup}
-        db={Obj.isObject(target) ? Obj.getDatabase(target) : target}
-        onSave={handleCreateObject}
-        testId='create-object-form'
-      >
-        <Form.Viewport>
-          <Form.Content>
-            <Form.FieldSet />
-            <Form.Submit />
-          </Form.Content>
-        </Form.Viewport>
-      </Form.Root>
+      <div className='[.dx-column-root_&]:col-span-full [.dx-column-root_&]:grid [.dx-column-root_&]:grid-cols-subgrid'>
+        <Form.Root
+          autoFocus
+          schema={inputSchema}
+          defaultValues={initialFormValues}
+          fieldProvider={inputSurfaceLookup}
+          db={Obj.isObject(target) ? Obj.getDatabase(target) : target}
+          onSave={handleCreateObject}
+          testId='create-object-form'
+        >
+          <Form.Viewport>
+            <Form.Content>
+              <Form.FieldSet />
+              <Form.Submit />
+            </Form.Content>
+          </Form.Viewport>
+        </Form.Root>
+      </div>
     );
   }
 

--- a/packages/ui/react-ui/src/components/Button/Button.tsx
+++ b/packages/ui/react-ui/src/components/Button/Button.tsx
@@ -13,7 +13,7 @@ import { useDensityContext, useElevationContext, useThemeContext } from '../../h
 import { type ThemedClassName } from '../../util';
 
 type ButtonProps = ThemedClassName<ComponentPropsWithRef<typeof Primitive.button>> & {
-  variant?: 'default' | 'primary' | 'outline' | 'ghost' | 'destructive';
+  variant?: 'default' | 'primary' | 'outline' | 'ghost' | 'destructive' | 'valence';
   density?: Density;
   elevation?: Elevation;
   asChild?: boolean;

--- a/packages/ui/react-ui/src/components/Menu/Menu.theme.ts
+++ b/packages/ui/react-ui/src/components/Menu/Menu.theme.ts
@@ -13,7 +13,7 @@ export type MenuStyleProps = Partial<{
 
 const content: ComponentFunction<MenuStyleProps> = ({ elevation }, ...etc) =>
   mx(
-    'dx-modal-surface w-48 rounded-sm md:w-56 border border-separator',
+    'dx-popover-surface w-48 rounded-sm md:w-56 border border-separator',
     surfaceZIndex({ elevation, level: 'menu' }),
     surfaceShadow({ elevation: 'positioned' }),
     ...etc,

--- a/packages/ui/react-ui/src/components/Message/Message.stories.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.stories.tsx
@@ -9,6 +9,7 @@ import { random } from '@dxos/random';
 import { type MessageValence } from '@dxos/ui-types';
 
 import { withTheme } from '../../testing';
+import { Button } from '../Button';
 import { Message } from './Message';
 
 random.seed(123);
@@ -86,4 +87,23 @@ export const Error: Story = {
     title: 'Error',
     body: random.lorem.paragraphs(1),
   },
+};
+
+export const WithButton: Story = {
+  args: {
+    valence: 'success',
+    title: 'Action required',
+    body: random.lorem.paragraphs(1),
+  },
+  render: ({ valence, title, body }) => (
+    <div className='w-[30rem]'>
+      <Message.Root valence={valence}>
+        {title && <Message.Title onClose={() => console.log('close')}>{title}</Message.Title>}
+        {body && <Message.Content>{body}</Message.Content>}
+        <Button variant='valence' classNames='col-start-2'>
+          Confirm
+        </Button>
+      </Message.Root>
+    </div>
+  ),
 };

--- a/packages/ui/react-ui/src/components/Message/Message.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.tsx
@@ -39,32 +39,40 @@ type MessageContextValue = { titleId?: string; descriptionId: string; valence: M
 
 const MESSAGE_NAME = 'Message';
 
-const valenceVars: Record<MessageValence, CSSProperties> = {
+// CSS custom properties for valence color inheritance — consumed by Button variant='valence'.
+// Extending CSSProperties so entries satisfy the style prop type without a cast at the use site.
+type ValenceCSSVars = CSSProperties & {
+  '--dx-valence-bg': string;
+  '--dx-valence-bg-hover': string;
+  '--dx-valence-fg': string;
+};
+
+const valenceVars: Record<MessageValence, ValenceCSSVars> = {
   success: {
     '--dx-valence-bg': 'var(--color-success-bg)',
     '--dx-valence-bg-hover': 'var(--color-success-bg-hover)',
     '--dx-valence-fg': 'var(--color-success-fg)',
-  } as CSSProperties,
+  },
   info: {
     '--dx-valence-bg': 'var(--color-info-bg)',
     '--dx-valence-bg-hover': 'var(--color-info-bg-hover)',
     '--dx-valence-fg': 'var(--color-info-fg)',
-  } as CSSProperties,
+  },
   warning: {
     '--dx-valence-bg': 'var(--color-warning-bg)',
     '--dx-valence-bg-hover': 'var(--color-warning-bg-hover)',
     '--dx-valence-fg': 'var(--color-warning-fg)',
-  } as CSSProperties,
+  },
   error: {
     '--dx-valence-bg': 'var(--color-error-bg)',
     '--dx-valence-bg-hover': 'var(--color-error-bg-hover)',
     '--dx-valence-fg': 'var(--color-error-fg)',
-  } as CSSProperties,
+  },
   neutral: {
     '--dx-valence-bg': 'var(--color-neutral-bg)',
     '--dx-valence-bg-hover': 'var(--color-neutral-bg-hover)',
     '--dx-valence-fg': 'var(--color-neutral-fg)',
-  } as CSSProperties,
+  },
 };
 
 const [MessageProvider, useMessageContext] = createContext<MessageContextValue>(MESSAGE_NAME);
@@ -100,7 +108,7 @@ const MessageRoot = forwardRef<HTMLDivElement, MessageRootProps>(
           aria-labelledby={titleId}
           aria-describedby={descriptionId}
           {...props}
-          style={valenceVars[valence]}
+          style={{ ...valenceVars[valence], ...(props.style || {}) }}
           classNames={tx('message.root', { valence, elevation }, classNames)}
           ref={forwardedRef}
         >

--- a/packages/ui/react-ui/src/components/Message/Message.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.tsx
@@ -5,7 +5,7 @@
 import { createContext } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
-import React, { type ComponentPropsWithRef, forwardRef } from 'react';
+import React, { type CSSProperties, type ComponentPropsWithRef, forwardRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useId } from '@dxos/react-hooks';
@@ -38,6 +38,34 @@ type MessageRootProps = ThemedClassName<ComponentPropsWithRef<typeof Primitive.d
 type MessageContextValue = { titleId?: string; descriptionId: string; valence: MessageValence };
 
 const MESSAGE_NAME = 'Message';
+
+const valenceVars: Record<MessageValence, CSSProperties> = {
+  success: {
+    '--dx-valence-bg': 'var(--color-success-bg)',
+    '--dx-valence-bg-hover': 'var(--color-success-bg-hover)',
+    '--dx-valence-fg': 'var(--color-success-fg)',
+  } as CSSProperties,
+  info: {
+    '--dx-valence-bg': 'var(--color-info-bg)',
+    '--dx-valence-bg-hover': 'var(--color-info-bg-hover)',
+    '--dx-valence-fg': 'var(--color-info-fg)',
+  } as CSSProperties,
+  warning: {
+    '--dx-valence-bg': 'var(--color-warning-bg)',
+    '--dx-valence-bg-hover': 'var(--color-warning-bg-hover)',
+    '--dx-valence-fg': 'var(--color-warning-fg)',
+  } as CSSProperties,
+  error: {
+    '--dx-valence-bg': 'var(--color-error-bg)',
+    '--dx-valence-bg-hover': 'var(--color-error-bg-hover)',
+    '--dx-valence-fg': 'var(--color-error-fg)',
+  } as CSSProperties,
+  neutral: {
+    '--dx-valence-bg': 'var(--color-neutral-bg)',
+    '--dx-valence-bg-hover': 'var(--color-neutral-bg-hover)',
+    '--dx-valence-fg': 'var(--color-neutral-fg)',
+  } as CSSProperties,
+};
 
 const [MessageProvider, useMessageContext] = createContext<MessageContextValue>(MESSAGE_NAME);
 
@@ -72,6 +100,7 @@ const MessageRoot = forwardRef<HTMLDivElement, MessageRootProps>(
           aria-labelledby={titleId}
           aria-describedby={descriptionId}
           {...props}
+          style={valenceVars[valence]}
           classNames={tx('message.root', { valence, elevation }, classNames)}
           ref={forwardedRef}
         >

--- a/packages/ui/react-ui/src/components/Popover/Popover.theme.ts
+++ b/packages/ui/react-ui/src/components/Popover/Popover.theme.ts
@@ -13,7 +13,7 @@ export type PopoverStyleProps = Partial<{
 
 const content: ComponentFunction<PopoverStyleProps> = ({ elevation }, ...etc) =>
   mx(
-    'dx-modal-surface border border-separator rounded-sm',
+    'dx-popover-surface border border-separator rounded-sm',
     surfaceShadow({ elevation: 'positioned' }),
     surfaceZIndex({ elevation, level: 'menu' }),
     'dx-focus-ring',

--- a/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
+++ b/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
@@ -17,7 +17,7 @@ const viewport: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
 
 const root: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
   mx(
-    'dx-modal-surface rounded-md p-1',
+    'dx-popover-surface rounded-md p-1',
     surfaceShadow({ elevation: 'toast' }),
     'radix-state-open:animate-toast-slide-in-bottom md:radix-state-open:animate-toast-slide-in-right',
     'radix-state-closed:animate-toast-hide',

--- a/packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts
+++ b/packages/ui/react-ui/src/components/Toolbar/Toolbar.theme.ts
@@ -16,7 +16,7 @@ const layout =
 
 const root: ComponentFunction<ToolbarStyleProps> = ({ density, disabled, layoutManaged }, ...etc) => {
   return mx(
-    'bg-toolbar-surface dx-toolbar',
+    'bg-toolbar-surface dx-toolbar shadow-sm',
     density === 'lg' && 'h-(--dx-rail-size) px-3!',
     density === 'sm' && 'h-7 px-2!',
     density === 'xs' && 'h-6 px-1!',

--- a/packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md
+++ b/packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md
@@ -58,7 +58,7 @@ The primitive `--dx-elevation-0…7` is defined in `semantic.css` using `light-d
 
 ### Visual hierarchy (dark)
 
-```
+```text
 popover/float   n-750  ↑ highest / closest to viewer
 modal/dialog    n-775
 toolbar         n-800  (sticky bar; content passes beneath)
@@ -103,7 +103,7 @@ The system has three orthogonal states. Pick by what the ARIA / markup is saying
 
 ### Visual hierarchy (state, dark)
 
-```
+```text
 card-surface          n-825    resting
 current-surface       n-100 / n-900    "I am the active one"
 current-surface-hover n-200 / n-800    hovering the active one

--- a/packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md
+++ b/packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md
@@ -6,11 +6,11 @@ This document describes how color tokens are organized in `ui-theme`, the naming
 
 Three layers, each consuming the one below:
 
-| Tier        | File                                         | Purpose                                                                                                                                                                              | Example                                                                 |
-| ----------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
-| 1. Scale    | [`theme/palette.css`](./theme/palette.css)   | Raw color values. Extends Tailwind's neutral/blue scales with intermediate stops and aliases the `primary-*` ramp to `blue-*`.                                                       | `--color-neutral-150`, `--color-primary-500`                            |
-| 2. Hue role | [`theme/styles.css`](./theme/styles.css)     | Per-hue role tokens for every Tailwind hue plus `neutral`. Six roles each: `bg`, `bg-hover`, `surface`, `fg`, `text`, `border`. Light/dark resolved via `light-dark()`.              | `--color-red-surface`, `--color-neutral-border`                         |
-| 3. Semantic | [`theme/semantic.css`](./theme/semantic.css) | Named UI surfaces and states. May reference hue-role tokens (e.g. `error-surface` → `rose-surface`) or compose directly from the scale.                                              | `--color-card-surface`, `--color-current-surface`, `--color-error-text` |
+| Tier        | File                                         | Purpose                                                                                                                                                                 | Example                                                                 |
+| ----------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| 1. Scale    | [`theme/palette.css`](./theme/palette.css)   | Raw color values. Extends Tailwind's neutral/blue scales with intermediate stops and aliases the `primary-*` ramp to `blue-*`.                                          | `--color-neutral-150`, `--color-primary-500`                            |
+| 2. Hue role | [`theme/styles.css`](./theme/styles.css)     | Per-hue role tokens for every Tailwind hue plus `neutral`. Six roles each: `bg`, `bg-hover`, `surface`, `fg`, `text`, `border`. Light/dark resolved via `light-dark()`. | `--color-red-surface`, `--color-neutral-border`                         |
+| 3. Semantic | [`theme/semantic.css`](./theme/semantic.css) | Named UI surfaces and states. May reference hue-role tokens (e.g. `error-surface` → `rose-surface`) or compose directly from the scale.                                 | `--color-card-surface`, `--color-current-surface`, `--color-error-text` |
 
 A consumer should reach for the highest tier that fits. Use `bg-card-surface`, not `bg-neutral-825`. Use `text-error-text`, not `text-rose-700`.
 
@@ -42,16 +42,16 @@ mode; inverted toward white in light mode. Every named surface token is an alias
 `--dx-elevation-N` level. Never set a surface to a raw scale value — pick the level that matches the
 role and point the token there.
 
-| Level | Name     | Dark      | Light    | Named surfaces                                                                              |
-| ----- | -------- | --------- | -------- | ------------------------------------------------------------------------------------------- |
-| 0     | `void`   | `n-950`   | `n-200`  | scrim base, window gaps                                                                     |
-| 1     | `rail`   | `n-900`   | `n-175`  | `l0-surface` (icon rail)                                                                    |
-| 2     | `chrome` | `n-875`   | `n-150`  | `sidebar-surface`, `header-surface`, `l1-surface`, `r0-surface`, `r1-surface`               |
-| 3     | `canvas` | `n-850`   | `n-125`  | `base-surface`, `deck-surface`                                                              |
-| 4     | `raised` | `n-825`   | `n-100`  | `card-surface`, `group-surface`, `input-surface`                                            |
-| 5     | `bar`    | `n-800`   | `n-75`   | `toolbar-surface` (sticky, drop-shadowed)                                                   |
-| 6     | `modal`  | `n-775`   | `n-50`   | `modal-surface` (dialogs)                                                                   |
-| 7     | `float`  | `n-750`   | `white`  | `popover-surface` (menus, popovers, toasts, tooltips)                                       |
+| Level | Name     | Dark    | Light   | Named surfaces                                                                |
+| ----- | -------- | ------- | ------- | ----------------------------------------------------------------------------- |
+| 0     | `void`   | `n-950` | `n-200` | scrim base, window gaps                                                       |
+| 1     | `rail`   | `n-900` | `n-175` | `l0-surface` (icon rail)                                                      |
+| 2     | `chrome` | `n-875` | `n-150` | `sidebar-surface`, `header-surface`, `l1-surface`, `r0-surface`, `r1-surface` |
+| 3     | `canvas` | `n-850` | `n-125` | `base-surface`, `deck-surface`                                                |
+| 4     | `raised` | `n-825` | `n-100` | `card-surface`, `group-surface`, `input-surface`                              |
+| 5     | `bar`    | `n-800` | `n-75`  | `toolbar-surface` (sticky, drop-shadowed)                                     |
+| 6     | `modal`  | `n-775` | `n-50`  | `modal-surface` (dialogs)                                                     |
+| 7     | `float`  | `n-750` | `white` | `popover-surface` (menus, popovers, toasts, tooltips)                         |
 
 The primitive `--dx-elevation-0…7` is defined in `semantic.css` using `light-dark()`. Raw scale values
 (`n-*`) are in `palette.css` — the table above is for human reference only.

--- a/packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md
+++ b/packages/ui/ui-theme/src/css/DESIGN_SYSTEM.md
@@ -6,13 +6,13 @@ This document describes how color tokens are organized in `ui-theme`, the naming
 
 Three layers, each consuming the one below:
 
-| Tier        | File                                         | Purpose                                                                                                                                                                                       | Example                                                                 |
-| ----------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| 1. Scale    | [`theme/palette.css`](./theme/palette.css)   | Raw color values. Extends Tailwind's neutral/blue scales with intermediate stops and aliases the `primary-*` ramp to `blue-*`.                                                                | `--color-neutral-150`, `--color-primary-500`                            |
-| 2. Hue role | [`theme/styles.css`](./theme/styles.css)     | Per-hue role tokens generated mechanically for every Tailwind hue plus `neutral`. Five roles each: `fill`, `surface`, `foreground`, `text`, `border`. Light/dark resolved via `light-dark()`. | `--color-red-surface`, `--color-neutral-border`                         |
-| 3. Semantic | [`theme/semantic.css`](./theme/semantic.css) | Named UI surfaces and states. May reference hue-role tokens (e.g. `error-surface` → `rose-surface`) or compose directly from the scale.                                                       | `--color-card-surface`, `--color-current-surface`, `--color-error-text` |
+| Tier        | File                                         | Purpose                                                                                                                                                                              | Example                                                                 |
+| ----------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| 1. Scale    | [`theme/palette.css`](./theme/palette.css)   | Raw color values. Extends Tailwind's neutral/blue scales with intermediate stops and aliases the `primary-*` ramp to `blue-*`.                                                       | `--color-neutral-150`, `--color-primary-500`                            |
+| 2. Hue role | [`theme/styles.css`](./theme/styles.css)     | Per-hue role tokens for every Tailwind hue plus `neutral`. Six roles each: `bg`, `bg-hover`, `surface`, `fg`, `text`, `border`. Light/dark resolved via `light-dark()`.              | `--color-red-surface`, `--color-neutral-border`                         |
+| 3. Semantic | [`theme/semantic.css`](./theme/semantic.css) | Named UI surfaces and states. May reference hue-role tokens (e.g. `error-surface` → `rose-surface`) or compose directly from the scale.                                              | `--color-card-surface`, `--color-current-surface`, `--color-error-text` |
 
-A consumer should reach for the highest tier that fits. Use `bg-card-surface`, not `bg-neutral-75`. Use `text-error-text`, not `text-rose-700`.
+A consumer should reach for the highest tier that fits. Use `bg-card-surface`, not `bg-neutral-825`. Use `text-error-text`, not `text-rose-700`.
 
 ## Naming convention
 
@@ -21,9 +21,10 @@ Token names follow `--color-{name}-{part}[-{state}]`:
 - **`name`** identifies the role or surface (`card`, `current`, `accent`, `error`, `red`).
 - **`part`** is one of a fixed vocabulary:
   - `surface` — the background fill of a thing.
-  - `foreground` — the text/icon color that sits on the surface (paired with `surface`).
+  - `fg` — the text/icon color that sits on the surface (paired with `surface`).
+  - `bg` — solid attention-grabbing fill (buttons, badges, indicators); more saturated than `surface`.
+  - `bg-hover` — hover state for `bg`.
   - `border` — border color on the surface.
-  - `fill` — solid attention-grabbing fill (badges, dots, indicators); more saturated than `surface`.
   - `text` — text color used standalone, on the base canvas (no enclosing surface).
 - **`state`** is optional, appended last: `hover`, `active` (pressed). State always follows the part it modifies.
 
@@ -36,21 +37,52 @@ Token names follow `--color-{name}-{part}[-{state}]`:
 
 ## Surfaces
 
-Layered fills, ordered from recessive to prominent:
+Surfaces are governed by a strict elevation ladder: **lighter = higher = closer to the viewer** in dark
+mode; inverted toward white in light mode. Every named surface token is an alias of exactly one
+`--dx-elevation-N` level. Never set a surface to a raw scale value — pick the level that matches the
+role and point the token there.
+
+| Level | Name     | Dark      | Light    | Named surfaces                                                                              |
+| ----- | -------- | --------- | -------- | ------------------------------------------------------------------------------------------- |
+| 0     | `void`   | `n-950`   | `n-200`  | scrim base, window gaps                                                                     |
+| 1     | `rail`   | `n-900`   | `n-175`  | `l0-surface` (icon rail)                                                                    |
+| 2     | `chrome` | `n-875`   | `n-150`  | `sidebar-surface`, `header-surface`, `l1-surface`, `r0-surface`, `r1-surface`               |
+| 3     | `canvas` | `n-850`   | `n-125`  | `base-surface`, `deck-surface`                                                              |
+| 4     | `raised` | `n-825`   | `n-100`  | `card-surface`, `group-surface`, `input-surface`                                            |
+| 5     | `bar`    | `n-800`   | `n-75`   | `toolbar-surface` (sticky, drop-shadowed)                                                   |
+| 6     | `modal`  | `n-775`   | `n-50`   | `modal-surface` (dialogs)                                                                   |
+| 7     | `float`  | `n-750`   | `white`  | `popover-surface` (menus, popovers, toasts, tooltips)                                       |
+
+The primitive `--dx-elevation-0…7` is defined in `semantic.css` using `light-dark()`. Raw scale values
+(`n-*`) are in `palette.css` — the table above is for human reference only.
+
+### Visual hierarchy (dark)
 
 ```
-base-surface          n-50  / n-950   the page canvas
-deck-surface          n-50  / n-950   deck panes
-toolbar-surface       n-75  / n-925   toolbars
-card-surface          n-75  / n-925   cards
-group-surface         n-100 / n-900   grouped containers
-modal-surface         n-100 / n-900   modals / dialogs
-sidebar-surface       n-100 / n-900   sidebars
-header-surface        n-100 / n-900   headers
-input-surface         n-200 / n-800   form controls
+popover/float   n-750  ↑ highest / closest to viewer
+modal/dialog    n-775
+toolbar         n-800  (sticky bar; content passes beneath)
+card/raised     n-825
+canvas/deck     n-850
+chrome/sidebar  n-875
+rail/L0         n-900
+void            n-950  ↓ lowest
 ```
 
 Each surface that hosts text declares a matching `*-fg` (defaulting to `n-950 / n-50`).
+
+## Elevation primitive
+
+The `--dx-elevation-0…7` custom properties in `semantic.css` are the single source of truth for the
+surface ladder. They are private (`--dx-*` prefix) — never use them directly in component CSS; use the
+named surface tokens (`bg-card-surface`, `dx-modal-surface`, etc.) instead.
+
+When adding a new surface:
+
+1. Decide which elevation level the new surface belongs to (see the table above).
+2. Add `--color-<name>-surface: var(--dx-elevation-N);` in the Surfaces block of `semantic.css`.
+3. Add a matching `--color-<name>-fg` if text/icons sit on it.
+4. If the surface needs a utility class (like `dx-modal-surface`), add it to `surface.css`.
 
 ## State tokens (rationalized)
 
@@ -69,10 +101,10 @@ The system has three orthogonal states. Pick by what the ARIA / markup is saying
 
 **Why these three.** `current` describes one-of-N navigation/selection state ("you are here"); `selected` describes a checked item in a set (multi-select-able); `hover` is transient pointer feedback. Driving the distinction off ARIA keeps markup and tokens in sync.
 
-### Visual hierarchy
+### Visual hierarchy (state, dark)
 
 ```
-card-surface          n-75  / n-925    resting
+card-surface          n-825    resting
 current-surface       n-100 / n-900    "I am the active one"
 current-surface-hover n-200 / n-800    hovering the active one
 hover-surface         n-250 / n-750    transient pointer-over anywhere else
@@ -91,10 +123,6 @@ These are merged into the rationalized state vocabulary:
 | `highlight-surface-text`  | `current-fg`            | Rename to the new `-fg` suffix.                                                                                                                                                   |
 | `*-surface-text` (all)    | `*-fg`                  | Repository-wide rename for every hue, semantic, and named-surface token (e.g. `base-surface-text` → `base-fg`, `red-surface-text` → `red-fg`, `error-surface-text` → `error-fg`). |
 
-### Visual change to expect
-
-The 9 `bg-active-surface` call sites become one shade subtler (from `n-200/800` to `n-100/900`). This aligns them with the existing `selected.css` treatment of `aria-current=true` and produces the coherent layering shown above.
-
 ### Out-of-scope drift to fix separately
 
 Two sites use `bg-hover-surface` as a _resting_ fill (not a hover state):
@@ -102,7 +130,7 @@ Two sites use `bg-hover-surface` as a _resting_ fill (not a hover state):
 - [packages/plugins/plugin-navtree/src/experimental/Tree.tsx:196](../../../../plugins/plugin-navtree/src/experimental/Tree.tsx)
 - [packages/plugins/plugin-script/src/components/TestPanel/TestPanel.tsx:171](../../../../plugins/plugin-script/src/components/TestPanel/TestPanel.tsx)
 
-These should probably move to `card-surface` or `current-surface` depending on intent. Tracked as a follow-up; not part of this rationalization.
+These should probably move to `card-surface` or `current-surface` depending on intent. Tracked as a follow-up.
 
 ## Accent (primary)
 
@@ -148,11 +176,11 @@ Status colors point at hue-role tokens:
 | `warning-*` | `amber-*`   |
 | `error-*`   | `rose-*`    |
 
-Each provides `fill`, `surface`, `foreground`, `text`, `border`.
+Each provides `bg`, `bg-hover`, `surface`, `fg`, `text`, `border`.
 
 ## Adding a new token
 
-1. Does an existing semantic token already cover it? If yes, use it.
+1. Does an existing semantic token already cover it? For a new named surface, check the elevation ladder first — the new surface probably fits an existing level and should alias `--dx-elevation-N` rather than a raw scale value.
 2. Does it represent a new named surface, state, or status? Add it to `semantic.css` referencing scale or hue-role tokens — never raw hex.
 3. Follow the suffix order: `{name}-{part}[-{state}]`.
 4. If the new token will be used through a Tailwind utility that the source-scan can't see (e.g. CSS file, dynamic class), add it to `@source inline(...)` in [`main.css`](./main.css).

--- a/packages/ui/ui-theme/src/css/components/button.css
+++ b/packages/ui/ui-theme/src/css/components/button.css
@@ -76,13 +76,13 @@
         }
       }
       &[data-variant='valence'] {
-        color: var(--dx-valence-fg);
-        background: var(--dx-valence-bg);
+        color: var(--dx-valence-fg, var(--color-neutral-fg));
+        background: var(--dx-valence-bg, var(--color-neutral-bg));
         &:hover,
         &[aria-pressed='true'],
         &[aria-checked='true'],
         &[data-state='open'] {
-          background: var(--dx-valence-bg-hover);
+          background: var(--dx-valence-bg-hover, var(--color-neutral-bg-hover));
         }
       }
     }

--- a/packages/ui/ui-theme/src/css/components/button.css
+++ b/packages/ui/ui-theme/src/css/components/button.css
@@ -75,6 +75,16 @@
           @apply bg-error-bg-hover;
         }
       }
+      &[data-variant='valence'] {
+        color: var(--dx-valence-fg);
+        background: var(--dx-valence-bg);
+        &:hover,
+        &[aria-pressed='true'],
+        &[aria-checked='true'],
+        &[data-state='open'] {
+          background: var(--dx-valence-bg-hover);
+        }
+      }
     }
   }
   /* Props */

--- a/packages/ui/ui-theme/src/css/components/surface.css
+++ b/packages/ui/ui-theme/src/css/components/surface.css
@@ -22,13 +22,9 @@
     @apply bg-attention-surface text-base-fg;
     --surface-bg: var(--color-attention-surface);
   }
-}
 
-/* TODO(burdon): Resolve. */
-/* @layer dx-tokens {
-  .dx-sidebar-surface, .dx-modal-surface {
-    --color-hover-surface: light-dark(var(--color-neutral-300), var(--color-neutral-700));
-    --color-input-surface: light-dark(var(--color-neutral-200), var(--color-neutral-800));
-    --color-separator: light-dark(var(--color-neutral-300), var(--color-neutral-700));
+  .dx-popover-surface {
+    @apply bg-popover-surface text-base-fg backdrop-blur-md;
+    --surface-bg: var(--color-popover-surface);
   }
-} */
+}

--- a/packages/ui/ui-theme/src/css/theme/palette.css
+++ b/packages/ui/ui-theme/src/css/theme/palette.css
@@ -38,6 +38,7 @@
   --color-neutral-600: oklch(0.439 var(--dx-neutral-chroma) var(--dx-neutral-hue));
   --color-neutral-700: oklch(0.371 var(--dx-neutral-chroma) var(--dx-neutral-hue));
   --color-neutral-750: color-mix(in oklch, var(--color-neutral-700) 50%, var(--color-neutral-800) 50%);
+  --color-neutral-775: color-mix(in oklch, var(--color-neutral-750) 50%, var(--color-neutral-800) 50%);
   --color-neutral-800: oklch(0.269 var(--dx-neutral-chroma) var(--dx-neutral-hue));
   --color-neutral-825: color-mix(in oklch, var(--color-neutral-800) 75%, var(--color-neutral-900) 25%);
   --color-neutral-850: color-mix(in oklch, var(--color-neutral-800) 50%, var(--color-neutral-900) 50%);

--- a/packages/ui/ui-theme/src/css/theme/semantic.css
+++ b/packages/ui/ui-theme/src/css/theme/semantic.css
@@ -9,8 +9,50 @@
  */
 
 @theme {
-  /* Surfaces */
-  --color-deck-surface: light-dark(var(--color-neutral-150), var(--color-neutral-850));
+  /*
+   * Elevation ladder — strictly monotonic, z-order low → high.
+   * Dark: darker = lower. Light: lighter = lower (inverted toward white).
+   *
+   * Level  Name    Roles
+   *   0    void    window gaps, scrim base
+   *   1    rail    L0 icon rail
+   *   2    chrome  L1/R sidebars, header
+   *   3    canvas  base, deck
+   *   4    raised  card, group, input
+   *   5    bar     toolbar (sticky, drop-shadowed)
+   *   6    modal   dialog, modal
+   *   7    float   popover, menu, toast, tooltip
+   *
+   * These are private (--dx-*) knobs — use named surface tokens in components, not these directly.
+   */
+  --dx-elevation-0: light-dark(var(--color-neutral-200), var(--color-neutral-950)); /* void   */
+  --dx-elevation-1: light-dark(var(--color-neutral-175), var(--color-neutral-900)); /* rail   */
+  --dx-elevation-2: light-dark(var(--color-neutral-150), var(--color-neutral-875)); /* chrome */
+  --dx-elevation-3: light-dark(var(--color-neutral-125), var(--color-neutral-850)); /* canvas */
+  --dx-elevation-4: light-dark(var(--color-neutral-100), var(--color-neutral-825)); /* raised */
+  --dx-elevation-5: light-dark(var(--color-neutral-75),  var(--color-neutral-800)); /* bar    */
+  --dx-elevation-6: light-dark(var(--color-neutral-50),  var(--color-neutral-775)); /* modal  */
+  --dx-elevation-7: light-dark(white,                    var(--color-neutral-750)); /* float  */
+
+  /* Surfaces — each maps to exactly one elevation level */
+  --color-deck-surface:      var(--dx-elevation-3);
+  --color-base-surface:      var(--dx-elevation-3);
+  --color-sidebar-surface:   var(--dx-elevation-2);
+  --color-header-surface:    var(--dx-elevation-2);
+  --color-toolbar-surface:   var(--dx-elevation-5);
+  --color-card-surface:      var(--dx-elevation-4);
+  --color-group-surface:     var(--dx-elevation-4);
+  --color-group-alt-surface: var(--dx-elevation-4);
+  --color-input-surface:     var(--dx-elevation-4);
+  --color-modal-surface:     var(--dx-elevation-6);
+  --color-popover-surface:   var(--dx-elevation-7); /* float tier — popovers, menus, toasts, tooltips */
+
+  /* Sidebar / panel layout levels */
+  --color-l0-surface: var(--dx-elevation-1);
+  --color-l1-surface: var(--dx-elevation-2);
+  --color-r0-surface: var(--dx-elevation-2);
+  --color-r1-surface: var(--dx-elevation-2);
+
   --color-scrim-surface: light-dark(
     oklch(from var(--color-neutral-50) l c h / 0.5),
     oklch(from var(--color-neutral-950) l c h / 0.25)
@@ -19,7 +61,6 @@
   --color-inverse-surface: light-dark(var(--color-neutral-800), var(--color-neutral-200));
   --color-inverse-fg: light-dark(var(--color-neutral-50), var(--color-neutral-950));
 
-  --color-base-surface: light-dark(var(--color-neutral-75), var(--color-neutral-850));
   --color-base-fg: light-dark(var(--color-neutral-950), var(--color-neutral-150));
 
   /* Focus */
@@ -31,24 +72,7 @@
   --color-attention-surface: var(--color-focus-surface);
   --color-attention-contains: oklch(from var(--color-accent-bg) l c h / 0.3);
 
-  --color-header-surface: light-dark(var(--color-neutral-175), var(--color-neutral-875));
-  --color-toolbar-surface: light-dark(var(--color-neutral-100), var(--color-neutral-825));
-  --color-sidebar-surface: light-dark(var(--color-neutral-100), var(--color-neutral-800));
-
-  /* Sidebar */
-  --color-l0-surface: var(--color-header-surface);
-  --color-l1-surface: var(--color-sidebar-surface);
-  --color-r0-surface: var(--color-sidebar-surface);
-  --color-r1-surface: var(--color-base-surface);
-
-  --color-modal-surface: light-dark(var(--color-neutral-100), var(--color-neutral-825));
-
-  --color-group-surface: light-dark(var(--color-neutral-150), var(--color-neutral-850));
-  --color-group-alt-surface: light-dark(var(--color-neutral-100), var(--color-neutral-875));
-  --color-card-surface: light-dark(var(--color-neutral-75), var(--color-neutral-825));
-
   /* input */
-  --color-input-surface: light-dark(var(--color-neutral-150), var(--color-neutral-850));
   --color-input-bg: light-dark(var(--color-neutral-250), var(--color-neutral-700));
   --color-input-fg: light-dark(var(--color-neutral-950), var(--color-neutral-150));
 

--- a/packages/ui/ui-theme/src/css/theme/semantic.css
+++ b/packages/ui/ui-theme/src/css/theme/semantic.css
@@ -30,22 +30,22 @@
   --dx-elevation-2: light-dark(var(--color-neutral-150), var(--color-neutral-875)); /* chrome */
   --dx-elevation-3: light-dark(var(--color-neutral-125), var(--color-neutral-850)); /* canvas */
   --dx-elevation-4: light-dark(var(--color-neutral-100), var(--color-neutral-825)); /* raised */
-  --dx-elevation-5: light-dark(var(--color-neutral-75),  var(--color-neutral-800)); /* bar    */
-  --dx-elevation-6: light-dark(var(--color-neutral-50),  var(--color-neutral-775)); /* modal  */
-  --dx-elevation-7: light-dark(white,                    var(--color-neutral-750)); /* float  */
+  --dx-elevation-5: light-dark(var(--color-neutral-75), var(--color-neutral-800)); /* bar    */
+  --dx-elevation-6: light-dark(var(--color-neutral-50), var(--color-neutral-775)); /* modal  */
+  --dx-elevation-7: light-dark(white, var(--color-neutral-750)); /* float  */
 
   /* Surfaces — each maps to exactly one elevation level */
-  --color-deck-surface:      var(--dx-elevation-3);
-  --color-base-surface:      var(--dx-elevation-3);
-  --color-sidebar-surface:   var(--dx-elevation-2);
-  --color-header-surface:    var(--dx-elevation-2);
-  --color-toolbar-surface:   var(--dx-elevation-5);
-  --color-card-surface:      var(--dx-elevation-4);
-  --color-group-surface:     var(--dx-elevation-4);
+  --color-deck-surface: var(--dx-elevation-3);
+  --color-base-surface: var(--dx-elevation-3);
+  --color-sidebar-surface: var(--dx-elevation-2);
+  --color-header-surface: var(--dx-elevation-2);
+  --color-toolbar-surface: var(--dx-elevation-5);
+  --color-card-surface: var(--dx-elevation-4);
+  --color-group-surface: var(--dx-elevation-4);
   --color-group-alt-surface: var(--dx-elevation-4);
-  --color-input-surface:     var(--dx-elevation-4);
-  --color-modal-surface:     var(--dx-elevation-6);
-  --color-popover-surface:   var(--dx-elevation-7); /* float tier — popovers, menus, toasts, tooltips */
+  --color-input-surface: var(--dx-elevation-4);
+  --color-modal-surface: var(--dx-elevation-6);
+  --color-popover-surface: var(--dx-elevation-7); /* float tier — popovers, menus, toasts, tooltips */
 
   /* Sidebar / panel layout levels */
   --color-l0-surface: var(--dx-elevation-1);

--- a/packages/ui/ui-theme/src/css/theme/semantic.css
+++ b/packages/ui/ui-theme/src/css/theme/semantic.css
@@ -25,14 +25,14 @@
    *
    * These are private (--dx-*) knobs — use named surface tokens in components, not these directly.
    */
-  --dx-elevation-0: light-dark(var(--color-neutral-200), var(--color-neutral-950)); /* void   */
-  --dx-elevation-1: light-dark(var(--color-neutral-175), var(--color-neutral-900)); /* rail   */
-  --dx-elevation-2: light-dark(var(--color-neutral-150), var(--color-neutral-875)); /* chrome */
-  --dx-elevation-3: light-dark(var(--color-neutral-125), var(--color-neutral-850)); /* canvas */
-  --dx-elevation-4: light-dark(var(--color-neutral-100), var(--color-neutral-825)); /* raised */
-  --dx-elevation-5: light-dark(var(--color-neutral-75), var(--color-neutral-800)); /* bar    */
-  --dx-elevation-6: light-dark(var(--color-neutral-50), var(--color-neutral-775)); /* modal  */
-  --dx-elevation-7: light-dark(white, var(--color-neutral-750)); /* float  */
+  --dx-elevation-0: light-dark(var(--color-neutral-200), var(--color-neutral-950));
+  --dx-elevation-1: light-dark(var(--color-neutral-175), var(--color-neutral-900));
+  --dx-elevation-2: light-dark(var(--color-neutral-150), var(--color-neutral-875));
+  --dx-elevation-3: light-dark(var(--color-neutral-125), var(--color-neutral-850));
+  --dx-elevation-4: light-dark(var(--color-neutral-100), var(--color-neutral-825));
+  --dx-elevation-5: light-dark(var(--color-neutral-75), var(--color-neutral-800));
+  --dx-elevation-6: light-dark(var(--color-neutral-50), var(--color-neutral-775));
+  --dx-elevation-7: light-dark(white, var(--color-neutral-750));
 
   /* Surfaces — each maps to exactly one elevation level */
   --color-deck-surface: var(--dx-elevation-3);
@@ -45,7 +45,7 @@
   --color-group-alt-surface: var(--dx-elevation-4);
   --color-input-surface: var(--dx-elevation-4);
   --color-modal-surface: var(--dx-elevation-6);
-  --color-popover-surface: var(--dx-elevation-7); /* float tier — popovers, menus, toasts, tooltips */
+  --color-popover-surface: var(--dx-elevation-7);
 
   /* Sidebar / panel layout levels */
   --color-l0-surface: var(--dx-elevation-1);

--- a/packages/ui/ui-theme/src/css/theme/semantic.css
+++ b/packages/ui/ui-theme/src/css/theme/semantic.css
@@ -11,7 +11,7 @@
 @theme {
   /*
    * Elevation ladder — strictly monotonic, z-order low → high.
-   * Dark: darker = lower. Light: lighter = lower (inverted toward white).
+   * Dark: darker = lower. Light: lighter = higher (inverted toward white).
    *
    * Level  Name    Roles
    *   0    void    window gaps, scrim base

--- a/packages/ui/ui-theme/src/util/valence.ts
+++ b/packages/ui/ui-theme/src/util/valence.ts
@@ -31,3 +31,11 @@ export const messageValence = (valence?: MessageValence) => {
       return 'font-medium border-neutral-text bg-neutral-surface';
   }
 };
+
+/**
+ * Classes for a Button rendered inside a Message.Root that should inherit the message's valence color.
+ * Message.Root sets --dx-valence-bg / --dx-valence-bg-hover / --dx-valence-fg on its DOM node.
+ * Pass variant='valence' to the Button so button.css reads those variables.
+ */
+export const buttonValence = (_valence?: MessageValence): string =>
+  'text-(--dx-valence-fg) bg-(--dx-valence-bg) hover:bg-(--dx-valence-bg-hover)';


### PR DESCRIPTION
## Summary

Introduces a strict `--dx-elevation-0…7` numbered scale as the single source of truth for surface colors, making the elevation system monotonic (lighter = higher = closer to the viewer in dark mode; inverted toward white in light mode). Two component-level fixes are bundled in the same branch.

### Elevation primitive (`ui-theme`)

- Add `--dx-elevation-0…7` private CSS custom properties to `semantic.css` using `light-dark()` — one level per named role in the UI.
- Remap **all named surface tokens** (`base-surface`, `card-surface`, `toolbar-surface`, `modal-surface`, etc.) to point at the appropriate level instead of raw `n-*` scale values.
- Add `--color-neutral-775` interpolation step to `palette.css` (needed for the modal level in dark mode).
- Add `--color-popover-surface` (level 7, lightest/highest) and `.dx-popover-surface` utility in `surface.css`.

**Before:** five roles collapsed onto `n-825` (toolbar = card = modal = popover = toast); the ramp was non-monotonic (header darker than deck).  
**After:** each role is a distinct step; card↔toolbar are one level apart (plus toolbar drop shadow); floating overlays are 2–3 steps above the deck.

### Overlay components (`react-ui`)

- `Popover.theme.ts`, `Toast.theme.ts`, `Menu.theme.ts` → switched from `dx-modal-surface` to `dx-popover-surface` (float tier, level 7). `Dialog.theme.ts` stays on `dx-modal-surface` (level 6).
- `Toolbar.theme.ts` → adds `shadow-sm` so scrolling content reads as passing beneath a raised bar.

### Message-button valence (`react-ui`, `ui-theme`)

- `Message.Root` now sets `--dx-valence-bg / --dx-valence-bg-hover / --dx-valence-fg` CSS custom properties scoped to the message element (using the existing `--surface-bg` re-derivation idiom from `main.css`).
- New `buttonValence()` export in `valence.ts` (for documentation/intent; the actual classes are applied via `variant='valence'` on the `Button`).
- New `data-variant='valence'` rule in `button.css` — reads the scoped vars, so any `<Button variant='valence'>` inside a `Message` auto-inherits the message color.
- `Button.tsx` variant union extended with `'valence'`.
- `Message.stories.tsx` adds a `WithButton` story demonstrating the pattern.

### `CreateObjectDialog` form nesting fix (`plugin-space`)

- `CreateObjectPanel` was rendering `Form.Root` as a non-participating child of `Dialog.Body`'s column grid, causing a double-nested padded panel.
- Fix: wrap the `inputSchema` branch in a `<div>` with the column-propagation classes (`[.dx-column-root_&]:col-span-full … grid-cols-subgrid`) so the form flows directly into the dialog's column layout — matching the working `CreateSpaceDialog` pattern.

### Docs

- `DESIGN_SYSTEM.md` rewritten: elevation ladder as the Surfaces source of truth, `fill` role removed (never existed — hue roles are `bg/bg-hover/surface/fg/text/border`), new "Elevation primitive" section, updated "Adding a new token" guidance.

## Reviewer notes

- The **light-canvas darkening** (`base-surface` / `deck-surface` light mode: was ~`n-75`, now `n-125`) is the most visually significant change — the app background in light mode reads slightly more "gray paper". This is intentional (required for a full 8-step monotonic light ramp).
- The `as CSSProperties` casts in `Message.tsx` are at a genuine type-system boundary (CSS custom properties aren't in TypeScript's `CSSProperties` by default); each is justified in code.
- Grid/sheet tokens (`axis-*`, `grid-*`) are intentionally untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added button styling variants within message components
  * Introduced elevation-based surface system for improved visual hierarchy

* **Bug Fixes**
  * Fixed form layout nesting in panels

* **Improvements**
  * Updated surface styling for popovers, menus, and toasts
  * Added shadow effect to toolbar for visual depth

* **Documentation**
  * Refined design system documentation with new elevation model

<!-- end of auto-generated comment: release notes by coderabbit.ai -->