### PR TITLE
fix(composer-app): update comments e2e to assert data-current attribute

### DIFF
--- a/packages/apps/composer-app/src/playwright/comments.spec.ts
+++ b/packages/apps/composer-app/src/playwright/comments.spec.ts
@@ -176,17 +176,17 @@ test.describe('Comments tests', () => {
     await Thread.createComment(host.page, plank.locator, random.lorem.sentence());
     await Markdown.select(editorTextbox, thirdMessage);
     await Thread.createComment(host.page, plank.locator, random.lorem.sentence());
-    await expect(Thread.getComment(host.page, thirdMessage)).toHaveAttribute('class', 'cm-comment-current');
+    await expect(Thread.getComment(host.page, thirdMessage)).toHaveAttribute('data-current', '1');
     await expect(Thread.getThread(host.page, thirdMessage)).toHaveAttribute('aria-current', 'location');
 
     // Selecting a comment should highlight the thread.
     await Thread.getComment(host.page, firstMessage).click();
-    await expect(Thread.getComment(host.page, firstMessage)).toHaveAttribute('class', 'cm-comment-current');
+    await expect(Thread.getComment(host.page, firstMessage)).toHaveAttribute('data-current', '1');
     await expect(Thread.getThread(host.page, firstMessage)).toHaveAttribute('aria-current', 'location');
 
     // Selecting a thread should highlight the comment.
     await Thread.getThread(host.page, secondMessage).click();
-    await expect(Thread.getComment(host.page, secondMessage)).toHaveAttribute('class', 'cm-comment-current');
+    await expect(Thread.getComment(host.page, secondMessage)).toHaveAttribute('data-current', '1');
     await expect(Thread.getThread(host.page, secondMessage)).toHaveAttribute('aria-current', 'location');
   });
 
@@ -203,7 +203,7 @@ test.describe('Comments tests', () => {
     await editorTextbox.fill(editorText);
     await Markdown.select(editorTextbox, messageText);
     await Thread.createComment(host.page, plank.locator, random.lorem.sentence());
-    await expect(Thread.getComment(host.page, messageText)).toHaveAttribute('class', 'cm-comment-current');
+    await expect(Thread.getComment(host.page, messageText)).toHaveAttribute('data-current', '1');
     await expect(Thread.getThread(host.page, messageText)).toHaveAttribute('aria-current', 'location');
 
     await Markdown.getMarkdownTextbox(host.page).focus();


### PR DESCRIPTION
## Summary

The `e2e` CI job has been failing on `main` (run [27009735907](https://github.com/dxos/dxos/actions/runs/27009735907)) on the test `comments.spec.ts › selecting comment highlights thread and vice versa`, on all three browsers (chromium, firefox, webkit).

## Root cause

[#11697](https://github.com/dxos/dxos/pull/11697) ("fix: Minor ui fixes") changed how the editor marks the *current* comment in `packages/ui/ui-editor/src/extensions/comments.ts`:

- Before: `class="cm-comment-current"`
- After: `class="cm-comment"` + `data-current="1"`

The e2e test still asserted the old `cm-comment-current` class, so it failed:

```
Expected: "cm-comment-current"
Received: "cm-comment"
  - locator resolved to <span data-current="1" class="cm-comment" data-testid="cm-comment" ...>
```

## Fix

Update the four assertions in `comments.spec.ts` to check the `data-current` attribute instead of the class.

## Verification

Ran the previously-failing test locally against a fresh production bundle (chromium):

```
✓ [chromium] › comments.spec.ts:161:3 › Comments tests › selecting comment highlights thread and vice versa (20.8s)
1 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for comment and thread highlighting to use DOM attributes instead of CSS classes for more reliable validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->