### PR TITLE
feat(sql-sqlite): configure WAL and synchronous PRAGMAs for OPFS SQLite

### DIFF
--- a/packages/common/sql-sqlite/src/OpfsWorker.ts
+++ b/packages/common/sql-sqlite/src/OpfsWorker.ts
@@ -20,6 +20,14 @@ import { log } from '@dxos/log';
 // @ts-ignore
 import { AccessHandlePoolVFS } from '@dxos/wa-sqlite/src/examples/AccessHandlePoolVFS.js';
 
+import {
+  applyOpfsPragmas,
+  DEFAULT_JOURNAL_MODE,
+  DEFAULT_SYNCHRONOUS,
+  type SqliteJournalMode,
+  type SqliteSynchronous,
+} from './internal/opfs-pragmas';
+
 /** @internal */
 type OpfsWorkerMessage =
   | [id: number, sql: string, params: ReadonlyArray<unknown>]
@@ -35,6 +43,8 @@ type OpfsWorkerMessage =
 export interface OpfsWorkerConfig {
   readonly port: EventTarget & Pick<MessagePort, 'postMessage' | 'close'>;
   readonly dbName: string;
+  readonly journalMode?: SqliteJournalMode;
+  readonly synchronous?: SqliteSynchronous;
 }
 
 /**
@@ -50,7 +60,14 @@ export const run = (options: OpfsWorkerConfig): Effect.Effect<void, SqlError.Sql
     let shutdownRequested = false;
     const db = yield* Effect.acquireRelease(
       Effect.try({
-        try: () => sqlite3.open_v2(options.dbName, undefined, 'opfs'),
+        try: () => {
+          const handle = sqlite3.open_v2(options.dbName, undefined, 'opfs');
+          applyOpfsPragmas(sqlite3, handle, {
+            journalMode: options.journalMode ?? DEFAULT_JOURNAL_MODE,
+            synchronous: options.synchronous ?? DEFAULT_SYNCHRONOUS,
+          });
+          return handle;
+        },
         catch: (cause) => new SqlError.SqlError({ cause, message: 'Failed to open database' }),
       }),
       (handle) =>
@@ -88,6 +105,10 @@ export const run = (options: OpfsWorkerConfig): Effect.Effect<void, SqlError.Sql
                   throw new Error('VACUUM failed while persisting imported database');
                 }
               }
+              applyOpfsPragmas(sqlite3, db, {
+                journalMode: options.journalMode ?? DEFAULT_JOURNAL_MODE,
+                synchronous: options.synchronous ?? DEFAULT_SYNCHRONOUS,
+              });
               options.port.postMessage([id, void 0, void 0]);
               return;
             }

--- a/packages/common/sql-sqlite/src/internal/opfs-client.ts
+++ b/packages/common/sql-sqlite/src/internal/opfs-client.ts
@@ -26,11 +26,15 @@ import { log } from '@dxos/log';
 // @ts-ignore - wa-sqlite example VFS without typed exports.
 import { AccessHandlePoolVFS } from '@dxos/wa-sqlite/src/examples/AccessHandlePoolVFS.js';
 
-/** SQLite journal mode (see https://www.sqlite.org/pragma.html#pragma_journal_mode). */
-export type SqliteJournalMode = 'delete' | 'truncate' | 'persist' | 'memory' | 'wal' | 'off';
+import {
+  applyOpfsPragmas,
+  DEFAULT_JOURNAL_MODE,
+  DEFAULT_SYNCHRONOUS,
+  type SqliteJournalMode,
+  type SqliteSynchronous,
+} from './opfs-pragmas';
 
-/** SQLite synchronous flag (see https://www.sqlite.org/pragma.html#pragma_synchronous). */
-export type SqliteSynchronous = 'off' | 'normal' | 'full' | 'extra';
+export type { SqliteJournalMode, SqliteSynchronous } from './opfs-pragmas';
 
 /** Config for in-process OPFS SQLite (worker-only, no MessagePort). */
 export interface OpfsConfig extends WasmSqliteClient.SqliteClientMemoryConfig {
@@ -55,10 +59,6 @@ const ATTR_DB_SYSTEM_NAME = 'db.system.name';
 
 const DEFAULT_VFS_DIRECTORY = 'opfs';
 
-const DEFAULT_JOURNAL_MODE: SqliteJournalMode = 'wal';
-
-const DEFAULT_SYNCHRONOUS: SqliteSynchronous = 'normal';
-
 const initModule = Effect.runSync(Effect.cached(Effect.promise(() => SQLiteESMFactory())));
 
 const initEffect = Effect.runSync(Effect.cached(initModule.pipe(Effect.map((module) => WaSqlite.Factory(module)))));
@@ -82,9 +82,18 @@ const vacuumDatabase = (sqlite3: ReturnType<typeof WaSqlite.Factory>, db: number
   }
 };
 
