### PR TITLE
fix(protocols): add pluginKey and manifestHash to PluginReleaseSchema

### DIFF
--- a/packages/core/protocols/src/edge/registry.ts
+++ b/packages/core/protocols/src/edge/registry.ts
@@ -61,6 +61,10 @@ export const PluginReleaseSchema = Schema.Struct({
    * SDK compatibility from the `@dxos/*` subset to decide whether to offer this release.
    */
   dependencies: Schema.optional(DependencyMapSchema),
+  /** Key of the parent `plugin.profile` record authored by the same DID (the plugin's NSID rkey). */
+  pluginKey: Schema.optional(Schema.String),
+  /** SHA-256 content hash of the published `manifest.json`, prefixed with `sha256-`. */
+  manifestHash: Schema.optional(Schema.String),
   /** ISO-8601 timestamp from the ATProto record. */
   createdAt: Schema.optional(Schema.String),
 });


### PR DESCRIPTION
These fields are written to every `plugin.release` ATProto record by the CLI publisher but were accidentally omitted from `PluginReleaseSchema` in #11887.

- `pluginKey` — key of the parent `plugin.profile` record, used by the edge indexer to join releases to their profile
- `manifestHash` — SHA-256 hash of `manifest.json`, used for release integrity verification

Both are `optional` so existing records without them still parse correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended plugin registry to track plugin keys and manifest hashes for improved plugin verification and identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->