### PR TITLE
fix(composer-app): fix welcome-focus e2e and comments flaky test

### DIFF
--- a/packages/apps/composer-app/src/playwright/comments.spec.ts
+++ b/packages/apps/composer-app/src/playwright/comments.spec.ts
@@ -165,10 +165,12 @@ test.describe('Comments tests', () => {
     const plank = host.deck.plank();
     const editorTextbox = Markdown.getMarkdownTextboxWithLocator(plank.locator);
 
-    const editorText = random.lorem.paragraphs(3);
-    const firstMessage = editorText.slice(0, 10);
-    const secondMessage = editorText.slice(100, 115);
-    const thirdMessage = editorText.slice(-20);
+    // Each selection must stay within a single paragraph: cm-comment decorations cannot span newlines.
+    const [p1, p2, p3] = [random.lorem.paragraph(), random.lorem.paragraph(), random.lorem.paragraph()];
+    const editorText = `${p1}\n\n${p2}\n\n${p3}`;
+    const firstMessage = p1.slice(0, 10);
+    const secondMessage = p2.slice(5, 20);
+    const thirdMessage = p3.slice(-15);
     await editorTextbox.fill(editorText);
     await Markdown.select(editorTextbox, firstMessage);
     await Thread.createComment(host.page, plank.locator, random.lorem.sentence());

--- a/packages/apps/composer-app/src/playwright/playwright.config.ts
+++ b/packages/apps/composer-app/src/playwright/playwright.config.ts
@@ -8,6 +8,8 @@ import { e2ePreset } from '@dxos/test-utils/playwright';
 
 export default defineConfig({
   ...e2ePreset(import.meta.dirname),
+  // Storybook-based tests require a separate webServer (see playwright-welcome-focus.config.ts).
+  testIgnore: ['**/welcome-focus.spec.ts'],
   timeout: 60_000,
   expect: { timeout: 10_000 },
   workers: 1,


### PR DESCRIPTION
## Summary

Two e2e test failures identified from recent CI failures on `main`.

### 1. `welcome-focus.spec.ts` — consistent connection refused (6 failures across all browsers)

`welcome-focus.spec.ts` connects to Storybook at `http://localhost:9009`, but the main e2e task uses `playwright.config.ts` which only starts `vite preview` on port 4173. The welcome-focus tests were added alongside a separate `playwright-welcome-focus.config.ts` config (and a dedicated `e2e-welcome-focus` moon task) that does start Storybook, but `playwright.config.ts` picked them up too via `testDir`.

**Fix:** Add `testIgnore: ['**/welcome-focus.spec.ts']` to `playwright.config.ts`. These tests now only run via `moon run composer-app:e2e-welcome-focus`.

### 2. `comments.spec.ts` "selecting comment highlights thread and vice versa" — flaky on firefox/webkit

Root cause: the `delete message` test skips on firefox/webkit (`test.skip()` when `browserName !== 'chromium'`), so it doesn't consume random values. This shifts the PRNG state for the subsequent `selecting comment highlights thread and vice versa` test. On firefox/webkit, `editorText.slice(100, 115)` fell on a paragraph boundary, producing a string like `'sed voluptas.\nQ'` containing a newline. CodeMirror `cm-comment` decorations cannot span newlines, so `filter({ hasText: textWithNewline })` found no element — causing the test to fail on first try but pass on retry (with a different PRNG state after retry).

**Fix:** Generate three separate `lorem.paragraph()` calls instead of slicing `lorem.paragraphs(3)`. Each selection slice is guaranteed to stay within a single paragraph (no newlines), regardless of the accumulated PRNG state.

## Test plan

- [x] `moon run composer-app:lint` passes
- [ ] CI Check workflow green (welcome-focus tests no longer run in main e2e; comments test is deterministically correct)

https://claude.ai/code/session_01QV2QzumgiLvdfceXvmk1yX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QV2QzumgiLvdfceXvmk1yX)_