### PR TITLE
fix: companion auto-select, mailbox nav, navtree order, switch label

### DIFF
--- a/packages/plugins/plugin-assistant/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-assistant/src/capabilities/app-graph-builder.ts
@@ -58,7 +58,7 @@ export default Capability.makeModule(
               type: Paths.GroupTypes.ai,
               label: ['nav-tree-group-ai.label', { ns: meta.profile.key }],
               space,
-              position: 100,
+              position: 300,
             }),
           ]),
       }),

--- a/packages/plugins/plugin-assistant/src/translations.ts
+++ b/packages/plugins/plugin-assistant/src/translations.ts
@@ -189,7 +189,7 @@ export const translations: Resource[] = [
         'space-home.suggestion-ideas.label': 'Suggest some ideas to work on',
         'space-home.prompt.placeholder': 'Ask the assistant anything…',
 
-        'nav-tree-group-ai.label': 'AI',
+        'nav-tree-group-ai.label': 'Intelligence',
       },
     },
   },

--- a/packages/plugins/plugin-inbox/src/capabilities/navigation-resolver.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/navigation-resolver.ts
@@ -15,7 +15,7 @@ import { getLinkedVariant, isLinkedSegment } from '@dxos/react-ui-attention';
 import { meta } from '#meta';
 import { Calendar, Mailbox } from '#types';
 
-import { getMailboxAllMailPath, getMailboxesSectionId } from '../paths';
+import { getMailboxPath, getMailboxesSectionId } from '../paths';
 
 /**
  * Creates a path resolver for feed-object navigation paths of the form
@@ -72,7 +72,7 @@ export default Capability.makeModule(
 
         return [
           {
-            path: getMailboxAllMailPath(db.spaceId, object.id),
+            path: getMailboxPath(db.spaceId, object.id),
             label: (object as Mailbox.Mailbox).name ?? '',
             type: Type.getTypename(Mailbox.Mailbox),
           },

--- a/packages/plugins/plugin-inbox/src/constants.ts
+++ b/packages/plugins/plugin-inbox/src/constants.ts
@@ -24,7 +24,6 @@ export const GOOGLE_CONTACTS_PROVIDER_ID = 'google-contacts';
 export const POPOVER_SAVE_FILTER = DXN.make(`${meta.profile.key}.saveFilterPopover`);
 
 export const MAILBOXES_SECTION_TYPE = `${meta.profile.key}.mailboxes-section`;
-export const MAILBOX_ALL_MAIL_TYPE = `${meta.profile.key}.all-mail`;
 export const MAILBOX_DRAFTS_TYPE = `${meta.profile.key}.drafts`;
 
 /**

--- a/packages/plugins/plugin-inbox/src/operations/add-mailbox.ts
+++ b/packages/plugins/plugin-inbox/src/operations/add-mailbox.ts
@@ -10,7 +10,7 @@ import { Database, Obj } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
 import { ObservabilityOperation } from '@dxos/plugin-observability';
 
-import { getMailboxAllMailPath } from '../paths';
+import { getMailboxPath } from '../paths';
 import { InboxOperation } from '../types';
 
 const handler: Operation.WithHandler<typeof InboxOperation.AddMailbox> = InboxOperation.AddMailbox.pipe(
@@ -37,7 +37,7 @@ const handler: Operation.WithHandler<typeof InboxOperation.AddMailbox> = InboxOp
 
       return {
         id: Obj.getURI(object),
-        subject: [getMailboxAllMailPath(db.spaceId, object.id)],
+        subject: [getMailboxPath(db.spaceId, object.id)],
         object,
       };
     }),

--- a/packages/plugins/plugin-inbox/src/paths.ts
+++ b/packages/plugins/plugin-inbox/src/paths.ts
@@ -15,7 +15,6 @@ const { getSectionPath: getCalendarsPath, getObjectPath: getCalendarPath } = Pat
 /** Well-known local segment names (private — use the path helpers below). */
 const Segments = {
   mailboxes: 'mailboxes',
-  allMail: 'all-mail',
   drafts: 'drafts',
 } as const;
 
@@ -29,13 +28,6 @@ export const getMailboxesPath = (spaceId: string): string =>
 /** Canonical qualified path to a specific mailbox within a space. */
 export const getMailboxPath = (spaceId: string, mailboxId: string): string =>
   `${getMailboxesPath(spaceId)}/${mailboxId}`;
