### PR TITLE
fix(plugin-space): navigate to space home immediately on invitation accept

### DIFF
--- a/packages/plugins/plugin-assistant/src/containers/TriggerStatus/TriggerStatus.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/TriggerStatus/TriggerStatus.tsx
@@ -8,7 +8,8 @@ import { AppSurface } from '@dxos/app-toolkit/ui';
 import { type InvocationsState } from '@dxos/functions-runtime';
 import { useTriggerRuntimeControls } from '@dxos/plugin-routine/hooks';
 import { StatusBar } from '@dxos/plugin-status-bar/components';
-import { useObject } from '@dxos/react-client/echo';
+import { useMulticastObservable } from '@dxos/react-client';
+import { SpaceState, useObject } from '@dxos/react-client/echo';
 import { IconButton, Popover, useTranslation } from '@dxos/react-ui';
 
 import { meta } from '#meta';
@@ -47,8 +48,11 @@ export const SpaceStatus = ({ space }: SpaceStatusProps) => {
   const { t } = useTranslation(meta.profile.key);
   const { state } = useTriggerRuntimeControls(space.db);
   const isEnabled = state?.enabled ?? false;
-  const [properties] = useObject(space.properties);
-  const computeEnvironment = properties.computeEnvironment ?? 'local';
+  // `space.properties` throws until the space finishes initializing (e.g. right after joining);
+  // gate on `space.state` so this component doesn't crash for a freshly-joined space.
+  const spaceState = useMulticastObservable(space.state);
+  const [properties] = useObject(spaceState === SpaceState.SPACE_READY ? space.properties : undefined);
+  const computeEnvironment = properties?.computeEnvironment ?? 'local';
 
   // Determine the current trigger status state.
   const triggerState: TriggerStatusState = useMemo(() => {

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.stories.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.stories.tsx
@@ -23,12 +23,7 @@ const DefaultStory = ({ state: initialState = WelcomeState.INIT, ...props }: Par
   return (
     <AlertDialog.Root defaultOpen>
       <AlertDialog.Overlay classNames={OVERLAY_CLASSES} style={OVERLAY_STYLE}>
-        <Welcome
-          identity={identity}
-          state={state}
-          onEmailLogin={() => setState(WelcomeState.LOGIN_SENT)}
-          {...props}
-        />
+        <Welcome identity={identity} state={state} onEmailLogin={() => setState(WelcomeState.LOGIN_SENT)} {...props} />
       </AlertDialog.Overlay>
     </AlertDialog.Root>
   );

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.stories.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.stories.tsx
@@ -27,7 +27,6 @@ const DefaultStory = ({ state: initialState = WelcomeState.INIT, ...props }: Par
           identity={identity}
           state={state}
           onEmailLogin={() => setState(WelcomeState.LOGIN_SENT)}
-          onGoToLogin={() => setState(WelcomeState.INIT)}
           {...props}
         />
       </AlertDialog.Overlay>
@@ -71,15 +70,4 @@ export const EmailPrimary: Story = {
 export const WithIdentity: Story = {
   decorators: [withClientProvider({ createIdentity: true })],
   args: {},
-};
-
-export const SpaceInvitation: Story = {
-  decorators: [withClientProvider()],
-  args: {
-    state: WelcomeState.SPACE_INVITATION,
-    onPasskey: () => console.log('passkey'),
-    onJoinIdentity: () => console.log('join identity'),
-    onRecoverIdentity: () => console.log('recover identity'),
-    onSpaceInvitation: () => console.log('space invitation'),
-  },
 };

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.tsx
@@ -66,8 +66,6 @@ export const Welcome = ({
   onCreateAccount,
   onCreateAccountWithOAuth,
   onJoinWaitlist,
-  onSpaceInvitation,
-  onGoToLogin,
 }: WelcomeScreenProps) => {
   const { t } = useTranslation(meta.profile.key);
 
@@ -422,25 +420,6 @@ export const Welcome = ({
           </Tabs.Root>
         )}
 
-        {state === WelcomeState.SPACE_INVITATION && (
-          <div className='flex flex-col gap-8'>
-            <div className='flex flex-col gap-2'>
-              <h1 className='text-2xl'>{t('space-invitation.title')}</h1>
-              <p className='text-description'>{t('space-invitation.description')}</p>
-            </div>
-            <CompoundRow icon='ph--planet--regular' onClick={onSpaceInvitation}>
-              {t('join-space-button.label')}
-            </CompoundRow>
-            <div className='flex flex-col gap-2'>
-              <h1 className='text-2xl'>{t('go-to-login.title')}</h1>
-              <p className='text-description'>{t('go-to-login.description')}</p>
-            </div>
-            <CompoundRow icon='ph--user--regular' onClick={onGoToLogin}>
-              {t('go-to-login-button.label')}
-            </CompoundRow>
-          </div>
-        )}
-
         {(state === WelcomeState.EMAIL_SENT || state === WelcomeState.LOGIN_SENT) && (
           <div className='flex flex-col gap-8'>
             <div className='flex flex-col gap-2'>
@@ -777,18 +756,6 @@ const InlineForm = ({
     </Input.Root>
   );
 };
-
-const CompoundRow = ({ children, icon, onClick }: PropsWithChildren<{ icon: string; onClick?: () => unknown }>) => (
-  <button
-    type='button'
-    className='flex items-center gap-3 px-4 py-3 rounded-md border border-separator hover:bg-neutral-800/50 text-left w-full'
-    onClick={onClick}
-  >
-    <Icon icon={icon} size={5} />
-    <span className='flex-1'>{children}</span>
-    <Icon icon='ph--caret-right--bold' size={4} />
-  </button>
-);
 
 /** Horizontal "or" separator between alternative auth methods. */
 const OrDivider = ({ children }: PropsWithChildren) => (

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/types.ts
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/types.ts
@@ -10,7 +10,6 @@ export enum WelcomeState {
   // TODO(wittjosiah): Remove this state once signups are auto-admitted.
   EMAIL_SENT = 1,
   LOGIN_SENT = 2,
-  SPACE_INVITATION = 3,
   WAITLIST_SUBMITTED = 4,
 }
 
@@ -45,10 +44,6 @@ export type WelcomeScreenProps = {
   onCreateAccountWithOAuth?: (args: { code: string; provider: string; loginHint?: string }) => MaybePromise<void>;
   /** Submit waitlist sign-up (no invitation code). */
   onJoinWaitlist?: (email: string) => MaybePromise<void>;
-
-  // Other.
-  onSpaceInvitation?: () => MaybePromise<void>;
-  onGoToLogin?: () => MaybePromise<void>;
 };
 
 export const validEmail = (email: string) => !!email.match(/.+@.+\..+/);

--- a/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
@@ -5,13 +5,15 @@
 import React, { useCallback, useRef, useState } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
-import { LayoutOperation } from '@dxos/app-toolkit';
+import { LayoutOperation, Paths } from '@dxos/app-toolkit';
+import { Trigger } from '@dxos/async';
 import { createDidFromIdentityKey } from '@dxos/credentials';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 import { ClientOperation } from '@dxos/plugin-client';
 import { SpaceOperation } from '@dxos/plugin-space';
 import { useClient } from '@dxos/react-client';
+import { type Space } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
 import { type InvitationResult } from '@dxos/react-client/invitations';
 import { ThemeProvider, defaultTx } from '@dxos/react-ui';
@@ -156,8 +158,25 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
 
     const handleDone = async (result: InvitationResult | null) => {
       await invokePromise(LayoutOperation.UpdateDialog, { state: false });
+
+      const spaceKey = result?.spaceKey;
+      let space = spaceKey ? client.spaces.get(spaceKey) : undefined;
+      if (spaceKey && !space) {
+        // TODO(wittjosiah): Add api to wait for a space.
+        const trigger = new Trigger<Space>();
+        client.spaces.subscribe(() => {
+          const found = client.spaces.get(spaceKey);
+          if (found) {
+            trigger.wake(found);
+          }
+        });
+        space = await trigger.wait();
+      }
+
+      // TODO(wittjosiah): `result.target` is ignored so acceptance navigates to the space home
+      // immediately; revisit how to incorporate the target once immediate navigation is settled.
       await invokePromise(LayoutOperation.SetLayoutMode, {
-        subject: result?.target ?? undefined,
+        subject: space ? Paths.getSpaceHomePath(space.id) : undefined,
         mode: 'solo',
       });
 

--- a/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
@@ -5,17 +5,13 @@
 import React, { useCallback, useRef, useState } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
-import { LayoutOperation, Paths } from '@dxos/app-toolkit';
-import { Trigger } from '@dxos/async';
+import { LayoutOperation } from '@dxos/app-toolkit';
 import { createDidFromIdentityKey } from '@dxos/credentials';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 import { ClientOperation } from '@dxos/plugin-client';
-import { SpaceOperation } from '@dxos/plugin-space';
 import { useClient } from '@dxos/react-client';
-import { type Space } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
-import { type InvitationResult } from '@dxos/react-client/invitations';
 import { ThemeProvider, defaultTx } from '@dxos/react-ui';
 
 import { joinWaitlist, login, redeemAccountInvitation, validateInvitationCode } from '../credentials';
@@ -23,21 +19,15 @@ import { useForceDarkTheme } from '../hooks';
 import { meta } from '../meta';
 import { OnboardingOperation } from '../operations';
 import { translations } from '../translations';
-import { removeQueryParamByValue } from '../util';
 import { Welcome, WelcomeState } from './Welcome';
 
 export const WELCOME_SCREEN = `${meta.profile.key}.component.welcome-screen`;
 
 export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
-  const searchProps = new URLSearchParams(window.location.search);
-  const spaceInvitationCode = searchProps.get('spaceInvitationCode') ?? undefined;
-
   const client = useClient();
   const identity = useIdentity();
   const { invokePromise } = useOperationInvoker();
-  const [state, setState] = useState<WelcomeState>(
-    spaceInvitationCode ? WelcomeState.SPACE_INVITATION : WelcomeState.INIT,
-  );
+  const [state, setState] = useState<WelcomeState>(WelcomeState.INIT);
   const [error, setError] = useState(false);
   const pendingRef = useRef(false);
 
@@ -144,59 +134,6 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
     },
     [invokePromise, error],
   );
-
-  const handleSpaceInvitation = async () => {
-    let identityCreated = true;
-    await invokePromise(ClientOperation.CreateIdentity, {}).catch(() => {
-      // This will happen if the identity already exists.
-      identityCreated = false;
-    });
-    const identity = client.halo.identity.get();
-    if (!identity) {
-      return;
-    }
-
-    const handleDone = async (result: InvitationResult | null) => {
-      await invokePromise(LayoutOperation.UpdateDialog, { state: false });
-
-      const spaceKey = result?.spaceKey;
-      let space = spaceKey ? client.spaces.get(spaceKey) : undefined;
-      if (spaceKey && !space) {
-        // TODO(wittjosiah): Add api to wait for a space.
-        const trigger = new Trigger<Space>();
-        client.spaces.subscribe(() => {
-          const found = client.spaces.get(spaceKey);
-          if (found) {
-            trigger.wake(found);
-          }
-        });
-        space = await trigger.wait();
-      }
-
-      // TODO(wittjosiah): `result.target` is ignored so acceptance navigates to the space home
-      // immediately; revisit how to incorporate the target once immediate navigation is settled.
-      await invokePromise(LayoutOperation.SetLayoutMode, {
-        subject: space ? Paths.getSpaceHomePath(space.id) : undefined,
-        mode: 'solo',
-      });
-
-      if (identityCreated) {
-        await invokePromise(ClientOperation.CreateAgent);
-      }
-    };
-
-    await invokePromise(SpaceOperation.Join, {
-      invitationCode: spaceInvitationCode,
-      onDone: handleDone,
-    });
-    spaceInvitationCode && removeQueryParamByValue(spaceInvitationCode);
-  };
-
-  const handleGoToLogin = useCallback(() => {
-    setState(WelcomeState.INIT);
-    // TODO(wittjosiah): Attempt to preserve the invitation code through the login flow.
-    spaceInvitationCode && removeQueryParamByValue(spaceInvitationCode);
-  }, []);
 
   const handleValidateInvitationCode = useCallback(
     async (code: string) => {
@@ -329,8 +266,6 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
         onCreateAccount={!identity ? handleCreateAccount : undefined}
         onCreateAccountWithOAuth={!identity ? handleCreateAccountWithOAuth : undefined}
         onJoinWaitlist={handleJoinWaitlist}
-        onSpaceInvitation={spaceInvitationCode ? handleSpaceInvitation : undefined}
-        onGoToLogin={handleGoToLogin}
       />
     </ThemeProvider>
   );

--- a/packages/plugins/plugin-onboarding/src/translations.ts
+++ b/packages/plugins/plugin-onboarding/src/translations.ts
@@ -72,15 +72,6 @@ export const translations = [
         'recover-identity-button.label': 'Continue with a recovery code',
         'recover-identity-button.description': 'Recover your identity using a paper key.',
 
-        'space-invitation.title': 'You have been invited to a space',
-        'space-invitation.description':
-          "You're not currently logged in on this device, click the button below to create a new account and accept the invitation, or log in on this device before accepting the invitation.",
-        'join-space-button.label': 'Create account & accept invitation',
-        'go-to-login.title': 'Already have an account?',
-        'go-to-login.description':
-          'If you already have an account, log in before accepting the invitation with that account.',
-        'go-to-login-button.label': 'Go to login',
-
         'passkey-setup-toast.title': 'Setup a passkey',
         'passkey-setup-toast.description':
           'Setup a passkey to ensure you maintain access to your account and sign in on other devices.',

--- a/packages/plugins/plugin-space/package.json
+++ b/packages/plugins/plugin-space/package.json
@@ -132,6 +132,7 @@
     "@dxos/echo": "workspace:*",
     "@dxos/echo-client": "workspace:*",
     "@dxos/effect": "workspace:*",
+    "@dxos/errors": "workspace:*",
     "@dxos/invariant": "workspace:*",
     "@dxos/keys": "workspace:*",
     "@dxos/log": "workspace:*",

--- a/packages/plugins/plugin-space/src/capabilities/navigation-handler/navigation-handler.ts
+++ b/packages/plugins/plugin-space/src/capabilities/navigation-handler/navigation-handler.ts
@@ -8,6 +8,7 @@ import { Capabilities, Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { log } from '@dxos/log';
+import { ClientCapabilities } from '@dxos/plugin-client';
 
 import { SpaceOperation } from '../../operations';
 
@@ -23,15 +24,24 @@ export default Capability.makeModule(
   Effect.fnUntraced(function* ({ invitationProp = 'spaceInvitationCode' }: NavigationHandlerOptions = {}) {
     const capabilities = yield* Capability.Service;
     const operationService = yield* Capability.get(Capabilities.OperationInvoker);
+    const client = yield* Capability.get(ClientCapabilities.Client);
 
     const handler: AppCapabilities.NavigationHandler = (url: URL) =>
       Effect.gen(function* () {
         const invitationCode = url.searchParams.get(invitationProp);
-        if (invitationCode) {
-          log('space invitation received via navigation');
-          removeQueryParam(invitationProp);
-          yield* Operation.invoke(SpaceOperation.Join, { invitationCode });
+        if (!invitationCode) {
+          return;
         }
+
+        // Ignore invitations that arrive before a local identity exists rather than forcing
+        // identity creation here, bypassing the normal onboarding flow.
+        if (!client.halo.identity.get()) {
+          return;
+        }
+
+        log('space invitation received via navigation');
+        removeQueryParam(invitationProp);
+        yield* Operation.invoke(SpaceOperation.Join, { invitationCode });
       }).pipe(
         Effect.provideService(Capability.Service, capabilities),
         Effect.provideService(Operation.Service, operationService),

--- a/packages/plugins/plugin-space/src/containers/JoinDialog/JoinDialog.tsx
+++ b/packages/plugins/plugin-space/src/containers/JoinDialog/JoinDialog.tsx
@@ -58,8 +58,6 @@ export const JoinDialog = ({ navigableCollections, onDone, ...props }: JoinDialo
         space = await trigger.wait();
       }
 
-      await invokePromise(LayoutOperation.SwitchWorkspace, { subject: Paths.getSpacePath(space.id) });
-
       // TODO(wittjosiah): `result.target` is ignored so acceptance navigates to the space home
       // immediately; revisit how to incorporate the target once immediate navigation is settled.
       await invokePromise(LayoutOperation.Open, {

--- a/packages/plugins/plugin-space/src/containers/JoinDialog/JoinDialog.tsx
+++ b/packages/plugins/plugin-space/src/containers/JoinDialog/JoinDialog.tsx
@@ -6,9 +6,7 @@ import React, { useCallback } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { LayoutOperation, Paths } from '@dxos/app-toolkit';
-import { useAppGraph } from '@dxos/app-toolkit/ui';
 import { Trigger } from '@dxos/async';
-import { Graph } from '@dxos/plugin-graph';
 import { ObservabilityOperation } from '@dxos/plugin-observability';
 import { useClient } from '@dxos/react-client';
 import { type Space } from '@dxos/react-client/echo';
@@ -28,7 +26,6 @@ export type JoinDialogProps = JoinPanelProps & {
 export const JoinDialog = ({ navigableCollections, onDone, ...props }: JoinDialogProps) => {
   const { invokePromise } = useOperationInvoker();
   const client = useClient();
-  const { graph } = useAppGraph();
   const { t } = useTranslation(meta.profile.key);
 
   const handleDone = useCallback(
@@ -63,21 +60,12 @@ export const JoinDialog = ({ navigableCollections, onDone, ...props }: JoinDialo
 
       await invokePromise(LayoutOperation.SwitchWorkspace, { subject: Paths.getSpacePath(space.id) });
 
-      const target = result?.target;
-      if (target) {
-        // Wait before navigating to the target node.
-        // If the target has not yet replicated, this will trigger a loading toast.
-        await Graph.waitForPath(graph, { target }).catch(() => {});
-        await Promise.all([
-          invokePromise(LayoutOperation.Open, { subject: [target] }),
-          invokePromise(LayoutOperation.Expose, { subject: target }),
-        ]);
-      } else {
-        await invokePromise(LayoutOperation.Open, {
-          subject: [Paths.getSpaceHomePath(space.id)],
-          workspace: Paths.getSpacePath(space.id),
-        });
-      }
+      // TODO(wittjosiah): `result.target` is ignored so acceptance navigates to the space home
+      // immediately; revisit how to incorporate the target once immediate navigation is settled.
+      await invokePromise(LayoutOperation.Open, {
+        subject: [Paths.getSpaceHomePath(space.id)],
+        workspace: Paths.getSpacePath(space.id),
+      });
 
       onDone?.(result);
 
@@ -90,7 +78,7 @@ export const JoinDialog = ({ navigableCollections, onDone, ...props }: JoinDialo
         });
       }
     },
-    [invokePromise, client, graph, navigableCollections, onDone],
+    [invokePromise, client, navigableCollections, onDone],
   );
 
   // TODO(burdon): Move JoinHeading into Dialog.Heading.

--- a/packages/plugins/plugin-space/src/containers/JoinDialog/JoinDialog.tsx
+++ b/packages/plugins/plugin-space/src/containers/JoinDialog/JoinDialog.tsx
@@ -63,6 +63,7 @@ export const JoinDialog = ({ navigableCollections, onDone, ...props }: JoinDialo
       await invokePromise(LayoutOperation.Open, {
         subject: [Paths.getSpaceHomePath(space.id)],
         workspace: Paths.getSpacePath(space.id),
+        navigation: 'immediate',
       });
 
       onDone?.(result);

--- a/packages/plugins/plugin-space/src/errors.ts
+++ b/packages/plugins/plugin-space/src/errors.ts
@@ -1,0 +1,11 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { BaseError } from '@dxos/errors';
+
+/** Space invitations authenticate against a local HALO identity; there is nothing to redeem without one. */
+export class NoIdentityError extends BaseError.extend(
+  'NoIdentityError',
+  'A local identity is required to accept a space invitation.',
+) {}

--- a/packages/plugins/plugin-space/src/index.ts
+++ b/packages/plugins/plugin-space/src/index.ts
@@ -2,6 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
+export * from './errors';
 export * from './meta';
 export * from './types';
 export * from './util';

--- a/packages/plugins/plugin-space/src/operations/join.ts
+++ b/packages/plugins/plugin-space/src/operations/join.ts
@@ -2,16 +2,35 @@
 
 import * as Effect from 'effect/Effect';
 
+import { Capability } from '@dxos/app-framework';
 import { LayoutOperation } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
+import { ClientCapabilities } from '@dxos/plugin-client';
+
+import { meta } from '#meta';
 
 import { JOIN_DIALOG } from '../constants';
 import { type JoinDialogProps } from '../containers/JoinDialog';
+import { NoIdentityError } from '../errors';
 import { SpaceOperation } from './definitions';
 
 const handler: Operation.WithHandler<typeof SpaceOperation.Join> = SpaceOperation.Join.pipe(
   Operation.withHandler(
     Effect.fnUntraced(function* (input) {
+      const client = yield* Capability.get(ClientCapabilities.Client);
+      if (!client.halo.identity.get()) {
+        // Space invitations authenticate against a local identity; there is nothing to redeem without one.
+        yield* Effect.ignore(
+          Operation.invoke(LayoutOperation.AddToast, {
+            id: `${meta.profile.key}.join-no-identity`,
+            icon: 'ph--warning--regular',
+            title: ['join-no-identity-toast.title', { ns: meta.profile.key }],
+            closeLabel: ['dismiss.label', { ns: meta.profile.key }],
+          }),
+        );
+        return yield* Effect.fail(new NoIdentityError());
+      }
+
       yield* Operation.invoke(LayoutOperation.UpdateDialog, {
         subject: JOIN_DIALOG,
         blockAlign: 'start',

--- a/packages/plugins/plugin-space/src/translations.ts
+++ b/packages/plugins/plugin-space/src/translations.ts
@@ -204,6 +204,7 @@ export const translations = [
         'sync-status.title': 'Sync status',
         'dismiss.label': 'Dismiss',
         'join-success.label': 'Successfully joined space',
+        'join-no-identity-toast.title': 'Sign in to accept this invitation',
         'name.label': 'Name',
         'name.placeholder': 'Name',
         'object-properties.label': 'Properties',

--- a/packages/plugins/plugin-space/src/translations.ts
+++ b/packages/plugins/plugin-space/src/translations.ts
@@ -204,7 +204,7 @@ export const translations = [
         'sync-status.title': 'Sync status',
         'dismiss.label': 'Dismiss',
         'join-success.label': 'Successfully joined space',
-        'join-no-identity-toast.title': 'Sign in to accept this invitation',
+        'join-no-identity-toast.title': 'Log in to accept this invitation',
         'name.label': 'Name',
         'name.placeholder': 'Name',
         'object-properties.label': 'Properties',

--- a/packages/plugins/plugin-space/tsconfig.json
+++ b/packages/plugins/plugin-space/tsconfig.json
@@ -32,6 +32,9 @@
       "path": "../../common/effect"
     },
     {
+      "path": "../../common/errors"
+    },
+    {
       "path": "../../common/invariant"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15093,6 +15093,9 @@ importers:
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../common/effect
+      '@dxos/errors':
+        specifier: workspace:*
+        version: link:../../common/errors
       '@dxos/invariant':
         specifier: workspace:*
         version: link:../../common/invariant


### PR DESCRIPTION
## Summary
- Space invitation acceptance now always navigates to the space home immediately, instead of waiting to resolve/replicate the invitation's `target` node.
- Applies to both the main in-app accept flow (`plugin-space`'s `JoinDialog`) and the pre-identity onboarding flow (`plugin-onboarding`'s `WelcomeScreen`).
- Left a `TODO(wittjosiah)` in both places noting that target-based navigation should be revisited later.

## Test plan
- [x] `moon run plugin-space:build`
- [x] `moon run plugin-onboarding:build`
- [x] `moon run plugin-space:lint`
- [x] `moon run plugin-onboarding:lint`
- [x] `moon run plugin-space:test`
- [x] `moon run plugin-onboarding:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invitation acceptance now requires you to be signed in first; if you aren’t, you’ll be prompted to log in.
  * After successfully joining a space, you’re taken directly to the space home immediately.

* **Bug Fixes**
  * Removed the outdated invitation-specific onboarding path so the welcome flow stays consistent.
  * Invitations received before your local identity is ready are now safely ignored until you can complete login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->