### PR TITLE
fix(composer-app): exclude welcome-focus from main e2e config; fix comments PRNG flakiness

### DIFF
--- a/packages/apps/composer-app/src/playwright/comments.spec.ts
+++ b/packages/apps/composer-app/src/playwright/comments.spec.ts
@@ -165,10 +165,12 @@ test.describe('Comments tests', () => {
     const plank = host.deck.plank();
     const editorTextbox = Markdown.getMarkdownTextboxWithLocator(plank.locator);
 
-    const editorText = random.lorem.paragraphs(3);
-    const firstMessage = editorText.slice(0, 10);
-    const secondMessage = editorText.slice(100, 115);
-    const thirdMessage = editorText.slice(-20);
+    // Each selection must stay within a single paragraph: cm-comment decorations cannot span newlines.
+    const [p1, p2, p3] = [random.lorem.paragraph(), random.lorem.paragraph(), random.lorem.paragraph()];
+    const editorText = `${p1}\n\n${p2}\n\n${p3}`;
+    const firstMessage = p1.slice(0, 10);
+    const secondMessage = p2.slice(5, 20);
+    const thirdMessage = p3.slice(-15);
     await editorTextbox.fill(editorText);
     await Markdown.select(editorTextbox, firstMessage);
     await Thread.createComment(host.page, plank.locator, random.lorem.sentence());

--- a/packages/apps/composer-app/src/playwright/playwright.config.ts
+++ b/packages/apps/composer-app/src/playwright/playwright.config.ts
@@ -8,6 +8,8 @@ import { e2ePreset } from '@dxos/test-utils/playwright';
 
 export default defineConfig({
   ...e2ePreset(import.meta.dirname),
+  // Storybook-based tests require a separate webServer (see playwright-welcome-focus.config.ts).
+  testIgnore: ['**/welcome-focus.spec.ts'],
   timeout: 60_000,
   expect: { timeout: 10_000 },
   workers: 1,

--- a/packages/apps/composer-app/src/playwright/welcome-focus.spec.ts
+++ b/packages/apps/composer-app/src/playwright/welcome-focus.spec.ts
@@ -64,7 +64,7 @@ const expectEmailHoldsFocus = (label: string, timeline: FocusSample[]) => {
   );
 };
 
-test.describe.skip('Welcome focus', () => {
+test.describe('Welcome focus', () => {
   test('EmailPrimary story keeps email focused', async ({ page }) => {
     await page.goto(storyUrl('apps-composer-app-welcome--email-primary'));
     await expect(page.getByPlaceholder('Your email')).toBeVisible({ timeout: 60_000 });


### PR DESCRIPTION
## Summary

Three fixes for tests flagged as failing/flaky in Trunk's June 15 scheduled run.

### 1. `welcome-focus.spec.ts` — 6 consistent failures across all browsers (not quarantined by Trunk)

`welcome-focus.spec.ts` connects to Storybook at `http://localhost:9009`, but the main e2e task uses `playwright.config.ts` which only starts `vite preview` on port 4173. A separate `playwright-welcome-focus.config.ts` config (and dedicated `e2e-welcome-focus` moon task) does start Storybook, but `playwright.config.ts` picked the tests up too via `testDir`.

**Fix in `playwright.config.ts`:** Add `testIgnore: ['**/welcome-focus.spec.ts']` — these tests now only run via `moon run composer-app:e2e-welcome-focus`.

**Fix in `welcome-focus.spec.ts`:** Remove the `test.describe.skip` added as a quick workaround in #11846. The `testIgnore` is the correct mechanism; the skip is now redundant (and would prevent the tests from running even via the dedicated `e2e-welcome-focus` config).

### 2. `comments.spec.ts` "selecting comment highlights thread and vice versa" — flaky on Firefox/WebKit (Trunk reported as flaky, passed on retry)

The `delete message` test skips on firefox/webkit (`test.skip()` when `browserName !== 'chromium'`), so it doesn't consume random values. This shifts the PRNG state for the subsequent test. On firefox/webkit, `editorText.slice(100, 115)` fell on a paragraph boundary, producing a string like `'sed voluptas.\nQ'` containing a newline. CodeMirror `cm-comment` decorations cannot span newlines, so `filter({ hasText: textWithNewline })` found 0 elements — causing the first try to fail but retry to pass (with a different PRNG state).

**Fix in `comments.spec.ts`:** Generate three separate `lorem.paragraph()` calls and slice within each. No cross-paragraph text is possible regardless of accumulated PRNG state.

## Relationship to existing PRs

- **Incorporates** open PR #11811 (same `testIgnore` + PRNG fix, created before #11846)
- **Extends** #11811 by also removing the `test.describe.skip` that #11846 added after #11811 was created
- PR #11822 (open, same topic as `undo delete thread`) is superseded by the already-merged #11846 and should be closed

## Test plan

- [ ] CI Check workflow green (welcome-focus tests no longer run in main e2e; comments test is deterministically correct)
- [ ] `moon run composer-app:e2e-welcome-focus` (local, with Storybook) passes for welcome-focus tests

https://claude.ai/code/session_019vEZNYrsnBxMxCzkgAubTt

---
_Generated by [Claude Code](https://claude.ai/code/session_019vEZNYrsnBxMxCzkgAubTt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined test infrastructure and improved configuration management for better test execution and reliability.
  * Enhanced comment selection test setup with improved paragraph isolation to prevent comment decorations spanning newlines.
  * Updated test execution workflow and test suite organization for clearer test management.

* **Chores**
  * Modified Playwright test configuration settings to optimize test execution workflow and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->