### PR TITLE
fix(plugin-client): change spaceKey: PublicKey to spaceId: SpaceId in IdentitySchema

### DIFF
--- a/packages/plugins/plugin-client/package.json
+++ b/packages/plugins/plugin-client/package.json
@@ -114,6 +114,7 @@
     "@dxos/context": "workspace:*",
     "@dxos/echo": "workspace:*",
     "@dxos/echo-db": "workspace:*",
+    "@dxos/echo-protocol": "workspace:*",
     "@dxos/effect": "workspace:*",
     "@dxos/functions": "workspace:*",
     "@dxos/invariant": "workspace:*",

--- a/packages/plugins/plugin-client/src/operations/create-identity.ts
+++ b/packages/plugins/plugin-client/src/operations/create-identity.ts
@@ -6,8 +6,8 @@ import * as Effect from 'effect/Effect';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
 import { Operation } from '@dxos/compute';
-import { runAndForwardErrors } from '@dxos/effect';
 import { createIdFromSpaceKey } from '@dxos/echo-protocol';
+import { runAndForwardErrors } from '@dxos/effect';
 import { ObservabilityOperation } from '@dxos/plugin-observability';
 
 import { ClientEvents } from '../types';
@@ -23,7 +23,11 @@ const handler: Operation.WithHandler<typeof CreateIdentity> = CreateIdentity.pip
       const spaceId = data.spaceKey ? yield* Effect.promise(() => createIdFromSpaceKey(data.spaceKey!)) : undefined;
       yield* Effect.promise(() => runAndForwardErrors(manager.activate(ClientEvents.IdentityCreated)));
       yield* Operation.schedule(ObservabilityOperation.SendEvent, { name: 'identity.create' });
-      return { identityKey: data.identityKey, ...(spaceId !== undefined && { spaceId }), ...(data.profile !== undefined && { profile: data.profile }) };
+      return {
+        identityKey: data.identityKey,
+        ...(spaceId !== undefined && { spaceId }),
+        ...(data.profile !== undefined && { profile: data.profile }),
+      };
     }),
   ),
 );

--- a/packages/plugins/plugin-client/src/operations/create-identity.ts
+++ b/packages/plugins/plugin-client/src/operations/create-identity.ts
@@ -7,6 +7,7 @@ import * as Effect from 'effect/Effect';
 import { Capabilities, Capability } from '@dxos/app-framework';
 import { Operation } from '@dxos/compute';
 import { runAndForwardErrors } from '@dxos/effect';
+import { createIdFromSpaceKey } from '@dxos/echo-protocol';
 import { ObservabilityOperation } from '@dxos/plugin-observability';
 
 import { ClientEvents } from '../types';
@@ -19,9 +20,10 @@ const handler: Operation.WithHandler<typeof CreateIdentity> = CreateIdentity.pip
       const manager = yield* Capability.get(Capabilities.PluginManager);
       const client = yield* Capability.get(ClientCapabilities.Client);
       const data = yield* Effect.promise(() => client.halo.createIdentity(profile));
+      const spaceId = data.spaceKey ? yield* Effect.promise(() => createIdFromSpaceKey(data.spaceKey!)) : undefined;
       yield* Effect.promise(() => runAndForwardErrors(manager.activate(ClientEvents.IdentityCreated)));
       yield* Operation.schedule(ObservabilityOperation.SendEvent, { name: 'identity.create' });
-      return data;
+      return { identityKey: data.identityKey, ...(spaceId !== undefined && { spaceId }), ...(data.profile !== undefined && { profile: data.profile }) };
     }),
   ),
 );

--- a/packages/plugins/plugin-client/src/operations/create-identity.ts
+++ b/packages/plugins/plugin-client/src/operations/create-identity.ts
@@ -20,7 +20,8 @@ const handler: Operation.WithHandler<typeof CreateIdentity> = CreateIdentity.pip
       const manager = yield* Capability.get(Capabilities.PluginManager);
       const client = yield* Capability.get(ClientCapabilities.Client);
       const data = yield* Effect.promise(() => client.halo.createIdentity(profile));
