### PR TITLE
fix(compute-runtime): prevent stuck RUNNING state when child exit notification races parent cleanup

### DIFF
--- a/packages/core/compute-runtime/src/ProcessHandle.ts
+++ b/packages/core/compute-runtime/src/ProcessHandle.ts
@@ -531,6 +531,15 @@ export class ProcessHandleImpl<I, O, R> implements ProcessManager.Handle<I, O> {
 
   requestChildEvent(event: Process.ChildEvent<unknown>): void {
     log('lifecycle: child event', { tag: event._tag, childPid: event.pid });
+    // Guard against late child-exit notifications that arrive after the parent has already
+    // reached a terminal state. Without this, onFinished fires after the parent succeeds
+    // (the child's async cleanup outlasts the parent's handler), requestChildEvent clobbers
+    // the parent status to RUNNING via #runHandler, and #handlerCompleted exits early
+    // (finished=true) without resetting it — leaving the process permanently RUNNING.
+    if (this.#finished) {
+      log('lifecycle: child event ignored (already finished)', { tag: event._tag, childPid: event.pid });
+      return;
+    }
     Effect.runFork(
       this.#persistence
         .appendEvent({ _tag: 'childEvent', event: toPersistedChildEvent(event) })
@@ -545,6 +554,16 @@ export class ProcessHandleImpl<I, O, R> implements ProcessManager.Handle<I, O> {
   ): Effect.Effect<Fiber.RuntimeFiber<void>> {
     return Effect.uninterruptibleMask((restore) =>
       Effect.gen(this, function* () {
+        // Secondary guard: the primary guard in requestChildEvent is synchronous, but the
+        // appendEvent(IDB) call before #runHandler yields to the scheduler, during which
+        // the process may have set #finished=true. Bail cleanly rather than clobbering state.
+        if (this.#finished) {
+          log('lifecycle: handler skipped (already finished)', { name, pid: this.pid });
+          if (eventSeq !== undefined) {
+            yield* this.#persistence.removeEvent(eventSeq).pipe(Effect.ignore);
+          }
+          return yield* Effect.forkDaemon(Effect.void);
+        }
         this.#activeHandlers++;
         this.#setStatus(Process.State.RUNNING);
         log('begin handler', { pid: this.pid, state: this.#currentStatus.state, activeHandlers: this.#activeHandlers });

--- a/packages/core/compute-runtime/src/ProcessManager.test.ts
+++ b/packages/core/compute-runtime/src/ProcessManager.test.ts
@@ -59,6 +59,26 @@ const Failing = Operation.make({
 });
 
 /**
+ * Child used by {@link ParentInvoker} to exercise the parent-child SUCCEEDED state invariant.
+ */
+const ChildPassthrough = Operation.make({
+  meta: { key: DXN.make('org.dxos.test.childPassthrough'), name: 'ChildPassthrough' },
+  input: Schema.Number,
+  output: Schema.Number,
+});
+
+/**
+ * Parent that invokes {@link ChildPassthrough} via `Operation.invoke` (blocking await).
+ * Used to reproduce the DX-999 race where a late child-exit notification can clobber
+ * a parent's SUCCEEDED status.
+ */
+const ParentInvoker = Operation.make({
+  meta: { key: DXN.make('org.dxos.test.parentInvoker'), name: 'ParentInvoker' },
+  input: Schema.Number,
+  output: Schema.Number,
+});
+
+/**
  * Per-test gate for {@link SlowChild}; set in the repro test before spawning the parent.
  */
 const SlowChildGate = {
@@ -99,6 +119,20 @@ const handlers = OperationHandlerSet.make(
         yield* Queue.offer(SlowChildGate.taskSignal, undefined);
         yield* Deferred.await(SlowChildGate.completeDeferred);
         return value;
+      }),
+    ),
+  ),
+  ChildPassthrough.pipe(
+    Operation.withHandler(
+      Effect.fn(function* (input) {
+        return input;
+      }),
+    ),
+  ),
+  ParentInvoker.pipe(
+    Operation.withHandler(
+      Effect.fn(function* (input) {
+        return yield* Operation.invoke(ChildPassthrough, input);
       }),
     ),
   ),
@@ -411,6 +445,26 @@ describe('ManagerImpl', () => {
       const handle = yield* manager.spawn(Process.fromOperation(Double, handlers));
       const outputs = yield* handle.runAndExit({ inputs: [{ value: 11 }] }).pipe(Stream.runCollect);
       expect(Chunk.toReadonlyArray(outputs)).toEqual([22]);
+      expect(handle.status.state).toEqual(Process.State.SUCCEEDED);
+    }, Effect.provide(TestLayer)),
+  );
+
+  it.effect(
+    'parent process remains SUCCEEDED after child completes — requestChildEvent race (DX-999)',
+    Effect.fn(function* ({ expect }) {
+      const manager = yield* ProcessManager.Service;
+
+      const handle = yield* manager.spawn(Process.fromOperation(ParentInvoker, handlers));
+      const outputs = yield* handle.runAndExit({ inputs: [7] }).pipe(Stream.runCollect);
+      expect(Chunk.toReadonlyArray(outputs)).toEqual([7]);
+
+      // Drain any background child-cleanup callbacks. Without the fix in
+      // ProcessHandle.requestChildEvent, the late child-exit notification would
+      // re-enter #runHandler after the parent set #finished=true, clobbering
+      // SUCCEEDED with RUNNING and leaving the process permanently stuck.
+      yield* Effect.yieldNow();
+      yield* Effect.yieldNow();
+
       expect(handle.status.state).toEqual(Process.State.SUCCEEDED);
     }, Effect.provide(TestLayer)),
   );


### PR DESCRIPTION
## Summary

- **Root cause (DX-999):** `ProcessHandle.requestChildEvent` had no guard against late child-exit notifications. When a parent process invokes a child via `invoke()`, both complete, but the child's async cleanup (IDB `storage.clear` + `Scope.close` + `deleteRecord`) can outlast the parent's own cleanup. When `onFinished` then fires `requestChildEvent`, `#runHandler` would re-enter, increment `#activeHandlers`, and clobber the parent's `SUCCEEDED` status with `RUNNING`. Because `#handlerCompleted` exits early when `#finished=true`, the `RUNNING` status was never cleared — leaving the process permanently stuck in the trace panel.
- **Fix:** Two guards in `ProcessHandle`:
  1. **Primary** — synchronous `#finished` check at the top of `requestChildEvent` (handles the common case)
  2. **Secondary** — `#finished` check at the start of `#runHandler`, after the `appendEvent(IDB)` yield (handles the subtler case where `appendEvent` yields and the parent finishes during that gap); cleans up the persisted event via `removeEvent`
- **Test:** Adds `ParentInvoker → ChildPassthrough` via `Operation.invoke`; asserts the parent ends in `SUCCEEDED` state after both complete (DX-999 regression).

## Race condition detail

The precise interleaving that causes the bug:
1. Child handler: `ctx.submitOutput(void)` + `ctx.succeed()` (sync) → `yield* removeEvent(IDB)` — yields
2. Child's `#handlerCompleted`: `#finished = true` (sync) → `#cleanup()` starts async  
3. `Queue.unsafeOffer(None)` wakes the output fiber → `invoke(child)` resolves in parent handler
4. Parent handler finishes → `ctx.succeed()` → `yield* removeEvent(IDB)` — yields
5. Child's `storage.clear` + `Scope.close` + `deleteRecord` complete → `#setStatus(SUCCEEDED)` → `onFinished` → **`parentHandle.requestChildEvent(exited)`**
6. Parent's `removeEvent` completes → `#handlerCompleted` → **`#finished = true`** (sync)
7. Child's `appendEvent(IDB)` completes → `#runHandler` → `#activeHandlers++` → **`#setStatus(RUNNING)`** ← CLOBBERS SUCCEEDED
8. `onChildEvent = Effect.void` handler completes → `#finished = true` already → early return → **stuck at RUNNING**

The primary guard in `requestChildEvent` prevents step 7 in the common case; the secondary guard in `#runHandler` covers the window between steps 5 and 6 where `appendEvent` yields.

closes DX-999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced process state stability when parent and child operations execute together, preventing inconsistent terminal states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->