### PR TITLE
fix(composer-app): increase collaboration E2E test timeout to 120s

### DIFF
--- a/packages/apps/composer-app/src/playwright/collaboration.spec.ts
+++ b/packages/apps/composer-app/src/playwright/collaboration.spec.ts
@@ -28,7 +28,8 @@ test.describe('Collaboration tests', () => {
   let guest: AppManager;
 
   test.beforeEach(async ({ browser, browserName }) => {
-    test.setTimeout(60_000);
+    // 120s: beforeEach init (host+guest, up to 30s) + invitation flow + navtree navigation.
+    test.setTimeout(120_000);
     test.skip(browserName === 'firefox' || browserName === 'webkit');
 
     host = new AppManager(browser, false);


### PR DESCRIPTION
## Summary

Fixes the two collaboration E2E tests that were flagged as **flaky** in CI on 2026-06-05 (Playwright reported "2 flaky" — failed on first attempt, passed on retry):

- `Collaboration tests › guest joins host's space`
- `Collaboration tests › host and guest can see each others' cursors when same document is in focus`

## Root cause

Both tests failed at `toggleTypeCollectionAll` with:
```
Test timeout of 60000ms exceeded.
Error: locator.click: Target page, context or browser has been closed
  - waiting for getByTestId('navtree.workspace.visible')
      .getByTestId('spacePlugin.typeCollectionAll.org.dxos.type.document')
      .getByRole('button').first()
```

`test.setTimeout(60_000)` applies to the **entire test including `beforeEach`**, which runs:
- `host.init()` — waits up to 15s for authentication
- `guest.init()` — waits up to 15s for authentication

On a loaded CI runner both inits together can consume ~30s, leaving only ~30s for the invitation flow + navtree navigation steps. This is too tight, and the tests occasionally time out before `spacePlugin.typeCollectionAll.org.dxos.type.document` appears in the navtree.

## Fix

Increase `test.setTimeout` from 60s → 120s. This gives ~90s of headroom after initialization for the WebRTC invitation flow and subsequent navtree expansion steps.

## Pre-existing open PRs checked

- PR #11596 — different test (echo-pipeline replication timeout)
- PR #11447 — different test (CLI chat --help)
- PR #11416 — different tests (dedicated worker leader election)
- PR #11464 — different test (authorizePut recovery)

No existing open PR was fixing the collaboration test flakiness.

https://claude.ai/code/session_01WnvQZYZDcByojdUFg8rdeJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnvQZYZDcByojdUFg8rdeJ)_