### PR TITLE
fix(react-ui-form): wrap ObjectProperties children in Form.Section

### DIFF
--- a/packages/plugins/plugin-space/src/containers/DefaultProperties/DefaultProperties.tsx
+++ b/packages/plugins/plugin-space/src/containers/DefaultProperties/DefaultProperties.tsx
@@ -26,7 +26,7 @@ export const DefaultProperties = forwardRef<HTMLDivElement, DefaultPropertiesPro
         <Panel.Toolbar asChild>
           <Toolbar.Root />
         </Panel.Toolbar>
-        <Panel.Content asChild>
+        <Panel.Content>
           <ObjectProperties object={object}>
             {/* TODO(burdon): Ambiguous naming since providers only replace parts; can't update Toolbar, etc. Consider DefaultSettings pattern. */}
             <Surface.Surface type={AppSurface.ObjectProperties} data={data} />

--- a/packages/ui/react-ui-form/src/components/ObjectProperties/ObjectProperties.tsx
+++ b/packages/ui/react-ui-form/src/components/ObjectProperties/ObjectProperties.tsx
@@ -128,7 +128,7 @@ export const ObjectProperties = composable<HTMLDivElement, ObjectPropertiesProps
         <Form.Viewport {...composableProps(props)} scroll ref={forwardedRef}>
           <Form.Content>
             <Form.FieldSet />
-            {children}
+            <Form.Section>{children}</Form.Section>
           </Form.Content>
         </Form.Viewport>
       </Form.Root>


### PR DESCRIPTION
## Summary
- Wrap the `ObjectProperties` child surface in `Form.Section` so injected content shares the form's section layout.
- Drop the redundant `asChild` on `Panel.Content` in `DefaultProperties`.

## Test Plan
- [ ] Verify object properties panel renders injected surfaces within the form section layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated component composition structure in form and properties panels to enhance layout and sectioning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->