### PR TITLE
fix(ui-theme): stop main.css HMR storm from dist build-output churn

### DIFF
--- a/packages/sdk/app-toolkit/src/state-map.test.ts
+++ b/packages/sdk/app-toolkit/src/state-map.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, test } from 'vitest';
 import { Database, DXN, Obj, Type } from '@dxos/echo';
 import { getObjectCore } from '@dxos/echo-db';
 import { EchoTestBuilder } from '@dxos/echo-db/testing';
-import { runAndForwardErrors } from '@dxos/effect';
+import { EffectEx } from '@dxos/effect';
 import { type EntityId } from '@dxos/keys';
 
 import * as StateMap from './StateMap';
@@ -58,6 +58,6 @@ describe('StateMap (database integration)', () => {
 
       // Each new entry: makeMap + set field ≈ 2–3 ops, well under 10 per entry.
       expect(totalOps).toBeLessThan(N * 10);
-    }).pipe(Effect.provide(testLayer), runAndForwardErrors);
+    }).pipe(Effect.provide(testLayer), EffectEx.runAndForwardErrors);
   });
 });

--- a/packages/ui/ui-theme/src/main.css
+++ b/packages/ui/ui-theme/src/main.css
@@ -76,7 +76,16 @@
  *   ../../../../tools/ → `tools/`
  *
  * Tailwind ignores `node_modules` and common build/output dirs by default,
- * so a broad workspace glob is safe.
+ * so a broad workspace glob is safe *for scanning*.
+ *
+ * NOTE: Tailwind's scanner respects `.gitignore` (so `dist/` is never
+ * scanned), but it hands Vite a coarse `dir-dependency` glob and Vite
+ * re-expands that itself, ignoring only `node_modules`. That re-expansion
+ * sweeps `dist/**` `.d.ts` files into the watch set and causes a `main.css`
+ * HMR storm on every package rebuild. Build outputs are excluded from the
+ * dev watcher in `plugins/ThemePlugin.ts` (`server.watch.ignored`) rather
+ * than here, because `@source not` does NOT propagate to the glob Vite
+ * re-expands.
  */
 @source "../../../**/*.{ts,tsx,html}";
 @source "../../../../tools/**/*.{ts,tsx,html}";

