### PR TITLE
fix(plugin-onboarding,client): surface real oauth recovery errors, fix stuck leader watcher

### DIFF
--- a/packages/plugins/plugin-onboarding/src/capabilities/oauth-recovery-redirect.ts
+++ b/packages/plugins/plugin-onboarding/src/capabilities/oauth-recovery-redirect.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
+import * as Cause from 'effect/Cause';
 import * as Effect from 'effect/Effect';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
@@ -84,6 +85,16 @@ const deleteSnapshot = (accessTokenId: string | undefined): void => {
 };
 
 /**
+ * `Effect.tryPromise` wraps a rejected promise in `UnknownException`, whose own `.message` is a
+ * generic boilerplate string ("An unknown error occurred in Effect.tryPromise") — the real cause
+ * lives in its `.error` property, so unwrap it before logging or it is silently lost.
+ */
+const describeError = (error: unknown): string => {
+  const cause = Cause.isUnknownException(error) ? error.error : error;
+  return cause instanceof Error ? cause.message : String(cause);
+};
+
+/**
  * Startup module that finalizes redirect-flow OAuth-recovery callbacks.
  *
  * atproto/bsky nullifies `window.opener`, so the register / recovery flows cannot relay their
@@ -113,11 +124,18 @@ export default Capability.makeModule(
           const invoker = yield* Capability.waitFor(Capabilities.OperationInvoker);
           yield* finalizeRedirect(client, invoker, params).pipe(
             Effect.catchAll((error) =>
-              Effect.sync(() =>
-                log.error('oauth recovery finalize failed', {
-                  error: error instanceof Error ? error.message : String(error),
-                }),
-              ),
+              Effect.gen(function* () {
+                log.error('oauth recovery finalize failed', { error: describeError(error) });
+                yield* invoker
+                  .invoke(LayoutOperation.AddToast, {
+                    id: 'oauth-recovery-error-unknown',
+                    title: 'OAuth recovery failed',
+                    description: 'Something went wrong completing sign-in. Please try again.',
+                    icon: 'ph--warning-circle--regular',
+                    duration: 10_000,
+                  })
+                  .pipe(Effect.ignore);
+              }),
             ),
             Effect.ensuring(Effect.sync(() => deleteSnapshot(params.accessTokenId))),
           );

--- a/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.test.ts
+++ b/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.test.ts
@@ -88,7 +88,7 @@ describe('DedicatedWorkerClientServices', { timeout: 1_000, retry: 0 }, () => {
   // Timeout override: exercises lock acquisition, the retry backoff, and a fresh WorkerRuntime
   // start, which typically takes ~300ms but has enough variance (verified over repeated runs) to
   // warrant more margin than the 1s describe-level default.
-  test('recovers when the leader session itself fails, backing off and re-electing', { timeout: 2_000 }, async () => {
+  test('recovers when the leader session itself fails, backing off and re-electing', { timeout: 4_000 }, async () => {
     const testBuilder = new TestBuilder();
     onTestFinished(() => testBuilder.destroy());
 

--- a/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.test.ts
+++ b/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.test.ts
@@ -11,7 +11,9 @@ import { log } from '@dxos/log';
 
 import { Client } from '../../client';
 import { TestBuilder } from '../../testing';
-import { LEADER_LOCK_KEY } from './dedicated-worker-client-services';
+import { TestWorkerFactory } from '../../testing/test-worker-factory';
+import { DedicatedWorkerClientServices, LEADER_LOCK_KEY } from './dedicated-worker-client-services';
+import { MemoryWorkerCoordiantor } from './memory-coordinator';
 
 describe('DedicatedWorkerClientServices', { timeout: 1_000, retry: 0 }, () => {
   test('open & close', async () => {
@@ -81,6 +83,41 @@ describe('DedicatedWorkerClientServices', { timeout: 1_000, retry: 0 }, () => {
 
     await using client = await new Client({ services }).initialize();
     await client.halo.createIdentity();
+  });
+
+  // Timeout override: exercises lock acquisition, the retry backoff, and a fresh WorkerRuntime
+  // start, which typically takes ~300ms but has enough variance (verified over repeated runs) to
+  // warrant more margin than the 1s describe-level default.
+  test('recovers when the leader session itself fails, backing off and re-electing', { timeout: 2_000 }, async () => {
+    const testBuilder = new TestBuilder();
+    onTestFinished(() => testBuilder.destroy());
+
+    const coordinator = new MemoryWorkerCoordiantor();
+    const workerFactory = new TestWorkerFactory(testBuilder.config);
+    await workerFactory.open();
+    onTestFinished(async () => {
+      await workerFactory.close();
+    });
+
+    // Simulate the worker crashing/failing to start on the first leader-election attempt (a
+    // non-abort error). The watcher must back off and re-elect rather than giving up permanently;
+    // the second attempt uses a real worker so the client should still connect.
+    let workerAttempts = 0;
+    await using services = await new DedicatedWorkerClientServices({
+      createWorker: () => {
+        workerAttempts++;
+        if (workerAttempts === 1) {
+          throw new Error('Simulated worker spawn failure');
+        }
+        return workerFactory.make();
+      },
+      createCoordinator: () => coordinator,
+      leaderTimeouts: { portTimeout: 200, staleTimeout: 100, heartbeatInterval: 50, retryBackoff: 100 },
+    }).open();
+
+    await using client = await new Client({ services }).initialize();
+    await client.halo.createIdentity();
+    expect(workerAttempts).toBeGreaterThanOrEqual(2);
   });
 
   // Flaky.

--- a/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.ts
+++ b/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.ts
@@ -4,7 +4,7 @@
 
 import * as Cause from 'effect/Cause';
 
-import { AsyncTask, Event, Trigger, asyncTimeout } from '@dxos/async';
+import { AsyncTask, Event, Trigger, asyncTimeout, sleepWithContext } from '@dxos/async';
 import { type ClientServices, type ClientServicesProvider, clientServiceBundle } from '@dxos/client-protocol';
 import { Config } from '@dxos/config';
 import { type Context, Resource } from '@dxos/context';
@@ -40,6 +40,9 @@ const DEFAULT_LEADER_HEARTBEAT_INTERVAL = 1_000;
 // since the heartbeat runs on the leader's main thread while data work runs in the worker.
 const DEFAULT_LEADER_STALE_TIMEOUT = 5_000;
 const DEFAULT_LEADER_PORT_TIMEOUT = LOCK_OR_RPC_WAIT_TIMEOUT;
+// Backoff before re-entering leader election after the leader session itself fails (as opposed to
+// the lock being stolen), so a persistently failing worker doesn't spin the election in a tight loop.
+const DEFAULT_LEADER_RETRY_BACKOFF = 1_000;
 
 // Sentinel resolved when a follower gives up waiting for a port from the leader.
 const LEADER_TIMEOUT = Symbol('leader-timeout');
@@ -58,6 +61,12 @@ export interface LeaderTimeoutOptions {
    * Duration a follower waits for a port from the leader before re-evaluating leadership.
    */
   portTimeout?: number;
