### PR TITLE
feat(echo): add Entity.labelAtom/labelProperty; wire reactive label into createObjectNode

### DIFF
--- a/packages/core/echo/echo/src/Entity.ts
+++ b/packages/core/echo/echo/src/Entity.ts
@@ -343,3 +343,5 @@ export const removeTag = (entity: Mutable<Unknown>, tag: Ref.Ref<Tag.Tag>): void
 //
 
 export const atom = objInternal.makeEntity;
+export const labelAtom = objInternal.makeLabelAtom;
+export const labelProperty = internal.getLabelProperty;

--- a/packages/core/echo/echo/src/Obj.ts
+++ b/packages/core/echo/echo/src/Obj.ts
@@ -926,3 +926,5 @@ export const version = (entity: Unknown | Snapshot): Version => internal.version
 export const atom = objInternal.makeAtom;
 export const atomReactive = objInternal.makeWithReactive;
 export const atomProperty = objInternal.makeProperty;
+export const labelAtom = objInternal.makeLabelAtom;
+export const labelProperty = internal.getLabelProperty;

--- a/packages/core/echo/echo/src/internal/Annotation/annotations.ts
+++ b/packages/core/echo/echo/src/internal/Annotation/annotations.ts
@@ -599,6 +599,21 @@ export const setLabel = (entity: Mutable<AnyProperties>, label: string) => {
 };
 
 /**
+ * Returns the primary label property key for an entity.
+ * Reads the first accessor from {@link LabelAnnotation}, defaulting to 'name'.
+ */
+export const getLabelProperty = (entity: AnyProperties): string => {
+  const schema = getSchema(entity);
+  if (schema == null) {
+    return 'name';
+  }
+  return LabelAnnotation.get(schema).pipe(
+    Option.map((fields) => fields[0]),
+    Option.getOrElse(() => 'name'),
+  );
+};
+
+/**
  * Get the description of an entity.
  * Accepts both reactive entities and snapshots.
  */

--- a/packages/core/echo/echo/src/internal/Annotation/annotations.ts
+++ b/packages/core/echo/echo/src/internal/Annotation/annotations.ts
@@ -608,7 +608,7 @@ export const getLabelProperty = (entity: AnyProperties): string => {
     return 'name';
   }
   return LabelAnnotation.get(schema).pipe(
-    Option.map((fields) => fields[0]),
+    Option.flatMap((fields) => Option.fromNullable(fields[0])),
     Option.getOrElse(() => 'name'),
   );
 };

--- a/packages/core/echo/echo/src/internal/Obj/atoms.ts
+++ b/packages/core/echo/echo/src/internal/Obj/atoms.ts
@@ -11,10 +11,10 @@ import * as Option from 'effect/Option';
 import { assertArgument } from '@dxos/invariant';
 
 import type * as Entity from '../../Entity';
-import { getLabel } from '../Annotation';
 import type * as Obj from '../../Obj';
 import type * as Ref from '../../Ref';
 import type * as Relation from '../../Relation';
+import { getLabel } from '../Annotation';
 import { subscribe } from '../common/proxy/reactive';
 import { isEntity, getDatabase } from '../Entity';
 import { RefTypeId } from '../Ref/ref';

--- a/packages/core/echo/echo/src/internal/Obj/atoms.ts
+++ b/packages/core/echo/echo/src/internal/Obj/atoms.ts
@@ -11,6 +11,7 @@ import * as Option from 'effect/Option';
 import { assertArgument } from '@dxos/invariant';
 
 import type * as Entity from '../../Entity';
+import { getLabel } from '../Annotation';
 import type * as Obj from '../../Obj';
 import type * as Ref from '../../Ref';
 import type * as Relation from '../../Relation';
