### PR TITLE
fix(plugin-space): remove archived-spaces settings toggle

### DIFF
--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
@@ -196,7 +196,7 @@ export const createSpaceExtensions = Effect.fnUntraced(function* () {
                 .sort((sortA, sortB) => orderMap.get(sortA.id)! - orderMap.get(sortB.id)!),
               ...spaces.filter((space) => !orderMap.has(space.id)),
             ]
-              .filter((space, idx) => (settings?.showHidden ? true : spaceStates[idx] !== SpaceState.SPACE_INACTIVE))
+              .filter((space, idx) => spaceStates[idx] !== SpaceState.SPACE_INACTIVE)
               .filter((space) => space.tags.length === 0 || isPersonalSpace(space) || isExemplarSpace(space))
               .map((space) =>
                 constructSpaceNode({

--- a/packages/plugins/plugin-space/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-space/src/capabilities/react-surface.tsx
@@ -9,7 +9,7 @@ import * as SchemaAST from 'effect/SchemaAST';
 import React, { type ComponentProps, useCallback } from 'react';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
-import { Surface, useAtomCapability, useOperationInvoker, useSettingsState } from '@dxos/app-framework/ui';
+import { Surface, useAtomCapability, useOperationInvoker } from '@dxos/app-framework/ui';
 import { RootCollectionAnnotation } from '@dxos/app-toolkit';
 import { AppSurface, useActiveSpace, useTypeOptions } from '@dxos/app-toolkit/ui';
 import { Annotation, Collection, Database, Entity, Obj, Type } from '@dxos/echo';
@@ -50,7 +50,6 @@ import {
   HueAnnotationId,
   IconAnnotationId,
   SpaceCapabilities,
-  type Settings,
   type TypeInputOptions,
   TypeInputOptionsAnnotationId,
 } from '#types';
@@ -86,14 +85,11 @@ export default Capability.makeModule(
       Surface.create({
         id: 'pluginSettings',
         filter: AppSurface.settings(AppSurface.Article, meta.id),
-        component: ({ data: { subject } }) => {
-          const { settings, updateSettings } = useSettingsState<Settings.Settings>(subject.atom);
-          const spaces = useSpaces({ all: settings.showHidden });
+        component: () => {
+          const spaces = useSpaces();
           const { invokePromise } = useOperationInvoker();
           return (
             <SpaceSettings
-              settings={settings}
-              onSettingsChange={updateSettings}
               spaces={spaces}
               onOpenSpaceSettings={(space: Space) => invokePromise(SpaceOperation.OpenSettings, { space })}
             />

--- a/packages/plugins/plugin-space/src/capabilities/settings.ts
+++ b/packages/plugins/plugin-space/src/capabilities/settings.ts
@@ -16,9 +16,7 @@ export default Capability.makeModule(() =>
     const settingsAtom = createKvsStore({
       key: meta.id,
       schema: Settings.Settings,
-      defaultValue: () => ({
-        showHidden: false,
-      }),
+      defaultValue: () => ({}),
     });
 
     return [

--- a/packages/plugins/plugin-space/src/components/SpaceSettings/SpaceSettings.stories.tsx
+++ b/packages/plugins/plugin-space/src/components/SpaceSettings/SpaceSettings.stories.tsx
@@ -26,9 +26,5 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {
-    settings: {
-      showHidden: false,
-    },
-  },
+  args: {},
 };

--- a/packages/plugins/plugin-space/src/components/SpaceSettings/SpaceSettings.tsx
+++ b/packages/plugins/plugin-space/src/components/SpaceSettings/SpaceSettings.tsx
@@ -5,38 +5,25 @@
 import React from 'react';
 
 import { isPersonalSpace } from '@dxos/app-toolkit';
-import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { type Space } from '@dxos/react-client/echo';
 import { IconButton, Input, List, ListItem, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { Settings as SettingsForm } from '@dxos/react-ui-form';
 
 import { meta } from '#meta';
-import { type Settings } from '#types';
 
 import { getSpaceDisplayName } from '../../util';
 
-export type SpaceSettingsProps = AppSurface.SettingsArticleProps<
-  Settings.Settings,
-  {
-    spaces?: Space[];
-    onOpenSpaceSettings?: (space: Space) => void;
-  }
->;
+export type SpaceSettingsProps = {
+  spaces?: Space[];
+  onOpenSpaceSettings?: (space: Space) => void;
+};
 
-export const SpaceSettings = ({ settings, onSettingsChange, spaces, onOpenSpaceSettings }: SpaceSettingsProps) => {
+export const SpaceSettings = ({ spaces, onOpenSpaceSettings }: SpaceSettingsProps) => {
   const { t } = useTranslation(meta.id);
 
   return (
     <SettingsForm.Viewport>
       <SettingsForm.Section title={t('space-settings.label')} description={t('space-settings.description')}>
-        <SettingsForm.Item title={t('show-hidden-spaces.label')} description={t('show-hidden-spaces.description')}>
-          <Input.Switch
-            disabled={!onSettingsChange}
-            checked={settings.showHidden}
-            onCheckedChange={(checked) => onSettingsChange?.((state) => ({ ...state, showHidden: !!checked }))}
-          />
-        </SettingsForm.Item>
-
         <SettingsForm.Panel>
           <Input.Root>
             <Input.Label>{t('settings.space-list.label')}</Input.Label>

--- a/packages/plugins/plugin-space/src/operations/open-settings.ts
+++ b/packages/plugins/plugin-space/src/operations/open-settings.ts
@@ -11,7 +11,7 @@ const handler: Operation.WithHandler<typeof SpaceOperation.OpenSettings> = Space
   Operation.withHandler(
     Effect.fnUntraced(function* (input) {
       yield* Operation.invoke(LayoutOperation.Open, {
-        subject: [`${getSpacePath(input.space.id)}/general`],
+        subject: [`${getSpacePath(input.space.id)}/settings/general`],
         workspace: getSpacePath(input.space.id),
       });
     }),

--- a/packages/plugins/plugin-space/src/translations.ts
+++ b/packages/plugins/plugin-space/src/translations.ts
@@ -151,9 +151,6 @@ export const translations = [
         'space-settings.label': 'Spaces',
         'space-settings.description':
           'Per-space settings for properties, membership, integrations, and other space-specific objects.',
-        'show-hidden-spaces.label': 'Show archived spaces',
-        'show-hidden-spaces.description':
-          'Display archived spaces in the sidebar so they can be accessed or unarchived.',
         'save-files-to-directory.label': 'Save files to disk',
         'select-path.label': 'Select path',
         'snapshot-by-schema.label': 'Snapshot of objects',
@@ -267,11 +264,6 @@ export const translations = [
         'hue.description': 'Color used to represent the space in the app.',
         'edge-replication.description':
           "Only change this if you know what you're doing. Disabling this will prevent the space from replicating through Composer's EDGE services, and relies solely on peer-to-peer sync.",
-        'archive-space.description':
-          'Archiving a space will remove it from the sidebar and stop replicating updates, but will not delete the data. Unarchive by enabling archived spaces in the app settings.',
-        'archive-space.label': 'Archive',
-        'unarchive-space.label': 'Unarchive',
-
         'space-key.title': 'Space Key',
         'space-key.description': 'The unique identifier for this space. Use this to connect external services.',
         'copy-space-key.label': 'Copy space key',

--- a/packages/plugins/plugin-space/src/types/Settings.ts
+++ b/packages/plugins/plugin-space/src/types/Settings.ts
@@ -6,13 +6,6 @@
 
 import * as Schema from 'effect/Schema';
 
-export const Settings = Schema.mutable(
-  Schema.Struct({
-    /**
-     * Show closed spaces.
-     */
-    showHidden: Schema.Boolean,
-  }),
-);
+export const Settings = Schema.mutable(Schema.Struct({}));
 
 export interface Settings extends Schema.Schema.Type<typeof Settings> {}


### PR DESCRIPTION
## Summary

- Removes the "Show archived spaces" toggle from the plugin-space settings panel — the space archiving feature no longer exists so this setting was dead UI
- Simplifies `SpaceSettings` component props (no longer carries `settings`/`onSettingsChange`)
- Drops orphaned translation keys: `show-hidden-spaces.*`, `archive-space.*`, `unarchive-space.*`
- The graph builder now unconditionally filters `SPACE_INACTIVE` spaces — legacy archived spaces stay hidden, and DevTools still exposes `open()`/`close()` for low-level control

## What changed

| File | Change |
|------|--------|
| `types/Settings.ts` | Removed `showHidden` field (empty struct) |
| `capabilities/settings.ts` | Removed `showHidden: false` default |
| `components/SpaceSettings/SpaceSettings.tsx` | Removed toggle item, simplified props |
| `components/SpaceSettings/SpaceSettings.stories.tsx` | Removed `settings` story arg |
| `capabilities/react-surface.tsx` | Dropped `useSettingsState` + `settings.showHidden` |
| `capabilities/app-graph-builder/extensions/spaces.ts` | Always filter `SPACE_INACTIVE` |
| `translations.ts` | Removed 5 orphaned translation keys |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the "show hidden spaces" toggle from the space settings interface
  * Simplified the space settings UI and wiring to initialize space list directly
* **Behavior Change**
  * Inactive (hidden/archived) spaces are now consistently excluded from the displayed list
* **Chores**
  * Default settings shape simplified; story and translation entries for hidden/archive options removed
* **UX**
  * Space settings now open to the general settings section within a space
<!-- end of auto-generated comment: release notes by coderabbit.ai -->