### PR TITLE
fix(app-framework): resolve import-map wrappers to host source graph

### DIFF
--- a/packages/sdk/app-framework/src/vite-plugin/import-map/index.ts
+++ b/packages/sdk/app-framework/src/vite-plugin/import-map/index.ts
@@ -361,6 +361,7 @@ export const importMapPlugin = (options?: { packages?: string[] }): Plugin[] => 
   let modules: string[] = [];
   let importMapIsDev = false;
   let base = '/';
+  let root = process.cwd();
 
   return [
     // Phase 1: Resolve all package entrypoints and emit chunks.
@@ -380,6 +381,7 @@ export const importMapPlugin = (options?: { packages?: string[] }): Plugin[] => 
       apply: 'build',
       configResolved(config) {
         base = config.base ?? '/';
+        root = config.root;
       },
       async buildStart() {
         importMapIsDev = this.environment.mode === 'dev';
@@ -416,7 +418,16 @@ export const importMapPlugin = (options?: { packages?: string[] }): Plugin[] => 
             continue;
           }
 
-          const resolved = await this.resolve(specifier);
+          // Resolve with a host-rooted importer (not a bare importer-less resolve). The host's
+          // `importSource` plugin — which routes `@dxos/*` to the `source` (TypeScript) export
+          // instead of the published `dist/` — bails out when `importer` is undefined, so an
+          // importer-less `this.resolve(specifier)` falls through to the `default`/dist export.
+          // That made wrapper chunks evaluate `dist/` while the host app evaluated `src/`,
+          // duplicating module-local identity (the private `ProxyHandlerSlot` class, `Ref`
+          // brand symbols, React contexts) and breaking `instanceof` across the host↔plugin
+          // boundary. Passing a host-rooted importer makes `importSource` resolve these
+          // wrappers to the exact same source module the host app uses.
+          const resolved = await this.resolve(specifier, path.join(root, 'index.html'));
           if (!resolved) {
             this.warn(`Import map: unable to resolve "${specifier}"; omitting from import map.`);
             continue;
@@ -470,16 +481,22 @@ export const importMapPlugin = (options?: { packages?: string[] }): Plugin[] => 
           return `export * from ${JSON.stringify(specifier)};\n${keepalive}\n`;
         }
 
+        // Re-export from the resolved absolute path, not the bare specifier. A bare re-export
+        // would let Rolldown resolve `@dxos/echo` a second way (the host app reaches it via the
+        // `source` export, this virtual module via the published `dist/`), evaluating the same
+        // source twice and duplicating module-local identity — the private `ProxyHandlerSlot`
+        // class, `Ref` brand symbols, React contexts — which breaks `instanceof` and context
+        // lookups across the host↔remote-plugin boundary. The resolved id (see the importer
+        // passed to `this.resolve` above) already points at the host's module.
         const filePath = trimQueryString(resolvedId);
         const isCjs = filePath.endsWith('.cjs') || (!filePath.endsWith('.mjs') && !resolvedIdIsEsmModule(filePath));
-
         if (isCjs) {
           const named = getCjsNamedExports(filePath);
           if (named.length > 0) {
-            return `export { default, ${named.join(', ')} } from ${JSON.stringify(specifier)};\n${keepalive}\n`;
+            return `export { default, ${named.join(', ')} } from ${JSON.stringify(filePath)};\n${keepalive}\n`;
           }
         }
-        return `export * from ${JSON.stringify(specifier)};\n${keepalive}\n`;
+        return `export * from ${JSON.stringify(filePath)};\n${keepalive}\n`;
       },
 
       // After bundling, map each specifier to the URL of its emitted chunk. Preserves


### PR DESCRIPTION
## Problem

Remote Composer plugins (e.g. a third-party Excalidraw plugin) externalize `@dxos/*` and load them through the host **import map**. Creating an object from such a plugin threw:

```
invariant violation [value instanceof ProxyHandlerSlot]
  at packages/core/echo/echo/src/internal/common/proxy/proxy-utils.ts:32
  at Database.add → _addObject → getProxySlot
```

(The same root cause also surfaces as `class instances are not supported: setting Ref(...)` and `Missing PluginManagerContext`.)

## Root cause

`@dxos/echo` was being **evaluated twice** in the composer-app build:

- The **host app** resolves `@dxos/*` to the `source` (TypeScript) export via the `importSource` plugin.
- The **import-map wrapper chunks** (what remote plugins resolve to) resolved to the published **`dist/`** export.

The reason: `importMapPlugin` called `this.resolve(specifier)` with **no importer**, and `importSource`'s `resolveId` returns `null` when `importer` is undefined — so resolution fell through to the `default`/`dist` export. Two physical evaluations of the same source ⇒ two `ProxyHandlerSlot` classes ⇒ `value instanceof ProxyHandlerSlot` is `false` across the host↔plugin boundary. (`Symbol.for('@dxos/schema/Proxy')` is global, so proxy *detection* survives duplication; only the class-identity `instanceof` breaks.)

## Fix

`packages/sdk/app-framework/src/vite-plugin/import-map/index.ts`:

1. Pass a host-rooted importer to `this.resolve` — `this.resolve(specifier, path.join(root, 'index.html'))` (capturing `root = config.root`) — so `importSource` fires and resolves each wrapper to the **same source module** the host app uses.
2. Re-export the virtual wrapper from the **resolved absolute path** instead of the bare specifier, so Rolldown cannot re-fork the resolution.

No new dependencies; `instanceof` is kept as-is. This is the dep-free equivalent of the previously-explored source-resolver approach (without `oxc-resolver`).

## Verification

Against a composer-app production build (`vite preview`):

- **Before**: the `@dxos/echo` import-map target reached a `dist` copy of `ProxyHandlerSlot`; the host `SpacePlugin`/`Database` path reached a `src` copy — different classes.
- **After**: all **346** import-map targets and the host converge on a **single** shared proxy chunk. Confirmed end-to-end by creating an object from the external plugin (the original failure path).
- Worker / devtools bundles keep their own copies by necessity (separate JS realms; objects cross via structured-clone, never as live proxies) and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module resolution consistency in the SDK framework's build plugin. The plugin now reliably uses the host application's source modules for wrapper chunks instead of potentially falling back to alternatives, ensuring more predictable module handling during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->