### PR TITLE
fix(react-ui-table): keep cell editor open on required-field validation

### DIFF
--- a/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
@@ -283,11 +283,6 @@ export const ArrayOfObjects: StoryObj = {
   },
 };
 
-// Regression test for DX-997: a required field must not prevent adding a new row.
-// The bug: opening the editor on an empty required cell ran validation, whose re-render
-// rebuilt the CodeMirror view (an unstable `slots` prop), and the teardown blur closed the
-// editor before the user could type. The play function opens the editor on the empty cell,
-// confirms it survives the (failing) validation pass, then types a value and commits the row.
 export const RequiredSchema: StoryObj = {
   render: DefaultStory,
   decorators: [
@@ -324,20 +319,17 @@ export const RequiredSchema: StoryObj = {
     const draftCell = await canvas.findByTestId('frozenRowsEnd.0.0');
     await userEvent.click(draftCell);
 
-    // Open the editor on the empty required cell (Enter), rather than typing to open — the
-    // latter would route the first character into dx-grid's `initialContent` and race the
-    // editor mount. The empty value fails validation; the editor must stay open regardless
-    // (this is the DX-997 regression — the editor used to close itself here).
+    // Open the editor with Enter rather than typing to open — the latter routes the first
+    // character into dx-grid's `initialContent` and races the editor mount. The empty value
+    // fails validation; the editor must stay open so the value below can be entered.
     await userEvent.keyboard('{Enter}');
     await canvas.findByTestId('grid.cell-editor');
 
-    // The editor is focused (autoFocus); type the required value and commit. On the regression
-    // the empty value's validation re-render closed the editor before this could be entered, so
-    // the row below never committed.
+    // The editor is focused (autoFocus); type the required value and commit.
     await userEvent.keyboard('Alice');
     await userEvent.keyboard('{Enter}');
 
-    // Draft row is committed; the real row should appear in the grid with the typed value.
+    // The draft row is committed and appears in the grid with the typed value.
     await waitFor(async () => {
       const cell = canvas.getByTestId('grid.0.0');
       const text = cell.querySelector('.dx-grid__cell__content')?.textContent;

--- a/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
@@ -5,6 +5,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import * as Schema from 'effect/Schema';
 import React, { useCallback } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { DXN, Annotation, type Database, Format, Obj, type QueryAST, Ref, Type, View } from '@dxos/echo';
 import { type Mutable, PropertyMetaAnnotationId } from '@dxos/echo/internal';
@@ -279,6 +280,69 @@ export const ArrayOfObjects: StoryObj = {
   parameters: {
     layout: 'fullscreen',
     translations,
+  },
+};
+
+// Regression test for DX-997: a required field must not prevent adding a new row.
+// The bug: opening the editor on an empty required cell ran validation, whose re-render
+// rebuilt the CodeMirror view (an unstable `slots` prop), and the teardown blur closed the
+// editor before the user could type. The play function opens the editor on the empty cell,
+// confirms it survives the (failing) validation pass, then types a value and commits the row.
+export const RequiredSchema: StoryObj = {
+  render: DefaultStory,
+  decorators: [
+    withClientProvider({
+      types: [View.View, Table.Table, TestSchema.Person],
+      createIdentity: true,
+      createSpace: true,
+      onCreateSpace: async ({ space }) => {
+        // TestSchema.Person has a required `name: Schema.String` field.
+        // No pre-populated rows so the add-row flow is the first interaction.
+        const { view, jsonSchema } = await ViewModel.makeFromDatabase({
+          db: space.db,
+          typename: Type.getTypename(TestSchema.Person),
+        });
+        const table = Table.make({ view, jsonSchema });
+        space.db.add(table);
+      },
+    }),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+    translations: [...translations, ...formTranslations],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 30 s covers ECHO client + space + table creation (the only inherently slow step).
+    const addRowButton = await canvas.findByTestId('table.toolbar.add-row', undefined, { timeout: 30_000 });
+
+    // Person.name is required, so db.add throws → useAddRow returns 'draft' →
+    // a draft row appears in frozenRowsEnd and focus is set to its first cell.
+    await userEvent.click(addRowButton);
+
+    const draftCell = await canvas.findByTestId('frozenRowsEnd.0.0');
+    await userEvent.click(draftCell);
+
+    // Open the editor on the empty required cell (Enter), rather than typing to open — the
+    // latter would route the first character into dx-grid's `initialContent` and race the
+    // editor mount. The empty value fails validation; the editor must stay open regardless
+    // (this is the DX-997 regression — the editor used to close itself here).
+    await userEvent.keyboard('{Enter}');
+    await canvas.findByTestId('grid.cell-editor');
+
+    // The editor is focused (autoFocus); type the required value and commit. On the regression
+    // the empty value's validation re-render closed the editor before this could be entered, so
+    // the row below never committed.
+    await userEvent.keyboard('Alice');
+    await userEvent.keyboard('{Enter}');
+
+    // Draft row is committed; the real row should appear in the grid with the typed value.
+    await waitFor(async () => {
+      const cell = canvas.getByTestId('grid.0.0');
+      const text = cell.querySelector('.dx-grid__cell__content')?.textContent;
+      await expect(text).toBe('Alice');
+    });
   },
 };
 

--- a/packages/ui/react-ui-table/src/components/TableCellEditor/TableCellEditor.tsx
+++ b/packages/ui/react-ui-table/src/components/TableCellEditor/TableCellEditor.tsx
@@ -90,6 +90,12 @@ export const TableValueEditor = <T extends Type.AnyEntity = Type.AnyEntity>({
   return <TableCellEditor model={model} modals={modals} onFocus={onFocus} onSave={onSave} __gridScope={__gridScope} />;
 };
 
+const cellEditorSlots: GridCellEditorProps['slots'] = {
+  content: {
+    className: '!py-(--dx-grid-cell-editor-padding-block)',
+  },
+};
+
 export const TableCellEditor = ({
   __gridScope,
   model,
@@ -245,11 +251,7 @@ export const TableCellEditor = ({
       <CellValidationMessage validationError={validationError} variant={validationVariant} __gridScope={__gridScope} />
       <GridCellEditor
         extensions={extensions}
-        slots={{
-          content: {
-            className: '!py-(--dx-grid-cell-editor-padding-block)',
-          },
-        }}
+        slots={cellEditorSlots}
         getCellContent={getCellContent}
         onBlur={handleBlur}
       />

--- a/packages/ui/react-ui-table/src/model/table-model.ts
+++ b/packages/ui/react-ui-table/src/model/table-model.ts
@@ -210,9 +210,15 @@ export class TableModel<T extends TableRow = TableRow> extends Resource {
 
     // Create derived atom for persisted sort from view.query.ast.
     this._persistedSort = Atom.make((_get) => {
-      // Note: This depends on the view being loaded and the projection being set.
-      // The view is loaded in _open().
-      const viewSnapshot = Obj.getSnapshot(this.view);
+      // The view is loaded asynchronously in _open() and torn down on disposal; this atom can be
+      // recomputed in either window, so read the target directly and bail rather than going through
+      // the `view` getter (which throws when the target is absent).
+      const view = this._object.view.target;
+      if (!view) {
+        return undefined;
+      }
+
+      const viewSnapshot = Obj.getSnapshot(view);
       const ast = viewSnapshot.query.ast;
       const orders = extractOrder(ast);
 
@@ -700,9 +706,10 @@ export class TableModel<T extends TableRow = TableRow> extends Resource {
 
       const validationResult = validateSchema(schema, snapshot);
       if (validationResult && validationResult.length > 0) {
-        const error = validationResult[0];
-        invariant(error.path === field.path);
-        return { valid: false, error: error.message };
+        const error = validationResult.find((err) => err.path === field.path);
+        if (error) {
+          return { valid: false, error: error.message };
+        }
       }
 
       return { valid: true };

--- a/packages/ui/react-ui-table/src/model/table-model.ts
+++ b/packages/ui/react-ui-table/src/model/table-model.ts
@@ -209,11 +209,10 @@ export class TableModel<T extends TableRow = TableRow> extends Resource {
     this._cellUpdateCounter = Atom.make<number>(0);
 
     // Create derived atom for persisted sort from view.query.ast.
-    this._persistedSort = Atom.make((_get) => {
-      // The view is loaded asynchronously in _open() and torn down on disposal; this atom can be
-      // recomputed in either window, so read the target directly and bail rather than going through
-      // the `view` getter (which throws when the target is absent).
-      const view = this._object.view.target;
+    this._persistedSort = Atom.make((get) => {
+      // Subscribe to the view ref's atom so this recomputes once the reference resolves; the view
+      // is loaded asynchronously in _open() and is absent before then (and after disposal).
+      const view = get(this._object.view.atom);
       if (!view) {
         return undefined;
       }


### PR DESCRIPTION
## Problem

Tables backed by a schema with a **required** field couldn't accept input into a new row — clicking into a required cell flashed a "required" validation error and immediately blurred/closed the editor, making it impossible to type and therefore to add a row.

## Root cause

Found via runtime instrumentation (traced every render / mount / blur / `setEditing`):

1. The editor opens on an empty required cell → validation runs → `setValidationError(...)` re-renders `TableCellEditor`.
2. That render passed `slots={{...}}` to `GridCellEditor` as an **inline object literal** — a new identity every render.
3. CodeMirror's `useTextEditor` lists `slots` in its dependency array, so the new identity rebuilt the `EditorView`.
4. Tearing down the old view fired a `blur` → `GridCellEditor.handleBlur` → `setEditing(null)` → the editor closed on the first keystroke.

Optional fields never hit this because a valid value makes `setValidationError(null)` a no-op (no re-render, no rebuild).

## Fix

- **`TableCellEditor`**: hoist the static `slots` object to a module-level constant (`cellEditorSlots`) so validation re-renders no longer rebuild the editor.

Plus two robustness fixes surfaced while debugging:

- **`table-model`**: `validateCellData` now uses `.find(err => err.path === field.path)` instead of `invariant(error.path === field.path)`, which crashed when a row had multiple invalid fields.
- **`table-model`**: the `_persistedSort` atom reads `view.target` defensively rather than via the throwing `view` getter, fixing an `invariant violation: Table model not initialized` unhandled rejection during the view load/teardown window (it was also making storybook tests flaky).

## Test

Added the `RequiredSchema` story + play function: add a row against `TestSchema.Person` (required `name`), open the editor on the empty cell, type a value, and assert the row commits. Verified it **fails on the buggy code** and **passes reliably** (no retries) on the fix. It opens the editor with Enter rather than type-to-edit to avoid a separate, pre-existing dx-grid "first character opens the editor" race unrelated to this bug.

closes DX-997

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table column sorting persistence during asynchronous view operations
  * Improved cell validation error messages to correctly identify and display field-specific validation issues
  * Enhanced handling of required fields during table row editing

* **Tests**
  * Added regression tests for required field behavior in table row operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->