--- a/packages/ui/ui-theme/src/plugins/ThemePlugin.ts
+++ b/packages/ui/ui-theme/src/plugins/ThemePlugin.ts
@@ -70,6 +70,35 @@ export const ThemePlugin = (options: ThemePluginOptions): Plugin => {
     name: 'vite-plugin-dxos-ui-theme',
     config: (): UserConfig => {
       return {
+        server: {
+          watch: {
+            // Stop build outputs from driving HMR — they are the root of the
+            // `main.css` HMR storm.
+            //
+            // Tailwind's `@source` scanning (see `src/main.css`) registers its
+            // scanned source files as Vite watch dependencies of the compiled
+            // theme CSS. Tailwind's own scanner respects `.gitignore` (and the
+            // `@source not` directives), so it never *scans* `dist/`. BUT the
+            // scanner hands Vite a coarse `dir-dependency` glob — e.g.
+            // `{**/*.html,**/*.ts,**/*.tsx}` — and Vite re-expands that glob
+            // itself, ignoring only `node_modules` (not `.gitignore`, not the
+            // `@source not` negations). The re-expansion therefore sweeps in
+            // every `packages/*/dist/**/*.d.ts` (`.d.ts` matches `**/*.ts`),
+            // making each emitted declaration file a watch-dependency of
+            // `main.css`. A single package rebuild emits dozens of `.d.ts` in a
+            // tight burst, and each write re-invalidates the theme — 40+ HMR
+            // pings for `main.css` in one second, repeating on every rebuild.
+            //
+            // Ignoring build outputs in the watcher is also semantically
+            // correct: in dev the workspace resolves `@dxos/*` via the `source`
+            // export condition (see `vite-plugin-import-source`), so `dist/`
+            // is never consumed at runtime and its churn should never trigger
+            // HMR. Vite concatenates these patterns with its built-in ignores
+            // (`**/node_modules/**`, `**/.git/**`, …), so this is purely
+            // additive.
+            ignored: ['**/dist/**', '**/out/**'],
+          },
+        },
         css: {
           postcss: {
             plugins: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12330,6 +12330,9 @@ importers:
       '@dxos/echo-query':
         specifier: workspace:*
         version: link:../../core/echo/echo-query
+      '@dxos/effect':
+        specifier: workspace:*
+        version: link:../../common/effect
       '@dxos/keys':
         specifier: workspace:*
         version: link:../../common/keys


### PR DESCRIPTION
## Problem

The compiled theme CSS (`packages/ui/ui-theme/src/main.css`) emits a storm of HMR updates — dozens of `hmr update .../main.css` in a single second, repeating throughout a dev session:

```
[vite] (client) hmr update /@fs/.../packages/ui/ui-theme/src/main.css   (×95 in one second)
```

This is a **separate mechanism** from the icon-sprite write that the existing `source(none)` comment in `main.css` addresses (that one is fixed).

## Root cause

1. `main.css` scans the monorepo via `@source "../../../**/*.{ts,tsx,html}"` (+ `tools/**`). Tailwind v4's PostCSS plugin registers everything it scans as a Vite **watch dependency** of the compiled CSS, so any change to a watched file re-emits an HMR update for `main.css`.
2. Tailwind's *scanner* respects `.gitignore`, so it never scans `dist/`. **But** the plugin hands Vite a coarse `dir-dependency` glob — `{**/*.html,**/*.ts,**/*.tsx}` — and **Vite re-expands that glob itself**, ignoring only `node_modules` (`ignore: ["**/node_modules/**"]` — not `.gitignore`, not the `@source not` negations).
3. `.d.ts` matches `**/*.ts`, so Vite's expansion sweeps in **every `packages/*/dist/**/*.d.ts`** as a dependency of `main.css`.
4. Whenever a package rebuilds (tsc/moon emitting declaration files), dozens of `.d.ts` land in a burst → each write re-invalidates the theme → the storm.

Reproduced end-to-end against this repo's Tailwind 4.2.0 + Vite 8.0.10: with a `dist/a.d.ts` present, Tailwind's `dependency` list correctly excludes it, yet Vite's glob expansion of the emitted `dir-dependency` lists `dist/a.d.ts` as a watched dep. `@source not "dist/**"` does **not** fix it — the negation is not propagated into the glob Vite re-expands.

## Fix

Exclude build outputs from the dev watcher in `ThemePlugin.ts`:

```ts
server: { watch: { ignored: ['**/dist/**', '**/out/**'] } }
```

Why this layer:
- Stops chokidar from emitting change events for `dist`/`out`, so declaration-file churn no longer drives HMR.
- **Additive** — Vite concatenates these with its built-in ignores (`**/node_modules/**`, `**/.git/**`), confirmed in Vite 8's `resolveChokidarOptions`.
- **Semantically correct**: in dev the workspace resolves `@dxos/*` via the `source` export condition (`vite-plugin-import-source`), so `dist/` is never consumed at runtime — its churn should never trigger HMR.
- Preserves Tailwind's full scan coverage (no classes lost), unlike narrowing `@source` to `src/**` (which would also drop root `*.html` entrypoints and `demos/`).

## Testing

- `moon run ui-theme:build` ✅ (28 tasks)
- `moon run ui-theme:lint` ✅
- Standalone `tsc` typecheck of `ThemePlugin.ts` ✅ (`server.watch.ignored` is valid on Vite's `UserConfig`)

https://claude.ai/code/session_014uBDAQkJDwJwGdtmWB4n1A

---
_Generated by [Claude Code](https://claude.ai/code/session_014uBDAQkJDwJwGdtmWB4n1A)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified theme scanning comments to explain safe scan configuration and hot-reload behavior.

* **Chores**
  * Reduced unnecessary theme hot-reload invalidations by excluding build output from file-watching.

* **Tests**
  * Updated a test's error-forwarding approach without changing its assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->