### PR TITLE
chore(markdown): publish @dxos/markdown to npm

### DIFF
--- a/packages/common/markdown/package.json
+++ b/packages/common/markdown/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/markdown",
   "version": "0.8.3",
-  "private": true,
   "description": "HTML to Markdown conversion and text normalization utilities",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",


### PR DESCRIPTION
Removes `"private": true` from `@dxos/markdown`'s `package.json` so it can be published to npm. The `publishConfig.access: "public"` was already in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Markdown package updated to enable public distribution and publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->