### PR TITLE
feat(react-ui-calendar): add Calendar.Week time-grid view

### DIFF
--- a/docs/superpowers/specs/2026-06-16-calendar-week-view-design.md
+++ b/docs/superpowers/specs/2026-06-16-calendar-week-view-design.md
@@ -1,0 +1,94 @@
+# Calendar Week View (`Calendar.Week`) — Design
+
+## Goal
+
+Add a week / time-grid variant to `@dxos/react-ui-calendar` that reuses the existing
+month grid's 7-day (x-axis) structure but maps the y-axis to hourly time slots, for
+displaying and editing events within a single week.
+
+## Scope
+
+- New `CalendarWeek` component exported as `Calendar.Week`, sibling to `Calendar.Grid`.
+- Factor the day-of-week header out of `CalendarGrid` into a shared `CalendarWeekdays`
+  component used by both views.
+- Faint hour grid lines; events rendered as positioned rectangles.
+- Drag-to-create (vertical only, within one day), drag-to-move (preserve duration,
+  vertical only), drag-to-resize (top/bottom edges, `ns-resize` cursor).
+- Side-by-side layout for overlapping events.
+- Non-virtualized vertical scroll (0–24h).
+
+## Files
+
+- `src/components/Calendar/Week.tsx` — new component.
+- `src/components/Calendar/Weekdays.tsx` — shared day-of-week header.
+- `src/components/Calendar/util.ts` — add time/overlap helpers (pure, unit-tested).
+- `src/components/Calendar/util.test.ts` — tests for new helpers.
+- `src/components/Calendar/Calendar.tsx` — use `CalendarWeekdays`.
+- `src/components/Calendar/Calendar.stories.tsx` — add `Week` story.
+- `src/components/Calendar/index.ts` (+ barrels) — export `Calendar.Week` and public types.
+
+## Layout
+
+- Shared CSS grid column template `[gutter] repeat(7, 1fr)` aligns header and body.
+- Body is a single non-virtualized `overflow-y-auto` region; content height `24 * hourHeight`.
+- Left gutter column shows hour labels; 7 day columns are `position: relative`, full day tall.
+- Faint horizontal hour lines (theme separator token) at each hour boundary.
+- Scrolls to ~08:00 on mount.
+- `weekStartsOn` read from `Calendar.Root` context (like `Toolbar`).
+- `date?: Date` prop selects the displayed week (default today); week = `startOfWeek(date, { weekStartsOn })` .. +6 days.
+
+## Shared header — `CalendarWeekdays`
+
+Props:
+- `weekStartsOn: Day`
+- `columnWidth?: number` — fixed px columns (month grid → 40); omitted → flex `1fr` (week view).
+- `gutter?: number` — leading spacer width (week view aligns over the hour gutter).
+- `dates?: Date[]` — when provided (week view), also render the day-of-month number.
+
+`CalendarGrid` adopts it with no behavioral change (passes `columnWidth = 40`).
+
+## Event model
+
+Plain UI prop type (no ECHO dependency):
+
+```ts
+export type CalendarEvent = { id: string; title?: string; start: Date; end: Date };
+```
+
+Callbacks:
+- `onEventCreate?: (event: { start: Date; end: Date }) => void`
+- `onEventUpdate?: (event: { id: string; start: Date; end: Date }) => void` — move and resize.
+
+## Overlap layout
+
+Pure function in `util.ts`:
+- Input: events for one day. Output: per-event `{ columnIndex, columnCount }`.
+- Sort by start; build transitive overlap clusters; greedily pack each cluster's events
+  into the first free column. `left = columnIndex / columnCount`, `width = 1 / columnCount`.
+
+## Interactions (all vertical-only, snap to 15 minutes)
+
+- **Create**: pointerdown on empty column area → pending rectangle anchored at that time;
+  Δy sets the other edge; constrained to the origin day column; pointerup → `onEventCreate`.
+- **Move**: pointerdown on event body (`cursor-move`) → start shifts by snapped Δy, duration
+  preserved, day unchanged; pointerup → `onEventUpdate`.
+- **Resize**: top/bottom handle strips (`cursor-ns-resize`); drag adjusts that edge only,
+  minimum duration 15 min; pointerup → `onEventUpdate`.
+- Gestures tracked with window `pointermove`/`pointerup` listeners and a `gestureRef`
+  (`{ kind, eventId, anchorMinutes, ... }`), mirroring `CalendarGrid`'s drag bookkeeping.
+
+## Time math (`util.ts`)
+
+- `yToMinutes(y, hourHeight)`, `minutesToY(minutes, hourHeight)`.
+- `snapMinutes(minutes, step = 15)`.
+- `minutesOfDay(date)`, `setMinutesOfDay(date, minutes)`.
+
+## Testing / verification
+
+- Unit tests for snap/overlap/time helpers in `util.test.ts`.
+- Visual verification in storybook for create/move/resize and overlap rendering.
+
+## Out of scope (YAGNI)
+
+- All-day event row, multi-week navigation, event deletion UI, keyboard editing,
+  ECHO schema binding, timezone handling beyond local time.

--- a/docs/superpowers/specs/2026-06-16-calendar-week-view-design.md
+++ b/docs/superpowers/specs/2026-06-16-calendar-week-view-design.md
@@ -40,6 +40,7 @@ displaying and editing events within a single week.
 ## Shared header — `CalendarWeekdays`
 
 Props:
+
 - `weekStartsOn: Day`
 - `columnWidth?: number` — fixed px columns (month grid → 40); omitted → flex `1fr` (week view).
 - `gutter?: number` — leading spacer width (week view aligns over the hour gutter).
