### PR TITLE
fix(plugin-chess): instruct agent to set pgn when setting chess position

### DIFF
--- a/packages/plugins/plugin-chess/src/blueprints/chess-blueprint.ts
+++ b/packages/plugins/plugin-chess/src/blueprints/chess-blueprint.ts
@@ -20,6 +20,10 @@ const make = () =>
         To analyze a game you can access the "pgn" property by loading the context object that represents the current game.
         You could suggest a good next move or offer to play a move.
         Don't actually make a move unless you are asked to.
+
+        When setting a chess position, always set the **pgn** field (move list in standard PGN notation) on the org.dxos.type.chess.state object.
+        The fen field is not used by the UI for display — the board is driven exclusively from pgn.
+        Setting fen alone or leaving pgn empty will result in the initial position being shown.
       `,
     }),
   });


### PR DESCRIPTION
## Summary

- Add blueprint instructions clarifying that the chess board UI is driven exclusively from the `pgn` field on `org.dxos.type.chess.state`, not `fen`.
- Agents setting a chess position must always populate `pgn` (standard PGN move list); leaving it empty or setting only `fen` shows the initial position.

closes DX-1020

## Test plan

- [x] Lint passes for `plugin-chess`
- [ ] CI Check workflow passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified instructions for setting chess positions, specifying proper field usage and clarifying how the UI renders board state based on provided input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->