### PR TITLE
feat(echo-client): working-set query executor — full plan execution over in-memory docs

### DIFF
--- a/packages/core/echo/echo-client/package.json
+++ b/packages/core/echo/echo-client/package.json
@@ -46,6 +46,7 @@
     "@dxos/echo-protocol": "workspace:*",
     "@dxos/edge-client": "workspace:*",
     "@dxos/effect": "workspace:*",
+    "@dxos/index-core": "workspace:*",
     "@dxos/invariant": "workspace:*",
     "@dxos/keys": "workspace:*",
     "@dxos/kv-store": "workspace:*",

--- a/packages/core/echo/echo-client/src/query/graph-query-context.ts
+++ b/packages/core/echo/echo-client/src/query/graph-query-context.ts
@@ -8,7 +8,7 @@ import { Event, asyncTimeout } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { type Obj, Query, type QueryResult } from '@dxos/echo';
 import { filterMatchDoc } from '@dxos/echo-host/filter';
-import { QueryPlanner } from '@dxos/echo-host';
+import { QueryPlanner } from '@dxos/echo-host/query';
 import { QueryAST } from '@dxos/echo-protocol';
 import { type EntityId, type SpaceId } from '@dxos/keys';
 import { log } from '@dxos/log';
@@ -465,9 +465,11 @@ const WORKING_SET_NODE_TYPES = new Set<QueryAST.Query['type']>([
 ]);
 
 /**
- * Returns true when the query contains traversal, relation, union, or set-difference nodes.
- * These query types cannot be satisfied by the SQL index and require the working-set executor.
- * Limit and order nodes alone do not qualify — those are handled entirely by the SQL source.
+ * Returns true when the query contains traversal, relation, union, set-difference, or child-of
+ * filter nodes. These query types cannot be satisfied by the SQL index and require the working-set
+ * executor. Limit and order nodes alone do not qualify — those are handled entirely by the SQL source.
+ * Child-of filters have no traversal AST node — they appear as filter predicates — so they must
+ * be detected by visiting the filter tree directly.
  */
 const requiresWorkingSetExecutor = (query: QueryAST.Query): boolean => {
   let found = false;
@@ -475,6 +477,27 @@ const requiresWorkingSetExecutor = (query: QueryAST.Query): boolean => {
     if (WORKING_SET_NODE_TYPES.has(node.type)) {
       found = true;
     }
+    if ((node.type === 'filter' || node.type === 'select') && _filterContainsChildOf(node.filter)) {
+      found = true;
+    }
   });
   return found;
+};
+
+/**
+ * Returns true if the filter is or composes a child-of predicate.
+ * Child-of filters require in-memory parent-chain traversal which the SQL index cannot handle.
+ */
+const _filterContainsChildOf = (filter: QueryAST.Filter): boolean => {
+  switch (filter.type) {
+    case 'child-of':
+      return true;
+    case 'not':
+      return _filterContainsChildOf(filter.filter);
+    case 'and':
+    case 'or':
+      return filter.filters.some(_filterContainsChildOf);
+    default:
+      return false;
+  }
 };

--- a/packages/core/echo/echo-client/src/query/graph-query-context.ts
+++ b/packages/core/echo/echo-client/src/query/graph-query-context.ts
@@ -8,8 +8,9 @@ import { Event, asyncTimeout } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { type Obj, Query, type QueryResult } from '@dxos/echo';
 import { filterMatchDoc } from '@dxos/echo-host/filter';
+import { QueryPlanner } from '@dxos/echo-host';
 import { QueryAST } from '@dxos/echo-protocol';
-import { type EntityId } from '@dxos/keys';
+import { type EntityId, type SpaceId } from '@dxos/keys';
 import { log } from '@dxos/log';
 
 import { type ItemsUpdatedEvent, type ObjectCore } from '../core-db';
@@ -17,6 +18,7 @@ import { prohibitSignalActions } from '../guarded-scope';
 import { type DatabaseImpl } from '../proxy-db';
 import { type QueryContext } from './query-context';
 import { getTargetSpacesForQuery, isSimpleSelectionQuery } from './util';