@@ -56,12 +57,14 @@ export type CalendarEvent = { id: string; title?: string; start: Date; end: Date
 ```
 
 Callbacks:
+
 - `onEventCreate?: (event: { start: Date; end: Date }) => void`
 - `onEventUpdate?: (event: { id: string; start: Date; end: Date }) => void` — move and resize.
 
 ## Overlap layout
 
 Pure function in `util.ts`:
+
 - Input: events for one day. Output: per-event `{ columnIndex, columnCount }`.
 - Sort by start; build transitive overlap clusters; greedily pack each cluster's events
   into the first free column. `left = columnIndex / columnCount`, `width = 1 / columnCount`.

--- a/packages/ui/react-ui-calendar/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/ui/react-ui-calendar/src/components/Calendar/Calendar.stories.tsx
@@ -3,15 +3,15 @@
 //
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import { format } from 'date-fns';
-import React, { useState } from 'react';
+import { addDays, addMinutes, format, startOfDay, startOfWeek } from 'date-fns';
+import React, { useMemo, useRef, useState } from 'react';
 
 import { Panel } from '@dxos/react-ui';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 
 import { translations } from '#translations';
 
-import { Calendar, type Range as DateRange } from './Calendar';
+import { Calendar, type CalendarEvent, type Range as DateRange } from './Calendar';
 
 const meta = {
   title: 'ui/react-ui-calendar/Calendar',
@@ -67,4 +67,44 @@ export const Column: Story = {
       </Panel.Root>
     </Calendar.Root>
   ),
+};
+
+export const Week: StoryObj<typeof Calendar.Week> = {
+  decorators: [withTheme(), withLayout({ layout: 'column', classNames: 'w-auto' })],
+  render: () => {
+    const idRef = useRef(100);
+    const initial = useMemo<CalendarEvent[]>(() => {
+      const weekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
+      const at = (dayOffset: number, hour: number, minute = 0) =>
+        addMinutes(startOfDay(addDays(weekStart, dayOffset)), hour * 60 + minute);
+      return [
+        { id: '1', title: 'Standup', start: at(1, 9, 0), end: at(1, 9, 30) },
+        { id: '2', title: 'Design review', start: at(1, 9, 15), end: at(1, 10, 30) },
+        { id: '3', title: 'Lunch', start: at(2, 12, 0), end: at(2, 13, 0) },
+        { id: '4', title: '1:1', start: at(3, 14, 0), end: at(3, 15, 0) },
+        { id: '5', title: 'Focus', start: at(3, 14, 30), end: at(3, 16, 0) },
+        { id: '6', title: 'Planning', start: at(4, 10, 0), end: at(4, 11, 30) },
+      ];
+    }, []);
+    const [events, setEvents] = useState<CalendarEvent[]>(initial);
+
+    return (
+      <Calendar.Root>
+        <Panel.Root>
+          <Panel.Toolbar asChild>
+            <Calendar.Toolbar />
+          </Panel.Toolbar>
+          <Calendar.Week
+            events={events}
+            onEventCreate={({ start, end }) =>
+              setEvents((current) => [...current, { id: `${idRef.current++}`, title: 'New event', start, end }])
+            }
+            onEventUpdate={({ id, start, end }) =>
+              setEvents((current) => current.map((event) => (event.id === id ? { ...event, start, end } : event)))
+            }
+          />
+        </Panel.Root>
+      </Calendar.Root>
+    );
+  },
 };

--- a/packages/ui/react-ui-calendar/src/components/Calendar/Calendar.tsx
+++ b/packages/ui/react-ui-calendar/src/components/Calendar/Calendar.tsx
@@ -2,14 +2,11 @@
 // Copyright 2025 DXOS.org
 //
 
-import { createContext } from '@radix-ui/react-context';
-import { type Day, addDays, format, startOfDay, startOfWeek } from 'date-fns';
+import { addDays, format, startOfDay } from 'date-fns';
 import React, {
-  type Dispatch,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   type PropsWithChildren,
-  type SetStateAction,
   forwardRef,
   useCallback,
   useEffect,
@@ -28,10 +25,20 @@ import { mx } from '@dxos/ui-theme';
 
 import { translationKey } from '#translations';
 
-import { getDate, getRowIndex, isSameDay } from './util';
+import {
+  type CalendarContextValue,
+  type CalendarController,
+  CalendarContextProvider,
+  type CalendarScrollEvent,
+  type Range,
+  useCalendarContext,
+} from './context';
+import { getDate, getRowIndex, gridEpoch, isSameDay } from './util';
+import { CalendarWeek, type CalendarEvent, type CalendarWeekProps } from './Week';
+import { Weekdays } from './Weekdays';
 
 const maxRows = 50 * 100;
-const start = new Date('1970-01-01');
+const start = gridEpoch;
 const size = 40;
 const defaultWidth = 7 * size;
 
@@ -49,15 +56,6 @@ const DATE_CLASS_NAMES = {
 //
 // Range
 //
-
-/**
- * Inclusive date range. `from <= to`. Both endpoints are anchored at the
- * start of their day; callers should not rely on time-of-day precision.
- */
-export type Range = {
-  from: Date;
-  to: Date;
-};
 
 /** Normalize an ordered pair of dates into a Range (start-of-day, from <= to). */
 const makeRange = (a: Date, b: Date): Range => {
@@ -89,44 +87,6 @@ const cellDate = (el: Element | null): Date | undefined => {
 };
 
 //
-// Context
-//
-
-type CalendarEvent = {
-  /** `scroll` brings a date into view; `select` also sets it as the grid's selected day. */
-  type: 'scroll' | 'select';
-  date: Date;
-};
-
-type CalendarContextValue = {
-  weekStartsOn: Day;
-  event: Event<CalendarEvent>;
-  index: number | undefined;
-  setIndex: Dispatch<SetStateAction<number | undefined>>;
-  selected: Date | undefined;
-  setSelected: Dispatch<SetStateAction<Date | undefined>>;
-  /** Committed date range, set by the most recent drag or shift+arrow selection. */
-  range: Range | undefined;
-  setRange: Dispatch<SetStateAction<Range | undefined>>;
-  /** Live drag preview; non-undefined only while the user is dragging. */
-  pendingRange: Range | undefined;
-  setPendingRange: Dispatch<SetStateAction<Range | undefined>>;
-};
-
-const [CalendarContextProvider, useCalendarContext] = createContext<CalendarContextValue>('Calendar');
-
-//
-// Controller
-//
-
-type CalendarController = {
-  /** Bring a date into view without changing the selection. */
-  scrollTo: (date: Date) => void;
-  /** Set the grid's selected day (and scroll it into view) — e.g. when the active event changes. */
-  select: (date: Date) => void;
-};
-
-//
 // Root
 //
 
@@ -134,7 +94,7 @@ type CalendarRootProps = PropsWithChildren<Partial<Pick<CalendarContextValue, 'w
 
 const CalendarRoot = forwardRef<CalendarController, CalendarRootProps>(
   ({ children, weekStartsOn = 1 }, forwardedRef) => {
-    const event = useMemo(() => new Event<CalendarEvent>(), []);
+    const event = useMemo(() => new Event<CalendarScrollEvent>(), []);
     const [selected, setSelected] = useState<Date | undefined>();
     const [index, setIndex] = useState<number | undefined>();
     const [range, setRange] = useState<Range | undefined>();
@@ -197,7 +157,6 @@ const CalendarToolbar = composable<HTMLDivElement, CalendarToolbarProps>(({ clas
         classNames: ['shrink-0 grid! grid-cols-3 items-center bg-toolbar-surface', classNames],
       })}
       ref={forwardedRef}
-      style={{ width: defaultWidth }}
     >
       <div className='flex justify-start'>
         <IconButton
@@ -314,14 +273,6 @@ const CalendarGrid = composable<HTMLDivElement, CalendarGridProps>(
         listRef.current?.scrollToRow(Math.max(0, index - scrollMargin));
       });
     }, [event, start, weekStartsOn, scrollMargin, setSelected]);
-
-    const days = useMemo(() => {
-      const weekStart = startOfWeek(new Date(), { weekStartsOn });
-      return Array.from({ length: 7 }, (_, i) => {
-        const day = addDays(weekStart, i);
-        return format(day, 'EEE'); // Short day name (Mon, Tue, etc.)
-      });
-    }, []);
 
     //
     // Selection refs.
@@ -695,12 +646,8 @@ const CalendarGrid = composable<HTMLDivElement, CalendarGridProps>(
         onKeyDown={handleKeyDown}
       >
         {/* Day of week labels */}
-        <div className='grid w-full grid-cols-7' style={{ width: defaultWidth }}>
-          {days.map((date, i) => (
-            <div key={i} className='flex justify-center p-2 text-sm font-thin'>
-              {date}
-            </div>
-          ))}
+        <div style={{ width: defaultWidth }}>
+          <Weekdays weekStartsOn={weekStartsOn} columnWidth={size} />
         </div>
 
         {/* Grid */}
@@ -734,6 +681,15 @@ export const Calendar = {
   Root: CalendarRoot,
   Toolbar: CalendarToolbar,
   Grid: CalendarGrid,
+  Week: CalendarWeek,
 };
 
-export type { CalendarController, CalendarRootProps, CalendarToolbarProps, CalendarGridProps };
+export type {
+  CalendarController,
+  CalendarEvent,
+  CalendarGridProps,
+  CalendarRootProps,
+  CalendarToolbarProps,
+  CalendarWeekProps,
+  Range,
+};

--- a/packages/ui/react-ui-calendar/src/components/Calendar/Week.tsx
+++ b/packages/ui/react-ui-calendar/src/components/Calendar/Week.tsx
@@ -1,0 +1,486 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { addDays, startOfDay, startOfWeek } from 'date-fns';
+import React, {
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { composable, composableProps } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+import { useCalendarContext } from './context';
+import {
+  MINUTES_PER_DAY,
+  SNAP_MINUTES,
+  getRowIndex,
+  gridEpoch,
+  isSameDay,
+  layoutDayEvents,
+  minutesOfDay,
+  minutesToY,
+  setMinutesOfDay,
+  snapMinutes,
+  yToMinutes,
+} from './util';
+import { Weekdays } from './Weekdays';
+
+const CALENDAR_WEEK_NAME = 'CalendarWeek';
+
+const HOUR_HEIGHT = 48; // px per hour.
+const GUTTER_WIDTH = 56; // px, hour-label column.
+const RESIZE_HANDLE = 6; // px, top/bottom hit zone for resizing.
+const MIN_DURATION = SNAP_MINUTES; // Minimum event duration (minutes).
+const INITIAL_HOUR = 8; // Hour scrolled into view on mount.
+
+/** An event rendered on the week's time grid. Times are interpreted in local time. */
+export type CalendarEvent = {
+  id: string;
+  title?: string;
+  start: Date;
+  end: Date;
+};
+
+type CalendarWeekProps = {
+  /** Any date within the week to display; the week is derived via `weekStartsOn`. Defaults to today. */
+  date?: Date;
+  events?: CalendarEvent[];
+  /** Fired when the user drags out a new time slot on an empty part of a day column. */
+  onEventCreate?: (event: { start: Date; end: Date }) => void;
+  /** Fired when an event is moved (duration preserved) or resized (one edge changed). */
+  onEventUpdate?: (event: { id: string; start: Date; end: Date }) => void;
+};
+
+type GestureKind = 'create' | 'move' | 'resize-start' | 'resize-end';
+
+// A live drag gesture. `anchorMinutes` is the fixed edge for create/resize; `grabOffset` is the
+// pointer's offset (minutes) into the event when moving, so the event doesn't jump under the cursor.
+type Gesture = {
+  kind: GestureKind;
+  day: Date;
+  eventId?: string;
+  anchorMinutes: number;
+  grabOffset: number;
+  durationMinutes: number;
+};
+
+// A pending edit (the gesture's live result) overlaid on the source events while dragging.
+type Draft = { start: Date; end: Date; eventId?: string };
+
+const CalendarWeek = composable<HTMLDivElement, CalendarWeekProps>(
+  ({ classNames, date, events = [], onEventCreate, onEventUpdate, ...props }, forwardedRef) => {
+    const { weekStartsOn, event: scrollEvent, setIndex } = useCalendarContext(CALENDAR_WEEK_NAME);
+    const today = useMemo(() => new Date(), []);
+
+    // Anchor of the displayed week. Seeded from the `date` prop and re-synced when it changes, but also
+    // driven by the shared scroll/select signal (e.g. the Toolbar's Today button, controller.scrollTo).
+    const [viewDate, setViewDate] = useState<Date>(() => date ?? today);
+    useEffect(() => {
+      if (date) {
+        setViewDate(date);
+      }
+    }, [date]);
+    useEffect(() => scrollEvent.on(({ date }) => setViewDate(date)), [scrollEvent]);
+
+    const weekDays = useMemo(() => {
+      const weekStart = startOfWeek(viewDate, { weekStartsOn });
+      return Array.from({ length: 7 }, (_, index) => startOfDay(addDays(weekStart, index)));
+    }, [viewDate, weekStartsOn]);
+
+    // Report the displayed week to the shared context so the Toolbar's month/year label tracks it.
+    useEffect(() => {
+      setIndex(getRowIndex(gridEpoch, weekDays[0], weekStartsOn));
+    }, [weekDays, weekStartsOn, setIndex]);
+
+    // Index events by day so each column lays out independently.
+    const eventsByDay = useMemo(() => {
+      const byDay = weekDays.map(() => [] as CalendarEvent[]);
+      for (const event of events) {
+        const dayIndex = weekDays.findIndex((day) => isSameDay(day, event.start));
+        if (dayIndex >= 0) {
+          byDay[dayIndex].push(event);
+        }
+      }
+      return byDay;
+    }, [events, weekDays]);
+
+    const scrollRef = useRef<HTMLDivElement>(null);
+    useLayoutEffect(() => {
+      scrollRef.current?.scrollTo({ top: minutesToY(INITIAL_HOUR * 60, HOUR_HEIGHT) });
+    }, []);
+
+    //
+    // Drag gesture: create / move / resize. All vertical-only, snapped to `SNAP_MINUTES`.
+    //
+    const gestureRef = useRef<Gesture | undefined>(undefined);
+    const columnsRef = useRef<(HTMLDivElement | null)[]>([]);
+    const [draft, setDraft] = useState<Draft | undefined>(undefined);
+
+    // All day columns share the same vertical geometry, so any column resolves clientY → minutes.
+    const pointerMinutes = useCallback((clientY: number): number => {
+      const rect = columnsRef.current.find(Boolean)?.getBoundingClientRect();
+      if (!rect) {
+        return 0;
+      }
+      return Math.max(0, Math.min(MINUTES_PER_DAY, yToMinutes(clientY - rect.top, HOUR_HEIGHT)));
+    }, []);
+
+    // The day column under clientX (used to move events across days); undefined when outside all columns.
+    const dayFromX = useCallback(
+      (clientX: number): Date | undefined => {
+        const index = columnsRef.current.findIndex((node) => {
+          const rect = node?.getBoundingClientRect();
+          return rect && clientX >= rect.left && clientX < rect.right;
+        });
+        return index >= 0 ? weekDays[index] : undefined;
+      },
+      [weekDays],
+    );
+
+    const applyGesture = useCallback(
+      (clientX: number, clientY: number): Draft | undefined => {
+        const gesture = gestureRef.current;
+        if (!gesture) {
+          return undefined;
+        }
+        const { kind, day, eventId, anchorMinutes, grabOffset, durationMinutes } = gesture;
+        const raw = pointerMinutes(clientY);
+        switch (kind) {
+          case 'create': {
+            const focus = snapMinutes(raw);
+            const from = Math.min(anchorMinutes, focus);
+            const to = Math.max(anchorMinutes, focus);
+            const end = Math.max(to, from + MIN_DURATION);
+            return { eventId, start: setMinutesOfDay(day, from), end: setMinutesOfDay(day, end) };
+          }
+          case 'move': {
+            // Moving may cross day columns; the time-of-day and duration are preserved.
+            const targetDay = dayFromX(clientX) ?? day;
+            let start = snapMinutes(raw - grabOffset);
+            start = Math.max(0, Math.min(MINUTES_PER_DAY - durationMinutes, start));
+            return {
+              eventId,
+              start: setMinutesOfDay(targetDay, start),
+              end: setMinutesOfDay(targetDay, start + durationMinutes),
+            };
+          }
+          case 'resize-start': {
+            const start = Math.min(snapMinutes(raw), anchorMinutes - MIN_DURATION);
+            return { eventId, start: setMinutesOfDay(day, start), end: setMinutesOfDay(day, anchorMinutes) };
+          }
+          case 'resize-end': {
+            const end = Math.max(snapMinutes(raw), anchorMinutes + MIN_DURATION);
+            return { eventId, start: setMinutesOfDay(day, anchorMinutes), end: setMinutesOfDay(day, end) };
+          }
+        }
+      },
+      [dayFromX, pointerMinutes],
+    );
+
+    // Latest commit callbacks, read at pointerup so the listeners attached on pointerdown never go stale.
+    const callbacksRef = useRef({ onEventCreate, onEventUpdate });
+    callbacksRef.current = { onEventCreate, onEventUpdate };
+
+    // Removes the active gesture's window listeners; replaced on each `beginGesture` and called on unmount.
+    const detachRef = useRef<() => void>(() => {});
+
+    const beginGesture = useCallback(
+      (gesture: Gesture, ev: ReactPointerEvent) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        gestureRef.current = gesture;
+        setDraft(applyGesture(ev.clientX, ev.clientY));
+
+        // Attach listeners imperatively (not via effect) so no pointer event is missed in the window
+        // between pointerdown and the next render.
+        const handleMove = (moveEv: PointerEvent) => {
+          if (gestureRef.current) {
+            setDraft(applyGesture(moveEv.clientX, moveEv.clientY));
+          }
+        };
+
+        const handleUp = (upEv: PointerEvent) => {
+          const active = gestureRef.current;
+          const result = applyGesture(upEv.clientX, upEv.clientY);
+          detachRef.current();
+          gestureRef.current = undefined;
+          setDraft(undefined);
+          if (active && result) {
+            if (active.kind === 'create') {
+              callbacksRef.current.onEventCreate?.({ start: result.start, end: result.end });
+            } else if (result.eventId) {
+              callbacksRef.current.onEventUpdate?.({ id: result.eventId, start: result.start, end: result.end });
+            }
+          }
+        };
+
+        detachRef.current = () => {
+          window.removeEventListener('pointermove', handleMove);
+          window.removeEventListener('pointerup', handleUp);
+          window.removeEventListener('pointercancel', handleUp);
+        };
+        window.addEventListener('pointermove', handleMove);
+        window.addEventListener('pointerup', handleUp);
+        window.addEventListener('pointercancel', handleUp);
+      },
+      [applyGesture],
+    );
+
+    useEffect(() => () => detachRef.current(), []);
+
+    const handleColumnPointerDown = useCallback(
+      (day: Date, event: ReactPointerEvent<HTMLDivElement>) => {
+        // Only the column background starts a create gesture; events stop propagation.
+        const rect = event.currentTarget.getBoundingClientRect();
+        const anchor = snapMinutes(yToMinutes(event.clientY - rect.top, HOUR_HEIGHT));
+        beginGesture({ kind: 'create', day, anchorMinutes: anchor, grabOffset: 0, durationMinutes: 0 }, event);
+      },
+      [beginGesture],
+    );
+
+    // Render an event block bound to the gesture handlers for a given day column. `day` is the column
+    // the block currently sits in (its original day, or the target day while being dragged across).
+    const renderEvent = useCallback(
+      (event: CalendarEvent, day: Date, start: Date, end: Date, columnIndex: number, columnCount: number) => (
+        <EventBlock
+          key={event.id}
+          event={event}
+          start={start}
+          end={end}
+          columnIndex={columnIndex}
+          columnCount={columnCount}
+          onMoveStart={(ev) =>
+            beginGesture(
+              {
+                kind: 'move',
+                day,
+                eventId: event.id,
+                anchorMinutes: 0,
+                grabOffset: pointerMinutes(ev.clientY) - minutesOfDay(event.start),
+                durationMinutes: minutesOfDay(event.end) - minutesOfDay(event.start),
+              },
+              ev,
+            )
+          }
+          onResizeStart={(ev) =>
+            beginGesture(
+              {
+                kind: 'resize-start',
+                day,
+                eventId: event.id,
+                anchorMinutes: minutesOfDay(event.end),
+                grabOffset: 0,
+                durationMinutes: 0,
+              },
+              ev,
+            )
+          }
+          onResizeEnd={(ev) =>
+            beginGesture(
+              {
+                kind: 'resize-end',
+                day,
+                eventId: event.id,
+                anchorMinutes: minutesOfDay(event.start),
+                grabOffset: 0,
+                durationMinutes: 0,
+              },
+              ev,
+            )
+          }
+        />
+      ),
+      [beginGesture, pointerMinutes],
+    );
+
+    // The event under an active move, resolved once so the origin column can drop it and the target
+    // column can render it while the pointer is over a different day.
+    const draggedEvent = draft?.eventId ? events.find((event) => event.id === draft.eventId) : undefined;
+
+    return (
+      <div
+        {...composableProps(props, {
+          classNames: ['flex flex-col h-full w-full overflow-hidden outline-hidden', classNames],
+        })}
+        ref={forwardedRef}
+      >
+        <Weekdays weekStartsOn={weekStartsOn} gutter={GUTTER_WIDTH} dates={weekDays} />
+
+        <div ref={scrollRef} className='flex-1 overflow-y-auto _scrollbar-thin'>
+          <div
+            className='grid relative'
+            style={{
+              height: minutesToY(MINUTES_PER_DAY, HOUR_HEIGHT),
+              gridTemplateColumns: `${GUTTER_WIDTH}px repeat(7, 1fr)`,
+            }}
+          >
+            {/* Hour gutter + faint hour lines spanning all columns. */}
+            <div className='relative'>
+              {Array.from({ length: 24 }, (_, hour) => (
+                <div
+                  key={hour}
+                  className='absolute right-1 -translate-y-1/2 text-xs text-description tabular-nums'
+                  style={{ top: minutesToY(hour * 60, HOUR_HEIGHT) }}
+                >
+                  {hour === 0 ? '' : `${hour.toString().padStart(2, '0')}:00`}
+                </div>
+              ))}
+            </div>
+
+            {weekDays.map((day, dayIndex) => {
+              const dayEvents = eventsByDay[dayIndex];
+              const layout = layoutDayEvents(dayEvents);
+              const isToday = isSameDay(day, today);
+              // The draft when it currently belongs to this column (origin for resize, target for a cross-day move).
+              const draftHere = draft && isSameDay(day, draft.start) ? draft : undefined;
+              return (
+                <div
+                  key={day.toISOString()}
+                  ref={(node) => {
+                    columnsRef.current[dayIndex] = node;
+                  }}
+                  data-date={day.toISOString()}
+                  className={mx(
+                    'relative border-l border-separator cursor-cell select-none',
+                    dayIndex === 6 && 'border-r',
+                    isToday && 'bg-primary-500/5',
+                  )}
+                  onPointerDown={(ev) => handleColumnPointerDown(day, ev)}
+                >
+                  {/* Faint hour lines. */}
+                  {Array.from({ length: 24 }, (_, hour) => (
+                    <div
+                      key={hour}
+                      className='absolute inset-x-0 border-t border-separator/60'
+                      style={{ top: minutesToY(hour * 60, HOUR_HEIGHT) }}
+                    />
+                  ))}
+
+                  {/* Events. */}
+                  {dayEvents.map((event, index) => {
+                    const slot = layout.get(index) ?? { columnIndex: 0, columnCount: 1 };
+                    const editing = draft && draft.eventId === event.id ? draft : undefined;
+                    // Dropped from this column while the move drags it onto another day.
+                    if (editing && !isSameDay(editing.start, day)) {
+                      return null;
+                    }
+                    const start = editing ? editing.start : event.start;
+                    const end = editing ? editing.end : event.end;
+                    return renderEvent(event, day, start, end, slot.columnIndex, slot.columnCount);
+                  })}
+
+                  {/* Event being dragged in from another day — rendered full-width above this column's events. */}
+                  {draftHere &&
+                    draggedEvent &&
+                    !dayEvents.some((event) => event.id === draggedEvent.id) &&
+                    renderEvent(draggedEvent, day, draft!.start, draft!.end, 0, 1)}
+
+                  {/* Pending create rectangle. */}
+                  {draftHere && draft && !draft.eventId && <PendingBlock start={draft.start} end={draft.end} />}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+CalendarWeek.displayName = CALENDAR_WEEK_NAME;
+
+//
+// EventBlock
+//
+
+const formatTime = (date: Date): string => {
+  const minutes = minutesOfDay(date);
+  const hour = Math.floor(minutes / 60);
+  const minute = Math.round(minutes % 60);
+  return `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
+};
+
+type EventBlockProps = {
+  event: CalendarEvent;
+  start: Date;
+  end: Date;
+  columnIndex: number;
+  columnCount: number;
+  onMoveStart: (ev: ReactPointerEvent<HTMLDivElement>) => void;
+  onResizeStart: (ev: ReactPointerEvent<HTMLDivElement>) => void;
+  onResizeEnd: (ev: ReactPointerEvent<HTMLDivElement>) => void;
+};
+
+const EventBlock = ({
+  event,
+  start,
+  end,
+  columnIndex,
+  columnCount,
+  onMoveStart,
+  onResizeStart,
+  onResizeEnd,
+}: EventBlockProps) => {
+  const top = minutesToY(minutesOfDay(start), HOUR_HEIGHT);
+  const height = Math.max(minutesToY(minutesOfDay(end) - minutesOfDay(start), HOUR_HEIGHT), RESIZE_HANDLE * 2);
+  // Leave a 1px gutter between side-by-side columns.
+  const widthPct = 100 / columnCount;
+  return (
+    <div
+      className='absolute rounded-sm bg-primary-500/80 text-inverse-fg overflow-hidden cursor-move shadow-sm'
+      style={{
+        top,
+        height,
+        left: `calc(${columnIndex * widthPct}% + 1px)`,
+        width: `calc(${widthPct}% - 2px)`,
+      }}
+      onPointerDown={onMoveStart}
+    >
+      <div
+        className='absolute inset-x-0 top-0 cursor-ns-resize'
+        style={{ height: RESIZE_HANDLE }}
+        onPointerDown={onResizeStart}
+      />
+      <div className='px-1 py-0.5 text-xs leading-tight'>
+        <div className='font-medium truncate'>{event.title ?? '(untitled)'}</div>
+        {/* <div className='tabular-nums opacity-80'>
+          {formatTime(start)}–{formatTime(end)}
+        </div> */}
+      </div>
+      <div
+        className='absolute inset-x-0 bottom-0 cursor-ns-resize'
+        style={{ height: RESIZE_HANDLE }}
+        onPointerDown={onResizeEnd}
+      />
+    </div>
+  );
+};
+
+//
+// PendingBlock
+//
+
+const PendingBlock = ({ start, end }: { start: Date; end: Date }) => {
+  const top = minutesToY(minutesOfDay(start), HOUR_HEIGHT);
+  const height = minutesToY(minutesOfDay(end) - minutesOfDay(start), HOUR_HEIGHT);
+  return (
+    <div
+      className='absolute inset-x-0 rounded bg-primary-500/40 border border-primary-500 pointer-events-none'
+      style={{ top, height }}
+    >
+      <div className='px-1 py-0.5 text-xs tabular-nums text-inverse-fg'>
+        {formatTime(start)}–{formatTime(end)}
+      </div>
+    </div>
+  );
+};
+
+export { CalendarWeek };
+export type { CalendarWeekProps };

