### PR TITLE
fix(devtools): SQLite panel — type safety and performance follow-ups from CodeRabbit review

### DIFF
--- a/packages/devtools/devtools/src/panels/client/SqlitePanel/SqlitePanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/SqlitePanel/SqlitePanel.tsx
@@ -257,6 +257,21 @@ export const SqlitePanel = () => {
     return pageSize * freelistCount;
   }, [databaseInfo]);
 
+  const configStaleInfo = useMemo(() => {
+    if (databaseInfo?.configuredSqliteMode == null) {
+      return null;
+    }
+    const label = formatSqliteMode(databaseInfo.configuredSqliteMode);
+    if (!label) {
+      return null;
+    }
+    const isStale =
+      (label.startsWith('OPFS') && !databaseInfo.backing?.startsWith('OPFS')) ||
+      (label === 'Memory' && databaseInfo.backing !== 'Memory') ||
+      (label.startsWith('File') && !databaseInfo.backing?.startsWith('File'));
+    return isStale ? `${label} (stale)` : null;
+  }, [databaseInfo]);
+
   return (
     <PanelContainer
       classNames='grid grid-cols-[240px_1fr] divide-x divide-separator h-full'
@@ -286,17 +301,7 @@ export const SqlitePanel = () => {
               <InfoItem label='Backing' value={databaseInfo.backing} />
               <InfoItem label='File' value={databaseInfo.databaseFile} />
               <InfoItem label='Services' value={formatServicesMode(databaseInfo.servicesMode)} />
-              {(() => {
-                const configuredModeLabel =
-                  databaseInfo.configuredSqliteMode != null
-                    ? formatSqliteMode(databaseInfo.configuredSqliteMode)
-                    : null;
-                const configIsStale =
-                  configuredModeLabel != null &&
-                  ((configuredModeLabel.startsWith('OPFS') && !databaseInfo.backing?.startsWith('OPFS')) ||
-                    (configuredModeLabel === 'Memory' && databaseInfo.backing !== 'Memory'));
-                return configIsStale ? <InfoItem label='Config' value={`${configuredModeLabel} (stale)`} /> : null;
-              })()}
+              {configStaleInfo && <InfoItem label='Config' value={configStaleInfo} />}
               <InfoItem label='Journal' value={databaseInfo.journalMode} />
               <InfoItem label='Size' value={databaseSize != null ? bytes.format(databaseSize) : undefined} />
               <InfoItem label='Free' value={freeSpace != null ? bytes.format(freeSpace) : undefined} />

--- a/packages/devtools/devtools/src/panels/client/SqlitePanel/SqlitePanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/SqlitePanel/SqlitePanel.tsx
@@ -286,10 +286,19 @@ export const SqlitePanel = () => {
               <InfoItem label='Backing' value={databaseInfo.backing} />
               <InfoItem label='File' value={databaseInfo.databaseFile} />
               <InfoItem label='Services' value={formatServicesMode(databaseInfo.servicesMode)} />
-              {databaseInfo.configuredSqliteMode != null &&
-                formatSqliteMode(databaseInfo.configuredSqliteMode) !== databaseInfo.backing && (
-                  <InfoItem label='Config' value={`${formatSqliteMode(databaseInfo.configuredSqliteMode)} (stale)`} />
-                )}
+              {(() => {
+                const configuredModeLabel =
+                  databaseInfo.configuredSqliteMode != null
+                    ? formatSqliteMode(databaseInfo.configuredSqliteMode)
+                    : null;
+                const configIsStale =
+                  configuredModeLabel != null &&
+                  ((configuredModeLabel.startsWith('OPFS') && !databaseInfo.backing?.startsWith('OPFS')) ||
+                    (configuredModeLabel === 'Memory' && databaseInfo.backing !== 'Memory'));
+                return configIsStale ? (
+                  <InfoItem label='Config' value={`${configuredModeLabel} (stale)`} />
+                ) : null;
+              })()}
               <InfoItem label='Journal' value={databaseInfo.journalMode} />
               <InfoItem label='Size' value={databaseSize != null ? bytes.format(databaseSize) : undefined} />
               <InfoItem label='Free' value={freeSpace != null ? bytes.format(freeSpace) : undefined} />
@@ -597,10 +606,11 @@ const formatHexDump = (data: Uint8Array): string => {
 };
 
 const BinaryCell = ({ data }: { data: Uint8Array }) => {
+  const [isOpen, setIsOpen] = useState(false);
   const text = isMostlyPrintable(data) ? new TextDecoder().decode(data) : undefined;
 
   return (
-    <details>
+    <details onToggle={(event) => setIsOpen((event.currentTarget as HTMLDetailsElement).open)}>
       <summary className='cursor-pointer list-none'>
         <span className='inline-flex flex-wrap items-center gap-1'>
           <span className='rounded bg-neutral-500/15 px-1 text-neutral-400'>blob</span>
@@ -612,7 +622,9 @@ const BinaryCell = ({ data }: { data: Uint8Array }) => {
           )}
         </span>
       </summary>
-      <pre className='mt-1 max-h-48 overflow-auto text-[10px] leading-4 whitespace-pre'>{formatHexDump(data)}</pre>
+      {isOpen && (
+        <pre className='mt-1 max-h-48 overflow-auto text-[10px] leading-4 whitespace-pre'>{formatHexDump(data)}</pre>
+      )}
     </details>
   );
 };

--- a/packages/devtools/devtools/src/panels/client/SqlitePanel/SqlitePanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/SqlitePanel/SqlitePanel.tsx
@@ -295,9 +295,7 @@ export const SqlitePanel = () => {
                   configuredModeLabel != null &&
                   ((configuredModeLabel.startsWith('OPFS') && !databaseInfo.backing?.startsWith('OPFS')) ||
                     (configuredModeLabel === 'Memory' && databaseInfo.backing !== 'Memory'));
-                return configIsStale ? (
-                  <InfoItem label='Config' value={`${configuredModeLabel} (stale)`} />
-                ) : null;
+                return configIsStale ? <InfoItem label='Config' value={`${configuredModeLabel} (stale)`} /> : null;
               })()}
               <InfoItem label='Journal' value={databaseInfo.journalMode} />
               <InfoItem label='Size' value={databaseSize != null ? bytes.format(databaseSize) : undefined} />

