### PR TITLE
fix(plugin-onboarding): pass origin as redirectUrl on login

### DIFF
--- a/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
@@ -54,7 +54,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
 
       try {
         pendingRef.current = true;
-        let result = await login({ hubUrl, email });
+        let result = await login({ hubUrl, email, redirectUrl: window.location.origin });
 
         // Server signaled that this email needs a local identity to bind a
         // fresh Account (test-email carve-out): create one and retry.

--- a/packages/plugins/plugin-onboarding/src/credentials/util.ts
+++ b/packages/plugins/plugin-onboarding/src/credentials/util.ts
@@ -102,16 +102,18 @@ export const login = async ({
   email,
   identityDid,
   identityKey,
+  redirectUrl,
 }: {
   hubUrl: string;
   email: string;
   identityDid?: string;
   identityKey?: string;
+  redirectUrl?: string;
 }): Promise<{ token?: string; needsIdentity?: boolean; admitted?: boolean }> => {
   const response = await fetch(new URL('/account/login', hubUrl), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, identityDid, identityKey }),
+    body: JSON.stringify({ email, identityDid, identityKey, redirectUrl }),
   });
   if (!response.ok) {
     throw new Error('login failed', { cause: response.statusText });


### PR DESCRIPTION
## Summary

- Adds `redirectUrl?: string` to the `login()` utility in `plugin-onboarding/src/credentials/util.ts`
- Passes `window.location.origin` as `redirectUrl` when calling `login()` from `WelcomeScreen`

## Context

The hub-service `/account/login` endpoint was added in June 2026 without `redirectUrl` support. The server stores the token in KV and, at magic-link redemption time, redirects to `data.redirectUrl ?? APP_URL`. Without `redirectUrl` being sent, the magic link always redirected to the environment's default `APP_URL` instead of back to the Composer instance the user was on.

The server-side half (accepting and storing `redirectUrl` in the token) is in dxos/edge.

The second `login()` call in `handleLogin` (the test-email retry path) intentionally does not pass `redirectUrl` — that path returns `{ admitted: true }` with no magic link, so the redirect is never used.

## Test plan

- [ ] Open Composer at a non-default URL (e.g. localhost:5173); log in with a real email; click the magic link; verify the redirect lands back on the correct origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved email login flow by including a redirect destination after sign-in, helping users return to the app seamlessly.
* **Bug Fixes**
  * Updated login requests to pass the app’s current origin when available, making authentication redirects more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->