### PR TITLE
feat(plugin-presenter): fade transitions, single-ESC exit, [ESC] caption, editor shortcut

### DIFF
--- a/.agents/skills/composer-plugins/MEMORY.md
+++ b/.agents/skills/composer-plugins/MEMORY.md
@@ -4,6 +4,14 @@ Session-logged rules for agents. Append a dated section per session (newest firs
 
 ---
 
+## 2026-06-16 — plugin-presenter (presenter mode UX)
+
+- Toggle/exit deck-layout flows must run sequentially in ONE operation handler (`yield*` Adjust then Open). Firing `Adjust` + `Open` as two concurrent `invokePromise` calls (the old `useExitPresenter`) races: `Open` reads stale deck state and clobbers `Adjust`'s `fullscreen:false` back to true → stuck fullscreen. Route exit through the op (`TogglePresentation` with `state:false`).
+- NEVER put side effects (`setTimeout`, sibling `setState`) inside a `setState(updater)` callback in plugin components. React dev StrictMode double-invokes updaters, so a fade-then-exit scheduled inside the updater fires twice → double exit/toggle. Guard one-shot transitions with a `useRef` boolean and keep side effects outside the updater (see `PresentationShell.handleExit`).
+- An operation that reads deck state (`Capabilities.getAtomValue(DeckCapabilities.State)`) or invokes deck ops must declare `services: [Capability.Service]` in `Operation.make` (handler context is `OperationService` only otherwise). Mirror `DeckOperation.Adjust`.
+- To make a keyboard shortcut work inside the markdown editor, contribute a `MarkdownCapabilities.ExtensionProvider` returning `Prec.highest(keymap.of([{ key:'Shift-Mod-p', preventDefault:true, stopPropagation:true, run }]))` (register via `Plugin.addModule({ activatesOn: MarkdownEvents.SetupExtensions })`). The global navtree `Keyboard` context (attention id) does not match the editor, so action `keyBinding` alone never fires while editing.
+- A fullscreen presenter must own ESC itself: a document **capture-phase** listener that `stopImmediatePropagation()` + exits, so the deck's `DeckSoloMode` bubble ESC handler never runs (that handler only drops fullscreen → caused the "second ESC" bug). Don't also wire `onExit` into a child (RevealPlayer/Pager) — single owner only.
+
 ## 2026-06-15 — plugin-calls (component/container stories, CallManager harness)
 
 ### Story harness for capability-backed components (CallsCapabilities.Manager)

--- a/packages/plugins/plugin-presenter/moon.yml
+++ b/packages/plugins/plugin-presenter/moon.yml
@@ -17,6 +17,7 @@ tasks:
       - '--entryPoint=src/components/index.ts'
       - '--entryPoint=src/containers/index.ts'
       - '--entryPoint=src/meta.ts'
+      - '--entryPoint=src/operations/index.ts'
       - '--entryPoint=src/plugin.ts'
       - '--entryPoint=src/translations.ts'
       - '--entryPoint=src/types/index.ts'

--- a/packages/plugins/plugin-presenter/package.json
+++ b/packages/plugins/plugin-presenter/package.json
@@ -33,6 +33,11 @@
       "types": "./dist/types/src/meta.d.ts",
       "default": "./dist/lib/neutral/meta.mjs"
     },
