### PR TITLE
fix(plugin-comments): batch anchor+thread removal to fix flaky undo-delete test

### DIFF
--- a/packages/plugins/plugin-comments/src/operations/delete.ts
+++ b/packages/plugins/plugin-comments/src/operations/delete.ts
@@ -5,9 +5,9 @@
 import * as Effect from 'effect/Effect';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
-import { sleep } from '@dxos/async';
 import { Operation } from '@dxos/compute';
 import { Obj, Relation } from '@dxos/echo';
+import { batchEvents } from '@dxos/echo/internal';
 import { ObservabilityOperation } from '@dxos/plugin-observability';
 import { Thread } from '@dxos/types';
 
@@ -42,10 +42,12 @@ const handler: Operation.WithHandler<typeof CommentOperation.Delete> = CommentOp
         return {};
       }
 
-      // TODO(wittjosiah): Without sleep, rendering crashes at `Relation.setSource(anchor)`.
-      db.remove(anchor);
-      yield* Effect.promise(() => sleep(100));
-      db.remove(thread);
+      // Batch both removals so a single reactive notification fires — prevents an intermediate
+      // render where anchor is removed but thread still exists (mirrors the batchEvents pattern in restore.ts).
+      batchEvents(() => {
+        db.remove(anchor);
+        db.remove(thread);
+      });
 
       yield* Operation.schedule(ObservabilityOperation.SendEvent, {
         name: 'comments.delete',

--- a/packages/ui/react-ui-search/DESIGN.md
+++ b/packages/ui/react-ui-search/DESIGN.md
@@ -97,16 +97,16 @@ Estimated: one PR, ~3-4 file changes. Low risk.
 
 ~9 plugin call sites still rolling their own `<ul>`/`<li>` + `<button>` rows:
 
-| File                                                                                | Replacement                                                |
-| ----------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `plugin-code/src/components/FileTree/FileTree.tsx`                                  | Reuse `react-ui-list/Tree` (after C1)                      |
-| `plugin-sidekick/src/components/ActionItems.tsx`                                    | `Listbox` + a per-row checkbox affordance (multi-select)   |
-| `plugin-assistant/src/components/ChatPrompt/ChatReferences.tsx`                     | `Listbox` (tag-pill row variant)                           |
-| `plugin-assistant/src/components/ChatPrompt/ChatMcpErrors.tsx`                      | `Listbox`                                                  |
-| `plugin-script/src/containers/DeploymentDialog/DeploymentDialog.tsx`                | `Listbox`                                                  |
-| `plugin-help/.../WelcomeTour.stories.tsx`                                           | `Listbox`                                                  |
-| `plugin-meeting/src/containers/MeetingsList/MeetingsList.tsx`                       | already on `Listbox`; drop the inner `<div role='list'>`   |
-| (one more in plugin-script)                                                         | `Listbox`                                                  |
+| File                                                                 | Replacement                                              |
+| -------------------------------------------------------------------- | -------------------------------------------------------- |
+| `plugin-code/src/components/FileTree/FileTree.tsx`                   | Reuse `react-ui-list/Tree` (after C1)                    |
+| `plugin-sidekick/src/components/ActionItems.tsx`                     | `Listbox` + a per-row checkbox affordance (multi-select) |
+| `plugin-assistant/src/components/ChatPrompt/ChatReferences.tsx`      | `Listbox` (tag-pill row variant)                         |
+| `plugin-assistant/src/components/ChatPrompt/ChatMcpErrors.tsx`       | `Listbox`                                                |
+| `plugin-script/src/containers/DeploymentDialog/DeploymentDialog.tsx` | `Listbox`                                                |
+| `plugin-help/.../WelcomeTour.stories.tsx`                            | `Listbox`                                                |
+| `plugin-meeting/src/containers/MeetingsList/MeetingsList.tsx`        | already on `Listbox`; drop the inner `<div role='list'>` |
+| (one more in plugin-script)                                          | `Listbox`                                                |
 
 Each is a small PR; parallelise across maintainers. High aggregate value (consistent
 `dx-selected` grammar), low per-PR risk.
@@ -129,6 +129,7 @@ Pick the cheaper option once B1 lands and the call-sites are visible.
 #### C1. `Tree` → aspects
 
 Refactor `react-ui-list/Tree` to compose:
+
 - `useReorderList` + `useReorderItem` for hierarchical DnD (above / below / into via
   pragmatic-dnd's `attachClosestEdge` + a `canDrop` predicate that reads `depth`).
 - `useListDisclosure({ mode: 'multi' })` for multi-branch expand state.
@@ -138,6 +139,7 @@ Refactor `react-ui-list/Tree` to compose:
   follow-up.
 
 Affects:
+
 - `plugin-navtree` (6 files — `state.ts`, `L1Panel`, `types.ts`, `NavTreeContainer`,
   `useNavTreeModel`, `update-state.ts`)
 - `devtools/ObjectsTree.tsx`
@@ -169,6 +171,7 @@ live inside the (still-unimplemented) `useListVirtualizer` aspect so consumers d
 re-derive it.
 
 Sequence:
+
 1. Implement `useListVirtualizer` with the `{ reorder }` slot from the design doc.
 2. Migrate `Mosaic.Stack` to `useReorderList` (no virtualization). Cross-stack drag stays
    via `canDrop`/`getInitialData` payloads.
@@ -203,6 +206,7 @@ Mosaic.Stack which handles this automatically." Still ~6 consumers (plugin-deck,
 plugin-script, plugin-stack, plugin-meeting). Independent of the aspect work above.
 
 Strands:
+
 1. Each consumer migrates to `Mosaic.Stack`. Per-consumer PR; can parallelise.
 2. After consumer count hits zero: delete `packages/ui/react-ui-stack/` entirely (source +
    `PLAN.md` + dependencies + tests).


### PR DESCRIPTION
## Summary

- **Root cause fix for flaky `undo delete thread` Playwright test** (`comments.spec.ts:135`): The delete operation was calling `db.remove(anchor)` then waiting 100ms (via `sleep`) before `db.remove(thread)`. This intermediate state — anchor removed, thread still in DB — caused `Relation.setSource(anchor)` to crash during a re-render on Firefox. After undo, `data-testid="thread"` showed 0 elements because the thread was never cleanly re-added after the crash.

- **Fix**: Replace the `sleep(100)` with `batchEvents(() => { db.remove(anchor); db.remove(thread); })`, making both mutations fire as a single reactive notification. This is the exact pattern already in use in `restore.ts` (the add-side of the same operation), which includes the comment explaining why the old sleep was needed.

- **DESIGN.md formatting**: Reformats `react-ui-search/DESIGN.md` to pass the `oxfmt --check` step that was introduced in the same commit that added the file (`ab0afa62`).

## What this does NOT overlap with

PR #11811 (`claude/exciting-curie-gwbtjz`) addresses:
- `welcome-focus.spec.ts` (excluded via `testIgnore`)
- `comments.spec.ts` "selecting comment highlights thread and vice versa" (PRNG fix)

This PR addresses the separate `undo delete thread` flakiness and the formatting check failure.

## Test plan

- [ ] CI `Check` workflow passes (build + test + lint + fmt)
- [ ] `comments.spec.ts` "undo delete thread" passes consistently across Firefox/Chromium/WebKit


---
_Generated by [Claude Code](https://claude.ai/code/session_01EK931E3xCpsr24vM4WKGGd)_