### PR TITLE
fix(plugin-assistant): fix duplicate run buttons on prompt code blocks

### DIFF
--- a/packages/plugins/plugin-assistant/src/capabilities/markdown-extension.ts
+++ b/packages/plugins/plugin-assistant/src/capabilities/markdown-extension.ts
@@ -17,7 +17,11 @@ export default Capability.makeModule(
     const capabilities = yield* Capability.Service;
 
     return Capability.contributes(MarkdownCapabilities.ExtensionProvider, [
-      ({ document: doc }) => {
+      ({ document: doc, viewMode }) => {
+        if (viewMode === 'source') {
+          return undefined;
+        }
+
         if (!doc) {
           return undefined;
         }

--- a/packages/plugins/plugin-assistant/src/extensions/prompt-extension.ts
+++ b/packages/plugins/plugin-assistant/src/extensions/prompt-extension.ts
@@ -3,7 +3,7 @@
 //
 
 import { syntaxTree } from '@codemirror/language';
-import { type Extension } from '@codemirror/state';
+import { Facet, type Extension, type Range } from '@codemirror/state';
 import { Decoration, type DecorationSet, EditorView, ViewPlugin, type ViewUpdate, WidgetType } from '@codemirror/view';
 
 import { Domino } from '@dxos/ui';
@@ -13,73 +13,104 @@ export type PromptExtensionOptions = {
   onRun: (promptText: string) => void;
 };
 
-/**
- * CodeMirror extension that adds a green "run" button to ```prompt fenced code blocks.
- */
-export const promptRunExtension = ({ onRun }: PromptExtensionOptions): Extension => {
-  return [
-    ViewPlugin.fromClass(
-      class {
-        decorations: DecorationSet;
+type OnRun = (text: string) => void;
 
-        constructor(view: EditorView) {
-          this.decorations = this.buildDecorations(view);
-        }
+// Module-level facet so the plugin singleton can read the latest handler.
+const promptHandlerFacet = Facet.define<OnRun, OnRun | null>({
+  combine: (handlers) => handlers[0] ?? null,
+});
 
-        update(update: ViewUpdate) {
-          if (update.docChanged || update.viewportChanged || update.selectionSet || update.focusChanged) {
-            this.decorations = this.buildDecorations(update.view);
-          }
-        }
+// Module-level singleton — CM6 deduplicates by reference equality, preventing duplicate buttons
+// when the extension is contributed more than once.
+const promptPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
 
-        buildDecorations(view: EditorView): DecorationSet {
-          const decorations: Array<{ from: number; to: number; decoration: Decoration }> = [];
+    constructor(view: EditorView) {
+      this.decorations = this.buildDecorations(view);
+    }
 
-          syntaxTree(view.state).iterate({
-            enter: (node) => {
-              if (node.name === 'FencedCode') {
-                const info = node.node.getChild('CodeInfo');
-                if (info) {
-                  const type = view.state.sliceDoc(info.from, info.to);
-                  const text = node.node.getChild('CodeText');
-                  if (type === 'prompt' && text) {
-                    const content = view.state.sliceDoc(text.from, text.to).trim();
-                    if (content.length > 0) {
-                      const widget = new PromptRunWidget(content, onRun);
-                      decorations.push({
-                        from: node.from,
-                        to: node.from,
-                        decoration: Decoration.widget({ widget, side: -1 }),
-                      });
-                    }
-                  }
+    update(update: ViewUpdate) {
+      if (
+        update.docChanged ||
+        update.viewportChanged ||
+        update.selectionSet ||
+        update.focusChanged ||
+        update.startState.facet(promptHandlerFacet) !== update.state.facet(promptHandlerFacet)
+      ) {
+        this.decorations = this.buildDecorations(update.view);
+      }
+    }
+
+    buildDecorations(view: EditorView): DecorationSet {
+      const onRun = view.state.facet(promptHandlerFacet);
+      if (!onRun) {
+        return Decoration.none;
+      }
+
+      const ranges: Range<Decoration>[] = [];
+
+      syntaxTree(view.state).iterate({
+        enter: (node) => {
+          if (node.name === 'FencedCode') {
+            const info = node.node.getChild('CodeInfo');
+            if (info) {
+              const type = view.state.sliceDoc(info.from, info.to);
+              const text = node.node.getChild('CodeText');
+              if (type === 'prompt' && text) {
+                const content = view.state.sliceDoc(text.from, text.to).trim();
+                if (content.length > 0) {
+                  // Mark the header line as a positioned container for the button overlay.
+                  ranges.push(Decoration.line({ class: 'cm-prompt-header' }).range(node.from, node.from));
+                  ranges.push(
+                    Decoration.widget({ widget: new PromptRunWidget(content, onRun), side: -1 }).range(
+                      node.from,
+                      node.from,
+                    ),
+                  );
                 }
               }
-            },
-          });
+            }
+          }
+        },
+      });
 
-          return Decoration.set(
-            decorations.sort((a, b) => a.from - b.from || a.to - b.to).map((d) => d.decoration.range(d.from, d.to)),
-          );
-        }
-      },
-      {
-        decorations: (v) => v.decorations,
-      },
-    ),
-  ];
-};
+      // sort=true lets CM6 order by startSide (line decorations before widgets at the same position).
+      return Decoration.set(ranges, true);
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);
+
+// Base theme wires up the positioned container on the header line.
+const promptTheme = EditorView.baseTheme({
+  '.cm-prompt-header': {
+    position: 'relative',
+    overflow: 'visible',
+  },
+});
+
+/**
+ * CodeMirror extension that adds a "run" button to ```prompt fenced code blocks.
+ */
+export const promptRunExtension = ({ onRun }: PromptExtensionOptions): Extension => [
+  promptHandlerFacet.of(onRun),
+  promptPlugin,
+  promptTheme,
+];
 
 class PromptRunWidget extends WidgetType {
   constructor(
     private readonly prompt: string,
-    private readonly onClick: (promptText: string) => void,
+    private readonly onClick: OnRun,
   ) {
     super();
   }
 
   override eq(other: this) {
-    return this.prompt === other.prompt;
+    return this.prompt === other.prompt && this.onClick === other.onClick;
   }
 
   override ignoreEvent() {
@@ -87,24 +118,20 @@ class PromptRunWidget extends WidgetType {
   }
 
   override toDOM() {
-    return Domino.of('div')
-      .classNames('relative')
+    return Domino.of('button')
+      .classNames('dx-button p-1 absolute top-1 right-1')
+      .on('mousedown', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        this.onClick(this.prompt);
+      })
       .append(
-        Domino.of('button')
-          .classNames('dx-button absolute right-0 top-4')
-          .on('mousedown', (event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            this.onClick(this.prompt);
-          })
+        Domino.of('svg', Domino.SVG)
+          .classNames('w-4 h-4 cursor-pointer')
           .append(
-            Domino.of('svg', Domino.SVG)
-              .classNames('w-4 h-4 cursor-pointer')
-              .append(
-                Domino.of('use', Domino.SVG).attributes({
-                  href: Domino.icon('ph--play--regular'),
-                }),
-              ),
+            Domino.of('use', Domino.SVG).attributes({
+              href: Domino.icon('ph--play--regular'),
+            }),
           ),
       ).root;
   }

--- a/packages/plugins/plugin-assistant/src/extensions/prompt-extension.ts
+++ b/packages/plugins/plugin-assistant/src/extensions/prompt-extension.ts
@@ -119,7 +119,9 @@ class PromptRunWidget extends WidgetType {
 
   override toDOM() {
     return Domino.of('button')
-      .classNames('dx-button p-1 absolute top-1 right-1')
+      .classNames(
+        'dx-button h-6 w-6 min-h-0 p-1 absolute top-0 right-0 bg-green-bg hover:bg-green-surface text-green-fg',
+      )
       .on('mousedown', (event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -130,7 +132,7 @@ class PromptRunWidget extends WidgetType {
           .classNames('w-4 h-4 cursor-pointer')
           .append(
             Domino.of('use', Domino.SVG).attributes({
-              href: Domino.icon('ph--play--regular'),
+              href: Domino.icon('ph--sparkle--regular'),
             }),
           ),
       ).root;

--- a/packages/ui/ui-editor/src/extensions/markdown/styles.ts
+++ b/packages/ui/ui-editor/src/extensions/markdown/styles.ts
@@ -82,7 +82,8 @@ export const formattingStyles = EditorView.theme({
   },
   '& .cm-codeblock-line': {
     background: 'var(--color-cm-codeblock)',
-    paddingInline: '1rem !important',
+    paddingLeft: '1rem !important',
+    paddingRight: '1.5rem !important',
   },
   '& .cm-codeblock-start': {
     borderTopLeftRadius: '.25rem',


### PR DESCRIPTION
## Summary

- **Duplicate buttons**: `ViewPlugin` was instantiated once per `promptRunExtension()` call, so if the extension was contributed more than once (e.g. capability registered multiple times), CodeMirror could not deduplicate it and rendered two buttons. Moving the plugin to a module-level singleton lets CM6 deduplicate by reference equality. A module-level `Facet` passes the `onRun` callback in, and `update()` also watches for facet changes so the button DOM is rebuilt when the handler changes.

- **Plain-text mode**: The `MarkdownExtensionProvider` now receives `viewMode` and returns `undefined` when `viewMode === 'source'`, disabling the extension entirely in source/plain-text mode.

- **Button padding**: Added `p-1` to the run button's class list.

- **Absolute positioning**: Replaced the `div.relative > button.absolute` wrapper pattern with a `Decoration.line()` that adds the `cm-prompt-header` class (styled `position: relative; overflow: visible` via `EditorView.baseTheme`) to the fenced block's header line. The button widget is now returned directly from `toDOM()` with `absolute top-1 right-1`, so it sits in the top-right corner of the header `.cm-line` div. `Decoration.set(..., true)` handles sorting line vs widget decorations at the same position correctly.

## Test plan

- [ ] Create a markdown document with a ` ```prompt ` fenced code block — one run button should appear in the top-right corner of the header line
- [ ] Confirm only ONE button renders even if the assistant plugin capability is somehow contributed twice
- [ ] Switch to source/plain-text view mode — button should disappear
- [ ] Switch back to preview/default mode — button should reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown extension now respects source-view and no longer appears in source edit mode

* **Refactor**
  * Prompt run widget updated for more reliable rendering, positioning, and handler updates

* **Style**
  * Adjusted code block horizontal padding for improved spacing and readability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->