### PR TITLE
fix(assistant): unbreak storybook stories + chat error handling and model switching

### DIFF
--- a/packages/common/effect/src/errors.ts
+++ b/packages/common/effect/src/errors.ts
@@ -144,9 +144,9 @@ export const causeToError = (cause: Cause.Cause<any>): Error => {
 
     const getStackFrames = (): string[] => {
       // Bun requies the target object for `captureStackTrace` to be an Error.
-      const o = new Error();
-      Error.captureStackTrace(o, causeToError);
-      return o.stack!.split('\n').slice(1);
+      const err = new Error();
+      Error.captureStackTrace(err, causeToError);
+      return err.stack!.split('\n').slice(1);
     };
 
     const stackFrames = getStackFrames();

--- a/packages/core/compute/functions-runtime/src/agent-service/AgentService.ts
+++ b/packages/core/compute/functions-runtime/src/agent-service/AgentService.ts
@@ -128,14 +128,29 @@ export const layer = (opts?: {
     AgentService,
     Effect.gen(function* () {
       const processManager = yield* ProcessManager.Service;
-      const sessionCache = new Map<string, Session>();
+      // The agent's model is bound to its process at spawn time, so the cache tracks the model
+      // each session was created with. Requesting a different model for the same feed tears down
+      // the old process and spawns a fresh one (see below).
+      const sessionCache = new Map<
+        string,
+        { model: ModelName | undefined; handle: ProcessManager.Handle<string, void>; session: Session }
+      >();
 
       return {
         getSession: (feed: Feed.Feed, options?: GetSessionOptions) =>
           Effect.gen(function* () {
+            const model = options?.model ?? opts?.model;
             const cached = sessionCache.get(feed.id);
             if (cached) {
-              return cached;
+              if (cached.model === model) {
+                return cached.session;
+              }
+
+              // Model changed (e.g. the user toggled online/offline): terminate the existing
+              // process so the conversation continues on a fresh process bound to the new model.
+              // Conversation history is preserved via the feed, which the new process replays.
+              yield* cached.handle.terminate();
+              sessionCache.delete(feed.id);
             }
 
             const target = Obj.getURI(feed);
@@ -143,11 +158,15 @@ export const layer = (opts?: {
             const spaceId = parsedEchoUri ? EID.getSpaceId(parsedEchoUri) : undefined;
             const executable = AgentProcess({
               systemPrompt: opts?.systemPrompt,
-              model: options?.model ?? opts?.model,
+              model,
               getMcpServers: opts?.getMcpServers,
               enableToolBackgrounding: opts?.enableToolBackgrounding,
             });
-            const processes = yield* processManager.list({ target, key: executable.key });
+
+            // Reuse a still-running process for this feed only when there was no cached session
+            // (e.g. after the UI remounted). After a model change we always spawn a fresh process,
+            // since the process key does not encode the model.
+            const processes = cached ? [] : yield* processManager.list({ target, key: executable.key });
 
             let handle: ProcessManager.Handle<string, void>;
             if (processes.length > 0) {
@@ -167,7 +186,7 @@ export const layer = (opts?: {
             }
 
             const session = makeSession(handle, feed);
-            sessionCache.set(feed.id, session);
+            sessionCache.set(feed.id, { model, handle, session });
             return session;
           }),
       };

--- a/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
+++ b/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
@@ -12,12 +12,13 @@ import { Event } from '@dxos/async';
 import { type Feed, Filter, Obj, Query } from '@dxos/echo';
 import { useQuery } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
-import { composable, composableProps } from '@dxos/react-ui';
+import { Toast, composable, composableProps, useTranslation } from '@dxos/react-ui';
 import { type MarkdownStreamController } from '@dxos/react-ui-markdown';
 import { Menu, MenuRootProps } from '@dxos/react-ui-menu';
 import { Message } from '@dxos/types';
 
 import { useChatKeymapExtensions, useChatToolbarActions, useDebug } from '#hooks';
+import { meta } from '#meta';
 
 import {
   ChatStatus,
@@ -36,7 +37,7 @@ export { useChatContext };
 //
 
 type ChatRootProps = PropsWithChildren<
-  Pick<ChatContextValue, 'db' | 'chat' | 'processor'> & {
+  Pick<ChatContextValue, 'chat' | 'processor'> & {
     feed?: Feed.Feed;
     onEvent?: (event: ChatEvent) => void;
   }
@@ -48,7 +49,10 @@ const ChatRoot = ({ children, chat, feed, processor, onEvent, ...props }: ChatRo
   const active = useAtomValue(processor.active);
   const requestTiming = useRequestTiming({ active });
   const lastPrompt = useRef<string | undefined>(undefined);
-  const db = props.db ?? (chat && Obj.getDatabase(chat));
+  const db = chat && Obj.getDatabase(chat);
+
+  // Event sink.
+  const event = useMemo(() => new Event<ChatEvent>(), []);
 
   const feedMessages = useQuery(
     db,
@@ -62,7 +66,14 @@ const ChatRoot = ({ children, chat, feed, processor, onEvent, ...props }: ChatRo
 
   const dump = useDebug({ processor });
 
-  const event = useMemo(() => new Event<ChatEvent>(), []);
+  // Surface processor failures (e.g., AI service unavailable) to subscribers via the event bus.
+  const error = useAtomValue(processor.error);
+  useEffect(() => {
+    if (Option.isSome(error)) {
+      event.emit({ type: 'error', error: error.value });
+    }
+  }, [event, error]);
+
   useEffect(() => {
     return event.on((ev) => {
       switch (ev.type) {
@@ -192,11 +203,13 @@ const CHAT_THREAD_NAME = 'Chat.Thread';
 type ChatThreadProps = Omit<NaturalChatThreadProps, 'identity' | 'messages' | 'tools'>;
 
 const ChatThread = ({ viewType, debug: debugProp, ...props }: ChatThreadProps) => {
+  const { t } = useTranslation(meta.id);
   const { debug, event, messages, processor } = useChatContext(CHAT_THREAD_NAME);
-  const debugView = viewType === 'debug';
+  const extensions = useChatKeymapExtensions({ event });
   const identity = useIdentity();
   const error = useAtomValue(processor.error).pipe(Option.getOrUndefined);
-  const extensions = useChatKeymapExtensions({ event });
+  const [toastError, setToastError] = useState<Error | undefined>(undefined);
+  const debugView = viewType === 'debug';
 
   const controllerRef = useRef<MarkdownStreamController | null>(null);
   useEffect(() => {
@@ -211,6 +224,9 @@ const ChatThread = ({ viewType, debug: debugProp, ...props }: ChatThreadProps) =
           break;
         case 'nav-next':
           controllerRef.current?.navigateNext();
+          break;
+        case 'error':
+          setToastError(event.error);
           break;
       }
     });
@@ -228,17 +244,31 @@ const ChatThread = ({ viewType, debug: debugProp, ...props }: ChatThreadProps) =
   }
 
   return (
-    <NaturalChatThread
-      {...props}
-      identity={identity}
-      messages={messages}
-      error={error}
-      debug={debugProp ?? (debug || debugView)}
-      viewType={viewType}
-      extensions={extensions}
-      onEvent={handleEvent}
-      ref={controllerRef}
-    />
+    <>
+      <NaturalChatThread
+        {...props}
+        identity={identity}
+        messages={messages}
+        error={error}
+        debug={debugProp ?? (debug || debugView)}
+        viewType={viewType}
+        extensions={extensions}
+        onEvent={handleEvent}
+        ref={controllerRef}
+      />
+
+      <Toast.Root
+        type='foreground'
+        open={!!toastError}
+        duration={20_000}
+        onOpenChange={(open) => !open && setToastError(undefined)}
+      >
+        <Toast.Title icon='ph--warning--regular' onClose={() => setToastError(undefined)}>
+          {t('ai-service-error.label')}
+        </Toast.Title>
+        <Toast.Description>{toastError?.message}</Toast.Description>
+      </Toast.Root>
+    </>
   );
 };
 

--- a/packages/plugins/plugin-assistant/src/components/Chat/events.ts
+++ b/packages/plugins/plugin-assistant/src/components/Chat/events.ts
@@ -34,6 +34,13 @@ export type ChatEvent =
       object: Obj.Unknown;
     }
   //
+  // Errors
+  //
+  | {
+      type: 'error';
+      error: Error;
+    }
+  //
   // UX
   //
   | {

--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatPrompt.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatPrompt.tsx
@@ -33,8 +33,8 @@ export type ChatPromptProps = ThemedClassName<
       outline?: boolean;
       settings?: boolean;
       expandable?: boolean;
-      chat?: Chat.Chat;
       db?: Database.Database;
+      chat?: Chat.Chat;
       processor: AiChatProcessor;
       event: Event<ChatEvent>;
       online?: boolean;
@@ -49,8 +49,8 @@ export type ChatPromptProps = ThemedClassName<
 export const ChatPrompt = ({
   classNames,
   outline,
-  chat,
   db,
+  chat,
   processor,
   event,
   online,

--- a/packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.stories.tsx
@@ -6,6 +6,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import * as Effect from 'effect/Effect';
 import React from 'react';
 
+import { SERVICES_CONFIG } from '@dxos/ai/testing';
 import { withPluginManager } from '@dxos/app-framework/testing';
 import { AppActivationEvents } from '@dxos/app-toolkit';
 import { Chat } from '@dxos/assistant-toolkit';
@@ -15,6 +16,7 @@ import { AutomationPlugin } from '@dxos/plugin-automation/testing';
 import { initializeIdentity, ClientPlugin } from '@dxos/plugin-client/testing';
 import { PreviewPlugin } from '@dxos/plugin-preview/testing';
 import { StorybookPlugin, corePlugins } from '@dxos/plugin-testing';
+import { Config } from '@dxos/react-client';
 import { useQuery, useSpaces } from '@dxos/react-client/echo';
 import { Loading, withTheme } from '@dxos/react-ui/testing';
 
@@ -44,6 +46,7 @@ const meta = {
         ...corePlugins(),
         ClientPlugin({
           types: [Chat.Chat, Feed.Feed],
+          config: new Config({ runtime: { services: SERVICES_CONFIG.REMOTE } }),
           onClientInitialized: ({ client }) =>
             Effect.gen(function* () {
               yield* initializeIdentity(client);

--- a/packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.stories.tsx
@@ -52,9 +52,8 @@ const meta = {
               yield* initializeIdentity(client);
               const [space] = client.spaces.get();
               yield* Effect.promise(() => space.waitUntilReady());
-
               const feed = space.db.add(Feed.make());
-              space.db.add(Chat.make({ name: 'Test chat', feed: Ref.make(feed) }));
+              space.db.add(Chat.make({ name: 'Test', feed: Ref.make(feed) }));
               yield* Effect.promise(() => space.db.flush({ indexes: true }));
             }),
         }),

--- a/packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.tsx
@@ -71,7 +71,7 @@ export const ChatArticle = forwardRef<HTMLDivElement, ChatArticleProps>((props, 
   }
 
   return (
-    <ChatComponent.Root db={space?.db} chat={chat} feed={feedTarget} processor={processor} onEvent={onEvent}>
+    <ChatComponent.Root chat={chat} feed={feedTarget} processor={processor} onEvent={onEvent}>
       <Panel.Root role={role} ref={forwardedRef}>
         <Panel.Toolbar className='bg-toolbar-surface'>
           <ChatComponent.Toolbar classNames='dx-document' attendableId={attendableId} companionTo={companionTo} />

--- a/packages/plugins/plugin-assistant/src/processor/processor.ts
+++ b/packages/plugins/plugin-assistant/src/processor/processor.ts
@@ -3,7 +3,10 @@
 //
 
 import { Atom, Registry as AtomRegistry } from '@effect-atom/atom-react';
+import * as AiError from '@effect/ai/AiError';
+import * as Cause from 'effect/Cause';
 import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
 import * as Fiber from 'effect/Fiber';
 import * as Layer from 'effect/Layer';
 import * as Option from 'effect/Option';
@@ -29,7 +32,7 @@ import {
   Trace,
 } from '@dxos/compute';
 import { type Database, Feed, Obj, Ref, type Registry } from '@dxos/echo';
-import { runAndForwardErrors, unwrapExit } from '@dxos/effect';
+import { causeToError, runAndForwardErrors, unwrapExit } from '@dxos/effect';
 import { AgentService } from '@dxos/functions-runtime';
 import { log } from '@dxos/log';
 import { Message } from '@dxos/types';
@@ -88,6 +91,33 @@ export type ProcessorRequestOptions = {};
 export type ProcessorRequest = {
   message: string;
   options?: ProcessorRequestOptions;
+};
+
+/**
+ * Maps a failure from the agent fiber to an error suitable for display.
+ * {@link AiError}s originate from the AI service and are actionable by the user
+ * (e.g., "model 'x' not found", "Connection refused"), so their detail is propagated.
+ * Any other failure is treated as an internal/unexpected error and reported generically
+ * to avoid leaking implementation detail.
+ */
+const parseError = (err: unknown): Error => {
+  let message: string | undefined;
+  if (AiError.isAiError(err)) {
+    message = err.description?.trim() || err.message;
+  } else if (typeof err === 'string') {
+    // TODO(burdon): This is brittle.
+    // UnknownError: ChatCompletionsClient.streamText: model 'gemma3:27b' not found
+    const [, model] = err.match(/model\s+'([^']+)'\s+not\s+found/i) || [];
+    if (model) {
+      message = `The model is not available: ${model}`;
+    }
+  }
+
+  if (!message) {
+    message = 'An unexpected error occurred.';
+  }
+
+  return new Error(message, { cause: err });
 };
 
 /**
@@ -236,21 +266,25 @@ export class AiChatProcessor {
 
       this.#requestFiber = this._runtime.runFork(effect.pipe(Effect.provide(this._spaceLayer)));
 
-      try {
-        await this._runtime.runPromise(Fiber.join(this.#requestFiber));
-      } catch (err: any) {
-        if (err._tag === 'InterruptedException' || err.message?.includes('interrupted')) {
+      // Inspect the fiber's exit so the underlying failure (e.g. "model 'x' not found") is
+      // preserved as a clean Error rather than an opaque FiberFailure.
+      const exit = await this._runtime.runPromise(Fiber.await(this.#requestFiber));
+      if (Exit.isFailure(exit)) {
+        if (Cause.isInterruptedOnly(exit.cause)) {
           return;
         }
-        throw err;
+
+        throw causeToError(exit.cause);
       }
 
       this.#registry.set(this.error, Option.none());
       this.#lastRequest = undefined;
       this.#requestFiber = undefined;
     } catch (err) {
+      // `causeToError` above unwraps the fiber failure into the underlying error (e.g. an AiError
+      // carrying "model 'x' not found"); `parseError` decides what to surface to the user.
       log.error('request failed', { error: err });
-      this.#registry.set(this.error, Option.some(new Error('AI service error', { cause: err })));
+      this.#registry.set(this.error, Option.some(parseError(err)));
     } finally {
       log.info('setting active to false');
       this.#registry.set(this.active, false);

--- a/packages/plugins/plugin-assistant/src/translations.ts
+++ b/packages/plugins/plugin-assistant/src/translations.ts
@@ -152,6 +152,7 @@ export const translations: Resource[] = [
         'mcp-server-api-key.label': 'API key',
         'mcp-server-api-key.placeholder': 'API key (optional)',
         'mcp-server-error.label': 'MCP server unavailable',
+        'ai-service-error.label': 'AI service error',
 
         'debug.button': 'Debug',
         'online-switch.label': 'Online',

--- a/packages/stories/stories-assistant/src/testing/testing.tsx
+++ b/packages/stories/stories-assistant/src/testing/testing.tsx
@@ -335,13 +335,16 @@ const StoryPlugin = Plugin.define<StoryPluginOptions>(
     id: 'com.example.plugin.testing.module.operationHandler',
     activatesOn: ActivationEvents.SetupProcessManager,
     activate: Effect.fnUntraced(function* () {
-      const client = yield* Capability.get(ClientCapabilities.Client);
       return Capability.contributes(
         Capabilities.OperationHandler,
         OperationHandlerSet.make(
           Operation.withHandler(LayoutOperation.UpdateCompanion, () => Effect.void),
           Operation.withHandler(AssistantOperation.CreateChat, ({ db, name }) =>
             Effect.gen(function* () {
+              // Resolve the client lazily at invocation time: the `Client` capability is
+              // contributed on `Startup` (concurrently with `SetupProcessManager`), so it is
+              // not guaranteed to exist when this module activates.
+              const client = yield* Capability.get(ClientCapabilities.Client);
               const registry = yield* Capability.get(Capabilities.AtomRegistry);
               const space = client.spaces.get(db.spaceId);
               invariant(space, 'Space not found');

--- a/packages/ui/react-ui-components/src/components/TogglePanel/TogglePanel.tsx
+++ b/packages/ui/react-ui-components/src/components/TogglePanel/TogglePanel.tsx
@@ -94,7 +94,7 @@ const Header = ({ classNames, children, icon }: HeaderProps) => {
           classNames={['transition transition-transform ease-in-out', open ? 'rotate-90' : 'transform-none']}
         />
       </IconBlock>
-      <div className='flex items-center overflow-hidden truncate'>{children}</div>
+      <div className='flex gap-1 items-center overflow-hidden truncate'>{children}</div>
       {icon && <IconBlock>{icon}</IconBlock>}
     </div>
   );

--- a/packages/ui/react-ui/src/components/Message/Message.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.tsx
@@ -142,7 +142,7 @@ const MessageTitle = forwardRef<HTMLDivElement, MessageTitleProps>(
       <Column.Row classNames={tx('message.header', {}, classNames)} ref={forwardedRef}>
         {icon && (
           <div className={tx('message.icon', { valence })}>
-            <Icon icon={icon} size={5} />
+            <Icon icon={icon} />
           </div>
         )}
         <h2 className={tx('message.title', {}, classNames)} id={titleId}>

--- a/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
+++ b/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
@@ -34,12 +34,12 @@ const header: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('items
 
 const icon: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('col-start-1 grid place-items-center', ...etc);
 
-const title: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
-  mx('col-start-2 overflow-hidden truncate font-medium', ...etc);
+const title: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('col-start-2 truncate font-medium', ...etc);
 
 const close: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('col-start-3', ...etc);
 
-const description: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('col-start-2 text-description', ...etc);
+const description: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
+  mx('col-start-2 overflow-hidden text-description', ...etc);
 
 const actions: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('flex gap-2 mbs-1', ...etc);
 


### PR DESCRIPTION
## Summary

A series of fixes and improvements to the assistant chat, all surfaced while debugging the assistant storybook stories.

### 1. Storybook stories crashed at boot / on first prompt
- **Client capability race** ([`testing.tsx`](packages/stories/stories-assistant/src/testing/testing.tsx)): the test harness grabbed the `Client` capability at `SetupProcessManager`, racing its activation on `Startup`. Moved the lookup into the `CreateChat` handler so it resolves lazily.
- **EDGE not configured** ([`ChatArticle.stories.tsx`](packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.stories.tsx)): the story's `ClientPlugin` had no `edge.url`; added `SERVICES_CONFIG.REMOTE`.

### 2. AI errors are now surfaced to the user
Previously a failed request only logged to the console. Now `AiChatProcessor` captures the failure and the chat shows a toast.
- [`processor.ts`](packages/plugins/plugin-assistant/src/processor/processor.ts): `causeToError` unwraps the fiber failure; new `parseError` maps it to a user-facing message (AiError detail, e.g. "model 'x' not found"; generic otherwise).
- [`Chat.tsx`](packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx) / [`events.ts`](packages/plugins/plugin-assistant/src/components/Chat/events.ts): a new `error` `ChatEvent` is emitted from the processor's `error` atom and rendered as a `Toast`.

### 3. Online/offline model switch was stuck
[`AgentService.ts`](packages/core/compute/functions-runtime/src/agent-service/AgentService.ts): the agent session was cached per `feed.id` only, so the first model was frozen. The cache now tracks the model and respawns the agent process when it changes (history preserved via the feed).

### Misc
- Minor `TogglePanel`, `Message`, `Toast` theme and `errors.ts` tidy-ups.

## Verification
- `stories-assistant` + `plugin-assistant` storybook tests pass; manually verified Chat/ChatArticle render, first prompt works, error toast shows on failure (model-not-found / offline), and online↔offline switching routes to the correct backend.
- `functions-runtime` (59) and `plugin-assistant` (86) unit tests pass; lint, fmt, compile clean; no new casts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved capability timing during chat creation.
  * Improved AI request failure handling and surface actionable error messages as warning toasts in chats.

* **Style**
  * Improved TogglePanel.Header spacing and alignment.
  * Adjusted Toast title/description styling and relied on default Message icon sizing.

* **Chores**
  * Updated Storybook chat article to use remote runtime services.
  * Added an i18n string for AI service errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->