### PR TITLE
fix(echo-client): re-hydrate index query results when local objects load

### DIFF
--- a/packages/core/echo/echo-client/src/client/echo-client.ts
+++ b/packages/core/echo/echo-client/src/client/echo-client.ts
@@ -2,6 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
+import { type CleanupFn, Event } from '@dxos/async';
 import { type Context, ContextDisposedError, LifecycleState, Resource } from '@dxos/context';
 import type { Entity } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
@@ -14,7 +15,7 @@ import { type DataService } from '@dxos/protocols/proto/dxos/echo/service';
 import { HypergraphImpl } from '../hypergraph';
 import { DatabaseImpl } from '../proxy-db';
 import { QueueFactory } from '../queue';
-import { IndexQuerySourceProvider, type LoadObjectProps } from './index-query-source-provider';
+import { IndexQuerySourceProvider, type LoadObjectProps, type ObjectUpdate } from './index-query-source-provider';
 
 export type EchoClientProps = {};
 
@@ -67,6 +68,10 @@ export class EchoClient extends Resource {
 
   private _indexQuerySourceProvider: IndexQuerySourceProvider | undefined = undefined;
 
+  /** Aggregated local object-update signal across all databases, consumed by index query sources. */
+  private readonly _objectsUpdated = new Event<ObjectUpdate>();
+  private readonly _dbUpdateSubscriptions = new Map<SpaceId, CleanupFn>();
+
   constructor(_: EchoClientProps = {}) {
     super();
   }
@@ -105,6 +110,7 @@ export class EchoClient extends Resource {
       service: this._queryService,
       objectLoader: {
         loadObject: this._loadObjectFromDocument.bind(this),
+        updateEvent: this._objectsUpdated,
       },
       graph: this._graph,
     });
@@ -115,6 +121,10 @@ export class EchoClient extends Resource {
     if (this._indexQuerySourceProvider) {
       this._graph.unregisterQuerySourceProvider(this._indexQuerySourceProvider);
     }
+    for (const unsubscribe of this._dbUpdateSubscriptions.values()) {
+      unsubscribe();
+    }
+    this._dbUpdateSubscriptions.clear();
     for (const db of this._databases.values()) {
       this._graph._unregisterDatabase(db.spaceId);
       await db.close();
@@ -148,6 +158,16 @@ export class EchoClient extends Resource {
     });
     this._graph._registerDatabase(spaceId, db, owningObject);
     this._databases.set(spaceId, db);
+
+    // Forward this database's local object updates to the aggregated signal so reactive index
+    // sources can re-hydrate index hits once their documents become available locally.
+    this._dbUpdateSubscriptions.set(
+      spaceId,
+      db.coreDatabase._updateEvent.on((event) => {
+        this._objectsUpdated.emit({ spaceId, objectIds: event.itemsUpdated.map((item) => item.id) });
+      }),
+    );
+
     return db;
   }
 
@@ -187,6 +207,7 @@ export class EchoClient extends Resource {
         service: this._queryService,
         objectLoader: {
           loadObject: this._loadObjectFromDocument.bind(this),
+          updateEvent: this._objectsUpdated,
         },
         graph: this._graph,
       });

--- a/packages/core/echo/echo-client/src/client/index-query-source-provider.test.ts
+++ b/packages/core/echo/echo-client/src/client/index-query-source-provider.test.ts
@@ -4,18 +4,23 @@
 
 import { describe, expect, test } from 'vitest';
 
+import { Event } from '@dxos/async';
 import { Context } from '@dxos/context';
-import { type Hypergraph, Scope } from '@dxos/echo';
+import { type Entity, type Hypergraph, Scope } from '@dxos/echo';
 import { type QueryAST } from '@dxos/echo-protocol';
-import { DXN, SpaceId } from '@dxos/keys';
+import { DXN, EntityId, type SpaceId, SpaceId as SpaceIdNs } from '@dxos/keys';
 import { QueryReactivity, type QueryRequest, type QueryService } from '@dxos/protocols/proto/dxos/echo/query';
 
+import { type ObjectUpdate } from './index-query-source-provider';
 import { IndexQuerySource } from './index-query-source-provider';
 
 // Mock graph - only used for queue items which are not tested here.
 const mockGraph = {} as Hypergraph.Hypergraph;
 
