### PR TITLE
refactor(plugins): standardize settings articles

### DIFF
--- a/packages/plugins/plugin-code/package.json
+++ b/packages/plugins/plugin-code/package.json
@@ -104,6 +104,7 @@
     "@dxos/react-client": "workspace:*",
     "@dxos/react-ui": "workspace:*",
     "@dxos/react-ui-editor": "workspace:*",
+    "@dxos/react-ui-form": "workspace:*",
     "@dxos/react-ui-menu": "workspace:*",
     "@dxos/schema": "workspace:*",
     "@dxos/types": "workspace:*",

--- a/packages/plugins/plugin-code/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-code/src/capabilities/react-surface.tsx
@@ -44,7 +44,12 @@ export default Capability.makeModule(() =>
         filter: AppSurface.settings(AppSurface.Article, meta.profile.key),
         component: ({ data: { subject } }) => {
           const { settings, updateSettings } = useSettingsState<Settings.Settings>(subject.atom);
-          return <CodeSettings settings={settings} onSettingsChange={updateSettings} />;
+          return (
+            <CodeSettings
+              settings={settings}
+              onSettingsChange={(next: Settings.Settings) => updateSettings(() => next)}
+            />
+          );
         },
       }),
       Surface.create({

--- a/packages/plugins/plugin-code/src/containers/CodeSettings/CodeSettings.tsx
+++ b/packages/plugins/plugin-code/src/containers/CodeSettings/CodeSettings.tsx
@@ -20,6 +20,10 @@ export type CodeSettingsProps = {
   onSettingsChange: (settings: SettingsType.Settings) => void;
 };
 
+/**
+ * Settings panel for the Code plugin: manages the Anthropic API key (stored as
+ * an ECHO `AccessToken`) and the schema-driven build-service `endpoint`.
+ */
 export const CodeSettings = ({ settings, onSettingsChange }: CodeSettingsProps) => {
   const { t } = useTranslation(meta.profile.key);
   const spaces = useSpaces();

--- a/packages/plugins/plugin-code/src/containers/CodeSettings/CodeSettings.tsx
+++ b/packages/plugins/plugin-code/src/containers/CodeSettings/CodeSettings.tsx
@@ -2,21 +2,22 @@
 // Copyright 2026 DXOS.org
 //
 
-import React, { type ChangeEvent, useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { Filter, Obj } from '@dxos/echo';
 import { useQuery, useSpaces } from '@dxos/react-client/echo';
-import { Button, Icon, Input, Panel, ScrollArea, useTranslation } from '@dxos/react-ui';
+import { Button, Icon, Input, useTranslation } from '@dxos/react-ui';
+import { Settings } from '@dxos/react-ui-form';
 import { AccessToken } from '@dxos/types';
 
 import { meta } from '#meta';
-import { type Settings } from '#types';
+import { Settings as SettingsType } from '#types';
 
 const SERVICE = 'anthropic.com';
 
 export type CodeSettingsProps = {
-  settings: Settings.Settings;
-  onSettingsChange: (settings: Settings.Settings) => void;
+  settings: SettingsType.Settings;
+  onSettingsChange: (settings: SettingsType.Settings) => void;
 };
 
 export const CodeSettings = ({ settings, onSettingsChange }: CodeSettingsProps) => {
@@ -48,49 +49,30 @@ export const CodeSettings = ({ settings, onSettingsChange }: CodeSettingsProps) 
     }
   }, [existing, space]);
 
-  const handleEndpointChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      onSettingsChange({ ...settings, endpoint: event.target.value || undefined });
-    },
-    [onSettingsChange, settings],
-  );
-
   return (
-    <Panel.Root>
-      <Panel.Content asChild>
-        <ScrollArea.Root orientation='vertical'>
-          <ScrollArea.Viewport classNames='p-4 space-y-4'>
-            <Input.Root>
-              <Input.Label>{t('api-key.label')}</Input.Label>
-              <Input.TextInput
-                type='password'
-                placeholder={existing ? t('api-key.set.placeholder') : t('api-key.empty.placeholder')}
-                value={draft}
-                onChange={(event) => setDraft(event.target.value)}
-              />
-            </Input.Root>
-            <div className='flex gap-2'>
-              <Button onClick={handleSave} disabled={!draft.trim() || !space}>
-                <Icon icon='ph--floppy-disk--regular' size={4} />
-                {t('api-key.save.label')}
-              </Button>
-              <Button onClick={handleClear} disabled={!existing} variant='ghost'>
-                <Icon icon='ph--trash--regular' size={4} />
-                {t('api-key.clear.label')}
-              </Button>
-            </div>
-            <Input.Root>
-              <Input.Label>{t('endpoint.label')}</Input.Label>
-              <Input.TextInput
-                value={settings.endpoint ?? ''}
-                placeholder={t('endpoint.placeholder')}
-                onChange={handleEndpointChange}
-              />
-            </Input.Root>
-          </ScrollArea.Viewport>
-        </ScrollArea.Root>
-      </Panel.Content>
-    </Panel.Root>
+    <Settings.Viewport>
+      <Settings.Section title={meta.profile.name ?? meta.profile.key}>
+        <Settings.Item title={t('api-key.label')}>
+          <Input.TextInput
+            type='password'
+            placeholder={existing ? t('api-key.set.placeholder') : t('api-key.empty.placeholder')}
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+          />
+          <div className='flex justify-end gap-2 pt-trim-md'>
+            <Button onClick={handleSave} disabled={!draft.trim() || !space}>
+              <Icon icon='ph--floppy-disk--regular' size={4} />
+              {t('api-key.save.label')}
+            </Button>
+            <Button onClick={handleClear} disabled={!existing} variant='ghost'>
+              <Icon icon='ph--trash--regular' size={4} />
+              {t('api-key.clear.label')}
+            </Button>
+          </div>
+        </Settings.Item>
+        <Settings.FieldSet schema={SettingsType.Settings} values={settings} onValuesChanged={onSettingsChange} />
+      </Settings.Section>
+    </Settings.Viewport>
   );
 };
 

