### PR TITLE
feat(react-ui-form): collapsible nested object field sets

### DIFF
--- a/packages/ui/react-ui-form/src/components/Form/FormField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormField.tsx
@@ -7,7 +7,7 @@ import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 import * as SchemaAST from 'effect/SchemaAST';
 import * as String from 'effect/String';
-import React, { PropsWithChildren, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { Annotation, Format } from '@dxos/echo';
 import {
@@ -268,25 +268,24 @@ export const FormField = (props: FormFieldProps) => {
     if (typeLiteral) {
       const schema = Schema.make(typeLiteral);
       return (
-        <Nesting>
-          <FormFieldSet
-            schema={schema}
-            path={path}
-            readonly={readonly}
-            layout={layout}
-            label={label}
-            projection={projection}
-            fieldMap={fieldMap}
-            fieldProvider={fieldProvider}
-            createOptionLabel={createOptionLabel}
-            createOptionIcon={createOptionIcon}
-            createInitialValuePath={createInitialValuePath}
-            db={db}
-            useType={schemaHook}
-            getOptions={getOptions}
-            onCreate={onCreate}
-          />
-        </Nesting>
+        <FormFieldSet
+          schema={schema}
+          path={path}
+          readonly={readonly}
+          layout={layout}
+          label={label}
+          collapsible
+          projection={projection}
+          fieldMap={fieldMap}
+          fieldProvider={fieldProvider}
+          createOptionLabel={createOptionLabel}
+          createOptionIcon={createOptionIcon}
+          createInitialValuePath={createInitialValuePath}
+          db={db}
+          useType={schemaHook}
+          getOptions={getOptions}
+          onCreate={onCreate}
+        />
       );
     }
   }
@@ -299,14 +298,6 @@ FormField.displayName = 'Form.FormField';
 //
 // Layout components
 //
-
-// TODO(burdon): Options (nested or flat).
-// TODO(burdon): Support collapsible.
-export const Nesting = ({ children }: PropsWithChildren) => (
-  <div className='px-2 border border-subdued-separator rounded-sm mt-2'>
-    <div className='pb-2'>{children}</div>
-  </div>
-);
 
 export const IconBlock = ({ inline, ...props }: IconButtonProps & { inline?: boolean }) => {
   return (

--- a/packages/ui/react-ui-form/src/components/Form/FormFieldComponent.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormFieldComponent.tsx
@@ -15,7 +15,7 @@ import React, {
 } from 'react';
 
 import { type Database, Format } from '@dxos/echo';
-import { Icon, Input, Tooltip } from '@dxos/react-ui';
+import { Icon, Input, ThemedClassName, Tooltip } from '@dxos/react-ui';
 import { inputTextLabel } from '@dxos/react-ui';
 import { mx } from '@dxos/ui-theme';
 
@@ -78,26 +78,47 @@ export type FormFieldProvider = (props: {
 // FormFieldLabel
 //
 
-export type FormFieldLabelProps = {
-  asChild?: boolean;
-  error?: string;
-  /**
-   * JSON path of the field this label describes (e.g. `runtime.client.storage.persistent`).
-   * Surfaced as a hover tooltip on the label when the enclosing `Form.Root`
-   * has `tooltips` enabled (the default) -- useful for spotting which field
-   * maps to which path when authoring schemas or filing bugs against a form.
-   * Callers can supply the path unconditionally; the label suppresses the
-   * tooltip when `Form.Root tooltips={false}`.
-   */
-  path?: string;
-} & Pick<FormFieldComponentProps, 'label' | 'readonly'>;
+export type FormFieldLabelProps = ThemedClassName<
+  {
+    asChild?: boolean;
+    error?: string;
+    /**
+     * JSON path of the field this label describes (e.g. `runtime.client.storage.persistent`).
+     * Surfaced as a hover tooltip on the label when the enclosing `Form.Root`
+     * has `tooltips` enabled (the default) -- useful for spotting which field
+     * maps to which path when authoring schemas or filing bugs against a form.
+     * Callers can supply the path unconditionally; the label suppresses the
+     * tooltip when `Form.Root tooltips={false}`.
+     */
+    path?: string;
+    /**
+     * Trailing button rendered at the end of the label row (third grid column).
+     * Used by nested-object field sets to surface a collapse toggle.
+     */
+    button?: ReactNode;
+    onClick?: () => void;
+  } & Pick<FormFieldComponentProps, 'label' | 'readonly'>
+>;
 
-export const FormFieldLabel = ({ label, error, readonly, asChild, path }: FormFieldLabelProps) => {
+export const FormFieldLabel = ({
+  classNames,
+  label,
+  error,
+  readonly,
+  asChild,
+  path,
+  button,
+  onClick,
+}: FormFieldLabelProps) => {
   const tooltips = useFormTooltips();
   const Label = readonly || asChild ? 'span' : Input.Label;
   const labelNode = <Label className={mx(inputTextLabel, 'text-sm')}>{label}</Label>;
+
   return (
-    <div className='flex items-center justify-between'>
+    <div
+      className={mx('grid grid-cols-[1fr_auto_auto] items-center select-none', onClick && 'cursor-pointer', classNames)}
+      onClick={onClick}
+    >
       {tooltips && path ? (
         <Tooltip.Trigger asChild content={path} side='bottom'>
           {labelNode}
@@ -105,11 +126,14 @@ export const FormFieldLabel = ({ label, error, readonly, asChild, path }: FormFi
       ) : (
         labelNode
       )}
-      {error && (
+      {error ? (
         <Tooltip.Trigger asChild content={error} side='bottom'>
           <Icon icon='ph--warning--regular' size={4} classNames='text-error-text' />
         </Tooltip.Trigger>
+      ) : (
+        <span />
       )}
+      {button}
     </div>
   );
 };

--- a/packages/ui/react-ui-form/src/components/Form/FormFieldSet.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormFieldSet.tsx
@@ -3,10 +3,14 @@
 //
 
 import * as Option from 'effect/Option';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { type AnyProperties } from '@dxos/echo/internal';
 import { createJsonPath, type SchemaProperty } from '@dxos/effect';
+import { IconButton, useTranslation } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+import { translationKey } from '#translations';
 
 import { type FormHandlerProps } from '../../hooks';
 import { getFormProperties } from '../../util';
@@ -20,6 +24,11 @@ const FORM_FIELDSET_NAME = 'Form.FieldSet';
 export type FormFieldSetProps<T extends AnyProperties> = {
   label?: string;
   sort?: string[];
+  /**
+   * When set, renders a toggle button at the end of the label row that
+   * shows/hides the field set body. Used for nested objects.
+   */
+  collapsible?: boolean;
   exclude?: (props: SchemaProperty[]) => SchemaProperty[];
   /**
    * Picks a named layout out of `FormLayoutAnnotation` when present.
@@ -57,14 +66,18 @@ export const FormFieldSet = ({
   readonly,
   path,
   sort,
+  collapsible,
   exclude,
   projection,
   layout,
   layoutName = DEFAULT_LAYOUT_NAME,
   ...props
 }: FormFieldSetProps<any>) => {
+  const { t } = useTranslation(translationKey);
   const values = useFormValues(FORM_FIELDSET_NAME, path);
   const properties = useFormFieldSetProperties({ schema, values, exclude, sort, projection });
+  // TODO(burdon): Generalize collapse state (cf. useSelected in react-ui-attention, plugin-markdown cursor state).
+  const [collapsed, setCollapsed] = useState(false);
   if ((readonly || layout === 'static') && values == null) {
     return null;
   }
@@ -72,27 +85,19 @@ export const FormFieldSet = ({
   // If the schema carries a layout template, hand off to <Form.Layout/> which renders the DSL.
   // Linear rendering still runs when no annotation is present, so existing call sites are unchanged.
   const layouts = schema ? Option.getOrUndefined(FormLayoutAnnotation.get(schema)) : undefined;
-  if (layouts?.[layoutName] !== undefined && schema) {
-    return (
-      <>
-        {layout !== 'inline' && label && <FormFieldLabel label={label} path={createJsonPath(path ?? [])} asChild />}
-        <FormLayout
-          schema={schema}
-          name={layoutName}
-          path={path}
-          readonly={readonly}
-          layout={layout}
-          projection={projection}
-          {...props}
-        />
-      </>
-    );
-  }
-
-  return (
-    <>
-      {layout !== 'inline' && label && <FormFieldLabel label={label} path={createJsonPath(path ?? [])} asChild />}
-      {properties.map((property) => {
+  const body =
+    layouts?.[layoutName] !== undefined && schema ? (
+      <FormLayout
+        schema={schema}
+        name={layoutName}
+        path={path}
+        readonly={readonly}
+        layout={layout}
+        projection={projection}
+        {...props}
+      />
+    ) : (
+      properties.map((property) => {
         const name = property.name.toString();
         return (
           <FormFieldErrorBoundary key={name} path={[...(path ?? []), name]}>
@@ -107,9 +112,44 @@ export const FormFieldSet = ({
             />
           </FormFieldErrorBoundary>
         );
-      })}
+      })
+    );
+
+  const showBody = !(collapsible && collapsed);
+  const content = (
+    <>
+      {layout !== 'inline' && label && (
+        <FormFieldLabel
+          asChild
+          classNames='pl-2'
+          label={label}
+          path={createJsonPath(path ?? [])}
+          button={
+            collapsible && (
+              <IconButton
+                classNames='px-1 mr-0.5'
+                variant='ghost'
+                density='xs'
+                iconOnly
+                icon='ph--caret-right--regular'
+                iconClassNames={mx('transition-transform', !collapsed && 'rotate-90')}
+                label={t(collapsed ? 'expand-fields.label' : 'collapse-fields.label')}
+              />
+            )
+          }
+          onClick={() => setCollapsed((value) => !value)}
+        />
+      )}
+      {showBody && <div className='px-2 pb-2'>{body}</div>}
     </>
   );
+
+  // Nested field sets render inside an indented, bordered container with a collapse toggle.
+  if (collapsible) {
+    return <div className='border border-subdued-separator rounded-sm mt-2'>{content}</div>;
+  }
+
+  return content;
 };
 
 FormFieldSet.displayName = FORM_FIELDSET_NAME;

--- a/packages/ui/react-ui-form/src/components/Form/fields/InlineRefField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/InlineRefField.tsx
@@ -20,7 +20,6 @@ import { Button, Icon, Input, useTranslation } from '@dxos/react-ui';
 import { translationKey } from '#translations';
 
 import { Form, omitId } from '../Form';
-import { Nesting } from '../FormField';
 import { FormFieldLabel } from '../FormFieldComponent';
 import { type RefFieldProps } from './RefField';
 
@@ -135,12 +134,10 @@ const InlineForm = ({ reference, db, readonly, useType = defaultUseType }: Inlin
   }
 
   return (
-    <Nesting>
-      <Form.Root schema={formSchema} defaultValues={defaultValues as any} db={db} onValuesChanged={handleChange}>
-        <Form.Content>
-          <Form.FieldSet readonly={readonly} />
-        </Form.Content>
-      </Form.Root>
-    </Nesting>
+    <Form.Root db={db} schema={formSchema} defaultValues={defaultValues as any} onValuesChanged={handleChange}>
+      <Form.Content>
+        <Form.FieldSet collapsible readonly={readonly} />
+      </Form.Content>
+    </Form.Root>
   );
 };

--- a/packages/ui/react-ui-form/src/translations.ts
+++ b/packages/ui/react-ui-form/src/translations.ts
@@ -26,6 +26,8 @@ export const translations = [
         'boolean-input-false.value': 'No',
         'show-field.label': 'Show field',
         'hide-field.label': 'Hide field',
+        'expand-fields.label': 'Expand',
+        'collapse-fields.label': 'Collapse',
         'delete-field.label': 'Delete field',
         'create-option.label': 'Create',
         'add-tag.label': 'Add tag',


### PR DESCRIPTION
## Summary

Nested-object field sets in the form renderer can now be collapsed/expanded via a toggle on the label row.

## What changed

- **`FormFieldSet` gains a `collapsible` prop.** When set, the field set renders inside an indented, bordered container with a caret toggle at the end of the label row that shows/hides the body. The entire label row is clickable.
- **Single rotating caret icon.** The toggle uses one `ph--caret-right--regular` icon rotated 90° via a CSS transition — right when collapsed, down when expanded — instead of swapping two icons.
- **`Nesting` component removed.** Its bordered/indented container styling moved into `FormFieldSet`. Both nested surfaces now drive the box + toggle through `collapsible`:
  - schema nested structs (`FormField`)
  - inlined refs (`InlineRefField`)
- **Label factored into a common header.** Previously `FormFieldSet` repeated the `<FormFieldLabel>` in each of its two render branches (FormLayout DSL / linear fields). The body is now computed once and the label rendered once, giving the toggle a single home.
- **`FormFieldLabel` is now a `[label, error, button]` grid.** Added an optional trailing `button` slot (third column, with a placeholder span keeping it pinned right when there's no error) plus row-level `onClick`/`classNames`.

## Reviewer notes

- The label row and the caret button both toggle. The button has no own `onClick` — clicks (and keyboard activation) bubble to the row's `onClick`, so it toggles exactly once. An earlier iteration bound both handlers and they cancelled out (verified and fixed).
- No context provider: `collapsible` is an explicit prop, so the root form (which doesn't pass it) never sprouts a box or toggle.
- Collapse state is local `useState` (resets on remount); a `TODO` notes generalizing it later (cf. `useSelected` in react-ui-attention).
- The only `as any` in the diff (`defaultValues as any` in `InlineRefField`) is pre-existing and only moved lines.

## Verification

- `moon run react-ui-form:build` ✅
- `moon run react-ui-form:lint` ✅
- `moon run react-ui-form:test` ✅ (39 tests)
- Verified live in the `ui/react-ui-form/Form` **Default** story (nested `address` struct): collapse/expand via both the label row and the caret button, caret rotation, and the bordered container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible/expandable toggle for nested form fields with corresponding label translations
  * Added support for trailing clickable button elements in form field labels with click handlers

* **Refactor**
  * Simplified nested form field rendering architecture and layout structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->