### PR TITLE
fix(react-ui-list): compose caller onClick with internal toggle in OrderedList

### DIFF
--- a/packages/ui/react-ui-list/src/components/OrderedList/OrderedListItem.tsx
+++ b/packages/ui/react-ui-list/src/components/OrderedList/OrderedListItem.tsx
@@ -69,13 +69,22 @@ export const OrderedListDragHandle = () => {
 /** Clickable title; clicking toggles the item's expanded state. */
 export const OrderedListTitle = ({
   classNames,
+  onClick,
   children,
   ...props
 }: ThemedClassName<PropsWithChildren<ComponentProps<'div'>>>) => {
   const { id, toggle } = useOrderedListItemContext('OrderedListTitle');
   // The title carries a stable id so the expanded panel can name itself via `aria-labelledby`.
   return (
-    <List.ItemTitle id={`${id}-title`} classNames={classNames} onClick={toggle} {...props}>
+    <List.ItemTitle
+      id={`${id}-title`}
+      classNames={classNames}
+      onClick={(event) => {
+        toggle();
+        onClick?.(event);
+      }}
+      {...props}
+    >
       {children}
     </List.ItemTitle>
   );
@@ -91,7 +100,7 @@ export const OrderedListDeleteButton = ({
 );
 
 /** Expand/collapse caret; reflects and toggles the item's expanded state. */
-export const OrderedListExpandCaret = (props: Partial<IconButtonProps>) => {
+export const OrderedListExpandCaret = ({ onClick, ...props }: Partial<IconButtonProps>) => {
   const { t } = useTranslation(osTranslations);
   const { id, expanded, toggle } = useOrderedListItemContext('OrderedListExpandCaret');
   // Disclosure semantics: this button controls the expanded panel so assistive tech can
@@ -105,7 +114,10 @@ export const OrderedListExpandCaret = (props: Partial<IconButtonProps>) => {
       label={t('toggle-expand.label')}
       aria-expanded={expanded}
       aria-controls={`${id}-panel`}
-      onClick={toggle}
+      onClick={(event) => {
+        toggle();
+        onClick?.(event);
+      }}
       {...props}
     />
   );
@@ -158,7 +170,11 @@ export const OrderedListDetailItem = <T extends ListItemRecord>({
       <OrderedListDragHandle />
       <div className='flex flex-col border border-subdued-separator rounded-sm'>
         <div className='flex items-center'>
-          <OrderedListTitle classNames={mx('px-2', titleClassNames)}>{title}</OrderedListTitle>
+          {expandable ? (
+            <OrderedListTitle classNames={mx('px-2', titleClassNames)}>{title}</OrderedListTitle>
+          ) : (
+            <List.ItemTitle classNames={mx('px-2', titleClassNames)}>{title}</List.ItemTitle>
+          )}
           {actions}
           {expandable && <OrderedListExpandCaret />}
         </div>


### PR DESCRIPTION
Follows up [#11809](https://github.com/dxos/dxos/pull/11809) to address CodeRabbit review comments.

## Changes

- **`OrderedListTitle` / `OrderedListExpandCaret`**: extract caller-supplied `onClick` from spread props and compose it *after* the internal `toggle()` call, so passing an `onClick` no longer silently overwrites expand/collapse behavior.
- **`OrderedListDetailItem`**: when `expandable={false}`, render a plain `List.ItemTitle` (non-interactive) instead of `OrderedListTitle`, so clicking a non-expandable row does not inadvertently update `expandedId` and collapse another row's panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed click handling and expansion behavior for ordered list items
  * Non-expandable list items now render without expand controls

* **Refactor**
  * Improved component API for more flexible click handler management in ordered lists

<!-- end of auto-generated comment: release notes by coderabbit.ai -->