### PR TITLE
fix(plugin-magazine): export MagazineOperationHandlerSet from workerd entry

### DIFF
--- a/packages/plugins/plugin-magazine/src/plugin.workerd.ts
+++ b/packages/plugins/plugin-magazine/src/plugin.workerd.ts
@@ -3,3 +3,4 @@
 //
 
 export { MagazinePlugin, default } from './MagazinePlugin.workerd';
+export { MagazineOperationHandlerSet } from './operations';


### PR DESCRIPTION
## Problem

`plugin.workerd.ts` (the `workerd` variant of plugin-magazine's `./plugin` export) re-exported only `MagazinePlugin`, omitting the `MagazineOperationHandlerSet` that the default `plugin.ts` exports. So `@dxos/plugin-magazine/plugin` resolves to a module **without** `MagazineOperationHandlerSet` when bundled under the `workerd` export condition (esbuild/wrangler), breaking workerd consumers.

Concretely, this breaks the `edge` repo's `compute-intrinsics` Cloudflare Worker, which imports `MagazineOperationHandlerSet` from `@dxos/plugin-magazine/plugin` and merges it into its operation handler set. The tsc build passes (types resolve to `plugin.d.ts`), but the esbuild bundle fails:

```
No matching export in ".../plugin-magazine/dist/lib/neutral/plugin.workerd.mjs" for import "MagazineOperationHandlerSet"
```

## Fix

Export `MagazineOperationHandlerSet` from `plugin.workerd.ts` too, mirroring `plugin.ts`. The set is lazy (`OperationHandlerSet.lazy(...)`), so this only pulls in `@dxos/compute` at module load — the operations themselves load on demand — keeping the workerd entry lightweight and workerd-safe. This matches how `@dxos/assistant-toolkit` exposes its operation handler sets from its main entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the magazine plugin package to expose an additional public export for broader integration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->