### PR TITLE
feat(assistant): auto-rename chat on first message + fix bare entity ID navigation

### DIFF
--- a/packages/plugins/plugin-assistant/src/operations/update-chat-name.ts
+++ b/packages/plugins/plugin-assistant/src/operations/update-chat-name.ts
@@ -18,13 +18,8 @@ import { AssistantOperation } from '#types';
 const handler: Operation.WithHandler<typeof AssistantOperation.UpdateChatName> = AssistantOperation.UpdateChatName.pipe(
   Operation.withHandler(
     Effect.fnUntraced(
-      function* ({ chat }) {
+      function* ({ chat, prompt: initialPrompt }) {
         log.info('updating chat name', { chat });
-
-        const feed = yield* Database.load(chat.feed);
-        const history = yield* Feed.runQuery(feed, Filter.type(Message.Message));
-
-        log.info('history', { history: history.length });
 
         const system = trim`
           It is extremely important that you respond only with the title and nothing else.
@@ -35,17 +30,26 @@ const handler: Operation.WithHandler<typeof AssistantOperation.UpdateChatName> =
           Fishing Trip
           </example_reply>
         `;
-        const prompt = 'Suggest a name for this chat';
 
-        const historyPrompt = yield* AiPreprocessor.preprocessPrompt(history, {
-          system,
-          cacheControl: 'ephemeral',
-        });
+        let namePrompt: Prompt.Prompt;
+        if (initialPrompt) {
+          // Use the provided prompt text directly; the feed may not have messages yet.
+          namePrompt = Prompt.setSystem(
+            Prompt.make(`User's first message: "${initialPrompt}"\n\nSuggest a name for this chat.`),
+            system,
+          );
+        } else {
+          const feed = yield* Database.load(chat.feed);
+          const history = yield* Feed.runQuery(feed, Filter.type(Message.Message));
+          log.info('history', { history: history.length });
+          const historyPrompt = yield* AiPreprocessor.preprocessPrompt(history, {
+            system,
+            cacheControl: 'ephemeral',
+          });
+          namePrompt = Prompt.merge(historyPrompt, 'Suggest a name for this chat');
+        }
 
-        const response = yield* LanguageModel.generateText({
-          prompt: Prompt.merge(historyPrompt, prompt),
-        });
-
+        const response = yield* LanguageModel.generateText({ prompt: namePrompt });
         const newName = response.text.replaceAll(/[^a-zA-Z0-9\s]/g, '').trim();
 
         Obj.update(chat, (chat) => {

--- a/packages/plugins/plugin-assistant/src/processor/processor.ts
+++ b/packages/plugins/plugin-assistant/src/processor/processor.ts
@@ -73,17 +73,10 @@ export type AiChatProcessorOptions = {
    */
   chat?: Ref.Ref<Chat.Chat>;
   system?: string;
-  /**
-   * Probability of automatically updating chat name after each request.
-   * Chat name is always updated if it has no name.
-   * @default 0.1 (10%)
-   */
-  autoUpdateNameChance?: number;
 };
 
 const defaultOptions: Partial<AiChatProcessorOptions> = {
   model: DEFAULT_EDGE_MODEL,
-  autoUpdateNameChance: 0.1,
 };
 
 export type ProcessorRequestOptions = {};
@@ -256,12 +249,17 @@ export class AiChatProcessor {
         log('chat processor submitting prompt', { length: requestProp.message.length });
         yield* session.submitPrompt(requestProp.message);
         log('chat processor submitPrompt returned, waiting for agent', {});
+
+        // On the first message (no name yet), schedule rename immediately so it
+        // runs concurrently with the AI response rather than waiting for completion.
+        if (!this._options.chat?.target?.name) {
+          yield* this.#updateChatName(requestProp.message);
+        }
+
         yield* session.waitForCompletion();
         log.info('session complete');
 
         this.#flushStreaming();
-
-        yield* this.#maybeUpdateChatName();
       });
 
       this.#requestFiber = this._runtime.runFork(effect.pipe(Effect.provide(this._spaceLayer)));
@@ -408,18 +406,12 @@ export class AiChatProcessor {
   }
 
   /**
-   * Conditionally schedule chat name update in detached fork mode.
-   * Updates if chat has no name OR based on random chance (default 10%).
+   * Schedule a chat name update as a detached (fire-and-forget) operation.
+   * Called automatically on the first message; can also be invoked manually via the toolbar.
    */
-  #maybeUpdateChatName(): Effect.Effect<void, never, Operation.Service> {
+  #updateChatName(prompt?: string): Effect.Effect<void, never, Operation.Service> {
     const chat = this._options.chat?.target;
     if (!chat) {
-      return Effect.void;
-    }
-
-    const chance = this._options.autoUpdateNameChance ?? defaultOptions.autoUpdateNameChance ?? 0.1;
-    const shouldUpdate = !chat.name || Math.random() < chance;
-    if (!shouldUpdate) {
       return Effect.void;
     }
 
@@ -428,7 +420,8 @@ export class AiChatProcessor {
       return Effect.void;
     }
 
-    log.info('scheduling chat name update', { hasName: !!chat.name, chance });
-    return Operation.schedule(AssistantOperation.UpdateChatName, { chat }, { spaceId });
+    log.info('scheduling chat name update');
+    return Operation.schedule(AssistantOperation.UpdateChatName, { chat, prompt }, { spaceId });
   }
+
 }

--- a/packages/plugins/plugin-assistant/src/processor/processor.ts
+++ b/packages/plugins/plugin-assistant/src/processor/processor.ts
@@ -423,5 +423,4 @@ export class AiChatProcessor {
     log.info('scheduling chat name update');
     return Operation.schedule(AssistantOperation.UpdateChatName, { chat, prompt }, { spaceId });
   }
-
 }

--- a/packages/plugins/plugin-assistant/src/types/AssistantOperation.ts
+++ b/packages/plugins/plugin-assistant/src/types/AssistantOperation.ts
@@ -55,6 +55,8 @@ export const UpdateChatName = Operation.make({
   services: [Database.Service, Feed.FeedService, AiService.AiService],
   input: Schema.Struct({
     chat: Type.getSchema(Chat.Chat),
+    /** Initial user message text; used when the feed has no history yet (e.g. auto-rename on first send). */
+    prompt: Schema.optional(Schema.String),
   }),
   output: Schema.Void,
 });

--- a/packages/plugins/plugin-space/src/capabilities/navigation-resolver.ts
+++ b/packages/plugins/plugin-space/src/capabilities/navigation-resolver.ts
@@ -74,9 +74,23 @@ export default Capability.makeModule(
       return Effect.succeed(Option.some(EID.make({ spaceId, entityId: objectId as Key.EntityId })));
     };
 
+    // Resolve a bare entity ID (no path separators) against the current space.
+    // Agents sometimes pass raw entity IDs from object creation results instead of full paths.
+    // TODO(wittjosiah): Remove cast once NavigationPathResolver type includes Database.Service.
+    const bareEntityPathResolver: AppCaps.NavigationPathResolver = ((path: string) => {
+      if (path.includes('/') || !Key.EntityId.isValid(path)) {
+        return Effect.succeed(Option.none());
+      }
+      return Effect.gen(function* () {
+        const { db } = yield* Database.Service;
+        return Option.some(EID.make({ spaceId: db.spaceId, entityId: path as Key.EntityId }));
+      });
+    }) as AppCaps.NavigationPathResolver;
+
     return [
       Capability.contributes(AppCapabilities.NavigationTargetResolver, resolver),
       Capability.contributes(AppCapabilities.NavigationPathResolver, pathResolver),
+      Capability.contributes(AppCapabilities.NavigationPathResolver, bareEntityPathResolver),
     ];
   }),
 );

