### PR TITLE
fix(echo): add Type.declareObj/declareRelation; fix non-portable Trigger types

### DIFF
--- a/packages/core/compute/compute/src/Trigger.ts
+++ b/packages/core/compute/compute/src/Trigger.ts
@@ -146,59 +146,58 @@ export type Spec = Schema.Schema.Type<typeof Spec>;
  * Function is invoked with the `payload` passed as input data.
  * The event that triggers the function is available in the function context.
  */
-const TriggerSchema = Schema.Struct({
-  /**
-   * Function or workflow to invoke.
-   */
-  // TODO(burdon): Runnable?
-  // TODO(dmaretskyi): Can be a Ref(FunctionType) or Ref(ComputeGraphType).
-  function: Schema.optional(Ref.Ref(Obj.Unknown).annotations({ title: 'Function' })),
-  spec: Schema.optional(Spec),
-  enabled: Schema.optional(Schema.Boolean),
+export class Trigger extends Type.declareObj<Trigger>()(
+  Schema.Struct({
+    /**
+     * Function or workflow to invoke.
+     */
+    // TODO(burdon): Runnable?
+    // TODO(dmaretskyi): Can be a Ref(FunctionType) or Ref(ComputeGraphType).
+    function: Schema.optional(Ref.Ref(Obj.Unknown).annotations({ title: 'Function' })),
+    spec: Schema.optional(Spec),
+    enabled: Schema.optional(Schema.Boolean),
 
-  concurrency: Schema.Number.pipe(
-    Schema.annotations({
-      title: 'Concurrency',
-      default: 1,
-      description: 'Maximum number of concurrent invocations of the trigger.',
-    }),
-    Annotation.FormInputAnnotation.set(false),
-    Schema.optional,
+    concurrency: Schema.Number.pipe(
+      Schema.annotations({
+        title: 'Concurrency',
+        default: 1,
+        description: 'Maximum number of concurrent invocations of the trigger.',
+      }),
+      Annotation.FormInputAnnotation.set(false),
+      Schema.optional,
+    ),
+
+    /**
+     * Only used for workflowSchema.
+     * Specifies the input node in the circuit.
+     * @deprecated Remove and enforce a single input node in all compute graphSchema.
+     */
+    inputNodeId: Schema.String.pipe(
+      Schema.annotations({ title: 'Input Node ID' }),
+      Annotation.FormInputAnnotation.set(false),
+      Schema.optional,
+    ),
+
+    /**
+     * Passed as the input data to the function.
+     * Must match the function's input schema.
+     *
+     * @example
+     * {
+     *   item: '{{event.item}}',
+     *   instructions: 'Summarize and perform entity-extraction'
+     *   mailbox: { '/': 'echo://AAA/ZZZ' }
+     * }
+     */
+    input: Schema.Record({ key: Schema.String, value: Schema.Any }).pipe(
+      Annotation.FormInputAnnotation.set(false),
+      Schema.optional,
+    ),
+  }).pipe(
+    Annotation.IconAnnotation.set({ icon: 'ph--lightning--regular', hue: 'yellow' }),
+    HiddenAnnotation.set(true),
+    Type.makeObject(DXN.make('org.dxos.type.trigger', '0.1.0')),
   ),
-
-  /**
-   * Only used for workflowSchema.
-   * Specifies the input node in the circuit.
-   * @deprecated Remove and enforce a single input node in all compute graphSchema.
-   */
-  inputNodeId: Schema.String.pipe(
-    Schema.annotations({ title: 'Input Node ID' }),
-    Annotation.FormInputAnnotation.set(false),
-    Schema.optional,
-  ),
-
-  /**
-   * Passed as the input data to the function.
-   * Must match the function's input schema.
-   *
-   * @example
-   * {
-   *   item: '{{event.item}}',
-   *   instructions: 'Summarize and perform entity-extraction'
-   *   mailbox: { '/': 'echo://AAA/ZZZ' }
-   * }
-   */
-  input: Schema.Record({ key: Schema.String, value: Schema.Any }).pipe(
-    Annotation.FormInputAnnotation.set(false),
-    Schema.optional,
-  ),
-}).pipe(
-  Annotation.IconAnnotation.set({ icon: 'ph--lightning--regular', hue: 'yellow' }),
-  HiddenAnnotation.set(true),
-  Type.makeObject(DXN.make('org.dxos.type.trigger', '0.1.0')),
-);
-
-export type Trigger = Type.InstanceType<typeof TriggerSchema>;
-export const Trigger: Type.Obj<Trigger> = TriggerSchema as any;
+) {}
 
 export const make = (props: Obj.MakeProps<typeof Trigger>) => Obj.make(Trigger, props);

--- a/packages/core/echo/echo/src/Type.ts
+++ b/packages/core/echo/echo/src/Type.ts
@@ -749,3 +749,79 @@ export const removeFields = (type: AnyEntity, fieldNames: string[]): void => {
     draft.jsonSchema = internal.toJsonSchema(removed);
   });
 };
