### PR TITLE
fix(ci): resolve e2e build failures — plugin-trip fg rename and cli:bundle deps

### DIFF
--- a/packages/devtools/cli/moon.yml
+++ b/packages/devtools/cli/moon.yml
@@ -13,9 +13,12 @@ tasks:
     command: bun
     args:
       - ./scripts/build.ts
+    deps:
+      - ^:compile
     options:
       timeout: 60
     inputs:
+      - src/**/*
       - scripts/build.ts
       - bunfig.toml
       - package.json

--- a/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.tsx
+++ b/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.tsx
@@ -97,7 +97,7 @@ export const SegmentTile = forwardRef<HTMLDivElement, SegmentTileProps>(({ data,
       <Focus.Item asChild current={current} onCurrentChange={handleCurrentChange}>
         <Card.Root fullWidth border={false} ref={forwardedRef}>
           <Card.Header>
-            <Card.Icon icon={icon} classNames={iconStyles?.foreground} />
+            <Card.Icon icon={icon} classNames={iconStyles?.fg} />
             <Card.Title>{title}</Card.Title>
             <Card.ActionIconButton action='delete' onClick={handleDelete} label={t('segment.delete.label')} />
           </Card.Header>


### PR DESCRIPTION
## Summary

Fixes two CI build failures that have been blocking the e2e job on main:

- **`plugin-trip:build`**: `SegmentCard.tsx` used `iconStyles?.foreground` which was renamed to `.fg` by #11652 (`refactor(ui-theme): rename color roles fill→bg / foreground→fg`). The `plugin-trip` package was missed during that rename.

- **`cli:bundle`**: The `bundle` task had no `deps` on workspace package compile tasks, so when the e2e CI job runs `moon run :bundle`, Bun's bundler couldn't resolve `@dxos/*` packages — their `dist/` files (referenced by the `node` export condition) don't exist yet. Adding `^:compile` causes moon to pull those dist files from remote cache before bundling. Also adds `src/**/*` to inputs so cache is invalidated when source changes.

## Root cause analysis

- The `plugin-trip` fix is a straightforward missed update from the color-token rename PR.
- The `cli:bundle` failure has been present in every CI run since the task was introduced in #11657 (June 2). The original `compile` task inherited `^:compile` implicitly via the `ts-build` tag; the refactor that renamed it to `bundle` and dropped the `ts-build` tag accidentally removed that dependency.

https://claude.ai/code/session_015q7padavXPnk7UwxpZojMB

---
_Generated by [Claude Code](https://claude.ai/code/session_015q7padavXPnk7UwxpZojMB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed icon styling in segment cards to display correct color tints.

* **Chores**
  * Updated build task configuration with explicit dependency and input declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->