### PR TITLE
fix(docs): draft the capabilities blog post, add draft filtering support

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -58,6 +58,7 @@ export const collections = {
       featureImage: z.string().optional(),
       bskyPostUri: z.string().optional(),
       documentAtUri: z.string().optional(),
+      draft: z.boolean().default(false),
     }),
   }),
 };

--- a/docs/src/content/blog/2026-06-10-capabilities-how-composer-plugins-extend-each-other.md
+++ b/docs/src/content/blog/2026-06-10-capabilities-how-composer-plugins-extend-each-other.md
@@ -5,6 +5,7 @@ date: 2026-06-10
 description: A look at the capability mechanism in the DXOS app framework, which lets any plugin define typed extension points that other plugins implement — using comments as a worked example.
 author: Rich Burdon
 tags: [composer, plugins, architecture]
+draft: true
 ---
 
 Most plugin systems are one-way streets: the host application defines a fixed set of extension points, and plugins fill them in. Composer is built differently. In the DXOS app framework, _every plugin can define extension points_ — and every plugin can implement extension points defined by others. We call these typed contracts **capabilities**, and they are the reason Composer can be assembled from dozens of small plugins that compose without importing each other.

--- a/docs/src/pages/blog/[...slug].astro
+++ b/docs/src/pages/blog/[...slug].astro
@@ -13,7 +13,7 @@ import IconChevronRight from '../../components/svg/IconChevronRight.astro';
 const canonicalUrl = new URL(`/blog/${Astro.params.slug}`, Astro.site ?? 'https://dxos.org').href;
 
 export const getStaticPaths = async () => {
-  const posts = await getCollection('blog');
+  const posts = await getCollection('blog', ({ data }) => !data.draft);
   return posts.map((post) => ({
     params: { slug: post.data.slug },
     props: { post },

--- a/docs/src/pages/blog/index.astro
+++ b/docs/src/pages/blog/index.astro
@@ -7,7 +7,7 @@ import { getCollection } from 'astro:content';
 
 import BlogLayout from '../../layouts/BlogLayout.astro';
 
-const posts = (await getCollection('blog')).sort(
+const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
   (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
 );
 


### PR DESCRIPTION
## Summary

- Adds `draft: true` to the frontmatter of the June 2026 capabilities blog post to hide it from the live site
- Adds `draft: z.boolean().default(false)` to the blog collection schema in `content.config.ts`
- Filters out draft posts in both `blog/index.astro` (listing) and `blog/[...slug].astro` (`getStaticPaths`), so draft posts are excluded from the listing and produce no static routes

## Reviewer notes

The draft mechanism is now wired end-to-end: any post with `draft: true` in its frontmatter will be hidden from the listing and will 404 in production. To re-publish the capabilities post, remove the `draft: true` line from its frontmatter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added draft support for blog posts with automatic exclusion from published listings
  * One blog post has been marked as draft and will not appear in blog generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->