### PR TITLE
fix(storybook-react): downlevel using-declarations in dev-server transform

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,6 @@ catalogs:
     '@babel/core':
       specifier: ^7.18.13
       version: 7.28.0
-    '@babel/parser':
-      specifier: 7.28.5
-      version: 7.28.5
     '@babel/preset-typescript':
       specifier: ^7.27.1
       version: 7.27.1
@@ -23047,9 +23044,6 @@ importers:
 
   tools/storybook-react:
     devDependencies:
-      '@babel/parser':
-        specifier: 'catalog:'
-        version: 7.28.5
       '@dxos/log':
         specifier: workspace:*
         version: link:../../packages/common/log
@@ -23982,11 +23976,6 @@ packages:
   '@babel/helpers@7.27.6':
     resolution: {integrity: sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
@@ -44587,10 +44576,6 @@ snapshots:
   '@babel/helpers@7.27.6':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.29.0
-
-  '@babel/parser@7.28.5':
-    dependencies:
       '@babel/types': 7.29.0
 
   '@babel/parser@7.29.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,6 @@ catalog:
   '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.37
   '@automerge/automerge-subduction': 0.16.0
   '@babel/core': ^7.18.13
-  '@babel/parser': 7.28.5
   '@babel/preset-typescript': ^7.27.1
   '@babel/runtime': ^7.9.6
   '@babylonjs/core': ^7.52.5

--- a/tools/storybook-react/.storybook/main.ts
+++ b/tools/storybook-react/.storybook/main.ts
@@ -21,6 +21,10 @@ const __dirname = dirname(__filename);
 const isTrue = (str?: string) => str === 'true' || str === '1';
 const isFastBundle = isTrue(process.env.DX_FASTBUNDLE);
 
+// Browsers targeted for syntax transforms (also applied to `oxc` below so that dev-server
+// transforms downlevel syntax WebKit doesn't parse yet, e.g. `using`/`await using`).
+const browserTargets = ['chrome108', 'edge107', 'firefox104', 'safari16'];
+
 const baseDir = resolve(__dirname, '../');
 const rootDir = resolve(baseDir, '../../');
 const staticDir = resolve(baseDir, './static');
@@ -131,10 +135,16 @@ export const createConfig = ({
             '@dxos/client/opfs-worker': resolve(rootDir, 'packages/sdk/client/src/worker/opfs-worker.ts'),
           },
         },
+        // `build.target` only lowers syntax for `storybook build`; the e2e tests run against
+        // `storybook dev`, which otherwise serves source syntax untransformed straight to the
+        // browser. Setting `oxc.target` applies the same downleveling during dev.
+        oxc: {
+          target: browserTargets,
+        },
         build: {
           assetsInlineLimit: 0,
           // Target modern browsers that support top-level await natively.
-          target: ['chrome108', 'edge107', 'firefox104', 'safari16'],
+          target: browserTargets,
           rolldownOptions: {
             output: {
               assetFileNames: 'assets/[name].[hash][extname]', // Unique asset names

--- a/tools/storybook-react/.storybook/main.ts
+++ b/tools/storybook-react/.storybook/main.ts
@@ -3,11 +3,10 @@
 // This file has been automatically migrated to valid ESM format by Storybook.
 //
 
-import { parse } from '@babel/parser';
 import { type StorybookConfig } from '@storybook/react-vite';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { type InlineConfig, type Plugin } from 'vite';
+import { type InlineConfig } from 'vite';
 import turbosnap from 'vite-plugin-turbosnap';
 import wasm from 'vite-plugin-wasm';
 
@@ -244,8 +243,6 @@ export const createConfig = ({
           // NOTE: Order matters.
           //
 
-          fixAsyncEsmWrappers(),
-
           // RSS proxy middleware for CORS-free feed fetching.
           {
             name: 'rss-proxy',
@@ -343,82 +340,6 @@ export const createConfig = ({
     ) as InlineConfig;
 
     return finalConfig;
-  },
-});
-
-const FUNCTION_NODE_TYPES = new Set(['FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression']);
-
-/**
- * Re-add the `async` keyword to lazy `__esm`/`__esmMin` init wrappers that rolldown emits without
- * it. Vite 8 / rolldown's wrapped-ESM codegen drops `async` from the init thunk generated for a
- * module that awaits a transitive top-level await — the `@automerge/automerge-subduction` WASM
- * init, reached by most stories — leaving a bare `await` inside a synchronous function. The browser
- * then throws a parse-time "await is a reserved identifier" SyntaxError for the whole chunk, which
- * surfaces as the Storybook render error on most stories. composer-app sidesteps this by running
- * echo-host in a worker; the storybook bundle pulls the same graph into the page, so the wrappers
- * are generated here and must be patched. The runtime helper invokes the thunk and returns its
- * result (callers already `await init_X()`), so flipping the broken thunks to `async` is exactly the
- * shape rolldown intended — a function whose body contains `await` is only valid when `async`.
- * Workaround for the rolldown regression tracked in https://github.com/rolldown/rolldown/issues/3686;
- * remove once the bundled rolldown ships the fix.
- */
-const fixAsyncEsmWrappers = (): Plugin => ({
-  name: 'dxos:fix-async-esm-wrappers',
-  // `renderChunk` sees the already-emitted (and invalid) chunk. The bare `await` sits inside a
-  // synchronous function, which no standard parser accepts (acorn's `allowAwaitOutsideFunction`
-  // only permits module-scope await), so parse with Babel's `errorRecovery` to still build the AST.
-  renderChunk(code) {
-    if (!code.includes('await')) {
-      return null;
-    }
-
-    let ast;
-    try {
-      ast = parse(code, { sourceType: 'module', errorRecovery: true });
-    } catch {
-      return null;
-    }
-
-    // Offsets of non-async functions whose own body contains a top-level `await`.
-    const starts = new Set<number>();
-    const visit = (node: any, enclosingFn: any) => {
-      if (!node || typeof node.type !== 'string') {
-        return;
-      }
-      const fn = FUNCTION_NODE_TYPES.has(node.type) ? node : enclosingFn;
-      if (node.type === 'AwaitExpression' && fn && !fn.async && typeof fn.start === 'number') {
-        starts.add(fn.start);
-      }
-      for (const key in node) {
-        // Skip metadata keys (positions, comments, tokens, recovered errors) — not AST children.
-        if (key === 'type' || key === 'start' || key === 'end' || key === 'loc' || key === 'range') {
-          continue;
-        }
-        if (key === 'comments' || key === 'tokens' || key === 'errors' || key.endsWith('Comments')) {
-          continue;
-        }
-        const value = node[key];
-        if (Array.isArray(value)) {
-          for (const child of value) {
-            visit(child, fn);
-          }
-        } else if (value && typeof value.type === 'string') {
-          visit(value, fn);
-        }
-      }
-    };
-    visit(ast, null);
-
-    if (starts.size === 0) {
-      return null;
-    }
-
-    // Splice from the highest offset down so earlier offsets stay valid.
-    let patched = code;
-    for (const start of [...starts].sort((a, b) => b - a)) {
-      patched = `${patched.slice(0, start)}async ${patched.slice(start)}`;
-    }
-    return { code: patched, map: null };
   },
 });
 

--- a/tools/storybook-react/package.json
+++ b/tools/storybook-react/package.json
@@ -18,7 +18,6 @@
     "test": "test-storybook --url http://127.0.0.1:9009"
   },
   "devDependencies": {
-    "@babel/parser": "catalog:",
     "@dxos/log": "workspace:*",
     "@dxos/storybook-addon-logger": "workspace:*",
     "@dxos/storybook-utils": "workspace:*",


### PR DESCRIPTION
## Summary

- WebKit's JavaScriptCore doesn't yet parse `using`/`await using` declarations (used by `@dxos/context`, `@dxos/client`, `@dxos/client-services`), so `storybook dev` served that syntax raw to the browser and crashed WebKit smoke tests with a SyntaxError. `build.target` only lowers syntax for `storybook build`; setting `oxc.target` applies the same downleveling to the dev-server transform that the e2e tests actually run against.
- Removes the `fixAsyncEsmWrappers` `renderChunk` workaround added in #12039 for a rolldown missing-`async`-wrapper bug. Verified stories that reach the affected `@automerge/automerge-subduction` WASM init chain (e.g. `plugin-kanban`'s MutableSchema board) build and run correctly on webkit/chromium without it, both via `storybook dev` and `storybook build`. This also drops the now-unused `@babel/parser` dependency. The rest of #12039 (the `@vitejs/plugin-react-swc` → `@vitejs/plugin-react` switch) is kept intact.

Fixes the WebKit e2e failures seen on main in `react-ui-mosaic`, `plugin-kanban`, and `plugin-sheet` smoke tests (all failing with `Error: locator.waitFor: Target page, context or browser has been closed`).

## Test plan

- [x] Reproduced the WebKit crash locally and root-caused it to raw `await using ctx = ...` syntax served by the storybook dev server
- [x] `react-ui-mosaic` webkit smoke suite (7/7 passing)
- [x] `plugin-kanban` webkit smoke suite (5/5 passing)
- [x] `plugin-sheet` webkit smoke suite (3/3 passing)
- [x] chromium smoke suites unaffected (confirmed a pre-existing drag-and-drop flake is unrelated to this change)
- [x] `storybook build` for `plugin-kanban` succeeds with no syntax errors across all 705 bundled files (checked with `node --check`), confirming `fixAsyncEsmWrappers` is not needed
- [x] `moon run storybook-react:lint` clean
- [x] `moon run :lint -- --fix` clean across all 276 packages
- [x] `pnpm format` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Storybook compatibility by aligning development and build output with a shared modern browser target.
  * Removed a workaround that could affect generated output handling in Storybook.

* **Chores**
  * Cleaned up workspace and tool dependencies by removing an unused parser package entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->