### PR TITLE
fix(plugin-routine): schedule routine instructions in process monitor

### DIFF
--- a/packages/plugins/plugin-routine/src/operations/run-routine.ts
+++ b/packages/plugins/plugin-routine/src/operations/run-routine.ts
@@ -26,7 +26,11 @@ const handler: Operation.WithHandler<typeof RoutineOperation.RunRoutine> = Routi
       if (spec?.kind === 'instructions') {
         // The instructions carry their own context objects and skills; RunInstructions binds them when it
         // executes. No Chat session object is created — the run appears in the process monitor only.
-        yield* Operation.schedule(RunInstructions, { instructions: spec.instructions, input: {} }, { spaceId: db.spaceId });
+        yield* Operation.schedule(
+          RunInstructions,
+          { instructions: spec.instructions, input: {} },
+          { spaceId: db.spaceId },
+        );
         return;
       }
 

--- a/packages/plugins/plugin-routine/src/operations/run-routine.ts
+++ b/packages/plugins/plugin-routine/src/operations/run-routine.ts
@@ -4,6 +4,7 @@
 
 import * as Effect from 'effect/Effect';
 
+import { RunInstructions } from '@dxos/assistant-toolkit';
 import { Operation } from '@dxos/compute';
 import { Database, Obj } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
@@ -11,8 +12,8 @@ import { invariant } from '@dxos/invariant';
 import { RoutineOperation } from '../types';
 
 // A routine's action is its `runnable`: either an Operation (invoked directly) or the routine's owned
-// Instructions object (run as an agent prompt in a new background chat — the same path the assistant uses —
-// so its instructions and skills take effect).
+// Instructions object (run as a background process — the same path triggers use — without creating a new
+// Chat session object).
 const handler: Operation.WithHandler<typeof RoutineOperation.RunRoutine> = RoutineOperation.RunRoutine.pipe(
   Operation.withHandler(
     Effect.fnUntraced(function* ({ routine }) {
@@ -23,13 +24,9 @@ const handler: Operation.WithHandler<typeof RoutineOperation.RunRoutine> = Routi
       // The action kind is explicit in `spec`; dispatch by kind rather than dereferencing to classify.
       const spec = routineObj.spec;
       if (spec?.kind === 'instructions') {
-        // The instructions carry their own context objects and skills; RunInstructions binds them to the
-        // session, so the run does not forward context separately.
-        yield* Operation.invoke(RoutineOperation.RunPromptInNewChat, {
-          db,
-          instructions: spec.instructions,
-          background: true,
-        });
+        // The instructions carry their own context objects and skills; RunInstructions binds them when it
+        // executes. No Chat session object is created — the run appears in the process monitor only.
+        yield* Operation.schedule(RunInstructions, { instructions: spec.instructions, input: {} }, { spaceId: db.spaceId });
         return;
       }
 


### PR DESCRIPTION
## Summary
- Schedule instruction-based routines through `RunInstructions` instead of opening a new chat session.
- Keep the run visible in the process monitor while avoiding creation of a `Chat` session object.
- Preserve direct operation invocation for non-instruction routine specs.

## Testing
- Not run (PR summary generated from diff only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * “Instructions” routines now execute as background processes and show up in the process monitor instead of opening a new chat session.
  * Routine execution behavior for standard runnable items remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->