### PR TITLE
refactor(plugin-space): rename types graph extension to database, filter parented objects

### DIFF
--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/app-graph-builder.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/app-graph-builder.ts
@@ -12,9 +12,9 @@ import { type SpacePluginOptions } from '#types';
 import {
   createCollectionExtensions,
   createCompanionExtensions,
+  createDatabaseExtensions,
   createSettingsExtensions,
   createSpaceExtensions,
-  createTypeExtensions,
 } from './extensions';
 
 export default Capability.makeModule(
@@ -22,7 +22,7 @@ export default Capability.makeModule(
     const extensions = yield* Effect.all([
       createSpaceExtensions(),
       createSettingsExtensions(),
-      createTypeExtensions(),
+      createDatabaseExtensions(),
       createCollectionExtensions({ shareableLinkOrigin }),
       createCompanionExtensions(),
     ]);

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/database.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/database.ts
@@ -181,7 +181,7 @@ export const createDatabaseExtensions = Effect.fnUntraced(function* () {
         const schemas = client ? get(AtomQuery.make(client.graph.registry, Filter.type(Type.Type))) : [];
         const viewIndex = buildViewIndex(get, space, schemas);
         const objects = get(AtomQuery.make(space.db, Filter.typename(typename))).filter(
-          (object: Obj.Unknown) => !viewIndex.isView(object) && Obj.getParent(object) === undefined,
+          (object: Obj.Unknown) => !viewIndex.isView(object) && !Obj.getParent(object),
         );
 
         return Effect.succeed(

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/database.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/database.ts
@@ -40,8 +40,8 @@ import {
 // Extension Factory
 //
 
-/** Creates type-related extensions: types section, schema nodes, schema children, and schema actions. */
-export const createTypeExtensions = Effect.fnUntraced(function* () {
+/** Creates database extensions: types section, schema nodes, schema children, and schema actions. */
+export const createDatabaseExtensions = Effect.fnUntraced(function* () {
   const capabilities = yield* Capability.Service;
 
   return yield* Effect.all([
@@ -181,7 +181,7 @@ export const createTypeExtensions = Effect.fnUntraced(function* () {
         const schemas = client ? get(AtomQuery.make(client.graph.registry, Filter.type(Type.Type))) : [];
         const viewIndex = buildViewIndex(get, space, schemas);
         const objects = get(AtomQuery.make(space.db, Filter.typename(typename))).filter(
-          (object: Obj.Unknown) => !viewIndex.isView(object),
+          (object: Obj.Unknown) => !viewIndex.isView(object) && Obj.getParent(object) === undefined,
         );
 
         return Effect.succeed(

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/index.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/index.ts
@@ -3,7 +3,7 @@
 //
 
 export { createSpaceExtensions } from './spaces';
-export { createTypeExtensions } from './types';
+export { createDatabaseExtensions } from './database';
 export { createCollectionExtensions } from './collections';
 export { createCompanionExtensions } from './companions';
 export { createSettingsExtensions } from './settings';


### PR DESCRIPTION
## Summary

- Renames `extensions/types.ts` → `extensions/database.ts` and `createTypeExtensions` → `createDatabaseExtensions` to better match the "Database" section label already shown in the UI (database icon `ph--database--regular`).
- Adds a parent filter in the `typeCollectionObjects` connector so objects with a parent (`Obj.getParent(object) !== undefined`) are excluded from the top-level database listing — child objects belong under their parent, not as independent rows.

## Test plan

- [ ] Open Composer, navigate to a space's Database section — types and their objects appear as before.
- [ ] Create an object that has a parent set (e.g. via `Obj.setParent`) and verify it does not appear as a top-level row in the database listing.
- [ ] `moon run plugin-space:build` passes (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema object filtering to exclude objects with parent relationships, improving collection accuracy.

* **Refactor**
  * Updated internal graph builder extension structure for better clarity and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->