### PR TITLE
fix(e2e): boot-loader pointer-events and detach wait for composer-app tests

### DIFF
--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -53,6 +53,12 @@ export class AppManager {
     this.page.on('console', (message) => this._onConsoleMessage(message));
 
     await this.isAuthenticated({ timeout: 15_000 });
+    // Wait for the boot loader overlay to be fully removed before letting tests
+    // interact with the page. Without this, the fading-out loader (pointer-events
+    // fixed separately in boot-loader.css) can still affect click dispatch timing
+    // while it is present in the DOM. The fallback timer in the loader is 800ms
+    // after ready().
+    await this.page.waitForSelector('#boot-loader', { state: 'detached', timeout: 5_000 }).catch(() => {});
 
     this.shell = new ShellManager(this.page, this._inIframe);
     this._initialized = true;

--- a/packages/apps/todomvc/src/types.ts
+++ b/packages/apps/todomvc/src/types.ts
@@ -26,6 +26,8 @@ export const TodoListAnnotation = Annotation.make({
 
 export const createTodoList = (space: Space): TodoList => {
   const list = space.db.add(Obj.make(TodoList, { todos: [] }));
-  Annotation.set(space.properties, TodoListAnnotation, Ref.make(list));
+  Obj.update(space.properties, (properties) => {
+    Annotation.set(properties, TodoListAnnotation, Ref.make(list));
+  });
   return list;
 };

--- a/packages/sdk/app-framework/src/vite-plugin/boot-loader/loader-app/boot-loader.css
+++ b/packages/sdk/app-framework/src/vite-plugin/boot-loader/loader-app/boot-loader.css
@@ -77,6 +77,7 @@ body {
 
 #boot-loader[data-dismissing] {
   opacity: 0;
+  pointer-events: none;
 }
 
 /* Gently shrink the disc + mark as the loader fades, echoing the prior handoff. */


### PR DESCRIPTION
## Summary

After the boot loader Solid refactor (`ca431e14`), `treeView.userAccount` becomes visible while the boot loader is still **fully rendered** — identity creation completes before the app framework fires `ready()`. `AppManager.init()` then returns and test clicks fire while the overlay is actively covering the page.

Trace evidence from the collections `create-collection` test confirms the boot loader is fully visible at the exact moment `spacePlugin.addSpace` is clicked. Without `pointer-events: none`, that click is intercepted by the overlay for the entire ~800ms fallback-removal window.

**Fix 1 — `boot-loader.css`**: Add `pointer-events: none` to `#boot-loader[data-dismissing]` so clicks pass through immediately once the fade begins.

**Fix 2 — `AppManager.init()`**: Wait for `#boot-loader` to fully detach from the DOM before proceeding. Belt-and-suspenders with fix 1 — ensures no test starts clicking until the overlay is completely gone.

These fixes were originally in draft PR #11680 (`claude/modest-gauss-FkTwh`), which can now be closed.

## Test plan

- [ ] `composer-app` e2e: `collections create-collection` and other click-dependent tests pass
- [ ] `composer-app` e2e: full 126-test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boot loader overlay now prevents user interactions during dismissal animation, eliminating accidental clicks or taps while the overlay fades out.

* **Improvements**
  * Enhanced application startup sequence to ensure the boot loader is fully removed before accepting user input, improving initialization reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->