### PR TITLE
fix(plugin-inbox): wait for SetupSchema before asserting module activation

### DIFF
--- a/packages/plugins/plugin-inbox/src/InboxPlugin.test.ts
+++ b/packages/plugins/plugin-inbox/src/InboxPlugin.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, test } from 'vitest';
 
+import { AppActivationEvents } from '@dxos/app-toolkit';
 import { ClientPlugin } from '@dxos/plugin-client/plugin';
 import { createComposerTestApp } from '@dxos/plugin-testing/harness';
 
@@ -19,6 +20,9 @@ describe('InboxPlugin', () => {
       plugins: [ClientPlugin({}), InboxPlugin()],
     });
 
+    // SetupSchema fires after client.initialize() completes (via ClientReady); wait for it
+    // to ensure CreateObject and schema modules are contributed before asserting.
+    await harness.waitForEvent(AppActivationEvents.SetupSchema);
     expect(harness.manager.getActive()).toEqual(
       expect.arrayContaining([moduleId('CreateObject'), moduleId('schema'), moduleId('OperationHandler')]),
     );


### PR DESCRIPTION
## Summary

- Adds `await harness.waitForEvent(AppActivationEvents.SetupSchema)` before the module activation assertion in `InboxPlugin.test.ts`

## Background

The `InboxPlugin > modules activate on the expected events` test was flagged as FLAKY by Trunk. The test checks that `CreateObject`, `schema`, and `OperationHandler` are active after `createComposerTestApp` returns.

`CreateObject` and `schema` both activate on `SetupSchema`, which fires as a `firesBeforeActivation` of `SchemaDefs` — and `SchemaDefs` activates on `ClientReady`, which itself fires after `client.initialize()` completes asynchronously. Under CI load, there is a window where `createComposerTestApp` returns before `SetupSchema` has fully propagated through the activation chain.

`waitForEvent(SetupSchema)` is a no-op when the event has already fired (the common case), and correctly suspends until it completes otherwise. This mirrors the pattern in `ClientPlugin.test.ts` which explicitly fires `SetupProcessManager` before asserting `OperationHandler` is active.

## Test plan

- [x] Fix targets the specific test flagged as FLAKY by Trunk: `InboxPlugin > modules activate on the expected events` (test ID `50611102-1e64-5ae1-bde1-1a93e85ec501`)
- [x] No existing open PRs address this test
- [x] `waitForEvent` is idempotent — if `SetupSchema` already fired, it returns immediately without any activation side-effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZBDVRmVwimpjJeFCjPdc9

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZBDVRmVwimpjJeFCjPdc9)_