### PR TITLE
feat(plugin-explorer): make Graph view optional + require typename for view-backed types

### DIFF
--- a/packages/core/compute/assistant-e2e/src/harness.ts
+++ b/packages/core/compute/assistant-e2e/src/harness.ts
@@ -274,6 +274,10 @@ export const agentTest = (options: AgentTestOptions): ((ctx: TestContext) => Eff
   }, TestHelpers.provideTestContext);
 };
 
+// Memoized replays still initialize the test harness and process conversations — allow enough
+// headroom for slow CI nodes without enabling full LLM generation.
+const MEMOIZED_TEST_TIMEOUT = 60_000;
+
 // Use long timeout when generation is enabled or when running live (memoization disabled).
 export const agentTestTimeout = (opts?: Pick<AgentTestOptions, 'disableLlmMemoization'>) =>
-  MemoizedAiService.isGenerationEnabled() || opts?.disableLlmMemoization ? DEFAULT_TEST_TIMEOUT : undefined;
+  MemoizedAiService.isGenerationEnabled() || opts?.disableLlmMemoization ? DEFAULT_TEST_TIMEOUT : MEMOIZED_TEST_TIMEOUT;

--- a/packages/core/compute/assistant-e2e/src/harness.ts
+++ b/packages/core/compute/assistant-e2e/src/harness.ts
@@ -278,6 +278,9 @@ export const agentTest = (options: AgentTestOptions): ((ctx: TestContext) => Eff
 // headroom for slow CI nodes without enabling full LLM generation.
 const MEMOIZED_TEST_TIMEOUT = 60_000;
 
-// Use long timeout when generation is enabled or when running live (memoization disabled).
+/**
+ * Returns the appropriate e2e test timeout: full generation timeout when LLM generation is
+ * enabled or memoization is disabled, and a shorter replay timeout for memoized runs.
+ */
 export const agentTestTimeout = (opts?: Pick<AgentTestOptions, 'disableLlmMemoization'>) =>
   MemoizedAiService.isGenerationEnabled() || opts?.disableLlmMemoization ? DEFAULT_TEST_TIMEOUT : MEMOIZED_TEST_TIMEOUT;

--- a/packages/core/compute/assistant-e2e/src/harness.ts
+++ b/packages/core/compute/assistant-e2e/src/harness.ts
@@ -36,6 +36,9 @@ import { Employer, Organization, Person } from '@dxos/types';
 import { trim } from '@dxos/util';
 
 export const DEFAULT_TEST_TIMEOUT = 360_000;
+// Memoized replays still initialize the test harness and process conversations — allow enough
+// headroom for slow CI nodes without enabling full LLM generation.
+const MEMOIZED_TEST_TIMEOUT = 60_000;
 
 export const getDefaultSkills = () => [Ref.make(SkillManagerSkill.make()), Ref.make(DatabaseSkill.make())];
 
@@ -273,10 +276,6 @@ export const agentTest = (options: AgentTestOptions): ((ctx: TestContext) => Eff
     );
   }, TestHelpers.provideTestContext);
 };
