### PR TITLE
feat(plugin-chess): add pgn field instruction to chess blueprint

### DIFF
--- a/packages/plugins/plugin-chess/src/blueprints/chess-blueprint.ts
+++ b/packages/plugins/plugin-chess/src/blueprints/chess-blueprint.ts
@@ -20,6 +20,10 @@ const make = () =>
         To analyze a game you can access the "pgn" property by loading the context object that represents the current game.
         You could suggest a good next move or offer to play a move.
         Don't actually make a move unless you are asked to.
+
+        When setting a chess position, always set the "pgn" field (move list in standard PGN notation) on the org.dxos.type.chess.state object.
+        The "fen" field is not used by the UI for display — the board is driven exclusively from "pgn".
+        Setting "fen" alone or leaving "pgn" empty will result in the initial position being shown.
       `,
     }),
   });


### PR DESCRIPTION
## Summary

- Adds explicit instructions to the chess blueprint clarifying that the board UI is driven exclusively from the `pgn` field on `org.dxos.type.chess.state`, not `fen`
- Prevents the agent from setting only `fen` (which would leave the board showing the initial position)

## Test plan

- [ ] Verify chess blueprint loads and the new instructions appear when the agent runs

closes DX-1020

https://claude.ai/code/session_01THAJcYappSTfbpVEEbCyhz

---
_Generated by [Claude Code](https://claude.ai/code/session_01THAJcYappSTfbpVEEbCyhz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated chess blueprint instructions to clarify proper handling of chess position state, ensuring the system correctly populates move data for accurate UI display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->