### PR TITLE
feat(plugin-routine): Schedule minInterval constraint + MasterDetail gutter alignment

### DIFF
--- a/packages/plugins/plugin-routine/src/components/MasterDetail/MasterDetail.stories.tsx
+++ b/packages/plugins/plugin-routine/src/components/MasterDetail/MasterDetail.stories.tsx
@@ -1,0 +1,100 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Atom } from '@effect-atom/atom-react';
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import React, { useState } from 'react';
+
+import { Form } from '@dxos/react-ui-form';
+import { Panel, ScrollArea } from '@dxos/react-ui';
+import { withLayout, withTheme } from '@dxos/react-ui/testing';
+import * as Schema from 'effect/Schema';
+
+import { translations } from '#translations';
+
+import { MasterDetail, type MasterDetailIcon } from './MasterDetail';
+
+type Row = { id: string; label: string };
+
+const ROWS: Row[] = [
+  { id: '1', label: 'Daily digest' },
+  { id: '2', label: 'Sync inbox' },
+  { id: '3', label: 'Weekly report' },
+];
+
+const DetailSchema = Schema.Struct({
+  name: Schema.String.annotations({ title: 'Name' }),
+  description: Schema.optional(Schema.String).annotations({ title: 'Description' }),
+});
+
+// Mirrors RoutineForm's gutter (Form.Viewport owns a `Column.Root` gutter); used to check list/detail alignment.
+const MockDetail = ({ row }: { row: Row }) => (
+  <Form.Root schema={DetailSchema} values={{ name: row.label, description: '' }}>
+    <Form.Viewport>
+      <Form.Content>
+        <Form.FieldSet />
+      </Form.Content>
+    </Form.Viewport>
+  </Form.Root>
+);
+
+const getIcon = (_get: Atom.Context): MasterDetailIcon => ({ icon: 'ph--lightning--regular' });
+
+const DefaultStory = () => {
+  const [selectedId, setSelectedId] = useState<string | undefined>('1');
+  const selected = ROWS.find((row) => row.id === selectedId);
+
+  return (
+    <Panel.Root>
+      <Panel.Content asChild className='pt-trim-md'>
+        <ScrollArea.Root orientation='vertical'>
+          <ScrollArea.Viewport>
+            <MasterDetail<Row>
+              classNames='dx-document'
+              items={ROWS}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+              getLabel={(_get, row) => row.label}
+              getIcon={getIcon}
+              detail={selected ? <MockDetail row={selected} /> : null}
+              emptyLabel='No items'
+            />
+          </ScrollArea.Viewport>
+        </ScrollArea.Root>
+      </Panel.Content>
+    </Panel.Root>
+  );
+};
+
+const meta = {
+  title: 'plugins/plugin-routine/components/MasterDetail',
+  render: DefaultStory,
+  decorators: [withTheme(), withLayout({ layout: 'column' })],
+  parameters: { layout: 'fullscreen', translations },
+} satisfies Meta<typeof DefaultStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  render: () => (
+    <Panel.Root>
+      <Panel.Content asChild className='pt-trim-md'>
+        <ScrollArea.Root orientation='vertical'>
+          <ScrollArea.Viewport>
+            <MasterDetail<Row>
+              classNames='dx-document'
+              items={[]}
+              getLabel={(_get, row) => row.label}
+              emptyLabel='No items'
+            />
+          </ScrollArea.Viewport>
+        </ScrollArea.Root>
+      </Panel.Content>
+    </Panel.Root>
+  ),
+};

--- a/packages/plugins/plugin-routine/src/components/MasterDetail/MasterDetail.stories.tsx
+++ b/packages/plugins/plugin-routine/src/components/MasterDetail/MasterDetail.stories.tsx
@@ -4,12 +4,12 @@
 
 import { type Atom } from '@effect-atom/atom-react';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
+import * as Schema from 'effect/Schema';
 import React, { useState } from 'react';
 
-import { Form } from '@dxos/react-ui-form';
 import { Panel, ScrollArea } from '@dxos/react-ui';
+import { Form } from '@dxos/react-ui-form';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
-import * as Schema from 'effect/Schema';
 
 import { translations } from '#translations';
 

--- a/packages/plugins/plugin-routine/src/components/MasterDetail/MasterDetail.tsx
+++ b/packages/plugins/plugin-routine/src/components/MasterDetail/MasterDetail.tsx
@@ -5,10 +5,10 @@
 import { Atom, useAtomValue } from '@effect-atom/atom-react';
 import React, { type ReactNode, useMemo } from 'react';
 
