### PR TITLE
fix(edge-client): prevent reconnect storm when edge connection drops immediately

### DIFF
--- a/packages/common/async/src/persistent-lifecycle.test.ts
+++ b/packages/common/async/src/persistent-lifecycle.test.ts
@@ -57,6 +57,42 @@ describe('ConnectionState', () => {
     expect(timeToTrigger).to.be.greaterThanOrEqual(100);
   });
 
+  test('connection that drops immediately backs off instead of hot-looping', async () => {
+    const startTimes: number[] = [];
+    const maxStarts = 4;
+    const done = new Trigger();
+
+    const persistentLifecycle = new PersistentLifecycle({
+      start: async () => {
+        startTimes.push(Date.now());
+        if (startTimes.length >= maxStarts) {
+          done.wake();
+        }
+      },
+      stop: async () => {},
+      // Simulate the connection dropping the moment it is established.
+      onRestart: async () => {
+        if (startTimes.length < maxStarts) {
+          void persistentLifecycle.scheduleRestart();
+        }
+      },
+    });
+
+    await persistentLifecycle.open();
+    onTestFinished(async () => {
+      await persistentLifecycle.close();
+    });
+
+    // The initial open already performed the first start; simulate its immediate drop.
+    void persistentLifecycle.scheduleRestart();
+    await done.wait({ timeout: 5000 });
+
+    // Successive reconnects must back off (~0, ~100, ~200ms), not fire back-to-back.
+    const gaps = startTimes.slice(1).map((time, index) => time - startTimes[index]);
+    expect(gaps[1]).to.be.greaterThanOrEqual(90);
+    expect(gaps[2]).to.be.greaterThanOrEqual(180);
+  });
+
   test('finish `restart` before close', async () => {
     let restarted = false;
     const persistentLifecycle = new PersistentLifecycle({

--- a/packages/common/async/src/persistent-lifecycle.ts
+++ b/packages/common/async/src/persistent-lifecycle.ts
@@ -13,6 +13,13 @@ import { sleep } from './timeout';
 const INIT_RESTART_DELAY = 100;
 const DEFAULT_MAX_RESTART_DELAY = 5000;
 
+/**
+ * Minimum duration a connection must stay up before it is considered stable and the backoff is
+ * reset. A connection that drops sooner keeps escalating the delay, so an endpoint that accepts
+ * then immediately closes the connection cannot produce a zero-delay reconnect loop.
+ */
+const STABLE_CONNECTION_THRESHOLD = 5000;
+
 export type PersistentLifecycleProps<T> = {
   /**
    * Create connection.
@@ -50,6 +57,7 @@ export class PersistentLifecycle<T> extends Resource {
   private _currentState: T | undefined = undefined;
   private _restartTask?: DeferredTask = undefined;
   private _restartAfter = 0;
+  private _connectedAt: number | undefined = undefined;
 
   constructor({ start, stop, onRestart, maxRestartDelay = DEFAULT_MAX_RESTART_DELAY }: PersistentLifecycleProps<T>) {
     super();
@@ -78,15 +86,17 @@ export class PersistentLifecycle<T> extends Resource {
       }
     });
 
-    this._currentState = await this._start().catch((err) => {
+    try {
+      this._currentState = await this._start();
+      this._connectedAt = Date.now();
+    } catch (err) {
       // Suppress noise when shutdown was requested while the initial start was in flight.
       if (this._ctx?.disposed) {
-        return undefined;
+        return;
       }
       log.warn('Start failed', { err });
       this._restartTask?.schedule();
-      return undefined;
-    });
+    }
   }
 
   protected override async _close(): Promise<void> {
@@ -97,6 +107,15 @@ export class PersistentLifecycle<T> extends Resource {
 
   private async _restart(): Promise<void> {
     log(`restarting in ${this._restartAfter}ms`, { state: this._lifecycleState });
+
+    // Reset the backoff only if the previous connection stayed up long enough to be considered
+    // stable. A connection that drops shortly after starting must keep escalating the delay,
+    // otherwise reconnects degenerate into a hot loop.
+    if (this._connectedAt !== undefined && Date.now() - this._connectedAt >= STABLE_CONNECTION_THRESHOLD) {
+      this._restartAfter = 0;
+    }
+    this._connectedAt = undefined;
+
     await this._stopCurrentState();
     if (this._lifecycleState !== LifecycleState.OPEN) {
       return;
@@ -109,7 +128,7 @@ export class PersistentLifecycle<T> extends Resource {
       this._currentState = await this._start();
     });
 
-    this._restartAfter = 0;
+    this._connectedAt = Date.now();
     await this._onRestart?.();
   }
 

--- a/packages/core/mesh/edge-client/src/edge-client.ts
+++ b/packages/core/mesh/edge-client/src/edge-client.ts
@@ -269,9 +269,23 @@ export class EdgeClient extends Resource implements EdgeConnection {
     this._currentConnection = connection;
 
     await connection.open();
-    // Race with restartRequired so that restart is not blocked by _connect execution.
-    // Wait on ready to attempt a reconnect if it times out.
-    await Promise.race([this._ready.wait({ timeout: this._config.timeout ?? DEFAULT_TIMEOUT }), restartRequired]);
+
+    // The connection is only a successful start once the socket becomes ready. A socket that
+    // closes or errors before becoming ready (or never connects within the timeout) is a failed
+    // start: throwing lets PersistentLifecycle apply its backoff. Returning here would mark the
+    // attempt as successful and reset the backoff, degenerating reconnects into a hot loop when
+    // the server accepts then immediately drops the socket.
+    const becameReady = await Promise.race([
+      this._ready.wait({ timeout: this._config.timeout ?? DEFAULT_TIMEOUT }).then(
+        () => true,
+        () => false,
+      ),
+      restartRequired.wait().then(() => false),
+    ]);
+    if (!becameReady) {
+      throw new EdgeConnectionClosedError();
+    }
+
     return connection;
   }
 


### PR DESCRIPTION
## Summary

- **Fix `EdgeClient._connect`**: The old `Promise.race([this._ready.wait(...), restartRequired])` had a silent bug — `Trigger` has no `then` method so it's not thenable, causing `Promise.race` to treat it as an already-resolved value and return immediately before the socket became ready. Now both signals are properly awaited via `.then()` wrappers; if the socket doesn't become ready (closed, errored, or timed out), `_connect` throws `EdgeConnectionClosedError` so `PersistentLifecycle` applies backoff instead of treating the dud connection as successful.

- **Fix `PersistentLifecycle` backoff**: Previously `_restartAfter` was reset to `0` after _any_ non-throwing `start()`, so a connection that opened then immediately dropped reset the backoff every cycle → zero-delay reconnect loop. Added `STABLE_CONNECTION_THRESHOLD = 5000ms`; backoff only resets when the connection stays up ≥ 5 s.

- **Regression test**: Simulates a connection that succeeds then drops immediately (4 times) and asserts successive reconnects back off (~0 → ~100 → ~200 ms) rather than firing back-to-back.

## Root cause (DX-1001)

Edge-labs accepted the WebSocket then dropped it (code 1006). The two bugs cooperated to produce ~50 reconnects/second — each attempt ran an HTTP `fetch` + crypto auth-challenge signing on the dedicated worker where ECHO runs, saturating its event loop and preventing the UI from finishing startup.

Neither fix touches the app's local-first startup path — the SDK was already correctly non-blocking; the bugs were in the reconnect mechanism.

## Test plan

- [x] `async:test` — 61/61 pass (4 tests in `persistent-lifecycle.test.ts` including the new regression test)
- [x] `edge-client:test` — 14/14 pass + 2 skipped
- [x] Full repo `moon run :test` — no failures
- [x] Full repo `moon exec :build` — no errors
- [x] `moon run :lint -- --fix` — clean on both packages
- [x] No new casts (`git diff origin/main | grep -nE '\bas (any|unknown|[A-Z])'` returns nothing)

closes DX-1001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection stability with better handling when connections drop shortly after establishment.
  * Enhanced reconnection backoff behavior to prevent rapid reconnection loops.
  * Fixed websocket readiness detection in connection flows.

* **Tests**
  * Added test coverage for reconnection backoff scenarios under immediate connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->