+  /**
+   * Backoff before re-entering leader election after the leader session itself fails (as opposed
+   * to the lock being stolen), so a persistently failing worker doesn't spin the election in a
+   * tight loop.
+   */
+  retryBackoff?: number;
 }
 
 export interface DedeciatedWorkerClientServicesOptions {
@@ -91,6 +100,7 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
   readonly #leaderHeartbeatInterval: number;
   readonly #leaderStaleTimeout: number;
   readonly #leaderPortTimeout: number;
+  readonly #leaderRetryBackoff: number;
   // Timestamp (ms) of the last heartbeat seen from any leader; 0 if none observed yet.
   #lastLeaderHeartbeat = 0;
   // Timestamp (ms) of the last steal attempt; gates against thrashing re-election.
@@ -117,6 +127,7 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
     this.#leaderHeartbeatInterval = options.leaderTimeouts?.heartbeatInterval ?? DEFAULT_LEADER_HEARTBEAT_INTERVAL;
     this.#leaderStaleTimeout = options.leaderTimeouts?.staleTimeout ?? DEFAULT_LEADER_STALE_TIMEOUT;
     this.#leaderPortTimeout = options.leaderTimeouts?.portTimeout ?? DEFAULT_LEADER_PORT_TIMEOUT;
+    this.#leaderRetryBackoff = options.leaderTimeouts?.retryBackoff ?? DEFAULT_LEADER_RETRY_BACKOFF;
   }
 
   get descriptors(): ServiceBundle<ClientServices> {
@@ -221,26 +232,42 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
         );
         log('dedicated-worker-client-services: leader lock released');
       } catch (error: any) {
+        if (isAbortError(error) && this._ctx.disposed) {
+          // Normal shutdown: the leader-lock request was aborted because the resource is closing.
+          log('dedicated-worker-client-services: leader watch aborted (closing)');
+          return;
+        }
+        this.#leaderDone?.wake();
+        const session = this.#leaderSession;
+        this.#leaderSession = undefined;
+        await session?.close();
+        if (this._ctx.disposed) {
+          return;
+        }
         if (isAbortError(error)) {
-          if (this._ctx.disposed) {
-            // Normal shutdown: the leader-lock request was aborted because the resource is closing.
-            log('dedicated-worker-client-services: leader watch aborted (closing)');
-            return;
-          }
           // Our exclusive lock was stolen by another tab that judged this leader stale. The lock
           // callback keeps running per spec, so explicitly tear down our leader session (terminating
           // the worker so it stops contending for shared storage) and re-enter the election.
           log.warn('dedicated-worker-client-services: leader lock stolen, tearing down and re-watching', {
             clientId: this.#clientId,
           });
-          this.#leaderDone?.wake();
-          const session = this.#leaderSession;
-          this.#leaderSession = undefined;
-          await session?.close();
           this.#watchLeader();
           return;
         }
-        log.catch(error);
+        // The leader session itself failed (e.g. worker init/crash). The lock is released once this
+        // callback rejects, so re-enter the election after a backoff — otherwise this tab can never
+        // host or reconnect to a worker again, leaving followers retrying `provide-port` forever.
+        log.warn('dedicated-worker-client-services: leader session failed, backing off and re-watching', {
+          clientId: this.#clientId,
+          error,
+        });
+        try {
+          await sleepWithContext(this._ctx, this.#leaderRetryBackoff);
+        } catch {
+          // Disposed while backing off.
+          return;
+        }
+        this.#watchLeader();
       }
     });
   }