-
-// Memoized replays still initialize the test harness and process conversations — allow enough
-// headroom for slow CI nodes without enabling full LLM generation.
-const MEMOIZED_TEST_TIMEOUT = 60_000;
 
 /**
  * Returns the appropriate e2e test timeout: full generation timeout when LLM generation is

--- a/packages/plugins/plugin-explorer/src/capabilities/create-object.ts
+++ b/packages/plugins/plugin-explorer/src/capabilities/create-object.ts
@@ -21,7 +21,9 @@ export default Capability.makeModule(
       createObject: (props, options) =>
         Effect.gen(function* () {
           const object = yield* Effect.promise(async () => {
-            const { view } = await ViewModel.makeFromDatabase({ db: options.db, typename: props.typename });
+            const view = props.typename
+              ? (await ViewModel.makeFromDatabase({ db: options.db, typename: props.typename })).view
+              : undefined;
             return Graph.make({ name: props.name, view });
           });
           return yield* Operation.invoke(SpaceOperation.AddObject, {

--- a/packages/plugins/plugin-explorer/src/types/Graph.ts
+++ b/packages/plugins/plugin-explorer/src/types/Graph.ts
@@ -10,7 +10,7 @@ import { ViewAnnotation } from '@dxos/schema';
 
 const GraphSchema = Schema.Struct({
   name: Schema.optional(Schema.String),
-  view: Ref.Ref(View.View).pipe(FormInputAnnotation.set(false)),
+  view: Ref.Ref(View.View).pipe(FormInputAnnotation.set(false), Schema.optional),
   query: Schema.Struct({
     raw: Schema.optional(Schema.String),
     ast: QueryAST.Query,
@@ -26,7 +26,7 @@ export interface Graph extends Type.InstanceType<typeof GraphSchema> {}
 export const Graph: Type.Obj<Graph> = GraphSchema as any;
 
 type MakeProps = Omit<Partial<Obj.MakeProps<typeof Graph>>, 'view'> & {
-  view: View.View;
+  view?: View.View;
 };
 
 /**
@@ -36,6 +36,6 @@ export const make = ({
   name,
   query = { raw: '', ast: Query.select(Filter.nothing()).ast },
   view,
-}: MakeProps): Graph => {
-  return Obj.make(Graph, { name, view: Ref.make(view), query });
+}: MakeProps = {}): Graph => {
+  return Obj.make(Graph, { name, view: view && Ref.make(view), query });
 };

--- a/packages/plugins/plugin-kanban/src/capabilities/create-object.ts
+++ b/packages/plugins/plugin-kanban/src/capabilities/create-object.ts
@@ -21,12 +21,15 @@ export default Capability.makeModule(
       createObject: (props, options) =>
         Effect.gen(function* () {
           const object = yield* Effect.promise(async () => {
-            const { view } = await ViewModel.makeFromDatabase({
-              db: options.db,
-              typename: props.typename,
-              pivotFieldName: props.initialPivotColumn,
-            });
-            return Kanban.make({ name: props.name, view });
+            if (props.typename) {
+              const { view } = await ViewModel.makeFromDatabase({
+                db: options.db,
+                typename: props.typename,
+                pivotFieldName: props.initialPivotColumn,
+              });
+              return Kanban.make({ name: props.name, view });
+            }
+            return Kanban.makeItems({ name: props.name, pivotField: props.initialPivotColumn ?? '' });
           });
           return yield* Operation.invoke(SpaceOperation.AddObject, {
             object,

--- a/packages/plugins/plugin-kanban/src/types/schema.ts
+++ b/packages/plugins/plugin-kanban/src/types/schema.ts
@@ -51,6 +51,7 @@ export const CreateKanbanSchema = Schema.Struct({
       location: ['database', 'runtime'],
       kind: ['user'],
     }),
+    Schema.optional,
   ),
   initialPivotColumn: Schema.optional(
     Schema.String.annotations({

--- a/packages/plugins/plugin-kanban/src/types/schema.ts
+++ b/packages/plugins/plugin-kanban/src/types/schema.ts
@@ -51,7 +51,6 @@ export const CreateKanbanSchema = Schema.Struct({
       location: ['database', 'runtime'],
       kind: ['user'],
     }),
-    Schema.optional,
   ),
   initialPivotColumn: Schema.optional(
     Schema.String.annotations({

--- a/packages/plugins/plugin-masonry/src/types/MasonryAction.ts
+++ b/packages/plugins/plugin-masonry/src/types/MasonryAction.ts
@@ -15,6 +15,5 @@ export const MasonryProps = Schema.Struct({
       location: ['database', 'runtime'],
       kind: ['user'],
     }),
-    Schema.optional,
   ),
 });

--- a/packages/plugins/plugin-table/src/types/TableOperation.ts
+++ b/packages/plugins/plugin-table/src/types/TableOperation.ts
@@ -22,7 +22,6 @@ export const CreateTableSchema = Schema.Struct({
       location: ['database', 'runtime'],
       kind: ['user'],
     }),
-    Schema.optional,
   ),
 });
 


### PR DESCRIPTION
## Summary

- **Graph/Explorer**: The `view` field on the `Graph` type is now optional. When creating a Graph without selecting a type, it is created without a `View` reference and surfaces as a standalone object in the sidebar (not as a view of any type). When a typename is selected, the existing view-backed behaviour is preserved — the Graph appears as a child of that type node.

- **Table, Kanban, Masonry**: The `typename` field in their creation schemas is now required. This prevents the accidental auto-creation of unnamed/default types just to satisfy the form, which was the previous behaviour when the field was left empty.

## Context

The `ViewAnnotation` infrastructure in `plugin-space` places objects as "view instances" under a type node only when their declared `Ref<View>` field resolves to a non-null target. Making the Graph's `view` optional means a typename-less Graph simply doesn't resolve a view ref and falls back to appearing as a regular object.

The `ExplorerArticle` never read the Graph's `view.query` anyway — it builds its own graph model from the database directly — so this change has no effect on the explorer's rendering behaviour.

## Test plan

- [ ] Create a Graph without selecting a type → appears as a standalone object, not nested under a type
- [ ] Create a Graph with a type selected → appears as a child of that type in the sidebar (existing behaviour)
- [ ] Attempt to create a Table/Kanban/Masonry without selecting a type → form should not submit (typename required)
- [ ] Create a Table/Kanban/Masonry with a type selected → works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Object creation now gracefully handles cases where no linked view is provided.
  * Improved validation by making `typename`/type inputs required across kanban, masonry, and table creation flows.
* **Tests**
  * Updated end-to-end test timeouts so memoized replay runs use a consistent, fixed timeout value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->