### PR TITLE
feat(plugin-trip): live OSRM routing, geocoding precedence, and supporting UI/schema fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@
 
 ## Workflow
 
-- Never work on `main`; always work within the session generated worktree.
+- Never work on `main`; always work within the session-generated worktree.
   - If there are unstaged changes, stash these and move them into the worktree; tell the user.
   - Before working on code, tell the user the worktree.
   - IMPORTANT: Do not change the branch or worktree name after you have started unless you are instructed to directly by the user.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,11 +78,9 @@
 
 ## Workflow
 
-- Never work on `main`
-  - Before working on code, suggest to the user a worktree name then create the worktree using this or the name provided by the user (adding the agent-name prefix, e.g., `claude/`).
-  - When creating worktrees/branches, use a short (2-4 word) descriptive title (kebab-case) prefixed with the agent name (e.g., `claude/add-auth-to-client`).
-  - Worktrees must be created inside the main repo (e.g., `.claude/worktrees/<branch-short-name>`).
-  - If there are unstaged changes, stash these and move them into the worktree.
+- Never work on `main`; always work within the session generated worktree.
+  - If there are unstaged changes, stash these and move them into the worktree; tell the user.
+  - Before working on code, tell the user the worktree.
   - IMPORTANT: Do not change the branch or worktree name after you have started unless you are instructed to directly by the user.
   - **IMPORTANT**: Always work in the worktree directory the harness assigned to you — do NOT `cd` into other worktrees or create parallel worktrees on the side. The harness UI tracks progress by watching that directory; working elsewhere makes changes invisible to the user. If the user asks you to continue a different branch, check out that branch in the assigned worktree (clean up the old branch first if needed); do not switch to another worktree path.
 - Check `moon.yml` for available package tasks
@@ -132,7 +130,7 @@ Examples:
   - Merge `origin/main` in to current branch and resolve conflicts.
   - Format code with `pnpm format` and check that `moon run :lint -- --fix` succeeds.
   - Check `moon run :test` succeeds.
-  - Commit and push all pending changes.
+  - Commit and push all pending changes (including any edits that the user may have made in the worktree).
   - **IMPORTANT**: Verify `git status` shows a clean working tree after the final push. If any files remain modified or untracked, either commit them or confirm with the user before proceeding.
   - Monitor CI (every 5 minutes): `gh run list --branch <branch> --limit 3 --workflow "Check"` and `pnpm -w gh-action --verify --watch`.
   - You must attempt to diagnose and if possible fix all CI errors -- regardless of whether they relate to the current branch

--- a/packages/common/markdown/src/markdown.test.ts
+++ b/packages/common/markdown/src/markdown.test.ts
@@ -57,6 +57,15 @@ describe('markdown', () => {
     expect(normalizeText('aaa  \nbbb')).to.equal('aaa\nbbb');
   });
 
+  test('strips trailing invisible characters from each line', ({ expect }) => {
+    // Zero-width space, soft hyphen, word joiner, combining grapheme joiner, ZWNBSP — the invisible
+    // chars that `.trim()` and the visible-whitespace pass leave behind when they trail visible text.
+    expect(normalizeText('aaa​​\nbbb')).to.equal('aaa\nbbb');
+    expect(normalizeText('word­')).to.equal('word');
+    expect(normalizeText('a⁠﻿\nb͏')).to.equal('a\nb');
+    expect(normalizeText('mixed ​  \nnext')).to.equal('mixed\nnext');
+  });
+
   test('collapses multiple blank lines in plain text', ({ expect }) => {
     // Three or more blank lines between text → one blank line.
     expect(normalizeText('aaa\n\n\n\nbbb')).to.equal('aaa\n\nbbb');

--- a/packages/common/markdown/src/markdown.ts
+++ b/packages/common/markdown/src/markdown.ts
@@ -88,8 +88,10 @@ const stripWhitespace = (str: string): string => {
       .replace(/^(?!---$)[^\p{L}\p{N}\n]*$/gmu, '')
       // Replace multiple newlines with double newlines.
       .replace(WHITESPACE, '\n\n')
-      // Trim trailing whitespace from every line.
-      .replace(/[ \t\u00A0]+$/gm, '')
+      // Trim trailing whitespace \u2014 including the invisible/zero-width chars (soft hyphen, zero-width
+      // space/joiners, word joiner, ZWNBSP) that `.trim()` and the visible-whitespace set miss \u2014 from
+      // every line.
+      .replace(new RegExp(`[${INVISIBLE}]+$`, 'gm'), '')
       // Keep a quoted block contiguous: drop blank lines between consecutive quoted (`>`) lines.
       // Turndown prefixes every blockquote line with `> `, so paragraph breaks within a quote
       // surface as a bare `> ` line that the no-letter pass above blanks; this rejoins them (and

--- a/packages/core/echo/echo/src/internal/Format/format.test.ts
+++ b/packages/core/echo/echo/src/internal/Format/format.test.ts
@@ -74,3 +74,24 @@ describe('formats', () => {
     }
   });
 });
+
+describe('GeoPoint', () => {
+  const decode = Schema.decodeUnknownSync(Format.GeoPoint);
+
+  test('rounds high-precision coordinates to 7 decimal places', ({ expect }) => {
+    // Live geocoders (e.g. Nominatim/OSRM) emit > 7 decimals; rounding keeps them valid GeoPoints.
+    expect(decode([-0.12776534, 51.50744561])).toEqual([-0.1277653, 51.5074456]);
+  });
+
+  test('passes through coordinates already within precision', ({ expect }) => {
+    expect(decode([2.3522, 48.8566])).toEqual([2.3522, 48.8566]);
+  });
+
+  test('preserves an optional altitude', ({ expect }) => {
+    expect(decode([-0.12776534, 51.50744561, 42])).toEqual([-0.1277653, 51.5074456, 42]);
+  });
+
+  test('clamps out-of-range coordinates', ({ expect }) => {
+    expect(decode([200, 100])).toEqual([180, 90]);
+  });
+});

--- a/packages/core/echo/echo/src/internal/Format/object.ts
+++ b/packages/core/echo/echo/src/internal/Format/object.ts
@@ -68,8 +68,9 @@ export namespace GeoLocation {
    */
   export const toGeoPoint = ({ longitude, latitude, height }: GeoLocation): GeoPoint => {
     // TODO(ZaymonFC): Use schema validation instead of doing this manually.
-    const clampedLongitude = clamp(longitude, -180, 180);
-    const clampedLatitude = clamp(latitude, -90, 90);
+    // Clamp + round to match the `Format.GeoPoint` decode/encode path so both produce identical tuples.
+    const clampedLongitude = roundCoordinate(clamp(longitude, -180, 180));
+    const clampedLatitude = roundCoordinate(clamp(latitude, -90, 90));
     return height !== undefined ? [clampedLongitude, clampedLatitude, height] : [clampedLongitude, clampedLatitude];
   };
 

--- a/packages/core/echo/echo/src/internal/Format/object.ts
+++ b/packages/core/echo/echo/src/internal/Format/object.ts
@@ -20,9 +20,25 @@ import { FormatAnnotation, TypeFormat } from './types';
  * }
  * Note: optional third element for altitude.
  */
