### PR TITLE
refactor(app-framework): extract bootLoader driver into App/loader

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -16,7 +16,7 @@ import { createRoot } from 'react-dom/client';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 
 import { EdgeRegistryPluginProvider, type Plugin, PluginAssetCache, UrlLoader } from '@dxos/app-framework';
-import { useApp } from '@dxos/app-framework/ui';
+import { bootLoader, useApp } from '@dxos/app-framework/ui';
 import { AppActivationEvents } from '@dxos/app-toolkit';
 import { EdgeHttpClient } from '@dxos/edge-client';
 import { EffectEx } from '@dxos/effect';
@@ -64,15 +64,12 @@ declare global {
   var downloadLogs: () => Promise<void>;
 }
 
-// `window.__bootLoader` is declared globally by `@dxos/app-framework/ui`
-// (alongside the React `Placeholder` that calls `dismiss()`).
-
 /**
  * Updates the native-DOM boot loader text. No-op once React has replaced #root.
  * The CSS animation in `index.html` keeps painting on the compositor thread
  * regardless of main-thread work, so this is purely textual feedback.
  */
-const bootStatus = (text: string) => window.__bootLoader?.status({ humanized: text });
+const bootStatus = (text: string) => bootLoader?.status({ humanized: text });
 
 // Stamp every (re-)evaluation of this module so we can tell Vite HMR reloads
 // from a true page boot. Dev-only — production has no HMR and the diagnostic
@@ -433,19 +430,19 @@ const main = async () => {
         // Pass `range` so the loader updates the existing line in place
         // ("Loading plugins (3/12)") instead of appending a fresh entry per
         // tick — keeps the visible log compact.
-        window.__bootLoader?.status({ humanized: 'Loading plugins', range: { index: loaded, total } });
+        bootLoader?.status({ humanized: 'Loading plugins', range: { index: loaded, total } });
         // The ring spans two phases — remote-plugin preload (0 → 50%) and
         // module activation (50 → 100%, driven from `Placeholder` once
         // React mounts). Splitting the range keeps it monotonic across
         // the boundary.
-        window.__bootLoader?.progress((loaded / total) * 0.5);
+        bootLoader?.progress((loaded / total) * 0.5);
       },
     }),
   );
 
   bootStatus('Starting Composer…');
   // Park the ring at 50% — preload done, activation about to take over.
-  window.__bootLoader?.progress(0.5);
+  bootLoader?.progress(0.5);
   const remotePlugins: Plugin.Plugin[] = remotePluginsResult;
   const plugins = [...builtinPlugins, ...remotePlugins];
   const pluginLoader = UrlLoader.make(builtinPlugins, { cache: assetCache });

--- a/packages/sdk/app-framework/src/ui/components/App/App.tsx
+++ b/packages/sdk/app-framework/src/ui/components/App/App.tsx
@@ -7,44 +7,15 @@ import React, { type PropsWithChildren, useEffect, useLayoutEffect } from 'react
 import { Capabilities } from '../../../common';
 import { topologicalSort } from '../../../helpers';
 import { LoadingState, type StartupProgress, type UseAppOptions, useCapabilities, useLoading } from '../../hooks';
+import { bootLoader } from './loader';
 
-declare global {
-  interface Window {
-    /**
-     * Driver injected by `@dxos/app-framework/vite-plugin`'s `bootLoaderPlugin`
-     * (a Solid app inlined into `index.html`). Declared here — on a module that
-     * is part of the `@dxos/app-framework/ui` export surface — so the React side
-     * and host apps (e.g. composer-app) can drive the loader without each
-     * re-declaring the type. The canonical definition lives in the plugin's
-     * `loader-app/types.ts`; this mirror exists because that source compiles in a
-     * separate (Solid) program that doesn't ship its globals to consumers.
-     */
-    __bootLoader?: {
-      status: (payload: {
-        event?: string;
-        module?: string;
-        humanized: string;
-        /**
-         * Optional `(index/total)` tick. When present, the loader replaces the
-         * current line in place ("Loading plugins (12/80)") instead of appending
-         * a new entry — keeps the visible log compact during long counted phases.
-         */
-        range?: { index: number; total: number };
-      }) => void;
-      progress: (fraction?: number) => void;
-      ready: () => void;
-      dismiss: () => void;
-    };
-  }
-}
+const FIRST_INTERACTIVE_MARK = 'app-framework:first-interactive';
 
 export type AppProps = Pick<UseAppOptions, 'debounce'> & {
   ready: boolean;
   error: unknown;
   progress?: StartupProgress;
 };
