### PR TITLE
fix(preview): point PR preview deployments at edge-main

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           NODE_ENV: production
           LOG_FILTER: error
+          DX_EDGE_BASE_URL: https://edge-main.dxos.workers.dev
 
       - name: Write deploy metadata
         run: |


### PR DESCRIPTION
## Summary

- Sets `DX_EDGE_BASE_URL=https://edge-main.dxos.workers.dev` in the `preview.yml` build step so PR preview deployments connect to `edge-main` instead of `edge-production`
- The env var is mapped to `runtime.services.edge.url` via `dx-env.yml` and takes priority over the `edge-production` default baked into `dx.yml`
- No change to ICE providers — those are infrastructure-level STUN/TURN and are independent of which edge signaling environment is used

## How it works

`ConfigPlugin` reads `DX_EDGE_BASE_URL` at bundle time and bakes it into `__CONFIG_ENVS__`. At runtime the config priority is `Storage > Envs > Local > Defaults`, so the baked-in `Envs` value overrides the `Defaults` from `dx.yml`.

https://claude.ai/code/session_01N932VAbbWN2kGEdHPfjdft

---
_Generated by [Claude Code](https://claude.ai/code/session_01N932VAbbWN2kGEdHPfjdft)_