### PR TITLE
chore(echo-host): bump automerge dependencies

### DIFF
--- a/packages/core/echo/echo-host/src/automerge/automerge-repo-subduction-policy.test.ts
+++ b/packages/core/echo/echo-host/src/automerge/automerge-repo-subduction-policy.test.ts
@@ -820,13 +820,10 @@ describe.skipIf(process.env.CI)('SubductionPolicy', () => {
     //   1. `host.shareConfigChanged()` + `client.shareConfigChanged()`
     //      after the flip does not deliver the doc within 1.5s.
     //   2. `reconnectAdapters` (full peer-disconnected + peer-candidate
-    //      cycle on both sides) also does NOT deliver the doc — the
-    //      bridge does not retry a `lastSyncResult === 'all-failed'`
-    //      entry on connection-generation bumps.
-    //   3. A fresh local commit on the holder enqueues a new outbound
-    //      batch that sidesteps the stuck entry, so the now-allowing
-    //      policy finally lets the doc land.
-    test('authorizePut deny → allow recovers via fresh holder commit, not reconnect', { timeout: 20_000 }, async () => {
+    //      cycle on both sides) does deliver the doc — the connection-
+    //      generation bump re-drives the holder's stuck
+    //      `lastSyncResult === 'all-failed'` push.
+    test('authorizePut deny → allow recovers via reconnect', { timeout: 20_000 }, async () => {
       let allowPut = false;
       const { repos, adapters } = await createHostClientRepoTopology({
         subductionPolicies: {
@@ -859,21 +856,13 @@ describe.skipIf(process.env.CI)('SubductionPolicy', () => {
       await sleep(NEGATIVE_ASSERTION_DELAY_MS);
       expect(progress.peek().state).to.not.equal('ready');
 
-      // Reconnect alone also does not recover: the bridge does not retry an
-      // 'all-failed' entry on connection-generation bumps.
+      // Reconnect recovers: the connection-generation bump re-drives the
+      // holder's stuck 'all-failed' push, and the now-allowing policy lets
+      // it land.
       await reconnectAdapters(adapters);
-      await sleep(NEGATIVE_ASSERTION_DELAY_MS);
-      expect(progress.peek().state).to.not.equal('ready');
-
-      // A fresh local commit on the holder enqueues a new outbound batch
-      // that sidesteps the stuck entry; the now-allowing policy lets it
-      // land, bringing the whole sedimentree (including 'gated-put') across.
-      handle.change((doc: any) => {
-        doc.text = 'after-flip';
-      });
       await expect
         .poll(async () => (await client.find<{ text?: string }>(handle.url)).doc()?.text, { timeout: 10_000 })
-        .toEqual('after-flip');
+        .toEqual('gated-put');
     });
 
     // Hypothesis: without `shareConfigChanged()`, recovery is left to

--- a/packages/core/echo/echo-host/src/automerge/automerge-repo-subduction.test.ts
+++ b/packages/core/echo/echo-host/src/automerge/automerge-repo-subduction.test.ts
@@ -67,6 +67,10 @@ describe.skipIf(process.env.CI)('AutomergeRepo with Subduction', () => {
       await repo.shutdown();
     }
 
+    // `Repo.shutdown()` closes its storage adapter; reopen before reusing it for
+    // the second `Repo` that simulates a reload from disk.
+    await storage.open();
+
     {
       const repo = createRepo({ network: [], storage });
       const handle = await repo.find<{ field?: string }>(url as AutomergeUrl);
@@ -168,6 +172,9 @@ describe.skipIf(process.env.CI)('AutomergeRepo with Subduction', () => {
         await shutdownRepo(peer1);
       }
 
+      // `Repo.shutdown()` closes its storage adapter; reopen before reusing it in the topology.
+      await storage.open();
+
       const { repos, adapters } = await createHostClientRepoTopology({ storages: [storage] });
       const [peer1, peer2] = repos;
       await connectAdapters(adapters);
@@ -209,6 +216,9 @@ describe.skipIf(process.env.CI)('AutomergeRepo with Subduction', () => {
       expect(serverHandle.doc()!.field).to.deep.equal(value);
       await waitForSubductionSave();
       await repo.shutdown();
+
+      // `Repo.shutdown()` closes its storage adapter; reopen before reusing it for `repo2`.
+      await storage.open();
 
       const repo2 = createRepo({ network: [], storage });
       const reloaded = await repo2.find<any>(documentId);

--- a/packages/core/echo/echo-host/src/automerge/leveldb-storage-adapter.ts
+++ b/packages/core/echo/echo-host/src/automerge/leveldb-storage-adapter.ts
@@ -5,7 +5,6 @@
 import { type Chunk, type StorageAdapterInterface, type StorageKey } from '@automerge/automerge-repo';
 import { type MixedEncoding } from 'level-transcoder';
 
-import { Resource } from '@dxos/context';
 import { type BatchLevel, type SublevelDB } from '@dxos/kv-store';
 import { type MaybePromise } from '@dxos/util';
 
@@ -29,9 +28,9 @@ export interface StorageCallbacks {
   afterSave(path: StorageKey): MaybePromise<void>;
 }
 
-export class LevelDBStorageAdapter extends Resource implements StorageAdapterInterface {
+export class LevelDBStorageAdapter implements StorageAdapterInterface {
   /**
-   * In-flight `loadRange` / `removeRange` iterations. Awaited in `_close` so
+   * In-flight `loadRange` / `removeRange` iterations. Awaited in `close` so
    * the adapter doesn't return from close while a `for await` on the sublevel
    * is still pending — otherwise the kv owner upstream would close the
    * sublevel and the iterator's next `.next()` would reject with
@@ -42,15 +41,26 @@ export class LevelDBStorageAdapter extends Resource implements StorageAdapterInt
    */
   readonly #inFlightIterations = new Set<Promise<unknown>>();
 
-  constructor(private readonly _params: LevelDBStorageAdapterProps) {
-    super();
+  #open = false;
+
+  constructor(private readonly _params: LevelDBStorageAdapterProps) {}
+
+  get isOpen(): boolean {
+    return this.#open;
   }
 
-  protected override async _close(): Promise<void> {
-    // New `loadRange`/`removeRange` calls already short-circuit on `!isOpen`
-    // (the Resource base flips state before invoking `_close`). Wait for any
-    // iterations that started while we were still open to finish before
-    // returning, so the upstream `kv` owner can safely close the sublevel.
+  async open(): Promise<void> {
+    this.#open = true;
+  }
+
+  async close(): Promise<void> {
+    if (!this.#open) {
+      return;
+    }
+    this.#open = false;
+    // New `loadRange`/`removeRange` calls already short-circuit on `!isOpen`.
+    // Wait for any iterations that started while we were still open to finish
+    // before returning, so the upstream `kv` owner can safely close the sublevel.
     if (this.#inFlightIterations.size > 0) {
       await Promise.all(this.#inFlightIterations);
     }

--- a/packages/core/echo/echo-host/src/automerge/sqlite-storage-adapter.ts
+++ b/packages/core/echo/echo-host/src/automerge/sqlite-storage-adapter.ts
@@ -7,7 +7,6 @@ import * as SqlClient from '@effect/sql/SqlClient';
 import type * as SqlError from '@effect/sql/SqlError';
 import * as Effect from 'effect/Effect';
 
-import { Resource } from '@dxos/context';
 import { RuntimeProvider } from '@dxos/effect';
 import { log } from '@dxos/log';
 import { SqlTransaction } from '@dxos/sql-sqlite';
@@ -33,16 +32,29 @@ export type SqliteStorageCallbacks = {
  * Stores automerge document chunks in the `automerge_chunks` table.
  * Replaces LevelDBStorageAdapter.
  */
-export class SqliteStorageAdapter extends Resource implements StorageAdapterInterface {
+export class SqliteStorageAdapter implements StorageAdapterInterface {
   readonly #runtime: RuntimeProvider.RuntimeProvider<SqlClient.SqlClient | SqlTransactionTag>;
   readonly #callbacks?: SqliteStorageCallbacks;
   readonly #monitor?: StorageAdapterDataMonitor;
 
+  #open = false;
+
   constructor({ runtime, callbacks, monitor }: SqliteStorageAdapterProps) {
-    super();
     this.#runtime = runtime;
     this.#callbacks = callbacks;
     this.#monitor = monitor;
+  }
+
+  get isOpen(): boolean {
+    return this.#open;
+  }
+
+  async open(): Promise<void> {
+    this.#open = true;
+  }
+
+  async close(): Promise<void> {
+    this.#open = false;
   }
 
   /**

--- a/patches/@automerge__automerge-repo@2.6.0-subduction.39.patch
+++ b/patches/@automerge__automerge-repo@2.6.0-subduction.39.patch
@@ -20,10 +20,10 @@ index 6d59fcf90a6a89235c5c7d1e563a485100e38885..e5432f1c3280418648a32db19424bbda
       * A Subduction peer (e.g. the sync server) advertised new heads for a
       * document. `storageId` is the peer's verifying-key peer id. Fires only for
 diff --git a/dist/Repo.js b/dist/Repo.js
-index d13f731f39ba31bdd46883887b62f7a9827d87c5..a9616e1e9cf2eb352f0dee27bbf38a30dc937d69 100644
+index fc9206088bf1c79e27f854abcbe748ea36ca72f4..ae3d41d4eab981d290c377bf5fa6ee0c41dcf479 100644
 --- a/dist/Repo.js
 +++ b/dist/Repo.js
-@@ -156,6 +156,18 @@ export class Repo extends EventEmitter {
+@@ -159,6 +159,18 @@ export class Repo extends EventEmitter {
              onConnectionChanged: connected => {
                  this.emit("subduction-connection", { connected });
              },
@@ -185,10 +185,10 @@ index 58e2506731d668f6c555f83f57ba29c3351b4723..9d782faf41382c2a20d2d386e821d63f
      isConnected(): boolean;
      generation(): number;
 diff --git a/dist/subduction/SubductionConnections.js b/dist/subduction/SubductionConnections.js
-index bb0aecdca57b83b798e60101a16ac22366a6d1a1..6af71251baa294166e168060fd9b7d03c6ac3b60 100644
+index e20460653181da69b68a092d13d17840859d38a9..2d016f0a6945afa49c01ab0b99b72bcd3e227469 100644
 --- a/dist/subduction/SubductionConnections.js
 +++ b/dist/subduction/SubductionConnections.js
-@@ -7,11 +7,13 @@ export class SubductionConnections {
+@@ -15,11 +15,13 @@ export class SubductionConnections {
      #log = debug("automerge-repo:subduction:connections");
      #subduction;
      #onChangeCallback = null;
@@ -203,7 +203,7 @@ index bb0aecdca57b83b798e60101a16ac22366a6d1a1..6af71251baa294166e168060fd9b7d03
      }
      // ── ConnectionManager interface ─────────────────────────────────────
      isConnecting() {
-@@ -48,10 +50,21 @@ export class SubductionConnections {
+@@ -57,11 +59,22 @@ export class SubductionConnections {
                      break;
                  }
                  const subduction = await this.#subduction;
@@ -211,6 +211,7 @@ index bb0aecdca57b83b798e60101a16ac22366a6d1a1..6af71251baa294166e168060fd9b7d03
 +                const subductionPeerId = await subduction.connectTransport(transport, serviceName);
                  this.#setConnectionState(url, "running");
                  this.#log(`connected to ${url}`);
+                 lifecycle(`connected to ${url}`);
                  backoff = RECONNECT_BASE_MS;
 +                // Notify after the connection state has flipped to "running"
 +                // so consumers reading repo state from inside the listener see
@@ -225,8 +226,8 @@ index bb0aecdca57b83b798e60101a16ac22366a6d1a1..6af71251baa294166e168060fd9b7d03
 +                }
                  await transport.closed();
                  this.#log(`disconnected from ${url}`);
-             }
-@@ -74,6 +87,7 @@ export class SubductionConnections {
+                 lifecycle(`disconnected from ${url}`, "warn");
+@@ -87,6 +100,7 @@ export class SubductionConnections {
      }
      shutdown() {
          this.#isShutdown = true;
@@ -291,7 +292,7 @@ index 783d9f61eae0684037d8fbbe0b676a924ba53c18..bf8e9f45ae02e6d5345e310dffb44ca4
      isConnected(): boolean;
      getSubduction(): Promise<Subduction>;
 diff --git a/dist/subduction/source.js b/dist/subduction/source.js
-index 9a5dfa03ce3d57babf77423519db6cd7b7b2f6d2..0aacd923fe07a3366fa7e5a5ff3f3951ada4b3bb 100644
+index 33db9f0538a41312079e7ccb31ca57f6cb975ce9..0843ce5697de4edc350a98fd310e1536a36e9f44 100644
 --- a/dist/subduction/source.js
 +++ b/dist/subduction/source.js
 @@ -50,7 +50,7 @@ export class SubductionSource {

--- a/patches/@automerge__automerge-repo@2.6.0-subduction.40.patch
+++ b/patches/@automerge__automerge-repo@2.6.0-subduction.40.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/Repo.d.ts b/dist/Repo.d.ts
-index 6d59fcf90a6a89235c5c7d1e563a485100e38885..e5432f1c3280418648a32db19424bbdaf9d3b305 100644
+index de3b577133f1ee0ac56a60a09576cc6e37f37e72..f07b0a65869cef8b4dc9dfebfb08713f7531a0d4 100644
 --- a/dist/Repo.d.ts
 +++ b/dist/Repo.d.ts
 @@ -8,6 +8,7 @@ import { StorageAdapterInterface } from "./storage/StorageAdapterInterface.js";
@@ -10,7 +10,7 @@ index 6d59fcf90a6a89235c5c7d1e563a485100e38885..e5432f1c3280418648a32db19424bbda
  import type { AnyDocumentId, AutomergeUrl, DocumentId, PeerId, UrlHeads } from "./types.js";
  import { AbortOptions } from "./helpers/abortable.js";
  import { type Subduction } from "@automerge/automerge-subduction/slim";
-@@ -317,6 +318,8 @@ export interface RepoEvents {
+@@ -329,6 +330,8 @@ export interface RepoEvents {
      "heal-exhausted": (payload: {
          documentId: DocumentId;
      }) => void;
@@ -20,10 +20,10 @@ index 6d59fcf90a6a89235c5c7d1e563a485100e38885..e5432f1c3280418648a32db19424bbda
       * A Subduction peer (e.g. the sync server) advertised new heads for a
       * document. `storageId` is the peer's verifying-key peer id. Fires only for
 diff --git a/dist/Repo.js b/dist/Repo.js
-index fc9206088bf1c79e27f854abcbe748ea36ca72f4..ae3d41d4eab981d290c377bf5fa6ee0c41dcf479 100644
+index 3de5b46b4de4340580996a9379ee2fae5cceef23..5751e8482c10a4364682715ecdc09210e1d97eb1 100644
 --- a/dist/Repo.js
 +++ b/dist/Repo.js
-@@ -159,6 +159,18 @@ export class Repo extends EventEmitter {
+@@ -157,6 +157,18 @@ export class Repo extends EventEmitter {
              onConnectionChanged: connected => {
                  this.emit("subduction-connection", { connected });
              },
@@ -185,11 +185,11 @@ index 58e2506731d668f6c555f83f57ba29c3351b4723..9d782faf41382c2a20d2d386e821d63f
      isConnected(): boolean;
      generation(): number;
 diff --git a/dist/subduction/SubductionConnections.js b/dist/subduction/SubductionConnections.js
-index e20460653181da69b68a092d13d17840859d38a9..2d016f0a6945afa49c01ab0b99b72bcd3e227469 100644
+index d9dcbded092b95e69d41d142fe73a25b108de585..ff91b96b86aff5e9efd8ac06fcffb6383098ab20 100644
 --- a/dist/subduction/SubductionConnections.js
 +++ b/dist/subduction/SubductionConnections.js
-@@ -15,11 +15,13 @@ export class SubductionConnections {
-     #log = debug("automerge-repo:subduction:connections");
+@@ -7,11 +7,13 @@ export class SubductionConnections {
+     #log = makeLogger("automerge-repo:subduction:connections");
      #subduction;
      #onChangeCallback = null;
 +    #onPeerBound;
@@ -203,15 +203,14 @@ index e20460653181da69b68a092d13d17840859d38a9..2d016f0a6945afa49c01ab0b99b72bcd
      }
      // ── ConnectionManager interface ─────────────────────────────────────
      isConnecting() {
-@@ -57,11 +59,22 @@ export class SubductionConnections {
+@@ -48,10 +50,21 @@ export class SubductionConnections {
                      break;
                  }
                  const subduction = await this.#subduction;
 -                await subduction.connectTransport(transport, serviceName);
 +                const subductionPeerId = await subduction.connectTransport(transport, serviceName);
                  this.#setConnectionState(url, "running");
-                 this.#log(`connected to ${url}`);
-                 lifecycle(`connected to ${url}`);
+                 this.#log.debug(`connected to ${url}`);
                  backoff = RECONNECT_BASE_MS;
 +                // Notify after the connection state has flipped to "running"
 +                // so consumers reading repo state from inside the listener see
@@ -221,13 +220,13 @@ index e20460653181da69b68a092d13d17840859d38a9..2d016f0a6945afa49c01ab0b99b72bcd
 +                        this.#onPeerBound({ subductionPeerId, url });
 +                    }
 +                    catch (e) {
-+                        this.#log("onPeerBound threw for %s: %O", url, e);
++                        this.#log.warn(`onPeerBound threw for ${url}:`, e);
 +                    }
 +                }
                  await transport.closed();
-                 this.#log(`disconnected from ${url}`);
-                 lifecycle(`disconnected from ${url}`, "warn");
-@@ -87,6 +100,7 @@ export class SubductionConnections {
+                 this.#log.warn(`disconnected from ${url}`);
+             }
+@@ -74,6 +87,7 @@ export class SubductionConnections {
      }
      shutdown() {
          this.#isShutdown = true;
@@ -236,7 +235,7 @@ index e20460653181da69b68a092d13d17840859d38a9..2d016f0a6945afa49c01ab0b99b72bcd
              clearTimeout(timer);
              resolve();
 diff --git a/dist/subduction/source.d.ts b/dist/subduction/source.d.ts
-index 783d9f61eae0684037d8fbbe0b676a924ba53c18..bf8e9f45ae02e6d5345e310dffb44ca4539eebfc 100644
+index 825f7407bd8bf1f4b1f4fafe17f67e82778781a6..2a10de3c01e415de407c345f60698d38ce445d32 100644
 --- a/dist/subduction/source.d.ts
 +++ b/dist/subduction/source.d.ts
 @@ -1,4 +1,4 @@
@@ -282,29 +281,29 @@ index 783d9f61eae0684037d8fbbe0b676a924ba53c18..bf8e9f45ae02e6d5345e310dffb44ca4
      policy?: Policy;
      /**
       * What priority this source should have w.r.t to other sources
-@@ -111,7 +134,7 @@ export interface SubductionSourceOptions {
+@@ -116,7 +139,7 @@ export interface SubductionSourceOptions {
  export declare class SubductionSource implements DocumentSource {
      #private;
      readonly priority: SourcePriority;
--    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onConnectionChanged, priority, policy, timeouts, blobInterceptor, }: SubductionSourceOptions);
-+    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onConnectionChanged, onPeerBound, priority, policy, timeouts, blobInterceptor, }: SubductionSourceOptions);
+-    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onConnectionChanged, priority, policy, timeouts, compactionDeleteConcurrency, blobInterceptor, }: SubductionSourceOptions);
++    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onConnectionChanged, onPeerBound, priority, policy, timeouts, compactionDeleteConcurrency, blobInterceptor, }: SubductionSourceOptions);
      /** True if any connection manager has an established connection. */
      isConnected(): boolean;
      getSubduction(): Promise<Subduction>;
 diff --git a/dist/subduction/source.js b/dist/subduction/source.js
-index 33db9f0538a41312079e7ccb31ca57f6cb975ce9..0843ce5697de4edc350a98fd310e1536a36e9f44 100644
+index 890813ea22ab990a13b1af60ee8e3b2103652ac7..e06a3e5bc0f609c4fb02d2ffcfc5bff7e85896dc 100644
 --- a/dist/subduction/source.js
 +++ b/dist/subduction/source.js
-@@ -50,7 +50,7 @@ export class SubductionSource {
+@@ -60,7 +60,7 @@ export class SubductionSource {
       */
      #shuttingDown = false;
      priority;
--    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onConnectionChanged, priority = 2, policy, timeouts, blobInterceptor, }) {
-+    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onConnectionChanged, onPeerBound, priority = 2, policy, timeouts, blobInterceptor, }) {
+-    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onConnectionChanged, priority = 2, policy, timeouts, compactionDeleteConcurrency = DEFAULT_COMPACTION_DELETE_CONCURRENCY, blobInterceptor, }) {
++    constructor({ peerId, storage, signer, websocketEndpoints, adapters, onRemoteHeadsChanged, onEphemeral, onHealExhausted, onConnectionChanged, onPeerBound, priority = 2, policy, timeouts, compactionDeleteConcurrency = DEFAULT_COMPACTION_DELETE_CONCURRENCY, blobInterceptor, }) {
          this.#blobInterceptor = blobInterceptor;
          this.#onConnectionChanged = onConnectionChanged;
          this.priority = priority;
-@@ -108,12 +108,23 @@ export class SubductionSource {
+@@ -119,12 +119,23 @@ export class SubductionSource {
              ...defaultTimeoutOption,
          }));
          // ── Connection managers ─────────────────────────────────────────

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,17 +40,17 @@ catalogs:
       specifier: ^0.19.5
       version: 0.19.11
     '@automerge/automerge-repo':
-      specifier: 2.6.0-subduction.37
-      version: 2.6.0-subduction.37
+      specifier: 2.6.0-subduction.39
+      version: 2.6.0-subduction.39
     '@automerge/automerge-repo-network-broadcastchannel':
-      specifier: 2.6.0-subduction.37
-      version: 2.6.0-subduction.37
+      specifier: 2.6.0-subduction.39
+      version: 2.6.0-subduction.39
     '@automerge/automerge-repo-network-websocket':
-      specifier: 2.6.0-subduction.37
-      version: 2.6.0-subduction.37
+      specifier: 2.6.0-subduction.39
+      version: 2.6.0-subduction.39
     '@automerge/automerge-repo-storage-indexeddb':
-      specifier: 2.6.0-subduction.37
-      version: 2.6.0-subduction.37
+      specifier: 2.6.0-subduction.39
+      version: 2.6.0-subduction.39
     '@babel/core':
       specifier: ^7.18.13
       version: 7.28.0
@@ -1880,7 +1880,7 @@ catalogs:
       version: 8.8.5
 
 overrides:
-  '@automerge/automerge': 3.3.0-fragments.2
+  '@automerge/automerge': 3.3.0-fragments.1
   '@automerge/automerge-subduction': 0.16.0
   '@dxos/docs>vite': ^7.3.2
   '@grpc/grpc-js': '>=1.10.9'
@@ -1934,9 +1934,9 @@ overrides:
 pnpmfileChecksum: sha256-cQVl+jrEHH0V4IgNkydwSKNmLoShP2mLkufXFXEHIjU=
 
 patchedDependencies:
-  '@automerge/automerge-repo@2.6.0-subduction.37':
-    hash: 563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd
-    path: patches/@automerge__automerge-repo@2.6.0-subduction.37.patch
+  '@automerge/automerge-repo@2.6.0-subduction.39':
+    hash: af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799
+    path: patches/@automerge__automerge-repo@2.6.0-subduction.39.patch
   '@automerge/automerge-subduction@0.16.0':
     hash: 6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669
     path: patches/@automerge__automerge-subduction@0.16.0.patch
@@ -2349,11 +2349,11 @@ importers:
   .agents/skills/composer-forensics/scripts:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
       '@dxos/keys':
         specifier: workspace:*
         version: link:../../../../packages/common/keys
@@ -2431,11 +2431,11 @@ importers:
         specifier: 'catalog:'
         version: 3.2.10(@types/react@19.2.17)(react@19.2.7)
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.20.3
@@ -4689,8 +4689,8 @@ importers:
   packages/core/compute/assistant:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@dxos/ai':
         specifier: workspace:*
         version: link:../ai
@@ -5502,8 +5502,8 @@ importers:
         version: 1.6.0
     devDependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@aws-sdk/client-s3':
         specifier: 3.955.0
         version: 3.955.0
@@ -5895,11 +5895,11 @@ importers:
   packages/core/echo/echo-client:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../../common/async
@@ -5989,8 +5989,8 @@ importers:
   packages/core/echo/echo-client-e2e:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@dxos/async':
         specifier: workspace:*
         version: link:../../../common/async
@@ -6043,8 +6043,8 @@ importers:
   packages/core/echo/echo-doc:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@dxos/echo':
         specifier: workspace:*
         version: link:../echo
@@ -6067,8 +6067,8 @@ importers:
   packages/core/echo/echo-generator:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@dxos/client':
         specifier: workspace:*
         version: link:../../../sdk/client
@@ -6101,11 +6101,11 @@ importers:
   packages/core/echo/echo-host:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
       '@automerge/automerge-subduction':
         specifier: 0.16.0
         version: 0.16.0(patch_hash=6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669)
@@ -7425,8 +7425,8 @@ importers:
   packages/devtools/devtools:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -7829,17 +7829,17 @@ importers:
   packages/e2e/blade-runner:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
       '@automerge/automerge-repo-network-websocket':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37
+        version: 2.6.0-subduction.39
       '@automerge/automerge-repo-storage-indexeddb':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37
+        version: 2.6.0-subduction.39
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -11961,8 +11961,8 @@ importers:
   packages/plugins/plugin-markdown:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@codemirror/state':
         specifier: 'catalog:'
         version: 6.7.0
@@ -14020,8 +14020,8 @@ importers:
   packages/plugins/plugin-script:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.20.3
@@ -14867,8 +14867,8 @@ importers:
   packages/plugins/plugin-sketch:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -17480,8 +17480,8 @@ importers:
         version: 2.11.1
     devDependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@dxos/echo-client':
         specifier: workspace:*
         version: link:../../core/echo/echo-client
@@ -17510,11 +17510,11 @@ importers:
   packages/sdk/client:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -17736,11 +17736,11 @@ importers:
   packages/sdk/client-services:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -17999,11 +17999,11 @@ importers:
   packages/sdk/migrations:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
       '@dxos/client':
         specifier: workspace:*
         version: link:../client
@@ -18301,8 +18301,8 @@ importers:
         version: 3.21.4
     devDependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@dxos/react-client':
         specifier: workspace:*
         version: link:../react-client
@@ -20444,8 +20444,8 @@ importers:
   packages/ui/react-ui-editor:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.20.3
@@ -20614,10 +20614,10 @@ importers:
     devDependencies:
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
       '@automerge/automerge-repo-network-broadcastchannel':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37
+        version: 2.6.0-subduction.39
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -22577,8 +22577,8 @@ importers:
   packages/ui/ui-editor:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.20.3
@@ -22726,10 +22726,10 @@ importers:
     devDependencies:
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
       '@automerge/automerge-repo-network-broadcastchannel':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.37
+        version: 2.6.0-subduction.39
       '@dxos/config':
         specifier: workspace:*
         version: link:../../sdk/config
@@ -23623,27 +23623,27 @@ packages:
   '@atproto/xrpc@0.7.7':
     resolution: {integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==}
 
-  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.37':
-    resolution: {integrity: sha512-OEm6cuCQcEThxb5o7hLk8g471omeu8daaeGoLqaGXvTpzE/1HacJK9WpdZQ7SWudkHYdum56nmR4X9BwDkfS3Q==}
+  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.39':
+    resolution: {integrity: sha512-yBUrWKLGHAe9D7nfvO2rVdA6CIgvcy7MD6sQt60M8INb9b8eoxDuNYDTraQPnusidQH6r8+/E67h8YIGF7uhPQ==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.37':
-    resolution: {integrity: sha512-BgxKPgnnEnNgQYUvzinhfnYYNRP0eWhTVgg/ut3JYZdjq7h+OyYrIEiy6eGIkKBn/8USIZKQnvhJH1TXwyfyGg==}
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.39':
+    resolution: {integrity: sha512-SVx/jA19+tCB1jCoXao+rC8v4TrYPQBgKcRcSgW3KXiVhFfIjQlk19AzZH9siKaIxo9RcnAF0+cdymYh/pMVlg==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.37':
-    resolution: {integrity: sha512-mNr6Pgf5zbFN/g4KzP/OsPvOmI4jf8KNeJcC3EkYGXEm+/c/aV/Upi+9NTY17uRTLwL/K3eURs800Mi57h7uhg==}
+  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.39':
+    resolution: {integrity: sha512-/teyLHObHm21E5HX0/xg6q+GZKHW7mR6sdRXjMXhfAf2rFTRNOAxhWN+tGXarub9bhpNjgPAcuumPgaNKhSCLQ==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo@2.6.0-subduction.37':
-    resolution: {integrity: sha512-YEnO34sMOKfXkyW0paqfa5BFehXT/VnwMhpxGcLrVLQbGzvXk14uT1vGp//u1wmrFw+iVj++W0E+owA615SbdA==}
+  '@automerge/automerge-repo@2.6.0-subduction.39':
+    resolution: {integrity: sha512-YREc25rNf/AE1d90rPTLQJEKPORDdBthKw8siu1VjkAGs5eJL6IgQK6U1mytVR/ex7MukBpmzwNa19tnGHsGcw==}
     engines: {node: '>=22.13'}
 
   '@automerge/automerge-subduction@0.16.0':
     resolution: {integrity: sha512-BOOn/4p8cF4LhjDUQdgM3qyZFya+M7ZuZywuC99x/kbhk4UK7dw/QcsifcHG5E1TAW4R/K17ZGFUC5nCVUSSWg==}
 
-  '@automerge/automerge@3.3.0-fragments.2':
-    resolution: {integrity: sha512-F5KL+YXD0GMFH/as0/kJ3+lotpuJsH1SSrhhKdYSGtR+S9ytBNTw+s3pAjF2Vr0+ZdTMHxsGjqj5SRkJiSNokQ==}
+  '@automerge/automerge@3.3.0-fragments.1':
+    resolution: {integrity: sha512-Im2n3qcYSuIsLDSjofTRo7CZyyvFn5pKLSCCO5sjWzESw+9q9G25ZIrL2mczDX43cXtyzi+w/4b9VUaiNdY56Q==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -43927,17 +43927,17 @@ snapshots:
       '@atproto/lexicon': 0.6.2
       zod: 3.25.76
 
-  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.37':
+  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.39':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+      '@automerge/automerge-repo': 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.37':
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.39':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+      '@automerge/automerge-repo': 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
       cbor-x: 1.6.4
       debug: 4.4.3(supports-color@5.5.0)
       eventemitter3: 5.0.4
@@ -43947,17 +43947,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.37':
+  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.39':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)
+      '@automerge/automerge-repo': 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo@2.6.0-subduction.37(patch_hash=563a7369aae1dd655f3beef22d027dfdf429c2708a2543568b1d63cbf9f90acd)':
+  '@automerge/automerge-repo@2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)':
     dependencies:
-      '@automerge/automerge': 3.3.0-fragments.2
+      '@automerge/automerge': 3.3.0-fragments.1
       '@automerge/automerge-subduction': 0.16.0(patch_hash=6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669)
       bs58check: 4.0.0
       cbor-x: 1.6.4
@@ -43975,7 +43975,7 @@ snapshots:
 
   '@automerge/automerge-subduction@0.16.0(patch_hash=6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669)': {}
 
-  '@automerge/automerge@3.3.0-fragments.2': {}
+  '@automerge/automerge@3.3.0-fragments.1': {}
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,17 +40,17 @@ catalogs:
       specifier: ^0.19.5
       version: 0.19.11
     '@automerge/automerge-repo':
-      specifier: 2.6.0-subduction.39
-      version: 2.6.0-subduction.39
+      specifier: 2.6.0-subduction.40
+      version: 2.6.0-subduction.40
     '@automerge/automerge-repo-network-broadcastchannel':
-      specifier: 2.6.0-subduction.39
-      version: 2.6.0-subduction.39
+      specifier: 2.6.0-subduction.40
+      version: 2.6.0-subduction.40
     '@automerge/automerge-repo-network-websocket':
-      specifier: 2.6.0-subduction.39
-      version: 2.6.0-subduction.39
+      specifier: 2.6.0-subduction.40
+      version: 2.6.0-subduction.40
     '@automerge/automerge-repo-storage-indexeddb':
-      specifier: 2.6.0-subduction.39
-      version: 2.6.0-subduction.39
+      specifier: 2.6.0-subduction.40
+      version: 2.6.0-subduction.40
     '@babel/core':
       specifier: ^7.18.13
       version: 7.28.0
@@ -1880,7 +1880,7 @@ catalogs:
       version: 8.8.5
 
 overrides:
-  '@automerge/automerge': 3.3.0-fragments.1
+  '@automerge/automerge': 3.3.0-fragments.2
   '@automerge/automerge-subduction': 0.16.0
   '@dxos/docs>vite': ^7.3.2
   '@grpc/grpc-js': '>=1.10.9'
@@ -1934,9 +1934,9 @@ overrides:
 pnpmfileChecksum: sha256-cQVl+jrEHH0V4IgNkydwSKNmLoShP2mLkufXFXEHIjU=
 
 patchedDependencies:
-  '@automerge/automerge-repo@2.6.0-subduction.39':
-    hash: af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799
-    path: patches/@automerge__automerge-repo@2.6.0-subduction.39.patch
+  '@automerge/automerge-repo@2.6.0-subduction.40':
+    hash: 2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db
+    path: patches/@automerge__automerge-repo@2.6.0-subduction.40.patch
   '@automerge/automerge-subduction@0.16.0':
     hash: 6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669
     path: patches/@automerge__automerge-subduction@0.16.0.patch
@@ -2349,11 +2349,11 @@ importers:
   .agents/skills/composer-forensics/scripts:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+        version: 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
       '@dxos/keys':
         specifier: workspace:*
         version: link:../../../../packages/common/keys
@@ -2431,11 +2431,11 @@ importers:
         specifier: 'catalog:'
         version: 3.2.10(@types/react@19.2.17)(react@19.2.7)
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+        version: 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.20.3
@@ -4689,8 +4689,8 @@ importers:
   packages/core/compute/assistant:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/ai':
         specifier: workspace:*
         version: link:../ai
@@ -5502,8 +5502,8 @@ importers:
         version: 1.6.0
     devDependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@aws-sdk/client-s3':
         specifier: 3.955.0
         version: 3.955.0
@@ -5895,11 +5895,11 @@ importers:
   packages/core/echo/echo-client:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+        version: 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../../common/async
@@ -5989,8 +5989,8 @@ importers:
   packages/core/echo/echo-client-e2e:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/async':
         specifier: workspace:*
         version: link:../../../common/async
@@ -6043,8 +6043,8 @@ importers:
   packages/core/echo/echo-doc:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/echo':
         specifier: workspace:*
         version: link:../echo
@@ -6067,8 +6067,8 @@ importers:
   packages/core/echo/echo-generator:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/client':
         specifier: workspace:*
         version: link:../../../sdk/client
@@ -6101,11 +6101,11 @@ importers:
   packages/core/echo/echo-host:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+        version: 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
       '@automerge/automerge-subduction':
         specifier: 0.16.0
         version: 0.16.0(patch_hash=6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669)
@@ -7425,8 +7425,8 @@ importers:
   packages/devtools/devtools:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -7829,17 +7829,17 @@ importers:
   packages/e2e/blade-runner:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+        version: 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
       '@automerge/automerge-repo-network-websocket':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39
+        version: 2.6.0-subduction.40
       '@automerge/automerge-repo-storage-indexeddb':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39
+        version: 2.6.0-subduction.40
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -11961,8 +11961,8 @@ importers:
   packages/plugins/plugin-markdown:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@codemirror/state':
         specifier: 'catalog:'
         version: 6.7.0
@@ -14020,8 +14020,8 @@ importers:
   packages/plugins/plugin-script:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.20.3
@@ -14867,8 +14867,8 @@ importers:
   packages/plugins/plugin-sketch:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -17480,8 +17480,8 @@ importers:
         version: 2.11.1
     devDependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/echo-client':
         specifier: workspace:*
         version: link:../../core/echo/echo-client
@@ -17510,11 +17510,11 @@ importers:
   packages/sdk/client:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+        version: 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -17736,11 +17736,11 @@ importers:
   packages/sdk/client-services:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+        version: 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -17999,11 +17999,11 @@ importers:
   packages/sdk/migrations:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+        version: 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
       '@dxos/client':
         specifier: workspace:*
         version: link:../client
@@ -18301,8 +18301,8 @@ importers:
         version: 3.21.4
     devDependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@dxos/react-client':
         specifier: workspace:*
         version: link:../react-client
@@ -20444,8 +20444,8 @@ importers:
   packages/ui/react-ui-editor:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.20.3
@@ -20614,10 +20614,10 @@ importers:
     devDependencies:
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+        version: 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
       '@automerge/automerge-repo-network-broadcastchannel':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39
+        version: 2.6.0-subduction.40
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -22577,8 +22577,8 @@ importers:
   packages/ui/ui-editor:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@codemirror/autocomplete':
         specifier: 'catalog:'
         version: 6.20.3
@@ -22726,10 +22726,10 @@ importers:
     devDependencies:
       '@automerge/automerge-repo':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+        version: 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
       '@automerge/automerge-repo-network-broadcastchannel':
         specifier: 'catalog:'
-        version: 2.6.0-subduction.39
+        version: 2.6.0-subduction.40
       '@dxos/config':
         specifier: workspace:*
         version: link:../../sdk/config
@@ -23623,27 +23623,27 @@ packages:
   '@atproto/xrpc@0.7.7':
     resolution: {integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==}
 
-  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.39':
-    resolution: {integrity: sha512-yBUrWKLGHAe9D7nfvO2rVdA6CIgvcy7MD6sQt60M8INb9b8eoxDuNYDTraQPnusidQH6r8+/E67h8YIGF7uhPQ==}
+  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.40':
+    resolution: {integrity: sha512-2Gz5CZUGGz6oIkaShvAS3YNG02x2FHybASzjklcOAcIIMYtkxsDxF7YTwT5iFFr40yyefMR8tw/fKdTa4wqv/Q==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.39':
-    resolution: {integrity: sha512-SVx/jA19+tCB1jCoXao+rC8v4TrYPQBgKcRcSgW3KXiVhFfIjQlk19AzZH9siKaIxo9RcnAF0+cdymYh/pMVlg==}
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.40':
+    resolution: {integrity: sha512-tzMdGgLXgCU3IFRmdisRacAovr3XllwiGVS0y9urYFPdvV3pxanLS2Ozj/YXyMO06UXUnM4YhpU0JzLLhfiI6g==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.39':
-    resolution: {integrity: sha512-/teyLHObHm21E5HX0/xg6q+GZKHW7mR6sdRXjMXhfAf2rFTRNOAxhWN+tGXarub9bhpNjgPAcuumPgaNKhSCLQ==}
+  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.40':
+    resolution: {integrity: sha512-fD7iTlHXv+9rfmR4tJYDN9SuTLMU43VNmIhvjX0JBmgluVC+gI4HBh5X3EFKN2zH7LgUFyvnZwxzED4ufXs4EA==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo@2.6.0-subduction.39':
-    resolution: {integrity: sha512-YREc25rNf/AE1d90rPTLQJEKPORDdBthKw8siu1VjkAGs5eJL6IgQK6U1mytVR/ex7MukBpmzwNa19tnGHsGcw==}
+  '@automerge/automerge-repo@2.6.0-subduction.40':
+    resolution: {integrity: sha512-9r3GS8FtZKoIJOtJqkQR0ukF7HSu+IyV5Iqf7MP3ELDz/TEaUbZV8ysyl5Ju4fVZjmagI/n3oH2h4ySk4FdEFQ==}
     engines: {node: '>=22.13'}
 
   '@automerge/automerge-subduction@0.16.0':
     resolution: {integrity: sha512-BOOn/4p8cF4LhjDUQdgM3qyZFya+M7ZuZywuC99x/kbhk4UK7dw/QcsifcHG5E1TAW4R/K17ZGFUC5nCVUSSWg==}
 
-  '@automerge/automerge@3.3.0-fragments.1':
-    resolution: {integrity: sha512-Im2n3qcYSuIsLDSjofTRo7CZyyvFn5pKLSCCO5sjWzESw+9q9G25ZIrL2mczDX43cXtyzi+w/4b9VUaiNdY56Q==}
+  '@automerge/automerge@3.3.0-fragments.2':
+    resolution: {integrity: sha512-F5KL+YXD0GMFH/as0/kJ3+lotpuJsH1SSrhhKdYSGtR+S9ytBNTw+s3pAjF2Vr0+ZdTMHxsGjqj5SRkJiSNokQ==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -43927,17 +43927,17 @@ snapshots:
       '@atproto/lexicon': 0.6.2
       zod: 3.25.76
 
-  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.39':
+  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.40':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+      '@automerge/automerge-repo': 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.39':
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.40':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+      '@automerge/automerge-repo': 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
       cbor-x: 1.6.4
       debug: 4.4.3(supports-color@5.5.0)
       eventemitter3: 5.0.4
@@ -43947,17 +43947,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.39':
+  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.40':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)
+      '@automerge/automerge-repo': 2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo@2.6.0-subduction.39(patch_hash=af1ef41b4b3f1c6b34d1cfe79bc40fe1825fc76b0d2da5993e7df9f8eeecd799)':
+  '@automerge/automerge-repo@2.6.0-subduction.40(patch_hash=2bd882245924580ad001599ff56a0021f57f85479833e8d7939e1178f1c527db)':
     dependencies:
-      '@automerge/automerge': 3.3.0-fragments.1
+      '@automerge/automerge': 3.3.0-fragments.2
       '@automerge/automerge-subduction': 0.16.0(patch_hash=6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669)
       bs58check: 4.0.0
       cbor-x: 1.6.4
@@ -43975,7 +43975,7 @@ snapshots:
 
   '@automerge/automerge-subduction@0.16.0(patch_hash=6c2eab31f38b39d6a71ee88d80615921e44111af935631335727862eabc84669)': {}
 
-  '@automerge/automerge@3.3.0-fragments.1': {}
+  '@automerge/automerge@3.3.0-fragments.2': {}
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,11 +25,11 @@ catalog:
   '@atlaskit/pragmatic-drag-and-drop-hitbox': 1.1.0
   '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator': 3.2.10
   '@atproto/api': ^0.19.5
-  '@automerge/automerge': 3.3.0-fragments.1
-  '@automerge/automerge-repo': 2.6.0-subduction.39
-  '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.39
-  '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.39
-  '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.39
+  '@automerge/automerge': 3.3.0-fragments.2
+  '@automerge/automerge-repo': 2.6.0-subduction.40
+  '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.40
+  '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.40
+  '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.40
   '@automerge/automerge-subduction': 0.16.0
   '@babel/core': ^7.18.13
   '@babel/preset-typescript': ^7.27.1
@@ -777,7 +777,7 @@ overrides:
   ws: '>=8.17.1'
 
 patchedDependencies:
-  '@automerge/automerge-repo@2.6.0-subduction.39': patches/@automerge__automerge-repo@2.6.0-subduction.39.patch
+  '@automerge/automerge-repo@2.6.0-subduction.40': patches/@automerge__automerge-repo@2.6.0-subduction.40.patch
   '@automerge/automerge-subduction@0.16.0': patches/@automerge__automerge-subduction@0.16.0.patch
   '@effect-atom/atom@0.5.3': patches/@effect-atom__atom@0.5.3.patch
   '@vitest/browser@4.1.8': patches/@vitest__browser@4.1.8.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,11 +25,11 @@ catalog:
   '@atlaskit/pragmatic-drag-and-drop-hitbox': 1.1.0
   '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator': 3.2.10
   '@atproto/api': ^0.19.5
-  '@automerge/automerge': 3.3.0-fragments.2
-  '@automerge/automerge-repo': 2.6.0-subduction.37
-  '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.37
-  '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.37
-  '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.37
+  '@automerge/automerge': 3.3.0-fragments.1
+  '@automerge/automerge-repo': 2.6.0-subduction.39
+  '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.39
+  '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.39
+  '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.39
   '@automerge/automerge-subduction': 0.16.0
   '@babel/core': ^7.18.13
   '@babel/preset-typescript': ^7.27.1
@@ -777,7 +777,7 @@ overrides:
   ws: '>=8.17.1'
 
 patchedDependencies:
-  '@automerge/automerge-repo@2.6.0-subduction.37': patches/@automerge__automerge-repo@2.6.0-subduction.37.patch
+  '@automerge/automerge-repo@2.6.0-subduction.39': patches/@automerge__automerge-repo@2.6.0-subduction.39.patch
   '@automerge/automerge-subduction@0.16.0': patches/@automerge__automerge-subduction@0.16.0.patch
   '@effect-atom/atom@0.5.3': patches/@effect-atom__atom@0.5.3.patch
   '@vitest/browser@4.1.8': patches/@vitest__browser@4.1.8.patch


### PR DESCRIPTION
## Summary
- Bumped the automerge catalog family in `pnpm-workspace.yaml`:
  - `@automerge/automerge-repo` (+ `network-broadcastchannel`, `network-websocket`, `storage-indexeddb`): `2.6.0-subduction.37` → `2.6.0-subduction.39`
  - `@automerge/automerge`: `3.3.0-fragments.2` → `3.3.0-fragments.1`
  - `@automerge/automerge-subduction` unchanged at `0.16.0`
- Regenerated the `automerge-repo` dist patch (`onPeerBound` callback + `subduction-peer-bound` `Repo` event, consumed by `echo-host`'s `automerge-host.ts`) against the new version — one hunk needed a manual reapply due to upstream line shifts.
- Updated `automerge-repo-subduction-policy.test.ts`: the `subduction.39` line now retries a stuck `'all-failed'` outbound push on reconnect (previously it did not), so the `authorizePut deny → allow` recovery test was rewritten to match this improved, empirically-verified behavior.

## Test plan
- [x] `moon run echo-host:build`
- [x] `moon run echo-host:lint` (0 warnings, 0 errors)
- [x] `moon run echo-host:test` — 250 passed, 2 skipped, 1 todo, 0 failed
- [x] Confirmed the one initially-failing test was a genuine upstream behavior change (not a flake) by running it against both old and new automerge versions
- [x] `pnpm install --frozen-lockfile` succeeds against the regenerated lockfile
- [x] `pnpm format` clean
- [x] Cast audit: only hits are import aliases inside the vendored patch file, not real casts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new peer-bound event so apps can detect when a verified connection is linked to a repo peer identity.
  * Improved connection recovery so previously gated content can appear again after reconnecting.

* **Bug Fixes**
  * Fixed storage reload flows to reopen persistence safely after shutdown.
  * Improved adapter shutdown handling to avoid closing while work is still in progress.

* **Tests**
  * Updated coverage for reconnect, persistence, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->