### PR TITLE
refactor(pipeline): make Stage/Pipeline pipe-composable via Effect Requirements

### DIFF
--- a/packages/core/compute/pipeline-email/src/testing/email-pipeline.test.ts
+++ b/packages/core/compute/pipeline-email/src/testing/email-pipeline.test.ts
@@ -4,6 +4,7 @@
 
 import * as LanguageModel from '@effect/ai/LanguageModel';
 import * as Cause from 'effect/Cause';
+import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as ManagedRuntime from 'effect/ManagedRuntime';
@@ -115,16 +116,20 @@ type Stats = {
   spam: number;
 };
 
-// Shared context threaded through every stage and the sink. The service closure and db are built
-// once up-front so each stage's Effect has `R = never` (Pipeline.run carries no requirements type),
-// keeping the stages themselves lightweight (Effect + closures) — Cloudflare-Worker-shaped. The heavy
-// bits (Ollama runtime, better-sqlite3-backed db) live here in the test harness, which is why the
-// whole suite is env-gated.
-type Ctx = {
-  readonly summarize: (text: string) => Promise<Summary>;
-  readonly db: Database.Database;
-  readonly stats: Stats;
-};
+// Shared context threaded through every stage via Effect's Requirements channel. The service
+// closure and db are built once up-front and provided at the edge (`Effect.provide` below), so the
+// individual stage Effects carry `R = Ctx` but the fully-composed program is reduced back to
+// `R = never` before `EffectEx.runPromise` — the same "provide at the edge" idiom used elsewhere in
+// this repo (e.g. `Database.layer`). The heavy bits (Ollama runtime, better-sqlite3-backed db) live
+// here in the test harness, which is why the whole suite is env-gated.
+class Ctx extends Context.Tag('EmailPipelineCtx')<
+  Ctx,
+  {
+    readonly summarize: (text: string) => Promise<Summary>;
+    readonly db: Database.Database;
+    readonly stats: Stats;
+  }
+>() {}
 
 // Stage 1: LLM summarization. Appends a second text block carrying the summary and records spam /
 // keyword metadata on `Message.properties` (ContentBlock.Text has no metadata field). Produces a new
