### PR TITLE
fix(deps): publish packages that public packages depend on

### DIFF
--- a/packages/common/i18n/package.json
+++ b/packages/common/i18n/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/i18n",
   "version": "0.9.0",
-  "private": true,
   "description": "Framework-agnostic i18next instance and translation utilities.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/core/compute/compute-hyperformula/package.json
+++ b/packages/core/compute/compute-hyperformula/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/compute-hyperformula",
   "version": "0.9.0",
-  "private": true,
   "description": "HyperFormula-based compute graph (spreadsheet) engine.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/core/echo/echo-doc/package.json
+++ b/packages/core/echo/echo-doc/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/echo-doc",
   "version": "0.9.0",
-  "private": true,
   "description": "Opinionated Automerge document wrapper for ECHO.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/core/echo/echo-doc/package.json
+++ b/packages/core/echo/echo-doc/package.json
@@ -32,5 +32,8 @@
     "@dxos/log": "workspace:*",
     "@dxos/util": "workspace:*",
     "effect": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-comments/package.json
+++ b/packages/plugins/plugin-comments/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-comments",
   "version": "0.9.0",
-  "private": true,
   "description": "DXOS Comments plugin",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-file/package.json
+++ b/packages/plugins/plugin-file/package.json
@@ -132,5 +132,8 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/plugin-file/package.json
+++ b/packages/plugins/plugin-file/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-file",
   "version": "0.9.0",
-  "private": true,
   "description": "Inline file (image / PDF) storage plugin for DXOS",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-game/package.json
+++ b/packages/plugins/plugin-game/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-game",
   "version": "0.9.0",
-  "private": true,
   "description": "Game plugin for DXOS Composer (unifies game variants like chess, tic-tac-toe).",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/ui/react-ui-introspect/package.json
+++ b/packages/ui/react-ui-introspect/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/react-ui-introspect",
   "version": "0.9.0",
-  "private": true,
   "description": "React UI for browsing and invoking the introspect-mcp tool surface.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/ui/react-ui-introspect/package.json
+++ b/packages/ui/react-ui-introspect/package.json
@@ -58,5 +58,8 @@
     "@dxos/ui-theme": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Problem

Several **public** (published) packages declare runtime `dependencies` on packages marked `private: true`. The pkg.pr.new publish step (`scripts/pkg-pr-new-publish.sh`) only publishes non-private packages, so those private deps are never published. External consumers (e.g. the `edge` repo, which installs `@dxos/*` from pkg.pr.new) then fall back to the public npm registry for them and hit `ERR_PNPM_FETCH_404`.

Example chain that breaks `edge`:
- `@dxos/react-ui` → `@dxos/i18n` (private)
- `@dxos/assistant`, `@dxos/plugin-inbox`, `@dxos/plugin-markdown`, `@dxos/react-ui-editor`, `@dxos/react-ui-form` → `@dxos/echo-doc` (private)

## Fix

Remove `private: true` from every private package that is transitively reachable from a public package via `dependencies`, so the publish step includes them. This restores the invariant: **no published package depends on an unpublished one.**

Affected packages (7):

| package | depended on by (examples) |
|---|---|
| `@dxos/i18n` | react-ui, app-toolkit, plugin-theme |
| `@dxos/echo-doc` | assistant, plugin-inbox, plugin-markdown, react-ui-editor/-form |
| `@dxos/compute-hyperformula` | plugin-sheet, plugin-debug |
| `@dxos/plugin-comments` | plugin-sheet |
| `@dxos/plugin-file` | plugin-wnfs |
| `@dxos/plugin-game` | plugin-chess, plugin-script |
| `@dxos/react-ui-introspect` | plugin-debug |

## Verification

Re-scanned all workspace `package.json`s after the change: **0 remaining public→private dependency edges** (excluding `@fixture/*` test packages, which are not depended on by any public package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple package manifests to remove private visibility and allow wider publishing.
  * Added public publish configuration where needed so selected compute, core, UI, and plugin packages can be released and consumed more broadly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->