### PR TITLE
fix(sql-sqlite): checkpoint WAL on export and clear stale sidecars on import

### DIFF
--- a/packages/common/sql-sqlite/src/OpfsPool.ts
+++ b/packages/common/sql-sqlite/src/OpfsPool.ts
@@ -279,11 +279,7 @@ export const writeDatabase = async (database: Uint8Array, dbFilename: string = D
   // Disassociate stale rollback/WAL sidecars left by a previous database. A freshly imported
   // main file paired with a leftover `-wal`/`-shm` (or `-journal`) opens as
   // "database disk image is malformed", so the sidecars must be released alongside the main write.
-  const staleSidecars = new Set([
-    `${associatedPath}-journal`,
-    `${associatedPath}-wal`,
-    `${associatedPath}-shm`,
-  ]);
+  const staleSidecars = new Set([`${associatedPath}-journal`, `${associatedPath}-wal`, `${associatedPath}-shm`]);
   for (const file of files) {
     if (staleSidecars.has(file.associatedPath)) {
       await writeAssociatedPath(file.handle, '', 0);

--- a/packages/common/sql-sqlite/src/OpfsPool.ts
+++ b/packages/common/sql-sqlite/src/OpfsPool.ts
@@ -276,8 +276,16 @@ export const writeDatabase = async (database: Uint8Array, dbFilename: string = D
     await writable.close();
   }
 
+  // Disassociate stale rollback/WAL sidecars left by a previous database. A freshly imported
+  // main file paired with a leftover `-wal`/`-shm` (or `-journal`) opens as
+  // "database disk image is malformed", so the sidecars must be released alongside the main write.
+  const staleSidecars = new Set([
+    `${associatedPath}-journal`,
+    `${associatedPath}-wal`,
+    `${associatedPath}-shm`,
+  ]);
   for (const file of files) {
-    if (file.associatedPath === `${associatedPath}-journal`) {
+    if (staleSidecars.has(file.associatedPath)) {
       await writeAssociatedPath(file.handle, '', 0);
     }
   }

--- a/packages/common/sql-sqlite/src/OpfsWorker.ts
+++ b/packages/common/sql-sqlite/src/OpfsWorker.ts
@@ -22,6 +22,7 @@ import { AccessHandlePoolVFS } from '@dxos/wa-sqlite/src/examples/AccessHandlePo
 
 import {
   applyOpfsPragmas,
+  checkpointWal,
   DEFAULT_JOURNAL_MODE,
   DEFAULT_SYNCHRONOUS,
   type SqliteJournalMode,
@@ -115,6 +116,9 @@ export const run = (options: OpfsWorkerConfig): Effect.Effect<void, SqlError.Sql
             case 'export': {
               const [, id] = message;
               messageId = id;
+              // Checkpoint so the snapshot reflects all committed WAL frames and the on-disk
+              // main file is left authoritative (raw pool reads stay correct).
+              checkpointWal(sqlite3, db);
               const data = sqlite3.serialize(db, 'main');
               options.port.postMessage([id, undefined, data], [data.buffer]);
               return;

--- a/packages/common/sql-sqlite/src/internal/opfs-client.ts
+++ b/packages/common/sql-sqlite/src/internal/opfs-client.ts
@@ -28,6 +28,7 @@ import { AccessHandlePoolVFS } from '@dxos/wa-sqlite/src/examples/AccessHandlePo
 
 import {
   applyOpfsPragmas,
+  checkpointWal,
   DEFAULT_JOURNAL_MODE,
   DEFAULT_SYNCHRONOUS,
   type SqliteJournalMode,
@@ -241,7 +242,12 @@ export const makeOpfs = (
           );
         },
         export: Effect.try({
-          try: () => sqlite3.serialize(db, 'main'),
+          // Checkpoint so the serialized snapshot (and the on-disk main file) reflects all
+          // committed WAL frames; leaves the WAL empty so a later raw pool read stays correct.
+          try: () => {
+            checkpointWal(sqlite3, db);
+            return sqlite3.serialize(db, 'main');
+          },
           catch: (cause) => new SqlError.SqlError({ cause, message: 'Failed to export database' }),
         }),
         import: (data: Uint8Array) =>

--- a/packages/common/sql-sqlite/src/internal/opfs-pragmas.ts
+++ b/packages/common/sql-sqlite/src/internal/opfs-pragmas.ts
@@ -45,9 +45,22 @@ export const applyOpfsPragmas = (sqlite3: Sqlite3, db: number, options: OpfsPrag
  * Required before any raw (non-SQLite) read of the OPFS pool file so the main file is
  * authoritative and no committed data is stranded in the `-wal` sidecar. A harmless no-op
  * when the connection is not in WAL mode (per SQLite `wal_checkpoint` semantics).
+ * Throws if the checkpoint is blocked or skipped (status ≠ 0), which would leave committed
+ * frames in the sidecar and cause the serialized snapshot to be incomplete.
  */
 export const checkpointWal = (sqlite3: Sqlite3, db: number): void => {
   for (const stmt of sqlite3.statements(db, 'PRAGMA wal_checkpoint(TRUNCATE)')) {
-    while (sqlite3.step(stmt) === WaSqlite.SQLITE_ROW) {}
+    let status: number | undefined;
+    while (sqlite3.step(stmt) === WaSqlite.SQLITE_ROW) {
+      const row = sqlite3.row(stmt);
+      // wal_checkpoint returns (busy, log, checkpointed); first column is 0=OK, 1=BUSY, 2=PASSTHROUGH.
+      const first = row[0];
+      if (typeof first === 'number') {
+        status = first;
+      }
+    }
+    if (status !== undefined && status !== 0) {
+      throw new Error(`WAL checkpoint incomplete (status=${status}); export would omit committed frames.`);
+    }
   }
 };

--- a/packages/common/sql-sqlite/src/internal/opfs-pragmas.ts
+++ b/packages/common/sql-sqlite/src/internal/opfs-pragmas.ts
@@ -39,3 +39,15 @@ export const applyOpfsPragmas = (sqlite3: Sqlite3, db: number, options: OpfsPrag
     }
   }
 };
+
+/**
+ * Force a full WAL checkpoint into the main database file and truncate the WAL.
+ * Required before any raw (non-SQLite) read of the OPFS pool file so the main file is
+ * authoritative and no committed data is stranded in the `-wal` sidecar. A harmless no-op
+ * when the connection is not in WAL mode (per SQLite `wal_checkpoint` semantics).
+ */
+export const checkpointWal = (sqlite3: Sqlite3, db: number): void => {
+  for (const stmt of sqlite3.statements(db, 'PRAGMA wal_checkpoint(TRUNCATE)')) {
+    while (sqlite3.step(stmt) === WaSqlite.SQLITE_ROW) {}
+  }
+};

--- a/packages/common/sql-sqlite/src/testing/01-opfs-worker-protocol.browser.test.ts
+++ b/packages/common/sql-sqlite/src/testing/01-opfs-worker-protocol.browser.test.ts
@@ -63,4 +63,52 @@ describe('opfs-worker protocol browser test', { timeout: 60_000, sequential: tru
       await shutdownWorker(worker);
     }
   });
+
+  test('export checkpoints committed WAL frames into the raw pool main file', async () => {
+    // Worker A: write data (committed to the WAL), export (triggers wal_checkpoint(TRUNCATE)),
+    // then read the raw on-disk main file while A is still alive — before any close-time checkpoint.
+    const workerA = spawnOpfsWorker();
+    let payloadDuringSession: Uint8Array;
+    try {
+      await waitForWorkerMessage(workerA, ([id]) => id === 'ready');
+      await runSqlOnWorker(workerA, 1, 'CREATE TABLE IF NOT EXISTS checkpoint_probe (value TEXT)');
+      await runSqlOnWorker(workerA, 2, "INSERT INTO checkpoint_probe (value) VALUES ('committed-via-wal')");
+
+      const exportId = 3;
+      const exportPromise = waitForWorkerMessage(workerA, ([id]) => id === exportId);
+      workerA.postMessage(['export', exportId]);
+      const [, exportError] = await exportPromise;
+      expect(exportError).toBeUndefined();
+
+      payloadDuringSession = await OpfsPool.readDatabase(OpfsPool.DEFAULT_DB_FILENAME);
+      expect(OpfsPool.isValidSqliteDatabase(payloadDuringSession)).toBe(true);
+    } finally {
+      await shutdownWorker(workerA);
+    }
+
+    // Worker B: re-import the captured raw payload and confirm the committed row survived,
+    // proving export flushed the WAL into the main file (not lost in a `-wal` sidecar).
+    const workerB = spawnOpfsWorker();
+    try {
+      await waitForWorkerMessage(workerB, ([id]) => id === 'ready');
+
+      const importId = 1;
+      const importCopy = new Uint8Array(payloadDuringSession.byteLength);
+      importCopy.set(payloadDuringSession);
+      const importPromise = waitForWorkerMessage(workerB, ([id]) => id === importId);
+      workerB.postMessage(['import', importId, importCopy], [importCopy.buffer]);
+      const [, importError] = await importPromise;
+      expect(importError).toBeUndefined();
+
+      const queryId = 2;
+      const queryPromise = waitForWorkerMessage(workerB, ([id]) => id === queryId);
+      workerB.postMessage([queryId, 'SELECT value FROM checkpoint_probe ORDER BY rowid', []]);
+      const [, queryError, results] = await queryPromise;
+      expect(queryError).toBeUndefined();
+      const [, rows] = results as [string[], unknown[][]];
+      expect(rows).toEqual([['committed-via-wal']]);
+    } finally {
+      await shutdownWorker(workerB);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Hardens OPFS SQLite export/import against WAL-mode inconsistencies introduced when WAL became the default journal mode (#11969).

- **Export checkpoints the WAL.** `OpfsWorker` and the in-process OPFS client now call `PRAGMA wal_checkpoint(TRUNCATE)` (via a new `checkpointWal` helper) before `sqlite3.serialize`. This ensures the serialized snapshot — and the on-disk main file — reflect all committed WAL frames. Without it, a raw (non-SQLite) pool read can miss data stranded in the `-wal` sidecar and surface as `database disk image is malformed`.
- **Import clears stale sidecars.** `OpfsPool.writeDatabase` now releases stale `-wal`/`-shm` sidecars in addition to `-journal`. A freshly written main file paired with a leftover sidecar from a previous database opens as malformed.
- **Test.** Adds a two-worker browser test: worker A writes a row (committed to the WAL) and exports (triggering the checkpoint); worker B re-imports the captured raw main-file bytes and confirms the row survived — proving export flushes the WAL into the main file rather than losing it in a sidecar.

## Context

While investigating `database disk image is malformed` errors in `app.log`, the root cause traced to WAL-mode sidecar inconsistency between the main pool file and leftover `-wal`/`-shm` files during import/upgrade, plus raw pool reads that ignore un-checkpointed WAL frames.

> Note: a separate foot-gun remains — running the Composer app (dedicated worker, OPFS+WAL) concurrently with the recovery UI on the same origin produces a live `-wal` and corrupts raw reads. A guard that refuses recovery operations while another context holds the storage lock is tracked separately.

## Test plan

- [ ] `moon run sql-sqlite:test` (incl. new browser test)
- [ ] Manual: import a `.dxprofile` via recovery UI with the app fully closed, run diagnostics, verify no `-wal` and `integrity: ok`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exported database snapshots now include all committed changes from write-ahead logging, reducing the risk of missing recent updates.
  * Stale SQLite sidecar files are now cleaned up more reliably during writes, including journal, WAL, and shared-memory files.
* **Tests**
  * Added browser coverage to verify exports produce a valid database file and preserve inserted data after re-import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->