### PR TITLE
chore(compute): make extractor-lib and pipeline publishable

### DIFF
--- a/packages/core/compute/extractor-lib/package.json
+++ b/packages/core/compute/extractor-lib/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/extractor-lib",
   "version": "0.10.0",
-  "private": true,
   "description": "Reusable contact/organization extraction, resolvers, and domain utilities.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/core/compute/pipeline/package.json
+++ b/packages/core/compute/pipeline/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/pipeline",
   "version": "0.9.0",
-  "private": true,
   "description": "Generic back-pressured streaming pipeline (source → stages → sink).",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",


### PR DESCRIPTION
## Summary

- Remove `"private": true` from `@dxos/extractor-lib` and `@dxos/pipeline`.
- Both packages already have `"publishConfig": { "access": "public" }`; this aligns them for npm publishing.

## Test plan

- [ ] CI Check workflow (not run locally before opening PR)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata for two core components so they are no longer marked as private and can be published if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->