### PR TITLE
fix(storybook): align wrangler.toml deploy path with moon bundle output

### DIFF
--- a/tools/storybook-react/moon.yml
+++ b/tools/storybook-react/moon.yml
@@ -2,7 +2,7 @@ layer: tool
 language: typescript
 tasks:
   #
-  # Test locally via: npx http-server ./tools/storybook-reactout/storybook
+  # Test locally via: npx http-server ./out/storybook-react
   #
   bundle:
     command: storybook build

--- a/tools/storybook-react/wrangler.toml
+++ b/tools/storybook-react/wrangler.toml
@@ -5,15 +5,15 @@
 
 name = "dxos-storybook"
 compatibility_date = "2024-04-05"
-pages_build_output_dir = "./out/stories"
+pages_build_output_dir = "./out/storybook-react"
 
 #
 # Dev
 # http://localhost:8788
-# moon run storybook:bundle
+# moon run storybook-react:bundle
 # wrangler pages dev
 #
 # Prod is pushed via GH Actions CI.
-# wrangler pages deploy out/stories
+# wrangler pages deploy out/storybook-react
 # https://dxos-storybook.pages.dev
 #


### PR DESCRIPTION
## Summary

- `tools/storybook-react/wrangler.toml`: corrected `pages_build_output_dir` from `./out/stories` → `./out/storybook-react` to match the actual moon bundle task output
- Updated stale comments in `wrangler.toml` and fixed a typo in `moon.yml`'s local test command

## Why

The `wrangler.toml` was created in #10352 (Dec 22, 2025) with `pages_build_output_dir = "./out/stories"`. Two days later #10365 changed the moon bundle task to output to `out/storybook-react`, but the `wrangler.toml` was never updated. The `deploy-apps.sh` script also passes `out/storybook-react` explicitly — so Wrangler was either using the wrong default path or pointing reviewers/developers at a non-existent directory.

## Test plan

- [ ] CI `Publish` workflow successfully deploys `dxos-storybook` to Cloudflare Pages after a merge to main
- [ ] `wrangler pages deploy out/storybook-react` from `tools/storybook-react/` uses the correct directory (consistent with moon bundle output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Storybook-related configuration notes and deployment targets to use the correct output directory.
  * Aligned local test, build, and Pages deployment references with the current Storybook React output path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->