--- a/packages/ui/react-ui-calendar/src/components/Calendar/Week.tsx
+++ b/packages/ui/react-ui-calendar/src/components/Calendar/Week.tsx
@@ -382,10 +382,10 @@ const CalendarWeek = composable<HTMLDivElement, CalendarWeekProps>(
                   {draftHere &&
                     draggedEvent &&
                     !dayEvents.some((event) => event.id === draggedEvent.id) &&
-                    renderEvent(draggedEvent, day, draft!.start, draft!.end, 0, 1)}
+                    renderEvent(draggedEvent, day, draftHere.start, draftHere.end, 0, 1)}
 
                   {/* Pending create rectangle. */}
-                  {draftHere && draft && !draft.eventId && <PendingBlock start={draft.start} end={draft.end} />}
+                  {draftHere && !draftHere.eventId && <PendingBlock start={draftHere.start} end={draftHere.end} />}
                 </div>
               );
             })}

--- a/packages/ui/react-ui-calendar/src/components/Calendar/Week.tsx
+++ b/packages/ui/react-ui-calendar/src/components/Calendar/Week.tsx
@@ -87,7 +87,9 @@ const CalendarWeek = composable<HTMLDivElement, CalendarWeekProps>(
         setViewDate(date);
       }
     }, [date]);