+/** Decimal places retained for stored coordinates (~1.1cm at the equator). */
+export const GEO_PRECISION = 7;
+
+const roundCoordinate = (value: number): number => {
+  const factor = 10 ** GEO_PRECISION;
+  return Math.round(value * factor) / factor;
+};
+
+/** Longitude/latitude clamped to range and rounded to {@link GEO_PRECISION} decimal places. */
+const Coordinate = (min: number, max: number, title: string) =>
+  Schema.transform(Schema.Number.pipe(Schema.clamp(min, max)), Schema.Number, {
+    strict: true,
+    decode: roundCoordinate,
+    encode: roundCoordinate,
+  }).annotations({ title });
+
 export const GeoPoint = Schema.Tuple(
-  Schema.Number.pipe(Schema.annotations({ title: 'Longitude' }), Schema.clamp(-180, 180), Schema.multipleOf(0.000001)),
-  Schema.Number.pipe(Schema.annotations({ title: 'Latitude' }), Schema.clamp(-90, 90), Schema.multipleOf(0.000001)),
+  Coordinate(-180, 180, 'Longitude'),
+  Coordinate(-90, 90, 'Latitude'),
   Schema.optionalElement(Schema.Number).annotations({
     title: 'Height ASL (m)',
   }),

--- a/packages/plugins/plugin-map/src/components/Map/MapControl.tsx
+++ b/packages/plugins/plugin-map/src/components/Map/MapControl.tsx
@@ -43,7 +43,7 @@ export const MapControl = composable<HTMLDivElement, MapControlProps>(
 
     return (
       <Map.Root {...props} onChange={onChange} ref={forwardedRef}>
-        <Map.Content ref={setController} center={center} zoom={zoom}>
+        <Map.Content ref={setController} center={center} zoom={zoom} minZoom={3}>
           <Map.Tiles url={tileUrl} />
           <Map.Lines lines={lines} />
           <Map.Markers markers={markers} lines={lines} selected={selected} onSelect={onSelect} />

--- a/packages/plugins/plugin-map/src/containers/MapArticle/MapArticle.tsx
+++ b/packages/plugins/plugin-map/src/containers/MapArticle/MapArticle.tsx
@@ -30,8 +30,9 @@ const interpolate = (value: number, from: [number, number], to: [number, number]
   return to[0] + t * (to[1] - to[0]);
 };
 
-const mapMapToGlobeZoom = (zoom: number) => interpolate(zoom, ZOOM_ANCHORS.map, ZOOM_ANCHORS.globe);
-const mapGlobeToMapZoom = (zoom: number) => interpolate(zoom, ZOOM_ANCHORS.globe, ZOOM_ANCHORS.map);
+// Clamp map zoom-out to 4.
+const mapToGlobeZoom = (zoom: number) => interpolate(Math.max(4, zoom), ZOOM_ANCHORS.map, ZOOM_ANCHORS.globe);
+const globeToMapZoom = (zoom: number) => Math.floor(interpolate(zoom, ZOOM_ANCHORS.globe, ZOOM_ANCHORS.map));
 
 export type MapControlType = 'globe' | 'map';
 
@@ -81,11 +82,11 @@ const MapArticleInner = ({
   attendableId,
   provider,
   tileUrl,
-  onSelect,
   type: typeProp = 'map',
   center: centerProp,
   zoom: zoomProp,
   onChange,
+  onSelect,
   role: _role,
   ...props
 }: MapArticleInnerProps) => {
@@ -118,7 +119,6 @@ const MapArticleInner = ({
 
   const handleSelect = useCallback((id: string) => onSelect?.(contextId, mode, id), [onSelect, contextId, mode]);
 
-  // Store zoom in map units; convert when emitted by the globe.
   const handleMapChange = useCallback(
     (ev: { center: LatLngLiteral; zoom: number }) => {
       setViewport(ev);
@@ -126,9 +126,10 @@ const MapArticleInner = ({
     },
     [onChange],
   );
+
   const handleGlobeChange = useCallback(
     (ev: { center: LatLngLiteral; zoom: number }) => {
-      const mapped = { center: ev.center, zoom: mapGlobeToMapZoom(ev.zoom) };
+      const mapped = { center: ev.center, zoom: globeToMapZoom(ev.zoom) };
       setViewport(mapped);
       onChange?.(mapped);
     },
@@ -156,7 +157,7 @@ const MapArticleInner = ({
       selected={selected}
       onSelect={handleSelect}
       center={viewport.center}
-      zoom={mapMapToGlobeZoom(viewport.zoom)}
+      zoom={mapToGlobeZoom(viewport.zoom)}
       onChange={handleGlobeChange}
       onToggle={() => setType('map')}
     />

--- a/packages/plugins/plugin-osrm/package.json
+++ b/packages/plugins/plugin-osrm/package.json
@@ -57,6 +57,7 @@
     "@dxos/app-toolkit": "workspace:*",
     "@dxos/echo": "workspace:*",
     "@dxos/keys": "workspace:*",
+    "@dxos/log": "workspace:*",
     "@dxos/plugin-trip": "workspace:*",
     "@dxos/util": "workspace:*",
     "effect": "catalog:"

--- a/packages/plugins/plugin-osrm/src/services/OsrmClient.ts
+++ b/packages/plugins/plugin-osrm/src/services/OsrmClient.ts
@@ -27,7 +27,8 @@ export const fetchRoute = async (
   const path = coordinates.map(([lon, lat]) => `${lon},${lat}`).join(';');
   const url = `${baseUrl}/route/v1/driving/${path}?overview=full&geometries=geojson&steps=true`;
 
-  log('osrm route request', { url, waypoints: coordinates.length });
+  // Log the host + waypoint count only — the URL path embeds the user's exact coordinates.
+  log('osrm route request', { host: new URL(baseUrl).host, profile: 'driving', waypoints: coordinates.length });
   const response = await fetchFn(url);
   log('osrm route response', { status: response.status, ok: response.ok });
   if (!response.ok) {

--- a/packages/plugins/plugin-osrm/src/services/OsrmClient.ts
+++ b/packages/plugins/plugin-osrm/src/services/OsrmClient.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
+import { log } from '@dxos/log';
 import { Routing } from '@dxos/plugin-trip';
 
 import { type OsrmResponse } from './osrm-mapping';
@@ -26,7 +27,9 @@ export const fetchRoute = async (
   const path = coordinates.map(([lon, lat]) => `${lon},${lat}`).join(';');
   const url = `${baseUrl}/route/v1/driving/${path}?overview=full&geometries=geojson&steps=true`;
 
+  log('osrm route request', { url, waypoints: coordinates.length });
   const response = await fetchFn(url);
+  log('osrm route response', { status: response.status, ok: response.ok });
   if (!response.ok) {
     throw new Routing.RouteError(`OSRM request failed: ${response.status}`);
   }

--- a/packages/plugins/plugin-osrm/tsconfig.json
+++ b/packages/plugins/plugin-osrm/tsconfig.json
@@ -21,6 +21,9 @@
       "path": "../../common/keys"
     },
     {
+      "path": "../../common/log"
+    },
+    {
       "path": "../../common/util"
     },
     {

--- a/packages/plugins/plugin-trip/src/containers/SegmentArticle/SegmentArticle.tsx
+++ b/packages/plugins/plugin-trip/src/containers/SegmentArticle/SegmentArticle.tsx
@@ -18,9 +18,9 @@ type ViewMode = 'form' | 'search';
 
 /**
  * Companion surface for a selected Segment. A toolbar toggles between the
- * schema-driven edit Form and the BookingSearch surface. Defaults to Search
- * when the segment has no booking yet, otherwise Form. The user can switch
- * either way — the toolbar drives the view, it is not a hard conditional.
+ * schema-driven edit Form and the BookingSearch surface. Defaults to the Form
+ * view; the user can switch either way — the toolbar drives the view, it is not
+ * a hard conditional.
  */
 export type SegmentArticleProps = AppSurface.ArticleProps<Segment.Segment, {}, Trip.Trip>;
 

--- a/packages/plugins/plugin-trip/src/containers/SegmentArticle/SegmentArticle.tsx
+++ b/packages/plugins/plugin-trip/src/containers/SegmentArticle/SegmentArticle.tsx
@@ -29,7 +29,7 @@ export const SegmentArticle = ({ role, subject: segment }: SegmentArticleProps) 
   const type = Obj.getType(segment);
   const echoSchema = type && Type.getSchema(type);
   const schema = useMemo(() => echoSchema && omitId(echoSchema), [echoSchema]);
-  const [viewMode, setViewMode] = useState<ViewMode>(segment.booking ? 'form' : 'search');
+  const [viewMode, setViewMode] = useState<ViewMode>('form');
 
   const handleSave = useCallback(
     (values: Record<string, unknown>, { changed }: { changed: Record<string, boolean> }) => {

--- a/packages/plugins/plugin-trip/src/containers/TripArticle/TripArticle.stories.tsx
+++ b/packages/plugins/plugin-trip/src/containers/TripArticle/TripArticle.stories.tsx
@@ -22,7 +22,8 @@ import { AttendableContainer, useSelected } from '@dxos/react-ui-attention';
 import { Loading, withLayout } from '@dxos/react-ui/testing';
 
 import { PLACES, TripBuilder, fakeRoute, fakeRoutingService } from '#testing';
-import { Booking, type Routing, Segment, Trip, TripCapabilities } from '#types';
+import { translations } from '#translations';
+import { Booking, type Place, Routing, Segment, Trip, TripCapabilities } from '#types';
 
 import { TripPlugin } from '../../testing';
 import { SegmentArticle } from '../SegmentArticle/SegmentArticle';
@@ -53,6 +54,85 @@ const seedRoadTrip = (space: Space, name: string, cities: string[]): void => {
   space.db.add(trip);
 };
 
+//
+// Live OSRM + Nominatim routing service hitting the public demo servers. Network-dependent and
+// non-deterministic; used only by the `LiveRoute` story to exercise real geocoding + routing of
+// arbitrary city names. The OSRM/Nominatim mapping is inlined here (mirrors @dxos/plugin-osrm)
+// because plugin-trip cannot depend on plugin-osrm — which depends on plugin-trip.
+//
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+type NominatimResult = { lat: string; lon: string };
+type OsrmStep = { name?: string; ref?: string; geometry?: { coordinates?: Array<[number, number]> } };
+type OsrmLeg = { distance?: number; duration?: number; summary?: string; steps?: OsrmStep[] };
+type OsrmRoute = { distance?: number; duration?: number; legs?: OsrmLeg[] };
+type OsrmResponse = { routes?: OsrmRoute[] };
+
+const liveRoutingService: Routing.RoutingService = {
+  id: 'osrm-live',
+  label: 'OSRM (live)',
+  profiles: ['driving'],
+  route: async ({ waypoints }) => {
+    const places: Place.Place[] = [];
+    let geocodeCount = 0;
+    for (const waypoint of waypoints) {
+      if (typeof waypoint !== 'string') {
+        places.push(waypoint);
+        continue;
+      }
+      // Respect Nominatim's ≤ 1 req/s policy.
+      if (geocodeCount++ > 0) {
+        await delay(1_100);
+      }
+      const response = await fetch(
+        `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(waypoint)}&format=jsonv2&limit=1`,
+        { headers: { Accept: 'application/json' } },
+      );
+      if (!response.ok) {
+        throw new Routing.GeocodeError(waypoint);
+      }
+      // External, untyped JSON — asserted to the documented Nominatim shape at this boundary.
+      const [first] = (await response.json()) as NominatimResult[];
+      if (!first) {
+        throw new Routing.GeocodeError(waypoint);
+      }
+      places.push({ name: waypoint, geo: [Number(first.lon), Number(first.lat)] });
+    }
+
+    const path = places
+      .map((place) => place.geo)
+      .filter((geo): geo is NonNullable<typeof geo> => geo != null)
+      .map(([lon, lat]) => `${lon},${lat}`)
+      .join(';');
+    if (path.split(';').length < 2) {
+      throw new Routing.RouteError('All waypoints must resolve to coordinates to plan a route.');
+    }
+
+    const response = await fetch(
+      `https://router.project-osrm.org/route/v1/driving/${path}?overview=full&geometries=geojson&steps=true`,
+    );
+    if (!response.ok) {
+      throw new Routing.RouteError(`OSRM request failed: ${response.status}`);
+    }
+    // External, untyped JSON — asserted to the documented OSRM shape at this boundary.
+    const data = (await response.json()) as OsrmResponse;
+    const routes: Routing.Route[] = (data.routes ?? []).map((route) => ({
+      distance: route.distance ?? 0,
+      duration: route.duration ?? 0,
+      legs: (route.legs ?? []).map((leg) => ({
+        distance: leg.distance ?? 0,
+        duration: leg.duration ?? 0,
+        summary: leg.summary || undefined,
+        geometry: (leg.steps ?? []).flatMap((step) => step.geometry?.coordinates ?? []),
+        steps: (leg.steps ?? []).map((step) => ({ name: step.name || undefined, ref: step.ref || undefined })),
+      })),
+    }));
+
+    return { waypoints: places, routes };
+  },
+};
+
 const ATTENDABLE_ID = 'story';
 
 // Initialize the global keyboard system (normally done by plugin-navtree) so the
@@ -62,6 +142,7 @@ const withKeyboard: Decorator = (Story) => {
     Keyboard.singleton.initialize();
     return () => Keyboard.singleton.destroy();
   }, []);
+
   return <Story />;
 };
 
@@ -145,7 +226,10 @@ const MapStory = () => {
 const meta = {
   title: 'plugins/plugin-trip/containers/TripArticle',
   render: DefaultStory,
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    translations,
+  },
 } satisfies Meta<typeof DefaultStory>;
 
 export default meta;
@@ -251,6 +335,50 @@ export const RoadTripMap: Story = {
   decorators: baseDecorators((space) => {
     seedRoadTrip(space, 'London → Barcelona (via Avignon)', ['London', 'Avignon', 'Barcelona']);
   }),
+};
+
+// A single road segment whose origin/destination have ONLY the `city` property set (no name, code,
+// or geo). Exercises the city-based geocoding path (`toWaypoint` → "City" query → RoutingService)
+// and the segment form rendering city-only places. The London → Avignon pair has a captured route
+// fixture, so planning yields a real road-following polyline (not a straight haversine fallback).
+export const CityOnly: Story = {
+  args: { showMap: true },
+  decorators: baseDecorators((space) => {
+    const trip = Trip.make({ name: 'London → Avignon (city only)' });
+    const segment = Segment.make({
+      details: {
+        _tag: 'road',
+        subKind: 'car',
+        origin: { city: 'London' },
+        destination: { city: 'Avignon' },
+      },
+    });
+    Trip.addSegment(trip, segment);
+    space.db.add(segment);
+    space.db.add(trip);
+  }),
+};
+
+// Single city-only road segment planned against the LIVE public OSRM + Nominatim demo servers
+// (network, non-deterministic). Unlike the fake router's fixed table, this geocodes arbitrary city
+// names (e.g. Birmingham) and returns real road geometry. May be slow or fail if the demo servers
+// are down or rate-limit the request.
+export const LiveRoute: Story = {
+  args: { showMap: true },
+  decorators: baseDecorators((space) => {
+    const trip = Trip.make({ name: 'London → Birmingham (live)' });
+    const segment = Segment.make({
+      details: {
+        _tag: 'road',
+        subKind: 'car',
+        origin: { city: 'London' },
+        destination: { city: 'Birmingham' },
+      },
+    });
+    Trip.addSegment(trip, segment);
+    space.db.add(segment);
+    space.db.add(trip);
+  }, liveRoutingService),
 };
 
 export const Empty: Story = {

--- a/packages/plugins/plugin-trip/src/containers/TripArticle/TripArticle.tsx
+++ b/packages/plugins/plugin-trip/src/containers/TripArticle/TripArticle.tsx
@@ -9,6 +9,7 @@ import { Surface, useCapabilities, useOperationInvoker } from '@dxos/app-framewo
 import { LayoutOperation, getObjectPathFromObject } from '@dxos/app-toolkit';
 import { type AppSurface, useShowItem } from '@dxos/app-toolkit/ui';
 import { Obj } from '@dxos/echo';
+import { log } from '@dxos/log';
 import { MapCapabilities } from '@dxos/plugin-map/types';
 import { getSpace, useObject, useObjects } from '@dxos/react-client/echo';
 import { Panel } from '@dxos/react-ui';
@@ -19,7 +20,7 @@ import { mx } from '@dxos/ui-theme';
 
 import { SegmentStack, type SegmentCardAction } from '#components';
 import { meta } from '#meta';
-import { RoutingOperation, Segment, Trip } from '#types';
+import { Routing, RoutingOperation, Segment, Trip } from '#types';
 
 export type TripArticleProps = AppSurface.ObjectArticleProps<Trip.Trip> & {
   /** Start with the inline map surface visible (otherwise toggled via the toolbar). */
@@ -160,11 +161,15 @@ export const TripArticle = ({ role, subject, attendableId, defaultShowGlobe }: T
         throw error;
       }
     } catch (err) {
-      // Surface routing failures (no provider / geocode / network) as a toast.
+      // Log the technical error; surface a friendly, non-technical toast. Known routing errors
+      // (no provider / geocode miss / OSRM failure) already carry user-facing messages.
+      log.catch(err);
+      const friendly =
+        err instanceof Routing.GeocodeError || err instanceof Routing.RouteError ? err.message : undefined;
       await invokePromise(LayoutOperation.AddToast, {
         id: `${meta.id}/plan-route-error`,
         title: ['route.error.label', { ns: meta.id }],
-        description: err instanceof Error ? err.message : undefined,
+        description: friendly ?? ['route.error.message', { ns: meta.id }],
         icon: 'ph--warning--regular',
       });
     } finally {

--- a/packages/plugins/plugin-trip/src/operations/plan-route.test.ts
+++ b/packages/plugins/plugin-trip/src/operations/plan-route.test.ts
@@ -111,7 +111,7 @@ describe('PlanRoute', () => {
     await expect(plan(trip)).rejects.toThrow(/No routing service/);
   });
 
-  test('geocoding query prefers code, then "city, country", then name', async ({ expect }) => {
+  test('geocoding query prefers geo, then code, then "city, country", then name', async ({ expect }) => {
     const seen: Routing.Waypoint[] = [];
     const recordingService: Routing.RoutingService = {
       id: 'recording',
@@ -124,6 +124,15 @@ describe('PlanRoute', () => {
     };
 
     const segments = [
+      // Resolved coordinates win over every string fallback — the Place passes through unchanged.
+      Segment.make({
+        details: {
+          _tag: 'road',
+          subKind: 'car',
+          origin: { geo: [2.3522, 48.8566], code: 'CDG', city: 'Paris' },
+          destination: { geo: [4.8357, 45.764], city: 'Lyon' },
+        },
+      }),
       // Code wins over city/name; city + country are joined.
       Segment.make({
         details: {
@@ -142,6 +151,8 @@ describe('PlanRoute', () => {
     await db.flush();
 
     await plan(trip, recordingService);
-    expect(seen).toEqual(['CDG', 'Lyon, France', 'Bath', 'Stonehenge']);
+    // Geo waypoints pass through as the Place (compared by their coordinates); the rest are query strings.
+    const normalized = seen.map((waypoint) => (typeof waypoint === 'string' ? waypoint : waypoint.geo));
+    expect(normalized).toEqual([[2.3522, 48.8566], [4.8357, 45.764], 'CDG', 'Lyon, France', 'Bath', 'Stonehenge']);
   });
 });

--- a/packages/plugins/plugin-trip/src/operations/plan-route.test.ts
+++ b/packages/plugins/plugin-trip/src/operations/plan-route.test.ts
@@ -110,4 +110,38 @@ describe('PlanRoute', () => {
     await db.flush();
     await expect(plan(trip)).rejects.toThrow(/No routing service/);
   });
+
+  test('geocoding query prefers code, then "city, country", then name', async ({ expect }) => {
+    const seen: Routing.Waypoint[] = [];
+    const recordingService: Routing.RoutingService = {
+      id: 'recording',
+      label: 'Recording',
+      profiles: ['driving'],
+      route: async ({ waypoints }) => {
+        seen.push(...waypoints);
+        return { waypoints: [], routes: [] };
+      },
+    };
+
+    const segments = [
+      // Code wins over city/name; city + country are joined.
+      Segment.make({
+        details: {
+          _tag: 'road',
+          subKind: 'car',
+          origin: { code: 'CDG', city: 'Paris', name: 'Charles de Gaulle' },
+          destination: { city: 'Lyon', country: 'France', name: 'Lyon Part-Dieu' },
+        },
+      }),
+      // City without country falls back to just the city; name is the last resort.
+      Segment.make({
+        details: { _tag: 'road', subKind: 'car', origin: { city: 'Bath' }, destination: { name: 'Stonehenge' } },
+      }),
+    ];
+    const trip = addTrip(segments);
+    await db.flush();
+
+    await plan(trip, recordingService);
+    expect(seen).toEqual(['CDG', 'Lyon, France', 'Bath', 'Stonehenge']);
+  });
 });

--- a/packages/plugins/plugin-trip/src/operations/plan-route.ts
+++ b/packages/plugins/plugin-trip/src/operations/plan-route.ts
@@ -9,7 +9,7 @@ import { Operation } from '@dxos/compute';
 import { Obj } from '@dxos/echo';
 import { log } from '@dxos/log';
 
-import { type Place, type Routing, RoutingOperation, Segment, TripCapabilities, Trip } from '#types';
+import { type Place, Routing, RoutingOperation, Segment, TripCapabilities, Trip } from '#types';
 
 const EMPTY = { legs: 0, distanceMeters: 0, durationSeconds: 0 } as const;
 
@@ -23,7 +23,7 @@ export default RoutingOperation.PlanRoute.pipe(
       const services = yield* Capability.getAll(TripCapabilities.RoutingService);
       const service = provider ? services.find((candidate) => candidate.id === provider) : services[0];
       if (!service) {
-        return yield* Effect.fail(new Error('No routing service configured.'));
+        return yield* Effect.fail(new Routing.RouteError('No routing service configured.'));
       }
 
       // Road segments with both endpoints, in itinerary order. Each is routed independently so the
@@ -40,7 +40,7 @@ export default RoutingOperation.PlanRoute.pipe(
         const waypoints = [toWaypoint(Segment.getOrigin(segment)), toWaypoint(Segment.getDestination(segment))].filter(
           (waypoint): waypoint is Routing.Waypoint => waypoint != null,
         );
-        log.info('request', { waypoints });
+        log.info('request', { provider: service.id, waypoints: waypoints.length });
         if (waypoints.length < 2) {
           continue;
         }
@@ -53,7 +53,7 @@ export default RoutingOperation.PlanRoute.pipe(
         });
 
         const route = result.routes[0];
-        log.info('response', { route });
+        log.info('response', { provider: service.id, routes: result.routes.length });
         if (!route) {
           continue;
         }

--- a/packages/plugins/plugin-trip/src/operations/plan-route.ts
+++ b/packages/plugins/plugin-trip/src/operations/plan-route.ts
@@ -7,6 +7,7 @@ import * as Effect from 'effect/Effect';
 import { Capability } from '@dxos/app-framework';
 import { Operation } from '@dxos/compute';
 import { Obj } from '@dxos/echo';
+import { log } from '@dxos/log';
 
 import { type Place, type Routing, RoutingOperation, Segment, TripCapabilities, Trip } from '#types';
 
@@ -39,17 +40,20 @@ export default RoutingOperation.PlanRoute.pipe(
         const waypoints = [toWaypoint(Segment.getOrigin(segment)), toWaypoint(Segment.getDestination(segment))].filter(
           (waypoint): waypoint is Routing.Waypoint => waypoint != null,
         );
+        log.info('request', { waypoints });
         if (waypoints.length < 2) {
           continue;
         }
 
-        // `tryPromise` routes a rejection (GeocodeError / RouteError / MissingApiKeyError) to the
-        // operation's failure channel, preserving the original Error for the UI.
+        // `tryPromise` routes a rejection (GeocodeError / RouteError / MissingApiKeyError)
+        // to the operation's failure channel, preserving the original Error for the UI.
         const result = yield* Effect.tryPromise({
           try: () => service.route({ waypoints, profile: 'driving' }),
           catch: (error) => (error instanceof Error ? error : new Error(String(error))),
         });
+
         const route = result.routes[0];
+        log.info('response', { route });
         if (!route) {
           continue;
         }
@@ -65,7 +69,7 @@ export default RoutingOperation.PlanRoute.pipe(
   ),
 );
 
-/** Routing input for a stop: the resolved Place when it has coordinates, otherwise its name to geocode. */
+/** Routing input for a stop: the resolved Place when it has coordinates, otherwise a string to geocode. */
 const toWaypoint = (place: Place.Place | undefined): Routing.Waypoint | undefined => {
   if (!place) {
     return undefined;
@@ -73,7 +77,15 @@ const toWaypoint = (place: Place.Place | undefined): Routing.Waypoint | undefine
   if (place.geo) {
     return place;
   }
-  return place.name ?? place.city ?? place.code;
+  // Geocoding query: prefer an unambiguous code, then "City, Country", then the free-form name.
+  if (place.code) {
+    return place.code;
+  }
+  if (place.city) {
+    return [place.city, place.country].filter(Boolean).join(', ');
+  }
+
+  return place.name;
 };
 
 /** Writes the computed route(s) onto a road segment and fills endpoint geo from the geocoded stops. */
@@ -86,6 +98,7 @@ const writeRoute = (
     if (segment.details._tag !== 'road') {
       return;
     }
+
     const origin = waypoints[0];
     const destination = waypoints[waypoints.length - 1];
     if (segment.details.origin && origin?.geo) {
@@ -94,17 +107,19 @@ const writeRoute = (
     if (segment.details.destination && destination?.geo) {
       Object.assign(segment.details.destination, { geo: [destination.geo[0], destination.geo[1]] });
     }
+
     // Deep-copy to plain mutable arrays (the live segment's GeoPoint fields are mutable number[][]).
     segment.details.routes = routes.map(cloneRoute);
   });
 
 // Return type is inferred (plain mutable arrays) so it assigns to the live segment's GeoPoint fields.
+// Distance (meters) and duration (seconds) are floored to whole units; sub-unit precision is noise.
 const cloneRoute = (route: Routing.Route) => ({
-  distance: route.distance,
-  duration: route.duration,
+  distance: Math.floor(route.distance),
+  duration: Math.floor(route.duration),
   legs: route.legs.map((leg) => ({
-    distance: leg.distance,
-    duration: leg.duration,
+    distance: Math.floor(leg.distance),
+    duration: Math.floor(leg.duration),
     summary: leg.summary,
     geometry: leg.geometry.map((point) => [point[0], point[1]]),
     steps: leg.steps.map((step) => ({ name: step.name, ref: step.ref })),

--- a/packages/plugins/plugin-trip/src/testing/routing.ts
+++ b/packages/plugins/plugin-trip/src/testing/routing.ts
@@ -90,7 +90,9 @@ export const fakeRoute = (
     if (typeof waypoint !== 'string') {
       return waypoint;
     }
-    const geo = coords[normalize(waypoint)];
+    // `toWaypoint` emits "City, Country" for city-based geocoding; fall back to the city-only key.
+    const normalized = normalize(waypoint);
+    const geo = coords[normalized] ?? coords[normalized.split(',')[0]!.trim()];
     if (!geo) {
       throw new Routing.GeocodeError(waypoint);
     }

--- a/packages/plugins/plugin-trip/src/testing/routing.ts
+++ b/packages/plugins/plugin-trip/src/testing/routing.ts
@@ -11,8 +11,16 @@ export const CITY_COORDS: Record<string, [number, number]> = {
   barcelona: [2.1734, 41.3851],
   oxford: [-1.2577, 51.752],
   bath: [-2.3597, 51.3781],
+  birmingham: [-1.8904, 52.4862],
+  manchester: [-2.2426, 53.4808],
   paris: [2.3522, 48.8566],
   lyon: [4.8357, 45.764],
+  marseille: [5.3698, 43.2965],
+  brussels: [4.3517, 50.8503],
+  amsterdam: [4.9041, 52.3676],
+  geneva: [6.1432, 46.2044],
+  milan: [9.19, 45.4642],
+  madrid: [-3.7038, 40.4168],
 };
 
 const normalize = (name: string): string => name.trim().toLowerCase();

--- a/packages/plugins/plugin-trip/src/translations.ts
+++ b/packages/plugins/plugin-trip/src/translations.ts
@@ -51,6 +51,7 @@ export const translations = [
         'route.plan.label': 'Plan route',
         'route.planning.label': 'Planning route…',
         'route.error.label': 'Could not plan route.',
+        'route.error.message': 'Something went wrong planning this route. Check the stops and try again.',
       },
     },
   },

--- a/packages/plugins/plugin-trip/src/types/Place.ts
+++ b/packages/plugins/plugin-trip/src/types/Place.ts
@@ -20,9 +20,11 @@ export const Place = Schema.Struct({
       examples: ['JFK', 'CDG', 'LAX', 'BKK'],
     }),
   ),
+  // TODO(burdon): Change to Address (short format).
   city: Schema.optional(Schema.String.annotations({ title: 'City' })),
   country: Schema.optional(Schema.String.annotations({ title: 'Country' })),
-  geo: Format.GeoPoint.pipe(Schema.optional),
+  // Coordinates are set by geocoding (PlanRoute), not user-editable.
+  geo: Format.GeoPoint.pipe(Annotation.FormInputAnnotation.set(false), Schema.optional),
 }).pipe(Annotation.LabelAnnotation.set(['name']));
 
 export interface Place extends Schema.Schema.Type<typeof Place> {}

--- a/packages/plugins/plugin-trip/src/types/Routing.ts
+++ b/packages/plugins/plugin-trip/src/types/Routing.ts
@@ -52,8 +52,8 @@ export interface RouteStep extends Schema.Schema.Type<typeof RouteStep> {}
 
 /** A leg between two consecutive route waypoints. `geometry` is the decoded `[lon, lat]` polyline. */
 export const RouteLeg = Schema.Struct({
-  distance: Schema.Number,
-  duration: Schema.Number,
+  distance: Schema.Number.annotations({ description: 'Distance in meters.' }),
+  duration: Schema.Number.annotations({ description: 'Duration in seconds.' }),
   summary: Schema.optional(Schema.String),
   // Hidden from schema-driven forms — geometry is computed/plotted, not user-editable.
   geometry: Schema.Array(Format.GeoPoint).pipe(Annotation.FormInputAnnotation.set(false)),
@@ -63,8 +63,8 @@ export interface RouteLeg extends Schema.Schema.Type<typeof RouteLeg> {}
 
 /** A computed route. Its geometry is derived from the legs (see {@link routeGeometry}), not stored. */
 export const Route = Schema.Struct({
-  distance: Schema.Number,
-  duration: Schema.Number,
+  distance: Schema.Number.annotations({ description: 'Total distance in meters.' }),
+  duration: Schema.Number.annotations({ description: 'Total duration in seconds.' }),
   legs: Schema.Array(RouteLeg),
 });
 export interface Route extends Schema.Schema.Type<typeof Route> {}

--- a/packages/sdk/app-framework/src/vite-plugin/boot-loader/loader-app/Loader.tsx
+++ b/packages/sdk/app-framework/src/vite-plugin/boot-loader/loader-app/Loader.tsx
@@ -6,21 +6,13 @@ import { type Component, For, createEffect, createSignal, onCleanup, onMount } f
 
 import { type LoaderStore } from './store';
 
-export type LoaderProps = {
-  /** Reactive source of truth for progress, status lines, and lifecycle phase. */
-  store: LoaderStore;
-  /** Inline SVG markup for the brand mark rendered inside the ring. */
-  markSvg?: string;
-};
-
 // Ring geometry in the SVG's `0 0 100 100` viewBox. The radius leaves a couple
 // of units of padding so the stroke, its round cap, and the end marker aren't
 // clipped at the viewBox edge.
 const RING_RADIUS = 48;
 const RING_CENTER = 50;
-// Leading-edge marker: a small dot drawn via SVG `marker-end` on the arc path.
-const MARKER_RADIUS = 0.5; // viewBox units → ~3.8px on the 384px disc
-const MARKER_BOX = 2; // marker viewport (must exceed the dot diameter)
+// Leading-edge marker: a small dot drawn at the arc's head in an unmasked layer.
+const MARKER_RADIUS = 1; // viewBox units → ~3.8px on the 384px disc
 
 /**
  * Read an element's *current animated* translateY (px) from its live transform
@@ -46,6 +38,13 @@ const readTranslateY = (element: HTMLElement): number => {
     return Number.parseFloat(values[13]) || 0;
   }
   return 0;
+};
+
+export type LoaderProps = {
+  /** Reactive source of truth for progress, status lines, and lifecycle phase. */
+  store: LoaderStore;
+  /** Inline SVG markup for the brand mark rendered inside the ring. */
+  markSvg?: string;
 };
 
 /**
@@ -101,9 +100,11 @@ export const Loader: Component<LoaderProps> = (props) => {
     }
     raf = requestAnimationFrame(animate);
   };
+
   onMount(() => {
     raf = requestAnimationFrame(animate);
   });
+
   onCleanup(() => {
     if (raf != null) {
       cancelAnimationFrame(raf);
@@ -111,23 +112,26 @@ export const Loader: Component<LoaderProps> = (props) => {
   });
 
   // Determinate ring as an SVG `<path>` arc: an anticlockwise sweep starting at
-  // 12 o'clock whose angle grows with the eased `shown()` progress. The path's
-  // `marker-end` places the leading-edge dot at the arc's end automatically (no
-  // separate positioned element). The sweep is capped just shy of a full turn so
-  // the single arc command never degenerates at 100%.
-  const arcPath = () => {
+  // 12 o'clock whose angle grows with the eased `shown()` progress. The sweep is
+  // capped just shy of a full turn so the single arc command never degenerates at
+  // 100%. The leading-edge dot is its `head` point, rendered separately (below) in
+  // an *unmasked* layer — drawing it via `marker-end` on this path would put it
+  // under the ring's conic fade mask, whose hard edge bisects the dot into a
+  // half-circle.
+  const arc = () => {
     const fraction = Math.min(shown() / 100, 0.9999);
     const sweep = fraction * 2 * Math.PI;
     const start = -Math.PI / 2; // 12 o'clock
     const end = start - sweep; // anticlockwise (decreasing angle)
     const x0 = RING_CENTER + RING_RADIUS * Math.cos(start);
     const y0 = RING_CENTER + RING_RADIUS * Math.sin(start);
-    const x1 = RING_CENTER + RING_RADIUS * Math.cos(end);
-    const y1 = RING_CENTER + RING_RADIUS * Math.sin(end);
+    const headX = RING_CENTER + RING_RADIUS * Math.cos(end);
+    const headY = RING_CENTER + RING_RADIUS * Math.sin(end);
     const largeArc = sweep > Math.PI ? 1 : 0;
     // sweep-flag 0 = anticlockwise (negative-angle) direction.
-    return `M ${x0} ${y0} A ${RING_RADIUS} ${RING_RADIUS} 0 ${largeArc} 0 ${x1} ${y1}`;
+    return { d: `M ${x0} ${y0} A ${RING_RADIUS} ${RING_RADIUS} 0 ${largeArc} 0 ${headX} ${headY}`, headX, headY };
   };
+
   // Once host-driven, the brand mark eases grayscale → colour and stays there.
   const isHostDriven = () => props.store.phase() !== 'creep';
 
@@ -140,22 +144,15 @@ export const Loader: Component<LoaderProps> = (props) => {
           aria-hidden='true'
           style={{ '--boot-loader-arc': String(shown()) }}
         >
-          <defs>
-            <marker
-              id='boot-loader-ring-marker'
-              markerUnits='userSpaceOnUse'
-              markerWidth={MARKER_BOX}
-              markerHeight={MARKER_BOX}
-              refX={MARKER_BOX / 2}
-              refY={MARKER_BOX / 2}
-            >
-              <circle class='boot-loader-ring-marker' cx={MARKER_BOX / 2} cy={MARKER_BOX / 2} r={MARKER_RADIUS} />
-            </marker>
-          </defs>
-          {shown() > 0 ? (
-            <path class='boot-loader-ring-progress' d={arcPath()} marker-end='url(#boot-loader-ring-marker)' />
-          ) : null}
+          {shown() > 0 ? <path class='boot-loader-ring-progress' d={arc().d} /> : null}
         </svg>
+        {/* Leading-edge dot in its own unmasked layer (see `arc()`), so the ring's fade mask
+            never clips it. Stacked over `#boot-loader-ring` via the disc grid. */}
+        {shown() > 0 ? (
+          <svg id='boot-loader-ring-head' viewBox='0 0 100 100' aria-hidden='true'>
+            <circle class='boot-loader-ring-marker' cx={arc().headX} cy={arc().headY} r={MARKER_RADIUS} />
+          </svg>
+        ) : null}
         {props.markSvg ? <div id='boot-loader-mark' innerHTML={props.markSvg} /> : null}
       </div>
       <div id='boot-loader-status'>

--- a/packages/sdk/app-framework/src/vite-plugin/boot-loader/loader-app/boot-loader.css
+++ b/packages/sdk/app-framework/src/vite-plugin/boot-loader/loader-app/boot-loader.css
@@ -39,19 +39,10 @@ body {
    */
   --boot-loader-mark-size: min(300px, 62.5vmin);
   --boot-loader-status-gap: 32px;
-  /*
-   * Arc + marker colour. Defaults to the loader's text colour (`currentcolor`)
-   * so the ring matches the status text out of the box; a host can recolour the
-   * ring independently by setting `--boot-loader-accent-light` / `-dark` on
-   * `:root` (same pattern as the `--boot-loader-bg-*` / `-fg-*` tokens).
-   */
-  --boot-loader-accent: var(--boot-loader-accent-light, #5ac2f8);
 
   position: fixed;
   inset: 0;
   z-index: 10;
-  background: var(--boot-loader-bg-light, #fafafa);
-  color: var(--boot-loader-fg-light, #0a0a0a);
   font-size: 13px;
   font-family:
     ui-sans-serif,
@@ -69,14 +60,10 @@ body {
   transition: opacity 500ms ease-out;
 }
 
-#boot-loader[data-dismissing] {
-  opacity: 0;
-}
-
-/* Gently shrink the disc + mark as the loader fades, echoing the prior handoff. */
-#boot-loader[data-dismissing] #boot-loader-disc {
-  transform: translate(-50%, -50%) scale(0.92);
-  transition: transform 500ms ease-out;
+#boot-loader {
+  background: var(--boot-loader-bg-light, #fafafa);
+  color: var(--boot-loader-fg-light, #0a0a0a);
+  --boot-loader-accent: var(--boot-loader-accent-light, #5ac2f8);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -85,6 +72,16 @@ body {
     color: var(--boot-loader-fg-dark, #fafafa);
     --boot-loader-accent: var(--boot-loader-accent-dark, #06c5fd);
   }
+}
+
+#boot-loader[data-dismissing] {
+  opacity: 0;
+}
+
+/* Gently shrink the disc + mark as the loader fades, echoing the prior handoff. */
+#boot-loader[data-dismissing] #boot-loader-disc {
+  transform: translate(-50%, -50%) scale(0.92);
+  transition: transform 500ms ease-out;
 }
 
 /*
@@ -189,7 +186,7 @@ body {
   /* opacity: 0.5; */
   stroke-linecap: round;
   /* Dashed line: dash + gap lengths in viewBox units (~2 units ≈ 7.7px @384px). */
-  stroke-dasharray: 1 2;
+  stroke-dasharray: 2 1;
 }
 
 /* The `marker-end` dot at the arc's leading edge. */

--- a/packages/sdk/app-framework/src/vite-plugin/boot-loader/loader-app/boot-loader.css
+++ b/packages/sdk/app-framework/src/vite-plugin/boot-loader/loader-app/boot-loader.css
@@ -21,10 +21,11 @@ body {
  * to the rendered React shell.
  */
 #boot-loader {
-  /*
-   * Tunable sizes — change these in one place and every derived calc()
-   * (mark size, status offset, …) follows.
-   */
+  --color-composer-100: rgb(5 40 61);
+  --color-composer-200: rgb(10 75 105);
+  --color-composer-300: rgb(1 122 183);
+  --color-composer-400: rgb(6 197 253);
+
   /*
    * Caps the disc / mark at the design pixel sizes on roomy viewports while
    * shrinking proportionally on narrow ones (`vmin` follows the smaller of
@@ -63,14 +64,14 @@ body {
 #boot-loader {
   background: var(--boot-loader-bg-light, #fafafa);
   color: var(--boot-loader-fg-light, #0a0a0a);
-  --boot-loader-accent: var(--boot-loader-accent-light, #5ac2f8);
+  --boot-loader-accent: var(--boot-loader-accent-light, var(--color-composer-200));
 }
 
 @media (prefers-color-scheme: dark) {
   #boot-loader {
     background: var(--boot-loader-bg-dark, #0a0a0a);
     color: var(--boot-loader-fg-dark, #fafafa);
-    --boot-loader-accent: var(--boot-loader-accent-dark, #06c5fd);
+    --boot-loader-accent: var(--boot-loader-accent-dark, var(--color-composer-300));
   }
 }
 
@@ -160,17 +161,18 @@ body {
    * curve — `Loader.tsx` writes the eased progress into `--boot-loader-arc`
    * (0–100), and the arc occupies the conic range `(100 - arc)%`…`100%`, so the
    * head sits at `(100 - arc)%` (opaque) and the tail at `100%` (transparent).
+   * NOTE: We start at -1.16deg so that we don't mask the marker.
    */
   --boot-loader-arc: 0;
   mask: conic-gradient(
-    from 0deg at 50% 50%,
+    from -1.16deg at 50% 50%,
     transparent 0,
     transparent calc((100 - var(--boot-loader-arc)) * 1%),
     #000 calc((100 - var(--boot-loader-arc)) * 1%),
     transparent 100%
   );
   -webkit-mask: conic-gradient(
-    from 0deg at 50% 50%,
+    from -1.16deg at 50% 50%,
     transparent 0,
     transparent calc((100 - var(--boot-loader-arc)) * 1%),
     #000 calc((100 - var(--boot-loader-arc)) * 1%),
@@ -178,21 +180,34 @@ body {
   );
 }
 
+/*
+ * The leading-edge dot's layer — same geometry as `#boot-loader-ring` but with no
+ * mask, so the dot renders as a full circle (the ring's conic fade mask would
+ * otherwise bisect it where it sits on the mask's transparent→opaque edge).
+ */
+#boot-loader-ring-head {
+  width: var(--boot-loader-disc-size);
+  height: var(--boot-loader-disc-size);
+  overflow: visible;
+}
+
 .boot-loader-ring-progress {
   fill: none;
   stroke: var(--boot-loader-accent);
   /* viewBox units: ~1.9px on the 384px disc, scaling down on smaller viewports. */
-  stroke-width: 0.125;
-  /* opacity: 0.5; */
-  stroke-linecap: round;
+  stroke-width: 0.5;
+  opacity: 0.5;
+  stroke-linecap: butt;
+  overflow: visible;
   /* Dashed line: dash + gap lengths in viewBox units (~2 units ≈ 7.7px @384px). */
-  stroke-dasharray: 2 1;
+  /* stroke-dasharray: 2 1; */
 }
 
 /* The `marker-end` dot at the arc's leading edge. */
 .boot-loader-ring-marker {
   fill: var(--boot-loader-accent);
   stroke: none;
+  overflow: visible;
   /* opacity: 0.5; */
 }
 

--- a/packages/sdk/app-framework/src/vite-plugin/boot-loader/loader-app/store.ts
+++ b/packages/sdk/app-framework/src/vite-plugin/boot-loader/loader-app/store.ts
@@ -15,7 +15,7 @@ import { type StatusPayload } from './types';
 /** Creep timer cadence, in milliseconds. */
 export const CREEP_TICK_MS = 100;
 /** State-1 ease rate — a gentle "we're alive" hint before real progress lands. */
-export const STATE_1_RATE = 0.08;
+export const STATE_1_RATE = 0.05;
 /** State-1 asymptote (percent) the creep eases toward before host progress. */
 export const STATE_1_ASYMPTOTE = 40;
 /** State-2 ease rate — bridges the gap between sparse host `progress()` calls. */

--- a/packages/ui/react-ui-form/src/components/Form/Form.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/Form.stories.tsx
@@ -102,7 +102,7 @@ const DefaultStory = <T extends AnyProperties = AnyProperties>({
           onCancel={handleCancel}
           {...props}
         >
-          <Form.Viewport>
+          <Form.Viewport scroll>
             <Form.Content>
               <Form.Section label='Section' description='This is a section' />
               <Form.FieldSet />

--- a/packages/ui/react-ui-form/src/components/Form/FormField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormField.tsx
@@ -20,8 +20,9 @@ import {
   isLiteralUnion,
   isNestedType,
 } from '@dxos/effect';
-import { useTranslation } from '@dxos/react-ui';
+import { IconButton, IconButtonProps, useTranslation } from '@dxos/react-ui';
 import { type ProjectionModel } from '@dxos/schema';
+import { mx } from '@dxos/ui-theme';
 
 import { translationKey } from '#translations';
 
@@ -295,18 +296,25 @@ export const FormField = (props: FormFieldProps) => {
 
 FormField.displayName = 'Form.FormField';
 
-/**
- * Nesting
- */
+//
+// Layout components
+//
 
 // TODO(burdon): Options (nested or flat).
 // TODO(burdon): Support collapsible.
 export const Nesting = ({ children }: PropsWithChildren) => (
-  <div className='flex flex-col px-2 border border-subdued-separator rounded-sm mt-2'>
-    {children}
-    <div className='pb-2' />
+  <div className='px-2 border border-subdued-separator rounded-sm mt-2'>
+    <div className='pb-2'>{children}</div>
   </div>
 );
+
+export const IconBlock = ({ inline, ...props }: IconButtonProps & { inline?: boolean }) => {
+  return (
+    <div className={mx('h-full flex px-1', inline ? 'items-center' : 'flex-col pt-2.5')}>
+      <IconButton variant='ghost' density='xs' square iconOnly {...props} />
+    </div>
+  );
+};
 
 /**
  * Get property input component.

--- a/packages/ui/react-ui-form/src/components/Form/FormField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormField.tsx
@@ -7,7 +7,7 @@ import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 import * as SchemaAST from 'effect/SchemaAST';
 import * as String from 'effect/String';
-import React, { useMemo } from 'react';
+import React, { PropsWithChildren, useMemo } from 'react';
 
 import { Annotation, Format } from '@dxos/echo';
 import {
@@ -267,23 +267,25 @@ export const FormField = (props: FormFieldProps) => {
     if (typeLiteral) {
       const schema = Schema.make(typeLiteral);
       return (
-        <FormFieldSet
-          schema={schema}
-          path={path}
-          readonly={readonly}
-          layout={layout}
-          label={label}
-          projection={projection}
-          fieldMap={fieldMap}
-          fieldProvider={fieldProvider}
-          createOptionLabel={createOptionLabel}
-          createOptionIcon={createOptionIcon}
-          createInitialValuePath={createInitialValuePath}
-          db={db}
-          useType={schemaHook}
-          getOptions={getOptions}
-          onCreate={onCreate}
-        />
+        <Nesting>
+          <FormFieldSet
+            schema={schema}
+            path={path}
+            readonly={readonly}
+            layout={layout}
+            label={label}
+            projection={projection}
+            fieldMap={fieldMap}
+            fieldProvider={fieldProvider}
+            createOptionLabel={createOptionLabel}
+            createOptionIcon={createOptionIcon}
+            createInitialValuePath={createInitialValuePath}
+            db={db}
+            useType={schemaHook}
+            getOptions={getOptions}
+            onCreate={onCreate}
+          />
+        </Nesting>
       );
     }
   }
@@ -292,6 +294,19 @@ export const FormField = (props: FormFieldProps) => {
 };
 
 FormField.displayName = 'Form.FormField';
+
+/**
+ * Nesting
+ */
+
+// TODO(burdon): Options (nested or flat).
+// TODO(burdon): Support collapsible.
+export const Nesting = ({ children }: PropsWithChildren) => (
+  <div className='flex flex-col px-2 border border-subdued-separator rounded-sm mt-2'>
+    {children}
+    <div className='pb-2' />
+  </div>
+);
 
 /**
  * Get property input component.

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -16,12 +16,13 @@ import {
   isNestedType,
 } from '@dxos/effect';
 import { IconButton, IconButtonProps, useTranslation } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
 
 import { translationKey } from '#translations';
 
 import { getFormProperties } from '../../../util';
 import { useFormValues } from '../Form';
-import { FormField, type FormFieldProps } from '../FormField';
+import { FormField, Nesting, type FormFieldProps } from '../FormField';
 import { FormFieldLabel, type FormFieldStateProps } from '../FormFieldComponent';
 
 export type ArrayFieldProps = {
@@ -96,7 +97,7 @@ export const ArrayField = ({
             <FormFieldLabel readonly={readonly} label={label} path={createJsonPath(path ?? [])} asChild />
           </div>
           {!readonly && layout !== 'static' && (
-            <IconBlock icon='ph--plus--regular' label={t('add-item.button')} onClick={handleAdd} />
+            <IconBlock inline icon='ph--plus--regular' label={t('add-item.button')} onClick={handleAdd} />
           )}
         </div>
       )}
@@ -128,12 +129,7 @@ export const ArrayField = ({
 
           return (
             <div key={index} className='grid grid-cols-[1fr_min-content] items-center mb-1 last:mb-form-gap'>
-              {renderItemAsObject ? (
-                <div className='p-1 border border-subdued-separator'>{fieldField}</div>
-              ) : (
-                fieldField
-              )}
-
+              {renderItemAsObject ? <Nesting>{fieldField}</Nesting> : fieldField}
               {!readonly && layout !== 'static' && (
                 <IconBlock icon='ph--x--regular' label={t('remove-item.button')} onClick={() => handleDelete(index)} />
               )}
@@ -147,9 +143,9 @@ export const ArrayField = ({
 
 ArrayField.displayName = 'Form.ArrayField';
 
-const IconBlock = (props: IconButtonProps) => {
+const IconBlock = ({ inline, ...props }: IconButtonProps & { inline?: boolean }) => {
   return (
-    <div className='flex items-center h-full px-1'>
+    <div className={mx('h-full flex px-1', inline ? 'items-center' : 'flex-col')}>
       <IconButton variant='ghost' density='xs' square iconOnly {...props} />
     </div>
   );

--- a/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/ArrayField.tsx
@@ -15,14 +15,13 @@ import {
   isDiscriminatedUnion,
   isNestedType,
 } from '@dxos/effect';
-import { IconButton, IconButtonProps, useTranslation } from '@dxos/react-ui';
-import { mx } from '@dxos/ui-theme';
+import { useTranslation } from '@dxos/react-ui';
 
 import { translationKey } from '#translations';
 
 import { getFormProperties } from '../../../util';
 import { useFormValues } from '../Form';
-import { FormField, Nesting, type FormFieldProps } from '../FormField';
+import { FormField, IconBlock, type FormFieldProps } from '../FormField';
 import { FormFieldLabel, type FormFieldStateProps } from '../FormFieldComponent';
 
 export type ArrayFieldProps = {
@@ -105,6 +104,7 @@ export const ArrayField = ({
       <div className='flex flex-col'>
         {values?.map((_, index) => {
           const isLast = index === values.length - 1;
+
           // Object items: each row contains a recursively-rendered FormField
           //   (multiple sub-rows for the object's fields) wrapped in a border,
           //   with the delete button bottom-aligned next to it.
@@ -129,9 +129,14 @@ export const ArrayField = ({
 
           return (
             <div key={index} className='grid grid-cols-[1fr_min-content] items-center mb-1 last:mb-form-gap'>
-              {renderItemAsObject ? <Nesting>{fieldField}</Nesting> : fieldField}
+              {fieldField}
               {!readonly && layout !== 'static' && (
-                <IconBlock icon='ph--x--regular' label={t('remove-item.button')} onClick={() => handleDelete(index)} />
+                <IconBlock
+                  inline={!renderItemAsObject}
+                  icon='ph--x--regular'
+                  label={t('remove-item.button')}
+                  onClick={() => handleDelete(index)}
+                />
               )}
             </div>
           );
@@ -142,14 +147,6 @@ export const ArrayField = ({
 };
 
 ArrayField.displayName = 'Form.ArrayField';
-
-const IconBlock = ({ inline, ...props }: IconButtonProps & { inline?: boolean }) => {
-  return (
-    <div className={mx('h-full flex px-1', inline ? 'items-center' : 'flex-col')}>
-      <IconButton variant='ghost' density='xs' square iconOnly {...props} />
-    </div>
-  );
-};
 
 /**
  * Returns the default empty value for a given AST.

--- a/packages/ui/react-ui-form/src/components/Form/fields/InlineRefField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/InlineRefField.tsx
@@ -20,6 +20,7 @@ import { Button, Icon, Input, useTranslation } from '@dxos/react-ui';
 import { translationKey } from '#translations';
 
 import { Form, omitId } from '../Form';
+import { Nesting } from '../FormField';
 import { FormFieldLabel } from '../FormFieldComponent';
 import { type RefFieldProps } from './RefField';
 
@@ -134,12 +135,12 @@ const InlineForm = ({ reference, db, readonly, useType = defaultUseType }: Inlin
   }
 
   return (
-    <div className='p-1 border border-subdued-separator rounded-sm'>
+    <Nesting>
       <Form.Root schema={formSchema} defaultValues={defaultValues as any} db={db} onValuesChanged={handleChange}>
         <Form.Content>
           <Form.FieldSet readonly={readonly} />
         </Form.Content>
       </Form.Root>
-    </div>
+    </Nesting>
   );
 };

--- a/packages/ui/react-ui-form/src/components/testing.tsx
+++ b/packages/ui/react-ui-form/src/components/testing.tsx
@@ -32,7 +32,7 @@ type TestPanelProps = ThemedClassName<PropsWithChildren>;
 
 export const TestPanel = slottable<HTMLDivElement, TestPanelProps>(({ children }, forwardedRef) => {
   return (
-    <div {...composableProps({ classNames: 'dx-container bg-modal-surface rounded-md' })} ref={forwardedRef}>
+    <div {...composableProps({ classNames: 'dx-container bg-card-surface rounded-md' })} ref={forwardedRef}>
       {children}
     </div>
   );

--- a/packages/ui/react-ui-form/src/util/properties.test.ts
+++ b/packages/ui/react-ui-form/src/util/properties.test.ts
@@ -3,9 +3,12 @@
 //
 
 import * as Schema from 'effect/Schema';
+import * as SchemaAST from 'effect/SchemaAST';
 import { describe, test } from 'vitest';
 
 import { DXN, Annotation, JsonSchema, Type } from '@dxos/echo';
+import { Format } from '@dxos/echo/internal';
+import { findNode, getArrayElementType } from '@dxos/effect';
 
 import { getFormProperties } from './properties';
 
@@ -59,6 +62,46 @@ describe('getFormProperties', () => {
     const names = getFormProperties(Type.getSchema(TestSchema).ast).map((prop) => prop.name);
     expect(names).toContain('name');
     expect(names).not.toContain('userId');
+  });
+
+  test('preserves a deeply-nested FormInputAnnotation through unions and arrays', ({ expect }) => {
+    // Regression: a hidden field nested below a discriminated union and arrays of structs (e.g.
+    // Segment.details(road).routes[].legs[].geometry). `encodedBoundAST` strips annotations from
+    // non-keyword inner types, so without keeping container types raw the annotation is lost by
+    // the time the form recurses to the leaf field. The transformation element (GeoPoint) is the
+    // trigger that forces the encode rebuild.
+    const Leg = Schema.Struct({
+      distance: Schema.Number,
+      geometry: Schema.Array(Format.GeoPoint).pipe(Annotation.FormInputAnnotation.set(false)),
+    });
+    const Route = Schema.Struct({ legs: Schema.Array(Leg) });
+    const TestSchema = Schema.Struct({
+      details: Schema.Union(
+        Schema.TaggedStruct('road', { routes: Schema.optional(Schema.Array(Route)) }),
+        Schema.TaggedStruct('other', { note: Schema.optional(Schema.String) }),
+      ),
+    }).pipe(Type.makeObject(DXN.make('org.dxos.test.nestedHidden', '0.1.0')));
+
+    // Drill as the form does: getFormProperties at each level, descending via the property type
+    // (array element / type literal) returned by the previous level.
+    const findTypeLiteralWith = (ast: SchemaAST.AST, prop: string) =>
+      findNode(
+        ast,
+        (node) => SchemaAST.isTypeLiteral(node) && SchemaAST.getPropertySignatures(node).some((p) => p.name === prop),
+      )!;
+    const propType = (ast: SchemaAST.AST, name: string) => getFormProperties(ast).find((p) => p.name === name)!.type;
+
+    const detailsType = propType(Type.getSchema(TestSchema).ast, 'details');
+    const roadTypeLiteral = findTypeLiteralWith(detailsType, 'routes');
+    const routeTypeLiteral = findNode(
+      getArrayElementType(propType(roadTypeLiteral, 'routes'))!,
+      SchemaAST.isTypeLiteral,
+    )!;
+    const legTypeLiteral = findNode(getArrayElementType(propType(routeTypeLiteral, 'legs'))!, SchemaAST.isTypeLiteral)!;
+
+    const names = getFormProperties(legTypeLiteral).map((prop) => prop.name);
+    expect(names).toContain('distance');
+    expect(names).not.toContain('geometry');
   });
 
   test('preserves annotation when chained with .annotations()', ({ expect }) => {

--- a/packages/ui/react-ui-form/src/util/properties.ts
+++ b/packages/ui/react-ui-form/src/util/properties.ts
@@ -9,10 +9,17 @@ import { Annotation } from '@dxos/echo';
 import { type SchemaProperty, getProperties, isArrayType, isNestedType } from '@dxos/effect';
 
 /** The property's type with an optional `T | undefined` union unwrapped to its inner `T`. */
-const unwrapOptional = (prop: SchemaAST.PropertySignature): SchemaAST.AST =>
-  prop.isOptional && SchemaAST.isUnion(prop.type)
-    ? (prop.type.types.find((type) => type._tag !== 'UndefinedKeyword') ?? prop.type)
-    : prop.type;
+const unwrapOptional = (prop: SchemaAST.PropertySignature): SchemaAST.AST => {
+  if (!prop.isOptional || !SchemaAST.isUnion(prop.type)) {
+    return prop.type;
+  }
+  // Drop the `undefined` member, preserving the remaining union (don't collapse `A | B | undefined` to `A`).
+  const defined = prop.type.types.filter((type) => type._tag !== 'UndefinedKeyword');
+  if (defined.length === 0) {
+    return prop.type;
+  }
+  return defined.length === 1 ? defined[0] : SchemaAST.Union.make(defined, prop.type.annotations);
+};
 
 /**
  * Get the property types of an AST and filter out properties that are not form inputs.

--- a/packages/ui/react-ui-form/src/util/properties.ts
+++ b/packages/ui/react-ui-form/src/util/properties.ts
@@ -6,7 +6,13 @@ import * as Option from 'effect/Option';
 import * as SchemaAST from 'effect/SchemaAST';
 
 import { Annotation } from '@dxos/echo';
-import { type SchemaProperty, getProperties } from '@dxos/effect';
+import { type SchemaProperty, getProperties, isArrayType, isNestedType } from '@dxos/effect';
+
+/** The property's type with an optional `T | undefined` union unwrapped to its inner `T`. */
+const unwrapOptional = (prop: SchemaAST.PropertySignature): SchemaAST.AST =>
+  prop.isOptional && SchemaAST.isUnion(prop.type)
+    ? (prop.type.types.find((type) => type._tag !== 'UndefinedKeyword') ?? prop.type)
+    : prop.type;
 
 /**
  * Get the property types of an AST and filter out properties that are not form inputs.
@@ -20,19 +26,29 @@ import { type SchemaProperty, getProperties } from '@dxos/effect';
  * For optional fields, `prop.type` is the union `T | undefined` — the annotation
  * lives on the inner `T`. Unwrap before reading so that the conventional pattern
  * `Schema.String.pipe(FormInputAnnotation.set(false), Schema.optional)` works.
+ *
+ * Container properties (nested structs, unions, arrays) keep their *raw* AST rather than
+ * the `encodedBoundAST` produced by `getProperties`. `encodedBoundAST` strips annotations
+ * from non-keyword inner types, so a `FormInputAnnotation` nested beneath an encoded container
+ * (e.g. `RouteLeg.geometry`, reached via `Segment → details → routes → Route → legs`) would
+ * otherwise be lost by the time recursion reaches it. Leaf/transformation fields stay encoded
+ * (e.g. a `DateTime` still renders as its encoded string input).
  */
 export const getFormProperties = (ast: SchemaAST.AST): SchemaProperty[] => {
+  const signatures = SchemaAST.getPropertySignatures(ast);
+  const rawByName = new Map<PropertyKey, SchemaAST.AST>(signatures.map((prop) => [prop.name, unwrapOptional(prop)]));
   const hidden = new Set(
-    SchemaAST.getPropertySignatures(ast)
-      .filter((prop) => {
-        // Unwrap `T | undefined` for optional fields so the inner annotation is visible.
-        const type =
-          prop.isOptional && SchemaAST.isUnion(prop.type)
-            ? (prop.type.types.find((t) => t._tag !== 'UndefinedKeyword') ?? prop.type)
-            : prop.type;
-        return Annotation.FormInputAnnotation.getFromAst(type).pipe(Option.getOrElse(() => true)) === false;
-      })
+    signatures
+      .filter(
+        (prop) =>
+          Annotation.FormInputAnnotation.getFromAst(unwrapOptional(prop)).pipe(Option.getOrElse(() => true)) === false,
+      )
       .map((prop) => prop.name),
   );
-  return getProperties(ast).filter((prop) => !hidden.has(prop.name));
+  return getProperties(ast)
+    .filter((prop) => !hidden.has(prop.name))
+    .map((prop) => {
+      const raw = rawByName.get(prop.name);
+      return raw && (isNestedType(raw) || isArrayType(raw)) ? { ...prop, type: raw } : prop;
+    });
 };

--- a/packages/ui/react-ui/src/components/Input/Input.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.tsx
@@ -16,6 +16,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import {
   DescriptionAndValidation as DescriptionAndValidationPrimitive,
@@ -41,8 +42,11 @@ import {
 import { mx } from '@dxos/ui-theme';
 import { type Density, type Elevation, type Size } from '@dxos/ui-types';
 
+import { translationKey } from '#translations';
+
 import { useDensityContext, useElevationContext, useThemeContext } from '../../hooks';
 import { type ThemedClassName } from '../../util';
+import { IconButton, IconButtonProps } from '../Button';
 import { Icon } from '../Icon';
 import {
   SegmentedDate,
@@ -125,31 +129,26 @@ Root.displayName = 'Input.Root';
 // when no field in the surrounding `Input.Root` has registered an opener.
 //
 
-type TriggerIconProps = ThemedClassName<
-  Omit<ComponentPropsWithRef<'button'>, 'children' | 'onClick'> & {
-    icon?: string;
-  }
->;
+// `label` and `icon` have defaults below, so both are optional for callers (e.g. `<Input.TriggerIcon />`).
+type TriggerIconProps = Omit<IconButtonProps, 'label'> & { label?: string };
 
 const TriggerIcon = forwardRef<HTMLButtonElement, TriggerIconProps>(
-  ({ classNames, icon = 'ph--calendar--regular', 'aria-label': ariaLabel, ...props }, forwardedRef) => {
+  ({ classNames, icon = 'ph--calendar--regular', 'aria-label': ariaLabel, label, ...props }, forwardedRef) => {
+    const { t } = useTranslation(translationKey);
     const ctx = useContext(InputTriggerContext);
-    const { tx } = useThemeContext();
     if (!ctx?.hasTrigger) {
       return null;
     }
 
     return (
-      <button
-        type='button'
-        ref={forwardedRef}
-        aria-label={ariaLabel ?? 'Open picker'}
-        {...props}
+      <IconButton
+        variant='ghost'
+        icon={icon}
+        iconOnly
+        label={label ?? t('trigger-button.label')}
         onClick={ctx.trigger}
-        className={tx('input.triggerIcon', {}, classNames) ?? undefined}
-      >
-        <Icon size={4} icon={icon} />
-      </button>
+        {...props}
+      />
     );
   },
 );

--- a/packages/ui/react-ui/src/components/Input/Input.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.tsx
@@ -130,7 +130,8 @@ Root.displayName = 'Input.Root';
 //
 
 // `label` and `icon` have defaults below, so both are optional for callers (e.g. `<Input.TriggerIcon />`).
-type TriggerIconProps = Omit<IconButtonProps, 'label'> & { label?: string };
+// `onClick` is reserved — the trigger always opens the registered picker.
+type TriggerIconProps = Omit<IconButtonProps, 'label' | 'onClick'> & { label?: string };
 
 const TriggerIcon = forwardRef<HTMLButtonElement, TriggerIconProps>(
   ({ classNames, icon = 'ph--calendar--regular', 'aria-label': ariaLabel, label, ...props }, forwardedRef) => {
@@ -142,12 +143,15 @@ const TriggerIcon = forwardRef<HTMLButtonElement, TriggerIconProps>(
 
     return (
       <IconButton
+        ref={forwardedRef}
         variant='ghost'
         icon={icon}
         iconOnly
-        label={label ?? t('trigger-button.label')}
-        onClick={ctx.trigger}
+        classNames={classNames}
+        aria-label={ariaLabel}
+        label={label ?? ariaLabel ?? t('trigger-button.label')}
         {...props}
+        onClick={ctx.trigger}
       />
     );
   },

--- a/packages/ui/react-ui/src/components/Input/SegmentedInput.tsx
+++ b/packages/ui/react-ui/src/components/Input/SegmentedInput.tsx
@@ -450,4 +450,5 @@ const SegmentedDateTime = forwardRef<HTMLDivElement, InputScopedProps<SegmentedD
 SegmentedDateTime.displayName = 'Input.SegmentedDateTime';
 
 export { SegmentedDate, SegmentedTime, SegmentedDateTime };
+
 export type { SegmentedDateProps, SegmentedTimeProps, SegmentedDateTimeProps };

--- a/packages/ui/react-ui/src/components/Message/Message.stories.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.stories.tsx
@@ -26,9 +26,11 @@ const DefaultStory = ({ valence, title, body, button }: DefaultStoryProps) => (
     <Message.Root valence={valence}>
       {title && <Message.Title onClose={() => console.log('close')}>{title}</Message.Title>}
       {body && (
-        <Message.Content classNames='gap-2'>
-          <p>{body}</p>
-          {button && <Button>Test</Button>}
+        <Message.Content asChild classNames='gap-2'>
+          <div>
+            <p>{body}</p>
+            {button && <Button>Test</Button>}
+          </div>
         </Message.Content>
       )}
     </Message.Root>

--- a/packages/ui/react-ui/src/components/Message/Message.stories.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.stories.tsx
@@ -18,13 +18,19 @@ type DefaultStoryProps = {
   valence: MessageValence;
   title: string;
   body: string;
+  button?: boolean;
 };
 
-const DefaultStory = ({ valence, title, body }: DefaultStoryProps) => (
+const DefaultStory = ({ valence, title, body, button }: DefaultStoryProps) => (
   <div className='w-[30rem]'>
     <Message.Root valence={valence}>
       {title && <Message.Title onClose={() => console.log('close')}>{title}</Message.Title>}
-      {body && <Message.Content>{body}</Message.Content>}
+      {body && (
+        <Message.Content classNames='gap-2'>
+          <p>{body}</p>
+          {button && <Button>Test</Button>}
+        </Message.Content>
+      )}
     </Message.Root>
   </div>
 );
@@ -54,6 +60,7 @@ export const Default: Story = {
     valence: 'neutral',
     title: 'Default',
     body: random.lorem.paragraphs(1),
+    button: true,
   },
 };
 
@@ -62,6 +69,7 @@ export const Success: Story = {
     valence: 'success',
     title: 'Success',
     body: random.lorem.paragraphs(1),
+    button: true,
   },
 };
 
@@ -70,6 +78,7 @@ export const Info: Story = {
     valence: 'info',
     title: 'Info',
     body: random.lorem.paragraphs(1),
+    button: true,
   },
 };
 
@@ -78,6 +87,7 @@ export const Warning: Story = {
     valence: 'warning',
     title: 'Warning',
     body: random.lorem.paragraphs(1),
+    button: true,
   },
 };
 
@@ -86,24 +96,6 @@ export const Error: Story = {
     valence: 'error',
     title: 'Error',
     body: random.lorem.paragraphs(1),
+    button: true,
   },
-};
-
-export const WithButton: Story = {
-  args: {
-    valence: 'success',
-    title: 'Action required',
-    body: random.lorem.paragraphs(1),
-  },
-  render: ({ valence, title, body }) => (
-    <div className='w-[30rem]'>
-      <Message.Root valence={valence}>
-        {title && <Message.Title onClose={() => console.log('close')}>{title}</Message.Title>}
-        {body && <Message.Content>{body}</Message.Content>}
-        <Button variant='valence' classNames='col-start-2'>
-          Confirm
-        </Button>
-      </Message.Root>
-    </div>
-  ),
 };

--- a/packages/ui/react-ui/src/components/Message/Message.theme.ts
+++ b/packages/ui/react-ui/src/components/Message/Message.theme.ts
@@ -31,7 +31,7 @@ const close: ComponentFunction<MessageStyleProps> = (_, etc) => {
 };
 
 const content: ComponentFunction<MessageStyleProps> = (_, etc) => {
-  return mx('col-start-2 first:font-medium pb-1.5', etc);
+  return mx('col-start-2 flex flex-col first:font-medium pb-1.5', etc);
 };
 
 export const messageTheme: Theme<MessageStyleProps> = {

--- a/packages/ui/react-ui/src/components/Message/Message.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.tsx
@@ -149,14 +149,13 @@ const MessageTitle = forwardRef<HTMLDivElement, MessageTitleProps>(
           {children}
         </h2>
         {onClose && (
-          <div>
+          <div className={tx('message.close', {})}>
             <IconButton
               variant='ghost'
               icon='ph--x--regular'
               iconOnly
               density='sm'
               label={t('toolbar-close.label')}
-              classNames={tx('message.close', {})}
               onClick={onClose}
             />
           </div>

--- a/packages/ui/react-ui/src/components/Message/Message.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.tsx
@@ -44,34 +44,34 @@ const MESSAGE_NAME = 'Message';
 type ValenceCSSVars = CSSProperties & {
   '--dx-valence-bg': string;
   '--dx-valence-bg-hover': string;
-  '--dx-valence-fg': string;
+  '--dx-valence-text': string;
 };
 
 const valenceVars: Record<MessageValence, ValenceCSSVars> = {
   success: {
     '--dx-valence-bg': 'var(--color-success-bg)',
     '--dx-valence-bg-hover': 'var(--color-success-bg-hover)',
-    '--dx-valence-fg': 'var(--color-success-fg)',
+    '--dx-valence-text': 'var(--color-success-text)',
   },
   info: {
     '--dx-valence-bg': 'var(--color-info-bg)',
     '--dx-valence-bg-hover': 'var(--color-info-bg-hover)',
-    '--dx-valence-fg': 'var(--color-info-fg)',
+    '--dx-valence-text': 'var(--color-info-text)',
   },
   warning: {
     '--dx-valence-bg': 'var(--color-warning-bg)',
     '--dx-valence-bg-hover': 'var(--color-warning-bg-hover)',
-    '--dx-valence-fg': 'var(--color-warning-fg)',
+    '--dx-valence-text': 'var(--color-warning-text)',
   },
   error: {
     '--dx-valence-bg': 'var(--color-error-bg)',
     '--dx-valence-bg-hover': 'var(--color-error-bg-hover)',
-    '--dx-valence-fg': 'var(--color-error-fg)',
+    '--dx-valence-text': 'var(--color-error-text)',
   },
   neutral: {
     '--dx-valence-bg': 'var(--color-neutral-bg)',
     '--dx-valence-bg-hover': 'var(--color-neutral-bg-hover)',
-    '--dx-valence-fg': 'var(--color-neutral-fg)',
+    '--dx-valence-text': 'var(--color-neutral-text)',
   },
 };
 
@@ -149,14 +149,17 @@ const MessageTitle = forwardRef<HTMLDivElement, MessageTitleProps>(
           {children}
         </h2>
         {onClose && (
-          <IconButton
-            variant='ghost'
-            icon='ph--x--regular'
-            iconOnly
-            label={t('toolbar-close.label')}
-            classNames={tx('message.close', {})}
-            onClick={onClose}
-          />
+          <div>
+            <IconButton
+              variant='ghost'
+              icon='ph--x--regular'
+              iconOnly
+              density='sm'
+              label={t('toolbar-close.label')}
+              classNames={tx('message.close', {})}
+              onClick={onClose}
+            />
+          </div>
         )}
       </Column.Row>
     );

--- a/packages/ui/react-ui/src/translations.ts
+++ b/packages/ui/react-ui/src/translations.ts
@@ -26,6 +26,7 @@ export const translations = [
         'calendar.nav.previous.label': 'Previous month',
         'calendar.nav.next.label': 'Next month',
         'calendar.footer.today.label': 'Today',
+        'trigger-button.label': 'Open',
       },
     },
   },

--- a/packages/ui/ui-theme/src/css/components/button.css
+++ b/packages/ui/ui-theme/src/css/components/button.css
@@ -15,7 +15,7 @@
     /* The default variant inherits ambient valence colors when rendered inside a valence surface
      * (e.g. Message.Root, which sets --dx-valence-*); otherwise it falls back to the base input styling. */
     &[data-variant='default'] {
-      color: var(--dx-valence-fg, inherit);
+      color: var(--dx-valence-text, inherit);
       background: var(--dx-valence-bg, var(--color-input-bg));
     }
     &[aria-pressed='true'],

--- a/packages/ui/ui-theme/src/css/components/button.css
+++ b/packages/ui/ui-theme/src/css/components/button.css
@@ -12,6 +12,12 @@
   .dx-button {
     @apply shrink-0 inline-flex select-none items-center justify-center overflow-hidden min-h-[2rem] px-3;
     @apply font-medium transition-colors duration-100 ease-linear bg-input-bg;
+    /* The default variant inherits ambient valence colors when rendered inside a valence surface
+     * (e.g. Message.Root, which sets --dx-valence-*); otherwise it falls back to the base input styling. */
+    &[data-variant='default'] {
+      color: var(--dx-valence-fg, inherit);
+      background: var(--dx-valence-bg, var(--color-input-bg));
+    }
     &[aria-pressed='true'],
     &[aria-checked='true'] {
       @apply text-accent-text bg-attention-surface;
@@ -57,6 +63,20 @@
         @apply bg-hover-surface;
       }
 
+      &[data-variant='default']:hover {
+        color: var(--dx-valence-text);
+        background-color: var(--dx-valence-bg-hover, var(--color-hover-surface));
+      }
+
+      /* 
+       * Inside a valence surface the (otherwise transparent) ghost hover adopts the valence background;
+       * elsewhere it falls back to the standard hover surface. 
+       */
+      &[data-variant='ghost']:hover {
+        color: var(--dx-valence-text);
+        background-color: var(--dx-valence-bg, var(--color-hover-surface));
+      }
+
       &[data-variant='primary'] {
         @apply text-accent-fg bg-accent-bg;
         &:hover,
@@ -87,6 +107,7 @@
       }
     }
   }
+
   /* Props */
   .dx-button:not([data-props~='grouped']) {
     @apply rounded-xs;

--- a/packages/ui/ui-theme/src/css/theme/semantic.css
+++ b/packages/ui/ui-theme/src/css/theme/semantic.css
@@ -35,12 +35,11 @@
   --dx-elevation-7: light-dark(white, var(--color-neutral-750));
 
   /* Surfaces — each maps to exactly one elevation level */
-  --color-deck-surface: var(--dx-elevation-3);
-  --color-base-surface: var(--dx-elevation-3);
   --color-sidebar-surface: var(--dx-elevation-2);
   --color-header-surface: var(--dx-elevation-2);
-  --color-toolbar-surface: var(--dx-elevation-5);
-  --color-card-surface: var(--dx-elevation-4);
+  --color-deck-surface: var(--dx-elevation-3);
+  --color-base-surface: var(--dx-elevation-3);
+  --color-card-surface: var(--dx-elevation-3);
   --color-group-surface: var(--dx-elevation-4);
   /* Subtle alternate of group-surface for zebra striping (e.g. calendar months) — offset off
    * elevation-4 via relative oklch so it tracks the ramp: darker in light mode, lighter in dark. */
@@ -49,6 +48,7 @@
     oklch(from var(--dx-elevation-4) calc(l + 0.03) c h)
   );
   --color-input-surface: var(--dx-elevation-4);
+  --color-toolbar-surface: var(--dx-elevation-5);
   --color-modal-surface: var(--dx-elevation-6);
   --color-popover-surface: var(--dx-elevation-7);
 

--- a/packages/ui/ui-theme/src/util/valence.ts
+++ b/packages/ui/ui-theme/src/util/valence.ts
@@ -36,8 +36,8 @@ export const messageValence = (valence?: MessageValence) => {
 
 /**
  * Classes for a Button rendered inside a Message.Root that should inherit the message's valence color.
- * Message.Root sets --dx-valence-bg / --dx-valence-bg-hover / --dx-valence-fg on its DOM node.
+ * Message.Root sets --dx-valence-bg / --dx-valence-bg-hover / --dx-valence-text on its DOM node.
  * Pass variant='valence' to the Button so button.css reads those variables.
  */
 export const buttonValence = (_valence?: MessageValence): string =>
-  'text-(--dx-valence-fg) bg-(--dx-valence-bg) hover:bg-(--dx-valence-bg-hover)';
+  'text-(--dx-valence-text) bg-(--dx-valence-bg) hover:bg-(--dx-valence-bg-hover)';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12725,6 +12725,9 @@ importers:
       '@dxos/keys':
         specifier: workspace:*
         version: link:../../common/keys
+      '@dxos/log':
+        specifier: workspace:*
+        version: link:../../common/log
       '@dxos/plugin-trip':
         specifier: workspace:*
         version: link:../plugin-trip


### PR DESCRIPTION
## Summary

A cluster of driving-route (plugin-trip / plugin-osrm) improvements plus the supporting schema/form/UI fixes they surfaced.

### Driving route — plugin-trip / plugin-osrm
- **Geocoding query precedence**: OSRM origin/destination now uses `code` → `city, country` → `name` (was `name → city → code`).
- **Units**: `RouteLeg`/`Route` `distance`/`duration` floored to whole units on write; added description annotations (meters / seconds).
- **OSRM logging**: request (url + waypoint count) and response (status) logged via `@dxos/log`.
- **Friendly errors**: "plan route" failures now log the technical error (`log.catch`) and show a friendly toast — `GeocodeError`/`RouteError` keep their user-facing message, everything else falls back to a generic message.
- **Stories**: `CityOnly` (single city-only segment) and `LiveRoute` (live OSRM + Nominatim demo servers); added more cities (Birmingham, Manchester, …) to the deterministic fake router.

### Schema — echo
- **`Format.GeoPoint` rounds to 7 dp** (`GEO_PRECISION`) instead of rejecting non-multiples. Live geocoder coordinates (>6 dp) previously failed `multipleOf(0.000001)` validation, breaking route planning; they now round and store cleanly. Clamping preserved; altitude preserved.

### Forms — react-ui-form
- **Nested `FormInputAnnotation` now honored**: `getFormProperties` keeps nested container types (structs/unions/arrays) raw so deeply-nested annotations survive `encodedBoundAST`. Fixes `RouteLeg.geometry` (a huge GeoPoint polyline) leaking into the segment form. Hid the computed `Place.geo` coordinates too.

### UI — react-ui / ui-theme
- **Button valence**: a `Button` (incl. `IconButton`) inside `Message.Root` with no explicit variant defaults to the `valence` variant; the `ghost` variant adopts the valence background on hover. Valence text now uses the `-text` token.
- **`Input.TriggerIcon`** wraps `IconButton` with an optional `label`.

### Other
- **Map** `minZoom` set to 3.
- **markdown** `stripWhitespace` now strips trailing invisible / zero-width characters (soft hyphen, zero-width space/joiners, word joiner, ZWNBSP), not just space/tab/NBSP.

## Reviewer notes
- The `Format.GeoPoint` change affects all GeoPoint consumers across the app — it now rounds rather than rejects (more permissive). Tests added in `format.test.ts`.
- The `react-ui-form` change alters nested-field derivation for **all** forms (net: nested annotations now work; previously-silently-dropped nested scalar GeoPoint fields now render unless hidden). Regression test added.
- Tests added/updated: echo `format.test.ts`, react-ui-form `properties.test.ts`, plugin-trip `plan-route.test.ts`, markdown `markdown.test.ts`.

## Test plan
- `moon run :build` / `:test` / `:lint` for echo, react-ui, react-ui-form, ui-theme, plugin-trip, plugin-osrm, plugin-map, markdown — all green locally.
- `LiveRoute` story planned a real London→Birmingham route against the OSRM demo server (network-dependent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced routing: smarter waypoint selection, live routing story, and clearer user-facing route error messages
  * Map improvements: minimum zoom constraint and refined map↔globe zoom conversion
  * Form UI: new nested layout and icon block for cleaner nested editing

* **Bug Fixes**
  * Standardized coordinate precision (7 decimal places) and clamped invalid coordinates
  * Text normalization removes trailing invisible Unicode characters
  * Deeply nested form fields respect hidden/input annotations

* **UI/Style**
  * Updated message/button valence styling and surface elevation adjustments

* **Tests**
  * Added tests for geo-point rounding and text normalization

* **Documentation**
  * Clarified session worktree and committing workflow instructions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->