### PR TITLE
fix(plugin-code): make plugin spec node reactive to runtime enable/disable

### DIFF
--- a/packages/plugins/plugin-code/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-code/src/capabilities/app-graph-builder.ts
@@ -26,15 +26,11 @@ import { makePluginSpecSubject } from '../plugin-spec';
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
     // Fire the asset-contribution event so each plugin's `addPluginAssetModule`
-    // has activated by the time the graph queries the registry. The connector
-    // below reads contributions live (via `capabilities.getAll`) so that
-    // plugins enabled later in the session also get spec nodes.
+    // has activated by the time the graph queries the registry.
     yield* Plugin.activate(AppActivationEvents.SetupPluginAssets);
-    const capabilities = yield* Capability.Service;
-    const resolveSpecContent = (pluginId: string, specPath: string): string | undefined =>
-      capabilities
-        .getAll(AppCapabilities.PluginAsset)
-        .find((entry) => entry.pluginId === pluginId && entry.path === specPath)?.content;
+    // Subscribe to the reactive asset atom so the connector re-runs when a
+    // plugin enabled later in the session contributes (or removes) its spec.
+    const pluginAssetsAtom = yield* Capability.atom(AppCapabilities.PluginAsset);
 
     const extensions = yield* Effect.all([
       // Per-plugin `spec` child node, attached to the registry's
@@ -49,13 +45,15 @@ export default Capability.makeModule(
       GraphBuilder.createExtension({
         id: 'pluginSpec',
         match: NodeMatcher.whenNodeType('org.dxos.plugin'),
-        connector: (node) => {
+        connector: (node, get) => {
           const plugin = node.data as PluginNS.Plugin;
           const { id, name, spec } = plugin.meta;
           if (!spec) {
             return Effect.succeed([]);
           }
-          const content = resolveSpecContent(id, spec);
+          const content = get(pluginAssetsAtom).find(
+            (entry) => entry.pluginId === id && entry.path === spec,
+          )?.content;
           if (!content) {
             return Effect.succeed([]);
           }

--- a/packages/plugins/plugin-code/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-code/src/capabilities/app-graph-builder.ts
@@ -51,9 +51,7 @@ export default Capability.makeModule(
           if (!spec) {
             return Effect.succeed([]);
           }
-          const content = get(pluginAssetsAtom).find(
-            (entry) => entry.pluginId === id && entry.path === spec,
-          )?.content;
+          const content = get(pluginAssetsAtom).find((entry) => entry.pluginId === id && entry.path === spec)?.content;
           if (!content) {
             return Effect.succeed([]);
           }


### PR DESCRIPTION
## Summary

- The **"Open Specification"** button in the plugin registry was only visible for plugins enabled at app startup. Enabling a plugin at runtime showed no button until the page was reloaded.
- Root cause: the `pluginSpec` graph extension in `plugin-code` captured a one-time snapshot of contributed `PluginAsset` capabilities via `capabilities.getAll()` at module init, so the graph connector had no reactive dependency on asset changes.
- Fix: replace the snapshot with `Capability.atom(AppCapabilities.PluginAsset)`, a reactive `Atom.Atom<PluginAsset[]>`. The connector reads it via `get()`, registering a live dependency. Now whenever a plugin is enabled (its `SetupPluginAssets` module fires and contributes the asset) or disabled (asset is removed), the graph extension re-runs automatically — no reload needed.

## Changed file

- `packages/plugins/plugin-code/src/capabilities/app-graph-builder.ts` — swap `Capability.Service` + `getAll()` for `Capability.atom()`, pass `get` into the connector, read assets reactively.

## Reviewer notes

The `Plugin.activate(AppActivationEvents.SetupPluginAssets)` call is preserved — it ensures already-enabled plugins' assets are present before the graph first builds. The new reactive atom subscription then keeps it up to date for any subsequent enable/disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Plugin specification handling now updates reactively during a session: when plugins contribute or remove assets, the app’s plugin spec graph updates automatically without requiring a manual refresh.
  * No public or exported interfaces were changed; existing integrations should continue to work while benefiting from live updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->