### PR TITLE
fix(observability): tag fatal-dialog errors and forward log context to PostHog

### DIFF
--- a/packages/apps/composer-app/src/components/ResetDialog/ResetDialog.tsx
+++ b/packages/apps/composer-app/src/components/ResetDialog/ResetDialog.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { type IdbLogStore } from '@dxos/log-store-idb';
+import { log } from '@dxos/log';
 import { type Observability } from '@dxos/observability';
 import { type SupportOperation } from '@dxos/plugin-support';
 import { FeedbackForm } from '@dxos/plugin-support/components';
@@ -82,6 +83,15 @@ export const ResetDialog = ({
     const timeout = setTimeout(() => setFeedbackSent(false), 3_000);
     return () => clearTimeout(timeout);
   }, [feedbackSent]);
+
+  // Tag any error that surfaces the fatal dialog so alerts can key off `fatal_dialog: true`.
+  // Logging routes through all processors (PostHog + OTEL/SigNoz) unlike captureException.
+  useEffect(() => {
+    if (!errorProp) {
+      return;
+    }
+    log.error('fatal dialog', { error: errorProp, fatal_dialog: true });
+  }, [errorProp]);
 
   const handleCopyError = useCallback(() => {
     void navigator.clipboard.writeText(JSON.stringify(error));

--- a/packages/apps/composer-app/src/components/ResetDialog/ResetDialog.tsx
+++ b/packages/apps/composer-app/src/components/ResetDialog/ResetDialog.tsx
@@ -4,8 +4,8 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { type IdbLogStore } from '@dxos/log-store-idb';
 import { log } from '@dxos/log';
+import { type IdbLogStore } from '@dxos/log-store-idb';
 import { type Observability } from '@dxos/observability';
 import { type SupportOperation } from '@dxos/plugin-support';
 import { FeedbackForm } from '@dxos/plugin-support/components';

--- a/packages/sdk/observability/src/extensions/posthog/log-processor.ts
+++ b/packages/sdk/observability/src/extensions/posthog/log-processor.ts
@@ -5,7 +5,7 @@
 import posthog from 'posthog-js';
 
 import { InvariantViolation } from '@dxos/invariant';
-import { type LogConfig, type LogEntry, LogLevel, type LogProcessor, shouldLog } from '@dxos/log';
+import { type LogConfig, type LogEntry, LogLevel, type LogProcessor, getContextFromEntry, shouldLog } from '@dxos/log';
 
 export const logProcessor: LogProcessor = (config: LogConfig, entry: LogEntry) => {
   // Don't forward logs from remote sessions.
@@ -37,6 +37,16 @@ export const logProcessor: LogProcessor = (config: LogConfig, entry: LogEntry) =
 
   if (capturedError instanceof InvariantViolation) {
     additionalProperties.invariant_violation = true;
+  }
+
+  // Forward primitive context values so callers can attach queryable attributes (e.g. fatal_dialog: true).
+  const context = getContextFromEntry(entry);
+  if (context) {
+    for (const [key, value] of Object.entries(context)) {
+      if (typeof value === 'string' || typeof value === 'boolean' || typeof value === 'number') {
+        additionalProperties[key] = value;
+      }
+    }
   }
 
   posthog.captureException(capturedError, additionalProperties);


### PR DESCRIPTION
## Summary

- **`ResetDialog`**: when the Composer fatal-dialog mounts with an error, it now calls `log.error('fatal dialog', { error, fatal_dialog: true })`. This fans out through all registered log processors — PostHog and OTEL/SigNoz — so the error is queryable in both destinations with a `fatal_dialog: true` attribute for alerting.

- **PostHog log processor**: previously only forwarded a hardcoded set of computed fields (`transaction`, `uptime_seconds`, etc.) as `additionalProperties` on `captureException`. It now also iterates the log entry's context and forwards any primitive (`string | boolean | number`) values. Objects and `Error` instances are skipped (the error is already the main captured event). This makes arbitrary call-site attributes — like `fatal_dialog: true` — queryable as PostHog exception properties.

## Why

Errors that trigger the fatal startup/crash dialog were not reliably captured in SigNoz at all (only `captureException` went to PostHog), and had no distinguishing attribute to key alerts off. The `log.error` path routes through the OTEL processor (→ SigNoz) and the PostHog log processor, giving both destinations the `fatal_dialog: true` signal.

## Reviewer notes

- The context-forwarding in the log processor only promotes primitives; nested objects are intentionally dropped since PostHog exception properties must be flat scalars.
- The `ResetDialog` effect depends only on `errorProp` (not `observabilityProp` — no async await needed since `log` is a module-level singleton).
- This is additive: errors that were already captured via `log.error` elsewhere before hitting the boundary may produce two PostHog events, but the one with `fatal_dialog: true` is distinct and unambiguous for alert queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added logging of fatal dialog error events when an error is present in the dialog, improving error visibility.
  * Enhanced analytics capture to include primitive context attributes (strings, numbers, booleans) for richer event details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->