### PR TITLE
fix(protocols): add pluginKey and manifestHash to PluginReleaseSchema

### DIFF
--- a/packages/core/protocols/src/edge/registry.ts
+++ b/packages/core/protocols/src/edge/registry.ts
@@ -61,6 +61,10 @@ export const PluginReleaseSchema = Schema.Struct({
    * SDK compatibility from the `@dxos/*` subset to decide whether to offer this release.
    */
   dependencies: Schema.optional(DependencyMapSchema),
+  /** Key of the parent `plugin.profile` record authored by the same DID (the plugin's NSID rkey). */
+  pluginKey: Schema.optional(Schema.String),
+  /** SHA-256 content hash of the published `manifest.json`, prefixed with `sha256-`. */
+  manifestHash: Schema.optional(Schema.String),
   /** ISO-8601 timestamp from the ATProto record. */
   createdAt: Schema.optional(Schema.String),
 });

--- a/packages/core/protocols/src/edge/registry.ts
+++ b/packages/core/protocols/src/edge/registry.ts
@@ -61,6 +61,12 @@ export const PluginReleaseSchema = Schema.Struct({
    * SDK compatibility from the `@dxos/*` subset to decide whether to offer this release.
    */
   dependencies: Schema.optional(DependencyMapSchema),
+  /** ATProto repo/package identifier the bundle was published under. */
+  package: Schema.optional(Schema.String),
+  /** SHA-256 hex digest of the uploaded bundle, for integrity verification. */
+  manifestHash: Schema.optional(Schema.String),
+  /** ISO-8601 timestamp from the ATProto record. */
+  createdAt: Schema.optional(Schema.String),
 });
 export type PluginRelease = Schema.Schema.Type<typeof PluginReleaseSchema>;
 
@@ -90,6 +96,8 @@ export const PluginProfileSchema = Schema.Struct({
   dependsOn: Schema.optional(Schema.Array(Schema.String)),
   /** Relative path inside the package to a bundled MDL spec (consumed by plugin-code). */
   spec: Schema.optional(Schema.String),
+  /** ISO-8601 timestamp from the ATProto record. */
+  createdAt: Schema.optional(Schema.String),
 });
 export type PluginProfile = Schema.Schema.Type<typeof PluginProfileSchema>;
 

