### PR TITLE
feat(plugin-assistant): auto-generate space home starter prompts from recent objects

### DIFF
--- a/packages/plugins/plugin-assistant/src/capabilities/state.ts
+++ b/packages/plugins/plugin-assistant/src/capabilities/state.ts
@@ -27,9 +27,16 @@ export default Capability.makeModule(() =>
 
     const companionChatCacheAtom = Atom.make<Record<string, Obj.Unknown | undefined>>({}).pipe(Atom.keepAlive);
 
+    const homeSuggestionsCacheAtom = createKvsStore({
+      key: `${meta.profile.key}.home-suggestions`,
+      schema: AssistantCapabilities.HomeSuggestionsCacheSchema,
+      defaultValue: () => ({}),
+    });
+
     return [
       Capability.contributes(AssistantCapabilities.State, stateAtom),
       Capability.contributes(AssistantCapabilities.CompanionChatCache, companionChatCacheAtom),
+      Capability.contributes(AssistantCapabilities.HomeSuggestionsCache, homeSuggestionsCacheAtom),
     ];
   }),
 );

--- a/packages/plugins/plugin-assistant/src/containers/SpaceHomeSuggestions/SpaceHomeSuggestions.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/SpaceHomeSuggestions/SpaceHomeSuggestions.tsx
@@ -9,15 +9,8 @@ import { RoutineOperation } from '@dxos/plugin-routine/types';
 import { type Space } from '@dxos/react-client/echo';
 import { Card, IconButton, useTranslation } from '@dxos/react-ui';
 
+import { useHomeSuggestions } from '#hooks';
 import { meta } from '#meta';
