### PR TITLE
fix(plugins): ship dx.config.ts in published files for all plugin packages

### DIFF
--- a/packages/plugins/plugin-assistant/package.json
+++ b/packages/plugins/plugin-assistant/package.json
@@ -123,6 +123,7 @@
   "files": [
     "assets",
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-attention/package.json
+++ b/packages/plugins/plugin-attention/package.json
@@ -59,6 +59,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-automation/package.json
+++ b/packages/plugins/plugin-automation/package.json
@@ -102,6 +102,7 @@
   "files": [
     "assets",
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-bluesky/package.json
+++ b/packages/plugins/plugin-bluesky/package.json
@@ -66,6 +66,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-board/package.json
+++ b/packages/plugins/plugin-board/package.json
@@ -70,6 +70,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-bookmarks/package.json
+++ b/packages/plugins/plugin-bookmarks/package.json
@@ -81,6 +81,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-calls/package.json
+++ b/packages/plugins/plugin-calls/package.json
@@ -86,6 +86,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-chess/package.json
+++ b/packages/plugins/plugin-chess/package.json
@@ -101,6 +101,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-client/package.json
+++ b/packages/plugins/plugin-client/package.json
@@ -99,6 +99,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-code/package.json
+++ b/packages/plugins/plugin-code/package.json
@@ -81,6 +81,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-comments/package.json
+++ b/packages/plugins/plugin-comments/package.json
@@ -102,6 +102,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-commerce/package.json
+++ b/packages/plugins/plugin-commerce/package.json
@@ -41,6 +41,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-conductor/package.json
+++ b/packages/plugins/plugin-conductor/package.json
@@ -65,6 +65,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-crm/package.json
+++ b/packages/plugins/plugin-crm/package.json
@@ -82,6 +82,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-crx/package.json
+++ b/packages/plugins/plugin-crx/package.json
@@ -76,6 +76,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-debug/package.json
+++ b/packages/plugins/plugin-debug/package.json
@@ -76,6 +76,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-deck/package.json
+++ b/packages/plugins/plugin-deck/package.json
@@ -86,6 +86,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-discord/package.json
+++ b/packages/plugins/plugin-discord/package.json
@@ -66,6 +66,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-doctor/package.json
+++ b/packages/plugins/plugin-doctor/package.json
@@ -86,6 +86,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-duffel/package.json
+++ b/packages/plugins/plugin-duffel/package.json
@@ -60,6 +60,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-explorer/package.json
+++ b/packages/plugins/plugin-explorer/package.json
@@ -90,6 +90,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-feed/package.json
+++ b/packages/plugins/plugin-feed/package.json
@@ -90,6 +90,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-file/package.json
+++ b/packages/plugins/plugin-file/package.json
@@ -90,6 +90,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-gallery/package.json
+++ b/packages/plugins/plugin-gallery/package.json
@@ -76,6 +76,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-game/package.json
+++ b/packages/plugins/plugin-game/package.json
@@ -83,6 +83,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-generator/package.json
+++ b/packages/plugins/plugin-generator/package.json
@@ -81,6 +81,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-github/package.json
+++ b/packages/plugins/plugin-github/package.json
@@ -66,6 +66,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-graph/package.json
+++ b/packages/plugins/plugin-graph/package.json
@@ -49,6 +49,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-inbox/package.json
+++ b/packages/plugins/plugin-inbox/package.json
@@ -115,6 +115,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-integration/package.json
+++ b/packages/plugins/plugin-integration/package.json
@@ -90,6 +90,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-iroh-beacon/package.json
+++ b/packages/plugins/plugin-iroh-beacon/package.json
@@ -70,6 +70,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-kanban/package.json
+++ b/packages/plugins/plugin-kanban/package.json
@@ -102,6 +102,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-linear/package.json
+++ b/packages/plugins/plugin-linear/package.json
@@ -66,6 +66,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-map-solid/package.json
+++ b/packages/plugins/plugin-map-solid/package.json
@@ -56,6 +56,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-map/package.json
+++ b/packages/plugins/plugin-map/package.json
@@ -106,6 +106,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-markdown/package.json
+++ b/packages/plugins/plugin-markdown/package.json
@@ -114,6 +114,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-masonry/package.json
+++ b/packages/plugins/plugin-masonry/package.json
@@ -70,6 +70,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-meeting/package.json
+++ b/packages/plugins/plugin-meeting/package.json
@@ -80,6 +80,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-mermaid/package.json
+++ b/packages/plugins/plugin-mermaid/package.json
@@ -45,6 +45,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-native-filesystem/package.json
+++ b/packages/plugins/plugin-native-filesystem/package.json
@@ -76,6 +76,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-native/package.json
+++ b/packages/plugins/plugin-native/package.json
@@ -65,6 +65,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-navtree/package.json
+++ b/packages/plugins/plugin-navtree/package.json
@@ -91,6 +91,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-observability/package.json
+++ b/packages/plugins/plugin-observability/package.json
@@ -75,6 +75,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-osrm/package.json
+++ b/packages/plugins/plugin-osrm/package.json
@@ -50,6 +50,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-outliner/package.json
+++ b/packages/plugins/plugin-outliner/package.json
@@ -75,6 +75,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-pipeline/package.json
+++ b/packages/plugins/plugin-pipeline/package.json
@@ -81,6 +81,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-presenter/package.json
+++ b/packages/plugins/plugin-presenter/package.json
@@ -82,6 +82,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-preview/package.json
+++ b/packages/plugins/plugin-preview/package.json
@@ -65,6 +65,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-pwa/package.json
+++ b/packages/plugins/plugin-pwa/package.json
@@ -49,6 +49,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-registry/package.json
+++ b/packages/plugins/plugin-registry/package.json
@@ -52,6 +52,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-sample/package.json
+++ b/packages/plugins/plugin-sample/package.json
@@ -86,6 +86,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-sandbox/package.json
+++ b/packages/plugins/plugin-sandbox/package.json
@@ -61,6 +61,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-script/package.json
+++ b/packages/plugins/plugin-script/package.json
@@ -116,6 +116,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-search/package.json
+++ b/packages/plugins/plugin-search/package.json
@@ -85,6 +85,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-sequencer/package.json
+++ b/packages/plugins/plugin-sequencer/package.json
@@ -82,6 +82,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-settings/package.json
+++ b/packages/plugins/plugin-settings/package.json
@@ -45,6 +45,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-sheet/package.json
+++ b/packages/plugins/plugin-sheet/package.json
@@ -82,6 +82,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-sidekick/package.json
+++ b/packages/plugins/plugin-sidekick/package.json
@@ -76,6 +76,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-simple-layout/package.json
+++ b/packages/plugins/plugin-simple-layout/package.json
@@ -74,6 +74,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-sketch/package.json
+++ b/packages/plugins/plugin-sketch/package.json
@@ -81,6 +81,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-slack/package.json
+++ b/packages/plugins/plugin-slack/package.json
@@ -66,6 +66,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-space/package.json
+++ b/packages/plugins/plugin-space/package.json
@@ -105,6 +105,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-spacetime/package.json
+++ b/packages/plugins/plugin-spacetime/package.json
@@ -71,6 +71,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "docs/PLUGIN.mdl",
     "PLUGIN.mdl"

--- a/packages/plugins/plugin-spotlight/package.json
+++ b/packages/plugins/plugin-spotlight/package.json
@@ -71,6 +71,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-stack/package.json
+++ b/packages/plugins/plugin-stack/package.json
@@ -70,6 +70,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-status-bar/package.json
+++ b/packages/plugins/plugin-status-bar/package.json
@@ -69,6 +69,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-support/package.json
+++ b/packages/plugins/plugin-support/package.json
@@ -91,6 +91,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-table/package.json
+++ b/packages/plugins/plugin-table/package.json
@@ -96,6 +96,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-template/package.json
+++ b/packages/plugins/plugin-template/package.json
@@ -64,6 +64,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-testing/package.json
+++ b/packages/plugins/plugin-testing/package.json
@@ -64,6 +64,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-theme/package.json
+++ b/packages/plugins/plugin-theme/package.json
@@ -54,6 +54,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src"
   ],
   "dependencies": {

--- a/packages/plugins/plugin-thread/package.json
+++ b/packages/plugins/plugin-thread/package.json
@@ -91,6 +91,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-tictactoe/package.json
+++ b/packages/plugins/plugin-tictactoe/package.json
@@ -76,6 +76,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-transcription/package.json
+++ b/packages/plugins/plugin-transcription/package.json
@@ -111,6 +111,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-transformer/package.json
+++ b/packages/plugins/plugin-transformer/package.json
@@ -60,6 +60,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-trello/package.json
+++ b/packages/plugins/plugin-trello/package.json
@@ -66,6 +66,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-trip/package.json
+++ b/packages/plugins/plugin-trip/package.json
@@ -92,6 +92,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-video/package.json
+++ b/packages/plugins/plugin-video/package.json
@@ -86,6 +86,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-voxel/package.json
+++ b/packages/plugins/plugin-voxel/package.json
@@ -80,6 +80,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-wnfs/package.json
+++ b/packages/plugins/plugin-wnfs/package.json
@@ -71,6 +71,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],

--- a/packages/plugins/plugin-zen/package.json
+++ b/packages/plugins/plugin-zen/package.json
@@ -76,6 +76,7 @@
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist",
+    "dx.config.ts",
     "src",
     "PLUGIN.mdl"
   ],


