### PR TITLE
feat(plugin-support): add enableGitHubIssues setting to feedback panel

### DIFF
--- a/packages/plugins/plugin-support/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-support/src/capabilities/react-surface.tsx
@@ -6,7 +6,7 @@ import * as Effect from 'effect/Effect';
 import React from 'react';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
-import { Surface, useOperationInvoker } from '@dxos/app-framework/ui';
+import { Surface, useOperationInvoker, useSettingsState } from '@dxos/app-framework/ui';
 import { LayoutOperation, getPersonalSpace, getSpaceHomePath, getSpacePath } from '@dxos/app-toolkit';
 import { AppSurface, useActiveSpace } from '@dxos/app-toolkit/ui';
 import { Annotation } from '@dxos/echo';
@@ -26,7 +26,7 @@ import {
   SupportCompanion,
 } from '#containers';
 import { meta } from '#meta';
-import { Support } from '#types';
+import { Support, type Settings } from '#types';
 
 import { WelcomeDismissedAnnotation } from '../annotations';
 import { SHORTCUTS_DIALOG, SPACE_HOME_NODE_TYPE } from '../constants';
@@ -98,11 +98,12 @@ export default Capability.makeModule(() =>
       Surface.create({
         id: 'settings',
         filter: AppSurface.settings(AppSurface.Article, meta.id),
-        component: () => {
+        component: ({ data: { subject } }) => {
           const client = useClient();
           const { invokePromise } = useOperationInvoker();
           const personal = getPersonalSpace(client);
           const [, updateProperties] = useObject(personal?.properties);
+          const { settings, updateSettings } = useSettingsState<Settings.Settings>(subject.atom);
           const handleShowWelcome = () => {
             if (!personal) {
               return;
@@ -111,7 +112,9 @@ export default Capability.makeModule(() =>
             const workspace = getSpacePath(personal.id);
             void invokePromise(LayoutOperation.Open, { subject: [getSpaceHomePath(personal.id)], workspace });
           };
-          return <SupportSettings onShowWelcome={handleShowWelcome} />;
+          return (
+            <SupportSettings settings={settings} onSettingsChange={updateSettings} onShowWelcome={handleShowWelcome} />
+          );
         },
       }),
     ]),

--- a/packages/plugins/plugin-support/src/components/SupportSettings/SupportSettings.stories.tsx
+++ b/packages/plugins/plugin-support/src/components/SupportSettings/SupportSettings.stories.tsx
@@ -21,4 +21,8 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    settings: {},
+  },
+};

--- a/packages/plugins/plugin-support/src/components/SupportSettings/SupportSettings.tsx
+++ b/packages/plugins/plugin-support/src/components/SupportSettings/SupportSettings.tsx
@@ -4,24 +4,32 @@
 
 import React from 'react';
 
+import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { Button, useTranslation } from '@dxos/react-ui';
 import { Settings as SettingsForm } from '@dxos/react-ui-form';
 
 import { meta } from '#meta';
+import { Settings } from '#types';
 
