### PR TITLE
feat(observability): add localStorage toggle for OTEL debug log level

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -175,13 +175,13 @@ const main = async () => {
     enableDebugLogs: () => {
       void Observability.storeOtelLogLevel(APP_KEY, 'debug');
       // eslint-disable-next-line no-console
-      console.info('[otel] Debug log level enabled — all debug logs will be sent to SignOz.');
+      console.info('[otel] Debug log level enabled — reload to apply. All debug logs will be sent to SignOz.');
     },
     /** Remove the debug override and revert to the default INFO log level. */
     disableDebugLogs: () => {
       void Observability.storeOtelLogLevel(APP_KEY, null);
       // eslint-disable-next-line no-console
-      console.info('[otel] Debug log level override removed — reverted to INFO.');
+      console.info('[otel] Debug log level override removed — reload to apply. Reverted to INFO.');
     },
     /** Return the active OTEL log level override, or null if using the default. */
     getLogLevel: async (): Promise<string | null> => {

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -170,23 +170,22 @@ const main = async () => {
   profiler?.measure('dynamic-imports', 'dynamic-imports:start', 'dynamic-imports:end');
 
   // Namespace for global Composer test & debug hooks.
-  const OTEL_LOG_LEVEL_KEY = 'composer/otel-log-level';
   const otel = {
-    /** Enable debug-level OTEL log export for this device (persisted across reloads). */
+    /** Enable debug-level OTEL log export for this device (persisted across reloads, works in workers). */
     enableDebugLogs: () => {
-      localStorage.setItem(OTEL_LOG_LEVEL_KEY, 'debug');
+      void Observability.storeOtelLogLevel(APP_KEY, 'debug');
       // eslint-disable-next-line no-console
       console.info('[otel] Debug log level enabled — all debug logs will be sent to SignOz.');
     },
     /** Remove the debug override and revert to the default INFO log level. */
     disableDebugLogs: () => {
-      localStorage.removeItem(OTEL_LOG_LEVEL_KEY);
+      void Observability.storeOtelLogLevel(APP_KEY, null);
       // eslint-disable-next-line no-console
       console.info('[otel] Debug log level override removed — reverted to INFO.');
     },
-    /** Return the active OTEL log level override, or undefined if using the default. */
-    getLogLevel: (): string | null => {
-      const level = localStorage.getItem(OTEL_LOG_LEVEL_KEY);
+    /** Return the active OTEL log level override, or null if using the default. */
+    getLogLevel: async (): Promise<string | null> => {
+      const level = await Observability.getOtelLogLevel(APP_KEY);
       // eslint-disable-next-line no-console
       console.info(`[otel] Log level: ${level ?? 'default (INFO)'}`);
       return level;

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -174,20 +174,17 @@ const main = async () => {
     /** Enable debug-level OTEL log export for this device (persisted across reloads, works in workers). */
     enableDebugLogs: () => {
       void Observability.storeOtelLogLevel(APP_KEY, 'debug');
-      // eslint-disable-next-line no-console
-      console.info('[otel] Debug log level enabled — reload to apply. All debug logs will be sent to SignOz.');
+      log.info('otel debug log level enabled — reload to apply');
     },
     /** Remove the debug override and revert to the default INFO log level. */
     disableDebugLogs: () => {
       void Observability.storeOtelLogLevel(APP_KEY, null);
-      // eslint-disable-next-line no-console
-      console.info('[otel] Debug log level override removed — reload to apply. Reverted to INFO.');
+      log.info('otel debug log level override removed — reload to apply');
     },
     /** Return the active OTEL log level override, or null if using the default. */
     getLogLevel: async (): Promise<string | null> => {
       const level = await Observability.getOtelLogLevel(APP_KEY);
-      // eslint-disable-next-line no-console
-      console.info(`[otel] Log level: ${level ?? 'default (INFO)'}`);
+      log.info('otel log level', { level: level ?? 'default (INFO)' });
       return level;
     },
   };

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -170,7 +170,29 @@ const main = async () => {
   profiler?.measure('dynamic-imports', 'dynamic-imports:start', 'dynamic-imports:end');
 
   // Namespace for global Composer test & debug hooks.
-  (window as any).composer = { profiler };
+  const OTEL_LOG_LEVEL_KEY = 'composer/otel-log-level';
+  const otel = {
+    /** Enable debug-level OTEL log export for this device (persisted across reloads). */
+    enableDebugLogs: () => {
+      localStorage.setItem(OTEL_LOG_LEVEL_KEY, 'debug');
+      // eslint-disable-next-line no-console
+      console.info('[otel] Debug log level enabled — all debug logs will be sent to SignOz.');
+    },
+    /** Remove the debug override and revert to the default INFO log level. */
+    disableDebugLogs: () => {
+      localStorage.removeItem(OTEL_LOG_LEVEL_KEY);
+      // eslint-disable-next-line no-console
+      console.info('[otel] Debug log level override removed — reverted to INFO.');
+    },
+    /** Return the active OTEL log level override, or undefined if using the default. */
+    getLogLevel: (): string | null => {
+      const level = localStorage.getItem(OTEL_LOG_LEVEL_KEY);
+      // eslint-disable-next-line no-console
+      console.info(`[otel] Log level: ${level ?? 'default (INFO)'}`);
+      return level;
+    },
+  };
+  (window as any).composer = { profiler, otel };
 
   Migrations.define(APP_KEY, __COMPOSER_MIGRATIONS__);
 

--- a/packages/sdk/observability/src/extensions/otel/extension.ts
+++ b/packages/sdk/observability/src/extensions/otel/extension.ts
@@ -15,7 +15,7 @@ import { isNode, isNonNullable } from '@dxos/util';
 
 import buildSecrets from '../../cli-observability-secrets.json';
 import { type Extension, type ExtensionApi } from '../../observability-extension';
-import { isObservabilityDisabled, storeObservabilityDisabled } from '../../storage';
+import { getOtelLogLevel, isObservabilityDisabled, storeObservabilityDisabled } from '../../storage';
 import { stubExtension } from '../stub';
 
 export type ExtensionsOptions = {
@@ -58,6 +58,9 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
 
   const cachedDisabled = yield* Effect.promise(() => isObservabilityDisabled(serviceName));
   const disabled = cachedDisabled || isObservabilityDisabledSync(serviceName);
+  const storedLogLevel = yield* Effect.promise(() => getOtelLogLevel(serviceName));
+  const resolvedLogLevel =
+    storedLogLevel != null ? (LogLevel[storedLogLevel.toUpperCase() as keyof typeof LogLevel] ?? logLevel) : logLevel;
   const enabledRef = yield* Ref.make(!disabled);
   const tags = new Map<string, string>();
 
@@ -123,7 +126,7 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
         headers: resolvedHeaders,
         resource,
         getTags: () => Object.fromEntries(tags),
-        logLevel,
+        logLevel: resolvedLogLevel,
       })
     : undefined;
 

--- a/packages/sdk/observability/src/extensions/otel/logs.ts
+++ b/packages/sdk/observability/src/extensions/otel/logs.ts
@@ -5,7 +5,7 @@
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { BatchLogRecordProcessor, LoggerProvider } from '@opentelemetry/sdk-logs';
-import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 
 import {
   type LogConfig,
@@ -16,41 +16,9 @@ import {
   getRelativeFilename,
 } from '@dxos/log';
 
-import { getOtelLogLevel } from '../../storage';
 import { type OtelOptions, resolveOtlpUrl, setDiagLogger } from './otel';
 
 const FLATTEN_DEPTH = 1;
-
-// Must match the key written by storeOtelLogLevel in storage/browser.ts.
-const OTEL_LOG_LEVEL_STORAGE_KEY = (serviceName: string) => `${serviceName}/otel-log-level`;
-
-// Primed from localForage at OtelLogs construction so worker contexts (where localStorage
-// is unavailable) can still respect a persisted log level override.
-const _logLevelCache = new Map<string, LogLevel | undefined>();
-
-const parseLogLevel = (stored: string): LogLevel | undefined => {
-  const level = LogLevel[stored.toUpperCase() as keyof typeof LogLevel];
-  return typeof level === 'number' ? level : undefined;
-};
-
-/** Returns the persisted log level override for this service, or undefined if none is set. */
-const getStoredLogLevel = (serviceName: string): LogLevel | undefined => {
-  // Main thread: check localStorage directly for live updates without a reload.
-  try {
-    if (typeof localStorage !== 'undefined') {
-      const stored = localStorage.getItem(OTEL_LOG_LEVEL_STORAGE_KEY(serviceName));
-      if (stored) {
-        return parseLogLevel(stored);
-      }
-      // Explicit null/absence in localStorage means the override was cleared.
-      return undefined;
-    }
-  } catch {
-    // localStorage not available (e.g., in workers) — fall through to cache.
-  }
-  // Workers: use value primed from localForage at construction time.
-  return _logLevelCache.get(serviceName);
-};
 
 export type OtelLogOptions = OtelOptions & {
   logLevel: LogLevel;
@@ -64,6 +32,7 @@ export type OtelLogOptions = OtelOptions & {
 
 export class OtelLogs {
   private _loggerProvider: LoggerProvider;
+
   constructor(private readonly options: OtelLogOptions) {
     setDiagLogger(options.consoleDiagLogLevel);
     const logExporter = new OTLPLogExporter({
@@ -75,13 +44,6 @@ export class OtelLogs {
       resource: this.options.resource,
       processors: [new BatchLogRecordProcessor(logExporter)],
     });
-
-    // Prime the module-level cache from localForage so worker contexts (which lack localStorage)
-    // can also respect a persisted log level override.
-    const serviceName = options.resource.attributes[ATTR_SERVICE_NAME]?.toString() ?? '';
-    void getOtelLogLevel(serviceName).then((stored) => {
-      _logLevelCache.set(serviceName, stored ? parseLogLevel(stored) : undefined);
-    });
   }
 
   public readonly logProcessor: LogProcessor = (_config: LogConfig, entry: LogEntry) => {
@@ -90,9 +52,10 @@ export class OtelLogs {
       this.options.resource.attributes[ATTR_SERVICE_VERSION]?.toString(),
     );
 
-    const serviceName = this.options.resource.attributes[ATTR_SERVICE_NAME]?.toString() ?? '';
-    const effectiveLogLevel = getStoredLogLevel(serviceName) ?? this.options.logLevel;
-    if (entry.level < effectiveLogLevel || (!this.options.includeSharedWorkerLogs && entry.meta?.S?.remoteSessionId)) {
+    if (
+      entry.level < this.options.logLevel ||
+      (!this.options.includeSharedWorkerLogs && entry.meta?.S?.remoteSessionId)
+    ) {
       return;
     }
 

--- a/packages/sdk/observability/src/extensions/otel/logs.ts
+++ b/packages/sdk/observability/src/extensions/otel/logs.ts
@@ -32,7 +32,6 @@ export type OtelLogOptions = OtelOptions & {
 
 export class OtelLogs {
   private _loggerProvider: LoggerProvider;
-
   constructor(private readonly options: OtelLogOptions) {
     setDiagLogger(options.consoleDiagLogLevel);
     const logExporter = new OTLPLogExporter({

--- a/packages/sdk/observability/src/extensions/otel/logs.ts
+++ b/packages/sdk/observability/src/extensions/otel/logs.ts
@@ -16,28 +16,40 @@ import {
   getRelativeFilename,
 } from '@dxos/log';
 
+import { getOtelLogLevel } from '../../storage';
 import { type OtelOptions, resolveOtlpUrl, setDiagLogger } from './otel';
 
 const FLATTEN_DEPTH = 1;
 
-/** localStorage key for per-device OTEL log level override (e.g. `composer/otel-log-level`). */
-export const otelLogLevelStorageKey = (serviceName: string) => `${serviceName}/otel-log-level`;
+// Must match the key written by storeOtelLogLevel in storage/browser.ts.
+const OTEL_LOG_LEVEL_STORAGE_KEY = (serviceName: string) => `${serviceName}/otel-log-level`;
 
-/** Returns a persisted log level override for this service, or undefined if none is set. */
+// Primed from localForage at OtelLogs construction so worker contexts (where localStorage
+// is unavailable) can still respect a persisted log level override.
+const _logLevelCache = new Map<string, LogLevel | undefined>();
+
+const parseLogLevel = (stored: string): LogLevel | undefined => {
+  const level = LogLevel[stored.toUpperCase() as keyof typeof LogLevel];
+  return typeof level === 'number' ? level : undefined;
+};
+
+/** Returns the persisted log level override for this service, or undefined if none is set. */
 const getStoredLogLevel = (serviceName: string): LogLevel | undefined => {
+  // Main thread: check localStorage directly for live updates without a reload.
   try {
-    if (typeof localStorage === 'undefined') {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem(OTEL_LOG_LEVEL_STORAGE_KEY(serviceName));
+      if (stored) {
+        return parseLogLevel(stored);
+      }
+      // Explicit null/absence in localStorage means the override was cleared.
       return undefined;
     }
-    const stored = localStorage.getItem(otelLogLevelStorageKey(serviceName));
-    if (!stored) {
-      return undefined;
-    }
-    const level = LogLevel[stored.toUpperCase() as keyof typeof LogLevel];
-    return typeof level === 'number' ? level : undefined;
   } catch {
-    return undefined;
+    // localStorage not available (e.g., in workers) — fall through to cache.
   }
+  // Workers: use value primed from localForage at construction time.
+  return _logLevelCache.get(serviceName);
 };
 
 export type OtelLogOptions = OtelOptions & {
@@ -62,6 +74,13 @@ export class OtelLogs {
     this._loggerProvider = new LoggerProvider({
       resource: this.options.resource,
       processors: [new BatchLogRecordProcessor(logExporter)],
+    });
+
+    // Prime the module-level cache from localForage so worker contexts (which lack localStorage)
+    // can also respect a persisted log level override.
+    const serviceName = options.resource.attributes[ATTR_SERVICE_NAME]?.toString() ?? '';
+    void getOtelLogLevel(serviceName).then((stored) => {
+      _logLevelCache.set(serviceName, stored ? parseLogLevel(stored) : undefined);
     });
   }
 

--- a/packages/sdk/observability/src/extensions/otel/logs.ts
+++ b/packages/sdk/observability/src/extensions/otel/logs.ts
@@ -5,7 +5,7 @@
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { BatchLogRecordProcessor, LoggerProvider } from '@opentelemetry/sdk-logs';
-import { ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 
 import {
   type LogConfig,
@@ -19,6 +19,26 @@ import {
 import { type OtelOptions, resolveOtlpUrl, setDiagLogger } from './otel';
 
 const FLATTEN_DEPTH = 1;
+
+/** localStorage key for per-device OTEL log level override (e.g. `composer/otel-log-level`). */
+export const otelLogLevelStorageKey = (serviceName: string) => `${serviceName}/otel-log-level`;
+
+/** Returns a persisted log level override for this service, or undefined if none is set. */
+const getStoredLogLevel = (serviceName: string): LogLevel | undefined => {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return undefined;
+    }
+    const stored = localStorage.getItem(otelLogLevelStorageKey(serviceName));
+    if (!stored) {
+      return undefined;
+    }
+    const level = LogLevel[stored.toUpperCase() as keyof typeof LogLevel];
+    return typeof level === 'number' ? level : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 export type OtelLogOptions = OtelOptions & {
   logLevel: LogLevel;
@@ -51,8 +71,10 @@ export class OtelLogs {
       this.options.resource.attributes[ATTR_SERVICE_VERSION]?.toString(),
     );
 
+    const serviceName = this.options.resource.attributes[ATTR_SERVICE_NAME]?.toString() ?? '';
+    const effectiveLogLevel = getStoredLogLevel(serviceName) ?? this.options.logLevel;
     if (
-      entry.level < this.options.logLevel ||
+      entry.level < effectiveLogLevel ||
       (!this.options.includeSharedWorkerLogs && entry.meta?.S?.remoteSessionId)
     ) {
       return;

--- a/packages/sdk/observability/src/extensions/otel/logs.ts
+++ b/packages/sdk/observability/src/extensions/otel/logs.ts
@@ -73,10 +73,7 @@ export class OtelLogs {
 
     const serviceName = this.options.resource.attributes[ATTR_SERVICE_NAME]?.toString() ?? '';
     const effectiveLogLevel = getStoredLogLevel(serviceName) ?? this.options.logLevel;
-    if (
-      entry.level < effectiveLogLevel ||
-      (!this.options.includeSharedWorkerLogs && entry.meta?.S?.remoteSessionId)
-    ) {
+    if (entry.level < effectiveLogLevel || (!this.options.includeSharedWorkerLogs && entry.meta?.S?.remoteSessionId)) {
       return;
     }
 

--- a/packages/sdk/observability/src/storage/browser.ts
+++ b/packages/sdk/observability/src/storage/browser.ts
@@ -96,17 +96,4 @@ export const storeOtelLogLevel = async (namespace: string, value: string | null)
   } catch (err) {
     log.catch('Failed to store OTEL log level', err);
   }
-  // Mirror to localStorage so the synchronous check in OtelLogs picks it up immediately on the main thread.
-  try {
-    if (typeof localStorage !== 'undefined') {
-      const key = `${namespace}/${OTEL_LOG_LEVEL_KEY}`;
-      if (value === null) {
-        localStorage.removeItem(key);
-      } else {
-        localStorage.setItem(key, value);
-      }
-    }
-  } catch {
-    // localStorage not available (e.g., in workers).
-  }
 };

--- a/packages/sdk/observability/src/storage/browser.ts
+++ b/packages/sdk/observability/src/storage/browser.ts
@@ -10,6 +10,7 @@ import { compositeKey } from '@dxos/util';
 
 const OBSERVABILITY_DISABLED_KEY = 'observability-disabled';
 const OBSERVABILITY_GROUP_KEY = 'observability-group';
+const OTEL_LOG_LEVEL_KEY = 'otel-log-level';
 
 /** No-op in browser contexts. */
 export const showObservabilityBanner = () => {
@@ -67,5 +68,45 @@ export const storeObservabilityGroup = async (namespace: string, value: string) 
     await localForage.setItem(compositeKey(namespace, OBSERVABILITY_GROUP_KEY), value);
   } catch (err) {
     log.catch('Failed to store observability group', err);
+  }
+};
+
+/**
+ * @param namespace - localForage key prefix used to scope the observability state in browser storage.
+ */
+export const getOtelLogLevel = async (namespace: string): Promise<string | null> => {
+  try {
+    return await localForage.getItem<string>(compositeKey(namespace, OTEL_LOG_LEVEL_KEY));
+  } catch (err) {
+    log.catch('Failed to get OTEL log level', err);
+    return null;
+  }
+};
+
+/**
+ * @param namespace - localForage key prefix used to scope the observability state in browser storage.
+ */
+export const storeOtelLogLevel = async (namespace: string, value: string | null) => {
+  try {
+    if (value === null) {
+      await localForage.removeItem(compositeKey(namespace, OTEL_LOG_LEVEL_KEY));
+    } else {
+      await localForage.setItem(compositeKey(namespace, OTEL_LOG_LEVEL_KEY), value);
+    }
+  } catch (err) {
+    log.catch('Failed to store OTEL log level', err);
+  }
+  // Mirror to localStorage so the synchronous check in OtelLogs picks it up immediately on the main thread.
+  try {
+    if (typeof localStorage !== 'undefined') {
+      const key = `${namespace}/${OTEL_LOG_LEVEL_KEY}`;
+      if (value === null) {
+        localStorage.removeItem(key);
+      } else {
+        localStorage.setItem(key, value);
+      }
+    }
+  } catch {
+    // localStorage not available (e.g., in workers).
   }
 };

--- a/packages/sdk/observability/src/storage/node.ts
+++ b/packages/sdk/observability/src/storage/node.ts
@@ -105,6 +105,12 @@ const initializeState = async (idPath: string): Promise<PersistentObservabilityS
   return observabilityState;
 };
 
+/** Not applicable in Node.js contexts; OTEL log level override is browser-only. */
+export const getOtelLogLevel = async (_namespace: string): Promise<string | null> => null;
+
+/** Not applicable in Node.js contexts; OTEL log level override is browser-only. */
+export const storeOtelLogLevel = async (_namespace: string, _value: string | null): Promise<void> => {};
+
 const validate = (contextString: string) => {
   const context = yaml.load(contextString) as PersistentObservabilityState;
   if (Boolean(context.installationId) && validateUuid(context.installationId!)) {


### PR DESCRIPTION
## Summary

- Adds a `window.composer.otel` debug helper to the Composer app that lets you toggle the OTEL log level to `DEBUG` for a specific device, persisted via localStorage, without a page reload or code change.
- The override is read dynamically on every `OtelLogs.logProcessor` call, so it takes effect immediately.
- Exports `otelLogLevelStorageKey(serviceName)` from the observability package for reuse in other apps.

## Usage (browser devtools)

```js
// Send debug+ logs to SignOz for this device
window.composer.otel.enableDebugLogs()

// Revert to default INFO level
window.composer.otel.disableDebugLogs()

// Check current override
window.composer.otel.getLogLevel()
```

The toggle writes `composer/otel-log-level = "debug"` to localStorage — consistent with the existing `{serviceName}/observability-disabled` key pattern. Removing the key (or calling `disableDebugLogs()`) falls back to the configured `logLevel` (INFO by default).

## Reviewer notes

- No reload required — `getStoredLogLevel` is called inline in the log processor on every emission.
- The localStorage check is guarded with a try/catch and `typeof localStorage === 'undefined'` so it's safe in worker contexts (where localStorage is unavailable) — it simply returns `undefined` and defers to the configured level.
- The `otelLogLevelStorageKey` export is intentionally minimal; it's just the key-derivation function so other services can adopt the same convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debug logging controls accessible via the browser console, enabling developers to enable or disable debug logs and check current log levels for enhanced troubleshooting.
  * Debug logging preferences are now persisted across browser sessions.
  * Enabled per-service log level overrides for granular control over debug output based on specific service requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->