### PR TITLE
fix(docs): tab icons not rendering + waitlist form error flash

### DIFF
--- a/docs/src/pages/composer-welcome.astro
+++ b/docs/src/pages/composer-welcome.astro
@@ -108,8 +108,11 @@ import IconX from '../components/svg/IconX.astro';
     document.querySelectorAll('.early-access-form').forEach(function (form) {
       form.addEventListener('submit', async function (e) {
         e.preventDefault();
+        e.stopPropagation();
         const email = form.querySelector('[name="email"]').value;
         const block = form.closest('.w-form');
+        block.querySelector('.w-form-done').style.display = 'none';
+        block.querySelector('.w-form-fail').style.display = 'none';
         try {
           const res = await fetch('https://hub.dxos.network/account/request-access', {
             method: 'POST',
@@ -127,7 +130,7 @@ import IconX from '../components/svg/IconX.astro';
           block.querySelector('.w-form-fail').style.display = 'block';
           form.style.display = 'none';
         }
-      });
+      }, true);
     });
   </script>
 </WebflowLayout>

--- a/docs/src/pages/composer.astro
+++ b/docs/src/pages/composer.astro
@@ -213,27 +213,27 @@ import IconX from '../components/svg/IconX.astro';
                 <div class="circle-tabs-menu floating w-tab-menu">
                   <a data-w-tab="Tab 1" id="w-node-d90799aa-b9a2-5ea5-88cd-1b01d09ea10e-d09ea0ff" data-w-id="d90799aa-b9a2-5ea5-88cd-1b01d09ea10e" class="scroll-icon-outer tab floating _1 w-inline-block w-tab-link">
                     <div class="scroll-icon-inner tab floating">
-                      <div class="w-embed"><img src="/webflow/svg/tabs/cloudless.svg" alt="" loading="lazy" /></div>
+                      <div class="w-embed"><img src="/webflow/svg/tabs/cloudless.svg" alt="" width="32" height="32" /></div>
                     </div>
                   </a>
                   <a data-w-tab="Tab 2" id="w-node-d90799aa-b9a2-5ea5-88cd-1b01d09ea111-d09ea0ff" data-w-id="d90799aa-b9a2-5ea5-88cd-1b01d09ea111" class="scroll-icon-outer tab floating _2 w-inline-block w-tab-link">
                     <div class="scroll-icon-inner tab floating">
-                      <div class="w-embed"><img src="/webflow/svg/tabs/ownership.svg" alt="" loading="lazy" /></div>
+                      <div class="w-embed"><img src="/webflow/svg/tabs/ownership.svg" alt="" width="32" height="32" /></div>
                     </div>
                   </a>
                   <a data-w-tab="Tab 3" id="w-node-d90799aa-b9a2-5ea5-88cd-1b01d09ea114-d09ea0ff" data-w-id="d90799aa-b9a2-5ea5-88cd-1b01d09ea114" class="scroll-icon-outer tab floating _3 w-inline-block w-tab-link">
                     <div class="scroll-icon-inner tab floating">
-                      <div class="w-embed"><img src="/webflow/svg/tabs/sync.svg" alt="" loading="lazy" /></div>
+                      <div class="w-embed"><img src="/webflow/svg/tabs/sync.svg" alt="" width="32" height="32" /></div>
                     </div>
                   </a>
                   <a data-w-tab="Tab 4" id="w-node-d90799aa-b9a2-5ea5-88cd-1b01d09ea117-d09ea0ff" data-w-id="d90799aa-b9a2-5ea5-88cd-1b01d09ea117" class="scroll-icon-outer tab floating _4 w-inline-block w-tab-link w--current">
                     <div class="scroll-icon-inner tab floating">
-                      <div class="w-embed"><img src="/webflow/svg/tabs/functions.svg" alt="" loading="lazy" /></div>
+                      <div class="w-embed"><img src="/webflow/svg/tabs/functions.svg" alt="" width="32" height="32" /></div>
                     </div>
                   </a>
                   <a data-w-tab="Tab 5" id="w-node-d90799aa-b9a2-5ea5-88cd-1b01d09ea11a-d09ea0ff" data-w-id="d90799aa-b9a2-5ea5-88cd-1b01d09ea11a" class="scroll-icon-outer tab floating _5 w-inline-block w-tab-link">
                     <div class="scroll-icon-inner tab floating">
-                      <div class="w-embed"><img src="/webflow/svg/tabs/ai-sparkle.svg" alt="" loading="lazy" /></div>
+                      <div class="w-embed"><img src="/webflow/svg/tabs/ai-sparkle.svg" alt="" width="32" height="32" /></div>
                     </div>
                   </a>
                 </div>
@@ -288,27 +288,27 @@ import IconX from '../components/svg/IconX.astro';
                 <div class="circle-tabs-menu w-tab-menu">
                   <a data-w-tab="Tab 1" data-w-id="d90799aa-b9a2-5ea5-88cd-1b01d09ea148" class="scroll-icon-outer tab w-inline-block w-tab-link">
                     <div class="scroll-icon-inner tab">
