### PR TITLE
feat(space): rename space key label and hide personal danger zone

### DIFF
--- a/packages/plugins/plugin-space/src/containers/SpaceSettingsContainer/SpaceSettingsContainer.tsx
+++ b/packages/plugins/plugin-space/src/containers/SpaceSettingsContainer/SpaceSettingsContainer.tsx
@@ -193,17 +193,17 @@ export const SpaceSettingsContainer = ({ space }: AppSurface.SpaceArticleProps) 
           </Form.Section>
 
           <Form.Section title={t('space-controls.title')} description={t('space-controls.description')}>
-            <Form.Row label={t('space-key.title')} description={t('space-key.description')}>
+            <Form.Row label={t('space-id.title')} description={t('space-id.description')}>
               <div className='flex items-center gap-2'>
                 <Input.Root>
-                  <Input.TextInput value={space.key.toHex()} disabled classNames='flex-1 font-mono text-xs' />
+                  <Input.TextInput value={space.id} disabled classNames='flex-1 font-mono text-xs' />
                 </Input.Root>
                 <IconButton
                   icon='ph--copy--regular'
                   iconOnly
-                  label={t('copy-space-key.label')}
+                  label={t('copy-space-id.label')}
                   onClick={() => {
-                    void navigator.clipboard.writeText(space.key.toHex());
+                    void navigator.clipboard.writeText(space.id);
                   }}
                 />
               </div>

--- a/packages/plugins/plugin-space/src/containers/SpaceSettingsContainer/SpaceSettingsContainer.tsx
+++ b/packages/plugins/plugin-space/src/containers/SpaceSettingsContainer/SpaceSettingsContainer.tsx
@@ -231,8 +231,8 @@ export const SpaceSettingsContainer = ({ space }: AppSurface.SpaceArticleProps) 
             </Form.Row>
           </Form.Section>
 
-          <Form.Section title={t('danger-zone.title')} description={t('danger-zone.description')}>
-            {!personal && (
+          {!personal && (
+            <Form.Section title={t('danger-zone.title')} description={t('danger-zone.description')}>
               <Form.Row label={t('delete-space.title')} description={t('delete-space.description')}>
                 <Dialog.Root open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
                   <Dialog.Trigger asChild>
@@ -266,8 +266,8 @@ export const SpaceSettingsContainer = ({ space }: AppSurface.SpaceArticleProps) 
                   </Dialog.Portal>
                 </Dialog.Root>
               </Form.Row>
-            )}
-          </Form.Section>
+            </Form.Section>
+          )}
         </Form.Content>
       </Form.Viewport>
     </Form.Root>

--- a/packages/plugins/plugin-space/src/translations.ts
+++ b/packages/plugins/plugin-space/src/translations.ts
@@ -266,9 +266,9 @@ export const translations = [
         'hue.description': 'Color used to represent the space in the app.',
         'edge-replication.description':
           "Only change this if you know what you're doing. Disabling this will prevent the space from replicating through Composer's EDGE services, and relies solely on peer-to-peer sync.",
-        'space-key.title': 'Space Key',
+        'space-key.title': 'Space ID',
         'space-key.description': 'The unique identifier for this space. Use this to connect external services.',
-        'copy-space-key.label': 'Copy space key',
+        'copy-space-key.label': 'Copy space ID',
 
         'space-controls.title': 'Space Controls',
         'space-controls.description': 'Advanced controls for this space.',

--- a/packages/plugins/plugin-space/src/translations.ts
+++ b/packages/plugins/plugin-space/src/translations.ts
@@ -266,9 +266,9 @@ export const translations = [
         'hue.description': 'Color used to represent the space in the app.',
         'edge-replication.description':
           "Only change this if you know what you're doing. Disabling this will prevent the space from replicating through Composer's EDGE services, and relies solely on peer-to-peer sync.",
-        'space-key.title': 'Space ID',
-        'space-key.description': 'The unique identifier for this space. Use this to connect external services.',
-        'copy-space-key.label': 'Copy space ID',
+        'space-id.title': 'Space ID',
+        'space-id.description': 'The unique identifier for this space. Use this to connect external services.',
+        'copy-space-id.label': 'Copy space ID',
 
         'space-controls.title': 'Space Controls',
         'space-controls.description': 'Advanced controls for this space.',


### PR DESCRIPTION
## Summary
- Rename the space key label and copy action to use "Space ID" terminology.
- Hide the danger zone section entirely for personal spaces instead of rendering an empty section wrapper.

## Testing
- Not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Updated the “space identity” row to show the Space ID (instead of the Space Key), including the copy-to-clipboard label text.
  * Personal spaces now hide the entire “danger zone” settings section, reducing clutter on the settings page.
* **Localization**
  * Updated English strings to replace “Space Key” terminology with “Space ID,” including the associated title, description, and copy label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->