### PR TITLE
fix(composer-app): correct Storybook path in welcome-focus e2e config

### DIFF
--- a/packages/apps/composer-app/src/playwright/playwright-welcome-focus.config.ts
+++ b/packages/apps/composer-app/src/playwright/playwright-welcome-focus.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   testMatch: '**/welcome-focus.spec.ts',
   timeout: 120_000,
   webServer: {
-    command: 'pnpm --dir ../../../tools/storybook-react exec storybook dev --port 9009 --no-open --ci',
+    command: 'pnpm --dir ../../../../../tools/storybook-react exec storybook dev --port 9009 --no-open --ci',
     port: 9009,
     reuseExistingServer: true,
     timeout: 300_000,


### PR DESCRIPTION
## Summary
Follow-up to #11804 — fixes the `webServer` Storybook path in `playwright-welcome-focus.config.ts`. Playwright runs the command from the config directory (`src/playwright/`), so the path needs five `../` segments to reach `tools/storybook-react` at the repo root.

## Test plan
- [x] `moon run composer-app:e2e-welcome-focus` — both tests pass locally


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration for improved build setup consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->