### PR TITLE
chore(deps): bump @automerge/automerge-repo family to 2.6.0-subduction.37

### DIFF
--- a/patches/@automerge__automerge-repo@2.6.0-subduction.37.patch
+++ b/patches/@automerge__automerge-repo@2.6.0-subduction.37.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/Repo.d.ts b/dist/Repo.d.ts
-index e00ecc498da732c03d229d9613f1df937682746d..82d51d81bdf750d34de8adfa0ae56d383464261f 100644
+index 6d59fcf90a6a89235c5c7d1e563a485100e38885..e5432f1c3280418648a32db19424bbdaf9d3b305 100644
 --- a/dist/Repo.d.ts
 +++ b/dist/Repo.d.ts
 @@ -8,6 +8,7 @@ import { StorageAdapterInterface } from "./storage/StorageAdapterInterface.js";
@@ -7,25 +7,25 @@ index e00ecc498da732c03d229d9613f1df937682746d..82d51d81bdf750d34de8adfa0ae56d38
  import { StorageId } from "./storage/types.js";
  import { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js";
 +import type { SubductionPeerBinding } from "./subduction/source.js";
- import type { AnyDocumentId, AutomergeUrl, DocumentId, PeerId } from "./types.js";
+ import type { AnyDocumentId, AutomergeUrl, DocumentId, PeerId, UrlHeads } from "./types.js";
  import { AbortOptions } from "./helpers/abortable.js";
  import { type Subduction } from "@automerge/automerge-subduction/slim";
-@@ -294,5 +295,7 @@ export interface RepoEvents {
+@@ -317,6 +318,8 @@ export interface RepoEvents {
      "heal-exhausted": (payload: {
          documentId: DocumentId;
      }) => void;
 +    /** A subduction handshake bound a verified peer identity to a transport. */
 +    "subduction-peer-bound": (binding: SubductionPeerBinding) => void;
- }
- //# sourceMappingURL=Repo.d.ts.map
-\ No newline at end of file
+     /**
+      * A Subduction peer (e.g. the sync server) advertised new heads for a
+      * document. `storageId` is the peer's verifying-key peer id. Fires only for
 diff --git a/dist/Repo.js b/dist/Repo.js
-index 25770b92ad37867241cbd27f51e8b463483e60ef..eb4e87f631d13a549f9cdd9ace13cb16f11edf2e 100644
+index d13f731f39ba31bdd46883887b62f7a9827d87c5..a9616e1e9cf2eb352f0dee27bbf38a30dc937d69 100644
 --- a/dist/Repo.js
 +++ b/dist/Repo.js
-@@ -137,6 +137,18 @@ export class Repo extends EventEmitter {
-             onHealExhausted: documentId => {
-                 this.emit("heal-exhausted", { documentId });
+@@ -156,6 +156,18 @@ export class Repo extends EventEmitter {
+             onConnectionChanged: connected => {
+                 this.emit("subduction-connection", { connected });
              },
 +            onPeerBound: binding => {
 +                // Surfaces the subduction ↔ repo PeerId binding so consumers can
@@ -62,7 +62,7 @@ index d8cd3b7aa432704098b20eecd9fe848f05a3d40e..9e22da1c7c84ef2513212cade1193873
  export type { NetworkAdapterEvents, OpenPayload, PeerCandidatePayload, PeerDisconnectedPayload, PeerMetadata, } from "./network/NetworkAdapterInterface.js";
  export type { NetworkSubsystemEvents, PeerPayload, } from "./network/NetworkSubsystem.js";
 diff --git a/dist/subduction/AdapterConnections.d.ts b/dist/subduction/AdapterConnections.d.ts
-index 1cdd94c3443bd0be41a149059d271bac61d0e3a7..c9496513751c0582546e8017af51e8a56aa421bd 100644
+index 55231beca6494ed4ab0eaeb45383b822bcea5fe3..826676a1b2ea406a000f874d429b11e3ff0caa98 100644
 --- a/dist/subduction/AdapterConnections.d.ts
 +++ b/dist/subduction/AdapterConnections.d.ts
 @@ -1,10 +1,17 @@
@@ -83,10 +83,10 @@ index 1cdd94c3443bd0be41a149059d271bac61d0e3a7..c9496513751c0582546e8017af51e8a5
 -    constructor(subduction: Promise<Subduction>, localPeerId: PeerId);
 +    constructor(subduction: Promise<Subduction>, localPeerId: PeerId, onPeerBound?: OnAdapterPeerBound);
      isConnecting(): boolean;
+     isConnected(): boolean;
      generation(): number;
-     onChange(callback: () => void): void;
 diff --git a/dist/subduction/AdapterConnections.js b/dist/subduction/AdapterConnections.js
-index 3bbc0b648d1b2b6fc894fb1e9299a25f78f93a88..79a7fec746c60341cb800db0ae20173b97b8ae42 100644
+index 40f525a6be944be10dd5e707c73f6af48d7ffde1..8f49c6c91b5af46e3d4924674ced0034e99d2c63 100644
 --- a/dist/subduction/AdapterConnections.js
 +++ b/dist/subduction/AdapterConnections.js
 @@ -1,15 +1,19 @@
@@ -110,7 +110,7 @@ index 3bbc0b648d1b2b6fc894fb1e9299a25f78f93a88..79a7fec746c60341cb800db0ae20173b
      }
      // ── ConnectionManager interface ─────────────────────────────────────
      isConnecting() {
-@@ -26,6 +30,7 @@ export class AdapterConnections {
+@@ -32,6 +36,7 @@ export class AdapterConnections {
      shutdown() {
          this.#isShutdown = true;
          this.#onChangeCallback = null;
@@ -118,7 +118,7 @@ index 3bbc0b648d1b2b6fc894fb1e9299a25f78f93a88..79a7fec746c60341cb800db0ae20173b
      }
      // ── Adapter management ──────────────────────────────────────────────
      addAdapter(adapter, serviceName, role) {
-@@ -48,15 +53,14 @@ export class AdapterConnections {
+@@ -54,15 +59,14 @@ export class AdapterConnections {
          }
      }
      async #startTransport(adapter, serviceName, peerId, role) {
@@ -139,7 +139,7 @@ index 3bbc0b648d1b2b6fc894fb1e9299a25f78f93a88..79a7fec746c60341cb800db0ae20173b
          }
          catch {
              // Transport connection failed (e.g. peer disconnected during handshake)
-@@ -66,6 +70,23 @@ export class AdapterConnections {
+@@ -72,6 +76,23 @@ export class AdapterConnections {
              this.#generation++;
              this.#onChangeCallback?.();
          }
@@ -165,7 +165,7 @@ index 3bbc0b648d1b2b6fc894fb1e9299a25f78f93a88..79a7fec746c60341cb800db0ae20173b
  //# sourceMappingURL=AdapterConnections.js.map
 \ No newline at end of file
 diff --git a/dist/subduction/SubductionConnections.d.ts b/dist/subduction/SubductionConnections.d.ts
-index 4bfff03372c0f8faf56bff71a1d488ca48f13a45..7912b0862c75fa471d6d455f1d7f98309991e18b 100644
+index 58e2506731d668f6c555f83f57ba29c3351b4723..9d782faf41382c2a20d2d386e821d63fce2c3f85 100644
 --- a/dist/subduction/SubductionConnections.d.ts
 +++ b/dist/subduction/SubductionConnections.d.ts
 @@ -1,9 +1,13 @@
@@ -182,10 +182,10 @@ index 4bfff03372c0f8faf56bff71a1d488ca48f13a45..7912b0862c75fa471d6d455f1d7f9830
 -    constructor(subduction: Promise<Subduction>);
 +    constructor(subduction: Promise<Subduction>, onPeerBound?: OnWebSocketPeerBound);
      isConnecting(): boolean;
+     isConnected(): boolean;
      generation(): number;
-     onChange(callback: () => void): void;
 diff --git a/dist/subduction/SubductionConnections.js b/dist/subduction/SubductionConnections.js
-index 5f75d7e74feb08ec11f5fbf7c760db75f04bb00a..35a6d43fdfffed9c8e833fcbaa694be25cfd0831 100644
+index bb0aecdca57b83b798e60101a16ac22366a6d1a1..6af71251baa294166e168060fd9b7d03c6ac3b60 100644
 --- a/dist/subduction/SubductionConnections.js
 +++ b/dist/subduction/SubductionConnections.js
 @@ -7,11 +7,13 @@ export class SubductionConnections {
@@ -203,7 +203,7 @@ index 5f75d7e74feb08ec11f5fbf7c760db75f04bb00a..35a6d43fdfffed9c8e833fcbaa694be2
      }
      // ── ConnectionManager interface ─────────────────────────────────────
      isConnecting() {
-@@ -41,10 +43,21 @@ export class SubductionConnections {
+@@ -48,10 +50,21 @@ export class SubductionConnections {
                      break;
                  }
                  const subduction = await this.#subduction;
@@ -226,7 +226,7 @@ index 5f75d7e74feb08ec11f5fbf7c760db75f04bb00a..35a6d43fdfffed9c8e833fcbaa694be2
                  await transport.closed();
                  this.#log(`disconnected from ${url}`);
              }
-@@ -67,6 +80,7 @@ export class SubductionConnections {
+@@ -74,6 +87,7 @@ export class SubductionConnections {
      }
      shutdown() {
          this.#isShutdown = true;
@@ -235,7 +235,7 @@ index 5f75d7e74feb08ec11f5fbf7c760db75f04bb00a..35a6d43fdfffed9c8e833fcbaa694be2
              clearTimeout(timer);
              resolve();
 diff --git a/dist/subduction/source.d.ts b/dist/subduction/source.d.ts
-index f4cac22c59a5a962b1dd10421c99e3766a46e222..d5795829b39ff063548bc1f46b3678fd7930d22c 100644
+index 783d9f61eae0684037d8fbbe0b676a924ba53c18..bf8e9f45ae02e6d5345e310dffb44ca4539eebfc 100644
 --- a/dist/subduction/source.d.ts
 +++ b/dist/subduction/source.d.ts
 @@ -1,4 +1,4 @@
@@ -272,38 +272,38 @@ index f4cac22c59a5a962b1dd10421c99e3766a46e222..d5795829b39ff063548bc1f46b3678fd
 +export type OnSubductionPeerBound = (binding: SubductionPeerBinding) => void;
  /** Intercepts and transforms incoming and outgoing blobs (e.g., for E2EE). */
  export interface BlobInterceptor {
-     /** Return null to skip the blob (e.g., doc not yet available for encryption). */
-@@ -80,6 +102,7 @@ export interface SubductionSourceOptions {
-     onRemoteHeadsChanged?: OnRemoteHeadsChanged;
-     onEphemeral?: OnEphemeral;
-     onHealExhausted?: (documentId: DocumentId) => void;
+     /**
+@@ -99,6 +121,7 @@ export interface SubductionSourceOptions {
+      * dropping → `false`). Lets a consumer surface online/offline status.
+      */
+     onConnectionChanged?: (connected: boolean) => void;
 +    onPeerBound?: OnSubductionPeerBound;
      policy?: Policy;
      /**
       * What priority this source should have w.r.t to other sources
-@@ -92,7 +115,7 @@ export interface SubductionSourceOptions {
+@@ -111,7 +134,7 @@ export interface SubductionSourceOptions {
  export declare class SubductionSource implements DocumentSource {
      #private;
      readonly priority: SourcePriority;
--    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, priority, policy, timeouts, blobInterceptor, }: SubductionSourceOptions);
-+    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onPeerBound, priority, policy, timeouts, blobInterceptor, }: SubductionSourceOptions);
+-    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onConnectionChanged, priority, policy, timeouts, blobInterceptor, }: SubductionSourceOptions);
++    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onConnectionChanged, onPeerBound, priority, policy, timeouts, blobInterceptor, }: SubductionSourceOptions);
+     /** True if any connection manager has an established connection. */
+     isConnected(): boolean;
      getSubduction(): Promise<Subduction>;
-     attach(query: DocumentQuery<unknown>): void;
-     detach(_documentId: DocumentId): void;
 diff --git a/dist/subduction/source.js b/dist/subduction/source.js
-index b079a8173d6051fb64ac22c5ac4d9a3bc7cc41ab..d29d36f3701b8c6a4786017c58f2dc29f7d52a84 100644
+index 9a5dfa03ce3d57babf77423519db6cd7b7b2f6d2..0aacd923fe07a3366fa7e5a5ff3f3951ada4b3bb 100644
 --- a/dist/subduction/source.js
 +++ b/dist/subduction/source.js
-@@ -41,7 +41,7 @@ export class SubductionSource {
+@@ -50,7 +50,7 @@ export class SubductionSource {
       */
      #shuttingDown = false;
      priority;
--    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, priority = 2, policy, timeouts, blobInterceptor, }) {
-+    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onPeerBound, priority = 2, policy, timeouts, blobInterceptor, }) {
+-    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onConnectionChanged, priority = 2, policy, timeouts, blobInterceptor, }) {
++    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onConnectionChanged, onPeerBound, priority = 2, policy, timeouts, blobInterceptor, }) {
          this.#blobInterceptor = blobInterceptor;
+         this.#onConnectionChanged = onConnectionChanged;
          this.priority = priority;
-         this.#syncTimeoutMs = timeouts?.syncMs ?? DEFAULT_SYNC_TIMEOUT_MS;
-@@ -95,12 +95,23 @@ export class SubductionSource {
+@@ -108,12 +108,23 @@ export class SubductionSource {
              ...defaultTimeoutOption,
          }));
          // ── Connection managers ─────────────────────────────────────────

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,17 +40,17 @@ catalogs:
       specifier: ^0.19.5
       version: 0.19.11
     '@automerge/automerge-repo':
-      specifier: 2.6.0-subduction.34
-      version: 2.6.0-subduction.34
+      specifier: 2.6.0-subduction.37
+      version: 2.6.0-subduction.37
     '@automerge/automerge-repo-network-broadcastchannel':
-      specifier: 2.6.0-subduction.34
-      version: 2.6.0-subduction.34
+      specifier: 2.6.0-subduction.37
+      version: 2.6.0-subduction.37
     '@automerge/automerge-repo-network-websocket':
-      specifier: 2.6.0-subduction.34
-      version: 2.6.0-subduction.34
+      specifier: 2.6.0-subduction.37
+      version: 2.6.0-subduction.37
     '@automerge/automerge-repo-storage-indexeddb':
-      specifier: 2.6.0-subduction.34
-      version: 2.6.0-subduction.34
+      specifier: 2.6.0-subduction.37
+      version: 2.6.0-subduction.37
     '@babel/core':
       specifier: ^7.18.13
       version: 7.28.0
@@ -1904,9 +1904,9 @@ overrides:
 pnpmfileChecksum: sha256-cQVl+jrEHH0V4IgNkydwSKNmLoShP2mLkufXFXEHIjU=
 
 patchedDependencies:
-  '@automerge/automerge-repo@2.6.0-subduction.34':
-    hash: feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1
-    path: patches/@automerge__automerge-repo@2.6.0-subduction.34.patch
+  '@automerge/automerge-repo@2.6.0-subduction.37':
+    hash: 563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd
+    path: patches/@automerge__automerge-repo@2.6.0-subduction.37.patch
   '@automerge/automerge-subduction@0.16.0':
     hash: 6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669
     path: patches/@automerge__automerge-subduction@0.16.0.patch
@@ -2320,7 +2320,7 @@ importers:
         version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
       '@dxos/keys':
         specifier: workspace:*
         version: link:../../../../packages/common/keys
@@ -2402,7 +2402,7 @@ importers:
         version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.20.2
@@ -5685,7 +5685,7 @@ importers:
         version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../../common/async
@@ -5882,7 +5882,7 @@ importers:
         version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
       '@automerge/automerge-subduction':
         specifier: 0.16.0
         version: 0.16.0(patch_hash=6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669)
@@ -7607,13 +7607,13 @@ importers:
         version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
       '@automerge/automerge-repo-network-websocket':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34
+        version: 2.6.0-subduction.37
       '@automerge/automerge-repo-storage-indexeddb':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34
+        version: 2.6.0-subduction.37
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -17025,7 +17025,7 @@ importers:
         version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -17251,7 +17251,7 @@ importers:
         version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -17514,7 +17514,7 @@ importers:
         version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
       '@dxos/client':
         specifier: workspace:*
         version: link:../client
@@ -19998,10 +19998,10 @@ importers:
     devDependencies:
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
       '@automerge/automerge-repo-network-broadcastchannel':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34
+        version: 2.6.0-subduction.37
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -22016,10 +22016,10 @@ importers:
     devDependencies:
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
       '@automerge/automerge-repo-network-broadcastchannel':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.34
+        version: 2.6.0-subduction.37
       '@dxos/config':
         specifier: workspace:*
         version: link:../../sdk/config
@@ -22910,20 +22910,20 @@ packages:
   '@atproto/xrpc@0.7.7':
     resolution: {integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==}
 
-  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.34':
-    resolution: {integrity: sha512-3YLCrzZZoBecmdyvP3Kw3+/et36EfrNvv4N3zHVjcIklRrcMII0kjF3x3XNBExd155pHOiwn0BGo1lbD00xHfA==}
+  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.37':
+    resolution: {integrity: sha512-OEm6cuCQcEThxb5o7hLk8g471omeu8daaeGoLqaGXvTpzE/1HacJK9WpdZQ7SWudkHYdum56nmR4X9BwDkfS3Q==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.34':
-    resolution: {integrity: sha512-m+e46/+T74SnV39FCHaujyH5lKL85/Q35vdPv1D7tg7uSB68+0UVDShdLX7e7jcK0xBhYxuxQoksDz3ky2TjBQ==}
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.37':
+    resolution: {integrity: sha512-BgxKPgnnEnNgQYUvzinhfnYYNRP0eWhTVgg/ut3JYZdjq7h+OyYrIEiy6eGIkKBn/8USIZKQnvhJH1TXwyfyGg==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.34':
-    resolution: {integrity: sha512-ajLxo5iBQjI4EWyyrDFklksYlFfq5wSVESSld1Udl94iD5lEeRJrqnct4w5El4lhCkHLB65f5mDibv1DPB5TEg==}
+  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.37':
+    resolution: {integrity: sha512-mNr6Pgf5zbFN/g4KzP/OsPvOmI4jf8KNeJcC3EkYGXEm+/c/aV/Upi+9NTY17uRTLwL/K3eURs800Mi57h7uhg==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo@2.6.0-subduction.34':
-    resolution: {integrity: sha512-haobq94PQ1Z74DsXMfMFfWAowR6cdoTAjfUAqJQQIevzuOVn2oioTctPp7t0FvVsdGHR5L3Im107L57WYOtJCA==}
+  '@automerge/automerge-repo@2.6.0-subduction.37':
+    resolution: {integrity: sha512-YEnO34sMOKfXkyW0paqfa5BFehXT/VnwMhpxGcLrVLQbGzvXk14uT1vGp//u1wmrFw+iVj++W0E+owA615SbdA==}
     engines: {node: '>=22.13'}
 
   '@automerge/automerge-subduction@0.16.0':
@@ -41839,17 +41839,17 @@ snapshots:
       '@atproto/lexicon': 0.6.2
       zod: 3.25.76
 
-  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.34':
+  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.37':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+      '@automerge/automerge-repo': 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.34':
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.37':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+      '@automerge/automerge-repo': 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
       cbor-x: 1.6.4
       debug: 4.4.3(supports-color@5.5.0)
       eventemitter3: 5.0.4
@@ -41859,15 +41859,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.34':
+  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.37':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)
+      '@automerge/automerge-repo': 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo@2.6.0-subduction.34(patch_hash=feaf82b4c0f51f7dc95d351c64d38af23f3970c00bc2990e003752e42e8f7fc1)':
+  '@automerge/automerge-repo@2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)':
     dependencies:
       '@automerge/automerge': 3.3.0-fragments.1
       '@automerge/automerge-subduction': 0.16.0(patch_hash=6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669)
@@ -58857,7 +58857,7 @@ snapshots:
 
   p-queue@8.1.1:
     dependencies:
-      eventemitter3: 5.0.1
+      eventemitter3: 5.0.4
       p-timeout: 6.1.2
 
   p-queue@9.1.2:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,10 +26,10 @@ catalog:
   '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator': 3.2.10
   '@atproto/api': ^0.19.5
   '@automerge/automerge': 3.3.0-fragments.1
-  '@automerge/automerge-repo': 2.6.0-subduction.34
-  '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.34
-  '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.34
-  '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.34
+  '@automerge/automerge-repo': 2.6.0-subduction.37
+  '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.37
+  '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.37
+  '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.37
   '@automerge/automerge-subduction': 0.16.0
   '@babel/core': ^7.18.13
   '@babel/preset-typescript': ^7.27.1
@@ -766,7 +766,7 @@ overrides:
   ws: '>=8.17.1'
 
 patchedDependencies:
-  '@automerge/automerge-repo@2.6.0-subduction.34': patches/@automerge__automerge-repo@2.6.0-subduction.34.patch
+  '@automerge/automerge-repo@2.6.0-subduction.37': patches/@automerge__automerge-repo@2.6.0-subduction.37.patch
   '@automerge/automerge-subduction@0.16.0': patches/@automerge__automerge-subduction@0.16.0.patch
   '@effect-atom/atom@0.5.3': patches/@effect-atom__atom@0.5.3.patch
   '@vitest/browser@4.1.8': patches/@vitest__browser@4.1.8.patch


### PR DESCRIPTION
## Summary

Bumps the `@automerge/automerge-repo` catalog family in lockstep from `2.6.0-subduction.34` → `.37`:

- `@automerge/automerge-repo`
- `@automerge/automerge-repo-network-broadcastchannel`
- `@automerge/automerge-repo-network-websocket`
- `@automerge/automerge-repo-storage-indexeddb`

`@automerge/automerge` (`3.3.0-fragments.1`) and `@automerge/automerge-subduction` (`0.16.0`) were already at the requested versions and are unchanged.

## Patch regeneration

The vendored `automerge-repo` patch edits the package's compiled `dist/` to add an `onPeerBound` callback + `subduction-peer-bound` Repo event — consumed only by `echo-host` (`packages/core/echo/echo-host/src/automerge/automerge-host.ts`, which imports `SubductionPeerBinding`/`SubductionPeerId` and listens for `subduction-peer-bound`).

`.37` changed those exact `dist/` files (notably a new `onConnectionChanged` constructor param), so the patch hunks rejected against the old base. The patch was rebased onto `.37` — preserving `onConnectionChanged` — and regenerated canonically via `pnpm patch` → `pnpm patch-commit`. The `@automerge/automerge-subduction@0.16.0` patch is untouched (version unchanged).

## Verification

- ✅ `pnpm install --frozen-lockfile` clean → lockfile reproducible
- ✅ Patch confirmed applied in `node_modules` (all consumers link to the patched store dir)
- ✅ Builds pass across all direct consumers (echo-host, echo-client, client, client-services, migrations, ui-editor, react-ui-editor, blade-runner + transitive plugins) — 313 build tasks
- ✅ `echo-host` tests: 250 passed (incl. the 23 `automerge-repo-subduction-policy` handshake tests that exercise the patched code paths)
- ✅ `echo-client` tests: 587 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)