-const makeQuery = (): QueryAST.Query => ({
+/** No-op update signal for tests that don't exercise re-hydration. */
+const noopUpdateEvent = new Event<ObjectUpdate>();
+
+const makeQuery = (spaceId: SpaceId = SpaceIdNs.random()): QueryAST.Query => ({
   type: 'from',
   query: {
     type: 'select',
@@ -27,7 +32,7 @@ const makeQuery = (): QueryAST.Query => ({
   },
   from: {
     _tag: 'scope',
-    scopes: [Scope.space({ id: SpaceId.random() })],
+    scopes: [Scope.space({ id: spaceId })],
   },
 });
 
@@ -51,6 +56,7 @@ describe('IndexQuerySource', () => {
       service,
       objectLoader: {
         loadObject: async () => undefined,
+        updateEvent: noopUpdateEvent,
       },
       graph: mockGraph,
     });
@@ -89,6 +95,7 @@ describe('IndexQuerySource', () => {
       service,
       objectLoader: {
         loadObject: async () => undefined,
+        updateEvent: noopUpdateEvent,
       },
       graph: mockGraph,
     });
@@ -104,5 +111,61 @@ describe('IndexQuerySource', () => {
     expect(results).toEqual([]);
     expect(calls).toHaveLength(1);
     expect(calls[0].reactivity).toBe(QueryReactivity.ONE_SHOT);
+  });
+
+  test('re-hydrates reactive results when a previously-unavailable object loads', async () => {
+    const spaceId = SpaceIdNs.random();
+    const objectId = EntityId.random();
+
+    // First host response references an object that isn't loadable yet (simulating a hydration
+    // timeout / unavailable document); a later object update makes it loadable.
+    // Fake entity at the loader boundary — only `id` is read by the source under test.
+    let loaded: Entity.Unknown | undefined;
+
+    let emit!: (results: any[]) => void;
+    const service = {
+      execQuery: (request: QueryRequest) => ({
+        subscribe: (next: any) => {
+          emit = (results) => next({ queryId: request.queryId, results });
+        },
+        close: async () => {},
+      }),
+    } as unknown as QueryService;
+
+    const updateEvent = new Event<ObjectUpdate>();
+    const source = new IndexQuerySource({
+      service,
+      objectLoader: {
+        loadObject: async () => loaded,
+        updateEvent,
+      },
+      graph: mockGraph,
+    });
+
+    const ctx = new Context();
+    const nextChanged = () =>
+      new Promise<void>((resolve) => {
+        source.changed.once(() => resolve());
+      });
+
+    const query = makeQuery(spaceId);
+    source.open();
+    source.update(query);
+
+    // Host returns the index hit, but the object can't be hydrated yet → empty results.
+    const settled = nextChanged();
+    emit([{ id: objectId, spaceId, rank: 0 } as any]);
+    await settled;
+    expect(source.getResults()).toEqual([]);
+
+    // The object's document loads locally; the update signal triggers re-hydration of the
+    // remembered host records without a new host response.
+    loaded = { id: objectId } as unknown as Entity.Unknown;
+    const rehydrated = nextChanged();
+    updateEvent.emit({ spaceId, objectIds: [objectId] });
+    await rehydrated;
+    expect(source.getResults().map((entry) => entry.id)).toEqual([objectId]);
+
+    void ctx.dispose();
   });
 });

--- a/packages/core/echo/echo-client/src/client/index-query-source-provider.ts
+++ b/packages/core/echo/echo-client/src/client/index-query-source-provider.ts
@@ -4,7 +4,7 @@
 
 import * as Array from 'effect/Array';
 
-import { Event, TimeoutError, asyncTimeout } from '@dxos/async';
+import { type CleanupFn, Event, type ReadOnlyEvent, TimeoutError, asyncTimeout } from '@dxos/async';
 import { type Stream } from '@dxos/codec-protobuf/stream';
 import { Context } from '@dxos/context';
 import { Entity, type Hypergraph, Obj, Query, type QueryResult } from '@dxos/echo';
@@ -31,8 +31,23 @@ export type LoadObjectProps = {
   documentId: string | undefined;
 };
 
+/**
+ * Notification that objects became available (or changed) in the local working set.
+ * Plumbed from `DatabaseImpl` update events so reactive index sources can re-hydrate.
+ */
+export type ObjectUpdate = {
+  spaceId: SpaceId;
+  objectIds: string[];
+};
+
 export interface ObjectLoader {
   loadObject(params: LoadObjectProps): Promise<Entity.Unknown | undefined>;
+
+  /**
+   * Fires when objects are added/updated locally. Lets reactive index results re-hydrate
+   * index hits that previously failed to load (e.g. timed out before their document arrived).
+   */
+  readonly updateEvent: ReadOnlyEvent<ObjectUpdate>;
 }
 
 export type IndexQueryProviderProps = {
@@ -77,15 +92,43 @@ export class IndexQuerySource implements QuerySource {
   private _stream?: Stream<QueryResponse>;
   private _open = false;
 
+  /**
+   * Raw records from the host's last reactive response. Retained so we can re-hydrate when the
+   * objects they reference finish loading locally (see {@link _onObjectsUpdated}).
+   */
+  private _lastRemoteResults?: readonly RemoteQueryResult[] = undefined;
+
+  /** queryId of the active reactive stream, kept for log correlation on update-driven re-hydration. */
+  private _reactiveQueryId?: number = undefined;
+
+  /** Context of the in-flight hydration pass; disposed on close so its results are dropped. */
+  private _hydrationCtx?: Context = undefined;
+
+  /** True while {@link _hydrateLoop} is running, so concurrent triggers coalesce instead of racing. */
+  private _hydrating = false;
+
+  /** Set when a new trigger arrives mid-pass, causing {@link _hydrateLoop} to run one more iteration. */
+  private _hydratePending = false;
+
+  /** Subscription to local object-load updates (plumbed from `DatabaseImpl`). */
+  private _updateSubscription?: CleanupFn = undefined;
+
   constructor(private readonly _params: IndexQuerySourceProps) {}
 
   open(): void {
     this._open = true;
+    this._updateSubscription = this._params.objectLoader.updateEvent.on((event) => this._onObjectsUpdated(event));
   }
 
   close(): void {
     this._open = false;
     this._results = undefined;
+    this._lastRemoteResults = undefined;
+    this._reactiveQueryId = undefined;
+    this._updateSubscription?.();
+    this._updateSubscription = undefined;
+    void this._hydrationCtx?.dispose().catch(() => {});
+    this._hydrationCtx = undefined;
     this._closeStream();
   }
 
@@ -96,7 +139,7 @@ export class IndexQuerySource implements QuerySource {
   async run(_ctx: Context, query: QueryAST.Query): Promise<QueryResult.EntityEntry[]> {
     this._query = query;
     return new Promise((resolve, reject) => {
-      this._queryIndex(query, QueryReactivity.ONE_SHOT, resolve, reject);
+      this._runOneShot(query, resolve, reject);
     });
   }
 
@@ -104,6 +147,11 @@ export class IndexQuerySource implements QuerySource {
     this._query = query;
 
     this._closeStream();
+    this._lastRemoteResults = undefined;
+    this._reactiveQueryId = undefined;
+    // Drop any in-flight hydration pass so it doesn't apply results for the previous query.
+    void this._hydrationCtx?.dispose().catch(() => {});
+    this._hydrationCtx = undefined;
     this._results = [];
     this.changed.emit();
 
@@ -113,112 +161,198 @@ export class IndexQuerySource implements QuerySource {
       return;
     }
 
-    this._queryIndex(query, QueryReactivity.REACTIVE, (results) => {
-      this._results = results;
-      this.changed.emit();
-    });
+    this._startReactive(query);
   }
 
-  private _queryIndex(
+  /** Single-use query: resolves with the first host response, then closes the stream. */
+  private _runOneShot(
     query: QueryAST.Query,
-    queryType: QueryReactivity,
-    onResult: (results: QueryResult.EntityEntry[]) => void,
-    onError?: (error: Error) => void,
+    resolve: (results: QueryResult.EntityEntry[]) => void,
+    reject: (error: Error) => void,
   ): void {
     const queryId = nextQueryId++;
-
     log('queryIndex', { queryId, query: Query.pretty(Query.fromAst(query)) });
     const start = Date.now();
-    let currentCtx: Context;
+    let settled = false;
 
     const stream = this._params.service.execQuery(
-      {
-        query: JSON.stringify(query),
-        queryId: String(queryId),
-        reactivity: queryType,
-      },
+      { query: JSON.stringify(query), queryId: String(queryId), reactivity: QueryReactivity.ONE_SHOT },
       { timeout: QUERY_SERVICE_TIMEOUT },
     );
-
-    if (queryType === QueryReactivity.REACTIVE) {
-      if (this._stream) {
-        log.warn('Query stream already open');
-      }
-      this._stream = stream;
-    }
 
     stream.subscribe(
       async (response) => {
         try {
-          const targetSpaces = getTargetSpacesForQuery(query);
-          if (targetSpaces.length > 0) {
-            invariant(
-              response.results?.every((r) => targetSpaces.includes(SpaceId.make(r.spaceId))),
-              'Result spaceId mismatch',
-            );
+          this._assertResultSpaces(query, response);
+          if (settled) {
+            return;
           }
-
-          if (queryType === QueryReactivity.ONE_SHOT) {
-            if (currentCtx) {
-              return;
-            }
-            void stream.close().catch(() => {});
-          }
-
-          await currentCtx?.dispose();
-          const ctx = new Context();
-          currentCtx = ctx;
-
-          log('queryIndex raw results', {
-            queryId,
-            query: Query.pretty(Query.fromAst(query)),
-            length: response.results?.length ?? 0,
-          });
-
-          const processedResults = await Promise.all(
-            (response.results ?? []).map((result) => this._filterMapResult(ctx, start, result)),
-          );
-          const results = processedResults.filter(isNonNullable);
-          const resultsWithNoSchema = results.filter((_) => _.result && !Entity.getType(_.result));
-          if (resultsWithNoSchema.length > 0) {
-            log.warn('unable to resolve schema for queried objects', {
-              count: resultsWithNoSchema.length,
-              types: Array.dedupe(results.map((_) => _.result && Entity.getTypeURI(_.result)?.toString())),
-            });
-          }
-
-          log('queryIndex processed results', {
-            queryId,
-            query: Query.pretty(Query.fromAst(query)),
-            fetchedFromIndex: response.results?.length ?? 0,
-            loaded: results.length,
-          });
-
-          if (currentCtx === ctx) {
-            onResult(results);
-          } else {
-            log.warn('results from the previous update are ignored', {
-              queryId,
-            });
-          }
+          settled = true;
+          void stream.close().catch(() => {});
+          const results = await this._mapRecords(new Context(), queryId, query, start, response.results ?? []);
+          resolve(results);
         } catch (err: any) {
-          if (onError) {
-            onError(err);
-          } else {
-            log.catch(err);
-          }
+          reject(err);
         }
       },
       (err) => {
         if (err != null) {
-          if (onError) {
-            onError(err);
-          } else if (!(err instanceof RpcClosedError)) {
-            log.catch(err);
-          }
+          reject(err);
         }
       },
     );
+  }
+
+  /** Reactive query: pushes results on every host response and remembers the raw records. */
+  private _startReactive(query: QueryAST.Query): void {
+    const queryId = nextQueryId++;
+    this._reactiveQueryId = queryId;
+    log('queryIndex', { queryId, query: Query.pretty(Query.fromAst(query)) });
+
+    const stream = this._params.service.execQuery(
+      { query: JSON.stringify(query), queryId: String(queryId), reactivity: QueryReactivity.REACTIVE },
+      { timeout: QUERY_SERVICE_TIMEOUT },
+    );
+
+    if (this._stream) {
+      log.warn('Query stream already open');
+    }
+    this._stream = stream;
+
+    stream.subscribe(
+      async (response) => {
+        try {
+          this._assertResultSpaces(query, response);
+          // Remember the raw host records so a later local object load can re-hydrate them.
+          this._lastRemoteResults = response.results ?? [];
+          this._scheduleHydrate();
+        } catch (err: any) {
+          log.catch(err);
+        }
+      },
+      (err) => {
+        if (err != null && !(err instanceof RpcClosedError)) {
+          log.catch(err);
+        }
+      },
+    );
+  }
+
+  /**
+   * Re-hydrate the remembered host records when a referenced object loads locally. This lets index
+   * hits that previously failed to load (e.g. timed out before their document arrived) appear once
+   * their documents become available, without waiting for a host-side index invalidation.
+   */
+  private _onObjectsUpdated(event: ObjectUpdate): void {
+    // Only reactive queries retain remembered records; one-shot results are not refreshed.
+    if (!this._open || this._query == null || this._reactiveQueryId == null) {
+      return;
+    }
+    const records = this._lastRemoteResults;
+    if (records == null || records.length === 0) {
+      return;
+    }
+
+    // Re-hydrate only when an updated object is among the records the host returned.
+    const updated = new Set(event.objectIds);
+    const affectsResults = records.some((record) => record.spaceId === event.spaceId && updated.has(record.id));
+    if (!affectsResults) {
+      return;
+    }
+
+    log('re-hydrating index results after object update', { queryId: this._reactiveQueryId, spaceId: event.spaceId });
+    this._scheduleHydrate();
+  }
+
+  /**
+   * Coalesce hydration triggers (stream responses and object updates) into a single serialized loop.
+   * Rapid bursts of update events would otherwise launch overlapping passes that supersede each other;
+   * instead we run one pass at a time and re-run once more if new triggers arrived while it was in flight.
+   */
+  private _scheduleHydrate(): void {
+    if (this._hydrating) {
+      this._hydratePending = true;
+      return;
+    }
+    void this._hydrateLoop();
+  }
+
+  /** Hydrate the latest remembered records, set `_results`, and emit — repeating while triggers arrive. */
+  private async _hydrateLoop(): Promise<void> {
+    this._hydrating = true;
+    try {
+      do {
+        this._hydratePending = false;
+
+        const query = this._query;
+        const queryId = this._reactiveQueryId;
+        if (!this._open || query == null || queryId == null) {
+          break;
+        }
+        const records = this._lastRemoteResults ?? [];
+
+        const ctx = new Context();
+        this._hydrationCtx = ctx;
+        const results = await this._mapRecords(ctx, queryId, query, Date.now(), records);
+
+        // Dropped if the source closed (or was re-opened with a new query) during hydration.
+        if (this._hydrationCtx !== ctx) {
+          return;
+        }
+
+        this._results = results;
+        this.changed.emit();
+      } while (this._hydratePending);
+    } catch (err: any) {
+      log.catch(err);
+    } finally {
+      this._hydrating = false;
+    }
+  }
+
+  /** Hydrate raw host records into query entries, dropping objects that fail to load or validate. */
+  private async _mapRecords(
+    ctx: Context,
+    queryId: number,
+    query: QueryAST.Query,
+    start: number,
+    records: readonly RemoteQueryResult[],
+  ): Promise<QueryResult.EntityEntry[]> {
+    log('queryIndex raw results', {
+      queryId,
+      query: Query.pretty(Query.fromAst(query)),
+      length: records.length,
+    });
+
+    const processedResults = await Promise.all(records.map((result) => this._filterMapResult(ctx, start, result)));
+    const results = processedResults.filter(isNonNullable);
+
+    const resultsWithNoSchema = results.filter((_) => _.result && !Entity.getType(_.result));
+    if (resultsWithNoSchema.length > 0) {
+      log.warn('unable to resolve schema for queried objects', {
+        count: resultsWithNoSchema.length,
+        types: Array.dedupe(results.map((_) => _.result && Entity.getTypeURI(_.result)?.toString())),
+      });
+    }
+
+    log('queryIndex processed results', {
+      queryId,
+      query: Query.pretty(Query.fromAst(query)),
+      fetchedFromIndex: records.length,
+      loaded: results.length,
+    });
+
+    return results;
+  }
+
+  private _assertResultSpaces(query: QueryAST.Query, response: QueryResponse): void {
+    const targetSpaces = getTargetSpacesForQuery(query);
+    if (targetSpaces.length > 0) {
+      invariant(
+        response.results?.every((r) => targetSpaces.includes(SpaceId.make(r.spaceId))),
+        'Result spaceId mismatch',
+      );
+    }
   }
 
   private async _filterMapResult(

--- a/packages/core/echo/echo-client/src/core-db/load-op.ts
+++ b/packages/core/echo/echo-client/src/core-db/load-op.ts
@@ -119,6 +119,27 @@ export class LoadOpTable {
   }
 
   /**
+   * Re-probe the working set for the cached op at `uri` (if any) and promote it to `ready` when the
+   * entity is now materialized. Lets a local materialization (e.g. `db.add`) heal an op that latched
+   * `requesting`/`unavailable` while the entity was absent: the working-set tier is the cheapest and
+   * authoritative, so a hit settles the op regardless of any in-flight higher-ceiling load (whose IO
+   * is cancelled). No-op when no op is cached for the URI — nothing is waiting on it.
+   */
+  refreshFromWorkingSet(uri: URI.URI): void {
+    const op = this.#ops.get(uri);
+    if (op == null || op.state === 'ready') {
+      return;
+    }
+    const probed = this._routeBackend(uri)?.probe(uri);
+    if (probed == null) {
+      return;
+    }
+    op.cancel?.();
+    op.cancel = undefined;
+    this.#set(op, 'ready', probed);
+  }
+
+  /**
    * Decrement the refcount; at zero, cancel IO and drop the op (does not evict the entity from its
    * backing store's working set).
    */

--- a/packages/core/echo/echo-client/src/core-db/strong-deps-stall.test.ts
+++ b/packages/core/echo/echo-client/src/core-db/strong-deps-stall.test.ts
@@ -362,4 +362,62 @@ describe('Query pipeline strong-dependency stalls', () => {
     // Well under the per-hit hydration timeout — no stall, no timeout-driven completion.
     expect(performance.now() - begin).toBeLessThan(1500);
   });
+
+  // The strong-dep closure resolves via cached, coalesced load ops that only probe the working set
+  // at acquire time. A dep that was absent (settled `unavailable`, or left `requesting` while a
+  // queue polled for replication) latched its op, so a LATER local materialization of that dep did
+  // not surface the dependent: nothing re-probed the working set. `HypergraphImpl._onUpdate` now
+  // re-probes cached ops on every local db update, healing the dependent without a fresh request.
+  test('a dependent surfaces once its absent strong dep is materialized locally', async () => {
+    const testBuilder = new EchoTestBuilder();
+    await openAndClose(testBuilder);
+    const { peer, db } = await testBuilder.createDatabase();
+
+    const mainObjectId = EntityId.random();
+    const depObjectId = EntityId.random();
+
+    const mainDocHandle = await peer.host.createDoc<DatabaseDirectory>({
+      version: SpaceDocVersion.CURRENT,
+      access: { spaceKey: db.spaceKey.toHex() },
+      objects: {
+        [mainObjectId]: {
+          meta: { keys: [] },
+          data: { title: 'main' },
+          system: { kind: 'object', type: { '/': EID.make({ entityId: depObjectId }) } },
+        },
+      },
+    });
+
+    // Link only main; the dep is absent from the directory, so its load op settles `unavailable`
+    // and main is omitted. This latches the cached op that the local materialization must heal.
+    const spaceRootHandle = db.coreDatabase._automergeDocLoader.getSpaceRootDocHandle();
+    spaceRootHandle.change((newDoc: DatabaseDirectory) => {
+      newDoc.links ??= {};
+      newDoc.links[mainObjectId] = new A.RawString(mainDocHandle.url);
+    });
+    await sleep(200);
+
+    const before = await asyncTimeout(db.coreDatabase.loadObjectCoreById(mainObjectId, { diskOnly: true }), 1000);
+    expect(before, 'main omitted while its strong dep is absent').toBeUndefined();
+
+    // Materialize the dep locally: plant its document and link it into the space root. The link
+    // change emits a local db update that must re-probe the cached (unavailable) dep op.
+    const depDocHandle = await peer.host.createDoc<DatabaseDirectory>({
+      version: SpaceDocVersion.CURRENT,
+      access: { spaceKey: db.spaceKey.toHex() },
+      objects: {
+        [depObjectId]: { meta: { keys: [] }, data: { name: 'dep' }, system: { kind: 'object' } },
+      },
+    });
+    spaceRootHandle.change((newDoc: DatabaseDirectory) => {
+      newDoc.links![depObjectId] = new A.RawString(depDocHandle.url);
+    });
+
+    // The local materialization heals the cached resolution, so main now surfaces.
+    await expect
+      .poll(async () => (await db.coreDatabase.loadObjectCoreById(mainObjectId, { diskOnly: true }))?.id, {
+        timeout: 5_000,
+      })
+      .toEqual(mainObjectId);
+  });
 });

--- a/packages/core/echo/echo-client/src/hypergraph.ts
+++ b/packages/core/echo/echo-client/src/hypergraph.ts
@@ -781,6 +781,14 @@ export class HypergraphImpl implements Hypergraph.Hypergraph {
   }
 
   private _onUpdate(updateEvent: ItemsUpdatedEvent): void {
+    // Heal resolution requests that latched `requesting`/`unavailable` before the object was
+    // materialized locally: re-probe the working set for any cached load op now that the object is
+    // present, so its dependents (e.g. index-query hydration gated on the strong-dep closure)
+    // recompute to `ready` instead of polling/timing out.
+    for (const item of updateEvent.itemsUpdated) {
+      this.#loadOpTable.refreshFromWorkingSet(EID.make({ spaceId: updateEvent.spaceId, entityId: item.id }));
+    }
+
     const listenerMap = this._resolveEvents.get(updateEvent.spaceId);
     if (listenerMap) {
       batchEvents(() => {


### PR DESCRIPTION
## Summary

Reactive **traversal** queries (`referencedBy` / `reference` / `Query.all(...)`) are served only by the host index — the local `SpaceQuerySource` handles only simple selections. So a matching object created locally surfaces only after the host re-indexes it and the client re-hydrates it from the index result.

That re-hydration could stall indefinitely. Hydration loads each index hit through the disk-only object loader, which gates surfacing on the object's **strong-dependency closure** being resolved. Strong-dep resolution uses coalesced, cached per-URI load ops that only probe the working set **at acquire time**. If a dependency was absent when its load op was first acquired (the normal race right after local creation, or a queue-backed ref that polls for replication), the op latched `requesting`/`unavailable` and was **never re-probed** once the dependency materialized locally. The dependent object therefore never surfaced and the per-hit index load timed out on every reactive poll (`index object load timed out`).

## Changes

- **Heal cached resolution on local materialization (root cause).**
  - Add `LoadOpTable.refreshFromWorkingSet(uri)` — re-probes the working set for a cached load op and promotes it to `ready` (cancelling any in-flight higher-ceiling IO) when the entity is now present.
  - Call it from `HypergraphImpl._onUpdate` for every locally-updated id, so a `db.add` of a dependency flips its op to `ready`, the dependent's `RefResolverRequest` recomputes, and the dependent surfaces — no fresh request needed.

- **Re-hydrate index query results on local object loads (self-heal at the query layer).**
  - Add an `updateEvent` to `ObjectLoader`, plumbed from each `DatabaseImpl`'s update events and aggregated by `EchoClient`.
  - `IndexQuerySource` remembers the last raw host records and, when a referenced object loads locally, re-runs hydration. Rapid update bursts are coalesced into a single serialized hydration pass (replacing the previous per-event passes that superseded each other and logged `results from the previous update are ignored`).

Together: the resolver layer flips the stuck dependency to `ready` and emits a db update; that update drives the index source to re-hydrate, so the previously-timed-out object now surfaces.

## Test plan

- [x] New regression test `a dependent surfaces once its absent strong dep is materialized locally` in `strong-deps-stall.test.ts` — **fails without the fix** (object stays omitted), passes with it.
- [x] New `IndexQuerySource` test for update-driven re-hydration of a previously-unavailable object.
- [x] `moon run echo-client:test` — 559 passing (was 558), no regressions, lints clean.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reactive index queries now automatically refresh and display results when previously unavailable objects become available locally.
  * Enhanced object update event aggregation across databases.

* **Bug Fixes**
  * Dependent objects now correctly surface when their strong dependencies materialize locally, resolving previous stalling issues.

* **Tests**
  * Added test coverage for dependent object materialization and reactive query re-hydration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->