### PR TITLE
fix(echo-host): drain all in-flight LevelDB ops before adapter close

### DIFF
--- a/packages/core/echo/echo-host/src/automerge/leveldb-storage-adapter.ts
+++ b/packages/core/echo/echo-host/src/automerge/leveldb-storage-adapter.ts
@@ -30,16 +30,16 @@ export interface StorageCallbacks {
 
 export class LevelDBStorageAdapter implements StorageAdapterInterface {
   /**
-   * In-flight `loadRange` / `removeRange` iterations. Awaited in `close` so
-   * the adapter doesn't return from close while a `for await` on the sublevel
-   * is still pending — otherwise the kv owner upstream would close the
-   * sublevel and the iterator's next `.next()` would reject with
-   * `LEVEL_ITERATOR_NOT_OPEN`.
+   * In-flight DB operations (point reads/writes and `loadRange` / `removeRange`
+   * iterations). Awaited in `close` so the adapter doesn't return from close
+   * while work against the sublevel is still pending — otherwise the kv owner
+   * upstream could close the sublevel while a `.get`/`.batch`/iterator is
+   * still in flight, causing late rejections or lost writes.
    *
    * Promises stored here resolve regardless of outcome (the wrapper
    * `.catch`es) so `Promise.all` won't reject.
    */
-  readonly #inFlightIterations = new Set<Promise<unknown>>();
+  readonly #inFlightOperations = new Set<Promise<unknown>>();
 
   #open = false;
 
@@ -58,27 +58,31 @@ export class LevelDBStorageAdapter implements StorageAdapterInterface {
       return;
     }
     this.#open = false;
-    // New `loadRange`/`removeRange` calls already short-circuit on `!isOpen`.
-    // Wait for any iterations that started while we were still open to finish
-    // before returning, so the upstream `kv` owner can safely close the sublevel.
-    if (this.#inFlightIterations.size > 0) {
-      await Promise.all(this.#inFlightIterations);
+    // New calls already short-circuit on `!isOpen`. Wait for any operations
+    // that started while we were still open to finish before returning, so
+    // the upstream `kv` owner can safely close the sublevel.
+    if (this.#inFlightOperations.size > 0) {
+      await Promise.all(this.#inFlightOperations);
     }
   }
 
-  #trackIteration<T>(work: Promise<T>): Promise<T> {
+  #trackOperation<T>(work: Promise<T>): Promise<T> {
     const settled = work.catch(() => undefined);
-    this.#inFlightIterations.add(settled);
-    void settled.finally(() => this.#inFlightIterations.delete(settled));
+    this.#inFlightOperations.add(settled);
+    void settled.finally(() => this.#inFlightOperations.delete(settled));
     return work;
   }
 
   async load(keyArray: StorageKey): Promise<Uint8Array | undefined> {
+    if (!this.isOpen) {
+      // TODO(mykola): this should be an error.
+      return undefined;
+    }
+    return this.#trackOperation(this.#doLoad(keyArray));
+  }
+
+  async #doLoad(keyArray: StorageKey): Promise<Uint8Array | undefined> {
     try {
-      if (!this.isOpen) {
-        // TODO(mykola): this should be an error.
-        return undefined;
-      }
       const startMs = Date.now();
       const chunk = await this._params.db.get<StorageKey, Uint8Array>(keyArray, { ...encodingOptions });
       this._params.monitor?.recordBytesLoaded(chunk.byteLength);
@@ -96,6 +100,10 @@ export class LevelDBStorageAdapter implements StorageAdapterInterface {
     if (!this.isOpen) {
       return undefined;
     }
+    return this.#trackOperation(this.#doSave(keyArray, binary));
+  }
+
+  async #doSave(keyArray: StorageKey, binary: Uint8Array): Promise<void> {
     const startMs = Date.now();
     const batch = this._params.db.batch();
 
@@ -117,6 +125,10 @@ export class LevelDBStorageAdapter implements StorageAdapterInterface {
     if (!this.isOpen || entries.length === 0) {
       return undefined;
     }
+    return this.#trackOperation(this.#doSaveBatch(entries));
+  }
+
+  async #doSaveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void> {
     const startMs = Date.now();
     const batch = this._params.db.batch();
 
@@ -143,14 +155,14 @@ export class LevelDBStorageAdapter implements StorageAdapterInterface {
     if (!this.isOpen) {
       return undefined;
     }
-    await this._params.db.del<StorageKey>(keyArray, { ...encodingOptions });
+    return this.#trackOperation(this._params.db.del<StorageKey>(keyArray, { ...encodingOptions }));
   }
 
   async loadRange(keyPrefix: StorageKey): Promise<Chunk[]> {
     if (!this.isOpen) {
       return [];
     }
-    return this.#trackIteration(this.#doLoadRange(keyPrefix));
+    return this.#trackOperation(this.#doLoadRange(keyPrefix));
   }
 
   async #doLoadRange(keyPrefix: StorageKey): Promise<Chunk[]> {
@@ -175,7 +187,7 @@ export class LevelDBStorageAdapter implements StorageAdapterInterface {
     if (!this.isOpen) {
       return undefined;
     }
-    await this.#trackIteration(this.#doRemoveRange(keyPrefix));
+    await this.#trackOperation(this.#doRemoveRange(keyPrefix));
   }
 
   async #doRemoveRange(keyPrefix: StorageKey): Promise<void> {


### PR DESCRIPTION
## Summary
- Post-merge follow-up to [#12069](https://github.com/dxos/dxos/pull/12069): a CodeRabbit finding landed after that PR's branch was already in the merge queue, so it couldn't be pushed there.
- `LevelDBStorageAdapter.close()` only awaited in-flight `loadRange`/`removeRange` iterations. `load`, `save`, `saveBatch`, and `remove` weren't tracked, so a still-pending point operation could still be running when `close()` resolved. If the upstream `kv` owner closed the underlying sublevel right after, that operation could reject late or lose a write.
- Renamed `#inFlightIterations`/`#trackIteration` to `#inFlightOperations`/`#trackOperation` and routed all six storage methods through the same tracking set that `close()` drains.

## Test plan
- [x] `moon run echo-host:build`
- [x] `moon run echo-host:lint` (0 warnings, 0 errors)
- [x] `echo-host` full vitest suite: 250 passed, 2 skipped, 1 todo, 0 failed
- [x] Cast audit: no new casts introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage reliability by ensuring all pending read and write operations finish before shutdown.
  * Reduced the chance of data loss or unexpected errors when closing the app during active database activity.
  * Kept existing behavior for unavailable storage, with reads and writes still returning empty results instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->