### PR TITLE
fix(plugin-trip): rename ColorStyles.foreground → fg in SegmentCard

### DIFF
--- a/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.tsx
+++ b/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.tsx
@@ -97,7 +97,7 @@ export const SegmentTile = forwardRef<HTMLDivElement, SegmentTileProps>(({ data,
       <Focus.Item asChild current={current} onCurrentChange={handleCurrentChange}>
         <Card.Root fullWidth border={false} ref={forwardedRef}>
           <Card.Header>
-            <Card.Icon icon={icon} classNames={iconStyles?.foreground} />
+            <Card.Icon icon={icon} classNames={iconStyles?.fg} />
             <Card.Title>{title}</Card.Title>
             <Card.ActionIconButton action='delete' onClick={handleDelete} label={t('segment.delete.label')} />
           </Card.Header>


### PR DESCRIPTION
## Summary

- Fixes a TypeScript build error (`TS2339: Property 'foreground' does not exist on type 'ColorStyles'`) in `SegmentCard.tsx`
- The `ui-theme` refactor in #11652 renamed the `foreground` color role to `fg`, but `SegmentCard` was not updated to match

## Test plan

- [x] `moon run plugin-trip:build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected icon styling application in segment card components to ensure proper visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->