### PR TITLE
fix(echo,plugin-assistant): reactive ref resolution — useObject/Obj.atom instead of .target

### DIFF
--- a/packages/core/echo/echo-react/src/useObject.ts
+++ b/packages/core/echo/echo-react/src/useObject.ts
@@ -24,9 +24,16 @@ export const useObject: {
    * Hook to subscribe to a Ref's target object.
    * Automatically dereferences the ref and handles async loading.
    * Returns a snapshot (undefined if the ref hasn't loaded yet).
+   * Re-renders the component when the ref resolves or the target object changes.
    *
    * @param ref - The Ref to dereference and subscribe to
    * @returns The current target snapshot (or undefined if not loaded) and update callback
+   *
+   * @idiom org.dxos.echo-react.useObjectReactive
+   *   applies: Reading a ref's target (or a specific property) inside a React component — establishes a reactive subscription so the component re-renders when the ref resolves or the value changes
+   *   instead-of: `ref.target` — synchronous and not reactive; returns `undefined` when the target isn't loaded yet and never triggers a re-render when it becomes available
+   *   uses: {@link useObject}
+   *   related: org.dxos.echo.objAtomReactive, org.dxos.echo.refLoad
    */
   <T extends Obj.Unknown>(ref: Ref.Ref<T>): [Obj.Snapshot<T> | undefined, ObjectUpdateCallback<T>];
 

--- a/packages/core/echo/echo/src/Obj.ts
+++ b/packages/core/echo/echo/src/Obj.ts
@@ -943,6 +943,17 @@ export const version = (entity: Unknown | Snapshot): Version => internal.version
 // Atoms
 //
 
+/**
+ * Create a reactive snapshot atom for an ECHO object or ref.
+ * Use inside atom computations (e.g. `Atom.make((get) => get(Obj.atom(ref)))`) to subscribe
+ * to a ref's target — the atom re-fires when the target loads or changes.
+ *
+ * @idiom org.dxos.echo.objAtomReactive
+ *   applies: Subscribing to a ref's target inside an atom computation or a non-React reactive context
+ *   instead-of: `ref.target` — synchronous and not reactive; returns `undefined` when the target isn't loaded yet and never notifies when it becomes available
+ *   uses: {@link atom}
+ *   related: org.dxos.echo-react.useObjectReactive
+ */
 export const atom = objInternal.makeAtom;
 export const atomReactive = objInternal.makeWithReactive;
 export const atomProperty = objInternal.makeProperty;

--- a/packages/core/echo/echo/src/Obj.ts
+++ b/packages/core/echo/echo/src/Obj.ts
@@ -6,6 +6,7 @@
 
 import * as Effect from 'effect/Effect';
 import * as Equal from 'effect/Equal';
+import * as Exit from 'effect/Exit';
 import * as Function from 'effect/Function';
 import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
@@ -298,6 +299,22 @@ export const getReactiveOption = <T extends Unknown>(snapshot: Snapshot<T>): Eff
  */
 export const getReactiveOrThrow = <T extends Unknown>(snapshot: Snapshot<T>): T =>
   Effect.runSync(getReactive(snapshot));
+
+/**
+ * Synchronous version of `Obj.getReactive` that returns `undefined` instead of throwing.
+ * Accepts `undefined` input so callers can pass the result of `useObject` directly.
+ *
+ * @param snapshot - A snapshot of the object (from `Obj.getSnapshot` or `useObject`), or `undefined`.
+ * @returns The reactive object, or `undefined` if the snapshot is `undefined` or unresolvable.
+ */
+export const getReactiveOrUndefined = <T extends Unknown>(snapshot: Snapshot<T> | undefined): T | undefined => {
+  if (snapshot === undefined) {
+    return undefined;
+  }
+  return Effect.runSyncExit(getReactive(snapshot)).pipe(
+    Exit.match({ onSuccess: (value) => value, onFailure: () => undefined }),
+  );
+};
 
 export type CloneOptions = {
   /**

--- a/packages/core/echo/echo/src/internal/Ref/ref.ts
+++ b/packages/core/echo/echo/src/internal/Ref/ref.ts
@@ -189,7 +189,14 @@ export interface Ref<T> extends Pipeable.Pipeable {
   /**
    * @returns Promise that will resolves with the target object.
    * Will load the object from disk if it is not present in the working set.
+   * Short-circuits immediately when the target is already loaded.
    * @throws If the object is not available locally.
+   *
+   * @idiom org.dxos.echo.refLoad
+   *   applies: Resolving a ref inside an async function or Effect handler — guarantees the object is available before proceeding
+   *   instead-of: `ref.target` — not guaranteed to be defined in async contexts; use `await ref.load()` (or `yield* Database.load(ref)` in Effect) to ensure the target is present
+   *   uses: {@link load}
+   *   related: org.dxos.echo-react.useObjectReactive
    */
   load(): Promise<T>;
 

--- a/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
+++ b/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
@@ -11,8 +11,8 @@ import React, { type PropsWithChildren, useCallback, useEffect, useMemo, useRef,
 import { Plan } from '@dxos/assistant-toolkit';
 import { Event } from '@dxos/async';
 import { getSpace } from '@dxos/client/echo';
-import { type Database, type Feed, Filter, Obj, Query } from '@dxos/echo';
-import { useQuery } from '@dxos/react-client/echo';
+import { type Database, Filter, Obj, Query } from '@dxos/echo';
+import { useObject, useQuery } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
 import { Button, Toast, composable, composableProps, useTranslation } from '@dxos/react-ui';
 import { type MarkdownStreamController } from '@dxos/react-ui-markdown';
@@ -39,7 +39,6 @@ import { type ChatEvent } from './events';
 
 type ChatRootProps = PropsWithChildren<
   Pick<ChatContextValue, 'chat' | 'processor'> & {
-    feed?: Feed.Feed;
     /** Fallback database when the chat is transient (not yet persisted). */
     db?: Database.Database;
     onEvent?: (event: ChatEvent) => void;
@@ -51,7 +50,7 @@ type ChatRootProps = PropsWithChildren<
   }
 >;
 
-const ChatRoot = ({ children, chat, feed, processor, db: dbFallback, onEvent, onSubmit, ...props }: ChatRootProps) => {
+const ChatRoot = ({ children, chat, processor, db: dbFallback, onEvent, onSubmit, ...props }: ChatRootProps) => {
   const [debug, setDebug] = useState(false);
   const streaming = useAtomValue(processor.streaming);
   const active = useAtomValue(processor.active);
@@ -60,6 +59,10 @@ const ChatRoot = ({ children, chat, feed, processor, db: dbFallback, onEvent, on
   // Transient chats have no database of their own; fall back to the supplied space db so
   // the message query and context controls operate before the chat is persisted.
   const db = (chat && Obj.getDatabase(chat)) || dbFallback;
+
+  // Reactive subscription — re-renders when the feed ref resolves. Direct `.target` reads are not reactive.
+  const [feedSnapshot] = useObject(chat?.feed);
+  const feed = Obj.getReactiveOrUndefined(feedSnapshot);
 
   // Event sink.
   const event = useMemo(() => new Event<ChatEvent>(), []);

--- a/packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.tsx
@@ -75,13 +75,7 @@ export const ChatArticle = forwardRef<HTMLDivElement, ChatArticleProps>(
     }
 
     return (
-      <ChatComponent.Root
-        chat={chat}
-        db={space?.db}
-        processor={processor}
-        onEvent={onEvent}
-        onSubmit={onSubmit}
-      >
+      <ChatComponent.Root chat={chat} db={space?.db} processor={processor} onEvent={onEvent} onSubmit={onSubmit}>
         <Panel.Root role={role} ref={forwardedRef}>
           <Panel.Toolbar classNames='bg-toolbar-surface'>
             <ChatComponent.Toolbar classNames='dx-document' attendableId={attendableId} companionTo={companionTo} />

--- a/packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.tsx
@@ -77,7 +77,6 @@ export const ChatArticle = forwardRef<HTMLDivElement, ChatArticleProps>(
     return (
       <ChatComponent.Root
         chat={chat}
-        feed={chat?.feed.target}
         db={space?.db}
         processor={processor}
         onEvent={onEvent}

--- a/packages/plugins/plugin-assistant/src/containers/ChatCompanion/ChatCompanion.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatCompanion/ChatCompanion.tsx
@@ -13,7 +13,7 @@ import { getSpace } from '@dxos/client/echo';
 import { Skill } from '@dxos/compute';
 import { Entity, Filter, Obj, Ref, Type } from '@dxos/echo';
 import { SpaceOperation } from '@dxos/plugin-space';
-import { useQuery, useRegistry } from '@dxos/react-client/echo';
+import { useObject, useQuery, useRegistry } from '@dxos/react-client/echo';
 import { useAsyncEffect } from '@dxos/react-ui';
 
 import { useContextBinder } from '#hooks';
@@ -73,7 +73,8 @@ export const ChatCompanion = forwardRef<HTMLDivElement, ChatCompanionProps>(
 const useSkills = ({ subject: chat, companionTo }: Pick<ChatCompanionProps, 'subject' | 'companionTo'>) => {
   const registry = useRegistry();
   const space = getSpace(companionTo);
-  const feedTarget = chat?.feed.target;
+  const [feedSnapshot] = useObject(chat?.feed);
+  const feedTarget = Obj.getReactiveOrUndefined(feedSnapshot);
   const binder = useContextBinder(space, feedTarget);
 
   const skillKeys = useMemo(() => {

--- a/packages/plugins/plugin-assistant/src/hooks/useChatProcessor.ts
+++ b/packages/plugins/plugin-assistant/src/hooks/useChatProcessor.ts
@@ -13,10 +13,10 @@ import { useCapability } from '@dxos/app-framework/ui';
 import { AiSession } from '@dxos/assistant';
 import { type Chat } from '@dxos/assistant-toolkit';
 import { AgentService, Credential, ServiceResolver } from '@dxos/compute';
-import { Database, Ref, Registry } from '@dxos/echo';
+import { Database, Obj, Ref, Registry } from '@dxos/echo';
 import { EffectEx } from '@dxos/effect';
 import { log } from '@dxos/log';
-import { type Space } from '@dxos/react-client/echo';
+import { useObject, type Space } from '@dxos/react-client/echo';
 import { useAsyncEffect } from '@dxos/react-ui';
 
 import { type Assistant } from '#types';
@@ -45,21 +45,21 @@ export const useChatProcessor = ({
 }: UseChatProcessorProps): AiChatProcessor | undefined => {
   const observableRegistry = useContext(RegistryContext);
 
+  // Reactive subscription — re-renders when the feed ref resolves. Direct `.target` reads are not reactive.
+  const [feedSnapshot] = useObject(chat?.feed);
+  const feed = Obj.getReactiveOrUndefined(feedSnapshot);
+
   const [session, setSession] = useState<AiSession.Session>();
   useAsyncEffect(async () => {
-    if (!space || !chat) {
+    if (!space || !chat || !feed) {
       return;
     }
 
-    const feedTarget = chat.feed.target;
-    if (!feedTarget) {
-      return;
-    }
     const runtime = await EffectEx.runAndForwardErrors(
       Effect.runtime<Database.Service>().pipe(Effect.provide(Database.layer(space.db))),
     );
     const session = new AiSession.Session({
-      feed: feedTarget,
+      feed,
       runtime,
       registry: observableRegistry,
     });
@@ -69,9 +69,8 @@ export const useChatProcessor = ({
       void session.close();
       setSession(undefined);
     };
-  }, [space, chat?.feed.target]);
+  }, [space, chat, feed]);
 
-  const feed = chat?.feed.target;
   const serviceResolver = useCapability(Capabilities.ServiceResolver);
 
   const processor = useMemo(() => {

--- a/packages/plugins/plugin-assistant/src/operations/fork-chat.ts
+++ b/packages/plugins/plugin-assistant/src/operations/fork-chat.ts
@@ -21,8 +21,7 @@ const handler: Operation.WithHandler<typeof AssistantOperation.ForkChat> = Assis
   Operation.withHandler(
     Effect.fnUntraced(function* ({ chat, companionTo }) {
       const { db } = yield* Database.Service;
-      const sourceFeed = chat.feed.target;
-      invariant(sourceFeed, 'Chat feed not found.');
+      const sourceFeed = yield* Database.load(chat.feed);
 
       const client = yield* Capability.get(ClientCapabilities.Client);
       const space = client.spaces.get(db.spaceId);
@@ -43,8 +42,7 @@ const handler: Operation.WithHandler<typeof AssistantOperation.ForkChat> = Assis
         db,
         name: sourceName ? `${sourceName} (fork)` : undefined,
       });
-      const newFeed = newChat.feed.target;
-      invariant(newFeed, 'New chat feed not found.');
+      const newFeed = yield* Database.load(newChat.feed);
 
       if (sorted.length > 0) {
         const lastMessage = sorted[sorted.length - 1];

--- a/packages/plugins/plugin-assistant/src/operations/run-prompt-in-new-chat.ts
+++ b/packages/plugins/plugin-assistant/src/operations/run-prompt-in-new-chat.ts
@@ -29,8 +29,7 @@ const handler: Operation.WithHandler<typeof RoutineOperation.RunPromptInNewChat>
           const { object: chat } = yield* Operation.invoke(AssistantOperation.CreateChat, { db });
 
           if ((objects && objects.length > 0) || (skills && skills.length > 0)) {
-            const feedTarget = chat.feed.target;
-            invariant(feedTarget, 'Chat feed not found.');
+            const feedTarget = yield* Database.load(chat.feed);
             const client = yield* Capability.get(ClientCapabilities.Client);
             const space = client.spaces.get(db.spaceId);
             invariant(space, 'Space not found.');


### PR DESCRIPTION
closes DX-1040

## Summary
- Switched chat feed consumers from direct `.target` reads to reactive resolution so components re-render when the feed ref becomes available.
- Added `Obj.getReactiveOrUndefined` to safely resolve optional snapshots without throwing.
- Updated chat processor and companion wiring to use `useObject` and the resolved feed value.
- Replaced invariant-based feed access in chat fork and new-chat operations with `Database.load`.
- Added `@idiom` tags on `useObject`, `Obj.atom`, and `Ref.load` documenting the reactive vs async patterns.