### PR TITLE
feat(react-ui): unify Splitter into headless ratio-based component

### DIFF
--- a/packages/plugins/plugin-simple-layout/src/components/MobileLayout/MobileLayout.stories.tsx
+++ b/packages/plugins/plugin-simple-layout/src/components/MobileLayout/MobileLayout.stories.tsx
@@ -80,33 +80,33 @@ const StoryPanel = ({ children, label }: PropsWithChildren<{ label: string }>) =
 };
 
 const DefaultStory = () => {
-  const [splitterMode, setSplitterMode] = useState<SplitterMode>('top');
+  const [splitterMode, setSplitterMode] = useState<SplitterMode>('start');
   const [keyboardOpen, setKeyboardOpen] = useState(false);
 
   useEffect(() => {
-    setSplitterMode(splitterMode === 'split' ? 'bottom' : splitterMode);
+    setSplitterMode((current) => (current === 'split' ? 'end' : current));
   }, [keyboardOpen]);
 
   return (
     <WithKeyboard>
       <MobileLayout.Root onKeyboardOpenChange={setKeyboardOpen}>
-        <MobileLayout.Panel safe={{ top: true, bottom: splitterMode === 'top' }}>
-          <Splitter.Root mode={splitterMode} ratio={0.5}>
-            <Splitter.Panel position='top'>
+        <MobileLayout.Panel safe={{ top: true, bottom: splitterMode === 'start' }}>
+          <Splitter.Root orientation='vertical' mode={splitterMode} ratio={0.5}>
+            <Splitter.Panel position='start'>
               <StoryPanel label='Main'>
-                {splitterMode === 'top' && (
+                {splitterMode === 'start' && (
                   <Toolbar.IconButton icon='ph--plus--regular' label='Open' onClick={() => setSplitterMode('split')} />
                 )}
               </StoryPanel>
             </Splitter.Panel>
-            <Splitter.Panel position='bottom'>
+            <Splitter.Panel position='end'>
               <StoryPanel label='Drawer'>
                 <Toolbar.IconButton
-                  icon={splitterMode === 'bottom' ? 'ph--arrow-down--regular' : 'ph--arrow-up--regular'}
-                  label={splitterMode === 'bottom' ? 'Collapse' : 'Expand'}
-                  onClick={() => setSplitterMode((splitterMode) => (splitterMode === 'split' ? 'bottom' : 'split'))}
+                  icon={splitterMode === 'end' ? 'ph--arrow-down--regular' : 'ph--arrow-up--regular'}
+                  label={splitterMode === 'end' ? 'Collapse' : 'Expand'}
+                  onClick={() => setSplitterMode((splitterMode) => (splitterMode === 'split' ? 'end' : 'split'))}
                 />
-                <Toolbar.IconButton icon='ph--x--regular' label='Close' onClick={() => setSplitterMode('top')} />
+                <Toolbar.IconButton icon='ph--x--regular' label='Close' onClick={() => setSplitterMode('start')} />
               </StoryPanel>
             </Splitter.Panel>
           </Splitter.Root>

--- a/packages/plugins/plugin-simple-layout/src/components/SimpleLayout/SimpleLayout.tsx
+++ b/packages/plugins/plugin-simple-layout/src/components/SimpleLayout/SimpleLayout.tsx
@@ -19,14 +19,14 @@ import { Main } from './Main';
 export const SimpleLayout = () => {
   const { state } = useSimpleLayoutState();
   const [keyboardOpen, setKeyboardOpen] = useState(false);
-  const [splitterMode, setSplitterMode] = useState<SplitterMode>('top');
+  const [splitterMode, setSplitterMode] = useState<SplitterMode>('start');
 
   const drawerRef = useRef<HTMLDivElement>(null);
 
   // Restore Splitter mode when keyboard closes.
   useLayoutEffect(() => {
     if (!keyboardOpen) {
-      setSplitterMode(state.drawerState === 'closed' ? 'top' : state.drawerState === 'open' ? 'split' : 'bottom');
+      setSplitterMode(state.drawerState === 'closed' ? 'start' : state.drawerState === 'open' ? 'split' : 'end');
     }
   }, [state.drawerState, keyboardOpen]);
 
@@ -38,12 +38,12 @@ export const SimpleLayout = () => {
             classNames='dx-container grid relative bg-toolbar-surface'
             onKeyboardOpenChange={(nextKeyboardOpen) => setKeyboardOpen(nextKeyboardOpen)}
           >
-            <MobileLayout.Panel safe={{ top: true, bottom: splitterMode === 'top' }}>
-              <Splitter.Root mode={splitterMode} ratio={0.55}>
-                <Splitter.Panel position='top'>
+            <MobileLayout.Panel safe={{ top: true, bottom: splitterMode === 'start' }}>
+              <Splitter.Root orientation='vertical' mode={splitterMode} ratio={0.55}>
+                <Splitter.Panel position='start'>
                   <Main />
                 </Splitter.Panel>
-                <Splitter.Panel position='bottom' ref={drawerRef}>
+                <Splitter.Panel position='end' ref={drawerRef}>
                   <Drawer />
                 </Splitter.Panel>
               </Splitter.Root>

--- a/packages/plugins/plugin-zen/src/components/Mixer/Mixer.tsx
+++ b/packages/plugins/plugin-zen/src/components/Mixer/Mixer.tsx
@@ -144,8 +144,8 @@ export const Mixer = ({ classNames, dream, engine }: MixerProps) => {
   }, []);
 
   return (
-    <Splitter.Root mode={selectedLayer ? 'split' : 'top'} classNames={classNames}>
-      <Splitter.Panel asChild position='top'>
+    <Splitter.Root orientation='vertical' mode={selectedLayer ? 'split' : 'start'} classNames={classNames}>
+      <Splitter.Panel asChild position='start'>
         <Panel.Root>
           <Panel.Toolbar asChild>
             <Toolbar.Root>
@@ -186,7 +186,7 @@ export const Mixer = ({ classNames, dream, engine }: MixerProps) => {
         </Panel.Root>
       </Splitter.Panel>
 
-      <Splitter.Panel asChild position='bottom'>
+      <Splitter.Panel asChild position='end'>
         {displayedLayer && <Sound sequence={displayedLayer} onUpdate={handleUpdate} />}
       </Splitter.Panel>
     </Splitter.Root>

--- a/packages/ui/react-ui/src/components/Splitter/Splitter.stories.tsx
+++ b/packages/ui/react-ui/src/components/Splitter/Splitter.stories.tsx
@@ -9,7 +9,7 @@ import { withLayout, withTheme } from '../../testing';
 import { Panel } from '../Panel';
 import { ScrollArea } from '../ScrollArea';
 import { Toolbar } from '../Toolbar';
-import { Splitter, type SplitterRootProps } from './Splitter';
+import { Splitter, type SplitterMode, type SplitterRootProps } from './Splitter';
 
 const PanelContent = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'> & { label: string }>(
   ({ label, ...props }, forwardedRef) => (
@@ -32,29 +32,44 @@ const PanelContent = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'> 
   ),
 );
 
-const DefaultStory = (props: SplitterRootProps) => {
-  const [mode, setMode] = useState(props.mode ?? 'split');
-  const [ratio, setRatio] = useState(props.ratio ?? 0.5);
+const Panes = () => (
+  <>
+    <Splitter.Panel position='start'>
+      <PanelContent label='A' />
+    </Splitter.Panel>
+    <Splitter.Handle />
+    <Splitter.Panel position='end'>
+      <PanelContent label='B' />
+    </Splitter.Panel>
+  </>
+);
 
+// Renders the splitter with no surrounding chrome (Panel.Root keeps the height chain without a toolbar).
+const BasicStory = (args: SplitterRootProps) => (
+  <Panel.Root>
+    <Panel.Content asChild>
+      <Splitter.Root {...args}>
+        <Panes />
+      </Splitter.Root>
+    </Panel.Content>
+  </Panel.Root>
+);
+
+// Toolbar drives the animated collapse via `mode`.
+const ToolbarStory = (args: SplitterRootProps) => {
+  const [mode, setMode] = useState<SplitterMode>(args.mode ?? 'split');
   return (
     <Panel.Root>
       <Panel.Toolbar asChild>
         <Toolbar.Root>
-          <Toolbar.Button onClick={() => setMode('top')}>A</Toolbar.Button>
+          <Toolbar.Button onClick={() => setMode('start')}>A</Toolbar.Button>
           <Toolbar.Button onClick={() => setMode('split')}>A+B</Toolbar.Button>
-          <Toolbar.Button onClick={() => setMode('bottom')}>B</Toolbar.Button>
-          <Toolbar.Separator />
-          <Toolbar.Button onClick={() => setRatio((r) => 1 - r)}>Toggle</Toolbar.Button>
+          <Toolbar.Button onClick={() => setMode('end')}>B</Toolbar.Button>
         </Toolbar.Root>
       </Panel.Toolbar>
       <Panel.Content asChild>
-        <Splitter.Root mode={mode} ratio={ratio}>
-          <Splitter.Panel asChild position='top'>
-            <PanelContent label='A' />
-          </Splitter.Panel>
-          <Splitter.Panel asChild position='bottom'>
-            <PanelContent label='B' />
-          </Splitter.Panel>
+        <Splitter.Root {...args} mode={mode}>
+          <Panes />
         </Splitter.Root>
       </Panel.Content>
     </Panel.Root>
@@ -64,7 +79,7 @@ const DefaultStory = (props: SplitterRootProps) => {
 const meta: Meta<SplitterRootProps> = {
   title: 'ui/react-ui-core/components/Splitter',
   component: Splitter.Root,
-  render: DefaultStory,
+  render: BasicStory,
   decorators: [withTheme(), withLayout({ layout: 'column' })],
   parameters: {
     layout: 'fullscreen',
@@ -75,9 +90,38 @@ export default meta;
 
 type Story = StoryObj<SplitterRootProps>;
 
-export const Default: Story = {
+export const Vertical: Story = {
   args: {
-    mode: 'split',
-    ratio: 0.4,
+    resizable: true,
+    defaultRatio: 0.4,
+    minRatio: 0.2,
+    maxRatio: 0.8,
+  },
+};
+
+export const VerticalAnimated: Story = {
+  render: ToolbarStory,
+  args: {
+    transition: 250,
+    defaultRatio: 0.4,
+  },
+};
+
+export const Horizontal: Story = {
+  args: {
+    orientation: 'horizontal',
+    resizable: true,
+    defaultRatio: 0.4,
+    minRatio: 0.2,
+    maxRatio: 0.8,
+  },
+};
+
+export const HorizontalAnimated: Story = {
+  render: ToolbarStory,
+  args: {
+    orientation: 'horizontal',
+    transition: 250,
+    defaultRatio: 0.4,
   },
 };

--- a/packages/ui/react-ui/src/components/Splitter/Splitter.theme.ts
+++ b/packages/ui/react-ui/src/components/Splitter/Splitter.theme.ts
@@ -5,14 +5,32 @@
 import { mx } from '@dxos/ui-theme';
 import { type ComponentFunction, type Theme } from '@dxos/ui-types';
 
-export type SplitterStyleProps = {};
+export type SplitterStyleProps = {
+  orientation?: 'horizontal' | 'vertical';
+};
 
-const root: ComponentFunction<SplitterStyleProps> = (_props, ...etc) => mx('relative h-full overflow-hidden', ...etc);
+const root: ComponentFunction<SplitterStyleProps> = ({ orientation }, ...etc) =>
+  mx('relative flex w-full h-full overflow-hidden', orientation === 'vertical' ? 'flex-col' : 'flex-row', ...etc);
 
 const panel: ComponentFunction<SplitterStyleProps> = (_props, ...etc) =>
-  mx('absolute inset-x-0 flex flex-col overflow-hidden', ...etc);
+  mx('relative grid overflow-hidden min-w-0 min-h-0', ...etc);
+
+// A grab area with a centered divider line that reveals on hover/focus, matching the react-ui-dnd
+// `ResizeHandle` treatment (subtle neutral line, not the accent color). The actual extent is governed
+// by `ratio`; this only renders the divider affordance.
+const handle: ComponentFunction<SplitterStyleProps> = ({ orientation }, ...etc) =>
+  mx(
+    'group relative shrink-0 touch-none select-none',
+    'before:absolute before:block before:bg-focus-ring-subtle',
+    'before:transition-opacity before:duration-100 before:ease-in-out before:opacity-0 hover:before:opacity-100 focus-visible:before:opacity-100 active:before:opacity-100',
+    orientation === 'vertical'
+      ? 'h-2 cursor-row-resize before:inset-x-0 before:top-1/2 before:-translate-y-1/2 before:h-1.5'
+      : 'w-2 cursor-col-resize before:inset-y-0 before:left-1/2 before:-translate-x-1/2 before:w-1.5',
+    ...etc,
+  );
 
 export const splitterTheme: Theme<SplitterStyleProps> = {
   root,
   panel,
+  handle,
 };

--- a/packages/ui/react-ui/src/components/Splitter/Splitter.tsx
+++ b/packages/ui/react-ui/src/components/Splitter/Splitter.tsx
@@ -2,31 +2,59 @@
 // Copyright 2026 DXOS.org
 //
 
-import { createContextScope } from '@radix-ui/react-context';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
+import { createContext } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
-import React from 'react';
+import { useControllableState } from '@radix-ui/react-use-controllable-state';
+import React, { type PointerEvent, type RefObject, useCallback, useRef, useState } from 'react';
+
+import { type SlottableProps } from '@dxos/ui-types';
 
 import { useThemeContext } from '../../hooks';
 import { composableProps, slottable } from '../../util';
-import { ThemedClassName } from '../../util';
 
-type ScopedProps<P> = P & { __scopeSplitter?: any };
+type Orientation = 'horizontal' | 'vertical';
 
-// TODO(burdon): Generalize horizontal/vertical and change to start/end.
-type Mode = 'top' | 'bottom' | 'split';
+// Animated panel visibility: collapse to the start panel, the end panel, or show both at `ratio`.
+type SplitterMode = 'start' | 'end' | 'split';
 
-type SplitterContextValue = {
-  mode: Mode;
-  ratio?: number;
-  transition: number;
-};
+type Position = 'start' | 'end';
+
+//
+// Context
+//
 
 const SPLITTER_NAME = 'Splitter';
 
-const [createSplitterContext, createSplitterScope] = createContextScope(SPLITTER_NAME);
+type SplitterContextValue = {
+  orientation: Orientation;
+  mode: SplitterMode;
+  ratio: number;
+  transition: number;
+  resizable: boolean;
+  minRatio: number;
+  maxRatio: number;
+  dragging: boolean;
+  rootRef: RefObject<HTMLDivElement | null>;
+  setRatio: (ratio: number) => void;
+  setDragging: (dragging: boolean) => void;
+};
 
-const [SplitterProvider, useSplitterContext] = createSplitterContext<SplitterContextValue>(SPLITTER_NAME);
+const [SplitterProvider, useSplitterContext] = createContext<SplitterContextValue>(SPLITTER_NAME);
+
+// Flex-grow share allotted to a panel: governed by `ratio` when both are visible, otherwise 1/0 so the
+// collapsed panel shrinks to zero (its content stays mounted but clipped).
+const panelGrow = (position: Position, mode: SplitterMode, ratio: number): number => {
+  switch (mode) {
+    case 'start':
+      return position === 'start' ? 1 : 0;
+    case 'end':
+      return position === 'start' ? 0 : 1;
+    default:
+      return position === 'start' ? ratio : 1 - ratio;
+  }
+};
 
 //
 // Root
@@ -34,18 +62,65 @@ const [SplitterProvider, useSplitterContext] = createSplitterContext<SplitterCon
 
 const ROOT_NAME = 'Splitter.Root';
 
-type SplitterRootProps = Partial<SplitterContextValue>;
+type SplitterRootElementProps = {
+  orientation?: Orientation;
+  mode?: SplitterMode;
+  ratio?: number;
+  defaultRatio?: number;
+  onRatioChange?: (ratio: number) => void;
+  transition?: number;
+  resizable?: boolean;
+  minRatio?: number;
+  maxRatio?: number;
+};
 
-const SplitterRoot = slottable<HTMLDivElement, SplitterRootProps>(
-  ({ asChild, mode = 'top', ratio = 0.5, transition = 250, children, ...props }, forwardedRef) => {
+type SplitterRootProps = SlottableProps<SplitterRootElementProps>;
+
+const SplitterRoot = slottable<HTMLDivElement, SplitterRootElementProps>(
+  (
+    {
+      asChild,
+      children,
+      orientation = 'vertical',
+      mode = 'split',
+      ratio: ratioProp,
+      defaultRatio = 0.5,
+      onRatioChange,
+      transition = 250,
+      resizable = false,
+      minRatio = 0,
+      maxRatio = 1,
+      ...props
+    },
+    forwardedRef,
+  ) => {
     const { tx } = useThemeContext();
-    const { __scopeSplitter, ...rest } = props as ScopedProps<typeof props>;
-    const { className, ...restProps } = composableProps(rest);
+    const rootRef = useRef<HTMLDivElement>(null);
+    const composedRef = useComposedRefs(forwardedRef, rootRef);
+    const [ratio = defaultRatio, setRatio] = useControllableState({
+      prop: ratioProp,
+      defaultProp: defaultRatio,
+      onChange: onRatioChange,
+    });
+    const [dragging, setDragging] = useState(false);
+    const { className, ...rest } = composableProps(props);
     const Comp = asChild ? Slot : Primitive.div;
 
     return (
-      <SplitterProvider scope={__scopeSplitter} mode={mode} ratio={ratio} transition={transition}>
-        <Comp {...restProps} ref={forwardedRef} className={tx('splitter.root', {}, className)}>
+      <SplitterProvider
+        orientation={orientation}
+        mode={mode}
+        ratio={ratio}
+        transition={transition}
+        resizable={resizable}
+        minRatio={minRatio}
+        maxRatio={maxRatio}
+        dragging={dragging}
+        rootRef={rootRef}
+        setRatio={setRatio}
+        setDragging={setDragging}
+      >
+        <Comp {...rest} ref={composedRef} className={tx('splitter.root', { orientation }, className)}>
           {children}
         </Comp>
       </SplitterProvider>
@@ -61,42 +136,28 @@ SplitterRoot.displayName = ROOT_NAME;
 
 const PANEL_NAME = 'Splitter.Panel';
 
-type SplitterPanelProps = ThemedClassName<{
-  position: 'top' | 'bottom';
-}>;
+type SplitterPanelProps = SlottableProps<{ position: Position }>;
 
-const SplitterPanel = slottable<HTMLDivElement, SplitterPanelProps>(
-  ({ classNames, asChild, children, position, style, ...props }, forwardedRef) => {
+const SplitterPanel = slottable<HTMLDivElement, { position: Position }>(
+  ({ asChild, children, position, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
-    const { __scopeSplitter, ...rest } = props as ScopedProps<typeof props>;
+    const { mode, ratio, transition, dragging } = useSplitterContext(PANEL_NAME);
+    const { className, style, ...rest } = composableProps(props);
     const Comp = asChild ? Slot : Primitive.div;
-    const { mode, ratio = 0.5, transition } = useSplitterContext(PANEL_NAME, __scopeSplitter);
-    const { className, ...restProps } = composableProps(rest);
 
-    // Calculate position and height based on mode and ratio.
-    const isTopPanel = position === 'top';
-    const topOffset = isTopPanel ? '0%' : mode === 'top' ? '100%' : mode === 'bottom' ? '0%' : `${ratio * 100}%`;
-    const height = isTopPanel
-      ? mode === 'top'
-        ? '100%'
-        : mode === 'bottom'
-          ? '0%'
-          : `${ratio * 100}%`
-      : mode === 'bottom'
-        ? '100%'
-        : mode === 'top'
-          ? '0%'
-          : `${(1 - ratio) * 100}%`;
+    // Disable the animation while dragging so the panel tracks the pointer; otherwise animate collapse.
+    const animate = transition > 0 && !dragging;
 
     return (
       <Comp
-        {...restProps}
+        {...rest}
         ref={forwardedRef}
         className={tx('splitter.panel', {}, className)}
         style={{
-          top: topOffset,
-          height,
-          transition: `top ${transition}ms, height ${transition}ms ease-out`,
+          flexGrow: panelGrow(position, mode, ratio),
+          flexShrink: 1,
+          flexBasis: 0,
+          transition: animate ? `flex-grow ${transition}ms ease-out` : undefined,
           ...style,
         }}
       >
@@ -109,14 +170,101 @@ const SplitterPanel = slottable<HTMLDivElement, SplitterPanelProps>(
 SplitterPanel.displayName = PANEL_NAME;
 
 //
+// Handle
+//
+
+const HANDLE_NAME = 'Splitter.Handle';
+
+type SplitterHandleProps = SlottableProps;
+
+const SplitterHandle = slottable<HTMLDivElement>(({ asChild, children, ...props }, forwardedRef) => {
+  const { tx } = useThemeContext();
+  const { orientation, resizable, minRatio, maxRatio, rootRef, setRatio, setDragging } =
+    useSplitterContext(HANDLE_NAME);
+  const { className, ...rest } = composableProps(props);
+  const Comp = asChild ? Slot : Primitive.div;
+
+  const handlePointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) {
+        return;
+      }
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      setDragging(true);
+    },
+    [setDragging],
+  );
+
+  // Map the pointer position within the Root into a ratio for the start panel, clamped to [min, max].
+  const handlePointerMove = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (!event.currentTarget.hasPointerCapture(event.pointerId)) {
+        return;
+      }
+      const root = rootRef.current;
+      if (!root) {
+        return;
+      }
+      const rect = root.getBoundingClientRect();
+      const next =
+        orientation === 'horizontal'
+          ? (event.clientX - rect.left) / rect.width
+          : (event.clientY - rect.top) / rect.height;
+      setRatio(Math.min(maxRatio, Math.max(minRatio, next)));
+    },
+    [orientation, minRatio, maxRatio, rootRef, setRatio],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      setDragging(false);
+    },
+    [setDragging],
+  );
+
+  if (!resizable) {
+    return null;
+  }
+
+  return (
+    <Comp
+      {...rest}
+      ref={forwardedRef}
+      role='separator'
+      aria-orientation={orientation === 'horizontal' ? 'vertical' : 'horizontal'}
+      className={tx('splitter.handle', { orientation }, className)}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+    >
+      {children}
+    </Comp>
+  );
+});
+
+SplitterHandle.displayName = HANDLE_NAME;
+
+//
 // Splitter
 //
 
 const Splitter = {
   Root: SplitterRoot,
   Panel: SplitterPanel,
+  Handle: SplitterHandle,
 };
 
-export { Splitter, createSplitterScope };
+export { Splitter };
 
-export type { Mode as SplitterMode, SplitterRootProps, SplitterPanelProps };
+export type {
+  Orientation as SplitterOrientation,
+  SplitterMode,
+  SplitterRootProps,
+  SplitterPanelProps,
+  SplitterHandleProps,
+};


### PR DESCRIPTION
## Summary

Unifies the `Splitter` into a single headless, Radix-style, **ratio-based** composite in `@dxos/react-ui`, replacing the previous vertical-only, absolute-positioned implementation. This is the `@dxos/react-ui`-scoped slice (the deck-side migration of the presentational Splitter tile lands separately on its own stack).

### New API
- **`Splitter.Root`** — flex container: `orientation` (`horizontal`/`vertical`), `ratio`/`defaultRatio`/`onRatioChange` (via `useControllableState`), `mode` (`start`/`end`/`split`) for animated collapse, `transition` (ms; 0 = off), `resizable`, `minRatio`/`maxRatio`.
- **`Splitter.Panel`** — `position: 'start' | 'end'`, sized via `flex-grow` by `ratio` (or `1`/`0` when `mode` collapses it), animated with `transition: flex-grow`. Collapsed panels stay mounted (content clipped, not unmounted).
- **`Splitter.Handle`** *(new)* — a ratio-based pointer-drag divider that maps the pointer position within `Root` to a clamped ratio; rendered only when `resizable`. Deliberately **not** the rem-based `react-ui-dnd` `ResizeHandle` (that stays for tile/plank rem-width resize).

`resizable` (drag) and `mode` (animated collapse) are independent options. Panel `position` is generalized from `top`/`bottom` to `start`/`end` with **no back-compat shim**.

### Consumer migrations (required — breaking API change)
- `plugin-zen` `Mixer`
- `plugin-simple-layout` `SimpleLayout` + `MobileLayout` story

→ `orientation='vertical'` + `position`/`mode` `start`/`end`.

## Verification
Built + linted + formatted `@dxos/react-ui`, `@dxos/plugin-zen`, `@dxos/plugin-simple-layout`. Drove the Splitter story in storybook:
- Resize drag updates `ratio` and clamps to `min/max`; `onRatioChange` syncs controlled state.
- `mode` collapse: `split` → `[0.4, 0.6]`, `start` → `[1, 0]`, `end` → `[0, 1]`.
- Both orientations (flex-row + `aria-orientation=vertical`; flex-col + `aria-orientation=horizontal`).

No new casts (`as any`/`as T`); `@dxos/*` deps remain `workspace:*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Splitter now supports both **horizontal** and **vertical** orientations.
  * Added a **Handle** for resizing with controllable **ratio** plus **min/max** constraints.
  * Splitter mode and panel positioning are now modeled as **start/end** (with `split`).

* **Bug Fixes**
  * Updated SimpleLayout, MobileLayout stories, and the Mixer splitter positioning to match the new start/end behavior.

* **Documentation**
  * Refreshed Splitter Storybook controls and added **Horizontal** and **Vertical** variants with live ratio support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->