### PR TITLE
refactor: replace declaration-emit fake imports with explicit annotations

### DIFF
--- a/packages/plugins/plugin-assistant/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-assistant/src/capabilities/blueprint-definition.ts
@@ -28,14 +28,12 @@ import {
   DelegationHandlers,
   makeDelegationStrategy,
 } from '@dxos/assistant-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 import { AutomationCapabilities } from '@dxos/plugin-automation';
 
 import { AssistantBlueprint } from '#blueprints';
 
-// TODO(dmaretskyi): Force this type for all Capability.makeModule calls.
-const blueprintDefinition: () => Effect.Effect<Capability.Capability<unknown>[]> = Capability.makeModule(() =>
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<Capability.Capability<unknown>[]> = () =>
   Effect.succeed([
     Capability.contributes(AppCapabilities.BlueprintDefinition, AssistantBlueprint),
     Capability.contributes(AppCapabilities.BlueprintDefinition, BrowserBlueprint),
@@ -62,7 +60,6 @@ const blueprintDefinition: () => Effect.Effect<Capability.Capability<unknown>[]>
     // Run the conversational agent as a supervisor: delegate in-progress plan tasks to sub-agents
     // and fold their results back into the conversation (consumed by the AgentService LayerSpec).
     Capability.contributes(AutomationCapabilities.AgentDelegationStrategy, makeDelegationStrategy()),
-  ]),
-);
+  ]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-assistant/src/capabilities/index.ts
+++ b/packages/plugins/plugin-assistant/src/capabilities/index.ts
@@ -3,8 +3,7 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 import type { AssistantPluginOptions } from '#types';
 

--- a/packages/plugins/plugin-bookmarks/src/capabilities/comment-config.ts
+++ b/packages/plugins/plugin-bookmarks/src/capabilities/comment-config.ts
@@ -6,19 +6,22 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Operation } from '@dxos/compute';
 import { Type } from '@dxos/echo';
 
 import { Bookmark } from '#types';
 
-export default Capability.makeModule(
-  Effect.fnUntraced(function* () {
-    // Unanchored: comments attach to the bookmark as a whole. Anchored (range) comments require the
-    // comment-sync editor extension, which currently only targets Markdown.Document content.
-    return Capability.contributes(AppCapabilities.CommentConfig, {
-      id: Type.getTypename(Bookmark.Bookmark),
-      comments: 'unanchored',
-    });
-  }),
-);
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const activate: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.CommentConfig>,
+  never,
+  Capability.Service
+> = Effect.fnUntraced(function* () {
+  // Unanchored: comments attach to the bookmark as a whole. Anchored (range) comments require the
+  // comment-sync editor extension, which currently only targets Markdown.Document content.
+  return Capability.contributes(AppCapabilities.CommentConfig, {
+    id: Type.getTypename(Bookmark.Bookmark),
+    comments: 'unanchored',
+  });
+});
+
+export default activate;

