### PR TITLE
fix(echo): restore memoized query atom family to stop subscription leak

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -15,6 +15,7 @@
     "@dxos/eslint-plugin-rules/translation-key-format": "warn",
     "@dxos/eslint-plugin-rules/no-effect-run-promise": "error",
     "@dxos/eslint-plugin-rules/no-empty-promise-catch": "error",
+    "@dxos/eslint-plugin-rules/no-query-result-atom-getter": "error",
     "eslint/curly": ["error", "all"],
     "eslint/no-async-promise-executor": "off",
     "eslint/no-constant-binary-expression": "off",

--- a/packages/common/eslint-plugin-rules/index.js
+++ b/packages/common/eslint-plugin-rules/index.js
@@ -12,6 +12,7 @@ import importAsNamespace from './rules/import-as-namespace.js';
 import noBareDotImports from './rules/no-bare-dot-imports.js';
 import noEffectRunPromise from './rules/no-effect-run-promise.js';
 import noEmptyPromiseCatch from './rules/no-empty-promise-catch.js';
+import noQueryResultAtomGetter from './rules/no-query-result-atom-getter.js';
 import translationKeyFormat from './rules/translation-key-format.js';
 
 const pkg = JSON.parse(fs.readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
@@ -31,6 +32,7 @@ const plugin = {
     'no-bare-dot-imports': noBareDotImports,
     'no-effect-run-promise': noEffectRunPromise,
     'no-empty-promise-catch': noEmptyPromiseCatch,
+    'no-query-result-atom-getter': noQueryResultAtomGetter,
     'translation-key-format': translationKeyFormat,
   },
   configs: {
@@ -45,6 +47,7 @@ const plugin = {
         'dxos-plugin/no-bare-dot-imports': 'error',
         'dxos-plugin/no-effect-run-promise': 'error',
         'dxos-plugin/no-empty-promise-catch': 'error',
+        'dxos-plugin/no-query-result-atom-getter': 'error',
         // TODO(dmaretskyi): Turned off due to large number of errors and no auto-fix.
         // 'dxos-plugin/comment': 'error',
       },

--- a/packages/common/eslint-plugin-rules/rules/no-query-result-atom-getter.js
+++ b/packages/common/eslint-plugin-rules/rules/no-query-result-atom-getter.js
@@ -1,0 +1,63 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+'use strict';
+
+/**
+ * ESLint rule to prevent the per-instance `QueryResult.atom` getter from being used inline on a
+ * fresh `query(...)` call.
+ *
+ * `database.query(filter)` (and `queue.query(...)`, `registry.query(...)`) constructs a NEW
+ * QueryResult every call, so `database.query(filter).atom` creates a new atom — and a new query
+ * subscription — on every evaluation. Inside graph-builder connectors/actions and other atom
+ * computes, which re-run on each reactive change, that subscription leaks: it is never released and
+ * accumulates without bound (the type-create / plugin-enable freeze).
+ *
+ * Use the memoized `QueryResult.atom(queryable, query)` family from `@dxos/echo`, which keys the
+ * atom by the queryable identifier and serialized query so the same query reuses one subscription.
+ * The per-instance getter remains valid when accessed on a QueryResult held stable across renders
+ * (e.g. behind a `useMemo`) — that is `held.atom`, not `held.query(...).atom`.
+ *
+ * @example
+ * // bad
+ * get(space.db.query(filter).atom);
+ *
+ * // good
+ * get(QueryResult.atom(space.db, filter));
+ */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow `.query(...).atom`; use the memoized QueryResult.atom(queryable, query) family.',
+      recommended: true,
+    },
+    messages: {
+      noInlineQueryAtom:
+        'Avoid `.query(...).atom`: it builds a new QueryResult (and leaks a subscription) on every ' +
+        'evaluation. Use the memoized `QueryResult.atom(queryable, query)` family from @dxos/echo instead.',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      MemberExpression(node) {
+        const isAtomGetter =
+          node.property.type === 'Identifier' &&
+          node.property.name === 'atom' &&
+          node.object.type === 'CallExpression' &&
+          node.object.callee.type === 'MemberExpression' &&
+          node.object.callee.property.type === 'Identifier' &&
+          node.object.callee.property.name === 'query';
+
+        if (isAtomGetter) {
+          context.report({
+            node,
+            messageId: 'noInlineQueryAtom',
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/core/echo/echo-client/src/query/query-result.test.ts
+++ b/packages/core/echo/echo-client/src/query/query-result.test.ts
@@ -4,7 +4,7 @@
 
 import * as Registry from '@effect-atom/atom/Registry';
 import * as Schema from 'effect/Schema';
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, test } from 'vitest';
 
 import { DXN, Filter, Obj, Query, QueryResult, Type } from '@dxos/echo';
 import { TestSchema } from '@dxos/echo/testing';
@@ -40,7 +40,7 @@ describe('QueryResult per-instance atom getter', () => {
     await testBuilder.close();
   });
 
-  test('creates atom with initial results', async () => {
+  test('creates atom with initial results', async ({ expect }) => {
     db.add(Obj.make(TestItem, { name: 'Object 1', value: 100 }));
     db.add(Obj.make(TestItem, { name: 'Object 2', value: 100 }));
     await db.flush();
@@ -54,12 +54,12 @@ describe('QueryResult per-instance atom getter', () => {
     expect(results.map((result) => result.name).sort()).toEqual(['Object 1', 'Object 2']);
   });
 
-  test('memoizes the atom per instance', async () => {
+  test('memoizes the atom per instance', async ({ expect }) => {
     const queryResult = db.query(Query.select(Filter.type(TestItem, { value: 100 })));
     expect(queryResult.atom).toBe(queryResult.atom);
   });
 
-  test('registry.subscribe fires on QueryResult changes', async () => {
+  test('registry.subscribe fires on QueryResult changes', async ({ expect }) => {
     db.add(Obj.make(TestItem, { name: 'Initial', value: 200 }));
     await db.flush();
 
@@ -82,7 +82,7 @@ describe('QueryResult per-instance atom getter', () => {
     expect(latestResults).toHaveLength(2);
   });
 
-  test('registry.subscribe fires when objects are removed', async () => {
+  test('registry.subscribe fires when objects are removed', async ({ expect }) => {
     const obj1 = db.add(Obj.make(TestItem, { name: 'Object 1', value: 300 }));
     db.add(Obj.make(TestItem, { name: 'Object 2', value: 300 }));
     await db.flush();
@@ -107,7 +107,7 @@ describe('QueryResult per-instance atom getter', () => {
     expect(latestResults[0].name).toBe('Object 2');
   });
 
-  test('unsubscribing from registry stops receiving updates', async () => {
+  test('unsubscribing from registry stops receiving updates', async ({ expect }) => {
     db.add(Obj.make(TestItem, { name: 'Initial', value: 400 }));
     await db.flush();
 
@@ -134,7 +134,7 @@ describe('QueryResult per-instance atom getter', () => {
     expect(updateCount).toBe(countAfterFirstAdd);
   });
 
-  test('works with empty query results', async () => {
+  test('works with empty query results', async ({ expect }) => {
     const queryResult = db.query(Query.select(Filter.type(TestItem, { value: 999 })));
     await queryResult.run();
 
@@ -149,7 +149,7 @@ describe('QueryResult.atom (memoized family)', () => {
     atomRegistry = Registry.make();
   });
 
-  test('memoizes per registry instance', () => {
+  test('memoizes per registry instance', ({ expect }) => {
     const registry = makeRegistry({ initial: [TestItem] });
 
     // Same queryable + filter must yield the same atom instance. Otherwise reactive connectors
@@ -163,7 +163,7 @@ describe('QueryResult.atom (memoized family)', () => {
     expect(QueryResult.atom(otherRegistry, Filter.type(Type.Type))).not.toBe(atom1);
   });
 
-  test('queries registry type entities', () => {
+  test('queries registry type entities', ({ expect }) => {
     const registry = makeRegistry({ initial: [TestItem] });
 
     const atom = QueryResult.atom(registry, Filter.type(Type.Type));
@@ -172,7 +172,7 @@ describe('QueryResult.atom (memoized family)', () => {
     expect(results.map((type) => Type.getTypename(type))).toContain('com.example.type.testItem');
   });
 
-  test('updates when registry contents change', () => {
+  test('updates when registry contents change', ({ expect }) => {
     const registry = makeRegistry({ initial: [TestItem] });
 
     const atom = QueryResult.atom(registry, Filter.type(Type.Type));
@@ -203,7 +203,7 @@ describe('QueryResult.atom on queues', () => {
     await testBuilder.close();
   });
 
-  test('Filter.type on queue', async () => {
+  test('Filter.type on queue', async ({ expect }) => {
     const peer = await testBuilder.createPeer({ types: [TestSchema.Person] });
     const spaceId = SpaceId.random();
     const queues = peer.client.constructQueueFactory(spaceId);
@@ -223,7 +223,7 @@ describe('QueryResult.atom on queues', () => {
     expect(results.map((result) => result.name).sort()).toEqual(['jane', 'john']);
   });
 
-  test('Filter.id on queue', async () => {
+  test('Filter.id on queue', async ({ expect }) => {
     const peer = await testBuilder.createPeer({ types: [TestSchema.Person] });
     const spaceId = SpaceId.random();
     const queues = peer.client.constructQueueFactory(spaceId);

--- a/packages/core/echo/echo-client/src/query/query-result.test.ts
+++ b/packages/core/echo/echo-client/src/query/query-result.test.ts
@@ -1,0 +1,247 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Registry from '@effect-atom/atom/Registry';
+import * as Schema from 'effect/Schema';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { DXN, Filter, Obj, Query, QueryResult, Type } from '@dxos/echo';
+import { TestSchema } from '@dxos/echo/testing';
+import { SpaceId } from '@dxos/keys';
+
+import { type EchoDatabase } from '../proxy-db/database';
+import { makeRegistry } from '../registry/registry';
+import { EchoTestBuilder } from '../testing';
+
+const TestItem = Schema.Struct({
+  name: Schema.String,
+  value: Schema.Number,
+}).pipe(Type.makeObject(DXN.make('com.example.type.testItem', '0.1.0')));
+type TestItem = Type.InstanceType<typeof TestItem>;
+
+const TestItem2 = Schema.Struct({
+  title: Schema.String,
+}).pipe(Type.makeObject(DXN.make('com.example.type.testItem2', '0.1.0')));
+
+describe('QueryResult per-instance atom getter', () => {
+  let testBuilder: EchoTestBuilder;
+  let db: EchoDatabase;
+  let registry: Registry.Registry;
+
+  beforeEach(async () => {
+    testBuilder = await new EchoTestBuilder().open();
+    const { db: database } = await testBuilder.createDatabase({ types: [TestItem] });
+    db = database;
+    registry = Registry.make();
+  });
+
+  afterEach(async () => {
+    await testBuilder.close();
+  });
+
+  test('creates atom with initial results', async () => {
+    db.add(Obj.make(TestItem, { name: 'Object 1', value: 100 }));
+    db.add(Obj.make(TestItem, { name: 'Object 2', value: 100 }));
+    await db.flush();
+
+    const queryResult = db.query(Query.select(Filter.type(TestItem, { value: 100 })));
+    await queryResult.run();
+
+    const results = registry.get(queryResult.atom);
+
+    expect(results).toHaveLength(2);
+    expect(results.map((result) => result.name).sort()).toEqual(['Object 1', 'Object 2']);
+  });
+
+  test('memoizes the atom per instance', async () => {
+    const queryResult = db.query(Query.select(Filter.type(TestItem, { value: 100 })));
+    expect(queryResult.atom).toBe(queryResult.atom);
+  });
+
+  test('registry.subscribe fires on QueryResult changes', async () => {
+    db.add(Obj.make(TestItem, { name: 'Initial', value: 200 }));
+    await db.flush();
+
+    const queryResult = db.query(Query.select(Filter.type(TestItem, { value: 200 })));
+    await queryResult.run();
+
+    expect(registry.get(queryResult.atom)).toHaveLength(1);
+
+    let updateCount = 0;
+    let latestResults: TestItem[] = [];
+    registry.subscribe(queryResult.atom, () => {
+      updateCount++;
+      latestResults = registry.get(queryResult.atom);
+    });
+
+    db.add(Obj.make(TestItem, { name: 'New Object', value: 200 }));
+    await db.flush({ updates: true });
+
+    expect(updateCount).toBeGreaterThan(0);
+    expect(latestResults).toHaveLength(2);
+  });
+
+  test('registry.subscribe fires when objects are removed', async () => {
+    const obj1 = db.add(Obj.make(TestItem, { name: 'Object 1', value: 300 }));
+    db.add(Obj.make(TestItem, { name: 'Object 2', value: 300 }));
+    await db.flush();
+
+    const queryResult = db.query(Query.select(Filter.type(TestItem, { value: 300 })));
+    await queryResult.run();
+
+    expect(registry.get(queryResult.atom)).toHaveLength(2);
+
+    let updateCount = 0;
+    let latestResults: TestItem[] = [];
+    registry.subscribe(queryResult.atom, () => {
+      updateCount++;
+      latestResults = registry.get(queryResult.atom);
+    });
+
+    db.remove(obj1);
+    await db.flush({ updates: true });
+
+    expect(updateCount).toBeGreaterThan(0);
+    expect(latestResults).toHaveLength(1);
+    expect(latestResults[0].name).toBe('Object 2');
+  });
+
+  test('unsubscribing from registry stops receiving updates', async () => {
+    db.add(Obj.make(TestItem, { name: 'Initial', value: 400 }));
+    await db.flush();
+
+    const queryResult = db.query(Query.select(Filter.type(TestItem, { value: 400 })));
+    await queryResult.run();
+
+    expect(registry.get(queryResult.atom)).toHaveLength(1);
+
+    let updateCount = 0;
+    const unsubscribe = registry.subscribe(queryResult.atom, () => {
+      updateCount++;
+    });
+
+    db.add(Obj.make(TestItem, { name: 'Object 2', value: 400 }));
+    await db.flush({ updates: true });
+    const countAfterFirstAdd = updateCount;
+    expect(countAfterFirstAdd).toBeGreaterThan(0);
+
+    unsubscribe();
+
+    db.add(Obj.make(TestItem, { name: 'Object 3', value: 400 }));
+    await db.flush({ updates: true });
+
+    expect(updateCount).toBe(countAfterFirstAdd);
+  });
+
+  test('works with empty query results', async () => {
+    const queryResult = db.query(Query.select(Filter.type(TestItem, { value: 999 })));
+    await queryResult.run();
+
+    expect(registry.get(queryResult.atom)).toHaveLength(0);
+  });
+});
+
+describe('QueryResult.atom (memoized family)', () => {
+  let atomRegistry: Registry.Registry;
+
+  beforeEach(() => {
+    atomRegistry = Registry.make();
+  });
+
+  test('memoizes per registry instance', () => {
+    const registry = makeRegistry({ initial: [TestItem] });
+
+    // Same queryable + filter must yield the same atom instance. Otherwise reactive connectors
+    // re-create the atom on every recompute, opening a new query subscription each run and leaking
+    // it (the type-create freeze regression).
+    const atom1 = QueryResult.atom(registry, Filter.type(Type.Type));
+    const atom2 = QueryResult.atom(registry, Filter.type(Type.Type));
+    expect(atom1).toBe(atom2);
+
+    const otherRegistry = makeRegistry({ initial: [TestItem] });
+    expect(QueryResult.atom(otherRegistry, Filter.type(Type.Type))).not.toBe(atom1);
+  });
+
+  test('queries registry type entities', () => {
+    const registry = makeRegistry({ initial: [TestItem] });
+
+    const atom = QueryResult.atom(registry, Filter.type(Type.Type));
+    const results = atomRegistry.get(atom);
+
+    expect(results.map((type) => Type.getTypename(type))).toContain('com.example.type.testItem');
+  });
+
+  test('updates when registry contents change', () => {
+    const registry = makeRegistry({ initial: [TestItem] });
+
+    const atom = QueryResult.atom(registry, Filter.type(Type.Type));
+    expect(atomRegistry.get(atom)).toHaveLength(1);
+
+    let updateCount = 0;
+    atomRegistry.subscribe(atom, () => {
+      updateCount++;
+    });
+
+    registry.add([TestItem2]);
+
+    expect(updateCount).toBeGreaterThan(0);
+    expect(atomRegistry.get(atom)).toHaveLength(2);
+  });
+});
+
+describe('QueryResult.atom on queues', () => {
+  let testBuilder: EchoTestBuilder;
+  let registry: Registry.Registry;
+
+  beforeEach(async () => {
+    testBuilder = await new EchoTestBuilder().open();
+    registry = Registry.make();
+  });
+
+  afterEach(async () => {
+    await testBuilder.close();
+  });
+
+  test('Filter.type on queue', async () => {
+    const peer = await testBuilder.createPeer({ types: [TestSchema.Person] });
+    const spaceId = SpaceId.random();
+    const queues = peer.client.constructQueueFactory(spaceId);
+    const queue = queues.create();
+
+    const john = Obj.make(TestSchema.Person, { name: 'john' });
+    const jane = Obj.make(TestSchema.Person, { name: 'jane' });
+    await queue.append([john, jane]);
+
+    const directResult = await queue.query(Query.select(Filter.type(TestSchema.Person))).run();
+    expect(directResult).toHaveLength(2);
+
+    const atom = QueryResult.atom<TestSchema.Person>(queue, Filter.type(TestSchema.Person));
+    const results = registry.get(atom);
+
+    expect(results).toHaveLength(2);
+    expect(results.map((result) => result.name).sort()).toEqual(['jane', 'john']);
+  });
+
+  test('Filter.id on queue', async () => {
+    const peer = await testBuilder.createPeer({ types: [TestSchema.Person] });
+    const spaceId = SpaceId.random();
+    const queues = peer.client.constructQueueFactory(spaceId);
+    const queue = queues.create();
+
+    const john = Obj.make(TestSchema.Person, { name: 'john' });
+    const jane = Obj.make(TestSchema.Person, { name: 'jane' });
+    const alice = Obj.make(TestSchema.Person, { name: 'alice' });
+    await queue.append([john, jane, alice]);
+
+    const directResult = await queue.query(Query.select(Filter.id(jane.id))).run();
+    expect(directResult).toHaveLength(1);
+
+    const atom = QueryResult.atom<TestSchema.Person>(queue, Filter.id(jane.id));
+    const results = registry.get(atom);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toEqual(jane.id);
+    expect(results[0].name).toEqual('jane');
+  });
+});

--- a/packages/core/echo/echo/src/QueryResult.ts
+++ b/packages/core/echo/echo/src/QueryResult.ts
@@ -9,6 +9,7 @@ import * as Option from 'effect/Option';
 import { type CleanupFn } from '@dxos/async';
 
 import type * as Entity from './Entity';
+import * as QueryAtoms from './internal/QueryAtoms';
 
 /**
  * Individual query result entry.
@@ -110,7 +111,13 @@ export interface QueryResult<T> {
 
   /**
    * Self-updating atom. Updates automatically when query results change.
-   * Memoized per QueryResult instance — repeated accesses return the same Atom.
+   *
+   * Memoized per QueryResult instance — repeated accesses on the same instance return the same
+   * Atom. Safe only when the QueryResult is itself held stable across re-renders (e.g. behind a
+   * `useMemo`). It must NOT be used in graph-builder connectors/actions or other atom computes,
+   * where `db.query(...)` is called fresh on each re-evaluation: every run constructs a new
+   * QueryResult and so a new atom + subscription, leaking the previous ones. Use the memoized
+   * {@link atom} family there instead.
    */
   readonly atom: Atom.Atom<T[]>;
 }
@@ -122,3 +129,14 @@ export interface QueryResultEffect<T, E, R> extends Effect.Effect<QueryResult<T>
   run: Effect.Effect<T[], E, R>;
   first: Effect.Effect<Option.Option<T>, E, R>;
 }
+
+/**
+ * Memoized query atom for a Queryable (Database, Queue, Registry), keyed by the
+ * queryable's identifier and the serialized query AST. The same queryable + query/filter always
+ * returns the same atom instance and shares a single subscription.
+ *
+ * Use this — not the per-instance {@link QueryResult.atom} getter — anywhere the query is rebuilt
+ * on every run (graph-builder connectors/actions, atom computes), where the getter would leak a
+ * subscription per evaluation. To wrap a QueryResult you already hold stable, use its `.atom` getter.
+ */
+export const atom = QueryAtoms.make;

--- a/packages/core/echo/echo/src/internal/QueryAtoms.ts
+++ b/packages/core/echo/echo/src/internal/QueryAtoms.ts
@@ -1,0 +1,92 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import * as Atom from '@effect-atom/atom/Atom';
+
+import { URI } from '@dxos/keys';
+import { WeakDictionary } from '@dxos/util';
+
+import * as Database from '../Database';
+import type * as Entity from '../Entity';
+import type * as Filter from '../Filter';
+import * as Query from '../Query';
+import type * as QueryResult from '../QueryResult';
+import * as Registry from '../Registry';
+
+// Keyed by queryable identifier. Holds the Queryable weakly so it is collected with its space.
+const queryableRegistry = new WeakDictionary<string, Database.Queryable>();
+
+// Separator that cannot appear in a queryable identifier (DXN/EID strings use colons, not '~').
+const KEY_SEPARATOR = '~';
+
+// Keyed by `<identifier>~<serialized-query-AST>` so the same queryable + query returns the same atom.
+const queryFamily = Atom.family((key: string) => {
+  // Split and parse once per key (not on every recompute).
+  const separatorIndex = key.indexOf(KEY_SEPARATOR);
+  const identifier = key.slice(0, separatorIndex);
+  const serializedAst = key.slice(separatorIndex + 1);
+
+  // Resolve the queryable once per key; the closure keeps it reachable for the family entry's lifetime.
+  const queryable = queryableRegistry.get(identifier);
+  if (!queryable) {
+    return Atom.make(() => [] as Entity.Unknown[]);
+  }
+
+  const ast = JSON.parse(serializedAst);
+  const queryResult = queryable.query(Query.fromAst(ast)) as QueryResult.QueryResult<Entity.Unknown>;
+
+  return Atom.make((get) => {
+    const unsubscribe = queryResult.subscribe(() => {
+      get.setSelf(queryResult.runSync());
+    });
+    get.addFinalizer(unsubscribe);
+    return queryResult.runSync();
+  });
+});
+
+/**
+ * Derive a stable identifier from a Queryable. Supports Database (spaceId), Registry (id), and
+ * Queue (uri).
+ */
+const getQueryableIdentifier = (queryable: Database.Queryable): string => {
+  if (Database.isDatabase(queryable)) {
+    return queryable.spaceId;
+  }
+  if (Registry.isRegistry(queryable)) {
+    return queryable.id;
+  }
+  // Queue and similar: a URI (EID or DXN) is a stable per-instance identifier.
+  if ('uri' in queryable && URI.isURI((queryable as { uri: unknown }).uri)) {
+    return (queryable as { uri: URI.URI }).uri;
+  }
+  if ('id' in queryable && typeof (queryable as { id: unknown }).id === 'string') {
+    return (queryable as { id: string }).id;
+  }
+  throw new Error('Unable to derive identifier from queryable.');
+};
+
+/**
+ * Memoized query atom for any {@link Database.Queryable} (Database, Queue, Registry).
+ *
+ * Keyed by queryable identifier + serialized query AST, so the same queryable and query/filter
+ * always return the same atom instance — and therefore a single shared subscription. This is the
+ * required form inside graph-builder connectors/actions and other atom computes, which re-run on
+ * every reactive change: the per-instance `queryResult.atom` getter would open (and leak) a new
+ * subscription on each run because `queryable.query(...)` constructs a fresh QueryResult each call.
+ */
+export const make = <T extends Entity.Unknown>(
+  queryable: Database.Queryable,
+  queryOrFilter: Query.Query<T> | Filter.Filter<T>,
+): Atom.Atom<T[]> => {
+  const identifier = getQueryableIdentifier(queryable);
+  // WeakDictionary releases the queryable once nothing else references it.
+  queryableRegistry.set(identifier, queryable);
+
+  const normalizedQuery: Query.Any = Query.is(queryOrFilter)
+    ? queryOrFilter
+    : Query.select(queryOrFilter as Filter.Filter<T>);
+
+  const key = `${identifier}${KEY_SEPARATOR}${JSON.stringify(normalizedQuery.ast)}`;
+  return queryFamily(key) as Atom.Atom<T[]>;
+};

--- a/packages/core/echo/echo/src/internal/QueryAtoms.ts
+++ b/packages/core/echo/echo/src/internal/QueryAtoms.ts
@@ -17,6 +17,18 @@ import * as Registry from '../Registry';
 // Keyed by queryable identifier. Holds the Queryable weakly so it is collected with its space.
 const queryableRegistry = new WeakDictionary<string, Database.Queryable>();
 
+/**
+ * Recursively sorts object keys before stringifying so that semantically identical ASTs
+ * (whose key insertion orders may differ across call sites) produce the same string.
+ */
+const stableStringify = (value: unknown): string =>
+  JSON.stringify(value, (_, val) => {
+    if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
+      return Object.fromEntries(Object.entries(val as Record<string, unknown>).sort(([a], [b]) => (a < b ? -1 : 1)));
+    }
+    return val;
+  });
+
 // Separator that cannot appear in a queryable identifier (DXN/EID strings use colons, not '~').
 const KEY_SEPARATOR = '~';
 
@@ -74,6 +86,9 @@ const getQueryableIdentifier = (queryable: Database.Queryable): string => {
  * required form inside graph-builder connectors/actions and other atom computes, which re-run on
  * every reactive change: the per-instance `queryResult.atom` getter would open (and leak) a new
  * subscription on each run because `queryable.query(...)` constructs a fresh QueryResult each call.
+ *
+ * If the queryable is garbage-collected (no longer referenced externally), the returned atom
+ * produces an empty array rather than throwing.
  */
 export const make = <T extends Entity.Unknown>(
   queryable: Database.Queryable,
@@ -87,6 +102,6 @@ export const make = <T extends Entity.Unknown>(
     ? queryOrFilter
     : Query.select(queryOrFilter as Filter.Filter<T>);
 
-  const key = `${identifier}${KEY_SEPARATOR}${JSON.stringify(normalizedQuery.ast)}`;
+  const key = `${identifier}${KEY_SEPARATOR}${stableStringify(normalizedQuery.ast)}`;
   return queryFamily(key) as Atom.Atom<T[]>;
 };

--- a/packages/devtools/devtools/src/components/ObjectsTree.tsx
+++ b/packages/devtools/devtools/src/components/ObjectsTree.tsx
@@ -14,7 +14,7 @@ import { createContext, useCallback, useContext, useEffect, useState } from 'rea
 import React from 'react';
 
 import { raise } from '@dxos/debug';
-import { type Database, Entity, Filter, Obj, Query, Ref, Relation } from '@dxos/echo';
+import { type Database, Entity, Filter, Obj, Query, QueryResult, Ref, Relation } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
 import { EID, EntityId } from '@dxos/keys';
 import { log } from '@dxos/log';
@@ -236,7 +236,8 @@ class ObjectsTreeModel {
     if (typeof anchor === 'string') {
       invariant(EntityId.isValid(anchor));
 
-      const entities: Atom.Atom<Entity.Unknown[]> = this.#database.query(
+      const entities: Atom.Atom<Entity.Unknown[]> = QueryResult.atom(
+        this.#database,
         Query.all(
           Query.select(Filter.id(anchor)).children(),
           Query.select(Filter.id(anchor)).sourceOf(),
@@ -248,7 +249,7 @@ class ObjectsTreeModel {
             deleted: 'include',
           })
           .from(this.#database),
-      ).atom;
+      );
 
       return Atom.make((get) =>
         pipe(
@@ -261,9 +262,10 @@ class ObjectsTreeModel {
     } else if (this.#root !== null) {
       return Entity.atom(this.#root).pipe((_) => Atom.make((get) => [this.#mapEntityToTreeItems(get(_), null)]));
     } else {
-      const entities: Atom.Atom<Entity.Unknown[]> = this.#database.query(
+      const entities: Atom.Atom<Entity.Unknown[]> = QueryResult.atom(
+        this.#database,
         Query.select(Filter.everything()).options({ deleted: 'include' }).from(this.#database),
-      ).atom;
+      );
 
       return Atom.make((get) =>
         pipe(

--- a/packages/plugins/plugin-assistant/src/containers/TracePanel/TracePanel.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/TracePanel/TracePanel.tsx
@@ -14,7 +14,7 @@ import { useCapability, useAtomCapability, useOperationInvoker } from '@dxos/app
 import { LayoutOperation } from '@dxos/app-toolkit';
 import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { Process, Trace } from '@dxos/compute';
-import { Filter, Query } from '@dxos/echo';
+import { Filter, Query, QueryResult } from '@dxos/echo';
 import { FeedTraceSink } from '@dxos/functions-runtime';
 import { EID } from '@dxos/keys';
 import { type Space } from '@dxos/react-client/echo';
@@ -181,15 +181,16 @@ const useExecutionGraph = (space: Space, { eventLimit }: UseExecutionGraphOption
  */
 const getTraceMessagesAtom = (space: Space): Atom.Atom<readonly Trace.Message[]> =>
   pipe(
-    space.db.query(FeedTraceSink.query).atom,
+    QueryResult.atom(space.db, FeedTraceSink.query),
     Atom.map(
       (feeds) =>
         // TODO(dmaretskyi): This should be possible in a single query with properly working limit(1) and feed > feed contents traversal.
-        space.db.query(
+        QueryResult.atom(
+          space.db,
           feeds.length > 0
             ? Query.type(Trace.Message).from(feeds[0])
             : (Query.select(Filter.nothing()) as Query.Query<never>),
-        ).atom,
+        ),
     ),
     (atom) => Atom.make((get) => get(get(atom))),
   );

--- a/packages/plugins/plugin-assistant/src/containers/TracePanel/TracePanel.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/TracePanel/TracePanel.tsx
@@ -182,15 +182,14 @@ const useExecutionGraph = (space: Space, { eventLimit }: UseExecutionGraphOption
 const getTraceMessagesAtom = (space: Space): Atom.Atom<readonly Trace.Message[]> =>
   pipe(
     QueryResult.atom(space.db, FeedTraceSink.query),
-    Atom.map(
-      (feeds) =>
-        // TODO(dmaretskyi): This should be possible in a single query with properly working limit(1) and feed > feed contents traversal.
-        QueryResult.atom(
-          space.db,
-          feeds.length > 0
-            ? Query.type(Trace.Message).from(feeds[0])
-            : (Query.select(Filter.nothing()) as Query.Query<never>),
-        ),
+    Atom.map((feeds) =>
+      // TODO(dmaretskyi): This should be possible in a single query with properly working limit(1) and feed > feed contents traversal.
+      QueryResult.atom(
+        space.db,
+        feeds.length > 0
+          ? Query.type(Trace.Message).from(feeds[0])
+          : (Query.select(Filter.nothing()) as Query.Query<never>),
+      ),
     ),
     (atom) => Atom.make((get) => get(get(atom))),
   );

--- a/packages/plugins/plugin-code/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-code/src/capabilities/app-graph-builder.ts
@@ -8,7 +8,7 @@ import * as Option from 'effect/Option';
 import { Capability, Plugin, type Plugin as PluginNS } from '@dxos/app-framework';
 import { AppActivationEvents, AppCapabilities, AppNode, AppNodeMatcher } from '@dxos/app-toolkit';
 import { isSpace } from '@dxos/client/echo';
-import { Filter, Type } from '@dxos/echo';
+import { Filter, QueryResult, Type } from '@dxos/echo';
 import { GraphBuilder, Node, NodeMatcher } from '@dxos/plugin-graph';
 
 import { meta } from '#meta';
@@ -79,7 +79,7 @@ export default Capability.makeModule(
         id: 'codeProjectsSection',
         match: AppNodeMatcher.whenSpace,
         connector: (space, get) => {
-          const projects = get(space.db.query(Filter.type(CodeProject.CodeProject)).atom);
+          const projects = get(QueryResult.atom(space.db, Filter.type(CodeProject.CodeProject)));
           if (projects.length === 0) {
             return Effect.succeed([]);
           }
@@ -106,7 +106,7 @@ export default Capability.makeModule(
           return node.type === CODE_PROJECTS_SECTION_TYPE && space ? Option.some(space) : Option.none();
         },
         connector: (space, get) => {
-          const projects = get(space.db.query(Filter.type(CodeProject.CodeProject)).atom);
+          const projects = get(QueryResult.atom(space.db, Filter.type(CodeProject.CodeProject)));
 
           return Effect.succeed(
             projects.map((project: CodeProject.CodeProject) => {

--- a/packages/plugins/plugin-comments/src/containers/CommentsArticle/CommentsArticle.stories.tsx
+++ b/packages/plugins/plugin-comments/src/containers/CommentsArticle/CommentsArticle.stories.tsx
@@ -19,7 +19,7 @@ import {
 } from '@dxos/app-toolkit';
 import { AppSurface, useAppGraph } from '@dxos/app-toolkit/ui';
 import { Operation, OperationHandlerSet } from '@dxos/compute';
-import { Filter, Obj, Query, Ref, Relation } from '@dxos/echo';
+import { Filter, Obj, Query, QueryResult, Ref, Relation } from '@dxos/echo';
 import { createDocAccessor, toCursorRange } from '@dxos/echo-client';
 import { DXN } from '@dxos/keys';
 import { ClientCapabilities } from '@dxos/plugin-client';
@@ -154,7 +154,7 @@ const StoryGraphPlugin = Plugin.define(
             if (!space) {
               return [];
             }
-            const docs = get(space.db.query(Filter.type(Markdown.Document)).atom);
+            const docs = get(QueryResult.atom(space.db, Filter.type(Markdown.Document)));
             return docs
               .map((object) => createObjectNode({ db: space.db, object, droppable: false }))
               .filter(isNonNullable);

--- a/packages/plugins/plugin-commerce/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-commerce/src/capabilities/app-graph-builder.ts
@@ -8,7 +8,7 @@ import * as Option from 'effect/Option';
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities, AppNodeMatcher, createObjectNode } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
-import { Filter, Obj, Ref, Type } from '@dxos/echo';
+import { Filter, Obj, QueryResult, Ref, Type } from '@dxos/echo';
 import { GraphBuilder, Node } from '@dxos/plugin-graph';
 import { SpaceOperation } from '@dxos/plugin-space';
 
@@ -23,7 +23,7 @@ export default Capability.makeModule(
         id: 'commerceProviders',
         match: AppNodeMatcher.whenSpace,
         connector: (space, get) => {
-          const providers = get(space.db.query(Filter.type(Provider.Provider)).atom);
+          const providers = get(QueryResult.atom(space.db, Filter.type(Provider.Provider)));
           if (providers.length === 0) {
             return Effect.succeed([]);
           }

--- a/packages/plugins/plugin-feed/src/atoms/post-content.ts
+++ b/packages/plugins/plugin-feed/src/atoms/post-content.ts
@@ -4,7 +4,7 @@
 
 import { Atom, useAtomValue } from '@effect-atom/atom-react';
 
-import { Obj } from '@dxos/echo';
+import { Obj, QueryResult } from '@dxos/echo';
 
 import { Subscription } from '../types';
 
@@ -24,7 +24,7 @@ export const postContentAtom = Atom.family((post: Subscription.Post) =>
     if (!db || !query) {
       return undefined;
     }
-    const entries = get(db.query(query).atom);
+    const entries = get(QueryResult.atom(db, query));
     return Subscription.pickLatestPostContent(entries);
   }).pipe(Atom.keepAlive),
 );

--- a/packages/plugins/plugin-feed/src/atoms/post-tags.ts
+++ b/packages/plugins/plugin-feed/src/atoms/post-tags.ts
@@ -4,7 +4,7 @@
 
 import { Atom, useAtomValue } from '@effect-atom/atom-react';
 
-import { type Database, Filter, Obj, Tag } from '@dxos/echo';
+import { type Database, Filter, Obj, QueryResult, Tag } from '@dxos/echo';
 import { TagIndex } from '@dxos/schema';
 
 import { Subscription } from '../types';
@@ -26,7 +26,7 @@ const uriForTag = (tags: readonly Tag.Tag[], key: { source: string; id: string }
  * Tag set changes (rare — on first star/archive). Shared by every per-Post tag slice.
  */
 const tagUrisAtom = Atom.family((db: Database.Database) =>
-  db.query(Filter.type(Tag.Tag)).atom.pipe(
+  QueryResult.atom(db, Filter.type(Tag.Tag)).pipe(
     Atom.map((tags) => ({
       starredUri: uriForTag(tags, Subscription.SYSTEM_TAGS.starred.key),
       archivedUri: uriForTag(tags, Subscription.SYSTEM_TAGS.archived.key),

--- a/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
@@ -16,7 +16,7 @@ import {
 } from '@dxos/app-toolkit';
 import { isSpace } from '@dxos/client/echo';
 import { Operation } from '@dxos/compute';
-import { type Feed, Filter, Key, Obj, Query, Ref, Type } from '@dxos/echo';
+import { type Feed, Filter, Key, Obj, Query, QueryResult, Ref, Type } from '@dxos/echo';
 import { EID } from '@dxos/keys';
 import { AttentionCapabilities } from '@dxos/plugin-attention';
 import { ClientCapabilities } from '@dxos/plugin-client';
@@ -59,7 +59,7 @@ export default Capability.makeModule(
         id: 'mailboxesSection',
         match: AppNodeMatcher.whenSpace,
         connector: (space, get) => {
-          const mailboxes = get(space.db.query(Filter.type(Mailbox.Mailbox)).atom);
+          const mailboxes = get(QueryResult.atom(space.db, Filter.type(Mailbox.Mailbox)));
           if (mailboxes.length === 0) {
             return Effect.succeed([]);
           }
@@ -85,7 +85,7 @@ export default Capability.makeModule(
           return node.type === MAILBOXES_SECTION_TYPE && space ? Option.some(space) : Option.none();
         },
         connector: (space, get) => {
-          const mailboxes = get(space.db.query(Filter.type(Mailbox.Mailbox)).atom);
+          const mailboxes = get(QueryResult.atom(space.db, Filter.type(Mailbox.Mailbox)));
 
           return Effect.succeed(
             mailboxes.map((mailbox: Mailbox.Mailbox) => {
@@ -96,7 +96,7 @@ export default Capability.makeModule(
               // the snapshot is structurally the feed for query purposes.
               const feed = mailbox.feed ? (get(mailbox.feed.atom) as Feed.Feed | undefined) : undefined;
               const messages = feed
-                ? get(space.db.query(Query.select(Filter.type(Message.Message)).from(feed)).atom)
+                ? get(QueryResult.atom(space.db, Query.select(Filter.type(Message.Message)).from(feed)))
                 : [];
               const modifiedCount = Mailbox.getNewMessageCount(mailbox, messages);
 
@@ -184,7 +184,7 @@ export default Capability.makeModule(
 
           const mailboxUri = Obj.getURI(mailbox);
           const messageId = get(selectedId(node.id));
-          const message = messageId ? get(db.query(Query.select(Filter.id(messageId))).atom)[0] : undefined;
+          const message = messageId ? get(QueryResult.atom(db, Query.select(Filter.id(messageId))))[0] : undefined;
           const draft = message && DraftMessage.belongsTo(message, mailboxUri) ? message : undefined;
           return Effect.succeed([
             AppNode.makeCompanion({
@@ -230,7 +230,7 @@ export default Capability.makeModule(
 
           const messageId = get(selectedId(matched.nodeId));
           const message = get(
-            db.query(Query.select(messageId ? Filter.id(messageId) : Filter.nothing()).from(feed)).atom,
+            QueryResult.atom(db, Query.select(messageId ? Filter.id(messageId) : Filter.nothing()).from(feed)),
           )[0];
           return Effect.succeed([
             AppNode.makeCompanion({
@@ -275,7 +275,7 @@ export default Capability.makeModule(
               return null;
             }
 
-            const mailboxes = get(space.db.query(Filter.type(Mailbox.Mailbox)).atom);
+            const mailboxes = get(QueryResult.atom(space.db, Filter.type(Mailbox.Mailbox)));
             const mailbox = mailboxes.find((m: Mailbox.Mailbox) => m.id === mailboxId);
             if (!mailbox) {
               return null;
@@ -287,10 +287,10 @@ export default Capability.makeModule(
             // TODO(wittjosiah): This is awkward, clean it up.
             let message: Message.Message | undefined;
             if (feed) {
-              message = get(space.db.query(Query.select(Filter.id(messageId)).from(feed)).atom)[0];
+              message = get(QueryResult.atom(space.db, Query.select(Filter.id(messageId)).from(feed)))[0];
             }
             if (!message) {
-              const fromDb = get(space.db.query(Query.select(Filter.id(messageId))).atom)[0];
+              const fromDb = get(QueryResult.atom(space.db, Query.select(Filter.id(messageId))))[0];
               if (fromDb && DraftMessage.belongsTo(fromDb, mailboxUri)) {
                 message = fromDb;
               }
@@ -352,11 +352,11 @@ export default Capability.makeModule(
 
           const eventId = get(selectedId(matched.nodeId));
           const fromFeed = get(
-            db.query(Query.select(eventId ? Filter.id(eventId) : Filter.nothing()).from(feed)).atom,
+            QueryResult.atom(db, Query.select(eventId ? Filter.id(eventId) : Filter.nothing()).from(feed)),
           )[0];
           // Draft events live in the space db (not the feed); fall back to a db lookup so the
           // companion resolves a locally-created event too.
-          const fromDb = eventId ? get(db.query(Query.select(Filter.id(eventId))).atom)[0] : undefined;
+          const fromDb = eventId ? get(QueryResult.atom(db, Query.select(Filter.id(eventId))))[0] : undefined;
           const event = fromFeed ?? fromDb;
           return Effect.succeed([
             AppNode.makeCompanion({
@@ -377,7 +377,7 @@ export default Capability.makeModule(
           if (!db) {
             return Effect.succeed([]);
           }
-          const integrations = get(db.query(Filter.type(Integration.Integration)).atom);
+          const integrations = get(QueryResult.atom(db, Filter.type(Integration.Integration)));
           const integration = integrations.find((integration) =>
             integration.targets.some(
               (target) => target.object && EID.getEntityId(EID.tryParse(target.object.uri)!) === mailbox.id,
@@ -422,7 +422,7 @@ export default Capability.makeModule(
           if (!db) {
             return Effect.succeed([]);
           }
-          const integrations = get(db.query(Filter.type(Integration.Integration)).atom);
+          const integrations = get(QueryResult.atom(db, Filter.type(Integration.Integration)));
           const integration = integrations.find((integration) =>
             integration.targets.some(
               (target) => target.object && EID.getEntityId(EID.tryParse(target.object.uri)!) === calendar.id,

--- a/packages/plugins/plugin-integration/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-integration/src/capabilities/app-graph-builder.ts
@@ -9,7 +9,7 @@ import { Capability } from '@dxos/app-framework';
 import { AppCapabilities, AppNodeMatcher, createObjectNode } from '@dxos/app-toolkit';
 import { isSpace } from '@dxos/client/echo';
 import { Operation } from '@dxos/compute';
-import { Filter, Obj, Ref } from '@dxos/echo';
+import { Filter, Obj, QueryResult, Ref } from '@dxos/echo';
 import { GraphBuilder, Node } from '@dxos/plugin-graph';
 import { SpaceOperation } from '@dxos/plugin-space';
 
@@ -83,7 +83,7 @@ export default Capability.makeModule(
         id: 'integrationsSection',
         match: AppNodeMatcher.whenSpace,
         connector: (space, get) => {
-          const integrations = get(space.db.query(Filter.type(Integration.Integration)).atom);
+          const integrations = get(QueryResult.atom(space.db, Filter.type(Integration.Integration)));
           if (integrations.length === 0) {
             return Effect.succeed([]);
           }
@@ -114,7 +114,7 @@ export default Capability.makeModule(
           return node.type === INTEGRATIONS_SECTION_TYPE && space ? Option.some(space) : Option.none();
         },
         connector: (space, get) => {
-          const integrations = get(space.db.query(Filter.type(Integration.Integration)).atom);
+          const integrations = get(QueryResult.atom(space.db, Filter.type(Integration.Integration)));
           return Effect.succeed(
             integrations
               .map((integration) =>

--- a/packages/plugins/plugin-kanban/src/containers/KanbanArticle/KanbanArticle.tsx
+++ b/packages/plugins/plugin-kanban/src/containers/KanbanArticle/KanbanArticle.tsx
@@ -8,7 +8,7 @@ import React, { useCallback, useContext, useMemo } from 'react';
 import { useCapabilities, useOperationInvoker } from '@dxos/app-framework/ui';
 import { AppCapabilities } from '@dxos/app-toolkit';
 import { useSchemaFilter, type AppSurface } from '@dxos/app-toolkit/ui';
-import { Filter, Obj, Query, type Ref, Type } from '@dxos/echo';
+import { Filter, Obj, Query, QueryResult, type Ref, Type } from '@dxos/echo';
 import { useObject, useType } from '@dxos/react-client/echo';
 import { Panel, Toolbar } from '@dxos/react-ui';
 import { getTagFromQuery, getTypenameFromQuery } from '@dxos/schema';
@@ -52,7 +52,7 @@ const ViewKanbanArticle = ({ role, subject: object }: KanbanArticleProps) => {
       return null;
     }
     const query = tag ? Query.select(baseFilter).select(Filter.tag(tag)) : Query.select(baseFilter);
-    return db.query(query).atom;
+    return QueryResult.atom(db, query);
   }, [db, baseFilter, tag]);
 
   const projection = useProjectionModel(cardSchema, object, registry);

--- a/packages/plugins/plugin-native-filesystem/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-native-filesystem/src/capabilities/app-graph-builder.ts
@@ -8,7 +8,7 @@ import * as Effect from 'effect/Effect';
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities, getPersonalSpace, LayoutOperation } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
-import { Filter, Obj, Type } from '@dxos/echo';
+import { Filter, Obj, QueryResult, Type } from '@dxos/echo';
 import { ClientCapabilities } from '@dxos/plugin-client';
 import { Graph, GraphBuilder, Node, NodeMatcher } from '@dxos/plugin-graph';
 import { SHARED } from '@dxos/plugin-space';
@@ -144,7 +144,7 @@ export default Capability.makeModule(
 
           let spacesOrder: Obj.Any | undefined;
           let orderMap = new Map<string, number>();
-          const [order] = get(personalSpace.db.query(Filter.type(Expando.Expando, { key: SHARED })).atom);
+          const [order] = get(QueryResult.atom(personalSpace.db, Filter.type(Expando.Expando, { key: SHARED })));
           if (order) {
             const snapshot = get(Obj.atom(order)) as { order?: string[] } | undefined;
             const orderArray: string[] = snapshot?.order ?? [];

--- a/packages/plugins/plugin-pipeline/src/hooks/usePipelineBoardModel.ts
+++ b/packages/plugins/plugin-pipeline/src/hooks/usePipelineBoardModel.ts
@@ -7,7 +7,7 @@ import * as Schema from 'effect/Schema';
 import { useMemo } from 'react';
 
 import { getQueryTarget } from '@dxos/app-toolkit/query';
-import { Obj, Query } from '@dxos/echo';
+import { Obj, Query, QueryResult } from '@dxos/echo';
 import { getSpace, isSpace } from '@dxos/react-client/echo';
 import { type BoardModel } from '@dxos/react-ui-mosaic';
 import { Pipeline } from '@dxos/types';
@@ -45,7 +45,7 @@ export const usePipelineBoardModel = (
         if (!queryTarget) {
           return [];
         }
-        const raw = get(queryTarget.query(query).atom);
+        const raw = get(QueryResult.atom(queryTarget, query));
         return isSpace(queryTarget) ? raw : [...raw].reverse();
       }),
     );

--- a/packages/plugins/plugin-sample/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-sample/src/capabilities/app-graph-builder.ts
@@ -14,7 +14,7 @@ import { Capability } from '@dxos/app-framework';
 import { AppCapabilities, AppNode, AppNodeMatcher, createObjectNode } from '@dxos/app-toolkit';
 import { isSpace } from '@dxos/client/echo';
 import { Operation } from '@dxos/compute';
-import { Filter } from '@dxos/echo';
+import { Filter, QueryResult } from '@dxos/echo';
 import { GraphBuilder, Node, NodeMatcher } from '@dxos/plugin-graph';
 
 import { meta } from '#meta';
@@ -66,7 +66,7 @@ export default Capability.makeModule(
         id: 'section',
         match: AppNodeMatcher.whenSpace,
         connector: (space, get) => {
-          const items = get(space.db.query(Filter.type(SampleItem.SampleItem)).atom);
+          const items = get(QueryResult.atom(space.db, Filter.type(SampleItem.SampleItem)));
           if (items.length === 0) {
             return Effect.succeed([]);
           }
@@ -94,7 +94,7 @@ export default Capability.makeModule(
           return node.type === SAMPLE_SECTION_TYPE && space ? Option.some(space) : Option.none();
         },
         connector: (space, get) => {
-          const items = get(space.db.query(Filter.type(SampleItem.SampleItem)).atom);
+          const items = get(QueryResult.atom(space.db, Filter.type(SampleItem.SampleItem)));
           return Effect.succeed(
             items
               .map((item) => createObjectNode({ db: space.db, object: item }))

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/database.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/database.ts
@@ -11,7 +11,7 @@ import { Capability, type CapabilityManager } from '@dxos/app-framework';
 import { AppNode, AppNodeMatcher, LayoutOperation, Segments } from '@dxos/app-toolkit';
 import { type Space, SpaceState, isSpace } from '@dxos/client/echo';
 import { Operation } from '@dxos/compute';
-import { Annotation, Collection, Entity, Filter, Obj, Query, Scope, Type } from '@dxos/echo';
+import { Annotation, Collection, Entity, Filter, Obj, Query, QueryResult, Scope, Type } from '@dxos/echo';
 import { HiddenAnnotation } from '@dxos/echo/internal';
 import { ClientCapabilities } from '@dxos/plugin-client';
 import { CreateAtom, GraphBuilder, Node } from '@dxos/plugin-graph';
@@ -79,7 +79,7 @@ export const createDatabaseExtensions = Effect.fnUntraced(function* () {
         // Persisted types live in the space db; static/runtime types live in the shared registry.
         // Fan across both so the space's own types appear without leaking other spaces' types.
         const allSchemas = get(
-          space.db.query(Query.select(Filter.type(Type.Type)).from(Scope.space(), Scope.registry())).atom,
+          QueryResult.atom(space.db, Query.select(Filter.type(Type.Type)).from(Scope.space(), Scope.registry())),
         );
 
         const userSchemas = allSchemas.filter((type) => {
@@ -106,7 +106,7 @@ export const createDatabaseExtensions = Effect.fnUntraced(function* () {
             return true;
           }
           const typename = Type.getTypename(schema);
-          const objects = get(space.db.query(Filter.typename(typename)).atom);
+          const objects = get(QueryResult.atom(space.db, Filter.typename(typename)));
           if (ViewAnnotation.has(schema)) {
             return objects.some((obj) => !viewIndex.isView(obj));
           }
@@ -126,7 +126,7 @@ export const createDatabaseExtensions = Effect.fnUntraced(function* () {
       },
       connector: ({ space, schema }, get) => {
         const client = get(capabilities.atom(ClientCapabilities.Client)).at(0);
-        const schemas = client ? get(client.graph.registry.query(Filter.type(Type.Type)).atom) : [];
+        const schemas = client ? get(QueryResult.atom(client.graph.registry, Filter.type(Type.Type))) : [];
 
         const typename = Type.getTypename(schema);
 
@@ -177,9 +177,9 @@ export const createDatabaseExtensions = Effect.fnUntraced(function* () {
       },
       connector: ({ space, typename }, get) => {
         const client = get(capabilities.atom(ClientCapabilities.Client)).at(0);
-        const schemas = client ? get(client.graph.registry.query(Filter.type(Type.Type)).atom) : [];
+        const schemas = client ? get(QueryResult.atom(client.graph.registry, Filter.type(Type.Type))) : [];
         const viewIndex = buildViewIndex(get, space, schemas);
-        const objects = get(space.db.query(Filter.typename(typename)).atom).filter(
+        const objects = get(QueryResult.atom(space.db, Filter.typename(typename))).filter(
           (object: Obj.Unknown) => !viewIndex.isView(object) && !Obj.getParent(object),
         );
 
@@ -212,7 +212,7 @@ export const createDatabaseExtensions = Effect.fnUntraced(function* () {
       },
       actions: ({ space, schema }, get) => {
         const client = get(capabilities.atom(ClientCapabilities.Client)).at(0);
-        const schemas = client ? get(client.graph.registry.query(Filter.type(Type.Type)).atom) : [];
+        const schemas = client ? get(QueryResult.atom(client.graph.registry, Filter.type(Type.Type))) : [];
 
         const targetTypename = Type.getTypename(schema);
         const viewIndex = buildViewIndex(get, space, schemas);

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.ts
@@ -7,7 +7,7 @@ import * as Option from 'effect/Option';
 
 import { type Space, SpaceState, isSpace } from '@dxos/client/echo';
 import { type Operation } from '@dxos/compute';
-import { Annotation, Filter, Obj, Type } from '@dxos/echo';
+import { Annotation, Filter, Obj, QueryResult, Type } from '@dxos/echo';
 import { MigrationVersionAnnotation, Migrations } from '@dxos/migrations';
 import { type Node } from '@dxos/plugin-graph';
 import { type TreeData } from '@dxos/react-ui-list';
@@ -146,7 +146,7 @@ export const buildViewIndex = (get: Atom.Context, space: Space, schemas: Type.An
 
   if (viewSchemas.length > 0) {
     const filter = Filter.or(...viewSchemas.map((schema) => Filter.type(schema)));
-    const viewObjects = get(space.db.query(filter).atom);
+    const viewObjects = get(QueryResult.atom(space.db, filter));
 
     for (const viewObject of viewObjects) {
       if (!Obj.isObject(viewObject)) {

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
@@ -15,7 +15,7 @@ import {
 } from '@dxos/app-toolkit';
 import { type Space, SpaceState } from '@dxos/client/echo';
 import { Operation } from '@dxos/compute';
-import { Filter, Obj } from '@dxos/echo';
+import { Filter, Obj, QueryResult } from '@dxos/echo';
 import { Migrations } from '@dxos/migrations';
 import { ClientCapabilities } from '@dxos/plugin-client';
 import { CreateAtom, Graph, GraphBuilder, Node, NodeMatcher } from '@dxos/plugin-graph';
@@ -174,7 +174,7 @@ export const createSpaceExtensions = Effect.fnUntraced(function* () {
         const ephemeralState = get(ephemeralAtom);
 
         try {
-          const [spacesOrder] = get(personalSpace.db.query(Filter.type(Expando.Expando, { key: SHARED })).atom);
+          const [spacesOrder] = get(QueryResult.atom(personalSpace.db, Filter.type(Expando.Expando, { key: SHARED })));
           const { graph } = capabilities.get(AppCapabilities.AppGraph);
 
           const spacesOrderSnapshot = spacesOrder ? get(Obj.atom(spacesOrder)) : undefined;

--- a/packages/plugins/plugin-trello/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-trello/src/capabilities/app-graph-builder.ts
@@ -8,7 +8,7 @@ import * as Option from 'effect/Option';
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
-import { Filter, Obj, Ref } from '@dxos/echo';
+import { Filter, Obj, QueryResult, Ref } from '@dxos/echo';
 import { EID } from '@dxos/keys';
 import { GraphBuilder } from '@dxos/plugin-graph';
 import { Integration } from '@dxos/plugin-integration';
@@ -43,7 +43,7 @@ export default Capability.makeModule(
           if (!db) {
             return Effect.succeed([]);
           }
-          const integrations = get(db.query(Filter.type(Integration.Integration)).atom);
+          const integrations = get(QueryResult.atom(db, Filter.type(Integration.Integration)));
           const integration = integrations.find((integration) =>
             integration.targets.some(
               (target) => target.object && EID.getEntityId(EID.tryParse(target.object.uri)!) === kanban.id,

--- a/packages/sdk/app-graph/src/stories/EchoGraph.stories.tsx
+++ b/packages/sdk/app-graph/src/stories/EchoGraph.stories.tsx
@@ -9,7 +9,7 @@ import * as Option from 'effect/Option';
 import React, { type PropsWithChildren, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { type Space, SpaceState, isSpace } from '@dxos/client/echo';
-import { Filter, Obj, Query } from '@dxos/echo';
+import { Filter, Obj, Query, QueryResult } from '@dxos/echo';
 import { TestSchema } from '@dxos/echo/testing';
 import { random } from '@dxos/random';
 import { type Client, useClient } from '@dxos/react-client';
@@ -83,7 +83,7 @@ const createGraph = (client: Client, registry: Registry.Registry): Graph.Expanda
           get(node),
           Option.flatMap((node) => (isSpace(node.data) ? Option.some(node.data) : Option.none())),
           Option.map((space) => {
-            const objects = get(space.db.query(Query.type(TestSchema.Expando, { type: 'test' })).atom);
+            const objects = get(QueryResult.atom(space.db, Query.type(TestSchema.Expando, { type: 'test' })));
             return objects.map((object) => ({
               id: object.id,
               type: 'org.dxos.type.test',

--- a/packages/sdk/app-toolkit/src/type-section-extension.ts
+++ b/packages/sdk/app-toolkit/src/type-section-extension.ts
@@ -6,7 +6,7 @@ import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 
 import { GraphBuilder, Node } from '@dxos/app-graph';
-import { Annotation, Filter, Obj, Type } from '@dxos/echo';
+import { Annotation, Filter, Obj, QueryResult, Type } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
 
 import { whenSpace } from './app-node-matcher';
@@ -61,7 +61,7 @@ export const createTypeSectionExtension = (
     id: typename,
     match: whenSpace,
     connector: (space, get) => {
-      const objects = get(space.db.query(filter).atom) as Obj.Unknown[];
+      const objects = get(QueryResult.atom(space.db, filter)) as Obj.Unknown[];
       if (objects.length === 0) {
         return Effect.succeed([]);
       }

--- a/packages/ui/react-ui-mosaic/src/components/Board/Board.stories.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/Board/Board.stories.tsx
@@ -7,7 +7,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React, { useContext, useMemo } from 'react';
 import { expect, within } from 'storybook/test';
 
-import { type Database, Filter, Obj, Ref } from '@dxos/echo';
+import { type Database, Filter, Obj, QueryResult, Ref } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
 import { random } from '@dxos/random';
 import { useClientStory, withClientProvider } from '@dxos/react-client/testing';
@@ -72,7 +72,8 @@ const useTestBoardModel = (): TestBoardModelResult => {
     const orderAtom = Atom.make<string[]>([]);
 
     // Source of truth for which columns exist; subscribed to ECHO query.
-    const columnsAtom = space?.db != null ? space.db.query(Filter.type(TestColumn)).atom : Atom.make<TestColumn[]>([]);
+    const columnsAtom =
+      space?.db != null ? QueryResult.atom(space.db, Filter.type(TestColumn)) : Atom.make<TestColumn[]>([]);
 
     // If orderAtom is empty, use Echo order as-is; else sort by orderAtom and append new columns.
     const orderedColumnsAtom = Atom.make((get) => {


### PR DESCRIPTION
## Summary

Composer froze when enabling a plugin / creating types. The cause is a query-subscription leak: `db.query(filter)` constructs a **new `QueryResult` on every call**, so the per-instance `queryResult.atom` getter is memoized only *per instance*. Inline `X.query(...).atom` inside a graph-builder connector/action (or any effect-atom compute) opened a fresh ECHO `ExecQuery` stream on **every re-evaluation** and never released the prior one, accumulating open streams until the main thread stalled.

This regressed in #11729 ("migrate @dxos/echo-atom into core"), which deleted the memoized `AtomQuery.make(queryable, query)` family (keyed by serialized query AST) and rewrote ~37 call sites to the leaking inline `.query(...).atom` form.

## What changed

- **Restored the memoized family** as `QueryResult.atom(queryable, query)` in `@dxos/echo` ([`internal/QueryAtoms.ts`](packages/core/echo/echo/src/internal/QueryAtoms.ts)) — an `Atom.family` keyed by `<queryable-identifier>~<serialized-query-AST>` (Database→`spaceId`, Registry→`id`, Queue→`uri`), holding the queryable weakly. Same queryable + query ⇒ same atom ⇒ one shared subscription.
- **Kept the per-instance `.atom` getter** (valid when a `QueryResult` is held stable, e.g. behind `useMemo`) and documented it as a footgun in re-eval contexts. **Dropped the redundant `fromQuery` helper** — it duplicated the per-instance getter that #11729 added.
- **Migrated all leaking `X.query(...).atom` call sites** to the family: graph-builder extensions in plugin-space / inbox / code / integration / commerce / sample / trello / native-filesystem, `app-toolkit`'s `createTypeSectionExtension`, plus `.tsx` sites in plugin-assistant (`TracePanel`), plugin-kanban (`KanbanArticle`), plugin-comments (story), and `react-ui-mosaic` (story).
- **Added oxlint rule** [`no-query-result-atom-getter`](packages/common/eslint-plugin-rules/rules/no-query-result-atom-getter.js) (error) that flags any inline `.query(...).atom` while allowing `held.atom` on a stable instance — so this can't regress.
- **Ported the `echo-atom` regression suite** to [`echo-client/query-result.test.ts`](packages/core/echo/echo-client/src/query/query-result.test.ts), including the critical `QueryResult.atom(x, q) === QueryResult.atom(x, q)` memoization assertion and queue/registry coverage.

## Reviewer notes

- The per-instance getter is intentionally retained — the rule distinguishes the safe `held.atom` from the leaking inline `X.query(...).atom`.
- The one `as Obj.Unknown[]` in `type-section-extension.ts` is pre-existing (only the inner expression changed); no new casts were introduced.

## Verification

- `moon run echo:build`, `echo-client:test` (incl. 11 new query-result tests), and builds of all touched plugins + `app-toolkit` / `app-graph` / `react-ui-mosaic` pass.
- plugin-space `shared.test.ts` and plugin-feed `atoms.test.ts` pass.
- Lint clean; full-repo sweep confirms zero remaining inline `.query(...).atom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a memoized QueryResult.atom API for safer, more efficient reactive database queries with shared subscriptions and caching.

* **Tests**
  * Added comprehensive tests covering memoization, subscription updates, and queue-based query behavior.

* **Chores**
  * Introduced an ESLint rule to discourage inline query .atom usage.
  * Updated multiple plugins/components to adopt the new QueryResult.atom API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->