### PR TITLE
feat(echo-client): implement pkg-e2e-pattern convention

### DIFF
--- a/docs/superpowers/specs/2026-06-15-pkg-e2e-pattern-design.md
+++ b/docs/superpowers/specs/2026-06-15-pkg-e2e-pattern-design.md
@@ -1,0 +1,183 @@
+# `<pkg>-e2e` Test Package Pattern
+
+Date: 2026-06-15
+Status: Design (approved for spec review)
+
+## Problem
+
+Tests colocated inside a source package have three recurring problems:
+
+1. **They drift away from the public API.** Colocated tests can reach into relative
+   internal modules (`../echo-handler`, `../proxy-db`), so they test implementation
+   details rather than the contract consumers actually use.
+2. **They force test-only dependencies onto the package.** Heavy integration deps
+   (e.g. `@dxos/teleport/testing`, `@dxos/echo-host`) end up as `devDependencies`
+   of the package under test, bloating its graph and risking dependency cycles.
+3. **Nothing stops other packages from depending on test scaffolding.** A test
+   package shaped as a normal library can be imported by production code.
+
+## Goal
+
+Establish a repeatable convention: for a package `@dxos/<pkg>`, public-API and
+integration tests live in a sibling, test-only package `@dxos/<pkg>-e2e`.
+
+This:
+
+- **Forces public-API testing** — the `-e2e` package can only import `@dxos/<pkg>`
+  and `@dxos/<pkg>/testing`, never internals.
+- **Isolates extra deps** — heavy/integration deps live on `-e2e`, never on the
+  package under test, avoiding cycles and graph bloat.
+- **Is unimportable** — moon's layer enforcement forbids any project depending on
+  an `-e2e` package.
+
+## Non-Goals
+
+- Replacing fast white-box/unit tests. Those stay colocated in `@dxos/<pkg>`.
+- Playwright/browser e2e. Those keep using the existing moon `e2e` tag and the
+  `packages/e2e/*` Playwright harnesses; this pattern is for node/vitest suites.
+- Publishing. `-e2e` packages are never published.
+
+## Convention
+
+### Naming & location
+
+- Package name: `@dxos/<pkg>-e2e`.
+- Location: sibling directory next to the package under test, e.g.
+  `packages/core/echo/echo-client-e2e` next to `packages/core/echo/echo-client`.
+
+### Package shape (test-only)
+
+`package.json`:
+
+- `"private": true`.
+- **No** public `publishConfig`, **no** `exports`/library entrypoint, **no**
+  `src/index.ts` to export. The package contains only `*.test.ts`.
+- `dependencies`: `@dxos/<pkg>` as `workspace:*`, plus any heavy/extra deps the
+  suite needs (workspace deps as `workspace:*`, externals from the catalog).
+
+Because nothing can depend on this package (see enforcement), those extra deps
+never enter the graph of `@dxos/<pkg>` — no cycles, no bloat.
+
+### moon.yml
+
+```yaml
+layer: automation
+language: typescript
+tags:
+  - ts-test
+  - typecheck
+```
+
+- `layer: automation` — moon's top layer. `enforceLayerRelationships` (on by
+  default) means **no project may depend on it**, while it may still depend on
+  any lower layer (`library`/`application`/`tool`). This is the entire enforcement
+  mechanism; no custom `constraints`/`tagRelationships` are required.
+- `ts-test` — runs vitest (`test` task); already deps on `^:compile`, so upstream
+  deps are compiled automatically.
+- `typecheck` — runs `tsc --noEmit` (`build` task) with no build artifact.
+- **No** `ts-build`, `pack`, or `compile` entrypoint — there is no library output.
+
+### Where helpers live
+
+Shared test harness, builders, and fixtures live in `@dxos/<pkg>/testing` (the
+existing `./testing` entrypoint). Both the package's own colocated tests and the
+`-e2e` package import them. The `-e2e` package contains **only `*.test.ts`** — no
+shared code, no exports.
+
+### Test split
+
+| Test kind | Location | May import |
+| --- | --- | --- |
+| Fast unit / white-box | `@dxos/<pkg>/src/**/*.test.ts` | public API, `./testing`, relative internals (`../foo`) |
+| Public-API | `@dxos/<pkg>-e2e/src/**/*.test.ts` | `@dxos/<pkg>`, `@dxos/<pkg>/testing` only |
+| Integration / heavy-dep | `@dxos/<pkg>-e2e/src/**/*.test.ts` | the above + extra `-e2e`-only deps |
+
+Heuristic: a test belongs in `-e2e` if it is expressible purely against
+`@dxos/<pkg>` + `@dxos/<pkg>/testing`. A test that fundamentally needs relative
+internal modules or sibling units stays colocated as a white-box test.
+
+### Terminology
+
+The `-e2e` **package suffix** (node/vitest public-API suite) is distinct from the
+moon `e2e` **tag** (Playwright browser suite, `tag-e2e.yml`). A node `-e2e`
+package never carries the `e2e` tag.
+
+## Enforcement
+
+`layer: automation` + `enforceLayerRelationships: true` (moon default). The layer
+hierarchy, highest to lowest, is:
+
+```
+automation → application → tool → library → scaffolding → configuration
+```
+
+A layer may depend on lower layers but never higher ones, and `automation`/
+`application` may not even depend on themselves. Since `automation` is the top
+layer, any project that lists an `-e2e` package as a dependency fails at task-graph
+build time. No bespoke script or lint rule is needed.
+
+## Reference Migration: `assistant-e2e`
+
+`@dxos/assistant-e2e` (`packages/core/compute/assistant-e2e`) currently violates
+the convention: `layer: library`, `pack` tag, public `publishConfig`, a `compile`
+entrypoint, and `exports` — i.e. it is a publishable library that other packages
+*could* depend on. Bring it into conformance:
+
+- `package.json`: keep `"private": true`; remove `publishConfig`, remove `exports`
+  (and the `src/index.ts` library entrypoint if unused by tests), keep deps.
+- `moon.yml`: set `layer: automation`; tags become `[ts-test, typecheck]` (plus
+  `memoized-llm` which it already needs); drop `pack`, `ts-build`, and the
+  `compile` entrypoint args.
+- Verify `moon run assistant-e2e:test` and typecheck still pass.
+
+## Migration: `echo-client` → `echo-client-e2e` (conservative)
+
+Create `packages/core/echo/echo-client-e2e` following the convention, then move
+**only** tests expressible against the public + `./testing` API as-is. Genuinely
+white-box tests stay colocated. No new internal-symbol promotion unless trivial.
+
+### Move (strong candidates)
+
+The suites already under `src/testing/` are public-API/integration oriented and
+pull heavy, test-only deps that should leave `echo-client`:
+
+- `src/testing/integration.test.ts` — uses `@dxos/teleport/testing`,
+  `@dxos/echo-host`, `@dxos/echo/internal`; the clearest case for relocation.
+- `src/testing/queue.test.ts`
+- `src/testing/Obj.updateFrom.test.ts`
+
+Plus any top-level `*.test.ts` whose only non-public imports are symbols already
+re-exported from `@dxos/echo-client/testing` (e.g. `getObjectCore`,
+`EchoTestBuilder`, `createTmpPath`). These are rewritten to import from
+`@dxos/echo-client` and `@dxos/echo-client/testing` instead of relative paths.
+
+### Stay colocated (white-box)
+
+Tests that import relative internals or sibling units remain in `echo-client`,
+e.g. those importing `../proxy-db` types (`DatabaseImpl`, `EchoDatabase`),
+`../automerge`, or a sibling module under test (`./core-database`).
+
+### Dependency cleanup
+
+After moving, audit `echo-client`'s `devDependencies` and drop any that are now
+used only by relocated tests (moving them to `echo-client-e2e`). This is the
+concrete payoff: heavy test deps and potential cycles leave the runtime package.
+
+### Per-file classification
+
+Classification of the 32 existing test files is an implementation-plan step, using
+the heuristic above (movable iff expressible against public + `./testing`). The
+plan enumerates each file's destination and any import rewrites.
+
+## Rollout order
+
+1. Land the convention (this spec) + the `assistant-e2e` conformance migration as
+   the canonical reference.
+2. Create `echo-client-e2e` and perform the conservative `echo-client` migration.
+3. Apply the pattern to further packages as their test suites warrant it.
+
+## Open questions
+
+None blocking. Future packages may reveal cases where promoting a few internal
+symbols into `./testing` unlocks materially more public-API coverage; handle those
+case-by-case rather than pre-emptively widening the public surface.