-    useEffect(() => scrollEvent.on(({ date }) => setViewDate(date)), [scrollEvent]);
+    useEffect(() => {
+      return scrollEvent.on(({ date }) => setViewDate(date));
+    }, [scrollEvent]);
 
     const weekDays = useMemo(() => {
       const weekStart = startOfWeek(viewDate, { weekStartsOn });

--- a/packages/ui/react-ui-calendar/src/components/Calendar/Weekdays.tsx
+++ b/packages/ui/react-ui-calendar/src/components/Calendar/Weekdays.tsx
@@ -1,0 +1,57 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type Day, addDays, format, startOfWeek } from 'date-fns';
+import React, { useMemo } from 'react';
+
+import { mx } from '@dxos/ui-theme';
+
+import { isSameDay } from './util';
+
+export type WeekdaysProps = {
+  weekStartsOn: Day;
+  /** Fixed column width in px (e.g. the month grid's cells); omit for flexible `1fr` columns. */
+  columnWidth?: number;
+  /** Leading spacer width in px, aligning the labels over a body gutter (e.g. the week view's hour column). */
+  gutter?: number;
+  /** When provided, the matching day-of-month number is rendered beneath each label (week view). */
+  dates?: Date[];
+};
+
+/**
+ * Shared day-of-week header for the calendar views. Renders seven short day labels
+ * ordered by `weekStartsOn`; when `dates` is supplied it also shows the day number and
+ * highlights today.
+ */
+export const Weekdays = ({ weekStartsOn, columnWidth, gutter, dates }: WeekdaysProps) => {
+  const labels = useMemo(() => {
+    const weekStart = startOfWeek(new Date(), { weekStartsOn });
+    return Array.from({ length: 7 }, (_, index) => format(addDays(weekStart, index), 'EEE'));
+  }, [weekStartsOn]);
+
+  const today = useMemo(() => new Date(), []);
+  const columnTemplate = columnWidth ? `repeat(7, ${columnWidth}px)` : 'repeat(7, 1fr)';
+
+  return (
+    <div
+      className='grid w-full shrink-0'
+      style={{ gridTemplateColumns: gutter ? `${gutter}px ${columnTemplate}` : columnTemplate }}
+    >
+      {gutter != null && <div aria-hidden />}
+      {labels.map((label, index) => {
+        const date = dates?.[index];
+        const isToday = !!date && isSameDay(date, today);
+        return (
+          <div
+            key={index}
+            className={mx('flex flex-col items-center p-2 text-sm font-thin', isToday && 'text-accent-text')}
+          >
+            <span>{label}</span>
+            {date && <span className='text-lg font-normal tabular-nums'>{date.getDate()}</span>}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/ui/react-ui-calendar/src/components/Calendar/context.ts
+++ b/packages/ui/react-ui-calendar/src/components/Calendar/context.ts
@@ -1,0 +1,60 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { createContext } from '@radix-ui/react-context';
+import { type Day } from 'date-fns';
+import { type Dispatch, type SetStateAction } from 'react';
+
+import { type Event } from '@dxos/async';
+
+//
+// Range
+//
+
+/**
+ * Inclusive date range. `from <= to`. Both endpoints are anchored at the
+ * start of their day; callers should not rely on time-of-day precision.
+ */
+export type Range = {
+  from: Date;
+  to: Date;
+};
+
+//
+// Controller
+//
+
+export type CalendarController = {
+  /** Bring a date into view without changing the selection. */
+  scrollTo: (date: Date) => void;
+  /** Set the grid's selected day (and scroll it into view) — e.g. when the active event changes. */
+  select: (date: Date) => void;
+};
+
+//
+// Context
+//
+
+/** Imperative grid signal: `scroll` brings a date into view; `select` also sets it as the selected day. */
+export type CalendarScrollEvent = {
+  type: 'scroll' | 'select';
+  date: Date;
+};
+
+export type CalendarContextValue = {
+  weekStartsOn: Day;
+  event: Event<CalendarScrollEvent>;
+  index: number | undefined;
+  setIndex: Dispatch<SetStateAction<number | undefined>>;
+  selected: Date | undefined;
+  setSelected: Dispatch<SetStateAction<Date | undefined>>;
+  /** Committed date range, set by the most recent drag or shift+arrow selection. */
+  range: Range | undefined;
+  setRange: Dispatch<SetStateAction<Range | undefined>>;
+  /** Live drag preview; non-undefined only while the user is dragging. */
+  pendingRange: Range | undefined;
+  setPendingRange: Dispatch<SetStateAction<Range | undefined>>;
+};
+
+export const [CalendarContextProvider, useCalendarContext] = createContext<CalendarContextValue>('Calendar');

--- a/packages/ui/react-ui-calendar/src/components/Calendar/util.test.ts
+++ b/packages/ui/react-ui-calendar/src/components/Calendar/util.test.ts
@@ -1,0 +1,97 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import {
+  layoutDayEvents,
+  minutesOfDay,
+  minutesToY,
+  setMinutesOfDay,
+  snapMinutes,
+  yToMinutes,
+} from './util';
+
+// 2026-06-16 is a Tuesday.
+const day = new Date(2026, 5, 16);
+const at = (hours: number, minutes = 0) => setMinutesOfDay(day, hours * 60 + minutes);
+
+describe('time helpers', () => {
+  test('minutesOfDay / setMinutesOfDay round-trip', ({ expect }) => {
+    const date = at(9, 30);
+    expect(minutesOfDay(date)).toEqual(9 * 60 + 30);
+    expect(setMinutesOfDay(day, 9 * 60 + 30).getTime()).toEqual(date.getTime());
+  });
+
+  test('yToMinutes / minutesToY are inverses', ({ expect }) => {
+    const hourHeight = 48;
+    expect(yToMinutes(48, hourHeight)).toEqual(60);
+    expect(minutesToY(60, hourHeight)).toEqual(48);
+    expect(minutesToY(yToMinutes(123, hourHeight), hourHeight)).toBeCloseTo(123);
+  });
+
+  test('snapMinutes rounds to step and clamps to the day', ({ expect }) => {
+    expect(snapMinutes(7)).toEqual(0);
+    expect(snapMinutes(8)).toEqual(15);
+    expect(snapMinutes(22, 15)).toEqual(15);
+    expect(snapMinutes(23, 15)).toEqual(30);
+    expect(snapMinutes(-10)).toEqual(0);
+    expect(snapMinutes(24 * 60 + 100)).toEqual(24 * 60);
+  });
+});
+
+describe('layoutDayEvents', () => {
+  test('non-overlapping events each get the full width', ({ expect }) => {
+    const events = [
+      { start: at(9), end: at(10) },
+      { start: at(11), end: at(12) },
+    ];
+    const layout = layoutDayEvents(events);
+    expect(layout.get(0)).toEqual({ columnIndex: 0, columnCount: 1 });
+    expect(layout.get(1)).toEqual({ columnIndex: 0, columnCount: 1 });
+  });
+
+  test('two overlapping events split into two columns', ({ expect }) => {
+    const events = [
+      { start: at(9), end: at(11) },
+      { start: at(10), end: at(12) },
+    ];
+    const layout = layoutDayEvents(events);
+    expect(layout.get(0)).toEqual({ columnIndex: 0, columnCount: 2 });
+    expect(layout.get(1)).toEqual({ columnIndex: 1, columnCount: 2 });
+  });
+
+  test('result is independent of input order', ({ expect }) => {
+    const events = [
+      { start: at(10), end: at(12) },
+      { start: at(9), end: at(11) },
+    ];
+    const layout = layoutDayEvents(events);
+    expect(layout.get(1)).toEqual({ columnIndex: 0, columnCount: 2 });
+    expect(layout.get(0)).toEqual({ columnIndex: 1, columnCount: 2 });
+  });
+
+  test('a freed column is reused within the same cluster', ({ expect }) => {
+    // C overlaps B (which holds the cluster open) but starts after A ends, so it reuses A's column.
+    const events = [
+      { start: at(9), end: at(10) }, // A
+      { start: at(9, 30), end: at(12) }, // B
+      { start: at(10, 30), end: at(11) }, // C
+    ];
+    const layout = layoutDayEvents(events);
+    expect(layout.get(0)).toEqual({ columnIndex: 0, columnCount: 2 });
+    expect(layout.get(1)).toEqual({ columnIndex: 1, columnCount: 2 });
+    expect(layout.get(2)).toEqual({ columnIndex: 0, columnCount: 2 });
+  });
+
+  test('adjacent (touching) events do not overlap', ({ expect }) => {
+    const events = [
+      { start: at(9), end: at(10) },
+      { start: at(10), end: at(11) },
+    ];
+    const layout = layoutDayEvents(events);
+    expect(layout.get(0)).toEqual({ columnIndex: 0, columnCount: 1 });
+    expect(layout.get(1)).toEqual({ columnIndex: 0, columnCount: 1 });
+  });
+});

--- a/packages/ui/react-ui-calendar/src/components/Calendar/util.test.ts
+++ b/packages/ui/react-ui-calendar/src/components/Calendar/util.test.ts
@@ -4,14 +4,7 @@
 
 import { describe, test } from 'vitest';
 
-import {
-  layoutDayEvents,
-  minutesOfDay,
-  minutesToY,
-  setMinutesOfDay,
-  snapMinutes,
-  yToMinutes,
-} from './util';
+import { layoutDayEvents, minutesOfDay, minutesToY, setMinutesOfDay, snapMinutes, yToMinutes } from './util';
 
 // 2026-06-16 is a Tuesday.
 const day = new Date(2026, 5, 16);

--- a/packages/ui/react-ui-calendar/src/components/Calendar/util.ts
+++ b/packages/ui/react-ui-calendar/src/components/Calendar/util.ts
@@ -2,7 +2,13 @@
 // Copyright 2025 DXOS.org
 //
 
-import { type Day, differenceInCalendarDays } from 'date-fns';
+import { type Day, differenceInCalendarDays, startOfDay } from 'date-fns';
+
+/**
+ * Fixed origin (row 0, column 0 anchor) for the infinite month grid. All row-index math is relative
+ * to this epoch, so any view that reports a row index to the shared context must use the same value.
+ */
+export const gridEpoch = new Date('1970-01-01');
 
 export const getDate = (start: Date, weekNumber: number, dayOfWeek: number, weekStartsOn: Day): Date => {
   const result = new Date(start);
@@ -37,4 +43,89 @@ export const isSameDay = (date1: Date, date2: Date | undefined): boolean => {
     date1.getMonth() === date2.getMonth() &&
     date1.getDate() === date2.getDate()
   );
+};
+
+//
+// Time-grid (week view) helpers.
+//
+
+export const MINUTES_PER_DAY = 24 * 60;
+
+/** Default snap granularity for create/move/resize gestures, in minutes. */
+export const SNAP_MINUTES = 15;
+
+/** Minutes elapsed since the start of `date`'s day (0 .. 1439). */
+export const minutesOfDay = (date: Date): number => (date.getTime() - startOfDay(date).getTime()) / 60_000;
+
+/** Return a new Date on the same calendar day as `date`, at `minutes` past midnight. */
+export const setMinutesOfDay = (date: Date, minutes: number): Date =>
+  new Date(startOfDay(date).getTime() + minutes * 60_000);
+
+/** Convert a vertical offset (px from the top of the day column) into minutes past midnight. */
+export const yToMinutes = (y: number, hourHeight: number): number => (y / hourHeight) * 60;
+
+/** Convert minutes past midnight into a vertical offset (px from the top of the day column). */
+export const minutesToY = (minutes: number, hourHeight: number): number => (minutes / 60) * hourHeight;
+
+/** Round `minutes` to the nearest `step`, clamped to a single day. */
+export const snapMinutes = (minutes: number, step: number = SNAP_MINUTES): number => {
+  const snapped = Math.round(minutes / step) * step;
+  return Math.max(0, Math.min(MINUTES_PER_DAY, snapped));
+};
+
+/**
+ * Side-by-side layout slot for an overlapping-event cluster: the event occupies
+ * `1 / columnCount` of the day column width, offset by `columnIndex` columns.
+ */
+export type EventLayout = { columnIndex: number; columnCount: number };
+
+/**
+ * Compute side-by-side columns for events within a single day. Events that overlap in
+ * time (transitively) form a cluster and split the column width evenly; non-overlapping
+ * events each get the full width. Input order is irrelevant; results are keyed by index
+ * into `events`.
+ */
+export const layoutDayEvents = <T extends { start: Date; end: Date }>(events: T[]): Map<number, EventLayout> => {
+  const layout = new Map<number, EventLayout>();
+  // Preserve original indices so callers can map results back to their event list.
+  const ordered = events
+    .map((event, index) => ({ index, start: event.start.getTime(), end: event.end.getTime() }))
+    .sort((a, b) => a.start - b.start);
+
+  let cluster: { index: number; start: number; end: number }[] = [];
+  let clusterMax = -Infinity;
+
+  const flush = () => {
+    if (cluster.length === 0) {
+      return;
+    }
+    // Greedy column packing: place each event in the first column whose previous event has ended.
+    const columnEnds: number[] = [];
+    const assigned = cluster.map(({ index, start, end }) => {
+      let column = columnEnds.findIndex((columnEnd) => columnEnd <= start);
+      if (column === -1) {
+        column = columnEnds.length;
+      }
+      columnEnds[column] = end;
+      return { index, column };
+    });
+    const columnCount = columnEnds.length;
+    for (const { index, column } of assigned) {
+      layout.set(index, { columnIndex: column, columnCount });
+    }
+    cluster = [];
+    clusterMax = -Infinity;
+  };
+
+  for (const entry of ordered) {
+    if (cluster.length > 0 && entry.start >= clusterMax) {
+      // No overlap with the running cluster — close it out before starting fresh.
+      flush();
+    }
+    cluster.push(entry);
+    clusterMax = Math.max(clusterMax, entry.end);
+  }
+  flush();
+
+  return layout;
 };


### PR DESCRIPTION
## Summary

Adds a week / time-grid view (`Calendar.Week`) to `@dxos/react-ui-calendar`, alongside the existing month `Calendar.Grid`. It reuses the same 7-day x-axis but maps the y-axis to hourly time slots for displaying and editing events within a week.

## What changed

- **`Calendar.Week`** — non-virtualized vertical scroll over 0–24h, faint hour grid lines, hour gutter, today's column tinted. Events render as positioned rectangles; overlapping events lay out side-by-side (overlap-cluster column packing).
- **Interactions** (all snapped to 15 min):
  - **Create** — drag on an empty part of a day column (vertical only).
  - **Move** — drag the event body; duration preserved; can move **across days** (the live preview follows the cursor to the target column).
  - **Resize** — top/bottom edge handles (`ns-resize` cursor), min duration 15 min.
- **Shared `Weekdays` header** — factored out of `CalendarGrid` so both views share the day-of-week row (month grid keeps fixed-width columns; week view adds the hour gutter + day numbers).
- **Toolbar integration** — `Calendar.Week` reports its displayed week into the shared context and listens to the Root scroll/select signal, so the existing `Calendar.Toolbar` month/year label tracks the week and the **Today** button (and `controller.scrollTo` / `select`) navigates the week view. No Toolbar changes required.

## Structure / refactor

- Extracted the shared context (`Range`, `CalendarController`, context provider/hook) into `context.ts`. This breaks the `Calendar ↔ Week` import cycle so the `Calendar` namespace object is assembled in `Calendar.tsx` (Radix-style) and `index.ts` is exports-only.
- The private emitter event type was renamed `CalendarEvent` → `CalendarScrollEvent` to avoid clashing with the new public `CalendarEvent` (the event-with-times type).
- Shared the grid epoch (`gridEpoch`) via `util.ts` so the week view computes the same row index the Toolbar reads.

## Testing

- Unit tests for the time math and overlap-layout helpers (`util.test.ts`).
- Verified in Storybook (`ui/react-ui-calendar/Calendar` → Week story): create, move (incl. cross-day), both resize edges, overlap side-by-side rendering, correct Toolbar label, and the Today button navigating the week.
- `build`, `lint`, and `test` pass for the package.

## Notes for reviewers

- New plain UI event model (no ECHO dependency): `CalendarEvent = { id; title?; start; end }`; callbacks `onEventCreate({ start, end })` and `onEventUpdate({ id, start, end })`.
- Design spec: `docs/superpowers/specs/2026-06-16-calendar-week-view-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Calendar Week View with a scrollable hourly 0–24h grid and interactive event create/move/resize, with 15-minute snapping.
  * Added a Weekdays header with configurable gutter/column width, week-start ordering, and “today” highlighting.
  * Exposed the `Calendar.Week` API along with related public types (including range/event definitions).
* **Documentation**
  * Added a Week View design spec and a Storybook “Week” example.
* **Tests**
  * Added unit tests for week-view time helpers and overlapping event layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->