--- a/packages/plugins/plugin-code/tsconfig.json
+++ b/packages/plugins/plugin-code/tsconfig.json
@@ -73,6 +73,9 @@
       "path": "../../ui/react-ui-editor"
     },
     {
+      "path": "../../ui/react-ui-form"
+    },
+    {
       "path": "../../ui/react-ui-menu"
     },
     {

--- a/packages/plugins/plugin-inbox/dx.config.ts
+++ b/packages/plugins/plugin-inbox/dx.config.ts
@@ -19,7 +19,7 @@ export default Config2.make({
 
       An Inbox blueprint gives AI agents tools to read, draft, classify, and sync mail, plus message extractors that parse confirmation emails (flights, hotels, reservations) into structured Trip and Event objects in the space.
     `,
-    icon: { key: 'ph--address-book-tabs--regular', hue: 'rose' },
+    icon: { key: 'ph--mailbox--regular', hue: 'rose' },
     source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-inbox',
     tags: ['integration'],
   },

--- a/packages/plugins/plugin-kanban/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-kanban/src/capabilities/react-surface.tsx
@@ -13,7 +13,7 @@ import { SchemaEx } from '@dxos/effect';
 import { type FormFieldRendererProps, SelectField, useFormValues } from '@dxos/react-ui-form';
 import { Position } from '@dxos/util';
 
-import { KanbanArticle, KanbanSettings } from '#containers';
+import { KanbanArticle, KanbanProperties } from '#containers';
 import { Kanban, PivotColumnAnnotationId } from '#types';
 
 export default Capability.makeModule(() =>
@@ -32,7 +32,7 @@ export default Capability.makeModule(() =>
         id: 'objectProperties',
         position: Position.first,
         filter: AppSurface.object(AppSurface.ObjectProperties, Kanban.Kanban),
-        component: ({ data }) => <KanbanSettings subject={data.subject} />,
+        component: ({ data }) => <KanbanProperties subject={data.subject} />,
       }),
       Surface.create({
         id: 'createInitialSchemaForm',

--- a/packages/plugins/plugin-kanban/src/containers/KanbanProperties/KanbanProperties.tsx
+++ b/packages/plugins/plugin-kanban/src/containers/KanbanProperties/KanbanProperties.tsx
@@ -15,16 +15,16 @@ import { getTypeURIFromQuery } from '@dxos/schema';
 import { useProjectionModel } from '#hooks';
 import { type Kanban, KanbanSettingsSchema, KanbanViewSettingsSchema, UNCATEGORIZED_VALUE } from '#types';
 
-export type KanbanSettingsProps = AppSurface.ObjectPropertiesProps<Kanban.Kanban>;
+export type KanbanPropertiesProps = AppSurface.ObjectPropertiesProps<Kanban.Kanban>;
 
 /**
- * Settings panel for a Kanban. Renders fields common to every kanban
+ * Object-properties panel for a Kanban. Renders fields common to every kanban
  * (currently the "Hide uncategorized column" toggle); for view-variant
  * kanbans an additional "Column field" picker drives the View's pivot
  * field. Items-variant kanbans use a hardcoded `spec.pivotField`, so that
  * field is omitted there.
  */
-export const KanbanSettings = ({ subject: object }: KanbanSettingsProps) => {
+export const KanbanProperties = ({ subject: object }: KanbanPropertiesProps) => {
   const registry = useContext(RegistryContext);
   const db = Obj.getDatabase(object);
   const isView = object.spec.kind === 'view';

--- a/packages/plugins/plugin-kanban/src/containers/KanbanProperties/index.ts
+++ b/packages/plugins/plugin-kanban/src/containers/KanbanProperties/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export { KanbanProperties as default } from './KanbanProperties';

--- a/packages/plugins/plugin-kanban/src/containers/KanbanSettings/index.ts
+++ b/packages/plugins/plugin-kanban/src/containers/KanbanSettings/index.ts
@@ -1,5 +1,0 @@
-//
-// Copyright 2026 DXOS.org
-//
-
-export { KanbanSettings as default } from './KanbanSettings';

--- a/packages/plugins/plugin-kanban/src/containers/index.ts
+++ b/packages/plugins/plugin-kanban/src/containers/index.ts
@@ -5,4 +5,4 @@
 import { type ComponentType, lazy } from 'react';
 
 export const KanbanArticle: ComponentType<any> = lazy(() => import('./KanbanArticle'));
-export const KanbanSettings: ComponentType<any> = lazy(() => import('./KanbanSettings'));
+export const KanbanProperties: ComponentType<any> = lazy(() => import('./KanbanProperties'));

--- a/packages/plugins/plugin-kanban/src/types/schema.ts
+++ b/packages/plugins/plugin-kanban/src/types/schema.ts
@@ -20,7 +20,7 @@ export const PivotColumnAnnotationId = Symbol.for('@dxos/plugin-kanban/annotatio
 
 /**
  * Settings common to every Kanban (view or items). Rendered as form fields
- * by `KanbanSettings`.
+ * by `KanbanProperties`.
  */
 export const KanbanSettingsSchema = Schema.Struct({
   hideUncategorized: Schema.Boolean.annotations({

--- a/packages/plugins/plugin-map/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-map/src/capabilities/react-surface.tsx
@@ -6,7 +6,7 @@ import * as Effect from 'effect/Effect';
 import React, { useMemo } from 'react';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
-import { Surface } from '@dxos/app-framework/ui';
+import { Surface, useSettingsState } from '@dxos/app-framework/ui';
 import { AppSurface } from '@dxos/app-toolkit/ui';
 import { Database, JsonSchema, Obj, Type } from '@dxos/echo';
 import { Format } from '@dxos/echo/Format';
@@ -14,8 +14,11 @@ import { SchemaEx } from '@dxos/effect';
 import { type FormFieldRendererProps, SelectField, useFormValues } from '@dxos/react-ui-form';
 import { Position } from '@dxos/util';
 
-import { MapSurface, MapViewEditor } from '#containers';
+import { MapSettings, MapSurface, MapViewEditor } from '#containers';
+import { meta } from '#meta';
 import { LocationAnnotationId, Map, MapInline } from '#types';
+
+import { type Settings } from '../types/Settings';
 
 export default Capability.makeModule(() =>
   Effect.succeed(
@@ -56,6 +59,14 @@ export default Capability.makeModule(() =>
         position: Position.first,
         filter: AppSurface.object(AppSurface.ObjectProperties, Map.Map),
         component: ({ data }) => <MapViewEditor object={data.subject} />,
+      }),
+      Surface.create({
+        id: 'surface.settings',
+        filter: AppSurface.settings(AppSurface.Article, meta.profile.key),
+        component: ({ data: { subject } }) => {
+          const { settings, updateSettings } = useSettingsState<Settings>(subject.atom);
+          return <MapSettings settings={settings} onSettingsChange={updateSettings} />;
+        },
       }),
       Surface.create({
         // TODO(burdon): Why this title?

--- a/packages/plugins/plugin-map/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-map/src/capabilities/react-surface.tsx
@@ -65,7 +65,7 @@ export default Capability.makeModule(() =>
         filter: AppSurface.settings(AppSurface.Article, meta.profile.key),
         component: ({ data: { subject } }) => {
           const { settings, updateSettings } = useSettingsState<Settings>(subject.atom);
-          return <MapSettings settings={settings} onSettingsChange={updateSettings} />;
+          return <MapSettings settings={settings} onSettingsChange={(next: Settings) => updateSettings(() => next)} />;
         },
       }),
       Surface.create({

--- a/packages/plugins/plugin-map/src/containers/MapSettings/MapSettings.stories.tsx
+++ b/packages/plugins/plugin-map/src/containers/MapSettings/MapSettings.stories.tsx
@@ -8,7 +8,6 @@ import React, { useState } from 'react';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 
 import { type Settings as SettingsType } from '../../types/Settings';
-
 import { MapSettings } from './MapSettings';
 
 const DefaultStory = ({ initial }: { initial?: SettingsType }) => {

--- a/packages/plugins/plugin-map/src/containers/MapSettings/MapSettings.stories.tsx
+++ b/packages/plugins/plugin-map/src/containers/MapSettings/MapSettings.stories.tsx
@@ -1,0 +1,36 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import React, { useState } from 'react';
+
+import { withLayout, withTheme } from '@dxos/react-ui/testing';
+
+import { type Settings as SettingsType } from '../../types/Settings';
+
+import { MapSettings } from './MapSettings';
+
+const DefaultStory = ({ initial }: { initial?: SettingsType }) => {
+  const [settings, setSettings] = useState<SettingsType>(initial ?? {});
+  return <MapSettings settings={settings} onSettingsChange={setSettings} />;
+};
+
+const meta = {
+  title: 'plugins/plugin-map/MapSettings',
+  render: DefaultStory,
+  decorators: [withTheme(), withLayout({ layout: 'fullscreen' })],
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof DefaultStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithKey: Story = {
+  args: {
+    initial: { apiKeys: [{ name: 'maptiler.com', domain: 'maptiler.com', apiKey: 'secret-key' }] },
+  },
+};

--- a/packages/plugins/plugin-map/src/containers/MapSettings/MapSettings.tsx
+++ b/packages/plugins/plugin-map/src/containers/MapSettings/MapSettings.tsx
@@ -1,0 +1,76 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React, { useCallback } from 'react';
+
+import { Input } from '@dxos/react-ui';
+import { Settings, type SettingsFieldMap, type SettingsFieldProps } from '@dxos/react-ui-form';
+import { type APIKey } from '@dxos/schema';
+
+import { meta } from '#meta';
+
+import { RECOGNIZED_API_KEY_DOMAINS, Settings as MapSettingsSchema } from '../../types/Settings';
+
+export type MapSettingsProps = {
+  settings: MapSettingsSchema;
+  onSettingsChange: (settings: MapSettingsSchema) => void;
+};
+
+/**
+ * Custom renderer for the `apiKeys` array field. Arrays are not handled by the
+ * generic `Settings.FieldSet`, so each recognized domain gets a password input
+ * bound to its matching `APIKey` entry; clearing an input removes the entry.
+ */
+const ApiKeysField = ({ value, onChange, readonly }: SettingsFieldProps<readonly APIKey[] | undefined>) => {
+  const handleChange = useCallback(
+    (domain: string, apiKey: string) => {
+      const others = (value ?? []).filter((entry) => entry.domain !== domain);
+      const trimmed = apiKey.trim();
+      onChange(trimmed.length > 0 ? [...others, { name: domain, domain, apiKey: trimmed }] : others);
+    },
+    [value, onChange],
+  );
+
+  return (
+    <div className='flex flex-col gap-trim-md'>
+      {RECOGNIZED_API_KEY_DOMAINS.map((domain) => (
+        <Input.Root key={domain}>
+          <Input.Label classNames='text-description'>{domain}</Input.Label>
+          <Input.TextInput
+            type='password'
+            disabled={readonly}
+            value={value?.find((entry) => entry.domain === domain)?.apiKey ?? ''}
+            onChange={(event) => handleChange(domain, event.target.value)}
+          />
+        </Input.Root>
+      ))}
+    </div>
+  );
+};
+
+// `SettingsFieldMap<MapSettingsSchema>` forces array-typed keys into the nested-map branch and
+// cannot type a custom renderer for an array field; the default map resolves the key to the
+// `React.FC | nested` union, which accepts the field component.
+const fieldMap: SettingsFieldMap = { apiKeys: ApiKeysField };
+
+/**
+ * Settings panel for Maps. Drives the schema-based form via `Settings.FieldSet`
+ * and supplies a custom field renderer for the `apiKeys` array.
+ */
+export const MapSettings = ({ settings, onSettingsChange }: MapSettingsProps) => {
+  return (
+    <Settings.Viewport>
+      <Settings.Section title={meta.profile.name ?? meta.profile.key}>
+        <Settings.FieldSet
+          schema={MapSettingsSchema}
+          values={settings}
+          onValuesChanged={onSettingsChange}
+          fieldMap={fieldMap}
+        />
+      </Settings.Section>
+    </Settings.Viewport>
+  );
+};
+
+export default MapSettings;

--- a/packages/plugins/plugin-map/src/containers/MapSettings/index.ts
+++ b/packages/plugins/plugin-map/src/containers/MapSettings/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './MapSettings';
+export { MapSettings as default } from './MapSettings';

--- a/packages/plugins/plugin-map/src/containers/index.ts
+++ b/packages/plugins/plugin-map/src/containers/index.ts
@@ -8,4 +8,5 @@ export { type MapArticleProps, type MapControlType } from './MapArticle';
 export * from './MapSurface';
 
 export const MapArticle: ComponentType<any> = lazy(() => import('./MapArticle'));
+export const MapSettings: ComponentType<any> = lazy(() => import('./MapSettings'));
 export const MapViewEditor: ComponentType<any> = lazy(() => import('./MapViewEditor'));

--- a/packages/plugins/plugin-meeting/src/capabilities/settings.ts
+++ b/packages/plugins/plugin-meeting/src/capabilities/settings.ts
@@ -5,12 +5,15 @@
 import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
-import { AppCapabilities } from '@dxos/app-toolkit';
 import { createKvsStore } from '@dxos/effect';
 
 import { meta } from '#meta';
 import { MeetingCapabilities, Settings } from '#types';
 
+// Meeting has no user-configurable settings, so it does NOT contribute
+// `AppCapabilities.Settings` (an empty schema renders a blank settings article).
+// The store is retained only to fire the settings activation event that gates
+// `CallExtension`.
 export default Capability.makeModule(() =>
   Effect.sync(() => {
     const settingsAtom = createKvsStore({
@@ -19,13 +22,6 @@ export default Capability.makeModule(() =>
       defaultValue: () => ({}),
     });
 
-    return [
-      Capability.contributes(MeetingCapabilities.Settings, settingsAtom),
-      Capability.contributes(AppCapabilities.Settings, {
-        prefix: meta.profile.key,
-        schema: Settings.Settings,
-        atom: settingsAtom,
-      }),
-    ];
+    return [Capability.contributes(MeetingCapabilities.Settings, settingsAtom)];
   }),
 );

--- a/packages/plugins/plugin-settings/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-settings/src/capabilities/react-surface.tsx
@@ -6,7 +6,7 @@ import * as Effect from 'effect/Effect';
 import React from 'react';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
-import { Surface, useSettingsState } from '@dxos/app-framework/ui';
+import { Surface, usePluginManager, useSettingsState } from '@dxos/app-framework/ui';
 import { type AppCapabilities } from '@dxos/app-toolkit';
 import { AppSurface } from '@dxos/app-toolkit/ui';
 import { Settings as SettingsForm } from '@dxos/react-ui-form';
@@ -18,21 +18,26 @@ import { Position } from '@dxos/util';
  * contributed `schema`/`atom`, so plugins whose settings are plain editable
  * fields need not register a bespoke settings surface.
  *
- * No section title is rendered: the settings plank heading already names the
- * plugin. Registered with `position: Position.last` so a plugin-specific surface
- * (matching by prefix) always wins under the settings article's `limit={1}`
- * dispatch.
+ * The contributing plugin's name is rendered as the section heading (resolved
+ * by matching `subject.prefix` against each plugin's `meta.profile.key`) so
+ * every schema-driven settings article shows a consistent title. Registered
+ * with `position: Position.last` so a plugin-specific surface (matching by
+ * prefix) always wins under the settings article's `limit={1}` dispatch.
  */
 const DefaultSettings = ({ subject }: { subject: AppCapabilities.Settings }) => {
+  const manager = usePluginManager();
   const { settings, updateSettings } = useSettingsState<Record<string, any>>(subject.atom);
+  const title = manager.getPlugins().find((plugin) => plugin.meta.profile.key === subject.prefix)?.meta.profile.name;
 
   return (
     <SettingsForm.Viewport>
-      <SettingsForm.FieldSet
-        schema={subject.schema}
-        values={settings}
-        onValuesChanged={(values) => updateSettings(() => values)}
-      />
+      <SettingsForm.Section title={title ?? subject.prefix}>
+        <SettingsForm.FieldSet
+          schema={subject.schema}
+          values={settings}
+          onValuesChanged={(values) => updateSettings(() => values)}
+        />
+      </SettingsForm.Section>
     </SettingsForm.Viewport>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9128,6 +9128,9 @@ importers:
       '@dxos/react-ui-editor':
         specifier: workspace:*
         version: link:../../ui/react-ui-editor
+      '@dxos/react-ui-form':
+        specifier: workspace:*
+        version: link:../../ui/react-ui-form
       '@dxos/react-ui-menu':
         specifier: workspace:*
         version: link:../../ui/react-ui-menu


### PR DESCRIPTION
## Summary

Standardize plugin **settings articles** so they are consistently schema-driven and show a header. Audited the eight plugins with reported settings issues and fixed each at the root cause.

The shared root cause for the "missing header/title" group was the generic settings surface rendering the auto-generated form with no in-content heading; the "blank page" cases were a field type the form can't render and an empty schema.

## Changes

| Plugin | Issue | Fix |
|---|---|---|
| plugin-settings | (infra) | Generic `DefaultSettings` surface now wraps the form in `Settings.Section` titled with the plugin name, resolved via `usePluginManager` matching `subject.prefix` against `meta.profile.key`. |
| plugin-duffel / plugin-inbox / plugin-transcription / plugin-trip | missing header/title | Fixed for free by the generic-surface change (all contribute schema-only settings). No per-plugin change. |
| plugin-code | not using `Settings.*` / Panel | Rewrote `CodeSettings` to use `Settings.Viewport/Section/Item/FieldSet`; API key stays a custom `Settings.Item` (it's an ECHO `AccessToken`), `endpoint` via `Settings.FieldSet`. Added `@dxos/react-ui-form` dep. |
| plugin-map | blank page | `SettingsFieldSet` returns `null` for array fields. Added a thin settings surface with a `fieldMap` custom renderer for the `apiKeys` array (one input per recognized domain). |
| plugin-meeting | blank page | Settings schema was empty `{}`. Dropped the `AppCapabilities.Settings` contribution; kept the internal store atom that fires `SettingsReady` (gates `CallExtension`). |
| plugin-kanban | "no settings registered" | `KanbanSettings` was actually an **object-properties** surface, not plugin settings → renamed `KanbanProperties`. Kanban has no plugin-level settings (correct). |

## Notes for reviewers

- A settings node only appears when a contributed `AppCapabilities.Settings` has `prefix === plugin.meta.profile.key` (app-graph-builder); the node/plank label is `meta.profile.name`.
- `SettingsFieldMap<T>` cannot type a custom renderer for an array-typed key (arrays fall into the nested-map branch), so map's `fieldMap` is declared with the default untyped `SettingsFieldMap` — not a cast.
- plugin-meeting's `MeetingCapabilities.Settings` atom value is never read; it exists only as an activation gate, so removing only the `AppCapabilities.Settings` contribution is safe (activation test still passes).

## Verification

- Builds green: plugin-settings, plugin-code, plugin-map, plugin-meeting, plugin-kanban, plugin-inbox.
- Lint clean; no new casts.
- Tests pass: plugin-settings, plugin-kanban (14), plugin-meeting (module-activation graph intact).
- Visual: new `MapSettings` story renders the "Maps" title + the maptiler.com key input (previously blank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Maps plugin settings panel with per-provider API key configuration.
  * Settings panels now show a section title derived from the contributing plugin.

* **Refactor**
  * Improved the Code plugin settings UI with a structured, schema-driven layout and dedicated API key actions.
  * Renamed the Kanban object properties panel (replacing the former settings view).
  * Simplified Meeting plugin settings so it no longer exposes user-configurable settings.

* **Style**
  * Updated the Inbox plugin icon.

* **Tests**
  * Added Storybook coverage for the Maps settings component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->