-      const spaceId = data.spaceKey ? yield* Effect.promise(() => createIdFromSpaceKey(data.spaceKey!)) : undefined;
+      const spaceKey = data.spaceKey;
+      const spaceId = spaceKey ? yield* Effect.promise(() => createIdFromSpaceKey(spaceKey)) : undefined;
       yield* Effect.promise(() => runAndForwardErrors(manager.activate(ClientEvents.IdentityCreated)));
       yield* Operation.schedule(ObservabilityOperation.SendEvent, { name: 'identity.create' });
       return {

--- a/packages/plugins/plugin-client/src/operations/definitions.ts
+++ b/packages/plugins/plugin-client/src/operations/definitions.ts
@@ -7,7 +7,7 @@ import * as Schema from 'effect/Schema';
 import { Capability } from '@dxos/app-framework';
 import { PublicKey } from '@dxos/client';
 import { Operation } from '@dxos/compute';
-import { DXN } from '@dxos/keys';
+import { DXN, SpaceId } from '@dxos/keys';
 
 import { meta } from '#meta';
 
@@ -15,7 +15,7 @@ const makeKey = (name: string) => DXN.make(`${meta.id}.operation.${name}`);
 
 const IdentitySchema = Schema.Struct({
   identityKey: Schema.instanceOf(PublicKey),
-  spaceKey: Schema.optional(Schema.instanceOf(PublicKey)),
+  spaceId: Schema.optional(SpaceId),
   profile: Schema.optional(
     Schema.Struct({
       displayName: Schema.optional(Schema.String),

--- a/packages/plugins/plugin-client/src/types/schema.ts
+++ b/packages/plugins/plugin-client/src/types/schema.ts
@@ -7,13 +7,14 @@ import * as Schema from 'effect/Schema';
 
 import { Capability } from '@dxos/app-framework';
 import { type Client, type ClientOptions, PublicKey } from '@dxos/client';
+import { SpaceId } from '@dxos/keys';
 
 import { meta } from '#meta';
 
 // TODO(wittjosiah): Factor out. Generate?
 const IdentitySchema = Schema.Struct({
   identityKey: Schema.instanceOf(PublicKey),
-  spaceKey: Schema.optional(Schema.instanceOf(PublicKey)),
+  spaceId: Schema.optional(SpaceId),
   profile: Schema.optional(
     Schema.Struct({
       displayName: Schema.optional(Schema.String),

--- a/packages/plugins/plugin-client/tsconfig.json
+++ b/packages/plugins/plugin-client/tsconfig.json
@@ -54,6 +54,9 @@
       "path": "../../core/echo/echo-db"
     },
     {
+      "path": "../../core/echo/echo-protocol"
+    },
+    {
       "path": "../../core/protocols"
     },
     {

--- a/packages/ui/react-ui-form/src/components/FieldEditor/FieldEditor.test.tsx
+++ b/packages/ui/react-ui-form/src/components/FieldEditor/FieldEditor.test.tsx
@@ -15,7 +15,10 @@ import { type FieldEditorDebugObjects } from './FieldEditor.stories';
 const { Default } = composeStories(stories);
 
 describe('FieldEditor', () => {
-  afterEach(() => {
+  afterEach(async () => {
+    // Flush pending React scheduler work before teardown to prevent
+    // "window is not defined" errors from setImmediate callbacks firing after happy-dom cleanup.
+    await act(async () => {});
     cleanup();
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8927,6 +8927,9 @@ importers:
       '@dxos/echo-db':
         specifier: workspace:*
         version: link:../../core/echo/echo-db
+      '@dxos/echo-protocol':
+        specifier: workspace:*
+        version: link:../../core/echo/echo-protocol
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../common/effect


### PR DESCRIPTION
## Summary

- Replace `spaceKey: Schema.optional(Schema.instanceOf(PublicKey))` with `spaceId: Schema.optional(SpaceId)` in `IdentitySchema` in both `operations/definitions.ts` and `types/schema.ts`
- Update `create-identity.ts` handler to convert `data.spaceKey` → `spaceId` using `createIdFromSpaceKey` from `@dxos/echo-protocol`
- Add `@dxos/echo-protocol` as a workspace dependency

## Motivation

`Schema.instanceOf(PublicKey)` has no JSON Schema annotation so the `createIdentity` operation was silently skipped during ECHO registration with:
```
WARN skipping operation that failed to serialize for echo registration {
  key: 'dxn:org.dxos.plugin.client.operation.createIdentity',
  error: Error: Missing annotation at path: ["identityKey"]
  ...Generating a JSON Schema for this schema requires a "jsonSchema" annotation
```

`SpaceId` extends `Schema.String` with a filter, so it serializes to JSON Schema correctly.

## Test plan

- [ ] Verify `createIdentity` operation is registered without the serialization warning
- [ ] Verify identity creation still works end-to-end

https://claude.ai/code/session_01Fpkondzv5BPUYVMgHa5eRD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fpkondzv5BPUYVMgHa5eRD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Identity creation now returns a structured object with identityKey plus an optional spaceId and profile, replacing the previous raw space key in responses.

* **Chores**
  * Added support for the echo protocol dependency and updated project references to enable related protocol operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->