### PR TITLE
fix(plugin-explorer): address CodeRabbit review on Visualization + tree projector

### DIFF
--- a/packages/plugins/plugin-explorer/src/components/Visualization/Visualization.tsx
+++ b/packages/plugins/plugin-explorer/src/components/Visualization/Visualization.tsx
@@ -84,7 +84,7 @@ export type VisualizationGraphProps = {
  * model, variant definition, and focus from `Visualization.Root` context; owns the live projector,
  * click-driven focus, and the layout snapshot that lets each variant swap animate from prior positions.
  */
-const VisualizationGraph = ({ debug = true, onNodeHover }: VisualizationGraphProps) => {
+const VisualizationGraph = ({ debug = false, onNodeHover }: VisualizationGraphProps) => {
   const { model, variant, focus } = useVisualizationContext('Visualization.Graph');
 
   const svgRef = useRef<SVGContext>(null);
@@ -175,18 +175,22 @@ const VisualizationGraph = ({ debug = true, onNodeHover }: VisualizationGraphPro
   return (
     <SVG.Root ref={svgRef}>
       <SVG.Zoom extent={[1 / 2, 2]}>
-        <SVG.Graph<SpaceGraphNode, SpaceGraphEdge>
-          model={model}
-          projector={projector}
-          renderNode={variant.renderNode}
-          applyNode={variant.applyNode}
-          edgeOpacity={variant.edgeOpacity}
-          drag={variant.drag}
-          highlightOnHover={variant.highlightOnHover}
-          onSelect={handleSelect}
-          onInspect={handleInspect}
-          {...pointerProps}
-        />
+        {/* Mount only once the variant's projector exists; otherwise SVG.Graph falls back to a
+            force projector for a frame, flashing the wrong layout for non-force variants. */}
+        {projector && (
+          <SVG.Graph<SpaceGraphNode, SpaceGraphEdge>
+            model={model}
+            projector={projector}
+            renderNode={variant.renderNode}
+            applyNode={variant.applyNode}
+            edgeOpacity={variant.edgeOpacity}
+            drag={variant.drag}
+            highlightOnHover={variant.highlightOnHover}
+            onSelect={handleSelect}
+            onInspect={handleInspect}
+            {...pointerProps}
+          />
+        )}
       </SVG.Zoom>
       {debug && <SVG.FPS />}
     </SVG.Root>

--- a/packages/ui/react-ui-graph/src/graph/projector/graph-tree-projector.ts
+++ b/packages/ui/react-ui-graph/src/graph/projector/graph-tree-projector.ts
@@ -221,25 +221,28 @@ export class GraphTreeProjector<
     this.layout.graph.nodes = placed;
 
     // Synthesize hierarchy edges for both sides; paths are filled by onTickFrame from current positions.
+    // Left-side links are reversed so the rendered edge keeps the real inbound direction (source → focus)
+    // rather than the layout's parent → child (focus → source) orientation.
     const edges: GraphLayoutEdge<NodeData>[] = [];
-    const addLinks = (root: HierarchyPointNode<HierDatum>) => {
+    const addLinks = (root: HierarchyPointNode<HierDatum>, reverse = false) => {
       root.links().forEach((link) => {
-        const source = link.source.data.node;
-        const target = link.target.data.node;
-        if (!source || !target) {
+        const parent = link.source.data;
+        const child = link.target.data;
+        const [from, to] = reverse ? [child, parent] : [parent, child];
+        if (!from.node || !to.node) {
           return;
         }
         edges.push({
-          id: `${HIER_EDGE_PREFIX}${link.source.data.id}->${link.target.data.id}`,
+          id: `${HIER_EDGE_PREFIX}${from.id}->${to.id}`,
           type: 'hierarchy',
-          source,
-          target,
+          source: from.node,
+          target: to.node,
           data: undefined,
         });
       });
     };
     addLinks(rightPoint);
-    addLinks(leftPoint);
+    addLinks(leftPoint, true);
     this.layout.graph.edges = edges;
 
     // Seed initial paths so the topology emit has correct geometry to enter into the DOM.


### PR DESCRIPTION
Follow-up to #11964 (which was already in the merge queue when this review landed, so these fixes land separately).

Addresses the actionable CodeRabbit findings on the explorer Visualization / ego tree projector:

- **FPS overlay opt-in** — `Visualization.Graph` now defaults `debug={false}`. The component is reusable (lives in `#components`), so the FPS counter should not render on production surfaces unless explicitly requested.
- **Gate `SVG.Graph` on the projector** — only mount `SVG.Graph` once the variant's projector exists; otherwise it falls back to a force projector for one frame, flashing the wrong layout for non-force variants (cluster/bundle/plexus/lattice/swarm/neighborhood).
- **Preserve inbound edge direction** — in `GraphTreeProjector`, left-side (inbound) hierarchy links now reverse source/target so the rendered edge keeps the real direction (`source → focus`) instead of the layout's `focus → source`.

### Declined (not changed), with reasoning
- **`companionTo` binding in `app-graph-builder`** — the `connector: () =>` form matches the established companion idiom (`plugin-routine` `automationCompanion`, `plugin-comments`); the framework derives `companionTo` from the matched parent node. The companion renders correctly. Manually spreading `companionTo` would diverge from the idiom.
- **Dismiss event dispatch target** — `NeighborhoodCompanion.handleDismiss` mirrors the existing `ExplorerArticle.handleDismiss`. If the window-target vs capture-root behaviour is a real issue it is pre-existing and repo-wide, and should be fixed once for both rather than diverging this one container.

## Verification
- `react-ui-graph` + `plugin-explorer`: build ✓, lint ✓, storybook 20/20 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph rendering so it waits for the projector to be ready before drawing, reducing incorrect initial output.
  * Fixed link direction handling for left-side graph edges so inbound connections display correctly.
* **Style**
  * Graph debug mode now defaults to off, making the standard experience cleaner by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->