### PR TITLE
feat(echo): closure-aware strong-dependency resolution via unified RefResolver

### DIFF
--- a/docs/superpowers/plans/2026-06-15-strong-deps-refresolver-progress.md
+++ b/docs/superpowers/plans/2026-06-15-strong-deps-refresolver-progress.md
@@ -1,0 +1,58 @@
+# Strong-deps RefResolver — execution notes
+
+Branch: `claude/intelligent-darwin-apde4r` (same commit as `dm/strong-deps-refresolver`).
+
+Baseline (before changes): `strong-deps-resolution.test.ts` 5 fail / rest green; whole echo-client suite 619 pass.
+
+Acceptance (drive green):
+- relation automerge→feed: in-memory / after reload / multi-peer
+- relation cross-space (automerge→automerge): in-memory
+- parent automerge→feed: in-memory
+
+## Design decisions (deviations from spec, all sound)
+
+- New `RefResolver.resolve(uri, { source }) -> RefResolverRequest` is the canonical surface.
+  Legacy `resolveSync` / `resolveLegacy` (was async `resolve`) / `resolveSchema` / `resolveType`
+  kept (deprecated) until the final cleanup task so the build stays green per step.
+- Strong-dep extraction is **store-aware at the backend**: each `LoadOp` carries a `strongDeps()`
+  thunk supplied by its backend — echo-db reads the reliable `ObjectCore` encoded refs, queue reads
+  the decoded entity via public symbols, registry returns `[]`. This is more correct than a single
+  live-entity extractor (live db proxies don't expose a parent *URI*, only a resolved parent).
+- Type dep semantics unchanged: a type is a strong dep only when persisted (echo-URI). Static /
+  registry types (`dxn:`) are always available, so they are not gated (matches current behaviour and
+  keeps the stored-schema regression test green).
+
+## Status
+
+- [x] Task 1: new resolver types + StaticRefResolver.resolve (legacy kept)
+- [x] Task 2: strong-dep extractor (`getStrongDependencies` / `getStrongDependencyUris`)
+- [x] Task 3: LoadOpTable (coalesced body loading + refcount + escalation)
+- [x] Task 4: RequestImpl walker (cycle-safe BFS, microtask-deferred stateChanged)
+- [x] Task 5: HypergraphImpl backends + resolve() — registry / per-space / cross-space-by-id
+- [x] Task 6: CoreDatabase satisfaction delegated to resolver (`_areDepsSatisfied`/`_areDepsResolved`
+      → request state; retired `_strongDepsIndex` + BFS waking)
+- [x] Task 7: relation source/target + parent read path → `resolve(working-set).getResult()`
+- [ ] Task 8: RefImpl single lazy request (still uses legacy resolveSync/resolveLegacy)
+- [ ] Task 9: json-serializer migration (still uses resolveLegacy/resolveSchema/resolveType)
+- [ ] Task 10: remove middleware
+- [ ] Task 11: remove legacy methods + port remaining callers
+- [ ] Task 12: feature tests (ref-resolver.test.ts, relation-endpoints.test.ts)
+
+## Test state
+
+Acceptance suite `strong-deps-resolution.test.ts`: 10/11 pass.
+- ✅ feed in-memory, feed reload, parent feed, cross-space in-memory, + all regression guards.
+- 🔴 multi-peer feed (from network) — queue items must replicate/fetch to peer 2; the disk-tier
+  queue poll doesn't surface them within the timeout. Open: wire a network pull (`queue.sync`) or
+  raise the queue ceiling. (Flagged as an open item in the handoff.)
+
+The 2 transient regressions (deleted-object re-add / deleted-after-reload) were fixed by making
+resolution deleted-agnostic (deletion is the query's filter, not resolution's).
+
+## Key decision
+
+Cross-space relations store their endpoint refs **space-less** (a relation created in-memory has no
+db yet, so `createRef` can't know the endpoint's space). Per the spec ("only the load/surface path
+changes"), resolution treats a local `echo:` EID as resolvable across **all** registered spaces
+(entity ids are globally unique) rather than assuming the owning space.
+

--- a/packages/core/echo/echo-client/src/core-db/core-database.ts
+++ b/packages/core/echo/echo-client/src/core-db/core-database.ts
@@ -27,7 +27,7 @@ import {
   type EntityStructure,
   type SpaceState,
 } from '@dxos/echo-protocol';
-import { batchEvents } from '@dxos/echo/internal';
+import { batchEvents, type RefResolver, type RefResolverRequest } from '@dxos/echo/internal';
 import { invariant } from '@dxos/invariant';
 import { EID, type EntityId, type PublicKey, type SpaceId, type URI } from '@dxos/keys';
 import { log } from '@dxos/log';
@@ -93,13 +93,6 @@ export class CoreDatabase {
   private readonly _objects = new Map<string, ObjectCore>();
 
   /**
-   * DXN string -> EntityId.
-   * Stores the targets of strong dependencies to the objects that depend on them.
-   * When we load an object that doesn't have it's strong deps resolved, we wait for the deps to be loaded first.
-   */
-  private readonly _strongDepsIndex = new Map<string, EntityId[]>();
-
-  /**
    * Object ids whose backing document was determined to be not on local disk
    * via a `diskOnly` load probe. Used by `loadObjectCoreById` to bail out
    * of the wait without resolving when the doc would otherwise require
@@ -107,6 +100,15 @@ export class CoreDatabase {
    * `undefined` return.
    */
   private readonly _unavailableObjects = new Set<EntityId>();
+
+  /**
+   * Per-entity closure-aware satisfaction requests. Strong-dependency satisfaction is delegated to
+   * the {@link RefResolver}: each surfaced entity holds a disk-bound request whose `ready` state is
+   * the surface gate, spanning same-space db, cross-space db, feed queues, and the registry.
+   */
+  private readonly _satisfactionRequests = new Map<EntityId, RefResolverRequest>();
+
+  private _refResolver: RefResolver | undefined;
 
   readonly _updateEvent = new Event<ItemsUpdatedEvent>();
 
@@ -184,6 +186,12 @@ export class CoreDatabase {
 
     await this._repoProxy.open();
     this._ctx.onDispose(() => this._unsubscribeFromHandles());
+    this._ctx.onDispose(() => {
+      for (const request of this._satisfactionRequests.values()) {
+        request.abort();
+      }
+      this._satisfactionRequests.clear();
+    });
     this._automergeDocLoader.onObjectDocumentLoaded.on(this._ctx, this._onObjectDocumentLoaded.bind(this));
     this._automergeDocLoader.onObjectUnavailable.on(this._ctx, this._onObjectUnavailable.bind(this));
 
@@ -900,10 +908,8 @@ export class CoreDatabase {
   private _onObjectDocumentLoaded({ handle, objectId }: ObjectDocumentLoaded): void {
     handle.on('change', this._onDocumentUpdate);
 
-    // The dep was previously marked unavailable but its bytes have now
-    // arrived (e.g. a peer eventually delivered them); clear the mark so
-    // any new `loadObjectCoreById` waiters for this object — or for its
-    // dependents — see a fresh resolution.
+    // The body was previously marked unavailable but its bytes have now arrived (e.g. a peer
+    // eventually delivered them); clear the mark so any in-flight body load resolves afresh.
     this._markObjectAvailable(objectId);
 
     // Skip objects that were already materialized locally.
@@ -911,45 +917,11 @@ export class CoreDatabase {
       return;
     }
 
-    const core = this._createObjectInDocument(handle, objectId);
-    const depsSatisfied = this._areDepsSatisfied(core);
-    if (depsSatisfied) {
-      this._scheduleThrottledUpdate([objectId]);
-    } else {
-      // Recursive strong-dep loads always use `diskOnly: true`. Deps are
-      // a system-internal hydration step, not a user-driven request: we
-      // surface a clear "unavailable" signal instead of blocking on the
-      // network. Callers that explicitly want network-backed dep loading
-      // can issue per-dep requests themselves.
-      for (const dep of core.getStrongDependencies()) {
-        if (!EID.isLocal(dep)) {
-          continue;
-        }
-        const id = EID.getEntityId(dep);
-        if (id) {
-          this._automergeDocLoader.loadObjectDocument(id, { diskOnly: true });
-        }
-      }
-    }
-    const queue = [objectId],
-      seen = new Set<string>();
-    while (queue.length > 0) {
-      const id = queue.shift()!;
-      if (seen.has(id)) {
-        continue;
-      }
-      seen.add(id);
-
-      if (this._objects.has(id)) {
-        for (const dep of this._strongDepsIndex.get(id) ?? []) {
-          queue.push(dep);
-          const core = this._objects.get(dep);
-          if (core && this._areDepsSatisfied(core)) {
-            this._scheduleThrottledUpdate([core.id]);
-          }
-        }
-      }
-    }
+    this._createObjectInDocument(handle, objectId);
+    // Surface the new body. The query pipeline re-evaluates strong-dep satisfaction through the
+    // resolver; dependents whose closure includes this entity are woken by their satisfaction
+    // request's load op transitioning to ready.
+    this._scheduleThrottledUpdate([objectId]);
   }
 
   /**
@@ -977,96 +949,57 @@ export class CoreDatabase {
       assignFromLocalState: false,
     });
 
-    const deps = core.getStrongDependencies();
-    for (const dep of deps) {
-      if (!EID.isLocal(dep)) {
-        continue;
-      }
-      const depObjectId = EID.getEntityId(dep);
-      if (!depObjectId || this._objects.has(depObjectId)) {
-        continue;
-      }
-
-      defaultMap(this._strongDepsIndex, depObjectId, []).push(core.id);
-    }
-
     return core;
   }
 
   /**
-   * Whether every local strong dependency is loaded and satisfied.
-   * Query paths require this before surfacing an object.
+   * Whether the entity's full strong-dependency closure is loaded and satisfied.
+   * Query paths require this before surfacing an object. Delegated to the resolver, so it spans
+   * same-space / cross-space db objects, feed-queue objects, and registry types uniformly.
    */
   areStrongDepsSatisfied(core: ObjectCore): boolean {
     return this._areDepsSatisfied(core);
   }
 
-  private _areDepsSatisfied(core: ObjectCore, seen?: Set<EntityId>): boolean {
-    seen ??= new Set<EntityId>();
-    const deps = core.getStrongDependencies();
-
-    seen.add(core.id);
-    return deps.every((dep) => {
-      if (!EID.isLocal(dep)) {
-        return true;
-      }
-      const depObjectId = EID.getEntityId(dep);
-      if (!depObjectId) {
-        return true;
-      }
-      const depCore = this._objects.get(depObjectId);
-      if (!depCore) {
-        return false;
-      }
-      if (seen.has(depCore.id)) {
-        return true;
-      }
-      return this._areDepsSatisfied(depCore, seen);
-    });
+  private _areDepsSatisfied(core: ObjectCore): boolean {
+    return this._ensureSatisfactionRequest(core).state === 'ready';
   }
 
   /**
-   * Returns true when every strong dep is either loaded (== `_areDepsSatisfied`)
-   * OR has been determined unavailable on disk. Used by `loadObjectCoreById`
-   * so it can resolve (with `undefined`) instead of waiting forever when a
-   * recursive dep doc is unreachable. Recursive strong-dep loads always
-   * use `diskOnly: true`, so deps surface as unavailable promptly even for
-   * non-`diskOnly` top-level callers.
+   * Returns true when the strong-dep closure is either satisfied OR settled `unavailable` at the
+   * disk ceiling. Used by `loadObjectCoreById` so it resolves (with `undefined`) instead of waiting
+   * forever when a dependency is unreachable on disk.
    */
-  private _areDepsResolved(core: ObjectCore, seen?: Set<EntityId>): boolean {
-    seen ??= new Set<EntityId>();
-    const deps = core.getStrongDependencies();
-
-    seen.add(core.id);
-    return deps.every((dep) => {
-      if (!EID.isLocal(dep)) {
-        return true;
-      }
-      const depObjectId = EID.getEntityId(dep);
-      if (!depObjectId || this._unavailableObjects.has(depObjectId)) {
-        return true;
-      }
-      const depCore = this._objects.get(depObjectId);
-      if (!depCore) {
-        return false;
-      }
-      if (seen.has(depCore.id)) {
-        return true;
-      }
-      return this._areDepsResolved(depCore, seen);
-    });
+  private _areDepsResolved(core: ObjectCore): boolean {
+    const state = this._ensureSatisfactionRequest(core).state;
+    return state === 'ready' || state === 'unavailable';
   }
 
   /**
-   * Clears a stale `_unavailableObjects` mark once an object becomes available and wakes its
-   * dependents so any `loadObjectCoreById` waiter — or query hydration that dropped the object —
-   * re-evaluates. The mark is set when an id is probed (`diskOnly`) while absent from the space
-   * directory; an object later materialized locally (added) or whose document arrives must clear
-   * it, otherwise `diskOnly` loads keep short-circuiting to `undefined` until the database is rebuilt.
+   * Returns (creating on first use) the closure-aware satisfaction request for an entity. Surfacing
+   * subscribes to its state changes so the query pipeline re-evaluates as the closure loads.
+   */
+  private _ensureSatisfactionRequest(core: ObjectCore): RefResolverRequest {
+    let request = this._satisfactionRequests.get(core.id);
+    if (request == null) {
+      this._refResolver ??= this._hypergraph.createRefResolver({ context: { space: this._spaceId } });
+      const uri = EID.make({ spaceId: this._spaceId, entityId: core.id });
+      request = this._refResolver.resolve(uri, { source: 'disk' });
+      this._satisfactionRequests.set(core.id, request);
+      request.stateChanged.on(this._ctx, () => this._scheduleThrottledUpdate([core.id]));
+    }
+    return request;
+  }
+
+  /**
+   * Clears a stale `_unavailableObjects` mark once an object's body becomes available, waking any
+   * in-flight body load. The mark is set when an id is probed (`diskOnly`) while absent from the
+   * space directory; an object later materialized locally (added) or whose document arrives must
+   * clear it, otherwise `diskOnly` loads keep short-circuiting to `undefined`.
    */
   private _markObjectAvailable(objectId: string): void {
     if (this._unavailableObjects.delete(objectId)) {
-      this._scheduleThrottledUpdate([objectId, ...(this._strongDepsIndex.get(objectId) ?? [])]);
+      this._scheduleThrottledUpdate([objectId]);
     }
   }
 
@@ -1075,22 +1008,9 @@ export class CoreDatabase {
       return;
     }
     this._unavailableObjects.add(objectId);
-    // Walk transitive dependents (`A → B → C`, C unavailable wakes B
-    // and A) so any `loadObjectCoreById` waiter higher up in the chain
-    // re-evaluates `_areDepsResolved` and resolves with `undefined`
-    // instead of hanging. Mirrors the BFS in `_onObjectDocumentLoaded`.
-    const toWake = new Set<EntityId>([objectId]);
-    const queue: EntityId[] = [objectId];
-    while (queue.length > 0) {
-      const id = queue.shift()!;
-      for (const dep of this._strongDepsIndex.get(id) ?? []) {
-        if (!toWake.has(dep)) {
-          toWake.add(dep);
-          queue.push(dep);
-        }
-      }
-    }
-    this._scheduleThrottledUpdate([...toWake]);
+    // Wake any in-flight body load so it settles `unavailable` instead of hanging; satisfaction
+    // requests whose closure includes this body re-evaluate via their load op transitioning.
+    this._scheduleThrottledUpdate([objectId]);
   }
 
   private _rebindObjects(docHandle: DocHandleProxy<DatabaseDirectory>, objectIds: string[]): void {

--- a/packages/core/echo/echo-client/src/core-db/load-op.ts
+++ b/packages/core/echo/echo-client/src/core-db/load-op.ts
@@ -1,0 +1,166 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Event } from '@dxos/async';
+import { type AnyProperties, type RefSource } from '@dxos/echo/internal';
+import { type URI } from '@dxos/keys';
+
+/**
+ * Resolution states of a load op's BODY tier (never the closure):
+ * - `pending`: created, not yet started (one-way entry state; never re-entered).
+ * - `requesting`: the backend is loading the body.
+ * - `ready`: the body is materialized in the working set; {@link LoadOp.result} is non-null.
+ * - `unavailable`: unreachable at the pursued ceiling.
+ */
+export type LoadOpState = 'pending' | 'requesting' | 'ready' | 'unavailable';
+
+/**
+ * Result of a working-set probe / completed load: the materialized entity plus its direct
+ * strong-dependency URIs (computed store-side, where the raw references are reliably readable).
+ */
+export interface LoadResult {
+  result: AnyProperties;
+  strongDeps: URI.URI[];
+}
+
+/**
+ * A coalesced, per-URI body-loading operation shared by all live requests referencing the URI.
+ * Tracks only the body tier; closure satisfaction lives in the request layer.
+ */
+export interface LoadOp {
+  readonly uri: URI.URI;
+  /** Highest ceiling currently pursued; only ever escalated, never lowered. */
+  maxCeiling: RefSource;
+  state: LoadOpState;
+  result: AnyProperties | null;
+  /** Direct strong-dep URIs of {@link result}; empty unless `state === 'ready'`. */
+  strongDeps: URI.URI[];
+  /** Fires on any state / result / strongDeps change. */
+  readonly changed: Event<void>;
+  /** Number of live requests referencing this op. */
+  refcount: number;
+  /** Backend IO cancellation, set while loading. */
+  cancel?: () => void;
+}
+
+/**
+ * Drives a {@link LoadOp}'s state. Each backend owns a URI kind / space.
+ */
+export interface LoadBackend {
+  /** Synchronous working-set probe; never performs IO. */
+  probe(uri: URI.URI): LoadResult | undefined;
+
+  /**
+   * Begin loading the body at the given ceiling (always ≥ `disk`); drives the op via `set`.
+   * Returns a cancellation function.
+   */
+  load(uri: URI.URI, source: RefSource, set: (state: LoadOpState, result: LoadResult | undefined) => void): () => void;
+}
+
+const CEILING_RANK: Record<RefSource, number> = { 'working-set': 0, disk: 1, network: 2 };
+
+const isHigherCeiling = (a: RefSource, b: RefSource): boolean => CEILING_RANK[a] > CEILING_RANK[b];
+
+/**
+ * Owns the set of coalesced {@link LoadOp}s. Dedup lives here, below the resolver: each URI has at
+ * most one in-flight op; requests share it and refcount it.
+ */
+export class LoadOpTable {
+  readonly #ops = new Map<URI.URI, LoadOp>();
+
+  constructor(private readonly _routeBackend: (uri: URI.URI) => LoadBackend | undefined) {}
+
+  /**
+   * Acquire (create-or-reuse) the op for `uri` at the given ceiling, incrementing its refcount.
+   * Escalates the ceiling (and re-invokes the backend) when a higher tier is requested.
+   */
+  acquire(uri: URI.URI, source: RefSource): LoadOp {
+    const existing = this.#ops.get(uri);
+    if (existing) {
+      existing.refcount++;
+      if (isHigherCeiling(source, existing.maxCeiling)) {
+        existing.maxCeiling = source;
+        if (existing.state !== 'ready') {
+          this.#startLoad(existing, source);
+        }
+      }
+      return existing;
+    }
+
+    const op: LoadOp = {
+      uri,
+      maxCeiling: source,
+      state: 'pending',
+      result: null,
+      strongDeps: [],
+      changed: new Event<void>(),
+      refcount: 1,
+    };
+    this.#ops.set(uri, op);
+
+    const backend = this._routeBackend(uri);
+    // Always probe the working set first.
+    const probed = backend?.probe(uri);
+    if (probed) {
+      op.state = 'ready';
+      op.result = probed.result;
+      op.strongDeps = probed.strongDeps;
+      return op;
+    }
+
+    if (source === 'working-set' || backend == null) {
+      op.state = 'unavailable';
+      return op;
+    }
+
+    this.#startLoad(op, source);
+    return op;
+  }
+
+  /**
+   * Decrement the refcount; at zero, cancel IO and drop the op (does not evict the entity from its
+   * backing store's working set).
+   */
+  release(op: LoadOp): void {
+    if (--op.refcount > 0) {
+      return;
+    }
+    op.cancel?.();
+    op.cancel = undefined;
+    this.#ops.delete(op.uri);
+  }
+
+  /** @internal Testing / introspection. */
+  get size(): number {
+    return this.#ops.size;
+  }
+
+  #startLoad(op: LoadOp, source: RefSource): void {
+    const backend = this._routeBackend(op.uri);
+    if (backend == null) {
+      this.#set(op, 'unavailable', undefined);
+      return;
+    }
+    op.cancel?.();
+    op.state = 'requesting';
+    op.cancel = backend.load(op.uri, source, (state, result) => this.#set(op, state, result));
+  }
+
+  #set(op: LoadOp, state: LoadOpState, result: LoadResult | undefined): void {
+    // `pending` is a one-way entry state; never re-enter it.
+    const nextState = state === 'pending' ? 'requesting' : state;
+    const nextResult = result?.result ?? null;
+    const nextDeps = result?.strongDeps ?? [];
+    if (op.state === nextState && op.result === nextResult && sameUris(op.strongDeps, nextDeps)) {
+      return;
+    }
+    op.state = nextState;
+    op.result = nextResult;
+    op.strongDeps = nextDeps;
+    op.changed.emit();
+  }
+}
+
+const sameUris = (a: URI.URI[], b: URI.URI[]): boolean =>
+  a.length === b.length && a.every((uri, index) => uri === b[index]);

--- a/packages/core/echo/echo-client/src/core-db/object-core.ts
+++ b/packages/core/echo/echo-client/src/core-db/object-core.ts
@@ -14,7 +14,7 @@ import {
   type EntityStructure,
   isEncodedReference,
 } from '@dxos/echo-protocol';
-import { EntityKind, type EntityMeta } from '@dxos/echo/internal';
+import { EntityKind, type EntityMeta, getStrongDependencyUris } from '@dxos/echo/internal';
 import { isProxy } from '@dxos/echo/internal';
 import { assertArgument, invariant } from '@dxos/invariant';
 import { EID, EntityId, URI } from '@dxos/keys';
@@ -518,49 +518,23 @@ export class ObjectCore {
   }
 
   /**
-   * EIDs of objects that this object strongly depends on.
-   * Strong references are loaded together with the source object — only ECHO-scheme refs
-   * (object refs) qualify; type DXNs are resolved separately via the schema registry.
-   * Currently this is the schema reference (when stored as an object), source/target for
-   * relations, and the parent ref.
+   * URIs of the entities that this entity strongly depends on: the schema reference (when stored as
+   * an object), source/target for relations, and the parent ref. Strong dependencies are loaded
+   * together with the depending entity before it is surfaced. URIs may be cross-space `echo:` EIDs
+   * or queue-item EIDs; the resolver routes each to the appropriate backend.
    */
-  getStrongDependencies(): EID.EID[] {
-    const res: EID.EID[] = [];
-
+  getStrongDependencies(): URI.URI[] {
     const typeRef = this.getType();
-    if (typeRef) {
-      const typeEchoUri = EID.tryParse(EncodedReference.toURI(typeRef));
-      if (typeEchoUri) {
-        res.push(typeEchoUri);
-      }
-    }
-
-    if (this.getKind() === EntityKind.Relation) {
-      const sourceRef = this.getSource();
-      if (sourceRef) {
-        const id = EID.tryParse(EncodedReference.toURI(sourceRef));
-        if (id) {
-          res.push(id);
-        }
-      }
-      const targetRef = this.getTarget();
-      if (targetRef) {
-        const id = EID.tryParse(EncodedReference.toURI(targetRef));
-        if (id) {
-          res.push(id);
-        }
-      }
-    }
-
+    const sourceRef = this.getSource();
+    const targetRef = this.getTarget();
     const parentRef = this.getParent();
-    if (parentRef) {
-      const id = EID.tryParse(EncodedReference.toURI(parentRef));
-      if (id) {
-        res.push(id);
-      }
-    }
-
-    return res;
+    return getStrongDependencyUris({
+      kind: this.getKind(),
+      type: typeRef ? EncodedReference.toURI(typeRef) : undefined,
+      source: sourceRef ? EncodedReference.toURI(sourceRef) : undefined,
+      target: targetRef ? EncodedReference.toURI(targetRef) : undefined,
+      parent: parentRef ? EncodedReference.toURI(parentRef) : undefined,
+    });
   }
 }
 

--- a/packages/core/echo/echo-client/src/core-db/ref-resolver-request.ts
+++ b/packages/core/echo/echo-client/src/core-db/ref-resolver-request.ts
@@ -1,0 +1,165 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Event } from '@dxos/async';
+import { type AnyProperties, type RefResolverRequest, type RefSource } from '@dxos/echo/internal';
+import { type URI } from '@dxos/keys';
+
+import { type LoadOp, type LoadOpTable } from './load-op';
+
+/**
+ * A closure-aware {@link RefResolverRequest}: an un-coalesced per-call handle over a root
+ * {@link LoadOp} plus the strong-dependency closure discovered by a cycle-safe BFS.
+ *
+ * `state` is derived: `unavailable` if the root or any closure member body is unavailable at the
+ * requested ceiling; `ready` when the root and the whole closure are body-ready; otherwise
+ * `requesting` / `pending`. The walker waits on member BODIES (not their closure-readiness), so
+ * mutually-citing entities (`A.source→B, B.parent→A`) cannot deadlock.
+ */
+export class RequestImpl implements RefResolverRequest {
+  readonly stateChanged = new Event<void>();
+
+  #state: RefResolverRequest['state'];
+  #emitScheduled = false;
+  #aborted = false;
+
+  /** Discovered closure members (excludes the root). */
+  readonly #members = new Map<URI.URI, { op: LoadOp; unsub: () => void }>();
+  readonly #rootUnsub: () => void;
+
+  constructor(
+    private readonly _table: LoadOpTable,
+    private readonly _root: LoadOp,
+    private readonly _source: RefSource,
+  ) {
+    this.#state = 'pending';
+    this.#rootUnsub = this._root.changed.on(() => this.#recompute());
+    // Discover the initial closure synchronously (so `getResult()` is correct immediately) but defer
+    // the first `stateChanged` to a microtask per the resolver contract.
+    this.#recompute();
+  }
+
+  get state(): RefResolverRequest['state'] {
+    return this.#state;
+  }
+
+  getResult(): AnyProperties | undefined {
+    return this.#state === 'ready' ? (this._root.result ?? undefined) : undefined;
+  }
+
+  async wait(): Promise<AnyProperties | undefined> {
+    if (this.#state === 'ready' || this.#state === 'unavailable') {
+      return this.getResult();
+    }
+    return new Promise((resolve) => {
+      const unsub = this.stateChanged.on(() => {
+        if (this.#state === 'ready' || this.#state === 'unavailable') {
+          unsub();
+          resolve(this.getResult());
+        }
+      });
+    });
+  }
+
+  abort(): void {
+    if (this.#aborted) {
+      return;
+    }
+    this.#aborted = true;
+    this.#rootUnsub();
+    for (const { op, unsub } of this.#members.values()) {
+      unsub();
+      this._table.release(op);
+    }
+    this.#members.clear();
+    this._table.release(this._root);
+  }
+
+  /**
+   * Re-walk the closure from the root's materialized body, attach load ops for newly-discovered
+   * dependency URIs, recompute the public state, and emit `stateChanged` (deferred) on change.
+   */
+  #recompute(): void {
+    if (this.#aborted) {
+      return;
+    }
+
+    // Cycle-safe BFS over already-materialized bodies; a node contributes its dep edges only once
+    // its own body is ready, so cycles terminate against the `seen` set.
+    const seen = new Set<URI.URI>([this._root.uri]);
+    const queue: LoadOp[] = [this._root];
+    while (queue.length > 0) {
+      const op = queue.shift()!;
+      if (op.state !== 'ready') {
+        continue;
+      }
+      for (const depUri of op.strongDeps) {
+        if (seen.has(depUri)) {
+          continue;
+        }
+        seen.add(depUri);
+        let member = this.#members.get(depUri);
+        if (member == null) {
+          const depOp = this._table.acquire(depUri, this._source);
+          const unsub = depOp.changed.on(() => this.#recompute());
+          member = { op: depOp, unsub };
+          this.#members.set(depUri, member);
+        }
+        queue.push(member.op);
+      }
+    }
+
+    // Release members that are no longer reachable (dep edges removed).
+    for (const [uri, member] of this.#members) {
+      if (!seen.has(uri)) {
+        member.unsub();
+        this._table.release(member.op);
+        this.#members.delete(uri);
+      }
+    }
+
+    // Derive the public state over the root + reachable members.
+    let anyUnavailable = false;
+    let allReady = true;
+    for (const uri of seen) {
+      const op = uri === this._root.uri ? this._root : this.#members.get(uri)?.op;
+      if (op == null) {
+        continue;
+      }
+      if (op.state === 'unavailable') {
+        anyUnavailable = true;
+      }
+      if (op.state !== 'ready') {
+        allReady = false;
+      }
+    }
+
+    const nextState: RefResolverRequest['state'] = anyUnavailable
+      ? 'unavailable'
+      : allReady
+        ? 'ready'
+        : this._root.state === 'pending'
+          ? 'pending'
+          : 'requesting';
+
+    if (nextState !== this.#state) {
+      this.#state = nextState;
+      this.#scheduleEmit();
+    }
+  }
+
+  // Defer `stateChanged` to a microtask to avoid re-entrant listener storms during closure discovery.
+  #scheduleEmit(): void {
+    if (this.#emitScheduled) {
+      return;
+    }
+    this.#emitScheduled = true;
+    queueMicrotask(() => {
+      this.#emitScheduled = false;
+      if (!this.#aborted) {
+        this.stateChanged.emit();
+      }
+    });
+  }
+}

--- a/packages/core/echo/echo-client/src/echo-handler/echo-handler.ts
+++ b/packages/core/echo/echo-client/src/echo-handler/echo-handler.ts
@@ -383,13 +383,7 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
     const database = target[symbolInternals].database;
     if (database) {
       // TODO(dmaretskyi): Put refs into proxy cache.
-      return database.graph
-        .createRefResolver({
-          context: {
-            space: database.spaceId,
-          },
-        })
-        .resolveSync(parentDXN, false);
+      return this._resolveStrongDepFromWorkingSet(database, parentDXN);
     } else {
       invariant(target[symbolInternals].linkCache);
       const parentEchoUri = EID.tryParse(parentDXN);
@@ -399,6 +393,20 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
     }
   }
 
+  /**
+   * Resolve a strong-dependency endpoint (relation source/target, parent) from the working set. The
+   * endpoint is a strong dep preloaded to `ready` before its holder surfaces, so the synchronous
+   * working-set probe succeeds — including for feed-queue and cross-space endpoints.
+   */
+  private _resolveStrongDepFromWorkingSet(database: EchoDatabase, uri: URI.URI): any {
+    const request = database.graph
+      .createRefResolver({ context: { space: database.spaceId } })
+      .resolve(uri, { source: 'working-set' });
+    const result = request.getResult();
+    request.abort();
+    return result;
+  }
+
   private _getRelationSource(target: ProxyTarget): any {
     const sourceRef = target[symbolInternals].core.getSource();
     invariant(sourceRef);
@@ -406,13 +414,7 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
     const database = target[symbolInternals].database;
     if (database) {
       // TODO(dmaretskyi): Put refs into proxy cache.
-      return database.graph
-        .createRefResolver({
-          context: {
-            space: database.spaceId,
-          },
-        })
-        .resolveSync(sourceDXN, false);
+      return this._resolveStrongDepFromWorkingSet(database, sourceDXN);
     } else {
       invariant(target[symbolInternals].linkCache);
       const sourceEchoId = EID.tryParse(sourceDXN);
@@ -428,13 +430,7 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
     const targetDXN = EncodedReference.toURI(targetRef);
     const database = target[symbolInternals].database;
     if (database) {
-      return database.graph
-        .createRefResolver({
-          context: {
-            space: database.spaceId,
-          },
-        })
-        .resolveSync(targetDXN, false);
+      return this._resolveStrongDepFromWorkingSet(database, targetDXN);
     } else {
       invariant(target[symbolInternals].linkCache);
       const targetEchoId = EID.tryParse(targetDXN);

--- a/packages/core/echo/echo-client/src/hypergraph.ts
+++ b/packages/core/echo/echo-client/src/hypergraph.ts
@@ -6,13 +6,22 @@ import { Event } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { StackTrace } from '@dxos/debug';
 import { type Database, type Entity, Feed, Filter, type Hypergraph, Query, Ref, type Registry, Type } from '@dxos/echo';
-import { batchEvents, type AnyProperties, setRefResolver } from '@dxos/echo/internal';
+import {
+  batchEvents,
+  type AnyProperties,
+  getStrongDependencies,
+  type RefResolverRequest,
+  type RefSource,
+  setRefResolver,
+} from '@dxos/echo/internal';
 import { DXN, EID, type EntityId, type SpaceId, type URI } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { trace } from '@dxos/tracing';
 import { entry } from '@dxos/util';
 
 import { type ItemsUpdatedEvent } from './core-db';
+import { type LoadBackend, type LoadResult, LoadOpTable } from './core-db/load-op';
+import { RequestImpl } from './core-db/ref-resolver-request';
 import { type DatabaseImpl } from './proxy-db';
 import {
   GraphQueryContext,
@@ -53,6 +62,12 @@ export class HypergraphImpl implements Hypergraph.Hypergraph {
   // Idle (unsubscribed) cached results would not receive those updates and would miss newly
   // registered databases, so we discard them on every topology change.
   #queryResultCache = new QueryResultCache();
+
+  // Coalesced per-URI body loading shared by all resolution requests. Routed to a backend by URI
+  // kind / space; closure satisfaction lives in the per-call `RequestImpl`s.
+  readonly #loadOpTable = new LoadOpTable((uri) => this.#routeBackend(uri));
+  readonly #spaceBackends = new Map<SpaceId, LoadBackend>();
+  #crossSpaceBackend: LoadBackend | undefined;
 
   constructor() {
     this._registry = makeRegistry();
@@ -169,6 +184,11 @@ export class HypergraphImpl implements Hypergraph.Hypergraph {
     // TODO(dmaretskyi): Rewrite resolution algorithm with tracks for absolute and relative DXNs.
 
     return {
+      resolve: (uri: URI.URI, { source }: { source: RefSource }): RefResolverRequest => {
+        const root = this.#loadOpTable.acquire(uri, source);
+        return new RequestImpl(this.#loadOpTable, root, source);
+      },
+
       // TODO(dmaretskyi): Respect `load` flag.
       resolveSync: (uri: URI.URI, load: boolean, onLoad?: () => void) => {
         if (EID.isEID(uri)) {
@@ -186,7 +206,7 @@ export class HypergraphImpl implements Hypergraph.Hypergraph {
         return undefined; // Unsupported URI kind.
       },
 
-      resolve: async (uri) => {
+      resolveLegacy: async (uri) => {
         const obj = await this._resolveAsync(uri, context);
         if (obj) {
           return middleware(obj);
@@ -227,6 +247,235 @@ export class HypergraphImpl implements Hypergraph.Hypergraph {
         return this.#resolveRegistryType(uri) ?? (await this._resolveTypeFromDatabase(uri, context));
       },
     } satisfies Ref.Resolver;
+  }
+
+  /**
+   * Route a URI to its resolution backend: registry for `dxn:`, a single-space backend for a
+   * space-qualified `echo:` EID, and a cross-space backend for a space-less (local) `echo:` EID.
+   * Entity ids are globally unique, so a local EID is resolvable by searching every registered
+   * space — this is how a relation/parent endpoint stored space-less (created before its holder
+   * joined a db) resolves cross-space.
+   */
+  #routeBackend(uri: URI.URI): LoadBackend | undefined {
+    if (DXN.isDXN(uri)) {
+      return this.#registryBackend;
+    }
+    const eid = EID.tryParse(uri);
+    if (!eid || EID.getEntityId(eid) == null) {
+      return undefined;
+    }
+    return this.#entityBackend(EID.getSpaceId(eid));
+  }
+
+  // Registry backend — fully in-memory; effectively `working-set`.
+  readonly #registryBackend: LoadBackend = {
+    probe: (uri) => {
+      const entity = this._registry.getByURI(uri.toString());
+      return entity ? { result: entity as AnyProperties, strongDeps: [] } : undefined;
+    },
+    load: (_uri, _source, set) => {
+      // Registry entities never load asynchronously; a probe miss is permanent.
+      set('unavailable', undefined);
+      return () => {};
+    },
+  };
+
+  /**
+   * Backend resolving an entity by id across one space (when `spaceId` is set) or every registered
+   * space (when it is undefined). Cached per routing key so its identity is stable for the table.
+   */
+  #entityBackend(spaceId: SpaceId | undefined): LoadBackend {
+    if (spaceId == null) {
+      return (this.#crossSpaceBackend ??= {
+        probe: (uri) => this.#probeEntity(uri, undefined),
+        load: (uri, source, set) => this.#loadEntity(uri, source, set, undefined),
+      });
+    }
+    return entry(this.#spaceBackends, spaceId).orInsert({
+      probe: (uri) => this.#probeEntity(uri, spaceId),
+      load: (uri, source, set) => this.#loadEntity(uri, source, set, spaceId),
+    }).value;
+  }
+
+  /** Candidate spaces for a resolution: just `spaceId` when qualified, otherwise every space. */
+  #candidateSpaceIds(spaceId: SpaceId | undefined): SpaceId[] {
+    if (spaceId != null) {
+      return [spaceId];
+    }
+    return [...new Set([...this._databases.keys(), ...this._queueFactories.keys()])];
+  }
+
+  /**
+   * Synchronous working-set probe for an entity across candidate spaces: each local db, then its
+   * known feed queues. Resolves regardless of the deleted flag — deletion is filtered by the query
+   * pipeline, not by resolution (gating a deleted object's own satisfaction would hide it from
+   * deleted-only queries and break re-add).
+   */
+  #probeEntity(uri: URI.URI, spaceId: SpaceId | undefined): LoadResult | undefined {
+    const eid = EID.tryParse(uri);
+    const entityId = eid ? EID.getEntityId(eid) : undefined;
+    if (entityId == null) {
+      return undefined;
+    }
+
+    for (const candidateSpaceId of this.#candidateSpaceIds(spaceId)) {
+      const db = this._databases.get(candidateSpaceId);
+      if (db) {
+        const core = db.coreDatabase.getObjectCoreById(entityId, { load: false });
+        if (core != null) {
+          const obj = db.getObjectById(entityId, { deleted: true });
+          if (obj != null) {
+            return { result: obj as AnyProperties, strongDeps: core.getStrongDependencies() };
+          }
+        }
+      }
+
+      const queueFactory = this._queueFactories.get(candidateSpaceId);
+      if (queueFactory) {
+        for (const queue of queueFactory.knownQueues()) {
+          const item = queue.getCachedObjectById(entityId);
+          if (item != null) {
+            return { result: item as AnyProperties, strongDeps: getStrongDependencies(item) };
+          }
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Load an entity's body at the given ceiling across candidate spaces: each local db document
+   * (disk-bound unless `network`) and/or its feed queues. Queue items have no definitive "absent"
+   * signal, so when at least one known queue could hold the item the op stays `requesting` and polls
+   * for replication rather than settling `unavailable`.
+   */
+  #loadEntity(
+    uri: URI.URI,
+    source: RefSource,
+    set: (state: 'pending' | 'requesting' | 'ready' | 'unavailable', result: LoadResult | undefined) => void,
+    spaceId: SpaceId | undefined,
+  ): () => void {
+    const eid = EID.tryParse(uri);
+    const entityId = eid ? EID.getEntityId(eid) : undefined;
+    if (entityId == null) {
+      set('unavailable', undefined);
+      return () => {};
+    }
+
+    let settled = false;
+    let cancelled = false;
+    const cleanups: Array<() => void> = [];
+    const cleanupAll = () => {
+      for (const cleanup of cleanups.splice(0)) {
+        cleanup();
+      }
+    };
+    const finishReady = (result: AnyProperties, strongDeps: URI.URI[]) => {
+      if (settled || cancelled) {
+        return;
+      }
+      settled = true;
+      cleanupAll();
+      set('ready', { result, strongDeps });
+    };
+
+    const candidateSpaceIds = this.#candidateSpaceIds(spaceId);
+    let pendingDb = 0;
+    let pendingQueue = 0;
+    let queuePolling = false;
+    const maybeUnavailable = () => {
+      if (!settled && !cancelled && pendingDb === 0 && pendingQueue === 0 && !queuePolling) {
+        settled = true;
+        cleanupAll();
+        set('unavailable', undefined);
+      }
+    };
+
+    const diskOnly = source !== 'network';
+    for (const candidateSpaceId of candidateSpaceIds) {
+      const db = this._databases.get(candidateSpaceId);
+      if (db) {
+        pendingDb++;
+        void db.coreDatabase
+          .loadObjectCoreById(entityId, { diskOnly, returnWithUnsatisfiedDeps: true })
+          .then((core) => {
+            pendingDb--;
+            if (!cancelled && core != null) {
+              const obj = db.getObjectById(entityId, { deleted: true });
+              if (obj != null) {
+                finishReady(obj as AnyProperties, core.getStrongDependencies());
+                return;
+              }
+            }
+            maybeUnavailable();
+          })
+          .catch(() => {
+            pendingDb--;
+            maybeUnavailable();
+          });
+      }
+
+      const queueFactory = this._queueFactories.get(candidateSpaceId);
+      if (queueFactory) {
+        pendingQueue++;
+        void this.#searchQueues(candidateSpaceId, entityId, queueFactory)
+          .then((item) => {
+            pendingQueue--;
+            if (cancelled) {
+              return;
+            }
+            if (item != null) {
+              finishReady(item as AnyProperties, getStrongDependencies(item));
+              return;
+            }
+            // Poll known queues so replicated items surface without a fresh request.
+            const queues = [...queueFactory.knownQueues()];
+            if (queues.length > 0) {
+              queuePolling = true;
+              for (const queue of queues) {
+                cleanups.push(queue.beginPolling());
+                cleanups.push(
+                  queue.subscribe(() => {
+                    const cached = queue.getCachedObjectById(entityId);
+                    if (cached != null) {
+                      finishReady(cached as AnyProperties, getStrongDependencies(cached));
+                    }
+                  }),
+                );
+              }
+            }
+            maybeUnavailable();
+          })
+          .catch(() => {
+            pendingQueue--;
+            maybeUnavailable();
+          });
+      }
+    }
+
+    maybeUnavailable();
+
+    return () => {
+      cancelled = true;
+      cleanupAll();
+    };
+  }
+
+  async #searchQueues(spaceId: SpaceId, entityId: EntityId, queueFactory: QueueFactory): Promise<Entity.Unknown | undefined> {
+    for (const queue of queueFactory.knownQueues()) {
+      const cached = queue.getCachedObjectById(entityId);
+      if (cached != null) {
+        return cached;
+      }
+    }
+    for (const queue of queueFactory.knownQueues()) {
+      const [item] = await queue.getObjectsById([entityId]);
+      if (item != null) {
+        return item;
+      }
+    }
+    return this._resolveObjectInSpaceFeeds(spaceId, entityId, queueFactory);
   }
 
   /**

--- a/packages/core/echo/echo-client/src/queue/memory-queue.ts
+++ b/packages/core/echo/echo-client/src/queue/memory-queue.ts
@@ -93,6 +93,15 @@ export class MemoryQueue<T extends Entity.Unknown> implements Queue<T> {
     return ids.map((id) => this._objects.find((object) => object.id === id));
   }
 
+  getCachedObjectById(id: EntityId): T | undefined {
+    return this._objects.find((object) => object.id === id);
+  }
+
+  beginPolling(): () => void {
+    // In-memory queues are always fully loaded; nothing to poll.
+    return () => {};
+  }
+
   async delete(ids: EntityId[]): Promise<void> {
     // TODO(dmaretskyi): Restrict types.
     this._objects = this._objects.filter((object) => !ids.includes(object.id));

--- a/packages/core/echo/echo-client/src/queue/queue.ts
+++ b/packages/core/echo/echo-client/src/queue/queue.ts
@@ -363,6 +363,10 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
     return this._objects;
   }
 
+  getCachedObjectById(id: EntityId): T | undefined {
+    return this._objectCache.get(id);
+  }
+
   /**
    * @deprecated Use `query` method instead.
    */

--- a/packages/core/echo/echo-client/src/queue/types.ts
+++ b/packages/core/echo/echo-client/src/queue/types.ts
@@ -84,4 +84,16 @@ export interface Queue<T extends Entity.Unknown = Entity.Unknown> extends Databa
    */
   // TODO(dmaretskyi): Remove.
   refresh(): Promise<void>;
+
+  /**
+   * Synchronous working-set lookup of a previously-loaded item by id. Does not perform IO.
+   * Used by the reference resolver's working-set probe.
+   */
+  getCachedObjectById(id: EntityId): T | undefined;
+
+  /**
+   * Begin periodically refreshing the queue from the server, emitting {@link subscribe} on change.
+   * @returns Function that stops polling.
+   */
+  beginPolling(): () => void;
 }

--- a/packages/core/echo/echo-client/src/testing/queue.test.ts
+++ b/packages/core/echo/echo-client/src/testing/queue.test.ts
@@ -65,9 +65,10 @@ describe('queues', () => {
       // context is the correct way to resolve them.
       const resolved = await peer.client.graph
         .createRefResolver({ context: { space: spaceId, feed: queue.uri } })
-        .resolve(EID.make({ entityId: obj.id }));
+        .resolve(EID.make({ entityId: obj.id }), { source: 'network' })
+        .wait();
       expect(resolved?.id).toEqual(obj.id);
-      expect(resolved?.name).toEqual('john');
+      expect((resolved as TestSchema.Person | undefined)?.name).toEqual('john');
       expect(Obj.getType(resolved as Obj.Unknown)).toEqual(TestSchema.Person);
     }
   });

--- a/packages/core/echo/echo-client/src/testing/strong-deps-resolution.test.ts
+++ b/packages/core/echo/echo-client/src/testing/strong-deps-resolution.test.ts
@@ -62,8 +62,8 @@ describe('strong dependency resolution', () => {
 
       const [obj] = await db.query(Filter.id(relation.id)).run();
       assert(Relation.isRelation(obj), 'relation with feed endpoints must surface');
-      expect(Relation.getSource(obj).name).toEqual('Bob');
-      expect(Relation.getTarget(obj).name).toEqual('Alice');
+      expect((Relation.getSource(obj) as TestSchema.Person).name).toEqual('Bob');
+      expect((Relation.getTarget(obj) as TestSchema.Person).name).toEqual('Alice');
     });
 
     test('after reload (from disk)', async () => {
@@ -101,8 +101,8 @@ describe('strong dependency resolution', () => {
 
         const [obj] = await db.query(Filter.id(relationId)).run();
         assert(Relation.isRelation(obj), 'reloaded relation with feed endpoints must surface');
-        expect(Relation.getSource(obj).name).toEqual('Bob');
-        expect(Relation.getTarget(obj).name).toEqual('Alice');
+        expect((Relation.getSource(obj) as TestSchema.Person).name).toEqual('Bob');
+        expect((Relation.getTarget(obj) as TestSchema.Person).name).toEqual('Alice');
       }
     });
 
@@ -136,8 +136,8 @@ describe('strong dependency resolution', () => {
 
       const obj = await waitForRelation(db2, relation.id);
       assert(Relation.isRelation(obj), 'relation with feed endpoints must surface on a remote peer');
-      expect(Relation.getSource(obj).name).toEqual('Bob');
-      expect(Relation.getTarget(obj).name).toEqual('Alice');
+      expect((Relation.getSource(obj) as TestSchema.Person).name).toEqual('Bob');
+      expect((Relation.getTarget(obj) as TestSchema.Person).name).toEqual('Alice');
     });
   });
 
@@ -234,8 +234,8 @@ describe('strong dependency resolution', () => {
         await using db = await peer.openLastDatabase();
         const [obj] = await db.query(Filter.id(relationId)).run();
         assert(Relation.isRelation(obj), 'same-db relation must surface');
-        expect(Relation.getSource(obj).name).toEqual('Bob');
-        expect(Relation.getTarget(obj).name).toEqual('Alice');
+        expect((Relation.getSource(obj) as TestSchema.Person).name).toEqual('Bob');
+        expect((Relation.getTarget(obj) as TestSchema.Person).name).toEqual('Alice');
       }
     });
 
@@ -265,8 +265,8 @@ describe('strong dependency resolution', () => {
 
       const obj = await waitForRelation(db2, relation.id);
       assert(Relation.isRelation(obj), 'same-db relation must surface on a remote peer');
-      expect(Relation.getSource(obj).name).toEqual('Bob');
-      expect(Relation.getTarget(obj).name).toEqual('Alice');
+      expect((Relation.getSource(obj) as TestSchema.Person).name).toEqual('Bob');
+      expect((Relation.getTarget(obj) as TestSchema.Person).name).toEqual('Alice');
     });
   });
 
@@ -294,8 +294,8 @@ describe('strong dependency resolution', () => {
 
       const [obj] = await dbA.query(Filter.id(relation.id)).run();
       assert(Relation.isRelation(obj), 'cross-space relation must surface');
-      expect(Relation.getSource(obj).name).toEqual('Bob');
-      expect(Relation.getTarget(obj).name).toEqual('Alice');
+      expect((Relation.getSource(obj) as TestSchema.Person).name).toEqual('Bob');
+      expect((Relation.getTarget(obj) as TestSchema.Person).name).toEqual('Alice');
     });
   });
 

--- a/packages/core/echo/echo/src/Database.ts
+++ b/packages/core/echo/echo/src/Database.ts
@@ -250,7 +250,7 @@ export const resolve: {
             space: db.spaceId,
           },
         })
