### PR TITLE
refactor(compute): promote byokHeaderLayer to Header namespace as Header.byokLayer

### DIFF
--- a/packages/core/compute/compute/src/Header.test.ts
+++ b/packages/core/compute/compute/src/Header.test.ts
@@ -11,10 +11,10 @@ import { describe, test } from 'vitest';
 
 import { EffectEx } from '@dxos/effect';
 
-import { byokHeaderLayer } from './byok';
 import * as Credential from './Credential';
+import * as Header from './Header';
 
-describe('byokHeaderLayer', () => {
+describe('Header.byokLayer', () => {
   test('attaches X-BYOK header when a credential is found for the provider host', async ({ expect }) => {
     const sink: { lastHeader?: string } = {};
 
@@ -25,7 +25,7 @@ describe('byokHeaderLayer', () => {
 
     const runnable = program.pipe(
       Effect.provide(
-        byokHeaderLayer('anthropic.com').pipe(
+        Header.byokLayer('anthropic.com').pipe(
           Layer.provide(captureHeaderClient(sink)),
           Layer.provide(credentialsLayer([{ service: 'anthropic.com', apiKey: 'sk-ant-user' }])),
         ),
@@ -46,7 +46,7 @@ describe('byokHeaderLayer', () => {
 
     const runnable = program.pipe(
       Effect.provide(
-        byokHeaderLayer('anthropic.com').pipe(
+        Header.byokLayer('anthropic.com').pipe(
           Layer.provide(captureHeaderClient(sink)),
           Layer.provide(credentialsLayer([])),
         ),
@@ -67,7 +67,7 @@ describe('byokHeaderLayer', () => {
 
     const runnable = program.pipe(
       Effect.provide(
-        byokHeaderLayer('anthropic.com').pipe(
+        Header.byokLayer('anthropic.com').pipe(
           Layer.provide(captureHeaderClient(sink)),
           Layer.provide(credentialsLayer([{ service: 'anthropic.com' }])),
         ),
@@ -97,7 +97,7 @@ describe('byokHeaderLayer', () => {
 
     const runnable = program.pipe(
       Effect.provide(
-        byokHeaderLayer('anthropic.com').pipe(
+        Header.byokLayer('anthropic.com').pipe(
           Layer.provide(captureHeaderClient(sink)),
           Layer.provide(failingCredentials),
         ),

--- a/packages/core/compute/compute/src/Header.ts
+++ b/packages/core/compute/compute/src/Header.ts
@@ -2,6 +2,8 @@
 // Copyright 2026 DXOS.org
 //
 
+// @import-as-namespace
+
 import * as HttpClient from '@effect/platform/HttpClient';
 import * as HttpClientRequest from '@effect/platform/HttpClientRequest';
 import * as Effect from 'effect/Effect';
@@ -15,7 +17,7 @@ import * as Credential from './Credential';
  * Wraps an `HttpClient` so outbound requests carry `X-BYOK: <apiKey>` whenever the active space
  * has an `AccessToken` for `providerHost`. Lookup failures pass the request through unchanged.
  */
-export const byokHeaderLayer = (
+export const byokLayer = (
   providerHost: string,
 ): Layer.Layer<HttpClient.HttpClient, never, HttpClient.HttpClient | Credential.CredentialsService> =>
   Layer.effect(

--- a/packages/core/compute/compute/src/index.ts
+++ b/packages/core/compute/compute/src/index.ts
@@ -3,10 +3,10 @@
 //
 
 export * from './errors';
-export { byokHeaderLayer } from './byok';
 
 export * as Blueprint from './Blueprint';
 export * as Credential from './Credential';
+export * as Header from './Header';
 export * as McpServer from './McpServer';
 export * as LayerSpec from './LayerSpec';
 export * as Operation from './Operation';

--- a/packages/core/compute/functions-runtime/src/agent-service/agent-process.ts
+++ b/packages/core/compute/functions-runtime/src/agent-service/agent-process.ts
@@ -83,7 +83,7 @@ export const AgentProcess = (options: AgentProcessOptions) =>
         Feed.FeedService,
         ProcessManager.ProcessOperationInvoker.Service,
         AiService.AiService,
-        // Needed in the fiber's context — `byokHeaderLayer`'s per-request callback reads it.
+        // Needed in the fiber's context — `Header.byokLayer`'s per-request callback reads it.
         Credential.CredentialsService,
       ],
     },

--- a/packages/core/compute/functions/src/protocol/protocol.ts
+++ b/packages/core/compute/functions/src/protocol/protocol.ts
@@ -12,11 +12,11 @@ import { AiModelResolver, AiService, OpaqueToolkit } from '@dxos/ai';
 import { AnthropicResolver } from '@dxos/ai/resolvers';
 import {
   FunctionError,
+  Header,
   InvalidOperationInputError,
   InvalidOperationOutputError,
   Operation,
   Trace,
-  byokHeaderLayer,
 } from '@dxos/compute';
 import { LifecycleState, Resource } from '@dxos/context';
 import { Database, Feed, JsonSchema, Ref, Registry, type Type } from '@dxos/echo';
@@ -273,7 +273,7 @@ const makeTraceWriterLayer = (traceService: TraceProtocol.TraceService): Layer.L
 /** Proxies Anthropic requests through the EDGE-provided `FunctionsAiService`, BYOK-wrapped. */
 const InternalAiServiceLayer = (functionsAiService: EdgeFunctionEnv.FunctionsAiService) => {
   // `apiUrl` is a sentinel — the request gets re-routed by the AI gateway in EDGE.
-  const httpClient = byokHeaderLayer('anthropic.com').pipe(
+  const httpClient = Header.byokLayer('anthropic.com').pipe(
     Layer.provide(FunctionsAiHttpClient.layer(functionsAiService)),
   );
   const anthropicClient = AnthropicClient.layer({ apiUrl: 'http://internal/provider/anthropic' }).pipe(

--- a/packages/plugins/plugin-assistant/src/capabilities/edge-model-resolver.ts
+++ b/packages/plugins/plugin-assistant/src/capabilities/edge-model-resolver.ts
@@ -10,7 +10,7 @@ import { AnthropicResolver } from '@dxos/ai/resolvers';
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
 import { createEdgeIdentity } from '@dxos/client/edge';
-import { byokHeaderLayer } from '@dxos/compute';
+import { Header } from '@dxos/compute';
 import { EdgeAiHttpClient, EdgeHttpClient } from '@dxos/edge-client';
 import { invariant } from '@dxos/invariant';
 import { ClientCapabilities } from '@dxos/plugin-client';
@@ -52,8 +52,8 @@ const edgeModelResolver = Capability.makeModule<[], EdgeModelResolverCapabilitie
     };
 
     // `apiUrl` is a sentinel; `EdgeAiHttpClient` rewrites the request onto the EDGE
-    // `/ai/generate/anthropic` route. `byokHeaderLayer` wraps that client to inject `X-BYOK`.
-    const httpClient = byokHeaderLayer(ANTHROPIC_SOURCE).pipe(Layer.provide(EdgeAiHttpClient.layer(getEdgeClient)));
+    // `/ai/generate/anthropic` route. `Header.byokLayer` wraps that client to inject `X-BYOK`.
+    const httpClient = Header.byokLayer(ANTHROPIC_SOURCE).pipe(Layer.provide(EdgeAiHttpClient.layer(getEdgeClient)));
     const anthropicClient = AnthropicClient.layer({ apiUrl: 'http://edge.internal' }).pipe(Layer.provide(httpClient));
     const anthropicResolverLayer = AnthropicResolver.make().pipe(Layer.provide(anthropicClient));
 

--- a/packages/plugins/plugin-assistant/src/constants.ts
+++ b/packages/plugins/plugin-assistant/src/constants.ts
@@ -5,5 +5,5 @@
 /** Stable id used by `plugin-integration` to look up the Anthropic provider entry. */
 export const ANTHROPIC_PROVIDER_ID = 'anthropic';
 
-/** Source string used in `AccessToken.source` and matched by `byokHeaderLayer('anthropic.com')`. */
+/** Source string used in `AccessToken.source` and matched by `Header.byokLayer('anthropic.com')`. */
 export const ANTHROPIC_SOURCE = 'anthropic.com';

--- a/packages/sdk/app-toolkit/src/capabilities.ts
+++ b/packages/sdk/app-toolkit/src/capabilities.ts
@@ -153,7 +153,7 @@ export namespace AppCapabilities {
   /**
    * Plugins can contribute model resolvers. The `Credential.CredentialsService` requirement is
    * supplied by the active-space resolver — BYOK-aware resolvers wrap their HTTP client with
-   * `byokHeaderLayer(...)`; the rest carry it through unused.
+   * `Header.byokLayer(...)`; the rest carry it through unused.
    */
   export const AiModelResolver = Capability$.make<
     Layer$.Layer<AiModelResolver$.AiModelResolver, never, Credential.CredentialsService>


### PR DESCRIPTION
## Summary

- Renames `byok.ts` → `Header.ts` and `byokHeaderLayer` → `byokLayer`, making it a proper namespace export (`Header.byokLayer`) consistent with `Blueprint`, `Credential`, `McpServer`, etc.
- Adds `// @import-as-namespace` directive to `Header.ts`
- Updates `index.ts` to `export * as Header from './Header'` replacing the bare named export
- Updates all call sites in `functions/protocol.ts`, `plugin-assistant/edge-model-resolver.ts`, and related comments

## Test Plan

- [x] `compute:test` passes (4 test files, 25 tests)
- [x] `compute:build`, `functions:build`, `plugin-assistant:build` all succeed
- [x] No remaining references to `byokHeaderLayer` in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module structure and exports related to BYOK header injection functionality across multiple packages. Updated import statements and references throughout the codebase to align with the new export structure.

* **Tests**
  * Updated test cases to reflect the reorganized exports.

* **Documentation**
  * Updated documentation comments and inline notes to reference the updated export structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->