### PR TITLE
fix(e2e): fix root causes of four flaky Playwright tests

### DIFF
--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -264,8 +264,12 @@ export class AppManager {
 
   async toggleSection(testId: string, delay = 100, timeout = 15_000): Promise<void> {
     const section = this.currentWorkspace.getByTestId(testId);
-    await section.waitFor({ state: 'attached', timeout });
-    await section.getByRole('button').first().click({ delay });
+    await section.waitFor({ state: 'visible', timeout });
+    const toggle = section.getByTestId('treeItem.toggle');
+    // Only expand if not already open — clicking a closed section would collapse it.
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+      await toggle.click({ delay });
+    }
   }
 
   async createObject({ type, name, nth }: { type: string; name?: string; nth?: number }): Promise<void> {
@@ -313,6 +317,7 @@ export class AppManager {
   }
 
   async deleteObject(nth = 0): Promise<void> {
+    await this.getObjectLinks().nth(nth).hover();
     await this.getObjectLinks().nth(nth).getByTestId('navtree.treeItem.actionsLevel2').first().click();
     // TODO(thure): For some reason, actions move around when simulating the mouse in Firefox.
     await this.page.keyboard.press('ArrowDown');

--- a/packages/apps/composer-app/src/playwright/plugins/thread.ts
+++ b/packages/apps/composer-app/src/playwright/plugins/thread.ts
@@ -2,12 +2,17 @@
 // Copyright 2024 DXOS.org
 //
 
+import { expect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
 
 // TODO(wittjosiah): If others find this useful, factor out the thread plugin.
 export const Thread = {
   createComment: async (page: Page, plankLocator: Locator, comment: string) => {
-    await plankLocator.getByTestId('comments.comment.add').click();
+    const addButton = plankLocator.getByTestId('comments.comment.add');
+    // The selectionAspect is updated via a 100ms debounce after the CodeMirror selection dispatch,
+    // which controls the disabled state. Explicitly wait for enabled before clicking.
+    await expect(addButton).toBeEnabled();
+    await addButton.click();
     const currentThread = Thread.getCurrentThread(page);
     // Wait for the newly-created draft thread to appear with aria-current="location".
     // After the click, there is a brief window where React has not yet re-rendered
@@ -31,7 +36,11 @@ export const Thread = {
 
   getCurrentThread: (page: Page) => page.locator('[data-testid=thread][aria-current="location"]'),
 
-  deleteThread: (thread: Locator) => thread.getByTestId('thread.delete').click(),
+  deleteThread: async (thread: Locator) => {
+    // Thread.Header uses hoverableControls — the delete button is opacity:0 until hovered.
+    await thread.hover();
+    await thread.getByTestId('thread.delete').click();
+  },
 
   getMessages: (thread: Locator) => thread.getByTestId('thread.message'),
 


### PR DESCRIPTION
## Summary

Fixes the root causes of four tests flagged as FLAKY in Trunk CI. All fixes address actual behavioral issues rather than timing workarounds.

**Affected tests:**
- `Collection tests › delete a collection` (FLAKY)
- `Collection tests › create collection` (FLAKY)
- `Comments tests › delete thread` (FLAKY)
- `Comments tests › create` (FLAKY)

### Root causes and fixes

**`deleteObject` missing `hover()` (`app-manager.ts`)**

Tree item rows use `hoverableControls` which sets `--controls-opacity:0` on hover-capable devices (desktop). The `navtree.treeItem.actionsLevel2` dropdown trigger has `hoverableControlItem` (`opacity: var(--controls-opacity)`) and is effectively opacity:0 until the row is hovered. `renameObject` already had the correct `hover()` call; `deleteObject` was missing it.

**`toggleSection` could collapse instead of expand (`app-manager.ts`)**

The old implementation used `waitFor({ state: 'attached' })` (weaker than `visible`) and clicked `getByRole('button').first()` (imprecise — first button in the section row may vary). Replaced with: wait for `visible`, target the `treeItem.toggle` button by testId, and check `aria-expanded` to skip the click if the section is already open. Prevents the case where the section starts expanded and a toggle click would inadvertently collapse it.

**`Thread.deleteThread` missing hover (`plugins/thread.ts`)**

`Thread.Content` sets `[--controls-opacity:0]` on the container. `Thread.Header` (which houses the delete button) applies `hoverableControls`, making the delete button opacity:0 until `Thread.Header` is hovered. Added `thread.hover()` before the click.

**`Thread.createComment` implicit wait for enabled state (`plugins/thread.ts`)**

The markdown editor extension updates `selectionAspect` (which controls the `comments.comment.add` button's `disabled` state) via a **100ms debounce** after a CodeMirror selection dispatch. The previous code called `click()` immediately after `Markdown.select`. Added an explicit `expect(addButton).toBeEnabled()` wait to surface the dependency clearly and ensure the debounce has fired before the click is attempted.

## Test plan

- [ ] `Collection tests › create collection` passes consistently
- [ ] `Collection tests › delete a collection` passes consistently
- [ ] `Comments tests › create` passes consistently
- [ ] `Comments tests › delete thread` passes consistently
- [ ] All other collection and comments tests still pass (no regression)

No overlap with PR #11882 (which fixes `renameObject` testId only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKrwf9M1nfbrQbqV9HDCws

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKrwf9M1nfbrQbqV9HDCws)_