-export type SupportSettingsProps = {
+export type SupportSettingsProps = AppSurface.SettingsArticleProps<Settings.Settings> & {
   onShowWelcome?: () => void;
 };
 
-export const SupportSettings = ({ onShowWelcome }: SupportSettingsProps) => {
+export const SupportSettings = ({ settings, onSettingsChange, onShowWelcome }: SupportSettingsProps) => {
   const { t } = useTranslation(meta.id);
 
   return (
     <SettingsForm.Viewport>
       <SettingsForm.Section title={t('settings.title', { ns: meta.id })}>
-        <SettingsForm.Item title={t('show-welcome.label')} description={t('show-welcome.description')}>
+        <SettingsForm.Item title={t('show-welcome.label')}>
           <Button onClick={onShowWelcome}>{t('show-welcome.label')}</Button>
         </SettingsForm.Item>
+        <SettingsForm.FieldSet
+          readonly={!onSettingsChange}
+          schema={Settings.Settings}
+          values={settings}
+          onValuesChanged={(values) => onSettingsChange?.(() => values)}
+        />
       </SettingsForm.Section>
     </SettingsForm.Viewport>
   );

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/FeedbackPanel.tsx
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/FeedbackPanel.tsx
@@ -5,7 +5,7 @@
 import * as Effect from 'effect/Effect';
 import React, { useMemo, useState } from 'react';
 
-import { useCapability, usePluginManager } from '@dxos/app-framework/ui';
+import { useAtomCapability, useCapability, usePluginManager } from '@dxos/app-framework/ui';
 import { EffectEx } from '@dxos/effect';
 import { ObservabilityCapabilities } from '@dxos/plugin-observability';
 import { useConfig } from '@dxos/react-client';
@@ -14,6 +14,7 @@ import { Panel } from '@dxos/react-ui';
 import { Form } from '@dxos/react-ui-form';
 
 import { type FeedbackPluginOption, FeedbackForm } from '#components';
+import { SupportCapabilities } from '#types';
 
 import { DiscordAction } from './DiscordAction';
 import { DownloadLogsAction } from './DownloadLogsAction';
@@ -23,6 +24,7 @@ import { GitHubAction } from './GitHubAction';
 /** Renders the feedback form, disabling the PostHog/Discord submit paths when the survey is unavailable. */
 export const FeedbackPanel = () => {
   const observability = useCapability(ObservabilityCapabilities.Observability);
+  const settings = useAtomCapability(SupportCapabilities.Settings);
   const [feedbackAvailable, setFeedbackAvailable] = useState(false);
   const config = useConfig();
   const manager = usePluginManager();
@@ -40,6 +42,7 @@ export const FeedbackPanel = () => {
   );
 
   const hidden = useMemo(() => ({ version }), [version]);
+  const excludeImage = useMemo(() => !settings?.enableGitHubIssues, [settings?.enableGitHubIssues]);
 
   useAsyncEffect(
     async (controller) => {
@@ -61,12 +64,12 @@ export const FeedbackPanel = () => {
         <FeedbackForm.Root hidden={hidden} plugins={plugins}>
           <Form.Viewport>
             <Form.Content>
-              <Form.FieldSet />
+              <Form.FieldSet exclude={excludeImage ? (props) => props.filter((p) => p.name !== 'image') : undefined} />
               <DownloadLogsAction />
               {/* GH only opens a prefilled URL — independent of PostHog feedback availability. */}
               {/* PostHog + Discord both call `CaptureUserFeedback`, so they share the gate. */}
               <FeedbackSubmitAction disabled={!feedbackAvailable} />
-              <GitHubAction />
+              {settings?.enableGitHubIssues && <GitHubAction />}
               <DiscordAction disabled={!feedbackAvailable} />
             </Form.Content>
           </Form.Viewport>

--- a/packages/plugins/plugin-support/src/types/Settings.ts
+++ b/packages/plugins/plugin-support/src/types/Settings.ts
@@ -6,6 +6,13 @@
 
 import * as Schema from 'effect/Schema';
 
-export const Settings = Schema.mutable(Schema.Struct({}));
+export const Settings = Schema.Struct({
+  enableGitHubIssues: Schema.optional(
+    Schema.Boolean.annotations({
+      title: 'Enable GitHub issue submission',
+      description: 'Show the "Create GitHub Issue" button in the feedback panel.',
+    }),
+  ),
+});
 
 export interface Settings extends Schema.Schema.Type<typeof Settings> {}

--- a/packages/plugins/plugin-support/src/types/SupportOperation.ts
+++ b/packages/plugins/plugin-support/src/types/SupportOperation.ts
@@ -74,8 +74,8 @@ export const SupportRequest = Schema.Struct({
   severity: Severity,
   image: Schema.Boolean.pipe(
     Schema.annotations({
-      title: 'Attach screenshot',
-      description: 'Capture the current view and attach it to the report. Form fields are obscured for privacy.',
+      title: 'Attach screenshot (GitHub only)',
+      description: 'Capture the current view and attach it to the GitHub issue. Form fields are obscured for privacy.',
     }),
     Schema.optional,
   ),


### PR DESCRIPTION
## Summary

- Adds an `enableGitHubIssues` boolean setting to `plugin-support` (off by default) that gates the GitHub-specific UI in the feedback deck companion
- When disabled: the "Create GitHub Issue" button and "Attach screenshot (GitHub only)" field are hidden from the feedback form
- When enabled: both appear as before, and the setting is toggled from the Support plugin's settings article
- Updates the `image` field label to "(GitHub only)" to make scope explicit

## Changes

- **`Settings.ts`** — new `enableGitHubIssues: Schema.optional(Schema.Boolean)` field (immutable schema, no `mutable` pipe)
- **`FeedbackPanel.tsx`** — reads `SupportCapabilities.Settings` via `useAtomCapability`; gates `<GitHubAction />` and excludes the `image` field from `<Form.FieldSet />` when setting is off
- **`SupportOperation.ts`** — `image` field title updated to `"Attach screenshot (GitHub only)"`
- **`SupportSettings.tsx`** — adds `AppSurface.SettingsArticleProps` to props; renders `SettingsForm.FieldSet` for the plugin settings below the existing "Show welcome" button
- **`react-surface.tsx`** — settings surface wires `useSettingsState` through `subject.atom` and passes `settings`/`onSettingsChange` to `SupportSettings`
- **`SupportSettings.stories.tsx`** — updated story to supply required `settings` arg

## Test plan

- [ ] Open the feedback deck companion — "Create GitHub Issue" button and screenshot toggle should be absent
- [ ] Open Support plugin settings, enable "Enable GitHub issue submission"
- [ ] Re-open the feedback companion — button and screenshot toggle should now appear
- [ ] Disable the setting — button and toggle disappear again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new settings interface for the support plugin that allows users to configure feature availability
  * Users can now enable or disable GitHub issue creation from the feedback panel
  * The feedback form dynamically adapts based on configured settings, showing or hiding GitHub-specific fields

* **Documentation**
  * Updated screenshot field descriptions to clarify GitHub-only attachment behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->