+
+/**
+ * Return type for {@link declareObj}.
+ *
+ * Not to be used directly, but must be exported for typescript to infer the type.
+ */
+export interface ObjClass<Self, T, Fields extends Schema.Struct.Fields> extends Obj<Self, Fields> {
+  new (_: never): T & EntityModule.OfKind<typeof EntityModule.Kind.Object>;
+}
+
+/**
+ * Declare a schema definition and a typescript type in one statement.
+ *
+ * Giving the type a nominal class name keeps its inferred type portable for
+ * declaration emit: structural expansion (which can pull in unnameable union
+ * members from referenced schemas) is replaced by a reference to the class.
+ *
+ * @example
+ * ```ts
+ * export class MyType extends Type.declareObj<MyType>()(Schema.Struct({
+ *   name: Schema.String,
+ * }).pipe(Type.makeObject(DXN.make('com.example.type.myType', '0.1.0')))) {}
+ * ```
+ */
+export const declareObj =
+  <Self>() =>
+  <T, Fields extends Schema.Struct.Fields>(type: Obj<T, Fields>): ObjClass<Self, T, Fields> => {
+    return makeEntityClass(type);
+  };
+
+/**
+ * Return type for {@link declareRelation}.
+ *
+ * Not to be used directly, but must be exported for typescript to infer the type.
+ */
+export interface RelationClass<Self, T, Source, Target, Fields extends Schema.Struct.Fields> extends Relation<
+  Self,
+  Source,
+  Target,
+  Fields
+> {
+  new (_: never): RelationModule.Endpoints<Source, Target> & T & EntityModule.OfKind<typeof EntityModule.Kind.Relation>;
+}
+
+/**
+ * Declare a relation schema definition and a typescript type in one statement.
+ *
+ * Relation sibling of {@link declareObj}; see its note on portability.
+ *
+ * @example
+ * ```ts
+ * export class MyRelation extends Type.declareRelation<MyRelation>()(Schema.Struct({
+ *   name: Schema.String,
+ * }).pipe(Type.makeRelation({ dxn, source, target }))) {}
+ * ```
+ */
+export const declareRelation =
+  <Self>() =>
+  <T, Source, Target, Fields extends Schema.Struct.Fields>(
+    type: Relation<T, Source, Target, Fields>,
+  ): RelationClass<Self, T, Source, Target, Fields> => {
+    return makeEntityClass(type);
+  };
+
+/**
+ * Adapt a runtime type-schema entity into a constructor usable as the base of a
+ * `class X extends ... {}` declaration. The entity is a plain (proxy) value, so
+ * it is placed on the constructor's prototype chain: static property access on
+ * the subclass falls through to the entity (fields, jsonSchema, brands), while
+ * the wrapper satisfies the `extends` requirement of being a constructor.
+ */
+const makeEntityClass = (entity: object): any => {
+  const constructor = function EntityClass() {};
+  Object.setPrototypeOf(constructor, entity);
+  return constructor;
+};

--- a/packages/core/echo/echo/src/Type.ts
+++ b/packages/core/echo/echo/src/Type.ts
@@ -820,6 +820,9 @@ export const declareRelation =
  * the subclass falls through to the entity (fields, jsonSchema, brands), while
  * the wrapper satisfies the `extends` requirement of being a constructor.
  */