--- a/packages/plugins/plugin-space/src/capabilities/navigation-resolver.ts
+++ b/packages/plugins/plugin-space/src/capabilities/navigation-resolver.ts
@@ -76,8 +76,7 @@ export default Capability.makeModule(
 
     // Resolve a bare entity ID (no path separators) against the current space.
     // Agents sometimes pass raw entity IDs from object creation results instead of full paths.
-    // TODO(wittjosiah): Remove cast once NavigationPathResolver type includes Database.Service.
-    const bareEntityPathResolver: AppCaps.NavigationPathResolver = ((path: string) => {
+    const bareEntityPathResolver: AppCaps.NavigationPathResolver = (path) => {
       if (path.includes('/') || !Key.EntityId.isValid(path)) {
         return Effect.succeed(Option.none());
       }
@@ -85,7 +84,7 @@ export default Capability.makeModule(
         const { db } = yield* Database.Service;
         return Option.some(EID.make({ spaceId: db.spaceId, entityId: path as Key.EntityId }));
       });
-    }) as AppCaps.NavigationPathResolver;
+    };
 
     return [
       Capability.contributes(AppCapabilities.NavigationTargetResolver, resolver),

--- a/packages/sdk/app-toolkit/src/capabilities.ts
+++ b/packages/sdk/app-toolkit/src/capabilities.ts
@@ -258,7 +258,7 @@ export namespace AppCapabilities {
    * Used to validate navigation targets against remote services (e.g., edge).
    * @category Capability
    */
-  export type NavigationPathResolver = (qualifiedPath: string) => Effect$.Effect<Option.Option<EID.EID>>;
+  export type NavigationPathResolver = (qualifiedPath: string) => Effect$.Effect<Option.Option<EID.EID>, never, Database.Service>;
 
   export const NavigationPathResolver = Capability$.make<NavigationPathResolver>(
     'org.dxos.app-framework.capability.navigation-path-resolver',

--- a/packages/sdk/app-toolkit/src/capabilities.ts
+++ b/packages/sdk/app-toolkit/src/capabilities.ts
@@ -258,7 +258,9 @@ export namespace AppCapabilities {
    * Used to validate navigation targets against remote services (e.g., edge).
    * @category Capability
    */
-  export type NavigationPathResolver = (qualifiedPath: string) => Effect$.Effect<Option.Option<EID.EID>, never, Database.Service>;
+  export type NavigationPathResolver = (
+    qualifiedPath: string,
+  ) => Effect$.Effect<Option.Option<EID.EID>, never, Database.Service>;
 
   export const NavigationPathResolver = Capability$.make<NavigationPathResolver>(
     'org.dxos.app-framework.capability.navigation-path-resolver',

--- a/packages/sdk/app-toolkit/src/not-found.ts
+++ b/packages/sdk/app-toolkit/src/not-found.ts
@@ -6,7 +6,7 @@ import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 
 import { Graph, Node } from '@dxos/app-graph';
-import { Filter, Key, Query, Scope } from '@dxos/echo';
+import { Database, Filter, Key, Query, Scope } from '@dxos/echo';
 import { EID } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { expandAttendableId } from '@dxos/react-ui-attention/types';
@@ -57,7 +57,7 @@ export const validateNavigationTarget = (params: {
   pathResolvers: AppCapabilities.NavigationPathResolver[];
   checkLocalExistence?: ExistenceChecker;
   checkRemoteExistence?: ExistenceChecker;
-}): Effect.Effect<string> => {
+}): Effect.Effect<string, never, Database.Service> => {
   const { graph, subjectId, pathResolvers, checkLocalExistence, checkRemoteExistence } = params;
 
   // Skip validation for system paths.

--- a/packages/sdk/app-toolkit/src/operations.ts
+++ b/packages/sdk/app-toolkit/src/operations.ts
@@ -305,7 +305,7 @@ export namespace LayoutOperation {
       navigation: Schema.optional(
         NavigationMode.annotations({
           description:
-            'How navigation should resolve the requested path. Validate checks the path first; immediate opens it directly and lets the graph catch up.',
+            'How navigation should resolve the requested path. Use validate (the default) to check the path exists before navigating. Immediate is for internal use only.',
         }),
       ),
       pivotId: Schema.optional(

--- a/packages/sdk/app-toolkit/src/operations.ts
+++ b/packages/sdk/app-toolkit/src/operations.ts
@@ -6,6 +6,7 @@ import * as Schema from 'effect/Schema';
 
 import { Capability } from '@dxos/app-framework';
 import { Operation } from '@dxos/compute';
+import { Database } from '@dxos/echo';
 import { DXN } from '@dxos/keys';
 import { SelectionSchema } from '@dxos/react-ui-attention/types';
 
@@ -285,7 +286,7 @@ export namespace LayoutOperation {
       icon: 'ph--arrow-square-out--regular',
     },
     executionMode: 'sync',
-    services: [Capability.Service],
+    services: [Capability.Service, Database.Service],
     input: Schema.Struct({
       // TODO(dmaretskyi): use Ref.Ref(Obj.Unknown)
       subject: Schema.Array(


### PR DESCRIPTION
## Summary

- **Auto-rename chat on first message**: When a user sends their first message to a new AI chat (no name yet), the `UpdateChatName` operation is scheduled immediately after `submitPrompt` — running concurrently with the AI response rather than waiting for completion. The user's message text is passed directly to the rename operation (instead of querying the feed) because the feed write is async/alarm-based and the message won't be present when the rename runs. Removes the previous random-chance periodic re-naming on every completed turn.
- **Fix bare entity ID navigation**: Agents sometimes pass raw entity IDs (e.g. `01KTKJVCAF70XQM6GT04KWXGYV`) directly to the `Open` operation after creating objects, instead of fully-qualified graph paths. These previously resolved to not-found because no path resolver could handle them. Added a `NavigationPathResolver` in `plugin-space` that detects bare entity IDs (no path separators) and pairs them with the current space's `db.spaceId`. Uses the same `Database.Service` cast pattern as the existing `NavigationTargetResolver`.
- **Steer agents away from `immediate` navigation**: Updated the `navigation` field description on `LayoutOperation.Open` so agents default to `validate` (which runs the path resolver pipeline) rather than `immediate` (which bypasses it entirely).

## Changes

- `plugin-assistant/src/processor/processor.ts` — fire `UpdateChatName` after first `submitPrompt` if chat has no name; remove post-completion random rename
- `plugin-assistant/src/operations/update-chat-name.ts` — accept optional `prompt` text; use it directly when provided (avoids empty-feed hallucination), fall back to feed history for manual toolbar invocations
- `plugin-assistant/src/types/AssistantOperation.ts` — add optional `prompt` field to `UpdateChatName` input
- `plugin-space/src/capabilities/navigation-resolver.ts` — add `bareEntityPathResolver` for bare entity IDs
- `app-toolkit/src/operations.ts` — update `navigation` field description

## Reviewer notes

- The `bareEntityPathResolver` cast is intentional and matches the existing `NavigationTargetResolver` cast pattern (see TODO comment). Both rely on `Database.Service` being available at call time through the space-scoped operation layer.
- The `UpdateChatName` prompt-text path is only taken on auto-trigger (first message); manual toolbar invocations omit `prompt` and use the full feed history as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat name generation can use an initial prompt for more accurate names
  * Navigation now resolves bare entity IDs (simple IDs without path separators)

* **Improvements**
  * Chat names update immediately on first message when unnamed
  * Removed probabilistic auto-update option from chat processor

* **Documentation**
  * Clarified navigation validation behavior and the intended use of “immediate” mode
<!-- end of auto-generated comment: release notes by coderabbit.ai -->