### PR TITLE
feat(plugin-crx): enforce enabled and autoOpenAfterClip settings in the bridge

### DIFF
--- a/packages/apps/composer-crx/src/components/PageActions/PageActions.tsx
+++ b/packages/apps/composer-crx/src/components/PageActions/PageActions.tsx
@@ -27,6 +27,7 @@ const ERROR_HINTS: Record<string, string> = {
   extractorFailed: 'could not read the page',
   timeout: 'Composer did not respond',
   noSpace: 'open a space in Composer first',
+  disabled: 'extension actions are disabled in Composer settings',
   unknownAction: 'action not recognized — update Composer or the extension',
 };
 

--- a/packages/plugins/plugin-crx/PLUGIN.mdl
+++ b/packages/plugins/plugin-crx/PLUGIN.mdl
@@ -37,9 +37,10 @@ type Settings
     are documented per field.
   fields:
     enabled?: boolean            # default: true. Master switch: when false, the
-                                 # bridge ignores incoming clips.
+                                 # bridge ignores incoming clips and page
+                                 # actions (acked with `disabled`).
     autoOpenAfterClip?: boolean  # default: false. Navigate to the created
-                                 # object after a successful clip.
+                                 # object after a successful clip or page action.
     renderProxyEnabled?: boolean  # default: true. Master switch: when false,
                                   # plugins use the edge HTTP proxy instead.
     renderTimeout?: number        # default: 20000. Max ms to wait for a render.
@@ -168,6 +169,24 @@ feat F-2b: Render-Proxy Settings
 ```
 
 ```mdl
+feat F-2c: Settings Enforcement
+
+  req F-2c.1:
+    when: `enabled` is false and a clip or page-action invoke arrives
+    then: |
+      no object is created; the request is still acked (so the extension does
+      not time out) with the stable error code `disabled`
+
+  req F-2c.2:
+    when: `autoOpenAfterClip` is true and a clip or page action succeeds
+    then: the created object is opened via LayoutOperation.Open
+
+  req F-2c.3:
+    when: `autoOpenAfterClip` is false (default)
+    then: focus is not moved; only the success toast is shown
+```
+
+```mdl
 feat F-3: Clip Ingestion Listener
 
   req F-3.1:
@@ -268,7 +287,7 @@ feat F-8: Page Actions Registry & Invocation
     descriptors and executes invoke requests (`composer:page-action:invoke`)
     by resolving the active space and invoking the target operation with
     `{ snapshot, target }`. Every request is acked with stable error codes
