### PR TITLE
feat(config): configure sandbox service URL for deployed envs

### DIFF
--- a/packages/apps/composer-app/dx.yml
+++ b/packages/apps/composer-app/dx.yml
@@ -17,6 +17,8 @@ runtime:
       - urls: https://edge-production.dxos.workers.dev/ice
     ai:
       server: https://ai-service.dxos.workers.dev
+    sandbox:
+      url: https://sandbox-service.dxos.workers.dev
     ipfs:
       server: https://api.ipfs.dxos.network/api/v0
       gateway: https://gateway.ipfs.dxos.network/ipfs

--- a/packages/sdk/config/AUDIT.md
+++ b/packages/sdk/config/AUDIT.md
@@ -42,9 +42,9 @@ Three independent sources currently encode the same URLs:
 | Source                                                          | What it sets                                                        |
 | --------------------------------------------------------------- | ------------------------------------------------------------------- |
 | [`config-service.ts`](src/config-service.ts) `defaultConfig`    | `edge.url`, `iceProviders`, `ai.server`, `ipfs.*`                   |
-| [`preset.ts`](src/preset.ts) `configPreset`                     | `edge.url` per `local/dev/main/production`                          |
-| [`composer-app/dx.yml`](../../apps/composer-app/dx.yml)         | production `edge`, `iceProviders`, `ai`, `ipfs`                     |
-| [`composer-app/dx-env.yml`](../../apps/composer-app/dx-env.yml) | `DX_EDGE_BASE_URL`→`edge.url`, `DX_EDGE_AI_SERVICE_URL`→`ai.server` |
+| [`preset.ts`](src/preset.ts) `configPreset`                     | `edge.url`, `sandbox.url` per `local/dev/main/production`           |
+| [`composer-app/dx.yml`](../../apps/composer-app/dx.yml)         | production `edge`, `iceProviders`, `ai`, `sandbox`, `ipfs`          |
+| [`composer-app/dx-env.yml`](../../apps/composer-app/dx-env.yml) | `DX_EDGE_BASE_URL`→`edge.url`, `DX_EDGE_AI_SERVICE_URL`→`ai.server`, `DX_SANDBOX_SERVICE_URL`→`sandbox.url` |
 
 The production EDGE host (`edge-production.dxos.workers.dev`) and AI host
 (`ai-service.dxos.workers.dev`) are duplicated across all four. Any other service

--- a/packages/sdk/config/AUDIT.md
+++ b/packages/sdk/config/AUDIT.md
@@ -39,11 +39,11 @@ config.proto  ──build-protobuf──▶  @dxos/protocols (ConfigProto type)
 
 Three independent sources currently encode the same URLs:
 
-| Source                                                          | What it sets                                                        |
-| --------------------------------------------------------------- | ------------------------------------------------------------------- |
-| [`config-service.ts`](src/config-service.ts) `defaultConfig`    | `edge.url`, `iceProviders`, `ai.server`, `ipfs.*`                   |
-| [`preset.ts`](src/preset.ts) `configPreset`                     | `edge.url`, `sandbox.url` per `local/dev/main/production`           |
-| [`composer-app/dx.yml`](../../apps/composer-app/dx.yml)         | production `edge`, `iceProviders`, `ai`, `sandbox`, `ipfs`          |
+| Source                                                          | What it sets                                                                                                |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [`config-service.ts`](src/config-service.ts) `defaultConfig`    | `edge.url`, `iceProviders`, `ai.server`, `ipfs.*`                                                           |
+| [`preset.ts`](src/preset.ts) `configPreset`                     | `edge.url`, `sandbox.url` per `local/dev/main/production`                                                   |
+| [`composer-app/dx.yml`](../../apps/composer-app/dx.yml)         | production `edge`, `iceProviders`, `ai`, `sandbox`, `ipfs`                                                  |
 | [`composer-app/dx-env.yml`](../../apps/composer-app/dx-env.yml) | `DX_EDGE_BASE_URL`→`edge.url`, `DX_EDGE_AI_SERVICE_URL`→`ai.server`, `DX_SANDBOX_SERVICE_URL`→`sandbox.url` |
 
 The production EDGE host (`edge-production.dxos.workers.dev`) and AI host

--- a/packages/sdk/config/src/preset.ts
+++ b/packages/sdk/config/src/preset.ts
@@ -28,12 +28,13 @@ const edgeUrl = (edge: NonNullable<ConfigPresetOptions['edge']>) =>
     Match.exhaustive,
   );
 
+// TODO(burdon): Hosted environments share a single worker until per-env deployments exist.
 const sandboxUrl = (sandbox: NonNullable<ConfigPresetOptions['sandbox']>) =>
   Match.value(sandbox).pipe(
     Match.when('local', () => 'http://localhost:8792'),
-    Match.when('dev', () => 'https://sandbox.dxos.workers.dev'),
-    Match.when('main', () => 'https://sandbox-main.dxos.workers.dev'),
-    Match.when('production', () => 'https://sandbox-production.dxos.workers.dev'),
+    Match.when('dev', () => 'https://sandbox-service.dxos.workers.dev'),
+    Match.when('main', () => 'https://sandbox-service.dxos.workers.dev'),
+    Match.when('production', () => 'https://sandbox-service.dxos.workers.dev'),
     Match.exhaustive,
   );
 


### PR DESCRIPTION
## Summary

Sandboxes were failing in deployed environments because `runtime.services.sandbox.url` was never set in the deployed config — `getSandboxServiceUrl()` throws when it's missing. Local dev already had the URL in `dx-local.yml`, but the production `dx.yml` did not.

This follows the same pattern as `edge.url` / `ai.server`:

- **`composer-app/dx.yml`** — add `runtime.services.sandbox.url: https://sandbox-service.dxos.workers.dev` alongside the existing `edge`/`ai` service entries, so the deployed app can reach the sandbox service. (The `DX_SANDBOX_SERVICE_URL` env mapping in `dx-env.yml` already existed for per-deploy overrides.)
- **`config/preset.ts`** — point the hosted `configPreset` envs (`dev`/`main`/`production`) at the single `sandbox-service.dxos.workers.dev` worker, since the previously-referenced per-env worker names don't exist yet. `local` continues to target the localhost worker (`http://localhost:8792`). A TODO notes these will diverge once per-env deployments exist.
- **`config/AUDIT.md`** — keep the config-source table accurate (`sandbox` in `dx.yml`, `sandbox.url` in preset, `DX_SANDBOX_SERVICE_URL` mapping).

## Testing

- `moon run config:build` — passes.
- `moon run plugin-sandbox:test` — passes (live network tests remain skipped without a running worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014VE5BDjrYjiE2gpRur34Rj

---
_Generated by [Claude Code](https://claude.ai/code/session_014VE5BDjrYjiE2gpRur34Rj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new sandbox service endpoint in app runtime configuration.
  * Hosted environments now resolve to a shared sandbox service URL for consistent behavior across environments.
* **Documentation**
  * Updated configuration docs to include the sandbox service setting and clarify how environment overrides apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->