--- a/packages/core/protocols/src/edge/registry.ts
+++ b/packages/core/protocols/src/edge/registry.ts
@@ -48,7 +48,7 @@ export type PluginManifest = Schema.Schema.Type<typeof PluginManifestSchema>;
 // ─── ATProto-native registry view ────────────────────────────────────────────
 
 /**
- * A single installable release of a plugin, projected from a `package.release`
+ * A single installable release of a plugin, projected from a `plugin.release`
  * ATProto record.
  */
 export const PluginReleaseSchema = Schema.Struct({
@@ -61,22 +61,18 @@ export const PluginReleaseSchema = Schema.Struct({
    * SDK compatibility from the `@dxos/*` subset to decide whether to offer this release.
    */
   dependencies: Schema.optional(DependencyMapSchema),
-  /** ATProto repo/package identifier the bundle was published under. */
-  package: Schema.optional(Schema.String),
-  /** SHA-256 hex digest of the uploaded bundle, for integrity verification. */
-  manifestHash: Schema.optional(Schema.String),
   /** ISO-8601 timestamp from the ATProto record. */
   createdAt: Schema.optional(Schema.String),
 });
 export type PluginRelease = Schema.Schema.Type<typeof PluginReleaseSchema>;
 
 /**
- * Verbatim content of a `package.profile` ATProto record. `key` is the record's rkey (a reverse-domain
+ * Verbatim content of a `plugin.profile` ATProto record. `key` is the record's rkey (a reverse-domain
  * NSID), denormalized into the body. Version-independent identity + display metadata; provenance
  * (`author`) is resolved separately from the publisher DID/handle.
  */
 export const PluginProfileSchema = Schema.Struct({
-  /** Reverse-domain NSID — the plugin's globally-unique key and the `package.profile` rkey (e.g. `org.dxos.plugin.excalidraw`). */
+  /** Reverse-domain NSID — the plugin's globally-unique key and the `plugin.profile` rkey (e.g. `org.dxos.plugin.excalidraw`). */
   key: Schema.String.pipe(Schema.nonEmptyString()),
   /** Plugin display name. */
   name: Schema.String.pipe(Schema.nonEmptyString()),
@@ -105,7 +101,7 @@ export type PluginProfile = Schema.Schema.Type<typeof PluginProfileSchema>;
  * A single hydrated plugin entry returned by `GET /registry/plugins`.
  *
  * This is an indexer-assembled *view* — analogous to emdash's `PackageView` — projected
- * from four ATProto record types: `package.profile`, `package.release`,
+ * from four ATProto record types: `plugin.profile`, `plugin.release`,
  * `publisher.profile`, and `publisher.verification`. It is NOT a direct serialization
  * of any single ATProto record.
  *
@@ -121,7 +117,7 @@ export type PluginProfile = Schema.Schema.Type<typeof PluginProfileSchema>;
 export const PluginViewSchema = Schema.Struct({
   // ── Addressing / provenance (indexer-derived) ────────────────────────────
   /**
-   * `at://` URI of the source `package.profile` record.
+   * `at://` URI of the source `plugin.profile` record.
    * Globally unique and stable — never changes after the record is published.
    */
   uri: Schema.String.pipe(Schema.nonEmptyString()),
@@ -143,7 +139,7 @@ export const PluginViewSchema = Schema.Struct({
   // ── Verbatim profile record content ─────────────────────────────────────
   profile: PluginProfileSchema,
 
-  // ── Releases (projected from package.release records) ───────────────────
+  // ── Releases (projected from plugin.release records) ────────────────────
   /**
    * All known releases for this package, ordered newest-first.
    * Powers the version picker directly — no separate endpoint needed.
@@ -197,8 +193,8 @@ export type PublisherVerification = Schema.Schema.Type<typeof PublisherVerificat
 
 /** NSID constants for the four `org.dxos.experimental.*` record collections. */
 export const NSID = {
-  PackageProfile: 'org.dxos.experimental.package.profile',
-  PackageRelease: 'org.dxos.experimental.package.release',
+  PluginProfile: 'org.dxos.experimental.plugin.profile',
+  PluginRelease: 'org.dxos.experimental.plugin.release',
   PublisherProfile: 'org.dxos.experimental.publisher.profile',
   PublisherVerification: 'org.dxos.experimental.publisher.verification',
 } as const;
@@ -206,8 +202,8 @@ export const NSID = {
 export type RegistryNsid = (typeof NSID)[keyof typeof NSID];
 
 export const ALL_NSIDS: readonly RegistryNsid[] = [
-  NSID.PackageProfile,
-  NSID.PackageRelease,
+  NSID.PluginProfile,
+  NSID.PluginRelease,
   NSID.PublisherProfile,
   NSID.PublisherVerification,
 ];

--- a/packages/core/protocols/src/lexicons/org.dxos.experimental/README.md
+++ b/packages/core/protocols/src/lexicons/org.dxos.experimental/README.md
@@ -6,8 +6,8 @@ Experimental AT Protocol lexicons for the DXOS plugin registry. The `experimenta
 
 | NSID                                           | rkey               | Purpose                                               |
 | ---------------------------------------------- | ------------------ | ----------------------------------------------------- |
-| `org.dxos.experimental.package.profile`        | `<key>`            | Mutable package metadata (one per key per DID).       |
-| `org.dxos.experimental.package.release`        | `<key>:<version>`  | Versioned artifact record (conceptually single-write).|
+| `org.dxos.experimental.plugin.profile`         | `<key>`            | Mutable plugin metadata (one per key per DID).        |
+| `org.dxos.experimental.plugin.release`         | `<key>:<version>`  | Versioned artifact record (conceptually single-write).|
 | `org.dxos.experimental.publisher.profile`      | `self`             | Identity-level publisher metadata.                    |
 | `org.dxos.experimental.publisher.verification` | `<verified DID>`   | Trust attestation about a publisher.                  |
 

--- a/packages/core/protocols/src/lexicons/org.dxos.experimental/plugin.profile.json
+++ b/packages/core/protocols/src/lexicons/org.dxos.experimental/plugin.profile.json
@@ -1,11 +1,11 @@
 {
   "lexicon": 1,
-  "id": "org.dxos.experimental.package.profile",
+  "id": "org.dxos.experimental.plugin.profile",
   "defs": {
     "main": {
       "type": "record",
       "key": "literal:key",
-      "description": "Mutable metadata for a discoverable plugin/module published on the DXOS experimental registry. The rkey is the plugin key (reverse-domain NSID, e.g. org.dxos.plugin.excalidraw). Companion org.dxos.experimental.package.release records carry versioned artifacts.",
+      "description": "Mutable metadata for a discoverable plugin/module published on the DXOS experimental registry. The rkey is the plugin key (reverse-domain NSID, e.g. org.dxos.plugin.excalidraw). Companion org.dxos.experimental.plugin.release records carry versioned artifacts.",
       "record": {
         "type": "object",
         "required": ["key", "name", "createdAt"],

--- a/packages/core/protocols/src/lexicons/org.dxos.experimental/plugin.release.json
+++ b/packages/core/protocols/src/lexicons/org.dxos.experimental/plugin.release.json
@@ -1,18 +1,18 @@
 {
   "lexicon": 1,
-  "id": "org.dxos.experimental.package.release",
+  "id": "org.dxos.experimental.plugin.release",
   "defs": {
     "main": {
       "type": "record",
       "key": "any",
-      "description": "Release record for a versioned artifact of an org.dxos.experimental.package.profile. Conventionally keyed as '<key>:<version>'. One record per version; conceptually single-write (a new version is a new record), though the author retains write access — integrity is anchored by manifestHash rather than enforced immutability.",
+      "description": "Release record for a versioned artifact of an org.dxos.experimental.plugin.profile. Conventionally keyed as '<key>:<version>'. One record per version; conceptually single-write (a new version is a new record), though the author retains write access — integrity is anchored by manifestHash rather than enforced immutability.",
       "record": {
         "type": "object",
-        "required": ["package", "version", "moduleUrl", "createdAt"],
+        "required": ["pluginKey", "version", "moduleUrl", "createdAt"],
         "properties": {
-          "package": {
+          "pluginKey": {
             "type": "string",
-            "description": "Key of the parent package.profile record authored by the same DID.",
+            "description": "Key of the parent plugin.profile record authored by the same DID.",
             "maxLength": 63
           },
           "version": {

--- a/packages/plugins/plugin-registry/src/commands/registry/publish-package.ts
+++ b/packages/plugins/plugin-registry/src/commands/registry/publish-package.ts
@@ -17,7 +17,7 @@ import { AUTH_OPTION_DESCRIPTIONS, NSID, putRecord, resolveSession } from './uti
 
 /**
  * `dx registry publish-package` — publishes both the mutable
- * `package.profile` (rkey = key) and a `package.release`
+ * `plugin.profile` (rkey = key) and a `plugin.release`
  * (rkey = `<key>:<version>`) record to the authenticated user's PDS.
  *
  * The two writes are independent `putRecord` (upsert) calls; if the second fails the
@@ -94,12 +94,12 @@ export const publishPackage = Command.make(
           createdAt,
         };
 
-        const profileResult = yield* putRecord(session, NSID.PackageProfile, options.key, profile);
+        const profileResult = yield* putRecord(session, NSID.PluginProfile, options.key, profile);
         yield* Console.log(`Profile  ${profileResult.uri}`);
 
         const manifestHash = Option.getOrUndefined(options.manifestHash);
-        const release: PluginRelease & { package: string; createdAt: string } = {
-          package: options.key,
+        const release: PluginRelease & { pluginKey: string; manifestHash?: string; createdAt: string } = {
+          pluginKey: options.key,
           version: options.version,
           moduleUrl: options.moduleUrl,
           createdAt,
@@ -108,7 +108,7 @@ export const publishPackage = Command.make(
 
         const releaseResult = yield* putRecord(
           session,
-          NSID.PackageRelease,
+          NSID.PluginRelease,
           `${options.key}:${options.version}`,
           release,
         );

--- a/packages/plugins/plugin-registry/src/commands/registry/publish.ts
+++ b/packages/plugins/plugin-registry/src/commands/registry/publish.ts
@@ -43,8 +43,8 @@ const sha256Base64 = async (bytes: Uint8Array): Promise<string> => {
  * Reads the build/publish orchestration from `dx.config.ts`, runs the declared build command,
  * reads the emitted `manifest.json`, hosts the bundle (default: upload the build
  * output to the DXOS edge registry; override with `publish.assetBaseUrl` to point
- * at your own already-hosted directory), then writes the `package.profile` and
- * `package.release` records to the authenticated publisher's PDS. Release
+ * at your own already-hosted directory), then writes the `plugin.profile` and
+ * `plugin.release` records to the authenticated publisher's PDS. Release
  * integrity is anchored by `manifestHash` (sha256 of `manifest.json`) in the
  * signed release record.
  */
@@ -181,11 +181,11 @@ export const publish = Command.make(
           profile.spec = manifest.spec;
         }
 
-        const profileResult = yield* putRecord(session, NSID.PackageProfile, key, profile);
+        const profileResult = yield* putRecord(session, NSID.PluginProfile, key, profile);
         yield* Console.log(`Profile    ${profileResult.uri}`);
 
-        const releaseResult = yield* putRecord(session, NSID.PackageRelease, `${key}:${version}`, {
-          package: key,
+        const releaseResult = yield* putRecord(session, NSID.PluginRelease, `${key}:${version}`, {
+          pluginKey: key,
           version,
           moduleUrl,
           manifestHash,

--- a/packages/plugins/plugin-registry/src/commands/registry/unpublish.ts
+++ b/packages/plugins/plugin-registry/src/commands/registry/unpublish.ts
@@ -17,8 +17,8 @@ import { AUTH_OPTION_DESCRIPTIONS, NSID, deleteRecord, listRecords, resolveSessi
 const rkeyOf = (uri: string): string => uri.split('/').pop() ?? '';
 
 /**
- * `dx registry unpublish` — removes a package from the authenticated user's PDS:
- * deletes the `package.profile` (rkey = key) and every `package.release`
+ * `dx registry unpublish` — removes a plugin from the authenticated user's PDS:
+ * deletes the `plugin.profile` (rkey = key) and every `plugin.release`
  * (rkey = `<key>:<version>`). The registry indexer unindexes on its next sweep.
  * Hosted bundles in edge R2 are immutable and are not removed.
  */
@@ -31,7 +31,7 @@ export const unpublish = Command.make(
       Options.optional,
     ),
     key: Options.text('key').pipe(
-      Options.withDescription('Package key (the profile rkey). Removes its profile and all releases.'),
+      Options.withDescription('Plugin key (the profile rkey). Removes its profile and all releases.'),
     ),
   },
   (options) =>
@@ -49,12 +49,12 @@ export const unpublish = Command.make(
         let cursor: string | undefined;
         let deletedReleases = 0;
         do {
-          const releases = yield* listRecords(session, NSID.PackageRelease, { limit: 100, cursor });
+          const releases = yield* listRecords(session, NSID.PluginRelease, { limit: 100, cursor });
           cursor = releases.cursor;
           for (const record of releases.records) {
             const rkey = rkeyOf(record.uri);
             if (rkey.startsWith(`${key}:`)) {
-              yield* deleteRecord(session, NSID.PackageRelease, rkey);
+              yield* deleteRecord(session, NSID.PluginRelease, rkey);
               yield* Console.log(`Deleted release ${rkey}`);
               deletedReleases += 1;
             }
@@ -62,7 +62,7 @@ export const unpublish = Command.make(
         } while (cursor !== undefined);
 
         // Delete the profile (rkey = key).
-        yield* deleteRecord(session, NSID.PackageProfile, key);
+        yield* deleteRecord(session, NSID.PluginProfile, key);
         yield* Console.log(`Deleted profile ${key} (${deletedReleases} release(s) removed)`);
       }),
       Effect.provide(FetchHttpClient.layer),

--- a/packages/sdk/app-framework/docs/registry-spec.md
+++ b/packages/sdk/app-framework/docs/registry-spec.md
@@ -31,13 +31,13 @@ and will be renamed to a final namespace before promotion (see [Versioning](#ver
 
 The machine-readable lexicons are the canonical definition:
 
-- **Lexicon JSON** — `packages/sdk/edge-protocol/lexicons/org.dxos.experimental/*.json` (edge repo).
+- **Lexicon JSON** — `packages/core/protocols/src/lexicons/org.dxos.experimental/*.json` (dxos repo).
   These are the source of truth.
-- **Effect-Schema validators** — `packages/sdk/edge-protocol/src/registry.ts`
-  (edge repo). Decoders used at the indexing/validation seam to reject malformed records before they
-  enter the store. These mirror the JSON lexicons and live alongside them in the protocol package.
-- **`PluginView`** — `packages/core/protocols/src/edge/registry.ts` (dxos repo). The catalog shape
-  the indexer serves to Composer.
+- **`PluginView` + view schemas** — `packages/core/protocols/src/edge/registry.ts` (dxos repo). The
+  catalog shape the indexer serves to Composer, plus the shared profile/release view schemas.
+- **Effect-Schema validators** — `packages/services/registry-service/src/registry/atproto/schema.ts`
+  (edge repo). Indexer-side decoders that extend the view schemas with the raw ATProto record fields
+  (`pluginKey`, `manifestHash`), used to reject malformed records before they enter the store.
 - **CLI writers** — `packages/plugins/plugin-registry/src/commands/registry/` (dxos repo). The `dx`
   CLI assembles record bodies and writes them via XRPC.
 - **App-view / indexer** — `packages/services/registry-service/src/registry/atproto/{indexer,curator,backfill}.ts`
@@ -59,7 +59,7 @@ The machine-readable lexicons are the canonical definition:
                                    └─────────────┘
 ```
 
-1. A publisher writes `package.profile` / `package.release` records (and a one-time
+1. A publisher writes `plugin.profile` / `plugin.release` records (and a one-time
    `publisher.profile`) to their own PDS using the `dx` CLI.
 2. A verifier writes `publisher.verification` records, one per trusted DID, to their own PDS.
 3. The indexer learns the verified-DID set, then ingests matching records from verified publishers —
@@ -73,8 +73,8 @@ The machine-readable lexicons are the canonical definition:
 | ---------------------------------------------- | ----------------- | --------- | -------------------------------------- |
 | `org.dxos.experimental.publisher.profile`      | `self`            | publisher | Identity-level publisher metadata.     |
 | `org.dxos.experimental.publisher.verification` | `<verified DID>`  | verifier  | A trust attestation about a publisher. |
-| `org.dxos.experimental.package.profile`        | `<key>`           | publisher | Plugin metadata (one per key per DID). |
-| `org.dxos.experimental.package.release`        | `<key>:<version>` | publisher | A versioned artifact of a package.     |
+| `org.dxos.experimental.plugin.profile`         | `<key>`           | publisher | Plugin metadata (one per key per DID). |
+| `org.dxos.experimental.plugin.release`         | `<key>:<version>` | publisher | A versioned artifact of a plugin.      |
 
 All record bodies carry a `$type` field set to the NSID (standard ATProto convention; stamped by
 the CLI on write). All records live in the author's own repo and are therefore mutable by that
@@ -111,7 +111,7 @@ policy applied at indexing time, not a write-time restriction (see [Trust model]
 
 Written by `dx registry verify`.
 
-### `package.profile`
+### `plugin.profile`
 
 Mutable metadata for a discoverable plugin. `rkey = <key>` (reverse-domain NSID, e.g.
 `org.dxos.plugin.excalidraw`). The `key` field is the plugin's globally-unique identifier and
@@ -134,16 +134,16 @@ matches the `key` in `dx.config.ts`.
 Written by `dx registry publish` (from the manifest emitted by `composerPlugin` reading `dx.config.ts`)
 or `dx registry publish-package`.
 
-### `package.release`
+### `plugin.release`
 
-A record for one version of a package. `rkey = <key>:<version>`. Conceptually append-only: a new
+A record for one version of a plugin. `rkey = <key>:<version>`. Conceptually append-only: a new
 version is a new record, and the registry treats the first release seen per `(did, key, version)`
 as canonical — but the author technically retains write access to it (see
 [Integrity & tamper detection](#integrity--tamper-detection)).
 
 | Field          | Required | Type              | Constraints | Notes                                                                                                             |
 | -------------- | -------- | ----------------- | ----------- | ----------------------------------------------------------------------------------------------------------------- |
-| `package`      | yes      | string            | ≤63 chars   | Key of the parent `package.profile` authored by the same DID.                                                     |
+| `pluginKey`    | yes      | string            | ≤63 chars   | Key of the parent `plugin.profile` authored by the same DID.                                                      |
 | `version`      | yes      | string            | ≤32 chars   | Semver subset without build metadata; pre-release suffixes allowed (`1.2.3-rc.1`). Taken from `package.json`.     |
 | `moduleUrl`    | yes      | string (uri)      | non-empty   | HTTPS URL of the module entrypoint / `manifest.json`. v0 trusts the publisher; content addressing is a follow-on. |
 | `manifestHash` | no       | string            | ≤256 chars  | Integrity hash of the module manifest, e.g. `sha256-<base64>`.                                                    |
@@ -162,7 +162,7 @@ makes the catalog trustworthy is the **indexing policy**, not a write gate:
 
 - **Today (single verifier).** The indexer is configured with one trusted verifier DID
   (`REGISTRY_CURATOR_DID`) and honors `publisher.verification` records **only** from that DID. The
-  verified-DID set is the set of `subject`s across that verifier's records. A `package.*` or
+  verified-DID set is the set of `subject`s across that verifier's records. A `plugin.*` or
   `publisher.profile` record is indexed only if its author DID is in the verified set. This is a
   deliberate moderation simplification while the registry is young — not a protocol restriction.
 - **Revocation.** Deleting the verification record removes the publisher from the verified set on the
@@ -179,7 +179,7 @@ until a trusted verifier vouches for them.
 ## Integrity & tamper detection
 
 Immutability is an **app-view guarantee, not an AT Protocol one.** Like every AT Protocol repo, a
-publisher owns their PDS records and can mutate or delete any of them — including `package.release` —
+publisher owns their PDS records and can mutate or delete any of them — including `plugin.release` —
 and no protocol mechanism makes a record cryptographically immutable. Enforcement therefore lives at
 the **registry app-view** (the edge service that indexes the firehose and serves the catalog to
 Composer): the PDS is the mutable source, and the app-view is the canonical, immutable view of what
@@ -199,7 +199,7 @@ What the app-view enforces:
 
 What stays mutable (the AT Protocol layer):
 
-- The PDS `package.release` record is written with `putRecord` (upsert), and the publisher can change
+- The PDS `plugin.release` record is written with `putRecord` (upsert), and the publisher can change
   its `moduleUrl` / `manifestHash` at will. That is fine — the app-view's pin means such a change is not
   re-served (the PDS is the mutable source; the app-view is the canonical view).
 
@@ -217,9 +217,9 @@ publisher-trusted at the record level (the hosted bundle itself is already immut
 
 - **Bootstrap / backfill.** On first run (and periodically), the indexer walks the verifier's repo
   for verification records to compute the verified-DID set, then lists each verified publisher's repo
-  for `package.*` records (`runBackfill`). The catalog (`GET /registry/plugins`) collects releases
-  per `(authorDid, package-key)` — grouped by the release's `package` field, **not** by parsing the
-  rkey — newest-first, anchored by `at://<authorDid>/org.dxos.experimental.package.profile/<key>`.
+  for `plugin.*` records (`runBackfill`). The catalog (`GET /registry/plugins`) collects releases
+  per `(authorDid, pluginKey)` — grouped by the release's `pluginKey` field, **not** by parsing the
+  rkey — newest-first, anchored by `at://<authorDid>/org.dxos.experimental.plugin.profile/<key>`.
 - **Live updates.** The indexer subscribes to the Jetstream firehose; commits for the four NSIDs are
   validated (Effect-Schema) and written/deleted in DO storage, keyed by `record:<nsid>|<did>|<rkey>`.
 - **Validation seam.** Malformed records are rejected at ingestion against the Effect-Schema mirrors
@@ -257,7 +257,7 @@ works if it was built against an SDK compatible with what Composer ships. DXOS s
 **Mechanism — the manifest dependency snapshot.** The build (`composerPlugin`) auto-populates a
 `dependencies` map into the plugin's `manifest.json`: every declared dependency resolved to its
 concrete installed version (`{ "@dxos/app-framework": "0.8.3", "react": "19.2.0", … }`). This flows
-into the `package.release` record and the catalog (`PluginRelease.dependencies`). The host computes
+into the `plugin.release` record and the catalog (`PluginRelease.dependencies`). The host computes
 compatibility from the **subset it shares with the plugin** — the externalized `@dxos/*` packages —
 comparing each against its own shipped version under a policy (pre-1.0: **same minor**; post-1.0:
 caret). The remaining (bundled) deps are recorded for transparency/audit. A release with no
@@ -296,9 +296,9 @@ runtime sandbox surface is defined. (rkey conventions now match emdash, includin
 ## Schema reconciliation
 
 The JSON lexicons, the Effect-Schema validators, `PluginView`, and the CLI previously had field-level
-drift on `package.profile`. All items listed here are resolved.
+drift on `plugin.profile`. All items listed here are resolved.
 
-- **`slug` → `key`** — the identity field on `package.profile` is now named `key` everywhere: the
+- **`slug` → `key`** — the identity field on `plugin.profile` is now named `key` everywhere: the
   lexicon, the Effect-Schema validator, `PluginProfileSchema` in `@dxos/protocols`, the CLI flags
   (`--key`), and the runtime `Plugin.Meta.profile.key`.
 - **`homepage` → `homePage`** — camelCase alignment across the lexicon, validator, `PluginProfileSchema`,
@@ -308,12 +308,12 @@ drift on `package.profile`. All items listed here are resolved.
 - **`screenshots`** — unified as `{ light?, dark? }[]` (object-only form) across `dx.config.ts`,
   `PluginProfileSchema`, the validator, and the indexer projection. Plain URL strings are no longer
   accepted at authoring time; use `{ dark: 'url' }` or `{ light: 'url', dark: 'url' }`.
-- **`dependsOn`** — added to `package.profile` (author-declared runtime plugin deps, NSIDs),
+- **`dependsOn`** — added to `plugin.profile` (author-declared runtime plugin deps, NSIDs),
   `PluginProfileSchema`, the validator, and `dx.config.ts`.
-- **`spec`** — added to `package.profile` (relative path to a bundled MDL spec),
+- **`spec`** — added to `plugin.profile` (relative path to a bundled MDL spec),
   `PluginProfileSchema`, the validator, and `dx.config.ts`.
-- **`dependencies`** (SDK-compat snapshot on `package.release`) — `composerPlugin` emits the full
-  resolved dependency map into `manifest.json`; the CLI writes it into the `package.release` record;
+- **`dependencies`** (SDK-compat snapshot on `plugin.release`) — `composerPlugin` emits the full
+  resolved dependency map into `manifest.json`; the CLI writes it into the `plugin.release` record;
   the validator preserves it in storage; `PluginReleaseSchema` in `@dxos/protocols` types it.
 
 ## Open questions & follow-ons

--- a/packages/sdk/app-framework/src/ui/components/Surface/SurfaceComponent.tsx
+++ b/packages/sdk/app-framework/src/ui/components/Surface/SurfaceComponent.tsx
@@ -37,7 +37,7 @@ import {
   type WebComponentDefinition,
 } from './types';
 
-const DEBUG = import.meta.env.VITE_DEBUG;
+const DEBUG = import.meta.env?.VITE_DEBUG;
 
 const DEFAULT_PLACEHOLDER = <Fragment />;
 


### PR DESCRIPTION
These fields are written to every `plugin.release` ATProto record by the CLI publisher but were accidentally omitted from `PluginReleaseSchema` in the previous PR (#11887).

- `pluginKey` — the parent `plugin.profile` rkey, used by the edge indexer to join releases to their profile
- `manifestHash` — SHA-256 hash of `manifest.json`, used for release integrity verification

Both are optional on the view schema (existing records without them still parse).

## Test plan
- [ ] `protocols:compile` passes (verified locally)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin registry system now supports expanded metadata including manifest hashes and creation timestamps
  
* **Bug Fixes**
  * Fixed potential runtime error in Surface component when environment variables are unavailable

* **Documentation**
  * Updated Plugin Registry specification with comprehensive schema and implementation details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->