+// Returns `any`: the result is a constructor (to satisfy `class X extends ...`) that
+// nonetheless delegates to a plain entity object — a shape TypeScript cannot express,
+// so the public `ObjClass` / `RelationClass` types are applied by the callers' signatures.
 const makeEntityClass = (entity: object): any => {
   const constructor = function EntityClass() {};
   Object.setPrototypeOf(constructor, entity);

--- a/packages/core/echo/echo/src/internal/Entity/type-uri.ts
+++ b/packages/core/echo/echo/src/internal/Entity/type-uri.ts
@@ -23,7 +23,9 @@ export const getTypeURIFromSpecifier = (input: Schema.Schema.All | AnyEntity | U
   if (Schema.isSchema(input)) {
     return getSchemaURI(input) ?? raise(new TypeError('Schema has no URI'));
   }
-  if (typeof input === 'object' && input !== null && KindId in input) {
+  // Type entities are normally proxy objects, but `Type.declareObj` declares them as
+  // classes (functions) whose prototype chain reaches the entity, so accept functions too.
+  if (input !== null && (typeof input === 'object' || typeof input === 'function') && KindId in input) {
     // `Type.Type` entity. Both in-memory and persisted forms expose the schema
     // they declare via `StaticTypeSchemaSlot`, whose URI is exactly what
     // `Obj.make` stamps on `system.type` — a static declaration carries

--- a/packages/core/echo/echo/src/internal/common/types/entity.ts
+++ b/packages/core/echo/echo/src/internal/common/types/entity.ts
@@ -42,12 +42,20 @@ export const StaticTypeSchemaSlot = '~@dxos/echo/Type.StaticSchema' as const;
 export type StaticTypeSchemaSlot = typeof StaticTypeSchemaSlot;
 
 /**
+ * Whether a value can carry an entity brand/slot. Class-declared types
+ * (`Type.declareObj`) are functions whose prototype chain reaches the entity,
+ * so brand/slot lookups must accept functions as well as plain objects.
+ */
+const isBrandCarrier = (value: unknown): boolean =>
+  value != null && (typeof value === 'object' || typeof value === 'function');
+
+/**
  * Read the hidden `StaticTypeSchemaSlot` off any value that may carry one.
- * Returns `undefined` for raw schemas (no slot) and non-object inputs.
+ * Returns `undefined` for raw schemas (no slot) and inputs that cannot carry a brand.
  * Single point-of-cast for the slot lookup.
  */
 export const getStaticTypeSchema = (value: unknown): Schema.Schema.AnyNoContext | undefined => {
-  if (value == null || typeof value !== 'object') {
+  if (!isBrandCarrier(value)) {
     return undefined;
   }
   return (value as { [StaticTypeSchemaSlot]?: Schema.Schema.AnyNoContext })[StaticTypeSchemaSlot];
@@ -55,11 +63,11 @@ export const getStaticTypeSchema = (value: unknown): Schema.Schema.AnyNoContext 
 
 /**
  * Read the `[SchemaKindId]` brand off a value. Returns `undefined` for raw
- * schemas (which don't carry the brand on their static type) and non-object
- * inputs. Single point-of-cast for the brand lookup.
+ * schemas (which don't carry the brand on their static type) and inputs that
+ * cannot carry a brand. Single point-of-cast for the brand lookup.
  */
 export const getSchemaKind = (value: unknown): EntityKind | undefined => {
-  if (value == null || typeof value !== 'object') {
+  if (!isBrandCarrier(value)) {
     return undefined;
   }
   return (value as { [SchemaKindId]?: EntityKind })[SchemaKindId];
@@ -67,10 +75,10 @@ export const getSchemaKind = (value: unknown): EntityKind | undefined => {
 
 /**
  * Read the `[KindId]` brand off a value. Returns `undefined` for raw schemas
- * and non-object inputs. Companion to {@link getSchemaKind}.
+ * and inputs that cannot carry a brand. Companion to {@link getSchemaKind}.
  */
 export const getEntityKindBrand = (value: unknown): EntityKind | undefined => {
-  if (value == null || typeof value !== 'object') {
+  if (!isBrandCarrier(value)) {
     return undefined;
   }
   return (value as { [KindId]?: EntityKind })[KindId];

--- a/packages/plugins/plugin-automation/src/types/Automation.ts
+++ b/packages/plugins/plugin-automation/src/types/Automation.ts
@@ -16,30 +16,30 @@ import * as Runnable from './Runnable';
  * User-facing automation: a thin aggregate of an action (`runnable`) and the triggers that fire it.
  * App-level only — EDGE stays unaware of it (triggers point directly at the runnable).
  */
-export const Automation = Schema.Struct({
-  name: Schema.String.pipe(Schema.optional),
-  description: Schema.String.pipe(Schema.optional),
+export class Automation extends Type.declareObj<Automation>()(
+  Schema.Struct({
+    name: Schema.String.pipe(Schema.optional),
+    description: Schema.String.pipe(Schema.optional),
 
-  /**
-   * The action to run. A trigger's `function` Ref points directly at this (so EDGE/the dispatcher can run
-   * it). `Runnable` is the type seam — currently just Operation; see Runnable.ts.
-   */
-  // TODO(burdon): Change to Array?
-  runnable: Ref.Ref(Runnable.Runnable).pipe(Schema.optional),
+    /**
+     * The action to run. A trigger's `function` Ref points directly at this (so EDGE/the dispatcher can run
+     * it). `Runnable` is the type seam — currently just Operation; see Runnable.ts.
+     */
+    // TODO(burdon): Change to Array?
+    runnable: Ref.Ref(Runnable.Runnable).pipe(Schema.optional),
 
-  /**
-   * Explicit membership, bi-directional with `trigger.function → runnable`. Required (not derived by query)
-   * because the runnable may be a shared registry operation referenced by multiple automations, which would
-   * conflate triggers. MVP enforces length <= 1.
-   */
-  triggers: Schema.Array(Ref.Ref(Trigger.Trigger)),
-}).pipe(
-  LabelAnnotation.set(['name']),
-  Annotation.IconAnnotation.set({ icon: 'ph--lightning--regular', hue: 'amber' }),
-  Type.makeObject(DXN.make('org.dxos.type.automation', '0.1.0')),
-);
-
-export type Automation = Type.InstanceType<typeof Automation>;
+    /**
+     * Explicit membership, bi-directional with `trigger.function → runnable`. Required (not derived by query)
+     * because the runnable may be a shared registry operation referenced by multiple automations, which would
+     * conflate triggers. MVP enforces length <= 1.
+     */
+    triggers: Schema.Array(Ref.Ref(Trigger.Trigger)),
+  }).pipe(
+    LabelAnnotation.set(['name']),
+    Annotation.IconAnnotation.set({ icon: 'ph--lightning--regular', hue: 'amber' }),
+    Type.makeObject(DXN.make('org.dxos.type.automation', '0.1.0')),
+  ),
+) {}
 
 export const instanceOf = (value: unknown): value is Automation => Obj.instanceOf(Automation, value);
 


### PR DESCRIPTION
## Problem

`moon run plugin-automation:build` fails on `main` with a cascade of **TS2883 "not portable"** errors:

```
Automation.ts: The inferred type of 'make' cannot be named without a reference to
  'QueryOptionsClause' from '.../@dxos/echo-protocol/src/query/ast'. This is likely
  not portable. A type annotation is necessary.
```

…repeated for every `QueryXxxClause` across `make`, `AppliesTo`, `makeAppliesTo` (`Automation.ts`) and `RunAutomation` (`AutomationOperation.ts`).

### Root cause

`Trigger` was declared as:

```ts
export type Trigger = Type.InstanceType<typeof TriggerSchema>;
export const Trigger: Type.Obj<Trigger> = TriggerSchema as any;
```

`Type.InstanceType<…>` is a transparent type **alias**, so when `Automation` references `Ref.Ref(Trigger.Trigger)`, declaration emit expands `Trigger` structurally. That expansion reaches `SubscriptionSpec.query.ast: QueryAST.Query` — a discriminated union whose member interfaces are only reachable through a `export * as` namespace re-export, which is not a portable name source for `.d.ts` emit.

## Fix

Introduce **`Type.declareObj`** / **`Type.declareRelation`**: declare an ECHO schema and its TypeScript type in a single `class X extends …` statement. The nominal class name keeps the type portable for declaration emit — downstream references point at the class instead of expanding its structure.

```ts
export class Trigger extends Type.declareObj<Trigger>()(
  Schema.Struct({ … }).pipe(…, Type.makeObject(DXN.make('org.dxos.type.trigger', '0.1.0'))),
) {}
```

`Trigger` and `Automation` are converted to this pattern; the `as any` cast is removed.

### Runtime support

A type entity returned by `Type.makeObject(…)` is a reactive **proxy object**, not a constructor, so `class X extends entity {}` would throw `Class extends value #<Object> is not a constructor`. The helper therefore wraps the entity in a function whose prototype chain reaches the entity (so static property access — `fields`, `jsonSchema`, brands — falls through to it, while the wrapper satisfies the `extends` requirement of being a constructor).

Because a constructor is necessarily `typeof === 'function'`, the centralized type-entity introspection seams are widened to read through functions as well as plain objects:
- `getStaticTypeSchema` / `getSchemaKind` / `getEntityKindBrand` (the documented "single point-of-cast" lookups)
- `getTypeURIFromSpecifier`

These are widenings only — existing object/proxy callers are unaffected.

## Scope

This extracts **only the type-declaration portability fix** from #11912 (the Sandbox blueprint PR) so the broken `main` build is fixed independently of the feature work. `declareRelation` is included as the documented sibling of `declareObj` (they share the same runtime path) even though this change only needs `declareObj`.

## Verification

- `moon run plugin-automation:build` — ✅ (previously failing with TS2883)
- Full repo build `moon exec --on-failure continue :build` — ✅ exit 0
- Tests: `echo` (28 pass / 1 skip), `compute` (25 pass, incl. `umbrella.test.ts`), `plugin-automation` (38 pass), `functions-runtime` (incl. `trigger-dispatcher`), `functions-testing`, `assistant-toolkit` — all ✅
- Lint (`echo`, `compute`, `plugin-automation`) — ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5daKTvArbij8NTMb9Ux7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5daKTvArbij8NTMb9Ux7s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated core trigger and automation definitions to use class-based exports, improving consistency with the platform’s type/metadata system.
  * Enhanced the ECHO type utilities to support class-style inheritance patterns for entity and relation types.

* **Bug Fixes**
  * Improved type URI resolution to correctly handle “Type.Type” inputs when determining entity types.
  * Broadened internal branding/slot detection to work when carriers are provided as functions as well as objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->