### PR TITLE
fix(welcome): always render the welcome screen in dark mode

### DIFF
--- a/packages/apps/composer-app/src/plugins/welcome/components/WelcomeScreen.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/components/WelcomeScreen.tsx
@@ -14,11 +14,13 @@ import { SpaceOperation } from '@dxos/plugin-space';
 import { useClient } from '@dxos/react-client';
 import { useIdentity } from '@dxos/react-client/halo';
 import { type InvitationResult } from '@dxos/react-client/invitations';
+import { ThemeProvider, defaultTx } from '@dxos/react-ui';
 
 import { removeQueryParamByValue } from '../../../util';
 import { joinWaitlist, login, redeemAccountInvitation, validateInvitationCode } from '../credentials';
 import { meta } from '../meta';
 import { WelcomeOperation } from '../operations';
+import { translations } from '../translations';
 import { Welcome, WelcomeState } from './Welcome';
 
 export const WELCOME_SCREEN = `${meta.id}.component.welcome-screen`;
@@ -289,22 +291,26 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
     [hubUrl, identity],
   );
 
+  // The welcome surface has a fixed dark gradient backdrop, so force dark mode regardless of the
+  // app/system theme (DXOS resolves theme via ThemeProvider's themeMode, not a `.dark` class).
   return (
-    <Welcome
-      state={state}
-      error={error}
-      identity={identity}
-      onEmailLogin={handleLogin}
-      onPasskey={!identity ? handlePasskey : undefined}
-      onJoinIdentity={!identity ? handleJoinIdentity : undefined}
-      onRecoverIdentity={!identity ? handleRecoverIdentity : undefined}
-      onRecoverWithOAuth={!identity ? handleRecoverWithOAuth : undefined}
-      onValidateInvitationCode={!identity ? handleValidateInvitationCode : undefined}
-      onCreateAccount={!identity ? handleCreateAccount : undefined}
-      onCreateAccountWithOAuth={!identity ? handleCreateAccountWithOAuth : undefined}
-      onJoinWaitlist={handleJoinWaitlist}
-      onSpaceInvitation={spaceInvitationCode ? handleSpaceInvitation : undefined}
-      onGoToLogin={handleGoToLogin}
-    />
+    <ThemeProvider tx={defaultTx} themeMode='dark' resourceExtensions={translations}>
+      <Welcome
+        state={state}
+        error={error}
+        identity={identity}
+        onEmailLogin={handleLogin}
+        onPasskey={!identity ? handlePasskey : undefined}
+        onJoinIdentity={!identity ? handleJoinIdentity : undefined}
+        onRecoverIdentity={!identity ? handleRecoverIdentity : undefined}
+        onRecoverWithOAuth={!identity ? handleRecoverWithOAuth : undefined}
+        onValidateInvitationCode={!identity ? handleValidateInvitationCode : undefined}
+        onCreateAccount={!identity ? handleCreateAccount : undefined}
+        onCreateAccountWithOAuth={!identity ? handleCreateAccountWithOAuth : undefined}
+        onJoinWaitlist={handleJoinWaitlist}
+        onSpaceInvitation={spaceInvitationCode ? handleSpaceInvitation : undefined}
+        onGoToLogin={handleGoToLogin}
+      />
+    </ThemeProvider>
   );
 };

--- a/packages/apps/composer-app/src/plugins/welcome/components/WelcomeScreen.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/components/WelcomeScreen.tsx
@@ -291,8 +291,6 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
     [hubUrl, identity],
   );
 
-  // The welcome surface has a fixed dark gradient backdrop, so force dark mode regardless of the
-  // app/system theme (DXOS resolves theme via ThemeProvider's themeMode, not a `.dark` class).
   return (
     <ThemeProvider tx={defaultTx} themeMode='dark' resourceExtensions={translations}>
       <Welcome


### PR DESCRIPTION
## Summary

The welcome screen has a fixed dark gradient backdrop, but it was rendering in **light mode** when the app/system theme is light — dark text on the dark backdrop.

Root cause: DXOS resolves theme through `ThemeProvider`'s `themeMode` (consumed by `tx()`), **not** a `.dark` CSS class. The existing `dark` class on the welcome surface was a no-op, so the screen just followed the app's root theme.

Fix: wrap the welcome surface in a `ThemeProvider` pinned to `themeMode='dark'` (`tx={defaultTx}` + the welcome translations), matching the `composer-crx` container pattern. Done in `WelcomeScreen.tsx` so it applies wherever the surface mounts.

## Notes
- The Storybook `Welcome` story already renders dark (its `withTheme` decorator defaults to `themeMode='dark'`); this was an app-only regression.
- The stale no-op `dark` class on the inner Welcome `<div>` is left as-is (harmless); can be cleaned up separately.

## Test plan
- App: open the welcome dialog with the app/system theme set to light — it now renders dark.
- `tsc --build`, oxfmt, and `composer-app:lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated Welcome screen to use a refined dark theme for a more polished visual experience and backdrop.
* **Localization**
  * Enabled additional translation resources on the Welcome screen for improved language support and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->