-const importDatabase = (sqlite3: ReturnType<typeof WaSqlite.Factory>, db: number, data: Uint8Array): void => {
+const importDatabase = (
+  sqlite3: ReturnType<typeof WaSqlite.Factory>,
+  db: number,
+  data: Uint8Array,
+  pragmaOptions: OpfsConfig,
+): void => {
   sqlite3.deserialize(db, 'main', data, data.length, data.length, 1 | 2);
   vacuumDatabase(sqlite3, db);
+  applyOpfsPragmas(sqlite3, db, {
+    journalMode: pragmaOptions.journalMode ?? DEFAULT_JOURNAL_MODE,
+    synchronous: pragmaOptions.synchronous ?? DEFAULT_SYNCHRONOUS,
+  });
 };
 
 const recordSqliteQueryMetrics = (
@@ -146,22 +155,8 @@ export const makeOpfs = (
         (handle) => Effect.sync(() => sqlite3.close(handle)),
       );
 
-      // PRAGMAs must run before any reads/writes. WAL on AccessHandlePoolVFS has no shared-memory
-      // (xShm) support, so it is only valid under exclusive locking, and locking_mode must precede
-      // journal_mode. journal_mode returns a row, so results are stepped through.
       yield* Effect.try({
-        try: () => {
-          const pragmas = [
-            ...(journalMode === 'wal' ? ['PRAGMA locking_mode=EXCLUSIVE'] : []),
-            `PRAGMA journal_mode=${journalMode}`,
-            `PRAGMA synchronous=${synchronous}`,
-          ];
-          for (const pragma of pragmas) {
-            for (const stmt of sqlite3.statements(db, pragma)) {
-              while (sqlite3.step(stmt) === WaSqlite.SQLITE_ROW) {}
-            }
-          }
-        },
+        try: () => applyOpfsPragmas(sqlite3, db, { journalMode, synchronous }),
         catch: (cause) => new SqlError.SqlError({ cause, message: 'Failed to configure database PRAGMAs' }),
       });
 
@@ -253,7 +248,7 @@ export const makeOpfs = (
           Effect.try({
             try: () => {
               log('opfs import', { bytes: data.byteLength });
-              importDatabase(sqlite3, db, data);
+              importDatabase(sqlite3, db, data, options);
             },
             catch: (cause) => new SqlError.SqlError({ cause, message: 'Failed to import database' }),
           }),

--- a/packages/common/sql-sqlite/src/internal/opfs-client.ts
+++ b/packages/common/sql-sqlite/src/internal/opfs-client.ts
@@ -26,15 +26,38 @@ import { log } from '@dxos/log';
 // @ts-ignore - wa-sqlite example VFS without typed exports.
 import { AccessHandlePoolVFS } from '@dxos/wa-sqlite/src/examples/AccessHandlePoolVFS.js';
 
+/** SQLite journal mode (see https://www.sqlite.org/pragma.html#pragma_journal_mode). */
+export type SqliteJournalMode = 'delete' | 'truncate' | 'persist' | 'memory' | 'wal' | 'off';
+
+/** SQLite synchronous flag (see https://www.sqlite.org/pragma.html#pragma_synchronous). */
+export type SqliteSynchronous = 'off' | 'normal' | 'full' | 'extra';
+
 /** Config for in-process OPFS SQLite (worker-only, no MessagePort). */
 export interface OpfsConfig extends WasmSqliteClient.SqliteClientMemoryConfig {
   readonly dbName: string;
   readonly vfsDirectory?: string;
+
+  /**
+   * Journal mode applied to every connection. Defaults to `wal`.
+   * `wal` on {@link AccessHandlePoolVFS} requires exclusive locking because the VFS has no
+   * shared-memory (`xShm`) support, so selecting `wal` also applies `PRAGMA locking_mode=EXCLUSIVE`.
+   */
+  readonly journalMode?: SqliteJournalMode;
+
+  /**
+   * Synchronous flag applied to every connection. Defaults to `normal`, which is corruption-safe
+   * under WAL and avoids a per-commit fsync (`xSync` -> OPFS `flush`).
+   */
+  readonly synchronous?: SqliteSynchronous;
 }
 
 const ATTR_DB_SYSTEM_NAME = 'db.system.name';
 
 const DEFAULT_VFS_DIRECTORY = 'opfs';
+
+const DEFAULT_JOURNAL_MODE: SqliteJournalMode = 'wal';
+
+const DEFAULT_SYNCHRONOUS: SqliteSynchronous = 'normal';
 
 const initModule = Effect.runSync(Effect.cached(Effect.promise(() => SQLiteESMFactory())));
 
@@ -102,6 +125,8 @@ export const makeOpfs = (
       ? Statement.defaultTransforms(options.transformResultNames).array
       : undefined;
     const vfsDirectory = options.vfsDirectory ?? DEFAULT_VFS_DIRECTORY;
+    const journalMode = options.journalMode ?? DEFAULT_JOURNAL_MODE;
+    const synchronous = options.synchronous ?? DEFAULT_SYNCHRONOUS;
 
     const makeConnection = Effect.gen(function* () {
       const sqlite3 = yield* initEffect;
@@ -120,6 +145,25 @@ export const makeOpfs = (
         }),
         (handle) => Effect.sync(() => sqlite3.close(handle)),
       );
+
+      // PRAGMAs must run before any reads/writes. WAL on AccessHandlePoolVFS has no shared-memory
+      // (xShm) support, so it is only valid under exclusive locking, and locking_mode must precede
+      // journal_mode. journal_mode returns a row, so results are stepped through.
+      yield* Effect.try({
+        try: () => {
+          const pragmas = [
+            ...(journalMode === 'wal' ? ['PRAGMA locking_mode=EXCLUSIVE'] : []),
+            `PRAGMA journal_mode=${journalMode}`,
+            `PRAGMA synchronous=${synchronous}`,
+          ];
+          for (const pragma of pragmas) {
+            for (const stmt of sqlite3.statements(db, pragma)) {
+              while (sqlite3.step(stmt) === WaSqlite.SQLITE_ROW) {}
+            }
+          }
+        },
+        catch: (cause) => new SqlError.SqlError({ cause, message: 'Failed to configure database PRAGMAs' }),
+      });
 
       if (options.installReactivityHooks) {
         sqlite3.update_hook(db, (_op, _db, table, rowid) => {

--- a/packages/common/sql-sqlite/src/internal/opfs-pragmas.ts
+++ b/packages/common/sql-sqlite/src/internal/opfs-pragmas.ts
@@ -1,0 +1,41 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as WaSqlite from '@effect/wa-sqlite';
+
+/** SQLite journal mode (see https://www.sqlite.org/pragma.html#pragma_journal_mode). */
+export type SqliteJournalMode = 'delete' | 'truncate' | 'persist' | 'memory' | 'wal' | 'off';
+
+/** SQLite synchronous flag (see https://www.sqlite.org/pragma.html#pragma_synchronous). */
+export type SqliteSynchronous = 'off' | 'normal' | 'full' | 'extra';
+
+export type OpfsPragmaOptions = {
+  readonly journalMode?: SqliteJournalMode;
+  readonly synchronous?: SqliteSynchronous;
+};
+
+export const DEFAULT_JOURNAL_MODE: SqliteJournalMode = 'wal';
+
+export const DEFAULT_SYNCHRONOUS: SqliteSynchronous = 'normal';
+
+type Sqlite3 = ReturnType<typeof WaSqlite.Factory>;
+
+/**
+ * Apply OPFS SQLite durability PRAGMAs on a connection.
+ * WAL on AccessHandlePoolVFS requires exclusive locking because the VFS has no shared-memory (`xShm`) support.
+ */
+export const applyOpfsPragmas = (sqlite3: Sqlite3, db: number, options: OpfsPragmaOptions = {}): void => {
+  const journalMode = options.journalMode ?? DEFAULT_JOURNAL_MODE;
+  const synchronous = options.synchronous ?? DEFAULT_SYNCHRONOUS;
+  const pragmas = [
+    ...(journalMode === 'wal' ? ['PRAGMA locking_mode=EXCLUSIVE'] : []),
+    `PRAGMA journal_mode=${journalMode}`,
+    `PRAGMA synchronous=${synchronous}`,
+  ];
+  for (const pragma of pragmas) {
+    for (const stmt of sqlite3.statements(db, pragma)) {
+      while (sqlite3.step(stmt) === WaSqlite.SQLITE_ROW) {}
+    }
+  }
+};


### PR DESCRIPTION
## Summary

- Apply configurable OPFS SQLite durability PRAGMAs on connection open: `locking_mode=EXCLUSIVE` (when WAL), `journal_mode=WAL`, and `synchronous=NORMAL` by default.
- Add `journalMode` and `synchronous` options to `OpfsConfig` so callers can override defaults.
- Extract shared `applyOpfsPragmas` helper and use it in both `makeOpfs` and `OpfsWorker` so MessagePort and in-process OPFS paths stay consistent (including after database import).

WAL on `AccessHandlePoolVFS` requires exclusive locking because the VFS has no shared-memory (`xShm`) support. The defaults reduce per-commit `xSync` → OPFS `flush` overhead while remaining corruption-safe under WAL.

## Test plan

- [x] `moon run sql-sqlite:test-browser` (all OPFS browser tests pass)
- [x] `moon run sql-sqlite:lint -- --fix`
- [x] `moon run sql-sqlite:build`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing SQLite OPFS connection settings, including journal mode and synchronous level.
  * Imported databases now automatically use the same connection settings as newly opened databases.

* **Bug Fixes**
  * Improved consistency after database import so OPFS-backed databases are configured correctly before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->