### PR TITLE
fix(react-ui-form): allow number inputs to be cleared before typing a new value

### DIFF
--- a/packages/ui/react-ui-form/src/components/Form/fields/NumberField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/NumberField.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { Input, type TextInputProps } from '@dxos/react-ui';
 import { safeParseFloat } from '@dxos/util';
@@ -13,25 +13,52 @@ export const NumberField = ({
   type,
   readonly,
   placeholder,
+  getValue,
   onValueChange,
   onBlur,
   ...props
 }: FormFieldComponentProps<number>) => {
+  // Track raw string input so the user can clear the field before typing a new number.
+  // We only commit to onValueChange when the raw string parses to a valid number.
+  const [raw, setRaw] = useState<string>(() => {
+    const v = getValue();
+    return v !== undefined ? String(v) : '';
+  });
+
   const handleChange = useCallback<NonNullable<TextInputProps['onChange']>>(
-    (event) => onValueChange(type, safeParseFloat(event.target.value) || 0),
+    (event) => {
+      const value = event.target.value;
+      setRaw(value);
+      const parsed = safeParseFloat(value);
+      if (parsed !== undefined) {
+        onValueChange(type, parsed);
+      }
+    },
     [type, onValueChange],
   );
 
+  const handleBlur = useCallback(
+    (event: React.FocusEvent<HTMLElement>) => {
+      // If the field was left empty or invalid, reset to the last committed value.
+      if (safeParseFloat(raw) === undefined) {
+        const committed = getValue();
+        setRaw(committed !== undefined ? String(committed) : '');
+      }
+      onBlur(event);
+    },
+    [raw, getValue, onBlur],
+  );
+
   return (
-    <FormFieldWrapper<number> readonly={readonly} {...props}>
-      {({ value = '' }) => (
+    <FormFieldWrapper<number> readonly={readonly} getValue={getValue} {...props}>
+      {() => (
         <Input.TextInput
           type='number'
           disabled={!!readonly}
           placeholder={placeholder}
-          value={value}
+          value={raw}
           onChange={handleChange}
-          onBlur={onBlur}
+          onBlur={handleBlur}
         />
       )}
     </FormFieldWrapper>

--- a/packages/ui/react-ui-form/src/components/Form/fields/NumberField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/fields/NumberField.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { Input, type TextInputProps } from '@dxos/react-ui';
 import { safeParseFloat } from '@dxos/util';
@@ -24,6 +24,16 @@ export const NumberField = ({
     const v = getValue();
     return v !== undefined ? String(v) : '';
   });
+
+  // Sync display when an external change updates the committed value (e.g. reactive form
+  // calculations). Only overwrite raw when the external value differs from what raw parses
+  // to, preserving partial edits like "1." which correctly parse to 1.
+  const externalValue = getValue();
+  useEffect(() => {
+    if (externalValue !== safeParseFloat(raw)) {
+      setRaw(externalValue !== undefined ? String(externalValue) : '');
+    }
+  }, [externalValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleChange = useCallback<NonNullable<TextInputProps['onChange']>>(
     (event) => {


### PR DESCRIPTION
## Summary

- Fixes a bug where backspacing through a number field (e.g. deleting the only `0`) would immediately snap back to `0`, making it impossible to clear the field and type a new value.
- Replaces the immediate `safeParseFloat(value) || 0` commit with a local `raw` string state. `onValueChange` is only called when the string parses to a valid number.
- On blur, if the field was left empty or invalid, the display resets to the last committed value.

## Test plan

- [ ] Open the Email integration panel in Composer and focus the "Sync Back Days" field.
- [ ] Backspace to clear the `0` — the field should now show empty and accept new input.
- [ ] Type a new number (e.g. `5`) — it should be committed correctly.
- [ ] Clear the field and tab/click away — it should revert to the previously committed value.
- [ ] All `react-ui-form` tests pass (`moon run react-ui-form:test`).

closes DX-990

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Number inputs now preserve partial text while typing and only commit when a valid number is parsed.
  * Clearing or entering invalid values won’t be converted to zero; on blur invalid/empty entries reset to the last committed value.
  * External updates now sync correctly without overwriting in-progress edits that still represent the same parsed value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->