### PR TITLE
refactor(composer-crx): source page-action wire types from @dxos/crx-protocol

### DIFF
--- a/packages/apps/composer-crx/package.json
+++ b/packages/apps/composer-crx/package.json
@@ -17,6 +17,7 @@
     "@cloudflare/ai-chat": "catalog:",
     "@dxos/brand": "workspace:*",
     "@dxos/config": "workspace:*",
+    "@dxos/crx-protocol": "workspace:*",
     "@dxos/devtools": "workspace:*",
     "@dxos/edge-client": "workspace:*",
     "@dxos/effect": "workspace:*",

--- a/packages/apps/composer-crx/src/components/Chat/Chat.tsx
+++ b/packages/apps/composer-crx/src/components/Chat/Chat.tsx
@@ -15,7 +15,7 @@ import { MarkdownStream, type MarkdownStreamController, type MarkdownStreamProps
 import { compactSlots } from '@dxos/ui-editor';
 import { mx } from '@dxos/ui-theme';
 
-import { SpaceId as SpaceIdConfig, SpaceMode } from '../../core/state';
+import { SpaceId as SpaceIdConfig, SpaceMode } from '../../core';
 import { translationKey } from '../../translations';
 
 // Minimal registry: only the block-level `prompt` tag (user turns render as bubbles). No widgets,

--- a/packages/apps/composer-crx/src/components/Chat/Chat.tsx
+++ b/packages/apps/composer-crx/src/components/Chat/Chat.tsx
@@ -6,7 +6,6 @@ import { type UIMessage } from '@ai-sdk/react';
 import { useAgentChat } from 'agents/ai-react';
 import { useAgent } from 'agents/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import browser from 'webextension-polyfill';
 
 import { SpaceId } from '@dxos/keys';
 import { log } from '@dxos/log';
@@ -16,7 +15,7 @@ import { MarkdownStream, type MarkdownStreamController, type MarkdownStreamProps
 import { compactSlots } from '@dxos/ui-editor';
 import { mx } from '@dxos/ui-theme';
 
-import { SPACE_ID_PROP, SPACE_MODE_PROP } from '../../config';
+import { SpaceId as SpaceIdConfig, SpaceMode } from '../../core/state';
 import { translationKey } from '../../translations';
 
 // Minimal registry: only the block-level `prompt` tag (user turns render as bubbles). No widgets,
@@ -166,9 +165,8 @@ export const Chat = ({ classNames, host, url, onError }: ChatProps) => {
         }
 
         // Determine space mode.
-        const stored = await browser.storage.sync.get([SPACE_MODE_PROP, SPACE_ID_PROP]);
-        const spaceMode = stored?.[SPACE_MODE_PROP];
-        const spaceId = stored?.[SPACE_ID_PROP];
+        const spaceMode = await SpaceMode.get();
+        const spaceId = await SpaceIdConfig.get();
         if (spaceMode && spaceId) {
           if (SpaceId.isValid(spaceId) && (spaceId !== spaceIdRef.current || messages.length === 0)) {
             context.push(`Otherwise use the configured Space to retrieve information.`, `The Space ID is: ${spaceId}`);

--- a/packages/apps/composer-crx/src/components/Options/Options.tsx
+++ b/packages/apps/composer-crx/src/components/Options/Options.tsx
@@ -3,15 +3,20 @@
 //
 
 import React, { type ChangeEvent, useEffect, useState } from 'react';
-import browser from 'webextension-polyfill';
 
 import { Composer, DXOSHorizontalType } from '@dxos/brand';
 import { SpaceId } from '@dxos/keys';
 import { Input, ScrollArea, useTranslation } from '@dxos/react-ui';
 import { composable, composableProps } from '@dxos/react-ui';
 
-import { DEVELOPER_MODE_PROP, SPACE_ID_PROP, SPACE_MODE_PROP, getProp } from '../../config';
-import { DEFAULT_COMPOSER_URLS, getComposerUrls, setComposerUrls } from '../../core';
+import {
+  DEFAULT_COMPOSER_URLS,
+  DeveloperMode,
+  SpaceId as SpaceIdConfig,
+  SpaceMode,
+  getComposerUrls,
+  setComposerUrls,
+} from '../../core';
 import { translationKey } from '../../translations';
 
 export type OptionsProps = {};
@@ -31,14 +36,14 @@ export const Options = composable<HTMLDivElement, OptionsProps>((props, forwarde
 
   useEffect(() => {
     void (async () => {
-      setDeveloperMode(Boolean(await getProp(DEVELOPER_MODE_PROP)));
+      setDeveloperMode(await DeveloperMode.get());
     })();
   }, []);
 
   useEffect(() => {
     void (async () => {
-      const stored = await getProp(SPACE_ID_PROP);
-      if (SpaceId.isValid(stored)) {
+      const stored = await SpaceIdConfig.get();
+      if (stored && SpaceId.isValid(stored)) {
         setSpaceId(stored);
       }
     })();
@@ -46,19 +51,19 @@ export const Options = composable<HTMLDivElement, OptionsProps>((props, forwarde
 
   const handleDeveloperModeChange = async (checked: boolean | 'indeterminate') => {
     const next = checked === 'indeterminate' ? false : Boolean(checked);
-    await browser.storage.sync.set({ [DEVELOPER_MODE_PROP]: next });
+    await DeveloperMode.set(next);
     setDeveloperMode(next);
   };
 
   const handleSpaceModeChange = async (checked: boolean | 'indeterminate') => {
     const next = checked === 'indeterminate' ? false : Boolean(checked);
-    await browser.storage.sync.set({ [SPACE_MODE_PROP]: next });
+    await SpaceMode.set(next);
     setSpaceMode(next);
   };
 
   const handleSpaceIdChange = async (ev: ChangeEvent<HTMLInputElement>) => {
     const next = ev.target.value;
-    await browser.storage.sync.set({ [SPACE_ID_PROP]: next });
+    await SpaceIdConfig.set(next);
     setSpaceId(next);
   };
 

--- a/packages/apps/composer-crx/src/components/Options/Options.tsx
+++ b/packages/apps/composer-crx/src/components/Options/Options.tsx
@@ -63,8 +63,13 @@ export const Options = composable<HTMLDivElement, OptionsProps>((props, forwarde
 
   const handleSpaceIdChange = async (ev: ChangeEvent<HTMLInputElement>) => {
     const next = ev.target.value;
-    await SpaceIdConfig.set(next);
+    // Reflect typing immediately, but persist only a valid (or cleared) id so the stored value stays
+    // consistent with the validated read path — a partial/malformed id would otherwise silently
+    // vanish on reload.
     setSpaceId(next);
+    if (next === '' || SpaceId.isValid(next)) {
+      await SpaceIdConfig.set(next);
+    }
   };
 
   // One match pattern per line; blank lines ignored. An empty editor restores the defaults so a

--- a/packages/apps/composer-crx/src/components/Sidepanel/Sidepanel.tsx
+++ b/packages/apps/composer-crx/src/components/Sidepanel/Sidepanel.tsx
@@ -63,10 +63,10 @@ const SidepanelContent = () => {
       }
     };
 
-    void consume();
+    void consume().catch((err) => log.catch(err));
     return ThumbnailUrl.subscribe((url) => {
       if (url) {
-        void consume();
+        void consume().catch((err) => log.catch(err));
       }
     });
   }, []);

--- a/packages/apps/composer-crx/src/components/Sidepanel/Sidepanel.tsx
+++ b/packages/apps/composer-crx/src/components/Sidepanel/Sidepanel.tsx
@@ -10,8 +10,8 @@ import { log } from '@dxos/log';
 import { ErrorBoundary, IconButton, Panel, Toolbar, useTranslation } from '@dxos/react-ui';
 import { mx } from '@dxos/ui-theme';
 
-import { THUMBNAIL_PROP, getConfig } from '../../config';
-import { focusOrOpenComposerTab } from '../../core';
+import { getConfig } from '../../config';
+import { ThumbnailUrl, focusOrOpenComposerTab } from '../../core';
 import { debugLog } from '../../debug-log';
 import { translationKey } from '../../translations';
 import { Chat } from '../Chat';
@@ -56,22 +56,19 @@ const SidepanelContent = () => {
   // (re)opening, so consume it on mount and whenever it is written to storage.
   useEffect(() => {
     const consume = async () => {
-      const result = await browser.storage.local.get(THUMBNAIL_PROP);
-      const url = result?.[THUMBNAIL_PROP] as string | undefined;
+      const url = await ThumbnailUrl.get();
       if (url) {
         setThumbnailUrl(url);
-        await browser.storage.local.remove(THUMBNAIL_PROP);
+        await ThumbnailUrl.remove();
       }
     };
 
     void consume();
-    const onChanged = (changes: Record<string, browser.Storage.StorageChange>, area: string) => {
-      if (area === 'local' && changes[THUMBNAIL_PROP]?.newValue) {
+    return ThumbnailUrl.subscribe((url) => {
+      if (url) {
         void consume();
       }
-    };
-    browser.storage.onChanged.addListener(onChanged);
-    return () => browser.storage.onChanged.removeListener(onChanged);
+    });
   }, []);
 
   const handleLaunchComposer = useCallback(() => {

--- a/packages/apps/composer-crx/src/config.ts
+++ b/packages/apps/composer-crx/src/config.ts
@@ -2,14 +2,10 @@
 // Copyright 2024 DXOS.org
 //
 
-import browser from 'webextension-polyfill';
-
+// Deep import (not the `./core` barrel) so this module — reachable from lean contexts — does not
+// pull background-only weight (e.g. the edge-client-backed `image` action).
+import { DeveloperMode } from './core/state';
 import { debugLog } from './debug-log';
-
-export const DEVELOPER_MODE_PROP = 'developer-mode';
-export const SPACE_MODE_PROP = 'space-mode';
-export const THUMBNAIL_PROP = 'thumbnail-url';
-export const SPACE_ID_PROP = 'space-id';
 
 export const HOME_URL = 'https://labs.composer.space';
 
@@ -25,13 +21,9 @@ export type Config = {
   imageServiceUrl: string;
 };
 
-export const getProp = async (prop: string): Promise<boolean> => {
-  const storage = await browser.storage.sync.get(prop);
-  return Boolean(storage?.[prop]);
-};
-
+/** Resolve the runtime config; service endpoints switch to local dev servers in developer mode. */
 export const getConfig = async (): Promise<Config> => {
-  const devmode = Boolean(await getProp(DEVELOPER_MODE_PROP));
+  const devmode = await DeveloperMode.get();
   const config = {
     devmode,
     chatAgentUrl: devmode ? DEV_CHAT_AGENT_URL : MAIN_CHAT_AGENT_URL,

--- a/packages/apps/composer-crx/src/content.ts
+++ b/packages/apps/composer-crx/src/content.ts
@@ -7,10 +7,6 @@ import browser from 'webextension-polyfill';
 
 import { log } from '@dxos/log';
 
-// Import specific `core/` submodules rather than the top-level barrel: this is the content
-// script injected into every page, so it deliberately avoids pulling in background-only weight
-// (e.g. `bridge/sender`'s tab APIs, the `image` edge-client action) via a barrel.
-import { DEVELOPER_MODE_PROP, getProp } from './config';
 import {
   PAGE_ACTION_DELIVER_MESSAGE_TYPE,
   PAGE_ACTION_EXTRACT_MESSAGE_TYPE,
@@ -45,6 +41,10 @@ import {
   decodeRenderAck,
   decodeRenderRequest,
 } from './core/proxy';
+// Import specific `core/` submodules rather than the top-level barrel: this is the content
+// script injected into every page, so it deliberately avoids pulling in background-only weight
+// (e.g. `bridge/sender`'s tab APIs, the `image` edge-client action) via a barrel.
+import { DeveloperMode } from './core/state';
 
 /**
  * Content script — loaded on every page at document_start. Hosts the DOM
@@ -283,7 +283,7 @@ const main = async () => {
 
     // When `developer-mode` is on, show the serialized JSON before delivery so
     // the user can inspect (and copy) the payload independently of Composer.
-    const debug = Boolean(await getProp(DEVELOPER_MODE_PROP));
+    const debug = await DeveloperMode.get();
     if (debug) {
       const confirmed = await showDebugPreview(picked.actionId, picked);
       if (!confirmed) {

--- a/packages/apps/composer-crx/src/core/DESIGN.md
+++ b/packages/apps/composer-crx/src/core/DESIGN.md
@@ -27,7 +27,7 @@ self-contained module exported via its `index.ts`.
 - **Functionality** — `findComposerTab` (query tabs matching the configured patterns and pick the best-scored one), `focusOrOpenComposerTab` / `openComposerTab`, and origin helpers `isComposerUrl` / `matchesPattern` (a small chrome match-pattern implementation).
 - **Lifecycle** — pure on-demand calls; no background listeners of its own. Invoked when the user launches Composer, when the registry refreshes, when the proxy origin-guards a sender, and when the picker resolves actions.
 - **Protocol / integration** — wraps `browser.tabs` / `browser.windows`; consumed by `actions/`, `proxy/` (origin guard), and the panel/background (launch button, `open-composer`).
-- **State** — the configured origins live in `browser.storage.sync` under `COMPOSER_URLS_PROP` (default `DEFAULT_COMPOSER_URLS`); `sender.ts` keeps an in-memory `lastUsedTabId` to bias tab scoring.
+- **State** — the configured origins are read/written via `getComposerUrls`/`setComposerUrls` (a `state/` `ComposerUrls` entry over `browser.storage.sync`, default `DEFAULT_COMPOSER_URLS`); `sender.ts` keeps an in-memory `lastUsedTabId` to bias tab scoring.
 
 ## Page extractors
 
@@ -42,7 +42,7 @@ self-contained module exported via its `index.ts`.
 - **Purpose** — the single image/thumbnail action (formerly the generic `actions/`).
 - **Functionality** — `createThumbnail(imageUrl)`: fetch the image, normalize its content-type, upload it to the EDGE image service, and persist the hosted URL.
 - **Lifecycle** — triggered from the background's `Create Thumbnail…` context-menu handler; the side panel is opened in the same gesture and shows the result.
-- **Protocol / integration** — uses `EdgeServiceClient` / `Image.thumbnail` (`@dxos/edge-client`); writes the hosted URL to `browser.storage.local` (`THUMBNAIL_PROP`), which the panel observes via `storage.onChanged`.
+- **Protocol / integration** — uses `EdgeServiceClient` / `Image.thumbnail` (`@dxos/edge-client`); writes the hosted URL via the `state/` `ThumbnailUrl` entry (`browser.storage.local`), which the panel observes via `ThumbnailUrl.subscribe`.
 - **State** — writes the hosted-URL result to `storage.local`; sets a transient error/success badge on the toolbar action; otherwise stateless.
 
 ## Element picker

--- a/packages/apps/composer-crx/src/core/actions/deliver.ts
+++ b/packages/apps/composer-crx/src/core/actions/deliver.ts
@@ -6,16 +6,56 @@ import { log } from '@dxos/log';
 
 import { type DeliverInvokeOptions, type InvokeBridgeApi, deliverInvoke } from './invoke';
 import { enrichSnapshotWithThumbnail } from './thumbnail';
-import { type InvokeAck, type InvokeRequest, type Snapshot } from './types';
+import { type InvokeAck, type InvokeRequest, type Snapshot, type SnapshotHints, type SnapshotSelection } from './types';
 import { nextId } from './util';
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+
+/** Structurally validate the optional selection sub-object; `undefined` if absent/invalid. */
+const decodeSelection = (value: unknown): SnapshotSelection | undefined => {
+  if (!isRecord(value) || typeof value.text !== 'string') {
+    return undefined;
+  }
+  const rect = value.rect;
+  const decodedRect =
+    isRecord(rect) &&
+    typeof rect.x === 'number' &&
+    typeof rect.y === 'number' &&
+    typeof rect.width === 'number' &&
+    typeof rect.height === 'number'
+      ? { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+      : undefined;
+  return {
+    text: value.text,
+    ...(typeof value.html === 'string' ? { html: value.html } : {}),
+    ...(typeof value.htmlTruncated === 'boolean' ? { htmlTruncated: value.htmlTruncated } : {}),
+    ...(decodedRect ? { rect: decodedRect } : {}),
+  };
+};
+
+/** Structurally validate the optional hints sub-object; `undefined` if absent. */
+const decodeHints = (value: unknown): SnapshotHints | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return {
+    ...(typeof value.ogTitle === 'string' ? { ogTitle: value.ogTitle } : {}),
+    ...(typeof value.ogDescription === 'string' ? { ogDescription: value.ogDescription } : {}),
+    ...(typeof value.ogImage === 'string' ? { ogImage: value.ogImage } : {}),
+    ...(typeof value.h1 === 'string' ? { h1: value.h1 } : {}),
+    ...(typeof value.firstImage === 'string' ? { firstImage: value.firstImage } : {}),
+    ...(Array.isArray(value.jsonLd) ? { jsonLd: value.jsonLd } : {}),
+  };
+};
 
 /**
  * Validate an inbound runtime-message payload for the deliver handler.
  * The message crosses a trust boundary (content script → background worker),
  * so every required field is checked before `deliverPickedSnapshot` is called.
  * Returns the typed payload on success, `undefined` on any validation failure.
+ *
+ * Built immutably (the shared schema types are readonly): validate the required
+ * shape, copy known fields via conditional spreads, tolerate unknown extras.
  */
 export const decodeDeliverPayload = (value: unknown): { actionId: string; snapshot: Snapshot } | undefined => {
   if (!isRecord(value)) {
@@ -36,78 +76,23 @@ export const decodeDeliverPayload = (value: unknown): { actionId: string; snapsh
     return undefined;
   }
 
-  // Build the source sub-object from validated fields.
   const source: Snapshot['source'] = {
     url: rawSource.url,
     title: rawSource.title,
     clippedAt: rawSource.clippedAt,
+    ...(typeof rawSource.favicon === 'string' ? { favicon: rawSource.favicon } : {}),
   };
-  if (typeof rawSource.favicon === 'string') {
-    source.favicon = rawSource.favicon;
-  }
 
-  // Build the snapshot, copying optional sub-objects through structural guards
-  // (mirrors the decodeDescriptor pattern: validate the required shape, copy
-  // known fields, tolerate unknown extras).
-  const snapshot: Snapshot = { source };
-
-  if (isRecord(raw.selection) && typeof raw.selection.text === 'string') {
-    const sel: NonNullable<Snapshot['selection']> = { text: raw.selection.text };
-    if (typeof raw.selection.html === 'string') {
-      sel.html = raw.selection.html;
-    }
-    if (typeof raw.selection.htmlTruncated === 'boolean') {
-      sel.htmlTruncated = raw.selection.htmlTruncated;
-    }
-    if (
-      isRecord(raw.selection.rect) &&
-      typeof raw.selection.rect.x === 'number' &&
-      typeof raw.selection.rect.y === 'number' &&
-      typeof raw.selection.rect.width === 'number' &&
-      typeof raw.selection.rect.height === 'number'
-    ) {
-      sel.rect = {
-        x: raw.selection.rect.x,
-        y: raw.selection.rect.y,
-        width: raw.selection.rect.width,
-        height: raw.selection.rect.height,
-      };
-    }
-    snapshot.selection = sel;
-  }
-
-  if (isRecord(raw.hints)) {
-    const hints: NonNullable<Snapshot['hints']> = {};
-    if (typeof raw.hints.ogTitle === 'string') {
-      hints.ogTitle = raw.hints.ogTitle;
-    }
-    if (typeof raw.hints.ogDescription === 'string') {
-      hints.ogDescription = raw.hints.ogDescription;
-    }
-    if (typeof raw.hints.ogImage === 'string') {
-      hints.ogImage = raw.hints.ogImage;
-    }
-    if (typeof raw.hints.h1 === 'string') {
-      hints.h1 = raw.hints.h1;
-    }
-    if (typeof raw.hints.firstImage === 'string') {
-      hints.firstImage = raw.hints.firstImage;
-    }
-    if (Array.isArray(raw.hints.jsonLd)) {
-      hints.jsonLd = raw.hints.jsonLd;
-    }
-    snapshot.hints = hints;
-  }
-
-  if (typeof raw.imageData === 'string') {
-    snapshot.imageData = raw.imageData;
-  }
-  if (typeof raw.html === 'string') {
-    snapshot.html = raw.html;
-  }
-  if (typeof raw.htmlTruncated === 'boolean') {
-    snapshot.htmlTruncated = raw.htmlTruncated;
-  }
+  const selection = decodeSelection(raw.selection);
+  const hints = decodeHints(raw.hints);
+  const snapshot: Snapshot = {
+    source,
+    ...(selection ? { selection } : {}),
+    ...(hints ? { hints } : {}),
+    ...(typeof raw.imageData === 'string' ? { imageData: raw.imageData } : {}),
+    ...(typeof raw.html === 'string' ? { html: raw.html } : {}),
+    ...(typeof raw.htmlTruncated === 'boolean' ? { htmlTruncated: raw.htmlTruncated } : {}),
+  };
 
   return { actionId: value.actionId, snapshot };
 };

--- a/packages/apps/composer-crx/src/core/actions/registry.ts
+++ b/packages/apps/composer-crx/src/core/actions/registry.ts
@@ -82,7 +82,8 @@ export const refreshRegistry = async (
         log.info('page-actions registry refresh failed', { error: ack.error });
         return;
       }
-      const registry: PageActionsRegistry = { fetchedAt: new Date().toISOString(), actions: ack.actions };
+      // Copy the readonly ack array into the registry's mutable actions field.
+      const registry: PageActionsRegistry = { fetchedAt: new Date().toISOString(), actions: [...ack.actions] };
       await api.storageSet(PAGE_ACTIONS_STORAGE_KEY, registry);
       log.info('page-actions registry refreshed', { count: ack.actions.length });
       return;

--- a/packages/apps/composer-crx/src/core/actions/registry.ts
+++ b/packages/apps/composer-crx/src/core/actions/registry.ts
@@ -7,6 +7,7 @@ import browser from 'webextension-polyfill';
 import { log } from '@dxos/log';
 
 import { findComposerTab } from '../bridge/sender';
+import { defineState } from '../state';
 import { matchesUrlPatterns } from './match-pattern';
 import {
   PAGE_ACTIONS_LIST_MESSAGE_TYPE,
@@ -100,14 +101,18 @@ export const refreshRegistry = async (
 };
 
 /**
- * Read the cached registry (empty when never fetched). The stored value is
- * re-validated on every read — storage content survives extension upgrades
- * and is treated as untrusted input.
+ * The cached page-actions registry. The stored value is re-validated on every read via
+ * {@link decodeRegistry} — storage content survives extension upgrades and is treated as untrusted.
  */
-export const getRegistry = async (): Promise<PageActionsRegistry> => {
-  const stored = await browser.storage.local.get(PAGE_ACTIONS_STORAGE_KEY);
-  return decodeRegistry(stored?.[PAGE_ACTIONS_STORAGE_KEY]) ?? { fetchedAt: '', actions: [] };
-};
+const RegistryState = defineState<PageActionsRegistry>(
+  'local',
+  PAGE_ACTIONS_STORAGE_KEY,
+  { fetchedAt: '', actions: [] },
+  decodeRegistry,
+);
+
+/** Read the cached registry (empty when never fetched). */
+export const getRegistry = (): Promise<PageActionsRegistry> => RegistryState.get();
 
 /**
  * Cached actions applicable to a URL in a given context.

--- a/packages/apps/composer-crx/src/core/actions/types.ts
+++ b/packages/apps/composer-crx/src/core/actions/types.ts
@@ -2,41 +2,46 @@
 // Copyright 2026 DXOS.org
 //
 
+import type { PageAction } from '@dxos/crx-protocol';
+
 /**
- * Page-actions wire protocol.
+ * Page-actions wire protocol (extension side).
  *
- * Extension-side mirror of `@dxos/plugin-crx`'s `types/PageAction.ts` — the
- * two modules MUST stay in sync. The extension does not depend on `effect`,
- * so the shapes are plain TypeScript types with hand-rolled validators in the
- * style of `../search-proxy/types.ts`.
+ * The serializable *shapes* are the single source of truth in `@dxos/crx-protocol` and are imported
+ * here **type-only** (erased at build) — so the extension, and in particular the per-page content
+ * script, carries no `effect` runtime. Decoding is done by the hand-rolled validators below (also
+ * `effect`-free) rather than `effect/Schema`, keeping the content-script bundle lean.
  *
- * Composer plugins contribute page actions; the extension caches their
- * serializable descriptors and surfaces them on web pages (popup toolbar,
- * context menu). The page and the extension exchange messages over
- * same-origin `window` CustomEvents (page <-> content script) and runtime
- * messages (content script <-> background). Both ends decode through the
- * exported validators so a malformed payload is rejected rather than trusted.
+ * Composer plugins contribute page actions; the extension caches their serializable descriptors and
+ * surfaces them on web pages (popup toolbar, context menu). The page and the extension exchange
+ * messages over same-origin `window` CustomEvents (page <-> content script) and runtime messages
+ * (content script <-> background). Both ends decode through the exported validators so a malformed
+ * payload is rejected rather than trusted.
+ *
+ * The cross-tab CustomEvent name constants below are plain string literals (not imported, to avoid
+ * pulling the `effect`-based schema module at runtime); their values MUST match the corresponding
+ * `PageAction.*_EVENT` constants in `@dxos/crx-protocol`.
  */
 
 /**
  * Window CustomEvent name the content script dispatches on a Composer page to
- * request the list of contributed page actions.
+ * request the list of contributed page actions. Matches `PageAction.LIST_EVENT`.
  */
 export const PAGE_ACTIONS_LIST_EVENT = 'composer:page-actions:list';
 
 /**
- * Window CustomEvent name the Composer page dispatches with the list ack.
+ * Window CustomEvent name the Composer page dispatches with the list ack. Matches `PageAction.LIST_ACK_EVENT`.
  */
 export const PAGE_ACTIONS_LIST_ACK_EVENT = 'composer:page-actions:list:ack';
 
 /**
  * Window CustomEvent name the content script dispatches on a Composer page to
- * invoke a page action with extracted inputs.
+ * invoke a page action with extracted inputs. Matches `PageAction.INVOKE_EVENT`.
  */
 export const PAGE_ACTION_INVOKE_EVENT = 'composer:page-action:invoke';
 
 /**
- * Window CustomEvent name the Composer page dispatches with the invoke ack.
+ * Window CustomEvent name the Composer page dispatches with the invoke ack. Matches `PageAction.INVOKE_ACK_EVENT`.
  */
 export const PAGE_ACTION_INVOKE_ACK_EVENT = 'composer:page-action:invoke:ack';
 
@@ -78,9 +83,8 @@ export const PAGE_ACTION_DELIVER_MESSAGE_TYPE = 'composer-crx:page-action:delive
 
 /**
  * Window CustomEvent dispatched by the Composer page once its page-actions
- * listeners are attached (mirrors `PageAction.READY_EVENT` in plugin-crx —
- * keep the string value in sync). The content-script relay listens for this
- * and forwards a ready runtime message to the background.
+ * listeners are attached. Matches `PageAction.READY_EVENT`. The content-script
+ * relay listens for this and forwards a ready runtime message to the background.
  */
 export const PAGE_ACTIONS_PAGE_READY_EVENT = 'composer:page-actions:ready';
 
@@ -101,7 +105,7 @@ export const PAGE_ACTIONS_STORAGE_KEY = 'composer-crx:page-actions-registry';
 /**
  * Where a page action can be surfaced.
  */
-export type PageActionContext = 'popup' | 'page' | 'selection' | 'link' | 'picker';
+export type PageActionContext = PageAction.Context;
 
 const PAGE_ACTION_CONTEXTS: readonly string[] = ['popup', 'page', 'selection', 'link', 'picker'];
 
@@ -110,83 +114,39 @@ const PAGE_ACTION_CONTEXTS: readonly string[] = ['popup', 'page', 'selection', '
  * `operation` carries the operation key for display/diagnostics only —
  * invocation is correlated by `id`.
  */
-export type PageActionDescriptor = {
-  id: string;
-  label: string;
-  icon: string;
-  urlPatterns: string[];
-  /** Lazy DOM condition evaluated at popup-open / invoke time. */
-  predicate?: { exists: string };
-  /** Named built-in extractor reference (extension-bundled), with optional params. */
-  extractor: { name: string; params?: unknown };
-  contexts: PageActionContext[];
-  operation: string;
-};
+export type PageActionDescriptor = PageAction.Descriptor;
 
 /**
- * Cached registry of page actions, persisted under
- * {@link PAGE_ACTIONS_STORAGE_KEY}.
+ * Cached registry of page actions, persisted under {@link PAGE_ACTIONS_STORAGE_KEY}.
+ * Extension-local (not part of the wire protocol): wraps the shared descriptors with a fetch time.
  */
 export type PageActionsRegistry = { fetchedAt: string; actions: PageActionDescriptor[] };
 
 /**
  * Reply to a page-actions list request.
  */
-export type ListAck =
-  | { version: 1; id: string; ok: true; actions: PageActionDescriptor[] }
-  | { version: 1; id: string; ok: false; error: string };
+export type ListAck = PageAction.ListAck;
 
 /**
  * Request to invoke a page action with inputs extracted from a page.
  */
-export type InvokeRequest = {
-  version: 1;
-  /** Correlation id; the ack echoes it back. */
-  id: string;
-  actionId: string;
-  page: { url: string; title: string; favicon?: string };
-  inputs: unknown;
-  invokedFrom: 'popup' | 'contextMenu' | 'picker';
-};
+export type InvokeRequest = PageAction.InvokeRequest;
 
 /**
  * Reply to an {@link InvokeRequest}.
  */
-export type InvokeAck =
-  | { version: 1; id: string; ok: true; objectId?: string }
-  | { version: 1; id: string; ok: false; error: string };
+export type InvokeAck = PageAction.InvokeAck;
 
 /**
  * Generic page capture produced by the extension's `snapshot` extractor.
- * Mirrors plugin-crx's `PageAction.Snapshot` (Clip source/selection/hints).
  */
-export type Snapshot = {
-  source: { url: string; title: string; favicon?: string; clippedAt: string };
-  selection?: {
-    text: string;
-    html?: string;
-    htmlTruncated?: boolean;
-    rect?: { x: number; y: number; width: number; height: number };
-  };
-  hints?: {
-    ogTitle?: string;
-    ogDescription?: string;
-    ogImage?: string;
-    jsonLd?: unknown[];
-    h1?: string;
-    firstImage?: string;
-  };
-  /** Downscaled thumbnail of the page's primary image as a data URL, captured by the background worker. */
-  imageData?: string;
-  html?: string;
-  htmlTruncated?: boolean;
-};
+export type Snapshot = PageAction.Snapshot;
 
 /** Nominal alias for the selection sub-shape of a {@link Snapshot}. */
-export type SnapshotSelection = NonNullable<Snapshot['selection']>;
+export type SnapshotSelection = NonNullable<PageAction.Snapshot['selection']>;
 
 /** Nominal alias for the hints sub-shape of a {@link Snapshot}. */
-export type SnapshotHints = NonNullable<Snapshot['hints']>;
+export type SnapshotHints = NonNullable<PageAction.Snapshot['hints']>;
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
 
@@ -225,22 +185,26 @@ export const decodeDescriptor = (value: unknown): PageActionDescriptor | undefin
     return undefined;
   }
 
-  const descriptor: PageActionDescriptor = {
+  // Build immutably: the shared schema types are readonly, so fields cannot be assigned post-construction.
+  const predicate =
+    isRecord(value.predicate) && typeof value.predicate.exists === 'string'
+      ? { exists: value.predicate.exists }
+      : undefined;
+  const extractor =
+    value.extractor.params !== undefined
+      ? { name: value.extractor.name, params: value.extractor.params }
+      : { name: value.extractor.name };
+
+  return {
     id: value.id,
     label: value.label,
     icon: value.icon,
     urlPatterns: [...value.urlPatterns],
-    extractor: { name: value.extractor.name },
+    extractor,
     contexts: value.contexts.filter(isPageActionContext),
     operation: value.operation,
+    ...(predicate ? { predicate } : {}),
   };
-  if (isRecord(value.predicate) && typeof value.predicate.exists === 'string') {
-    descriptor.predicate = { exists: value.predicate.exists };
-  }
-  if (value.extractor.params !== undefined) {
-    descriptor.extractor.params = value.extractor.params;
-  }
-  return descriptor;
 };
 
 /**
@@ -305,11 +269,9 @@ export const decodeInvokeAck = (value: unknown): InvokeAck | undefined => {
     if (value.objectId !== undefined && typeof value.objectId !== 'string') {
       return undefined;
     }
-    const ack: InvokeAck = { version: 1, id: value.id, ok: true };
-    if (typeof value.objectId === 'string') {
-      ack.objectId = value.objectId;
-    }
-    return ack;
+    return typeof value.objectId === 'string'
+      ? { version: 1, id: value.id, ok: true, objectId: value.objectId }
+      : { version: 1, id: value.id, ok: true };
   }
   if (value.ok === false) {
     if (typeof value.error !== 'string') {

--- a/packages/apps/composer-crx/src/core/bridge/urls.ts
+++ b/packages/apps/composer-crx/src/core/bridge/urls.ts
@@ -2,9 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-import browser from 'webextension-polyfill';
-
-export const COMPOSER_URLS_PROP = 'composer-urls';
+import { decodeStringArray, defineState } from '../state';
 
 /**
  * Default list of URL patterns (chrome `match` form) the extension will scan
@@ -18,18 +16,12 @@ export const DEFAULT_COMPOSER_URLS = [
   'https://labs.composer.space/*',
 ];
 
-export const getComposerUrls = async (): Promise<string[]> => {
-  const stored = await browser.storage.sync.get(COMPOSER_URLS_PROP);
-  const value = stored?.[COMPOSER_URLS_PROP];
-  if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
-    return value as string[];
-  }
-  return DEFAULT_COMPOSER_URLS;
-};
+/** Configured Composer URL patterns, synced across the user's browsers (defaults to {@link DEFAULT_COMPOSER_URLS}). */
+const ComposerUrlsState = defineState('sync', 'composer-urls', DEFAULT_COMPOSER_URLS, decodeStringArray);
 
-export const setComposerUrls = async (urls: string[]): Promise<void> => {
-  await browser.storage.sync.set({ [COMPOSER_URLS_PROP]: urls });
-};
+export const getComposerUrls = (): Promise<string[]> => ComposerUrlsState.get();
+
+export const setComposerUrls = (urls: string[]): Promise<void> => ComposerUrlsState.set(urls);
 
 /**
  * Test a candidate URL against a single chrome-style match pattern.

--- a/packages/apps/composer-crx/src/core/image/image.ts
+++ b/packages/apps/composer-crx/src/core/image/image.ts
@@ -8,7 +8,8 @@ import { EdgeServiceClient, Image } from '@dxos/edge-client/service';
 import { EffectEx } from '@dxos/effect';
 import { log } from '@dxos/log';
 
-import { THUMBNAIL_PROP, getConfig } from '../../config';
+import { getConfig } from '../../config';
+import { ThumbnailUrl } from '../state';
 
 /**
  * Get content type from URL extension.
@@ -79,7 +80,7 @@ export const createThumbnail = async (imageUrl: string) => {
       Image.thumbnail(client, blob, { filename: getFilenameFromUrl(imageUrl) }),
     );
     if (resultUrl) {
-      await browser.storage.local.set({ [THUMBNAIL_PROP]: resultUrl });
+      await ThumbnailUrl.set(resultUrl);
     }
   } catch (err) {
     log.error('thumbnail creation failed', { err });

--- a/packages/apps/composer-crx/src/core/index.ts
+++ b/packages/apps/composer-crx/src/core/index.ts
@@ -8,3 +8,4 @@ export * from './extractors';
 export * from './image';
 export * from './picker';
 export * from './proxy';
+export * from './state';

--- a/packages/apps/composer-crx/src/core/proxy/types.ts
+++ b/packages/apps/composer-crx/src/core/proxy/types.ts
@@ -2,85 +2,51 @@
 // Copyright 2026 DXOS.org
 //
 
-/**
- * Search render-proxy protocol.
- *
- * The Composer web page asks the extension to fetch + JS-render a URL in a
- * background tab and returns the rendered HTML. This lets the commerce
- * plugin scrape client-rendered / anti-bot SPA sites a plain HTTP proxy
- * cannot. The extension is a PROXY ONLY — it performs no extraction.
- *
- * The page and the extension exchange messages over same-origin `window`
- * CustomEvents (page <-> content script) and a runtime message
- * (content script <-> background). This module is the single source of truth
- * for the wire shapes; both ends decode through the exported validators so a
- * malformed payload is rejected rather than trusted.
- */
+import type { Proxy } from '@dxos/crx-protocol';
 
 /**
- * Window CustomEvent name the page dispatches to request a render.
+ * Search render-proxy + ping protocol (extension side).
+ *
+ * The serializable wire *shapes* are the single source of truth in `@dxos/crx-protocol` (`Proxy`)
+ * and are imported here **type-only** (erased at build) so the extension — in particular the
+ * per-page content script, which decodes these directly — carries no `effect` runtime. Decoding is
+ * done by the hand-rolled validators below (also `effect`-free).
+ *
+ * The cross-tab CustomEvent name constants are plain string literals (not imported, to avoid pulling
+ * the `effect`-based schema module at runtime); their values MUST match the corresponding
+ * `Proxy.*` constants in `@dxos/crx-protocol`.
  */
+
+/** Window CustomEvent name the page dispatches to request a render. Matches `Proxy.RENDER_EVENT`. */
 export const RENDER_EVENT = 'composer:proxy:render';
 
-/**
- * Window CustomEvent name the content script dispatches with the ack.
- */
+/** Window CustomEvent name the content script dispatches with the ack. Matches `Proxy.RENDER_ACK_EVENT`. */
 export const RENDER_ACK_EVENT = 'composer:proxy:render:ack';
 
 /**
  * Runtime message `type` discriminator the content script forwards to the
- * background worker.
+ * background worker (extension-internal; not part of the shared cross-tab protocol).
  */
 export const RENDER_MESSAGE_TYPE = 'composer-crx:proxy:render';
 
 /**
  * `documentElement` dataset key the content relay sets once it is listening on
- * a Composer page (`document.documentElement.dataset.composerProxy`).
- * Lets the page detect render-proxy availability synchronously rather than
- * waiting for a request to time out.
+ * a Composer page. Lets the page detect render-proxy availability synchronously.
+ * Matches `Proxy.RENDER_READY_DATASET_KEY`.
  */
 export const RENDER_READY_DATASET_KEY = 'composerProxy';
 
-/**
- * Default ceiling for a single render before it is aborted.
- */
+/** Default ceiling for a single render before it is aborted. */
 export const DEFAULT_RENDER_TIMEOUT_MS = 20_000;
 
-/**
- * Request to render a URL in a background tab.
- */
-export type RenderRequest = {
-  version: 1;
-  /** Correlation id; the ack echoes it back. */
-  id: string;
-  url: string;
-  /** Poll for this CSS selector before reading the HTML. */
-  waitForSelector?: string;
-  /** Additional fixed delay (ms) before reading the HTML. */
-  waitForMs?: number;
-  /** Overall ceiling (ms) before the render is aborted. */
-  timeoutMs?: number;
-  /** Render in a focused (foreground) tab. Helps sites that gate background tabs. Default false. */
-  active?: boolean;
-};
+/** Request to render a URL in a background tab. */
+export type RenderRequest = Proxy.RenderRequest;
 
-/**
- * Discriminated set of failure modes returned in a non-ok ack.
- *   - `badRequest`      : the request failed validation.
- *   - `forbiddenOrigin` : the sender is not a configured Composer origin.
- *   - `noTab`           : the background tab could not be created.
- *   - `timeout`         : the render exceeded its time budget.
- *   - `invalidAck`      : the injected script returned an unexpected shape.
- *   - `transportError`  : an unexpected browser-API error.
- */
-export type RenderError = 'badRequest' | 'forbiddenOrigin' | 'noTab' | 'timeout' | 'invalidAck' | 'transportError';
+/** Discriminated set of failure modes returned in a non-ok ack. */
+export type RenderError = Proxy.RenderError;
 
-/**
- * Reply to a {@link RenderRequest}.
- */
-export type RenderAck =
-  | { version: 1; id: string; ok: true; html: string; finalUrl: string }
-  | { version: 1; id: string; ok: false; error: RenderError };
+/** Reply to a {@link RenderRequest}. */
+export type RenderAck = Proxy.RenderAck;
 
 const RENDER_ERRORS: readonly string[] = [
   'badRequest',
@@ -124,20 +90,16 @@ export const decodeRenderRequest = (value: unknown): RenderRequest | undefined =
     return undefined;
   }
 
-  const request: RenderRequest = { version: 1, id: value.id, url: value.url };
-  if (typeof value.waitForSelector === 'string') {
-    request.waitForSelector = value.waitForSelector;
-  }
-  if (typeof value.waitForMs === 'number') {
-    request.waitForMs = value.waitForMs;
-  }
-  if (typeof value.timeoutMs === 'number') {
-    request.timeoutMs = value.timeoutMs;
-  }
-  if (typeof value.active === 'boolean') {
-    request.active = value.active;
-  }
-  return request;
+  // Built immutably: the shared schema types are readonly.
+  return {
+    version: 1,
+    id: value.id,
+    url: value.url,
+    ...(typeof value.waitForSelector === 'string' ? { waitForSelector: value.waitForSelector } : {}),
+    ...(typeof value.waitForMs === 'number' ? { waitForMs: value.waitForMs } : {}),
+    ...(typeof value.timeoutMs === 'number' ? { timeoutMs: value.timeoutMs } : {}),
+    ...(typeof value.active === 'boolean' ? { active: value.active } : {}),
+  };
 };
 
 /**
@@ -166,38 +128,23 @@ export const decodeRenderAck = (value: unknown): RenderAck | undefined => {
   return undefined;
 };
 
-/**
- * Window CustomEvent name the page dispatches to probe the extension.
- */
+/** Window CustomEvent name the page dispatches to probe the extension. Matches `Proxy.PING_EVENT`. */
 export const PING_EVENT = 'composer:proxy:ping';
 
-/**
- * Window CustomEvent name the content script dispatches with the ping ack.
- */
+/** Window CustomEvent name the content script dispatches with the ping ack. Matches `Proxy.PING_ACK_EVENT`. */
 export const PING_ACK_EVENT = 'composer:proxy:ping:ack';
 
 /**
- * Runtime message `type` discriminator the content script forwards for a ping.
+ * Runtime message `type` discriminator the content script forwards for a ping
+ * (extension-internal; not part of the shared cross-tab protocol).
  */
 export const PING_MESSAGE_TYPE = 'composer-crx:proxy:ping';
 
-/**
- * Health-check round-trip: the page asks the extension to identify itself. Exercises the same
- * page → content-script → background path the render-proxy uses, so a successful ack proves the
- * messaging path (not just that the content script loaded).
- */
-export type PingRequest = {
-  version: 1;
-  /** Correlation id; the ack echoes it back. */
-  id: string;
-};
+/** Health-check round-trip: the page asks the extension to identify itself. */
+export type PingRequest = Proxy.PingRequest;
 
-/**
- * Reply to a {@link PingRequest}, carrying the extension's manifest identity.
- */
-export type PingAck =
-  | { version: 1; id: string; ok: true; extensionVersion: string; extensionName: string }
-  | { version: 1; id: string; ok: false; error: RenderError };
+/** Reply to a {@link PingRequest}, carrying the extension's manifest identity. */
+export type PingAck = Proxy.PingAck;
 
 /**
  * Validate and narrow an unknown value to a {@link PingRequest}.

--- a/packages/apps/composer-crx/src/core/proxy/types.ts
+++ b/packages/apps/composer-crx/src/core/proxy/types.ts
@@ -43,12 +43,12 @@ export const DEFAULT_RENDER_TIMEOUT_MS = 20_000;
 export type RenderRequest = Proxy.RenderRequest;
 
 /** Discriminated set of failure modes returned in a non-ok ack. */
-export type RenderError = Proxy.RenderError;
+export type ProxyError = Proxy.ProxyError;
 
 /** Reply to a {@link RenderRequest}. */
 export type RenderAck = Proxy.RenderAck;
 
-const RENDER_ERRORS: readonly string[] = [
+const PROXY_ERRORS: readonly string[] = [
   'badRequest',
   'forbiddenOrigin',
   'noTab',
@@ -59,8 +59,7 @@ const RENDER_ERRORS: readonly string[] = [
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
 
-const isRenderError = (value: unknown): value is RenderError =>
-  typeof value === 'string' && RENDER_ERRORS.includes(value);
+const isProxyError = (value: unknown): value is ProxyError => typeof value === 'string' && PROXY_ERRORS.includes(value);
 
 /**
  * Validate and narrow an unknown value to a {@link RenderRequest}. Returns
@@ -120,7 +119,7 @@ export const decodeRenderAck = (value: unknown): RenderAck | undefined => {
     return { version: 1, id: value.id, ok: true, html: value.html, finalUrl: value.finalUrl };
   }
   if (value.ok === false) {
-    if (!isRenderError(value.error)) {
+    if (!isProxyError(value.error)) {
       return undefined;
     }
     return { version: 1, id: value.id, ok: false, error: value.error };
@@ -176,7 +175,7 @@ export const decodePingAck = (value: unknown): PingAck | undefined => {
     };
   }
   if (value.ok === false) {
-    if (!isRenderError(value.error)) {
+    if (!isProxyError(value.error)) {
       return undefined;
     }
     return { version: 1, id: value.id, ok: false, error: value.error };

--- a/packages/apps/composer-crx/src/core/state/index.ts
+++ b/packages/apps/composer-crx/src/core/state/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './state';
+export * from './keys';

--- a/packages/apps/composer-crx/src/core/state/keys.ts
+++ b/packages/apps/composer-crx/src/core/state/keys.ts
@@ -1,0 +1,25 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { decodeBoolean, decodeString, defineState } from './state';
+
+//
+// Config — `browser.storage.sync` (user-set, synced across the user's browsers).
+//
+
+/** Whether developer mode is enabled (verbose logging, debug preview, local service endpoints). */
+export const DeveloperMode = defineState('sync', 'developer-mode', false, decodeBoolean);
+
+/** Whether the assistant should use the configured Space to retrieve information. */
+export const SpaceMode = defineState('sync', 'space-mode', false, decodeBoolean);
+
+/** The configured Space id the assistant queries when {@link SpaceMode} is enabled. */
+export const SpaceId = defineState<string | undefined>('sync', 'space-id', undefined, decodeString);
+
+//
+// Session — `browser.storage.local` (per-install).
+//
+
+/** Thumbnail data URL handed from the context-menu action to the side panel on (re)open. */
+export const ThumbnailUrl = defineState<string | undefined>('local', 'thumbnail-url', undefined, decodeString);

--- a/packages/apps/composer-crx/src/core/state/state.ts
+++ b/packages/apps/composer-crx/src/core/state/state.ts
@@ -1,0 +1,64 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import browser from 'webextension-polyfill';
+
+/**
+ * Typed extension state.
+ *
+ * A thin, schema-validated layer over `browser.storage` that replaces scattered raw `storage.get`/
+ * `set` calls and loose string key constants. Each {@link StateEntry} owns one storage key: its area
+ * (`sync` for user config synced across the user's browsers, `local` for per-install session data),
+ * its default, and a decoder that rejects malformed persisted values (storage survives extension
+ * upgrades, so it is treated as untrusted input).
+ *
+ * Kept dependency-light (no `effect`) so it is safe to use from the per-page content script.
+ */
+export type StorageArea = 'sync' | 'local';
+
+export type StateEntry<T> = {
+  /** Read the current value, falling back to the default when unset or malformed. */
+  readonly get: () => Promise<T>;
+  /** Persist a value. */
+  readonly set: (value: T) => Promise<void>;
+  /** Remove the key. */
+  readonly remove: () => Promise<void>;
+  /** Observe changes to this key; returns an unsubscribe function. */
+  readonly subscribe: (onChange: (value: T) => void) => () => void;
+};
+
+/** Define a typed, validated accessor over a single `browser.storage` key. */
+export const defineState = <T>(
+  area: StorageArea,
+  key: string,
+  fallback: T,
+  decode: (raw: unknown) => T | undefined,
+): StateEntry<T> => ({
+  get: async () => {
+    const stored = await browser.storage[area].get(key);
+    return decode(stored?.[key]) ?? fallback;
+  },
+  set: async (value) => {
+    await browser.storage[area].set({ [key]: value });
+  },
+  remove: async () => {
+    await browser.storage[area].remove(key);
+  },
+  subscribe: (onChange) => {
+    const listener = (changes: Record<string, browser.Storage.StorageChange>, changedArea: string) => {
+      if (changedArea === area && key in changes) {
+        onChange(decode(changes[key]?.newValue) ?? fallback);
+      }
+    };
+    browser.storage.onChanged.addListener(listener);
+    return () => browser.storage.onChanged.removeListener(listener);
+  },
+});
+
+export const decodeBoolean = (raw: unknown): boolean | undefined => (typeof raw === 'boolean' ? raw : undefined);
+
+export const decodeString = (raw: unknown): string | undefined => (typeof raw === 'string' ? raw : undefined);
+
+export const decodeStringArray = (raw: unknown): string[] | undefined =>
+  Array.isArray(raw) && raw.every((entry) => typeof entry === 'string') ? [...raw] : undefined;

--- a/packages/apps/composer-crx/tsconfig.json
+++ b/packages/apps/composer-crx/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../../../tools/vite-plugin-shutdown"
     },
     {
+      "path": "../../common/crx-protocol"
+    },
+    {
       "path": "../../common/effect"
     },
     {

--- a/packages/common/crx-protocol/src/Proxy.test.ts
+++ b/packages/common/crx-protocol/src/Proxy.test.ts
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Either from 'effect/Either';
+import * as Schema from 'effect/Schema';
+import { describe, test } from 'vitest';
+
+import { Proxy } from './index';
+
+describe('Proxy schema', () => {
+  test('decodes a render request with optional fields', ({ expect }) => {
+    const decoded = Schema.decodeUnknownEither(Proxy.RenderRequest)({
+      version: 1,
+      id: 'r1',
+      url: 'https://example.com',
+      waitForSelector: '#root',
+      active: true,
+    });
+    expect(Either.isRight(decoded)).toBe(true);
+  });
+
+  test('rejects a render request with a wrong version', ({ expect }) => {
+    const decoded = Schema.decodeUnknownEither(Proxy.RenderRequest)({ version: 2, id: 'r1', url: 'https://x' });
+    expect(Either.isLeft(decoded)).toBe(true);
+  });
+
+  test('round-trips a render ack (ok)', ({ expect }) => {
+    const ack: Proxy.RenderAck = { version: 1, id: 'r1', ok: true, html: '<html/>', finalUrl: 'https://x' };
+    expect(Schema.decodeUnknownSync(Proxy.RenderAck)(Schema.encodeSync(Proxy.RenderAck)(ack))).toEqual(ack);
+  });
+
+  test('rejects a render ack with an unknown error code', ({ expect }) => {
+    const decoded = Schema.decodeUnknownEither(Proxy.RenderAck)({ version: 1, id: 'r1', ok: false, error: 'nope' });
+    expect(Either.isLeft(decoded)).toBe(true);
+  });
+
+  test('round-trips a ping ack (ok)', ({ expect }) => {
+    const ack: Proxy.PingAck = { version: 1, id: 'p1', ok: true, extensionVersion: '0.1.0', extensionName: 'Composer' };
+    expect(Schema.decodeUnknownSync(Proxy.PingAck)(Schema.encodeSync(Proxy.PingAck)(ack))).toEqual(ack);
+  });
+});

--- a/packages/common/crx-protocol/src/Proxy.ts
+++ b/packages/common/crx-protocol/src/Proxy.ts
@@ -39,7 +39,7 @@ export const RENDER_READY_DATASET_KEY = 'composerProxy';
  *   - `invalidAck`      : the injected script returned an unexpected shape.
  *   - `transportError`  : an unexpected browser-API error.
  */
-export const RenderError = Schema.Literal(
+export const ProxyError = Schema.Literal(
   'badRequest',
   'forbiddenOrigin',
   'noTab',
@@ -47,7 +47,7 @@ export const RenderError = Schema.Literal(
   'invalidAck',
   'transportError',
 );
-export type RenderError = Schema.Schema.Type<typeof RenderError>;
+export type ProxyError = Schema.Schema.Type<typeof ProxyError>;
 
 /** Request to render a URL in a background tab. */
 export const RenderRequest = Schema.Struct({
@@ -70,7 +70,7 @@ export const RenderAck = Schema.Union(
     html: Schema.String,
     finalUrl: Schema.String,
   }),
-  Schema.Struct({ version: Schema.Literal(1), id: Schema.String, ok: Schema.Literal(false), error: RenderError }),
+  Schema.Struct({ version: Schema.Literal(1), id: Schema.String, ok: Schema.Literal(false), error: ProxyError }),
 );
 export type RenderAck = Schema.Schema.Type<typeof RenderAck>;
 
@@ -87,6 +87,6 @@ export const PingAck = Schema.Union(
     extensionVersion: Schema.String,
     extensionName: Schema.String,
   }),
-  Schema.Struct({ version: Schema.Literal(1), id: Schema.String, ok: Schema.Literal(false), error: RenderError }),
+  Schema.Struct({ version: Schema.Literal(1), id: Schema.String, ok: Schema.Literal(false), error: ProxyError }),
 );
 export type PingAck = Schema.Schema.Type<typeof PingAck>;

--- a/packages/common/crx-protocol/src/Proxy.ts
+++ b/packages/common/crx-protocol/src/Proxy.ts
@@ -1,0 +1,92 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as Schema from 'effect/Schema';
+
+//
+// Search render-proxy + health-check (ping) wire protocol.
+//
+// The Composer page asks the extension to fetch + JS-render a URL in a background tab (the extension
+// is a proxy only; it performs no extraction), and to identify itself via a ping round-trip. Both
+// exchanges cross the page <-> content-script <-> background boundary; this is the shared source of
+// truth for their serializable shapes, consumed by both `plugin-crx` and `composer-crx`.
+//
+
+/** Window CustomEvent the page dispatches to request a render. */
+export const RENDER_EVENT = 'composer:proxy:render';
+
+/** Window CustomEvent the content relay dispatches with the render ack. */
+export const RENDER_ACK_EVENT = 'composer:proxy:render:ack';
+
+/** Window CustomEvent the page dispatches to probe the extension. */
+export const PING_EVENT = 'composer:proxy:ping';
+
+/** Window CustomEvent the content relay dispatches with the ping ack. */
+export const PING_ACK_EVENT = 'composer:proxy:ping:ack';
+
+/** `documentElement` dataset key the content relay sets once it is listening (availability marker). */
+export const RENDER_READY_DATASET_KEY = 'composerProxy';
+
+/**
+ * Failure modes returned in a non-ok ack:
+ *   - `badRequest`      : the request failed validation.
+ *   - `forbiddenOrigin` : the sender is not a configured Composer origin.
+ *   - `noTab`           : the background tab could not be created.
+ *   - `timeout`         : the render exceeded its time budget.
+ *   - `invalidAck`      : the injected script returned an unexpected shape.
+ *   - `transportError`  : an unexpected browser-API error.
+ */
+export const RenderError = Schema.Literal(
+  'badRequest',
+  'forbiddenOrigin',
+  'noTab',
+  'timeout',
+  'invalidAck',
+  'transportError',
+);
+export type RenderError = Schema.Schema.Type<typeof RenderError>;
+
+/** Request to render a URL in a background tab. */
+export const RenderRequest = Schema.Struct({
+  version: Schema.Literal(1),
+  id: Schema.String,
+  url: Schema.String,
+  waitForSelector: Schema.optional(Schema.String),
+  waitForMs: Schema.optional(Schema.Number),
+  timeoutMs: Schema.optional(Schema.Number),
+  active: Schema.optional(Schema.Boolean),
+});
+export type RenderRequest = Schema.Schema.Type<typeof RenderRequest>;
+
+/** Reply to a {@link RenderRequest}. */
+export const RenderAck = Schema.Union(
+  Schema.Struct({
+    version: Schema.Literal(1),
+    id: Schema.String,
+    ok: Schema.Literal(true),
+    html: Schema.String,
+    finalUrl: Schema.String,
+  }),
+  Schema.Struct({ version: Schema.Literal(1), id: Schema.String, ok: Schema.Literal(false), error: RenderError }),
+);
+export type RenderAck = Schema.Schema.Type<typeof RenderAck>;
+
+/** Health-check round-trip: the page asks the extension to identify itself. */
+export const PingRequest = Schema.Struct({ version: Schema.Literal(1), id: Schema.String });
+export type PingRequest = Schema.Schema.Type<typeof PingRequest>;
+
+/** Reply to a {@link PingRequest}, carrying the extension's manifest identity. */
+export const PingAck = Schema.Union(
+  Schema.Struct({
+    version: Schema.Literal(1),
+    id: Schema.String,
+    ok: Schema.Literal(true),
+    extensionVersion: Schema.String,
+    extensionName: Schema.String,
+  }),
+  Schema.Struct({ version: Schema.Literal(1), id: Schema.String, ok: Schema.Literal(false), error: RenderError }),
+);
+export type PingAck = Schema.Schema.Type<typeof PingAck>;

--- a/packages/common/crx-protocol/src/index.ts
+++ b/packages/common/crx-protocol/src/index.ts
@@ -3,6 +3,7 @@
 //
 
 export * as PageAction from './PageAction';
+export * as Proxy from './Proxy';
 export * from './channel';
 export * as Message from './Message';
 export * from './rpc';

--- a/packages/plugins/plugin-crx/src/containers/CrxSettings/CrxSettings.stories.tsx
+++ b/packages/plugins/plugin-crx/src/containers/CrxSettings/CrxSettings.stories.tsx
@@ -5,11 +5,11 @@
 import { type Decorator, type Meta, type StoryObj } from '@storybook/react-vite';
 import React, { useEffect, useState } from 'react';
 
+import { Proxy } from '@dxos/crx-protocol';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 
 import { translations } from '../../translations';
 import { Settings } from '../../types';
-import { PING_ACK_EVENT, PING_EVENT, RENDER_READY_DATASET_KEY } from '../../util';
 import { CrxSettings } from './CrxSettings';
 
 /**
@@ -19,11 +19,11 @@ import { CrxSettings } from './CrxSettings';
  */
 const withFakeExtension: Decorator = (Story) => {
   useEffect(() => {
-    document.documentElement.dataset[RENDER_READY_DATASET_KEY] = '1';
+    document.documentElement.dataset[Proxy.RENDER_READY_DATASET_KEY] = '1';
     const listener = (event: Event) => {
       const detail = (event as CustomEvent).detail as { id: string };
       window.dispatchEvent(
-        new CustomEvent(PING_ACK_EVENT, {
+        new CustomEvent(Proxy.PING_ACK_EVENT, {
           detail: {
             version: 1,
             id: detail.id,
@@ -34,10 +34,10 @@ const withFakeExtension: Decorator = (Story) => {
         }),
       );
     };
-    window.addEventListener(PING_EVENT, listener);
+    window.addEventListener(Proxy.PING_EVENT, listener);
     return () => {
-      delete document.documentElement.dataset[RENDER_READY_DATASET_KEY];
-      window.removeEventListener(PING_EVENT, listener);
+      delete document.documentElement.dataset[Proxy.RENDER_READY_DATASET_KEY];
+      window.removeEventListener(Proxy.PING_EVENT, listener);
     };
   }, []);
   return <Story />;

--- a/packages/plugins/plugin-crx/src/util/pingExtension.test.ts
+++ b/packages/plugins/plugin-crx/src/util/pingExtension.test.ts
@@ -5,7 +5,9 @@
 
 import { afterEach, beforeEach, describe, test } from 'vitest';
 
-import { PING_ACK_EVENT, PING_EVENT, isExtensionAvailable, pingExtension } from './pingExtension';
+import { Proxy } from '@dxos/crx-protocol';
+
+import { isExtensionAvailable, pingExtension } from './pingExtension';
 
 const setAvailable = (available: boolean) => {
   if (available) {
@@ -19,10 +21,10 @@ const setAvailable = (available: boolean) => {
 const installFakeRelay = (respond: (id: string) => unknown) => {
   const listener = (event: Event) => {
     const detail = (event as CustomEvent).detail as { id: string };
-    window.dispatchEvent(new CustomEvent(PING_ACK_EVENT, { detail: respond(detail.id) }));
+    window.dispatchEvent(new CustomEvent(Proxy.PING_ACK_EVENT, { detail: respond(detail.id) }));
   };
-  window.addEventListener(PING_EVENT, listener);
-  return () => window.removeEventListener(PING_EVENT, listener);
+  window.addEventListener(Proxy.PING_EVENT, listener);
+  return () => window.removeEventListener(Proxy.PING_EVENT, listener);
 };
 
 describe('pingExtension', () => {

--- a/packages/plugins/plugin-crx/src/util/pingExtension.test.ts
+++ b/packages/plugins/plugin-crx/src/util/pingExtension.test.ts
@@ -11,9 +11,9 @@ import { isExtensionAvailable, pingExtension } from './pingExtension';
 
 const setAvailable = (available: boolean) => {
   if (available) {
-    document.documentElement.dataset.composerProxy = '1';
+    document.documentElement.dataset[Proxy.RENDER_READY_DATASET_KEY] = '1';
   } else {
-    delete document.documentElement.dataset.composerProxy;
+    delete document.documentElement.dataset[Proxy.RENDER_READY_DATASET_KEY];
   }
 };
 

--- a/packages/plugins/plugin-crx/src/util/pingExtension.ts
+++ b/packages/plugins/plugin-crx/src/util/pingExtension.ts
@@ -2,30 +2,15 @@
 // Copyright 2026 DXOS.org
 //
 
+import { Proxy } from '@dxos/crx-protocol';
+
 /**
  * Page side of the composer-crx extension's ping contract — a health-check round-trip that proves
  * the page → content-script → background messaging path and reports the extension's identity.
  *
- * The event names and wire shapes mirror `packages/apps/composer-crx/src/proxy/types.ts` (the source
- * of truth); they are re-declared here because the plugin must not depend on the extension app
- * package.
+ * The event names and wire shapes are the shared `@dxos/crx-protocol` `Proxy` protocol (the single
+ * source of truth, consumed by both the plugin and the extension).
  */
-
-/**
- * Window CustomEvent name the page dispatches to probe the extension. Exported so tests and
- * stories can stand in for the extension's content relay.
- */
-export const PING_EVENT = 'composer:proxy:ping';
-
-/**
- * Window CustomEvent name the extension's content relay dispatches with the ping ack.
- */
-export const PING_ACK_EVENT = 'composer:proxy:ping:ack';
-
-/**
- * `documentElement` dataset key the extension's content relay sets once it is listening.
- */
-export const RENDER_READY_DATASET_KEY = 'composerProxy';
 
 const DEFAULT_PING_TIMEOUT_MS = 4_000;
 
@@ -44,7 +29,7 @@ const nextId = (): string => globalThis.crypto?.randomUUID?.() ?? `ping-${(count
  * dataset marker once the relay is listening).
  */
 export const isExtensionAvailable = (): boolean =>
-  typeof document !== 'undefined' && document.documentElement?.dataset[RENDER_READY_DATASET_KEY] === '1';
+  typeof document !== 'undefined' && document.documentElement?.dataset[Proxy.RENDER_READY_DATASET_KEY] === '1';
 
 /**
  * Ping the composer-crx extension and resolve with its identity. Rejects if the extension is not
@@ -61,7 +46,7 @@ export const pingExtension = (timeoutMs: number = DEFAULT_PING_TIMEOUT_MS): Prom
     let settled = false;
 
     const cleanup = () => {
-      window.removeEventListener(PING_ACK_EVENT, onAck);
+      window.removeEventListener(Proxy.PING_ACK_EVENT, onAck);
       clearTimeout(timer);
     };
 
@@ -93,6 +78,6 @@ export const pingExtension = (timeoutMs: number = DEFAULT_PING_TIMEOUT_MS): Prom
       reject(new Error(`Extension did not respond within ${timeoutMs}ms`));
     }, timeoutMs);
 
-    window.addEventListener(PING_ACK_EVENT, onAck);
-    window.dispatchEvent(new CustomEvent(PING_EVENT, { detail: { version: 1, id } }));
+    window.addEventListener(Proxy.PING_ACK_EVENT, onAck);
+    window.dispatchEvent(new CustomEvent(Proxy.PING_EVENT, { detail: { version: 1, id } }));
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3247,6 +3247,9 @@ importers:
       '@dxos/config':
         specifier: workspace:*
         version: link:../../sdk/config
+      '@dxos/crx-protocol':
+        specifier: workspace:*
+        version: link:../../common/crx-protocol
       '@dxos/devtools':
         specifier: workspace:*
         version: link:../../devtools/devtools
@@ -7373,7 +7376,7 @@ importers:
         version: 0.96.2(effect@3.21.4)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/printer':
         specifier: 'catalog:'
         version: 0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4)
@@ -7506,7 +7509,7 @@ importers:
         version: 0.96.2(effect@3.21.4)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/printer':
         specifier: 'catalog:'
         version: 0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4)
@@ -9845,7 +9848,7 @@ importers:
         version: 0.75.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@tauri-apps/api':
         specifier: 'catalog:'
         version: 2.11.1
@@ -48845,7 +48848,7 @@ snapshots:
       effect: 3.21.4
       multipasta: 0.2.7
 
-  '@effect/platform-bun@0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)':
+  '@effect/platform-bun@0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)':
     dependencies:
       '@effect/cluster': 0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/platform': 0.96.2(effect@3.21.4)


### PR DESCRIPTION
## Summary

Phase 2 of the CRX↔Composer protocol work: repoint `composer-crx` onto the shared `@dxos/crx-protocol` package and delete the hand-rolled type mirror in `core/actions/types.ts`.

Previously `composer-crx` kept a duplicate of plugin-crx's page-action shapes ("MUST stay in sync") because the extension deliberately avoids the `effect` runtime. Now the shapes are imported **type-only** from `@dxos/crx-protocol`, so:

- The shared package is the **single source of truth** for the wire types — the type-drift risk is gone.
- The import is **erased at build** (type-only), and the decoders stay **hand-rolled** (not `effect/Schema`), so **no `effect` runtime enters the extension** — in particular the per-page content script, which calls the decoders directly, stays lean. (This is the same lean-bundle concern behind the recent quickjs/tiktoken fixes.)

## Details
- `core/actions/types.ts`: type definitions replaced with aliases to `PageAction.*`; CRX-internal message-type constants and cross-tab event-name literals kept local (event strings must still match `PageAction.*_EVENT`).
- Decoders refactored to construct **immutably** (the shared schema types are readonly). Lenient behavior — drop malformed descriptor entries, filter unknown `contexts` — is unchanged.
- `deliver.ts` snapshot builder and `registry.ts` updated for the readonly types.

## Verification
- composer-crx: build + lint clean; **104/104 tests pass** (incl. `types.test.ts` 25, `deliver.test.ts` 9 — the lenient-decode assertions).
- No casts.

Follow-up (not in this PR): wire the content-script relay to a `Channel` adapter (`CustomEvent` ⇄ `chrome.runtime`) per the design doc §5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved page-action handling with safer optional selection/hints processing and tighter protocol alignment for snapshots.
  * Migrated extension settings and thumbnail URL persistence to typed, schema-validated storage (developer/space modes, composer URLs, space ID).
  * Standardized render/ping protocol constants via shared `crx-protocol`.

* **Bug Fixes**
  * Hardened deliver payload validation to ignore malformed optional snapshot details.
  * Prevented page-action registry caching from reusing mutable action arrays.
  * Avoided persisting invalid partial space IDs when updating settings.

* **Documentation**
  * Updated core design docs for the new state-backed configuration and thumbnail flow.

* **Tests**
  * Added protocol schema coverage and updated ping/extension test wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->