+    "#operations": {
+      "source": "./src/operations/index.ts",
+      "types": "./dist/types/src/operations/index.d.ts",
+      "default": "./dist/lib/neutral/operations/index.mjs"
+    },
     "#plugin": {
       "source": {
         "workerd": "./src/PresenterPlugin.workerd.ts",
@@ -81,6 +86,7 @@
     "PLUGIN.mdl"
   ],
   "dependencies": {
+    "@codemirror/state": "catalog:",
     "@dxos/app-framework": "workspace:*",
     "@dxos/app-toolkit": "workspace:*",
     "@dxos/compute": "workspace:*",
@@ -94,6 +100,7 @@
     "@dxos/plugin-markdown": "workspace:*",
     "@dxos/react-ui-attention": "workspace:*",
     "@dxos/react-ui-form": "workspace:*",
+    "@dxos/ui-editor": "workspace:*",
     "@dxos/util": "workspace:*",
     "@effect-atom/atom-react": "catalog:",
     "hastscript": "catalog:",

--- a/packages/plugins/plugin-presenter/src/PresenterPlugin.tsx
+++ b/packages/plugins/plugin-presenter/src/PresenterPlugin.tsx
@@ -4,8 +4,9 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
+import { MarkdownEvents } from '@dxos/plugin-markdown';
 
-import { AppGraphBuilder, PresenterSettings, ReactSurface } from '#capabilities';
+import { AppGraphBuilder, MarkdownExtension, OperationHandler, PresenterSettings, ReactSurface } from '#capabilities';
 import { meta } from '#meta';
 import { translations } from '#translations';
 
@@ -17,8 +18,14 @@ import pluginSpec from '../PLUGIN.mdl?raw';
 
 export const PresenterPlugin = Plugin.define(meta).pipe(
   AppPlugin.addAppGraphModule({ activate: AppGraphBuilder }),
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
   AppPlugin.addSettingsModule({ activate: PresenterSettings }),
   AppPlugin.addSurfaceModule({ activate: ReactSurface }),
+  Plugin.addModule({
+    id: `${meta.id}/markdown`,
+    activatesOn: MarkdownEvents.SetupExtensions,
+    activate: MarkdownExtension,
+  }),
   AppPlugin.addTranslationsModule({ translations }),
   AppPlugin.addPluginAssetModule({
     asset: { pluginId: meta.id, path: 'PLUGIN.mdl', content: pluginSpec, mimeType: 'application/x-mdl' },

--- a/packages/plugins/plugin-presenter/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-presenter/src/capabilities/app-graph-builder.ts
@@ -5,11 +5,10 @@
 import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 
-import { Capabilities, Capability } from '@dxos/app-framework';
-import { AppCapabilities, AppNode, LayoutOperation, getObjectPathFromObject, getSpacePath } from '@dxos/app-toolkit';
+import { Capability } from '@dxos/app-framework';
+import { AppCapabilities, AppNode } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { Collection, Obj } from '@dxos/echo';
-import { DeckCapabilities, DeckOperation } from '@dxos/plugin-deck';
 import { GraphBuilder, type Node, NodeMatcher } from '@dxos/plugin-graph';
 import { Markdown } from '@dxos/plugin-markdown';
 import { linkedSegment } from '@dxos/react-ui-attention';
@@ -61,27 +60,12 @@ export default Capability.makeModule(
         if (!isPresentable || !db) {
           return Effect.succeed([]);
         }
-        const objectPath = getObjectPathFromObject(object);
 
         return Effect.succeed([
           {
             id: PresenterOperation.TogglePresentation.meta.key,
-            // TODO(burdon): Allow function so can generate state when activated.
-            //  So can set explicit fullscreen state coordinated with current presenter state.
             data: Effect.fnUntraced(function* () {
-              const deckState = yield* Capabilities.getAtomValue(DeckCapabilities.State);
-              const deck = deckState.decks[deckState.activeDeck];
-              const presenterId = `${objectPath}/${linkedSegment('presenter')}`;
-              if (!deck?.fullscreen) {
-                yield* Operation.invoke(DeckOperation.Adjust, {
-                  type: 'solo--fullscreen' as const,
-                  id: presenterId,
-                });
-              }
-              yield* Operation.invoke(LayoutOperation.Open, {
-                subject: [presenterId],
-                workspace: getSpacePath(db.spaceId),
-              });
+              yield* Operation.invoke(PresenterOperation.TogglePresentation, { object });
             }),
             properties: {
               label: ['toggle-presentation.label', { ns: meta.id }],

--- a/packages/plugins/plugin-presenter/src/capabilities/index.ts
+++ b/packages/plugins/plugin-presenter/src/capabilities/index.ts
@@ -3,7 +3,13 @@
 //
 
 import { Capability } from '@dxos/app-framework';
+import type { OperationHandlerSet } from '@dxos/compute';
 
 export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
+export const MarkdownExtension = Capability.lazy('MarkdownExtension', () => import('./markdown-extension'));
+export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
+  'OperationHandler',
+  () => import('./operation-handler'),
+);
 export const ReactSurface = Capability.lazy('ReactSurface', () => import('./react-surface'));
 export const PresenterSettings = Capability.lazy('PresenterSettings', () => import('./settings'));

--- a/packages/plugins/plugin-presenter/src/capabilities/markdown-extension.ts
+++ b/packages/plugins/plugin-presenter/src/capabilities/markdown-extension.ts
@@ -1,0 +1,45 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Prec } from '@codemirror/state';
+import * as Effect from 'effect/Effect';
+
+import { Capabilities, Capability } from '@dxos/app-framework';
+import { MarkdownCapabilities } from '@dxos/plugin-markdown/types';
+import { keymap } from '@dxos/ui-editor';
+
+import { PresenterOperation } from '#types';
+
+/**
+ * Contributes the present shortcut (Shift+Cmd+P) to the markdown editor so presentation
+ * can be toggled while editing without relying on the global navtree keyboard context.
+ */
+export default Capability.makeModule(
+  Effect.fnUntraced(function* () {
+    const capabilities = yield* Capability.Service;
+
+    return Capability.contributes(MarkdownCapabilities.ExtensionProvider, [
+      ({ document }) => {
+        if (!document) {
+          return undefined;
+        }
+
+        const { invokePromise } = capabilities.get(Capabilities.OperationInvoker);
+        return Prec.highest(
+          keymap.of([
+            {
+              key: 'Shift-Mod-p',
+              preventDefault: true,
+              stopPropagation: true,
+              run: () => {
+                void invokePromise(PresenterOperation.TogglePresentation, { object: document });
+                return true;
+              },
+            },
+          ]),
+        );
+      },
+    ]);
+  }),
+);

--- a/packages/plugins/plugin-presenter/src/capabilities/operation-handler.ts
+++ b/packages/plugins/plugin-presenter/src/capabilities/operation-handler.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capabilities, Capability } from '@dxos/app-framework';
+import type { OperationHandlerSet } from '@dxos/compute';
+
+import { PresenterOperationHandlerSet } from '#operations';
+
+export default Capability.makeModule<OperationHandlerSet.OperationHandlerSet>(
+  Effect.fnUntraced(function* () {
+    return Capability.contributes(Capabilities.OperationHandler, PresenterOperationHandlerSet);
+  }),
+);

--- a/packages/plugins/plugin-presenter/src/components/Presenter/PresentationShell.tsx
+++ b/packages/plugins/plugin-presenter/src/components/Presenter/PresentationShell.tsx
@@ -1,0 +1,96 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import React, { type PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
+
+import { composable, composableProps } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+export type PresentationShellProps = PropsWithChildren<{
+  /** Invoked once the exit fade-out has completed. */
+  onExit?: () => void;
+  /** Fade-in/out duration (ms). */
+  fadeDuration?: number;
+  /** Duration the [ESC] hint remains visible (ms). */
+  hintDuration?: number;
+}>;
+
+/**
+ * Wraps presentation content with a fade-in/out transition, an ESC handler that exits in a
+ * single keypress (intercepting before the deck's fullscreen handler), and a transient [ESC]
+ * caption shown on enter.
+ */
+export const PresentationShell = composable<HTMLDivElement, PresentationShellProps>(
+  ({ children, onExit, fadeDuration = 300, hintDuration = 3000, ...props }, forwardedRef) => {
+    const [visible, setVisible] = useState(false);
+    const [exiting, setExiting] = useState(false);
+    const [showHint, setShowHint] = useState(true);
+    const exitTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
+    // Guards against exiting twice; a state updater can't gate this since React double-invokes
+    // updaters in dev, which would schedule the exit (and its side effects) more than once.
+    const exitingRef = useRef(false);
+
+    // Fade in once mounted.
+    useEffect(() => {
+      const frame = requestAnimationFrame(() => setVisible(true));
+      return () => cancelAnimationFrame(frame);
+    }, []);
+
+    // Hide the hint after the configured duration.
+    useEffect(() => {
+      const timer = setTimeout(() => setShowHint(false), hintDuration);
+      return () => clearTimeout(timer);
+    }, [hintDuration]);
+
+    const handleExit = useCallback(() => {
+      if (exitingRef.current) {
+        return;
+      }
+      exitingRef.current = true;
+      setExiting(true);
+      setVisible(false);
+      exitTimeout.current = setTimeout(() => onExit?.(), fadeDuration);
+    }, [onExit, fadeDuration]);
+
+    useEffect(() => () => clearTimeout(exitTimeout.current), []);
+
+    // Capture ESC before the deck/reveal handlers so a single keypress exits directly.
+    useEffect(() => {
+      const handler = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          handleExit();
+        }
+      };
+
+      document.addEventListener('keydown', handler, { capture: true });
+      return () => document.removeEventListener('keydown', handler, { capture: true });
+    }, [handleExit]);
+
+    return (
+      <div
+        {...composableProps(props, {
+          classNames: [
+            'relative grow overflow-hidden bg-black transition-opacity',
+            visible && !exiting ? 'opacity-100' : 'opacity-0',
+          ],
+          style: { transitionDuration: `${fadeDuration}ms` },
+        })}
+        ref={forwardedRef}
+      >
+        {children}
+
+        <div
+          className={mx(
+            'absolute top-4 left-4 z-[300] transition-opacity duration-500',
+            showHint && !exiting ? 'opacity-100' : 'opacity-0',
+          )}
+        >
+          <span className='rounded-sm bg-white/10 px-2 py-1 font-mono text-sm text-white/70'>[ESC]</span>
+        </div>
+      </div>
+    );
+  },
+);

--- a/packages/plugins/plugin-presenter/src/components/Presenter/index.ts
+++ b/packages/plugins/plugin-presenter/src/components/Presenter/index.ts
@@ -4,3 +4,4 @@
 
 export * from './Layout';
 export * from './Pager';
+export * from './PresentationShell';

--- a/packages/plugins/plugin-presenter/src/containers/CollectionPresenterArticle/CollectionPresenterArticle.tsx
+++ b/packages/plugins/plugin-presenter/src/containers/CollectionPresenterArticle/CollectionPresenterArticle.tsx
@@ -9,7 +9,7 @@ import { AppSurface } from '@dxos/app-toolkit/ui';
 import { type Collection, Obj } from '@dxos/echo';
 import { Panel } from '@dxos/react-ui';
 
-import { PageNumber, Pager, Layout as PresenterLayout } from '#components';
+import { PageNumber, Pager, PresentationShell, Layout as PresenterLayout } from '#components';
 import { PresenterContext } from '#types';
 
 import { useExitPresenter } from '../../useExitPresenter';
@@ -24,26 +24,28 @@ export const CollectionPresenterArticle = ({ role, subject: collection }: Collec
   return (
     <Panel.Root role={role} classNames='relative'>
       <Panel.Content asChild>
-        <PresenterLayout
-          bottomRight={<PageNumber index={slide} count={collection.objects.length} />}
-          bottomLeft={
-            <Pager
-              index={slide}
-              count={collection.objects.length}
-              keys={running}
-              onChange={setSlide}
-              onExit={handleExit}
+        <PresentationShell onExit={handleExit}>
+          <PresenterLayout
+            bottomRight={<PageNumber index={slide} count={collection.objects.length} />}
+            bottomLeft={
+              <Pager
+                index={slide}
+                count={collection.objects.length}
+                keys={running}
+                onChange={setSlide}
+                onExit={handleExit}
+              />
+            }
+          >
+            <Surface.Surface
+              type={AppSurface.Slide}
+              data={{
+                subject: collection.objects[slide],
+                attendableId: Obj.getURI(collection),
+              }}
             />
-          }
-        >
-          <Surface.Surface
-            type={AppSurface.Slide}
-            data={{
-              subject: collection.objects[slide],
-              attendableId: Obj.getURI(collection),
-            }}
-          />
-        </PresenterLayout>
+          </PresenterLayout>
+        </PresentationShell>
       </Panel.Content>
     </Panel.Root>
   );

--- a/packages/plugins/plugin-presenter/src/containers/CollectionPresenterArticle/CollectionPresenterArticle.tsx
+++ b/packages/plugins/plugin-presenter/src/containers/CollectionPresenterArticle/CollectionPresenterArticle.tsx
@@ -28,13 +28,7 @@ export const CollectionPresenterArticle = ({ role, subject: collection }: Collec
           <PresenterLayout
             bottomRight={<PageNumber index={slide} count={collection.objects.length} />}
             bottomLeft={
-              <Pager
-                index={slide}
-                count={collection.objects.length}
-                keys={running}
-                onChange={setSlide}
-                onExit={handleExit}
-              />
+              <Pager index={slide} count={collection.objects.length} keys={running} onChange={setSlide} />
             }
           >
             <Surface.Surface

--- a/packages/plugins/plugin-presenter/src/containers/CollectionPresenterArticle/CollectionPresenterArticle.tsx
+++ b/packages/plugins/plugin-presenter/src/containers/CollectionPresenterArticle/CollectionPresenterArticle.tsx
@@ -27,9 +27,7 @@ export const CollectionPresenterArticle = ({ role, subject: collection }: Collec
         <PresentationShell onExit={handleExit}>
           <PresenterLayout
             bottomRight={<PageNumber index={slide} count={collection.objects.length} />}
-            bottomLeft={
-              <Pager index={slide} count={collection.objects.length} keys={running} onChange={setSlide} />
-            }
+            bottomLeft={<Pager index={slide} count={collection.objects.length} keys={running} onChange={setSlide} />}
           >
             <Surface.Surface
               type={AppSurface.Slide}

--- a/packages/plugins/plugin-presenter/src/containers/DocumentPresenterContainer/DocumentPresenterContainer.tsx
+++ b/packages/plugins/plugin-presenter/src/containers/DocumentPresenterContainer/DocumentPresenterContainer.tsx
@@ -7,7 +7,7 @@ import React, { type FC } from 'react';
 import { type Markdown } from '@dxos/plugin-markdown';
 import { Panel } from '@dxos/react-ui';
 
-import { RevealPlayer } from '#components';
+import { PresentationShell, RevealPlayer } from '#components';
 
 import { useExitPresenter } from '../../useExitPresenter';
 
@@ -17,7 +17,9 @@ export const DocumentPresenterContainer: FC<{ document: Markdown.Document }> = (
   return (
     <Panel.Root classNames='relative'>
       <Panel.Content asChild>
-        <RevealPlayer content={document.content.target?.content ?? ''} onExit={handleExit} />
+        <PresentationShell onExit={handleExit}>
+          <RevealPlayer content={document.content.target?.content ?? ''} />
+        </PresentationShell>
       </Panel.Content>
     </Panel.Root>
   );

--- a/packages/plugins/plugin-presenter/src/operations/index.ts
+++ b/packages/plugins/plugin-presenter/src/operations/index.ts
@@ -1,0 +1,7 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { OperationHandlerSet } from '@dxos/compute';
+
+export const PresenterOperationHandlerSet = OperationHandlerSet.lazy(() => import('./toggle-presentation'));

--- a/packages/plugins/plugin-presenter/src/operations/toggle-presentation.ts
+++ b/packages/plugins/plugin-presenter/src/operations/toggle-presentation.ts
@@ -1,0 +1,58 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capabilities } from '@dxos/app-framework';
+import { LayoutOperation, getObjectPathFromObject, getSpacePath } from '@dxos/app-toolkit';
+import { Operation } from '@dxos/compute';
+import { Obj } from '@dxos/echo';
+import { DeckCapabilities, DeckOperation } from '@dxos/plugin-deck';
+import { linkedSegment } from '@dxos/react-ui-attention';
+
+import { PresenterOperation } from '#types';
+
+/**
+ * Enters or exits presentation for the given object. When `state` is omitted the
+ * current presentation state is toggled. Entering fullscreens the presenter companion;
+ * exiting reverts fullscreen and re-opens the source object.
+ */
+const handler: Operation.WithHandler<typeof PresenterOperation.TogglePresentation> =
+  PresenterOperation.TogglePresentation.pipe(
+    Operation.withHandler(
+      Effect.fnUntraced(function* ({ object, state }) {
+        const db = Obj.getDatabase(object);
+        if (!db) {
+          return;
+        }
+
+        const objectPath = getObjectPathFromObject(object);
+        const presenterId = `${objectPath}/${linkedSegment('presenter')}`;
+        const deckState = yield* Capabilities.getAtomValue(DeckCapabilities.State);
+        const deck = deckState.decks[deckState.activeDeck];
+        const presenting = Boolean(deck?.fullscreen && deck?.solo === presenterId);
+        const next = state ?? !presenting;
+
+        if (next) {
+          if (!deck?.fullscreen) {
+            yield* Operation.invoke(DeckOperation.Adjust, { type: 'solo--fullscreen' as const, id: presenterId });
+          }
+          yield* Operation.invoke(LayoutOperation.Open, {
+            subject: [presenterId],
+            workspace: getSpacePath(db.spaceId),
+          });
+        } else {
+          if (deck?.fullscreen) {
+            yield* Operation.invoke(DeckOperation.Adjust, { type: 'solo--fullscreen' as const, id: objectPath });
+          }
+          yield* Operation.invoke(LayoutOperation.Open, {
+            subject: [objectPath],
+            workspace: getSpacePath(db.spaceId),
+          });
+        }
+      }),
+    ),
+  );
+
+export default handler;

--- a/packages/plugins/plugin-presenter/src/types/PresenterOperation.ts
+++ b/packages/plugins/plugin-presenter/src/types/PresenterOperation.ts
@@ -6,6 +6,7 @@
 
 import * as Schema from 'effect/Schema';
 
+import { Capability } from '@dxos/app-framework';
 import { Operation } from '@dxos/compute';
 import { Collection, Type, DXN } from '@dxos/echo';
 import { Markdown } from '@dxos/plugin-markdown';
@@ -14,13 +15,13 @@ import { meta } from '#meta';
 
 const makeKey = (name: string) => DXN.make(`${meta.id}.operation.${name}`);
 
-// TODO(wittjosiah): This appears to be unused.
 export const TogglePresentation = Operation.make({
   meta: {
     key: makeKey('togglePresentation'),
     name: 'Toggle Presentation',
     icon: 'ph--presentation--regular',
   },
+  services: [Capability.Service],
   input: Schema.Struct({
     object: Schema.Union(Type.getSchema(Markdown.Document), Type.getSchema(Collection.Collection)),
     state: Schema.optional(Schema.Boolean),

--- a/packages/plugins/plugin-presenter/src/useExitPresenter.ts
+++ b/packages/plugins/plugin-presenter/src/useExitPresenter.ts
@@ -2,35 +2,22 @@
 // Copyright 2025 DXOS.org
 //
 
-import { useAtomValue } from '@effect-atom/atom-react';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
-import { useCapability, useOperationInvoker } from '@dxos/app-framework/ui';
-import { LayoutOperation, getObjectPathFromObject, getSpacePath } from '@dxos/app-toolkit';
-import { Obj } from '@dxos/echo';
-import { DeckCapabilities, DeckOperation } from '@dxos/plugin-deck';
+import { useOperationInvoker } from '@dxos/app-framework/ui';
 
+import { PresenterOperation } from '#types';
+
+/**
+ * Exits presentation for the given object. Delegates to the toggle operation so the
+ * fullscreen-revert and re-open run sequentially in a single handler — invoking them
+ * separately races, leaving the deck stuck in fullscreen.
+ */
 export const useExitPresenter = (object: any) => {
   const { invokePromise } = useOperationInvoker();
-  const stateAtom = useCapability(DeckCapabilities.State);
-  const state = useAtomValue(stateAtom);
 
-  // Compute deck from decks[activeDeck] since the getter doesn't survive spread operations.
-  const deck = useMemo(() => state.decks[state.activeDeck], [state.decks, state.activeDeck]);
-
-  return useCallback(() => {
-    const objectPath = getObjectPathFromObject(object);
-    const db = Obj.getDatabase(object);
-    if (deck?.fullscreen) {
-      void invokePromise(DeckOperation.Adjust, {
-        type: 'solo--fullscreen' as const,
-        id: objectPath,
-      });
-    }
-
-    return invokePromise(LayoutOperation.Open, {
-      subject: [objectPath],
-      workspace: db ? getSpacePath(db.spaceId) : undefined,
-    });
-  }, [invokePromise, object, deck]);
+  return useCallback(
+    () => invokePromise(PresenterOperation.TogglePresentation, { object, state: false }),
+    [invokePromise, object],
+  );
 };

--- a/packages/plugins/plugin-presenter/tsconfig.json
+++ b/packages/plugins/plugin-presenter/tsconfig.json
@@ -57,6 +57,9 @@
       "path": "../../ui/react-ui-form"
     },
     {
+      "path": "../../ui/ui-editor"
+    },
+    {
       "path": "../../ui/ui-theme"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12665,6 +12665,9 @@ importers:
 
   packages/plugins/plugin-presenter:
     dependencies:
+      '@codemirror/state':
+        specifier: 'catalog:'
+        version: 6.6.0
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -12704,6 +12707,9 @@ importers:
       '@dxos/react-ui-form':
         specifier: workspace:*
         version: link:../../ui/react-ui-form
+      '@dxos/ui-editor':
+        specifier: workspace:*
+        version: link:../../ui/ui-editor
       '@dxos/util':
         specifier: workspace:*
         version: link:../../common/util


### PR DESCRIPTION
## Summary

Improves the presenter-mode experience when entering from the article header menu (or via shortcut):

1. **Fade in/out** — the presentation fades in on enter and fades out on exit, rather than appearing/disappearing abruptly. Implemented via a new `PresentationShell` wrapper that applies an opacity transition.
2. **Single-ESC exit** — pressing ESC while presenting now returns directly to the app. Previously it dropped to fullscreen mode and required a second ESC. The shell captures ESC at the document **capture phase** and stops propagation so the deck's `DeckSoloMode` fullscreen handler no longer double-handles it.
3. **`[ESC]` caption** — a transient `[ESC]` hint is shown top-left for 3s on enter, then fades.
4. **Shift+Cmd+P from the Markdown editor** — the shortcut now toggles presentation while editing, contributed as a CodeMirror keymap via `MarkdownCapabilities.ExtensionProvider`. The global navtree `Keyboard` context (keyed on the attended id) doesn't match the editor, so the action's `keyBinding` alone never fired there.

## Why / notable changes

- The inline toggle logic in the app-graph builder was promoted into a real `TogglePresentation` **operation handler**, so the header-menu action, the keyboard shortcut, and the exit path all share one code path. `TogglePresentation` now declares `services: [Capability.Service]` (required to read deck state / invoke deck ops).
- Exit is routed through that single operation (`state: false`) so the un-fullscreen (`Adjust`) and re-open (`Open`) run **sequentially**. The previous `useExitPresenter` fired them as two concurrent `invokePromise` calls, which raced — `Open` read stale deck state and clobbered `Adjust`'s `fullscreen: false` back to `true`, leaving the deck stuck in fullscreen.
- `PresentationShell` guards its one-shot fade-then-exit with a `useRef` rather than inside a `setState` updater, because React dev StrictMode double-invokes updaters and would otherwise schedule (and fire) the exit twice — a second cause of the stuck-fullscreen behavior.

## Testing

- `moon run plugin-presenter:build lint test` — all green.
- Verified end-to-end in the running Composer app (Playwright): entering via both the **header "Present ⇧⌘P" menu** and the **Shift+Cmd+P** shortcut, the `[ESC]` caption appearing then fading, and a single ESC returning to the editor with `fullscreen: false` and the sidebar restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a markdown editor keyboard shortcut to toggle presentation mode.
  * Introduced a presenter shell experience with smooth fade-in/out transitions and a temporary “[ESC]” hint overlay.
* **Improvements**
  * Enhanced presentation exit handling with reliable Escape key behavior (including fullscreen).
  * Centralized slide exit flow for more consistent presenter stopping and reopening.
* **Bug Fixes**
  * Reduced cases where presentation mode could race or desync during rapid toggle/exit actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->