### PR TITLE
fix(inbox): complete JMAP sync pagination

### DIFF
--- a/packages/plugins/plugin-inbox/src/operations/jmap/mail/sync.test.ts
+++ b/packages/plugins/plugin-inbox/src/operations/jmap/mail/sync.test.ts
@@ -38,10 +38,12 @@ const TestLayer = Layer.mergeAll(
 let originalFetch: typeof globalThis.fetch;
 let emailQueryIds: string[];
 let emailQueryPositions: number[];
+let emailQueryCalculateTotals: (boolean | undefined)[];
 
 beforeEach(() => {
   emailQueryIds = ['e1', 'e2', 'e3'];
   emailQueryPositions = [];
+  emailQueryCalculateTotals = [];
   originalFetch = globalThis.fetch;
   globalThis.fetch = vi.fn(async (...args: Parameters<typeof fetch>): Promise<Response> => {
     const [input, init] = args;
@@ -113,6 +115,24 @@ describe('JMAP sync read path', () => {
       expect(ids[0]).toBe('e1');
       expect(ids.at(-1)).toBe('e550');
       expect(emailQueryPositions).toEqual([0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500]);
+      expect(emailQueryCalculateTotals).toEqual(Array.from({ length: 11 }, () => true));
+    }, Effect.provide(TestLayer)),
+  );
+
+  it.effect(
+    'stops querying JMAP ids when total ends on a page boundary',
+    Effect.fnUntraced(function* ({ expect }) {
+      emailQueryIds = Array.from({ length: 100 }, (_, i) => `e${i + 1}`);
+
+      const ids = yield* streamJmapEmailIds({ apiUrl: API_URL, accountId: ACCOUNT_ID }, { inMailbox: 'mb-inbox' }).pipe(
+        Stream.runCollect,
+        Effect.map(Chunk.toArray),
+      );
+
+      expect(ids).toHaveLength(100);
+      expect(ids.at(-1)).toBe('e100');
+      expect(emailQueryPositions).toEqual([0, 50]);
+      expect(emailQueryCalculateTotals).toEqual([true, true]);
     }, Effect.provide(TestLayer)),
   );
 });
@@ -143,6 +163,7 @@ const respondToPost = (body: any): unknown => {
       const position = args.position ?? 0;
       const limit = args.limit ?? emailQueryIds.length;
       emailQueryPositions.push(position);
+      emailQueryCalculateTotals.push(args.calculateTotal);
       return {
         methodResponses: [
           [

--- a/packages/plugins/plugin-inbox/src/operations/jmap/mail/sync.test.ts
+++ b/packages/plugins/plugin-inbox/src/operations/jmap/mail/sync.test.ts
@@ -4,9 +4,11 @@
 
 import * as FetchHttpClient from '@effect/platform/FetchHttpClient';
 import { describe, it } from '@effect/vitest';
+import * as Chunk from 'effect/Chunk';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as Predicate from 'effect/Predicate';
+import * as Stream from 'effect/Stream';
 import { afterEach, beforeEach, vi } from 'vitest';
 
 import { Obj } from '@dxos/echo';
@@ -15,6 +17,7 @@ import { Jmap, JmapMail } from '../../../apis';
 import { JMAP_MESSAGE_SOURCE } from '../../../constants';
 import { InboxResolver, JmapCredentials } from '../../../services';
 import { mapEmail } from './mapper';
+import { streamJmapEmailIds } from './sync';
 
 const HOST = 'api.fastmail.com';
 const ACCOUNT_ID = 'u9999';
@@ -33,8 +36,12 @@ const TestLayer = Layer.mergeAll(
 );
 
 let originalFetch: typeof globalThis.fetch;
+let emailQueryIds: string[];
+let emailQueryPositions: number[];
 
 beforeEach(() => {
+  emailQueryIds = ['e1', 'e2', 'e3'];
+  emailQueryPositions = [];
   originalFetch = globalThis.fetch;
   globalThis.fetch = vi.fn(async (...args: Parameters<typeof fetch>): Promise<Response> => {
     const [input, init] = args;
@@ -91,6 +98,23 @@ describe('JMAP sync read path', () => {
       expect(first.mailboxIds).toContain('mb-inbox');
     }, Effect.provide(TestLayer)),
   );
+
+  it.effect(
+    'continues querying JMAP ids past the old scan window',
+    Effect.fnUntraced(function* ({ expect }) {
+      emailQueryIds = Array.from({ length: 550 }, (_, i) => `e${i + 1}`);
+
+      const ids = yield* streamJmapEmailIds({ apiUrl: API_URL, accountId: ACCOUNT_ID }, { inMailbox: 'mb-inbox' }).pipe(
+        Stream.runCollect,
+        Effect.map(Chunk.toArray),
+      );
+
+      expect(ids).toHaveLength(550);
+      expect(ids[0]).toBe('e1');
+      expect(ids.at(-1)).toBe('e550');
+      expect(emailQueryPositions).toEqual([0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500]);
+    }, Effect.provide(TestLayer)),
+  );
 });
 
 const makeEmail = (id: string) => ({
@@ -115,8 +139,24 @@ const respondToPost = (body: any): unknown => {
           ['Mailbox/get', { accountId: ACCOUNT_ID, list: [{ id: 'mb-inbox', name: 'Inbox', role: 'inbox' }] }, '0'],
         ],
       };
-    case 'Email/query':
-      return { methodResponses: [['Email/query', { accountId: ACCOUNT_ID, ids: ['e1', 'e2', 'e3'], total: 3 }, '0']] };
+    case 'Email/query': {
+      const position = args.position ?? 0;
+      const limit = args.limit ?? emailQueryIds.length;
+      emailQueryPositions.push(position);
+      return {
+        methodResponses: [
+          [
+            'Email/query',
+            {
+              accountId: ACCOUNT_ID,
+              ids: emailQueryIds.slice(position, position + limit),
+              total: emailQueryIds.length,
+            },
+            '0',
+          ],
+        ],
+      };
+    }
     case 'Email/get':
       return { methodResponses: [['Email/get', { accountId: ACCOUNT_ID, list: args.ids.map(makeEmail) }, '0']] };
     default:

--- a/packages/plugins/plugin-inbox/src/operations/jmap/mail/sync.ts
+++ b/packages/plugins/plugin-inbox/src/operations/jmap/mail/sync.ts
@@ -185,17 +185,20 @@ const syncMailbox = ({ binding, mailbox }: { binding: SyncBinding.SyncBinding; m
     return count;
   });
 
+/** Paginates JMAP email ids via `Email/query` until the query is exhausted. */
 export const streamJmapEmailIds = (target: JmapMail.Target, filter: Jmap.Filter | undefined) =>
   Stream.paginateChunkEffect(0, (position) =>
     Effect.gen(function* () {
-      const { ids } = yield* JmapMail.emailQuery(target, {
+      const { ids, total } = yield* JmapMail.emailQuery(target, {
         filter,
         sort: [{ property: 'receivedAt', isAscending: false }],
         position,
         limit: PAGE_SIZE,
+        calculateTotal: true,
       });
-      log('jmap sync: queried page', { position, count: ids.length });
-      const next = ids.length < PAGE_SIZE ? Option.none<number>() : Option.some(position + ids.length);
+      log('jmap sync: queried page', { position, count: ids.length, total });
+      const isExhausted = total !== undefined ? position + ids.length >= total : ids.length < PAGE_SIZE;
+      const next = isExhausted ? Option.none<number>() : Option.some(position + ids.length);
       return [Chunk.fromIterable(ids), next];
     }),
   );

--- a/packages/plugins/plugin-inbox/src/operations/jmap/mail/sync.ts
+++ b/packages/plugins/plugin-inbox/src/operations/jmap/mail/sync.ts
@@ -30,7 +30,6 @@ const MAIL_ACCOUNT_CAPABILITY = 'urn:ietf:params:jmap:mail';
 const PAGE_SIZE = 50;
 const FETCH_CONCURRENCY = 5;
 const BATCH_SIZE = 10;
-const MAX_SCAN = 500;
 
 export default InboxOperation.JmapSync.pipe(
   Operation.withHandler(({ binding: bindingRef }) =>
@@ -102,9 +101,9 @@ const syncMailbox = ({ binding, mailbox }: { binding: SyncBinding.SyncBinding; m
     const inbox = folders.find((folder) => folder.role === 'inbox');
     log('jmap sync: folders resolved', { folders: folders.length, inboxId: inbox?.id });
 
-    // Dedup set — same pattern as Gmail's `existingGmailIds`.
+    // JMAP sync drains the provider query, so dedup against all known JMAP ids to keep retries idempotent.
     const objects = yield* Feed.query(feed, Filter.type(Message.Message)).run;
-    const existingIds = collectForeignIds(objects, JMAP_MESSAGE_SOURCE, MAX_SCAN);
+    const existingIds = collectForeignIds(objects, JMAP_MESSAGE_SOURCE, objects.length);
 
     // Build the query filter: Inbox scope + optional date window + optional Gmail-like query DSL.
     const options = readBindingOptions(binding);
@@ -140,20 +139,7 @@ const syncMailbox = ({ binding, mailbox }: { binding: SyncBinding.SyncBinding; m
     // Stream pages of ids → concurrent email fetch → map → batch append.
     // Mirrors Gmail's streamGmailMessagesToFeed structure: Stream.flatMap with concurrency
     // decouples id-fetching from email-fetching so both pipeline stages run in parallel.
-    const count = yield* Stream.paginateChunkEffect(0, (position) =>
-      Effect.gen(function* () {
-        const { ids } = yield* JmapMail.emailQuery(target, {
-          filter,
-          sort: [{ property: 'receivedAt', isAscending: false }],
-          position,
-          limit: PAGE_SIZE,
-        });
-        log('jmap sync: queried page', { position, total: ids.length });
-        const next = ids.length < PAGE_SIZE ? Option.none<number>() : Option.some(position + ids.length);
-        return [Chunk.fromIterable(ids), next];
-      }),
-    ).pipe(
-      Stream.take(MAX_SCAN),
+    const count = yield* streamJmapEmailIds(target, filter).pipe(
       Stream.filter((id) => !existingIds.has(id)),
       // Fetch each email concurrently — same concurrency as Gmail's messageFetchConcurrency.
       Stream.flatMap(
@@ -198,3 +184,18 @@ const syncMailbox = ({ binding, mailbox }: { binding: SyncBinding.SyncBinding; m
     log('jmap sync complete', { newMessages: count });
     return count;
   });
+
+export const streamJmapEmailIds = (target: JmapMail.Target, filter: Jmap.Filter | undefined) =>
+  Stream.paginateChunkEffect(0, (position) =>
+    Effect.gen(function* () {
+      const { ids } = yield* JmapMail.emailQuery(target, {
+        filter,
+        sort: [{ property: 'receivedAt', isAscending: false }],
+        position,
+        limit: PAGE_SIZE,
+      });
+      log('jmap sync: queried page', { position, count: ids.length });
+      const next = ids.length < PAGE_SIZE ? Option.none<number>() : Option.some(position + ids.length);
+      return [Chunk.fromIterable(ids), next];
+    }),
+  );


### PR DESCRIPTION
## Summary

- Remove the hard 500-id cap from JMAP mail sync pagination.
- Deduplicate against all existing JMAP message ids before fetching and appending.
- Add a regression that mocks 550 JMAP ids and verifies pagination continues past the previous scan window.

## Root cause

JMAP mail sync queried newest-first pages but truncated the provider id stream at 500 ids. A successful initial or long-gap sync could record completion after importing only that newest window, with no continuation state to reach older matching messages.

## Why it matters

Mailboxes with more than 500 matching messages could be left incomplete without an error. Later syncs would revisit the same newest window and still never reach older matching messages.

## Validation

- `git diff --check`
- Not run: `pnpm exec vitest run packages/plugins/plugin-inbox/src/operations/jmap/mail/sync.test.ts --config packages/plugins/plugin-inbox/vitest.config.ts` because this fresh worktree had no dependencies and `pnpm exec` entered dependency installation; the install was stopped after repeated registry fetch retry backoff before tests began.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbox syncing so it reliably fetches messages beyond earlier scan limits, ensuring older items are included.
  * Enhanced retry safety by improving deduplication using all previously known messages.
  * Refined inbox pagination to fetch in consistent page sizes, correctly stopping when totals are reached.
* **Tests**
  * Added streaming-based coverage to validate pagination behavior and stop conditions, including parameterized request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->