-
-const FIRST_INTERACTIVE_MARK = 'app-framework:first-interactive';
 
 export const App = ({ ready, error, debounce, progress }: AppProps) => {
   const reactContexts = useCapabilities(Capabilities.ReactContext);
@@ -62,10 +33,11 @@ export const App = ({ ready, error, debounce, progress }: AppProps) => {
     if (stage >= LoadingState.FadeOut) {
       return;
     }
+
     const fraction = progress?.progress ?? 0;
-    window.__bootLoader?.progress(0.5 + fraction * 0.5);
+    bootLoader?.progress(0.5 + fraction * 0.5);
     if (progress?.humanizedName) {
-      window.__bootLoader?.status({
+      bootLoader?.status({
         event: progress.event,
         module: progress.module,
         humanized: `Activating ${progress.humanizedName}`,
@@ -78,7 +50,7 @@ export const App = ({ ready, error, debounce, progress }: AppProps) => {
   // same frame the real shell starts rendering beneath it.
   useLayoutEffect(() => {
     if (stage >= LoadingState.FadeOut) {
-      window.__bootLoader?.ready();
+      bootLoader?.ready();
     }
   }, [stage]);
 
@@ -97,7 +69,7 @@ export const App = ({ ready, error, debounce, progress }: AppProps) => {
     if (performance.getEntriesByName(FIRST_INTERACTIVE_MARK).length === 0) {
       performance.mark(FIRST_INTERACTIVE_MARK);
     }
-    window.__bootLoader?.dismiss();
+    bootLoader?.dismiss();
   }, [placeholderDismissed]);
 
   // Used in tests to exercise the error boundary & reset dialog (see

--- a/packages/sdk/app-framework/src/ui/components/App/index.ts
+++ b/packages/sdk/app-framework/src/ui/components/App/index.ts
@@ -3,3 +3,4 @@
 //
 
 export * from './App';
+export * from './loader';

--- a/packages/sdk/app-framework/src/ui/components/App/loader.ts
+++ b/packages/sdk/app-framework/src/ui/components/App/loader.ts
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+declare global {
+  interface BootLoader {
+    status: (payload: {
+      event?: string;
+      module?: string;
+      humanized: string;
+      /**
+       * Optional `(index/total)` tick. When present, the loader replaces the
+       * current line in place ("Loading plugins (12/80)") instead of appending
+       * a new entry — keeps the visible log compact during long counted phases.
+       */
+      range?: { index: number; total: number };
+    }) => void;
+    progress: (fraction?: number) => void;
+    ready: () => void;
+    dismiss: () => void;
+  }
+
+  interface Window {
+    /**
+     * Driver injected by `@dxos/app-framework/vite-plugin`'s `bootLoaderPlugin`
+     * (a Solid app inlined into `index.html`). Declared here — on a module that
+     * is part of the `@dxos/app-framework/ui` export surface — so the React side
+     * and host apps (e.g. composer-app) can drive the loader without each
+     * re-declaring the type. The canonical definition lives in the plugin's
+     * `loader-app/types.ts`; this mirror exists because that source compiles in a
+     * separate (Solid) program that doesn't ship its globals to consumers.
+     */
+    __bootLoader?: BootLoader;
+  }
+}
+
+export const bootLoader = window.__bootLoader;

--- a/packages/sdk/app-framework/src/ui/components/App/loader.ts
+++ b/packages/sdk/app-framework/src/ui/components/App/loader.ts
@@ -34,4 +34,6 @@ declare global {
   }
 }
 
-export const bootLoader = window.__bootLoader;
+// Guarded: `@dxos/app-framework/ui` has a `node` export and this module is re-exported through the
+// UI barrel, so a bare top-level `window` read would throw when imported in SSR / tests / tooling.
+export const bootLoader = typeof window !== 'undefined' ? window.__bootLoader : undefined;


### PR DESCRIPTION
## Summary

Extract the `window.__bootLoader` driver and its `BootLoader`/`Window` global type declarations into `app-framework/src/ui/components/App/loader.ts`, exported from the `@dxos/app-framework/ui` surface. This lets the React side and host apps (e.g. composer-app) drive the boot loader without each re-declaring the global types (the canonical definition still lives in the vite plugin's Solid `loader-app/types.ts`; this is the consumer-facing mirror).

- New `App/loader.ts` exporting `bootLoader` + the `BootLoader` global type.
- `App/index.ts` re-exports it.
- `App.tsx` and composer-app `main.tsx` simplified to consume `bootLoader` instead of inline access.
- `useApp.tsx`: minor param reorder.

Split out of the composer-crx branch as its own change (unrelated to that work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup status, progress, and lifecycle handling by using a safe, shared boot loader reference instead of relying on a global.
  * Loading feedback is updated more consistently during plugin/module preload and subsequent launch phases (including the initial progress handoff).
  * Preserved the existing startup handoff/placeholder behavior while making loader events and dismissal/ready signaling more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->