### PR TITLE
fix(observability): fix ipdata schema to match actual API response

### DIFF
--- a/packages/sdk/observability/src/providers/ip-data.ts
+++ b/packages/sdk/observability/src/providers/ip-data.ts
@@ -17,12 +17,14 @@ import { type DataProvider } from '../observability';
 
 const IP_DATA_CACHE_TIMEOUT = 6 * 60 * 60 * 1000; // 6 hours
 
+// ipdata.co v1 response — city/region/latitude/longitude are nullable for some IPs (VPNs, CDNs, etc.),
+// and the country field is named `country_name`, not `country`.
 const IPData = Schema.Struct({
-  city: Schema.String,
-  region: Schema.String,
-  country: Schema.String,
-  latitude: Schema.optional(Schema.Number),
-  longitude: Schema.optional(Schema.Number),
+  city: Schema.NullOr(Schema.String),
+  region: Schema.NullOr(Schema.String),
+  country_name: Schema.String,
+  latitude: Schema.NullOr(Schema.Number),
+  longitude: Schema.NullOr(Schema.Number),
 });
 type IPData = Schema.Schema.Type<typeof IPData>;
 
@@ -45,23 +47,31 @@ const getIPData = Effect.fn(function* (config: Config) {
 
   // Fetch data if not cached.
   const IPDATA_API_KEY = config.get('runtime.app.env.DX_IPDATA_API_KEY');
-  if (IPDATA_API_KEY) {
-    const data = yield* HttpClientRequest.get(`https://api.ipdata.co?api-key=${IPDATA_API_KEY}`).pipe(
-      httpClientNoTrace.execute,
-      Effect.flatMap((res) => res.json),
-      Effect.flatMap(Schema.decodeUnknown(IPData)),
-    );
-
-    // Cache data.
-    yield* Effect.promise(() =>
-      localForage.setItem('dxos:observability:ipdata', {
-        data,
-        timestamp: Date.now(),
-      }),
-    );
-
-    return data;
+  if (!IPDATA_API_KEY) {
+    log.warn('DX_IPDATA_API_KEY is not configured; IP geolocation tags will be absent from telemetry');
+    return cachedData?.data;
   }
+
+  const data = yield* HttpClientRequest.get(`https://api.ipdata.co?api-key=${IPDATA_API_KEY}`).pipe(
+    httpClientNoTrace.execute,
+    Effect.flatMap((res) => res.json),
+    Effect.flatMap(Schema.decodeUnknown(IPData)),
+    // On failure fall back to stale cache rather than emitting no tags.
+    Effect.catchAll((err) =>
+      Effect.sync(() => {
+        log.warn('ipdata fetch failed; IP geolocation tags will be absent or stale', { err });
+        return cachedData?.data;
+      }),
+    ),
+  );
+
+  if (data) {
+    yield* Effect.promise(() =>
+      localForage.setItem('dxos:observability:ipdata', { data, timestamp: Date.now() }),
+    );
+  }
+
+  return data;
 });
 
 /** Fetches IP geolocation data and sets city/region/country tags on the observability instance. */
@@ -75,17 +85,17 @@ export const provider =
       }
 
       observability.setTags({
-        city: ipData.city,
-        region: ipData.region,
-        country: ipData.country,
-        latitude: ipData.latitude,
-        longitude: ipData.longitude,
+        ...(ipData.city != null && { city: ipData.city }),
+        ...(ipData.region != null && { region: ipData.region }),
+        country: ipData.country_name,
+        ...(ipData.latitude != null && { latitude: ipData.latitude }),
+        ...(ipData.longitude != null && { longitude: ipData.longitude }),
       });
     }).pipe(
       Effect.provide(FetchHttpClient.layer),
       Effect.catchAll((err) =>
         Effect.sync(() => {
-          log.verbose('ipdata fetch failed', { err });
+          log.warn('ipdata provider failed', { err });
         }),
       ),
     );

--- a/packages/sdk/observability/src/providers/ip-data.ts
+++ b/packages/sdk/observability/src/providers/ip-data.ts
@@ -67,9 +67,7 @@ const getIPData = Effect.fn(function* (config: Config) {
   );
 
   if (data) {
-    yield* Effect.promise(() =>
-      localForage.setItem('dxos:observability:ipdata:v2', { data, timestamp: Date.now() }),
-    );
+    yield* Effect.promise(() => localForage.setItem('dxos:observability:ipdata:v2', { data, timestamp: Date.now() }));
   }
 
   return data;

--- a/packages/sdk/observability/src/providers/ip-data.ts
+++ b/packages/sdk/observability/src/providers/ip-data.ts
@@ -40,7 +40,8 @@ const getIPData = Effect.fn(function* (config: Config) {
   const httpClientNoTrace = httpClient.pipe(HttpClient.withTracerDisabledWhen(() => true));
 
   // Check cache first.
-  const cachedData = yield* Effect.promise(() => localForage.getItem<CachedIPData>('dxos:observability:ipdata'));
+  // v2 key discards entries cached by the previous schema (which used `country` instead of `country_name`).
+  const cachedData = yield* Effect.promise(() => localForage.getItem<CachedIPData>('dxos:observability:ipdata:v2'));
   if (cachedData && cachedData.timestamp > Date.now() - IP_DATA_CACHE_TIMEOUT) {
     return cachedData.data;
   }
@@ -67,7 +68,7 @@ const getIPData = Effect.fn(function* (config: Config) {
 
   if (data) {
     yield* Effect.promise(() =>
-      localForage.setItem('dxos:observability:ipdata', { data, timestamp: Date.now() }),
+      localForage.setItem('dxos:observability:ipdata:v2', { data, timestamp: Date.now() }),
     );
   }
 


### PR DESCRIPTION
## Summary

- The `IPData` schema used field names that don't match the ipdata.co v1 API: the country field is `country_name` (not `country`), and `city`, `region`, `latitude`, `longitude` are nullable for VPNs/CDNs/IPs without city-level data
- `Schema.decodeUnknown` was failing on every real response; the error was caught and logged at `verbose` level, making it completely invisible in SigNoz
- As a result, IP geolocation tags (`city`, `region`, `country`) have never been attached to Composer logs or traces

## Changes

- Fix schema field names and nullability to match ipdata.co v1 API (`country_name`, `NullOr` for city/region/lat/lng)
- Emit nullable fields as tags only when non-null; map `country_name` → `country` tag for consistency
- Raise error log level from `verbose` → `warn` so fetch/decode failures are visible in SigNoz
- On fetch failure, fall back to stale cached data rather than emitting no tags

## Reviewer notes

The `CachedIPData` wrapper (with `timestamp`) is preserved so the 6-hour TTL still triggers a refresh. The cache key (`dxos:observability:ipdata`) is unchanged, but existing cached entries had the old schema shape (with a `country` field) — those will fail the new schema decode on first load and trigger a fresh fetch, which is the correct behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * IP data provider now tolerates nullable location fields and avoids populating tags with null values.
  * Country mapping updated to use full country names.
  * Caching refreshed to isolate new results from prior cache and persist successful lookups under a new key.
  * getIPData now requires an API key; when missing, it logs a warning and falls back to cached data.
  * On fetch or decode failures, the system logs a warning and uses stale cached results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->