### PR TITLE
fix(messaging): derive TestPeer identityDid after createSignalManager

### DIFF
--- a/packages/core/mesh/messaging/src/testing/test-peer.ts
+++ b/packages/core/mesh/messaging/src/testing/test-peer.ts
@@ -46,8 +46,10 @@ export class TestPeer extends Resource {
   }
 
   protected override async _open(): Promise<void> {
-    this._identityDid = await createDidFromIdentityKey(this.peerId);
+    // `createSignalManager` (e.g. edge's factory) may reassign `peerId` to match its own signer,
+    // so the DID must be derived AFTER it resolves — not from the constructor-time random key.
     this.signalManager = await this.testBuilder.createSignalManager(this);
+    this._identityDid = await createDidFromIdentityKey(this.peerId);
     this.messenger = new Messenger({ signalManager: this.signalManager, retryDelay: 300 });
 
     await this.signalManager.open();

--- a/packages/core/mesh/messaging/src/testing/test-peer.ts
+++ b/packages/core/mesh/messaging/src/testing/test-peer.ts
@@ -6,6 +6,7 @@ import { Event } from '@dxos/async';
 import { Resource } from '@dxos/context';
 import { createDidFromIdentityKey } from '@dxos/credentials';
 import { PeerSchema } from '@dxos/edge-client';
+import { invariant } from '@dxos/invariant';
 import { type IdentityDid, PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { buf } from '@dxos/protocols/buf';
@@ -17,19 +18,24 @@ import { type TestBuilder } from './test-builder';
 import { expectPeerAvailable, expectPeerLeft, expectReceivedMessage } from './utils';
 
 export class TestPeer extends Resource {
-  public peerId = PublicKey.random();
+  /**
+   * Undefined until `_open()`: a `createSignalManager` factory (e.g. edge's) may install its own
+   * signer-backed key, otherwise a random one is generated. Read via {@link peerInfo} after opening.
+   */
+  public peerId?: PublicKey;
   public signalManager!: SignalManager;
   public messenger!: Messenger;
   public defaultReceived = new Event<Message>();
 
-  /** Set in `_open()`, mirroring the real derivation edge connections use (`createDeviceEdgeIdentity`). */
-  private _identityDid!: IdentityDid;
+  /** DID derived from {@link peerId} in `_open()`, mirroring `createDeviceEdgeIdentity`. */
+  private _identityDid?: IdentityDid;
 
   constructor(private readonly testBuilder: TestBuilder) {
     super();
   }
 
   get peerInfo(): PeerInfo {
+    invariant(this.peerId && this._identityDid, 'TestPeer not open');
     return buf.create(PeerSchema, { peerKey: this.peerId.toHex(), identityDid: this._identityDid });
   }
 
@@ -46,9 +52,10 @@ export class TestPeer extends Resource {
   }
 
   protected override async _open(): Promise<void> {
-    // `createSignalManager` (e.g. edge's factory) may reassign `peerId` to match its own signer,
-    // so the DID must be derived AFTER it resolves — not from the constructor-time random key.
+    // `createSignalManager` (e.g. edge's factory) may populate `peerId` with its own signer-backed
+    // key; otherwise fall back to a random one. Derive the DID only after `peerId` is settled.
     this.signalManager = await this.testBuilder.createSignalManager(this);
+    this.peerId ??= PublicKey.random();
     this._identityDid = await createDidFromIdentityKey(this.peerId);
     this.messenger = new Messenger({ signalManager: this.signalManager, retryDelay: 300 });
 


### PR DESCRIPTION
## Summary
- Follow-up to #12048, which fixed `TestPeer.peerInfo` to derive a real `identityDid` instead of fabricating one — but computed it in `_open()` **before** `createSignalManager()` resolved.
- Edge's own `edge-signal-manager.node.test.ts` factory reassigns `peer.peerId` to a fresh key from its own `Keyring` signer *inside* `createSignalManager()` (`peer.peerId = await signer.createKey()`), so `_identityDid` was still being derived from the stale constructor-time random key — reintroducing the same `EdgeIdentityChangedError` #12048 targeted, just via a different mismatch source (peerId reassignment race instead of DID fabrication).
- Fix: move the `createDidFromIdentityKey(this.peerId)` call to after `createSignalManager()` resolves, so it picks up whatever `peerId` the factory ultimately settled on.

## Verification
Confirmed by patching the compiled dist of the *previous* fix (#12048) directly in `dxos/edge`'s `node_modules` and rerunning the previously-failing suite:
- Before this fix: `edge-signal-manager.node.test.ts` — 10 failed (10) — `EdgeIdentityChangedError` via `EdgeSignalManager.join`.
- After this fix (same reorder, applied by hand to the dist): 10 passed (10).

- [x] `moon run messaging:build` — passes
- [x] `moon run messaging:lint` — 0 warnings/errors
- [x] `moon run messaging:test` — 13 passed, 6 skipped (same as before, no regression)
- [ ] Once published, bump `dxos/edge`'s catalog pin and rerun `edge-signal-manager.node.test.ts` against the real (unpatched) build to close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer startup by deferring initialization of identity-related values until they’re ready, reducing intermittent failures when bringing up test peers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->