### PR TITLE
feat(ui-theme): sidebar text tokens + elevated-surface state color tuning

### DIFF
--- a/packages/ui/ui-theme/src/css/components/surface.css
+++ b/packages/ui/ui-theme/src/css/components/surface.css
@@ -41,12 +41,12 @@
   .dx-modal-surface,
   .dx-popover-surface {
     --color-hover-surface: light-dark(
-      oklch(from var(--surface-bg) calc(l - 0.05) c h),
-      oklch(from var(--surface-bg) calc(l + 0.05) c h)
-    );
-    --color-current-surface: light-dark(
       oklch(from var(--surface-bg) calc(l - 0.08) c h),
       oklch(from var(--surface-bg) calc(l + 0.08) c h)
+    );
+    --color-current-surface: light-dark(
+      oklch(from var(--surface-bg) calc(l - 0.1) c h),
+      oklch(from var(--surface-bg) calc(l + 0.1) c h)
     );
     --color-current-surface-hover: light-dark(
       oklch(from var(--surface-bg) calc(l - 0.12) c h),

--- a/packages/ui/ui-theme/src/css/layout/main.css
+++ b/packages/ui/ui-theme/src/css/layout/main.css
@@ -81,7 +81,13 @@
       @apply backdrop-blur-lg;
     }
     background-color: var(--color-sidebar-surface);
+    color: var(--color-sidebar-fg);
     --surface-bg: var(--color-sidebar-surface);
+
+    /* Current / selected items read one stop brighter than default body text. */
+    & :is([aria-current]:not([aria-current='false']), [aria-selected='true']) {
+      color: var(--color-sidebar-current-fg);
+    }
 
     transition-property: inset-inline-start, inset-inline-end, inline-size;
     inset-block-start: max(0.5rem, env(safe-area-inset-top));

--- a/packages/ui/ui-theme/src/css/theme/semantic.css
+++ b/packages/ui/ui-theme/src/css/theme/semantic.css
@@ -50,7 +50,7 @@
   --color-input-surface: var(--dx-elevation-4);
   --color-toolbar-surface: var(--dx-elevation-5);
   --color-modal-surface: var(--dx-elevation-6);
-  --color-popover-surface: var(--dx-elevation-7);
+  --color-popover-surface: var(--dx-elevation-6);
 
   /* Sidebar / panel layout levels */
   --color-l0-surface: var(--dx-elevation-1);
@@ -67,6 +67,10 @@
   --color-inverse-fg: light-dark(var(--color-neutral-50), var(--color-neutral-950));
 
   --color-base-fg: light-dark(var(--color-neutral-950), var(--color-neutral-150));
+
+  /* Sidebar body text. Default sits one ramp stop below the current/selected emphasis. */
+  --color-sidebar-fg: light-dark(var(--color-neutral-700), var(--color-neutral-250));
+  --color-sidebar-current-fg: light-dark(var(--color-neutral-950), var(--color-neutral-75));
 
   /* Focus */
   --color-focus-surface: light-dark(var(--color-neutral-50), var(--color-neutral-850));
@@ -86,7 +90,7 @@
    * `*-base` primitives are the un-offset values; 
    * surface contexts (e.g. .dx-main-sidebar in state.css) re-derive the public token off the base via relative oklch. 
    */
-  --dx-hover-surface-base: light-dark(var(--color-neutral-200), var(--color-neutral-750));
+  --dx-hover-surface-base: light-dark(var(--color-neutral-200), var(--color-neutral-850));
   --color-hover-surface: var(--dx-hover-surface-base);
   --color-hover-fg: light-dark(var(--color-neutral-950), var(--color-neutral-150));
 

--- a/packages/ui/ui-theme/src/css/theme/semantic.css
+++ b/packages/ui/ui-theme/src/css/theme/semantic.css
@@ -20,8 +20,8 @@
    *   3    canvas  base, deck
    *   4    raised  card, group, input
    *   5    bar     toolbar (sticky, drop-shadowed)
-   *   6    modal   dialog, modal
-   *   7    float   popover, menu, toast, tooltip
+   *   6    modal   dialog, modal, popover
+   *   7    float   menu, toast, tooltip
    *
    * These are private (--dx-*) knobs — use named surface tokens in components, not these directly.
    */

--- a/packages/ui/ui-theme/src/plugins/main.css
+++ b/packages/ui/ui-theme/src/plugins/main.css
@@ -24,22 +24,25 @@ body {
 }
 
 /* Pre-CSS color fallbacks so text is readable before and during Vite HMR. */
-/* Values are intentionally kept in sync with @theme tokens in semantic.css. */
+/* Values are intentionally kept in sync with @theme tokens in semantic.css:
+ *   color            ← --color-base-fg      = light-dark(neutral-950, neutral-150)
+ *   background-color ← --color-base-surface = elevation-3 = light-dark(neutral-125, neutral-850)
+ * The literals carry the ramp tint (chroma 0.001, hue 190) so first paint matches the loaded theme. */
 :root {
   color-scheme: light;
 }
 html {
-  color: oklch(0.145 0 0);
-  background-color: oklch(0.985 0 0);
+  color: oklch(0.145 0.001 190);
+  background-color: oklch(0.92 0.001 190);
 }
 html.dark {
   color-scheme: dark;
-  color: oklch(0.985 0 0);
-  background-color: oklch(0.145 0 0);
+  color: oklch(0.905 0.001 190);
+  background-color: oklch(0.237 0.001 190);
 }
 @media (prefers-color-scheme: dark) {
   html:not(.dark) {
-    color: oklch(0.985 0 0);
-    background-color: oklch(0.145 0 0);
+    color: oklch(0.905 0.001 190);
+    background-color: oklch(0.237 0.001 190);
   }
 }


### PR DESCRIPTION
## What

Theme/design-system color tuning, all in `packages/ui/ui-theme`:

- **Sidebar text tokens.** Adds `--color-sidebar-fg` and `--color-sidebar-current-fg` and applies them on `.dx-main-sidebar` (layout/main.css). Previously the L1 navtree had *no* text-color rule — it inherited the critical `<html>` pre-paint fallback, which is why devtools showed an inherited color with no class. Now the sidebar has an explicit, semantic foreground, and current/selected items (`aria-current` / `aria-selected`) read brighter than default body text.
- **Critical fallbacks synced.** `plugins/main.css` (the styles the Vite `ThemePlugin` injects into `<head>` before stylesheets load) were stale: zero-chroma `neutral-50`/`neutral-950`, out of sync with the theme. They now mirror `--color-base-fg` / `--color-base-surface` and carry the ramp tint (chroma 0.001, hue 190), so first paint matches the loaded theme.
- **Elevated-surface state colors.** Tunes the modal/popover hover & current re-derivations in surface.css and lowers `--color-popover-surface` to elevation-6; adjusts the dark `--dx-hover-surface-base`.

## Why

The L1 sidebar text rendered brighter than intended (and with the wrong tint) because it was riding an inherited, out-of-sync `<html>` fallback rather than a real token. Giving the sidebar its own semantic fg tokens fixes that and lets current/selected items be emphasized independently of base body text. The fallback sync removes a first-paint color flash. The elevated-surface tweaks keep hover/current highlights visible on popover/modal surfaces.

## Reviewer notes

- All changes are CSS tokens / declarations — no TS, no casts.
- `@theme` token changes are **not reliably HMR'd** — a dev-server restart is required to regenerate the `:root` custom properties (see the existing note near the grid tokens in semantic.css).
- The cool ramp tint (hue 190) means exact warm target hexes can't be matched by level selection alone; lightness is matched to the nearest ramp stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Increased contrast for modal and popover hover and active states to make highlights more visually distinct from base surfaces.
  * Added explicit foreground colors for sidebar items and a distinct color for current/selected sidebar entries for clearer navigation cues.
  * Refined theme color mappings and fallback values to improve overall visual consistency across light and dark modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->