### PR TITLE
fix(plugin-space): restore related objects section to RecordArticle

### DIFF
--- a/packages/plugins/plugin-space/src/containers/RecordArticle/RecordArticle.tsx
+++ b/packages/plugins/plugin-space/src/containers/RecordArticle/RecordArticle.tsx
@@ -66,7 +66,9 @@ export const RecordArticle = ({ role, subject }: AppSurface.ObjectArticleProps) 
             </div>
 
             {related.length > 0 && (
-              <div className={mx('dx-expander flex flex-col gap-form-gap', singleColumn ? 'dx-card-max-width' : 'w-full')}>
+              <div
+                className={mx('dx-expander flex flex-col gap-form-gap', singleColumn ? 'dx-card-max-width' : 'w-full')}
+              >
                 <Input.Root>
                   <Input.Label>{t('related-objects.label')}</Input.Label>
                 </Input.Root>

--- a/packages/plugins/plugin-space/src/containers/RecordArticle/RecordArticle.tsx
+++ b/packages/plugins/plugin-space/src/containers/RecordArticle/RecordArticle.tsx
@@ -2,13 +2,17 @@
 // Copyright 2023 DXOS.org
 //
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { Surface } from '@dxos/app-framework/ui';
-import { AppSurface } from '@dxos/app-toolkit/ui';
-import { Obj, Type } from '@dxos/echo';
-import { Card, Icon, Input, Panel, ScrollArea, Toolbar, useTranslation } from '@dxos/react-ui';
+import { AppSurface, useObjectMenuItems } from '@dxos/app-toolkit/ui';
+import { Entity, Obj, Type } from '@dxos/echo';
+import { Card, Icon, IconButton, Input, Panel, ScrollArea, Toolbar, useTranslation } from '@dxos/react-ui';
+import { Masonry } from '@dxos/react-ui-masonry';
+import { Menu } from '@dxos/react-ui-menu';
+import { mx } from '@dxos/ui-theme';
 
+import { useRelatedObjects } from '#hooks';
 import { meta } from '#meta';
 
 export const RecordArticle = ({ role, subject }: AppSurface.ObjectArticleProps) => {
@@ -29,6 +33,9 @@ export const RecordArticle = ({ role, subject }: AppSurface.ObjectArticleProps) 
     schema && Type.getDatabase(schema) != null
       ? 'ph--cube--regular'
       : (Obj.getIcon(subject)?.icon ?? 'ph--circle-dashed--regular');
+
+  const related = useRelatedObjects(db, subject, { references: true, relations: true });
+  const singleColumn = related.length === 1;
 
   return (
     <Panel.Root role={role}>
@@ -57,9 +64,56 @@ export const RecordArticle = ({ role, subject }: AppSurface.ObjectArticleProps) 
               </Input.Root>
               <Surface.Surface role='prompts' data={{ subject }} limit={1} />
             </div>
+
+            {related.length > 0 && (
+              <div className={mx('dx-expander flex flex-col gap-form-gap', singleColumn ? 'dx-card-max-width' : 'w-full')}>
+                <Input.Root>
+                  <Input.Label>{t('related-objects.label')}</Input.Label>
+                </Input.Root>
+                <Masonry.Root Tile={ObjectCard} columns={singleColumn ? 1 : undefined}>
+                  <Masonry.Content>
+                    <Masonry.Viewport items={related} />
+                  </Masonry.Content>
+                </Masonry.Root>
+              </div>
+            )}
           </ScrollArea.Viewport>
         </ScrollArea.Root>
       </Panel.Content>
     </Panel.Root>
+  );
+};
+
+const ObjectCard = ({ data: subject, classNames }: { data: Entity.Unknown; classNames?: string }) => {
+  const { t } = useTranslation(meta.id);
+  const data = useMemo(() => ({ subject }), [subject]);
+  const icon = Entity.getIcon(subject)?.icon ?? 'ph--circle-dashed--regular';
+  const menuItems = useObjectMenuItems(subject);
+
+  return (
+    <Menu.Root>
+      <Card.Root classNames={classNames}>
+        <Card.Header>
+          <Card.Block>
+            <Icon icon={icon} />
+          </Card.Block>
+          <Card.Title>{Entity.getLabel(subject, { fallback: 'typename' })}</Card.Title>
+          <Card.Block end>
+            <Menu.Trigger asChild disabled={!menuItems?.length}>
+              <IconButton
+                iconOnly
+                variant='ghost'
+                icon='ph--dots-three-vertical--regular'
+                label={t('more-actions.label')}
+              />
+            </Menu.Trigger>
+            <Menu.Content items={menuItems} />
+          </Card.Block>
+        </Card.Header>
+        <Card.Body>
+          <Surface.Surface type={AppSurface.Card} data={data} limit={1} />
+        </Card.Body>
+      </Card.Root>
+    </Menu.Root>
   );
 };


### PR DESCRIPTION
## Summary

- Restores the related objects masonry grid that was removed from `RecordArticle` in #10965 when the `RelatedArticle` companion was extracted
- Related Actions (prompts) appear above Related Objects, matching the intended ordering
- Each related object renders as a card with icon, title, context menu, and a `AppSurface.Card` body surface — consistent with the `RelatedArticle` companion

## Background

When #10965 extracted the `RelatedArticle` companion panel, it stripped the inline related objects section from `RecordArticle` entirely. This meant objects connected via ECHO relations or direct references were only visible if the user explicitly opened the companion panel — they no longer appeared in the record article itself.

## What reviewers should know

- `useRelatedObjects` is unchanged — this is purely a UI restoration
- The `ObjectCard` component added here mirrors the one in `RelatedArticle`; both could be extracted to a shared location in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Related articles/objects now show in record views via an expandable “related” section
  * Related items are presented in a masonry grid for clearer visual grouping
  * When there is exactly one related item, the layout switches to a single-column view
  * Each related item includes its own action menu for quick access to available options
<!-- end of auto-generated comment: release notes by coderabbit.ai -->