+import { WorkingSetQueryExecutor, type WorkingSetDataProvider, type WorkingSetItem } from './working-set-executor';
 
 export type GraphQueryContextProps = {
   // TODO(dmaretskyi): Make async.
@@ -168,8 +170,21 @@ export class SpaceQuerySource implements QuerySource {
   private _ctx: Context = new Context();
   private _query: QueryAST.Query | undefined = undefined;
   private _results?: QueryResult.EntityEntry<Obj.Any>[] = undefined;
+  private readonly _executor: WorkingSetQueryExecutor;
+  private readonly _planner: QueryPlanner;
 
-  constructor(private readonly _database: DatabaseImpl) {}
+  constructor(private readonly _database: DatabaseImpl) {
+    const provider: WorkingSetDataProvider = {
+      get spaceId(): SpaceId {
+        return _database.spaceId;
+      },
+      allCores: () => _database.coreDatabase.allObjectCores(),
+      getCoreById: (id, load) => _database.coreDatabase.getObjectCoreById(id, { load: load ?? false }),
+      areStrongDepsSatisfied: (core) => _database.coreDatabase.areStrongDepsSatisfied(core),
+    };
+    this._executor = new WorkingSetQueryExecutor(provider);
+    this._planner = new QueryPlanner({ defaultTextSearchKind: 'full-text', noIndexes: true });
+  }
 
   get spaceId() {
     return this._database.spaceId;
@@ -192,24 +207,28 @@ export class SpaceQuerySource implements QuerySource {
     }
 
     prohibitSignalActions(() => {
+      // Results haven't been computed yet — no stale cache to invalidate.
+      if (!this._results) {
+        return;
+      }
+
       // TODO(dmaretskyi): Could be optimized to recompute changed only to the relevant space.
       const changed = updateEvent.itemsUpdated.some(({ id: objectId }) => {
-        const core = this._database.coreDatabase.getObjectCoreById(objectId, {
-          load: false,
-        });
-
-        const trivial = isSimpleSelectionQuery(this._query!);
-        if (!trivial || trivial.hasQueues) {
-          return false;
+        // If any updated object was in previous results, invalidate.
+        if (this._results!.find((result) => result.id === objectId)) {
+          return true;
         }
 
-        const { filter, options } = trivial;
+        // For simple queries, use the lightweight filter check for the newly-updated object.
+        const trivial = isSimpleSelectionQuery(this._query!);
+        if (trivial && !trivial.hasQueues) {
+          const core = this._database.coreDatabase.getObjectCoreById(objectId, { load: false });
+          return core != null && this._filterCore(core, trivial.filter, trivial.options);
+        }
 
-        return (
-          !this._results ||
-          this._results.find((result) => result.id === objectId) ||
-          (core && this._filterCore(core, filter, options))
-        );
+        // For complex queries (handled by executor), conservatively invalidate on any update.
+        // The next getResults() call will recompute via the executor.
+        return true;
       });
 
       if (changed) {
@@ -225,10 +244,25 @@ export class SpaceQuerySource implements QuerySource {
     }
 
     const simple = isSimpleSelectionQuery(query);
+
+    // For queries that contain traversals, unions, or set-difference nodes — structures that the
+    // SQL-backed source cannot handle — try the working-set executor. If it can satisfy the query
+    // entirely from in-memory cores, return those results; otherwise return empty.
+    if (requiresWorkingSetExecutor(query)) {
+      const executorResults = this._tryExecuteWithWorkingSet(query);
+      if (executorResults !== null) {
+        return executorResults.map((item) => this._mapItemToResult(item));
+      }
+      return [];
+    }
+
+    // Simple path returned null for non-traversal reasons (limit, order, etc.) — the SQL-backed
+    // source handles those entirely; this source has nothing to contribute.
     if (!simple || simple.hasQueues) {
       return [];
     }
 
+    // Simple selection path: load by id when needed, then scan the working set.
     const { filter, options } = simple;
     const results: QueryResult.EntityEntry<Obj.Any>[] = [];
     if (isObjectIdFilter(filter)) {
@@ -258,20 +292,37 @@ export class SpaceQuerySource implements QuerySource {
       return [];
     }
 
-    const trivial = isSimpleSelectionQuery(this._query);
-    if (!trivial || trivial.hasQueues) {
-      return [];
-    }
-
-    const { filter, options } = trivial;
-
     if (!this._results) {
       prohibitSignalActions(() => {
-        this._results = this._queryWorkingSet(filter, options);
+        this._results = this._computeResults(this._query!);
       });
     }
 
     return this._results!;
+  }
+
+  private _computeResults(query: QueryAST.Query): QueryResult.EntityEntry<Obj.Unknown>[] {
+    // For queries that contain traversals, unions, or set-difference nodes, the SQL-backed source
+    // cannot handle them — use the working-set executor instead.
+    if (requiresWorkingSetExecutor(query)) {
+      const executorResults = this._tryExecuteWithWorkingSet(query);
+      if (executorResults !== null) {
+        return executorResults.map((item) => this._mapItemToResult(item));
+      }
+      return [];
+    }
+
+    const trivial = isSimpleSelectionQuery(query);
+
+    // Non-traversal reasons for isSimpleSelectionQuery returning null (limit, order, etc.) —
+    // the SQL-backed source handles those; this source has nothing to contribute.
+    if (!trivial || trivial.hasQueues) {
+      return [];
+    }
+
+    // Simple selection path: scan the working set directly.
+    const { filter, options } = trivial;
+    return this._queryWorkingSet(filter, options);
   }
 
   update(query: QueryAST.Query): void {
@@ -305,6 +356,32 @@ export class SpaceQuerySource implements QuerySource {
       : this._database.coreDatabase.allObjectCores().filter((core) => this._filterCore(core, filter, options));
 
     return filteredCores.map((core) => this._mapCoreToResult(core));
+  }
+
+  /**
+   * Attempt to resolve a query entirely from the in-memory working set.
+   * Returns null when the plan requires SQL index capabilities.
+   */
+  private _tryExecuteWithWorkingSet(query: QueryAST.Query): WorkingSetItem[] | null {
+    try {
+      const plan = this._planner.createPlan(query);
+      return this._executor.tryExecute(plan);
+    } catch {
+      // Query planner threw (e.g. unsupported query shape). Fall back.
+      return null;
+    }
+  }
+
+  private _mapItemToResult(item: WorkingSetItem): QueryResult.EntityEntry<Obj.Unknown> {
+    return {
+      id: item.objectId,
+      result: this._database.getObjectById(item.objectId, { deleted: true }),
+      match: { rank: 1 },
+      resolution: {
+        source: 'local',
+        time: 0,
+      },
+    };
   }
 
   private _isValidSourceForQuery(query: QueryAST.Query): boolean {
@@ -371,4 +448,19 @@ const filterCoreByDeletedFlag = (core: ObjectCore, options: QueryAST.QueryOption
     case 'only':
       return core.isDeleted();
   }
+};
+
+/**
+ * Returns true when the query contains traversal, union, or set-difference nodes.
+ * These query types cannot be satisfied by the SQL index and require the working-set executor.
+ * Limit and order nodes alone do not qualify — those are handled entirely by the SQL source.
+ */
+const requiresWorkingSetExecutor = (query: QueryAST.Query): boolean => {
+  let found = false;
+  QueryAST.visit(query, (node) => {
+    if (node.type === 'traverse' || node.type === 'union' || node.type === 'set-difference') {
+      found = true;
+    }
+  });
+  return found;
 };

--- a/packages/core/echo/echo-client/src/query/graph-query-context.ts
+++ b/packages/core/echo/echo-client/src/query/graph-query-context.ts
@@ -451,14 +451,28 @@ const filterCoreByDeletedFlag = (core: ObjectCore, options: QueryAST.QueryOption
 };
 
 /**
- * Returns true when the query contains traversal, union, or set-difference nodes.
+ * Query node types whose shapes the SQL-backed source does not satisfy locally; the working-set
+ * executor handles them. Plain select/filter/limit/order queries stay on the SQL path.
+ */
+const WORKING_SET_NODE_TYPES = new Set<QueryAST.Query['type']>([
+  'reference-traversal',
+  'relation-traversal',
+  'hierarchy-traversal',
+  'incoming-references',
+  'relation',
+  'union',
+  'set-difference',
+]);
+
+/**
+ * Returns true when the query contains traversal, relation, union, or set-difference nodes.
  * These query types cannot be satisfied by the SQL index and require the working-set executor.
  * Limit and order nodes alone do not qualify — those are handled entirely by the SQL source.
  */
 const requiresWorkingSetExecutor = (query: QueryAST.Query): boolean => {
   let found = false;
   QueryAST.visit(query, (node) => {
-    if (node.type === 'traverse' || node.type === 'union' || node.type === 'set-difference') {
+    if (WORKING_SET_NODE_TYPES.has(node.type)) {
       found = true;
     }
   });

--- a/packages/core/echo/echo-client/src/query/index.ts
+++ b/packages/core/echo/echo-client/src/query/index.ts
@@ -8,3 +8,4 @@ export * from './query-result';
 export * from './query-result-cache';
 export * from './registry-query-source';
 export * from './util';
+export * from './working-set-executor';

--- a/packages/core/echo/echo-client/src/query/working-set-executor.test.ts
+++ b/packages/core/echo/echo-client/src/query/working-set-executor.test.ts
@@ -5,39 +5,12 @@
 import { afterEach, beforeEach, describe, test } from 'vitest';
 
 import { Filter, Obj, Order, Query, Ref, Relation } from '@dxos/echo';
-import { QueryPlanner } from '@dxos/echo-host';
+import { QueryPlanner } from '@dxos/echo-host/query';
 import { TestSchema } from '@dxos/echo/testing';
 
-import { type DatabaseImpl } from '../proxy-db';
+import { DatabaseImpl } from '../proxy-db';
 import { EchoTestBuilder } from '../testing';
 import { WorkingSetQueryExecutor, type WorkingSetDataProvider } from './working-set-executor';
-
-// ── Test layer ─────────────────────────────────────────────────────────────
-
-const makeNoIndexPlanner = () => new QueryPlanner({ defaultTextSearchKind: 'full-text', noIndexes: true });
-
-// The provider reaches the in-memory cores via `coreDatabase`, a getter only the concrete
-// `DatabaseImpl` exposes (not the public `EchoDatabase` interface).
-const makeProvider = (db: DatabaseImpl): WorkingSetDataProvider => ({
-  get spaceId() {
-    return db.spaceId;
-  },
-  allCores: () => db.coreDatabase.allObjectCores(),
-  getCoreById: (id, load) => db.coreDatabase.getObjectCoreById(id, { load: load ?? false }),
-  areStrongDepsSatisfied: (core) => db.coreDatabase.areStrongDepsSatisfied(core),
-});
-
-const makeExecutor = (db: DatabaseImpl) => new WorkingSetQueryExecutor(makeProvider(db));
-
-// ── Helpers ─────────────────────────────────────────────────────────────────
-
-const planAndExecute = (db: DatabaseImpl, query: Query.Query<any>) => {
-  const planner = makeNoIndexPlanner();
-  const executor = makeExecutor(db);
-  // All queries must be scoped; bind to the given database so the planner sees a from() clause.
-  const plan = planner.createPlan(query.from(db).ast);
-  return executor.tryExecute(plan);
-};
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
@@ -63,10 +36,8 @@ describe('WorkingSetQueryExecutor', () => {
     db.add(bob);
     await db.flush();
 
-    // Filter.everything() produces a wildcard filter.
     const results = planAndExecute(db, Query.select(Filter.everything()));
-    expect(results).not.toBeNull();
-    const ids = results!.map((item) => item.objectId);
+    const ids = results.map((item) => item.objectId);
     expect(ids).toContain(alice.id);
     expect(ids).toContain(bob.id);
   });
@@ -79,8 +50,7 @@ describe('WorkingSetQueryExecutor', () => {
     await db.flush();
 
     const results = planAndExecute(db, Query.select(Filter.type(TestSchema.Person)));
-    expect(results).not.toBeNull();
-    const ids = results!.map((item) => item.objectId);
+    const ids = results.map((item) => item.objectId);
     expect(ids).toContain(alice.id);
     expect(ids).not.toContain(task.id);
   });
@@ -93,8 +63,7 @@ describe('WorkingSetQueryExecutor', () => {
     await db.flush();
 
     const results = planAndExecute(db, Query.select(Filter.id(alice.id)));
-    expect(results).not.toBeNull();
-    expect(results!.map((item) => item.objectId)).toEqual([alice.id]);
+    expect(results.map((item) => item.objectId)).toEqual([alice.id]);
   });
 
   test('property filter matches correct objects', async ({ expect }) => {
@@ -105,8 +74,7 @@ describe('WorkingSetQueryExecutor', () => {
     await db.flush();
 
     const results = planAndExecute(db, Query.select(Filter.type(TestSchema.Person, { name: 'Alice' })));
-    expect(results).not.toBeNull();
-    const ids = results!.map((item) => item.objectId);
+    const ids = results.map((item) => item.objectId);
     expect(ids).toContain(alice.id);
     expect(ids).not.toContain(bob.id);
   });
@@ -140,8 +108,7 @@ describe('WorkingSetQueryExecutor', () => {
       db,
       Query.select(Filter.or(Filter.type(TestSchema.Person), Filter.type(TestSchema.Task))),
     );
-    expect(results).not.toBeNull();
-    const ids = results!.map((item) => item.objectId);
+    const ids = results.map((item) => item.objectId);
     expect(ids).toContain(alice.id);
     expect(ids).toContain(task.id);
   });
@@ -155,8 +122,7 @@ describe('WorkingSetQueryExecutor', () => {
 
     // Find the person that task.assignee points to.
     const results = planAndExecute(db, Query.select(Filter.type(TestSchema.Task)).reference('assignee'));
-    expect(results).not.toBeNull();
-    const ids = results!.map((item) => item.objectId);
+    const ids = results.map((item) => item.objectId);
     expect(ids).toContain(alice.id);
   });
 
@@ -169,8 +135,7 @@ describe('WorkingSetQueryExecutor', () => {
 
     // Find all objects that reference alice.
     const results = planAndExecute(db, Query.select(Filter.id(alice.id)).referencedBy());
-    expect(results).not.toBeNull();
-    const ids = results!.map((item) => item.objectId);
+    const ids = results.map((item) => item.objectId);
     expect(ids).toContain(task.id);
   });
 
@@ -180,8 +145,7 @@ describe('WorkingSetQueryExecutor', () => {
     await db.flush();
 
     const results = planAndExecute(db, Query.select(Filter.id(parent.id)).children());
-    expect(results).not.toBeNull();
-    const ids = results!.map((item) => item.objectId);
+    const ids = results.map((item) => item.objectId);
     expect(ids).toContain(child.id);
   });
 
@@ -216,8 +180,7 @@ describe('WorkingSetQueryExecutor', () => {
       db,
       Query.select(Filter.type(TestSchema.Person)).orderBy(Order.property('name', 'asc')),
     );
-    expect(results).not.toBeNull();
-    const personResults = results!.filter((item) => {
+    const personResults = results.filter((item) => {
       const data = item.core?.getObjectStructure().data;
       const name = data?.['name'];
       return name === 'Alice' || name === 'Bob' || name === 'Charlie';
@@ -233,8 +196,7 @@ describe('WorkingSetQueryExecutor', () => {
     await db.flush();
 
     const results = planAndExecute(db, Query.select(Filter.type(TestSchema.Person)).limit(3));
-    expect(results).not.toBeNull();
-    expect(results!.length).toBeLessThanOrEqual(3);
+    expect(results).toHaveLength(3);
   });
 
   test('TextSelector causes executor to return null', async ({ expect }) => {
@@ -272,21 +234,54 @@ describe('WorkingSetQueryExecutor', () => {
 
     // Find all relations where alice is the source.
     const results = planAndExecute(db, Query.select(Filter.id(alice.id)).sourceOf());
-    expect(results).not.toBeNull();
-    const ids = results!.map((item) => item.objectId);
+    const ids = results.map((item) => item.objectId);
     expect(ids).toContain(manages.id);
   });
 
   test('filter-deleted step filters out deleted objects', async ({ expect }) => {
     const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    const bob = Obj.make(TestSchema.Person, { name: 'Bob' });
     db.add(alice);
+    db.add(bob);
     await db.flush();
     db.remove(alice);
     await db.flush();
 
     const results = planAndExecute(db, Query.select(Filter.type(TestSchema.Person)));
-    expect(results).not.toBeNull();
-    const ids = results!.map((item) => item.objectId);
+    const ids = results.map((item) => item.objectId);
+    // Deleted alice must be excluded; non-deleted bob must be present.
     expect(ids).not.toContain(alice.id);
+    expect(ids).toContain(bob.id);
   });
 });
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const makeNoIndexPlanner = () => new QueryPlanner({ defaultTextSearchKind: 'full-text', noIndexes: true });
+
+const makeProvider = (db: DatabaseImpl): WorkingSetDataProvider => ({
+  get spaceId() {
+    return db.spaceId;
+  },
+  allCores: () => db.coreDatabase.allObjectCores(),
+  getCoreById: (id, load) => db.coreDatabase.getObjectCoreById(id, { load: load ?? false }),
+  areStrongDepsSatisfied: (core) => db.coreDatabase.areStrongDepsSatisfied(core),
+});
+
+const makeExecutor = (db: DatabaseImpl) => new WorkingSetQueryExecutor(makeProvider(db));
+
+/**
+ * Plans and executes a query against the given database.
+ * Throws if the executor cannot satisfy the plan (i.e. it returned null).
+ */
+const planAndExecute = (db: DatabaseImpl, query: Query.Query<any>) => {
+  const planner = makeNoIndexPlanner();
+  const executor = makeExecutor(db);
+  // All queries must be scoped; bind to the given database so the planner sees a from() clause.
+  const plan = planner.createPlan(query.from(db).ast);
+  const result = executor.tryExecute(plan);
+  if (result === null) {
+    throw new Error('WorkingSetQueryExecutor returned null — plan requires SQL index');
+  }
+  return result;
+};

--- a/packages/core/echo/echo-client/src/query/working-set-executor.test.ts
+++ b/packages/core/echo/echo-client/src/query/working-set-executor.test.ts
@@ -1,0 +1,290 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { afterEach, beforeEach, describe, test } from 'vitest';
+
+import { Filter, Obj, Order, Query, Ref, Relation } from '@dxos/echo';
+import { QueryPlanner } from '@dxos/echo-host';
+import { TestSchema } from '@dxos/echo/testing';
+
+import { type EchoDatabase } from '../proxy-db';
+import { EchoTestBuilder } from '../testing';
+import { WorkingSetQueryExecutor, type WorkingSetDataProvider } from './working-set-executor';
+
+// ── Test layer ─────────────────────────────────────────────────────────────
+
+const makeNoIndexPlanner = () => new QueryPlanner({ defaultTextSearchKind: 'full-text', noIndexes: true });
+
+const makeProvider = (db: EchoDatabase): WorkingSetDataProvider => ({
+  get spaceId() {
+    return db.spaceId;
+  },
+  allCores: () => db.coreDatabase.allObjectCores(),
+  getCoreById: (id, load) => db.coreDatabase.getObjectCoreById(id, { load: load ?? false }),
+  areStrongDepsSatisfied: (core) => db.coreDatabase.areStrongDepsSatisfied(core),
+});
+
+const makeExecutor = (db: EchoDatabase) => new WorkingSetQueryExecutor(makeProvider(db));
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const planAndExecute = (db: EchoDatabase, query: Query.Query<any>) => {
+  const planner = makeNoIndexPlanner();
+  const executor = makeExecutor(db);
+  // All queries must be scoped; bind to the given database so the planner sees a from() clause.
+  const plan = planner.createPlan(query.from(db).ast);
+  return executor.tryExecute(plan);
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('WorkingSetQueryExecutor', () => {
+  let builder: EchoTestBuilder;
+  let db: EchoDatabase;
+
+  beforeEach(async () => {
+    builder = new EchoTestBuilder();
+    await builder.open();
+    const peer = await builder.createPeer({ types: [TestSchema.Person, TestSchema.Task, TestSchema.HasManager] });
+    db = await peer.createDatabase();
+  });
+
+  afterEach(async () => {
+    await builder.close();
+  });
+
+  test('wildcard select returns all loaded cores', async ({ expect }) => {
+    const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    const bob = Obj.make(TestSchema.Person, { name: 'Bob' });
+    db.add(alice);
+    db.add(bob);
+    await db.flush();
+
+    // Filter.everything() produces a wildcard filter.
+    const results = planAndExecute(db, Query.select(Filter.everything()));
+    expect(results).not.toBeNull();
+    const ids = results!.map((item) => item.objectId);
+    expect(ids).toContain(alice.id);
+    expect(ids).toContain(bob.id);
+  });
+
+  test('type filter returns only objects of matching type', async ({ expect }) => {
+    const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    const task = Obj.make(TestSchema.Task, { title: 'Task 1' });
+    db.add(alice);
+    db.add(task);
+    await db.flush();
+
+    const results = planAndExecute(db, Query.select(Filter.type(TestSchema.Person)));
+    expect(results).not.toBeNull();
+    const ids = results!.map((item) => item.objectId);
+    expect(ids).toContain(alice.id);
+    expect(ids).not.toContain(task.id);
+  });
+
+  test('id filter returns the specific object', async ({ expect }) => {
+    const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    const bob = Obj.make(TestSchema.Person, { name: 'Bob' });
+    db.add(alice);
+    db.add(bob);
+    await db.flush();
+
+    const results = planAndExecute(db, Query.select(Filter.id(alice.id)));
+    expect(results).not.toBeNull();
+    expect(results!.map((item) => item.objectId)).toEqual([alice.id]);
+  });
+
+  test('property filter matches correct objects', async ({ expect }) => {
+    const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    const bob = Obj.make(TestSchema.Person, { name: 'Bob' });
+    db.add(alice);
+    db.add(bob);
+    await db.flush();
+
+    const results = planAndExecute(db, Query.select(Filter.type(TestSchema.Person, { name: 'Alice' })));
+    expect(results).not.toBeNull();
+    const ids = results!.map((item) => item.objectId);
+    expect(ids).toContain(alice.id);
+    expect(ids).not.toContain(bob.id);
+  });
+
+  test('set-difference (without) excludes matching objects', async ({ expect }) => {
+    const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    const bob = Obj.make(TestSchema.Person, { name: 'Bob' });
+    db.add(alice);
+    db.add(bob);
+    await db.flush();
+
+    // Query.without produces a SetDifferenceStep: all persons minus alice.
+    const all = Query.select(Filter.type(TestSchema.Person)).from(db);
+    const justAlice = Query.select(Filter.id(alice.id)).from(db);
+    const plan = makeNoIndexPlanner().createPlan(Query.without(all, justAlice).ast);
+    const results = makeExecutor(db).tryExecute(plan);
+    expect(results).not.toBeNull();
+    const ids = results!.map((item) => item.objectId);
+    expect(ids).not.toContain(alice.id);
+    expect(ids).toContain(bob.id);
+  });
+
+  test('OR filter (union of types) includes objects of either type', async ({ expect }) => {
+    const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    const task = Obj.make(TestSchema.Task, { title: 'Task 1' });
+    db.add(alice);
+    db.add(task);
+    await db.flush();
+
+    const results = planAndExecute(
+      db,
+      Query.select(Filter.or(Filter.type(TestSchema.Person), Filter.type(TestSchema.Task))),
+    );
+    expect(results).not.toBeNull();
+    const ids = results!.map((item) => item.objectId);
+    expect(ids).toContain(alice.id);
+    expect(ids).toContain(task.id);
+  });
+
+  test('outgoing reference traversal follows refs', async ({ expect }) => {
+    const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    const task = Obj.make(TestSchema.Task, { title: 'Task 1', assignee: Ref.make(alice) });
+    db.add(alice);
+    db.add(task);
+    await db.flush();
+
+    // Find the person that task.assignee points to.
+    const results = planAndExecute(db, Query.select(Filter.type(TestSchema.Task)).reference('assignee'));
+    expect(results).not.toBeNull();
+    const ids = results!.map((item) => item.objectId);
+    expect(ids).toContain(alice.id);
+  });
+
+  test('incoming reference traversal finds referencing objects', async ({ expect }) => {
+    const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    const task = Obj.make(TestSchema.Task, { title: 'Task 1', assignee: Ref.make(alice) });
+    db.add(alice);
+    db.add(task);
+    await db.flush();
+
+    // Find all objects that reference alice.
+    const results = planAndExecute(db, Query.select(Filter.id(alice.id)).referencedBy());
+    expect(results).not.toBeNull();
+    const ids = results!.map((item) => item.objectId);
+    expect(ids).toContain(task.id);
+  });
+
+  test('children traversal finds child objects', async ({ expect }) => {
+    const parent = db.add(Obj.make(TestSchema.Expando, { name: 'Parent' }));
+    const child = db.add(Obj.make(TestSchema.Expando, { [Obj.Parent]: parent, name: 'Child' }));
+    await db.flush();
+
+    const results = planAndExecute(db, Query.select(Filter.id(parent.id)).children());
+    expect(results).not.toBeNull();
+    const ids = results!.map((item) => item.objectId);
+    expect(ids).toContain(child.id);
+  });
+
+  test('union query (Query.all) combines results from multiple sub-queries', async ({ expect }) => {
+    const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    const task = Obj.make(TestSchema.Task, { title: 'Task 1' });
+    db.add(alice);
+    db.add(task);
+    await db.flush();
+
+    // Query.all produces a UnionStep over the given sub-queries.
+    const persons = Query.select(Filter.type(TestSchema.Person)).from(db);
+    const tasks = Query.select(Filter.type(TestSchema.Task)).from(db);
+    const plan = makeNoIndexPlanner().createPlan(Query.all(persons, tasks).ast);
+    const results = makeExecutor(db).tryExecute(plan);
+    expect(results).not.toBeNull();
+    const ids = results!.map((item) => item.objectId);
+    expect(ids).toContain(alice.id);
+    expect(ids).toContain(task.id);
+  });
+
+  test('order by property sorts results', async ({ expect }) => {
+    const charlie = Obj.make(TestSchema.Person, { name: 'Charlie' });
+    const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    const bob = Obj.make(TestSchema.Person, { name: 'Bob' });
+    db.add(charlie);
+    db.add(alice);
+    db.add(bob);
+    await db.flush();
+
+    const results = planAndExecute(
+      db,
+      Query.select(Filter.type(TestSchema.Person)).orderBy(Order.property('name', 'asc')),
+    );
+    expect(results).not.toBeNull();
+    const personResults = results!.filter((item) => {
+      const data = item.core?.getObjectStructure().data;
+      const name = data?.['name'];
+      return name === 'Alice' || name === 'Bob' || name === 'Charlie';
+    });
+    const names = personResults.map((item) => item.core!.getObjectStructure().data['name']);
+    expect(names).toEqual(['Alice', 'Bob', 'Charlie']);
+  });
+
+  test('limit step caps the result count', async ({ expect }) => {
+    for (let idx = 0; idx < 5; idx++) {
+      db.add(Obj.make(TestSchema.Person, { name: `Person ${idx}` }));
+    }
+    await db.flush();
+
+    const results = planAndExecute(db, Query.select(Filter.type(TestSchema.Person)).limit(3));
+    expect(results).not.toBeNull();
+    expect(results!.length).toBeLessThanOrEqual(3);
+  });
+
+  test('TextSelector causes executor to return null', async ({ expect }) => {
+    const planner = makeNoIndexPlanner();
+    const executor = makeExecutor(db);
+    const query = Query.select(Filter.text('foo')).from(db);
+    const plan = planner.createPlan(query.ast);
+    const results = executor.tryExecute(plan);
+    // TextSelector requires SQL index — executor must bail.
+    expect(results).toBeNull();
+  });
+
+  test('TimestampSelector (updated) causes executor to return null', async ({ expect }) => {
+    const planner = makeNoIndexPlanner();
+    const executor = makeExecutor(db);
+    const query = Query.select(Filter.updated({ after: new Date(0) })).from(db);
+    const plan = planner.createPlan(query.ast);
+    const results = executor.tryExecute(plan);
+    // TimestampSelector requires SQL index — executor must bail.
+    expect(results).toBeNull();
+  });
+
+  test('relation source-to-relation traversal', async ({ expect }) => {
+    const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    const bob = Obj.make(TestSchema.Person, { name: 'Bob' });
+    db.add(alice);
+    db.add(bob);
+
+    const manages = Relation.make(TestSchema.HasManager, {
+      [Relation.Source]: alice,
+      [Relation.Target]: bob,
+    });
+    db.add(manages);
+    await db.flush();
+
+    // Find all relations where alice is the source.
+    const results = planAndExecute(db, Query.select(Filter.id(alice.id)).sourceOf());
+    expect(results).not.toBeNull();
+    const ids = results!.map((item) => item.objectId);
+    expect(ids).toContain(manages.id);
+  });
+
+  test('filter-deleted step filters out deleted objects', async ({ expect }) => {
+    const alice = Obj.make(TestSchema.Person, { name: 'Alice' });
+    db.add(alice);
+    await db.flush();
+    db.remove(alice);
+    await db.flush();
+
+    const results = planAndExecute(db, Query.select(Filter.type(TestSchema.Person)));
+    expect(results).not.toBeNull();
+    const ids = results!.map((item) => item.objectId);
+    expect(ids).not.toContain(alice.id);
+  });
+});

--- a/packages/core/echo/echo-client/src/query/working-set-executor.test.ts
+++ b/packages/core/echo/echo-client/src/query/working-set-executor.test.ts
@@ -8,7 +8,7 @@ import { Filter, Obj, Order, Query, Ref, Relation } from '@dxos/echo';
 import { QueryPlanner } from '@dxos/echo-host';
 import { TestSchema } from '@dxos/echo/testing';
 
-import { type EchoDatabase } from '../proxy-db';
+import { type DatabaseImpl } from '../proxy-db';
 import { EchoTestBuilder } from '../testing';
 import { WorkingSetQueryExecutor, type WorkingSetDataProvider } from './working-set-executor';
 
@@ -16,7 +16,9 @@ import { WorkingSetQueryExecutor, type WorkingSetDataProvider } from './working-
 
 const makeNoIndexPlanner = () => new QueryPlanner({ defaultTextSearchKind: 'full-text', noIndexes: true });
 
-const makeProvider = (db: EchoDatabase): WorkingSetDataProvider => ({
+// The provider reaches the in-memory cores via `coreDatabase`, a getter only the concrete
+// `DatabaseImpl` exposes (not the public `EchoDatabase` interface).
+const makeProvider = (db: DatabaseImpl): WorkingSetDataProvider => ({
   get spaceId() {
     return db.spaceId;
   },
@@ -25,11 +27,11 @@ const makeProvider = (db: EchoDatabase): WorkingSetDataProvider => ({
   areStrongDepsSatisfied: (core) => db.coreDatabase.areStrongDepsSatisfied(core),
 });
 
-const makeExecutor = (db: EchoDatabase) => new WorkingSetQueryExecutor(makeProvider(db));
+const makeExecutor = (db: DatabaseImpl) => new WorkingSetQueryExecutor(makeProvider(db));
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-const planAndExecute = (db: EchoDatabase, query: Query.Query<any>) => {
+const planAndExecute = (db: DatabaseImpl, query: Query.Query<any>) => {
   const planner = makeNoIndexPlanner();
   const executor = makeExecutor(db);
   // All queries must be scoped; bind to the given database so the planner sees a from() clause.
@@ -41,7 +43,7 @@ const planAndExecute = (db: EchoDatabase, query: Query.Query<any>) => {
 
 describe('WorkingSetQueryExecutor', () => {
   let builder: EchoTestBuilder;
-  let db: EchoDatabase;
+  let db: DatabaseImpl;
 
   beforeEach(async () => {
     builder = new EchoTestBuilder();

--- a/packages/core/echo/echo-client/src/query/working-set-executor.ts
+++ b/packages/core/echo/echo-client/src/query/working-set-executor.ts
@@ -3,7 +3,8 @@
 //
 
 import { type Obj } from '@dxos/echo';
-import { filterMatchDoc, filterMatchObjectJSON, type QueryPlan } from '@dxos/echo-host';
+import { filterMatchDoc, filterMatchObjectJSON } from '@dxos/echo-host/filter';
+import { type QueryPlan } from '@dxos/echo-host/query';
 import {
   EncodedReference,
   EntityStructure,

--- a/packages/core/echo/echo-client/src/query/working-set-executor.ts
+++ b/packages/core/echo/echo-client/src/query/working-set-executor.ts
@@ -1,0 +1,639 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type Obj } from '@dxos/echo';
+import { filterMatchDoc, filterMatchObjectJSON, type QueryPlan } from '@dxos/echo-host';
+import {
+  EncodedReference,
+  EntityStructure,
+  type EntityPropPath,
+  type QueryAST,
+  isEncodedReference,
+} from '@dxos/echo-protocol';
+import { ATTR_PARENT, ATTR_RELATION_SOURCE, ATTR_RELATION_TARGET } from '@dxos/echo/internal';
+import { EscapedPropPath } from '@dxos/index-core';
+import { EID, type EntityId, type SpaceId } from '@dxos/keys';
+import { getDeep, isNonNullable, visitValues } from '@dxos/util';
+
+import type { ObjectCore } from '../core-db';
+
+export type WorkingSetItem = {
+  objectId: EntityId;
+  spaceId: SpaceId;
+  queueId: EntityId | null;
+  queueNamespace: string | null;
+  /** Automerge-backed object core. */
+  core: ObjectCore | null;
+  /** Feed/queue JSON payload. */
+  data: Obj.JSON | null;
+};
+
+const WorkingSetItem = Object.freeze({
+  isDeleted(item: WorkingSetItem): boolean {
+    if (item.core) {
+      return item.core.isDeleted();
+    }
+    if (item.data) {
+      return item.data['@deleted'] === true;
+    }
+    return false;
+  },
+
+  getProperty(item: WorkingSetItem, property: EntityPropPath): unknown {
+    if (item.core) {
+      return getDeep(item.core.getObjectStructure().data, property);
+    }
+    if (item.data) {
+      return getDeep(item.data, property);
+    }
+    return undefined;
+  },
+
+  getParentEid(item: WorkingSetItem): EID.EID | undefined {
+    let raw: string | undefined;
+    if (item.core) {
+      raw = EntityStructure.getParent(item.core.getObjectStructure())?.['/'];
+    } else if (item.data) {
+      raw = item.data[ATTR_PARENT];
+    }
+    return raw !== undefined ? EID.tryParse(raw) : undefined;
+  },
+});
+
+export type WorkingSetDataProvider = {
+  spaceId: SpaceId;
+  allCores(): ObjectCore[];
+  getCoreById(id: EntityId, load?: boolean): ObjectCore | undefined;
+  areStrongDepsSatisfied(core: ObjectCore): boolean;
+  /** Optional: enumerate locally-cached feed items for the given queue IDs. */
+  getFeedItems?: (queueIds: EntityId[]) => WorkingSetFeedItem[];
+};
+
+export type WorkingSetFeedItem = {
+  objectId: EntityId;
+  spaceId: SpaceId;
+  queueId: EntityId;
+  queueNamespace: string | null;
+  data: Obj.JSON;
+};
+
+/**
+ * Executes a QueryPlan against the client-side in-memory working set.
+ * No SQL index access — all selection is done by scanning loaded cores.
+ * Returns null when the plan requires index capabilities (TextSelector, TimestampSelector).
+ */
+export class WorkingSetQueryExecutor {
+  constructor(private readonly _provider: WorkingSetDataProvider) {}
+
+  /**
+   * Try to execute the plan against the in-memory working set.
+   * Returns null if the plan requires SQL index access.
+   */
+  tryExecute(plan: QueryPlan.Plan): WorkingSetItem[] | null {
+    return this._execPlan(plan, []);
+  }
+
+  private _execPlan(plan: QueryPlan.Plan, ws: WorkingSetItem[]): WorkingSetItem[] | null {
+    for (const step of plan.steps) {
+      const result = this._execStep(step, ws);
+      if (result === null) {
+        return null;
+      }
+      ws = result;
+    }
+    return ws;
+  }
+
+  private _execStep(step: QueryPlan.Step, ws: WorkingSetItem[]): WorkingSetItem[] | null {
+    switch (step._tag) {
+      case 'ClearWorkingSetStep':
+        return [];
+      case 'SelectStep':
+        return this._execSelectStep(step, ws);
+      case 'FilterStep':
+        return this._execFilterStep(step, ws);
+      case 'FilterDeletedStep':
+        return this._execFilterDeletedStep(step, ws);
+      case 'TraverseStep':
+        return this._execTraverseStep(step, ws);
+      case 'UnionStep':
+        return this._execUnionStep(step, ws);
+      case 'SetDifferenceStep':
+        return this._execSetDifferenceStep(step, ws);
+      case 'OrderStep':
+        return this._execOrderStep(step, ws);
+      case 'LimitStep':
+        return ws.slice(0, step.limit);
+      default:
+        return null;
+    }
+  }
+
+  private _execSelectStep(step: QueryPlan.SelectStep, ws: WorkingSetItem[]): WorkingSetItem[] | null {
+    // TextSelector and TimestampSelector require index — bail out.
+    if (step.selector._tag === 'TextSelector' || step.selector._tag === 'TimestampSelector') {
+      return null;
+    }
+
+    // Check if this scope includes our space.
+    const spaceScopes = step.scope.filter((scope): scope is QueryAST.SpaceScope => scope._tag === 'space');
+    const feedScopes = step.scope.filter((scope): scope is QueryAST.FeedScope => scope._tag === 'feed');
+
+    const scopeIncludesOurSpace =
+      spaceScopes.length === 0 ||
+      spaceScopes.some(
+        // SpaceScope.spaceId is a plain string from the schema AST; SpaceId is a branded type
+        // in this package. Both carry the same runtime value — the cast is the boundary.
+        (scope) => scope.spaceId === undefined || (scope.spaceId as SpaceId) === this._provider.spaceId,
+      );
+
+    const newItems: WorkingSetItem[] = [...ws];
+
+    if (scopeIncludesOurSpace) {
+      switch (step.selector._tag) {
+        case 'WildcardSelector':
+        case 'TypeSelector': {
+          // Enumerate all loaded cores; FilterStep enforces any type predicate.
+          const cores = this._provider.allCores().filter((core) => this._provider.areStrongDepsSatisfied(core));
+          newItems.push(...cores.map((core) => this._coreToItem(core)));
+          break;
+        }
+        case 'IdSelector': {
+          for (const id of step.selector.objectIds) {
+            const core = this._provider.getCoreById(id, true);
+            if (core && this._provider.areStrongDepsSatisfied(core)) {
+              newItems.push(this._coreToItem(core));
+            }
+          }
+          break;
+        }
+      }
+    }
+
+    // Feed items for explicit feed scopes.
+    if (feedScopes.length > 0 && this._provider.getFeedItems) {
+      const queueIds = feedScopes
+        .map((scope) => {
+          const eid = EID.tryParse(String(scope.feedUri));
+          return eid ? EID.getEntityId(eid) : null;
+        })
+        .filter(isNonNullable);
+      const feedItems = this._provider.getFeedItems(queueIds);
+      newItems.push(
+        ...feedItems.map(
+          (feedItem): WorkingSetItem => ({
+            objectId: feedItem.objectId,
+            spaceId: feedItem.spaceId,
+            queueId: feedItem.queueId,
+            queueNamespace: feedItem.queueNamespace,
+            core: null,
+            data: feedItem.data,
+          }),
+        ),
+      );
+    }
+
+    // Deduplicate by objectId.
+    const seen = new Set<EntityId>();
+    const deduped = newItems.filter((item) => {
+      if (seen.has(item.objectId)) {
+        return false;
+      }
+      seen.add(item.objectId);
+      return true;
+    });
+
+    return step.limit !== undefined ? deduped.slice(0, step.limit) : deduped;
+  }
+
+  private _execFilterStep(step: QueryPlan.FilterStep, ws: WorkingSetItem[]): WorkingSetItem[] | null {
+    // child-of filter requires transitive parent traversal against in-memory objects.
+    if (step.filter.type === 'child-of') {
+      return this._execChildOfFilterStep(step.filter, ws);
+    }
+
+    // Timestamp filter requires index — bail.
+    if (_filterContainsTimestamp(step.filter)) {
+      return null;
+    }
+
+    return ws.filter((item) => {
+      if (item.core) {
+        return filterMatchDoc(step.filter, {
+          id: item.objectId,
+          doc: item.core.getObjectStructure(),
+          spaceId: item.spaceId,
+        });
+      }
+      if (item.data) {
+        return filterMatchObjectJSON(step.filter, item.data);
+      }
+      return false;
+    });
+  }
+
+  private _execChildOfFilterStep(filter: QueryAST.FilterChildOf, ws: WorkingSetItem[]): WorkingSetItem[] | null {
+    const parentObjectIds = new Set<EntityId>();
+    for (const parentDxnStr of filter.parents) {
+      const echoUri = EID.tryParse(parentDxnStr);
+      if (echoUri) {
+        const objectId = EID.getEntityId(echoUri);
+        if (objectId) {
+          parentObjectIds.add(objectId);
+        }
+      }
+    }
+
+    const maxDepth = filter.transitive ? MAX_DEPTH_FOR_CHILD_OF_TRACING : 1;
+
+    return ws.filter((item) => this._isChildOfAny(item, parentObjectIds, maxDepth));
+  }
+
+  private _isChildOfAny(item: WorkingSetItem, parentObjectIds: Set<EntityId>, remainingDepth: number): boolean {
+    if (remainingDepth <= 0) {
+      return false;
+    }
+
+    const parentEid = WorkingSetItem.getParentEid(item);
+    if (!parentEid) {
+      return false;
+    }
+
+    const parentId = EID.getEntityId(parentEid);
+    if (!parentId) {
+      return false;
+    }
+
+    if (parentObjectIds.has(parentId)) {
+      return true;
+    }
+
+    // Recurse up the parent chain.
+    const parentCore = this._provider.getCoreById(parentId);
+    if (!parentCore) {
+      return false;
+    }
+    return this._isChildOfAny(this._coreToItem(parentCore), parentObjectIds, remainingDepth - 1);
+  }
+
+  private _execFilterDeletedStep(step: QueryPlan.FilterDeletedStep, ws: WorkingSetItem[]): WorkingSetItem[] | null {
+    const expected = step.mode === 'only-deleted';
+    return ws.filter((item) => WorkingSetItem.isDeleted(item) === expected);
+  }
+
+  private _execTraverseStep(step: QueryPlan.TraverseStep, ws: WorkingSetItem[]): WorkingSetItem[] | null {
+    switch (step.traversal._tag) {
+      case 'ReferenceTraversal':
+        return this._execReferenceTraversal(step.traversal, ws);
+      case 'RelationTraversal':
+        return this._execRelationTraversal(step.traversal, ws);
+      case 'HierarchyTraversal':
+        return this._execHierarchyTraversal(step.traversal, ws);
+      default:
+        return null;
+    }
+  }
+
+  private _execReferenceTraversal(traversal: QueryPlan.ReferenceTraversal, ws: WorkingSetItem[]): WorkingSetItem[] {
+    if (traversal.direction === 'outgoing') {
+      const result: WorkingSetItem[] = [];
+      for (const item of ws) {
+        const refs = this._collectOutgoingRefs(item, traversal.property);
+        for (const ref of refs) {
+          const eid = EID.tryParse(EncodedReference.toURI(ref));
+          if (!eid) {
+            continue;
+          }
+          const id = EID.getEntityId(eid);
+          if (!id) {
+            continue;
+          }
+          const core = this._provider.getCoreById(id);
+          if (core) {
+            result.push(this._coreToItem(core));
+          }
+        }
+      }
+      return result;
+    } else {
+      // Incoming references: scan all loaded cores for those referencing any ws item.
+      const wsIds = new Set(ws.map((item) => item.objectId));
+      const result: WorkingSetItem[] = [];
+      for (const core of this._provider.allCores()) {
+        const structure = core.getObjectStructure();
+        if (_structureReferencesAny(structure, wsIds, traversal.property)) {
+          result.push(this._coreToItem(core));
+        }
+      }
+      return result;
+    }
+  }
+
+  private _collectOutgoingRefs(item: WorkingSetItem, property: EscapedPropPath | null): EncodedReference[] {
+    if (item.core) {
+      const structure = item.core.getObjectStructure();
+      if (property !== null) {
+        // Collect refs at specified property path only.
+        const path = EscapedPropPath.unescape(property);
+        const value = getDeep(structure.data, path);
+        const refs: EncodedReference[] = [];
+        if (isEncodedReference(value)) {
+          refs.push(value);
+        } else if (Array.isArray(value)) {
+          for (const element of value) {
+            if (isEncodedReference(element)) {
+              refs.push(element);
+            }
+          }
+        }
+        return refs;
+      } else {
+        // Collect all outgoing refs.
+        return EntityStructure.getAllOutgoingReferences(structure).map((refEntry) => refEntry.reference);
+      }
+    }
+    return [];
+  }
+
+  private _execRelationTraversal(traversal: QueryPlan.RelationTraversal, ws: WorkingSetItem[]): WorkingSetItem[] {
+    const all = this._provider.allCores();
+
+    switch (traversal.direction) {
+      case 'relation-to-source':
+      case 'relation-to-target': {
+        const result: WorkingSetItem[] = [];
+        for (const item of ws) {
+          let raw: string | undefined;
+          if (item.core) {
+            const ref =
+              traversal.direction === 'relation-to-source'
+                ? EntityStructure.getRelationSource(item.core.getObjectStructure())
+                : EntityStructure.getRelationTarget(item.core.getObjectStructure());
+            raw = ref?.['/'];
+          } else if (item.data) {
+            raw =
+              traversal.direction === 'relation-to-source'
+                ? (item.data[ATTR_RELATION_SOURCE] as string | undefined)
+                : (item.data[ATTR_RELATION_TARGET] as string | undefined);
+          }
+          if (!raw) {
+            continue;
+          }
+          const eid = EID.tryParse(raw);
+          if (!eid) {
+            continue;
+          }
+          const id = EID.getEntityId(eid);
+          if (!id) {
+            continue;
+          }
+          const core = this._provider.getCoreById(id);
+          if (core) {
+            result.push(this._coreToItem(core));
+          }
+        }
+        return result;
+      }
+
+      case 'source-to-relation':
+      case 'target-to-relation': {
+        const wsIds = new Set(ws.map((item) => item.objectId));
+        const result: WorkingSetItem[] = [];
+        for (const core of all) {
+          if (EntityStructure.getEntityKind(core.getObjectStructure()) !== 'relation') {
+            continue;
+          }
+          const ref =
+            traversal.direction === 'source-to-relation'
+              ? EntityStructure.getRelationSource(core.getObjectStructure())
+              : EntityStructure.getRelationTarget(core.getObjectStructure());
+          const raw = ref?.['/'];
+          if (!raw) {
+            continue;
+          }
+          const eid = EID.tryParse(raw);
+          if (!eid) {
+            continue;
+          }
+          const id = EID.getEntityId(eid);
+          if (id && wsIds.has(id)) {
+            result.push(this._coreToItem(core));
+          }
+        }
+        return result;
+      }
+    }
+  }
+
+  private _execHierarchyTraversal(traversal: QueryPlan.HierarchyTraversal, ws: WorkingSetItem[]): WorkingSetItem[] {
+    if (traversal.direction === 'to-parent') {
+      const result: WorkingSetItem[] = [];
+      for (const item of ws) {
+        if (!item.core) {
+          continue;
+        }
+        const ref = EntityStructure.getParent(item.core.getObjectStructure());
+        if (!ref || !EncodedReference.isEncodedReference(ref)) {
+          continue;
+        }
+        const eid = EID.tryParse(EncodedReference.toURI(ref));
+        if (!eid) {
+          continue;
+        }
+        const id = EID.getEntityId(eid);
+        if (!id) {
+          continue;
+        }
+        const core = this._provider.getCoreById(id);
+        if (core) {
+          result.push(this._coreToItem(core));
+        }
+      }
+      return result;
+    } else {
+      // to-children: scan all cores for those whose parent is in the working set.
+      const wsIds = new Set(ws.map((item) => item.objectId));
+      const result: WorkingSetItem[] = [];
+      for (const core of this._provider.allCores()) {
+        const ref = EntityStructure.getParent(core.getObjectStructure());
+        if (!ref || !EncodedReference.isEncodedReference(ref)) {
+          continue;
+        }
+        const eid = EID.tryParse(EncodedReference.toURI(ref));
+        if (!eid) {
+          continue;
+        }
+        const id = EID.getEntityId(eid);
+        if (id && wsIds.has(id)) {
+          result.push(this._coreToItem(core));
+        }
+      }
+      return result;
+    }
+  }
+
+  private _execUnionStep(step: QueryPlan.UnionStep, ws: WorkingSetItem[]): WorkingSetItem[] | null {
+    const results = new Map<EntityId, WorkingSetItem>();
+    for (const plan of step.plans) {
+      const subResult = this._execPlan(plan, [...ws]);
+      if (subResult === null) {
+        return null;
+      }
+      for (const item of subResult) {
+        results.set(item.objectId, item);
+      }
+    }
+    return [...results.values()];
+  }
+
+  private _execSetDifferenceStep(step: QueryPlan.SetDifferenceStep, ws: WorkingSetItem[]): WorkingSetItem[] | null {
+    const sourceResult = this._execPlan(step.source, [...ws]);
+    const excludeResult = this._execPlan(step.exclude, [...ws]);
+    if (sourceResult === null || excludeResult === null) {
+      return null;
+    }
+    const excludeIds = new Set(excludeResult.map((item) => item.objectId));
+    return sourceResult.filter((item) => !excludeIds.has(item.objectId));
+  }
+
+  private _execOrderStep(step: QueryPlan.OrderStep, ws: WorkingSetItem[]): WorkingSetItem[] | null {
+    const sorted = [...ws].sort((itemA, itemB) => {
+      for (const order of step.order) {
+        const cmp = this._compareByOrder(itemA, itemB, order);
+        if (cmp !== 0) {
+          return cmp;
+        }
+      }
+      return 0;
+    });
+    return step.limit !== undefined ? sorted.slice(0, step.limit) : sorted;
+  }
+
+  private _compareByOrder(itemA: WorkingSetItem, itemB: WorkingSetItem, order: QueryAST.Order): number {
+    switch (order.kind) {
+      case 'natural':
+        return itemA.objectId.localeCompare(itemB.objectId);
+      case 'rank':
+        // No rank info available in working set; treat as equal.
+        return 0;
+      case 'timestamp':
+        // No timestamp index on client; treat as equal.
+        return 0;
+      case 'property': {
+        const aVal = WorkingSetItem.getProperty(itemA, [order.property]);
+        const bVal = WorkingSetItem.getProperty(itemB, [order.property]);
+        const cmp = _compareValues(aVal, bVal);
+        return order.direction === 'desc' ? -cmp : cmp;
+      }
+      default:
+        return 0;
+    }
+  }
+
+  private _coreToItem(core: ObjectCore): WorkingSetItem {
+    return {
+      // ObjectCore.id is typed as string; this cast is a type-system boundary —
+      // entity ids are structurally EntityId strings but the core uses a plain string type.
+      objectId: core.id as EntityId,
+      spaceId: this._provider.spaceId,
+      queueId: null,
+      queueNamespace: null,
+      core,
+      data: null,
+    };
+  }
+}
+
+const MAX_DEPTH_FOR_CHILD_OF_TRACING = 16;
+
+const _compareValues = (valueA: unknown, valueB: unknown): number => {
+  if (valueA == null && valueB == null) {
+    return 0;
+  }
+  if (valueA == null) {
+    return 1;
+  }
+  if (valueB == null) {
+    return -1;
+  }
+  if (typeof valueA === 'string' && typeof valueB === 'string') {
+    return valueA.localeCompare(valueB);
+  }
+  if (typeof valueA === 'number' && typeof valueB === 'number') {
+    return valueA - valueB;
+  }
+  return String(valueA).localeCompare(String(valueB));
+};
+
+const _filterContainsTimestamp = (filter: QueryAST.Filter): boolean => {
+  if (filter.type === 'timestamp') {
+    return true;
+  }
+  if (filter.type === 'and' || filter.type === 'or') {
+    return filter.filters.some(_filterContainsTimestamp);
+  }
+  if (filter.type === 'not') {
+    return _filterContainsTimestamp(filter.filter);
+  }
+  return false;
+};
+
+/**
+ * Returns true if the given EntityStructure contains a reference to any object
+ * in targetIds, optionally restricted to the specified property path.
+ */
+const _structureReferencesAny = (
+  structure: EntityStructure,
+  targetIds: Set<EntityId>,
+  property: EscapedPropPath | null,
+): boolean => {
+  const data = structure.data;
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+
+  if (property !== null) {
+    // Check only the specified property path.
+    const path = EscapedPropPath.unescape(property);
+    const value = getDeep(data, path);
+    return _valueReferencesAny(value, targetIds);
+  }
+
+  // Check all data fields.
+  let found = false;
+  visitValues(data, (value) => {
+    if (found) {
+      return;
+    }
+    if (isEncodedReference(value)) {
+      const eid = EID.tryParse(EncodedReference.toURI(value));
+      if (eid) {
+        const id = EID.getEntityId(eid);
+        if (id && targetIds.has(id)) {
+          found = true;
+        }
+      }
+    }
+  });
+  return found;
+};
+
+const _valueReferencesAny = (value: unknown, targetIds: Set<EntityId>): boolean => {
+  if (isEncodedReference(value)) {
+    try {
+      const eid = EID.tryParse(EncodedReference.toURI(value));
+      if (!eid) {
+        return false;
+      }
+      const id = EID.getEntityId(eid);
+      return id != null && targetIds.has(id);
+    } catch {
+      return false;
+    }
+  }
+  if (Array.isArray(value)) {
+    return value.some((element) => _valueReferencesAny(element, targetIds));
+  }
+  return false;
+};

--- a/packages/core/echo/echo-client/tsconfig.json
+++ b/packages/core/echo/echo-client/tsconfig.json
@@ -71,6 +71,9 @@
     },
     {
       "path": "../echo-protocol"
+    },
+    {
+      "path": "../index-core"
     }
   ]
 }

--- a/packages/core/echo/echo-host/package.json
+++ b/packages/core/echo/echo-host/package.json
@@ -27,6 +27,11 @@
       "source": "./src/filter/index.ts",
       "types": "./dist/types/src/filter/index.d.ts",
       "default": "./dist/lib/neutral/filter/index.mjs"
+    },
+    "./query": {
+      "source": "./src/query/planner.ts",
+      "types": "./dist/types/src/query/planner.d.ts",
+      "default": "./dist/lib/neutral/query/planner.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/core/echo/echo-host/src/query/planner.ts
+++ b/packages/core/echo/echo-host/src/query/planner.ts
@@ -1,0 +1,10 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+// Lightweight query planning types and the planner — no SQL, no hypercore, no protobuf.
+// Exported via the `@dxos/echo-host/query` sub-path so workerd-compatible consumers can
+// import QueryPlan and QueryPlanner without pulling in the heavy server-only executor.
+export * from './errors';
+export * from './plan';
+export * from './query-planner';

--- a/packages/core/echo/echo-host/src/query/query-planner.ts
+++ b/packages/core/echo/echo-host/src/query/query-planner.ts
@@ -28,6 +28,12 @@ const queryTooComplexError = (query: QueryAST.Query | null): QueryError => {
 
 export type QueryPlannerOptions = {
   defaultTextSearchKind: QueryPlan.TextSearchKind;
+  /**
+   * When true, downgrade index-backed selectors to WildcardSelector + FilterStep.
+   * Use when executing against an in-memory working set without SQL index access.
+   * TextSelector and TimestampSelector remain as-is so the caller can detect them and bail.
+   */
+  noIndexes?: boolean;
 };
 
 const DEFAULT_OPTIONS: QueryPlannerOptions = {
@@ -164,15 +170,16 @@ export class QueryPlanner {
             },
           ]);
         } else if (filter.typename) {
+          // When noIndexes is set, use WildcardSelector so all loaded cores are scanned;
+          // the type predicate is enforced by the FilterStep that already follows.
+          const selector: QueryPlan.Selector = this._options.noIndexes
+            ? { _tag: 'WildcardSelector' }
+            : { _tag: 'TypeSelector', typename: [filter.typename], inverted: false };
           return QueryPlan.Plan.make([
             {
               _tag: 'SelectStep',
               scope: context.scope,
-              selector: {
-                _tag: 'TypeSelector',
-                typename: [filter.typename],
-                inverted: false,
-              },
+              selector,
             },
             ...this._generateDeletedHandlingSteps(context),
             // TODO(dmaretskyi): Normally we could skip filtering by typename here, but since the index does not separate schema versions, we need to do additional filter to only select the correct version.
@@ -411,15 +418,16 @@ export class QueryPlanner {
             return filter.typename;
           });
 
+          // When noIndexes is set, use WildcardSelector so all loaded cores are scanned;
+          // the type predicate is enforced by the FilterStep that already follows.
+          const orSelector: QueryPlan.Selector = this._options.noIndexes
+            ? { _tag: 'WildcardSelector' }
+            : { _tag: 'TypeSelector', typename: typenames, inverted: context.selectionInverted };
           return QueryPlan.Plan.make([
             {
               _tag: 'SelectStep',
               scope: context.scope,
-              selector: {
-                _tag: 'TypeSelector',
-                typename: typenames,
-                inverted: context.selectionInverted,
-              },
+              selector: orSelector,
             },
             ...this._generateDeletedHandlingSteps(context),
             {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5650,6 +5650,9 @@ importers:
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../../common/effect
+      '@dxos/index-core':
+        specifier: workspace:*
+        version: link:../index-core
       '@dxos/invariant':
         specifier: workspace:*
         version: link:../../../common/invariant


### PR DESCRIPTION
## Summary

- Adds `WorkingSetQueryExecutor` (`echo-client`) that executes `QueryPlan` steps (select, filter, traverse, union, set-difference, order, limit) against loaded `ObjectCore` objects, with no SQL index access. Returns `null` when the plan contains a `TextSelector` or `TimestampSelector`, signalling the SQL source must handle the query.
- Adds `noIndexes?: boolean` to `QueryPlannerOptions` (`echo-host`). When true, `TypeSelector` is downgraded to `WildcardSelector` so the in-memory scan path works correctly for all filter shapes.
- Wires the executor into `SpaceQuerySource`: traversal, union, and set-difference queries are now satisfied directly from the client-side working set rather than falling back to empty. Simple filter queries and limit/order queries continue to use the existing SQL-backed path.
- Adds 16 unit tests covering all executor step types.

## Test plan

- [x] `moon run echo-client:test` — all 629 tests pass, including 16 new `WorkingSetQueryExecutor` tests
- [x] `moon run echo-host:test` — all 250 tests pass (no regressions from `noIndexes` planner change)
- [x] `moon run echo-client:lint -- --fix` — no lint errors
- [x] Cast audit: `git diff origin/main | grep -nE '\bas (any|unknown|[A-Z])|as unknown as'` — two documented type-boundary casts in `working-set-executor.ts`, both with explanatory comments

https://claude.ai/code/session_014UXcW1ertNwDaMyBRGGtth

---
_Generated by [Claude Code](https://claude.ai/code/session_014UXcW1ertNwDaMyBRGGtth)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an in-memory query executor that runs queries over client-loaded working sets.
  * Updated query processing to route supported query shapes through the working-set executor.
  * Introduced a `noIndexes` planner option to force index-free planning.
  * Exposed working-set execution via the query module and added a new `query` export entry for the host.

* **Tests**
  * Added Vitest coverage for planning/execution, traversal, set operations, ordering, limits, and index-bailout behavior.

* **Chores**
  * Updated echo client dependency metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->