### PR TITLE
fix(plugin-support): hide Discord companion by default, gate on setting

### DIFF
--- a/packages/plugins/plugin-support/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-support/src/capabilities/app-graph-builder.ts
@@ -11,7 +11,7 @@ import { Operation } from '@dxos/compute';
 import { linkedSegment } from '@dxos/react-ui-attention';
 
 import { meta } from '#meta';
-import { HelpCapabilities, HelpOperation } from '#types';
+import { HelpCapabilities, HelpOperation, SupportCapabilities } from '#types';
 
 import { SHORTCUTS_DIALOG, SPACE_HOME_NODE_TYPE } from '../constants';
 
@@ -29,6 +29,9 @@ const SPACE_HOME_NODE_LABEL: LabelTuple = ['space-home-node.label', { ns: meta.i
 
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
+    const capabilities = yield* Capability.Service;
+    const settingsAtom = capabilities.get(SupportCapabilities.Settings);
+
     const extensions = yield* Effect.all([
       // Root actions: open welcome tour + open shortcuts.
       GraphBuilder.createExtension({
@@ -110,11 +113,16 @@ export default Capability.makeModule(
 
       // Deck companion: Discord community tab in the complementary sidebar (R1).
       // Renders the Discord widget iframe via the `deck-companion--discord` surface.
+      // Hidden by default; toggled via the showDiscordCompanion setting.
       GraphBuilder.createExtension({
         id: 'discord',
         match: NodeMatcher.whenRoot,
-        connector: () =>
-          Effect.succeed([
+        connector: (_root, get) => {
+          const settings = get(settingsAtom);
+          if (!settings.showDiscordCompanion) {
+            return Effect.succeed([]);
+          }
+          return Effect.succeed([
             AppNode.makeDeckCompanion({
               id: linkedSegment('discord'),
               label: DISCORD_LABEL,
@@ -122,7 +130,8 @@ export default Capability.makeModule(
               data: null,
               position: 'first',
             }),
-          ]),
+          ]);
+        },
       }),
 
       // Per-space Home virtual node, hoisted to the top of every space's navtree. The node is fully

--- a/packages/plugins/plugin-support/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-support/src/capabilities/react-surface.tsx
@@ -3,6 +3,7 @@
 //
 
 import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
 import React from 'react';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
@@ -102,8 +103,11 @@ export default Capability.makeModule(() =>
           const client = useClient();
           const { invokePromise } = useOperationInvoker();
           const personal = getPersonalSpace(client);
-          const [, updateProperties] = useObject(personal?.properties);
+          const [properties, updateProperties] = useObject(personal?.properties);
           const { settings, updateSettings } = useSettingsState<Settings.Settings>(subject.atom);
+          const welcomeDismissed = properties
+            ? Annotation.get(properties, WelcomeDismissedAnnotation).pipe(Option.getOrElse(() => false))
+            : false;
           const handleShowWelcome = () => {
             if (!personal) {
               return;
@@ -113,7 +117,11 @@ export default Capability.makeModule(() =>
             void invokePromise(LayoutOperation.Open, { subject: [getSpaceHomePath(personal.id)], workspace });
           };
           return (
-            <SupportSettings settings={settings} onSettingsChange={updateSettings} onShowWelcome={handleShowWelcome} />
+            <SupportSettings
+              settings={settings}
+              onSettingsChange={updateSettings}
+              onShowWelcome={welcomeDismissed ? handleShowWelcome : undefined}
+            />
           );
         },
       }),

--- a/packages/plugins/plugin-support/src/components/SupportSettings/SupportSettings.tsx
+++ b/packages/plugins/plugin-support/src/components/SupportSettings/SupportSettings.tsx
@@ -21,9 +21,11 @@ export const SupportSettings = ({ settings, onSettingsChange, onShowWelcome }: S
   return (
     <SettingsForm.Viewport>
       <SettingsForm.Section title={t('settings.title', { ns: meta.id })}>
-        <SettingsForm.Item title={t('show-welcome.label')}>
-          <Button onClick={onShowWelcome}>{t('show-welcome.label')}</Button>
-        </SettingsForm.Item>
+        {onShowWelcome && (
+          <SettingsForm.Item title={t('show-welcome.label')}>
+            <Button onClick={onShowWelcome}>{t('show-welcome.label')}</Button>
+          </SettingsForm.Item>
+        )}
         <SettingsForm.FieldSet
           readonly={!onSettingsChange}
           schema={Settings.Settings}

--- a/packages/plugins/plugin-support/src/types/Settings.ts
+++ b/packages/plugins/plugin-support/src/types/Settings.ts
@@ -13,6 +13,12 @@ export const Settings = Schema.Struct({
       description: 'Show the "Create GitHub Issue" button in the feedback panel.',
     }),
   ),
+  showDiscordCompanion: Schema.optional(
+    Schema.Boolean.annotations({
+      title: 'Show Discord community panel',
+      description: 'Show the Discord community tab in the sidebar.',
+    }),
+  ),
 });
 
 export interface Settings extends Schema.Schema.Type<typeof Settings> {}


### PR DESCRIPTION
## Summary

- **Discord companion hidden by default**: The Discord deck companion (sidebar tab) is now off by default. Users can enable it via a new **"Show Discord community panel"** toggle in Settings → Support. The connector reads the settings atom reactively so the tab appears/disappears immediately without a reload.
- **"Show welcome" button is conditional**: The "Show welcome" button in Support settings now only renders when the welcome content has actually been dismissed (i.e. `WelcomeDismissedAnnotation` is `true` on the personal space properties). Previously it always appeared.

## Changes

- `Settings.ts` — adds `showDiscordCompanion: Schema.optional(Schema.Boolean)` with title/description annotations; the existing `SettingsForm.FieldSet` auto-renders the checkbox.
- `app-graph-builder.ts` — yields `Capability.Service` to obtain the settings atom, then passes it into the Discord connector via `get(settingsAtom)` (reactive — the companion node is added/removed as the setting changes).
- `react-surface.tsx` — reads `WelcomeDismissedAnnotation` from personal space properties and only passes `onShowWelcome` when dismissed.
- `SupportSettings.tsx` — wraps the "Show welcome" item in `{onShowWelcome && ...}`.

## Test plan

- [ ] Open Composer → confirm Discord tab is absent from the complementary sidebar by default.
- [ ] Open Settings → Support → enable "Show Discord community panel" → confirm Discord tab appears in the sidebar immediately.
- [ ] Disable the setting → confirm Discord tab disappears.
- [ ] With welcome content visible (not dismissed), open Settings → Support → confirm "Show welcome" button is absent.
- [ ] Dismiss the welcome content → open Settings → Support → confirm "Show welcome" button appears and clicking it restores the welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting to control visibility of the Discord community panel in the sidebar.
  * Enhanced welcome dialog handling to respect user dismissal preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->