--- a/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.ts
+++ b/packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.ts
@@ -43,6 +43,9 @@ const DEFAULT_LEADER_PORT_TIMEOUT = LOCK_OR_RPC_WAIT_TIMEOUT;
 // Backoff before re-entering leader election after the leader session itself fails (as opposed to
 // the lock being stolen), so a persistently failing worker doesn't spin the election in a tight loop.
 const DEFAULT_LEADER_RETRY_BACKOFF = 1_000;
+// Cap on the exponential backoff below, so a worker that fails indefinitely still retries on a
+// bounded interval rather than backing off forever.
+const MAX_LEADER_RETRY_BACKOFF = 30_000;
 
 // Sentinel resolved when a follower gives up waiting for a port from the leader.
 const LEADER_TIMEOUT = Symbol('leader-timeout');
@@ -105,6 +108,9 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
   #lastLeaderHeartbeat = 0;
   // Timestamp (ms) of the last steal attempt; gates against thrashing re-election.
   #lastStealAttempt = 0;
+  // Consecutive leader-session open failures; grows the retry backoff and resets once a session
+  // opens successfully.
+  #leaderFailureCount = 0;
   // Resolves the leader-lock hold; woken on close, worker termination, or when our lock is stolen.
   #leaderDone: Trigger | undefined;
 