--- a/packages/sdk/client-services/src/packlets/devtools/devtools.ts
+++ b/packages/sdk/client-services/src/packlets/devtools/devtools.ts
@@ -186,8 +186,11 @@ export class DevtoolsServiceImpl implements DevtoolsHost {
 
   async runSqliteQuery(request: RunSqliteQueryRequest): Promise<RunSqliteQueryResponse> {
     try {
-      const params = request.params ? JSON.parse(request.params) : undefined;
-      const rows = await this.params.runSqliteQuery(request.query, params);
+      const parsedParams = request.params ? JSON.parse(request.params) : undefined;
+      if (parsedParams !== undefined && !Array.isArray(parsedParams)) {
+        throw new Error('Query params must be a JSON array.');
+      }
+      const rows = await this.params.runSqliteQuery(request.query, parsedParams);
       return { rows: JSON.stringify(rows) };
     } catch (err) {
       return { rows: '[]', error: err instanceof Error ? err.message : String(err) };

--- a/packages/sdk/client-services/src/packlets/services/service-host.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-host.ts
@@ -202,7 +202,7 @@ export class ClientServicesHost {
   /**
    * Debugging util.
    */
-  async runSqliteQuery(query: string, params?: any[]): Promise<readonly Record<string, unknown>[]> {
+  async runSqliteQuery(query: string, params?: unknown[]): Promise<readonly Record<string, unknown>[]> {
     return await RuntimeProvider.runPromise(this._runtime)(
       Effect.gen(function* () {
         const sql = yield* SqlClient.SqlClient;


### PR DESCRIPTION
## Summary

Follow-up fixes from CodeRabbit review of #11704 (SQLite devtools panel). The branch was locked in the merge queue when these were identified, so they are applied here as a separate PR.

- Validate that `runSqliteQuery` params is a JSON array before executing — prevents malformed input from reaching the SQL layer
- Change `params?: any[]` to `params?: unknown[]` in `ClientServicesHost.runSqliteQuery` for proper type safety
- Fix stale SQLite config comparison in `SqlitePanel` to use prefix-based OPFS detection instead of exact string match (avoids false "stale" label when backing strings differ in suffix)
- Lazy-render hex dump in `BinaryCell` using `useState` + `onToggle` — `formatHexDump` now only runs when the `<details>` element is expanded, avoiding unnecessary work on large binary blobs

## Test plan

- [ ] Open DevTools → Client → SQLite, verify binary columns show hex dump only after expanding
- [ ] Run a custom query with valid params array `[1, 2]` — should work
- [ ] Run a query with invalid params `{"a": 1}` — should return `{ rows: '[]', error: 'Query params must be a JSON array.' }`

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcqQnhb5HZaLMXTtznmYoF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate detection of stale database configuration in the SQLite panel.
  * Binary data viewer now loads hex dumps only when a section is expanded, improving performance.
  * Query execution now validates that provided parameters are a JSON array, returning a clear error if not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->