-
-/** Starter prompts shown on the Home page. Always rendered — they surface quick actions alongside
- * the recent-objects masonry rather than only as an empty-state fallback. */
-const SUGGESTION_KEYS = [
-  'space-home.suggestion-draft-doc.label',
-  'space-home.suggestion-data-type.label',
-  'space-home.suggestion-ideas.label',
-] as const;
 
 type SpaceScopedProps = {
   space?: Space;
@@ -31,6 +24,7 @@ type SpaceScopedProps = {
 export const SpaceHomeSuggestions = ({ space }: SpaceScopedProps) => {
   const { t } = useTranslation(meta.profile.key);
   const { invokePromise } = useOperationInvoker();
+  const suggestions = useHomeSuggestions(space);
 
   const handleRunPrompt = useCallback(
     (prompt: string) => {
@@ -42,30 +36,31 @@ export const SpaceHomeSuggestions = ({ space }: SpaceScopedProps) => {
     [invokePromise, space],
   );
 
+  if (!suggestions) {
+    return null;
+  }
+
   return (
     <div className='flex justify-center w-full'>
       <div className='flex flex-col gap-2 w-full max-w-[40rem]'>
         <h2 className='text-sm font-medium text-description'>{t('space-home.suggestions.heading')}</h2>
         <div className='flex flex-col gap-3'>
-          {SUGGESTION_KEYS.map((key) => {
-            const prompt = t(key);
-            return (
-              <Card.Root
-                key={key}
-                fullWidth
-                role='button'
-                classNames='cursor-pointer'
-                onClick={() => handleRunPrompt(prompt)}
-              >
-                <Card.Header>
-                  <Card.Block>
-                    <IconButton variant='ghost' label={prompt} icon='ph--sparkle--regular' iconOnly />
-                  </Card.Block>
-                  <Card.Title>{prompt}</Card.Title>
-                </Card.Header>
-              </Card.Root>
-            );
-          })}
+          {suggestions.map((prompt, index) => (
+            <Card.Root
+              key={`${index}:${prompt}`}
+              fullWidth
+              role='button'
+              classNames='cursor-pointer'
+              onClick={() => handleRunPrompt(prompt)}
+            >
+              <Card.Header>
+                <Card.Block>
+                  <IconButton variant='ghost' label={prompt} icon='ph--sparkle--regular' iconOnly />
+                </Card.Block>
+                <Card.Title>{prompt}</Card.Title>
+              </Card.Header>
+            </Card.Root>
+          ))}
         </div>
       </div>
     </div>

--- a/packages/plugins/plugin-assistant/src/containers/SpaceHomeSuggestions/SpaceHomeSuggestions.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/SpaceHomeSuggestions/SpaceHomeSuggestions.tsx
@@ -46,20 +46,35 @@ export const SpaceHomeSuggestions = ({ space }: SpaceScopedProps) => {
         <h2 className='text-sm font-medium text-description'>{t('space-home.suggestions.heading')}</h2>
         <div className='flex flex-col gap-3'>
           {suggestions.map((prompt, index) => (
-            <Card.Root
+            <div
               key={`${index}:${prompt}`}
-              fullWidth
               role='button'
-              classNames='cursor-pointer'
+              tabIndex={0}
+              className='cursor-pointer w-full'
               onClick={() => handleRunPrompt(prompt)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleRunPrompt(prompt);
+                }
+              }}
             >
-              <Card.Header>
-                <Card.Block>
-                  <IconButton variant='ghost' label={prompt} icon='ph--sparkle--regular' iconOnly />
-                </Card.Block>
-                <Card.Title>{prompt}</Card.Title>
-              </Card.Header>
-            </Card.Root>
+              <Card.Root fullWidth>
+                <Card.Header>
+                  <Card.Block>
+                    <IconButton
+                      variant='ghost'
+                      label={prompt}
+                      icon='ph--sparkle--regular'
+                      iconOnly
+                      tabIndex={-1}
+                      aria-hidden
+                    />
+                  </Card.Block>
+                  <Card.Title>{prompt}</Card.Title>
+                </Card.Header>
+              </Card.Root>
+            </div>
           ))}
         </div>
       </div>

--- a/packages/plugins/plugin-assistant/src/hooks/index.ts
+++ b/packages/plugins/plugin-assistant/src/hooks/index.ts
@@ -17,6 +17,7 @@ export * from './useOnline';
 export * from './usePresets';
 export * from './useReferencesProvider';
 export * from './useTraceMessages';
+export * from './useHomeSuggestions';
 export * from './useProcessEphemeralStatus';
 
 export { type AiChatProcessor } from '../processor';

--- a/packages/plugins/plugin-assistant/src/hooks/useHomeSuggestions.ts
+++ b/packages/plugins/plugin-assistant/src/hooks/useHomeSuggestions.ts
@@ -1,0 +1,50 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { useOperationInvoker } from '@dxos/app-framework/ui';
+import { type Space } from '@dxos/react-client/echo';
+import { useTranslation } from '@dxos/react-ui';
+
+import { meta } from '#meta';
+import { AssistantOperation } from '#types';
+
+const FALLBACK_SUGGESTION_KEYS = [
+  'space-home.suggestion-draft-doc.label',
+  'space-home.suggestion-data-type.label',
+  'space-home.suggestion-ideas.label',
+] as const;
+
+/**
+ * Returns starter prompts for the space Home page. Returns undefined while the request is in flight
+ * so the section stays hidden until settled. On success yields generated prompts; on empty result or
+ * error falls back to the hardcoded defaults.
+ */
+export const useHomeSuggestions = (space?: Space): readonly string[] | undefined => {
+  const { t } = useTranslation(meta.profile.key);
+  const { invokePromise } = useOperationInvoker();
+  const fallbacks = useMemo(() => FALLBACK_SUGGESTION_KEYS.map((key) => t(key)), [t]);
+  const [suggestions, setSuggestions] = useState<readonly string[] | undefined>(undefined);
+
+  useEffect(() => {
+    setSuggestions(undefined);
+    if (!space) {
+      return;
+    }
+    let cancelled = false;
+    void invokePromise(AssistantOperation.GenerateHomeSuggestions, { db: space.db }, { spaceId: space.db.spaceId }).then((result) => {
+      if (cancelled) {
+        return;
+      }
+      const prompts = result.data?.prompts;
+      setSuggestions(prompts && prompts.length > 0 ? prompts : fallbacks);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [space, invokePromise]);
+
+  return suggestions;
+};

--- a/packages/plugins/plugin-assistant/src/hooks/useHomeSuggestions.ts
+++ b/packages/plugins/plugin-assistant/src/hooks/useHomeSuggestions.ts
@@ -2,11 +2,11 @@
 // Copyright 2026 DXOS.org
 //
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { type Space } from '@dxos/react-client/echo';
-import { useTranslation } from '@dxos/react-ui';
+import { useAsyncEffect, useTranslation } from '@dxos/react-ui';
 
 import { meta } from '#meta';
 import { AssistantOperation } from '#types';
@@ -28,27 +28,25 @@ export const useHomeSuggestions = (space?: Space): readonly string[] | undefined
   const fallbacks = useMemo(() => FALLBACK_SUGGESTION_KEYS.map((key) => t(key)), [t]);
   const [suggestions, setSuggestions] = useState<readonly string[] | undefined>(undefined);
 
-  useEffect(() => {
-    setSuggestions(undefined);
-    if (!space) {
-      return;
-    }
-    let cancelled = false;
-    void invokePromise(
-      AssistantOperation.GenerateHomeSuggestions,
-      { db: space.db },
-      { spaceId: space.db.spaceId },
-    ).then((result) => {
-      if (cancelled) {
+  useAsyncEffect(
+    async (controller) => {
+      setSuggestions(undefined);
+      if (!space) {
+        return;
+      }
+      const result = await invokePromise(
+        AssistantOperation.GenerateHomeSuggestions,
+        { db: space.db },
+        { spaceId: space.db.spaceId },
+      );
+      if (controller.signal.aborted) {
         return;
       }
       const prompts = result.data?.prompts;
       setSuggestions(prompts && prompts.length > 0 ? prompts : fallbacks);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [space, invokePromise]);
+    },
+    [space, invokePromise],
+  );
 
   return suggestions;
 };

--- a/packages/plugins/plugin-assistant/src/hooks/useHomeSuggestions.ts
+++ b/packages/plugins/plugin-assistant/src/hooks/useHomeSuggestions.ts
@@ -34,7 +34,11 @@ export const useHomeSuggestions = (space?: Space): readonly string[] | undefined
       return;
     }
     let cancelled = false;
-    void invokePromise(AssistantOperation.GenerateHomeSuggestions, { db: space.db }, { spaceId: space.db.spaceId }).then((result) => {
+    void invokePromise(
+      AssistantOperation.GenerateHomeSuggestions,
+      { db: space.db },
+      { spaceId: space.db.spaceId },
+    ).then((result) => {
       if (cancelled) {
         return;
       }

--- a/packages/plugins/plugin-assistant/src/operations/generate-home-suggestions.test.ts
+++ b/packages/plugins/plugin-assistant/src/operations/generate-home-suggestions.test.ts
@@ -1,0 +1,103 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, it } from '@effect/vitest';
+import { Registry, Atom } from '@effect-atom/atom-react';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+
+import { Capabilities, Capability, CapabilityManager } from '@dxos/app-framework';
+import { Operation } from '@dxos/compute';
+import { Database } from '@dxos/echo';
+import { TestHelpers } from '@dxos/effect/testing';
+import { AssistantTestLayer } from '@dxos/functions-runtime/testing';
+import { EntityId } from '@dxos/keys';
+
+import { AssistantCapabilities, AssistantOperation } from '#types';
+
+import { AssistantOperationHandlerSet } from './index';
+
+EntityId.dangerouslyDisableRandomness();
+
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+// Shared registry and cache atom — each test sets its own cache state before invoking the operation.
+const testRegistry = Registry.make();
+const testCacheAtom = Atom.make<AssistantCapabilities.HomeSuggestionsCache>({}).pipe(Atom.keepAlive);
+const testManager = CapabilityManager.make({ registry: testRegistry });
+testManager.contribute({ module: 'test', interface: Capabilities.AtomRegistry, implementation: testRegistry });
+testManager.contribute({
+  module: 'test',
+  interface: AssistantCapabilities.HomeSuggestionsCache,
+  implementation: testCacheAtom,
+});
+
+const TestLayer = AssistantTestLayer({
+  operationHandlers: AssistantOperationHandlerSet,
+  // Provide Capability.Service so the handler can read/write the suggestions cache.
+  extraServices: Layer.succeed(Capability.Service, testManager),
+});
+
+describe('GenerateHomeSuggestions', () => {
+  it.effect(
+    'empty space returns empty prompts (fallback path)',
+    Effect.fnUntraced(
+      function* (_) {
+        const { db } = yield* Database.Service;
+        testRegistry.set(testCacheAtom, {});
+
+        const result = yield* Operation.invoke(AssistantOperation.GenerateHomeSuggestions, { db });
+
+        expect(result.prompts).toHaveLength(0);
+        // No cache entry written when prompts is empty.
+        const cached = testRegistry.get(testCacheAtom);
+        expect(cached[db.spaceId]).toBeUndefined();
+      },
+      Effect.provide(TestLayer),
+      TestHelpers.provideTestContext,
+    ),
+  );
+
+  it.effect(
+    'cache hit returns stored prompts without re-generating',
+    Effect.fnUntraced(
+      function* (_) {
+        const { db } = yield* Database.Service;
+        const stored = ['Refine the proposal', 'Review the schedule', 'Draft a summary'];
+        testRegistry.set(testCacheAtom, {
+          [db.spaceId]: { generatedAt: Date.now(), prompts: stored },
+        });
+
+        const result = yield* Operation.invoke(AssistantOperation.GenerateHomeSuggestions, { db });
+
+        expect(result.prompts).toEqual(stored);
+      },
+      Effect.provide(TestLayer),
+      TestHelpers.provideTestContext,
+    ),
+  );
+
+  it.effect(
+    'expired cache entry is not used — re-runs and returns empty for empty space',
+    Effect.fnUntraced(
+      function* (_) {
+        const { db } = yield* Database.Service;
+        const stale = ['Stale prompt A', 'Stale prompt B', 'Stale prompt C'];
+        testRegistry.set(testCacheAtom, {
+          [db.spaceId]: { generatedAt: Date.now() - 2 * CACHE_TTL_MS, prompts: stale },
+        });
+
+        // Empty space — expired entry is ignored, no LLM call, no new cache entry written.
+        const result = yield* Operation.invoke(AssistantOperation.GenerateHomeSuggestions, { db });
+
+        expect(result.prompts).toHaveLength(0);
+        // Cache not updated since prompts is empty.
+        const cached = testRegistry.get(testCacheAtom);
+        expect(cached[db.spaceId]?.prompts).toEqual(stale);
+      },
+      Effect.provide(TestLayer),
+      TestHelpers.provideTestContext,
+    ),
+  );
+});

--- a/packages/plugins/plugin-assistant/src/operations/generate-home-suggestions.test.ts
+++ b/packages/plugins/plugin-assistant/src/operations/generate-home-suggestions.test.ts
@@ -2,8 +2,8 @@
 // Copyright 2026 DXOS.org
 //
 
-import { describe, expect, it } from '@effect/vitest';
 import { Registry, Atom } from '@effect-atom/atom-react';
+import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 

--- a/packages/plugins/plugin-assistant/src/operations/generate-home-suggestions.ts
+++ b/packages/plugins/plugin-assistant/src/operations/generate-home-suggestions.ts
@@ -73,14 +73,16 @@ const handler: Operation.WithHandler<typeof AssistantOperation.GenerateHomeSugge
           }
         }
 
-        if (prompts.length > 0) {
+        const validPrompts = prompts.map((p) => p.trim()).filter((p) => p.length > 0);
+
+        if (validPrompts.length > 0) {
           yield* Capabilities.updateAtomValue(AssistantCapabilities.HomeSuggestionsCache, (current) => ({
             ...current,
-            [spaceId]: { generatedAt: Date.now(), prompts },
+            [spaceId]: { generatedAt: Date.now(), prompts: validPrompts },
           }));
         }
 
-        return { prompts };
+        return { prompts: validPrompts };
       }),
     ),
   );

--- a/packages/plugins/plugin-assistant/src/operations/generate-home-suggestions.ts
+++ b/packages/plugins/plugin-assistant/src/operations/generate-home-suggestions.ts
@@ -7,9 +7,9 @@ import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 
+import { AiService } from '@dxos/ai';
 import { Capabilities, Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-import { AiService } from '@dxos/ai';
 import { Operation } from '@dxos/compute';
 import { Collection, Filter, Obj, Order, Query, Type } from '@dxos/echo';
 import { HiddenAnnotation, getTypeAnnotation } from '@dxos/echo/Annotation';

--- a/packages/plugins/plugin-assistant/src/operations/generate-home-suggestions.ts
+++ b/packages/plugins/plugin-assistant/src/operations/generate-home-suggestions.ts
@@ -1,0 +1,109 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as LanguageModel from '@effect/ai/LanguageModel';
+import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
+import * as Schema from 'effect/Schema';
+
+import { Capabilities, Capability } from '@dxos/app-framework';
+import { AppCapabilities } from '@dxos/app-toolkit';
+import { AiService } from '@dxos/ai';
+import { Operation } from '@dxos/compute';
+import { Collection, Filter, Obj, Order, Query, Type } from '@dxos/echo';
+import { HiddenAnnotation, getTypeAnnotation } from '@dxos/echo/Annotation';
+import { Kind as EntityKind } from '@dxos/echo/Entity';
+import { log } from '@dxos/log';
+
+import { AssistantCapabilities, AssistantOperation } from '#types';
+
+const MODEL = 'ai.claude.model.claude-haiku-4-5';
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const RECENT_LIMIT = 20;
+const MAX_PROMPTS = 3;
+
+const handler: Operation.WithHandler<typeof AssistantOperation.GenerateHomeSuggestions> =
+  AssistantOperation.GenerateHomeSuggestions.pipe(
+    Operation.withHandler(
+      Effect.fnUntraced(function* ({ db }) {
+        const spaceId = db.spaceId;
+
+        // Cache check: return early if a fresh result exists.
+        const cache = yield* Capabilities.getAtomValue(AssistantCapabilities.HomeSuggestionsCache);
+        const entry = cache[spaceId];
+        if (entry && Date.now() - entry.generatedAt < CACHE_TTL_MS) {
+          return { prompts: [...entry.prompts] };
+        }
+
+        // Build the recent-objects filter (mirrors SpaceHomeRecent).
+        const schemas = yield* Capability.getAll(AppCapabilities.Schema);
+        const collectionTypename = Type.getTypename(Collection.Collection);
+        const types = schemas
+          .flat()
+          .filter(Type.isType)
+          .filter((type) => getTypeAnnotation(Type.getSchema(type))?.kind !== EntityKind.Relation)
+          .filter((type) => !HiddenAnnotation.get(Type.getSchema(type)).pipe(Option.getOrElse(() => false)))
+          .filter((type) => Type.getTypename(type) !== collectionTypename);
+
+        let prompts: string[] = [];
+
+        if (types.length > 0) {
+          const objects = yield* Effect.promise(() =>
+            db
+              .query(
+                Query.select(Filter.or(...types.map((type) => Filter.type(type))))
+                  .orderBy(Order.updated('desc'))
+                  .limit(RECENT_LIMIT),
+              )
+              .run(),
+          );
+
+          const items = objects
+            .filter(Obj.isObject)
+            .filter((obj) => !Obj.isDeleted(obj))
+            .flatMap((obj): { label: string; typename: string }[] => {
+              const label = Obj.getLabel(obj);
+              const typename = Obj.getTypename(obj);
+              return label && typename ? [{ label, typename }] : [];
+            });
+
+          if (items.length > 0) {
+            prompts = yield* generateSuggestions(items);
+          }
+        }
+
+        if (prompts.length > 0) {
+          yield* Capabilities.updateAtomValue(AssistantCapabilities.HomeSuggestionsCache, (current) => ({
+            ...current,
+            [spaceId]: { generatedAt: Date.now(), prompts },
+          }));
+        }
+
+        return { prompts };
+      }),
+    ),
+  );
+
+const generateSuggestions = (items: { label: string; typename: string }[]) =>
+  Effect.scoped(
+    LanguageModel.generateObject({
+      schema: Schema.Struct({ prompts: Schema.Array(Schema.String) }),
+      prompt: [
+        'Generate exactly 3 short, imperative, specific starter prompts for an AI assistant with access to this workspace.',
+        'Each prompt must be one sentence, at most 10 words, with no markdown or numbering.',
+        '',
+        'Recent workspace objects:',
+        ...items.map(({ label, typename }) => `- ${label} (${typename})`),
+      ].join('\n'),
+    }),
+  ).pipe(
+    Effect.map(({ value }) => [...value.prompts.slice(0, MAX_PROMPTS)]),
+    Effect.catchAll((err) => {
+      log.warn('generate-home-suggestions: LLM call failed', { err });
+      return Effect.succeed<string[]>([]);
+    }),
+    Effect.provide(AiService.model(MODEL)),
+  );
+
+export default handler;

--- a/packages/plugins/plugin-assistant/src/operations/index.ts
+++ b/packages/plugins/plugin-assistant/src/operations/index.ts
@@ -8,6 +8,7 @@ export const AssistantOperationHandlerSet = OperationHandlerSet.lazy(
   () => import('./create-chat'),
   () => import('./ensure-companion-chat'),
   () => import('./fork-chat'),
+  () => import('./generate-home-suggestions'),
   () => import('./resolve-navigation-targets'),
   () => import('./run-prompt-in-new-chat'),
   () => import('./set-current-chat'),

--- a/packages/plugins/plugin-assistant/src/types/AssistantCapabilities.ts
+++ b/packages/plugins/plugin-assistant/src/types/AssistantCapabilities.ts
@@ -38,9 +38,9 @@ export const HomeSuggestionsCacheSchema = Schema.mutable(
   Schema.Record({
     key: Schema.String,
     value: Schema.Struct({
-      /** Epoch ms timestamp of the last generation attempt (success, empty, or failure). */
+      /** Epoch ms timestamp of the successful generation that produced these prompts. */
       generatedAt: Schema.Number,
-      /** Generated prompts; empty array means fall back to hardcoded defaults. */
+      /** Non-empty, trimmed prompts from a successful generation. */
       prompts: Schema.Array(Schema.String),
     }),
   }),

--- a/packages/plugins/plugin-assistant/src/types/AssistantCapabilities.ts
+++ b/packages/plugins/plugin-assistant/src/types/AssistantCapabilities.ts
@@ -33,3 +33,21 @@ export const State = Capability.make<Atom.Writable<AssistantState>>(`${meta.prof
 export const CompanionChatCache = Capability.make<Atom.Writable<Record<string, Obj.Unknown | undefined>>>(
   `${meta.profile.key}.capability.companion-chat-cache`,
 );
+
+export const HomeSuggestionsCacheSchema = Schema.mutable(
+  Schema.Record({
+    key: Schema.String,
+    value: Schema.Struct({
+      /** Epoch ms timestamp of the last generation attempt (success, empty, or failure). */
+      generatedAt: Schema.Number,
+      /** Generated prompts; empty array means fall back to hardcoded defaults. */
+      prompts: Schema.Array(Schema.String),
+    }),
+  }),
+);
+export type HomeSuggestionsCache = Schema.Schema.Type<typeof HomeSuggestionsCacheSchema>;
+
+/** Per-space cache of LLM-generated home starter prompts, persisted across page reloads. */
+export const HomeSuggestionsCache = Capability.make<Atom.Writable<HomeSuggestionsCache>>(
+  `${meta.profile.key}.capability.home-suggestions-cache`,
+);

--- a/packages/plugins/plugin-assistant/src/types/AssistantOperation.ts
+++ b/packages/plugins/plugin-assistant/src/types/AssistantOperation.ts
@@ -124,6 +124,19 @@ export const SkillForm = Schema.Struct({
   description: Schema.optional(Schema.String),
 });
 
+export const GenerateHomeSuggestions = Operation.make({
+  meta: {
+    key: makeKey('generateHomeSuggestions'),
+    name: 'Generate Home Suggestions',
+    icon: 'ph--sparkle--regular',
+    // Internal UI operation — not exposed as an agent tool.
+    skipRegistry: true,
+  },
+  services: [Capability.Service, AiService.AiService],
+  input: Schema.Struct({ db: Database.Database }),
+  output: Schema.Struct({ prompts: Schema.Array(Schema.String) }),
+});
+
 export const ToggleTracePanelDebug = Operation.make({
   meta: {
     key: makeKey('toggleTracePanelDebug'),


### PR DESCRIPTION
## Summary

- Adds a `GenerateHomeSuggestions` operation that queries the space's recently-modified objects and calls Claude Haiku to produce 3 relevant starter prompts
- Results are cached in localStorage (per space, 1-hour TTL) — only cached when prompts are non-empty, so empty/offline spaces always retry
- `useHomeSuggestions` hook hides the section until the request settles, then shows generated prompts or falls back to the hardcoded defaults
- Invocation passes `spaceId` so the process-affinity `AiService` resolves correctly in the `LayerStack`

## Test plan

- [ ] Open a space with several named objects — after ~1–2s the three suggestion cards appear with content-specific prompts
- [ ] Open a brand-new / empty space — suggestion cards appear with the generic fallback prompts after the operation resolves
- [ ] Clear `localStorage.removeItem('org.dxos.plugin.assistant.home-suggestions')` and reload — prompts regenerate on next visit; cached hit is instant on subsequent visits
- [ ] Take the app offline — suggestion cards appear with fallback prompts (no spinner stuck)
- [ ] Unit tests: `moon run plugin-assistant:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamically generated, per-space home starter prompts powered by an assistant operation and saved in a persistent cache with TTL-based reuse.
  * Updated the Space home suggestions UI to load via `useHomeSuggestions`, hide until ready, and render one card per returned prompt with accessible keyboard/click handling.
  * Exposed the new `useHomeSuggestions` hook for reuse by consumers.
* **Tests**
  * Added tests covering empty-space behavior, cache hits, and stale-cache TTL handling for home suggestions generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->