-import { Icon, IconBlock, IconButton, type ThemedClassName, Tooltip, useTranslation } from '@dxos/react-ui';
+import { Column, Icon, IconBlock, IconButton, type ThemedClassName, Tooltip, useTranslation } from '@dxos/react-ui';
 import { Empty, OrderedList } from '@dxos/react-ui-list';
 import { Menu, type ActionGraphProps, useMenuBuilder } from '@dxos/react-ui-menu';
-import { getStyles, mx } from '@dxos/ui-theme';
+import { getStyles } from '@dxos/ui-theme';
 
 import { meta } from '#meta';
 
@@ -72,31 +72,36 @@ export const MasterDetail = <T extends MasterDetailRecord>({
   emptyLabel,
   detail,
 }: MasterDetailProps<T>) => {
+  // The gutter is owned by a `Column.Root` (not an ad-hoc wrapper) so the list aligns to the surface's
+  // column system: rows and their selection highlight sit in the centre track (`Column.Center`), matching
+  // the inset of the detail's form. The detail bleeds the full width since its own `Form` owns its gutter.
   return (
-    <div className={mx('flex flex-col min-bs-0', classNames)}>
-      {(items.length === 0 && <Empty label={emptyLabel} />) || (
-        <OrderedList.Root<T> items={items}>
-          {({ items }) => (
-            <OrderedList.Content>
-              {items.map((item) => (
-                <MasterDetailRow
-                  key={item.id}
-                  item={item}
-                  selected={item.id === selectedId}
-                  getLabel={getLabel}
-                  getIcon={getIcon}
-                  getAdornment={getAdornment}
-                  getMenu={getMenu}
-                  onSelect={onSelect}
-                />
-              ))}
-            </OrderedList.Content>
-          )}
-        </OrderedList.Root>
-      )}
+    <Column.Root gutter='sm' classNames={classNames}>
+      <Column.Center>
+        {(items.length === 0 && <Empty label={emptyLabel} />) || (
+          <OrderedList.Root<T> items={items}>
+            {({ items }) => (
+              <OrderedList.Content>
+                {items.map((item) => (
+                  <MasterDetailRow
+                    key={item.id}
+                    item={item}
+                    selected={item.id === selectedId}
+                    getLabel={getLabel}
+                    getIcon={getIcon}
+                    getAdornment={getAdornment}
+                    getMenu={getMenu}
+                    onSelect={onSelect}
+                  />
+                ))}
+              </OrderedList.Content>
+            )}
+          </OrderedList.Root>
+        )}
+      </Column.Center>
 
-      <div className='pt-trim-md'>{detail}</div>
-    </div>
+      <div className='col-span-full pt-trim-md'>{detail}</div>
+    </Column.Root>
   );
 };
 

--- a/packages/plugins/plugin-routine/src/components/Schedule/Schedule.stories.tsx
+++ b/packages/plugins/plugin-routine/src/components/Schedule/Schedule.stories.tsx
@@ -11,7 +11,7 @@ import { translations } from '#translations';
 
 import { Schedule, type ScheduleValue } from './Schedule';
 