--- a/packages/plugins/plugin-bookmarks/src/capabilities/index.ts
+++ b/packages/plugins/plugin-bookmarks/src/capabilities/index.ts
@@ -4,7 +4,6 @@
 
 import { Capability } from '@dxos/app-framework';
 import { type AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
 import type { OperationHandlerSet } from '@dxos/compute';
 import { type CrxCapabilities } from '@dxos/plugin-crx/types';
 

--- a/packages/plugins/plugin-chess/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-chess/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { ChessBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, ChessBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, ChessBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-chess/src/capabilities/index.ts
+++ b/packages/plugins/plugin-chess/src/capabilities/index.ts
@@ -3,10 +3,15 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const GameVariant = Capability.lazy('GameVariant', () => import('./game-variant'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',

--- a/packages/plugins/plugin-code/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-code/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { CoderBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, CoderBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, CoderBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-code/src/capabilities/index.ts
+++ b/packages/plugins/plugin-code/src/capabilities/index.ts
@@ -3,11 +3,16 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const BuildRunState = Capability.lazy('BuildRunState', () => import('./build-run-state'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(

--- a/packages/plugins/plugin-comments/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-comments/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { CommentBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, CommentBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, CommentBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-comments/src/capabilities/index.ts
+++ b/packages/plugins/plugin-comments/src/capabilities/index.ts
@@ -3,12 +3,17 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AgentRunner = Capability.lazy('AgentRunner', () => import('./agent-runner'));
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const Markdown = Capability.lazy('MarkdownExtension', () => import('./markdown-extension'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',

--- a/packages/plugins/plugin-commerce/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-commerce/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { ProviderBlueprint } from '../blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, ProviderBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, ProviderBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-crm/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-crm/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { CrmBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, CrmBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, CrmBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-crm/src/capabilities/index.ts
+++ b/packages/plugins/plugin-crm/src/capabilities/index.ts
@@ -3,12 +3,17 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
 
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',

--- a/packages/plugins/plugin-doctor/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-doctor/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { DoctorBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, DoctorBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, DoctorBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-doctor/src/capabilities/index.ts
+++ b/packages/plugins/plugin-doctor/src/capabilities/index.ts
@@ -3,11 +3,16 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const DiagnosticProviders = Capability.lazy('DiagnosticProviders', () => import('./diagnostic-providers'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',

--- a/packages/plugins/plugin-feed/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-feed/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { MagazineBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, MagazineBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, MagazineBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-feed/src/capabilities/index.ts
+++ b/packages/plugins/plugin-feed/src/capabilities/index.ts
@@ -3,12 +3,17 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
 export const NavigationResolver = Capability.lazy('NavigationResolver', () => import('./navigation-resolver'));
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',

--- a/packages/plugins/plugin-file/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-file/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { FileBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, FileBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, FileBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-file/src/capabilities/index.ts
+++ b/packages/plugins/plugin-file/src/capabilities/index.ts
@@ -3,11 +3,15 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
 import { OperationHandlerSet } from '@dxos/compute';
 
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const FileUploader = Capability.lazy('FileUploader', () => import('./file-uploader'));
 export const InlineBackend = Capability.lazy('InlineBackend', () => import('./inline-backend'));

--- a/packages/plugins/plugin-inbox/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/blueprint-definition.ts
@@ -6,17 +6,19 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { CalendarBlueprint, InboxBlueprint, InboxSendBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule(() =>
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () =>
   Effect.succeed([
     Capability.contributes(AppCapabilities.BlueprintDefinition, InboxBlueprint),
     Capability.contributes(AppCapabilities.BlueprintDefinition, InboxSendBlueprint),
     Capability.contributes(AppCapabilities.BlueprintDefinition, CalendarBlueprint),
-  ]),
-);
+  ]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-inbox/src/capabilities/index.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/index.ts
@@ -3,11 +3,16 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const IntegrationProvider = Capability.lazy('IntegrationProvider', () => import('./integration-provider'));
 export const NavigationResolver = Capability.lazy('NavigationResolver', () => import('./navigation-resolver'));

--- a/packages/plugins/plugin-kanban/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-kanban/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { KanbanBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, KanbanBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, KanbanBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-kanban/src/capabilities/index.ts
+++ b/packages/plugins/plugin-kanban/src/capabilities/index.ts
@@ -3,10 +3,15 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',

--- a/packages/plugins/plugin-map/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-map/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { MapBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, MapBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, MapBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-map/src/capabilities/index.ts
+++ b/packages/plugins/plugin-map/src/capabilities/index.ts
@@ -3,11 +3,16 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const MarkerProvider = Capability.lazy('MarkerProvider', () => import('./marker-provider'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(

--- a/packages/plugins/plugin-markdown/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-markdown/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { MarkdownBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, MarkdownBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, MarkdownBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-markdown/src/capabilities/comment-config.ts
+++ b/packages/plugins/plugin-markdown/src/capabilities/comment-config.ts
@@ -6,28 +6,31 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Operation } from '@dxos/compute';
 import { Type } from '@dxos/echo';
 import { createDocAccessor, getTextInRange } from '@dxos/echo-client';
 
 import { MarkdownOperation } from '#types';
 import { Markdown } from '#types';
 
-export default Capability.makeModule(
-  Effect.fnUntraced(function* () {
-    const config: AppCapabilities.CommentConfig = {
-      id: Type.getTypename(Markdown.Document),
-      comments: 'anchored',
-      selectionMode: 'multi-range',
-      getAnchorLabel: (doc: Markdown.Document, anchor: string): string | undefined => {
-        if (doc.content) {
-          const [start, end] = anchor.split(':');
-          return getTextInRange(createDocAccessor(doc.content.target!, ['content']), start, end);
-        }
-      },
-      scrollToAnchor: MarkdownOperation.ScrollToAnchor,
-    };
-    return Capability.contributes(AppCapabilities.CommentConfig, config);
-  }),
-);
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const activate: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.CommentConfig>,
+  never,
+  Capability.Service
+> = Effect.fnUntraced(function* () {
+  const config: AppCapabilities.CommentConfig = {
+    id: Type.getTypename(Markdown.Document),
+    comments: 'anchored',
+    selectionMode: 'multi-range',
+    getAnchorLabel: (doc: Markdown.Document, anchor: string): string | undefined => {
+      if (doc.content) {
+        const [start, end] = anchor.split(':');
+        return getTextInRange(createDocAccessor(doc.content.target!, ['content']), start, end);
+      }
+    },
+    scrollToAnchor: MarkdownOperation.ScrollToAnchor,
+  };
+  return Capability.contributes(AppCapabilities.CommentConfig, config);
+});
+
+export default activate;

--- a/packages/plugins/plugin-markdown/src/capabilities/index.ts
+++ b/packages/plugins/plugin-markdown/src/capabilities/index.ts
@@ -3,16 +3,26 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, Operation, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
 export const NavigationResolver = Capability.lazy('NavigationResolver', () => import('./navigation-resolver'));
 export const AnchorSort = Capability.lazy('AnchorSort', () => import('./anchor-sort'));
 export const AppGraphSerializer = Capability.lazy('AppGraphSerializer', () => import('./app-graph-serializer'));
-export const CommentConfig = Capability.lazy('CommentConfig', () => import('./comment-config'));
+// The contributed capability type references Operation types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const CommentConfig: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.CommentConfig>
+> = Capability.lazy('CommentConfig', () => import('./comment-config'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',
   () => import('./operation-handler'),

--- a/packages/plugins/plugin-meeting/src/capabilities/index.ts
+++ b/packages/plugins/plugin-meeting/src/capabilities/index.ts
@@ -4,11 +4,15 @@
 
 import { Capability } from '@dxos/app-framework';
 import { OperationHandlerSet } from '@dxos/compute';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { CallsCapabilities } from '@dxos/plugin-calls/types';
+import { type CallsCapabilities } from '@dxos/plugin-calls/types';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
-export const CallExtension = Capability.lazy('CallExtension', () => import('./call-extension'));
+// The contributed capability is declared in @dxos/plugin-calls, so the lazy wrapper needs an
+// explicit annotation to keep the inferred type portable (TS2742/TS2883).
+export const CallExtension: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof CallsCapabilities.EventHandler>
+> = Capability.lazy('CallExtension', () => import('./call-extension'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',
   () => import('./operation-handler'),

--- a/packages/plugins/plugin-sandbox/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-sandbox/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { SandboxBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, SandboxBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, SandboxBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-sandbox/src/capabilities/index.ts
+++ b/packages/plugins/plugin-sandbox/src/capabilities/index.ts
@@ -3,10 +3,15 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',
   () => import('./operation-handler'),

--- a/packages/plugins/plugin-script/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-script/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { ScriptBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, ScriptBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, ScriptBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-script/src/capabilities/index.ts
+++ b/packages/plugins/plugin-script/src/capabilities/index.ts
@@ -3,11 +3,16 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const Compiler = Capability.lazy('Compiler', () => import('./compiler'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(

--- a/packages/plugins/plugin-script/src/capabilities/node.ts
+++ b/packages/plugins/plugin-script/src/capabilities/node.ts
@@ -3,11 +3,16 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const Compiler = Capability.lazy('Compiler', () => import('./compiler'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(

--- a/packages/plugins/plugin-sequencer/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-sequencer/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { SequencerBlueprint } from '../blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, SequencerBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, SequencerBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-sequencer/src/capabilities/index.ts
+++ b/packages/plugins/plugin-sequencer/src/capabilities/index.ts
@@ -3,10 +3,15 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',

--- a/packages/plugins/plugin-sheet/src/capabilities/comment-config.ts
+++ b/packages/plugins/plugin-sheet/src/capabilities/comment-config.ts
@@ -6,20 +6,23 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Operation } from '@dxos/compute';
 import { Type } from '@dxos/echo';
 
 import { SheetOperation } from '#types';
 import { Sheet } from '#types';
 
-export default Capability.makeModule(
-  Effect.fnUntraced(function* () {
-    const config: AppCapabilities.CommentConfig = {
-      id: Type.getTypename(Sheet.Sheet),
-      comments: 'anchored',
-      scrollToAnchor: SheetOperation.ScrollToAnchor,
-    };
-    return Capability.contributes(AppCapabilities.CommentConfig, config);
-  }),
-);
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const activate: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.CommentConfig>,
+  never,
+  Capability.Service
+> = Effect.fnUntraced(function* () {
+  const config: AppCapabilities.CommentConfig = {
+    id: Type.getTypename(Sheet.Sheet),
+    comments: 'anchored',
+    scrollToAnchor: SheetOperation.ScrollToAnchor,
+  };
+  return Capability.contributes(AppCapabilities.CommentConfig, config);
+});
+
+export default activate;

--- a/packages/plugins/plugin-sheet/src/capabilities/index.ts
+++ b/packages/plugins/plugin-sheet/src/capabilities/index.ts
@@ -3,14 +3,18 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Operation } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
 import { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
 export const NavigationResolver = Capability.lazy('NavigationResolver', () => import('./navigation-resolver'));
 export const AnchorSort = Capability.lazy('AnchorSort', () => import('./anchor-sort'));
-export const CommentConfig = Capability.lazy('CommentConfig', () => import('./comment-config'));
+// The contributed capability type references Operation types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const CommentConfig: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.CommentConfig>
+> = Capability.lazy('CommentConfig', () => import('./comment-config'));
 export const ComputeGraphRegistry = Capability.lazy('ComputeGraphRegistry', () => import('./compute-graph-registry'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const Markdown = Capability.lazy('MarkdownExtension', () => import('./markdown-extension'));

--- a/packages/plugins/plugin-sidekick/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-sidekick/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { SidekickBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, SidekickBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, SidekickBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-sidekick/src/capabilities/index.ts
+++ b/packages/plugins/plugin-sidekick/src/capabilities/index.ts
@@ -3,8 +3,12 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
 
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const ReactSurface = Capability.lazy('ReactSurface', () => import('./react-surface'));

--- a/packages/plugins/plugin-sketch/src/capabilities/comment-config.ts
+++ b/packages/plugins/plugin-sketch/src/capabilities/comment-config.ts
@@ -6,17 +6,20 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Operation } from '@dxos/compute';
 import { Type } from '@dxos/echo';
 
 import { Sketch } from '#types';
 
-export default Capability.makeModule(
-  Effect.fnUntraced(function* () {
-    return Capability.contributes(AppCapabilities.CommentConfig, {
-      id: Type.getTypename(Sketch.Sketch),
-      comments: 'unanchored',
-    });
-  }),
-);
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const activate: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.CommentConfig>,
+  never,
+  Capability.Service
+> = Effect.fnUntraced(function* () {
+  return Capability.contributes(AppCapabilities.CommentConfig, {
+    id: Type.getTypename(Sketch.Sketch),
+    comments: 'unanchored',
+  });
+});
+
+export default activate;

--- a/packages/plugins/plugin-sketch/src/capabilities/index.ts
+++ b/packages/plugins/plugin-sketch/src/capabilities/index.ts
@@ -3,14 +3,18 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Operation } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
 import { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
 export const NavigationResolver = Capability.lazy('NavigationResolver', () => import('./navigation-resolver'));
 export const AppGraphSerializer = Capability.lazy('AppGraphSerializer', () => import('./app-graph-serializer'));
-export const CommentConfig = Capability.lazy('CommentConfig', () => import('./comment-config'));
+// The contributed capability type references Operation types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const CommentConfig: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.CommentConfig>
+> = Capability.lazy('CommentConfig', () => import('./comment-config'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/companions.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/companions.ts
@@ -8,9 +8,6 @@ import * as Option from 'effect/Option';
 import { AppNode } from '@dxos/app-toolkit';
 import { Obj, Type } from '@dxos/echo';
 import { GraphBuilder, NodeMatcher } from '@dxos/plugin-graph';
-// TODO(wittjosiah): This is currently necessary for type portability.
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Node } from '@dxos/plugin-graph';
 import { linkedSegment } from '@dxos/react-ui-attention';
 import type { EchoViewRefPath } from '@dxos/schema';
 import { ViewAnnotation } from '@dxos/schema';
@@ -22,69 +19,72 @@ import { meta } from '#meta';
 //
 
 /** Creates companion panel extensions: object settings and selected-objects. */
-export const createCompanionExtensions = Effect.fnUntraced(function* () {
-  return yield* Effect.all([
-    // Object settings plank companion.
-    GraphBuilder.createExtension({
-      id: 'settings',
-      match: NodeMatcher.whenEchoObjectMatches,
-      connector: (node) =>
-        Effect.succeed([
-          AppNode.makeCompanion({
-            id: linkedSegment('settings'),
-            label: ['object-properties.label', { ns: meta.id }],
-            icon: 'ph--sliders--regular',
-            data: 'settings', // TODO(burdon): Change to 'object-properties'.
-            position: 'last',
-          }),
-        ]),
-    }),
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/plugin-graph types (TS2883).
+export const createCompanionExtensions: () => Effect.Effect<GraphBuilder.BuilderExtension[][]> = Effect.fnUntraced(
+  function* () {
+    return yield* Effect.all([
+      // Object settings plank companion.
+      GraphBuilder.createExtension({
+        id: 'settings',
+        match: NodeMatcher.whenEchoObjectMatches,
+        connector: (node) =>
+          Effect.succeed([
+            AppNode.makeCompanion({
+              id: linkedSegment('settings'),
+              label: ['object-properties.label', { ns: meta.id }],
+              icon: 'ph--sliders--regular',
+              data: 'settings', // TODO(burdon): Change to 'object-properties'.
+              position: 'last',
+            }),
+          ]),
+      }),
 
-    // Related objects plank companion.
-    GraphBuilder.createExtension({
-      id: 'related',
-      match: NodeMatcher.whenEchoObjectMatches,
-      connector: (node) =>
-        Effect.succeed([
-          AppNode.makeCompanion({
-            id: linkedSegment('related'),
-            label: ['companion-related.label', { ns: meta.id }],
-            icon: 'ph--graph--regular',
-            data: 'related',
-            position: 'last',
-          }),
-        ]),
-    }),
+      // Related objects plank companion.
+      GraphBuilder.createExtension({
+        id: 'related',
+        match: NodeMatcher.whenEchoObjectMatches,
+        connector: (node) =>
+          Effect.succeed([
+            AppNode.makeCompanion({
+              id: linkedSegment('related'),
+              label: ['companion-related.label', { ns: meta.id }],
+              icon: 'ph--graph--regular',
+              data: 'related',
+              position: 'last',
+            }),
+          ]),
+      }),
 
-    // View selected objects companion.
-    GraphBuilder.createExtension({
-      id: 'selectedObjects',
-      match: (node) => {
-        if (!Obj.isObject(node.data)) {
-          return Option.none();
-        }
+      // View selected objects companion.
+      GraphBuilder.createExtension({
+        id: 'selectedObjects',
+        match: (node) => {
+          if (!Obj.isObject(node.data)) {
+            return Option.none();
+          }
 
-        const type = Obj.getType(node.data);
-        const path = type
-          ? ViewAnnotation.get(Type.getSchema(type)).pipe(Option.getOrElse(() => [] as EchoViewRefPath))
-          : [];
-        const isEchoViewBacked = type && path.length > 0 ? ViewAnnotation.hasRefAlongPath(node.data, path) : false;
+          const type = Obj.getType(node.data);
+          const path = type
+            ? ViewAnnotation.get(Type.getSchema(type)).pipe(Option.getOrElse(() => [] as EchoViewRefPath))
+            : [];
+          const isEchoViewBacked = type && path.length > 0 ? ViewAnnotation.hasRefAlongPath(node.data, path) : false;
 
-        if (!isEchoViewBacked) {
-          return Option.none();
-        }
+          if (!isEchoViewBacked) {
+            return Option.none();
+          }
 
-        return Option.some(node);
-      },
-      connector: (node) =>
-        Effect.succeed([
-          AppNode.makeCompanion({
-            id: linkedSegment('selected-objects'),
-            label: ['companion-selected-objects.label', { ns: meta.id }],
-            icon: 'ph--tree-view--regular',
-            data: 'selected-objects',
-          }),
-        ]),
-    }),
-  ]);
-});
+          return Option.some(node);
+        },
+        connector: (node) =>
+          Effect.succeed([
+            AppNode.makeCompanion({
+              id: linkedSegment('selected-objects'),
+              label: ['companion-selected-objects.label', { ns: meta.id }],
+              icon: 'ph--tree-view--regular',
+              data: 'selected-objects',
+            }),
+          ]),
+      }),
+    ]);
+  },
+);

--- a/packages/plugins/plugin-space/src/commands/database/add.ts
+++ b/packages/plugins/plugin-space/src/commands/database/add.ts
@@ -5,26 +5,33 @@
 import * as Command from '@effect/cli/Command';
 import * as Options from '@effect/cli/Options';
 import * as Prompt from '@effect/cli/Prompt';
+import type * as Terminal from '@effect/platform/Terminal';
 import * as Console from 'effect/Console';
 import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 
-// eslint-disable-next-line unused-imports/no-unused-imports
 import { type Capability, Plugin } from '@dxos/app-framework';
 import { AppActivationEvents, RootCollectionAnnotation } from '@dxos/app-toolkit';
-import { CommandConfig, Common, flushAndSync, print, spaceLayer } from '@dxos/cli-util';
+import { CommandConfig, Common, type SpaceNotFoundError, flushAndSync, print, spaceLayer } from '@dxos/cli-util';
+import { type ClientService } from '@dxos/client';
 import { SpaceProperties } from '@dxos/client/echo';
-// eslint-disable-next-line unused-imports/no-unused-imports
 import type { Operation } from '@dxos/compute';
-import { Annotation, Collection, Database, Filter, Obj, Query, Scope, Type } from '@dxos/echo';
+import { Annotation, Collection, Database, type Err, Filter, Obj, Query, Scope, Type } from '@dxos/echo';
 import { HiddenAnnotation, getTypeAnnotation } from '@dxos/echo/Annotation';
 import { Kind as EntityKind } from '@dxos/echo/Entity';
+import { type SpaceId } from '@dxos/keys';
 
 import { SpaceCapabilities } from '#types';
 
 import { printObject } from './util';
 
-export const add = Command.make(
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+export const add: Command.Command<
+  'add',
+  ClientService | CommandConfig | Operation.Service | Plugin.Service | Capability.Service | Terminal.Terminal,
+  Err.EntityNotFoundError | Error | SpaceNotFoundError,
+  { readonly spaceId: Option.Option<SpaceId>; readonly typename: Option.Option<string> }
+> = Command.make(
   'add',
   {
     spaceId: Common.spaceId.pipe(Options.optional),

--- a/packages/plugins/plugin-support/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-support/src/capabilities/blueprint-definition.ts
@@ -6,19 +6,18 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { ComposerBlueprint, SupportBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() =>
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () =>
   Effect.succeed([
     Capability.contributes(AppCapabilities.BlueprintDefinition, SupportBlueprint),
     Capability.contributes(AppCapabilities.BlueprintDefinition, ComposerBlueprint),
-  ]),
-);
+  ]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-support/src/capabilities/index.ts
+++ b/packages/plugins/plugin-support/src/capabilities/index.ts
@@ -3,11 +3,16 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const HelpState = Capability.lazy('HelpState', () => import('./help-state'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(

--- a/packages/plugins/plugin-table/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-table/src/capabilities/blueprint-definition.ts
@@ -6,15 +6,15 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { TableBlueprint } from '#blueprints';
 
 // TODO(wittjosiah): Remove? All table ops other than resizing columns are more generically handled as schema ops.
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, TableBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, TableBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-table/src/capabilities/comment-config.ts
+++ b/packages/plugins/plugin-table/src/capabilities/comment-config.ts
@@ -6,16 +6,19 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Operation } from '@dxos/compute';
 import { Type } from '@dxos/echo';
 import { Table } from '@dxos/react-ui-table/types';
 
-export default Capability.makeModule(
-  Effect.fnUntraced(function* () {
-    return Capability.contributes(AppCapabilities.CommentConfig, {
-      id: Type.getTypename(Table.Table),
-      comments: 'unanchored',
-    });
-  }),
-);
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const activate: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.CommentConfig>,
+  never,
+  Capability.Service
+> = Effect.fnUntraced(function* () {
+  return Capability.contributes(AppCapabilities.CommentConfig, {
+    id: Type.getTypename(Table.Table),
+    comments: 'unanchored',
+  });
+});
+
+export default activate;

--- a/packages/plugins/plugin-table/src/capabilities/index.ts
+++ b/packages/plugins/plugin-table/src/capabilities/index.ts
@@ -3,11 +3,21 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, Operation, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
-export const CommentConfig = Capability.lazy('CommentConfig', () => import('./comment-config'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Operation types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const CommentConfig: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.CommentConfig>
+> = Capability.lazy('CommentConfig', () => import('./comment-config'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',

--- a/packages/plugins/plugin-thread/src/capabilities/index.ts
+++ b/packages/plugins/plugin-thread/src/capabilities/index.ts
@@ -3,7 +3,6 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
 import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));

--- a/packages/plugins/plugin-tictactoe/src/capabilities/index.ts
+++ b/packages/plugins/plugin-tictactoe/src/capabilities/index.ts
@@ -3,7 +3,6 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
 import type { OperationHandlerSet } from '@dxos/compute';
 
 export const GameVariant = Capability.lazy('GameVariant', () => import('./game-variant'));

--- a/packages/plugins/plugin-transcription/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-transcription/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { TranscriptionBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, TranscriptionBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, TranscriptionBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-transcription/src/capabilities/index.ts
+++ b/packages/plugins/plugin-transcription/src/capabilities/index.ts
@@ -3,10 +3,15 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint, OperationHandlerSet } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import type { OperationHandlerSet } from '@dxos/compute';
 
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const TextContent = Capability.lazy('TextContent', () => import('./text-content'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',

--- a/packages/plugins/plugin-trip/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-trip/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { TripBlueprint } from '../blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, TripBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, TripBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-video/src/capabilities/comment-config.ts
+++ b/packages/plugins/plugin-video/src/capabilities/comment-config.ts
@@ -6,20 +6,23 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Operation } from '@dxos/compute';
 import { Type } from '@dxos/echo';
 
 import { Video } from '#types';
 
-export default Capability.makeModule(
-  Effect.fnUntraced(function* () {
-    // Unanchored: comments attach to the video as a whole. Anchored (range) comments into the
-    // transcript/summary text require the comment-sync editor extension, which currently only
-    // targets Markdown.Document content.
-    return Capability.contributes(AppCapabilities.CommentConfig, {
-      id: Type.getTypename(Video.Video),
-      comments: 'unanchored',
-    });
-  }),
-);
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const activate: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.CommentConfig>,
+  never,
+  Capability.Service
+> = Effect.fnUntraced(function* () {
+  // Unanchored: comments attach to the video as a whole. Anchored (range) comments into the
+  // transcript/summary text require the comment-sync editor extension, which currently only
+  // targets Markdown.Document content.
+  return Capability.contributes(AppCapabilities.CommentConfig, {
+    id: Type.getTypename(Video.Video),
+    comments: 'unanchored',
+  });
+});
+
+export default activate;

--- a/packages/plugins/plugin-video/src/capabilities/index.ts
+++ b/packages/plugins/plugin-video/src/capabilities/index.ts
@@ -4,7 +4,6 @@
 
 import { Capability } from '@dxos/app-framework';
 import { type AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
 import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));

--- a/packages/plugins/plugin-voxel/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-voxel/src/capabilities/blueprint-definition.ts
@@ -6,14 +6,14 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
 
 import { VoxelBlueprint } from '#blueprints';
 
-const blueprintDefinition = Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, VoxelBlueprint)]));
+// NOTE: Explicit annotation required: d.ts emit cannot portably name the inferred @dxos/compute types (TS2883).
+const blueprintDefinition: () => Effect.Effect<
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[],
+  never,
+  Capability.Service
+> = () => Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, VoxelBlueprint)]);
 
 export default blueprintDefinition;

--- a/packages/plugins/plugin-voxel/src/capabilities/index.ts
+++ b/packages/plugins/plugin-voxel/src/capabilities/index.ts
@@ -3,9 +3,13 @@
 //
 
 import { Capability } from '@dxos/app-framework';
-// eslint-disable-next-line unused-imports/no-unused-imports
-import type { Blueprint } from '@dxos/compute';
+import { type AppCapabilities } from '@dxos/app-toolkit';
 
-export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+// The contributed capability type references Blueprint types from @dxos/compute, so the lazy
+// wrapper needs an explicit annotation to keep the inferred type portable (TS2883).
+export const BlueprintDefinition: Capability.LazyCapability<
+  void,
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+> = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const CreateObject = Capability.lazy('CreateObject', () => import('./create-object'));
 export const ReactSurface = Capability.lazy('ReactSurface', () => import('./react-surface'));


### PR DESCRIPTION
## What

Replaces the "fake import" trick — unused `import type {...}` statements kept only so TypeScript declaration emit could name inferred types (TS2883), each marked with `// eslint-disable-next-line unused-imports/no-unused-imports` — with explicit type annotations on the exported values, across 58 files:

- **comment-config modules**: annotated `const activate: () => Effect.Effect<Capability.Capability<typeof AppCapabilities.CommentConfig>, never, Capability.Service>` with `export default activate`.
- **blueprint-definition modules**: annotated `const blueprintDefinition` returning `Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]` effects.
- **capabilities/index.ts barrels**: lazy capability exports annotated as `Capability.LazyCapability<...>`.
- **plugin-space**: `commands/database/add.ts` (`Command.Command<...>` annotation) and `app-graph-builder/extensions/companions.ts` (`GraphBuilder.BuilderExtension[][]` annotation).

## Why

Explicit annotations are copied verbatim into the emitted `.d.ts`, so declaration emit no longer depends on transitively-imported type names being in scope. This removes the lint-suppressed dead imports and makes the public types of these modules visible at the definition site. `Capability.makeModule` is an inference-only identity helper and is dropped where the value is now annotated.

## Intentionally skipped (fake imports remain)

20 sites where an explicit annotation is impractical:

- 7 files with large inferred schema types (annotating would mean restating huge structural types).
- 11 deep Effect Credential/AiService pipelines (inferred layer/effect types are not expressible concisely).
- plugin-support Tooltip ambient type augmentation imports.

## Verification

- `moon run <pkg>:build` green for plugin-space, plugin-inbox, plugin-markdown, plugin-table, plugin-video, plugin-meeting, plugin-script, plugin-assistant, plugin-bookmarks.
- `moon run composer-app:build` green (cross-package declaration-emit check).
- `:lint -- --fix` green across all 30 touched plugin packages; `pnpm format` produced no changes.
- `git diff origin/main --name-only` matches the intended 58-file list exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type annotations and import organization across plugin capabilities for better code maintainability and TypeScript compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->