### PR TITLE
fix(inbox): include year in older short dates

### DIFF
--- a/packages/plugins/plugin-inbox/src/util/util.ts
+++ b/packages/plugins/plugin-inbox/src/util/util.ts
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import { format, formatDistance, isThisWeek, isToday } from 'date-fns';
+import { format, formatDistance, isThisWeek, isThisYear, isToday } from 'date-fns';
 
 import { Obj } from '@dxos/echo';
 import { type Message } from '@dxos/types';
@@ -140,7 +140,13 @@ export const formatDateTime = (date: Date, now: Date, options?: FormatDateTimeOp
         : formatDistance(date, now, { addSuffix: true });
 
 export const formatShortDate = (date: Date) =>
-  isToday(date) ? format(date, 'hh:mm aaa') : isThisWeek(date) ? format(date, 'EEEE') : format(date, 'MMM d');
+  isToday(date)
+    ? format(date, 'hh:mm aaa')
+    : isThisWeek(date)
+      ? format(date, 'EEEE')
+      : isThisYear(date)
+        ? format(date, 'MMM d')
+        : format(date, 'MMM d, yyyy');
 
 type MessageProps = {
   id: string;


### PR DESCRIPTION
## Summary
- Update inbox short-date formatting to show the year for messages outside the current year.
- Keep existing behavior for today and earlier this week.
- Import `isThisYear` from `date-fns` to support the new date formatting branch.

## Testing
- Not run (PR description generated from diff only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Cleaned up date formatting code for better readability.
  * Adjusted import formatting and expanded a complex conditional into a clearer multi-line form.
  * No changes to app behavior, date output, or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->