@@ -222,6 +228,7 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
               log('dedicated-worker-client-services: opening leader session');
               await waitWithLockOrRpcTimeout(this.#leaderSession.open(), 'opening dedicated worker leader session');
               log('dedicated-worker-client-services: leader session opened');
+              this.#leaderFailureCount = 0;
               await done.wait(); // Hold until the leader session is closed.
               log('dedicated-worker-client-services: leader session done');
             } finally {
@@ -257,12 +264,20 @@ export class DedicatedWorkerClientServices extends Resource implements ClientSer
         // The leader session itself failed (e.g. worker init/crash). The lock is released once this
         // callback rejects, so re-enter the election after a backoff — otherwise this tab can never
         // host or reconnect to a worker again, leaving followers retrying `provide-port` forever.
+        // Back off exponentially (capped) with jitter so a persistently failing worker retries on a
+        // bounded interval instead of a tight loop, and so multiple tabs hitting the same failure
+        // don't all retry the lock in lockstep.
+        const backoff = Math.min(this.#leaderRetryBackoff * 2 ** this.#leaderFailureCount, MAX_LEADER_RETRY_BACKOFF);
+        const jitteredBackoff = backoff * (0.5 + Math.random() * 0.5);
+        this.#leaderFailureCount++;
         log.warn('dedicated-worker-client-services: leader session failed, backing off and re-watching', {
           clientId: this.#clientId,
           error,
+          failureCount: this.#leaderFailureCount,
+          backoff: jitteredBackoff,
         });
         try {
-          await sleepWithContext(this._ctx, this.#leaderRetryBackoff);
+          await sleepWithContext(this._ctx, jitteredBackoff);
         } catch {
           // Disposed while backing off.
           return;


### PR DESCRIPTION
## Summary

Investigated an `oauth recovery finalize failed` error surfaced in SigNoz (two occurrences this morning, same user, both failing identically), which uncovered two related bugs:

- **`plugin-onboarding`**: [`oauth-recovery-redirect.ts`](packages/plugins/plugin-onboarding/src/capabilities/oauth-recovery-redirect.ts) logged `UnknownException.message` on finalize failure. Since the RPC calls inside `finalizeRedirect` use bare `Effect.tryPromise(() => ...)` with no `catch` mapper, Effect always sets `.message` to the generic boilerplate `"An unknown error occurred in Effect.tryPromise"` — the real cause was sitting in `.error`/`.cause` and being silently discarded, making every occurrence of this error undiagnosable from telemetry. Now unwraps the real cause before logging, and shows a toast on the generic failure path so a failed OAuth finalize is no longer silent to the user (mirrors the existing `params.error` toast for kms-service pre-identity failures).
- **`client`**: [`DedicatedWorkerClientServices#watchLeader`](packages/sdk/client/src/services/dedicated/dedicated-worker-client-services.ts) gave up permanently after any non-abort error from the leader session (e.g. a worker crash/init failure), instead of retrying. Since the exclusive lock is released once the callback throws, this left the tab (and any followers) unable to ever elect a new leader for the lifetime of the page. This matches a real production symptom found in the same SigNoz window: two separate sessions stuck in a 6-minute loop of `waiting for dedicated worker provide-port RPC reply` timeouts, retrying every ~15s with no leader ever re-elected. Now backs off (`retryBackoff`, default 1s, configurable like the other `leaderTimeouts`) and re-enters election.

## Test plan

- [x] Added a regression test (`recovers when the leader session itself fails, backing off and re-electing`) that injects a `createWorker` failure on the first leader-election attempt and asserts the client still connects after the watcher retries.
- [x] Verified the regression test actually fails (hangs, times out) against the pre-fix `watchLeader` code, confirming it exercises the real bug rather than being a trivial happy-path check.
- [x] Verified the test is stable (10+ repeated no-cache `vitest run` invocations) after tuning `leaderTimeouts` — an earlier, overly aggressive shrink of those values caused genuine intermittent hangs from lock/timer races, not just slowness.
- [x] `moon run client:build client:lint client:test` and `moon run plugin-onboarding:build plugin-onboarding:lint plugin-onboarding:test` all pass.
- [x] No `as any`/`as unknown`/`as <Type>` casts introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth recovery failure handling with clearer, consistent error reporting and a reliable fallback notification.
  * Enhanced dedicated worker leader election to automatically recover when the leader session fails, using configurable retry backoff and avoiding follower stalls while waiting to connect.
* **Tests**
  * Added automated coverage to verify recovery behavior when worker leadership initialization fails, including retry/backoff and re-election.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->