### PR TITLE
feat(react-ui): Card.Block gutter slots — replace Card.Row icon prop

### DIFF
--- a/docs/superpowers/plans/2026-06-13-card-row-slots.md
+++ b/docs/superpowers/plans/2026-06-13-card-row-slots.md
@@ -19,6 +19,7 @@ Spec: `docs/superpowers/specs/2026-06-13-card-row-slots-design.md`
 ### Task 1: `data-slot` grid routing in `Column.Row` theme
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/components/Column/Column.theme.ts:22-24` (the `row` fn)
 
 - [ ] **Step 1: Update the `row` theme to route slots by `data-slot`**
@@ -59,6 +60,7 @@ git commit -m "feat(react-ui): route Column.Row children by data-slot"
 ### Task 2: Add `Column.Block`
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/components/Column/Column.tsx` (add component + export)
 - Modify: `packages/ui/react-ui/src/components/Column/Column.theme.ts` (add `block` style)
 
@@ -185,6 +187,7 @@ git commit -m "feat(react-ui): add Column.Block gutter slot"
 ### Task 3: Add `Card.Block`, remove `Card.Icon`/`Card.IconBlock`, rework helpers
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/components/Card/Card.tsx`
 - Modify: `packages/ui/react-ui/src/components/Card/Card.theme.ts`
 
@@ -308,6 +311,7 @@ git commit -m "feat(react-ui): add Card.Block; remove Card.Icon/Card.IconBlock"
 ### Task 4: `Card.Row` — drop `icon`; set `--icon-size` 4
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/components/Card/Card.tsx` (`CardRow`)
 
 - [ ] **Step 1: Rewrite `CardRow`** to remove the `icon` prop and set the row's icon size:
@@ -359,6 +363,7 @@ git commit -m "feat(react-ui): drop Card.Row icon prop; inherit icon size"
 ### Task 5: `Card.Header` — plain `<header>`, `--icon-size` 5, drop Toolbar
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/components/Card/Card.tsx` (`CardHeader`)
 - Modify: `packages/ui/react-ui/src/components/Card/Card.theme.ts` (`header`)
 
@@ -378,7 +383,7 @@ const CardHeader = slottable<HTMLDivElement, CardHeaderProps>(
     const Comp = asChild ? Slot : Primitive.header;
     return (
       <Comp
-        {...composableProps({ ...props, classNames }).rest ?? {}}
+        {...(composableProps({ ...props, classNames }).rest ?? {})}
         style={{ ...iconSize(5), ...style }}
         className={tx('card.header', {}, classNames)}
         ref={forwardedRef}
@@ -422,13 +427,16 @@ git commit -m "feat(react-ui): Card.Header is a plain header sharing Row layout"
 ### Task 6: Update `Card.stories.tsx`
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/components/Card/Card.stories.tsx`
 
 - [ ] **Step 1: Migrate existing stories** off `Card.Row icon=`/`Card.Icon`/`Card.IconBlock` to `Card.Block`, and add stories proving: start-only, end-only, both, `asChild`, conditional (falsy) block, `fullWidth` (blocks inert), Header vs Row icon size (5 vs 4), and passive-`Icon`-vs-`IconButton` alignment.
 
 ```tsx
 <Card.Row>
-  <Card.Block><Icon icon='ph--dot-outline--regular' /></Card.Block>
+  <Card.Block>
+    <Icon icon='ph--dot-outline--regular' />
+  </Card.Block>
   <Card.Text>Card.Text (default)</Card.Text>
   <Card.Block end>
     <IconButton iconOnly variant='ghost' icon='ph--x--regular' label='Remove' onClick={() => {}} />
@@ -455,6 +463,7 @@ git commit -m "test(react-ui): Card.Block stories"
 ### Task 7: `Dialog.Block`, `Dialog.Row`, `Dialog.Header` routing
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/components/Dialog/Dialog.tsx`
 - Modify: `packages/ui/react-ui/src/components/Dialog/Dialog.theme.ts`
 
