### PR TITLE
fix(plugin-calls): fix reactive call controls for mic/camera/screenshare

### DIFF
--- a/packages/plugins/plugin-calls/src/calls/call-manager.ts
+++ b/packages/plugins/plugin-calls/src/calls/call-manager.ts
@@ -46,7 +46,12 @@ export class CallManager extends Resource {
   private readonly _selfAtom = Atom.make((get) => get(this._stateAtom).call.self ?? {});
   private readonly _tracksAtom = Atom.make((get) => get(this._stateAtom).call.tracks ?? {});
   private readonly _usersAtom = Atom.make((get) => get(this._stateAtom).call.users ?? []);
-  private readonly _mediaAtom = Atom.make((get) => get(this._stateAtom).media);
+  private readonly _audioEnabledAtom = Atom.make((get) => get(this._stateAtom).media.audioEnabled ?? false);
+  private readonly _videoEnabledAtom = Atom.make((get) => get(this._stateAtom).media.videoEnabled ?? false);
+  private readonly _screensharingAtom = Atom.make((get) => get(this._stateAtom).media.screenshareTrack !== undefined);
+  private readonly _localVideoStreamAtom = Atom.make((get) => get(this._stateAtom).media.videoStream);
+  private readonly _screenshareVideoStreamAtom = Atom.make((get) => get(this._stateAtom).media.screenshareVideoStream);
+  private readonly _noStreamAtom = Atom.make<MediaStream | undefined>(() => undefined);
   private readonly _audioTracksToPlayAtom = Atom.make((get) => {
     const state = get(this._stateAtom);
     return (state.call.users ?? [])
@@ -109,9 +114,29 @@ export class CallManager extends Resource {
     return this._usersAtom;
   }
 
-  /** Derived atom for media. */
-  get mediaAtom(): Atom.Atom<MediaState> {
-    return this._mediaAtom;
+  /** Derived atom for whether the microphone is enabled. */
+  get audioEnabledAtom(): Atom.Atom<boolean> {
+    return this._audioEnabledAtom;
+  }
+
+  /** Derived atom for whether the camera is enabled. */
+  get videoEnabledAtom(): Atom.Atom<boolean> {
+    return this._videoEnabledAtom;
+  }
+
+  /** Derived atom for whether screen sharing is active. */
+  get screensharingAtom(): Atom.Atom<boolean> {
+    return this._screensharingAtom;
+  }
+
+  /** Derived atom for the local camera video stream. */
+  get localVideoStreamAtom(): Atom.Atom<MediaStream | undefined> {
+    return this._localVideoStreamAtom;
+  }
+
+  /** Derived atom for the local screenshare video stream. */
+  get screenshareVideoStreamAtom(): Atom.Atom<MediaStream | undefined> {
+    return this._screenshareVideoStreamAtom;
   }
 
   /** Derived atom for audioTracksToPlay. */
@@ -124,9 +149,9 @@ export class CallManager extends Resource {
     return this._stateAtom;
   }
 
-  /** Returns a derived atom for a video stream by name. */
-  videoStreamAtom(name: EncodedTrackName): Atom.Atom<MediaStream | undefined> {
-    return this._videoStreamAtomFamily(name);
+  /** Returns a derived atom for a pulled video stream by name; returns a no-op atom when name is undefined. */
+  videoStreamAtom(name: EncodedTrackName | undefined): Atom.Atom<MediaStream | undefined> {
+    return name !== undefined ? this._videoStreamAtomFamily(name) : this._noStreamAtom;
   }
 
   /** Returns a derived atom for an activity by key. */

--- a/packages/plugins/plugin-calls/src/components/Call/Toolbar.tsx
+++ b/packages/plugins/plugin-calls/src/components/Call/Toolbar.tsx
@@ -48,7 +48,9 @@ export const Toolbar = ({
   const { graph } = useAppGraph();
   const runAction = useActionRunner();
   const call = useCapability(CallsCapabilities.Manager);
-  const media = useAtomValue(call.mediaAtom);
+  const audioEnabled = useAtomValue(call.audioEnabledAtom);
+  const videoEnabled = useAtomValue(call.videoEnabledAtom);
+  const isScreensharing = useAtomValue(call.screensharingAtom);
   const joined = useAtomValue(call.joinedAtom);
   const raisedHand = useAtomValue(call.raisedHandAtom);
   // Room-scoped membership, not the global session: when joined to a *different* room this toolbar
@@ -60,7 +62,6 @@ export const Toolbar = ({
   const actions = useActions(graph, node?.id).filter((action) => action.properties.disposition === 'toolbar');
 
   // Screen sharing.
-  const isScreensharing = media.screenshareTrack !== undefined;
   const canSharescreen =
     typeof navigator.mediaDevices !== 'undefined' && navigator.mediaDevices.getDisplayMedia !== undefined;
 
@@ -69,7 +70,7 @@ export const Toolbar = ({
     <div className={mx('z-20 flex justify-center m-8', autoHideControls && groupHoverControlItemWithTransition)}>
       <NaturalToolbar.Root classNames={['p-2 bg-modal-surface rounded-md shadow-md', classNames]}>
         <ToggleButton
-          active={media.audioEnabled}
+          active={audioEnabled}
           state={{
             on: {
               icon: 'ph--microphone--regular',
@@ -85,7 +86,7 @@ export const Toolbar = ({
           }}
         />
         <ToggleButton
-          active={media.videoEnabled}
+          active={videoEnabled}
           state={{
             on: {
               icon: 'ph--video-camera--regular',

--- a/packages/plugins/plugin-calls/src/components/Lobby/Lobby.tsx
+++ b/packages/plugins/plugin-calls/src/components/Lobby/Lobby.tsx
@@ -42,10 +42,11 @@ type LobbyPreviewProps = {};
 const LobbyPreview = (_props: LobbyPreviewProps) => {
   const { t } = useTranslation(meta.id);
   const call = useCapability(CallsCapabilities.Manager);
-  const media = useAtomValue(call.mediaAtom);
+  const videoEnabled = useAtomValue(call.videoEnabledAtom);
+  const videoStream = useAtomValue(call.localVideoStreamAtom);
   const [classNames, setClassNames] = useState('');
   useEffect(() => {
-    if (!media.videoEnabled) {
+    if (!videoEnabled) {
       setClassNames('');
       return;
     }
@@ -56,14 +57,14 @@ const LobbyPreview = (_props: LobbyPreviewProps) => {
     }, 500);
 
     return () => clearTimeout(timeout);
-  }, [media.videoEnabled]);
+  }, [videoEnabled]);
 
   return (
     <div className='grid grow p-4'>
       <ResponsivePanel>
-        {(media.videoEnabled && (
+        {(videoEnabled && (
           <VideoObject
-            videoStream={media.videoStream}
+            videoStream={videoStream}
             flip
             muted
             classNames={mx(

--- a/packages/plugins/plugin-calls/src/components/Participant/Participant.tsx
+++ b/packages/plugins/plugin-calls/src/components/Participant/Participant.tsx
@@ -26,11 +26,24 @@ export const Participant = memo(({ item: user, debug, ...props }: ResponsiveGrid
 
   // Track name to display for non-self users; undefined when no video should show.
   const pulledTrackName = useMemo<EncodedTrackName | undefined>(() => {
-    if (isSelf) {return undefined;}
-    if (isScreenshare && user.tracks?.screenshareEnabled) {return user.tracks?.screenshare as EncodedTrackName;}
-    if (!isScreenshare && user.tracks?.videoEnabled) {return user.tracks?.video as EncodedTrackName;}
+    if (isSelf) {
+      return undefined;
+    }
+    if (isScreenshare && user.tracks?.screenshareEnabled) {
+      return user.tracks?.screenshare as EncodedTrackName;
+    }
+    if (!isScreenshare && user.tracks?.videoEnabled) {
+      return user.tracks?.video as EncodedTrackName;
+    }
     return undefined;
-  }, [isSelf, isScreenshare, user.tracks?.screenshare, user.tracks?.video, user.tracks?.screenshareEnabled, user.tracks?.videoEnabled]);
+  }, [
+    isSelf,
+    isScreenshare,
+    user.tracks?.screenshare,
+    user.tracks?.video,
+    user.tracks?.screenshareEnabled,
+    user.tracks?.videoEnabled,
+  ]);
 
   const pulledVideoStream = useAtomValue(call.videoStreamAtom(pulledTrackName));
 

--- a/packages/plugins/plugin-calls/src/components/Participant/Participant.tsx
+++ b/packages/plugins/plugin-calls/src/components/Participant/Participant.tsx
@@ -18,38 +18,28 @@ export const SCREENSHARE_SUFFIX = '_screenshare';
 export const Participant = memo(({ item: user, debug, ...props }: ResponsiveGridItemProps<UserState>) => {
   const call = useCapability(CallsCapabilities.Manager);
   const self = useAtomValue(call.selfAtom);
-  const media = useAtomValue(call.mediaAtom);
+  const videoEnabled = useAtomValue(call.videoEnabledAtom);
+  const localVideoStream = useAtomValue(call.localVideoStreamAtom);
+  const screenshareVideoStream = useAtomValue(call.screenshareVideoStreamAtom);
   const isSelf: boolean = self.id !== undefined && user.id !== undefined && user.id.startsWith(self.id);
   const isScreenshare = user.id?.endsWith(SCREENSHARE_SUFFIX);
 
-  // Get pulled video stream for non-self users.
-  const pulledVideoStream = useMemo<MediaStream | undefined>(() => {
-    if (isSelf) {
-      return undefined;
-    }
-    const trackName =
-      isScreenshare && user.tracks?.screenshareEnabled
-        ? (user.tracks?.screenshare as EncodedTrackName)
-        : !isScreenshare && user.tracks?.videoEnabled
-          ? (user.tracks?.video as EncodedTrackName)
-          : undefined;
-    return trackName ? media.pulledVideoStreams[trackName]?.stream : undefined;
-  }, [
-    isSelf,
-    isScreenshare,
-    media.pulledVideoStreams,
-    user.tracks?.screenshare,
-    user.tracks?.video,
-    user.tracks?.screenshareEnabled,
-    user.tracks?.videoEnabled,
-  ]);
+  // Track name to display for non-self users; undefined when no video should show.
+  const pulledTrackName = useMemo<EncodedTrackName | undefined>(() => {
+    if (isSelf) {return undefined;}
+    if (isScreenshare && user.tracks?.screenshareEnabled) {return user.tracks?.screenshare as EncodedTrackName;}
+    if (!isScreenshare && user.tracks?.videoEnabled) {return user.tracks?.video as EncodedTrackName;}
+    return undefined;
+  }, [isSelf, isScreenshare, user.tracks?.screenshare, user.tracks?.video, user.tracks?.screenshareEnabled, user.tracks?.videoEnabled]);
+
+  const pulledVideoStream = useAtomValue(call.videoStreamAtom(pulledTrackName));
 
   const videoStream = useMemo<MediaStream | undefined>(() => {
     if (isSelf) {
-      return isScreenshare ? media.screenshareVideoStream : media.videoStream;
+      return isScreenshare ? screenshareVideoStream : localVideoStream;
     }
     return pulledVideoStream;
-  }, [isSelf, isScreenshare, media.videoStream, media.screenshareVideoStream, pulledVideoStream]);
+  }, [isSelf, isScreenshare, localVideoStream, screenshareVideoStream, pulledVideoStream]);
 
   return (
     <ResponsiveGridItem
@@ -57,8 +47,8 @@ export const Participant = memo(({ item: user, debug, ...props }: ResponsiveGrid
       item={user}
       name={user.name}
       self={isSelf}
-      screenshare={!!media.screenshareVideoStream}
-      video={media.videoEnabled}
+      screenshare={!!screenshareVideoStream}
+      video={videoEnabled}
       mute={user ? !user.tracks?.audioEnabled : false}
       wave={user.raisedHand}
       speaking={user.speaking}


### PR DESCRIPTION
## Summary

- **Root cause**: `MediaState` is mutated in place (`this._state.audioEnabled = true`), so its object reference never changes. `mediaAtom` returned the whole `MediaState` object, which effect-atom's reference-equality check considered unchanged — suppressing re-renders on every toggle.
- **Fix**: Remove `mediaAtom` entirely. Replace it with fine-grained derived atoms that extract primitives or stable stream references, which change value when toggled and correctly notify subscribers.

## Changes

**`call-manager.ts`** — remove `_mediaAtom`/`mediaAtom`; add:
- `audioEnabledAtom` / `videoEnabledAtom` / `screensharingAtom` — boolean primitives for toolbar toggle state
- `localVideoStreamAtom` / `screenshareVideoStreamAtom` — local stream refs for the self-tile and lobby preview
- `_noStreamAtom` — stable fallback returned by `videoStreamAtom(undefined)` so callers don't need to guard

**`Toolbar.tsx`** — mic, camera, and screenshare toggle buttons subscribe to the boolean atoms directly; no more stale `active` prop.

**`Lobby.tsx`** — preview pane subscribes to `videoEnabledAtom` + `localVideoStreamAtom`.

**`Participant.tsx`** — self-tile subscribes to `localVideoStreamAtom` + `screenshareVideoStreamAtom`; pulled stream for remote participants migrated from a `useMemo` over `media.pulledVideoStreams` (stable object reference, same reactivity bug) to `useAtomValue(call.videoStreamAtom(pulledTrackName))`.

## Reviewer notes

The `as EncodedTrackName` casts in `Participant.tsx` are pre-existing — track names come from swarm state typed as `string`, and `EncodedTrackName` is the branded form. No new casts were introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal media state management architecture to enhance code organization and maintainability across the calls plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->