### PR TITLE
fix(passkey): reject passkeys without a user handle

### DIFF
--- a/packages/plugins/plugin-client/src/operations/redeem-passkey.ts
+++ b/packages/plugins/plugin-client/src/operations/redeem-passkey.ts
@@ -32,6 +32,9 @@ const handler: Operation.WithHandler<typeof RedeemPasskey> = RedeemPasskey.pipe(
               NativePasskey.loginNativePasskey({ challenge: Uint8Array.from(Buffer.from(challenge, 'base64')) }),
             );
             invariant(result, 'Native passkey login returned no result');
+            // user_handle may be empty if the passkey was registered without a userId or the
+            // native authenticator did not store one; an empty key would be rejected by the server.
+            invariant(result.user_handle, 'Passkey did not return a user handle — please re-register your passkey.');
             return {
               lookupKey: PublicKey.from(NativePasskey.decodeUrlSafeBase64(result.user_handle)),
               signature: Buffer.from(NativePasskey.decodeUrlSafeBase64(result.signature)),
@@ -51,8 +54,11 @@ const handler: Operation.WithHandler<typeof RedeemPasskey> = RedeemPasskey.pipe(
                 },
               }),
             );
+            const userHandle: ArrayBuffer | null = (credential as any).response.userHandle;
+            // userHandle is null for passkeys created without residentKey/userHandle stored.
+            invariant(userHandle, 'Passkey did not return a user handle — please re-register your passkey.');
             return {
-              lookupKey: PublicKey.from(new Uint8Array((credential as any).response.userHandle)),
+              lookupKey: PublicKey.from(new Uint8Array(userHandle)),
               signature: Buffer.from((credential as any).response.signature),
               clientDataJson: Buffer.from((credential as any).response.clientDataJSON),
               authenticatorData: Buffer.from((credential as any).response.authenticatorData),

--- a/packages/sdk/app-toolkit/src/app/NativePasskey.ts
+++ b/packages/sdk/app-toolkit/src/app/NativePasskey.ts
@@ -34,6 +34,7 @@ export type NativePasskeyLoginResult = {
   client_data_json: string;
   authenticator_data: string;
   signature: string;
+  /** Empty string when the authenticator stored no user handle (passkeys pre-dating userId requirement). */
   user_handle: string;
   prf_output: number[];
 };


### PR DESCRIPTION
## Summary
- Validate that passkey redemption returns a user handle before deriving the lookup key.
- Surface a clear re-registration error when native or web authenticator data omits the user handle.
- Document that `NativePasskeyLoginResult.user_handle` may be empty for older passkeys.

## Testing
- Not run (PR content only).
- Code review of the diff for native and web passkey redemption paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved passkey sign-in reliability by ensuring a valid user handle is present before deriving login lookup data.
  * Prevented failures when passkey responses return an empty or missing user handle, including browser fallback flows.

* **Documentation**
  * Added a note clarifying that some passkey logins may return an empty user handle for older credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->