-    (invalidPayload, unsupportedVersion, unknownAction, noSpace,
+    (invalidPayload, unsupportedVersion, disabled, unknownAction, noSpace,
     operationFailed); outcomes surface as toasts.
 ```
 

--- a/packages/plugins/plugin-crx/src/capabilities/install-clip-listener.ts
+++ b/packages/plugins/plugin-crx/src/capabilities/install-clip-listener.ts
@@ -8,6 +8,8 @@ import { Capabilities, Capability } from '@dxos/app-framework';
 import { LayoutOperation } from '@dxos/app-toolkit';
 import { log } from '@dxos/log';
 
+import { CrxCapabilities, Settings } from '#types';
+
 import { installClipListener } from '../listener';
 import { meta } from '../meta';
 
@@ -20,6 +22,7 @@ const SUCCESS_TOAST_BY_KIND: Record<string, string> = {
 const ERROR_TOAST_BY_CODE: Record<string, string> = {
   invalidPayload: 'toast.error.invalidPayload.message',
   unsupportedVersion: 'toast.error.unsupportedVersion.message',
+  disabled: 'toast.error.disabled.message',
   unsupportedKind: 'toast.error.unsupportedKind.message',
   noSpace: 'toast.error.noSpace.message',
   internal: 'toast.error.internal.message',
@@ -29,6 +32,8 @@ export default Capability.makeModule(
   Effect.fnUntraced(function* () {
     const capabilityManager = yield* Capability.Service;
     const invoker = yield* Capability.get(Capabilities.OperationInvoker);
+    const registry = yield* Capability.get(Capabilities.AtomRegistry);
+    const settingsAtom = yield* Capability.get(CrxCapabilities.Settings);
 
     installClipListener(capabilityManager, invoker, (ack, detail) => {
       const kind = (detail as { kind?: string } | null)?.kind;
@@ -38,6 +43,9 @@ export default Capability.makeModule(
           id: `${meta.id}.clip-${ack.id}`,
           title: [key, { ns: meta.id }],
         });
+        if (Settings.withDefaults(registry.get(settingsAtom)).autoOpenAfterClip) {
+          void invoker.invokePromise(LayoutOperation.Open, { subject: [ack.id] });
+        }
       } else {
         const errorKey = ERROR_TOAST_BY_CODE[ack.error] ?? 'toast.error.internal.message';
         void invoker.invokePromise(LayoutOperation.AddToast, {

--- a/packages/plugins/plugin-crx/src/capabilities/install-page-actions.ts
+++ b/packages/plugins/plugin-crx/src/capabilities/install-page-actions.ts
@@ -8,6 +8,8 @@ import { Capabilities, Capability } from '@dxos/app-framework';
 import { LayoutOperation } from '@dxos/app-toolkit';
 import { log } from '@dxos/log';
 
+import { CrxCapabilities, Settings } from '#types';
+
 import { meta } from '../meta';
 import { installPageActionListeners } from '../page-actions';
 
@@ -15,6 +17,8 @@ export default Capability.makeModule(
   Effect.fnUntraced(function* () {
     const capabilityManager = yield* Capability.Service;
     const invoker = yield* Capability.get(Capabilities.OperationInvoker);
+    const registry = yield* Capability.get(Capabilities.AtomRegistry);
+    const settingsAtom = yield* Capability.get(CrxCapabilities.Settings);
 
     // NOTE: The `Label` tuple only supports `ns`/`count`/`defaultValue`, so the
     // success toast uses a plain key rather than interpolating the action label.
@@ -24,6 +28,9 @@ export default Capability.makeModule(
           id: `${meta.id}.page-action-${ack.objectId ?? ack.id}`,
           title: ['toast.page-action.success.title', { ns: meta.id }],
         });
+        if (ack.objectId && Settings.withDefaults(registry.get(settingsAtom)).autoOpenAfterClip) {
+          void invoker.invokePromise(LayoutOperation.Open, { subject: [ack.objectId] });
+        }
       } else {
         void invoker.invokePromise(LayoutOperation.AddToast, {
           id: `${meta.id}.page-action-error-${Date.now()}`,

--- a/packages/plugins/plugin-crx/src/listener.ts
+++ b/packages/plugins/plugin-crx/src/listener.ts
@@ -5,13 +5,13 @@
 import * as Either from 'effect/Either';
 import * as Schema from 'effect/Schema';
 
-import { type Capabilities, type CapabilityManager } from '@dxos/app-framework';
+import { Capabilities, type CapabilityManager } from '@dxos/app-framework';
 import { getActiveSpace } from '@dxos/app-toolkit';
 import { log } from '@dxos/log';
 import { ClientCapabilities } from '@dxos/plugin-client';
 import { SpaceOperation } from '@dxos/plugin-space';
 
-import { Clip } from '#types';
+import { Clip, CrxCapabilities, Settings } from '#types';
 
 import { mapClip } from './mapping';
 
@@ -38,6 +38,14 @@ export const handleClipEvent = async (
   capabilities: CapabilityManager.CapabilityManager,
   invoker: Invoker,
 ): Promise<Clip.Ack> => {
+  // Master toggle: when off, the bridge acks (so the extension does not time
+  // out) but ignores all extension-initiated actions.
+  const settingsAtom = capabilities.get(CrxCapabilities.Settings);
+  if (!Settings.withDefaults(capabilities.get(Capabilities.AtomRegistry).get(settingsAtom)).enabled) {
+    log.info('ignored clip: extension actions disabled in settings');
+    return { ok: false, error: 'disabled' };
+  }
+
   const envelope = Schema.decodeUnknownEither(Clip.Envelope)(detail);
   if (Either.isLeft(envelope)) {
     // Do NOT log `detail` — it can contain clipped page text/HTML which we

--- a/packages/plugins/plugin-crx/src/page-actions.test.ts
+++ b/packages/plugins/plugin-crx/src/page-actions.test.ts
@@ -42,6 +42,7 @@ const request = {
 
 const deps = (overrides: Partial<Parameters<typeof handleInvokeEvent>[1]> = {}) => ({
   getActions: () => [action],
+  getSettings: () => ({}),
   getTarget: () => ({}) as any, // Stub database; never dereferenced by the handler.
   invoke: async () => ({ data: { id: 'obj-1' }, error: undefined }),
   ...overrides,
@@ -66,6 +67,27 @@ describe('page-actions', () => {
   test('invoke happy path returns objectId', async ({ expect }) => {
     const ack = await handleInvokeEvent(request, deps());
     expect(ack).toEqual({ version: 1, id: 'req-1', ok: true, objectId: 'obj-1' });
+  });
+
+  test('invoke is ignored when extension actions are disabled', async ({ expect }) => {
+    let invoked = false;
+    const ack = await handleInvokeEvent(
+      request,
+      deps({
+        getSettings: () => ({ enabled: false }),
+        invoke: async () => {
+          invoked = true;
+          return { data: { id: 'obj-1' }, error: undefined };
+        },
+      }),
+    );
+    expect(ack).toEqual({ version: 1, id: 'req-1', ok: false, error: 'disabled' });
+    expect(invoked).toBe(false);
+  });
+
+  test('invoke honors an explicit enabled=true', async ({ expect }) => {
+    const ack = await handleInvokeEvent(request, deps({ getSettings: () => ({ enabled: true }) }));
+    expect(ack).toMatchObject({ ok: true, objectId: 'obj-1' });
   });
 
   test('invoke rejects unsupported version', async ({ expect }) => {

--- a/packages/plugins/plugin-crx/src/page-actions.ts
+++ b/packages/plugins/plugin-crx/src/page-actions.ts
@@ -5,13 +5,13 @@
 import * as Either from 'effect/Either';
 import * as Schema from 'effect/Schema';
 
-import { type Capabilities, type CapabilityManager } from '@dxos/app-framework';
+import { Capabilities, type CapabilityManager } from '@dxos/app-framework';
 import { getActiveSpace } from '@dxos/app-toolkit';
 import { type Database } from '@dxos/echo';
 import { log } from '@dxos/log';
 import { ClientCapabilities } from '@dxos/plugin-client';
 
-import { CrxCapabilities, PageAction } from '#types';
+import { CrxCapabilities, PageAction, Settings } from '#types';
 
 /**
  * Dependencies for the invoke handler, injected so the handler can be
@@ -20,6 +20,7 @@ import { CrxCapabilities, PageAction } from '#types';
  */
 export type InvokeDeps = {
   getActions: () => PageAction.PageAction[];
+  getSettings: () => Settings.Settings;
   getTarget: () => Database.Database | undefined;
   invoke: (
     operation: PageAction.PageAction['operation'],
@@ -61,6 +62,14 @@ export const handleInvokeEvent = async (detail: unknown, deps: InvokeDeps): Prom
   }
   // Best-effort id echo so the extension can correlate failure acks.
   const envelopeId = envelope.right.id ?? '';
+
+  // Master toggle: when off, the bridge acks (so the extension does not time
+  // out) but ignores all extension-initiated actions.
+  if (!Settings.withDefaults(deps.getSettings()).enabled) {
+    log.info('ignored page action: extension actions disabled in settings');
+    return { version: 1, id: envelopeId, ok: false, error: 'disabled' };
+  }
+
   if (envelope.right.version !== 1) {
     log.info('rejected unsupported page-action version', { version: envelope.right.version });
     return { version: 1, id: envelopeId, ok: false, error: 'unsupportedVersion' };
@@ -119,6 +128,7 @@ export const installPageActionListeners = (
     const detail = (event as CustomEvent).detail;
     const deps: InvokeDeps = {
       getActions,
+      getSettings: () => capabilities.get(Capabilities.AtomRegistry).get(capabilities.get(CrxCapabilities.Settings)),
       getTarget: () => {
         const client = capabilities.get(ClientCapabilities.Client);
         return getActiveSpace(client, capabilities)?.db;

--- a/packages/plugins/plugin-crx/src/translations.ts
+++ b/packages/plugins/plugin-crx/src/translations.ts
@@ -22,6 +22,7 @@ export const translations = [
         'toast.error.title': 'Clip failed',
         'toast.error.invalidPayload.message': 'Unrecognized clip payload.',
         'toast.error.unsupportedVersion.message': 'Unsupported clip version — update Composer.',
+        'toast.error.disabled.message': 'Extension actions are disabled in settings.',
         'toast.error.unsupportedKind.message': 'Unsupported clip kind.',
         'toast.error.noSpace.message': 'Open a space first.',
         'toast.error.internal.message': 'Failed to save clip.',

--- a/packages/plugins/plugin-crx/src/types/Clip.ts
+++ b/packages/plugins/plugin-crx/src/types/Clip.ts
@@ -88,6 +88,7 @@ export type Clip = Schema.Schema.Type<typeof Clip>;
  * Stable error codes:
  *   - `invalidPayload`       : schema decoding failed
  *   - `unsupportedVersion`   : envelope version not supported
+ *   - `disabled`             : extension actions are disabled in settings
  *   - `unsupportedKind`      : kind not recognized (future kinds)
  *   - `noSpace`              : no active space to write into
  *   - `internal`             : unexpected error during creation

--- a/packages/plugins/plugin-crx/src/types/PageAction.ts
+++ b/packages/plugins/plugin-crx/src/types/PageAction.ts
@@ -144,6 +144,7 @@ export type InvokeRequest = Schema.Schema.Type<typeof InvokeRequest>;
  * Stable error codes:
  *   - `invalidPayload`     : schema decoding failed
  *   - `unsupportedVersion` : envelope version not supported
+ *   - `disabled`           : extension actions are disabled in settings
  *   - `unknownAction`      : no registered action with that id
  *   - `noSpace`            : no active space to write into
  *   - `operationFailed`    : the target operation returned an error

--- a/packages/plugins/plugin-crx/src/types/Settings.ts
+++ b/packages/plugins/plugin-crx/src/types/Settings.ts
@@ -14,24 +14,24 @@ import * as Schema from 'effect/Schema';
 export const Settings = Schema.mutable(
   Schema.Struct({
     /**
-     * Master toggle. When false, the bridge plugin ignores incoming clips.
-     * Defaults to `true`.
+     * Master toggle. When false, the bridge plugin ignores incoming clips and
+     * page-action invocations. Defaults to `true`.
      */
     enabled: Schema.optional(
       Schema.Boolean.annotations({
-        title: 'Accept clips',
-        description: 'When off, clips sent from the composer-crx browser extension are ignored.',
+        title: 'Accept extension actions',
+        description: 'When off, clips and actions sent from the composer-crx browser extension are ignored.',
       }),
     ),
 
     /**
-     * Navigate to the created object after a successful clip. Defaults to
-     * `false` to avoid yanking focus during active work.
+     * Navigate to the created object after a successful clip or page action.
+     * Defaults to `false` to avoid yanking focus during active work.
      */
     autoOpenAfterClip: Schema.optional(
       Schema.Boolean.annotations({
         title: 'Open after clip',
-        description: 'Navigate to the created object when a clip is received.',
+        description: 'Navigate to the created object when a clip or page action succeeds.',
       }),
     ),
 


### PR DESCRIPTION
## What

The plugin-crx Settings schema exposed an `enabled` master toggle and an `autoOpenAfterClip` option, but nothing read either field — both bridge paths (clips and page-action invokes) ignored them.

- **`enabled` guard (both bridge paths).** `handleInvokeEvent` (page actions) gains a `getSettings` dep and early-returns a new stable `disabled` error code when the toggle is off; the guard sits after envelope decode so the request id is still echoed and the extension does not time out. `handleClipEvent` (clips) gets the same guard — its JSDoc already promised this behavior. The setting is read per-event via `Capabilities.AtomRegistry` + the `CrxCapabilities.Settings` atom with `Settings.withDefaults` (same pattern as plugin-deck's url-handler).
- **`autoOpenAfterClip`.** After a successful clip or page action, the install modules now invoke `LayoutOperation.Open` with the created object id when the setting is on (default remains off to avoid yanking focus).
- **Surfacing.** `disabled` added to the documented stable error codes in `PageAction.ts`/`Clip.ts`, a `toast.error.disabled.message` translation, the clip toast code map, and — since composer-crx keeps a hand-validated lockstep mirror — a `disabled` hint in the extension popup's `ERROR_HINTS`.
- **Schema/spec.** `Settings.ts` annotations updated (`enabled` retitled "Accept extension actions", covering clips and page actions); `PLUGIN.mdl` gains feature block `F-2c: Settings Enforcement`.
- **Tests.** `page-actions.test.ts` covers the disabled path (ack is `disabled`, request id echoed, the operation is never invoked) and explicit `enabled: true`.

## Why

A user toggling "Accept extension actions" off had no effect, and the documented "open after clip" behavior did not exist. This wires both settings to the documented semantics rather than removing them.

## Notes for reviewers

- Scope choice: the registry **list** path still returns descriptors when disabled — only invokes/clips are rejected. Gating `handleListEvent` so the popup hides actions entirely would be a small follow-up if preferred.
- Verified with `moon run plugin-crx:test` (29 passing), `plugin-crx:lint`, `composer-crx:lint`, and builds of both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extension actions can now be enabled or disabled via settings; disabled actions return a proper error response.
  * Auto-open functionality for created objects after successful clip or page action invocation.

* **Improvements**
  * Enhanced error messaging to clarify when extension actions are disabled in settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->