### PR TITLE
fix(stories-assistant): load CommentsPlugin in WithMarkdown chat story

### DIFF
--- a/packages/stories/stories-assistant/src/stories/Chat.stories.tsx
+++ b/packages/stories/stories-assistant/src/stories/Chat.stories.tsx
@@ -261,12 +261,12 @@ export const WithWebSearch: Story = {
 export const WithMarkdown: Story = {
   decorators: getDecorators({
     lazyPlugins: async () => {
-      const [{ MarkdownPlugin }, { ThreadPlugin }] = await Promise.all([
+      const [{ MarkdownPlugin }, { CommentsPlugin }] = await Promise.all([
         import('@dxos/plugin-markdown/plugin'),
-        import('@dxos/plugin-thread/plugin'),
+        import('@dxos/plugin-comments/plugin'),
       ]);
       return {
-        plugins: [MarkdownPlugin(), ThreadPlugin()],
+        plugins: [MarkdownPlugin(), CommentsPlugin()],
       };
     },
     config: config.remote, // TODO(burdon): Issue making persistent.


### PR DESCRIPTION
## Summary

Follow-up to #11762 (flagged by CodeRabbit there, but that branch was already locked in the merge queue).

The `WithMarkdown` chat story renders `CommentsModule` (plugin-comments' companion surface) and uses `CommentBlueprint` (plugin-comments' operation handlers), but its decorator loaded `ThreadPlugin` — a leftover from before comments were factored out of plugin-thread. With only `ThreadPlugin` active, the comments surface has no contributor and the blueprint's `CreateProposals` operation has no handler.

`WithMail`/`WithResearch` keep `ThreadPlugin` since they use no comment features.

## Test plan

- `moon run stories-assistant:build` / `:lint` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated plugin demonstration in test stories to reflect current plugin configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->