### PR TITLE
fix(plugin-integration): nest Integrations folder under space settings

### DIFF
--- a/packages/plugins/plugin-integration/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-integration/src/capabilities/app-graph-builder.ts
@@ -6,13 +6,13 @@ import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 
 import { Capability } from '@dxos/app-framework';
-import { AppCapabilities, AppNodeMatcher, createObjectNode } from '@dxos/app-toolkit';
+import { AppCapabilities, createObjectNode } from '@dxos/app-toolkit';
 import { isSpace } from '@dxos/client/echo';
 import { Operation } from '@dxos/compute';
 import { Filter, Obj, Ref } from '@dxos/echo';
 import { AtomQuery } from '@dxos/echo-atom';
 import { GraphBuilder, Node } from '@dxos/plugin-graph';
-import { SpaceOperation } from '@dxos/plugin-space';
+import { SETTINGS_SECTION_TYPE, SpaceOperation } from '@dxos/plugin-space';
 
 import { meta } from '#meta';
 import { IntegrationProvider, type IntegrationProviderEntry } from '#types';
@@ -78,11 +78,15 @@ export default Capability.makeModule(
           }),
       }),
 
-      // Per-space integrations folder; kept empty until an Integration exists.
+      // Per-space integrations folder nested under the space's settings section
+      // (alongside Automations, Functions); kept empty until an Integration exists.
       // Separate listing extension so graph reacts when targets are deleted.
       GraphBuilder.createExtension({
         id: 'integrationsSection',
-        match: AppNodeMatcher.whenSpace,
+        match: (node) => {
+          const space = isSpace(node.properties.space) ? node.properties.space : undefined;
+          return node.type === SETTINGS_SECTION_TYPE && space ? Option.some(space) : Option.none();
+        },
         connector: (space, get) => {
           const integrations = get(AtomQuery.make(space.db, Filter.type(Integration.Integration)));
           if (integrations.length === 0) {


### PR DESCRIPTION
## What

Attach the per-space **Integrations** folder under the space's **Settings** section (alongside Automations and Functions) instead of directly under the Space node.

## Why

`app-graph-builder.ts` matched `AppNodeMatcher.whenSpace`, placing the integrations branch directly under the Space. But the plugin's navigation already assumed it lived under settings — `integrationDeckSubject` (in `constants.ts`) builds the deck path as `${spacePath}/${SETTINGS_SECTION_ID}/${INTEGRATIONS_SECTION_ID}/${integrationId}`, including the `settings` segment. The graph placement and the navigation path were out of sync.

## How

- `integrationsSection` extension now matches `SETTINGS_SECTION_TYPE` (from `@dxos/plugin-space`), reading `space` off the settings section node's `properties` — the same pattern Automations and Functions use.
- Removed the now-unused `AppNodeMatcher` import.

The downstream `integrationListing` extension is unchanged; it keys off the section node's `space` property, which is still set. The Settings node is itself a `role: 'branch'` navtree branch, so the Integrations folder nests as a child item the same way General / Members / Automations / Functions do.

## Notes for reviewer

- The folder remains gated — hidden until at least one Integration exists (unchanged behavior; creation happens via the space create-object menu).
- Verified: `plugin-integration:build` (exit 0) and `lint --fix` pass; no new casts.
- Automations/Functions use single settings *panels* (`makeSettingsPanel`); Integrations is a *branch folder* listing each integration as a child. Both nest under Settings. Flag if a single panel is preferred instead of an expandable folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined the integrations settings architecture by adjusting the node matching logic for the per-space integrations container, narrowing which settings sections are eligible to display per-space integration configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->