### PR TITLE
fix(react-ui-form): resolve ViewEditor 'delete property' test flakiness

### DIFF
--- a/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.test.tsx
+++ b/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.test.tsx
@@ -138,10 +138,16 @@ describe('ViewEditor', () => {
     expect(addedPropertyProjection!.props.property).toBe('added_property');
   });
 
-  // TODO(mykola): Fix flaky test.
-  test('delete property', { retry: 2 }, async () => {
+  test('delete property', async () => {
     await Default.run();
     await waitForViewEditor();
+
+    // Wait for the field list to render — useObject(view) inside ViewEditor resolves
+    // asynchronously after the outer story's type/view state is set, so the debug
+    // element can appear before the list items are in the DOM.
+    await waitFor(() => {
+      expect(screen.getByText('name')).toBeInTheDocument();
+    });
 
     // Find the delete button for the 'name' property.
     const nameProperty = screen.getByText('name');


### PR DESCRIPTION
## Summary

- Fixes the flaky `ViewEditor > delete property` test that had a `retry: 2` workaround and a `TODO(mykola): Fix flaky test.` comment
- Root cause: `waitForViewEditor()` resolved when the Syntax debug panel appeared in the DOM, but `ViewEditor` internally uses `useObject(view)` which resolves asynchronously — on first render `viewSnapshot` is `null`, so the field list hasn't mounted yet when the test tries to interact with it
- Fix: added a `waitFor(() => expect(screen.getByText('name')).toBeInTheDocument())` after `waitForViewEditor()` to wait for the field list to actually be in the DOM before proceeding
- Removed the `retry: 2` workaround and the `TODO` comment

## Test plan

- [x] `ViewEditor > delete property` passes consistently without retry (verified 2 consecutive runs)
- [x] All 5 ViewEditor tests pass (renders view editor, change property name, add new property, delete property, hide and show property)
- [x] Full `react-ui-form:test` suite passes (48 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLFiFBc1SwPm1BkREXNz4R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLFiFBc1SwPm1BkREXNz4R)_