### PR TITLE
fix(react-ui-components): use Filter.and in QueryForm to avoid unsupported QueryFilterClause

### DIFF
--- a/packages/ui/react-ui-components/src/components/QueryForm/QueryForm.tsx
+++ b/packages/ui/react-ui-components/src/components/QueryForm/QueryForm.tsx
@@ -39,15 +39,10 @@ export const QueryForm = ({ classNames, initialQuery, types, tags, onChange }: Q
     ({ type, tag }: { type: URI.URI | null; tag: string | null }) => {
       const typeFilter = type ? Filter.type(type) : null;
       const tagFilter = tag ? Filter.tag(tag) : null;
-      const query =
-        typeFilter && tagFilter
-          ? Query.select(typeFilter).select(tagFilter)
-          : typeFilter
-            ? Query.select(typeFilter)
-            : tagFilter
-              ? Query.select(tagFilter)
-              : Query.select(Filter.nothing());
-      onChange?.(query);
+      // Combine into a single select to avoid QueryFilterClause which queue contexts don't support.
+      const combined =
+        typeFilter && tagFilter ? Filter.and(typeFilter, tagFilter) : typeFilter ?? tagFilter ?? Filter.nothing();
+      onChange?.(Query.select(combined));
     },
     [onChange],
   );

--- a/packages/ui/react-ui-components/src/components/QueryForm/QueryForm.tsx
+++ b/packages/ui/react-ui-components/src/components/QueryForm/QueryForm.tsx
@@ -41,7 +41,7 @@ export const QueryForm = ({ classNames, initialQuery, types, tags, onChange }: Q
       const tagFilter = tag ? Filter.tag(tag) : null;
       // Combine into a single select to avoid QueryFilterClause which queue contexts don't support.
       const combined =
-        typeFilter && tagFilter ? Filter.and(typeFilter, tagFilter) : typeFilter ?? tagFilter ?? Filter.nothing();
+        typeFilter && tagFilter ? Filter.and(typeFilter, tagFilter) : (typeFilter ?? tagFilter ?? Filter.nothing());
       onChange?.(Query.select(combined));
     },
     [onChange],

--- a/packages/ui/react-ui-components/src/components/QueryForm/QueryForm.tsx
+++ b/packages/ui/react-ui-components/src/components/QueryForm/QueryForm.tsx
@@ -39,7 +39,6 @@ export const QueryForm = ({ classNames, initialQuery, types, tags, onChange }: Q
     ({ type, tag }: { type: URI.URI | null; tag: string | null }) => {
       const typeFilter = type ? Filter.type(type) : null;
       const tagFilter = tag ? Filter.tag(tag) : null;
-      // Combine into a single select to avoid QueryFilterClause which queue contexts don't support.
       const combined =
         typeFilter && tagFilter ? Filter.and(typeFilter, tagFilter) : (typeFilter ?? tagFilter ?? Filter.nothing());
       onChange?.(Query.select(combined));


### PR DESCRIPTION
## Summary

- Pipeline views with both a type and tag filter showed **"Error: Query not supported."** in the main view area.
- Root cause: `Query.select(typeFilter).select(tagFilter)` chains to produce a `QueryFilterClause` (`{ type: 'filter', selection, filter }`) — a query AST node that `QueueQueryContext.isSimpleSelectionQuery` does not handle, causing it to throw.
- Fix: replace the chained `.select()` calls with `Filter.and(typeFilter, tagFilter)` inside a single `Query.select()`, which produces a `select` node with an `and`-filter that queue contexts already support.

## Test plan

- [ ] Create a pipeline view in Composer with both a type (e.g. Message) and a tag (e.g. IMPORTANT) selected in the query editor — confirm no "Query not supported" error.
- [ ] Verify a pipeline view with only a type filter or only a tag filter still works.
- [ ] `moon run echo-client:test` — all tests pass.
- [ ] `moon run react-ui-components:lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how QueryForm combines **type** and **tag** selections into the resulting query. When both are chosen, they’re applied together as a single combined filter; when only one (or neither) is selected, the query now follows more consistent defaults—preserving existing behavior while making outcomes more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->