### PR TITLE
fix(tauri): publish production branch to default CrabNebula channel

### DIFF
--- a/.github/actions/cn-config/action.yml
+++ b/.github/actions/cn-config/action.yml
@@ -13,8 +13,7 @@ runs:
   using: 'composite'
   steps:
     - uses: ./.github/actions/cn-channel
-      # TODO(wittjosiah): Switch to production.
-      if: github.ref_name != 'labs'
+      if: github.ref_name != 'production'
       id: release-channel
 
     - name: Find tauri.conf.json
@@ -29,8 +28,7 @@ runs:
       shell: bash
 
     - name: Update endpoints in tauri.conf.json
-      # TODO(wittjosiah): Switch to production.
-      if: github.ref_name != 'labs'
+      if: github.ref_name != 'production'
       run: |
         jq \
           --arg channel "${{ steps.release-channel.outputs.channel }}" \

--- a/.github/actions/cn-release/action.yml
+++ b/.github/actions/cn-release/action.yml
@@ -22,13 +22,11 @@ runs:
   using: 'composite'
   steps:
     - uses: ./.github/actions/cn-channel
-      # TODO(wittjosiah): Switch to production.
-      if: github.ref_name != 'labs'
+      if: github.ref_name != 'production'
       id: release-channel
 
     - uses: FabianLars-crabnebula/cloud-release@e0bb6ccebcb78f71883ebde2320f76aae6b9eb92
       with:
-        # TODO(wittjosiah): Switch to production.
-        command: release ${{ inputs.command }} ${{ inputs.application }} --framework ${{ inputs.framework }}${{ github.ref_name != 'labs' && format(' --channel {0}', steps.release-channel.outputs.channel) || '' }}
+        command: release ${{ inputs.command }} ${{ inputs.application }} --framework ${{ inputs.framework }}${{ github.ref_name != 'production' && format(' --channel {0}', steps.release-channel.outputs.channel) || '' }}
         api-key: ${{ inputs.api-key }}
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/publish-tauri.yaml
+++ b/.github/workflows/publish-tauri.yaml
@@ -67,11 +67,11 @@ jobs:
         run: |
           # Determine channel argument: omit for production (default channel), use branch name otherwise.
           # Replace slashes with dashes to match the channel name used by cn-channel action.
-          BRANCH="${{ steps.extract_branch.outputs.branch }}"
+          # BRANCH is passed via env to avoid template-injection from expanding untrusted ref names into shell source.
           if [ "$BRANCH" = "production" ]; then
             CHANNEL_ARG=""
           else
-            CHANNEL=$(echo "$BRANCH" | sed 's|/|-|g')
+            CHANNEL=$(printf '%s' "$BRANCH" | sed 's|/|-|g')
             CHANNEL_ARG="--channel $CHANNEL"
           fi
 
@@ -113,6 +113,7 @@ jobs:
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "Final version to be used: $NEW_VERSION"
         env:
+          BRANCH: ${{ steps.extract_branch.outputs.branch }}
           CN_API_KEY: ${{ secrets.CN_API_KEY }}
 
       - name: Update tauri.conf.json

--- a/.github/workflows/publish-tauri.yaml
+++ b/.github/workflows/publish-tauri.yaml
@@ -65,14 +65,13 @@ jobs:
         #        └─ No → Skip bump
         id: bump-version
         run: |
-          # TODO(wittjosiah): Switch to production.
-          # Determine channel argument: omit for labs, use branch name otherwise.
+          # Determine channel argument: omit for production (default channel), use branch name otherwise.
           # Replace slashes with dashes to match the channel name used by cn-channel action.
           BRANCH="${{ steps.extract_branch.outputs.branch }}"
-          CHANNEL=$(echo "$BRANCH" | sed 's|/|-|g')
-          if [ "$BRANCH" = "labs" ]; then
+          if [ "$BRANCH" = "production" ]; then
             CHANNEL_ARG=""
           else
+            CHANNEL=$(echo "$BRANCH" | sed 's|/|-|g')
             CHANNEL_ARG="--channel $CHANNEL"
           fi
 


### PR DESCRIPTION
## Summary

- The `production` branch now publishes to CrabNebula's default (primary) channel — no `--channel` flag, matching how `labs` previously behaved.
- The `labs` branch now publishes to `--channel labs` explicitly.
- TestFlight uploads remain gated on `labs` (`if: github.ref_name == 'labs'`) — no change.
- Removed stale `TODO(wittjosiah): Switch to production.` comments that tracked this work.

## What changed

| Branch | Before | After |
|---|---|---|
| `production` | `--channel production` | no `--channel` (default) |
| `labs` | no `--channel` (default) | `--channel labs` |
| `labs` TestFlight | triggered | triggered (unchanged) |

The three affected files are the reusable actions (`cn-config`, `cn-release`) and the bump-version step in `publish-tauri.yaml`, which all had their `labs`-special-case condition swapped to `production`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated release-channel routing logic in GitHub Actions so the production branch follows default release behavior, while all other branches consistently set the appropriate channel.
  * Improved consistency of channel and version handling during Tauri publish workflows, including how branch names are translated into channel values.
  * Refined channel selection conditions within the release pipeline for more predictable draft and channel-based releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->