### PR TITLE
fix(icons): include dx.config.ts files in icon scanner content paths

### DIFF
--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -550,6 +550,7 @@ export default defineConfig((env) => ({
       contentPaths: [
         path.join(rootDir, '/{packages,tools}/**/dist/**/*.{mjs,html}'),
         path.join(rootDir, '/{packages,tools}/**/src/**/*.{ts,tsx,js,jsx,css,md,html}'),
+        path.join(rootDir, '/{packages,tools}/**/dx.config.{ts,tsx,js,jsx}'),
       ],
       // verbose: true,
     }),

--- a/packages/apps/composer-crx/vite.config.ts
+++ b/packages/apps/composer-crx/vite.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
       contentPaths: [
         path.join(rootDir, '/{packages,tools}/**/dist/**/*.{mjs,html}'),
         path.join(rootDir, '/{packages,tools}/**/src/**/*.{ts,tsx,js,jsx,css,md,html}'),
+        path.join(rootDir, '/{packages,tools}/**/dx.config.{ts,tsx,js,jsx}'),
       ],
       // Page-action descriptor icons are contributed by Composer plugins at
       // runtime; those sources are never imported by the extension bundle, so

--- a/tools/storybook-lit/.storybook/main.ts
+++ b/tools/storybook-lit/.storybook/main.ts
@@ -58,7 +58,7 @@ export const config = ({ stories: baseStories, ...baseConfig }: Partial<Storyboo
           assetPath: (name, variant) =>
             `${iconsDir}/${variant}/${name}${variant === 'regular' ? '' : `-${variant}`}.svg`,
           spriteFile: resolve(__dirname, '../static/icons.svg'),
-          contentPaths: [join(packages, '/**/src/**/*.{ts,tsx}')],
+          contentPaths: [join(packages, '/**/src/**/*.{ts,tsx}'), join(packages, '/**/dx.config.{ts,tsx,js,jsx}')],
         }),
 
         ThemePlugin({}),

--- a/tools/storybook-react/.storybook/main.ts
+++ b/tools/storybook-react/.storybook/main.ts
@@ -46,7 +46,10 @@ export const modules = [
 
 // NOTE: Storybook test depends on relative paths.
 export const stories = modules.map((dir) => join('../../../packages', dir, storyFiles));
-export const content = modules.map((dir) => join(packages, dir, contentFiles));
+export const content = [
+  ...modules.map((dir) => join(packages, dir, contentFiles)),
+  join(packages, '**/dx.config.{ts,tsx,js,jsx}'),
+];
 
 if (isTrue(process.env.DX_DEBUG)) {
   console.log(JSON.stringify({ stories, content }, null, 2));

--- a/tools/storybook-solid/.storybook/main.ts
+++ b/tools/storybook-solid/.storybook/main.ts
@@ -61,7 +61,7 @@ export const config = ({ stories: baseStories, ...baseConfig }: Partial<Storyboo
           assetPath: (name, variant) =>
             `${iconsDir}/${variant}/${name}${variant === 'regular' ? '' : `-${variant}`}.svg`,
           spriteFile: resolve(__dirname, '../static/icons.svg'),
-          contentPaths: [join(packages, '/**/src/**/*.{ts,tsx}')],
+          contentPaths: [join(packages, '/**/src/**/*.{ts,tsx}'), join(packages, '/**/dx.config.{ts,tsx,js,jsx}')],
         }),
 
         ThemePlugin({}),


### PR DESCRIPTION
## Summary

- `dx.config.ts` files live at the package root (e.g. `packages/plugins/plugin-file/dx.config.ts`), outside `src/`
- The `IconsPlugin` `contentPaths` globs only covered `**/src/**` and `**/dist/**`, so icon keys in `dx.config.ts` (e.g. `icon: { key: 'ph--file--regular' }`) were never scanned
- Adds `**/dx.config.{ts,tsx,js,jsx}` to `contentPaths` in all five icon-scanning configs: `composer-app`, `composer-crx`, `storybook-react`, `storybook-lit`, and `storybook-solid`

## Test plan

- [ ] Build composer-app and verify icons from plugin `dx.config.ts` files appear in the generated `icons.svg` sprite
- [ ] Confirm no new icons-related console errors in the browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded icon scanning so builds and Storybook now detect icons referenced from additional configuration files.
  * Improved coverage across app and tooling configurations, reducing cases where icons could be missing in previews or packaged output.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->