### PR TITLE
docs(react-ui-mosaic): design note for cross-container DnD

### DIFF
--- a/packages/ui/react-ui-mosaic/DESIGN.md
+++ b/packages/ui/react-ui-mosaic/DESIGN.md
@@ -54,14 +54,15 @@ not on `useListSelection`. (Why these diverge from react-ui-list's aspects — a
 whether they should converge — is the analysis in
 [`react-ui-list/AUDIT.md`](../react-ui-list/AUDIT.md).)
 
-## Cross-container drag-and-drop (planned)
+## Cross-container drag-and-drop
 
-Phases 1–3 made a single app-level `Mosaic.Root` the only live drag boundary, so
-every `Mosaic.Container` in the app registers into **one shared handler registry**
-keyed by `eventHandler.id`. This is the prerequisite for dragging a tile from one
-container into a _different_ one; the remaining work (Phase 4) is the drop policy.
+A single app-level `Mosaic.Root` is the only live drag boundary, so every
+`Mosaic.Container` in the app registers into **one shared handler registry** keyed
+by `eventHandler.id`. This is what lets a tile be dragged from one container into a
+_different_ one. The registry mechanics are in place; the cross-container drop
+**policy** is not yet built.
 
-**Invariants already in place:**
+**Invariants the shared registry relies on:**
 
 - **One live Root.** Each layout shell (`DeckLayout`, `SimpleLayout`, the testing
   layout) mounts a `Mosaic.Root`, and exactly one layout is mounted at runtime. No
@@ -77,7 +78,7 @@ container into a _different_ one; the remaining work (Phase 4) is the drop polic
   it; it exists so a target's drop logic can decide acceptance from typed data
   rather than by parsing the opaque `id`. Unpopulated until the rules below land.
 
-**Phase 4 — the drop rules (not yet built):**
+**The drop rules (not yet built):**
 
 1. **Thread the source payload to the target.** On drop, `Root` already resolves
    the source handler (`handlers[source.containerId]`); pass its `payload` into the
@@ -93,13 +94,12 @@ container into a _different_ one; the remaining work (Phase 4) is the drop polic
    package carries only the mechanism (registry, payload plumbing), never the
    policy.
 
-**Deferred within Phase 4 — Board-based containers.** `Board.Content` (kanban,
-pipeline) has _nested_ handlers: the columns container plus a per-column item
-container keyed by `column.columnValue`. Making those unique per instance requires
-threading a `useId()` discriminator through the tile-render path
+**Deferred — Board-based containers.** `Board.Content` (kanban, pipeline) has
+_nested_ handlers: the columns container plus a per-column item container keyed by
+`column.columnValue`. Making those unique per instance requires threading a
+`useId()` discriminator through the tile-render path
 (`Mosaic.Stack` → column `Tile` → `useKanbanItemEventHandler`), which `Mosaic.Stack`
-does not forward today. Their duplicate-mount collision predates the single-root
-change, so it was left for this phase rather than half-fixed.
+does not forward today. This is a known gap in the per-instance-id invariant above.
 
 ## Component hierarchies
 

--- a/packages/ui/react-ui-mosaic/DESIGN.md
+++ b/packages/ui/react-ui-mosaic/DESIGN.md
@@ -54,6 +54,53 @@ not on `useListSelection`. (Why these diverge from react-ui-list's aspects — a
 whether they should converge — is the analysis in
 [`react-ui-list/AUDIT.md`](../react-ui-list/AUDIT.md).)
 
+## Cross-container drag-and-drop (planned)
+
+Phases 1–3 made a single app-level `Mosaic.Root` the only live drag boundary, so
+every `Mosaic.Container` in the app registers into **one shared handler registry**
+keyed by `eventHandler.id`. This is the prerequisite for dragging a tile from one
+container into a _different_ one; the remaining work (Phase 4) is the drop policy.
+
+**Invariants already in place:**
+
+- **One live Root.** Each layout shell (`DeckLayout`, `SimpleLayout`, the testing
+  layout) mounts a `Mosaic.Root`, and exactly one layout is mounted at runtime. No
+  other component mounts its own Root — a nested Root would fork the registry and
+  isolate its subtree from cross-container drags.
+- **Per-instance container ids.** An id must be unique per _live container
+  instance_, not per object: the same ECHO object can mount in two containers at
+  once (the in-call chat companion beside the primary, or "open in new plank").
+  Object-derived ids therefore append a stable `useId()` discriminator —
+  `` `${objectUri}:${useId()}` ``.
+- **`payload` seam.** `MosaicEventHandler.payload?: unknown` is an open,
+  container-defined descriptor of what a container holds. Mosaic never interprets
+  it; it exists so a target's drop logic can decide acceptance from typed data
+  rather than by parsing the opaque `id`. Unpopulated until the rules below land.
+
+**Phase 4 — the drop rules (not yet built):**
+
+1. **Thread the source payload to the target.** On drop, `Root` already resolves
+   the source handler (`handlers[source.containerId]`); pass its `payload` into the
+   target's `canDrop`/`onDrop` as an additive argument. Targets then decide
+   acceptance from typed data, keeping identity (`id`) and semantics (`payload`)
+   separate.
+2. **Populate `payload` per container.** Object-bound containers set e.g.
+   `{ typename, uri }`; structural containers (deck, nav) a role tag. This is
+   non-uniform by construction — generic UI containers (`Thread`, `Board`) hold no
+   single object and must receive their `payload` from the plugin caller.
+3. **Accept-matrix is app policy, not a Mosaic concern.** Which tile types a
+   container accepts is decided per-plugin, in that container's `canDrop`. This
+   package carries only the mechanism (registry, payload plumbing), never the
+   policy.
+
+**Deferred within Phase 4 — Board-based containers.** `Board.Content` (kanban,
+pipeline) has _nested_ handlers: the columns container plus a per-column item
+container keyed by `column.columnValue`. Making those unique per instance requires
+threading a `useId()` discriminator through the tile-render path
+(`Mosaic.Stack` → column `Tile` → `useKanbanItemEventHandler`), which `Mosaic.Stack`
+does not forward today. Their duplicate-mount collision predates the single-root
+change, so it was left for this phase rather than half-fixed.
+
 ## Component hierarchies
 
 Compound nesting a consumer must follow. `*` marks an optional element.


### PR DESCRIPTION
## Summary

Adds a **"Cross-container drag-and-drop"** section to `packages/ui/react-ui-mosaic/DESIGN.md` — a living design note for the single-`Mosaic.Root` DnD model.

Captures:
- **Invariants the shared registry relies on** — one live `Mosaic.Root`, per-instance `useId()` container ids, and the open `payload?: unknown` seam on `MosaicEventHandler`.
- **The drop rules (not yet built)** — thread the source `payload` into the target's `canDrop`/`onDrop`; populate `payload` per container (non-uniform — generic UI containers receive it from their plugin caller); accept-matrix stays per-plugin policy, not a Mosaic concern.
- **Deferred Board work** — kanban/pipeline nested column/item handlers need a `useId()` discriminator threaded through the `Mosaic.Stack` → `Tile` → `useKanbanItemEventHandler` path.

Docs-only; no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for cross-container drag-and-drop in the mosaic UI.
  * Clarified key usage requirements for running with a single app-level root and unique container IDs.
  * Documented current limitations and recommended drop-handling behavior for app-defined rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->