### PR TITLE
fix(plugin-debug): fix empty Stats companion panel

### DIFF
--- a/packages/plugins/plugin-debug/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-debug/src/capabilities/app-graph-builder.ts
@@ -406,7 +406,7 @@ export default Capability.makeModule(
               id: 'devtoolsOverview',
               label: ['devtools-overview.label', { ns: meta.profile.key }],
               icon: 'ph--equalizer--regular',
-              data: 'devtools' as const,
+              data: 'devtoolsOverview' as const,
               position: Position.last,
             }),
           ]),

--- a/packages/plugins/plugin-debug/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-debug/src/capabilities/react-surface.tsx
@@ -234,7 +234,7 @@ export default Capability.makeModule(
       }),
       Surface.create({
         id: 'devtoolsOverview',
-        filter: Surface.makeFilter(AppSurface.deckCompanion('devtools')),
+        filter: Surface.makeFilter(AppSurface.deckCompanion('devtoolsOverview')),
         component: () => <DevtoolsOverviewContainer />,
       }),
       Surface.create({

--- a/packages/sdk/app-framework/src/ui/components/Surface/SurfaceProfilerContext.tsx
+++ b/packages/sdk/app-framework/src/ui/components/Surface/SurfaceProfilerContext.tsx
@@ -52,13 +52,22 @@ class SurfaceProfilerStore {
   private _snapshot: readonly SurfaceProfilerEntry[] = [];
   private _pendingNotify = false;
 
-  /** Records an entry and schedules a deferred notification to avoid re-render loops. */
+  /**
+   * Records an entry and schedules a deferred notification to avoid re-render loops.
+   * `_snapshot` is rebuilt only when the deferred notification actually fires
+   * ({@link _notifySync}) — not here — so `getSnapshot` stays referentially stable for any
+   * synchronous re-invocation React makes within the same commit (e.g. the tearing check a
+   * profiled subscriber's own `useSyncExternalStore` runs right after this Profiler's
+   * `onRender` callback). Rebuilding it synchronously here would change what `getSnapshot`
+   * returns before listeners are told, which React reads as a torn store and forces an
+   * immediate re-render — and if the re-rendering component is itself profiled, that
+   * re-render re-triggers `record`, looping forever.
+   */
   record(entry: SurfaceProfilerEntry) {
     this._entries.push(entry);
     if (this._entries.length > MAX_ENTRIES) {
       this._entries = this._entries.slice(-MAX_ENTRIES);
     }
-    this._snapshot = [...this._entries];
     this._scheduleNotify();
   }
 
@@ -94,6 +103,7 @@ class SurfaceProfilerStore {
   }
 
   private _notifySync() {
+    this._snapshot = [...this._entries];
     for (const listener of this._listeners) {
       listener();
     }


### PR DESCRIPTION
## Summary
- Fixed a variant-id mismatch introduced by #11935: the devtools deck-companion node's `id` was renamed from `'devtools'` to `'devtoolsOverview'`, but the Surface filter dispatching its content still matched on the stale `'devtools'` variant, so the Stats companion panel (right sidebar) rendered completely empty.
- Fixing the routing surfaced a second, pre-existing bug: `SurfaceProfilerStore.record()` rebuilt its cached snapshot synchronously while only deferring listener notification to the next animation frame. Since the Stats panel is itself a profiled Surface, React's `useSyncExternalStore` tearing check saw the snapshot change mid-commit and forced an immediate re-render, which re-triggered `record()`, looping forever ("Maximum update depth exceeded"). Snapshot rebuild is now deferred to the notify callback, matching the sibling `SurfaceMetricsStore` implementation.

## Test plan
- [x] Ran composer-app locally, opened the Stats companion panel in the right sidebar, confirmed it renders live Memory/Network/Surfaces/Database/etc. data (previously blank).
- [x] Expanded the profiler-driven "Surfaces" sub-panel and confirmed live updating counts with no crash (previously threw "Maximum update depth exceeded" / plank error).
- [x] Switched between Stats and other companions (Database) repeatedly with no regressions.
- [x] `moon run plugin-debug:lint app-framework:lint devtools:lint -- --fix` — 0 warnings/errors.
- [x] `moon run plugin-debug:build app-framework:build devtools:build` — all green.
- [x] No new type casts introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved surface profiling stability by delaying snapshot updates until notifications are sent, reducing the chance of re-render loops and inconsistent readings.
  * Corrected the DevTools overview surface to target the proper companion, so related UI elements now match the expected view more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->