@@ -132,51 +137,51 @@ type Ctx = {
 // Ollama is unreachable or a row fails (`tryPromise` captures the rejection so `orElse` can recover),
 // so the suite stays green whenever the dataset is checked out — real summaries when Ollama is up, an
 // empty-summary no-op otherwise.
-const summarizeStage: Stage.Stage<Message.Message, Message.Message, Ctx, never> = Stage.map(
-  'summarize',
-  (message, ctx) =>
-    Effect.gen(function* () {
-      const text = Message.extractText(message);
-      const result = yield* Effect.tryPromise(() => ctx.summarize(text)).pipe(
-        Effect.orElse(() => Effect.succeed<Summary>({ summary: '', isSpam: false, keywords: [] })),
-      );
-      const summaryBlock: ContentBlock.Text = { _tag: 'text', text: result.summary };
-      return Message.make({
-        created: message.created,
-        sender: message.sender,
-        blocks: [...message.blocks, summaryBlock],
-        properties: {
-          ...message.properties,
-          spam: result.isSpam,
-          keywords: result.keywords,
-        },
-      });
-    }),
+const summarizeStage: Stage.Stage<Message.Message, Message.Message, never, Ctx> = Stage.map('summarize', (message) =>
+  Effect.gen(function* () {
+    const { summarize } = yield* Ctx;
+    const text = Message.extractText(message);
+    const result = yield* Effect.tryPromise(() => summarize(text)).pipe(
+      Effect.orElse(() => Effect.succeed<Summary>({ summary: '', isSpam: false, keywords: [] })),
+    );
+    const summaryBlock: ContentBlock.Text = { _tag: 'text', text: result.summary };
+    return Message.make({
+      created: message.created,
+      sender: message.sender,
+      blocks: [...message.blocks, summaryBlock],
+      properties: {
+        ...message.properties,
+        spam: result.isSpam,
+        keywords: result.keywords,
+      },
+    });
+  }),
 );
 
 // Stage 2: run the shared `contactExtractor` (the `@dxos/extractor` abstraction) to build a Person
 // (+ Organization link by domain) from the sender, then persist the extractor's uncommitted output
 // (normally the dispatcher's role). The extractor's `extract` has R = never, so it composes into
-// `Pipeline.run` (which carries no requirements channel). Passes the Message through unchanged.
-const extractStage: Stage.Stage<Message.Message, Message.Message, Ctx, never> = Stage.map(
+// the Requirements channel the same way any other stage dependency does. Passes the Message through
+// unchanged.
+const extractStage: Stage.Stage<Message.Message, Message.Message, never, Ctx> = Stage.map(
   'extract-contact',
-  (message, ctx) =>
-    extractContact({ db: ctx.db, source: message }).pipe(
-      Effect.map((result) => {
-        for (const object of result.created) {
-          ctx.db.add(object);
-        }
-        return message;
-      }),
-    ),
+  (message) =>
+    Effect.gen(function* () {
+      const { db } = yield* Ctx;
+      const result = yield* extractContact({ db, source: message });
+      for (const object of result.created) {
+        db.add(object);
+      }
+      return message;
+    }),
 );
 
 // Stage 3: pure-JS running tallies (no analysis libs — a Cloudflare-safe option would be a small
 // pure-JS stats package, but none is added here). Mutates the context-carried accumulator and passes
 // the Message through so it reaches the sink for collection.
-const statsStage: Stage.Stage<Message.Message, Message.Message, Ctx, never> = Stage.map('stats', (message, ctx) =>
-  Effect.sync(() => {
-    const { stats } = ctx;
+const statsStage: Stage.Stage<Message.Message, Message.Message, never, Ctx> = Stage.map('stats', (message) =>
+  Effect.gen(function* () {
+    const { stats } = yield* Ctx;
     stats.total += 1;
     const sender = message.sender.email;
     if (sender) {
@@ -198,8 +203,9 @@ const statsStage: Stage.Stage<Message.Message, Message.Message, Ctx, never> = St
 
 // Bookend logging stage: emits one line describing the message as it enters/leaves the pipeline and
 // passes it through unchanged. (Visibility is controlled by LOG_FILTER, e.g. `LOG_FILTER=info`.)
-// Logs only the sender domain, not the full address, to avoid recording PII.
-const logStage = (label: string): Stage.Stage<Message.Message, Message.Message, Ctx, never> =>
+// Logs only the sender domain, not the full address, to avoid recording PII. Needs no shared context,
+// so it stays `R = never` even inside a pipeline that otherwise requires `Ctx`.
+const logStage = (label: string): Stage.Stage<Message.Message, Message.Message> =>
   Stage.map(`log:${label}`, (message) =>
     Effect.sync(() => {
       const senderDomain = message.sender.email?.split('@')[1];
@@ -266,23 +272,23 @@ describe.skipIf(!HAS_DATASET)('Enron email pipeline (ROOT_DIR + Ollama gated)', 
           ),
         );
 
-      const context: Ctx = { summarize, db, stats };
+      const context: Context.Tag.Service<typeof Ctx> = { summarize, db, stats };
 
       const { sink, items } = captureSink<Message.Message>();
       await EffectEx.runPromise(
-        Pipeline.run({
-          source: parquetSource(files).pipe(Stream.take(EMAIL_COUNT), Stream.map(emailToMessage)),
-          stages: [
-            // Stages
+        Effect.provide(
+          parquetSource(files).pipe(
+            Stream.take(EMAIL_COUNT),
+            Stream.map(emailToMessage),
             logStage('email.in'),
             summarizeStage,
             extractStage,
             statsStage,
             logStage('email.out'),
-          ],
-          sink,
-          context,
-        }),
+            Pipeline.run({ sink }),
+          ),
+          Layer.succeed(Ctx, context),
+        ),
       );
 
       // The pipeline processes up to EMAIL_COUNT messages (fewer only if the dataset is smaller).

--- a/packages/core/compute/pipeline-email/src/testing/parquet-email.test.ts
+++ b/packages/core/compute/pipeline-email/src/testing/parquet-email.test.ts
@@ -54,14 +54,7 @@ describe('email parquet → Message', () => {
     ];
 
     const { sink, items } = captureSink<SenderCount>();
-    await EffectEx.runPromise(
-      Pipeline.run({
-        source: Stream.fromIterable(rows),
-        stages: [countBySenderStage<never>()],
-        sink,
-        context: {},
-      }),
-    );
+    await EffectEx.runPromise(Stream.fromIterable(rows).pipe(countBySenderStage<never>(), Pipeline.run({ sink })));
 
     // The stage emits a running count per email; the final tally is the last count seen per sender.
     const totals = new Map(items.map(({ sender, count }) => [sender, count]));
@@ -108,9 +101,9 @@ describe('email parquet → Message', () => {
 // A pipeline stage that maintains a running count of emails per sender, emitting the updated count
 // for each email's sender as it flows through (a stateful scan; the counter map is bounded by the
 // number of distinct senders, not the stream length).
-const countBySenderStage = <E>(): Stage.Stage<ParquetRow, SenderCount, unknown, E> => ({
-  id: 'count-by-sender',
-  transform: (input) =>
+const countBySenderStage =
+  <E = never>(): Stage.Stage<ParquetRow, SenderCount, E> =>
+  (input) =>
     input.pipe(
       Stream.mapAccum(new Map<string, number>(), (counts, row) => {
         const sender = String(row.from ?? '');
@@ -118,5 +111,4 @@ const countBySenderStage = <E>(): Stage.Stage<ParquetRow, SenderCount, unknown, 
         counts.set(sender, count);
         return [counts, { sender, count }];
       }),
-    ),
-});
+    );

--- a/packages/core/compute/pipeline-transcription/src/PipelineRuntime.ts
+++ b/packages/core/compute/pipeline-transcription/src/PipelineRuntime.ts
@@ -3,7 +3,9 @@
 //
 
 import * as Cause from 'effect/Cause';
+import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
+import { pipe } from 'effect/Function';
 import * as Stream from 'effect/Stream';
 
 import { DXN } from '@dxos/echo';
@@ -67,6 +69,17 @@ type Slice = ContentBlock.Transcript[];
 /** A stage invocation's output paired with the slice it ran over (needed by {@link CommitFn}). */
 type Enriched = { readonly write: StageWrite; readonly window: Slice };
 
+/**
+ * Private bridge between this module's plain `StageContext` object and `@dxos/pipeline`'s
+ * Requirements-based `Stage`. Not part of any public contract: stage authors (see `Stage.ts`) keep
+ * receiving `ctx: StageContext` as an explicit parameter; only this module's internal wiring into
+ * `@dxos/pipeline` goes through Effect's Context/Layer mechanism.
+ */
+class StageContextService extends Context.Tag('@dxos/pipeline-transcription/StageContextService')<
+  StageContextService,
+  StageContext
+>() {}
+
 const triggerMatches = (stage: Stage<any, any>, kind: TranscriptEvent['kind']): boolean =>
   (stage.trigger === 'per-block' && kind === 'block') ||
   (stage.trigger === 'on-silence' && kind === 'silence') ||
@@ -78,24 +91,23 @@ const triggerKind = (stage: Stage<any, any>): TranscriptEvent['kind'] =>
 /**
  * Per-stage window + trigger, as a `@dxos/pipeline` stage. Maintains this branch's own rolling block
  * window (blocks appended, capped at {@link MAX_WINDOW}) and emits the window slice on events matching
- * the stage's trigger; `undefined` otherwise (dropped between stages before the run stage fires).
+ * the stage's trigger; otherwise it filters the item out, so a non-triggering event never reaches
+ * {@link runStage}.
  */
 const windowTrigger = (
   stage: Stage<any, any>,
   config: StageConfig | undefined,
-): PipelineStage.Stage<TranscriptEvent, Slice | undefined, StageContext> => {
+): PipelineStage.Stage<TranscriptEvent, Slice> => {
   const blocks = config?.window?.blocks ?? stage.window?.blocks;
-  return {
-    id: `${stage.id}:window`,
-    transform: (input) =>
-      input.pipe(
-        Stream.mapAccum([] as Slice, (window, event) => {
-          const next = event.kind === 'block' ? [...window, event.block].slice(-MAX_WINDOW) : window;
-          const slice = triggerMatches(stage, event.kind) ? (blocks ? next.slice(-blocks) : next) : undefined;
-          return [next, slice];
-        }),
-      ),
-  };
+  return (input) =>
+    input.pipe(
+      Stream.mapAccum([] as Slice, (window, event) => {
+        const next = event.kind === 'block' ? [...window, event.block].slice(-MAX_WINDOW) : window;
+        const slice = triggerMatches(stage, event.kind) ? (blocks ? next.slice(-blocks) : next) : undefined;
+        return [next, slice];
+      }),
+      Stream.filter((slice): slice is Slice => slice !== undefined),
+    );
 };
 
 /**
@@ -109,13 +121,14 @@ const runStage = (
   config: StageConfig | undefined,
   presetDefault: DXN.DXN | undefined,
   onTelemetry?: (event: TelemetryEvent) => void,
-): PipelineStage.Stage<Slice, Enriched | undefined, StageContext> => {
+): PipelineStage.Stage<Slice, Enriched, never, StageContextService> => {
   const model = resolveModel(config, stage, presetDefault);
   const trigger = triggerKind(stage);
   return PipelineStage.map(
     stage.id,
-    (slice: Slice, context: StageContext) =>
+    (slice: Slice) =>
       Effect.gen(function* () {
+        const context = yield* StageContextService;
         const started = yield* Effect.sync(() => Date.now());
         const input = stage.select ? stage.select(slice) : { window: slice };
         const write = yield* stage.run(input, context);
@@ -153,7 +166,7 @@ const run = (options: RunOptions): Effect.Effect<void> =>
 
       // Isolate commit failures per write: a failed commit must not fail its branch (which, under the
       // unbounded `Effect.forEach`, would interrupt the sibling branches). Log and drop instead.
-      const sink: Pipeline.Sink<Enriched, StageContext> = ({ write, window }) =>
+      const sink: Pipeline.Sink<Enriched> = ({ write, window }) =>
         commit(write, window).pipe(Effect.catchAllCause((cause) => Effect.sync(() => log.catch(Cause.squash(cause)))));
       const branches = yield* source.pipe(Stream.broadcast(enabled.length, BROADCAST_BUFFER));
 
@@ -163,12 +176,13 @@ const run = (options: RunOptions): Effect.Effect<void> =>
           const stage = enabled[index];
           const config = configFor(stage.id);
           const context: StageContext = { lookup, model: resolveModel(config, stage, presetDefault) };
-          return Pipeline.run({
-            source: branch,
-            stages: [windowTrigger(stage, config), runStage(stage, config, presetDefault, onTelemetry)],
-            sink,
-            context,
-          });
+          return pipe(
+            branch,
+            windowTrigger(stage, config),
+            runStage(stage, config, presetDefault, onTelemetry),
+            Pipeline.run({ sink }),
+            Effect.provideService(StageContextService, context),
+          );
         },
         { concurrency: 'unbounded', discard: true },
       );

--- a/packages/core/compute/pipeline/README.md
+++ b/packages/core/compute/pipeline/README.md
@@ -1,9 +1,10 @@
 # @dxos/pipeline
 
 Generic, back-pressured streaming pipeline. A pipeline runs an Effect `Stream` source through an
-ordered chain of stages — each a `Stream → Stream` transform sharing one injected context — and
+ordered chain of stages — each a pipeable `Stream → Stream` transform, composed with `pipe` — and
 drains the result to a sink. Back pressure is the default (pull-based `Stream`) and configurable
-per pipeline or per stage (`suspend` / `sliding` / `dropping`).
+per pipeline or per stage (`suspend` / `sliding` / `dropping`). Shared dependencies flow through
+Effect's Requirements channel (`Context.Tag` / `Layer`), provided once at the edge.
 
 ## Usage
 
@@ -15,13 +16,26 @@ import { EffectEx } from '@dxos/effect';
 import { Pipeline, Stage } from '@dxos/pipeline';
 
 await EffectEx.runPromise(
-  Pipeline.run({
-    source: Stream.fromIterable([1, 2, 3]),
-    stages: [Stage.map('double', (n: number) => Effect.succeed(n * 2))],
-    sink: (out) => Effect.sync(() => console.log(out)),
-    context: {},
-  }),
+  Stream.fromIterable([1, 2, 3]).pipe(
+    Stage.map('double', (n: number) => Effect.succeed(n * 2)),
+    Pipeline.run({ sink: (out) => Effect.sync(() => console.log(out)) }),
+  ),
 );
+```
+
+Shared dependencies flow through Effect's Requirements channel rather than an explicit `context`
+parameter — a stage reads them with `yield*` inside its `Effect.gen`, and the caller provides them
+once at the edge:
+
+```ts
+class Factor extends Context.Tag('Factor')<Factor, { readonly factor: number }>() {}
+
+const program = source.pipe(
+  Stage.map('scale', (n: number) => Factor.pipe(Effect.map(({ factor }) => n * factor))),
+  Pipeline.run({ sink }),
+);
+
+await EffectEx.runPromise(Effect.provide(program, Layer.succeed(Factor, { factor: 5 })));
 ```
 
 See [`@dxos/pipeline-email`](../pipeline-email) for a worked pipeline over the Enron email dataset.

--- a/packages/core/compute/pipeline/src/Pipeline.test.ts
+++ b/packages/core/compute/pipeline/src/Pipeline.test.ts
@@ -2,7 +2,9 @@
 // Copyright 2026 DXOS.org
 //
 
+import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
 import * as Stream from 'effect/Stream';
 import { describe, test } from 'vitest';
 
@@ -16,43 +18,33 @@ describe('Pipeline.run', () => {
   test('chains stages left-to-right and drains to the sink', async ({ expect }) => {
     const { sink, items } = captureSink<number>();
     await EffectEx.runPromise(
-      Pipeline.run({
-        source: Stream.fromIterable([1, 2, 3]),
-        stages: [
-          Stage.map<number, number, {}>('double', (n) => Effect.succeed(n * 2)),
-          Stage.map<number, number, {}>('inc', (n) => Effect.succeed(n + 1)),
-        ],
-        sink,
-        context: {},
-      }),
+      Stream.fromIterable([1, 2, 3]).pipe(
+        Stage.map('double', (n) => Effect.succeed(n * 2)),
+        Stage.map('inc', (n) => Effect.succeed(n + 1)),
+        Pipeline.run({ sink }),
+      ),
     );
     expect(items).toEqual([3, 5, 7]);
   });
 
-  test('propagates the shared context to every stage', async ({ expect }) => {
+  test('propagates the shared context via the Requirements channel', async ({ expect }) => {
+    class Factor extends Context.Tag('Factor')<Factor, { readonly factor: number }>() {}
     const { sink, items } = captureSink<number>();
-    await EffectEx.runPromise(
-      Pipeline.run({
-        source: Stream.fromIterable([1, 2]),
-        stages: [Stage.map<number, number, { factor: number }>('scale', (n, ctx) => Effect.succeed(n * ctx.factor))],
-        sink,
-        context: { factor: 5 },
-      }),
+    const program = Stream.fromIterable([1, 2]).pipe(
+      Stage.map('scale', (n) => Factor.pipe(Effect.map(({ factor }) => n * factor))),
+      Pipeline.run({ sink }),
     );
+    await EffectEx.runPromise(Effect.provide(program, Layer.succeed(Factor, { factor: 5 })));
     expect(items).toEqual([5, 10]);
   });
 
   test('skips undefined stage outputs before the sink', async ({ expect }) => {
     const { sink, items } = captureSink<number>();
     await EffectEx.runPromise(
-      Pipeline.run({
-        source: Stream.fromIterable([1, 2, 3, 4]),
-        stages: [
-          Stage.map<number, number | undefined, {}>('evens', (n) => Effect.succeed(n % 2 === 0 ? n : undefined)),
-        ],
-        sink,
-        context: {},
-      }),
+      Stream.fromIterable([1, 2, 3, 4]).pipe(
+        Stage.map('evens', (n) => Effect.succeed(n % 2 === 0 ? n : undefined)),
+        Pipeline.run({ sink }),
+      ),
     );
     expect(items).toEqual([2, 4]);
   });
@@ -60,17 +52,13 @@ describe('Pipeline.run', () => {
   test('drops undefined between stages so a mid-chain stage can no-op', async ({ expect }) => {
     const { sink, items } = captureSink<number>();
     await EffectEx.runPromise(
-      Pipeline.run({
-        source: Stream.fromIterable([1, 2, 3, 4]),
-        stages: [
-          // First stage no-ops on odds; the undefined must NOT reach the second stage.
-          Stage.map<number, number | undefined, {}>('evens', (n) => Effect.succeed(n % 2 === 0 ? n : undefined)),
-          // Second stage would produce NaN if it ever received `undefined`.
-          Stage.map<number, number, {}>('inc', (n) => Effect.succeed(n + 1)),
-        ],
-        sink,
-        context: {},
-      }),
+      Stream.fromIterable([1, 2, 3, 4]).pipe(
+        // First stage no-ops on odds; the undefined must NOT reach the second stage.
+        Stage.map('evens', (n) => Effect.succeed(n % 2 === 0 ? n : undefined)),
+        // Second stage would produce NaN if it ever received `undefined`.
+        Stage.map('inc', (n) => Effect.succeed(n + 1)),
+        Pipeline.run({ sink }),
+      ),
     );
     expect(items).toEqual([3, 5]);
   });
@@ -82,14 +70,10 @@ describe('Pipeline.run overflow', () => {
     // A sink that yields between commits; back pressure must still deliver all items.
     const sink = (out: number) => Effect.sync(() => items.push(out)).pipe(Effect.zipLeft(Effect.yieldNow()));
     await EffectEx.runPromise(
-      Pipeline.run({
-        source: Stream.fromIterable(Array.from({ length: 50 }, (_unused, index) => index)),
-        stages: [Stage.map<number, number, {}>('id', (n) => Effect.succeed(n))],
-        sink,
-        context: {},
-        overflow: 'suspend',
-        bufferSize: 4,
-      }),
+      Stream.fromIterable(Array.from({ length: 50 }, (_unused, index) => index)).pipe(
+        Stage.map('id', (n) => Effect.succeed(n)),
+        Pipeline.run({ sink, overflow: 'suspend', bufferSize: 4 }),
+      ),
     );
     expect(items).toEqual(Array.from({ length: 50 }, (_unused, index) => index));
   });
@@ -97,14 +81,10 @@ describe('Pipeline.run overflow', () => {
   test('sliding pipeline runs to completion and delivers the final item', async ({ expect }) => {
     const { sink, items } = captureSink<number>();
     await EffectEx.runPromise(
-      Pipeline.run({
-        source: Stream.fromIterable([1, 2, 3, 4, 5]),
-        stages: [Stage.map<number, number, {}>('id', (n) => Effect.succeed(n))],
-        sink,
-        context: {},
-        overflow: 'sliding',
-        bufferSize: 2,
-      }),
+      Stream.fromIterable([1, 2, 3, 4, 5]).pipe(
+        Stage.map('id', (n) => Effect.succeed(n)),
+        Pipeline.run({ sink, overflow: 'sliding', bufferSize: 2 }),
+      ),
     );
     expect(items.length).toBeGreaterThan(0);
     expect(items[items.length - 1]).toBe(5);
@@ -113,12 +93,10 @@ describe('Pipeline.run overflow', () => {
   test('per-stage overflow override runs to completion', async ({ expect }) => {
     const { sink, items } = captureSink<number>();
     await EffectEx.runPromise(
-      Pipeline.run({
-        source: Stream.fromIterable([1, 2, 3]),
-        stages: [Stage.map<number, number, {}>('id', (n) => Effect.succeed(n), { overflow: 'sliding', bufferSize: 1 })],
-        sink,
-        context: {},
-      }),
+      Stream.fromIterable([1, 2, 3]).pipe(
+        Stage.map('id', (n) => Effect.succeed(n), { overflow: 'sliding', bufferSize: 1 }),
+        Pipeline.run({ sink }),
+      ),
     );
     expect(items[items.length - 1]).toBe(3);
   });
@@ -127,15 +105,13 @@ describe('Pipeline.run overflow', () => {
     const runs: number[] = [];
     // A slow map over a synchronous 4-item source: while the first run sleeps, items 2/3/4 arrive and
     // the input-side sliding buffer (capacity 1) keeps only the latest, so intermediate items drop.
-    const slow = Stage.map<number, number, {}>(
+    const slow = Stage.map(
       'slow',
-      (n) => Effect.sync(() => runs.push(n)).pipe(Effect.zipRight(Effect.sleep('40 millis')), Effect.as(n)),
+      (n: number) => Effect.sync(() => runs.push(n)).pipe(Effect.zipRight(Effect.sleep('40 millis')), Effect.as(n)),
       { overflow: 'sliding', bufferSize: 1 },
     );
     const { sink } = captureSink<number>();
-    await EffectEx.runPromise(
-      Pipeline.run({ source: Stream.fromIterable([1, 2, 3, 4]), stages: [slow], sink, context: {} }),
-    );
+    await EffectEx.runPromise(Stream.fromIterable([1, 2, 3, 4]).pipe(slow, Pipeline.run({ sink })));
     expect(runs.length).toBeLessThan(4);
     expect(runs.at(-1)).toBe(4);
   });

--- a/packages/core/compute/pipeline/src/Pipeline.ts
+++ b/packages/core/compute/pipeline/src/Pipeline.ts
@@ -5,6 +5,7 @@
 // @import-as-namespace
 
 import * as Effect from 'effect/Effect';
+import * as Function from 'effect/Function';
 import * as Stream from 'effect/Stream';
 
 import * as Stage from './Stage';
@@ -14,17 +15,11 @@ import * as Stage from './Stage';
  * typed `Out` descriptions and the sink performs the side effect (in-memory capture in tests, a
  * database write in production).
  */
-export type Sink<Out, Ctx, E = never> = (out: Out, ctx: Ctx) => Effect.Effect<void, E>;
+export type Sink<Out, E = never, R = never> = (out: Out) => Effect.Effect<void, E, R>;
 
-export type RunOptions<In, Out, Ctx, E = never> = {
-  /** Source items; the run drains and resolves when this stream ends. */
-  readonly source: Stream.Stream<In, E>;
-  /** Ordered stages; each stage's `Out` is the next stage's `In`. */
-  readonly stages: readonly Stage.Stage<any, any, Ctx, E>[];
+export type RunOptions<Out, E = never, R = never> = {
   /** Terminal commit for the final stage output. */
-  readonly sink: Sink<Out, Ctx, E>;
-  /** Shared context injected into every stage and the sink. */
-  readonly context: Ctx;
+  readonly sink: Sink<Out, E, R>;
   /** Pipeline-level overflow policy. Defaults to `suspend` (back pressure, never drop). */
   readonly overflow?: Stage.Overflow;
   /** Pipeline-level bounded-buffer capacity. */
@@ -32,32 +27,28 @@ export type RunOptions<In, Out, Ctx, E = never> = {
 };
 
 /**
- * Run a pipeline: fold the stages over the source, apply the overflow buffer, and drain to the
- * sink. Cancellation is structural — interrupting the returned effect interrupts the stream and
- * all in-flight stage work; there are no daemon fibers to leak.
- *
- * `undefined` emitted by any stage means "no output for that item" and is dropped between stages
- * and before the sink, so a pipeline can never deliver `undefined` as a meaningful value. The
- * source, all stages, and the sink share one error type `E`; mixing stages with distinct error
- * types requires widening to their union at the call site.
+ * Drain a composed stream to a sink: apply the pipeline-level overflow buffer and run to
+ * completion. Cancellation is structural — interrupting the returned effect interrupts the stream
+ * and all in-flight stage work; there are no daemon fibers to leak. Compose with `pipe`, chaining
+ * `Stage` transforms ahead of it: `pipe(source, Stage.map(...), Stage.window(...), Pipeline.run({
+ * sink }))`. Mirrors `Stream.runForEach`'s own shape: the sink's `E`/`R` (bound once, from `options`)
+ * are kept independent of — and unioned with — the piped-in stream's own `E`/`R`, so the incoming
+ * stream's generics aren't forced to unify with the sink's at the call site.
  */
-export const run = <In, Out, Ctx, E = never>(options: RunOptions<In, Out, Ctx, E>): Effect.Effect<void, E> => {
-  const { source, stages, sink, context, overflow = 'suspend', bufferSize = Stage.DEFAULT_BUFFER_SIZE } = options;
-
-  // Fold stages left-to-right; each stage's Out is the next stage's In. A stage may emit
-  // `undefined` to no-op for an item; that value is dropped before it reaches the next stage
-  // (and before the sink), so no-op is well-defined at every position in the chain, not only
-  // the terminal stage. The `unknown`/`any` here are the heterogeneous-chain type-system
-  // boundary — confined to this fold, never surfacing in stage-author or caller signatures.
-  const chained = stages.reduce<Stream.Stream<unknown, E>>(
-    (stream, stage) => stage.transform(stream, context).pipe(Stream.filter((item) => item !== undefined)),
-    source,
-  );
-
-  return chained.pipe(
-    Stream.buffer({ capacity: bufferSize, strategy: overflow }),
-    // Narrow the chain's final output to `Out` for the sink (upstream already dropped `undefined`).
-    Stream.filter((out): out is Out => out !== undefined),
-    Stream.runForEach((out) => sink(out, context)),
-  );
-};
+export const run: {
+  <Out, E2, R2>(
+    options: RunOptions<Out, E2, R2>,
+  ): <E, R>(source: Stream.Stream<Out, E, R>) => Effect.Effect<void, E2 | E, R2 | R>;
+  <Out, E, R, E2, R2>(
+    source: Stream.Stream<Out, E, R>,
+    options: RunOptions<Out, E2, R2>,
+  ): Effect.Effect<void, E2 | E, R2 | R>;
+} = Function.dual(2, (source: Stream.Stream<any, any, any>, options: RunOptions<any, any, any>) =>
+  source.pipe(
+    Stream.buffer({
+      capacity: options.bufferSize ?? Stage.DEFAULT_BUFFER_SIZE,
+      strategy: options.overflow ?? 'suspend',
+    }),
+    Stream.runForEach(options.sink),
+  ),
+);

--- a/packages/core/compute/pipeline/src/Stage.test.ts
+++ b/packages/core/compute/pipeline/src/Stage.test.ts
@@ -3,6 +3,7 @@
 //
 
 import * as Chunk from 'effect/Chunk';
+import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
 import * as Stream from 'effect/Stream';
 import { describe, test } from 'vitest';
@@ -13,43 +14,49 @@ import * as Stage from './Stage';
 
 describe('Stage.map', () => {
   test('applies the function to each item in order (concurrency 1)', async ({ expect }) => {
-    const stage = Stage.map<number, number, {}>('double', (n) => Effect.succeed(n * 2));
-    const out = await collect(stage.transform(Stream.fromIterable([1, 2, 3]), {}));
+    // Standalone stage: annotate the callback parameter to pin `In` (nothing upstream to infer from).
+    const stage = Stage.map('double', (n: number) => Effect.succeed(n * 2));
+    const out = await collect(stage(Stream.fromIterable([1, 2, 3])));
     expect(out).toEqual([2, 4, 6]);
   });
 
-  test('injects the shared context', async ({ expect }) => {
-    const stage = Stage.map<number, number, { factor: number }>('scale', (n, ctx) => Effect.succeed(n * ctx.factor));
-    const out = await collect(stage.transform(Stream.fromIterable([1, 2, 3]), { factor: 10 }));
+  test('injects the shared context via the Requirements channel', async ({ expect }) => {
+    class Factor extends Context.Tag('Factor')<Factor, { readonly factor: number }>() {}
+    // `R` (the Factor requirement) infers from the callback; only `In` needs the annotation.
+    const stage = Stage.map('scale', (n: number) => Factor.pipe(Effect.map(({ factor }) => n * factor)));
+    const out = await collect(
+      stage(Stream.fromIterable([1, 2, 3])).pipe(Stream.provideService(Factor, { factor: 10 })),
+    );
     expect(out).toEqual([10, 20, 30]);
   });
 });
 
 describe('Stage.filter', () => {
   test('drops items that do not match the predicate', async ({ expect }) => {
-    const stage = Stage.filter<number, {}>('evens', (n) => n % 2 === 0);
-    const out = await collect(stage.transform(Stream.fromIterable([1, 2, 3, 4]), {}));
+    const stage = Stage.filter('evens', (n: number) => n % 2 === 0);
+    const out = await collect(stage(Stream.fromIterable([1, 2, 3, 4])));
     expect(out).toEqual([2, 4]);
   });
 });
 
 describe('Stage.window', () => {
   test('invokes with a growing then sliding window of the last `size` items', async ({ expect }) => {
-    const stage = Stage.window<number, readonly number[], {}>('win', 2, (window) => Effect.succeed([...window]));
-    const out = await collect(stage.transform(Stream.fromIterable([1, 2, 3, 4]), {}));
+    const stage = Stage.window('win', 2, (window: readonly number[]) => Effect.succeed([...window]));
+    const out = await collect(stage(Stream.fromIterable([1, 2, 3, 4])));
     expect(out).toEqual([[1], [1, 2], [2, 3], [3, 4]]);
   });
 
-  test('injects the shared context', async ({ expect }) => {
-    const stage = Stage.window<number, number, { base: number }>('sum', 2, (window, ctx) =>
-      Effect.succeed(window.reduce((total, item) => total + item, ctx.base)),
+  test('injects the shared context via the Requirements channel', async ({ expect }) => {
+    class Base extends Context.Tag('Base')<Base, { readonly base: number }>() {}
+    const stage = Stage.window('sum', 2, (window: readonly number[]) =>
+      Base.pipe(Effect.map(({ base }) => window.reduce((total, item) => total + item, base))),
     );
-    const out = await collect(stage.transform(Stream.fromIterable([1, 2, 3]), { base: 100 }));
+    const out = await collect(stage(Stream.fromIterable([1, 2, 3])).pipe(Stream.provideService(Base, { base: 100 })));
     expect(out).toEqual([101, 103, 105]);
   });
 
   test('rejects a non-positive window size', ({ expect }) => {
-    expect(() => Stage.window<number, number, {}>('bad', 0, (window) => Effect.succeed(window.length))).toThrow(
+    expect(() => Stage.window('bad', 0, (window: readonly number[]) => Effect.succeed(window.length))).toThrow(
       RangeError,
     );
   });

--- a/packages/core/compute/pipeline/src/Stage.ts
+++ b/packages/core/compute/pipeline/src/Stage.ts
@@ -4,7 +4,7 @@
 
 // @import-as-namespace
 
-import type * as Effect from 'effect/Effect';
+import * as Effect from 'effect/Effect';
 import * as Stream from 'effect/Stream';
 
 /**
@@ -19,14 +19,16 @@ export type Overflow = 'suspend' | 'sliding' | 'dropping';
 export const DEFAULT_BUFFER_SIZE = 16;
 
 /**
- * A pipeline stage: a `Stream → Stream` transform sharing the pipeline's injected context. Authors
- * build stages with {@link map} / {@link window} / {@link filter}; `transform` is the escape hatch.
+ * A pipeline stage: a pipeable `Stream → Stream` transform, the same shape `Stream.mapEffect` /
+ * `Stream.filter` already have — generic over the *input* stream's own error/requirements (`E0`/
+ * `R0`) and unioning in the stage's own `E`/`R`, so stages compose in a `pipe` chain the same way
+ * Effect's own Stream operators do. Authors build stages with {@link map} / {@link window} /
+ * {@link filter}; shared dependencies flow through `R`, provided once at the edge via
+ * `Effect.provide`.
  */
-export interface Stage<in In, out Out, in Ctx, out E = never> {
-  /** Identifies the stage for diagnostics/observability; not yet read by `run`. */
-  readonly id: string;
-  transform(input: Stream.Stream<In, E>, ctx: Ctx): Stream.Stream<Out, E>;
-}
+export type Stage<In, Out, E = never, R = never> = <E0 = never, R0 = never>(
+  self: Stream.Stream<In, E0, R0>,
+) => Stream.Stream<Out, E0 | E, R0 | R>;
 
 /** Options shared by buffering stage constructors. */
 type BufferOptions = {
@@ -53,61 +55,74 @@ export type WindowOptions = BufferOptions;
 // stays a pure transform and relies on the pipeline-level buffer.
 const withBuffer =
   (options: BufferOptions) =>
-  <A, E>(stream: Stream.Stream<A, E>): Stream.Stream<A, E> =>
+  <A, E, R>(stream: Stream.Stream<A, E, R>): Stream.Stream<A, E, R> =>
     options.overflow
       ? Stream.buffer(stream, { capacity: options.bufferSize ?? DEFAULT_BUFFER_SIZE, strategy: options.overflow })
       : stream;
 
-/** 1:1 async transform. `concurrency` defaults to 1 (ordered). */
-export const map = <In, Out, Ctx, E = never>(
-  id: string,
-  fn: (item: In, ctx: Ctx) => Effect.Effect<Out, E>,
-  options: MapOptions = {},
-): Stage<In, Out, Ctx, E> => ({
-  id,
-  // The overflow buffer sits *before* `mapEffect`: while a run is in flight it absorbs new input,
-  // so `sliding` coalesces to the latest queued item (latest-wins) and `dropping` sheds new arrivals.
-  // A buffer after `mapEffect` would bound outputs, not in-flight input, leaving overflow inert.
-  transform: (input, ctx) =>
-    input.pipe(
+/**
+ * 1:1 async transform. `fn` may return `undefined` to no-op for an item; the value is dropped
+ * before it reaches the next stage, so the returned stage's `Out` excludes `undefined`.
+ * `concurrency` defaults to 1 (ordered). `id` labels the per-item span for tracing.
+ *
+ * `Out`/`E`/`R` always infer from `fn`'s result; `In` only infers when the stage is composed inline
+ * in a `pipe` (pinned by the upstream stream). Built as a standalone value, pin `In` by annotating
+ * the callback parameter (`(item: T) => …`) or the binding (`const s: Stage<…> = …`). The four type
+ * parameters are intentionally all-or-nothing: passing a partial list (e.g. `map<In, Out>(…)`) is a
+ * compile error rather than silently forcing `E`/`R` to `never` and rejecting a service-using `fn`.
+ */
+export const map =
+  <In, Out, E, R>(
+    id: string,
+    fn: (item: In) => Effect.Effect<Out, E, R>,
+    options: MapOptions = {},
+  ): Stage<In, Exclude<Out, undefined>, E, R> =>
+  <E0, R0>(self: Stream.Stream<In, E0, R0>) =>
+    self.pipe(
       withBuffer(options),
-      Stream.mapEffect((item) => fn(item, ctx), { concurrency: options.concurrency ?? 1 }),
-    ),
-});
+      // The overflow buffer sits *before* `mapEffect`: while a run is in flight it absorbs new
+      // input, so `sliding` coalesces to the latest queued item (latest-wins) and `dropping` sheds
+      // new arrivals. A buffer after `mapEffect` would bound outputs, not in-flight input, leaving
+      // overflow inert.
+      Stream.mapEffect((item) => fn(item).pipe(Effect.withSpan(id)), { concurrency: options.concurrency ?? 1 }),
+      Stream.filter((item): item is Exclude<Out, undefined> => item !== undefined),
+    );
 
 /**
  * Sliding-window transform: invokes `fn` once per incoming item with a fixed-size rolling view of
  * the last `size` items. The window is bounded by `size`, so memory does not grow with stream
  * length; it composes with (and is distinct from) the overflow buffer, which bounds rate mismatch.
+ * `fn` may return `undefined` to no-op, narrowing `Out` the same way {@link map} does. Type
+ * parameters follow {@link map}: `Out`/`E`/`R` infer from `fn`, `In` is pinned inline by the
+ * upstream or (standalone) by annotating the callback parameter or the binding, and a partial type
+ * argument list is a compile error.
  */
-export const window = <In, Out, Ctx, E = never>(
+export const window = <In, Out, E, R>(
   id: string,
   size: number,
-  fn: (window: readonly In[], ctx: Ctx) => Effect.Effect<Out, E>,
+  fn: (window: readonly In[]) => Effect.Effect<Out, E, R>,
   options: WindowOptions = {},
-): Stage<In, Out, Ctx, E> => {
+): Stage<In, Exclude<Out, undefined>, E, R> => {
   // A window must retain at least one item; a non-positive size makes `.slice(-size)` degenerate
   // (`slice(-0)` returns the whole array, growing unbounded).
   if (!Number.isInteger(size) || size < 1) {
     throw new RangeError(`Stage.window size must be a positive integer: ${size}`);
   }
 
-  return {
-    id,
-    transform: (input, ctx) =>
-      input.pipe(
-        Stream.mapAccum([] as readonly In[], (buffer, item) => {
-          const next = [...buffer, item].slice(-size);
-          return [next, next];
-        }),
-        Stream.mapEffect((buffer) => fn(buffer, ctx), { concurrency: 1 }),
-        withBuffer(options),
-      ),
-  };
+  return <E0, R0>(self: Stream.Stream<In, E0, R0>) =>
+    self.pipe(
+      Stream.mapAccum([] as readonly In[], (buffer, item) => {
+        const next = [...buffer, item].slice(-size);
+        return [next, next];
+      }),
+      Stream.mapEffect((buffer) => fn(buffer).pipe(Effect.withSpan(id)), { concurrency: 1 }),
+      withBuffer(options),
+      Stream.filter((item): item is Exclude<Out, undefined> => item !== undefined),
+    );
 };
 
 /** Drop items that do not match `pred`. */
-export const filter = <In, Ctx, E = never>(id: string, pred: (item: In) => boolean): Stage<In, In, Ctx, E> => ({
-  id,
-  transform: (input) => input.pipe(Stream.filter(pred)),
-});
+export const filter =
+  <In>(id: string, pred: (item: In) => boolean): Stage<In, In> =>
+  <E0, R0>(self: Stream.Stream<In, E0, R0>) =>
+    self.pipe(Stream.filter(pred));

--- a/packages/core/compute/pipeline/src/testing/capture.test.ts
+++ b/packages/core/compute/pipeline/src/testing/capture.test.ts
@@ -12,7 +12,7 @@ import { captureSink } from './index';
 describe('captureSink', () => {
   test('records every committed value in order', async ({ expect }) => {
     const { sink, items } = captureSink<number>();
-    await EffectEx.runPromise(Effect.all([sink(1, {}), sink(2, {}), sink(3, {})]));
+    await EffectEx.runPromise(Effect.all([sink(1), sink(2), sink(3)]));
     expect(items).toEqual([1, 2, 3]);
   });
 });

--- a/packages/core/compute/pipeline/src/testing/capture.ts
+++ b/packages/core/compute/pipeline/src/testing/capture.ts
@@ -8,13 +8,13 @@ import * as Pipeline from '../Pipeline';
 
 /** In-memory sink capturing every emitted value for assertions. */
 export type CaptureSink<Out> = {
-  readonly sink: Pipeline.Sink<Out, unknown>;
+  readonly sink: Pipeline.Sink<Out>;
   readonly items: Out[];
 };
 
 export const captureSink = <Out>(): CaptureSink<Out> => {
   const items: Out[] = [];
-  const sink: Pipeline.Sink<Out, unknown> = (out) =>
+  const sink: Pipeline.Sink<Out> = (out) =>
     Effect.sync(() => {
       items.push(out);
     });


### PR DESCRIPTION
## Summary

Redesigns `@dxos/pipeline`'s public API to be Effect-native. Previously a pipeline was one monolithic options bag — `Pipeline.run({ source, stages: [...], sink, context })` — that folded a `stages: any[]` array over the source and hand-threaded a `context` parameter through every stage and the sink. This makes stages genuinely pipe-composable and moves shared context onto Effect's own Requirements (`R`) channel.

### Before
```ts
Pipeline.run({
  source: Stream.fromIterable([1, 2, 3]),
  stages: [Stage.map('double', (n, ctx) => Effect.succeed(n * ctx.factor))],
  sink,
  context: { factor: 2 },
});
```

### After
```ts
Stream.fromIterable([1, 2, 3]).pipe(
  Stage.map('double', (n) => Factor.pipe(Effect.map(({ factor }) => n * factor))),
  Pipeline.run({ sink }),
).pipe(Effect.provide(Layer.succeed(Factor, { factor: 2 })));
```

## What changed

- **`Stage<In, Out, E, R>` is now a pipeable `Stream → Stream` operator** — the same shape `Stream.mapEffect`/`Stream.filter` have. It's generic over the input stream's own error/requirements and unions in the stage's own, so a `pipe` chain type-checks each `In`/`Out` transition precisely instead of collapsing to the old fold's `unknown` boundary.
- **Shared context flows through the `R` channel** (`Context.Tag` / `Layer`), provided once at the edge with `Effect.provide`, instead of a `context` argument repeated on every stage and sink. Pipelines with no shared state need zero ceremony (`R` stays `never`).
- **`Pipeline.run` is a `Function.dual` terminal drain** composed as the final `pipe` step; the sink's `E`/`R` stay independent of and union with the upstream stream's, mirroring `Stream.runForEach`.
- **`undefined`-as-no-op filtering moved into `map`/`window`** so each stage guarantees it never emits `undefined` downstream, narrowing `Out` automatically.
- **`map`/`window` drop their `E`/`R` generic defaults** so a partial type-argument list (`map<In, Out>(…)`) is a compile error rather than silently forcing `E`/`R` to `never` and rejecting a service-using callback. Standalone stages pin `In` by annotating the callback parameter (`(item: T) => …`) or the binding.

## Consumer migration

The sole consumer, `pipeline-transcription`'s `PipelineRuntime`, is migrated via a **private** `StageContextService` tag that bridges into its existing, unchanged public `Stage`/`StageContext` contract — no compatibility shim, no ripple into transcription stage authors.

## Verification

- `pipeline`, `pipeline-email`, and `pipeline-transcription` all build.
- Tests pass: 15 + 4 + 34 (Ollama/dataset-gated suites correctly skipped).
- Lint clean; no new casts introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline stages can now be composed as a stream chain and run at the end of the flow.
  * Shared dependencies are now provided once to the pipeline and made available to stages automatically.

* **Bug Fixes**
  * Improved handling of `undefined` values so they no longer flow into later stages or the sink.
  * Updated buffering behavior for more predictable stage execution and overflow handling.

* **Documentation**
  * Revised pipeline usage examples to match the new stream-based API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->