### PR DESCRIPTION
## Summary

Plugin packages migrated to `dx.config.ts`, and their `src/meta.ts` now does `import config from '../dx.config'`. The packages expose a `source` export condition (`./src/index.ts`), but `dx.config.ts` was **not** included in the published tarball (`files: ['dist', 'src', ...]`).

External consumers that bundle a plugin package via the `source` condition fail with:

```
[UNRESOLVED_IMPORT] Could not resolve '../dx.config' in @dxos/plugin-space/src/meta.ts
```

This hits **community Composer plugins**, which by design bundle `@dxos/plugin-*` packages (only non-plugin `@dxos/*` get externalized by `composerPlugin`). It surfaced bumping `plugin-excalidraw` to the latest SDK.

This PR adds `dx.config.ts` to the `files` array of all 81 plugin packages that ship one, so the `source`-condition import resolves for external consumers. The in-monorepo build is unaffected (the root `dx.config.ts` was always present on disk).

## Test plan

- [ ] `pnpm pack` a plugin package (e.g. `@dxos/plugin-space`) and confirm `dx.config.ts` is in the tarball
- [ ] After pkg.pr.new republish, re-bump `plugin-excalidraw` and confirm `vite build` resolves `@dxos/plugin-*/src/meta.ts` → `../dx.config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing configurations across 89 plugins to ensure proper file inclusion in distributed packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->