### PR TITLE
fix(welcome): render "more ways to log in" menu above the dialog

### DIFF
--- a/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
@@ -642,7 +642,9 @@ const LoginTab = ({
             </button>
           </DropdownMenu.Trigger>
           <DropdownMenu.Portal>
-            <DropdownMenu.Content side='bottom' sideOffset={8} collisionPadding={16} classNames='!w-80'>
+            {/* Raise above the dialog overlay (z-40): radix copies the content's computed z-index
+                onto the popper wrapper, and the default menu z-20 renders behind the overlay. */}
+            <DropdownMenu.Content side='bottom' sideOffset={8} collisionPadding={16} classNames='!w-80 !z-50'>
               <DropdownMenu.Viewport>
                 {moreOptions.map((opt) => (
                   <DropdownMenu.Item key={opt.key} onSelect={opt.onClick} classNames='gap-3'>


### PR DESCRIPTION
## Summary

The "More ways to log in" dropdown on the welcome screen appeared not to open. It was actually opening every time — but rendering **behind** the welcome dialog, so it was invisible and unclickable.

## Root cause

The welcome screen draws its content directly inside the dialog overlay (`z-40`) with no intermediate `Dialog.Content` layer. Radix copies the **menu content's** computed z-index onto the popper wrapper (the positioned element), and the theme's default menu z-index is `z-20` — below the overlay. So the open menu stacked under the dialog.

Verified live on the deployed app: the menu mounts with 4 items, correctly positioned and visible, but `elementFromPoint` at its center returned the welcome content div (inside the `z-40` overlay), not the menu. Raising the wrapper above `z-40` made the menu items the topmost element at their own coordinates.

## Fix

Raise the welcome `DropdownMenu.Content` to `!z-50` (one line + comment), so its computed z-index — which radix propagates to the popper wrapper — beats the overlay. Scoped to the welcome dropdown; no theme or low-level component changes.

This is a pre-existing latent stacking conflict, not a regression from the recent dark-mode/focus work.

## Verification

- Reproduced and confirmed the fix via live DOM inspection on `main.composer.space`.
- `oxfmt`, `oxlint --fix`, and `composer-app:compile` (tsc) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dropdown menu layering in the sign-in options to ensure the menu displays correctly and doesn't render behind other interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->