### PR TITLE
fix(plugin-pipeline): restore view query/target editing in pipeline properties

### DIFF
--- a/packages/plugins/plugin-pipeline/src/containers/PipelineProperties/PipelineProperties.tsx
+++ b/packages/plugins/plugin-pipeline/src/containers/PipelineProperties/PipelineProperties.tsx
@@ -77,11 +77,8 @@ export const PipelineProperties = ({ classNames, pipeline }: PipelinePropertiesP
       }
 
       const queue = target;
-      const query = queue
-        ? Query.fromAst(newQuery).from([
-            Scope.feed(`dxn:queue:data:${EID.getSpaceId(queue)}:${EID.getEntityId(queue)}`),
-          ])
-        : Query.fromAst(newQuery);
+      // Store the canonical EID so the feed scope round-trips against Feed.getQueueUri when reading the view back.
+      const query = queue ? Query.fromAst(newQuery).from([Scope.feed(String(queue))]) : Query.fromAst(newQuery);
       updateView((view) => {
         view.query.ast = query.ast as Mutable<typeof query.ast>;
       });
@@ -209,20 +206,18 @@ export const PipelineProperties = ({ classNames, pipeline }: PipelinePropertiesP
                           <Form.FieldSet />
                         </Form.Content>
                       </Form.Root>
-                      {type && (
-                        <ViewEditor
-                          ref={projectionRef}
-                          mode='tag'
-                          readonly
-                          type={type}
-                          view={column.view.target}
-                          registry={db?.graph.registry}
-                          db={db}
-                          tags={tags}
-                          types={types}
-                          onQueryChanged={handleQueryChanged}
-                        />
-                      )}
+                      <ViewEditor
+                        ref={projectionRef}
+                        mode='tag'
+                        readonly
+                        type={type}
+                        view={column.view.target}
+                        registry={db?.graph.registry}
+                        db={db}
+                        tags={tags}
+                        types={types}
+                        onQueryChanged={handleQueryChanged}
+                      />
                     </div>
                   )}
                 </List.Item>

--- a/packages/plugins/plugin-pipeline/src/containers/PipelineProperties/PipelineProperties.tsx
+++ b/packages/plugins/plugin-pipeline/src/containers/PipelineProperties/PipelineProperties.tsx
@@ -77,7 +77,6 @@ export const PipelineProperties = ({ classNames, pipeline }: PipelinePropertiesP
       }
 
       const queue = target;
-      // Store the canonical EID so the feed scope round-trips against Feed.getQueueUri when reading the view back.
       const query = queue ? Query.fromAst(newQuery).from([Scope.feed(String(queue))]) : Query.fromAst(newQuery);
       updateView((view) => {
         view.query.ast = query.ast as Mutable<typeof query.ast>;

--- a/packages/ui/react-ui-components/src/components/QueryForm/query.ts
+++ b/packages/ui/react-ui-components/src/components/QueryForm/query.ts
@@ -18,7 +18,11 @@ export const extractTypename = (query: QueryAST.Query): Option.Option<string> =>
       const filterTypename = extractTypenameFromFilter(q.filter);
       return Option.isSome(selectionTypename) ? selectionTypename : filterTypename;
     }),
+    // Wrapper clauses carry the inner query; recurse so a select wrapped by from/order/limit still resolves.
     Match.when({ type: 'options' }, (q) => extractTypename(q.query)),
+    Match.when({ type: 'from' }, (q) => extractTypename(q.query)),
+    Match.when({ type: 'order' }, (q) => extractTypename(q.query)),
+    Match.when({ type: 'limit' }, (q) => extractTypename(q.query)),
     Match.orElse(() => Option.none()),
   );
 };
@@ -33,7 +37,11 @@ export const extractTag = (query: QueryAST.Query): Option.Option<string> => {
       const filterTag = extractTagFromFilter(q.filter);
       return Option.isSome(filterTag) ? filterTag : selectionTag;
     }),
+    // Wrapper clauses carry the inner query; recurse so a select wrapped by from/order/limit still resolves.
     Match.when({ type: 'options' }, (q) => extractTag(q.query)),
+    Match.when({ type: 'from' }, (q) => extractTag(q.query)),
+    Match.when({ type: 'order' }, (q) => extractTag(q.query)),
+    Match.when({ type: 'limit' }, (q) => extractTag(q.query)),
     Match.orElse(() => Option.none()),
   );
 };

--- a/packages/ui/react-ui-components/src/components/QueryForm/query.ts
+++ b/packages/ui/react-ui-components/src/components/QueryForm/query.ts
@@ -18,7 +18,6 @@ export const extractTypename = (query: QueryAST.Query): Option.Option<string> =>
       const filterTypename = extractTypenameFromFilter(q.filter);
       return Option.isSome(selectionTypename) ? selectionTypename : filterTypename;
     }),