@@ -480,7 +489,12 @@ const DialogBlock = slottable<HTMLDivElement, DialogBlockProps>(
     const { className, ...rest } = composableProps(props);
     const Comp = asChild ? Slot : Primitive.div;
     return (
-      <Comp {...rest} data-slot={end ? 'end' : 'start'} className={tx('dialog.block', { compact, square }, className)} ref={forwardedRef}>
+      <Comp
+        {...rest}
+        data-slot={end ? 'end' : 'start'}
+        className={tx('dialog.block', { compact, square }, className)}
+        ref={forwardedRef}
+      >
         {children}
       </Comp>
     );
@@ -506,8 +520,16 @@ const header: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
 const row: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
   mx('dx-dialog__row col-span-3 grid grid-cols-subgrid items-center', ...etc);
 
-const block: ComponentFunction<DialogStyleProps & { compact?: boolean; square?: boolean }> = ({ compact, square }, ...etc) =>
-  mx('grid place-items-center', square ? 'aspect-square' : 'w-[var(--dx-rail-item)]', compact ? '' : 'h-[var(--dx-rail-item)]', ...etc);
+const block: ComponentFunction<DialogStyleProps & { compact?: boolean; square?: boolean }> = (
+  { compact, square },
+  ...etc
+) =>
+  mx(
+    'grid place-items-center',
+    square ? 'aspect-square' : 'w-[var(--dx-rail-item)]',
+    compact ? '' : 'h-[var(--dx-rail-item)]',
+    ...etc,
+  );
 ```
 
 Add `row` and `block` to `dialogTheme`.
@@ -547,6 +569,7 @@ For each package below: edit files, run `moon run <pkg>:build`, fix, then commit
 ### Task 8: Migrate `react-ui` sibling packages
 
 **Files (per `grep` inventory):**
+
 - `react-ui-mosaic`: `src/testing/DefaultStackTile.tsx`, `src/components/SearchStack/SearchStack.tsx`, `src/components/Board/Item.tsx`
 - `react-ui-board`: `src/components/Board/Board.stories.tsx`
 - `react-ui-masonry`: `src/Masonry.stories.tsx`
@@ -559,6 +582,7 @@ For each package below: edit files, run `moon run <pkg>:build`, fix, then commit
 ### Task 9: Migrate plugins — group A (preview, feed, trip, inbox)
 
 **Files:**
+
 - `plugin-preview`: `cards/PersonCard.tsx`, `cards/OrganizationCard.tsx`, `cards/TaskCard.tsx`, `cards/FormCard.tsx`, `stories/Card.stories.tsx`
 - `plugin-feed`: `components/SubscriptionStack/SubscriptionStack.tsx`, `components/PostStack/PostStack.tsx`, `containers/PostCard/PostCard.tsx`, `containers/MagazineArticle/MagazineTile.tsx`
 - `plugin-trip`: `components/SegmentCard/SegmentEditableCard.tsx`, `components/SegmentCard/SegmentCard.tsx`, `components/OfferStack/OfferStack.tsx`
@@ -569,6 +593,7 @@ For each package below: edit files, run `moon run <pkg>:build`, fix, then commit
 ### Task 10: Migrate plugins — group B (rest)
 
 **Files:**
+
 - `plugin-deck`: `containers/DeckLayout/Popover.tsx`
 - `plugin-bookmarks`: `containers/BookmarkCard/BookmarkCard.tsx`, `containers/BookmarkArticle/BookmarkArticle.tsx`
 - `plugin-markdown`: `containers/MarkdownCard/MarkdownCard.tsx`, `containers/EditableMarkdownCard/EditableMarkdownCard.tsx`
@@ -588,9 +613,11 @@ For each package below: edit files, run `moon run <pkg>:build`, fix, then commit
 - [ ] **Step 1: Grep for any remaining removed symbols**
 
 Run:
+
 ```bash
 cd /Users/burdon/Code/dxos/dxos && grep -rn "Card\.Icon\b\|Card\.IconBlock\|Card\.Row[^>]*icon=" packages --include="*.tsx"
 ```
+
 Expected: no matches (only the standalone `IconBlock` remains).
 
 - [ ] **Step 2: Visually verify the ~20 multi-control `Card.Header`s** still tab through controls and align (Storybook + a few plugin stories via preview tools). Reslot any header whose buttons should sit in the trailing gutter using `<Card.Block end>`.

--- a/docs/superpowers/plans/2026-06-13-card-row-slots.md
+++ b/docs/superpowers/plans/2026-06-13-card-row-slots.md
@@ -1,0 +1,638 @@
+# Card/Dialog Row Slots Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `Card.Row`'s overloaded `icon` prop with explicit, symmetric start/end gutter slots (`Card.Block`) shared across `Column`, `Card`, and `Dialog`, and drop `Card.Header`'s toolbar role.
+
+**Architecture:** `Column.Row` gains Panel-style `data-slot` grid routing (start→col 1, end→col 3, anonymous→content). A new `Column.Block` reuses the existing `IconBlock` rail-item geometry and adds placement. `Card`/`Dialog` theme it as `Card.Block`/`Dialog.Block`. `Card.Header` becomes a plain `<header>` sharing `Card.Row`'s layout (only icon-size differs: 5 vs 4). `Card.Row.icon`, `Card.Icon`, `Card.IconBlock` are removed; the standalone `IconBlock` primitive stays. All call sites migrate in batched per-package commits.
+
+**Tech Stack:** React + `@radix-ui/react-slot` + `@radix-ui/react-primitive`, `tx()` theme functions (`@dxos/ui-theme`), `slottable()`/`composable()` utils, Storybook, vitest, moon.
+
+Spec: `docs/superpowers/specs/2026-06-13-card-row-slots-design.md`
+
+**Conventions:** package `@dxos/react-ui` at `packages/ui/react-ui`. Build: `moon run react-ui:build`. Lint: `moon run react-ui:lint -- --fix`. Storybook already runs on :9009 (reuse, never kill). Commit per task.
+
+---
+
+## Phase 1 — Column primitive
+
+### Task 1: `data-slot` grid routing in `Column.Row` theme
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/components/Column/Column.theme.ts:22-24` (the `row` fn)
+
+- [ ] **Step 1: Update the `row` theme to route slots by `data-slot`**
+
+Replace the `row` ComponentFunction body so children are placed by attribute, not order:
+
+```ts
+/**
+ * Three-column subgrid row. Children are placed by `data-slot`:
+ * - `start` → column 1 (leading gutter)
+ * - `end`   → column 3 (trailing gutter)
+ * - anything else (anonymous) → column 2 (center content)
+ * Placement is attribute-driven, not order-driven, so conditional children never shift content.
+ */
+const row: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
+  return mx(
+    'col-span-3 grid grid-cols-subgrid',
+    '[&>[data-slot=start]]:col-start-1',
+    '[&>[data-slot=end]]:col-start-3',
+    '[&>*:not([data-slot])]:col-start-2',
+    ...etc,
+  );
+};
+```
+
+- [ ] **Step 2: Build to typecheck**
+
+Run: `moon run react-ui:build`
+Expected: PASS (no consumers broken yet — `Column.Row` was already used only by Card/Dialog rows that currently place via order; placement classes are additive).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ui/react-ui/src/components/Column/Column.theme.ts
+git commit -m "feat(react-ui): route Column.Row children by data-slot"
+```
+
+### Task 2: Add `Column.Block`
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/components/Column/Column.tsx` (add component + export)
+- Modify: `packages/ui/react-ui/src/components/Column/Column.theme.ts` (add `block` style)
+
+- [ ] **Step 1: Add a `block` style to `Column.theme.ts`**
+
+Reuse the rail-item geometry (same classes as `icon.block` in `Icon.theme.ts`). Add after `center`:
+
+```ts
+/**
+ * Gutter slot geometry: a `--dx-rail-item` square that centers its child, so a passive
+ * `<Icon>` and an interactive `IconButton` line up to the pixel. Placement (col 1/3) is
+ * applied by the parent `row` via `data-slot`.
+ */
+const block: ComponentFunction<ColumnBlockStyleProps> = ({ compact, square }, ...etc) =>
+  mx(
+    'grid place-items-center [&>img]:max-w-[1.5rem]',
+    square ? 'aspect-square' : 'w-[var(--dx-rail-item)]',
+    compact ? '' : 'h-[var(--dx-rail-item)]',
+    ...etc,
+  );
+```
+
+Add the style-props type near the top of the file and include `block` in the export:
+
+```ts
+export type ColumnStyleProps = {};
+export type ColumnBlockStyleProps = { compact?: boolean; square?: boolean };
+```
+
+```ts
+export const columnTheme = {
+  root,
+  row,
+  block,
+  bleed,
+  center,
+};
+```
+
+- [ ] **Step 2: Add `ColumnBlock` to `Column.tsx`**
+
+Add after `ColumnCenter` (before the `Column` namespace object), importing the style-props type:
+
+```tsx
+//
+// Block
+//
+
+const COLUMN_BLOCK_NAME = 'Column.Block';
+
+type ColumnBlockProps = SlottableProps<{ end?: boolean; compact?: boolean; square?: boolean }>;
+
+/**
+ * A gutter slot inside a `Column.Row`. Sized to `--dx-rail-item` and centers its child.
+ * `end` opts into the trailing gutter (column 3); default is the leading gutter (column 1).
+ * Pass any child (`<Icon>`, `IconButton`, `Avatar`). Placement is via `data-slot`, so it is
+ * robust to conditional rendering and DOM order.
+ */
+const ColumnBlock = slottable<HTMLDivElement, ColumnBlockProps>(
+  ({ children, asChild, end, compact, square, ...props }, forwardedRef) => {
+    const { tx } = useThemeContext();
+    const { className, ...rest } = composableProps(props);
+    const Comp = asChild ? Slot : Primitive.div;
+    return (
+      <Comp
+        {...rest}
+        data-slot={end ? 'end' : 'start'}
+        className={tx('column.block', { compact, square }, className)}
+        ref={forwardedRef}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+
+ColumnBlock.displayName = COLUMN_BLOCK_NAME;
+```
+
+Update imports at top of `Column.tsx`:
+
+```tsx
+import { type ColumnBlockStyleProps } from './Column.theme';
+```
+
+(if `Column.tsx` does not already import from its theme, add the import; otherwise the type is only needed for `ColumnBlockProps` which inlines the shape — in that case skip the import.)
+
+- [ ] **Step 3: Export `Column.Block` and its props type**
+
+```tsx
+export const Column = {
+  Root: ColumnRoot,
+  Row: ColumnRow,
+  Block: ColumnBlock,
+  Bleed: ColumnBleed,
+  Center: ColumnCenter,
+};
+
+export type { ColumnRootProps, ColumnRowProps, ColumnBlockProps, ColumnBleedProps, ColumnCenterProps };
+```
+
+- [ ] **Step 4: Register `column.block` in the theme registry**
+
+Find where `columnTheme` is wired into the global `tx`/theme (search `columnTheme` under `packages/ui/ui-theme` or `react-ui` theme index) and confirm `block` is picked up (object spread of `columnTheme` — no change needed if it spreads the whole object). If keys are listed explicitly, add `'column.block'` mapping.
+
+Run: `cd /Users/burdon/Code/dxos/dxos && grep -rn "columnTheme" packages/ui`
+
+- [ ] **Step 5: Build**
+
+Run: `moon run react-ui:build`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/react-ui/src/components/Column/Column.tsx packages/ui/react-ui/src/components/Column/Column.theme.ts
+git commit -m "feat(react-ui): add Column.Block gutter slot"
+```
+
+---
+
+## Phase 2 — Card
+
+### Task 3: Add `Card.Block`, remove `Card.Icon`/`Card.IconBlock`, rework helpers
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/components/Card/Card.tsx`
+- Modify: `packages/ui/react-ui/src/components/Card/Card.theme.ts`
+
+- [ ] **Step 1: Add `Card.Block` to `Card.tsx`**
+
+Add a `CardBlock` part (themed `Column.Block`, subdued by default). Replace the `CardIconBlock`/`CardIcon` sections:
+
+```tsx
+//
+// Block
+//
+
+const CARD_BLOCK_NAME = 'Card.Block';
+
+type CardBlockProps = SlottableProps<{ end?: boolean; compact?: boolean; square?: boolean }>;
+
+/**
+ * Leading (default) or trailing (`end`) gutter slot of a Card row/header. Sized to the
+ * rail-item square so a passive `<Icon>` aligns with an `IconButton`. Defaults text color to
+ * `subdued` so a decorative `<Icon>` child needs no styling; interactive children set their own.
+ */
+const CardBlock = slottable<HTMLDivElement, CardBlockProps>(
+  ({ children, asChild, end, compact, square, classNames, ...props }, forwardedRef) => {
+    return (
+      <Column.Block
+        asChild={asChild}
+        end={end}
+        compact={compact}
+        square={square}
+        classNames={['text-subdued', classNames]}
+        {...props}
+        ref={forwardedRef}
+      >
+        {children}
+      </Column.Block>
+    );
+  },
+);
+
+CardBlock.displayName = CARD_BLOCK_NAME;
+```
+
+Note: `Column.Block` props are `SlottableProps`, so spread `classNames` via its prop (it uses `composableProps`). Confirm `Column.Block` accepts `classNames` (it does — `slottable` → `composableProps`).
+
+- [ ] **Step 2: Delete `CardIcon` and `CardIconBlock` definitions** (lines ~158-184) and remove `IconBlock`/`IconBlockProps` from the Card import if now unused. Keep `Icon`/`IconProps` import (still used by `CardPoster`, `CardAction`, `CardLink`).
+
+- [ ] **Step 3: Rewrite header helpers to use `Card.Block` placement instead of `CardIconBlock`**
+
+`CardDragHandle`, `CardActionIconButton`, `CardMenu` currently wrap their control in `<CardIconBlock>`. Wrap in `<CardBlock>` instead, and `CardMenu`'s trigger lands in the trailing gutter (`end`). Example for each:
+
+```tsx
+const CardDragHandle = forwardRef<HTMLButtonElement, CardDragHandleProps>((props, forwardedRef) => (
+  <CardBlock>
+    <Toolbar.DragHandle {...props} ref={forwardedRef} />
+  </CardBlock>
+));
+```
+
+```tsx
+const CardActionIconButton = forwardRef<HTMLButtonElement, CardActionIconButtonProps>((props, forwardedRef) => (
+  <CardBlock end>
+    <Toolbar.ActionIconButton {...props} ref={forwardedRef} />
+  </CardBlock>
+));
+```
+
+```tsx
+function CardMenu<T extends any | void = void>({ context, items, ...props }: CardMenuProps<T>) {
+  return (
+    <CardBlock end>
+      <Toolbar.Menu {...props} context={context} items={items ?? []} />
+    </CardBlock>
+  );
+}
+```
+
+NOTE: `Toolbar.DragHandle`/`ActionIconButton`/`Menu` still reference `Toolbar` even though `Card.Header` will no longer be a `Toolbar.Root`. These are plain `IconButton`-family controls; verify they render standalone (they do — `Toolbar.IconButton` works outside a toolbar, just without roving focus). If any throws without a toolbar context, switch to the non-toolbar `IconButton` equivalent.
+
+- [ ] **Step 4: Update the `Card` namespace + exports** in `Card.tsx`:
+
+Remove `IconBlock: CardIconBlock` and `Icon: CardIcon`; add `Block: CardBlock`. Add `CardBlockProps` to the exported types.
+
+```tsx
+export const Card = {
+  Root: CardRoot,
+  // Header
+  Header: CardHeader,
+  // Header / row parts
+  Block: CardBlock,
+  DragHandle: CardDragHandle,
+  ActionIconButton: CardActionIconButton,
+  Menu: CardMenu,
+  Title: CardTitle,
+  // Body
+  Body: CardBody,
+  Section: CardSection,
+  Row: CardRow,
+  // Body parts
+  Text: CardText,
+  Html: CardHtml,
+  Poster: CardPoster,
+  Action: CardAction,
+  Link: CardLink,
+};
+```
+
+- [ ] **Step 5: Build (expect failures only in `CardAction`/`CardLink` which used `CardIcon`)**
+
+`CardAction` and `CardLink` use `CardIcon` internally. Replace those internal uses with `<Column.Block><Icon .../></Column.Block>` or a plain `<Icon>` as appropriate (they are inside a flex button, not a row — a bare `<Icon>` is correct; keep the existing `size={4}`/classNames). Update those two functions.
+
+Run: `moon run react-ui:build`
+Expected: PASS after fixing `CardAction`/`CardLink`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/react-ui/src/components/Card/Card.tsx packages/ui/react-ui/src/components/Card/Card.theme.ts
+git commit -m "feat(react-ui): add Card.Block; remove Card.Icon/Card.IconBlock"
+```
+
+### Task 4: `Card.Row` — drop `icon`; set `--icon-size` 4
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/components/Card/Card.tsx` (`CardRow`)
+
+- [ ] **Step 1: Rewrite `CardRow`** to remove the `icon` prop and set the row's icon size:
+
+```tsx
+import { iconSize } from '@dxos/ui-theme'; // already imported
+
+type CardRowProps = { fullWidth?: boolean };
+
+/**
+ * A row inside a Card.
+ * - Default: spans all 3 columns as a subgrid; children align via `data-slot`
+ *   (`Card.Block` → gutters, anonymous → content). Sets `--icon-size` 4 for decorative icons.
+ * - `fullWidth`: spans all columns without a subgrid — children do their own layout; blocks are inert.
+ */
+const CardRow = slottable<HTMLDivElement, CardRowProps>(
+  ({ children, asChild, fullWidth, style, ...props }, forwardedRef) => {
+    const { tx } = useThemeContext();
+    const { className, ...rest } = composableProps(props);
+    const Comp = asChild ? Slot : Primitive.div;
+    return (
+      <Comp
+        {...rest}
+        style={{ ...iconSize(4), ...style }}
+        className={tx('card.row', { fullWidth }, className)}
+        ref={forwardedRef}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+```
+
+(`JSX` import may now be unused — remove from the React import if so.)
+
+- [ ] **Step 2: Build**
+
+Run: `moon run react-ui:build`
+Expected: PASS (the `react-ui` package itself; call-site packages break in Phase 4).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ui/react-ui/src/components/Card/Card.tsx
+git commit -m "feat(react-ui): drop Card.Row icon prop; inherit icon size"
+```
+
+### Task 5: `Card.Header` — plain `<header>`, `--icon-size` 5, drop Toolbar
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/components/Card/Card.tsx` (`CardHeader`)
+- Modify: `packages/ui/react-ui/src/components/Card/Card.theme.ts` (`header`)
+
+- [ ] **Step 1: Rewrite `CardHeader`** as a slottable header sharing the row layout:
+
+```tsx
+type CardHeaderProps = SlottableProps<{ density?: Density }>;
+
+/**
+ * Top header row of a Card. Shares `Card.Row`'s subgrid + `data-slot` layout; renders as a
+ * `<header>` (not a toolbar — most headers have 0–1 controls, so `role="toolbar"` was incorrect).
+ * Sets `--icon-size` 5 (header icons are larger than row icons).
+ */
+const CardHeader = slottable<HTMLDivElement, CardHeaderProps>(
+  ({ children, asChild, density: _density, classNames, style, ...props }, forwardedRef) => {
+    const { tx } = useThemeContext();
+    const Comp = asChild ? Slot : Primitive.header;
+    return (
+      <Comp
+        {...composableProps({ ...props, classNames }).rest ?? {}}
+        style={{ ...iconSize(5), ...style }}
+        className={tx('card.header', {}, classNames)}
+        ref={forwardedRef}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+```
+
+NOTE: match the exact `composableProps` destructure pattern used by sibling parts (`const { className, ...rest } = composableProps(props)`); the snippet above is illustrative — follow `CardRow`'s exact shape, using `Primitive.header` for the element. `density` is accepted for source-compat but no longer drives a toolbar; drop it if unused after migration audit.
+
+- [ ] **Step 2: Update `header` theme** in `Card.theme.ts` to drop toolbar-specific classes and add `data-slot` routing (same as `row`):
+
+```ts
+const header: ComponentFunction<CardStyleProps> = (_, ...etc) =>
+  mx(
+    'dx-card__header col-span-3 grid grid-cols-subgrid items-center',
+    '[&>[data-slot=start]]:col-start-1',
+    '[&>[data-slot=end]]:col-start-3',
+    '[&>*:not([data-slot])]:col-start-2',
+    ...etc,
+  );
+```
+
+- [ ] **Step 3: Remove now-unused `Toolbar`/`ToolbarRootProps`/`iconSize` imports if orphaned** (keep `iconSize` — still used by Row/Header; keep `Toolbar` — still used by DragHandle/ActionIconButton/Menu helpers).
+
+- [ ] **Step 4: Build**
+
+Run: `moon run react-ui:build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/react-ui/src/components/Card/Card.tsx packages/ui/react-ui/src/components/Card/Card.theme.ts
+git commit -m "feat(react-ui): Card.Header is a plain header sharing Row layout"
+```
+
+### Task 6: Update `Card.stories.tsx`
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/components/Card/Card.stories.tsx`
+
+- [ ] **Step 1: Migrate existing stories** off `Card.Row icon=`/`Card.Icon`/`Card.IconBlock` to `Card.Block`, and add stories proving: start-only, end-only, both, `asChild`, conditional (falsy) block, `fullWidth` (blocks inert), Header vs Row icon size (5 vs 4), and passive-`Icon`-vs-`IconButton` alignment.
+
+```tsx
+<Card.Row>
+  <Card.Block><Icon icon='ph--dot-outline--regular' /></Card.Block>
+  <Card.Text>Card.Text (default)</Card.Text>
+  <Card.Block end>
+    <IconButton iconOnly variant='ghost' icon='ph--x--regular' label='Remove' onClick={() => {}} />
+  </Card.Block>
+</Card.Row>
+```
+
+- [ ] **Step 2: Verify in Storybook** (already running on :9009; if not, start on an alternate port).
+
+Run: `curl -s localhost:9009 >/dev/null && echo up || moon run storybook-react:serve --port 9010`
+Then load the `Card` stories and confirm alignment + no console errors (use preview tools).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ui/react-ui/src/components/Card/Card.stories.tsx
+git commit -m "test(react-ui): Card.Block stories"
+```
+
+---
+
+## Phase 3 — Dialog
+
+### Task 7: `Dialog.Block`, `Dialog.Row`, `Dialog.Header` routing
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/components/Dialog/Dialog.tsx`
+- Modify: `packages/ui/react-ui/src/components/Dialog/Dialog.theme.ts`
+
+- [ ] **Step 1: Add `DialogRow` + `DialogBlock`** (themed `Column.Row`/`Column.Block`). `Dialog.Content` already wraps children in `Column.Root` (gutter `sm`), so a `Column.Row` child works directly:
+
+```tsx
+const DialogRow = slottable<HTMLDivElement>(({ children, asChild, ...props }, forwardedRef) => {
+  const { tx } = useThemeContext();
+  const { className, ...rest } = composableProps(props);
+  const Comp = asChild ? Slot : Primitive.div;
+  return (
+    <Comp {...rest} style={iconSize(4)} className={tx('dialog.row', {}, className)} ref={forwardedRef}>
+      {children}
+    </Comp>
+  );
+});
+DialogRow.displayName = 'Dialog.Row';
+
+type DialogBlockProps = SlottableProps<{ end?: boolean; compact?: boolean; square?: boolean }>;
+const DialogBlock = slottable<HTMLDivElement, DialogBlockProps>(
+  ({ children, asChild, end, compact, square, ...props }, forwardedRef) => {
+    const { tx } = useThemeContext();
+    const { className, ...rest } = composableProps(props);
+    const Comp = asChild ? Slot : Primitive.div;
+    return (
+      <Comp {...rest} data-slot={end ? 'end' : 'start'} className={tx('dialog.block', { compact, square }, className)} ref={forwardedRef}>
+        {children}
+      </Comp>
+    );
+  },
+);
+DialogBlock.displayName = 'Dialog.Block';
+```
+
+Import `iconSize` from `@dxos/ui-theme`.
+
+- [ ] **Step 2: Convert `DialogHeader`** from flex to the subgrid row layout (so title→content, close/actions→`end`). Change the `header` theme:
+
+```ts
+const header: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
+  mx(
+    'dx-dialog__header col-span-3 grid grid-cols-subgrid items-center pb-4',
+    '[&>[data-slot=start]]:col-start-1',
+    '[&>[data-slot=end]]:col-start-3',
+    '[&>*:not([data-slot])]:col-start-2',
+    ...etc,
+  );
+
+const row: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
+  mx('dx-dialog__row col-span-3 grid grid-cols-subgrid items-center', ...etc);
+
+const block: ComponentFunction<DialogStyleProps & { compact?: boolean; square?: boolean }> = ({ compact, square }, ...etc) =>
+  mx('grid place-items-center', square ? 'aspect-square' : 'w-[var(--dx-rail-item)]', compact ? '' : 'h-[var(--dx-rail-item)]', ...etc);
+```
+
+Add `row` and `block` to `dialogTheme`.
+
+NOTE: Dialog title is rendered by `Dialog.Title` (a `DialogPrimitive.Title`), which has no `data-slot` → routes to content (col 2). `Dialog.ActionIconButton`/close go in `<Dialog.Block end>`. Verify the title's heading semantics survive (it does — placement is CSS only).
+
+- [ ] **Step 3: Export `Row`/`Block`** in the `Dialog` namespace and add `DialogRowProps`/`DialogBlockProps` to exported types.
+
+- [ ] **Step 4: Build**
+
+Run: `moon run react-ui:build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/react-ui/src/components/Dialog
+git commit -m "feat(react-ui): add Dialog.Row/Dialog.Block; route Dialog.Header by data-slot"
+```
+
+---
+
+## Phase 4 — Migrate call sites (batched per package, build-green per commit)
+
+Migration patterns (apply mechanically):
+
+- `<Card.Row icon='ph--x--regular'>…` → `<Card.Row><Card.Block><Icon icon='ph--x--regular' /></Card.Block>…</Card.Row>` (import `Icon` from `@dxos/react-ui`).
+- `<Card.Row icon={<El/>}>…` → `<Card.Row><Card.Block><El/></Card.Block>…</Card.Row>`.
+- `<Card.Icon icon='x' … />` → `<Card.Block><Icon icon='x' … /></Card.Block>` (carry over `classNames`/`size` onto the `Icon`).
+- `<Card.IconBlock>…</Card.IconBlock>` → `<Card.Block>…</Card.Block>`; if it held a trailing/menu control, add `end`.
+- Trailing `IconButton`s sitting loose in row/header content → wrap in `<Card.Block end>`.
+- Standalone `IconBlock` (from `@dxos/react-ui`, not `Card.*`) → **leave unchanged**.
+- `Dialog.Header` with a loose close button → `<Dialog.Header><Dialog.Title/>…<Dialog.Block end><Dialog.ActionIconButton action='close'/></Dialog.Block></Dialog.Header>` where gutter alignment is desired (optional; only where the old flex layout looked wrong).
+
+For each package below: edit files, run `moon run <pkg>:build`, fix, then commit `refactor(<pkg>): migrate to Card.Block`.
+
+### Task 8: Migrate `react-ui` sibling packages
+
+**Files (per `grep` inventory):**
+- `react-ui-mosaic`: `src/testing/DefaultStackTile.tsx`, `src/components/SearchStack/SearchStack.tsx`, `src/components/Board/Item.tsx`
+- `react-ui-board`: `src/components/Board/Board.stories.tsx`
+- `react-ui-masonry`: `src/Masonry.stories.tsx`
+- `react-ui-editor`: `src/stories/Preview.stories.tsx`
+
+- [ ] Edit each, applying the patterns above. Leave standalone `IconBlock` usages alone.
+- [ ] Build each: `moon run react-ui-mosaic:build` (etc.).
+- [ ] Commit: `refactor(react-ui-mosaic): migrate to Card.Block` (group per package).
+
+### Task 9: Migrate plugins — group A (preview, feed, trip, inbox)
+
+**Files:**
+- `plugin-preview`: `cards/PersonCard.tsx`, `cards/OrganizationCard.tsx`, `cards/TaskCard.tsx`, `cards/FormCard.tsx`, `stories/Card.stories.tsx`
+- `plugin-feed`: `components/SubscriptionStack/SubscriptionStack.tsx`, `components/PostStack/PostStack.tsx`, `containers/PostCard/PostCard.tsx`, `containers/MagazineArticle/MagazineTile.tsx`
+- `plugin-trip`: `components/SegmentCard/SegmentEditableCard.tsx`, `components/SegmentCard/SegmentCard.tsx`, `components/OfferStack/OfferStack.tsx`
+- `plugin-inbox`: `components/Message/Message.tsx`, `components/MessageStack/MessageStack.tsx`, `components/Event/EventDetails.tsx`, `components/Event/EventEditor.tsx`, `components/Header/Header.tsx`, `containers/MessageCard/MessageCard.tsx`
+
+- [ ] Edit, build each plugin (`moon run plugin-preview:build`, …), fix, commit per plugin.
+
+### Task 10: Migrate plugins — group B (rest)
+
+**Files:**
+- `plugin-deck`: `containers/DeckLayout/Popover.tsx`
+- `plugin-bookmarks`: `containers/BookmarkCard/BookmarkCard.tsx`, `containers/BookmarkArticle/BookmarkArticle.tsx`
+- `plugin-markdown`: `containers/MarkdownCard/MarkdownCard.tsx`, `containers/EditableMarkdownCard/EditableMarkdownCard.tsx`
+- `plugin-table`: `containers/TableCard/TableCard.tsx`
+- `plugin-voxel`: `containers/VoxelCard/VoxelCard.tsx`
+- `plugin-kanban`: `testing/KanbanCardTileSimple.tsx`
+- `plugin-commerce`: `containers/ResultCard/ResultCard.tsx`
+- `plugin-pipeline`: `components/PipelineComponent/PipelineColumn.tsx`
+- `plugin-assistant`: `containers/AgentArticle/AgentArticle.tsx`
+- `plugin-search`: `components/SearchResultStack/SearchResultStack.tsx`
+- `stories-assistant`: `src/components/ContextModule.tsx`
+
+- [ ] Edit, build each, fix, commit per plugin.
+
+### Task 11: Sweep for stragglers + Card.Header / Dialog.Header reslots
+
+- [ ] **Step 1: Grep for any remaining removed symbols**
+
+Run:
+```bash
+cd /Users/burdon/Code/dxos/dxos && grep -rn "Card\.Icon\b\|Card\.IconBlock\|Card\.Row[^>]*icon=" packages --include="*.tsx"
+```
+Expected: no matches (only the standalone `IconBlock` remains).
+
+- [ ] **Step 2: Visually verify the ~20 multi-control `Card.Header`s** still tab through controls and align (Storybook + a few plugin stories via preview tools). Reslot any header whose buttons should sit in the trailing gutter using `<Card.Block end>`.
+
+- [ ] **Step 3: Verify `Dialog.Header` call sites** (24 files) still render title-left / close-right correctly after the flex→subgrid change. Where a header relied on `justify-between` flex with >2 children, wrap controls in `Dialog.Block` slots.
+
+- [ ] **Step 4: Commit any reslot fixes.**
+
+---
+
+## Phase 5 — Verify
+
+### Task 12: Full build / lint / test + cast audit
+
+- [ ] **Step 1: Build everything**
+
+Run: `moon exec --on-failure continue --quiet :build`
+Expected: all green.
+
+- [ ] **Step 2: Lint**
+
+Run: `moon run :lint -- --fix`
+Expected: clean.
+
+- [ ] **Step 3: Tests**
+
+Run: `MOON_CONCURRENCY=4 moon run :test -- --no-file-parallelism`
+Expected: pass.
+
+- [ ] **Step 4: Cast audit**
+
+Run: `git diff origin/main | grep -nE '\bas (any|unknown|[A-Z])|as unknown as'`
+Expected: no new casts (justify or remove any).
+
+- [ ] **Step 5: Final commit / clean tree**
+
+Run: `git status` → clean.
+
+---
+
+## Self-Review notes
+
+- Spec coverage: Column.Block (T2), Column.Row routing (T1), Card.Block (T3), Card.Row icon removal (T4), Card.Header plain+size (T5), stories (T6), Dialog.Row/Block/Header (T7), IconBlock kept (T2/T3 reuse geometry; migration leaves it), Card.Icon/IconBlock removed (T3), full migration (T8–T11), a11y (Block sets no blanket aria-hidden — verified in T3 code), verify (T12). ✓
+- The illustrative `CardHeader` snippet in T5 must be reconciled to the exact `composableProps` destructure used by `CardRow`/`CardBody` — do not ship the `?? {}` placeholder; follow the sibling pattern.
+- Icon size: Row sets `iconSize(4)`, Header `iconSize(5)`; decorative `<Icon>` children omit `size` to inherit (T4/T5).

--- a/docs/superpowers/specs/2026-06-13-card-row-slots-design.md
+++ b/docs/superpowers/specs/2026-06-13-card-row-slots-design.md
@@ -1,0 +1,173 @@
+# Card/Dialog Row Slots — Design
+
+Date: 2026-06-13
+Status: Proposed
+
+## Problem
+
+`Card.Row` conflates three concerns into one overloaded `icon` prop:
+
+- **What** goes in the slot — `icon?: string | JSX.Element` (string → auto `CardIcon size={4}`; element → caller's responsibility).
+- **Where** it goes — only column 1. There is no first-class column 3 slot; trailing `IconButton`s today are dumped into the content track and do not align to the right gutter.
+- **Geometry** — a passive `<Icon>` must be wrapped in `IconBlock` (sized to `--dx-rail-item`) to line up with an interactive `IconButton`. Callers must remember to do this; `IconBlock` and the `icon` convenience are both acknowledged hacks.
+
+`Card.Row` is, structurally, just `Column.Row` (a 3-column subgrid `gutter | minmax(0,1fr) | gutter`) with an icon shortcut bolted on. `Panel` already solves "place a child into a named track" cleanly: a `data-slot` attribute drives grid placement, and anonymous children auto-route to the content region. We adopt that idiom for the horizontal 3-column rows used by `Column`, `Card`, and `Dialog`.
+
+## Goals
+
+- Place an icon or `IconButton` in **either** gutter (column 1 or column 3) of a row.
+- A passive icon and an `IconButton` in a gutter share identical geometry **by construction**, not by callers remembering to wrap.
+- Keep the common case terse (one leading passive icon).
+- Remove the overloaded `Card.Row.icon` prop, `Card.Icon`, and `Card.IconBlock`; migrate all call sites (no compat shims). **Keep** the standalone `IconBlock` primitive — it has ~21 non-card uses (`react-ui-form`, `react-ui-list`, `react-ui-components`, …) and `Column.Block` is built on its geometry.
+- Apply the same mechanism to `Card.Header`, and to `Dialog.Header` / a new `Dialog.Row`.
+
+## Non-goals
+
+- Changing `fullWidth` row semantics (no subgrid → slots are inert; documented).
+- Reworking `Column.Center` / `Column.Bleed`.
+- Restyling existing visuals beyond what slot placement requires.
+
+## Design
+
+### 1. `Column` — the layout primitive
+
+`Column.Row` already spans all three columns via subgrid. Add explicit `data-slot` routing to its theme (mirroring `Panel`):
+
+```
+[&>[data-slot=start]]:[grid-column:1]
+[&>[data-slot=end]]:[grid-column:3]
+[&>*:not([data-slot])]:[grid-column:2]   // anonymous children → content track
+```
+
+Placement is driven by `data-slot`, not DOM order, so conditional children (`{cond && <Block/>}`) never shift content into a gutter.
+
+Add **`Column.Block`** — the gutter slot component. It **reuses `IconBlock`'s geometry** (the `icon.block` theme / `--dx-rail-item` square) and adds grid placement. It is a **pure geometry slot**: no `icon` shortcut, callers always pass a real child (`<Icon>`, `<IconButton>`, `<Avatar>`, …):
+
+```tsx
+type ColumnBlockProps = SlottableProps<{
+  end?: boolean;        // default: start (column 1). `end` opts into column 3.
+  compact?: boolean;    // from IconBlock: omit height constraint.
+  square?: boolean;     // from IconBlock: aspect-square vs width-only.
+}>;
+```
+
+Behavior:
+
+- Renders a `data-slot={end ? 'end' : 'start'}` element sized to `--dx-rail-item`
+  (`grid place-items-center`, the current `IconBlock` theme verbatim). The child is
+  centered in the rail-item square; a passive `<Icon>` and an `IconButton` align to the
+  pixel by construction.
+- **No `icon` / `size` props.** A decorative `<Icon>` child carries no explicit `size`,
+  so it inherits the `--icon-size` CSS var set by the enclosing row/header (via the
+  existing `iconSize()` helper) — `Card.Row` sets 4, `Card.Header` sets 5. The same
+  `Card.Block` renders correctly in either context with no per-call config.
+- `asChild` is inherited from `slottable()` (Slot vs `Primitive.div` + `COMPOSABLE`).
+  With `asChild`, the single child becomes the grid cell, receiving `data-slot` + the
+  layout-only rail geometry directly — useful for making a trailing `<a>` or control the
+  focusable cell rather than nesting it in a wrapper `<div>`.
+- **A11y fix:** the geometry wrapper does **not** blanket-set `aria-hidden` (today's
+  `IconBlock` does, which is wrong when it wraps an interactive control). Semantics are
+  left to the child — an `IconButton` carries its own label; a purely decorative `<Icon>`
+  block can be marked `aria-hidden` by the caller.
+
+### 2. `Card` — themed over `Column`
+
+- **`Card.Block`** = themed `Column.Block` (Card density). Defaults its text color to
+  subdued so a decorative `<Icon>` child inherits today's `text-subdued` look with no
+  per-call styling; interactive children (`IconButton`) set their own color. Inherits
+  `asChild`.
+- **`Card.Row`** = themed `Column.Row`, sets `--icon-size` 4. **Remove the `icon`
+  prop.** `fullWidth` unchanged; when set there is no subgrid, so blocks are inert
+  (documented).
+- **`Card.Header`** = themed `Column.Row` rendered as a `<header>` element, sets
+  `--icon-size` 5. **Drop `Toolbar.Root` entirely.** Header and Row share the exact
+  same subgrid + `data-slot` layout; the only differences are the semantic element and
+  the default icon size. Rationale: ~75% of `Card.Header` call sites have 0–1
+  interactive controls, where `role="toolbar"` + roving tabindex is incorrect or
+  pointless; the ~20% multi-control headers lose arrow-key roving, which is an
+  accepted trade for correct semantics and a uniform layout. `CardHeaderProps` becomes
+  `SlottableProps` (+ `density?`), no longer `ToolbarRootProps`.
+- **Header helpers reconciliation:** `Card.DragHandle` / `Card.ActionIconButton` /
+  `Card.Menu` no longer render inside `CardIconBlock` or rely on toolbar item roles.
+  They carry `data-slot` for placement and render plain `IconButton`s (`iconOnly
+  square`, already rail-item sized), so they need no geometry wrapper.
+- **Remove** `Card.IconBlock` and `Card.Icon`; `Card.Block` replaces both
+  (`<Card.Block><Icon …/></Card.Block>` for the passive case). The standalone
+  `IconBlock` primitive is **untouched** — `Column.Block` reuses its `icon.block` theme.
+
+### 3. `Dialog` — adopt the same mechanism
+
+`Dialog.Content` already wraps children in `Column.Root` (gutter `sm`).
+
+- **`Dialog.Header`**: convert from `flex justify-between` to the shared `data-slot`
+  routing (title → content/anonymous; close/actions → `end`). Visually equivalent for
+  the common title-left/close-right case, now with true gutter alignment.
+- **Add `Dialog.Row`** = themed `Column.Row` (parallels `Card.Row`).
+- **Add `Dialog.Block`** = themed `Column.Block` (dialog density).
+
+### Resulting usage
+
+```tsx
+<Card.Row>
+  <Card.Block><Icon icon='ph--user--regular' /></Card.Block>   {/* col 1 (default start) */}
+  <Card.Title>Alice</Card.Title>                               {/* anonymous → content */}
+  <Card.Block end>                                             {/* col 3 */}
+    <IconButton iconOnly icon='ph--x--regular' label='Remove' />
+  </Card.Block>
+</Card.Row>
+
+{author && (                                                   {/* conditional: safe, no shift */}
+  <Card.Block><Icon icon='ph--user--regular' /></Card.Block>
+)}
+
+<Card.Block end asChild>                                       {/* asChild */}
+  <a href={href}><Icon icon='ph--arrow-up-right--regular' /></a>
+</Card.Block>
+```
+
+## Surface change summary
+
+| Before | After |
+| --- | --- |
+| `Card.Row` `icon?: string \| JSX.Element` | removed |
+| `IconBlock` (public, standalone) | **kept** — `Column.Block` reuses its geometry |
+| `Card.IconBlock` | removed → `Card.Block` |
+| `Card.Icon` | removed → `<Card.Block><Icon/></Card.Block>` |
+| — | `Column.Block`, `Card.Block`, `Dialog.Block` |
+| — | `Dialog.Row` |
+| `Dialog.Header` flex | `data-slot` routing |
+| `Card.Header` = `Toolbar.Root` (`role="toolbar"`) | plain `<header>`, shared Row layout, `--icon-size` 5 |
+| `Card.Header` icon via helpers/`IconBlock` | `data-slot` routing + `Card.Block` |
+
+## Migration (full replace, per repo no-shim policy)
+
+Touch every call site in the same change:
+
+1. `<Card.Row icon='x'>…` → `<Card.Row><Card.Block><Icon icon='x'/></Card.Block>…</Card.Row>`.
+2. `<Card.Row icon={<El/>}>` → `<Card.Row><Card.Block><El/></Card.Block>…`.
+3. Trailing buttons living inside row content → wrap in `<Card.Block end>`.
+4. Replace `Card.IconBlock` / `Card.Icon` usages with `Card.Block`. **Standalone
+   `IconBlock` usages are left as-is.**
+5. `Dialog.Header` close/action buttons → `end` slot; add `Dialog.Row` where dialogs
+   hand-rolled gutter rows.
+6. Update `Card.stories.tsx` and any `Dialog` stories.
+
+Known call sites (non-exhaustive): `plugin-feed/PostStack`, `plugin-inbox/Header` & `Message`, `plugin-preview/PersonCard`, `plugin-trip/SegmentCard`, plus `react-ui` stories.
+
+## Testing
+
+- Storybook: `Card` stories cover start-only, end-only, both, `asChild`, conditional
+  (falsy) block, `fullWidth` (blocks inert), Header-vs-Row icon size (5 vs 4), and a
+  passive-icon-vs-`IconButton` alignment story proving identical geometry. Add
+  equivalent `Dialog` stories.
+- Visual regression via existing storybook snapshots where available.
+- Build + lint + `react-ui` tests green; audit diff for new casts.
+
+## Risks / open questions
+
+- Broad call-site churn across plugins (accepted: full replace).
+- `Dialog.Header` restyle could subtly shift spacing for non-title/close layouts —
+  verify each dialog visually.
+- Dropping `Toolbar.Root` from `Card.Header` removes arrow-key roving for the ~20
+  multi-control headers (accepted trade for correct ARIA semantics). Verify those
+  headers still tab through their controls normally.

--- a/docs/superpowers/specs/2026-06-13-card-row-slots-design.md
+++ b/docs/superpowers/specs/2026-06-13-card-row-slots-design.md
@@ -31,15 +31,19 @@ Status: Proposed
 
 ### 1. `Column` — the layout primitive
 
-`Column.Row` already spans all three columns via subgrid. Add explicit `data-slot` routing to its theme (mirroring `Panel`):
+`Column.Row` already spans all three columns via subgrid. Placement is explicit (not DOM-order), so conditional children (`{cond && <Block/>}`) never shift content into a gutter:
 
-```
-[&>[data-slot=start]]:[grid-column:1]
-[&>[data-slot=end]]:[grid-column:3]
-[&>*:not([data-slot])]:[grid-column:2]   // anonymous children → content track
-```
+- `Column.Block` **self-places** into column 1 (leading) or column 3 (`end`) with a plain
+  `col-start-1` / `col-start-3` utility, and carries a `dx-gutter` marker class.
+- The row places every non-gutter (content) child into column 2 via
+  `[&>*:not(.dx-gutter)]:col-start-2`.
 
-Placement is driven by `data-slot`, not DOM order, so conditional children (`{cond && <Block/>}`) never shift content into a gutter.
+**Implementation note:** the original design routed by `data-slot`
+(`[&>[data-slot=start]]:col-start-1`), mirroring `Panel`. That does not work here —
+Tailwind does not generate arbitrary variants that nest a square-bracket attribute
+selector, so the rule silently no-ops. Class-based placement (`dx-gutter` + `:not(.dx-gutter)`)
+is the pattern the codebase already uses (`withColumn.propagate`) and generates correctly.
+The `data-slot` attribute is still set on the block as a semantic marker.
 
 Add **`Column.Block`** — the gutter slot component. It **reuses `IconBlock`'s geometry** (the `icon.block` theme / `--dx-rail-item` square) and adds grid placement. It is a **pure geometry slot**: no `icon` shortcut, callers always pass a real child (`<Icon>`, `<IconButton>`, `<Avatar>`, …):
 
@@ -53,10 +57,10 @@ type ColumnBlockProps = SlottableProps<{
 
 Behavior:
 
-- Renders a `data-slot={end ? 'end' : 'start'}` element sized to `--dx-rail-item`
-  (`grid place-items-center`, the current `IconBlock` theme verbatim). The child is
-  centered in the rail-item square; a passive `<Icon>` and an `IconButton` align to the
-  pixel by construction.
+- Renders a `dx-gutter` element sized to `--dx-rail-item` (`grid place-items-center`, the
+  current `IconBlock` theme verbatim) that self-places into column 1 or 3. Also sets
+  `data-slot={end ? 'end' : 'start'}` as a semantic marker. The child is centered in the
+  rail-item square; a passive `<Icon>` and an `IconButton` align to the pixel by construction.
 - **No `icon` / `size` props.** A decorative `<Icon>` child carries no explicit `size`,
   so it inherits the `--icon-size` CSS var set by the enclosing row/header (via the
   existing `iconSize()` helper) — `Card.Row` sets 4, `Card.Header` sets 5. The same

--- a/docs/superpowers/specs/2026-06-13-card-row-slots-design.md
+++ b/docs/superpowers/specs/2026-06-13-card-row-slots-design.md
@@ -49,9 +49,9 @@ Add **`Column.Block`** — the gutter slot component. It **reuses `IconBlock`'s 
 
 ```tsx
 type ColumnBlockProps = SlottableProps<{
-  end?: boolean;        // default: start (column 1). `end` opts into column 3.
-  compact?: boolean;    // from IconBlock: omit height constraint.
-  square?: boolean;     // from IconBlock: aspect-square vs width-only.
+  end?: boolean; // default: start (column 1). `end` opts into column 3.
+  compact?: boolean; // from IconBlock: omit height constraint.
+  square?: boolean; // from IconBlock: aspect-square vs width-only.
 }>;
 ```
 
@@ -140,16 +140,16 @@ sound. The mechanism now lives in `Column` (`Column.Block` + `Column.Row` routin
 
 ## Surface change summary
 
-| Before | After |
-| --- | --- |
-| `Card.Row` `icon?: string \| JSX.Element` | removed |
-| `IconBlock` (public, standalone) | **kept** — `Column.Block` reuses its geometry |
-| `Card.IconBlock` | removed → `Card.Block` |
-| `Card.Icon` | removed → `<Card.Block><Icon/></Card.Block>` |
-| — | `Column.Block`, `Card.Block` |
-| `Dialog.Header` flex | unchanged (gutter too narrow for slots — deferred) |
+| Before                                            | After                                                |
+| ------------------------------------------------- | ---------------------------------------------------- |
+| `Card.Row` `icon?: string \| JSX.Element`         | removed                                              |
+| `IconBlock` (public, standalone)                  | **kept** — `Column.Block` reuses its geometry        |
+| `Card.IconBlock`                                  | removed → `Card.Block`                               |
+| `Card.Icon`                                       | removed → `<Card.Block><Icon/></Card.Block>`         |
+| —                                                 | `Column.Block`, `Card.Block`                         |
+| `Dialog.Header` flex                              | unchanged (gutter too narrow for slots — deferred)   |
 | `Card.Header` = `Toolbar.Root` (`role="toolbar"`) | plain `<header>`, shared Row layout, `--icon-size` 5 |
-| `Card.Header` icon via helpers/`IconBlock` | `data-slot` routing + `Card.Block` |
+| `Card.Header` icon via helpers/`IconBlock`        | `data-slot` routing + `Card.Block`                   |
 
 ## Migration (full replace, per repo no-shim policy)
 

--- a/docs/superpowers/specs/2026-06-13-card-row-slots-design.md
+++ b/docs/superpowers/specs/2026-06-13-card-row-slots-design.md
@@ -160,9 +160,9 @@ Touch every call site in the same change:
 3. Trailing buttons living inside row content → wrap in `<Card.Block end>`.
 4. Replace `Card.IconBlock` / `Card.Icon` usages with `Card.Block`. **Standalone
    `IconBlock` usages are left as-is.**
-5. `Dialog.Header` close/action buttons → `end` slot; add `Dialog.Row` where dialogs
-   hand-rolled gutter rows.
-6. Update `Card.stories.tsx` and any `Dialog` stories.
+5. Update `Card.stories.tsx`.
+6. **Dialog is deferred** (see §3) — `Dialog.Header` and dialog call sites are left
+   unchanged in this work.
 
 Known call sites (non-exhaustive): `plugin-feed/PostStack`, `plugin-inbox/Header` & `Message`, `plugin-preview/PersonCard`, `plugin-trip/SegmentCard`, plus `react-ui` stories.
 
@@ -170,16 +170,14 @@ Known call sites (non-exhaustive): `plugin-feed/PostStack`, `plugin-inbox/Header
 
 - Storybook: `Card` stories cover start-only, end-only, both, `asChild`, conditional
   (falsy) block, `fullWidth` (blocks inert), Header-vs-Row icon size (5 vs 4), and a
-  passive-icon-vs-`IconButton` alignment story proving identical geometry. Add
-  equivalent `Dialog` stories.
+  passive-icon-vs-`IconButton` alignment story proving identical geometry.
+  (Dialog slot stories deferred with Dialog adoption.)
 - Visual regression via existing storybook snapshots where available.
 - Build + lint + `react-ui` tests green; audit diff for new casts.
 
 ## Risks / open questions
 
 - Broad call-site churn across plugins (accepted: full replace).
-- `Dialog.Header` restyle could subtly shift spacing for non-title/close layouts —
-  verify each dialog visually.
 - Dropping `Toolbar.Root` from `Card.Header` removes arrow-key roving for the ~20
   multi-control headers (accepted trade for correct ARIA semantics). Verify those
   headers still tab through their controls normally.

--- a/docs/superpowers/specs/2026-06-13-card-row-slots-design.md
+++ b/docs/superpowers/specs/2026-06-13-card-row-slots-design.md
@@ -95,15 +95,20 @@ Behavior:
   (`<Card.Block><Icon …/></Card.Block>` for the passive case). The standalone
   `IconBlock` primitive is **untouched** — `Column.Block` reuses its `icon.block` theme.
 
-### 3. `Dialog` — adopt the same mechanism
+### 3. `Dialog` — deferred (gutter geometry mismatch)
 
-`Dialog.Content` already wraps children in `Column.Root` (gutter `sm`).
+**Decision (during implementation): not adopted in this change.** `Dialog.Content` wraps
+children in `Column.Root` with gutter `sm` (1rem). The rail-item block is `2rem`
+(`--dx-rail-item` = `--dx-rail-content` 3rem − 1rem), which is exactly the card `md`
+gutter (2rem) but **2× the dialog `sm` gutter**. So a gutter-placed `Card.Block`-style
+slot overflows in a dialog — which is precisely why `Dialog.Header` uses `flex
+justify-between` rather than a subgrid today.
 
-- **`Dialog.Header`**: convert from `flex justify-between` to the shared `data-slot`
-  routing (title → content/anonymous; close/actions → `end`). Visually equivalent for
-  the common title-left/close-right case, now with true gutter alignment.
-- **Add `Dialog.Row`** = themed `Column.Row` (parallels `Card.Row`).
-- **Add `Dialog.Block`** = themed `Column.Block` (dialog density).
+Adopting the gutter-slot model in `Dialog` therefore requires a separate decision about
+dialog gutter width (e.g. a `md`-gutter dialog variant) before it is geometrically
+sound. The mechanism now lives in `Column` (`Column.Block` + `Column.Row` routing), so
+`Dialog` can opt in later without rework. `Dialog.Header` is left unchanged; no
+`Dialog.Row`/`Dialog.Block` shipped (YAGNI — zero current consumers).
 
 ### Resulting usage
 
@@ -133,9 +138,8 @@ Behavior:
 | `IconBlock` (public, standalone) | **kept** — `Column.Block` reuses its geometry |
 | `Card.IconBlock` | removed → `Card.Block` |
 | `Card.Icon` | removed → `<Card.Block><Icon/></Card.Block>` |
-| — | `Column.Block`, `Card.Block`, `Dialog.Block` |
-| — | `Dialog.Row` |
-| `Dialog.Header` flex | `data-slot` routing |
+| — | `Column.Block`, `Card.Block` |
+| `Dialog.Header` flex | unchanged (gutter too narrow for slots — deferred) |
 | `Card.Header` = `Toolbar.Root` (`role="toolbar"`) | plain `<header>`, shared Row layout, `--icon-size` 5 |
 | `Card.Header` icon via helpers/`IconBlock` | `data-slot` routing + `Card.Block` |
 

--- a/docs/superpowers/specs/2026-06-13-card-row-slots-design.md
+++ b/docs/superpowers/specs/2026-06-13-card-row-slots-design.md
@@ -88,9 +88,13 @@ Behavior:
   accepted trade for correct semantics and a uniform layout. `CardHeaderProps` becomes
   `SlottableProps` (+ `density?`), no longer `ToolbarRootProps`.
 - **Header helpers reconciliation:** `Card.DragHandle` / `Card.ActionIconButton` /
-  `Card.Menu` no longer render inside `CardIconBlock` or rely on toolbar item roles.
-  They carry `data-slot` for placement and render plain `IconButton`s (`iconOnly
-  square`, already rail-item sized), so they need no geometry wrapper.
+  `Card.Menu` are reimplemented on the base `IconButton`/`DropdownMenu` (no
+  `Toolbar.*` primitives) and wrapped in `Card.Block` (`end` for actions/menus).
+  Because `Card.Header` no longer provides a `RovingFocusGroup`, **any raw
+  `Toolbar.IconButton`/`Toolbar.Separator` placed directly in a `Card.Header` at a
+  call site throws at runtime** and must be swapped for the base `IconButton`
+  (wrapped in `Card.Block`) — ~15 call sites. This is part of the migration, not
+  optional.
 - **Remove** `Card.IconBlock` and `Card.Icon`; `Card.Block` replaces both
   (`<Card.Block><Icon …/></Card.Block>` for the passive case). The standalone
   `IconBlock` primitive is **untouched** — `Column.Block` reuses its `icon.block` theme.

--- a/packages/plugins/plugin-assistant/src/containers/AgentArticle/AgentArticle.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/AgentArticle/AgentArticle.tsx
@@ -12,7 +12,7 @@ import { AppSurface, useObjectMenuItems } from '@dxos/app-toolkit/ui';
 import { Agent } from '@dxos/assistant-toolkit';
 import { Database, Feed, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { useQuery } from '@dxos/react-client/echo';
-import { Card, Icon, Message, Panel, ScrollArea, Toolbar, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, IconButton, Message, Panel, ScrollArea, Toolbar, useTranslation } from '@dxos/react-ui';
 import { composable } from '@dxos/react-ui';
 import { Masonry } from '@dxos/react-ui-masonry';
 import { Menu } from '@dxos/react-ui-menu';
@@ -153,7 +153,7 @@ const ArtifactTileCard = composable<HTMLDivElement, { data: Obj.Unknown }>(({ da
         {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
         <Card.Block end>
           <Menu.Trigger asChild disabled={!objectMenuItems?.length}>
-            <Toolbar.IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Actions' />
+            <IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Actions' />
           </Menu.Trigger>
           <Menu.Content items={objectMenuItems} />
         </Card.Block>

--- a/packages/plugins/plugin-assistant/src/containers/AgentArticle/AgentArticle.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/AgentArticle/AgentArticle.tsx
@@ -12,7 +12,7 @@ import { AppSurface, useObjectMenuItems } from '@dxos/app-toolkit/ui';
 import { Agent } from '@dxos/assistant-toolkit';
 import { Database, Feed, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { useQuery } from '@dxos/react-client/echo';
-import { Card, Message, Panel, ScrollArea, Toolbar, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, Message, Panel, ScrollArea, Toolbar, useTranslation } from '@dxos/react-ui';
 import { composable } from '@dxos/react-ui';
 import { Masonry } from '@dxos/react-ui-masonry';
 import { Menu } from '@dxos/react-ui-menu';
@@ -146,17 +146,17 @@ const ArtifactTileCard = composable<HTMLDivElement, { data: Obj.Unknown }>(({ da
   return (
     <Card.Root {...props} ref={forwardedRef} data-testid='board-item' fullWidth>
       <Card.Header>
-        <Card.IconBlock>
-          <Card.Icon icon={icon} />
-        </Card.IconBlock>
+        <Card.Block>
+          <Icon icon={icon} />
+        </Card.Block>
         <Card.Title>{Obj.getLabel(data, { fallback: 'typename' })}</Card.Title>
         {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
-        <Card.IconBlock>
+        <Card.Block end>
           <Menu.Trigger asChild disabled={!objectMenuItems?.length}>
             <Toolbar.IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Actions' />
           </Menu.Trigger>
           <Menu.Content items={objectMenuItems} />
-        </Card.IconBlock>
+        </Card.Block>
       </Card.Header>
       <Card.Body>
         <Surface.Surface

--- a/packages/plugins/plugin-bookmarks/src/containers/BookmarkArticle/BookmarkArticle.tsx
+++ b/packages/plugins/plugin-bookmarks/src/containers/BookmarkArticle/BookmarkArticle.tsx
@@ -88,9 +88,9 @@ export const BookmarkArticle = ({ role, attendableId, subject }: BookmarkArticle
         <Panel.Content classNames='dx-container flex flex-col'>
           <Card.Root fullWidth border={false}>
             <Card.Header>
-              <Card.IconBlock>
+              <Card.Block>
                 <img src={bookmark.favicon} alt={bookmark.title} />
-              </Card.IconBlock>
+              </Card.Block>
               <Card.Title>{bookmark.title}</Card.Title>
             </Card.Header>
             <Card.Body>

--- a/packages/plugins/plugin-commerce/src/containers/ResultCard/ResultCard.tsx
+++ b/packages/plugins/plugin-commerce/src/containers/ResultCard/ResultCard.tsx
@@ -61,7 +61,7 @@ export const ResultCard = composable<HTMLDivElement, ResultCardProps>(
           />
         )}
         <Card.Header>
-          <Card.IconBlock>
+          <Card.Block>
             <IconButton
               variant='ghost'
               iconOnly
@@ -71,12 +71,12 @@ export const ResultCard = composable<HTMLDivElement, ResultCardProps>(
               icon={starred ? 'ph--star--fill' : 'ph--star--regular'}
               onClick={handleToggleStar}
             />
-          </Card.IconBlock>
+          </Card.Block>
           <div className='flex flex-col gap-0.5 min-w-0 py-2'>
             <Card.Title classNames='line-clamp-2'>{result.title}</Card.Title>
             {price && <span className='text-sm text-description'>{price}</span>}
           </div>
-          <Card.IconBlock />
+          <Card.Block end />
         </Card.Header>
       </Card.Root>
     );

--- a/packages/plugins/plugin-deck/src/containers/DeckLayout/Popover.tsx
+++ b/packages/plugins/plugin-deck/src/containers/DeckLayout/Popover.tsx
@@ -10,6 +10,7 @@ import { AppSurface, useObjectMenuItems } from '@dxos/app-toolkit/ui';
 import { Obj } from '@dxos/echo';
 import {
   Card,
+  Icon,
   Popover,
   type PopoverContentInteractOutsideEvent,
   toLocalizedString,
@@ -129,10 +130,10 @@ export const PopoverContent = () => {
             <Menu.Root>
               <Card.Root border={false} classNames='dx-card-popover'>
                 <Card.Header>
-                  <Card.IconBlock>{icon && <Card.Icon icon={icon} />}</Card.IconBlock>
+                  <Card.Block>{icon && <Icon icon={icon} />}</Card.Block>
                   <Card.Title>{title}</Card.Title>
                   {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
-                  <Card.IconBlock>
+                  <Card.Block end>
                     <Menu.Trigger asChild disabled={!objectMenuItems.length}>
                       <Toolbar.IconButton
                         variant='ghost'
@@ -143,7 +144,7 @@ export const PopoverContent = () => {
                       />
                     </Menu.Trigger>
                     <Menu.Content items={objectMenuItems} />
-                  </Card.IconBlock>
+                  </Card.Block>
                 </Card.Header>
 
                 {content && 'subject' in content ? (

--- a/packages/plugins/plugin-deck/src/containers/DeckLayout/Popover.tsx
+++ b/packages/plugins/plugin-deck/src/containers/DeckLayout/Popover.tsx
@@ -11,10 +11,10 @@ import { Obj } from '@dxos/echo';
 import {
   Card,
   Icon,
+  IconButton,
   Popover,
   type PopoverContentInteractOutsideEvent,
   toLocalizedString,
-  Toolbar,
   useTranslation,
 } from '@dxos/react-ui';
 import { Menu } from '@dxos/react-ui-menu';
@@ -135,7 +135,7 @@ export const PopoverContent = () => {
                   {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
                   <Card.Block end>
                     <Menu.Trigger asChild disabled={!objectMenuItems.length}>
-                      <Toolbar.IconButton
+                      <IconButton
                         variant='ghost'
                         density='sm'
                         icon='ph--dots-three-vertical--regular'

--- a/packages/plugins/plugin-feed/src/components/PostStack/PostStack.tsx
+++ b/packages/plugins/plugin-feed/src/components/PostStack/PostStack.tsx
@@ -104,21 +104,24 @@ const PostTile = forwardRef<HTMLDivElement, PostTileProps>(({ data, location, cu
       <Focus.Item asChild current={current} onCurrentChange={handleCurrentChange}>
         <Card.Root ref={forwardedRef} fullWidth>
           <Card.Header>
-            <Card.IconBlock>
-              <Card.Icon icon='ph--dot-outline--regular' />
-            </Card.IconBlock>
+            <Card.Block>
+              <Icon icon='ph--dot-outline--regular' />
+            </Card.Block>
             <Card.Text classNames='truncate'>{post.title ?? t('post-title.placeholder')}</Card.Text>
             {post.link && (
-              <Card.IconBlock>
+              <Card.Block end>
                 <a href={post.link} target='_blank' rel='noreferrer' className='shrink-0'>
                   <Icon icon='ph--arrow-square-out--regular' size={4} />
                 </a>
-              </Card.IconBlock>
+              </Card.Block>
             )}
           </Card.Header>
           <Card.Body>
             {post.author && (
-              <Card.Row icon='ph--user--regular'>
+              <Card.Row>
+                <Card.Block>
+                  <Icon icon='ph--user--regular' />
+                </Card.Block>
                 <Card.Text variant='description'>{post.author}</Card.Text>
               </Card.Row>
             )}
@@ -131,7 +134,10 @@ const PostTile = forwardRef<HTMLDivElement, PostTileProps>(({ data, location, cu
               </Card.Row>
             )}
             {published && (
-              <Card.Row icon='ph--calendar--regular'>
+              <Card.Row>
+                <Card.Block>
+                  <Icon icon='ph--calendar--regular' />
+                </Card.Block>
                 <Card.Text variant='description'>{published}</Card.Text>
               </Card.Row>
             )}

--- a/packages/plugins/plugin-feed/src/components/SubscriptionStack/SubscriptionStack.tsx
+++ b/packages/plugins/plugin-feed/src/components/SubscriptionStack/SubscriptionStack.tsx
@@ -4,7 +4,7 @@
 
 import React, { type KeyboardEvent, forwardRef, useCallback, useMemo, useState } from 'react';
 
-import { Card, ScrollArea } from '@dxos/react-ui';
+import { Card, Icon, ScrollArea } from '@dxos/react-ui';
 import { composable, composableProps } from '@dxos/react-ui';
 import { Focus, Mosaic, type MosaicTileProps, useMosaicContainer } from '@dxos/react-ui-mosaic';
 
@@ -127,7 +127,9 @@ const SubscriptionTile = forwardRef<HTMLDivElement, SubscriptionTileProps>(
         <Focus.Item asChild current={current} onCurrentChange={handleCurrentChange}>
           <Card.Root ref={forwardedRef}>
             <Card.Header>
-              <Card.Icon icon={icon} classNames={iconClassName} />
+              <Card.Block>
+                <Icon icon={icon} classNames={iconClassName} />
+              </Card.Block>
               <Card.Title>{feed.name ?? 'Untitled feed'}</Card.Title>
               <Card.Menu items={menuItems} />
             </Card.Header>

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineTile.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineTile.tsx
@@ -50,7 +50,7 @@ export const MagazineTile = ({ post, magazine, current, onToggleStar, onOpen }: 
           <Card.Poster alt={snapshot.title ?? 'Article'} image={imageUrl} fit='cover' classNames='rounded-t-xs' />
         )}
         <Card.Header>
-          <Card.IconBlock>
+          <Card.Block>
             <IconButton
               variant='ghost'
               iconOnly
@@ -60,9 +60,9 @@ export const MagazineTile = ({ post, magazine, current, onToggleStar, onOpen }: 
               icon={starred ? 'ph--star--fill' : 'ph--star--regular'}
               onClick={handleToggleStar}
             />
-          </Card.IconBlock>
+          </Card.Block>
           {snapshot.title ? <Card.Title classNames='line-clamp-2'>{snapshot.title}</Card.Title> : <div />}
-          <Card.IconBlock />
+          <Card.Block end />
         </Card.Header>
         <Card.Body>
           {snippet && (

--- a/packages/plugins/plugin-gallery/src/components/GalleryImage/GalleryImage.tsx
+++ b/packages/plugins/plugin-gallery/src/components/GalleryImage/GalleryImage.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { Card, Icon, Toolbar, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, IconButton, useTranslation } from '@dxos/react-ui';
 import { File } from '@dxos/types';
 import { mx } from '@dxos/ui-theme';
 
@@ -37,14 +37,16 @@ export const GalleryImage = ({ file, classNames, onDelete }: GalleryImageProps) 
         <Icon icon='ph--image--regular' size={5} />
         <Card.Title>{file?.name ?? ''}</Card.Title>
         {onDelete && (
-          <Toolbar.IconButton
-            icon='ph--trash--regular'
-            iconOnly
-            variant='ghost'
-            label={t('delete-image.label')}
-            classNames='opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity'
-            onClick={onDelete}
-          />
+          <Card.Block end>
+            <IconButton
+              icon='ph--trash--regular'
+              iconOnly
+              variant='ghost'
+              label={t('delete-image.label')}
+              classNames='opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity'
+              onClick={onDelete}
+            />
+          </Card.Block>
         )}
       </Card.Header>
     </Card.Root>

--- a/packages/plugins/plugin-inbox/src/components/Event/EventDetails.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Event/EventDetails.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { type Database } from '@dxos/echo';
 import { useObject } from '@dxos/react-client/echo';
-import { Card, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, useTranslation } from '@dxos/react-ui';
 import { type Actor, type Event as EventType } from '@dxos/types';
 
 import { meta } from '#meta';
@@ -56,7 +56,10 @@ export const EventDetails = ({
   return (
     <>
       {title === 'heading' && (
-        <Card.Row icon='ph--check--regular'>
+        <Card.Row>
+          <Card.Block>
+            <Icon icon='ph--check--regular' />
+          </Card.Block>
           <h2 className='text-lg line-clamp-2'>{data.title ?? t('event-untitled.label')}</h2>
         </Card.Row>
       )}

--- a/packages/plugins/plugin-inbox/src/components/Event/EventEditor.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Event/EventEditor.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useRef } from 'react';
 
 import { type Database, Filter, Obj, Ref } from '@dxos/echo';
 import { useObject, useQuery } from '@dxos/react-client/echo';
-import { Card, IconBlock, Input, Select, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, IconBlock, Input, Select, useTranslation } from '@dxos/react-ui';
 import { type EditorController } from '@dxos/react-ui-editor';
 import { EMAIL_REGEX, REF_REGEX, RefEditor } from '@dxos/react-ui-form';
 import { type Actor, type Event as EventType, Person } from '@dxos/types';
@@ -191,13 +191,12 @@ export const EventEditor = ({ event, db, onContactCreate }: EventEditorProps) =>
       </Card.Row>
 
       <Input.Root>
-        <Card.Row
-          icon={
+        <Card.Row>
+          <Card.Block>
             <IconBlock>
               <Input.TriggerIcon icon='ph--calendar--regular' />
             </IconBlock>
-          }
-        >
+          </Card.Block>
           <div className={gridClasses}>
             {allDay ? (
               <Input.Date value={toDateInput(data.startDate)} onValueChange={handleStartDateChange} />
@@ -216,13 +215,12 @@ export const EventEditor = ({ event, db, onContactCreate }: EventEditorProps) =>
 
       {!allDay && (
         <Input.Root>
-          <Card.Row
-            icon={
+          <Card.Row>
+            <Card.Block>
               <IconBlock>
                 <Input.TriggerIcon icon='ph--calendar--regular' />
               </IconBlock>
-            }
-          >
+            </Card.Block>
             <div className={gridClasses}>
               <Input.DateTime value={toDateTimeInput(data.endDate)} onValueChange={handleEndDateTimeChange} />
               <SelectDuration value={presetValue} onValueChange={handleDurationChange} />
@@ -242,7 +240,10 @@ export const EventEditor = ({ event, db, onContactCreate }: EventEditorProps) =>
       ))}
 
       {/* Always-blank row for adding the next attendee. */}
-      <Card.Row icon='ph--user-plus--regular' classNames='items-center'>
+      <Card.Row classNames='items-center'>
+        <Card.Block>
+          <Icon icon='ph--user-plus--regular' />
+        </Card.Block>
         <RefEditor
           db={db}
           type={Person.Person}

--- a/packages/plugins/plugin-inbox/src/components/Header/Header.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Header/Header.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useRef } from 'react';
 
 import { Obj, type Database } from '@dxos/echo';
 import { EID, type URI } from '@dxos/keys';
-import { Card, DxAnchorActivate, IconButton, Tag, useTranslation } from '@dxos/react-ui';
+import { Card, DxAnchorActivate, Icon, IconButton, Tag, useTranslation } from '@dxos/react-ui';
 import { type Actor } from '@dxos/types';
 import { toHue } from '@dxos/ui-theme';
 
@@ -98,7 +98,10 @@ const HeaderDateRow = ({ start, end }: HeaderDateRowProps) => {
   const duration = [hours > 0 && `${hours}h`, minutes > 0 && `${minutes}m`].filter(Boolean).join(' ');
 
   return (
-    <Card.Row icon='ph--calendar--regular'>
+    <Card.Row>
+      <Card.Block>
+        <Icon icon='ph--calendar--regular' />
+      </Card.Block>
       <div className='flex items-center gap-2 overflow-hidden whitespace-nowrap'>
         <div className='truncate text-description'>{format(start, 'PPp')}</div>
         {duration.length > 0 && <div className='text-description text-xs'>({duration})</div>}
@@ -124,7 +127,10 @@ const HeaderObjectRow = ({ object }: HeaderObjectRowProps) => {
   const echoUri = EID.tryParse(Obj.getURI(object).toString());
 
   return (
-    <Card.Row icon={<AnchorIconButton icon={icon} label={label} title={label} value={echoUri} />}>
+    <Card.Row>
+      <Card.Block>
+        <AnchorIconButton icon={icon} label={label} title={label} value={echoUri} />
+      </Card.Block>
       <h3 className='truncate text-primary-text'>{label}</h3>
     </Card.Row>
   );
@@ -153,8 +159,8 @@ const HeaderPersonRow = ({ actor, db, onContactCreate, onRemove }: HeaderPersonR
 
   // TODO(burdon): Reconcile with Avatar if space member.
   return (
-    <Card.Row
-      icon={
+    <Card.Row>
+      <Card.Block>
         <AnchorIconButton
           compact
           icon='ph--user--regular'
@@ -165,18 +171,19 @@ const HeaderPersonRow = ({ actor, db, onContactCreate, onRemove }: HeaderPersonR
           value={contactDXN}
           onClick={onContactCreate ? handleContactCreate : undefined}
         />
-      }
-    >
+      </Card.Block>
       <h3 className='truncate'>{actor.name || actor.email}</h3>
       {/* Trailing action column. */}
       {onRemove && (
-        <IconButton
-          variant='ghost'
-          iconOnly
-          icon='ph--x--regular'
-          label={t('remove-attendee.label')}
-          onClick={onRemove}
-        />
+        <Card.Block end>
+          <IconButton
+            variant='ghost'
+            iconOnly
+            icon='ph--x--regular'
+            label={t('remove-attendee.label')}
+            onClick={onRemove}
+          />
+        </Card.Block>
       )}
     </Card.Row>
   );
@@ -203,7 +210,10 @@ const HeaderTagsRow = ({ tags, onTagClick }: TagsRowProps) => {
   }
 
   return (
-    <Card.Row icon='ph--tag--regular'>
+    <Card.Row>
+      <Card.Block>
+        <Icon icon='ph--tag--regular' />
+      </Card.Block>
       <div className='flex flex-wrap gap-1 py-1 -mx-0.5' data-testid='extracted-tags'>
         {tags.map((tag) => (
           <Tag

--- a/packages/plugins/plugin-inbox/src/components/Message/Message.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Message/Message.tsx
@@ -10,7 +10,7 @@ import { useCapabilities } from '@dxos/app-framework/ui';
 import { Filter, Obj, Tag as EchoTag } from '@dxos/echo';
 import { EID } from '@dxos/keys';
 import { getSpace, useQuery } from '@dxos/react-client/echo';
-import { Card, type ThemedClassName } from '@dxos/react-ui';
+import { Card, Icon, type ThemedClassName } from '@dxos/react-ui';
 import { composable, composableProps } from '@dxos/react-ui';
 import { Menu } from '@dxos/react-ui-menu';
 import { type Actor, type Message as MessageType } from '@dxos/types';
@@ -217,7 +217,10 @@ const MessageHeader = ({ onContactCreate }: MessageHeaderProps) => {
     <Card.Root border={false} fullWidth classNames='p-1 border-b border-subdued-separator' data-testid='message-header'>
       <Card.Body>
         {/* Subject row. */}
-        <Card.Row icon='ph--envelope-open--regular'>
+        <Card.Row>
+          <Card.Block>
+            <Icon icon='ph--envelope-open--regular' />
+          </Card.Block>
           <div className='flex flex-col gap-1 overflow-hidden'>
             <h2 className='text-lg line-clamp-2'>{message.properties?.subject}</h2>
             {message.created && (

--- a/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.tsx
+++ b/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.tsx
@@ -14,7 +14,7 @@ import React, {
 } from 'react';
 
 import { DxAvatar } from '@dxos/lit-ui/react';
-import { Card, ScrollArea } from '@dxos/react-ui';
+import { Card, Icon, ScrollArea } from '@dxos/react-ui';
 import { composable, composableProps } from '@dxos/react-ui';
 import { Focus, Mosaic, type MosaicTileProps, useMosaicContainer } from '@dxos/react-ui-mosaic';
 import { type Message } from '@dxos/types';
@@ -215,7 +215,7 @@ const MessageStackTile = forwardRef<HTMLDivElement, MessageStackTileProps>(
       <Focus.Item asChild current={current} onCurrentChange={onCurrentChange}>
         <Card.Root fullWidth border={false} onClick={onClick} ref={forwardedRef}>
           <Card.Header>
-            <Card.IconBlock>
+            <Card.Block>
               <DxAvatar
                 hue={hue}
                 hueVariant='surface'
@@ -224,7 +224,7 @@ const MessageStackTile = forwardRef<HTMLDivElement, MessageStackTileProps>(
                 fallback={fallback}
                 onClick={onAvatarClick}
               />
-            </Card.IconBlock>
+            </Card.Block>
             <Card.Title classNames='flex items-center gap-3'>{title}</Card.Title>
             <Card.Menu />
           </Card.Header>
@@ -294,7 +294,10 @@ const MessageTile = forwardRef<HTMLDivElement, MessageTileProps>(({ data, locati
         </>
       }
     >
-      <Card.Row icon='ph--user--regular'>
+      <Card.Row>
+        <Card.Block>
+          <Icon icon='ph--user--regular' />
+        </Card.Block>
         <Card.Text>{from}</Card.Text>
       </Card.Row>
 
@@ -373,7 +376,10 @@ const ThreadTile = forwardRef<HTMLDivElement, ThreadTileProps>(({ data, location
       {messages.slice(0, 4).map((message) => {
         const { from, date, snippet } = getMessageProps(message, new Date(), { compact: true, time: true });
         return (
-          <Card.Row key={message.id} icon='ph--user--duotone'>
+          <Card.Row key={message.id}>
+            <Card.Block>
+              <Icon icon='ph--user--duotone' />
+            </Card.Block>
             <div className='flex flex-col' onClick={(event) => handleMessageClick(event, message.id)}>
               <button type='button' className='flex items-center justify-between w-full h-8 text-start text-sm'>
                 {from && <span className='truncate'>{from}</span>}

--- a/packages/plugins/plugin-inbox/src/containers/MessageCard/MessageCard.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MessageCard/MessageCard.tsx
@@ -17,9 +17,9 @@ export const MessageCard = ({ subject: message }: AppSurface.ObjectCardProps<Mes
   return (
     <Card.Body>
       <Card.Header>
-        <Card.IconBlock>
+        <Card.Block>
           <DxAvatar hue={hue} hueVariant='surface' variant='square' size={7} fallback={from} />
-        </Card.IconBlock>
+        </Card.Block>
         <div className='flex gap-3 items-center justify-between col-span-2'>
           <span className='grow truncate'>{from}</span>
           <span className='text-xs text-description text-right whitespace-nowrap pe-2'>{date}</span>

--- a/packages/plugins/plugin-kanban/src/components/KanbanBoard/KanbanCard.tsx
+++ b/packages/plugins/plugin-kanban/src/components/KanbanBoard/KanbanCard.tsx
@@ -7,7 +7,7 @@ import React, { forwardRef, useCallback, useMemo, useState } from 'react';
 import { Surface } from '@dxos/app-framework/ui';
 import { AppSurface, useObjectMenuItems } from '@dxos/app-toolkit/ui';
 import { Obj } from '@dxos/echo';
-import { Card, Toolbar, useTranslation } from '@dxos/react-ui';
+import { Card, IconButton, useTranslation } from '@dxos/react-ui';
 import { Menu, createMenuAction } from '@dxos/react-ui-menu';
 import { Focus, Mosaic, useBoard } from '@dxos/react-ui-mosaic';
 
@@ -65,15 +65,17 @@ export const KanbanCard = forwardRef<HTMLDivElement, KanbanCardProps>(
                 <Card.DragHandle ref={dragHandleRef} testId='mosaicBoard.cardDragHandle' />
                 <Card.Title data-testid='mosaicBoard.cardTitle'>{Obj.getLabel(data)}</Card.Title>
                 {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
-                <Menu.Trigger asChild disabled={!menuItems?.length}>
-                  <Toolbar.IconButton
-                    iconOnly
-                    variant='ghost'
-                    icon='ph--dots-three-vertical--regular'
-                    label={t('action-menu.label')}
-                  />
-                </Menu.Trigger>
-                <Menu.Content items={menuItems} />
+                <Card.Block end>
+                  <Menu.Trigger asChild disabled={!menuItems?.length}>
+                    <IconButton
+                      iconOnly
+                      variant='ghost'
+                      icon='ph--dots-three-vertical--regular'
+                      label={t('action-menu.label')}
+                    />
+                  </Menu.Trigger>
+                  <Menu.Content items={menuItems} />
+                </Card.Block>
               </Card.Header>
               <Card.Body>
                 {projection && (

--- a/packages/plugins/plugin-kanban/src/testing/KanbanCardTileSimple.tsx
+++ b/packages/plugins/plugin-kanban/src/testing/KanbanCardTileSimple.tsx
@@ -5,7 +5,7 @@
 import React, { forwardRef, useCallback, useMemo, useState } from 'react';
 
 import { Obj } from '@dxos/echo';
-import { Card, Toolbar, useTranslation } from '@dxos/react-ui';
+import { Card, IconButton, useTranslation } from '@dxos/react-ui';
 import { Menu, createMenuAction } from '@dxos/react-ui-menu';
 import { Focus, Mosaic, useBoard } from '@dxos/react-ui-mosaic';
 
@@ -54,15 +54,17 @@ export const KanbanCardTileSimple = forwardRef<HTMLDivElement, KanbanCardProps>(
                 <Card.DragHandle ref={dragHandleRef} />
                 <Card.Title>{Obj.getLabel(data)}</Card.Title>
                 {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
-                <Menu.Trigger asChild disabled={!menuItems?.length}>
-                  <Toolbar.IconButton
-                    iconOnly
-                    variant='ghost'
-                    icon='ph--dots-three-vertical--regular'
-                    label={t('action-menu.label')}
-                  />
-                </Menu.Trigger>
-                <Menu.Content items={menuItems} />
+                <Card.Block end>
+                  <Menu.Trigger asChild disabled={!menuItems?.length}>
+                    <IconButton
+                      iconOnly
+                      variant='ghost'
+                      icon='ph--dots-three-vertical--regular'
+                      label={t('action-menu.label')}
+                    />
+                  </Menu.Trigger>
+                  <Menu.Content items={menuItems} />
+                </Card.Block>
               </Card.Header>
               <Card.Body>
                 <Card.Row fullWidth>

--- a/packages/plugins/plugin-masonry/src/containers/MasonryContainer/MasonryContainer.tsx
+++ b/packages/plugins/plugin-masonry/src/containers/MasonryContainer/MasonryContainer.tsx
@@ -9,7 +9,7 @@ import { AppCapabilities } from '@dxos/app-toolkit';
 import { AppSurface, useObjectMenuItems, useSchemaFilter } from '@dxos/app-toolkit/ui';
 import { Filter, Obj, Query, type Ref, Type, type View } from '@dxos/echo';
 import { useObject, useQuery } from '@dxos/react-client/echo';
-import { Card, Panel, Toolbar } from '@dxos/react-ui';
+import { Card, Icon, Panel, Toolbar } from '@dxos/react-ui';
 import { Masonry as MasonryComponent } from '@dxos/react-ui-masonry';
 import { Menu } from '@dxos/react-ui-menu';
 import { SearchList, useSearchListResults } from '@dxos/react-ui-search';
@@ -102,13 +102,17 @@ const Item = ({ data }: { data: any }) => {
     <Menu.Root>
       <Card.Root>
         <Card.Header>
-          <Card.Icon icon={icon} />
+          <Card.Block>
+            <Icon icon={icon} />
+          </Card.Block>
           <Card.Title>{Obj.getLabel(data, { fallback: 'typename' })}</Card.Title>
           {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
-          <Menu.Trigger asChild disabled={!objectMenuItems?.length}>
-            <Toolbar.IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Actions' />
-          </Menu.Trigger>
-          <Menu.Content items={objectMenuItems} />
+          <Card.Block end>
+            <Menu.Trigger asChild disabled={!objectMenuItems?.length}>
+              <Toolbar.IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Actions' />
+            </Menu.Trigger>
+            <Menu.Content items={objectMenuItems} />
+          </Card.Block>
         </Card.Header>
         <Surface.Surface
           type={AppSurface.Card}

--- a/packages/plugins/plugin-masonry/src/containers/MasonryContainer/MasonryContainer.tsx
+++ b/packages/plugins/plugin-masonry/src/containers/MasonryContainer/MasonryContainer.tsx
@@ -9,7 +9,7 @@ import { AppCapabilities } from '@dxos/app-toolkit';
 import { AppSurface, useObjectMenuItems, useSchemaFilter } from '@dxos/app-toolkit/ui';
 import { Filter, Obj, Query, type Ref, Type, type View } from '@dxos/echo';
 import { useObject, useQuery } from '@dxos/react-client/echo';
-import { Card, Icon, Panel, Toolbar } from '@dxos/react-ui';
+import { Card, Icon, IconButton, Panel, Toolbar } from '@dxos/react-ui';
 import { Masonry as MasonryComponent } from '@dxos/react-ui-masonry';
 import { Menu } from '@dxos/react-ui-menu';
 import { SearchList, useSearchListResults } from '@dxos/react-ui-search';
@@ -109,7 +109,7 @@ const Item = ({ data }: { data: any }) => {
           {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
           <Card.Block end>
             <Menu.Trigger asChild disabled={!objectMenuItems?.length}>
-              <Toolbar.IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Actions' />
+              <IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Actions' />
             </Menu.Trigger>
             <Menu.Content items={objectMenuItems} />
           </Card.Block>

--- a/packages/plugins/plugin-pipeline/src/components/PipelineComponent/PipelineColumn.tsx
+++ b/packages/plugins/plugin-pipeline/src/components/PipelineComponent/PipelineColumn.tsx
@@ -9,7 +9,7 @@ import { resolveSchemaWithRegistry } from '@dxos/app-toolkit/query';
 import { Filter, Obj, Query, Type } from '@dxos/echo';
 import { useObject } from '@dxos/react-client/echo';
 import { Panel, Toolbar, useAsyncEffect, useTranslation } from '@dxos/react-ui';
-import { Card } from '@dxos/react-ui';
+import { Card, Icon } from '@dxos/react-ui';
 import { Menu } from '@dxos/react-ui-menu';
 import { Board, Focus, Mosaic, type MosaicTileProps } from '@dxos/react-ui-mosaic';
 import { ProjectionModel, createEchoChangeCallback } from '@dxos/schema';
@@ -125,10 +125,12 @@ const ItemTile = forwardRef<HTMLDivElement, ItemTileProps>(
           <Focus.Item asChild>
             <Card.Root classNames={classNames} ref={composedRef}>
               <Card.Header>
-                <Card.Icon icon={icon} />
+                <Card.Block>
+                  <Icon icon={icon} />
+                </Card.Block>
                 <Card.Title>{Obj.getLabel(data, { fallback: 'typename' })}</Card.Title>
                 {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
-                <Card.IconBlock>
+                <Card.Block end>
                   <Menu.Trigger asChild>
                     <Toolbar.IconButton
                       iconOnly
@@ -138,7 +140,7 @@ const ItemTile = forwardRef<HTMLDivElement, ItemTileProps>(
                     />
                   </Menu.Trigger>
                   <Menu.Content />
-                </Card.IconBlock>
+                </Card.Block>
               </Card.Header>
               <Card.Body>
                 <Item {...itemProps} />

--- a/packages/plugins/plugin-pipeline/src/components/PipelineComponent/PipelineColumn.tsx
+++ b/packages/plugins/plugin-pipeline/src/components/PipelineComponent/PipelineColumn.tsx
@@ -8,8 +8,8 @@ import React, { forwardRef, useMemo, useRef, useState } from 'react';
 import { resolveSchemaWithRegistry } from '@dxos/app-toolkit/query';
 import { Filter, Obj, Query, Type } from '@dxos/echo';
 import { useObject } from '@dxos/react-client/echo';
-import { Panel, Toolbar, useAsyncEffect, useTranslation } from '@dxos/react-ui';
-import { Card, Icon } from '@dxos/react-ui';
+import { Panel, useAsyncEffect, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, IconButton } from '@dxos/react-ui';
 import { Menu } from '@dxos/react-ui-menu';
 import { Board, Focus, Mosaic, type MosaicTileProps } from '@dxos/react-ui-mosaic';
 import { ProjectionModel, createEchoChangeCallback } from '@dxos/schema';
@@ -132,12 +132,7 @@ const ItemTile = forwardRef<HTMLDivElement, ItemTileProps>(
                 {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
                 <Card.Block end>
                   <Menu.Trigger asChild>
-                    <Toolbar.IconButton
-                      iconOnly
-                      variant='ghost'
-                      icon='ph--dots-three-vertical--regular'
-                      label='Actions'
-                    />
+                    <IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Actions' />
                   </Menu.Trigger>
                   <Menu.Content />
                 </Card.Block>

--- a/packages/plugins/plugin-preview/src/cards/FormCard.tsx
+++ b/packages/plugins/plugin-preview/src/cards/FormCard.tsx
@@ -39,8 +39,19 @@ export const FormCard = ({ subject, projection, readonly = true, layout }: FormC
   // dynamic types whose schema isn't reachable via `Obj.getSchema` (DXN mismatch).
   const staticType = Obj.getType(subject);
   const db = Obj.getDatabase(subject);
-  // Obj.getTypeURI throws for corrupted objects; only evaluate it on the fallback path.
-  const runtimeType = useType(db, staticType ? undefined : Obj.getTypeURI(subject));
+  // `Obj.getTypeURI` throws on corrupted objects that are missing a type; swallow that
+  // and fall through to the "unable to create preview" path rather than crashing the card.
+  const fallbackTypeUri = useMemo(() => {
+    if (staticType) {
+      return undefined;
+    }
+    try {
+      return Obj.getTypeURI(subject);
+    } catch {
+      return undefined;
+    }
+  }, [staticType, subject]);
+  const runtimeType = useType(db, fallbackTypeUri);
   const schema = useMemo((): Schema.Schema.AnyNoContext | undefined => {
     const resolvedType = runtimeType ?? staticType;
     return resolvedType ? omitId(Type.getSchema(resolvedType)) : undefined;

--- a/packages/plugins/plugin-preview/src/cards/JsonCard.tsx
+++ b/packages/plugins/plugin-preview/src/cards/JsonCard.tsx
@@ -2,18 +2,28 @@
 // Copyright 2025 DXOS.org
 //
 
-import React from 'react';
+import React, { useState } from 'react';
 
-import { Card } from '@dxos/react-ui';
+import { Card, ToggleIconButton } from '@dxos/react-ui';
 import { JsonHighlighter } from '@dxos/react-ui-syntax-highlighter';
 
 export const JsonCard = ({ data }: { data: unknown }) => {
+  const [open, setOpen] = useState(false);
   return (
-    <Card.Body>
-      <span />
-      {/* TODO(wittjosiah): Span whole row. */}
-      <JsonHighlighter data={data} />
-      <span />
-    </Card.Body>
+    <Card.Row>
+      <Card.Block>
+        <ToggleIconButton
+          variant='ghost'
+          icon='ph--caret-right--regular'
+          iconOnly
+          active={open}
+          onClick={() => setOpen(!open)}
+          label='Toggle JSON'
+        />
+      </Card.Block>
+      {(open && <JsonHighlighter data={data} classNames='py-1.5 col-span-full text-xs overflow-auto' />) || (
+        <Card.Text variant='description'>{JSON.stringify(data).length}</Card.Text>
+      )}
+    </Card.Row>
   );
 };

--- a/packages/plugins/plugin-preview/src/cards/JsonCard.tsx
+++ b/packages/plugins/plugin-preview/src/cards/JsonCard.tsx
@@ -9,6 +9,11 @@ import { JsonHighlighter } from '@dxos/react-ui-syntax-highlighter';
 
 export const JsonCard = ({ data }: { data: unknown }) => {
   const [open, setOpen] = useState(false);
+  // JSON.stringify throws on circular references / unsupported values (e.g. BigInt); keep the card stable.
+  let collapsedLength = 0;
+  try {
+    collapsedLength = JSON.stringify(data)?.length ?? 0;
+  } catch {}
   return (
     <Card.Row>
       <Card.Block>
@@ -22,7 +27,7 @@ export const JsonCard = ({ data }: { data: unknown }) => {
         />
       </Card.Block>
       {(open && <JsonHighlighter data={data} classNames='py-1.5 col-span-full text-xs overflow-auto' />) || (
-        <Card.Text variant='description'>{JSON.stringify(data).length}</Card.Text>
+        <Card.Text variant='description'>{collapsedLength}</Card.Text>
       )}
     </Card.Row>
   );

--- a/packages/plugins/plugin-preview/src/cards/OrganizationCard.tsx
+++ b/packages/plugins/plugin-preview/src/cards/OrganizationCard.tsx
@@ -13,11 +13,7 @@ export const OrganizationCard = ({ subject }: AppSurface.ObjectCardProps<Organiz
 
   return (
     <Card.Body>
-      <Card.Poster
-        alt={name ?? ''}
-        {...(image ? { image } : { icon: 'ph--building-office--regular' })}
-        classNames={!image && 'opacity-50'}
-      />
+      {image && <Card.Poster alt={name ?? ''} image={image} />}
       {description && (
         <Card.Row>
           <Card.Text variant='description'>{description}</Card.Text>

--- a/packages/plugins/plugin-preview/src/cards/PersonCard.tsx
+++ b/packages/plugins/plugin-preview/src/cards/PersonCard.tsx
@@ -11,7 +11,7 @@ import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { Obj } from '@dxos/echo';
 import { EffectEx } from '@dxos/effect';
 import { Avatar } from '@dxos/react-ui';
-import { Card } from '@dxos/react-ui';
+import { Card, Icon } from '@dxos/react-ui';
 import { type Person } from '@dxos/types';
 
 export const PersonCard = ({ subject }: AppSurface.ObjectCardProps<Person.Person>) => {
@@ -53,7 +53,10 @@ export const PersonCard = ({ subject }: AppSurface.ObjectCardProps<Person.Person
           <Card.Action icon='ph--buildings--regular' label={organization.name} onClick={handleOrganizationClick} />
         )}
         {emails.map(({ value }) => (
-          <Card.Row key={value} icon='ph--at--regular'>
+          <Card.Row key={value}>
+            <Card.Block>
+              <Icon icon='ph--at--regular' />
+            </Card.Block>
             <Card.Text truncate className='text-primary-text'>
               {value}
             </Card.Text>

--- a/packages/plugins/plugin-preview/src/cards/PersonCard.tsx
+++ b/packages/plugins/plugin-preview/src/cards/PersonCard.tsx
@@ -53,16 +53,18 @@ export const PersonCard = ({ subject }: AppSurface.ObjectCardProps<Person.Person
       {organization?.name && (
         <Card.Action icon='ph--buildings--regular' label={organization.name} onClick={handleOrganizationClick} />
       )}
-      {emails.map(({ value }) => (
-        <Card.Row key={value}>
+      {emails.length > 0 && (
+        <Card.Row>
           <Card.Block>
             <Icon icon='ph--at--regular' />
           </Card.Block>
-          <Card.Text truncate className='text-primary-text'>
-            {value}
+          <Card.Text truncate className='text-primary-text text-sm'>
+            {emails.map(({ value }) => (
+              <div key={value}>{value}</div>
+            ))}
           </Card.Text>
         </Card.Row>
-      ))}
+      )}
     </Card.Body>
   );
 };

--- a/packages/plugins/plugin-preview/src/cards/PersonCard.tsx
+++ b/packages/plugins/plugin-preview/src/cards/PersonCard.tsx
@@ -38,7 +38,7 @@ export const PersonCard = ({ subject }: AppSurface.ObjectCardProps<Person.Person
     <Card.Body>
       <Avatar.Root>
         {image && (
-          <Card.Row className='py-1'>
+          <Card.Row>
             <Avatar.Content
               imgSrc={image}
               icon='ph--user--regular'

--- a/packages/plugins/plugin-preview/src/cards/PersonCard.tsx
+++ b/packages/plugins/plugin-preview/src/cards/PersonCard.tsx
@@ -36,33 +36,33 @@ export const PersonCard = ({ subject }: AppSurface.ObjectCardProps<Person.Person
 
   return (
     <Card.Body>
-      <Avatar.Root>
-        {image && (
-          <Card.Row>
+      {image && (
+        <Card.Row>
+          <Avatar.Root>
             <Avatar.Content
               imgSrc={image}
               icon='ph--user--regular'
               size={20}
-              classNames={!image && 'opacity-50'}
+              classNames={[!image && 'opacity-50']}
               hue='neutral'
               variant='square'
             />
-          </Card.Row>
-        )}
-        {organization?.name && (
-          <Card.Action icon='ph--buildings--regular' label={organization.name} onClick={handleOrganizationClick} />
-        )}
-        {emails.map(({ value }) => (
-          <Card.Row key={value}>
-            <Card.Block>
-              <Icon icon='ph--at--regular' />
-            </Card.Block>
-            <Card.Text truncate className='text-primary-text'>
-              {value}
-            </Card.Text>
-          </Card.Row>
-        ))}
-      </Avatar.Root>
+          </Avatar.Root>
+        </Card.Row>
+      )}
+      {organization?.name && (
+        <Card.Action icon='ph--buildings--regular' label={organization.name} onClick={handleOrganizationClick} />
+      )}
+      {emails.map(({ value }) => (
+        <Card.Row key={value}>
+          <Card.Block>
+            <Icon icon='ph--at--regular' />
+          </Card.Block>
+          <Card.Text truncate className='text-primary-text'>
+            {value}
+          </Card.Text>
+        </Card.Row>
+      ))}
     </Card.Body>
   );
 };

--- a/packages/plugins/plugin-preview/src/cards/PersonCard.tsx
+++ b/packages/plugins/plugin-preview/src/cards/PersonCard.tsx
@@ -58,7 +58,7 @@ export const PersonCard = ({ subject }: AppSurface.ObjectCardProps<Person.Person
           <Card.Block>
             <Icon icon='ph--at--regular' />
           </Card.Block>
-          <Card.Text truncate className='text-primary-text text-sm'>
+          <Card.Text truncate className='text-sky-text text-sm'>
             {emails.map(({ value }) => (
               <div key={value}>{value}</div>
             ))}

--- a/packages/plugins/plugin-preview/src/cards/ProjectCard.tsx
+++ b/packages/plugins/plugin-preview/src/cards/ProjectCard.tsx
@@ -16,7 +16,11 @@ export const ProjectCard = ({ subject }: AppSurface.ObjectCardProps<Pipeline.Pip
     <Card.Body>
       {image && <Card.Poster image={image} alt={Obj.getLabel(subject) ?? ''} aspect='auto' />}
       {/* <CardHeader label={name} subject={subject} db={db} /> */}
-      {description && <Card.Text variant='description'>{description}</Card.Text>}
+      {description && (
+        <Card.Row>
+          <Card.Text variant='description'>{description}</Card.Text>
+        </Card.Row>
+      )}
     </Card.Body>
   );
 };

--- a/packages/plugins/plugin-preview/src/stories/Card.stories.tsx
+++ b/packages/plugins/plugin-preview/src/stories/Card.stories.tsx
@@ -165,7 +165,7 @@ export const _Json = {
         <div className='dx-card-min-width dx-card-max-width'>
           <Card.Root>
             <Card.Header>
-              <Card.IconBlock />
+              <Card.Block />
               <Card.Title>JSON</Card.Title>
             </Card.Header>
             <JsonCard data={data} />

--- a/packages/plugins/plugin-preview/src/stories/Card.stories.tsx
+++ b/packages/plugins/plugin-preview/src/stories/Card.stories.tsx
@@ -3,19 +3,17 @@
 //
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import React from 'react';
 
 import { withPluginManager } from '@dxos/app-framework/testing';
 import { corePlugins } from '@dxos/plugin-testing';
 import { random } from '@dxos/random';
-import { Card } from '@dxos/react-ui';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 import { type Expando } from '@dxos/schema';
 import { type Organization, type Person, type Pipeline, type Task } from '@dxos/types';
 
 import { translations } from '#translations';
 
-import { ExpandoCard, FormCard, JsonCard, OrganizationCard, PersonCard, ProjectCard, TaskCard } from '../cards';
+import { ExpandoCard, FormCard, OrganizationCard, PersonCard, ProjectCard, TaskCard } from '../cards';
 import {
   DefaultStory,
   createExpando,
@@ -156,36 +154,5 @@ export const _Expando: StoryObj<typeof DefaultStory<Expando.Expando>> = {
   args: {
     Component: ExpandoCard,
     createObject: createExpando,
-  },
-};
-
-export const _Json = {
-  render: () => {
-    const data = {
-      subject: {
-        id: random.string.uuid(),
-        name: random.person.fullName(),
-        email: random.internet.email(),
-        tags: [random.lorem.word(), random.lorem.word(), random.lorem.word()],
-        nested: {
-          count: random.number.int({ max: 100 }),
-          active: random.datatype.boolean(),
-        },
-      },
-    };
-
-    return (
-      <div className='flex justify-center p-16'>
-        <div className='dx-card-min-width dx-card-max-width'>
-          <Card.Root>
-            <Card.Header>
-              <Card.Block />
-              <Card.Title>JSON</Card.Title>
-            </Card.Header>
-            <JsonCard data={data} />
-          </Card.Root>
-        </div>
-      </div>
-    );
   },
 };

--- a/packages/plugins/plugin-preview/src/stories/Card.stories.tsx
+++ b/packages/plugins/plugin-preview/src/stories/Card.stories.tsx
@@ -114,11 +114,25 @@ export const _Person: StoryObj<typeof DefaultStory<Person.Person>> = {
   },
 };
 
+export const _PersonNoImage: StoryObj<typeof DefaultStory<Person.Person>> = {
+  args: {
+    Component: PersonCard,
+    createObject: createPerson,
+  },
+};
+
 export const _Organization: StoryObj<typeof DefaultStory<Organization.Organization>> = {
   args: {
     Component: OrganizationCard,
     createObject: createOrganization,
     image: true,
+  },
+};
+
+export const _OrganizationNoImage: StoryObj<typeof DefaultStory<Organization.Organization>> = {
+  args: {
+    Component: OrganizationCard,
+    createObject: createOrganization,
   },
 };
 

--- a/packages/plugins/plugin-preview/src/stories/testing.tsx
+++ b/packages/plugins/plugin-preview/src/stories/testing.tsx
@@ -14,10 +14,13 @@ import { CardContainer, type CardContainerProps } from '@dxos/react-ui-mosaic/te
 import { Expando } from '@dxos/schema';
 import { Organization, Person, Pipeline, Task } from '@dxos/types';
 
+import { JsonCard } from '../cards';
+
 export type DefaultStoryProps<T extends Obj.Any, P extends {} = {}> = {
   Component: FC<AppSurface.ObjectCardProps<T> & P>;
   createObject: () => T;
   image?: boolean;
+  json?: boolean;
   componentProps?: P;
 };
 
@@ -25,6 +28,7 @@ export const DefaultStory = <T extends Obj.Any, P extends {} = {}>({
   Component,
   createObject,
   image,
+  json,
   componentProps,
 }: DefaultStoryProps<T, P>) => {
   const object = useMemo(() => createObject(), [createObject]);
@@ -48,6 +52,7 @@ export const DefaultStory = <T extends Obj.Any, P extends {} = {}>({
                   subject={image ? object : omitImage(object)}
                   {...(componentProps ?? ({} as P))}
                 />
+                {json && <JsonCard data={object} />}
               </Card.Root>
             </CardContainer>
           </div>

--- a/packages/plugins/plugin-search/src/components/SearchResultStack/SearchResultStack.tsx
+++ b/packages/plugins/plugin-search/src/components/SearchResultStack/SearchResultStack.tsx
@@ -94,17 +94,19 @@ const SearchResultTile = forwardRef<HTMLDivElement, SearchResultTileProps>(
           <Focus.Item asChild current={current} onCurrentChange={handleCurrentChange}>
             <Card.Root ref={forwardedRef} role='button' classNames='cursor-pointer'>
               <Card.Header>
-                <Card.IconBlock />
+                <Card.Block />
                 <Card.Title>{result.label ?? (result.object && Entity.getLabel(result.object))}</Card.Title>
-                <Menu.Trigger asChild disabled={!menuItems?.length}>
-                  <Toolbar.IconButton
-                    iconOnly
-                    variant='ghost'
-                    icon='ph--dots-three-vertical--regular'
-                    label='Actions'
-                  />
-                </Menu.Trigger>
-                <Menu.Content items={menuItems} />
+                <Card.Block end>
+                  <Menu.Trigger asChild disabled={!menuItems?.length}>
+                    <Toolbar.IconButton
+                      iconOnly
+                      variant='ghost'
+                      icon='ph--dots-three-vertical--regular'
+                      label='Actions'
+                    />
+                  </Menu.Trigger>
+                  <Menu.Content items={menuItems} />
+                </Card.Block>
               </Card.Header>
               <Surface.Surface type={AppSurface.Card} data={{ subject: result.object }} limit={1} />
             </Card.Root>

--- a/packages/plugins/plugin-search/src/components/SearchResultStack/SearchResultStack.tsx
+++ b/packages/plugins/plugin-search/src/components/SearchResultStack/SearchResultStack.tsx
@@ -7,7 +7,7 @@ import React, { type KeyboardEvent, forwardRef, useCallback, useMemo, useState }
 import { Surface } from '@dxos/app-framework/ui';
 import { AppSurface, useObjectMenuItems } from '@dxos/app-toolkit/ui';
 import { Entity } from '@dxos/echo';
-import { Card, Toolbar } from '@dxos/react-ui';
+import { Card, IconButton } from '@dxos/react-ui';
 import { ScrollArea } from '@dxos/react-ui';
 import { composable, composableProps } from '@dxos/react-ui';
 import { Menu } from '@dxos/react-ui-menu';
@@ -98,7 +98,7 @@ const SearchResultTile = forwardRef<HTMLDivElement, SearchResultTileProps>(
                 <Card.Title>{result.label ?? (result.object && Entity.getLabel(result.object))}</Card.Title>
                 <Card.Block end>
                   <Menu.Trigger asChild disabled={!menuItems?.length}>
-                    <Toolbar.IconButton
+                    <IconButton
                       iconOnly
                       variant='ghost'
                       icon='ph--dots-three-vertical--regular'

--- a/packages/plugins/plugin-search/src/components/SearchResultStack/SearchResultStack.tsx
+++ b/packages/plugins/plugin-search/src/components/SearchResultStack/SearchResultStack.tsx
@@ -98,12 +98,7 @@ const SearchResultTile = forwardRef<HTMLDivElement, SearchResultTileProps>(
                 <Card.Title>{result.label ?? (result.object && Entity.getLabel(result.object))}</Card.Title>
                 <Card.Block end>
                   <Menu.Trigger asChild disabled={!menuItems?.length}>
-                    <IconButton
-                      iconOnly
-                      variant='ghost'
-                      icon='ph--dots-three-vertical--regular'
-                      label='Actions'
-                    />
+                    <IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Actions' />
                   </Menu.Trigger>
                   <Menu.Content items={menuItems} />
                 </Card.Block>

--- a/packages/plugins/plugin-simple-layout/src/components/Home/Home.tsx
+++ b/packages/plugins/plugin-simple-layout/src/components/Home/Home.tsx
@@ -104,7 +104,7 @@ const WorkspaceTile: MosaicStackTileComponent<Node.Node> = (props) => {
       onClick={handleSelect}
       ref={cardRef}
     >
-      <Card.Header density='md'>
+      <Card.Header>
         <Avatar.Root>
           <Avatar.Content
             icon={data.properties.icon}

--- a/packages/plugins/plugin-space/src/containers/CollectionArticle/CollectionArticle.tsx
+++ b/packages/plugins/plugin-space/src/containers/CollectionArticle/CollectionArticle.tsx
@@ -9,7 +9,7 @@ import { LayoutOperation, getCollectionObjectPath, getObjectPathFromObject } fro
 import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { type Collection, Obj } from '@dxos/echo';
 import { ScrollArea, toLocalizedString, useTranslation } from '@dxos/react-ui';
-import { Card, Toolbar } from '@dxos/react-ui';
+import { Card, IconButton } from '@dxos/react-ui';
 import { Mosaic, type MosaicStackTileComponent } from '@dxos/react-ui-mosaic';
 import { SearchPanel, useSearchListResults } from '@dxos/react-ui-search';
 import { getStyles } from '@dxos/ui-theme';
@@ -68,7 +68,9 @@ const ObjectTile: MosaicStackTileComponent<ObjectItem> = ({ data: item }) => {
   return (
     <Card.Root fullWidth role='button' classNames='cursor-pointer' onClick={handleClick}>
       <Card.Header>
-        <Toolbar.IconButton variant='ghost' label={label} icon={item.icon} iconOnly iconClassNames={styles?.fg} />
+        <Card.Block>
+          <IconButton variant='ghost' label={label} icon={item.icon} iconOnly iconClassNames={styles?.fg} />
+        </Card.Block>
         <Card.Title>{label}</Card.Title>
         <Card.Menu />
       </Card.Header>

--- a/packages/plugins/plugin-space/src/containers/CollectionArticle/CollectionArticle.tsx
+++ b/packages/plugins/plugin-space/src/containers/CollectionArticle/CollectionArticle.tsx
@@ -9,7 +9,7 @@ import { LayoutOperation, getCollectionObjectPath, getObjectPathFromObject } fro
 import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { type Collection, Obj } from '@dxos/echo';
 import { ScrollArea, toLocalizedString, useTranslation } from '@dxos/react-ui';
-import { Card, IconButton } from '@dxos/react-ui';
+import { Card, Icon } from '@dxos/react-ui';
 import { Mosaic, type MosaicStackTileComponent } from '@dxos/react-ui-mosaic';
 import { SearchPanel, useSearchListResults } from '@dxos/react-ui-search';
 import { getStyles } from '@dxos/ui-theme';
@@ -69,7 +69,7 @@ const ObjectTile: MosaicStackTileComponent<ObjectItem> = ({ data: item }) => {
     <Card.Root fullWidth role='button' classNames='cursor-pointer' onClick={handleClick}>
       <Card.Header>
         <Card.Block>
-          <IconButton variant='ghost' label={label} icon={item.icon} iconOnly iconClassNames={styles?.fg} />
+          <Icon icon={item.icon} classNames={styles?.fg} />
         </Card.Block>
         <Card.Title>{label}</Card.Title>
         <Card.Menu />

--- a/packages/plugins/plugin-space/src/containers/RecordArticle/RecordArticle.tsx
+++ b/packages/plugins/plugin-space/src/containers/RecordArticle/RecordArticle.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { Surface } from '@dxos/app-framework/ui';
 import { AppSurface } from '@dxos/app-toolkit/ui';
 import { Obj, Type } from '@dxos/echo';
-import { Card, Input, Panel, ScrollArea, Toolbar, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, Input, Panel, ScrollArea, Toolbar, useTranslation } from '@dxos/react-ui';
 
 import { meta } from '#meta';
 
@@ -40,7 +40,9 @@ export const RecordArticle = ({ role, subject }: AppSurface.ObjectArticleProps) 
           <ScrollArea.Viewport classNames='p-4 space-y-4'>
             <Card.Root classNames='dx-card-max-width'>
               <Card.Header>
-                <Card.Icon icon={icon} />
+                <Card.Block>
+                  <Icon icon={icon} />
+                </Card.Block>
                 <Card.Title>{Obj.getLabel(subject, { fallback: 'typename' })}</Card.Title>
               </Card.Header>
               <Card.Body>

--- a/packages/plugins/plugin-space/src/containers/RelatedArticle/RelatedArticle.tsx
+++ b/packages/plugins/plugin-space/src/containers/RelatedArticle/RelatedArticle.tsx
@@ -7,7 +7,7 @@ import React, { useMemo } from 'react';
 import { Surface } from '@dxos/app-framework/ui';
 import { AppSurface, useObjectMenuItems } from '@dxos/app-toolkit/ui';
 import { Entity, Obj } from '@dxos/echo';
-import { Card, Panel, Toolbar, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, Panel, Toolbar, useTranslation } from '@dxos/react-ui';
 import { Masonry } from '@dxos/react-ui-masonry';
 import { Menu } from '@dxos/react-ui-menu';
 
@@ -53,17 +53,21 @@ const ObjectCard = ({ data: subject, classNames }: { data: Entity.Unknown; class
     <Menu.Root>
       <Card.Root classNames={classNames}>
         <Card.Header>
-          <Card.Icon icon={icon} />
+          <Card.Block>
+            <Icon icon={icon} />
+          </Card.Block>
           <Card.Title>{Entity.getLabel(subject, { fallback: 'typename' })}</Card.Title>
-          <Menu.Trigger asChild disabled={!menuItems?.length}>
-            <Toolbar.IconButton
-              iconOnly
-              variant='ghost'
-              icon='ph--dots-three-vertical--regular'
-              label={t('more-actions.label')}
-            />
-          </Menu.Trigger>
-          <Menu.Content items={menuItems} />
+          <Card.Block end>
+            <Menu.Trigger asChild disabled={!menuItems?.length}>
+              <Toolbar.IconButton
+                iconOnly
+                variant='ghost'
+                icon='ph--dots-three-vertical--regular'
+                label={t('more-actions.label')}
+              />
+            </Menu.Trigger>
+            <Menu.Content items={menuItems} />
+          </Card.Block>
         </Card.Header>
         <Card.Body>
           <Surface.Surface type={AppSurface.Card} data={data} limit={1} />

--- a/packages/plugins/plugin-space/src/containers/RelatedArticle/RelatedArticle.tsx
+++ b/packages/plugins/plugin-space/src/containers/RelatedArticle/RelatedArticle.tsx
@@ -7,7 +7,7 @@ import React, { useMemo } from 'react';
 import { Surface } from '@dxos/app-framework/ui';
 import { AppSurface, useObjectMenuItems } from '@dxos/app-toolkit/ui';
 import { Entity, Obj } from '@dxos/echo';
-import { Card, Icon, Panel, Toolbar, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, IconButton, Panel, Toolbar, useTranslation } from '@dxos/react-ui';
 import { Masonry } from '@dxos/react-ui-masonry';
 import { Menu } from '@dxos/react-ui-menu';
 
@@ -59,7 +59,7 @@ const ObjectCard = ({ data: subject, classNames }: { data: Entity.Unknown; class
           <Card.Title>{Entity.getLabel(subject, { fallback: 'typename' })}</Card.Title>
           <Card.Block end>
             <Menu.Trigger asChild disabled={!menuItems?.length}>
-              <Toolbar.IconButton
+              <IconButton
                 iconOnly
                 variant='ghost'
                 icon='ph--dots-three-vertical--regular'

--- a/packages/plugins/plugin-support/src/containers/SpaceHomeArticle/SpaceHomeArticle.tsx
+++ b/packages/plugins/plugin-support/src/containers/SpaceHomeArticle/SpaceHomeArticle.tsx
@@ -16,7 +16,7 @@ import { AssistantCapabilities, AssistantOperation, type ChatType } from '@dxos/
 import { ChatPrompt, type ChatEvent } from '@dxos/plugin-assistant/components';
 import { useChatProcessor, useChatServices, useOnline, usePresets } from '@dxos/plugin-assistant/hooks';
 import { type Space, useObject, useQuery, useRegistry } from '@dxos/react-client/echo';
-import { Card, Carousel, Icon, Panel, ScrollArea, Toolbar, toLocalizedString, useTranslation } from '@dxos/react-ui';
+import { Card, Carousel, Icon, IconButton, Panel, ScrollArea, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { Masonry } from '@dxos/react-ui-masonry';
 import { Menu, MenuBuilder, useMenuBuilder } from '@dxos/react-ui-menu';
 import { getStyles } from '@dxos/ui-theme';
@@ -361,7 +361,9 @@ const SuggestionCards = ({ space }: SpaceScopedProps) => {
             onClick={() => handleRunPrompt(prompt)}
           >
             <Card.Header>
-              <Toolbar.IconButton variant='ghost' label={prompt} icon='ph--sparkle--regular' iconOnly />
+              <Card.Block>
+                <IconButton variant='ghost' label={prompt} icon='ph--sparkle--regular' iconOnly />
+              </Card.Block>
               <Card.Title>{prompt}</Card.Title>
             </Card.Header>
           </Card.Root>

--- a/packages/plugins/plugin-support/src/containers/SpaceHomeArticle/SpaceHomeArticle.tsx
+++ b/packages/plugins/plugin-support/src/containers/SpaceHomeArticle/SpaceHomeArticle.tsx
@@ -16,7 +16,7 @@ import { AssistantCapabilities, AssistantOperation, type ChatType } from '@dxos/
 import { ChatPrompt, type ChatEvent } from '@dxos/plugin-assistant/components';
 import { useChatProcessor, useChatServices, useOnline, usePresets } from '@dxos/plugin-assistant/hooks';
 import { type Space, useObject, useQuery, useRegistry } from '@dxos/react-client/echo';
-import { Card, Carousel, Panel, ScrollArea, Toolbar, toLocalizedString, useTranslation } from '@dxos/react-ui';
+import { Card, Carousel, Icon, Panel, ScrollArea, Toolbar, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { Masonry } from '@dxos/react-ui-masonry';
 import { Menu, MenuBuilder, useMenuBuilder } from '@dxos/react-ui-menu';
 import { getStyles } from '@dxos/ui-theme';
@@ -399,7 +399,9 @@ const RecentObjectTile = ({ space, object }: RecentObjectTileProps) => {
   return (
     <Card.Root role='button' classNames='cursor-pointer' onClick={handleClick}>
       <Card.Header>
-        <Card.Icon icon={icon} classNames={iconStyles?.text} />
+        <Card.Block>
+          <Icon icon={icon} classNames={iconStyles?.text} />
+        </Card.Block>
         <Card.Title>{label}</Card.Title>
       </Card.Header>
     </Card.Root>

--- a/packages/plugins/plugin-trip/src/components/OfferStack/OfferStack.tsx
+++ b/packages/plugins/plugin-trip/src/components/OfferStack/OfferStack.tsx
@@ -5,7 +5,15 @@
 import { format } from 'date-fns';
 import React, { forwardRef, useCallback, useMemo } from 'react';
 
-import { Card, ScrollArea, type ThemedClassName, composable, composableProps, useTranslation } from '@dxos/react-ui';
+import {
+  Card,
+  Icon,
+  ScrollArea,
+  type ThemedClassName,
+  composable,
+  composableProps,
+  useTranslation,
+} from '@dxos/react-ui';
 import { Focus, Mosaic, type MosaicTileProps, useMosaicContainer } from '@dxos/react-ui-mosaic';
 
 import { meta } from '#meta';
@@ -51,7 +59,9 @@ const OfferTile = forwardRef<HTMLDivElement, OfferTileProps>(({ data, location, 
       <Focus.Item asChild current={current} onCurrentChange={handleCurrentChange}>
         <Card.Root fullWidth border={false} ref={forwardedRef}>
           <Card.Header>
-            <Card.Icon icon='ph--airplane--regular' />
+            <Card.Block>
+              <Icon icon='ph--airplane--regular' />
+            </Card.Block>
             <div className='flex items-baseline justify-between gap-2 min-w-0'>
               <Card.Title classNames='truncate'>{offer.operator.name}</Card.Title>
               <Card.Text classNames='font-mono shrink-0'>
@@ -68,7 +78,10 @@ const OfferTile = forwardRef<HTMLDivElement, OfferTileProps>(({ data, location, 
               </Card.Row>
             )}
             {departAt && (
-              <Card.Row icon='ph--calendar--regular'>
+              <Card.Row>
+                <Card.Block>
+                  <Icon icon='ph--calendar--regular' />
+                </Card.Block>
                 <Card.Text variant='description'>{format(new Date(departAt), 'PPp')}</Card.Text>
               </Card.Row>
             )}

--- a/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.tsx
+++ b/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentCard.tsx
@@ -6,7 +6,7 @@ import { format } from 'date-fns';
 import React, { type MouseEvent, forwardRef, useCallback } from 'react';
 
 import { Obj } from '@dxos/echo';
-import { Card, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, useTranslation } from '@dxos/react-ui';
 import { Form } from '@dxos/react-ui-form';
 import { Focus, Mosaic, type MosaicTileProps, useMosaicContainer } from '@dxos/react-ui-mosaic';
 import { getStyles } from '@dxos/ui-theme';
@@ -97,7 +97,9 @@ export const SegmentTile = forwardRef<HTMLDivElement, SegmentTileProps>(({ data,
       <Focus.Item asChild current={current} onCurrentChange={handleCurrentChange}>
         <Card.Root fullWidth border={false} ref={forwardedRef}>
           <Card.Header>
-            <Card.Icon icon={icon} classNames={iconStyles?.fg} />
+            <Card.Block>
+              <Icon icon={icon} classNames={iconStyles?.fg} />
+            </Card.Block>
             <Card.Title>{title}</Card.Title>
             <Card.ActionIconButton action='delete' onClick={handleDelete} label={t('segment.delete.label')} />
           </Card.Header>
@@ -125,7 +127,10 @@ export const SegmentTile = forwardRef<HTMLDivElement, SegmentTileProps>(({ data,
                   </Card.Row>
                 )}
                 {date && (
-                  <Card.Row icon='ph--calendar--regular'>
+                  <Card.Row>
+                    <Card.Block>
+                      <Icon icon='ph--calendar--regular' />
+                    </Card.Block>
                     <Card.Text variant='description'>{format(date, 'PPp')}</Card.Text>
                   </Card.Row>
                 )}

--- a/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentEditableCard.tsx
+++ b/packages/plugins/plugin-trip/src/components/SegmentCard/SegmentEditableCard.tsx
@@ -6,7 +6,7 @@ import { format as formatDate } from 'date-fns';
 import React, { type MouseEvent, forwardRef, useCallback } from 'react';
 
 import { Obj } from '@dxos/echo';
-import { Card, Input, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, Input, useTranslation } from '@dxos/react-ui';
 
 import { meta } from '#meta';
 import { Segment } from '#types';
@@ -76,7 +76,9 @@ export const FlightEditableCard = forwardRef<HTMLDivElement, FlightEditableCardP
     return (
       <Card.Root fullWidth ref={forwardedRef}>
         <Card.Header>
-          <Card.Icon icon={icon} />
+          <Card.Block>
+            <Icon icon={icon} />
+          </Card.Block>
           <Card.Title>{title}</Card.Title>
           <Card.ActionIconButton action='delete' onClick={handleDelete} label={t('segment.delete.label')} />
         </Card.Header>
@@ -86,7 +88,10 @@ export const FlightEditableCard = forwardRef<HTMLDivElement, FlightEditableCardP
               <Card.Text variant='description'>{route}</Card.Text>
             </Card.Row>
           )}
-          <Card.Row icon='ph--calendar--regular'>
+          <Card.Row>
+            <Card.Block>
+              <Icon icon='ph--calendar--regular' />
+            </Card.Block>
             <Input.Root>
               <Input.DateTime
                 aria-label={t('segment.depart.placeholder')}

--- a/packages/ui/react-ui-board/src/components/Board/BoardCell.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/BoardCell.tsx
@@ -78,7 +78,10 @@ export const BoardCell = ({ classNames, children, item, layout, draggable: isDra
               icon='ph--x--regular'
               iconOnly
               label={t('delete-object.button')}
-              onClick={() => onDelete?.(item.id)}
+              onClick={(event) => {
+                event.stopPropagation();
+                onDelete?.(item.id);
+              }}
             />
           </Card.Block>
         )}

--- a/packages/ui/react-ui-board/src/components/Board/BoardCell.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/BoardCell.tsx
@@ -8,7 +8,7 @@ import React, { type PropsWithChildren, useEffect, useRef, useState } from 'reac
 import { type Type } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
 import { type ThemedClassName, useTranslation } from '@dxos/react-ui';
-import { Card, Toolbar } from '@dxos/react-ui';
+import { Card, IconButton } from '@dxos/react-ui';
 import { mx } from '@dxos/ui-theme';
 
 import { translationKey } from '#translations';
@@ -71,15 +71,16 @@ export const BoardCell = ({ classNames, children, item, layout, draggable: isDra
     >
       <Card.Header>
         <Card.DragHandle ref={dragHandleRef} />
-        <Toolbar.Separator variant='gap' />
         {dragState !== 'dragging' && (
-          <Toolbar.IconButton
-            variant='ghost'
-            icon='ph--x--regular'
-            iconOnly
-            label={t('delete-object.button')}
-            onClick={() => onDelete?.(item.id)}
-          />
+          <Card.Block end>
+            <IconButton
+              variant='ghost'
+              icon='ph--x--regular'
+              iconOnly
+              label={t('delete-object.button')}
+              onClick={() => onDelete?.(item.id)}
+            />
+          </Card.Block>
         )}
       </Card.Header>
       {children}

--- a/packages/ui/react-ui-editor/src/stories/Preview.stories.tsx
+++ b/packages/ui/react-ui-editor/src/stories/Preview.stories.tsx
@@ -10,7 +10,7 @@ import { createPortal } from 'react-dom';
 
 import { invariant } from '@dxos/invariant';
 import { random } from '@dxos/random';
-import { Card, Popover, Toolbar } from '@dxos/react-ui';
+import { Card, Icon, Popover, Toolbar } from '@dxos/react-ui';
 import { Menu, createMenuAction } from '@dxos/react-ui-menu';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 import {
@@ -60,7 +60,9 @@ const PreviewCard = () => {
         <Popover.Viewport classNames='dx-card-popover-width'>
           <Card.Root border={false}>
             <Card.Header>
-              <Card.Icon icon='ph--file-text--regular' />
+              <Card.Block>
+                <Icon icon='ph--file-text--regular' />
+              </Card.Block>
               <Card.Title>{target.label}</Card.Title>
               <Popover.Close asChild>
                 <Card.ActionIconButton action='close' />
@@ -166,7 +168,9 @@ const PreviewBlockComponent = ({ link, el, view }: { link: PreviewLinkRef; el: H
       <Card.Root classNames={hoverableControls}>
         {!view?.state.readOnly && (
           <Card.Header>
-            <Card.Icon icon='ph--bookmark--regular' />
+            <Card.Block>
+              <Icon icon='ph--bookmark--regular' />
+            </Card.Block>
             <Card.Title>{link.label}</Card.Title>
             {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
             <Menu.Trigger asChild disabled={!menuItems?.length}>

--- a/packages/ui/react-ui-editor/src/stories/Preview.stories.tsx
+++ b/packages/ui/react-ui-editor/src/stories/Preview.stories.tsx
@@ -10,7 +10,7 @@ import { createPortal } from 'react-dom';
 
 import { invariant } from '@dxos/invariant';
 import { random } from '@dxos/random';
-import { Card, Icon, Popover, Toolbar } from '@dxos/react-ui';
+import { Card, Icon, IconButton, Popover } from '@dxos/react-ui';
 import { Menu, createMenuAction } from '@dxos/react-ui-menu';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 import {
@@ -173,9 +173,11 @@ const PreviewBlockComponent = ({ link, el, view }: { link: PreviewLinkRef; el: H
             </Card.Block>
             <Card.Title>{link.label}</Card.Title>
             {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
-            <Menu.Trigger asChild disabled={!menuItems?.length}>
-              <Toolbar.IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Menu' />
-            </Menu.Trigger>
+            <Card.Block end>
+              <Menu.Trigger asChild disabled={!menuItems?.length}>
+                <IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Menu' />
+              </Menu.Trigger>
+            </Card.Block>
             <Menu.Content items={menuItems} />
           </Card.Header>
         )}

--- a/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
@@ -9,7 +9,7 @@ import { Filter } from '@dxos/echo';
 import { random } from '@dxos/random';
 import { useQuery } from '@dxos/react-client/echo';
 import { useClientStory, withClientProvider } from '@dxos/react-client/testing';
-import { Card } from '@dxos/react-ui';
+import { Card, Icon } from '@dxos/react-ui';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 import { createObjectFactory } from '@dxos/schema/testing';
 import { Organization } from '@dxos/types';
@@ -20,7 +20,9 @@ const StoryItem = ({ data: { image, name, description } }: { data: Organization.
   return (
     <Card.Root>
       <Card.Header>
-        <Card.Icon icon='ph--building-office--regular' />
+        <Card.Block>
+          <Icon icon='ph--building-office--regular' />
+        </Card.Block>
         <Card.Title>{name}</Card.Title>
       </Card.Header>
       <Card.Poster alt={name!} {...(image ? { image } : { icon: 'ph--building-office--regular' })} />

--- a/packages/ui/react-ui-mosaic/src/components/Board/Item.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/Board/Item.tsx
@@ -6,7 +6,7 @@ import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import React, { type ReactElement, type Ref as ReactRef, forwardRef, useMemo, useRef, useState } from 'react';
 
 import { Obj } from '@dxos/echo';
-import { Card, Tag, Toolbar, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, Tag, Toolbar, useTranslation } from '@dxos/react-ui';
 import { Menu, createMenuAction } from '@dxos/react-ui-menu';
 import { getHashStyles } from '@dxos/ui-theme';
 
@@ -89,10 +89,16 @@ const BoardItemInner = forwardRef<HTMLDivElement, BoardItemProps>(
                 <Menu.Content items={items} />
               </Card.Header>
               {/* TODO(burdon): Replace with surface. */}
-              <Card.Row icon='ph--note--regular' classNames='text-description'>
+              <Card.Row classNames='text-description'>
+                <Card.Block>
+                  <Icon icon='ph--note--regular' />
+                </Card.Block>
                 <Card.Text>{description}</Card.Text>
               </Card.Row>
-              <Card.Row icon='ph--tag--regular'>
+              <Card.Row>
+                <Card.Block>
+                  <Icon icon='ph--tag--regular' />
+                </Card.Block>
                 {label && (
                   <div className='shrink-0 flex gap-1 items-center text-xs'>
                     <Tag palette={getHashStyles(label).hue}>{label}</Tag>

--- a/packages/ui/react-ui-mosaic/src/components/Board/Item.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/Board/Item.tsx
@@ -6,7 +6,7 @@ import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import React, { type ReactElement, type Ref as ReactRef, forwardRef, useMemo, useRef, useState } from 'react';
 
 import { Obj } from '@dxos/echo';
-import { Card, Icon, Tag, Toolbar, useTranslation } from '@dxos/react-ui';
+import { Card, Icon, IconButton, Tag, useTranslation } from '@dxos/react-ui';
 import { Menu, createMenuAction } from '@dxos/react-ui-menu';
 import { getHashStyles } from '@dxos/ui-theme';
 
@@ -78,14 +78,16 @@ const BoardItemInner = forwardRef<HTMLDivElement, BoardItemProps>(
                 <Card.DragHandle ref={setDragHandle} testId='mosaicBoard.cardDragHandle' />
                 <Card.Title data-testid='mosaicBoard.cardTitle'>{label}</Card.Title>
                 {/* TODO(wittjosiah): Reconcile with Card.Menu. */}
-                <Menu.Trigger asChild disabled={!items?.length}>
-                  <Toolbar.IconButton
-                    iconOnly
-                    variant='ghost'
-                    icon='ph--dots-three-vertical--regular'
-                    label={t('action-menu.label')}
-                  />
-                </Menu.Trigger>
+                <Card.Block end>
+                  <Menu.Trigger asChild disabled={!items?.length}>
+                    <IconButton
+                      iconOnly
+                      variant='ghost'
+                      icon='ph--dots-three-vertical--regular'
+                      label={t('action-menu.label')}
+                    />
+                  </Menu.Trigger>
+                </Card.Block>
                 <Menu.Content items={items} />
               </Card.Header>
               {/* TODO(burdon): Replace with surface. */}

--- a/packages/ui/react-ui-mosaic/src/components/SearchStack/SearchStack.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/SearchStack/SearchStack.tsx
@@ -116,7 +116,7 @@ const SearchTile = forwardRef<HTMLDivElement, SearchTileProps>(({ data, location
       <Focus.Item asChild current={current} onCurrentChange={handleCurrentChange}>
         <Card.Root fullWidth ref={forwardedRef}>
           <Card.Header>
-            <Card.IconBlock />
+            <Card.Block />
             <Card.Title>{result.label}</Card.Title>
           </Card.Header>
           {result.snippet && (

--- a/packages/ui/react-ui-mosaic/src/testing/DefaultStackTile.tsx
+++ b/packages/ui/react-ui-mosaic/src/testing/DefaultStackTile.tsx
@@ -5,7 +5,7 @@
 import React, { useMemo, useRef, useState } from 'react';
 
 import { Obj } from '@dxos/echo';
-import { Card, Toolbar } from '@dxos/react-ui';
+import { Card, IconButton } from '@dxos/react-ui';
 import { Menu, createMenuAction } from '@dxos/react-ui-menu';
 import { JsonHighlighter } from '@dxos/react-ui-syntax-highlighter';
 
@@ -38,9 +38,11 @@ export const DefaultStackTile: MosaicStackTileComponent<Obj.Any> = (props) => {
             <Card.Header>
               <Card.DragHandle ref={dragHandleRef} />
               <Card.Title>{Obj.getLabel(props.data) ?? props.data.id}</Card.Title>
-              <Menu.Trigger asChild disabled={!menuItems?.length}>
-                <Toolbar.IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Menu' />
-              </Menu.Trigger>
+              <Card.Block end>
+                <Menu.Trigger asChild disabled={!menuItems?.length}>
+                  <IconButton iconOnly variant='ghost' icon='ph--dots-three-vertical--regular' label='Menu' />
+                </Menu.Trigger>
+              </Card.Block>
               <Menu.Content items={menuItems} />
             </Card.Header>
             {open && (

--- a/packages/ui/react-ui-search/DESIGN.md
+++ b/packages/ui/react-ui-search/DESIGN.md
@@ -97,16 +97,16 @@ Estimated: one PR, ~3-4 file changes. Low risk.
 
 ~9 plugin call sites still rolling their own `<ul>`/`<li>` + `<button>` rows:
 
-| File                                                                                | Replacement                                                |
-| ----------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `plugin-code/src/components/FileTree/FileTree.tsx`                                  | Reuse `react-ui-list/Tree` (after C1)                      |
-| `plugin-sidekick/src/components/ActionItems.tsx`                                    | `Listbox` + a per-row checkbox affordance (multi-select)   |
-| `plugin-assistant/src/components/ChatPrompt/ChatReferences.tsx`                     | `Listbox` (tag-pill row variant)                           |
-| `plugin-assistant/src/components/ChatPrompt/ChatMcpErrors.tsx`                      | `Listbox`                                                  |
-| `plugin-script/src/containers/DeploymentDialog/DeploymentDialog.tsx`                | `Listbox`                                                  |
-| `plugin-help/.../WelcomeTour.stories.tsx`                                           | `Listbox`                                                  |
-| `plugin-meeting/src/containers/MeetingsList/MeetingsList.tsx`                       | already on `Listbox`; drop the inner `<div role='list'>`   |
-| (one more in plugin-script)                                                         | `Listbox`                                                  |
+| File                                                                 | Replacement                                              |
+| -------------------------------------------------------------------- | -------------------------------------------------------- |
+| `plugin-code/src/components/FileTree/FileTree.tsx`                   | Reuse `react-ui-list/Tree` (after C1)                    |
+| `plugin-sidekick/src/components/ActionItems.tsx`                     | `Listbox` + a per-row checkbox affordance (multi-select) |
+| `plugin-assistant/src/components/ChatPrompt/ChatReferences.tsx`      | `Listbox` (tag-pill row variant)                         |
+| `plugin-assistant/src/components/ChatPrompt/ChatMcpErrors.tsx`       | `Listbox`                                                |
+| `plugin-script/src/containers/DeploymentDialog/DeploymentDialog.tsx` | `Listbox`                                                |
+| `plugin-help/.../WelcomeTour.stories.tsx`                            | `Listbox`                                                |
+| `plugin-meeting/src/containers/MeetingsList/MeetingsList.tsx`        | already on `Listbox`; drop the inner `<div role='list'>` |
+| (one more in plugin-script)                                          | `Listbox`                                                |
 
 Each is a small PR; parallelise across maintainers. High aggregate value (consistent
 `dx-selected` grammar), low per-PR risk.
@@ -129,6 +129,7 @@ Pick the cheaper option once B1 lands and the call-sites are visible.
 #### C1. `Tree` → aspects
 
 Refactor `react-ui-list/Tree` to compose:
+
 - `useReorderList` + `useReorderItem` for hierarchical DnD (above / below / into via
   pragmatic-dnd's `attachClosestEdge` + a `canDrop` predicate that reads `depth`).
 - `useListDisclosure({ mode: 'multi' })` for multi-branch expand state.
@@ -138,6 +139,7 @@ Refactor `react-ui-list/Tree` to compose:
   follow-up.
 
 Affects:
+
 - `plugin-navtree` (6 files — `state.ts`, `L1Panel`, `types.ts`, `NavTreeContainer`,
   `useNavTreeModel`, `update-state.ts`)
 - `devtools/ObjectsTree.tsx`
@@ -169,6 +171,7 @@ live inside the (still-unimplemented) `useListVirtualizer` aspect so consumers d
 re-derive it.
 
 Sequence:
+
 1. Implement `useListVirtualizer` with the `{ reorder }` slot from the design doc.
 2. Migrate `Mosaic.Stack` to `useReorderList` (no virtualization). Cross-stack drag stays
    via `canDrop`/`getInitialData` payloads.
@@ -203,6 +206,7 @@ Mosaic.Stack which handles this automatically." Still ~6 consumers (plugin-deck,
 plugin-script, plugin-stack, plugin-meeting). Independent of the aspect work above.
 
 Strands:
+
 1. Each consumer migrates to `Mosaic.Stack`. Per-consumer PR; can parallelise.
 2. After consumer count hits zero: delete `packages/ui/react-ui-stack/` entirely (source +
    `PLAN.md` + dependencies + tests).

--- a/packages/ui/react-ui/src/components/Card/Card.stories.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.stories.tsx
@@ -212,27 +212,3 @@ export const Slots: Story = {
     );
   },
 };
-
-export const Mock = () => (
-  <div className='grid grid-cols-[2rem_1fr_2rem] w-full dx-card-min-width dx-card-max-width border border-separator rounded-xs'>
-    <div className='grid grid-cols-subgrid col-span-full'>
-      <div className='grid h-[var(--dx-rail-item)] w-[var(--dx-rail-item)] place-items-center'>
-        <Icon icon='ph--dots-six-vertical--regular' />
-      </div>
-      <div className='p-1 whitespace-normal break-words text-description items-center'>
-        This line is very very long and it should wrap.
-      </div>
-      <div className='grid h-[var(--dx-rail-item)] w-[var(--dx-rail-item)] place-items-center'>
-        <Icon icon='ph--x--regular' />
-      </div>
-    </div>
-    <div className='grid grid-cols-subgrid col-span-3'>
-      <div className='grid h-[var(--dx-rail-item)] w-[var(--dx-rail-item)] place-items-center'>
-        <Icon icon='ph--dots-six-vertical--regular' />
-      </div>
-      <div className='p-1 text-description items-center col-span-2'>
-        This line is very very long and it should wrap.
-      </div>
-    </div>
-  </div>
-);

--- a/packages/ui/react-ui/src/components/Card/Card.stories.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.stories.tsx
@@ -6,7 +6,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React, { useRef } from 'react';
 
 import { random } from '@dxos/random';
-import { Icon } from '@dxos/react-ui';
+import { Icon, IconButton } from '@dxos/react-ui';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 
 import { Card } from './Card';
@@ -32,10 +32,16 @@ const DefaultStory = ({ title, description, image, fullWidth }: DefaultStoryProp
       </Card.Header>
       <Card.Body>
         <Card.Poster alt='Card.Poster' image={image} />
-        <Card.Row icon='ph--dot-outline--regular'>
+        <Card.Row>
+          <Card.Block>
+            <Icon icon='ph--dot-outline--regular' />
+          </Card.Block>
           <Card.Text>Card.Text (default)</Card.Text>
         </Card.Row>
-        <Card.Row icon='ph--dot-outline--regular'>
+        <Card.Row>
+          <Card.Block>
+            <Icon icon='ph--dot-outline--regular' />
+          </Card.Block>
           <Card.Text variant='description'>
             Card.Text (description)
             <br />
@@ -140,6 +146,60 @@ export const Description: Story = {
         <Card.Body>
           <Card.Row>
             <Card.Text variant='description'>{description}</Card.Text>
+          </Card.Row>
+        </Card.Body>
+      </Card.Root>
+    );
+  },
+};
+
+export const Slots: Story = {
+  args: {
+    title: random.commerce.productName(),
+  },
+  render: ({ title }) => {
+    const showLeading = true;
+    return (
+      <Card.Root>
+        <Card.Header>
+          <Card.Title>{title}</Card.Title>
+          <Card.ActionIconButton action='close' onClick={() => console.log('close')} />
+        </Card.Header>
+        <Card.Body>
+          {/* Leading passive icon. */}
+          <Card.Row>
+            <Card.Block>
+              <Icon icon='ph--user--regular' />
+            </Card.Block>
+            <Card.Text>Start slot — passive Icon</Card.Text>
+          </Card.Row>
+          {/* Passive icon + trailing IconButton: the two gutters align to the pixel. */}
+          <Card.Row>
+            <Card.Block>
+              <Icon icon='ph--at--regular' />
+            </Card.Block>
+            <Card.Text>Start Icon + end IconButton (aligned)</Card.Text>
+            <Card.Block end>
+              <IconButton iconOnly variant='ghost' icon='ph--x--regular' label='Remove' onClick={() => {}} />
+            </Card.Block>
+          </Card.Row>
+          {/* Conditional leading slot: when falsy, content stays in the center track. */}
+          <Card.Row>
+            {showLeading && (
+              <Card.Block>
+                <Icon icon='ph--calendar--regular' />
+              </Card.Block>
+            )}
+            <Card.Text>Conditional start slot</Card.Text>
+          </Card.Row>
+          {/* asChild: the anchor itself becomes the trailing gutter cell. */}
+          <Card.Row>
+            <Card.Text>Trailing link via asChild</Card.Text>
+            <Card.Block end asChild>
+              <a href='https://dxos.org' target='_blank' rel='noreferrer'>
+                <Icon icon='ph--arrow-square-out--regular' />
+              </a>
+            </Card.Block>
           </Card.Row>
         </Card.Body>
       </Card.Root>

--- a/packages/ui/react-ui/src/components/Card/Card.stories.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.stories.tsx
@@ -58,7 +58,13 @@ const DefaultStory = ({ title, description, image, fullWidth }: DefaultStoryProp
 const meta = {
   title: 'ui/react-ui-core/components/Card',
   render: DefaultStory,
-  decorators: [withTheme(), withLayout({ layout: 'centered', classNames: 'grid w-[30rem] place-items-center' })],
+  decorators: [
+    withTheme(),
+    withLayout({
+      layout: 'centered',
+      classNames: 'grid w-[30rem] place-items-center bg-transparent',
+    }),
+  ],
 } satisfies Meta<typeof DefaultStory>;
 
 export default meta;

--- a/packages/ui/react-ui/src/components/Card/Card.theme.ts
+++ b/packages/ui/react-ui/src/components/Card/Card.theme.ts
@@ -53,13 +53,19 @@ const posterIcon: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
   mx('dx-card__poster-icon col-span-3 grid place-items-center bg-input-surface text-subdued max-h-[200px]', ...etc);
 
 const action: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
-  mx('dx-card__acztion col-span-3 !grid grid-cols-subgrid p-0! w-full text-start overflow-hidden', ...etc);
+  mx(
+    'dx-card__action col-span-3 !grid grid-cols-subgrid [&>*:not(.dx-gutter)]:col-start-2 p-0! w-full text-start overflow-hidden',
+    ...etc,
+  );
 
 const actionLabel: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
   mx('dx-card__action-label min-w-0 flex-1 truncate', ...etc);
 
 const link: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
-  mx('dx-card__link col-span-3 !grid grid-cols-subgrid group p-0! dx-button dx-focus-ring min-h-1!', ...etc);
+  mx(
+    'dx-card__link col-span-3 !grid grid-cols-subgrid [&>*:not(.dx-gutter)]:col-start-2 group p-0! dx-button dx-focus-ring min-h-1!',
+    ...etc,
+  );
 
 const linkLabel: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
   mx('dx-card__link-label min-w-0 flex-1 truncate', ...etc);

--- a/packages/ui/react-ui/src/components/Card/Card.theme.ts
+++ b/packages/ui/react-ui/src/components/Card/Card.theme.ts
@@ -27,7 +27,7 @@ const root: ComponentFunction<CardStyleProps> = ({ border, fullWidth }, ...etc) 
 const header: ComponentFunction<CardStyleProps> = (_, ...etc) =>
   mx(
     'dx-card__header col-span-3 grid grid-cols-subgrid items-center',
-    '[&>*:not(.dx-gutter)]:col-start-2',
+    '[&>*:not(.dx-gutter)]:col-start-2 [&>*:not(.dx-gutter)>*]:col-start-2',
     ...etc,
   );
 
@@ -54,7 +54,7 @@ const posterIcon: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
 
 const action: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
   mx(
-    'dx-card__action col-span-3 !grid grid-cols-subgrid [&>*:not(.dx-gutter)]:col-start-2 p-0! w-full text-start overflow-hidden',
+    'dx-card__action col-span-3 grid grid-cols-subgrid [&>*:not(.dx-gutter)]:col-start-2 [&>*:not(.dx-gutter)>*]:col-start-2 p-0! gap-0! w-full text-start overflow-hidden',
     ...etc,
   );
 
@@ -63,7 +63,7 @@ const actionLabel: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
 
 const link: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
   mx(
-    'dx-card__link col-span-3 !grid grid-cols-subgrid [&>*:not(.dx-gutter)]:col-start-2 group p-0! dx-button dx-focus-ring min-h-1!',
+    'dx-card__link col-span-3 grid grid-cols-subgrid [&>*:not(.dx-gutter)]:col-start-2 [&>*:not(.dx-gutter)>*]:col-start-2 group p-0! dx-button dx-focus-ring min-h-1!',
     ...etc,
   );
 
@@ -73,7 +73,12 @@ const linkLabel: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
 const row: ComponentFunction<CardStyleProps> = ({ fullWidth }, ...etc) =>
   mx(
     'dx-card__row',
-    fullWidth ? 'col-span-full' : 'col-span-3 grid grid-cols-subgrid [&>*:not(.dx-gutter)]:col-start-2',
+    fullWidth
+      ? 'col-span-full'
+      : // The `>*` selector reaches the real grid item when a content child is `display: contents`
+        // (e.g. `dx-avatar`), which the direct-child selector cannot target. It is inert for normal
+        // block children, whose inner nodes are not grid items of this row.
+        'col-span-3 grid grid-cols-subgrid [&>*:not(.dx-gutter)]:col-start-2 [&>*:not(.dx-gutter)>*]:col-start-2',
     ...etc,
   );
 

--- a/packages/ui/react-ui/src/components/Card/Card.theme.ts
+++ b/packages/ui/react-ui/src/components/Card/Card.theme.ts
@@ -17,8 +17,7 @@ export type CardStyleProps = {
 
 const root: ComponentFunction<CardStyleProps> = ({ border, fullWidth }, ...etc) =>
   mx(
-    'dx-card dx-card-min-width dx-card-max-width min-h-(--dx-rail-item) group/card relative overflow-hidden',
-    'dx-card-surface',
+    'dx-card dx-card-surface dx-card-min-width dx-card-max-width min-h-(--dx-rail-item) group/card relative overflow-hidden',
     border && 'border border-subdued-separator rounded-sm dx-focus-ring-group-y-indicator',
     fullWidth && 'max-w-none!',
     ...etc,
@@ -33,7 +32,9 @@ const header: ComponentFunction<CardStyleProps> = (_, ...etc) =>
 
 const title: ComponentFunction<CardStyleProps> = (_props, ...etc) => mx('dx-card__title grow truncate', ...etc);
 
-const body: ComponentFunction<CardStyleProps> = (_props, ...etc) => mx('dx-card__body contents pb-1 last:pb-0', ...etc);
+const body: ComponentFunction<CardStyleProps> = (_props, ...etc) => mx('dx-card__body contents', ...etc);
+
+const block: ComponentFunction<CardStyleProps> = (_props, ...etc) => mx('dx-card__block', ...etc);
 
 const text: ComponentFunction<CardStyleProps> = ({ variant = 'default', truncate: _truncate }, ...etc) =>
   mx(
@@ -47,7 +48,7 @@ const textSpan: ComponentFunction<CardStyleProps> = ({ variant = 'default', trun
   mx(variant === 'description' && 'text-sm text-description line-clamp-3', truncate && 'truncate', ...etc);
 
 const poster: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
-  mx('dx-card__poster col-span-3 max-h-[200px]', ...etc);
+  mx('dx-card__poster col-span-3 max-h-[200px] select-none pointer-events-none', ...etc);
 
 const posterIcon: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
   mx('dx-card__poster-icon col-span-3 grid place-items-center bg-input-surface text-subdued max-h-[200px]', ...etc);
@@ -72,7 +73,7 @@ const linkLabel: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
 
 const row: ComponentFunction<CardStyleProps> = ({ fullWidth }, ...etc) =>
   mx(
-    'dx-card__row',
+    'dx-card__row overflow-hidden',
     fullWidth
       ? 'col-span-full'
       : // The `>*` selector reaches the real grid item when a content child is `display: contents`
@@ -95,6 +96,7 @@ export const cardTheme: Theme<CardStyleProps> = {
   header,
   title,
   body,
+  block,
   row,
   section,
   'section-title': sectionTitle,

--- a/packages/ui/react-ui/src/components/Card/Card.theme.ts
+++ b/packages/ui/react-ui/src/components/Card/Card.theme.ts
@@ -69,7 +69,7 @@ const link: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
   );
 
 const linkLabel: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
-  mx('dx-card__link-label min-w-0 flex-1 truncate', ...etc);
+  mx('dx-card__link-label min-w-0 flex-1 truncate text-sm!', ...etc);
 
 const row: ComponentFunction<CardStyleProps> = ({ fullWidth }, ...etc) =>
   mx(

--- a/packages/ui/react-ui/src/components/Card/Card.theme.ts
+++ b/packages/ui/react-ui/src/components/Card/Card.theme.ts
@@ -26,7 +26,10 @@ const root: ComponentFunction<CardStyleProps> = ({ border, fullWidth }, ...etc) 
 
 const header: ComponentFunction<CardStyleProps> = (_, ...etc) =>
   mx(
-    'dx-card__header dx-density-md bg-transparent p-0! gap-0! col-span-3 grid! grid-cols-subgrid! shadow-none [contain:none]',
+    'dx-card__header col-span-3 grid grid-cols-subgrid items-center',
+    '[&>[data-slot=start]]:col-start-1',
+    '[&>[data-slot=end]]:col-start-3',
+    '[&>*:not([data-slot])]:col-start-2',
     ...etc,
   );
 

--- a/packages/ui/react-ui/src/components/Card/Card.theme.ts
+++ b/packages/ui/react-ui/src/components/Card/Card.theme.ts
@@ -27,9 +27,7 @@ const root: ComponentFunction<CardStyleProps> = ({ border, fullWidth }, ...etc) 
 const header: ComponentFunction<CardStyleProps> = (_, ...etc) =>
   mx(
     'dx-card__header col-span-3 grid grid-cols-subgrid items-center',
-    '[&>[data-slot=start]]:col-start-1',
-    '[&>[data-slot=end]]:col-start-3',
-    '[&>*:not([data-slot])]:col-start-2',
+    '[&>*:not(.dx-gutter)]:col-start-2',
     ...etc,
   );
 
@@ -67,7 +65,11 @@ const linkLabel: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
   mx('dx-card__link-label min-w-0 flex-1 truncate', ...etc);
 
 const row: ComponentFunction<CardStyleProps> = ({ fullWidth }, ...etc) =>
-  mx('dx-card__row', fullWidth ? 'col-span-full' : 'col-span-3 grid grid-cols-subgrid', ...etc);
+  mx(
+    'dx-card__row',
+    fullWidth ? 'col-span-full' : 'col-span-3 grid grid-cols-subgrid [&>*:not(.dx-gutter)]:col-start-2',
+    ...etc,
+  );
 
 // NOTE: Direct children that lack an explicit `col-*` utility default to the
 // Column.Root center track (via `--dx-col`); see `ui-theme`'s `css/components/card.css`.

--- a/packages/ui/react-ui/src/components/Card/Card.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.tsx
@@ -89,23 +89,25 @@ type CardHeaderProps = SlottableProps;
  * row icons (which use 4). Not a toolbar: most headers carry 0–1 controls, so `role="toolbar"`
  * was inaccurate; controls are reached by normal tab order.
  */
-const CardHeader = slottable<HTMLDivElement, CardHeaderProps>(({ children, asChild, style, ...props }, forwardedRef) => {
-  const { tx } = useThemeContext();
-  const { className, ...rest } = composableProps(props);
-  // `@radix-ui/react-primitive` has no `header` node; the intrinsic element handles asChild via Slot.
-  const Comp = asChild ? Slot : 'header';
+const CardHeader = slottable<HTMLDivElement, CardHeaderProps>(
+  ({ children, asChild, style, ...props }, forwardedRef) => {
+    const { tx } = useThemeContext();
+    const { className, ...rest } = composableProps(props);
+    // `@radix-ui/react-primitive` has no `header` node; the intrinsic element handles asChild via Slot.
+    const Comp = asChild ? Slot : 'header';
 
-  return (
-    <Comp
-      {...rest}
-      style={{ ...iconSize(5), ...style }}
-      className={tx('card.header', {}, className)}
-      ref={forwardedRef}
-    >
-      {children}
-    </Comp>
-  );
-});
+    return (
+      <Comp
+        {...rest}
+        style={{ ...iconSize(5), ...style }}
+        className={tx('card.header', {}, className)}
+        ref={forwardedRef}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
 
 CardHeader.displayName = CARD_HEADER_NAME;
 

--- a/packages/ui/react-ui/src/components/Card/Card.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.tsx
@@ -5,24 +5,23 @@
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
 import DOMPurify from 'dompurify';
-import React, { CSSProperties, JSX, MouseEventHandler, type ReactNode, forwardRef, useId, useMemo } from 'react';
+import React, { CSSProperties, MouseEventHandler, type ReactNode, forwardRef, useId, useMemo } from 'react';
 
 import { iconSize } from '@dxos/ui-theme';
-import { type Density } from '@dxos/ui-types';
+import { type Density, type SlottableProps } from '@dxos/ui-types';
 
 import { useThemeContext } from '../../hooks';
 import { composable, composableProps, slottable } from '../../util';
 import { type ThemedClassName } from '../../util';
 import { Button } from '../Button';
 import { Column } from '../Column';
-import { Icon, IconBlock, type IconBlockProps, type IconProps } from '../Icon';
+import { Icon, IconBlock } from '../Icon';
 import { Image, type ImageProps } from '../Image';
 import {
   Toolbar,
   type ToolbarActionIconButtonProps,
   ToolbarDragHandleProps,
   type ToolbarMenuProps,
-  type ToolbarRootProps,
 } from '../Toolbar';
 
 //
@@ -82,20 +81,30 @@ CardRoot.displayName = CARD_ROOT_NAME;
 
 const CARD_HEADER_NAME = 'Card.Header';
 
-type CardHeaderProps = ToolbarRootProps;
+type CardHeaderProps = SlottableProps;
 
 /**
- * Top "header" slot of a Card. Despite the name, this renders as an ARIA
- * toolbar (`role="toolbar"`) so its action children get keyboard navigation
- * for free — `<header>` is allowed to contain a toolbar.
+ * Top header row of a Card. Renders as a `<header>` and shares `Card.Row`'s subgrid +
+ * `data-slot` layout: `Card.Block` children land in the gutters, anonymous children
+ * (e.g. `Card.Title`) in the center. Sets `--icon-size` 5 — header icons are larger than
+ * row icons (which use 4). Not a toolbar: most headers carry 0–1 controls, so `role="toolbar"`
+ * was inaccurate; controls are reached by normal tab order.
  */
-const CardHeader = composable<HTMLDivElement, CardHeaderProps>(({ children, classNames, ...props }, forwardedRef) => {
+const CardHeader = slottable<HTMLDivElement, CardHeaderProps>(({ children, asChild, style, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
+  const { className, ...rest } = composableProps(props);
+  // `@radix-ui/react-primitive` has no `header` node; the intrinsic element handles asChild via Slot.
+  const Comp = asChild ? Slot : 'header';
 
   return (
-    <Toolbar.Root {...props} style={iconSize(5)} classNames={[tx('card.header', {}), classNames]} ref={forwardedRef}>
+    <Comp
+      {...rest}
+      style={{ ...iconSize(5), ...style }}
+      className={tx('card.header', {}, className)}
+      ref={forwardedRef}
+    >
       {children}
-    </Toolbar.Root>
+    </Comp>
   );
 });
 
@@ -111,9 +120,9 @@ type CardDragHandleProps = ToolbarDragHandleProps;
 
 const CardDragHandle = forwardRef<HTMLButtonElement, CardDragHandleProps>((props, forwardedRef) => {
   return (
-    <CardIconBlock>
+    <CardBlock>
       <Toolbar.DragHandle {...props} ref={forwardedRef} />
-    </CardIconBlock>
+    </CardBlock>
   );
 });
 
@@ -129,9 +138,9 @@ type CardActionIconButtonProps = ToolbarActionIconButtonProps;
 
 const CardActionIconButton = forwardRef<HTMLButtonElement, CardActionIconButtonProps>((props, forwardedRef) => {
   return (
-    <CardIconBlock>
+    <CardBlock end>
       <Toolbar.ActionIconButton {...props} ref={forwardedRef} />
-    </CardIconBlock>
+    </CardBlock>
   );
 });
 
@@ -147,41 +156,36 @@ type CardMenuProps<T extends any | void = void> = ToolbarMenuProps<T>;
 
 function CardMenu<T extends any | void = void>({ context, items, ...props }: CardMenuProps<T>) {
   return (
-    <CardIconBlock>
+    <CardBlock end>
       <Toolbar.Menu {...props} context={context} items={items ?? []} />
-    </CardIconBlock>
+    </CardBlock>
   );
 }
 
 CardMenu.displayName = CARD_MENU_NAME;
 
 //
-// Icon
+// Block
 //
 
-const CARD_ICON_NAME = 'Card.Icon';
+const CARD_BLOCK_NAME = 'Card.Block';
 
-function CardIcon(props: IconProps) {
+type CardBlockProps = SlottableProps<{ end?: boolean; compact?: boolean; square?: boolean }>;
+
+/**
+ * Leading (default) or trailing (`end`) gutter slot of a Card row/header. Sized to the
+ * rail-item square so a passive `<Icon>` aligns with an `IconButton`. Defaults text color to
+ * `subdued` so a decorative `<Icon>` child needs no styling; interactive children set their own.
+ */
+const CardBlock = slottable<HTMLDivElement, CardBlockProps>(({ children, classNames, ...props }, forwardedRef) => {
   return (
-    <CardIconBlock>
-      <Icon {...props} />
-    </CardIconBlock>
+    <Column.Block {...props} classNames={['text-subdued', classNames]} ref={forwardedRef}>
+      {children}
+    </Column.Block>
   );
-}
-
-CardIcon.displayName = CARD_ICON_NAME;
-
-//
-// IconBlock
-//
-
-const CARD_ICON_BLOCK_NAME = 'Card.IconBlock';
-
-const CardIconBlock = forwardRef<HTMLDivElement, IconBlockProps>((props, forwardedRef) => {
-  return <IconBlock {...props} ref={forwardedRef} />;
 });
 
-CardIconBlock.displayName = CARD_ICON_BLOCK_NAME;
+CardBlock.displayName = CARD_BLOCK_NAME;
 
 //
 // Title
@@ -271,32 +275,28 @@ CardSection.displayName = CARD_SECTION_NAME;
 
 const CARD_ROW_NAME = 'Card.Row';
 
-type CardRowProps = { icon?: string | JSX.Element; fullWidth?: boolean };
+type CardRowProps = { fullWidth?: boolean };
 
 /**
  * A row inside a Card.
- * - Default: spans all 3 columns and establishes a subgrid so children align to the Card's columns.
- *   An optional `icon` lands in the first column; when omitted, the first column is left empty.
- * - `fullWidth`: spans all columns without a subgrid — children do their own internal layout.
- *   The `icon` prop is ignored in this mode.
+ * - Default: spans all 3 columns as a subgrid; children align via `data-slot` — `Card.Block`
+ *   lands in the gutters (start/end), anonymous children in the center. Sets `--icon-size` 4.
+ * - `fullWidth`: spans all columns without a subgrid — children do their own internal layout;
+ *   `Card.Block` placement is inert in this mode.
  */
 const CardRow = slottable<HTMLDivElement, CardRowProps>(
-  ({ children, asChild, icon: iconProp, fullWidth, ...props }, forwardedRef) => {
+  ({ children, asChild, fullWidth, style, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
     const { className, ...rest } = composableProps(props);
     const Comp = asChild ? Slot : Primitive.div;
-    const icon =
-      typeof iconProp === 'string' ? (
-        <CardIcon classNames='text-subdued' icon={iconProp as string} size={4} />
-      ) : iconProp ? (
-        iconProp
-      ) : (
-        <div />
-      );
 
     return (
-      <Comp {...rest} className={tx('card.row', { fullWidth }, className)} ref={forwardedRef}>
-        {!fullWidth && icon}
+      <Comp
+        {...rest}
+        style={{ ...iconSize(4), ...style }}
+        className={tx('card.row', { fullWidth }, className)}
+        ref={forwardedRef}
+      >
         {children}
       </Comp>
     );
@@ -414,9 +414,19 @@ function CardAction({ icon, actionIcon = 'ph--arrow-right--regular', label, onCl
   const { tx } = useThemeContext();
   return (
     <Button variant='ghost' classNames={tx('card.action', {})} onClick={onClick}>
-      {icon ? <CardIcon classNames='text-subdued' icon={icon} size={4} /> : <div />}
+      {icon ? (
+        <IconBlock classNames='text-subdued'>
+          <Icon icon={icon} size={4} />
+        </IconBlock>
+      ) : (
+        <div />
+      )}
       <span className={tx('card.action-label', {}, !actionIcon ? 'col-span-2' : undefined)}>{label}</span>
-      {actionIcon && <CardIcon icon={actionIcon} size={4} />}
+      {actionIcon && (
+        <IconBlock>
+          <Icon icon={actionIcon} size={4} />
+        </IconBlock>
+      )}
     </Button>
   );
 }
@@ -435,9 +445,13 @@ function CardLink({ label, href }: CardLinkProps) {
   const { tx } = useThemeContext();
   return (
     <a className={tx('card.link', {})} data-variant='ghost' href={href} target='_blank' rel='noreferrer'>
-      <CardIcon classNames='text-subdued' icon='ph--link--regular' />
+      <IconBlock classNames='text-subdued'>
+        <Icon icon='ph--link--regular' />
+      </IconBlock>
       <span className={tx('card.link-label', {})}>{label}</span>
-      <CardIcon classNames='invisible group-hover:visible' icon='ph--arrow-square-out--regular' />
+      <IconBlock classNames='invisible group-hover:visible'>
+        <Icon icon='ph--arrow-square-out--regular' />
+      </IconBlock>
     </a>
   );
 }
@@ -454,12 +468,11 @@ export const Card = {
   // Header
   Header: CardHeader,
 
-  // Header parts
-  IconBlock: CardIconBlock,
+  // Header / row parts
+  Block: CardBlock,
   DragHandle: CardDragHandle,
   ActionIconButton: CardActionIconButton,
   Menu: CardMenu,
-  Icon: CardIcon,
   Title: CardTitle,
 
   // Body
@@ -478,6 +491,7 @@ export const Card = {
 export type {
   CardRootProps,
   CardHeaderProps,
+  CardBlockProps,
   CardDragHandleProps,
   CardActionIconButtonProps,
   CardMenuProps,

--- a/packages/ui/react-ui/src/components/Card/Card.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.tsx
@@ -18,7 +18,7 @@ import { composable, composableProps, slottable } from '../../util';
 import { type ThemedClassName } from '../../util';
 import { Button, IconButton } from '../Button';
 import { Column } from '../Column';
-import { Icon, IconBlock } from '../Icon';
+import { Icon } from '../Icon';
 import { Image, type ImageProps } from '../Image';
 import { DropdownMenu } from '../Menu';
 import { type ToolbarActionIconButtonProps, type ToolbarDragHandleProps, type ToolbarMenuProps } from '../Toolbar';
@@ -470,18 +470,16 @@ function CardAction({ icon, actionIcon = 'ph--arrow-right--regular', label, onCl
   const { tx } = useThemeContext();
   return (
     <Button variant='ghost' classNames={tx('card.action', {})} onClick={onClick}>
-      {icon ? (
-        <IconBlock classNames='text-subdued'>
+      {icon && (
+        <CardBlock>
           <Icon icon={icon} size={4} />
-        </IconBlock>
-      ) : (
-        <div />
+        </CardBlock>
       )}
-      <span className={tx('card.action-label', {}, !actionIcon ? 'col-span-2' : undefined)}>{label}</span>
+      <span className={tx('card.action-label', {})}>{label}</span>
       {actionIcon && (
-        <IconBlock>
+        <CardBlock end>
           <Icon icon={actionIcon} size={4} />
-        </IconBlock>
+        </CardBlock>
       )}
     </Button>
   );
@@ -501,13 +499,13 @@ function CardLink({ label, href }: CardLinkProps) {
   const { tx } = useThemeContext();
   return (
     <a className={tx('card.link', {})} data-variant='ghost' href={href} target='_blank' rel='noreferrer'>
-      <IconBlock classNames='text-subdued'>
-        <Icon icon='ph--link--regular' />
-      </IconBlock>
+      <CardBlock>
+        <Icon icon='ph--link--regular' size={4} />
+      </CardBlock>
       <span className={tx('card.link-label', {})}>{label}</span>
-      <IconBlock classNames='invisible group-hover:visible'>
-        <Icon icon='ph--arrow-square-out--regular' />
-      </IconBlock>
+      <CardBlock end classNames='invisible group-hover:visible'>
+        <Icon icon='ph--arrow-square-out--regular' size={4} />
+      </CardBlock>
     </a>
   );
 }

--- a/packages/ui/react-ui/src/components/Card/Card.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.tsx
@@ -6,23 +6,22 @@ import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
 import DOMPurify from 'dompurify';
 import React, { CSSProperties, MouseEventHandler, type ReactNode, forwardRef, useId, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { iconSize } from '@dxos/ui-theme';
 import { type Density, type SlottableProps } from '@dxos/ui-types';
 
+import { translationKey } from '#translations';
+
 import { useThemeContext } from '../../hooks';
 import { composable, composableProps, slottable } from '../../util';
 import { type ThemedClassName } from '../../util';
-import { Button } from '../Button';
+import { Button, IconButton } from '../Button';
 import { Column } from '../Column';
 import { Icon, IconBlock } from '../Icon';
 import { Image, type ImageProps } from '../Image';
-import {
-  Toolbar,
-  type ToolbarActionIconButtonProps,
-  ToolbarDragHandleProps,
-  type ToolbarMenuProps,
-} from '../Toolbar';
+import { DropdownMenu } from '../Menu';
+import { type ToolbarActionIconButtonProps, type ToolbarDragHandleProps, type ToolbarMenuProps } from '../Toolbar';
 
 //
 // Root
@@ -118,13 +117,27 @@ const CARD_DRAG_HANDLE_NAME = 'Card.DragHandle';
 
 type CardDragHandleProps = ToolbarDragHandleProps;
 
-const CardDragHandle = forwardRef<HTMLButtonElement, CardDragHandleProps>((props, forwardedRef) => {
-  return (
-    <CardBlock>
-      <Toolbar.DragHandle {...props} ref={forwardedRef} />
-    </CardBlock>
-  );
-});
+const CardDragHandle = forwardRef<HTMLButtonElement, CardDragHandleProps>(
+  ({ testId = 'drag-handle', label }, forwardedRef) => {
+    const { t } = useTranslation(translationKey);
+    return (
+      <CardBlock>
+        <IconButton
+          data-testid={testId}
+          tabIndex={-1}
+          noTooltip
+          iconOnly
+          icon='ph--dots-six-vertical--regular'
+          variant='ghost'
+          label={label ?? t('toolbar-drag-handle.label')}
+          classNames='dx-focus-ring-none cursor-pointer'
+          disabled={!forwardedRef}
+          ref={forwardedRef}
+        />
+      </CardBlock>
+    );
+  },
+);
 
 CardDragHandle.displayName = CARD_DRAG_HANDLE_NAME;
 
@@ -136,13 +149,28 @@ const CARD_ACTION_ICON_BUTTON_NAME = 'Card.ActionIconButton';
 
 type CardActionIconButtonProps = ToolbarActionIconButtonProps;
 
-const CardActionIconButton = forwardRef<HTMLButtonElement, CardActionIconButtonProps>((props, forwardedRef) => {
-  return (
-    <CardBlock end>
-      <Toolbar.ActionIconButton {...props} ref={forwardedRef} />
-    </CardBlock>
-  );
-});
+const CARD_ACTION_ICONS = { close: 'ph--x--regular', delete: 'ph--trash--regular' } as const;
+
+const CARD_ACTION_LABEL_KEYS = { close: 'toolbar-close.label', delete: 'toolbar-delete.label' } as const;
+
+const CardActionIconButton = forwardRef<HTMLButtonElement, CardActionIconButtonProps>(
+  ({ action, onClick, label }, forwardedRef) => {
+    const { t } = useTranslation(translationKey);
+    return (
+      <CardBlock end>
+        <IconButton
+          iconOnly
+          icon={CARD_ACTION_ICONS[action]}
+          variant='ghost'
+          label={label ?? t(CARD_ACTION_LABEL_KEYS[action])}
+          classNames='cursor-pointer'
+          onClick={onClick}
+          ref={forwardedRef}
+        />
+      </CardBlock>
+    );
+  },
+);
 
 CardActionIconButton.displayName = CARD_ACTION_ICON_BUTTON_NAME;
 
@@ -154,10 +182,36 @@ const CARD_MENU_NAME = 'Card.Menu';
 
 type CardMenuProps<T extends any | void = void> = ToolbarMenuProps<T>;
 
-function CardMenu<T extends any | void = void>({ context, items, ...props }: CardMenuProps<T>) {
+function CardMenu<T extends any | void = void>({ context, items }: CardMenuProps<T>) {
+  const { t } = useTranslation(translationKey);
   return (
     <CardBlock end>
-      <Toolbar.Menu {...props} context={context} items={items ?? []} />
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger disabled={!items?.length} asChild>
+          <IconButton
+            iconOnly
+            variant='ghost'
+            icon='ph--dots-three-vertical--regular'
+            label={t('toolbar-menu.label')}
+          />
+        </DropdownMenu.Trigger>
+        {(items?.length ?? 0) > 0 && (
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content>
+              <DropdownMenu.Viewport>
+                {items?.map(({ label, onClick: onSelect }, index) => (
+                  // `context` is the generic payload threaded to each handler; the cast is the
+                  // generic boundary (T may be `void`, so `context` is typed `T | undefined`).
+                  <DropdownMenu.Item key={index} onSelect={() => onSelect(context as T)}>
+                    {label}
+                  </DropdownMenu.Item>
+                ))}
+              </DropdownMenu.Viewport>
+              <DropdownMenu.Arrow />
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        )}
+      </DropdownMenu.Root>
     </CardBlock>
   );
 }

--- a/packages/ui/react-ui/src/components/Card/Card.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.tsx
@@ -132,7 +132,7 @@ const CardDragHandle = forwardRef<HTMLButtonElement, CardDragHandleProps>(
           icon='ph--dots-six-vertical--regular'
           variant='ghost'
           label={label ?? t('toolbar-drag-handle.label')}
-          classNames='dx-focus-ring-none cursor-pointer'
+          classNames='dx-focus-ring-none cursor-pointer text-base-fg'
           disabled={!forwardedRef}
           ref={forwardedRef}
         />
@@ -233,9 +233,12 @@ type CardBlockProps = SlottableProps<{ end?: boolean; compact?: boolean; square?
  * rail-item square so a passive `<Icon>` aligns with an `IconButton`. Defaults text color to
  * `subdued` so a decorative `<Icon>` child needs no styling; interactive children set their own.
  */
-const CardBlock = slottable<HTMLDivElement, CardBlockProps>(({ children, classNames, ...props }, forwardedRef) => {
+const CardBlock = composable<HTMLDivElement, CardBlockProps>(({ children, classNames, ...props }, forwardedRef) => {
+  const { tx } = useThemeContext();
+  const { className, ...rest } = composableProps(props);
+
   return (
-    <Column.Block {...props} classNames={['text-subdued', classNames]} ref={forwardedRef}>
+    <Column.Block {...rest} classNames={tx('card.block', {}, classNames)} ref={forwardedRef}>
       {children}
     </Column.Block>
   );
@@ -435,15 +438,21 @@ type CardPosterProps = ThemedClassName<
     Omit<ImageProps, 'src' | 'alt' | 'classNames'>
 >;
 
-function CardPoster({ classNames, alt, aspect: aspectProp, image, icon, ...imageProps }: CardPosterProps) {
+function CardPoster({
+  classNames,
+  alt,
+  aspect: aspectProp,
+  image,
+  icon,
+  fit = 'cover',
+  ...imageProps
+}: CardPosterProps) {
   const { tx } = useThemeContext();
   const aspect = aspectProp === 'auto' ? 'aspect-auto' : 'aspect-video';
 
   if (image) {
     return (
-      <div className='col-span-full'>
-        <Image classNames={[tx('card.poster', {}), aspect, classNames]} src={image} alt={alt} {...imageProps} />
-      </div>
+      <Image classNames={[tx('card.poster', {}), aspect, classNames]} src={image} alt={alt} fit={fit} {...imageProps} />
     );
   }
 

--- a/packages/ui/react-ui/src/components/Card/Card.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.tsx
@@ -233,12 +233,12 @@ type CardBlockProps = SlottableProps<{ end?: boolean; compact?: boolean; square?
  * rail-item square so a passive `<Icon>` aligns with an `IconButton`. Defaults text color to
  * `subdued` so a decorative `<Icon>` child needs no styling; interactive children set their own.
  */
-const CardBlock = composable<HTMLDivElement, CardBlockProps>(({ children, classNames, ...props }, forwardedRef) => {
+const CardBlock = composable<HTMLDivElement, CardBlockProps>(({ children, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
   const { className, ...rest } = composableProps(props);
 
   return (
-    <Column.Block {...rest} classNames={tx('card.block', {}, classNames)} ref={forwardedRef}>
+    <Column.Block {...rest} classNames={tx('card.block', {}, className)} ref={forwardedRef}>
       {children}
     </Column.Block>
   );

--- a/packages/ui/react-ui/src/components/Column/Column.theme.ts
+++ b/packages/ui/react-ui/src/components/Column/Column.theme.ts
@@ -9,19 +9,48 @@ import { withColumn } from './withColumn';
 
 export type ColumnStyleProps = {};
 
+export type ColumnBlockStyleProps = {
+  compact?: boolean;
+  /** Constrain to a square (1:1) slot rather than the default rail-item width. */
+  square?: boolean;
+};
+
 const root: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
   return mx('dx-column-root grid', ...etc);
 };
 
 /**
- * Three-column icon-slot row: spans all 3 columns of the parent Column.Root grid.
- * Uses CSS subgrid to inherit column sizing from the parent Column.
- * Children map to: [col-1: icon/slot] [col-2: content] [col-3: icon/action].
+ * Three-column subgrid row spanning all 3 columns of the parent Column.Root grid.
+ * Children are placed by `data-slot`, not by source order:
+ * - `start` → column 1 (leading gutter)
+ * - `end`   → column 3 (trailing gutter)
+ * - anything without a `data-slot` (anonymous content) → column 2 (center)
+ * Attribute-driven placement is robust to conditional children (a falsy leading slot
+ * never shifts content into a gutter).
  * NOTE: Must not use overflow-hidden here since it will clip input focus rings.
  */
 const row: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
-  return mx('col-span-3 grid grid-cols-subgrid', ...etc);
+  return mx(
+    'col-span-3 grid grid-cols-subgrid',
+    '[&>[data-slot=start]]:col-start-1',
+    '[&>[data-slot=end]]:col-start-3',
+    '[&>*:not([data-slot])]:col-start-2',
+    ...etc,
+  );
 };
+
+/**
+ * Gutter slot geometry: a `--dx-rail-item` square that centers its child, so a passive
+ * `<Icon>` and an interactive `IconButton` line up to the pixel. Column placement (1/3) is
+ * applied by the parent `row` via `data-slot`.
+ */
+const block: ComponentFunction<ColumnBlockStyleProps> = ({ compact, square }, ...etc) =>
+  mx(
+    'grid place-items-center [&>img]:max-w-[1.5rem]',
+    square ? 'aspect-square' : 'w-[var(--dx-rail-item)]',
+    compact ? '' : 'h-[var(--dx-rail-item)]',
+    ...etc,
+  );
 
 /**
  * Bleed placement: spans all 3 columns of the parent Column.Root grid (gutter-to-gutter).
@@ -43,6 +72,7 @@ const center: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
 export const columnTheme = {
   root,
   row,
+  block,
   bleed,
   center,
 };

--- a/packages/ui/react-ui/src/components/Column/Column.theme.ts
+++ b/packages/ui/react-ui/src/components/Column/Column.theme.ts
@@ -10,6 +10,8 @@ import { withColumn } from './withColumn';
 export type ColumnStyleProps = {};
 
 export type ColumnBlockStyleProps = {
+  /** Trailing gutter (column 3) instead of the default leading gutter (column 1). */
+  end?: boolean;
   compact?: boolean;
   /** Constrain to a square (1:1) slot rather than the default rail-item width. */
   square?: boolean;
@@ -21,32 +23,28 @@ const root: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
 
 /**
  * Three-column subgrid row spanning all 3 columns of the parent Column.Root grid.
- * Children are placed by `data-slot`, not by source order:
- * - `start` → column 1 (leading gutter)
- * - `end`   → column 3 (trailing gutter)
- * - anything without a `data-slot` (anonymous content) → column 2 (center)
- * Attribute-driven placement is robust to conditional children (a falsy leading slot
- * never shifts content into a gutter).
+ * Placement is explicit, not source-order based:
+ * - `Column.Block` self-places into column 1 (leading) or column 3 (trailing, `end`) and
+ *   carries the `dx-gutter` marker class.
+ * - Every other (content) child is placed in column 2 via `[&>*:not(.dx-gutter)]`.
+ * Class-based placement (rather than `[data-slot=…]`) is used because Tailwind does not
+ * generate arbitrary variants that nest a square-bracket attribute selector.
+ * Robust to conditional children: a falsy leading slot never shifts content into a gutter.
  * NOTE: Must not use overflow-hidden here since it will clip input focus rings.
  */
 const row: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
-  return mx(
-    'col-span-3 grid grid-cols-subgrid',
-    '[&>[data-slot=start]]:col-start-1',
-    '[&>[data-slot=end]]:col-start-3',
-    '[&>*:not([data-slot])]:col-start-2',
-    ...etc,
-  );
+  return mx('col-span-3 grid grid-cols-subgrid', '[&>*:not(.dx-gutter)]:col-start-2', ...etc);
 };
 
 /**
  * Gutter slot geometry: a `--dx-rail-item` square that centers its child, so a passive
- * `<Icon>` and an interactive `IconButton` line up to the pixel. Column placement (1/3) is
- * applied by the parent `row` via `data-slot`.
+ * `<Icon>` and an interactive `IconButton` line up to the pixel. Self-places into column 1
+ * (default) or column 3 (`end`); the `dx-gutter` marker keeps it out of the content track.
  */
-const block: ComponentFunction<ColumnBlockStyleProps> = ({ compact, square }, ...etc) =>
+const block: ComponentFunction<ColumnBlockStyleProps> = ({ end, compact, square }, ...etc) =>
   mx(
-    'grid place-items-center [&>img]:max-w-[1.5rem]',
+    'dx-gutter grid place-items-center [&>img]:max-w-[1.5rem]',
+    end ? 'col-start-3' : 'col-start-1',
     square ? 'aspect-square' : 'w-[var(--dx-rail-item)]',
     compact ? '' : 'h-[var(--dx-rail-item)]',
     ...etc,

--- a/packages/ui/react-ui/src/components/Column/Column.tsx
+++ b/packages/ui/react-ui/src/components/Column/Column.tsx
@@ -175,7 +175,7 @@ const ColumnBlock = slottable<HTMLDivElement, ColumnBlockProps>(
       <Comp
         {...rest}
         data-slot={end ? 'end' : 'start'}
-        className={tx('column.block', { compact, square }, className)}
+        className={tx('column.block', { end, compact, square }, className)}
         ref={forwardedRef}
       >
         {children}

--- a/packages/ui/react-ui/src/components/Column/Column.tsx
+++ b/packages/ui/react-ui/src/components/Column/Column.tsx
@@ -153,14 +153,49 @@ const ColumnCenter = slottable<HTMLDivElement>(({ children, asChild, ...props },
 ColumnCenter.displayName = COLUMN_CENTER_NAME;
 
 //
+// Block
+//
+
+const COLUMN_BLOCK_NAME = 'Column.Block';
+
+type ColumnBlockProps = SlottableProps<{ end?: boolean; compact?: boolean; square?: boolean }>;
+
+/**
+ * A gutter slot inside a Column.Row. Sized to `--dx-rail-item` and centers its child so a passive
+ * `<Icon>` and an interactive `IconButton` align to the pixel. `end` opts into the trailing gutter
+ * (column 3); default is the leading gutter (column 1). Placement is via `data-slot`, so it is
+ * robust to conditional rendering and source order.
+ */
+const ColumnBlock = slottable<HTMLDivElement, ColumnBlockProps>(
+  ({ children, asChild, end, compact, square, ...props }, forwardedRef) => {
+    const { tx } = useThemeContext();
+    const { className, ...rest } = composableProps(props);
+    const Comp = asChild ? Slot : Primitive.div;
+    return (
+      <Comp
+        {...rest}
+        data-slot={end ? 'end' : 'start'}
+        className={tx('column.block', { compact, square }, className)}
+        ref={forwardedRef}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+
+ColumnBlock.displayName = COLUMN_BLOCK_NAME;
+
+//
 // Column
 //
 
 export const Column = {
   Root: ColumnRoot,
   Row: ColumnRow,
+  Block: ColumnBlock,
   Bleed: ColumnBleed,
   Center: ColumnCenter,
 };
 
-export type { ColumnRootProps, ColumnRowProps, ColumnBleedProps, ColumnCenterProps };
+export type { ColumnRootProps, ColumnRowProps, ColumnBlockProps, ColumnBleedProps, ColumnCenterProps };


### PR DESCRIPTION
## Summary

Replaces `Card.Row`'s overloaded `icon` prop with explicit, symmetric **gutter slots** (`Card.Block`) shared across `Column` and `Card`, and turns `Card.Header` into a proper `<header>` (no longer an ARIA toolbar).

Design + plan: `docs/superpowers/specs/2026-06-13-card-row-slots-design.md`, `docs/superpowers/plans/2026-06-13-card-row-slots.md`.

## What changed

**New API**
- `Column.Block` / `Card.Block` — a `--dx-rail-item` gutter slot. Default = leading (column 1); `end` = trailing (column 3). Holds any child (`<Icon>`, `IconButton`, `Avatar`), supports `asChild`, and absorbs `IconBlock`'s geometry so a passive icon and an `IconButton` align to the pixel.
- Placement is **class-based** (`dx-gutter` marker + `[&>*:not(.dx-gutter)]:col-start-2`), not source-order — robust to conditional children.

**Removed (full migration, no shims)**
- `Card.Row.icon`, `Card.Icon`, `Card.IconBlock` → use `Card.Block`. Standalone `IconBlock` (21 non-card uses) is **kept** as the shared geometry primitive that `Column.Block` builds on.

**`Card.Header`**
- Now a plain `<header>` sharing `Card.Row`'s subgrid layout (only difference: `--icon-size` 5 vs row's 4). Dropped `Toolbar.Root` — ~75% of headers had 0–1 controls, so `role="toolbar"` was inaccurate. `Card.DragHandle`/`ActionIconButton`/`Menu` reimplemented on base `IconButton`/`DropdownMenu`; raw `Toolbar.*` items used in card headers across ~15 call sites were swapped to base `IconButton`.

**Migration**
- ~26 call sites across 13 plugins + 3 `react-ui` packages moved to `Card.Block`.

## Notable fixes found along the way
- **`display: contents` content** (e.g. `Avatar.Content`'s `<dx-avatar>`) generated no grid box, so it auto-flowed into the gutter. Content placement now also reaches one level down (`[&>*:not(.dx-gutter)>*]:col-start-2`) — inert for normal block content. Avatars now land in the center column.
- `Card.Action`/`Card.Link` routed through `Card.Block` (were bare `IconBlock` + auto-flow); fixed the `dx-card__acztion` typo.
- `ProjectCard` description wrapped in `Card.Row`; `FormCard` guarded against typeless objects (was crashing the empty-form stories).

## Reviewer notes
- **Dialog deferred**: dialog gutters are `sm` (1rem) but a rail-item is 2rem, so gutter slots would overflow. `Dialog.Header` is unchanged; the mechanism lives in `Column` for a future opt-in.
- One justified cast remains (`context as T` in `CardMenu`), copied verbatim from the old `ToolbarMenu` (generic payload boundary).
- Verified in Storybook: all `react-ui` Card stories + all 11 `plugin-preview` card stories render with correct gutter alignment and zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a slot-based layout system for Card headers using `Card.Block` for gutter/content routing.
  * Added `Column.Block` to support gutter-slot placement inside column rows.

* **Refactor**
  * Reworked Card/Dialog header and row composition to use explicit block-based icon/action/menu layout (replacing prior icon-prop patterns).

* **Bug Fixes**
  * Improved preview robustness when type resolution or `JSON.stringify` fails.
  * Prevented showing poster fallback UI when no image is available.

* **Documentation**
  * Added/updated migration and design guidance plus expanded Card story coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->