### PR TITLE
chore(deps): update esbuild group

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1075,8 +1075,8 @@ catalogs:
       specifier: ^0.0.9
       version: 0.0.9
     esbuild-plugin-raw:
-      specifier: 0.3.0
-      version: 0.3.0
+      specifier: 0.4.2
+      version: 0.4.2
     esbuild-plugin-wasm:
       specifier: ^1.1.0
       version: 1.1.0
@@ -2131,7 +2131,7 @@ importers:
         version: 1.4.1(esbuild@0.28.0)
       esbuild-plugin-raw:
         specifier: 'catalog:'
-        version: 0.3.0(esbuild@0.28.0)
+        version: 0.4.2(esbuild@0.28.0)
       esbuild-plugin-yaml:
         specifier: 'catalog:'
         version: 0.0.1
@@ -33105,8 +33105,8 @@ packages:
   esbuild-plugin-inline-image@0.0.9:
     resolution: {integrity: sha512-pw3ZgN2phh32Z7BpKrhRDtmI+iVCl+Gc0BLOT9croXg1MnMjRuN7aXhIQirhLeK39erkIwfFlhy6xieroBGc1Q==}
 
-  esbuild-plugin-raw@0.3.0:
-    resolution: {integrity: sha512-zO9UzFr/VVvSUPeYxV7Un4d2Uxb+TPOEx545rE/V9tL8ORQB0B8eXDgN1rk6FioB9ZjDKuB8tsu65eTNOH9tVw==}
+  esbuild-plugin-raw@0.4.2:
+    resolution: {integrity: sha512-a5uYNDg4uqrcMUiNlPkoqS7vSH99XA/KlAhAnS+FYgVNwYGCpIJvQ9fb4Ze7hfxi2rNQMmyS/tO4RlHdo1LH3g==}
     peerDependencies:
       esbuild: '>=0.28.0'
 
@@ -53550,7 +53550,7 @@ snapshots:
 
   esbuild-plugin-inline-image@0.0.9: {}
 
-  esbuild-plugin-raw@0.3.0(esbuild@0.28.0):
+  esbuild-plugin-raw@0.4.2(esbuild@0.28.0):
     dependencies:
       esbuild: 0.28.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -398,10 +398,10 @@ catalog:
   emoji-mart: ^5.5.2
   enquirer: ^2.3.6
   error-stack-parser: ^2.1.4
-  esbuild: 0.28.0
+  esbuild: 0.28.1
   esbuild-plugin-glsl: ^1.4.1
   esbuild-plugin-inline-image: ^0.0.9
-  esbuild-plugin-raw: 0.3.0
+  esbuild-plugin-raw: 0.4.2
   esbuild-plugin-wasm: ^1.1.0
   esbuild-plugin-yaml: ^0.0.1
   esbuild-style-plugin: ^1.6.3

--- a/tools/dx-compile/src/esbuild-plugin-raw-types.d.ts
+++ b/tools/dx-compile/src/esbuild-plugin-raw-types.d.ts
@@ -1,0 +1,8 @@
+// Type override for esbuild-plugin-raw@0.4.x whose root index.d.ts switched from
+// `export =` (CJS) to `export default` (ESM), breaking NodeNext module resolution.
+// The dist/index.d.ts correctly uses `export = rawPlugin`; we mirror that here.
+declare module 'esbuild-plugin-raw' {
+  import type { Plugin } from 'esbuild';
+  function rawPlugin(): Plugin;
+  export = rawPlugin;
+}


### PR DESCRIPTION
## Dependency updates — esbuild group

| Package | Old | New | Type |
|---------|-----|-----|------|
| `esbuild` | `0.28.0` | `0.28.1` | patch |
| `esbuild-plugin-raw` | `0.3.0` | `0.4.2` | minor |

Other esbuild-plugin-* packages (`esbuild-plugin-glsl`, `esbuild-plugin-wasm`, etc.) are already within their `^` ranges and resolve to the latest.

## Source changes

**`tools/dx-compile/src/esbuild-plugin-raw-types.d.ts` (new file)**

`esbuild-plugin-raw@0.4.x` changed its root `index.d.ts` from `export = rawPlugin` (CJS-compatible) to `export default rawPlugin` (ESM-only). TypeScript NodeNext module resolution picks up the root type file and can no longer correctly type-check `import RawPlugin from 'esbuild-plugin-raw'` — it sees the module namespace rather than the default export.

The package's `dist/index.d.ts` still correctly uses `export = rawPlugin` (the CJS types). The new ambient declaration file mirrors that, overriding the package's root types within this compilation unit only.

## Validation

- `pnpm install` completed cleanly (4 packages replaced)
- `moon run dx-compile:compile` passes
- `moon run dx-build:compile` passes (cached, unaffected)

## Classification: Trivial

Mechanical TypeScript type fix preserving the same runtime behavior. `esbuild` itself is a patch bump with no API changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GADHYtt4BbzZtLFVovvjYL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `esbuild` to version 0.28.1
  * Updated `esbuild-plugin-raw` to version 0.4.2
  * Fixed TypeScript type compatibility for build tooling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->