### PR TITLE
fix(client): steal stale leader lock to recover from zombie tabs

### DIFF
--- a/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.test.ts
+++ b/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.test.ts
@@ -11,6 +11,7 @@ import { log } from '@dxos/log';
 
 import { Client } from '../../client';
 import { TestBuilder } from '../../testing';
+import { LEADER_LOCK_KEY } from './dedicated-worker-client-services';
 
 describe('DedicatedWorkerClientServices', { timeout: 1_000, retry: 0 }, () => {
   test('open & close', async () => {
@@ -44,6 +45,42 @@ describe('DedicatedWorkerClientServices', { timeout: 1_000, retry: 0 }, () => {
     await using client2 = await new Client({ services: services2 }).initialize();
 
     expect(client2.halo.identity.get()).toEqual(identity);
+  });
+
+  test('steals the leader lock from a stale (zombie) holder', { timeout: 5_000 }, async () => {
+    const testBuilder = new TestBuilder();
+    onTestFinished(() => testBuilder.destroy());
+
+    // Simulate a zombie leader: hold the leader lock but never run a session or emit heartbeats,
+    // mimicking a frozen/dead tab that the browser hasn't torn down.
+    const acquired = new Trigger();
+    const stolen = new Trigger();
+    const releaseZombie = new Trigger();
+    onTestFinished(() => {
+      releaseZombie.wake();
+    });
+    void navigator.locks
+      .request(LEADER_LOCK_KEY, { mode: 'exclusive' }, async () => {
+        acquired.wake();
+        await releaseZombie.wait();
+      })
+      .catch((err) => {
+        if (err?.name === 'AbortError') {
+          stolen.wake();
+        }
+      });
+    await acquired.wait();
+
+    // A fresh client must detect the stale holder, steal the lock, become leader itself, and connect.
+    await using services = await testBuilder
+      .createDedicatedWorkerClientServices({
+        leaderTimeouts: { portTimeout: 200, staleTimeout: 100, heartbeatInterval: 50 },
+      })
+      .open();
+    await asyncTimeout(stolen.wait(), 4_000);
+
+    await using client = await new Client({ services }).initialize();
+    await client.halo.createIdentity();
   });
 
   // Flaky.

--- a/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.ts
+++ b/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.ts
@@ -25,7 +25,9 @@ import {
 export const LEADER_LOCK_KEY = '@dxos/client/DedicatedWorkerClientServices/LeaderLock';
 
 const DEFAULT_LEADER_HEARTBEAT_INTERVAL = 1_000;
-const DEFAULT_LEADER_STALE_TIMEOUT = 2_500;
+// ~5 missed heartbeats: tolerant of main-thread jank (GC pauses, heavy renders) on the leader tab,
+// since the heartbeat runs on the leader's main thread while data work runs in the worker.
+const DEFAULT_LEADER_STALE_TIMEOUT = 5_000;
 const DEFAULT_LEADER_PORT_TIMEOUT = 3_000;
 
 // Sentinel resolved when a follower gives up waiting for a port from the leader.
@@ -82,6 +84,8 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
   #lastLeaderHeartbeat = 0;
   // Timestamp (ms) of the last steal attempt; gates against thrashing re-election.
   #lastStealAttempt = 0;
+  // Resolves the leader-lock hold; woken on close, worker termination, or when our lock is stolen.
+  #leaderDone: Trigger | undefined;
 
   #initialConnection = new Trigger<void>();
   #isInitialConnection = true;
@@ -172,6 +176,7 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
 
           this.#leaderSession = new LeaderSession(this.#createWorker, this.#coordinator, this.#config, this.#clientId);
           const done = new Trigger();
+          this.#leaderDone = done;
           this._ctx.onDispose(() => done.wake());
           this.#leaderSession.onClose.on((error) => {
             log('dedicated-worker-client-services: leader session closed', { hasError: !!error });
@@ -190,12 +195,28 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
             log('dedicated-worker-client-services: leader session done');
           } finally {
             clearInterval(heartbeat);
+            this.#leaderDone = undefined;
           }
         });
         log('dedicated-worker-client-services: leader lock released');
       } catch (error: any) {
         if (isAbortError(error)) {
-          log('dedicated-worker-client-services: leader watch aborted');
+          if (this._ctx.disposed) {
+            // Normal shutdown: the leader-lock request was aborted because the resource is closing.
+            log('dedicated-worker-client-services: leader watch aborted (closing)');
+            return;
+          }
+          // Our exclusive lock was stolen by another tab that judged this leader stale. The lock
+          // callback keeps running per spec, so explicitly tear down our leader session (terminating
+          // the worker so it stops contending for shared storage) and re-enter the election.
+          log.warn('dedicated-worker-client-services: leader lock stolen, tearing down and re-watching', {
+            clientId: this.#clientId,
+          });
+          this.#leaderDone?.wake();
+          const session = this.#leaderSession;
+          this.#leaderSession = undefined;
+          await session?.close();
+          this.#watchLeader();
           return;
         }
         log.catch(error);
@@ -476,6 +497,9 @@ class LeaderSession extends Resource {
           break;
         case 'provide-port':
           // noop
+          break;
+        case 'leader-heartbeat':
+          // Broadcast by leaders (including ourselves) for follower liveness tracking; ignore here.
           break;
         case 'request-port':
           this.#sendMessage({ type: 'start-session', clientId: msg.clientId });

--- a/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.ts
+++ b/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.ts
@@ -22,7 +22,30 @@ import {
   type WorkerOrPort,
 } from './types';
 
-const LEADER_LOCK_KEY = '@dxos/client/DedicatedWorkerClientServices/LeaderLock';
+export const LEADER_LOCK_KEY = '@dxos/client/DedicatedWorkerClientServices/LeaderLock';
+
+const DEFAULT_LEADER_HEARTBEAT_INTERVAL = 1_000;
+const DEFAULT_LEADER_STALE_TIMEOUT = 2_500;
+const DEFAULT_LEADER_PORT_TIMEOUT = 3_000;
+
+// Sentinel resolved when a follower gives up waiting for a port from the leader.
+const LEADER_TIMEOUT = Symbol('leader-timeout');
+
+export interface LeaderTimeoutOptions {
+  /**
+   * Interval at which a leader broadcasts liveness heartbeats while holding the lock.
+   */
+  heartbeatInterval?: number;
+  /**
+   * Duration without a heartbeat after which a lock-holding leader is considered stale
+   * and its lock may be stolen to force re-election.
+   */
+  staleTimeout?: number;
+  /**
+   * Duration a follower waits for a port from the leader before re-evaluating leadership.
+   */
+  portTimeout?: number;
+}
 
 export interface DedeciatedWorkerClientServicesOptions {
   createWorker: () => WorkerOrPort;
@@ -31,6 +54,11 @@ export interface DedeciatedWorkerClientServicesOptions {
    * Config to pass to the dedicated worker.
    */
   config?: Config;
+  /**
+   * Overrides for leader liveness/steal timeouts. Defaults are tuned for production; tests pass
+   * small values for determinism.
+   */
+  leaderTimeouts?: LeaderTimeoutOptions;
 }
 
 /**
@@ -46,6 +74,14 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
   #coordinator: WorkerCoordinator | undefined = undefined;
   #connection: SharedWorkerConnection | undefined = undefined;
   readonly #clientId = `dedicated-worker-client-services-${crypto.randomUUID()}`;
+
+  readonly #leaderHeartbeatInterval: number;
+  readonly #leaderStaleTimeout: number;
+  readonly #leaderPortTimeout: number;
+  // Timestamp (ms) of the last heartbeat seen from any leader; 0 if none observed yet.
+  #lastLeaderHeartbeat = 0;
+  // Timestamp (ms) of the last steal attempt; gates against thrashing re-election.
+  #lastStealAttempt = 0;
 
   #initialConnection = new Trigger<void>();
   #isInitialConnection = true;
@@ -63,6 +99,9 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
     this.#createWorker = options.createWorker;
     this.#createCoordinator = options.createCoordinator;
     this.#config = options.config;
+    this.#leaderHeartbeatInterval = options.leaderTimeouts?.heartbeatInterval ?? DEFAULT_LEADER_HEARTBEAT_INTERVAL;
+    this.#leaderStaleTimeout = options.leaderTimeouts?.staleTimeout ?? DEFAULT_LEADER_STALE_TIMEOUT;
+    this.#leaderPortTimeout = options.leaderTimeouts?.portTimeout ?? DEFAULT_LEADER_PORT_TIMEOUT;
   }
 
   get descriptors(): ServiceBundle<ClientServices> {
@@ -79,6 +118,13 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
     log('dedicated-worker-client-services: creating coordinator');
     this.#coordinator = await this.#createCoordinator();
     log('dedicated-worker-client-services: coordinator created');
+    // Track leader liveness for the lifetime of the resource so the connect task can tell a live
+    // leader from a dead one before stealing the lock.
+    this.#coordinator.onMessage.on(this._ctx, (message) => {
+      if (message.type === 'leader-heartbeat') {
+        this.#lastLeaderHeartbeat = Date.now();
+      }
+    });
     this.#watchLeader();
     log('dedicated-worker-client-services: leader watch started');
     this.#connectTask.open();
@@ -115,6 +161,15 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
           });
           invariant(this.#coordinator);
           invariant(!this.#leaderSession);
+
+          // Heartbeat for the full duration we hold the lock (starting before the worker is ready)
+          // so followers can distinguish a live, slow-to-start leader from a dead one and avoid
+          // stealing the lock from a healthy leader.
+          const sendHeartbeat = () =>
+            this.#coordinator?.sendMessage({ type: 'leader-heartbeat', leaderId: this.#clientId });
+          sendHeartbeat();
+          const heartbeat = setInterval(sendHeartbeat, this.#leaderHeartbeatInterval);
+
           this.#leaderSession = new LeaderSession(this.#createWorker, this.#coordinator, this.#config, this.#clientId);
           const done = new Trigger();
           this._ctx.onDispose(() => done.wake());
@@ -127,11 +182,15 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
               done.wake();
             }
           });
-          log('dedicated-worker-client-services: opening leader session');
-          await this.#leaderSession.open();
-          log('dedicated-worker-client-services: leader session opened');
-          await done.wait(); // Hold until the leader session is closed.
-          log('dedicated-worker-client-services: leader session done');
+          try {
+            log('dedicated-worker-client-services: opening leader session');
+            await this.#leaderSession.open();
+            log('dedicated-worker-client-services: leader session opened');
+            await done.wait(); // Hold until the leader session is closed.
+            log('dedicated-worker-client-services: leader session done');
+          } finally {
+            clearInterval(heartbeat);
+          }
         });
         log('dedicated-worker-client-services: leader lock released');
       } catch (error: any) {
@@ -166,36 +225,56 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
     try {
       log('trying to connect', { clientId: this.#clientId });
       log('dedicated-worker-client-services: requesting port from leader (waiting for provide-port)');
-      const { appPort, systemPort, leaderId, livenessLockKey } = await new Promise<
-        WorkerCoordinatorMessage & { type: 'provide-port' }
-      >((resolve) => {
-        invariant(this.#coordinator);
+      const result = await new Promise<(WorkerCoordinatorMessage & { type: 'provide-port' }) | typeof LEADER_TIMEOUT>(
+        (resolve) => {
+          invariant(this.#coordinator);
 
-        const unsubscribe = this.#coordinator.onMessage.on((message) => {
-          if (message.type === 'provide-port' && message.clientId === this.#clientId) {
-            log('dedicated-worker-client-services: received provide-port from leader', {
-              leaderId: message.leaderId,
-            });
+          const unsubscribe = this.#coordinator.onMessage.on((message) => {
+            if (message.type === 'provide-port' && message.clientId === this.#clientId) {
+              log('dedicated-worker-client-services: received provide-port from leader', {
+                leaderId: message.leaderId,
+              });
+              unsubscribe();
+              resolve(message);
+            } else if (message.type === 'new-leader') {
+              log('dedicated-worker-client-services: new leader announced, requesting port', {
+                leaderId: message.leaderId,
+              });
+              // New leader announced, request a port from them.
+              this.#coordinator?.sendMessage({
+                type: 'request-port',
+                clientId: this.#clientId,
+              });
+            }
+          });
+
+          // Re-evaluate leadership if no port arrives; an unbounded wait would hang the tab behind a
+          // dead leader that still holds the lock (e.g. a frozen/zombie tab).
+          const timer = setTimeout(() => {
             unsubscribe();
-            resolve(message);
-          } else if (message.type === 'new-leader') {
-            log('dedicated-worker-client-services: new leader announced, requesting port', {
-              leaderId: message.leaderId,
-            });
-            // New leader announced, request a port from them.
-            this.#coordinator?.sendMessage({
-              type: 'request-port',
-              clientId: this.#clientId,
-            });
-          }
-        });
+            resolve(LEADER_TIMEOUT);
+          }, this.#leaderPortTimeout);
+          ctx.onDispose(() => clearTimeout(timer));
 
-        // Send initial request in case leader is already ready.
-        this.#coordinator.sendMessage({
-          type: 'request-port',
+          // Send initial request in case leader is already ready.
+          this.#coordinator.sendMessage({
+            type: 'request-port',
+            clientId: this.#clientId,
+          });
+        },
+      );
+
+      if (result === LEADER_TIMEOUT) {
+        log.warn('dedicated-worker-client-services: timed out waiting for provide-port', {
           clientId: this.#clientId,
         });
-      });
+        await this.#maybeStealStaleLeader();
+        // Retry the connect; a fresh leader (this tab or another) is now being elected.
+        this.#connectTask.schedule();
+        return;
+      }
+
+      const { appPort, systemPort, leaderId, livenessLockKey } = result;
       log('connected to worker', { leaderId });
 
       queueMicrotask(async () => {
@@ -251,6 +330,56 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
       this.#connectTask?.schedule();
     }
   });
+
+  /**
+   * Steal the leader lock when the current holder is unresponsive and shows no sign of life.
+   * The stolen holder's lock request rejects in its own context; releasing immediately lets queued
+   * requests (including this tab's own leader watcher) re-elect a healthy leader. This is safe
+   * because shared state lives behind the dedicated worker, not behind the lock itself.
+   */
+  async #maybeStealStaleLeader(): Promise<void> {
+    const sinceHeartbeat = Date.now() - this.#lastLeaderHeartbeat;
+    if (sinceHeartbeat < this.#leaderStaleTimeout) {
+      // A leader is alive (it heartbeats while holding the lock); it may just be slow to start.
+      log('dedicated-worker-client-services: leader unresponsive but alive, not stealing', { sinceHeartbeat });
+      return;
+    }
+
+    if (!(await this.#isLeaderLockHeld())) {
+      // No leader holds the lock; a normal election will elect one (this tab's watcher is queued).
+      log('dedicated-worker-client-services: no leader holds the lock, awaiting election');
+      return;
+    }
+
+    if (Date.now() - this.#lastStealAttempt < this.#leaderStaleTimeout) {
+      // Avoid thrashing: at most one steal per stale window.
+      log('dedicated-worker-client-services: steal on cooldown, awaiting re-election');
+      return;
+    }
+    this.#lastStealAttempt = Date.now();
+
+    log.warn('dedicated-worker-client-services: stealing stale leader lock', {
+      clientId: this.#clientId,
+      sinceHeartbeat,
+    });
+    try {
+      await navigator.locks.request(LEADER_LOCK_KEY, { steal: true }, async () => {
+        log.warn('dedicated-worker-client-services: stole stale leader lock, re-electing');
+      });
+    } catch (error: any) {
+      log.catch(error);
+    }
+  }
+
+  async #isLeaderLockHeld(): Promise<boolean> {
+    try {
+      const { held } = await navigator.locks.query();
+      return (held ?? []).some((lock) => lock.name === LEADER_LOCK_KEY);
+    } catch {
+      // If querying is unsupported, fall back to attempting the steal (gated by the heartbeat check).
+      return true;
+    }
+  }
 }
 
 /**

--- a/packages/sdk/client/src/services/dedicated/types.ts
+++ b/packages/sdk/client/src/services/dedicated/types.ts
@@ -75,6 +75,12 @@ export type WorkerCoordinatorMessage =
       leaderId: string;
     }
   | {
+      // Broadcast by a leader while it holds the leader lock so followers can distinguish a live
+      // (possibly slow-to-start) leader from a dead one before deciding to steal the lock.
+      type: 'leader-heartbeat';
+      leaderId: string;
+    }
+  | {
       type: 'request-port';
       clientId: string;
     }

--- a/packages/sdk/client/src/testing/test-builder.ts
+++ b/packages/sdk/client/src/testing/test-builder.ts
@@ -37,6 +37,7 @@ import { Client } from '../client';
 import {
   ClientServicesProxy,
   DedicatedWorkerClientServices,
+  type LeaderTimeoutOptions,
   LocalClientServices,
   MemoryWorkerCoordiantor,
 } from '../services';
@@ -160,7 +161,9 @@ export class TestBuilder {
    * Create dedicated worker client services.
    * All services share the same worker factory and coordinator.
    */
-  createDedicatedWorkerClientServices(): DedicatedWorkerClientServices {
+  createDedicatedWorkerClientServices(options?: {
+    leaderTimeouts?: LeaderTimeoutOptions;
+  }): DedicatedWorkerClientServices {
     // Shared coordinator for leader election across all services.
     if (!this._coordinator) {
       this._coordinator = new MemoryWorkerCoordiantor();
@@ -176,6 +179,7 @@ export class TestBuilder {
     const services = new DedicatedWorkerClientServices({
       createWorker: () => this._workerFactory!.make(),
       createCoordinator: () => this._coordinator!,
+      leaderTimeouts: options?.leaderTimeouts,
     });
 
     this._ctx.onDispose(() => services.close());


### PR DESCRIPTION
## Problem

On startup, a Composer tab can hang indefinitely waiting for the dedicated-worker client services to connect. Forensics on a captured log showed the tab stuck in `dedicated-worker-client-services: requesting port from leader (waiting for provide-port)` for ~30s until an unrelated plugin-activation timeout killed it — never acquiring the leader lock and never receiving `provide-port`.

The root cause class: the leadership token is a tab-held `navigator.locks` lock held across the entire session. Web Locks are released when the holding **agent is destroyed**, not when a tab visually goes away — so a frozen-but-alive tab (BFCache freeze-without-discard, aggressive background throttling, WKWebView) keeps `LEADER_LOCK` while its event loop is suspended. It neither releases the lock (followers stay queued forever) nor answers `request-port` (no `provide-port` ever comes). The follower's wait was an unbounded `Promise`, so there was no recovery path.

## Change

Add leader liveness signaling + a guarded steal-based recovery:

- **Heartbeat.** A leader broadcasts `leader-heartbeat` through the coordinator for the full duration it holds the lock, **starting before the worker is ready**, so a slow-but-alive leader is never mistaken for dead.
- **Bounded wait.** Followers race the `provide-port` wait against a `portTimeout` instead of waiting forever.
- **Steal-and-release.** On timeout, if no heartbeat arrived within `staleTimeout` **and** `navigator.locks.query()` confirms the lock is still held, the follower steals the lock (`{ steal: true }`) and releases it immediately. Eviction lets the normal queued requests run a clean re-election. A cooldown guards against thrashing.

Stealing is safe here because shared state lives behind the single dedicated worker, not behind the lock — a momentary two-leaders window during a steal just causes the evicted leader to tear down its worker.

Timeouts are configurable via a new `leaderTimeouts` option (defaults: 1s heartbeat, 2.5s stale, 3s port timeout) so tests use small deterministic values.

### Scope / non-goals

The heartbeat gate deliberately will **not** steal from a wedged-but-*alive* leader (e.g. a worker stuck opening a corrupt OPFS/SQLite database), since that would just hand leadership to another tab that hits the same on-disk wall and thrash. That failure mode — a hang that persists across closing *all* tabs and reopening — is a separate issue (persistent storage, not a leaked lock) and needs a worker-init timeout, not lock stealing. This PR targets the zombie/frozen-tab case.

## Testing

- New test `steals the leader lock from a stale (zombie) holder`: plants a raw lock holder that never sessions or heartbeats, asserts a fresh client steals it (verified via the `AbortError` on the zombie's request) and then connects + creates an identity.
- Full `@dxos/client` dedicated-worker suite passes (6/6); build, lint, and format clean.

## Files

- `dedicated-worker-client-services.ts` — heartbeat, bounded wait, `#maybeStealStaleLeader` / `#isLeaderLockHeld`, configurable timeouts, exported `LEADER_LOCK_KEY`.
- `types.ts` — `leader-heartbeat` coordinator message.
- `test-builder.ts` — forward `leaderTimeouts`.
- `dedicated-worker-client-services.test.ts` — zombie-steal test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved dedicated worker client reliability with automatic detection and recovery from unresponsive leader instances through heartbeat monitoring.
  * Added `leaderTimeouts` configuration option to customize heartbeat interval, staleness detection, and connection timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->