-
-/** Canonical segment ID for the all-mail child node. */
-export const getAllMailId = (): string => Segments.allMail;
-
-/** Canonical qualified path to a mailbox's all-mail view. */
-export const getMailboxAllMailPath = (spaceId: string, mailboxId: string): string =>
-  `${getMailboxPath(spaceId, mailboxId)}/${Segments.allMail}`;
 
 /** Canonical segment ID for the drafts child node. */
 export const getDraftsId = (): string => Segments.drafts;

--- a/packages/plugins/plugin-magazine/src/containers/MagazineArticle/MagazineArticle.tsx
+++ b/packages/plugins/plugin-magazine/src/containers/MagazineArticle/MagazineArticle.tsx
@@ -3,10 +3,10 @@
 //
 
 import { useAtomValue } from '@effect-atom/atom-react';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
-import { LayoutOperation, Paths } from '@dxos/app-toolkit';
+import { Paths } from '@dxos/app-toolkit';
 import { type AppSurface, useShowItem } from '@dxos/app-toolkit/ui';
 import { Obj, Ref } from '@dxos/echo';
 import { log } from '@dxos/log';
@@ -73,13 +73,6 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
   );
 
   const noPosts = posts.length === 0;
-  useEffect(() => {
-    if (noPosts) {
-      void invoker.invokePromise(LayoutOperation.UpdateCompanion, {
-        subject: linkedSegment('settings'),
-      });
-    }
-  }, [noPosts, invoker]);
 
   const tileItems = useMemo<TileData[]>(
     () =>

--- a/packages/plugins/plugin-magazine/src/containers/MagazineArticle/MagazineArticle.tsx
+++ b/packages/plugins/plugin-magazine/src/containers/MagazineArticle/MagazineArticle.tsx
@@ -3,10 +3,10 @@
 //
 
 import { useAtomValue } from '@effect-atom/atom-react';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
-import { Paths } from '@dxos/app-toolkit';
+import { LayoutOperation, Paths } from '@dxos/app-toolkit';
 import { type AppSurface, useShowItem } from '@dxos/app-toolkit/ui';
 import { Obj, Ref } from '@dxos/echo';
 import { log } from '@dxos/log';
@@ -73,6 +73,13 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
   );
 
   const noPosts = posts.length === 0;
+  useEffect(() => {
+    if (noPosts) {
+      void invoker.invokePromise(LayoutOperation.UpdateCompanion, {
+        subject: linkedSegment('settings'),
+      });
+    }
+  }, [noPosts, invoker]);
 
   const tileItems = useMemo<TileData[]>(
     () =>

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
@@ -255,7 +255,7 @@ export const createSpaceExtensions = Effect.fnUntraced(function* () {
             type: Paths.GroupTypes.communications,
             label: ['nav-tree-group-comm.label', { ns: meta.profile.key }],
             space,
-            position: 300,
+            position: 100,
           }),
         ]),
     }),

--- a/packages/ui/react-ui-menu/src/components/ToolbarMenu.tsx
+++ b/packages/ui/react-ui-menu/src/components/ToolbarMenu.tsx
@@ -127,7 +127,6 @@ const SwitchToolbarItem = ({ __menuScope, action }: MenuScopedProps<{ action: Me
 
   return (
     <Input.Root>
-      {!iconOnly && <Input.Label>{labelStr}</Input.Label>}
       {iconOnly ? (
         <Tooltip.Trigger asChild content={labelStr}>
           <Input.Block>{switchInput}</Input.Block>
@@ -135,6 +134,7 @@ const SwitchToolbarItem = ({ __menuScope, action }: MenuScopedProps<{ action: Me
       ) : (
         <Input.Block>{switchInput}</Input.Block>
       )}
+      {!iconOnly && <Input.Label>{labelStr}</Input.Label>}
     </Input.Root>
   );
 };


### PR DESCRIPTION
## Summary

- **Mailbox navigation**: Creating a mailbox was navigating to the now-invalid \`all-mail\` path. Removed all \`allMail\` path helpers from \`plugin-inbox\` (\`getAllMailId\`, \`getMailboxAllMailPath\`, \`allMail\` segment, \`MAILBOX_ALL_MAIL_TYPE\`) and updated \`add-mailbox.ts\` and \`navigation-resolver.ts\` to use \`getMailboxPath\` directly.

- **Navtree group order**: Swapped positions of Communications (100 ← 300) and Intelligence/AI (300 ← 100) so Communications appears higher in the sidebar. Also renamed the group label from "AI" to "Intelligence".

- **Switch toolbar label**: \`SwitchToolbarItem\` in \`ToolbarMenu.tsx\` now places the \`<Input.Label>\` after \`<Input.Block>\` so the label appears to the right of the toggle control.