### PR TITLE
feat(react-ui): default Dialog and AlertDialog gutter to 'lg'

### DIFF
--- a/packages/ui/react-ui/src/components/Dialog/AlertDialog.tsx
+++ b/packages/ui/react-ui/src/components/Dialog/AlertDialog.tsx
@@ -122,7 +122,7 @@ const AlertDialogContent: ForwardRefExoticComponent<AlertDialogContentProps> = f
       className={tx('dialog.content', { inOverlayLayout, size }, classNames)}
       ref={forwardedRef}
     >
-      <Column.Root classNames='dx-expander' gutter='md'>
+      <Column.Root classNames='dx-expander' gutter='lg'>
         {children}
       </Column.Root>
     </AlertDialogPrimitive.Content>

--- a/packages/ui/react-ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/react-ui/src/components/Dialog/Dialog.tsx
@@ -127,7 +127,7 @@ const DialogContent: ForwardRefExoticComponent<DialogContentProps> = forwardRef<
         )}
         ref={forwardedRef}
       >
-        <Column.Root classNames='dx-expander' gutter='md'>
+        <Column.Root classNames='dx-expander' gutter='lg'>
           {children}
         </Column.Root>
       </DialogPrimitive.Content>


### PR DESCRIPTION
## What

Change the default `Column` gutter inside `Dialog` and `AlertDialog` content from `'md'` to `'lg'`.

## Why

`'lg'` gives more comfortable default spacing for dialog content.

## Changes

- `packages/ui/react-ui/src/components/Dialog/Dialog.tsx`
- `packages/ui/react-ui/src/components/Dialog/AlertDialog.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dialog and alert dialog spacing for a roomier content layout.
  * Increased the gap inside dialog content areas, improving visual balance and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->