### PR TITLE
fix(composer-app,plugin-support): fix identity re-creation race on reload; wire SpaceHomeArticle attendableId

### DIFF
--- a/packages/apps/composer-app/src/plugins/welcome/onboarding-manager.ts
+++ b/packages/apps/composer-app/src/plugins/welcome/onboarding-manager.ts
@@ -90,6 +90,8 @@ export class OnboardingManager {
     this._accountInvitationCode = accountInvitationCode;
     this._email = email;
 
+    this._identity = this._client.halo.identity.get();
+
     this._subscriptions.add(
       this._client.halo.identity.subscribe((identity) => {
         if (this._destroyed) {

--- a/packages/plugins/plugin-support/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-support/src/capabilities/react-surface.tsx
@@ -47,9 +47,9 @@ export default Capability.makeModule(() =>
       Surface.create({
         id: 'spaceHome',
         filter: AppSurface.literal(AppSurface.Article, SPACE_HOME_NODE_TYPE),
-        component: ({ role }) => {
+        component: ({ data, role }) => {
           const space = useActiveSpace();
-          return <SpaceHomeArticle role={role} space={space} />;
+          return <SpaceHomeArticle role={role} attendableId={data.attendableId} space={space} />;
         },
       }),
       Surface.create({

--- a/packages/plugins/plugin-support/src/containers/SpaceHomeArticle/SpaceHomeArticle.tsx
+++ b/packages/plugins/plugin-support/src/containers/SpaceHomeArticle/SpaceHomeArticle.tsx
@@ -42,6 +42,7 @@ const WELCOME_SLIDE = {
 
 export type SpaceHomeArticleProps = {
   role?: string;
+  attendableId?: string;
   space: Space | undefined;
 };
 
@@ -50,7 +51,7 @@ export type SpaceHomeArticleProps = {
  * dismissed). Below that are the most-recently-modified objects (of registered, non-hidden types),
  * or starter prompts when the space is empty, above the assistant prompt pinned at the bottom.
  */
-export const SpaceHomeArticle = ({ role, space }: SpaceHomeArticleProps) => {
+export const SpaceHomeArticle = ({ role, attendableId, space }: SpaceHomeArticleProps) => {
   const { t } = useTranslation(meta.id);
   const { invokePromise } = useOperationInvoker();
 
@@ -109,7 +110,7 @@ export const SpaceHomeArticle = ({ role, space }: SpaceHomeArticleProps) => {
 
   return (
     <Panel.Root role={role}>
-      <Menu.Root {...menuActions}>
+      <Menu.Root {...menuActions} attendableId={attendableId}>
         <Panel.Toolbar asChild>
           <Menu.Toolbar />
         </Panel.Toolbar>

--- a/packages/sdk/app-framework/src/core/plugin-manager.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager.ts
@@ -1348,7 +1348,7 @@ class ManagerImpl implements PluginManager {
     return Effect.gen(this, function* () {
       yield* Ref.update(this._activatingModules, (activating) => Array.appendAll(activating, activatingModuleIds));
 
-      log.info('activation wave', { event: key, modules: activatingModuleIds });
+      log('activation wave', { event: key, modules: activatingModuleIds });
       performance.mark(`event:${key}:start`);
       yield* PubSub.publish(this.activation, { event: key, state: 'activating' });
 


### PR DESCRIPTION
## Summary

- **Identity race on reload**: `OnboardingManager` now seeds `_identity` synchronously from `client.halo.identity.get()` in the constructor, rather than relying solely on the subscribe callback. In edge cases (service reconnect during startup, HMR), the observable's `_value` can be stale-null at subscription time even when an identity exists — causing `initialize()` to enter the `createIdentity` path and fail with `"Identity already exists"`. Reading `get()` directly is always correct once `client.initialize()` has completed (which is guaranteed because the `Onboarding` module only activates after `ClientReady`).

- **SpaceHomeArticle attendableId**: The `spaceHome` surface was not forwarding `data.attendableId` to `SpaceHomeArticle`, so `Menu.Root` had no attendable ID. Attention-driven toolbar contributions (graph actions, plugin extensions, keyboard shortcuts) were not targeting the surface. Fixed by destructuring `data` in the surface component and threading `attendableId` through the props chain to `Menu.Root`.

## Test plan

- [ ] Create a fresh identity in Composer (local dev, no `DX_HUB_URL`), then reload — no `"Identity already exists"` error in the console.
- [ ] Open the space home page; confirm the toolbar menu actions are correctly scoped (attention glyph reflects focus, keyboard shortcuts apply to the surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized welcome onboarding flow to immediately detect cached identity state during initialization, preventing unnecessary welcome screens when user identity already exists locally.
  * Enhanced Space Home Article component to fully support attendable ID context, enabling more complete contextual operations within spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->