### PR TITLE
fix(e2e): update rename input testid to match new RenamePopover component

### DIFF
--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -307,8 +307,8 @@ export class AppManager {
     await this.page.keyboard.press('ArrowDown');
     await this.page.getByTestId('spacePlugin.renameObject').last().focus();
     await this.page.keyboard.press('Enter');
-    await this.page.getByTestId('spacePlugin.renameObject.input').fill(newName);
-    await this.page.getByTestId('spacePlugin.renameObject.input').press('Enter');
+    await this.page.getByTestId('spacePlugin.rename.input').fill(newName);
+    await this.page.getByTestId('spacePlugin.rename.input').press('Enter');
     await this.page.mouse.move(0, 0, { steps: 4 });
   }
 


### PR DESCRIPTION
## Summary

- The `RenamePopover` refactor in #11878 changed the rename input's `data-testid` from `spacePlugin.renameObject.input` to `spacePlugin.rename.input`
- This broke two e2e collection tests: "re-order collections" and "drag object into collection", both of which call `renameObject()` in the test helper
- Updates `app-manager.ts` to reference the new testid so `renameObject()` can find and interact with the input correctly

## Test plan

- [ ] Verify the "re-order collections" e2e test passes
- [ ] Verify the "drag object into collection" e2e test passes
- [ ] Confirm no other collection tests regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yyzMXcRyThMe84q6rTRST

---
_Generated by [Claude Code](https://claude.ai/code/session_011yyzMXcRyThMe84q6rTRST)_