### PR TITLE
refactor(react-ui-mosaic): make Mosaic.Root headless

### DIFF
--- a/packages/plugins/plugin-script/src/components/NotebookStack/NotebookStack.tsx
+++ b/packages/plugins/plugin-script/src/components/NotebookStack/NotebookStack.tsx
@@ -85,8 +85,14 @@ export const NotebookStack = composable<HTMLDivElement, NotebookStackProps>(
     );
 
     return (
-      <Mosaic.Root ref={forwardedRef}>
-        <Mosaic.Container asChild orientation='vertical' autoScroll={viewport} eventHandler={eventHandler}>
+      <Mosaic.Root>
+        <Mosaic.Container
+          asChild
+          orientation='vertical'
+          autoScroll={viewport}
+          eventHandler={eventHandler}
+          ref={forwardedRef}
+        >
           <ScrollArea.Root orientation='vertical' padding {...composableProps(props)}>
             <ScrollArea.Viewport ref={setViewport}>
               <Mosaic.Stack orientation='vertical' items={notebook?.cells ?? []} getId={getCellId} Tile={Tile} />

--- a/packages/plugins/plugin-thread/src/containers/ChannelArticle/ChannelArticle.tsx
+++ b/packages/plugins/plugin-thread/src/containers/ChannelArticle/ChannelArticle.tsx
@@ -117,10 +117,7 @@ export const ChannelArticle = ({ role, subject: channel, attendableId, chatOnly 
           <Surface.Surface type={AppSurface.Article} data={{ subject: { roomId: id }, attendableId }} limit={1} />
         </Panel.Content>
       ) : (
-        // Not `asChild`: Panel.Root is a CSS grid and the `grid-area: content` placement must land on
-        // a real box. MessageThread's outermost node is Mosaic.Root's `display:contents` div, which
-        // cannot be a grid item, so wrapping in Panel.Content's own box lets MessageThread fill via `h-full`.
-        <Panel.Content>
+        <Panel.Content asChild>
           <MessageThread
             id={id}
             classNames='dx-document'

--- a/packages/plugins/plugin-thread/src/containers/ThreadArticle/ThreadArticle.tsx
+++ b/packages/plugins/plugin-thread/src/containers/ThreadArticle/ThreadArticle.tsx
@@ -60,9 +60,7 @@ export const ThreadArticle = composable<HTMLDivElement, ThreadArticleProps>(
     return (
       <Panel.Root>
         <Panel.Toolbar></Panel.Toolbar>
-        {/* Not `asChild`: the grid-area placement must land on a real box, not MessageThread's
-            Mosaic.Root `display:contents` root (see ChannelArticle). */}
-        <Panel.Content>
+        <Panel.Content asChild>
           <MessageThread
             {...composableProps(props)}
             id={id}

--- a/packages/stories/stories-ui/src/MosaicSurface.stories.tsx
+++ b/packages/stories/stories-ui/src/MosaicSurface.stories.tsx
@@ -75,7 +75,7 @@ const DefaultStory = ({ columns: columnsProp = 1, debug = false }: StoryArgs) =>
   }, [columnsProp, db, registry]);
 
   return (
-    <Mosaic.Root asChild debug={debug}>
+    <Mosaic.Root>
       <div className={mx('grid overflow-hidden', debug && 'grid-cols-[1fr_20rem] gap-2')}>
         <Board.Root model={model}>
           <Board.Content id='board' debug={debug} />

--- a/packages/ui/react-ui-mosaic/src/components/Board/Board.stories.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/Board/Board.stories.tsx
@@ -172,7 +172,7 @@ const DefaultStory = ({ debug = false, columns: columnsProp = 0 }: StoryArgs) =>
   }
 
   return (
-    <Mosaic.Root asChild debug={debug}>
+    <Mosaic.Root>
       <div className={mx('grid md:p-2 overflow-hidden', debug && 'grid-cols-[1fr_20rem] gap-2')}>
         <Board.Root model={model}>
           <Board.Content id='board' debug={debug} eventHandler={eventHandler} Tile={DefaultBoardColumn} />

--- a/packages/ui/react-ui-mosaic/src/components/Board/Board.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/Board/Board.tsx
@@ -115,6 +115,7 @@ const BoardContentInner = composable<HTMLDivElement, BoardContentProps>(
             autoScroll={viewport}
             eventHandler={eventHandler}
             debug={debugHandler}
+            placeholderDebug={debug}
           >
             <ScrollArea.Root orientation='horizontal' centered padding>
               <ScrollArea.Viewport classNames='snap-mandatory snap-x md:snap-none' ref={setViewport}>

--- a/packages/ui/react-ui-mosaic/src/components/Mosaic/Container.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/Mosaic/Container.tsx
@@ -76,6 +76,9 @@ const [MosaicContainerContextProvider, useMosaicContainerContext] =
 // State attribute: [&:has(>_[data-mosaic-container-state=active])]
 const MOSAIC_CONTAINER_STATE_ATTR = 'mosaic-container-state';
 
+// State attribute: [&:has(>_[data-mosaic-debug=true])]
+const MOSAIC_CONTAINER_DEBUG_ATTR = 'mosaic-debug';
+
 // CSS variables: [var(--mosaic-placeholder-xxx)]
 const MOSAIC_CONTAINER_PLACEHOLDER_WIDTH = '--mosaic-placeholder-width';
 const MOSAIC_CONTAINER_PLACEHOLDER_HEIGHT = '--mosaic-placeholder-height';
@@ -104,6 +107,8 @@ type MosaicContainerProps = PropsWithChildren<
     /** Called when a tile requests to toggle selection. */
     onSelectionChange?: (id: string, selected: boolean) => void;
     debug?: () => ReactNode;
+    /** Toggles the `group` target that Placeholder's debug-highlight selectors read (see styles.ts). */
+    placeholderDebug?: boolean;
   }
 >;
 
@@ -126,6 +131,7 @@ const MosaicContainer = composable<HTMLDivElement, MosaicContainerProps>(
       selectedIds,
       onSelectionChange,
       debug,
+      placeholderDebug,
       ...props
     },
     forwardedRef,
@@ -317,7 +323,7 @@ const MosaicContainer = composable<HTMLDivElement, MosaicContainerProps>(
       >
         <Comp
           {...composableProps(props, {
-            classNames: 'h-full',
+            classNames: 'h-full group',
             style: {
               [MOSAIC_CONTAINER_PLACEHOLDER_WIDTH]:
                 state.type === 'active' && state.bounds ? `${state.bounds.width}px` : '0px',
@@ -327,6 +333,7 @@ const MosaicContainer = composable<HTMLDivElement, MosaicContainerProps>(
           })}
           {...{
             [`data-${MOSAIC_CONTAINER_STATE_ATTR}`]: state.type,
+            [`data-${MOSAIC_CONTAINER_DEBUG_ATTR}`]: placeholderDebug,
           }}
           ref={composedRef}
         >

--- a/packages/ui/react-ui-mosaic/src/components/Mosaic/Root.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/Mosaic/Root.tsx
@@ -5,11 +5,8 @@
 import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
 import { type ElementDragPayload, monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { type DragLocationHistory } from '@atlaskit/pragmatic-drag-and-drop/types';
-import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
-import { Primitive } from '@radix-ui/react-primitive';
-import { Slot } from '@radix-ui/react-slot';
-import React, { type PropsWithChildren, forwardRef, useCallback, useEffect, useRef, useState } from 'react';
+import React, { type PropsWithChildren, useCallback, useEffect, useState } from 'react';
 
 import { log } from '@dxos/log';
 
@@ -50,20 +47,13 @@ const [MosaicRootContextProvider, useMosaicRootContext] = createContext<MosaicRo
 
 const MOSAIC_ROOT_NAME = 'Mosaic.Root';
 
-// State attribute: [&:has(>_[data-mosaic-debug=true])]
-const MOSAIC_ROOT_DEBUG_ATTR = 'mosaic-debug';
+type MosaicRootProps = PropsWithChildren;
 
-type MosaicRootProps = PropsWithChildren<{
-  asChild?: boolean;
-  debug?: boolean;
-}>;
-
-// TODO(burdon): Make headless.
-const MosaicRoot = forwardRef<HTMLDivElement, MosaicRootProps>(({ children, asChild, debug }, forwardedRef) => {
-  const rootRef = useRef<HTMLDivElement>(null);
-  const composedRef = useComposedRefs<HTMLDivElement>(rootRef, forwardedRef);
-  const Comp = asChild ? Slot : Primitive.div;
-
+/**
+ * Headless: provides drag-and-drop orchestration and context only, renders no DOM of its own.
+ * Consumers wrap the visible chrome they control (typically via `Mosaic.Container`).
+ */
+const MosaicRoot = ({ children }: MosaicRootProps) => {
   const [handlers, setHandlers] = useState<Record<string, MosaicEventHandler>>({});
   const [dragging, setDragging] = useState<MosaicDraggingState | undefined>();
 
@@ -269,19 +259,10 @@ const MosaicRoot = forwardRef<HTMLDivElement, MosaicRootProps>(({ children, asCh
       }
       dragging={dragging}
     >
-      <Comp
-        // TODO(burdon): Make headless (move group to content).
-        className='contents group'
-        {...{
-          [`data-${MOSAIC_ROOT_DEBUG_ATTR}`]: debug,
-        }}
-        ref={composedRef}
-      >
-        {children}
-      </Comp>
+      {children}
     </MosaicRootContextProvider>
   );
-});
+};
 
 MosaicRoot.displayName = MOSAIC_ROOT_NAME;
 

--- a/packages/ui/react-ui-mosaic/src/components/Mosaic/Stack.stories.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/Mosaic/Stack.stories.tsx
@@ -36,7 +36,7 @@ const DefaultStackStory = (props: MosaicStackProps<Obj.Any>) => {
   const [DebugInfo, debugHandler] = useContainerDebug(props.debug);
   const [viewport, setViewport] = useState<HTMLElement | null>(null);
   return (
-    <Mosaic.Root debug={props.debug}>
+    <Mosaic.Root>
       <Panel.Root>
         <Panel.Toolbar asChild>
           <Toolbar.Root>
@@ -51,6 +51,7 @@ const DefaultStackStory = (props: MosaicStackProps<Obj.Any>) => {
               autoScroll={viewport}
               eventHandler={{ id: 'test', canDrop: () => true }}
               debug={debugHandler}
+              placeholderDebug={props.debug}
             >
               <ScrollArea.Root orientation='vertical'>
                 <ScrollArea.Viewport ref={setViewport}>
@@ -77,7 +78,7 @@ const VirtualStackStory = (props: MosaicStackProps<Obj.Any>) => {
   const [DebugInfo, debugHandler] = useContainerDebug(props.debug);
   const [viewport, setViewport] = useState<HTMLElement | null>(null);
   return (
-    <Mosaic.Root debug={props.debug}>
+    <Mosaic.Root>
       <Panel.Root>
         <Panel.Toolbar asChild>
           <Toolbar.Root>
@@ -91,6 +92,7 @@ const VirtualStackStory = (props: MosaicStackProps<Obj.Any>) => {
             autoScroll={viewport}
             eventHandler={{ id: 'test', canDrop: () => true }}
             debug={debugHandler}
+            placeholderDebug={props.debug}
           >
             <ScrollArea.Root orientation='vertical'>
               <ScrollArea.Viewport ref={setViewport}>


### PR DESCRIPTION
## Summary

Make `Mosaic.Root` **headless** — it renders no DOM box, providing only the `MosaicRootContextProvider` (+ DnD monitor) and passing `children` through. The `group` class and the `data-mosaic-debug` state selector move to `Mosaic.Container`.

## Why

`Mosaic.Root` rendered a `display:contents` wrapper `<div>` (carrying `group` + the debug selector). As a real DOM node it broke CSS-grid/flex placement: when a component whose outermost node is `Mosaic.Root` is placed via `Panel.Content asChild` into a grid area, the `grid-area` placement lands on the `display:contents` node — which can't be a grid item — so the real content collapsed (this is the `MessageThread` fill bug worked around in #12054 by dropping `asChild`). Making Root headless removes the footgun everywhere.

## Changes

- `react-ui-mosaic/Root.tsx`: headless (context-only; no `Comp`/`asChild`/`ref`/`display:contents` div). `MosaicRootProps` is now just `PropsWithChildren`.
- `react-ui-mosaic/Container.tsx`: hosts the `group` class + `data-mosaic-debug` selector (via a new `placeholderDebug` prop) that Root used to carry.
- `plugin-script/NotebookStack`: its `ref` moves from `Mosaic.Root` (no longer a DOM node) to `Mosaic.Container`.
- `plugin-thread/ChannelArticle` + `ThreadArticle`: restore `Panel.Content asChild` around `MessageThread` — the #12054 non-`asChild` workaround is no longer needed now that Root is headless.

## Verification

- `moon build/test/lint` green across `react-ui-mosaic`, `react-ui-thread`, `plugin-thread`, `plugin-deck`, `plugin-stack`, `plugin-script`, `plugin-space`, `plugin-simple-layout`.
- Audited all ~14 `Mosaic.Root` consumers: none use `asChild`/`ref` (now type-enforced — `MosaicRootProps` is `PropsWithChildren`).
- Public-barrel module-load smoke (DOM env) confirms no module-init/circular error.
- `MessageThread` fill verified in Storybook (fills the panel with `asChild` + headless Root); grouping/divider story renders unaffected.

## Follow-up (separate)

Enables hoisting a single `Mosaic.Root` to the app root for **global cross-container DnD** (scoped separately): unique container ids first, then one Root in `app-framework/App.tsx`, remove the per-consumer Roots, wire cross-container `canDrop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout behavior in notebook, thread, and channel views by adjusting how content wrappers and references are applied.
  * Fixed mosaic board rendering so placeholder debug styling is shown more reliably when enabled.

* **New Features**
  * Added placeholder debug styling support for mosaic containers, making placeholder states easier to inspect during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->