### PR TITLE
fix(welcome): restore UI polish lost in the OAuth-recovery main merge

### DIFF
--- a/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
@@ -9,6 +9,7 @@ import React, { type KeyboardEvent, type ReactNode, useCallback, useRef, useStat
 import { supportsNativePasskeys } from '@dxos/app-toolkit';
 import { DXOSHorizontalType } from '@dxos/brand';
 import { Button, DropdownMenu, Icon, Input, useTranslation } from '@dxos/react-ui';
+import { Tabs } from '@dxos/react-ui-tabs';
 import { mx } from '@dxos/ui-theme';
 
 import { meta } from '../../meta';
@@ -230,148 +231,152 @@ export const Welcome = ({
         </h1>
 
         {state === WelcomeState.INIT && (
-          <div className='flex flex-col gap-6'>
-            {/* Tabs */}
-            <div className='flex gap-1 border-b border-neutral-700'>
-              <TabButton active={tab === 'login'} onClick={() => setTab('login')}>
-                {t('login-tab.label')}
-              </TabButton>
-              <TabButton
-                active={tab === 'signup'}
-                onClick={() => {
-                  setTab('signup');
-                  setSignupStep('collect');
-                  setSignupMode('code');
-                }}
-              >
-                {t('signup-tab.label')}
-              </TabButton>
-            </div>
+          <Tabs.Root
+            orientation='horizontal'
+            defaultActivePart='list'
+            value={tab}
+            onValueChange={(value) => {
+              const next = value as Tab;
+              setTab(next);
+              if (next === 'signup') {
+                setSignupStep('collect');
+                setSignupMode('code');
+              }
+            }}
+          >
+            <Tabs.Viewport classNames='flex flex-col gap-6'>
+              <Tabs.Tablist classNames='border-b border-neutral-700'>
+                <Tabs.Tab value='login'>{t('login-tab.label')}</Tabs.Tab>
+                <Tabs.Tab value='signup'>{t('signup-tab.label')}</Tabs.Tab>
+              </Tabs.Tablist>
 
-            {tab === 'login' && (
-              <LoginTab
-                t={t}
-                identity={identity}
-                primary={loginPrimary}
-                setPrimary={setLoginPrimary}
-                emailValue={email}
-                setEmailValue={setEmail}
-                emailRef={emailRef}
-                emailError={error}
-                pending={pending}
-                onPasskey={onPasskey}
-                onSendSignInLink={handleSendSignInLink}
-                onEmailKeyDown={handleEmailKeyDown}
-                onJoinIdentity={onJoinIdentity}
-                onRecoverIdentity={onRecoverIdentity}
-                onRecoverWithOAuth={onRecoverWithOAuth ? handleRecoverWithOAuth : undefined}
-              />
-            )}
-
-            {tab === 'signup' && signupStep === 'collect' && signupMode === 'code' && (
-              <div className='flex flex-col gap-6'>
-                <div className='flex flex-col gap-2'>
-                  <h2 className='text-2xl'>{t('signup-code.title')}</h2>
-                  <p className='text-description'>{t('signup-code.description')}</p>
-                </div>
-                <InlineForm
-                  inputProps={{
-                    autoFocus: true,
-                    ref: codeRef,
-                    classNames: 'font-mono uppercase tracking-widest',
-                    placeholder: 'XXXX-XXXX',
-                    value: code,
-                    onChange: (ev) => setCode(ev.target.value.trim()),
-                    onKeyDown: handleCodeKeyDown,
-                  }}
-                  submitLabel={t('continue-button.label')}
-                  submitDisabled={!validInvitationCode(code) || pending}
-                  onSubmit={handleValidateCode}
-                  validation={codeError}
+              <Tabs.Panel value='login'>
+                <LoginTab
+                  t={t}
+                  identity={identity}
+                  primary={loginPrimary}
+                  setPrimary={setLoginPrimary}
+                  emailValue={email}
+                  setEmailValue={setEmail}
+                  emailRef={emailRef}
+                  emailError={error}
+                  pending={pending}
+                  onPasskey={onPasskey}
+                  onSendSignInLink={handleSendSignInLink}
+                  onEmailKeyDown={handleEmailKeyDown}
+                  onJoinIdentity={onJoinIdentity}
+                  onRecoverIdentity={onRecoverIdentity}
+                  onRecoverWithOAuth={onRecoverWithOAuth ? handleRecoverWithOAuth : undefined}
                 />
-                <SwapLink onClick={() => setSignupMode('waitlist')}>{t('no-invitation-code-link.label')}</SwapLink>
-              </div>
-            )}
+              </Tabs.Panel>
 
-            {tab === 'signup' && signupStep === 'collect' && signupMode === 'waitlist' && (
-              <div className='flex flex-col gap-6'>
-                <div className='flex flex-col gap-2'>
-                  <h2 className='text-2xl'>{t('waitlist.title')}</h2>
-                  <p className='text-description'>{t('waitlist.description')}</p>
-                </div>
-                <InlineForm
-                  inputProps={{
-                    autoFocus: true,
-                    placeholder: t('email-input.placeholder'),
-                    value: waitlistEmail,
-                    onChange: (ev) => setWaitlistEmail(ev.target.value.trim()),
-                    onKeyDown: handleWaitlistEmailKeyDown,
-                  }}
-                  submitLabel={t('waitlist-submit-button.label')}
-                  submitDisabled={!validEmail(waitlistEmail) || pending}
-                  onSubmit={handleJoinWaitlist}
-                />
-                <SwapLink onClick={() => setSignupMode('code')}>{t('have-invitation-code-link.label')}</SwapLink>
-              </div>
-            )}
-
-            {tab === 'signup' && signupStep === 'auth' && (
-              <div className='flex flex-col gap-6'>
-                <div className='flex flex-col gap-2'>
-                  <h2 className='text-2xl'>{t('signup-auth.title')}</h2>
-                  <p className='text-description'>{t('signup-auth.description')}</p>
-                </div>
-                <InlineForm
-                  inputProps={{
-                    autoFocus: true,
-                    ref: emailRef,
-                    placeholder: t('email-input.placeholder'),
-                    value: email,
-                    onChange: (ev) => setEmail(ev.target.value.trim()),
-                    onKeyDown: handleAuthEmailKeyDown,
-                  }}
-                  submitLabel={t('continue-button.label')}
-                  submitDisabled={!validEmail(email) || pending}
-                  onSubmit={handleCreateAccount}
-                  validation={error ? t('email-error.message') : null}
-                />
-                {onCreateAccountWithOAuth && (
-                  <>
-                    <OrDivider>{t('or-divider.label')}</OrDivider>
+              <Tabs.Panel value='signup'>
+                {signupStep === 'collect' && signupMode === 'code' && (
+                  <div className='flex flex-col gap-6'>
                     <div className='flex flex-col gap-2'>
-                      <p className='text-description'>{t('atmosphere-account-button.label')}</p>
-                      <InlineForm
-                        inputProps={{
-                          placeholder: t('atmosphere-handle-input.placeholder'),
-                          value: atmosphereHandle,
-                          onChange: (ev) => setAtmosphereHandle(ev.target.value.trim()),
-                          onKeyDown: (ev) => {
-                            if (ev.key === 'Enter' && atmosphereHandle && !pending) {
-                              void handleCreateAccountWithOAuth({
+                      <h2 className='text-2xl'>{t('signup-code.title')}</h2>
+                      <p className='text-description'>{t('signup-code.description')}</p>
+                    </div>
+                    <InlineForm
+                      inputProps={{
+                        autoFocus: true,
+                        ref: codeRef,
+                        classNames: 'font-mono uppercase tracking-widest',
+                        placeholder: 'XXXX-XXXX',
+                        value: code,
+                        onChange: (ev) => setCode(ev.target.value.trim()),
+                        onKeyDown: handleCodeKeyDown,
+                      }}
+                      submitLabel={t('continue-button.label')}
+                      submitDisabled={!validInvitationCode(code) || pending}
+                      onSubmit={handleValidateCode}
+                      validation={codeError}
+                    />
+                    <SwapLink onClick={() => setSignupMode('waitlist')}>{t('no-invitation-code-link.label')}</SwapLink>
+                  </div>
+                )}
+
+                {signupStep === 'collect' && signupMode === 'waitlist' && (
+                  <div className='flex flex-col gap-6'>
+                    <div className='flex flex-col gap-2'>
+                      <h2 className='text-2xl'>{t('waitlist.title')}</h2>
+                      <p className='text-description'>{t('waitlist.description')}</p>
+                    </div>
+                    <InlineForm
+                      inputProps={{
+                        autoFocus: true,
+                        placeholder: t('email-input.placeholder'),
+                        value: waitlistEmail,
+                        onChange: (ev) => setWaitlistEmail(ev.target.value.trim()),
+                        onKeyDown: handleWaitlistEmailKeyDown,
+                      }}
+                      submitLabel={t('waitlist-submit-button.label')}
+                      submitDisabled={!validEmail(waitlistEmail) || pending}
+                      onSubmit={handleJoinWaitlist}
+                    />
+                    <SwapLink onClick={() => setSignupMode('code')}>{t('have-invitation-code-link.label')}</SwapLink>
+                  </div>
+                )}
+
+                {signupStep === 'auth' && (
+                  <div className='flex flex-col gap-6'>
+                    <div className='flex flex-col gap-2'>
+                      <h2 className='text-2xl'>{t('signup-auth.title')}</h2>
+                      <p className='text-description'>{t('signup-auth.description')}</p>
+                    </div>
+                    <InlineForm
+                      inputProps={{
+                        autoFocus: true,
+                        ref: emailRef,
+                        placeholder: t('email-input.placeholder'),
+                        value: email,
+                        onChange: (ev) => setEmail(ev.target.value.trim()),
+                        onKeyDown: handleAuthEmailKeyDown,
+                      }}
+                      submitLabel={t('continue-button.label')}
+                      submitDisabled={!validEmail(email) || pending}
+                      onSubmit={handleCreateAccount}
+                      validation={error ? t('email-error.message') : null}
+                    />
+                    {onCreateAccountWithOAuth && (
+                      <>
+                        <OrDivider>{t('or-divider.label')}</OrDivider>
+                        <div className='flex flex-col gap-2'>
+                          <p className='text-description'>{t('atmosphere-account-button.label')}</p>
+                          <InlineForm
+                            inputProps={{
+                              placeholder: t('atmosphere-handle-input.placeholder'),
+                              value: atmosphereHandle,
+                              onChange: (ev) => setAtmosphereHandle(ev.target.value.trim()),
+                              onKeyDown: (ev) => {
+                                if (ev.key === 'Enter' && atmosphereHandle && !pending) {
+                                  void handleCreateAccountWithOAuth({
+                                    code,
+                                    provider: ATMOSPHERE_PROVIDER,
+                                    loginHint: atmosphereHandle,
+                                  });
+                                }
+                              },
+                            }}
+                            submitLabel={t('continue-button.label')}
+                            submitDisabled={!atmosphereHandle || pending}
+                            onSubmit={() =>
+                              handleCreateAccountWithOAuth({
                                 code,
                                 provider: ATMOSPHERE_PROVIDER,
                                 loginHint: atmosphereHandle,
-                              });
+                              })
                             }
-                          },
-                        }}
-                        submitLabel={t('continue-button.label')}
-                        submitDisabled={!atmosphereHandle || pending}
-                        onSubmit={() =>
-                          handleCreateAccountWithOAuth({
-                            code,
-                            provider: ATMOSPHERE_PROVIDER,
-                            loginHint: atmosphereHandle,
-                          })
-                        }
-                      />
-                    </div>
-                  </>
+                          />
+                        </div>
+                      </>
+                    )}
+                    <SwapLink onClick={() => setSignupStep('collect')}>{t('use-different-code-link.label')}</SwapLink>
+                  </div>
                 )}
-                <SwapLink onClick={() => setSignupStep('collect')}>{t('use-different-code-link.label')}</SwapLink>
-              </div>
-            )}
-          </div>
+              </Tabs.Panel>
+            </Tabs.Viewport>
+          </Tabs.Root>
         )}
 
         {state === WelcomeState.SPACE_INVITATION && (
@@ -431,19 +436,6 @@ export const Welcome = ({
 //
 // Sub-components
 //
-
-const TabButton = ({ active, onClick, children }: { active: boolean; onClick: () => void; children: ReactNode }) => (
-  <button
-    type='button'
-    onClick={onClick}
-    className={mx(
-      'flex-1 px-4 py-2 text-sm border-b-2 -mb-px transition-colors',
-      active ? 'border-white text-white' : 'border-transparent text-description hover:text-white',
-    )}
-  >
-    {children}
-  </button>
-);
 
 /**
  * Small "swap" link used at the bottom of forms to switch between alternative

--- a/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
@@ -580,20 +580,23 @@ const LoginTab = ({
         </Button>
       )}
       {primary === 'email' && (
-        <InlineForm
-          inputProps={{
-            autoFocus: true,
-            ref: emailRef,
-            placeholder: t('email-input.placeholder'),
-            value: emailValue,
-            onChange: (ev) => setEmailValue(ev.target.value.trim()),
-            onKeyDown: onEmailKeyDown,
-          }}
-          submitLabel={t('send-link-button.label')}
-          submitDisabled={!validEmail(emailValue) || pending}
-          onSubmit={onSendSignInLink}
-          validation={emailError ? t('email-error.message') : null}
-        />
+        <div className='flex flex-col gap-2'>
+          <p className='text-sm text-description'>{t('login-email.description')}</p>
+          <InlineForm
+            inputProps={{
+              autoFocus: true,
+              ref: emailRef,
+              placeholder: t('email-input.placeholder'),
+              value: emailValue,
+              onChange: (ev) => setEmailValue(ev.target.value.trim()),
+              onKeyDown: onEmailKeyDown,
+            }}
+            submitLabel={t('send-link-button.label')}
+            submitDisabled={!validEmail(emailValue) || pending}
+            onSubmit={onSendSignInLink}
+            validation={emailError ? t('email-error.message') : null}
+          />
+        </div>
       )}
       {primary === 'atproto' && onRecoverWithOAuth && (
         <div className='flex flex-col gap-2'>

--- a/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
@@ -24,6 +24,13 @@ const ATMOSPHERE_PROVIDER = 'atproto';
 export const OVERLAY_CLASSES = 'dark bg-neutral-950! bg-no-repeat bg-center';
 export const OVERLAY_STYLE = { backgroundImage: `url(${hero})` };
 
+// Underline tab style (overrides the react-ui Tabs.Tab button chrome) to match the prior look:
+// flat, full-width tabs with a bottom border that highlights the active one.
+const TAB_CLASSNAMES =
+  'flex-1 rounded-none shadow-none bg-transparent hover:bg-transparent px-4 py-2 text-sm font-normal -mb-px ' +
+  'border-b-2 border-transparent text-description transition-colors hover:text-white ' +
+  'data-[state=active]:border-white data-[state=active]:text-white';
+
 type Tab = 'login' | 'signup';
 type LoginMethod = 'passkey' | 'email' | 'atproto';
 type SignupMode = 'code' | 'waitlist';
@@ -219,7 +226,7 @@ export const Welcome = ({
       className={mx(
         'dark',
         'relative grid grid-cols-1 md:w-[40rem] max-w-[40rem] h-full md:h-[675px] overflow-hidden',
-        'rounded-xl shadow-md lg:translate-x-[-40%]',
+        'border-2 border-sky-950 rounded-xl lg:translate-x-[-40%]',
       )}
       style={{
         backgroundImage: 'radial-gradient(circle farthest-corner at 50% 50%, #2d6fff80, var(--color-neutral-950))',
@@ -232,6 +239,7 @@ export const Welcome = ({
 
         {state === WelcomeState.INIT && (
           <Tabs.Root
+            classNames='shrink-0'
             orientation='horizontal'
             defaultActivePart='list'
             value={tab}
@@ -245,9 +253,13 @@ export const Welcome = ({
             }}
           >
             <Tabs.Viewport classNames='flex flex-col gap-6'>
-              <Tabs.Tablist classNames='border-b border-neutral-700'>
-                <Tabs.Tab value='login'>{t('login-tab.label')}</Tabs.Tab>
-                <Tabs.Tab value='signup'>{t('signup-tab.label')}</Tabs.Tab>
+              <Tabs.Tablist classNames='p-0 gap-1 border-b border-neutral-700'>
+                <Tabs.Tab value='login' classNames={TAB_CLASSNAMES}>
+                  {t('login-tab.label')}
+                </Tabs.Tab>
+                <Tabs.Tab value='signup' classNames={TAB_CLASSNAMES}>
+                  {t('signup-tab.label')}
+                </Tabs.Tab>
               </Tabs.Tablist>
 
               <Tabs.Panel value='login'>
@@ -420,7 +432,7 @@ export const Welcome = ({
           </div>
         )}
 
-        <div className='z-[11] flex flex-col h-full justify-end'>
+        <div className='z-[11] mt-auto flex flex-col'>
           <a href='https://dxos.org' target='_blank' rel='noreferrer'>
             <div className='flex justify-center items-center text-sm gap-1 pr-3 pb-1 opacity-70'>
               <span className='text-description'>Powered by</span>

--- a/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
@@ -8,7 +8,7 @@ import React, { type KeyboardEvent, type ReactNode, useCallback, useRef, useStat
 
 import { supportsNativePasskeys } from '@dxos/app-toolkit';
 import { DXOSHorizontalType } from '@dxos/brand';
-import { Button, Icon, Input, useTranslation } from '@dxos/react-ui';
+import { Button, DropdownMenu, Icon, Input, useTranslation } from '@dxos/react-ui';
 import { mx } from '@dxos/ui-theme';
 
 import { meta } from '../../meta';
@@ -52,7 +52,6 @@ export const Welcome = ({
   // Tab + sub-state. Live in component state since they're transient UI.
   const [tab, setTab] = useState<Tab>('login');
   const [loginPrimary, setLoginPrimary] = useState<LoginMethod>(defaultLoginPrimary);
-  const [moreOpen, setMoreOpen] = useState(false);
   const [signupMode, setSignupMode] = useState<SignupMode>('code');
   const [signupStep, setSignupStep] = useState<SignupStep>('collect');
 
@@ -254,12 +253,7 @@ export const Welcome = ({
                 t={t}
                 identity={identity}
                 primary={loginPrimary}
-                setPrimary={(method) => {
-                  setLoginPrimary(method);
-                  setMoreOpen(false);
-                }}
-                moreOpen={moreOpen}
-                setMoreOpen={setMoreOpen}
+                setPrimary={setLoginPrimary}
                 emailValue={email}
                 setEmailValue={setEmail}
                 emailRef={emailRef}
@@ -471,8 +465,6 @@ type LoginTabProps = {
   identity?: ReturnType<typeof Object> | null;
   primary: LoginMethod;
   setPrimary: (method: LoginMethod) => void;
-  moreOpen: boolean;
-  setMoreOpen: (open: boolean) => void;
   emailValue: string;
   setEmailValue: (value: string) => void;
   emailRef: React.Ref<HTMLInputElement>;
@@ -499,8 +491,6 @@ const LoginTab = ({
   identity,
   primary,
   setPrimary,
-  moreOpen,
-  setMoreOpen,
   emailValue,
   setEmailValue,
   emailRef,
@@ -628,36 +618,32 @@ const LoginTab = ({
       )}
 
       {moreOptions.length > 0 && (
-        <div className='flex flex-col gap-2'>
-          <button
-            type='button'
-            onClick={() => setMoreOpen(!moreOpen)}
-            className='flex items-center justify-center gap-1 text-sm text-description hover:text-white underline underline-offset-4'
-          >
-            <span>{t('more-ways-to-sign-in.label')}</span>
-            <Icon icon={moreOpen ? 'ph--caret-up--regular' : 'ph--caret-down--regular'} size={4} />
-          </button>
-
-          {moreOpen && (
-            <div className='flex flex-col gap-1'>
-              {moreOptions.map((opt) => (
-                <button
-                  key={opt.key}
-                  type='button'
-                  onClick={opt.onClick}
-                  className='flex items-center gap-3 px-3 py-2 rounded-md border border-neutral-700 hover:border-neutral-500 hover:bg-neutral-800/50 text-left'
-                >
-                  <Icon icon={opt.icon} size={5} />
-                  <div className='flex-1 flex flex-col'>
-                    <span className='text-sm'>{opt.label}</span>
-                    <span className='text-xs text-description'>{opt.description}</span>
-                  </div>
-                  <Icon icon='ph--caret-right--regular' size={4} />
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger asChild>
+            <button
+              type='button'
+              className='flex items-center justify-center gap-1 text-sm text-description hover:text-white underline underline-offset-4'
+            >
+              <span>{t('more-ways-to-sign-in.label')}</span>
+              <Icon icon='ph--caret-down--regular' size={4} />
+            </button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content side='bottom' sideOffset={8} collisionPadding={16} classNames='!w-80'>
+              <DropdownMenu.Viewport>
+                {moreOptions.map((opt) => (
+                  <DropdownMenu.Item key={opt.key} onSelect={opt.onClick} classNames='gap-3'>
+                    <Icon icon={opt.icon} size={4} classNames='shrink-0' />
+                    <div className='flex flex-col gap-0.5'>
+                      <span>{opt.label}</span>
+                      <span className='text-xs text-description font-normal'>{opt.description}</span>
+                    </div>
+                  </DropdownMenu.Item>
+                ))}
+              </DropdownMenu.Viewport>
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
       )}
     </div>
   );

--- a/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
@@ -225,7 +225,7 @@ export const Welcome = ({
     <div
       className={mx(
         'dark',
-        'relative grid grid-cols-1 md:w-[40rem] max-w-[40rem] h-full md:h-[675px] overflow-hidden',
+        'relative grid grid-cols-1 md:w-[37rem] max-w-[37rem] h-full md:h-[675px] overflow-hidden',
         'border-2 border-sky-950 rounded-xl lg:translate-x-[-40%]',
       )}
       style={{


### PR DESCRIPTION
## Summary

The OAuth account-recovery client work (#11486) was merged into `main` by reconciling conflicts in favor of `main`'s landed versions, which **silently dropped several pieces of welcome-screen UI polish** that existed on the feature branch (and, in one case, on `main` itself a few days prior). This PR restores them. No behavior changes — UI only.

Each commit fixes one thing lost to a bad merge resolution:

- **Restore react-ui `DropdownMenu` for login "more ways to log in"** — the merge reverted this to an inline toggle list.
- **Description above the login email input** — the merge took `main`'s bare email form, dropping the description shown above it (it's present on the Atmosphere primary form).
- **Use `@dxos/react-ui-tabs` for the login/signup tabs** — replaces the custom `TabButton` bar with the real `Tabs` component (`Tabs.Root` → `Tabs.Viewport` → `Tablist` + `Panel`s), styled to match the prior underline tabs.
- **Restore the blue modal border** — `border-2 border-sky-950` was on the welcome modal on `main` as of 2026‑05‑24 (`db95429723`) and was dropped by the account-gating rewrite (#11149); restored.

## Test plan

- Storybook `apps/composer-app/Welcome → Default`: tabs render and switch; "more ways" opens a DropdownMenu; email tab shows its description; modal has the blue edge.
- `moon run composer-app:lint` + oxfmt + `tsc --build` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the login/signup tab interface for more consistent behavior and simplified controls.
  * Replaced the previous "More ways to sign in" control with a streamlined dropdown interaction.

* **Style**
  * Harmonized tab appearance and spacing for consistent visual alignment.
  * Adjusted outer panel and footer layout for improved presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->