### PR TITLE
feat(react-ui-menu): support Input.Switch in toolbar

### DIFF
--- a/packages/ui/react-ui-menu/src/builder.ts
+++ b/packages/ui/react-ui-menu/src/builder.ts
@@ -41,6 +41,9 @@ export interface ActionGroupBuilder {
   /** Add an action node as a child of the current group. */
   action<P extends {} = {}>(id: string, props: P & MenuActionProperties, invoke: () => void): this;
 
+  /** Add a switch action rendered as a labeled Input.Switch. */
+  switch(id: string, props: Omit<MenuActionProperties, 'variant'> & { checked: boolean }, invoke: () => void): this;
+
   /** Add a nested action group. */
   group(id: string, props: MenuItemGroupProperties, cb: ActionGroupBuilderFn): this;
 
@@ -92,6 +95,10 @@ class MenuBuilderImpl implements MenuBuilder {
     this._data.nodes.push(createMenuAction(id, invoke, props));
     this._data.edges.push({ source: this._rootId, target: id, relation: 'child' });
     return this;
+  }
+
+  switch(id: string, props: Omit<MenuActionProperties, 'variant'> & { checked: boolean }, invoke: () => void): this {
+    return this.action(id, { ...props, variant: 'switch' }, invoke);
   }
 
   group(id: string, props: MenuItemGroupProperties, cb: ActionGroupBuilderFn): this {

--- a/packages/ui/react-ui-menu/src/components/ToolbarMenu.stories.tsx
+++ b/packages/ui/react-ui-menu/src/components/ToolbarMenu.stories.tsx
@@ -4,7 +4,7 @@
 
 import { Atom, RegistryContext } from '@effect-atom/atom-react';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 
 import { random } from '@dxos/random';
 import { IconButton } from '@dxos/react-ui';
@@ -13,8 +13,9 @@ import { withRegistry } from '@dxos/storybook-utils';
 
 import { translations } from '#translations';
 
+import { MenuBuilder } from '../builder';
 import { Menu } from '../components';
-import { type ActionGraphProps, useMenuActions } from '../hooks';
+import { type ActionGraphProps, useMenuActions, useMenuBuilder } from '../hooks';
 import { createActions, createNestedActions, createNestedActionsResolver, useMutateActions } from '../testing';
 
 random.seed(1234);
@@ -88,6 +89,34 @@ export const UseMenuActionsToolbar: Story = {
 
     return (
       <Menu.Root {...menuActions}>
+        <Menu.Toolbar />
+      </Menu.Root>
+    );
+  },
+};
+
+/**
+ * Toolbar with both labeled and tooltip-only (iconOnly) Input.Switch items.
+ */
+export const SwitchToolbar: Story = {
+  render: () => {
+    const [wordWrap, setWordWrap] = useState(false);
+    const [lineNumbers, setLineNumbers] = useState(true);
+
+    const menuActions = useMenuBuilder(
+      () =>
+        MenuBuilder.make()
+          .root({ label: 'Editor settings' })
+          .switch('word-wrap', { label: 'Word wrap', checked: wordWrap }, () => setWordWrap((v) => !v))
+          .switch('line-numbers', { label: 'Line numbers', iconOnly: true, checked: lineNumbers }, () =>
+            setLineNumbers((v) => !v),
+          )
+          .build(),
+      [wordWrap, lineNumbers],
+    );
+
+    return (
+      <Menu.Root {...menuActions} alwaysActive>
         <Menu.Toolbar />
       </Menu.Root>
     );

--- a/packages/ui/react-ui-menu/src/components/ToolbarMenu.tsx
+++ b/packages/ui/react-ui-menu/src/components/ToolbarMenu.tsx
@@ -4,7 +4,14 @@
 
 import React, { useCallback } from 'react';
 
-import { Toolbar as NaturalToolbar, type ToolbarRootProps, useTranslation } from '@dxos/react-ui';
+import {
+  Input,
+  Toolbar as NaturalToolbar,
+  Tooltip,
+  type ToolbarRootProps,
+  toLocalizedString,
+  useTranslation,
+} from '@dxos/react-ui';
 import { composable, composableProps } from '@dxos/react-ui';
 import { useAttention } from '@dxos/react-ui-attention';
 import { type DropdownMenuItemGroupProperties, type ToggleGroupMenuItemGroupProperties } from '@dxos/ui-types';
@@ -87,6 +94,48 @@ const ActionToolbarItem = ({ __menuScope, action }: MenuScopedProps<{ action: Me
     <NaturalToolbar.Button key={action.id} {...commonProps}>
       <ActionLabel action={action} />
     </NaturalToolbar.Button>
+  );
+};
+
+const SwitchToolbarItem = ({ __menuScope, action }: MenuScopedProps<{ action: MenuAction }>) => {
+  const { onAction } = useMenuScoped('SwitchToolbarItem', __menuScope);
+  const { t } = useTranslation(translationKey);
+  const { label, iconOnly, disabled, testId, hidden, checked } = action.properties;
+  const labelStr = toLocalizedString(label, t);
+
+  const handleCheckedChange = useCallback(() => {
+    if (onAction) {
+      onAction(action, {});
+    } else {
+      void executeMenuAction(action);
+    }
+  }, [action, onAction]);
+
+  if (hidden) {
+    return null;
+  }
+
+  const switchInput = (
+    <Input.Switch
+      checked={checked}
+      disabled={disabled}
+      aria-label={iconOnly ? labelStr : undefined}
+      onCheckedChange={handleCheckedChange}
+      {...(testId && { 'data-testid': testId })}
+    />
+  );
+
+  return (
+    <Input.Root>
+      {!iconOnly && <Input.Label>{labelStr}</Input.Label>}
+      {iconOnly ? (
+        <Tooltip.Trigger asChild content={labelStr}>
+          <Input.Block>{switchInput}</Input.Block>
+        </Tooltip.Trigger>
+      ) : (
+        <Input.Block>{switchInput}</Input.Block>
+      )}
+    </Input.Root>
   );
 };
 
@@ -257,5 +306,10 @@ const ToolbarMenuItem = ({ __menuScope, item }: MenuScopedProps<{ item: MenuItem
     );
   }
 
-  return <ActionToolbarItem __menuScope={__menuScope} action={item as MenuAction} />;
+  const action = item as MenuAction;
+  if (action.properties?.variant === 'switch') {
+    return <SwitchToolbarItem __menuScope={__menuScope} action={action} />;
+  }
+
+  return <ActionToolbarItem __menuScope={__menuScope} action={action} />;
 };

--- a/packages/ui/ui-types/src/menu.ts
+++ b/packages/ui/ui-types/src/menu.ts
@@ -23,7 +23,7 @@ export type MenuItemChrome = {
 
 // TODO(burdon): Narrow MenuActionProperties to a discriminated union.
 export type MenuActionProperties = MenuItemChrome & {
-  variant?: 'action' | 'toggle';
+  variant?: 'action' | 'toggle' | 'switch';
   value?: string;
   checked?: boolean;
 };


### PR DESCRIPTION
## Summary

- Adds `variant: 'switch'` to `MenuActionProperties`, causing toolbar items to render as a labeled `Input.Switch` instead of a button.
- When `iconOnly: true`, the label is hidden and exposed as a hover tooltip via `Tooltip.Trigger asChild` wrapping `Input.Block`.
- Adds a `switch()` convenience method to `MenuBuilder` (and `ActionGroupBuilder` interface) that enforces `checked: boolean` and injects `variant: 'switch'` automatically.
- Adds a `SwitchToolbar` story showing both a labeled switch and an `iconOnly` (tooltip-label) switch side by side.

## Reviewer notes

- `Tooltip.Trigger asChild` wraps `Input.Block` (a `forwardRef` div), not `Input.Root` (a context provider), so pointer events attach to the correct visual element.
- `aria-label` is set on the switch input in `iconOnly` mode since `Input.Label` is omitted.

## Test plan

- [ ] Start Storybook (`moon run storybook-react:serve`) and open `ui/react-ui-menu/ToolbarMenu → SwitchToolbar`
- [ ] Confirm the first switch ("Word wrap") shows a visible label and toggles on click
- [ ] Confirm the second switch ("Line numbers") shows no label, toggles on click, and shows a tooltip on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for switch-style menu actions in toolbar menus.
  * Introduced a new toolbar story showing editor settings with Word wrap and Line numbers switches.
  * Improved switch handling in toolbar items, including icon-only display, tooltips, disabled state, and accessibility labels.

* **Bug Fixes**
  * Toolbar menus now render switch actions correctly instead of treating them as standard actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->