### PR TITLE
fix(plugin-calls): use participant-scoped video state for remote tiles

### DIFF
--- a/packages/plugins/plugin-calls/src/components/Participant/Participant.tsx
+++ b/packages/plugins/plugin-calls/src/components/Participant/Participant.tsx
@@ -54,14 +54,21 @@ export const Participant = memo(({ item: user, debug, ...props }: ResponsiveGrid
     return pulledVideoStream;
   }, [isSelf, isScreenshare, localVideoStream, screenshareVideoStream, pulledVideoStream]);
 
+  // For self tiles use local media state; for remote tiles use the participant's swarm-reported state.
+  const participantVideo = isSelf
+    ? videoEnabled
+    : isScreenshare
+      ? Boolean(user.tracks?.screenshareEnabled)
+      : Boolean(user.tracks?.videoEnabled);
+
   return (
     <ResponsiveGridItem
       {...props}
       item={user}
       name={user.name}
       self={isSelf}
-      screenshare={!!screenshareVideoStream}
-      video={videoEnabled}
+      screenshare={isScreenshare && participantVideo}
+      video={participantVideo}
       mute={user ? !user.tracks?.audioEnabled : false}
       wave={user.raisedHand}
       speaking={user.speaking}

--- a/packages/plugins/plugin-calls/src/components/Participant/Participant.tsx
+++ b/packages/plugins/plugin-calls/src/components/Participant/Participant.tsx
@@ -25,15 +25,17 @@ export const Participant = memo(({ item: user, debug, ...props }: ResponsiveGrid
   const isScreenshare = user.id?.endsWith(SCREENSHARE_SUFFIX);
 
   // Track name to display for non-self users; undefined when no video should show.
+  // Guard on both the enabled flag and track-ID presence — a track may be enabled in state
+  // before the ID has been published to the swarm.
   const pulledTrackName = useMemo<EncodedTrackName | undefined>(() => {
     if (isSelf) {
       return undefined;
     }
-    if (isScreenshare && user.tracks?.screenshareEnabled) {
-      return user.tracks?.screenshare as EncodedTrackName;
+    if (isScreenshare && user.tracks?.screenshareEnabled && user.tracks?.screenshare) {
+      return user.tracks.screenshare as EncodedTrackName;
     }
-    if (!isScreenshare && user.tracks?.videoEnabled) {
-      return user.tracks?.video as EncodedTrackName;
+    if (!isScreenshare && user.tracks?.videoEnabled && user.tracks?.video) {
+      return user.tracks.video as EncodedTrackName;
     }
     return undefined;
   }, [
@@ -55,11 +57,15 @@ export const Participant = memo(({ item: user, debug, ...props }: ResponsiveGrid
   }, [isSelf, isScreenshare, localVideoStream, screenshareVideoStream, pulledVideoStream]);
 
   // For self tiles use local media state; for remote tiles use the participant's swarm-reported state.
+  // Self screenshare tiles gate on screenshareVideoStream, not camera state.
+  // Remote tiles require both the enabled flag and track-ID presence to stay consistent with pulledTrackName.
   const participantVideo = isSelf
-    ? videoEnabled
+    ? isScreenshare
+      ? Boolean(screenshareVideoStream)
+      : videoEnabled
     : isScreenshare
-      ? Boolean(user.tracks?.screenshareEnabled)
-      : Boolean(user.tracks?.videoEnabled);
+      ? Boolean(user.tracks?.screenshareEnabled && user.tracks?.screenshare)
+      : Boolean(user.tracks?.videoEnabled && user.tracks?.video);
 
   return (
     <ResponsiveGridItem


### PR DESCRIPTION
## Summary

Follow-up to #11855. Remote participant tiles were reading `videoEnabled` and `screenshareEnabled` state from the local user's media atoms, so every remote tile reflected the local user's camera/screenshare status instead of that participant's own state.

Compute `participantVideo` from the participant's swarm-reported `user.tracks` for remote tiles; self tiles continue to read from local atoms.

## Changes

- `Participant.tsx` — introduce `participantVideo` derived from `user.tracks?.videoEnabled` / `user.tracks?.screenshareEnabled` for remote participants; use it for both the `video` and `screenshare` props passed to `ResponsiveGridItem`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected participant tile video rendering so screenshare and camera visibility reflect the participant’s actual enabled state and available media tracks.
  * Improved logic for self vs. non-self tiles to prevent incorrect video/screen sharing indicators and ensure tiles update reliably as tracks start or stop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->