### PR TITLE
perf(log-store-idb): chunked flush writes, key-based eviction, background flush scheduling

### DIFF
--- a/packages/common/log-store-idb/src/idb-log-store.browser.test.ts
+++ b/packages/common/log-store-idb/src/idb-log-store.browser.test.ts
@@ -34,6 +34,50 @@ const drop = (dbName: string): Promise<void> =>
     req.onblocked = () => resolve();
   });
 
+/** Count raw records in the store (chunks, not lines). */
+const countRecords = (dbName: string): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const openReq = indexedDB.open(dbName);
+    openReq.onsuccess = () => {
+      const db = openReq.result;
+      const countReq = db.transaction('logs', 'readonly').objectStore('logs').count();
+      countReq.onsuccess = () => {
+        db.close();
+        resolve(countReq.result);
+      };
+      countReq.onerror = () => {
+        db.close();
+        reject(countReq.error);
+      };
+    };
+    openReq.onerror = () => reject(openReq.error);
+  });
+
+/** Create a database with the v1 schema (one row per line, autoincrement keyPath). */
+const createV1Database = (dbName: string, lines: string[]): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const openReq = indexedDB.open(dbName, 1);
+    openReq.onupgradeneeded = () => {
+      openReq.result.createObjectStore('logs', { keyPath: 'seq', autoIncrement: true });
+    };
+    openReq.onsuccess = () => {
+      const db = openReq.result;
+      const tx = db.transaction('logs', 'readwrite');
+      for (const line of lines) {
+        tx.objectStore('logs').add({ line });
+      }
+      tx.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      tx.onerror = () => {
+        db.close();
+        reject(tx.error);
+      };
+    };
+    openReq.onerror = () => reject(openReq.error);
+  });
+
 describe('IdbLogStore', () => {
   let store: IdbLogStore | undefined;
   let dbName = '';
@@ -151,6 +195,22 @@ describe('IdbLogStore', () => {
     expect(jsonl).toContain('persisted');
   });
 
+  test('each flush writes a single chunk record', async ({ expect }) => {
+    store = new IdbLogStore({ dbName, flushInterval: 60_000 });
+    for (let i = 0; i < 5; i++) {
+      store.processor(fakeConfig, makeEntry(LogLevel.INFO, `first-${i}`));
+    }
+    await store.flush();
+    for (let i = 0; i < 3; i++) {
+      store.processor(fakeConfig, makeEntry(LogLevel.INFO, `second-${i}`));
+    }
+    await store.flush();
+
+    expect(await countRecords(dbName)).toBe(2);
+    const jsonl = await store.export();
+    expect(jsonl.split('\n')).toHaveLength(8);
+  });
+
   test('eviction trims down to maxRecords', async ({ expect }) => {
     store = new IdbLogStore({
       dbName,
@@ -158,16 +218,57 @@ describe('IdbLogStore', () => {
       maxRecords: 5,
       evictionInterval: 0, // disable timer; trigger manually
     });
+    // Flush per entry so eviction (whole chunks) can trim at line granularity.
     for (let i = 0; i < 12; i++) {
       store.processor(fakeConfig, makeEntry(LogLevel.INFO, `msg-${i}`));
+      await store.flush();
     }
-    await store.flush();
     await store.evictNow();
     const jsonl = await store.export();
     const lines = jsonl.split('\n').filter((line) => line.length > 0);
     expect(lines.length).toBe(5);
     // The newest line must always survive eviction.
     expect(JSON.parse(lines[lines.length - 1]).m).toBe('msg-11');
+  });
+
+  test('eviction drops whole chunks and always keeps the newest chunk', async ({ expect }) => {
+    store = new IdbLogStore({
+      dbName,
+      flushInterval: 10,
+      maxRecords: 5,
+      evictionInterval: 0,
+    });
+    // Older chunk of 3 lines, then a newest chunk of 12 lines (exceeds the budget alone).
+    for (let i = 0; i < 3; i++) {
+      store.processor(fakeConfig, makeEntry(LogLevel.INFO, `old-${i}`));
+    }
+    await store.flush();
+    for (let i = 0; i < 12; i++) {
+      store.processor(fakeConfig, makeEntry(LogLevel.INFO, `new-${i}`));
+    }
+    await store.flush();
+
+    await store.evictNow();
+    const messages = (await store.export())
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line).m);
+    // The newest chunk is never split or dropped; the older chunk is evicted.
+    expect(messages).toHaveLength(12);
+    expect(messages[0]).toBe('new-0');
+    expect(messages[11]).toBe('new-11');
+  });
+
+  test('upgrades a v1 database, discarding old single-line rows', async ({ expect }) => {
+    await createV1Database(dbName, ['{"m":"legacy"}']);
+
+    store = new IdbLogStore({ dbName, flushInterval: 10 });
+    store.processor(fakeConfig, makeEntry(LogLevel.INFO, 'fresh'));
+    await store.flush();
+
+    const jsonl = await store.export();
+    expect(jsonl).not.toContain('legacy');
+    expect(jsonl).toContain('fresh');
   });
 
   test('multiple stores against the same db preserve all writes', async ({ expect }) => {

--- a/packages/common/log-store-idb/src/idb-log-store.ts
+++ b/packages/common/log-store-idb/src/idb-log-store.ts
@@ -24,15 +24,26 @@ const DEFAULT_FLUSH_BATCH_SIZE = 500;
 const DEFAULT_MAX_RECORDS = 150_000;
 const DEFAULT_EVICTION_INTERVAL = 30_000;
 const EVICTION_LOCK_NAME = '@dxos/log-store-idb:evictor';
+// v2 introduced chunked rows with out-of-line array keys (v1 stored one row per line
+// under an autoincrement keyPath).
+const DB_VERSION = 2;
 
 /**
- * Stored log row. The line is pre-encoded JSONL (no trailing newline).
+ * Chunk key: `[epochMs, writerId, writerSeq, lineCount]`.
+ *
+ * Keys order chunks by flush time; `writerId`/`writerSeq` keep keys from concurrent
+ * writers unique. `lineCount` rides in the key so eviction can compute the retention
+ * budget from `getAllKeys()` alone, without deserializing chunk values.
  */
-type LogRow = {
-  /** Auto-incremented sequence (commit order). */
-  seq?: number;
-  /** Encoded JSONL line. */
-  line: string;
+type ChunkKey = [epochMs: number, writerId: string, writerSeq: number, lineCount: number];
+
+/**
+ * Stored row: one flush batch of pre-encoded JSONL lines joined with `\n` (no trailing
+ * newline). Storing the whole batch as a single record keeps the per-flush cost at one
+ * structured clone and one backend record regardless of batch size.
+ */
+type LogChunk = {
+  lines: string;
 };
 
 export type IdbLogStoreOptions = {
@@ -45,9 +56,10 @@ export type IdbLogStoreOptions = {
   /** Auto-flush when in-memory queue reaches this size. Default `500`. */
   flushBatchSize?: number;
   /**
-   * Soft cap on retained records. Older rows are evicted past this. Default `150_000`,
-   * sized for roughly 50 MB on disk at typical JSONL line sizes (~350 bytes average
-   * observed in the Composer app).
+   * Soft cap on retained log records (JSONL lines). Eviction drops whole flush chunks,
+   * oldest first; the newest chunk is always retained. Default `150_000`, sized for
+   * roughly 50 MB on disk at typical JSONL line sizes (~350 bytes average observed in
+   * the Composer app).
    */
   maxRecords?: number;
   /** Eviction sweep interval in milliseconds. Default `30_000`. */
@@ -67,13 +79,14 @@ export type IdbLogStoreOptions = {
 /**
  * IndexedDB-backed log store.
  *
- * Logs are batched in memory and flushed to IndexedDB as pre-encoded JSONL strings.
- * Multiple browsing contexts can write to the same database concurrently — IDB
- * serializes transactions, so no extra coordination is needed for writes.
- * Eviction is deduplicated across tabs via the Web Locks API (`ifAvailable`).
+ * Logs are batched in memory and each flush is written as a single chunk record of
+ * pre-encoded JSONL. Multiple browsing contexts can write to the same database
+ * concurrently — IDB serializes transactions, so no extra coordination is needed for
+ * writes. Eviction is deduplicated across tabs via the Web Locks API (`ifAvailable`).
  *
  * Flushes are triggered by:
- * - the configured interval timer,
+ * - a deferred task after `flushInterval` (background priority where the Scheduler API
+ *   is available, so flushes don't compete with input handling and rendering),
  * - the queue exceeding `flushBatchSize`,
  * - `visibilitychange` to `hidden` and `pagehide` events.
  */
@@ -86,9 +99,12 @@ export class IdbLogStore {
   readonly #evictionInterval: number;
   readonly #tabId: string;
   readonly #filters: LogFilter[];
+  /** Distinguishes chunk keys written by concurrent contexts against the same database. */
+  readonly #writerId = Math.random().toString(36).slice(2);
 
   #queue: string[] = [];
-  #flushTimer: ReturnType<typeof setTimeout> | undefined;
+  #writerSeq = 0;
+  #flushTask: ScheduledTask | undefined;
   #evictionTimer: ReturnType<typeof setInterval> | undefined;
   #pendingFlush: Promise<void> | undefined;
   #db: IDBDatabase | undefined;
@@ -129,9 +145,9 @@ export class IdbLogStore {
 
     if (this.#queue.length >= this.#flushBatchSize) {
       void this.flush();
-    } else if (this.#flushTimer === undefined) {
-      this.#flushTimer = setTimeout(() => {
-        this.#flushTimer = undefined;
+    } else if (this.#flushTask === undefined) {
+      this.#flushTask = scheduleBackgroundTask(() => {
+        this.#flushTask = undefined;
         void this.flush();
       }, this.#flushInterval);
     }
@@ -142,9 +158,9 @@ export class IdbLogStore {
    * Concurrent calls share a single in-flight flush.
    */
   async flush(): Promise<void> {
-    if (this.#flushTimer !== undefined) {
-      clearTimeout(this.#flushTimer);
-      this.#flushTimer = undefined;
+    if (this.#flushTask !== undefined) {
+      this.#flushTask.cancel();
+      this.#flushTask = undefined;
     }
     if (this.#pendingFlush) {
       return this.#pendingFlush;
@@ -171,11 +187,13 @@ export class IdbLogStore {
   async export(options: { maxSize?: number } = {}): Promise<string> {
     await this.flush();
     const db = await this.#open();
-    const lines = await readAllLines(db, this.#storeName);
+    const chunks = await readAllChunks(db, this.#storeName);
     if (options.maxSize !== undefined && options.maxSize >= 0) {
+      // Trim on individual lines so the size cap never under-fills by a whole chunk.
+      const lines = chunks.flatMap((chunk) => chunk.split('\n'));
       return trimJsonlToSize(lines, options.maxSize);
     }
-    return lines.join('\n');
+    return chunks.join('\n');
   }
 
   /**
@@ -183,9 +201,9 @@ export class IdbLogStore {
    */
   async clear(): Promise<void> {
     this.#queue = [];
-    if (this.#flushTimer !== undefined) {
-      clearTimeout(this.#flushTimer);
-      this.#flushTimer = undefined;
+    if (this.#flushTask !== undefined) {
+      this.#flushTask.cancel();
+      this.#flushTask = undefined;
     }
     const db = await this.#open();
     await runTransaction(db, this.#storeName, 'readwrite', (store) => {
@@ -244,11 +262,10 @@ export class IdbLogStore {
     }
 
     try {
+      const chunk: LogChunk = { lines: batch.join('\n') };
+      const key: ChunkKey = [Date.now(), this.#writerId, this.#writerSeq++, batch.length];
       await runTransaction(db, this.#storeName, 'readwrite', (store) => {
-        for (const line of batch) {
-          const row: LogRow = { line };
-          store.add(row);
-        }
+        store.add(chunk, key);
       });
     } catch {
       // Ignore write errors.
@@ -315,14 +332,12 @@ export class IdbLogStore {
       return;
     }
 
-    const count = await runTransaction(db, this.#storeName, 'readonly', (store) => promisifyRequest(store.count()));
-    if (count <= this.#maxRecords) {
-      return;
-    }
-
-    const toDelete = count - this.#maxRecords;
     await runTransaction(db, this.#storeName, 'readwrite', async (store) => {
-      const cutoff = await findCutoffKey(store, toDelete);
+      // Keys carry per-chunk line counts, so the retention budget is computed from
+      // getAllKeys() alone — no count() pre-pass and no chunk values are read.
+      // Cast: IDB types keys as IDBValidKey[]; this store only ever receives ChunkKey keys.
+      const keys = (await promisifyRequest(store.getAllKeys())) as ChunkKey[];
+      const cutoff = findEvictionCutoff(keys, this.#maxRecords);
       if (cutoff !== undefined) {
         store.delete(IDBKeyRange.upperBound(cutoff));
       }
@@ -362,12 +377,16 @@ export class IdbLogStore {
 
 const openDatabase = (name: string, storeName: string): Promise<IDBDatabase> => {
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open(name, 1);
+    const request = indexedDB.open(name, DB_VERSION);
     request.onupgradeneeded = () => {
       const db = request.result;
-      if (!db.objectStoreNames.contains(storeName)) {
-        db.createObjectStore(storeName, { keyPath: 'seq', autoIncrement: true });
+      // The v1 schema stored one row per line under an autoincrement keyPath; chunked
+      // storage requires out-of-line keys, so the store is recreated and v1 data is
+      // discarded (logs are expendable diagnostics).
+      if (db.objectStoreNames.contains(storeName)) {
+        db.deleteObjectStore(storeName);
       }
+      db.createObjectStore(storeName);
     };
     request.onsuccess = () => resolve(request.result);
     request.onerror = () => reject(request.error);
@@ -439,37 +458,54 @@ const runTransaction = <T>(
   });
 };
 
-const readAllLines = async (db: IDBDatabase, storeName: string): Promise<string[]> => {
+const readAllChunks = async (db: IDBDatabase, storeName: string): Promise<string[]> => {
   return runTransaction(db, storeName, 'readonly', (store) =>
-    promisifyRequest(store.getAll()).then((rows) => (rows as LogRow[]).map((row) => row.line)),
+    promisifyRequest(store.getAll()).then((rows) => (rows as LogChunk[]).map((row) => row.lines)),
   );
 };
 
 /**
- * Walk the store in key order and return the key of the `count`-th entry.
- * Returns `undefined` if the store has fewer than `count` entries.
+ * Given all chunk keys in ascending (key) order, return the key of the newest chunk that
+ * must be evicted — delete it and everything older — so the retained line total stays
+ * within `maxRecords`. The newest chunk is always retained, even if it alone exceeds the
+ * budget. Returns `undefined` when everything fits.
  */
-const findCutoffKey = (store: IDBObjectStore, count: number): Promise<IDBValidKey | undefined> => {
-  return new Promise((resolve, reject) => {
-    if (count <= 0) {
-      resolve(undefined);
-      return;
+const findEvictionCutoff = (keys: readonly ChunkKey[], maxRecords: number): ChunkKey | undefined => {
+  let retained = 0;
+  for (let index = keys.length - 1; index >= 0; index--) {
+    const [, , , lineCount] = keys[index];
+    retained += lineCount;
+    if (retained > maxRecords && index < keys.length - 1) {
+      return keys[index];
     }
-    const request = store.openKeyCursor();
-    let advanced = false;
-    request.onsuccess = () => {
-      const cursor = request.result;
-      if (!cursor) {
-        resolve(undefined);
-        return;
-      }
-      if (!advanced && count > 1) {
-        advanced = true;
-        cursor.advance(count - 1);
-        return;
-      }
-      resolve(cursor.key);
-    };
-    request.onerror = () => reject(request.error);
-  });
+  }
+  return undefined;
+};
+
+type ScheduledTask = { cancel: () => void };
+
+type SchedulerLike = {
+  postTask: (
+    callback: () => void,
+    options?: { priority?: 'background' | 'user-visible' | 'user-blocking'; delay?: number; signal?: AbortSignal },
+  ) => Promise<unknown>;
+};
+
+/**
+ * Run `callback` after `delay` ms at background priority where the Scheduler API is
+ * available, so deferred work yields to input handling and rendering; falls back to a
+ * plain timeout elsewhere.
+ */
+const scheduleBackgroundTask = (callback: () => void, delay: number): ScheduledTask => {
+  // The Scheduler API is not in the TS DOM lib yet.
+  const scheduler = (globalThis as { scheduler?: SchedulerLike }).scheduler;
+  if (typeof scheduler?.postTask === 'function') {
+    const controller = new AbortController();
+    scheduler.postTask(callback, { priority: 'background', delay, signal: controller.signal }).catch(() => {
+      // Rejects on abort; the callback never ran.
+    });
+    return { cancel: () => controller.abort() };
+  }
+  const timer = setTimeout(callback, delay);
+  return { cancel: () => clearTimeout(timer) };
 };


### PR DESCRIPTION
## Summary

Reduces the IDB log store's main-thread footprint along three axes:

- **Chunked writes** — each flush batch is stored as a single chunk record (pre-joined JSONL) instead of one `add()` per line. One structured clone and one backend record per flush regardless of batch size; `export()` deserializes hundreds of chunks instead of up to 150k single-line rows, which matters most since export runs while collecting diagnostics.
- **Key-based eviction** — chunk keys are out-of-line arrays `[epochMs, writerId, writerSeq, lineCount]`. Carrying the line count in the key lets the eviction sweep compute the retention cutoff from `getAllKeys()` alone: no `count()` pre-pass, no full key-cursor walk, no chunk values read, and the read+delete now happens in one atomic transaction (the old two-transaction sweep had a race window). `maxRecords` remains a soft cap on retained lines; eviction drops whole chunks oldest-first and always retains the newest chunk.
- **Background flush scheduling** — the deferred interval flush is scheduled via `scheduler.postTask(..., { priority: 'background', delay })` where the Scheduler API is available (with a `setTimeout` fallback), so flushes yield to input handling and rendering. Batch-threshold, `pagehide`/`visibilitychange`, and explicit `flush()` paths remain immediate.

## Schema migration

The chunked layout requires out-of-line keys, so the DB version is bumped to 2 and the object store is recreated on upgrade — **previously stored v1 logs are discarded once**. All consumers (Composer main/workers, recovery download, observability) go through the `IdbLogStore` public API, so nothing else changes. A v1 tab racing a v2 tab simply fails its writes silently (already the store's error posture).

## Testing

- Existing suite updated for chunk-granularity eviction; new tests pin one-record-per-flush storage, whole-chunk eviction with newest-chunk retention, and the v1→v2 upgrade discarding old rows.
- `moon run log-store-idb:test log-store-idb:test-browser` — 19/19 pass (Chromium); `log-store-idb:lint` and `:build` green.

https://claude.ai/code/session_01X9jgyiRocjgZtwa3S5gZXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9jgyiRocjgZtwa3S5gZXW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized log storage efficiency and system resource utilization with improved persistence handling.
  * Refined log eviction behavior to better respect retention limits while conserving system resources.
  * Enhanced upgrade path for legacy log data with full backward compatibility support.
  * Updated log flushing mechanism for more responsive and efficient performance across concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->