### PR TITLE
chore(deps): bump @automerge/automerge to 3.3.0-fragments.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1850,7 +1850,7 @@ catalogs:
       version: 8.8.5
 
 overrides:
-  '@automerge/automerge': 3.3.0-fragments.1
+  '@automerge/automerge': 3.3.0-fragments.2
   '@automerge/automerge-subduction': 0.16.0
   '@dxos/docs>vite': ^7.3.2
   '@grpc/grpc-js': '>=1.10.9'
@@ -2316,8 +2316,8 @@ importers:
   .agents/skills/composer-forensics/scripts:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
         version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
@@ -2398,8 +2398,8 @@ importers:
         specifier: 'catalog:'
         version: 3.2.10(@types/react@19.2.14)(react@19.2.6)
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
         version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
@@ -4653,8 +4653,8 @@ importers:
   packages/core/compute/assistant:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/ai':
         specifier: workspace:*
         version: link:../ai
@@ -5429,8 +5429,8 @@ importers:
         version: 1.6.0
     devDependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@aws-sdk/client-s3':
         specifier: 3.955.0
         version: 3.955.0
@@ -5743,8 +5743,8 @@ importers:
   packages/core/echo/echo-client:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
         version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
@@ -5837,8 +5837,8 @@ importers:
   packages/core/echo/echo-client-e2e:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/async':
         specifier: workspace:*
         version: link:../../../common/async
@@ -5885,8 +5885,8 @@ importers:
   packages/core/echo/echo-doc:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/echo':
         specifier: workspace:*
         version: link:../echo
@@ -5909,8 +5909,8 @@ importers:
   packages/core/echo/echo-generator:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/client':
         specifier: workspace:*
         version: link:../../../sdk/client
@@ -5943,8 +5943,8 @@ importers:
   packages/core/echo/echo-host:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
         version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
@@ -7264,8 +7264,8 @@ importers:
   packages/devtools/devtools:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -7668,8 +7668,8 @@ importers:
   packages/e2e/blade-runner:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
         version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
@@ -11782,8 +11782,8 @@ importers:
   packages/plugins/plugin-markdown:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@codemirror/state':
         specifier: 'catalog:'
         version: 6.6.0
@@ -13744,8 +13744,8 @@ importers:
   packages/plugins/plugin-script:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.20.2
@@ -14591,8 +14591,8 @@ importers:
   packages/plugins/plugin-sketch:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -17213,8 +17213,8 @@ importers:
         version: 2.11.0
     devDependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/echo-client':
         specifier: workspace:*
         version: link:../../core/echo/echo-client
@@ -17243,8 +17243,8 @@ importers:
   packages/sdk/client:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
         version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
@@ -17469,8 +17469,8 @@ importers:
   packages/sdk/client-services:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
         version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
@@ -17732,8 +17732,8 @@ importers:
   packages/sdk/migrations:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
         version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
@@ -18034,8 +18034,8 @@ importers:
         version: 3.21.3
     devDependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/react-client':
         specifier: workspace:*
         version: link:../react-client
@@ -20056,8 +20056,8 @@ importers:
   packages/ui/react-ui-editor:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.20.2
@@ -22098,8 +22098,8 @@ importers:
   packages/ui/ui-editor:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.20.2
@@ -23160,8 +23160,8 @@ packages:
   '@automerge/automerge-subduction@0.16.0':
     resolution: {integrity: sha512-BOOn/4p8cF4LhjDUQdgM3qyZFya+M7ZuZywuC99x/kbhk4UK7dw/QcsifcHG5E1TAW4R/K17ZGFUC5nCVUSSWg==}
 
-  '@automerge/automerge@3.3.0-fragments.1':
-    resolution: {integrity: sha512-Im2n3qcYSuIsLDSjofTRo7CZyyvFn5pKLSCCO5sjWzESw+9q9G25ZIrL2mczDX43cXtyzi+w/4b9VUaiNdY56Q==}
+  '@automerge/automerge@3.3.0-fragments.2':
+    resolution: {integrity: sha512-F5KL+YXD0GMFH/as0/kJ3+lotpuJsH1SSrhhKdYSGtR+S9ytBNTw+s3pAjF2Vr0+ZdTMHxsGjqj5SRkJiSNokQ==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -42100,7 +42100,7 @@ snapshots:
 
   '@automerge/automerge-repo@2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)':
     dependencies:
-      '@automerge/automerge': 3.3.0-fragments.1
+      '@automerge/automerge': 3.3.0-fragments.2
       '@automerge/automerge-subduction': 0.16.0(patch_hash=6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669)
       bs58check: 4.0.0
       cbor-x: 1.6.4
@@ -42118,7 +42118,7 @@ snapshots:
 
   '@automerge/automerge-subduction@0.16.0(patch_hash=6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669)': {}
 
-  '@automerge/automerge@3.3.0-fragments.1': {}
+  '@automerge/automerge@3.3.0-fragments.2': {}
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,7 +25,7 @@ catalog:
   '@atlaskit/pragmatic-drag-and-drop-hitbox': 1.1.0
   '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator': 3.2.10
   '@atproto/api': ^0.19.5
-  '@automerge/automerge': 3.3.0-fragments.1
+  '@automerge/automerge': 3.3.0-fragments.2
   '@automerge/automerge-repo': 2.6.0-subduction.37
   '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.37
   '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.37


### PR DESCRIPTION
## Summary

- Bumps `@automerge/automerge` from `3.3.0-fragments.1` → `3.3.0-fragments.2` (pre-release patch within the "fragments" channel)
- All other automerge packages (`automerge-repo`, `automerge-repo-network-*`, `automerge-repo-storage-indexeddb`, `automerge-subduction`) are already at their latest versions and unchanged

## Classification

**Trivial** — single pre-release patch bump within the existing fragments pre-release channel. No API changes expected.


---
_Generated by [Claude Code](https://claude.ai/code/session_019jMZSwSKfp8EWoFkhNsYq4)_