### PR TITLE
fix(composer-app): update comments E2E test assertions for new data-current attribute

### DIFF
--- a/packages/apps/composer-app/src/playwright/comments.spec.ts
+++ b/packages/apps/composer-app/src/playwright/comments.spec.ts
@@ -176,17 +176,17 @@ test.describe('Comments tests', () => {
     await Thread.createComment(host.page, plank.locator, random.lorem.sentence());
     await Markdown.select(editorTextbox, thirdMessage);
     await Thread.createComment(host.page, plank.locator, random.lorem.sentence());
-    await expect(Thread.getComment(host.page, thirdMessage)).toHaveAttribute('class', 'cm-comment-current');
+    await expect(Thread.getComment(host.page, thirdMessage)).toHaveAttribute('data-current', '1');
     await expect(Thread.getThread(host.page, thirdMessage)).toHaveAttribute('aria-current', 'location');
 
     // Selecting a comment should highlight the thread.
     await Thread.getComment(host.page, firstMessage).click();
-    await expect(Thread.getComment(host.page, firstMessage)).toHaveAttribute('class', 'cm-comment-current');
+    await expect(Thread.getComment(host.page, firstMessage)).toHaveAttribute('data-current', '1');
     await expect(Thread.getThread(host.page, firstMessage)).toHaveAttribute('aria-current', 'location');
 
     // Selecting a thread should highlight the comment.
     await Thread.getThread(host.page, secondMessage).click();
-    await expect(Thread.getComment(host.page, secondMessage)).toHaveAttribute('class', 'cm-comment-current');
+    await expect(Thread.getComment(host.page, secondMessage)).toHaveAttribute('data-current', '1');
     await expect(Thread.getThread(host.page, secondMessage)).toHaveAttribute('aria-current', 'location');
   });
 
@@ -203,7 +203,7 @@ test.describe('Comments tests', () => {
     await editorTextbox.fill(editorText);
     await Markdown.select(editorTextbox, messageText);
     await Thread.createComment(host.page, plank.locator, random.lorem.sentence());
-    await expect(Thread.getComment(host.page, messageText)).toHaveAttribute('class', 'cm-comment-current');
+    await expect(Thread.getComment(host.page, messageText)).toHaveAttribute('data-current', '1');
     await expect(Thread.getThread(host.page, messageText)).toHaveAttribute('aria-current', 'location');
 
     await Markdown.getMarkdownTextbox(host.page).focus();


### PR DESCRIPTION
## Summary

- Fixes consistently failing `Comments tests › selecting comment highlights thread and vice versa` Playwright test (failing on all 3 browsers in CI for the past day)
- The test was broken by commit `c237b44` which changed comment marks in the editor from using a `cm-comment-current` CSS class to using a `data-current="1"` attribute on the `cm-comment` element
- Updated 4 assertions across the active test and the skipped `cut & paste comment` test to use `toHaveAttribute('data-current', '1')` instead of `toHaveAttribute('class', 'cm-comment-current')`

## Root cause

In `packages/ui/ui-editor/src/extensions/comments.ts`, `createCommentMark` was changed from:
```ts
class: isCurrent ? 'cm-comment-current' : 'cm-comment'
```
to:
```ts
class: 'cm-comment',
attributes: { 'data-current': isCurrent ? '1' : '0' }
```

The Playwright test still checked for the old class attribute.

## Test plan

- [ ] Verify CI passes for the `Comments tests › selecting comment highlights thread and vice versa` test on all 3 browsers (chromium, firefox, webkit)

https://claude.ai/code/session_01RJPf1pBAatj71j8vLLRAd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJPf1pBAatj71j8vLLRAd1)_