### PR TITLE
fix(echo-client): reset query result cache on query source provider changes

### DIFF
--- a/packages/core/echo/echo-client/src/hypergraph.ts
+++ b/packages/core/echo/echo-client/src/hypergraph.ts
@@ -510,6 +510,7 @@ export class HypergraphImpl implements Hypergraph.Hypergraph {
     for (const context of this._queryContexts.values()) {
       context.addQuerySource(provider.create());
     }
+    this.#queryResultCache = new QueryResultCache();
   }
 
   /**
@@ -520,6 +521,7 @@ export class HypergraphImpl implements Hypergraph.Hypergraph {
     if (index !== -1) {
       this._querySourceProviders.splice(index, 1);
     }
+    this.#queryResultCache = new QueryResultCache();
   }
 
   private _onUpdate(updateEvent: ItemsUpdatedEvent): void {


### PR DESCRIPTION
## Summary

- `registerQuerySourceProvider` and `unregisterQuerySourceProvider` now reset `#queryResultCache` after mutating the provider list, exactly mirroring what `_registerDatabase`/`_unregisterDatabase` already do.
- Idle (unsubscribed) `QueryResultImpl` instances embed a `GraphQueryContext` snapshot at creation time. Without the reset, a result cached before a provider registers (e.g. the remote agent query source) permanently misses that source when later subscribed — the topology change is invisible to it.
- Active contexts are already patched via `_queryContexts`; this fix closes the same gap for idle cached ones.

## Test plan

- [x] `moon run echo-client:build` passes
- [x] `moon run echo-client:test` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTD9TGkt1y7RBMNCnaAPaz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where query results could become stale when query sources are registered or unregistered. Query results now properly refresh when the set of available query sources changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->