-const DefaultStory = ({ initial }: { initial: ScheduleValue }) => {
+const DefaultStory = ({ initial, minInterval }: { initial: ScheduleValue; minInterval?: number }) => {
   const [value, setValue] = useState<ScheduleValue>(initial);
 
   return (
@@ -19,6 +19,7 @@ const DefaultStory = ({ initial }: { initial: ScheduleValue }) => {
       <Schedule.Root
         classNames='bg-card-surface border border-separator rounded-sm p-2'
         timezone='EDT'
+        minInterval={minInterval}
         value={value}
         onValueChange={setValue}
       >
@@ -64,4 +65,9 @@ export const Monthly: Story = {
 
 export const Custom: Story = {
   args: { initial: { kind: 'custom', cron: '0 9 * * MON-FRI' } },
+};
+
+// A 5-minute minimum clamps a too-frequent custom cron (`* * * * *` -> `*/5 * * * *`).
+export const MinInterval: Story = {
+  args: { initial: { kind: 'custom', cron: '* * * * *' }, minInterval: 300 },
 };

--- a/packages/plugins/plugin-routine/src/components/Schedule/Schedule.tsx
+++ b/packages/plugins/plugin-routine/src/components/Schedule/Schedule.tsx
@@ -70,8 +70,11 @@ const DEFAULT_TIME = '08:00';
 const DEFAULT_MIN_INTERVAL_SECONDS = 60;
 
 /** Clamp a requested minimum interval to the achievable range; a 5-field cron cannot fire more often than every minute or require slower than hourly. */
-const normalizeMinInterval = (minInterval: number): number =>
-  Math.min(MAX_MIN_INTERVAL_SECONDS, Math.max(DEFAULT_MIN_INTERVAL_SECONDS, Math.round(minInterval)));
+const normalizeMinInterval = (minInterval: number): number => {
+  // Guard non-finite input (NaN/Infinity) so the clamp can't yield NaN and produce a `*/NaN` cron.
+  const finite = Number.isFinite(minInterval) ? minInterval : DEFAULT_MIN_INTERVAL_SECONDS;
+  return Math.min(MAX_MIN_INTERVAL_SECONDS, Math.max(DEFAULT_MIN_INTERVAL_SECONDS, Math.round(finite)));
+};
 
 const KIND_LABEL_KEYS: Record<ScheduleKind, string> = {
   // once: 'schedule.kind.once.label',

--- a/packages/plugins/plugin-routine/src/components/Schedule/Schedule.tsx
+++ b/packages/plugins/plugin-routine/src/components/Schedule/Schedule.tsx
@@ -18,7 +18,14 @@ import { mx } from '@dxos/ui-theme';
 
 import { meta } from '#meta';
 
-import { describeCron, fromCron, scheduleToCron } from './cron';
+import {
+  MAX_MIN_INTERVAL_SECONDS,
+  clampSchedule,
+  describeCron,
+  fromCron,
+  scheduleIntervalSeconds,
+  scheduleToCron,
+} from './cron';
 
 //
 // Value model.
@@ -58,6 +65,13 @@ export type ScheduleValue =
   | { kind: 'custom'; cron: string };
 
 const DEFAULT_TIME = '08:00';
+
+/** Default minimum interval: a schedule may fire at most once every 60s (the finest 5-field cron granularity). */
+const DEFAULT_MIN_INTERVAL_SECONDS = 60;
+
+/** Clamp a requested minimum interval to the achievable range; a 5-field cron cannot fire more often than every minute or require slower than hourly. */
+const normalizeMinInterval = (minInterval: number): number =>
+  Math.min(MAX_MIN_INTERVAL_SECONDS, Math.max(DEFAULT_MIN_INTERVAL_SECONDS, Math.round(minInterval)));
 
 const KIND_LABEL_KEYS: Record<ScheduleKind, string> = {
   // once: 'schedule.kind.once.label',
@@ -134,6 +148,8 @@ type ScheduleContextValue = {
   value: ScheduleValue;
   onValueChange: (value: ScheduleValue) => void;
   kinds: readonly ScheduleKind[];
+  /** Minimum seconds between fires; schedules that would fire more often are clamped. */
+  minInterval: number;
   timezone?: string;
 };
 
@@ -158,6 +174,11 @@ export type ScheduleRootProps = ThemedClassName<
     onValueChange?: (value: ScheduleValue) => void;
     /** Restrict which frequency tabs are offered (defaults to all kinds). */
     kinds?: readonly ScheduleKind[];
+    /**
+     * Minimum seconds between fires (default 60). Schedules that would fire more often are clamped, and
+     * frequency tabs that cannot satisfy it are hidden. Capped to the hourly cadence a 5-field cron can model.
+     */
+    minInterval?: number;
   }>
 >;
 
@@ -168,22 +189,46 @@ export type ScheduleRootProps = ThemedClassName<
  */
 const ScheduleRoot = composable<HTMLDivElement, ScheduleRootProps>(
   (
-    { children, value: valueProp, defaultValue, onValueChange, kinds = ScheduleKinds, timezone, ...props },
+    {
+      children,
+      value: valueProp,
+      defaultValue,
+      onValueChange,
+      kinds = ScheduleKinds,
+      minInterval: minIntervalProp = DEFAULT_MIN_INTERVAL_SECONDS,
+      timezone,
+      ...props
+    },
     forwardedRef,
   ) => {
-    const [value, setValue] = useState<ScheduleValue>(valueProp ?? defaultValue ?? DEFAULTS.weekly);
+    const minInterval = normalizeMinInterval(minIntervalProp);
+    const [value, setValue] = useState<ScheduleValue>(() =>
+      clampSchedule(valueProp ?? defaultValue ?? DEFAULTS.weekly, minInterval),
+    );
 
     const handleValueChange = useCallback(
       (next: ScheduleValue) => {
-        setValue(next);
-        onValueChange?.(next);
+        const clamped = clampSchedule(next, minInterval);
+        setValue(clamped);
+        onValueChange?.(clamped);
       },
-      [onValueChange],
+      [onValueChange, minInterval],
+    );
+
+    // Only offer frequencies whose cadence can satisfy the minimum; `custom` always stays (it is clamped on edit).
+    const allowedKinds = kinds.filter(
+      (kind) => kind === 'custom' || scheduleIntervalSeconds(DEFAULTS[kind]) >= minInterval,
     );
 
     return (
       <ScheduleContext.Provider
-        value={{ value: valueProp ?? value, onValueChange: handleValueChange, kinds, timezone }}
+        value={{
+          value: clampSchedule(valueProp ?? value, minInterval),
+          onValueChange: handleValueChange,
+          kinds: allowedKinds,
+          minInterval,
+          timezone,
+        }}
       >
         <div {...composableProps(props, { classNames: 'flex flex-col gap-y-3' })} ref={forwardedRef}>
           {children}

--- a/packages/plugins/plugin-routine/src/components/Schedule/cron.test.ts
+++ b/packages/plugins/plugin-routine/src/components/Schedule/cron.test.ts
@@ -4,7 +4,15 @@
 
 import { describe, test } from 'vitest';
 
-import { cronToSchedule, fromCron, scheduleToCron, toCron } from './cron';
+import {
+  clampSchedule,
+  cronIntervalSeconds,
+  cronToSchedule,
+  fromCron,
+  scheduleIntervalSeconds,
+  scheduleToCron,
+  toCron,
+} from './cron';
 import { type ScheduleValue } from './Schedule';
 
 describe('toCron', () => {
@@ -156,5 +164,41 @@ describe('Schedule <-> cron bridge', () => {
     expect(cronToSchedule('*/15 * * * *')).toEqual({ kind: 'custom', cron: '*/15 * * * *' });
     // Multiple days of the month.
     expect(cronToSchedule('0 8 1,15 * *')).toEqual({ kind: 'custom', cron: '0 8 1,15 * *' });
+  });
+});
+
+describe('minimum interval', () => {
+  test('cronIntervalSeconds reads common cadences', ({ expect }) => {
+    expect(cronIntervalSeconds('* * * * *')).toBe(60);
+    expect(cronIntervalSeconds('*/1 * * * *')).toBe(60);
+    expect(cronIntervalSeconds('*/5 * * * *')).toBe(300);
+    expect(cronIntervalSeconds('0,30 * * * *')).toBe(1800);
+    // Single minute, every hour.
+    expect(cronIntervalSeconds('0 * * * *')).toBe(3600);
+    // Single minute, every day (a weekday restriction only widens gaps, so the daily floor stands).
+    expect(cronIntervalSeconds('0 9 * * *')).toBe(86400);
+    expect(cronIntervalSeconds('0 9 * * 1-5')).toBe(86400);
+    // Expressions whose minute field cannot be analysed are treated as satisfying any minimum.
+    expect(cronIntervalSeconds('not a cron')).toBe(Number.POSITIVE_INFINITY);
+    expect(cronIntervalSeconds('0-5/2 * * * *')).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  test('scheduleIntervalSeconds covers structured kinds', ({ expect }) => {
+    expect(scheduleIntervalSeconds({ kind: 'hourly', minute: 0 })).toBe(3600);
+    expect(scheduleIntervalSeconds({ kind: 'daily', time: '09:00' })).toBe(86400);
+    expect(scheduleIntervalSeconds({ kind: 'custom', cron: '* * * * *' })).toBe(60);
+  });
+
+  test('clampSchedule rewrites a too-frequent custom cron', ({ expect }) => {
+    expect(clampSchedule({ kind: 'custom', cron: '* * * * *' }, 300)).toEqual({ kind: 'custom', cron: '*/5 * * * *' });
+    expect(clampSchedule({ kind: 'custom', cron: '*/1 * * * *' }, 300)).toEqual({ kind: 'custom', cron: '*/5 * * * *' });
+    // An hourly minimum collapses a sub-hourly step to the top of the hour.
+    expect(clampSchedule({ kind: 'custom', cron: '*/15 * * * *' }, 3600)).toEqual({ kind: 'custom', cron: '0 * * * *' });
+  });
+
+  test('clampSchedule leaves satisfying schedules untouched', ({ expect }) => {
+    expect(clampSchedule({ kind: 'custom', cron: '*/15 * * * *' }, 300)).toEqual({ kind: 'custom', cron: '*/15 * * * *' });
+    expect(clampSchedule({ kind: 'custom', cron: '0 9 * * 1' }, 300)).toEqual({ kind: 'custom', cron: '0 9 * * 1' });
+    expect(clampSchedule({ kind: 'hourly', minute: 0 }, 3600)).toEqual({ kind: 'hourly', minute: 0 });
   });
 });

--- a/packages/plugins/plugin-routine/src/components/Schedule/cron.test.ts
+++ b/packages/plugins/plugin-routine/src/components/Schedule/cron.test.ts
@@ -173,14 +173,21 @@ describe('minimum interval', () => {
     expect(cronIntervalSeconds('*/1 * * * *')).toBe(60);
     expect(cronIntervalSeconds('*/5 * * * *')).toBe(300);
     expect(cronIntervalSeconds('0,30 * * * *')).toBe(1800);
+    // Offset/range step forms carry the same cadence as `*\/N`.
+    expect(cronIntervalSeconds('0/15 * * * *')).toBe(900);
+    expect(cronIntervalSeconds('0-30/10 * * * *')).toBe(600);
+    // Cyclic wrap-around: 59 -> 0 of the next hour is a 1-minute gap, not 59.
+    expect(cronIntervalSeconds('0,59 * * * *')).toBe(60);
     // Single minute, every hour.
     expect(cronIntervalSeconds('0 * * * *')).toBe(3600);
+    // Hour-step narrows the daily cadence.
+    expect(cronIntervalSeconds('0 */6 * * *')).toBe(6 * 3600);
     // Single minute, every day (a weekday restriction only widens gaps, so the daily floor stands).
     expect(cronIntervalSeconds('0 9 * * *')).toBe(86400);
     expect(cronIntervalSeconds('0 9 * * 1-5')).toBe(86400);
     // Expressions whose minute field cannot be analysed are treated as satisfying any minimum.
     expect(cronIntervalSeconds('not a cron')).toBe(Number.POSITIVE_INFINITY);
-    expect(cronIntervalSeconds('0-5/2 * * * *')).toBe(Number.POSITIVE_INFINITY);
+    expect(cronIntervalSeconds('JAN * * * *')).toBe(Number.POSITIVE_INFINITY);
   });
 
   test('scheduleIntervalSeconds covers structured kinds', ({ expect }) => {
@@ -197,6 +204,16 @@ describe('minimum interval', () => {
     });
     // An hourly minimum collapses a sub-hourly step to the top of the hour.
     expect(clampSchedule({ kind: 'custom', cron: '*/15 * * * *' }, 3600)).toEqual({
+      kind: 'custom',
+      cron: '0 * * * *',
+    });
+    // Wrap-around list (real cadence 60s) is caught and clamped.
+    expect(clampSchedule({ kind: 'custom', cron: '0,59 * * * *' }, 300)).toEqual({
+      kind: 'custom',
+      cron: '*/5 * * * *',
+    });
+    // Offset-step form (every 15m) is caught when below an hourly minimum.
+    expect(clampSchedule({ kind: 'custom', cron: '0/15 * * * *' }, 3600)).toEqual({
       kind: 'custom',
       cron: '0 * * * *',
     });

--- a/packages/plugins/plugin-routine/src/components/Schedule/cron.test.ts
+++ b/packages/plugins/plugin-routine/src/components/Schedule/cron.test.ts
@@ -191,13 +191,22 @@ describe('minimum interval', () => {
 
   test('clampSchedule rewrites a too-frequent custom cron', ({ expect }) => {
     expect(clampSchedule({ kind: 'custom', cron: '* * * * *' }, 300)).toEqual({ kind: 'custom', cron: '*/5 * * * *' });
-    expect(clampSchedule({ kind: 'custom', cron: '*/1 * * * *' }, 300)).toEqual({ kind: 'custom', cron: '*/5 * * * *' });
+    expect(clampSchedule({ kind: 'custom', cron: '*/1 * * * *' }, 300)).toEqual({
+      kind: 'custom',
+      cron: '*/5 * * * *',
+    });
     // An hourly minimum collapses a sub-hourly step to the top of the hour.
-    expect(clampSchedule({ kind: 'custom', cron: '*/15 * * * *' }, 3600)).toEqual({ kind: 'custom', cron: '0 * * * *' });
+    expect(clampSchedule({ kind: 'custom', cron: '*/15 * * * *' }, 3600)).toEqual({
+      kind: 'custom',
+      cron: '0 * * * *',
+    });
   });
 
   test('clampSchedule leaves satisfying schedules untouched', ({ expect }) => {
-    expect(clampSchedule({ kind: 'custom', cron: '*/15 * * * *' }, 300)).toEqual({ kind: 'custom', cron: '*/15 * * * *' });
+    expect(clampSchedule({ kind: 'custom', cron: '*/15 * * * *' }, 300)).toEqual({
+      kind: 'custom',
+      cron: '*/15 * * * *',
+    });
     expect(clampSchedule({ kind: 'custom', cron: '0 9 * * 1' }, 300)).toEqual({ kind: 'custom', cron: '0 9 * * 1' });
     expect(clampSchedule({ kind: 'hourly', minute: 0 }, 3600)).toEqual({ kind: 'hourly', minute: 0 });
   });

--- a/packages/plugins/plugin-routine/src/components/Schedule/cron.ts
+++ b/packages/plugins/plugin-routine/src/components/Schedule/cron.ts
@@ -176,6 +176,124 @@ export const scheduleToCron = (value: ScheduleValue): string | undefined => {
   }
 };
 
+//
+// Minimum-interval constraint.
+//
+
+const MINUTE_SECONDS = 60;
+const HOUR_SECONDS = 60 * 60;
+const DAY_SECONDS = 24 * HOUR_SECONDS;
+
+/** Upper bound for a Schedule minimum interval: a 5-field cron's coarsest single-field cadence is hourly. */
+export const MAX_MIN_INTERVAL_SECONDS = HOUR_SECONDS;
+
+/** Parses a comma-separated list of bounded integers; returns undefined if any token is not a plain integer in range. */
+const parseList = (field: string, min: number, max: number): number[] | undefined => {
+  const tokens = field.split(',');
+  const values = tokens.map((token) => parseBoundedUInt(token, min, max)).filter((value): value is number => value !== undefined);
+  return values.length === tokens.length && values.length > 0 ? values : undefined;
+};
+
+/** Smallest gap between consecutive sorted values, or Infinity for a single value. */
+const minGap = (values: number[]): number => {
+  const sorted = [...values].sort((lhs, rhs) => lhs - rhs);
+  let gap = Number.POSITIVE_INFINITY;
+  for (let index = 1; index < sorted.length; index++) {
+    gap = Math.min(gap, sorted[index] - sorted[index - 1]);
+  }
+  return gap;
+};
+
+/** Minimum seconds between fires implied by a cron's hour field (independent of minute granularity). */
+const hourIntervalSeconds = (hour: string): number => {
+  const step = hour.match(/^\*\/(\d+)$/);
+  if (step) {
+    return parseInt(step[1]) * HOUR_SECONDS;
+  }
+  if (hour === '*') {
+    return HOUR_SECONDS;
+  }
+  const hours = parseList(hour, 0, 23);
+  if (hours) {
+    return hours.length > 1 ? minGap(hours) * HOUR_SECONDS : DAY_SECONDS;
+  }
+  return Number.POSITIVE_INFINITY;
+};
+
+/**
+ * Best-effort minimum seconds between consecutive fires of a 5-field cron expression. Recognises the patterns
+ * a too-frequent schedule can take (`* …`, `*\/N …`, explicit minute/hour lists); returns Infinity for
+ * expressions it cannot analyse, so unrecognised crons are treated as satisfying any minimum.
+ */
+export const cronIntervalSeconds = (cron: string): number => {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const [minute, hour] = parts;
+  const minuteStep = minute.match(/^\*\/(\d+)$/);
+  if (minuteStep) {
+    return parseInt(minuteStep[1]) * MINUTE_SECONDS;
+  }
+  if (minute === '*') {
+    return MINUTE_SECONDS;
+  }
+
+  const minutes = parseList(minute, 0, 59);
+  if (minutes) {
+    const minuteGap = minutes.length > 1 ? minGap(minutes) * MINUTE_SECONDS : Number.POSITIVE_INFINITY;
+    return Math.min(minuteGap, hourIntervalSeconds(hour));
+  }
+
+  return Number.POSITIVE_INFINITY;
+};
+
+/**
+ * Rewrites a cron's minute field so it fires no more often than `minIntervalSeconds`. Used to clamp a custom
+ * expression; leaves non-5-field expressions untouched since their cadence cannot be reasoned about.
+ */
+const clampCronMinute = (cron: string, minIntervalSeconds: number): string => {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    return cron;
+  }
+  const stepMinutes = Math.ceil(minIntervalSeconds / MINUTE_SECONDS);
+  // A step that spans the whole minute range fires only at minute 0; express that as the hourly cadence.
+  parts[0] = stepMinutes >= 60 ? '0' : `*/${stepMinutes}`;
+  return parts.join(' ');
+};
+
+/** Minimum seconds between fires for a recurring {@link ScheduleValue}. */
+export const scheduleIntervalSeconds = (value: ScheduleValue): number => {
+  switch (value.kind) {
+    case 'hourly':
+      return HOUR_SECONDS;
+    case 'daily':
+      return DAY_SECONDS;
+    // Consecutive selected weekdays sit one day apart at closest.
+    case 'weekly':
+      return DAY_SECONDS;
+    // Approximate the shortest month to stay conservative.
+    case 'monthly':
+      return 28 * DAY_SECONDS;
+    case 'custom':
+      return cronIntervalSeconds(value.cron);
+  }
+};
+
+/**
+ * Coerces a schedule so it fires no more often than `minIntervalSeconds`. Only `custom` expressions can exceed
+ * the limit (structured kinds are hourly or slower), so clamping rewrites the cron's minute field; all other
+ * values pass through unchanged.
+ */
+export const clampSchedule = (value: ScheduleValue, minIntervalSeconds: number): ScheduleValue => {
+  if (value.kind !== 'custom' || cronIntervalSeconds(value.cron) >= minIntervalSeconds) {
+    return value;
+  }
+  return { kind: 'custom', cron: clampCronMinute(value.cron, minIntervalSeconds) };
+};
+
 /**
  * Convert a cron expression to a recurring {@link ScheduleValue}. Patterns that Schedule cannot model exactly
  * (sub-hourly intervals, multi-day months, etc.) fall back to the `custom` kind preserving the raw expression.

--- a/packages/plugins/plugin-routine/src/components/Schedule/cron.ts
+++ b/packages/plugins/plugin-routine/src/components/Schedule/cron.ts
@@ -190,7 +190,9 @@ export const MAX_MIN_INTERVAL_SECONDS = HOUR_SECONDS;
 /** Parses a comma-separated list of bounded integers; returns undefined if any token is not a plain integer in range. */
 const parseList = (field: string, min: number, max: number): number[] | undefined => {
   const tokens = field.split(',');
-  const values = tokens.map((token) => parseBoundedUInt(token, min, max)).filter((value): value is number => value !== undefined);
+  const values = tokens
+    .map((token) => parseBoundedUInt(token, min, max))
+    .filter((value): value is number => value !== undefined);
   return values.length === tokens.length && values.length > 0 ? values : undefined;
 };
 

--- a/packages/plugins/plugin-routine/src/components/Schedule/cron.ts
+++ b/packages/plugins/plugin-routine/src/components/Schedule/cron.ts
@@ -196,28 +196,42 @@ const parseList = (field: string, min: number, max: number): number[] | undefine
   return values.length === tokens.length && values.length > 0 ? values : undefined;
 };
 
-/** Smallest gap between consecutive sorted values, or Infinity for a single value. */
-const minGap = (values: number[]): number => {
-  const sorted = [...values].sort((lhs, rhs) => lhs - rhs);
+/**
+ * Smallest cyclic gap between values in a field whose domain wraps at `span` (60 for minutes, 24 for hours),
+ * or Infinity for a single value. The wrap is required so e.g. minutes `0,59` register their 1-unit gap
+ * (59 → 0 of the next cycle), not just the 59-unit one.
+ */
+const minGap = (values: number[], span: number): number => {
+  const sorted = [...new Set(values)].sort((lhs, rhs) => lhs - rhs);
+  if (sorted.length <= 1) {
+    return Number.POSITIVE_INFINITY;
+  }
   let gap = Number.POSITIVE_INFINITY;
-  for (let index = 1; index < sorted.length; index++) {
-    gap = Math.min(gap, sorted[index] - sorted[index - 1]);
+  for (let index = 0; index < sorted.length; index++) {
+    const next = index === sorted.length - 1 ? sorted[0] + span : sorted[index + 1];
+    gap = Math.min(gap, next - sorted[index]);
   }
   return gap;
 };
 
+/** Step value of a `*\/N`, `M/N`, or `A-B/N` field (the cadence between fires), or undefined if not a step form. */
+const parseStep = (field: string, max: number): number | undefined => {
+  const match = field.match(/^(?:\*|\d+(?:-\d+)?)\/(\d+)$/);
+  return match ? parseBoundedUInt(match[1], 1, max) : undefined;
+};
+
 /** Minimum seconds between fires implied by a cron's hour field (independent of minute granularity). */
 const hourIntervalSeconds = (hour: string): number => {
-  const step = hour.match(/^\*\/(\d+)$/);
-  if (step) {
-    return parseInt(step[1]) * HOUR_SECONDS;
+  const step = parseStep(hour, 23);
+  if (step !== undefined) {
+    return step * HOUR_SECONDS;
   }
   if (hour === '*') {
     return HOUR_SECONDS;
   }
   const hours = parseList(hour, 0, 23);
   if (hours) {
-    return hours.length > 1 ? minGap(hours) * HOUR_SECONDS : DAY_SECONDS;
+    return hours.length > 1 ? minGap(hours, 24) * HOUR_SECONDS : DAY_SECONDS;
   }
   return Number.POSITIVE_INFINITY;
 };
@@ -234,9 +248,9 @@ export const cronIntervalSeconds = (cron: string): number => {
   }
 
   const [minute, hour] = parts;
-  const minuteStep = minute.match(/^\*\/(\d+)$/);
-  if (minuteStep) {
-    return parseInt(minuteStep[1]) * MINUTE_SECONDS;
+  const minuteStep = parseStep(minute, 59);
+  if (minuteStep !== undefined) {
+    return minuteStep * MINUTE_SECONDS;
   }
   if (minute === '*') {
     return MINUTE_SECONDS;
@@ -244,7 +258,7 @@ export const cronIntervalSeconds = (cron: string): number => {
 
   const minutes = parseList(minute, 0, 59);
   if (minutes) {
-    const minuteGap = minutes.length > 1 ? minGap(minutes) * MINUTE_SECONDS : Number.POSITIVE_INFINITY;
+    const minuteGap = minutes.length > 1 ? minGap(minutes, 60) * MINUTE_SECONDS : Number.POSITIVE_INFINITY;
     return Math.min(minuteGap, hourIntervalSeconds(hour));
   }
 

--- a/packages/plugins/plugin-routine/src/containers/RoutineCompanion/RoutineCompanion.tsx
+++ b/packages/plugins/plugin-routine/src/containers/RoutineCompanion/RoutineCompanion.tsx
@@ -191,7 +191,7 @@ export const RoutineCompanion = ({ subject: object, attendableId }: RoutineCompa
         <Panel.Toolbar className='bg-toolbar-surface'>
           <Menu.Toolbar className='dx-document' />
         </Panel.Toolbar>
-        <Panel.Content asChild>
+        <Panel.Content asChild className='pt-trim-md'>
           <ScrollArea.Root>
             <ScrollArea.Viewport>
               <MasterDetail<Routine.Routine>


### PR DESCRIPTION
## Summary

Two related plugin-routine UI changes plus a missing storybook.

### Schedule — configurable minimum interval
`Schedule.Root` gains a `minInterval` prop (seconds, default `60`) so a host can require schedules fire no more often than a floor.

- Normalized to `[60, 3600]`: a 5-field cron can't fire more often than every 60s, nor require a single-field cadence slower than hourly. Capping at 3600 means every structured kind (hourly and slower) always satisfies the minimum, so the constraint only ever acts on custom cron expressions.
- **Clamp silently**: a too-frequent custom cron is rewritten on edit (`* * * * *` → `*/5 * * * *` at 5m; `*/15` → `0 * * * *` at 1h).
- **Gate kinds**: frequency tabs whose cadence can't satisfy the minimum are hidden (`custom` always offered, since it's clamped).
- New helpers `cronIntervalSeconds` / `scheduleIntervalSeconds` / `clampSchedule` with unit tests; a `MinInterval` story.

With the default of 60, nothing is ever clamped (60s is already the cron floor) — it only bites when a consumer opts into a larger minimum.

### MasterDetail — gutter alignment
List rows (and their selection highlight) bled to the viewport edge while the detail's `Form` was inset, because the component wrapped everything in a plain `<div>` that never established a gutter column.

- Own the gutter via `Column.Root gutter='sm'`; the list sits in `Column.Center` (rows + highlight inset to the gutter), and the detail bleeds full width via `col-span-full` since its `Form` owns its own gutter.
- `Column.Bleed` was the wrong tool here — it adds `grid-cols-subgrid`, which collapsed the form fields into the narrow gutter track.
- Added a `MasterDetail` story (Default + Empty) replicating the companion's `Panel` + `ScrollArea` + `dx-document` layout — none existed before.
- Added `pt-trim-md` to the companion `Panel.Content` for top spacing below the toolbar.

## Verification
- Measured in storybook (dark theme): row highlight spans `8→404`, exactly matching the form input `8→404`.
- `plugin-routine` build, lint, and all 54 tests pass.
- No new casts (`git diff` audit clean).

| before | after |
|---|---|
| rows flush, highlight edge-to-edge (left=0) | rows + highlight inset 8px, aligned with form |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Storybook coverage for the master-detail view, including default and empty states.
  - Schedule settings now support a minimum interval, helping prevent overly frequent runs.
  - Added a new schedule example showing how minimum intervals affect custom schedules.

- **Bug Fixes**
  - Schedule selections are now constrained to valid intervals, with overly frequent custom values automatically adjusted.
  - Improved master-detail and detail panel spacing for more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->