-    // Wrapper clauses carry the inner query; recurse so a select wrapped by from/order/limit still resolves.
     Match.when({ type: 'options' }, (q) => extractTypename(q.query)),
     Match.when({ type: 'from' }, (q) => extractTypename(q.query)),
     Match.when({ type: 'order' }, (q) => extractTypename(q.query)),
@@ -37,7 +36,6 @@ export const extractTag = (query: QueryAST.Query): Option.Option<string> => {
       const filterTag = extractTagFromFilter(q.filter);
       return Option.isSome(filterTag) ? filterTag : selectionTag;
     }),
-    // Wrapper clauses carry the inner query; recurse so a select wrapped by from/order/limit still resolves.
     Match.when({ type: 'options' }, (q) => extractTag(q.query)),
     Match.when({ type: 'from' }, (q) => extractTag(q.query)),
     Match.when({ type: 'order' }, (q) => extractTag(q.query)),

--- a/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
+++ b/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
@@ -38,7 +38,7 @@ import {
 
 export type ViewEditorProps = ThemedClassName<
   {
-    type: Type.AnyEntity;
+    type?: Type.AnyEntity;
     view: View.View;
     mode?: 'schema' | 'tag';
     registry?: Registry.Registry;
@@ -52,7 +52,7 @@ export type ViewEditorProps = ThemedClassName<
 /**
  * Schema-based object form.
  */
-export const ViewEditor = forwardRef<ProjectionModel, ViewEditorProps>(
+export const ViewEditor = forwardRef<ProjectionModel | null, ViewEditorProps>(
   (
     {
       classNames,
@@ -71,10 +71,13 @@ export const ViewEditor = forwardRef<ProjectionModel, ViewEditorProps>(
     forwardedRef,
   ) => {
     const atomRegistry = useContext(RegistryContext);
-    const schemaReadonly = Type.getDatabase(type) == null;
+    const schemaReadonly = type == null || Type.getDatabase(type) == null;
     const { t } = useTranslation(translationKey);
 
     const projectionModel = useMemo(() => {
+      if (!type) {
+        return null;
+      }
       const jsonSchema = type.jsonSchema;
 
       // Always use createEchoChangeCallback since the view is ECHO-backed.
@@ -91,7 +94,11 @@ export const ViewEditor = forwardRef<ProjectionModel, ViewEditorProps>(
       return model;
     }, [atomRegistry, type, view]);
 
-    useImperativeHandle(forwardedRef, () => projectionModel, [projectionModel]);
+    useImperativeHandle<ProjectionModel | null, ProjectionModel | null>(
+      forwardedRef,
+      () => projectionModel,
+      [projectionModel],
+    );
 
     const queueTarget = Match.value(view.query.ast).pipe(
       Match.when({ type: 'from' }, ({ from }) => {
@@ -113,7 +120,12 @@ export const ViewEditor = forwardRef<ProjectionModel, ViewEditorProps>(
       if (!queueTarget) {
         return undefined;
       }
-      const feed = feeds.find((feed) => Feed.getQueueUri(feed)?.toString() === queueTarget);
+      // Normalize via EID so legacy (dxn:queue:…) and canonical (echo://…) feed URIs compare equal.
+      const targetEid = EID.tryParse(queueTarget);
+      const feed = feeds.find((feed) => {
+        const feedEid = Feed.getQueueUri(feed);
+        return feedEid != null && targetEid != null && EID.equals(feedEid, targetEid);
+      });
       return feed ? Ref.fromURI(Entity.getURI(feed)) : undefined;
     }, [queueTarget, feeds]);
 
@@ -199,22 +211,28 @@ export const ViewEditor = forwardRef<ProjectionModel, ViewEditorProps>(
         <Form.Root schema={viewSchema} values={viewValues} fieldMap={fieldMap} db={db} onValuesChanged={handleUpdate}>
           <Form.FieldSet />
 
-          <FormFieldLabel label={t('fields.label')} asChild />
-          <FieldList
-            type={type}
-            view={view}
-            registry={registry}
-            readonly={readonly}
-            showHeading={showHeading}
-            onDelete={handleDelete}
-          />
+          {type && (
+            <>
+              <FormFieldLabel label={t('fields.label')} asChild />
+              <FieldList
+                type={type}
+                view={view}
+                registry={registry}
+                readonly={readonly}
+                showHeading={showHeading}
+                onDelete={handleDelete}
+              />
+            </>
+          )}
         </Form.Root>
       </div>
     );
   },
 );
 
-type FieldListProps = Pick<ViewEditorProps, 'type' | 'view' | 'registry' | 'readonly' | 'showHeading' | 'onDelete'>;
+type FieldListProps = Omit<Pick<ViewEditorProps, 'type' | 'view' | 'registry' | 'readonly' | 'showHeading' | 'onDelete'>, 'type'> & {
+  type: Type.AnyEntity;
+};
 
 const FieldList = ({ type, view, registry, readonly, showHeading = false, onDelete }: FieldListProps) => {
   const atomRegistry = useContext(RegistryContext);

--- a/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
+++ b/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
@@ -94,11 +94,9 @@ export const ViewEditor = forwardRef<ProjectionModel | null, ViewEditorProps>(
       return model;
     }, [atomRegistry, type, view]);
 
-    useImperativeHandle<ProjectionModel | null, ProjectionModel | null>(
-      forwardedRef,
-      () => projectionModel,
-      [projectionModel],
-    );
+    useImperativeHandle<ProjectionModel | null, ProjectionModel | null>(forwardedRef, () => projectionModel, [
+      projectionModel,
+    ]);
 
     const queueTarget = Match.value(view.query.ast).pipe(
       Match.when({ type: 'from' }, ({ from }) => {
@@ -229,7 +227,10 @@ export const ViewEditor = forwardRef<ProjectionModel | null, ViewEditorProps>(
   },
 );
 
-type FieldListProps = Omit<Pick<ViewEditorProps, 'type' | 'view' | 'registry' | 'readonly' | 'showHeading' | 'onDelete'>, 'type'> & {
+type FieldListProps = Omit<
+  Pick<ViewEditorProps, 'type' | 'view' | 'registry' | 'readonly' | 'showHeading' | 'onDelete'>,
+  'type'
+> & {
   type: Type.AnyEntity;
 };
 

--- a/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
+++ b/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
@@ -120,7 +120,6 @@ export const ViewEditor = forwardRef<ProjectionModel | null, ViewEditorProps>(
       if (!queueTarget) {
         return undefined;
       }
-      // Normalize via EID so legacy (dxn:queue:…) and canonical (echo://…) feed URIs compare equal.
       const targetEid = EID.tryParse(queueTarget);
       const feed = feeds.find((feed) => {
         const feedEid = Feed.getQueueUri(feed);


### PR DESCRIPTION
## Summary

The pipeline view properties panel had regressed so that adding a view only let you edit its **name** — the query type and target feed could no longer be configured, and even when set, the values failed to round-trip when reopening the form.

This fixes three distinct causes:

### 1. ViewEditor never rendered for a new view
`ViewEditor` was gated behind a resolved `type`, but a freshly-added view starts from `Filter.nothing()`, which resolves no type. Since the query form (the only way to *pick* a type) lives inside `ViewEditor`, it never appeared — a chicken-and-egg deadlock.

`type` is now optional on `ViewEditor`; the query form renders unconditionally and only the field list is gated on a resolved type.

### 2. Query dropdown reverted to "None" after setting a target feed
Setting a target feed wraps the query AST in a `from` scope node (`{ type: 'from', query: { select… }, from: { scope } }`). `QueryForm`'s `extractTypename`/`extractTag` descended through `select`, `filter`, and `options` nodes but **not** the `from`/`order`/`limit` wrapper clauses, so the typename no longer resolved and the dropdown showed "None".

Both extractors now recurse through the wrapper clauses (all of which carry an inner `.query`).

### 3. Target Feed field came back empty
`PipelineProperties` wrote the feed scope as a legacy `dxn:queue:data:<space>:<entity>` string, while the read-back in `ViewEditor` compared against `Feed.getQueueUri(feed).toString()` — the canonical `echo://<space>/<entity>` form. The two never matched, so the target never repopulated (though the query still *worked*, since the executor normalizes legacy URIs).

Fixed by writing the canonical EID (`String(queue)`, consistent with `Query.from()`) **and** normalizing both sides via `EID.equals` on read so any already-stored legacy URIs still resolve.

## Testing

- `react-ui-form`, `react-ui-components`, `plugin-pipeline` build clean.
- `ViewEditor.test.tsx` (and the full `react-ui-form` suite, 39 tests) pass.
- No new casts introduced (audited per repo guidelines; widened the `forwardRef` handle type to `ProjectionModel | null` rather than asserting non-null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended query form support for additional query node types (from, order, limit operations)
  * Improved view editor component flexibility with optional type handling

* **Refactor**
  * Optimized queue-based query scope mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->