### PR TITLE
fix(plugin-deck): prevent article remount on companion open/close

### DIFF
--- a/packages/plugins/plugin-deck/src/components/Companion/Companion.tsx
+++ b/packages/plugins/plugin-deck/src/components/Companion/Companion.tsx
@@ -60,6 +60,20 @@ export const Companion = ({
     [companions, t],
   );
 
+  // Stable per-companion data objects so companion article surfaces don't receive a new prop reference on
+  // every parent re-render (the same pattern as the inline data fix in Plank).
+  const companionDataList = useMemo(
+    () =>
+      companions.map((node) => ({
+        attendableId,
+        subject: node.data,
+        companionTo,
+        variant: getLinkedVariant(node.id),
+        properties: node.properties,
+      })),
+    [companions, attendableId, companionTo],
+  );
+
   return (
     <Pane.Root classNames={classNames}>
       <Pane.Toolbar>
@@ -67,19 +81,9 @@ export const Companion = ({
         {controls}
       </Pane.Toolbar>
       {/* Panels stay mounted; the inactive ones are hidden so switching companions preserves their state. */}
-      {companions.map((node) => (
+      {companions.map((node, index) => (
         <Pane.Content key={node.id} classNames={mx(node.id !== selected && 'hidden')}>
-          <Surface.Surface
-            type={AppSurface.Article}
-            data={{
-              attendableId,
-              subject: node.data,
-              companionTo,
-              variant: getLinkedVariant(node.id),
-              properties: node.properties,
-            }}
-            limit={1}
-          />
+          <Surface.Surface type={AppSurface.Article} data={companionDataList[index]} limit={1} />
         </Pane.Content>
       ))}
     </Pane.Root>

--- a/packages/plugins/plugin-deck/src/containers/Deck/DeckPlank.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Deck/DeckPlank.tsx
@@ -149,7 +149,7 @@ export const DeckPlank = memo(
             onKeyDown={handleKeyDown}
           />
         </Splitter.Panel>
-        {companions.length > 0 && (
+        {hasCompanion && (
           <>
             <Splitter.Handle />
             <Splitter.Panel position='end'>

--- a/packages/plugins/plugin-deck/src/containers/Deck/DeckPlank.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Deck/DeckPlank.tsx
@@ -114,13 +114,19 @@ export const DeckPlank = memo(
     // Splitter.Root is always the outer element so <Plank> stays at the same tree position regardless of
     // whether the companion is open. A root-element-type change (Plank ↔ Splitter.Root) would force React
     // to unmount and remount the entire subtree on every companion toggle, resetting article state.
+    //
+    // `mode` drives the animated open/close: switching between 'split' and 'start' triggers the Splitter's
+    // built-in 250ms CSS transition, which slides the companion in/out without a flash. The companion panel
+    // stays mounted while companions exist (collapsed to 0 at mode='start') so the transition always has
+    // something to animate; conditional rendering would remount it on every open, losing companion state.
     return (
       <Splitter.Root
         orientation={companionOrientation}
         anchor='end'
+        mode={hasCompanion ? 'split' : 'start'}
         resizable={hasCompanion}
         size={companionSize}
-        minSize={hasCompanion ? 20 : 0}
+        minSize={20}
         onSizeChange={onCompanionSizeChange}
         classNames={classNames}
       >
@@ -143,7 +149,7 @@ export const DeckPlank = memo(
             onKeyDown={handleKeyDown}
           />
         </Splitter.Panel>
-        {hasCompanion && (
+        {companions.length > 0 && (
           <>
             <Splitter.Handle />
             <Splitter.Panel position='end'>

--- a/packages/plugins/plugin-deck/src/containers/Deck/DeckPlank.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Deck/DeckPlank.tsx
@@ -3,7 +3,7 @@
 //
 
 import { useFocusFinders } from '@fluentui/react-tabster';
-import React, { type KeyboardEvent, memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { type KeyboardEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Surface } from '@dxos/app-framework/ui';
 import { AppSurface } from '@dxos/app-toolkit/ui';
@@ -88,6 +88,18 @@ export const DeckPlank = memo(
     // Stable reference so Plank's useMemo on articleData doesn't bust every render.
     const articleData = useMemo(() => ({ path }), [path]);
 
+    // Keep the companion panel mounted for 250ms after hasCompanion goes false so the Splitter's
+    // CSS transition can complete before the subtree is removed from the DOM.
+    const [companionMounted, setCompanionMounted] = useState(hasCompanion);
+    useEffect(() => {
+      if (hasCompanion) {
+        setCompanionMounted(true);
+        return;
+      }
+      const timer = setTimeout(() => setCompanionMounted(false), 250);
+      return () => clearTimeout(timer);
+    }, [hasCompanion]);
+
     const companionControls = useMemo(() => <PlankCompanionControls primary={id} />, [id]);
 
     if (!node) {
@@ -120,9 +132,8 @@ export const DeckPlank = memo(
     // to unmount and remount the entire subtree on every companion toggle, resetting article state.
     //
     // `mode` drives the animated open/close: switching between 'split' and 'start' triggers the Splitter's
-    // built-in 250ms CSS transition, which slides the companion in/out without a flash. The companion panel
-    // stays mounted while companions exist (collapsed to 0 at mode='start') so the transition always has
-    // something to animate; conditional rendering would remount it on every open, losing companion state.
+    // built-in 250ms CSS transition. `companionMounted` trails `hasCompanion` by 250ms on close so the
+    // panel stays in the DOM long enough for the collapse animation to finish before being unmounted.
     return (
       <Splitter.Root
         orientation={companionOrientation}
@@ -153,7 +164,7 @@ export const DeckPlank = memo(
             onKeyDown={handleKeyDown}
           />
         </Splitter.Panel>
-        {hasCompanion && (
+        {companionMounted && (
           <>
             <Splitter.Handle />
             <Splitter.Panel position='end'>

--- a/packages/plugins/plugin-deck/src/containers/Deck/DeckPlank.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Deck/DeckPlank.tsx
@@ -17,6 +17,8 @@ import { PlankCompanionControls, PlankControls } from './PlankControls';
 import { PlankErrorFallback, PlankLoading } from './PlankFallback';
 import { useDeckPlank } from './useDeckPlank';
 
+const PLANK_LOADING = <PlankLoading />;
+
 export type DeckPlankProps = ThemedClassName<{
   id: string;
   part: ResolvedPart;
@@ -86,8 +88,10 @@ export const DeckPlank = memo(
     // Stable reference so Plank's useMemo on articleData doesn't bust every render.
     const articleData = useMemo(() => ({ path }), [path]);
 
+    const companionControls = useMemo(() => <PlankCompanionControls primary={id} />, [id]);
+
     if (!node) {
-      return <PlankLoading />;
+      return PLANK_LOADING;
     }
 
     const controls = (
@@ -144,7 +148,7 @@ export const DeckPlank = memo(
             navbarEnd={navbarEnd}
             sigilFooter={sigilFooter}
             fallback={PlankErrorFallback}
-            placeholder={<PlankLoading />}
+            placeholder={PLANK_LOADING}
             headless={headless}
             onKeyDown={handleKeyDown}
           />
@@ -159,7 +163,7 @@ export const DeckPlank = memo(
                 onValueChange={onUpdateCompanion}
                 attendableId={id}
                 companionTo={node.data}
-                controls={<PlankCompanionControls primary={id} />}
+                controls={companionControls}
               />
             </Splitter.Panel>
           </>

--- a/packages/plugins/plugin-deck/src/containers/Deck/DeckPlank.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Deck/DeckPlank.tsx
@@ -3,7 +3,7 @@
 //
 
 import { useFocusFinders } from '@fluentui/react-tabster';
-import React, { type KeyboardEvent, memo, useCallback, useEffect, useRef } from 'react';
+import React, { type KeyboardEvent, memo, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { Surface } from '@dxos/app-framework/ui';
 import { AppSurface } from '@dxos/app-toolkit/ui';
@@ -83,6 +83,9 @@ export const DeckPlank = memo(
       [findFirstFocusable],
     );
 
+    // Stable reference so Plank's useMemo on articleData doesn't bust every render.
+    const articleData = useMemo(() => ({ path }), [path]);
+
     if (!node) {
       return <PlankLoading />;
     }
@@ -108,55 +111,53 @@ export const DeckPlank = memo(
     // In fullscreen the toolbar is hidden so the content fills the viewport.
     const headless = layoutMode === 'solo--fullscreen';
 
-    // Apply positioning `classNames` to whichever element is outermost (the Splitter when a companion is
-    // shown, otherwise the Plank itself).
-    const renderPlank = (plankClassNames?: DeckPlankProps['classNames']) => (
-      <Plank
-        ref={rootRef}
-        node={node}
-        attendableId={id}
-        related={part === 'complementary'}
-        actions={sigilActions}
-        onAction={onAction}
-        popoverAnchorId={popoverAnchorId}
-        articleData={{ path }}
-        controls={controls}
-        navbarEnd={navbarEnd}
-        sigilFooter={sigilFooter}
-        fallback={PlankErrorFallback}
-        placeholder={<PlankLoading />}
-        headless={headless}
-        onKeyDown={handleKeyDown}
-        classNames={plankClassNames}
-      />
-    );
-
-    if (!hasCompanion) {
-      return renderPlank(classNames);
-    }
-
+    // Splitter.Root is always the outer element so <Plank> stays at the same tree position regardless of
+    // whether the companion is open. A root-element-type change (Plank ↔ Splitter.Root) would force React
+    // to unmount and remount the entire subtree on every companion toggle, resetting article state.
     return (
       <Splitter.Root
         orientation={companionOrientation}
         anchor='end'
-        resizable
+        resizable={hasCompanion}
         size={companionSize}
-        minSize={20}
+        minSize={hasCompanion ? 20 : 0}
         onSizeChange={onCompanionSizeChange}
         classNames={classNames}
       >
-        <Splitter.Panel position='start'>{renderPlank()}</Splitter.Panel>
-        <Splitter.Handle />
-        <Splitter.Panel position='end'>
-          <Companion
-            companions={companions}
-            value={resolvedCompanionId}
-            onValueChange={onUpdateCompanion}
+        <Splitter.Panel position='start'>
+          <Plank
+            ref={rootRef}
+            node={node}
             attendableId={id}
-            companionTo={node.data}
-            controls={<PlankCompanionControls primary={id} />}
+            related={part === 'complementary'}
+            actions={sigilActions}
+            onAction={onAction}
+            popoverAnchorId={popoverAnchorId}
+            articleData={articleData}
+            controls={controls}
+            navbarEnd={navbarEnd}
+            sigilFooter={sigilFooter}
+            fallback={PlankErrorFallback}
+            placeholder={<PlankLoading />}
+            headless={headless}
+            onKeyDown={handleKeyDown}
           />
         </Splitter.Panel>
+        {hasCompanion && (
+          <>
+            <Splitter.Handle />
+            <Splitter.Panel position='end'>
+              <Companion
+                companions={companions}
+                value={resolvedCompanionId}
+                onValueChange={onUpdateCompanion}
+                attendableId={id}
+                companionTo={node.data}
+                controls={<PlankCompanionControls primary={id} />}
+              />
+            </Splitter.Panel>
+          </>
+        )}
       </Splitter.Root>
     );
   },


### PR DESCRIPTION
## Summary

- Always renders `Splitter.Root` as the outer element in `DeckPlank` so `<Plank>` stays at the same React tree position regardless of whether the companion is open. Previously the component toggled between returning a bare `<Plank>` and a `<Splitter.Root>`, which caused React to unmount and remount the entire subtree on every companion toggle — resetting article state (chat scroll position, editor cursor, etc.).
- Memoizes `articleData` in `DeckPlank` and per-companion data objects in `Companion` to prevent Surface re-renders from new inline object references on every render.
- Uses Splitter `mode` prop (`'split'` / `'start'`) to animate the companion panel sliding in/out with a 250ms CSS transition instead of mounting/unmounting it on every toggle.
- Unmounts the companion panel when no companion is open (`hasCompanion`), preserving the user expectation that the panel is not kept alive when closed.

## Test plan

- [ ] Open a chat article, open its companion plank — chat should not flash or remount
- [ ] Open a table article, open its companion plank — table should not flash or remount  
- [ ] Open/close companion multiple times — no article state reset (scroll position, input text preserved)
- [ ] Sigil blue attention highlight should remain stable during companion open/close
- [ ] Markdown/document articles continue to work correctly
- [ ] Solo and fullscreen layout modes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering stability for companion panels by keeping article surface props reference-stable across parent updates.
  * Reduced unnecessary re-renders by memoizing companion and article data.
  * Improved splitter/layout behavior by consistently keeping the splitter container mounted while conditionally rendering companion content, allowing close animations to complete smoothly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->