--- a/docs/superpowers/specs/2026-06-15-pkg-e2e-pattern-design.md
+++ b/docs/superpowers/specs/2026-06-15-pkg-e2e-pattern-design.md
@@ -107,7 +107,7 @@ package never carries the `e2e` tag.
 `layer: automation` + `enforceLayerRelationships: true` (moon default). The layer
 hierarchy, highest to lowest, is:
 
-```
+```text
 automation → application → tool → library → scaffolding → configuration
 ```
 

--- a/docs/superpowers/specs/2026-06-15-pkg-e2e-pattern-design.md
+++ b/docs/superpowers/specs/2026-06-15-pkg-e2e-pattern-design.md
@@ -86,11 +86,11 @@ shared code, no exports.
 
 ### Test split
 
-| Test kind | Location | May import |
-| --- | --- | --- |
-| Fast unit / white-box | `@dxos/<pkg>/src/**/*.test.ts` | public API, `./testing`, relative internals (`../foo`) |
-| Public-API | `@dxos/<pkg>-e2e/src/**/*.test.ts` | `@dxos/<pkg>`, `@dxos/<pkg>/testing` only |
-| Integration / heavy-dep | `@dxos/<pkg>-e2e/src/**/*.test.ts` | the above + extra `-e2e`-only deps |
+| Test kind               | Location                           | May import                                             |
+| ----------------------- | ---------------------------------- | ------------------------------------------------------ |
+| Fast unit / white-box   | `@dxos/<pkg>/src/**/*.test.ts`     | public API, `./testing`, relative internals (`../foo`) |
+| Public-API              | `@dxos/<pkg>-e2e/src/**/*.test.ts` | `@dxos/<pkg>`, `@dxos/<pkg>/testing` only              |
+| Integration / heavy-dep | `@dxos/<pkg>-e2e/src/**/*.test.ts` | the above + extra `-e2e`-only deps                     |
 
 Heuristic: a test belongs in `-e2e` if it is expressible purely against
 `@dxos/<pkg>` + `@dxos/<pkg>/testing`. A test that fundamentally needs relative
@@ -121,7 +121,7 @@ build time. No bespoke script or lint rule is needed.
 `@dxos/assistant-e2e` (`packages/core/compute/assistant-e2e`) currently violates
 the convention: `layer: library`, `pack` tag, public `publishConfig`, a `compile`
 entrypoint, and `exports` — i.e. it is a publishable library that other packages
-*could* depend on. Bring it into conformance:
+_could_ depend on. Bring it into conformance:
 
 - `package.json`: keep `"private": true`; remove `publishConfig`, remove `exports`
   (and the `src/index.ts` library entrypoint if unused by tests), keep deps.

--- a/packages/core/compute/assistant-e2e/package.json
+++ b/packages/core/compute/assistant-e2e/package.json
@@ -12,17 +12,6 @@
   "license": "FSL-1.1-Apache-2.0",
   "author": "info@dxos.org",
   "type": "module",
-  "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "types": "./dist/types/src/index.d.ts",
-      "default": "./dist/lib/default/index.mjs"
-    }
-  },
-  "files": [
-    "dist",
-    "src"
-  ],
   "dependencies": {
     "@dxos/ai": "workspace:*",
     "@dxos/app-framework": "workspace:*",
@@ -41,8 +30,5 @@
     "@dxos/util": "workspace:*"
   },
   "devDependencies": {},
-  "publishConfig": {
-    "access": "public"
-  },
   "beast": {}
 }

--- a/packages/core/compute/assistant-e2e/src/index.ts
+++ b/packages/core/compute/assistant-e2e/src/index.ts
@@ -1,5 +1,0 @@
-//
-// Copyright 2026 DXOS.org
-//
-
-export {};

--- a/packages/core/echo/echo-client-e2e/moon.yml
+++ b/packages/core/echo/echo-client-e2e/moon.yml
@@ -3,4 +3,3 @@ language: typescript
 tags:
   - ts-test
   - typecheck
-  - memoized-llm

--- a/packages/core/echo/echo-client-e2e/package.json
+++ b/packages/core/echo/echo-client-e2e/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@dxos/echo-client-e2e",
+  "version": "0.8.3",
+  "private": true,
+  "description": "ECHO client public-API and integration tests.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dxos/dxos"
+  },
+  "license": "FSL-1.1-Apache-2.0",
+  "author": "info@dxos.org",
+  "type": "module",
+  "dependencies": {
+    "@dxos/async": "workspace:*",
+    "@dxos/context": "workspace:*",
+    "@dxos/echo": "workspace:*",
+    "@dxos/echo-client": "workspace:*",
+    "@dxos/echo-host": "workspace:*",
+    "@dxos/keys": "workspace:*",
+    "@dxos/protocols": "workspace:*",
+    "@dxos/teleport": "workspace:*",
+    "@dxos/util": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {},
+  "beast": {}
+}

--- a/packages/core/echo/echo-client-e2e/src/Obj.updateFrom.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/Obj.updateFrom.test.ts
@@ -5,10 +5,9 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import { Obj } from '@dxos/echo';
+import { EchoTestBuilder } from '@dxos/echo-client/testing';
 import { TestSchema } from '@dxos/echo/testing';
 import { PublicKey } from '@dxos/keys';
-
-import { EchoTestBuilder } from '@dxos/echo-client/testing';
 
 describe('Obj.updateFrom (database)', () => {
   let builder: EchoTestBuilder;

--- a/packages/core/echo/echo-client-e2e/src/Obj.updateFrom.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/Obj.updateFrom.test.ts
@@ -8,7 +8,7 @@ import { Obj } from '@dxos/echo';
 import { TestSchema } from '@dxos/echo/testing';
 import { PublicKey } from '@dxos/keys';
 
-import { EchoTestBuilder } from './echo-test-builder';
+import { EchoTestBuilder } from '@dxos/echo-client/testing';
 
 describe('Obj.updateFrom (database)', () => {
   let builder: EchoTestBuilder;

--- a/packages/core/echo/echo-client-e2e/src/integration.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/integration.test.ts
@@ -8,6 +8,7 @@ import { afterEach, assert, beforeEach, describe, expect, test } from 'vitest';
 import { Trigger, asyncTimeout } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { Entity, Filter, Obj, Query, Relation, Type } from '@dxos/echo';
+import { EchoTestBuilder, createDataAssertion } from '@dxos/echo-client/testing';
 import { MeshEchoReplicator } from '@dxos/echo-host';
 import {
   TestReplicationNetwork,
@@ -19,8 +20,6 @@ import { TestSchema } from '@dxos/echo/testing';
 import { DXN, type EntityId, PublicKey, type URI } from '@dxos/keys';
 import { TestBuilder as TeleportTestBuilder, TestPeer as TeleportTestPeer } from '@dxos/teleport/testing';
 import { deferAsync } from '@dxos/util';
-
-import { EchoTestBuilder, createDataAssertion } from '@dxos/echo-client/testing';
 
 describe('Integration tests', () => {
   let builder: EchoTestBuilder;

--- a/packages/core/echo/echo-client-e2e/src/integration.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/integration.test.ts
@@ -20,7 +20,7 @@ import { DXN, type EntityId, PublicKey, type URI } from '@dxos/keys';
 import { TestBuilder as TeleportTestBuilder, TestPeer as TeleportTestPeer } from '@dxos/teleport/testing';
 import { deferAsync } from '@dxos/util';
 
-import { EchoTestBuilder, createDataAssertion } from './echo-test-builder';
+import { EchoTestBuilder, createDataAssertion } from '@dxos/echo-client/testing';
 
 describe('Integration tests', () => {
   let builder: EchoTestBuilder;

--- a/packages/core/echo/echo-client-e2e/src/queue.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/queue.test.ts
@@ -10,7 +10,7 @@ import { TestSchema } from '@dxos/echo/testing';
 import { EID, SpaceId } from '@dxos/keys';
 import { FeedProtocol } from '@dxos/protocols';
 
-import { EchoTestBuilder } from './echo-test-builder';
+import { EchoTestBuilder } from '@dxos/echo-client/testing';
 
 describe('queues', () => {
   let builder: EchoTestBuilder;

--- a/packages/core/echo/echo-client-e2e/src/queue.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/queue.test.ts
@@ -6,11 +6,10 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import { Event } from '@dxos/async';
 import { Entity, Feed, Filter, Obj, Query, Ref, Relation } from '@dxos/echo';
+import { EchoTestBuilder } from '@dxos/echo-client/testing';
 import { TestSchema } from '@dxos/echo/testing';
 import { EID, SpaceId } from '@dxos/keys';
 import { FeedProtocol } from '@dxos/protocols';
-
-import { EchoTestBuilder } from '@dxos/echo-client/testing';
 
 describe('queues', () => {
   let builder: EchoTestBuilder;

--- a/packages/core/echo/echo-client-e2e/tsconfig.json
+++ b/packages/core/echo/echo-client-e2e/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {},
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../../../common/async"
+    },
+    {
+      "path": "../../../common/context"
+    },
+    {
+      "path": "../../../common/keys"
+    },
+    {
+      "path": "../../../common/util"
+    },
+    {
+      "path": "../../mesh/teleport"
+    },
+    {
+      "path": "../../protocols"
+    },
+    {
+      "path": "../echo"
+    },
+    {
+      "path": "../echo-client"
+    },
+    {
+      "path": "../echo-host"
+    }
+  ]
+}

--- a/packages/core/echo/echo-client-e2e/vitest.config.ts
+++ b/packages/core/echo/echo-client-e2e/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5706,6 +5706,39 @@ importers:
         specifier: workspace:*
         version: link:../../../common/test-utils
 
+  packages/core/echo/echo-client-e2e:
+    dependencies:
+      '@dxos/async':
+        specifier: workspace:*
+        version: link:../../../common/async
+      '@dxos/context':
+        specifier: workspace:*
+        version: link:../../../common/context
+      '@dxos/echo':
+        specifier: workspace:*
+        version: link:../echo
+      '@dxos/echo-client':
+        specifier: workspace:*
+        version: link:../echo-client
+      '@dxos/echo-host':
+        specifier: workspace:*
+        version: link:../echo-host
+      '@dxos/keys':
+        specifier: workspace:*
+        version: link:../../../common/keys
+      '@dxos/protocols':
+        specifier: workspace:*
+        version: link:../../protocols
+      '@dxos/teleport':
+        specifier: workspace:*
+        version: link:../../mesh/teleport
+      '@dxos/util':
+        specifier: workspace:*
+        version: link:../../../common/util
+      effect:
+        specifier: 3.21.3
+        version: 3.21.3
+
   packages/core/echo/echo-generator:
     dependencies:
       '@automerge/automerge':

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -365,6 +365,11 @@
         },
         {
           "type": "json",
+          "path": "packages/core/echo/echo-client-e2e/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/core/echo/echo-generator/package.json",
           "jsonpath": "$.version"
         },

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -205,6 +205,9 @@
       "path": "packages/core/echo/echo-client/tsconfig.json"
     },
     {
+      "path": "packages/core/echo/echo-client-e2e/tsconfig.json"
+    },
+    {
       "path": "packages/core/echo/echo-generator/tsconfig.json"
     },
     {


### PR DESCRIPTION
Implements the `-e2e` test package pattern described in [#11837](https://github.com/dxos/dxos/pull/11837).

## Summary

- **`@dxos/assistant-e2e` conformance migration**: Brings the existing package into spec conformance — removes `publishConfig`, `exports`, and the empty `src/index.ts` library entrypoint; changes `layer` from `library` to `automation`; replaces `ts-build` + `pack` tags with `typecheck`.

- **New `@dxos/echo-client-e2e` package** (`packages/core/echo/echo-client-e2e`): First canonical `-e2e` package, following the convention exactly — `layer: automation`, tags `[ts-test, typecheck]`, no `exports`/build artifacts, depends only on `@dxos/echo-client` and `@dxos/echo-client/testing` plus extra integration deps.

- **Test migration from `echo-client`**: Moves the three public-API/integration test suites from `echo-client/src/testing/` to `echo-client-e2e/src/`:
  - `integration.test.ts` — uses `@dxos/teleport/testing`, `@dxos/echo-host`
  - `queue.test.ts`
  - `Obj.updateFrom.test.ts`
  
  The single relative import (`./echo-test-builder`) in each file is rewritten to `@dxos/echo-client/testing`.

## Test plan

- [ ] `moon run assistant-e2e:build` passes (typecheck)
- [ ] `moon run echo-client-e2e:build` passes (typecheck)
- [ ] `moon run echo-client:test` passes (remaining colocated tests unaffected)
- [ ] `moon run echo-client-e2e:test` passes (migrated tests run successfully)

part of https://github.com/dxos/dxos/pull/11837

https://claude.ai/code/session_01PdaHVCE62JnDPS98UBM2Nt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdaHVCE62JnDPS98UBM2Nt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design specification for E2E test package pattern and conventions.

* **Refactor**
  * Restructured assistant-e2e package configuration, removing export declarations and publishable artifacts.
  * Created echo-client-e2e package with reorganized test structure and updated test utility dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->