### PR TITLE
fix: unbreak main CI — regenerate lockfile and migrate state-map.test to EffectEx

### DIFF
--- a/packages/sdk/app-toolkit/src/state-map.test.ts
+++ b/packages/sdk/app-toolkit/src/state-map.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, test } from 'vitest';
 import { Database, DXN, Obj, Type } from '@dxos/echo';
 import { getObjectCore } from '@dxos/echo-db';
 import { EchoTestBuilder } from '@dxos/echo-db/testing';
-import { runAndForwardErrors } from '@dxos/effect';
+import { EffectEx } from '@dxos/effect';
 import { type EntityId } from '@dxos/keys';
 
 import * as StateMap from './StateMap';
@@ -58,6 +58,6 @@ describe('StateMap (database integration)', () => {
 
       // Each new entry: makeMap + set field ≈ 2–3 ops, well under 10 per entry.
       expect(totalOps).toBeLessThan(N * 10);
-    }).pipe(Effect.provide(testLayer), runAndForwardErrors);
+    }).pipe(Effect.provide(testLayer), EffectEx.runAndForwardErrors);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12330,6 +12330,9 @@ importers:
       '@dxos/echo-query':
         specifier: workspace:*
         version: link:../../core/echo/echo-query
+      '@dxos/effect':
+        specifier: workspace:*
+        version: link:../../common/effect
       '@dxos/keys':
         specifier: workspace:*
         version: link:../../common/keys


### PR DESCRIPTION
## Problem

CI's **Check** workflow was failing on `main` (run [27142451686](https://github.com/dxos/dxos/actions/runs/27142451686), commit 6f815cf4). Two separate breakages from the recent effect refactor (#11721) were masking each other:

### 1. Lockfile drift (blocked every job at Setup)

All four jobs (`check`, `test`, `e2e`, `storybook`) aborted at the **Setup** step during `pnpm install`:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with packages/plugins/plugin-pipeline/package.json
* 1 dependencies were added: @dxos/effect@workspace:*
```

#11721 added `@dxos/effect: workspace:*` to `plugin-pipeline/package.json` but did not regenerate `pnpm-lock.yaml`. CI installs with `--frozen-lockfile`, so the mismatch aborted setup before any build/test/lint ran.

### 2. Stale import (surfaced once the build could run)

With the lockfile fixed, CI built far enough to reveal a pre-existing `TS2305`:

```
packages/sdk/app-toolkit/src/state-map.test.ts(13,10): error TS2305:
Module '"@dxos/effect"' has no exported member 'runAndForwardErrors'.
```

#11721 moved `runAndForwardErrors` into the `EffectEx` namespace and migrated `tag-index.test.ts`, but missed the sibling `state-map.test.ts` (added concurrently in #11722).

## Fix

1. Regenerated `pnpm-lock.yaml` — adds the missing `@dxos/effect` link entry for plugin-pipeline.
2. Updated `state-map.test.ts` to use `EffectEx.runAndForwardErrors` (matching `tag-index.test.ts`).

Swept the repo for other stale top-level imports of EffectEx-moved symbols — none remained. Verified locally that `pnpm install --frozen-lockfile` and `moon run app-toolkit:build` both succeed.

https://claude.ai/code/session_019zwNG6akXkjrzaHtYL8Pek