### PR TITLE
fix(functions): rename FunctionWrappingOptions.types to entities (Entity.Unknown[])

### DIFF
--- a/packages/core/compute/functions/src/protocol/protocol.ts
+++ b/packages/core/compute/functions/src/protocol/protocol.ts
@@ -20,7 +20,7 @@ import {
   Trace,
 } from '@dxos/compute';
 import { LifecycleState, Resource } from '@dxos/context';
-import { Database, Feed, JsonSchema, Ref, Registry, type Type } from '@dxos/echo';
+import { Database, Entity, Feed, JsonSchema, Ref, Registry } from '@dxos/echo';
 import {
   createFeedServiceLayer,
   EchoClient,
@@ -41,9 +41,13 @@ import { FunctionsAiHttpClient } from './functions-ai-http-client';
 
 export interface FunctionWrappingOptions {
   /**
-   * Additional types to register with the database.
+   * Additional entities to seed into the `Registry.Service` for the invocation.
+   * Accepts any ECHO entity — type schemas (`Type.AnyEntity`) as well as runtime
+   * object instances (e.g. blueprint instances from `Blueprint.make()`).
+   * When a space DB is present the entities are added to `db.graph.registry`;
+   * when there is no DB they are used to initialise a standalone in-memory registry.
    */
-  types?: Type.AnyEntity[];
+  entities?: Entity.Unknown[];
 
   /**
    * Toolkits to make available via the `OpaqueToolkitProvider`.
@@ -98,10 +102,19 @@ export const wrapFunctionHandler = (
 
         await using funcContext = await new FunctionContext(context, opts).open();
 
-        const types = [...(opts.types ?? []), ...(func.types ?? [])];
-        if (types.length > 0) {
+        // Schema types declared by the operation definition require a space DB for
+        // ECHO to decode objects of those types.
+        const schemaTypes = func.types ?? [];
+        if (schemaTypes.length > 0) {
           invariant(funcContext.db, 'Database is required for functions with types');
-          funcContext.db.graph.registry.add(types);
+          funcContext.db.graph.registry.add(schemaTypes);
+        }
+
+        // Caller-supplied entities (e.g. blueprint instances) are added to the DB
+        // registry when available; the no-DB path is handled in createLayer() via
+        // makeRegistry({ initial: opts.entities }).
+        if (funcContext.db && opts.entities?.length) {
+          funcContext.db.graph.registry.add(opts.entities);
         }
 
         const dataWithDecodedRefs =
@@ -230,12 +243,16 @@ class FunctionContext extends Resource {
       spaceId: this.context.spaceId,
       spaceRootUrl: this.context.spaceRootUrl,
       toolkits: this.opts.toolkits?.length ?? 0,
-      types: this.opts.types?.length ?? 0,
+      entities: this.opts.entities?.length ?? 0,
     });
 
+    // When a DB is open, opts.entities were already added to db.graph.registry before
+    // createLayer() was called (see wrapFunctionHandler). For the no-DB case seed a
+    // standalone in-memory registry with the caller-supplied entities so that e.g.
+    // blueprint instances are still resolvable via Blueprint.resolve().
     const registryLayer = this.db
       ? Layer.succeed(Registry.Service, this.db.graph.registry)
-      : Layer.succeed(Registry.Service, makeRegistry());
+      : Layer.succeed(Registry.Service, makeRegistry({ initial: this.opts.entities ?? [] }));
 
     return Layer.mergeAll(
       dbLayer,


### PR DESCRIPTION
## Summary

- Renames `FunctionWrappingOptions.types?: Type.AnyEntity[]` → `entities?: Entity.Unknown[]`
- `Type.AnyEntity` was too narrow — it only covers ECHO schema type definitions, which prevented passing blueprint instances (and other runtime ECHO objects) without a cast
- `Entity.Unknown[]` is the correct type: it covers the full entity universe (schema types + runtime objects)
- `func.types` (from `Operation.Definition`) still requires a DB — those are schema types that need ECHO to decode objects, unchanged
- Caller-supplied entities work without a DB too: the no-DB path uses `makeRegistry({ initial: opts.entities })` so e.g. blueprints are resolvable via `Blueprint.resolve()` even without a space context

## Test plan

- [ ] `packages/core/compute/functions` type-checks
- [ ] Existing `wrapFunctionHandler` tests still pass
- [ ] Edge `compute-intrinsics` can drop its `as Entity.Unknown[] as Type.AnyEntity[]` cast once this lands on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated function wrapping options API: replaced `types` parameter with `entities` for specifying function schema requirements
  * Improved registry initialization for both database-backed and in-memory configurations to support entity registration
  * Updated logging to track entity count instead of type count

<!-- end of auto-generated comment: release notes by coderabbit.ai -->