### PR TITLE
refactor(types): drop unused completedAt from HasSubject relation

### DIFF
--- a/packages/plugins/plugin-inbox/src/operations/classify-email.ts
+++ b/packages/plugins/plugin-inbox/src/operations/classify-email.ts
@@ -107,7 +107,6 @@ const handler: Operation.WithHandler<typeof InboxOperation.ClassifyEmail> = Inbo
             ...message,
             id: message.id,
           }),
-          completedAt: new Date().toISOString(),
         });
 
         yield* Feed.append(feed, [relation]);

--- a/packages/plugins/plugin-script/src/templates/commentary.ts
+++ b/packages/plugins/plugin-script/src/templates/commentary.ts
@@ -187,7 +187,6 @@ export default Commentary.pipe(
             Relation.make(HasSubject.HasSubject, {
               [Relation.Source]: document,
               [Relation.Target]: chessGame,
-              completedAt: new Date().toISOString(),
             }),
           );
         } else {

--- a/packages/sdk/types/src/types/HasSubject.ts
+++ b/packages/sdk/types/src/types/HasSubject.ts
@@ -7,14 +7,9 @@
 import * as Schema from 'effect/Schema';
 
 import { DXN, Obj, Relation, Type } from '@dxos/echo';
-import { Format } from '@dxos/echo/Format';
 
-/**
- * @deprecated Reconcile with AnchoredTo?
- */
 export const HasSubject = Schema.Struct({
   id: Obj.ID,
-  completedAt: Format.DateTime,
 }).pipe(
   Type.makeRelation({
     dxn: DXN.make('org.dxos.relation.hasSubject', '0.1.0'),
@@ -23,8 +18,5 @@ export const HasSubject = Schema.Struct({
   }),
 );
 
-/**
- * @deprecated Reconcile with AnchoredTo?
- */
 export type HasSubject = Type.InstanceType<typeof HasSubject>;
 export const make = (props: Relation.MakeProps<typeof HasSubject>) => Relation.make(HasSubject, props);


### PR DESCRIPTION
## What

- Remove the `completedAt` field from the `HasSubject` relation schema. It was **write-only** — set in `classify-email` and the `commentary` script template but never read anywhere.
- Remove the two `completedAt: new Date().toISOString()` write sites that fed it.
- Drop the `@deprecated Reconcile with AnchoredTo?` notes (and the now-unused `Format` import).

## Why

`HasSubject` ("Message is about subject X") and `AnchoredTo` ("Thread anchored at a position in a doc") are genuinely distinct relations, so they stay separate rather than being merged. The only thing tying them together was an open `@deprecated` question and a dead field, both removed.

## Reviewer notes

- The `org.dxos.relation.hasSubject` DXN is **unchanged**, so existing persisted relations still match `Filter.type(HasSubject)`.
- `completedAt` is removed with no replacement because nothing read it.
- Verified `types`, `plugin-inbox`, and `plugin-script` builds pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized email classification process by removing unnecessary completion timestamp tracking from classified messages.
  * Simplified commentary and document generation by eliminating redundant timestamp fields from relation tracking.
  * Updated core relation schema definitions to improve code maintainability and reduce system complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->