-                      <div class="w-embed"><img src="/webflow/svg/tabs/cloudless.svg" alt="" loading="lazy" /></div>
+                      <div class="w-embed"><img src="/webflow/svg/tabs/cloudless.svg" alt="" width="32" height="32" /></div>
                     </div>
                   </a>
                   <a data-w-tab="Tab 2" data-w-id="d90799aa-b9a2-5ea5-88cd-1b01d09ea14b" class="scroll-icon-outer tab w-inline-block w-tab-link">
                     <div class="scroll-icon-inner tab">
-                      <div class="w-embed"><img src="/webflow/svg/tabs/ownership.svg" alt="" loading="lazy" /></div>
+                      <div class="w-embed"><img src="/webflow/svg/tabs/ownership.svg" alt="" width="32" height="32" /></div>
                     </div>
                   </a>
                   <a data-w-tab="Tab 3" data-w-id="d90799aa-b9a2-5ea5-88cd-1b01d09ea14e" class="scroll-icon-outer tab w-inline-block w-tab-link">
                     <div class="scroll-icon-inner tab">
-                      <div class="w-embed"><img src="/webflow/svg/tabs/sync.svg" alt="" loading="lazy" /></div>
+                      <div class="w-embed"><img src="/webflow/svg/tabs/sync.svg" alt="" width="32" height="32" /></div>
                     </div>
                   </a>
                   <a data-w-tab="Tab 4" data-w-id="d90799aa-b9a2-5ea5-88cd-1b01d09ea151" class="scroll-icon-outer tab w-inline-block w-tab-link w--current">
                     <div class="scroll-icon-inner tab">
-                      <div class="w-embed"><img src="/webflow/svg/tabs/functions.svg" alt="" loading="lazy" /></div>
+                      <div class="w-embed"><img src="/webflow/svg/tabs/functions.svg" alt="" width="32" height="32" /></div>
                     </div>
                   </a>
                   <a data-w-tab="Tab 5" data-w-id="d90799aa-b9a2-5ea5-88cd-1b01d09ea154" class="scroll-icon-outer tab w-inline-block w-tab-link">
                     <div class="scroll-icon-inner tab">
-                      <div class="w-embed"><img src="/webflow/svg/tabs/ai-sparkle.svg" alt="" loading="lazy" /></div>
+                      <div class="w-embed"><img src="/webflow/svg/tabs/ai-sparkle.svg" alt="" width="32" height="32" /></div>
                     </div>
                   </a>
                 </div>
@@ -806,8 +806,11 @@ import IconX from '../components/svg/IconX.astro';
     document.querySelectorAll('.early-access-form').forEach(function (form) {
       form.addEventListener('submit', async function (e) {
         e.preventDefault();
+        e.stopPropagation();
         const email = form.querySelector('[name="email"]').value;
         const block = form.closest('.w-form');
+        block.querySelector('.w-form-done').style.display = 'none';
+        block.querySelector('.w-form-fail').style.display = 'none';
         try {
           const res = await fetch('https://hub.dxos.network/account/request-access', {
             method: 'POST',
@@ -825,7 +828,7 @@ import IconX from '../components/svg/IconX.astro';
           block.querySelector('.w-form-fail').style.display = 'block';
           form.style.display = 'none';
         }
-      });
+      }, true);
     });
   </script>
 </WebflowLayout>


### PR DESCRIPTION
## Summary

- **Tab icons invisible**: The 5 tab SVG icons in the \"Cloudless Collaboration\" rings section on `/composer` were not rendering. The SVGs have `width=\"100%\" height=\"100%\"` as their viewport dimensions, which gives them zero intrinsic size as `<img>` elements — lazy loading never fires for 0×0 images. Fixed by adding explicit `width=\"32\" height=\"32\"` to all 10 `<img>` tags (both the floating overlay menu and the bottom nav menu), matching the approach used by plugin scroll icons elsewhere on the page.

- **Waitlist form flashes error before success**: On submit, Webflow's bundled form handler (registered in bubble phase by `webflow.js`) was firing synchronously before our async `fetch()` completed, momentarily showing `.w-form-fail`. Fixed by registering our handler in the **capture phase** (`addEventListener(..., true)`), calling `e.stopPropagation()` to prevent the event reaching Webflow's parent listener, and pre-resetting both state panels at the start of each submission. Applied to both `composer.astro` and `composer-welcome.astro`.

## Test plan

- [ ] Visit `/composer` — the 5 circular tab icons (cloudless, ownership, sync, functions, ai-sparkle) are now visible as blue icons inside the dark circles
- [ ] Submit the waitlist form with a test email — success state appears immediately with no error flash
- [ ] Submit on `/composer-welcome` — same clean success behaviour
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced form submission handling for better responsiveness and user feedback
  * Optimized icon rendering performance in the Composer portal interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->