### PR TITLE
fix(echo): persist unsaved Ref targets set via Annotation.set

### DIFF
--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
@@ -2,12 +2,13 @@
 // Copyright 2024 DXOS.org
 //
 
+import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 import { inspect } from 'node:util';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import { Context } from '@dxos/context';
-import { DXN, Entity, Filter, Obj, Query, Ref, Relation, Type } from '@dxos/echo';
+import { Annotation, DXN, Entity, Filter, Obj, Query, Ref, Relation, Type } from '@dxos/echo';
 import { EncodedReference } from '@dxos/echo-protocol';
 import {
   ATTR_RELATION_SOURCE,
@@ -610,6 +611,48 @@ describe('Reactive Object with ECHO database', () => {
 
       expect(person.previousEmployment![0]!.target?.name).to.eq('DXOS');
       expect(person.previousEmployment![1]!.target?.name).to.eq('Braneframe');
+    });
+  });
+
+  // Annotations store their values in entity meta. A Ref-valued annotation must persist its
+  // unsaved target just like a Ref assigned to an ordinary property does, otherwise the stored
+  // DXN dangles and resolution throws EntityNotFoundError (see CollectionModel root collection).
+  describe('annotation references', () => {
+    const RootCollection = Schema.Struct({
+      name: Schema.optional(Schema.String),
+    }).pipe(Type.makeObject(DXN.make('com.example.type.rootCollection', '0.1.0')));
+
+    const RootRefAnnotation = Annotation.make({
+      id: 'com.example.annotation.rootRef',
+      schema: Ref.Ref(RootCollection),
+    });
+
+    test('Annotation.set persists an unsaved Ref target into the host database', async () => {
+      const { db, graph } = await builder.createDatabase();
+      graph.registry.add([RootCollection, TestSchema.Example]);
+
+      const host = db.add(Obj.make(TestSchema.Example, { string: 'host' }));
+      Obj.update(host, (host) => {
+        Annotation.set(host, RootRefAnnotation, Ref.make(Obj.make(RootCollection, { name: 'root' })));
+      });
+
+      const ref = Annotation.get(host, RootRefAnnotation).pipe(Option.getOrThrow);
+      const target = await ref.load();
+      expect(target.name).to.eq('root');
+    });
+
+    test('Annotation.set leaves an already-persisted Ref target untouched', async () => {
+      const { db, graph } = await builder.createDatabase();
+      graph.registry.add([RootCollection, TestSchema.Example]);
+
+      const root = db.add(Obj.make(RootCollection, { name: 'root' }));
+      const host = db.add(Obj.make(TestSchema.Example, { string: 'host' }));
+      Obj.update(host, (host) => {
+        Annotation.set(host, RootRefAnnotation, Ref.make(root));
+      });
+
+      const ref = Annotation.get(host, RootRefAnnotation).pipe(Option.getOrThrow);
+      expect((await ref.load()).id).to.eq(root.id);
     });
   });
 

--- a/packages/core/echo/echo/src/internal/Annotation/entity-dictionary.ts
+++ b/packages/core/echo/echo/src/internal/Annotation/entity-dictionary.ts
@@ -4,11 +4,15 @@
 
 import * as Option from 'effect/Option';
 
+import { deepMapValues } from '@dxos/util';
+
 import type * as Annotation from '../../Annotation';
 import type * as Entity from '../../Entity';
 import { getMetaChecked } from '../common/api/meta';
 import { type Mutable } from '../common/proxy/reactive';
+import { getDatabase } from '../Entity/api';
 import { isEntity, isSnapshot } from '../Entity/guard';
+import { Ref, getRefSavedTarget } from '../Ref';
 import { getDictionary, setDictionary } from './dictionary';
 
 /**
@@ -33,8 +37,38 @@ export const get = <T>(
 export const set = <T>(target: Mutable<Entity.Unknown>, annotation: Annotation.Annotation<T>, value: T): void => {
   if (isEntity(target)) {
     const meta = getMetaChecked(target);
+    // Persist any unsaved Ref targets in the value into the entity's database so
+    // the encoded DXN resolves on read. This mirrors normal property assignment,
+    // where the reactive proxy links unsaved ref targets via `createRef` →
+    // `database.add`. `setDictionary` pre-encodes the value (`Schema.encodeSync`),
+    // so the live Ref never reaches the proxy's link handling and would otherwise
+    // be stored as a dangling reference.
+    persistRefTargets(target, value);
     setDictionary(meta.annotations, annotation, value);
   } else {
     throw new TypeError('Target is not an annotation target.');
   }
+};
+
+/**
+ * Add any unsaved Ref targets found in `value` to the host entity's database, matching the
+ * auto-persistence applied to refs assigned to ordinary entity properties. Refs whose target
+ * already lives in a database (the host's or a foreign one) are left untouched.
+ */
+const persistRefTargets = (host: Entity.Unknown, value: unknown): void => {
+  const database = getDatabase(host);
+  if (database == null) {
+    return;
+  }
+
+  deepMapValues(value, (current, recurse) => {
+    if (Ref.isRef(current)) {
+      const refTarget = getRefSavedTarget(current);
+      if (refTarget != null && isEntity(refTarget) && getDatabase(refTarget) == null) {
+        database.add(refTarget);
+      }
+      return current;
+    }
+    return recurse(current);
+  });
 };


### PR DESCRIPTION
## Summary

Fixes the composer-app e2e failures by repairing the root cause in ECHO: `Annotation.set` did not persist unsaved `Ref` targets.

`Annotation.set` encodes its value with `Schema.encodeSync` before writing it into entity meta, so a `Ref` to an **unsaved** object was stored as a dangling DXN. Normal property assignment doesn't have this problem — the reactive proxy links unsaved ref targets via `createRef` → `database.add`. On read, resolving the dangling ref threw `EntityNotFoundError`.

This surfaced after #11658 migrated space property record keys to typed annotations. The personal space's `RootCollectionAnnotation` (seeded in `identity-created.ts`) and new spaces' root collection (`create.ts`) held a `Ref` to a `Collection.make()` that was never added to the database. Later, `CollectionModel.add` → `Database.load(rootCollectionRef)` threw `EntityNotFoundError`, breaking **every** composer-app e2e test routed through the `addObject` operation.

This is the same regression family as the todomvc break fixed in #11691 (which addressed the `Obj.update` change-context half); this PR fixes the ref-persistence half at its source.

## Fix

`Annotation.set` now walks its value for live `Ref`s and adds any unsaved targets to the host entity's database before encoding — mirroring property-assignment behavior. Refs whose target already lives in a database (the host's or a foreign one) are left untouched.

## Verification

CI failure pattern (run 26989857402, main) matched exactly: tests through `addObject` failed; tests that don't (`create space`, `create document`, comments, collaboration) passed.

Local e2e against the production bundle, before vs after:

| Spec | Before | After |
| --- | --- | --- |
| `collections.spec.ts` (5 tests) | 5 ✘ | 5 ✓ |
| `basic.spec.ts › space is created by default` | ✘ | ✓ |
| `stack.spec.ts › create`, `create new document section` | ✘ | ✓ |

Added `echo-db` tests covering the unsaved and already-persisted ref cases. `echo` and `echo-db` unit suites pass.

## Notes

The boot-loader overlay change originally on this branch was dropped — it was not the cause of these failures (click-dependent tests like `create space` passed in CI).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where annotations containing unsaved references were not being properly persisted to the database. References are now automatically saved when setting annotations, ensuring consistent data persistence.

* **Tests**
  * Added test suite for annotation reference behavior, verifying that unsaved reference targets are persisted and already-persisted references remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->