### PR TITLE
chore(transcription): publish react-ui-transcription and its private deps

### DIFF
--- a/packages/core/compute/nlp/package.json
+++ b/packages/core/compute/nlp/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/nlp",
   "version": "0.9.0",
-  "private": true,
   "description": "Natural-language parsing: per-word UPOS token structure for intention/transcript analysis.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -41,7 +40,7 @@
     "effect": "catalog:"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "beast": {}
 }

--- a/packages/core/compute/transcription-pipeline/package.json
+++ b/packages/core/compute/transcription-pipeline/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/transcription-pipeline",
   "version": "0.9.0",
-  "private": true,
   "description": "Streaming stage pipeline for transcription post-processing (correction, entity extraction, summarization).",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -55,7 +54,7 @@
     "effect": "catalog:"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "beast": {}
 }

--- a/packages/ui/react-ui-transcription/package.json
+++ b/packages/ui/react-ui-transcription/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/react-ui-transcription",
   "version": "0.9.0",
-  "private": true,
   "description": "Browser audio capture, transcription hooks, and UI for the transcription pipeline.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -65,6 +64,6 @@
     "react-dom": "catalog:"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

Makes three packages publishable so they reach **pkg.pr.new** (and npm on release). For each:
- remove `private: true`
- flip `publishConfig.access` from `"restricted"` → `"public"` (matching all other public `@dxos/*` packages)

Packages:
- `@dxos/react-ui-transcription` (`packages/ui/react-ui-transcription`)
- `@dxos/transcription-pipeline` (`packages/core/compute/transcription-pipeline`)
- `@dxos/nlp` (`packages/core/compute/nlp`)

## Why

`@dxos/plugin-assistant` depends on `@dxos/react-ui-transcription`. Because that package (and its private deps `transcription-pipeline` → `nlp`) were `private: true` / `access: restricted`, pkg.pr.new never published them, so downstream consumers that install plugin-assistant from pkg.pr.new (e.g. **dxos/edge**) couldn't resolve the dependency and had to maintain local workspace stubs. Publishing the closure lets edge consume the real packages and drop those stubs.

## Scope / correctness

- These three are the **complete private closure** reachable from `@dxos/react-ui-transcription` (walking `dependencies` + `peerDependencies`). No other private `@dxos/*` packages are pulled in.
- Both lockdown mechanisms had to change: they were marked private via `private: true` **and** `publishConfig.access: "restricted"`.
- Their only non-`@dxos` runtime deps are already public: `@effect/ai`, `wavefile`, `@codemirror/*`, `date-fns`, `extendable-media-recorder(-wav-encoder)`. Intra-closure links are `workspace:*`, which pkg.pr.new rewrites to per-commit URLs, so the chain resolves once all three are public.

## Blast radius

These will now publish to the public npm registry on the next release. If any should stay npm-internal, keep `access: "restricted"` (without `private: true`) instead — flag if so.

Co-Authored-By: Claude <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata for multiple components to remove the “private” flag.
  * Changed publication access settings to be publicly publishable, enabling broader distribution where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->