@@ -241,4 +242,34 @@ export const makeEntity = <T extends Entity.Unknown>(entity: T): Atom.Atom<Entit
 export const makeRelation = <T extends Relation.Unknown>(relation: T): Atom.Atom<Relation.Snapshot<T>> => {
   assertArgument(isEntity(relation), 'relation', 'Must be a reactive ECHO relation');
   return relationFamily(relation);
+};
+
+/**
+ * Atom family for an entity's label string.
+ * Fires only when the computed label actually changes, not on every entity mutation.
+ */
+const labelAtomFamily = Atom.family(<T extends Entity.Unknown>(entity: T): Atom.Atom<string | undefined> => {
+  return Atom.make<string | undefined>((get) => {
+    let previous = getLabel(entity);
+
+    const unsubscribe = subscribe(entity, () => {
+      const next = getLabel(entity);
+      if (next !== previous) {
+        previous = next;
+        get.setSelf(next);
+      }
+    });
+
+    get.addFinalizer(() => unsubscribe());
+    return previous;
+  }).pipe(Atom.keepAlive);
+});
+
+/**
+ * Create a read-only atom for the label of a reactive ECHO entity.
+ * Re-evaluates on entity mutation; only propagates when the label string changes.
+ */
+export const makeLabelAtom = <T extends Entity.Unknown>(entity: T): Atom.Atom<string | undefined> => {
+  assertArgument(isEntity(entity), 'entity', 'Must be a reactive ECHO entity');
+  return labelAtomFamily(entity);
 };

--- a/packages/plugins/plugin-comments/src/containers/CommentsArticle/CommentsArticle.stories.tsx
+++ b/packages/plugins/plugin-comments/src/containers/CommentsArticle/CommentsArticle.stories.tsx
@@ -156,7 +156,7 @@ const StoryGraphPlugin = Plugin.define(
             }
             const docs = get(space.db.query(Filter.type(Markdown.Document)).atom);
             return docs
-              .map((object) => createObjectNode({ db: space.db, object, droppable: false }))
+              .map((object) => createObjectNode({ get, db: space.db, object, droppable: false }))
               .filter(isNonNullable);
           }),
       });

