### PR TITLE
fix(plugin-inbox): pass spaceId when invoking ExtractMessage

### DIFF
--- a/packages/plugins/plugin-inbox/src/components/Message/useExtractorActions.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Message/useExtractorActions.tsx
@@ -48,8 +48,14 @@ export const useExtractorActions = (message: Message.Message): ExtractorMenuItem
       if (!space) {
         return Promise.resolve();
       }
+      // NOTE: `spaceId` scopes the spawned operation process so its space-affinity services
+      // (e.g. `AiService`) can materialize.
       return invoker
-        .invokePromise(InboxOperation.ExtractMessage, { db: space.db, source: message, extractorId })
+        .invokePromise(
+          InboxOperation.ExtractMessage,
+          { db: space.db, source: message, extractorId },
+          { spaceId: space.id },
+        )
         .catch((err) => {
           // Distinguish the startup race where the assistant plugin's `AiService` LayerSpec is not
           // yet in the process-manager runtime: surface an actionable message instead of an opaque

--- a/packages/plugins/plugin-inbox/src/operations/google/gmail/sync.ts
+++ b/packages/plugins/plugin-inbox/src/operations/google/gmail/sync.ts
@@ -362,11 +362,15 @@ const streamGmailMessagesToFeed = Effect.fn(function* (
                 }
               }
               if (best) {
-                yield* Operation.invoke(InboxOperation.ExtractMessage, {
-                  db,
-                  source: message,
-                  extractorId: best.extractor.id,
-                }).pipe(
+                yield* Operation.invoke(
+                  InboxOperation.ExtractMessage,
+                  {
+                    db,
+                    source: message,
+                    extractorId: best.extractor.id,
+                  },
+                  { spaceId: db.spaceId },
+                ).pipe(
                   Effect.catchAll((err) => {
                     // The AI service can be momentarily absent from the process-manager LayerStack
                     // during startup (the assistant plugin's `AiService` LayerSpec races the

--- a/packages/stories/stories-inbox/src/containers/MailboxExtract.stories.tsx
+++ b/packages/stories/stories-inbox/src/containers/MailboxExtract.stories.tsx
@@ -182,7 +182,7 @@ const FeedExtractHarness = () => {
     }
     for (const message of messages) {
       await invoker
-        .invokePromise(InboxOperation.ExtractMessage, { db, source: message })
+        .invokePromise(InboxOperation.ExtractMessage, { db, source: message }, { spaceId: db.spaceId })
         .catch((err) => log.warn('extract failed', { err, messageId: message.id }));
     }
     setRuns((count) => count + 1);


### PR DESCRIPTION
## Summary

- Pass `{ spaceId }` when invoking `ExtractMessage` from the message toolbar, Gmail auto-on-arrival sync, and the mailbox extract story harness.
- Fixes `ServiceNotAvailable: @dxos/ai/AiService` failures caused by spawning the operation process without a space context.

## Test plan

- [x] `moon run plugin-inbox:test -- src/operations/extractor/extract-message.test.ts`
- [ ] Open a message in Composer and run an extractor from the toolbar — extraction should succeed instead of logging `operation invocation failed`
- [ ] Verify auto-on-arrival extraction during Gmail sync still works


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized message extraction operations across the application by ensuring space context is consistently passed during extraction workflows, improving reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->