-        .resolve(dxn),
+        .resolveLegacy(dxn),
     );
 
     if (!object) {

--- a/packages/core/echo/echo/src/internal/Obj/json-serializer.ts
+++ b/packages/core/echo/echo/src/internal/Obj/json-serializer.ts
@@ -129,8 +129,8 @@ export const objectFromJSON = async (
     const sourceDxn = jsonData[ATTR_RELATION_SOURCE] ?? raise(new TypeError('Missing relation source'));
     const targetDxn = jsonData[ATTR_RELATION_TARGET] ?? raise(new TypeError('Missing relation target'));
 
-    const source = (await refResolver?.resolve(sourceDxn)) as AnyEntity | undefined;
-    const target = (await refResolver?.resolve(targetDxn)) as AnyEntity | undefined;
+    const source = (await refResolver?.resolveLegacy(sourceDxn)) as AnyEntity | undefined;
+    const target = (await refResolver?.resolveLegacy(targetDxn)) as AnyEntity | undefined;
 
     defineHiddenProperty(obj, KindId, EntityKind.Relation);
     defineHiddenProperty(obj, RelationSourceDXNId, sourceDxn);
@@ -161,7 +161,7 @@ export const objectFromJSON = async (
 
   if (jsonData[ATTR_PARENT]) {
     const parentDxn = jsonData[ATTR_PARENT];
-    const resolvedParent = (await refResolver?.resolve(parentDxn)) as Obj.Unknown | undefined;
+    const resolvedParent = (await refResolver?.resolveLegacy(parentDxn)) as Obj.Unknown | undefined;
     defineHiddenProperty(obj, ParentId, resolvedParent);
   } else if (parent) {
     defineHiddenProperty(obj, ParentId, parent);

--- a/packages/core/echo/echo/src/internal/Ref/index.ts
+++ b/packages/core/echo/echo/src/internal/Ref/index.ts
@@ -4,3 +4,4 @@
 
 export * from './ref';
 export * from './ref-array';
+export * from './strong-deps';

--- a/packages/core/echo/echo/src/internal/Ref/ref.ts
+++ b/packages/core/echo/echo/src/internal/Ref/ref.ts
@@ -380,22 +380,79 @@ const getSchemaExpectedName = (ast: SchemaAST.Annotated): string | undefined => 
   );
 };
 
+/**
+ * Load-source ceiling for a resolution request. Cheaper tiers are always probed first; the
+ * ceiling caps how far a request is allowed to reach:
+ * - `working-set`: synchronous, in-memory only. A miss settles `unavailable` immediately.
+ * - `disk`: probe the working set, then local storage; never the network.
+ * - `network`: probe the working set, disk, then fetch from peers.
+ *
+ * `unavailable` is always relative to the requested ceiling (disk-unavailable ≠ network-unavailable).
+ */
+export type RefSource = 'working-set' | 'disk' | 'network';
+
+/**
+ * A stateful, closure-aware handle to an in-flight (or settled) reference resolution.
+ *
+ * `ready` means the entity is FULLY USABLE: its own body and its strong-dependency closure are all
+ * materialized. The body-vs-closure split is internal; `requesting` transparently covers "a
+ * dependency is still loading".
+ */
+export interface RefResolverRequest {
+  /**
+   * `pending` is a one-way entry state (never re-entered). `requesting` means the body and/or
+   * closure is still loading. `ready` means fully usable. `unavailable` means unreachable at the
+   * requested ceiling.
+   */
+  readonly state: 'pending' | 'requesting' | 'ready' | 'unavailable';
+
+  /**
+   * Fires (deferred to a microtask) whenever {@link state} changes.
+   */
+  readonly stateChanged: Event<void>;
+
+  /**
+   * Synchronous snapshot of the resolved entity; defined iff `state === 'ready'`.
+   */
+  getResult(): AnyProperties | undefined;
+
+  /**
+   * Settles when `state ∈ {ready, unavailable}`.
+   */
+  wait(): Promise<AnyProperties | undefined>;
+
+  /**
+   * Decrements the refcount on the shared load op(s); cancels the underlying IO at zero.
+   */
+  abort(): void;
+}
+
 export interface RefResolver {
+  /**
+   * Resolve a reference, returning a stateful handle. `source` is a required ceiling; cheaper
+   * tiers are always probed first.
+   */
+  resolve(uri: URI.URI, options: { source: RefSource }): RefResolverRequest;
+
   /**
    * Resolve ref synchronously from the objects in the working set.
    *
    * @param uri
    * @param load If true the resolver should attempt to load the object from disk.
    * @param onLoad Callback to call when the object is loaded.
+   * @deprecated Use {@link resolve} with `{ source: 'working-set' }`. Removed in Task 11.
    */
   resolveSync(uri: URI.URI, load: boolean, onLoad?: () => void): AnyProperties | undefined;
 
   /**
    * Resolver ref asynchronously.
+   * @deprecated Use {@link resolve} with `{ source: 'network' }`. Removed in Task 11.
    */
-  resolve(uri: URI.URI): Promise<AnyProperties | undefined>;
+  resolveLegacy(uri: URI.URI): Promise<AnyProperties | undefined>;
 
-  // TODO(dmaretskyi): Combine with `resolve`.
+  /**
+   * @deprecated Use {@link resolve} + `Type.getSchema`. Removed in Task 11.
+   */
   resolveSchema(uri: URI.URI): Promise<Schema.Schema.AnyNoContext | undefined>;
 
   /**
@@ -404,9 +461,25 @@ export interface RefResolver {
    * via `Obj.getType` / `Entity.getType`. Optional — resolvers that only
    * carry raw schemas may leave this unimplemented; the deserializer falls
    * back to leaving the type entity unset.
+   * @deprecated Use {@link resolve}. Removed in Task 11.
    */
   resolveType?(uri: URI.URI): Promise<unknown | undefined>;
 }
+
+/**
+ * A settled {@link RefResolverRequest} with a fixed `state` and `result`, used by resolvers
+ * whose backends are fully synchronous (e.g. {@link StaticRefResolver}).
+ */
+export const makeSettledRequest = (
+  state: RefResolverRequest['state'],
+  result: AnyProperties | undefined,
+): RefResolverRequest => ({
+  state,
+  stateChanged: new Event<void>(),
+  getResult: () => (state === 'ready' ? result : undefined),
+  wait: async () => (state === 'ready' ? result : undefined),
+  abort: () => {},
+});
 
 export class RefImpl<T> implements Ref<T> {
   #uri: URI.URI;
@@ -465,7 +538,7 @@ export class RefImpl<T> implements Ref<T> {
       return this.#target;
     }
     invariant(this.#resolver, 'Resolver is not set');
-    const obj = await this.#resolver.resolve(this.#uri);
+    const obj = await this.#resolver.resolveLegacy(this.#uri);
     if (obj == null) {
       throw new Error('Object not found');
     }
@@ -480,7 +553,7 @@ export class RefImpl<T> implements Ref<T> {
       return this.#target;
     }
     invariant(this.#resolver, 'Resolver is not set');
-    return (await this.#resolver.resolve(this.#uri)) as T | undefined;
+    return (await this.#resolver.resolveLegacy(this.#uri)) as T | undefined;
   }
 
   /**
@@ -624,27 +697,29 @@ export class StaticRefResolver implements RefResolver {
     return this;
   }
 
-  resolveSync(uri: URI.URI, _load: boolean, _onLoad?: () => void): AnyProperties | undefined {
-    const echoUri = EID.tryParse(uri);
-    const id = echoUri ? EID.getEntityId(echoUri) : undefined;
-    if (id == null) {
-      return undefined;
-    }
-
-    return this.objects.get(id);
+  resolve(uri: URI.URI, _options: { source: RefSource }): RefResolverRequest {
+    const obj = this.#lookup(uri);
+    return makeSettledRequest(obj ? 'ready' : 'unavailable', obj);
   }
 
-  async resolve(uri: URI.URI): Promise<AnyProperties | undefined> {
-    const echoUri = EID.tryParse(uri);
-    const id = echoUri ? EID.getEntityId(echoUri) : undefined;
-    if (id == null) {
-      return undefined;
-    }
+  resolveSync(uri: URI.URI, _load: boolean, _onLoad?: () => void): AnyProperties | undefined {
+    return this.#lookup(uri);
+  }
 
-    return this.objects.get(id);
+  async resolveLegacy(uri: URI.URI): Promise<AnyProperties | undefined> {
+    return this.#lookup(uri);
   }
 
   async resolveSchema(uri: URI.URI): Promise<Schema.Schema.AnyNoContext | undefined> {
     return this.schemas.get(uri);
+  }
+
+  #lookup(uri: URI.URI): AnyProperties | undefined {
+    const echoUri = EID.tryParse(uri);
+    const id = echoUri ? EID.getEntityId(echoUri) : undefined;
+    if (id == null) {
+      return undefined;
+    }
+    return this.objects.get(id);
   }
 }

--- a/packages/core/echo/echo/src/internal/Ref/strong-deps.ts
+++ b/packages/core/echo/echo/src/internal/Ref/strong-deps.ts
@@ -1,0 +1,82 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { EID, type URI } from '@dxos/keys';
+
+import { EntityKind } from '../common/types/entity';
+import { RelationSourceDXNId, RelationTargetDXNId } from '../common/types/model-symbols';
+import { ParentId, TypeId } from '../common/types/typename';
+import { getObjectEchoUri } from '../Entity/util';
+
+/**
+ * Normalized view of the references that make up an entity's strong-dependency set, store-agnostic
+ * so it can be filled from an {@link ObjectCore} (db) or a decoded entity (queue item / snapshot).
+ */
+export interface StrongDepRefs {
+  /** Entity kind — relations additionally depend on their source/target. */
+  kind: EntityKind;
+  /** Type reference URI (`echo:` for a persisted stored schema, `dxn:` for a static/registry type). */
+  type?: URI.URI;
+  /** Relation source reference URI. */
+  source?: URI.URI;
+  /** Relation target reference URI. */
+  target?: URI.URI;
+  /** Parent reference URI. */
+  parent?: URI.URI;
+}
+
+/**
+ * Direct strong-dependency URIs of an entity: the schema (only when stored as an object), the
+ * relation source/target, and the parent. Returns URIs (cross-space `echo:` EIDs and queue-item
+ * EIDs included); a persisted schema is an `echo:` URI, a static/registry type is a `dxn:` URI.
+ *
+ * A static/registry type (`dxn:`) is intentionally NOT a strong dep: it is always synchronously
+ * available through the registry, so gating on it would needlessly delay surfacing. Only a
+ * persisted (db-backed) schema, addressed by an `echo:` URI, must load before its instances.
+ */
+export const getStrongDependencyUris = (refs: StrongDepRefs): URI.URI[] => {
+  const res: URI.URI[] = [];
+
+  if (refs.type != null && EID.tryParse(refs.type) != null) {
+    res.push(refs.type);
+  }
+
+  if (refs.kind === EntityKind.Relation) {
+    if (refs.source != null) {
+      res.push(refs.source);
+    }
+    if (refs.target != null) {
+      res.push(refs.target);
+    }
+  }
+
+  if (refs.parent != null) {
+    res.push(refs.parent);
+  }
+
+  return res;
+};
+
+/**
+ * Direct strong-dependency URIs of a live (decoded) entity — a queue item, cross-space proxy, or
+ * snapshot. Reads the reference URIs off the entity's hidden model symbols. ECHO db cores compute
+ * the same set from their raw encoded references via {@link getStrongDependencyUris}.
+ */
+export const getStrongDependencies = (entity: unknown): URI.URI[] => {
+  if (entity == null || typeof entity !== 'object') {
+    return [];
+  }
+  const props = entity as Record<symbol, unknown>;
+  const kind = props[RelationSourceDXNId] != null || props[RelationTargetDXNId] != null ? EntityKind.Relation : EntityKind.Object;
+  const parent = props[ParentId];
+
+  return getStrongDependencyUris({
+    kind,
+    type: typeof props[TypeId] === 'string' ? (props[TypeId] as URI.URI) : undefined,
+    source: props[RelationSourceDXNId] as URI.URI | undefined,
+    target: props[RelationTargetDXNId] as URI.URI | undefined,
+    // A parent is held as the resolved entity; derive its absolute URI for the dependency edge.
+    parent: parent != null ? getObjectEchoUri(parent) : undefined,
+  });
+};

--- a/packages/sdk/client/src/devtools/devtools.ts
+++ b/packages/sdk/client/src/devtools/devtools.ts
@@ -202,7 +202,7 @@ export const mountDevtoolsHooks = ({ client, host }: MountOptions) => {
     });
 
     hook.get = async (dxn) => {
-      return client.graph.createRefResolver({}).resolve(URI.make(dxn));
+      return client.graph.createRefResolver({}).resolveLegacy(URI.make(dxn));
     };
 
     hook.openDevtoolsApp = async () => {


### PR DESCRIPTION
## Summary

Refactors the reference resolver to support closure-aware resolution: entities are now surfaced only when their full strong-dependency closure (schema, relation endpoints, parent) is materialized. Introduces a new async `resolve(uri, { source })` API that returns a stateful `RefResolverRequest` handle, replacing the legacy synchronous/async split.

## Key Changes

- **New resolver API**: `RefResolver.resolve(uri, { source: RefSource })` returns a `RefResolverRequest` with state tracking (`pending` → `requesting` → `ready`/`unavailable`) and closure-aware satisfaction. Legacy `resolveSync` / `resolveLegacy` / `resolveSchema` / `resolveType` kept (deprecated) for incremental migration.

- **LoadOpTable**: Coalesced per-URI body-loading operations with refcounting and ceiling escalation. Deduplicates IO across concurrent requests for the same entity; routes URIs to backends by kind (registry for `dxn:`, per-space or cross-space for `echo:` EIDs).

- **RequestImpl**: Cycle-safe BFS walker over strong-dependency closure. Derives public state from root + reachable members; emits `stateChanged` (deferred to microtask) only on transitions. Holds refcounts on shared load ops; cancels IO at zero.

- **HypergraphImpl backends**: Registry backend (synchronous, in-memory), per-space entity backend (probes local db + feed queues, loads from disk/network), and cross-space backend (searches all registered spaces). Each backend supplies `probe()` (working-set only) and `load()` (async, with ceiling).

- **Strong-dependency extraction**: New `getStrongDependencies(entity)` and `getStrongDependencyUris(refs)` functions extract URIs from live entities (via hidden model symbols) and `ObjectCore` references. Type is a strong dep only when persisted (`echo:` URI); static/registry types (`dxn:`) are always available and not gated.

- **CoreDatabase satisfaction**: Delegated to resolver. `_areDepsSatisfied()` and `_areDepsResolved()` now check request state instead of local BFS. Retired `_strongDepsIndex` and waking logic; new `_satisfactionRequests` map holds per-entity requests. `_onObjectDocumentLoaded` simplified: creates the object and schedules update; closure satisfaction is re-evaluated by the query pipeline through the resolver.

- **EchoReactiveHandler**: Strong-dep endpoints (relation source/target, parent) resolved via `resolve(uri, { source: 'working-set' }).getResult()` — endpoints are preloaded to `ready` before their holder surfaces, so the synchronous probe succeeds.

- **Queue API**: Added `getCachedObjectById(id)` for working-set probe; added `beginPolling()` for long-poll fallback when a queue may hold an item but hasn't loaded it yet.

## Implementation Details

- **Ceiling semantics**: `working-set` (synchronous, in-memory) < `disk` (local storage) < `network` (peer fetch). Cheaper tiers always probed first; ceiling caps how far a request reaches. `unavailable` is relative to the ceiling.

- **Closure discovery**: Deferred to microtask to avoid re-entrant listener storms. Walker is cycle-safe: a node contributes its dep edges only once its own body is ready, so cycles terminate against the `seen` set.

- **Type dep semantics unchanged**: Persisted schemas (stored as objects, `echo:` URI) are strong deps and gate surfacing. Static/registry types (`dxn:`) are always available and do not gate — matches current behaviour and keeps the stored-schema regression test green.

- **Feed queue polling**: When a queue may hold an item but hasn't loaded it yet, the load op enters `requesting` state and polls known queues for replication rather than settling `unavailable`.

- **Deprecation path**: Legacy resolver methods kept until final cleanup task (Task 11) so the build stays green per step. `RefImpl` and `json-serializer` still use `resolveLegacy`; `RefImpl

https://claude.ai/code/session_01A4qpk1FWrV4nLc5Uo4PVK3