--- a/packages/plugins/plugin-commerce/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-commerce/src/capabilities/app-graph-builder.ts
@@ -43,6 +43,7 @@ export default Capability.makeModule(
               nodes: providers
                 .map((provider: Provider.Provider) =>
                   createObjectNode({
+                    get,
                     db: space.db,
                     object: provider,
                   }),

--- a/packages/plugins/plugin-integration/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-integration/src/capabilities/app-graph-builder.ts
@@ -111,6 +111,7 @@ export default Capability.makeModule(
             integrations
               .map((integration) =>
                 createObjectNode({
+                  get,
                   db: space.db,
                   object: integration,
                 }),

--- a/packages/plugins/plugin-sample/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-sample/src/capabilities/app-graph-builder.ts
@@ -97,7 +97,7 @@ export default Capability.makeModule(
           const items = get(space.db.query(Filter.type(SampleItem.SampleItem)).atom);
           return Effect.succeed(
             items
-              .map((item) => createObjectNode({ db: space.db, object: item }))
+              .map((item) => createObjectNode({ get, db: space.db, object: item }))
               .filter((node): node is NonNullable<typeof node> => node !== null),
           );
         },

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/collections.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/collections.ts
@@ -123,6 +123,7 @@ export const createCollectionExtensions = Effect.fnUntraced(function* ({
           objects
             .map((object: Obj.Unknown) =>
               createObjectNode({
+                get,
                 db: space.db,
                 object,
                 navigable: ephemeralState.navigableCollections,
@@ -159,6 +160,7 @@ export const createCollectionExtensions = Effect.fnUntraced(function* ({
               (object: Obj.Unknown) =>
                 db &&
                 createObjectNode({
+                  get,
                   object,
                   db,
                   navigable: ephemeralState.navigableCollections,

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/database.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/database.ts
@@ -158,6 +158,7 @@ export const createDatabaseExtensions = Effect.fnUntraced(function* () {
           .getViewsForTypeUri(typeUri)
           .map((object: Obj.Unknown) =>
             createObjectNode({
+              get,
               db: space.db,
               object,
               droppable: false,
@@ -191,6 +192,7 @@ export const createDatabaseExtensions = Effect.fnUntraced(function* () {
             .map((object: Obj.Unknown) => {
               get(Obj.atom(object));
               return createObjectNode({
+                get,
                 db: space.db,
                 object,
                 droppable: false,

--- a/packages/sdk/app-toolkit/src/object-node.ts
+++ b/packages/sdk/app-toolkit/src/object-node.ts
@@ -4,6 +4,7 @@
 
 import type { Instruction } from '@atlaskit/pragmatic-drag-and-drop-hitbox/tree-item';
 import * as Option from 'effect/Option';
+import type { Atom } from '@effect-atom/atom-react';
 
 import { Node } from '@dxos/app-graph';
 import { Annotation, Collection, type Database, Obj, Ref, Type } from '@dxos/echo';
@@ -127,6 +128,7 @@ export const getCollectionGraphNodePartials = ({
 
 /** Builds an app-graph node for an ECHO object. Uses the local object ID as the graph node ID. */
 export const createObjectNode = ({
+  get,
   db,
   object,
   disposition,
@@ -134,6 +136,8 @@ export const createObjectNode = ({
   navigable = false,
   parentCollection,
 }: {
+  /** Atom context from the enclosing connector — registers reactive subscriptions so property changes re-run the connector. */
+  get: Atom.Context;
   db: Database.Database;
   object: Obj.Unknown;
   disposition?: string;
@@ -178,7 +182,8 @@ export const createObjectNode = ({
     : graphProps;
 
   const label =
-    Obj.getLabel(object) || getDynamicLabel('object-name.placeholder', typename, { defaultValue: 'New item' });
+    get(Obj.labelAtom(object)) ||
+    getDynamicLabel('object-name.placeholder', typename, { defaultValue: 'New item' });
 
   const selectable =
     !Obj.instanceOf(Collection.Collection, object) || (navigable && Obj.instanceOf(Collection.Collection, object));

--- a/packages/sdk/app-toolkit/src/object-node.ts
+++ b/packages/sdk/app-toolkit/src/object-node.ts
@@ -3,8 +3,8 @@
 //
 
 import type { Instruction } from '@atlaskit/pragmatic-drag-and-drop-hitbox/tree-item';
-import * as Option from 'effect/Option';
 import type { Atom } from '@effect-atom/atom-react';
+import * as Option from 'effect/Option';
 
 import { Node } from '@dxos/app-graph';
 import { Annotation, Collection, type Database, Obj, Ref, Type } from '@dxos/echo';
@@ -182,8 +182,7 @@ export const createObjectNode = ({
     : graphProps;
 
   const label =
-    get(Obj.labelAtom(object)) ||
-    getDynamicLabel('object-name.placeholder', typename, { defaultValue: 'New item' });
+    get(Obj.labelAtom(object)) || getDynamicLabel('object-name.placeholder', typename, { defaultValue: 'New item' });
 
   const selectable =
     !Obj.instanceOf(Collection.Collection, object) || (navigable && Obj.instanceOf(Collection.Collection, object));

--- a/packages/sdk/app-toolkit/src/type-section-extension.ts
+++ b/packages/sdk/app-toolkit/src/type-section-extension.ts
@@ -105,7 +105,7 @@ export const createTypeSectionExtension = (
             ...(options?.position ? { position: options.position } : {}),
           },
           nodes: objects
-            .map((object) => createObjectNode({ db: space.db, object }))
+            .map((object) => createObjectNode({ get, db: space.db, object }))
             .filter((node): node is NonNullable<typeof node> => node !== null),
         }),
       ]);


### PR DESCRIPTION
## Summary

- **`Entity.labelProperty(entity)`** — returns the primary label field key from `LabelAnnotation` (defaults to `'name'`). Useful for rename flows and form editors that need to know which property to target.
- **`Entity.labelAtom(entity)`** / **`Obj.labelAtom(entity)`** — reactive atom that subscribes to entity mutations and propagates only when the computed label string actually changes (same fine-grained optimisation as `Obj.atomProperty`).
- **`createObjectNode` now requires `get: Atom.Context` as its first arg** and reads the label via `get(Obj.labelAtom(object))`, so the enclosing connector automatically re-runs when an object's label changes.
- All call sites updated: `createTypeSectionExtension`, `collections`, `database`, `plugin-commerce`, `plugin-integration`, `plugin-sample`.

## Motivation

`createObjectNode` was computing the node label with a bare `Obj.getLabel(object)` call — a static snapshot with no subscription. Renaming an object in the editor would not update the sidebar label until a full graph rebuild. This change makes labels reactive without re-running the connector on every property mutation.

## Test plan

- [ ] Build passes: `moon run echo:build app-toolkit:build`
- [ ] Echo unit tests pass: `moon run echo:test`
- [ ] Rename an object in the sidebar — label updates immediately without a page reload
- [ ] Verify the label atom fires only on label-field changes (not on unrelated property mutations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reactive, label-based helpers (including label atom/property utilities) for consistent object naming.
  * Object nodes now resolve labels from reactive label state, improving responsiveness to label changes.
* **Bug Fixes**
  * Fixed label handling to fall back gracefully and update when an object’s primary label accessor changes.
  * Resolved missing dependency context during object-node creation across listings, collections, schema/view generation, database/view extensions, and integration/comment graph extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->