### PR TITLE
refactor(react-ui-masonry): replace @virtuoso.dev/masonry with self-contained layout engine

### DIFF
--- a/docs/superpowers/specs/2026-07-04-masonry-layout-engine-design.md
+++ b/docs/superpowers/specs/2026-07-04-masonry-layout-engine-design.md
@@ -74,9 +74,11 @@ type LayoutResult = { rects: Rect[]; columnWidth: number; height: number };
 const layout = (opts: {
   heights: readonly number[]; // measured tile heights (px), item order
   columnCount: number;
-  containerWidth: number;     // px, already net of scrollbar allowance
+  containerWidth: number; // px, already net of scrollbar allowance
   gutterPx: number;
-}): LayoutResult => { /* ... */ };
+}): LayoutResult => {
+  /* ... */
+};
 ```
 
 - `columnWidth = (containerWidth - (columnCount - 1) * gutterPx) / columnCount`.
@@ -107,11 +109,11 @@ const layout = (opts: {
 
 - The Viewport container is `position: relative`, `height` set to the layout
   result height. Each tile wrapper is `position: absolute; width: columnWidth;
-  transform: translate(x, y)`.
+transform: translate(x, y)`.
 - **FLIP:** on layout change, capture previous `translate` per id (First), apply
   the new one (Last), then animate the delta via the Web Animations API
   (`element.animate([{ transform: prev }, { transform: next }], { duration,
-  easing })`). New items fade/scale in; removed items are dropped immediately
+easing })`). New items fade/scale in; removed items are dropped immediately
   (no exit animation in Phase 1).
 - **Reduced motion:** if `matchMedia('(prefers-reduced-motion: reduce)')`
   matches, skip animation and snap to the new transform.
@@ -164,7 +166,7 @@ navigation, and note the option in code.
   - shortest-column assignment: given heights `[10, 10, 100, 10]`, `columnCount=2`,
     item 3 lands in the column made shorter by item order, not `index % 2`.
   - geometry: `x`/`columnWidth` account for gutter; total `height = max column −
-    trailing gutter`.
+trailing gutter`.
   - `columnCount=1` stacks vertically; empty input → height 0.
   - stable tie-breaking (equal heights → lowest column index).
 - **Component/story smoke:** existing `Masonry.stories.tsx` re-pointed to the
@@ -176,10 +178,11 @@ navigation, and note the option in code.
 ## Story fixtures
 
 Update `Masonry.stories.tsx` to generate items with the same `@dxos/schema/testing`
-+ `@dxos/random` person generator used in the CRM `CollectionArticle` story
-(#12084), enriching `jobTitle`/`department`/`image`/`emails` locally in the story
-so cards have varied heights that exercise balancing. Do **not** add generator
-annotations to shared schemas.
+
+- `@dxos/random` person generator used in the CRM `CollectionArticle` story
+  (#12084), enriching `jobTitle`/`department`/`image`/`emails` locally in the story
+  so cards have varied heights that exercise balancing. Do **not** add generator
+  annotations to shared schemas.
 
 ## Migration / rollout
 

--- a/docs/superpowers/specs/2026-07-04-masonry-layout-engine-design.md
+++ b/docs/superpowers/specs/2026-07-04-masonry-layout-engine-design.md
@@ -1,0 +1,202 @@
+# Masonry Layout Engine — Design
+
+- **Date:** 2026-07-04
+- **Package:** `@dxos/react-ui-masonry`
+- **Status:** Approved (design decisions locked)
+
+## Summary
+
+Replace the third-party `@virtuoso.dev/masonry` dependency with a self-contained
+masonry layout engine inside `@dxos/react-ui-masonry`. The public `Masonry.Root /
+Masonry.Content / Masonry.Viewport` API is preserved exactly (strict drop-in); only
+the internals of `Masonry.Viewport` change. The new engine balances columns by
+height (shortest-column-first) rather than by index, and animates reflow with FLIP.
+
+## Motivation
+
+`VirtuosoMasonry` assigns items to columns **by index** (`item i → column i %
+columnCount`), so columns with tall items stay tall and short items never
+backfill — the columns visibly fail to balance. It also pulls in an external
+dependency whose scroll-container takeover requires a documented workaround
+(`react-virtuoso#1305`) and whose column-first DOM order forces a Tabster
+`axis: 'both'` navigation compromise. Owning the engine lets us:
+
+1. Balance columns by measured height (the actual user complaint).
+2. Drop the external dependency and its workarounds.
+3. Control DOM order and animation (FLIP reflow).
+
+## Goals
+
+- **Strict drop-in.** No consumer change. `Masonry.Root/Content/Viewport` props
+  (`Tile`, `columns`, `maxColumns`, `minColumnWidth`, `maxColumnWidth`, `gutter`,
+  `items`, `getId`, `classNames`, ScrollArea passthrough) keep their current
+  meaning. All 12 consumers compile and render unchanged.
+- **Height-balanced columns** via column-major greedy assignment.
+- **FLIP reflow animations** on layout change, gated on
+  `prefers-reduced-motion`.
+- **Remove** `@virtuoso.dev/masonry` from the package and the pnpm catalog.
+
+## Non-goals
+
+- **Virtualization.** Phase 1 renders all items. The engine is structured so a
+  windowing layer can be added later (Phase 2) without touching the pure layout
+  function or the public API. This is a deliberate seam, not a shipped feature.
+- **Mobile-specific behavior.** No separate mobile layout path; responsive column
+  count already flows from container width.
+- Drag-and-drop reordering (out of scope; consumers that reorder do so above the
+  Masonry layer).
+
+## Public API (unchanged)
+
+```tsx
+<Masonry.Root Tile={Card} minColumnWidth={16} maxColumnWidth={24} gutter={0.75}>
+  <Masonry.Content thin padding centered>
+    <Masonry.Viewport items={items} getId={(x) => x.id} />
+  </Masonry.Content>
+</Masonry.Root>
+```
+
+`Masonry.Root` and `Masonry.Content` are unchanged. `useColumnCount` (container
+width → column count, honoring `columns`/`maxColumns`/`min`/`maxColumnWidth`) is
+kept verbatim — it already produces the right count; only how items are placed
+into those columns changes.
+
+## Architecture (Approach B — absolute layout engine)
+
+Three concerns, separated:
+
+### 1. Pure layout function
+
+```ts
+type Rect = { x: number; y: number; column: number };
+type LayoutResult = { rects: Rect[]; columnWidth: number; height: number };
+
+const layout = (opts: {
+  heights: readonly number[]; // measured tile heights (px), item order
+  columnCount: number;
+  containerWidth: number;     // px, already net of scrollbar allowance
+  gutterPx: number;
+}): LayoutResult => { /* ... */ };
+```
+
+- `columnWidth = (containerWidth - (columnCount - 1) * gutterPx) / columnCount`.
+- **Column-major greedy (shortest-column-first):** maintain a `columnHeights`
+  array initialized to 0. For each item in order, place it in the column with the
+  smallest running height (ties → lowest index for stable order), set
+  `x = column * (columnWidth + gutterPx)`, `y = columnHeights[column]`, then
+  `columnHeights[column] += height + gutterPx`.
+- `height = max(columnHeights) - gutterPx` (trailing gutter trimmed).
+- Pure and synchronous → directly unit-testable with no DOM.
+
+### 2. Measurement
+
+- Each tile renders into an absolutely-positioned wrapper. A single
+  `ResizeObserver` (created once, reused) observes every tile wrapper and reports
+  height by item id.
+- Heights are stored in a ref-backed map keyed by `getId(item)` (fallback to
+  index when `getId` is absent). A state counter/version triggers re-layout when
+  a height changes past a small epsilon (avoid thrash on sub-pixel jitter).
+- Container width comes from the existing `Masonry.Content` width context
+  (`react-resize-detector`), net of the scrollbar allowance already subtracted in
+  the current Viewport.
+- **First paint:** before heights are known, render tiles at their natural flow
+  position (visibility-safe) so the observer can measure; apply absolute
+  positioning once measured. Guard `width <= 0` returns null (as today).
+
+### 3. Positioning + FLIP
+
+- The Viewport container is `position: relative`, `height` set to the layout
+  result height. Each tile wrapper is `position: absolute; width: columnWidth;
+  transform: translate(x, y)`.
+- **FLIP:** on layout change, capture previous `translate` per id (First), apply
+  the new one (Last), then animate the delta via the Web Animations API
+  (`element.animate([{ transform: prev }, { transform: next }], { duration,
+  easing })`). New items fade/scale in; removed items are dropped immediately
+  (no exit animation in Phase 1).
+- **Reduced motion:** if `matchMedia('(prefers-reduced-motion: reduce)')`
+  matches, skip animation and snap to the new transform.
+
+### Component structure
+
+```
+src/
+  Masonry.tsx            # Root, Content, Viewport (public namespace) — unchanged shells
+  layout.ts             # pure layout() + types
+  layout.test.ts        # unit tests for balancing/geometry
+  useMasonryLayout.ts   # hook: wires ResizeObserver + layout() + version state
+  useFlip.ts            # hook: FLIP transitions keyed by id, reduced-motion aware
+```
+
+`Masonry.Viewport` composes `useMasonryLayout` (heights + rects) and `useFlip`
+(animate on rect change), rendering absolutely-positioned tile wrappers inside
+`ScrollArea.Viewport`. Arrow-key navigation keeps `useArrowNavigationGroup`, but
+because DOM order can now follow item order (not column-first), revisit the axis:
+if tiles render in item order left-to-right within the flow, `axis: 'grid-linear'`
+may be usable; default to preserving `axis: 'both'` to avoid regressing
+navigation, and note the option in code.
+
+## Data flow
+
+1. `Masonry.Content` measures container width → context.
+2. `Masonry.Viewport` computes `columnCount` via `useColumnCount(width, …)`.
+3. Tiles render; `ResizeObserver` reports each tile height by id.
+4. `layout({ heights, columnCount, containerWidth, gutterPx })` → rects.
+5. Wrappers positioned via `translate`; `useFlip` animates deltas.
+6. Any change to items/width/columnCount/heights recomputes steps 3–5.
+
+## Edge cases
+
+- **Unmeasured tiles:** treated as height 0 until first measure; layout settles on
+  the next observer callback (one reflow). Acceptable; no layout thrash loop
+  because height writes are epsilon-gated.
+- **Single column / `columns=1`:** degenerates to a vertical stack; layout handles
+  `columnCount=1` naturally.
+- **Zero items:** height 0, renders empty viewport (matches today).
+- **`width <= 0`:** returns null (matches today), avoids divide-by-zero.
+- **Item removal/reorder:** rects recompute from current `items`; FLIP animates
+  survivors, new ids appear, missing ids are removed.
+- **Very tall single item:** column-major greedy still balances the rest around
+  it; no special-casing.
+
+## Testing
+
+- **`layout.test.ts` (pure, no DOM):**
+  - shortest-column assignment: given heights `[10, 10, 100, 10]`, `columnCount=2`,
+    item 3 lands in the column made shorter by item order, not `index % 2`.
+  - geometry: `x`/`columnWidth` account for gutter; total `height = max column −
+    trailing gutter`.
+  - `columnCount=1` stacks vertically; empty input → height 0.
+  - stable tie-breaking (equal heights → lowest column index).
+- **Component/story smoke:** existing `Masonry.stories.tsx` re-pointed to the
+  generator fixtures (see below); verify in Storybook that columns balance and
+  reflow animates. Follow repo rule: don't kill the user's :9009 server — reuse or
+  use an alternate port.
+- **Consumer build:** `moon run <each-consumer>:build` stays green (drop-in).
+
+## Story fixtures
+
+Update `Masonry.stories.tsx` to generate items with the same `@dxos/schema/testing`
++ `@dxos/random` person generator used in the CRM `CollectionArticle` story
+(#12084), enriching `jobTitle`/`department`/`image`/`emails` locally in the story
+so cards have varied heights that exercise balancing. Do **not** add generator
+annotations to shared schemas.
+
+## Migration / rollout
+
+- Remove `@virtuoso.dev/masonry` from `packages/ui/react-ui-masonry/package.json`
+  and delete the catalog entry in `pnpm-workspace.yaml` (preserve surrounding
+  comments), then `pnpm install`.
+- No consumer edits (strict drop-in). Validate with a full build + the consumers'
+  storybooks/tests.
+- The `VirtuosoMasonry` wrapper and the `react-virtuoso#1305` workaround comment
+  are deleted.
+
+## Risks
+
+- **Measurement flicker on first paint** — mitigated by measuring in flow then
+  switching to absolute; if visible, add a one-frame opacity gate.
+- **Navigation regression** — mitigated by keeping `axis: 'both'` unless verified
+  otherwise.
+- **Perf with many items (no virtualization)** — Phase 1 renders all; acceptable
+  for current consumer sizes (galleries/collections of tens–low hundreds). The
+  pure `layout()` seam allows Phase 2 windowing without API change.

--- a/packages/ui/react-ui-masonry/package.json
+++ b/packages/ui/react-ui-masonry/package.json
@@ -33,7 +33,6 @@
     "@fluentui/react-tabster": "catalog:",
     "@radix-ui/react-compose-refs": "catalog:",
     "@radix-ui/react-context": "catalog:",
-    "@virtuoso.dev/masonry": "catalog:",
     "react-resize-detector": "catalog:"
   },
   "devDependencies": {

--- a/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
@@ -5,30 +5,43 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
-import { Filter } from '@dxos/echo';
+import { Filter, Obj } from '@dxos/echo';
 import { random } from '@dxos/random';
 import { useQuery } from '@dxos/react-client/echo';
 import { useClientStory, withClientProvider } from '@dxos/react-client/testing';
-import { Card, Icon } from '@dxos/react-ui';
+import { Card } from '@dxos/react-ui';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
-import { createObjectFactory } from '@dxos/schema/testing';
-import { Organization } from '@dxos/types';
+import { type ValueGenerator, createObjectFactory } from '@dxos/schema/testing';
+import { Person } from '@dxos/types';
 
-import { Masonry, MasonryRootProps } from './Masonry';
+import { Masonry, type MasonryRootProps } from './Masonry';
 
-const StoryItem = ({ data: { image, name, description } }: { data: Organization.Organization }) => {
+random.seed(1);
+
+const generator: ValueGenerator = random as any;
+
+const StoryItem = ({ data: person }: { data: Person.Person }) => {
+  const { fullName, jobTitle, department, image, emails, notes } = person;
+  const role = [jobTitle, department].filter(Boolean).join(' · ');
   return (
     <Card.Root>
       <Card.Header>
-        <Card.Block>
-          <Icon icon='ph--building-office--regular' />
-        </Card.Block>
-        <Card.Title>{name}</Card.Title>
+        <Card.Title>{fullName}</Card.Title>
       </Card.Header>
-      <Card.Poster alt={name!} {...(image ? { image } : { icon: 'ph--building-office--regular' })} />
-      {description && (
+      {image && <Card.Poster alt={fullName ?? ''} image={image} />}
+      {role && (
+        <Card.Row classNames='px-2'>
+          <Card.Text variant='description'>{role}</Card.Text>
+        </Card.Row>
+      )}
+      {emails && emails.length > 0 && (
+        <Card.Row classNames='px-2'>
+          <Card.Text variant='description'>{emails.map((email) => email.value).join(', ')}</Card.Text>
+        </Card.Row>
+      )}
+      {notes && (
         <Card.Row classNames='px-2 pb-2'>
-          <Card.Text variant='description'>{description}</Card.Text>
+          <Card.Text variant='description'>{notes}</Card.Text>
         </Card.Row>
       )}
     </Card.Root>
@@ -37,12 +50,12 @@ const StoryItem = ({ data: { image, name, description } }: { data: Organization.
 
 const DefaultStory = (props: MasonryRootProps) => {
   const { space } = useClientStory();
-  const organizations = useQuery(space?.db, Filter.type(Organization.Organization));
+  const people = useQuery(space?.db, Filter.type(Person.Person));
 
   return (
     <Masonry.Root {...props} Tile={StoryItem}>
       <Masonry.Content centered>
-        <Masonry.Viewport items={organizations} />
+        <Masonry.Viewport items={people} getId={(person) => person.id} />
       </Masonry.Content>
     </Masonry.Root>
   );
@@ -55,19 +68,43 @@ const meta = {
     withTheme(),
     withLayout({ layout: 'fullscreen' }),
     withClientProvider({
-      types: [Organization.Organization],
+      types: [Person.Person],
       createIdentity: true,
       createSpace: true,
       onCreateSpace: async ({ space }) => {
-        const factory = createObjectFactory(space.db, random as any);
-        await factory([{ type: Organization.Organization, count: 36 }]);
+        const createObjects = createObjectFactory(space.db, generator);
+        const objects = await createObjects([{ type: Person.Person, count: 36 }]);
+
+        // The generator only populates fields with a GeneratorAnnotation and skips array fields;
+        // enrich each person (job data, distinct image, emails, variable-length notes) so cards vary
+        // in height and exercise the column-balancing layout.
+        objects
+          .filter((object): object is Person.Person => Obj.instanceOf(Person.Person, object))
+          .forEach((person, index) => {
+            Obj.update(person, (person: Obj.Mutable<Person.Person>) => {
+              person.jobTitle = random.person.jobTitle();
+              person.department = random.commerce.department();
+              person.image = `https://picsum.photos/seed/${random.string.uuid()}/256/256`;
+              const slug = (person.fullName ?? 'user')
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, '.')
+                .replace(/^\.+|\.+$/g, '');
+              person.emails = [
+                { value: `${slug}@example.com` },
+                ...(index % 3 === 0 ? [{ label: 'work', value: `${slug}@work.example.com` }] : []),
+              ];
+              if (index % 2 === 0) {
+                person.notes = random.lorem.sentences(random.number.int({ min: 1, max: 4 }));
+              }
+            });
+          });
       },
     }),
   ],
   parameters: {
     layout: 'fullscreen',
   },
-} satisfies Meta;
+} satisfies Meta<typeof DefaultStory>;
 
 export default meta;
 

--- a/packages/ui/react-ui-masonry/src/Masonry.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.tsx
@@ -5,21 +5,15 @@
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
-import { VirtuosoMasonry as NaturalVirtuosoMasonry, type VirtuosoMasonryProps } from '@virtuoso.dev/masonry';
-import React, {
-  type ComponentType,
-  type CSSProperties,
-  type JSX,
-  type PropsWithChildren,
-  type Ref,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { type ComponentType, type JSX, type PropsWithChildren, type Ref, useMemo, useRef } from 'react';
 import { useResizeDetector } from 'react-resize-detector';
 
 import { ScrollArea, ScrollAreaRootProps, ThemedClassName, usePx } from '@dxos/react-ui';
 import { composable, composableProps, scrollbar } from '@dxos/react-ui';
 import { cardMaxInlineSize, cardMinInlineSize } from '@dxos/ui-theme';
+
+import { useFlip } from './useFlip';
+import { useMasonryLayout } from './useMasonryLayout';
 
 //
 // Context
@@ -124,9 +118,10 @@ const MasonryContent = MasonryContentInner as (
 //
 // Viewport
 //
-// The inner render layer: renders the ScrollArea.Viewport wrapped around
-// VirtuosoMasonry. Style this layer separately from Content to control
-// the tile grid (e.g. inner padding, alignment).
+// The inner render layer: renders the ScrollArea.Viewport wrapped around the
+// absolute layout engine. Each tile is positioned with translate(x, y) into a
+// balanced (shortest-column-first) grid; reflow is animated with FLIP. Style
+// this layer separately from Content to control the tile grid.
 //
 
 type MasonryViewportProps<Item> = ThemedClassName<{
@@ -140,74 +135,77 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
   ({ items, getId, ...props }, forwardedRef) => {
     const { Tile, columns, maxColumns, minColumnWidth, maxColumnWidth, gutter } = useMasonryContext('Masonry.Viewport');
     const { width } = useMasonryContentContext('Masonry.Viewport');
-    const columnCount = useColumnCount(
-      width - (scrollbar.md.size + scrollbar.md.padding),
-      columns,
-      maxColumns,
-      minColumnWidth,
-      maxColumnWidth,
-      gutter,
-    );
+    const remInPx = usePx(1);
+    const contentWidth = width - (scrollbar.md.size + scrollbar.md.padding);
+    const columnCount = useColumnCount(contentWidth, columns, maxColumns, minColumnWidth, maxColumnWidth, gutter);
 
-    // Arrow-key navigation across tiles. Uses Tabster's `both` axis so all
-    // four arrows move focus through the items. True 2D (grid) axis doesn't
-    // work inside a masonry because VirtuosoMasonry lays items out column-
-    // first in the DOM — tabster's Grid direction requires the next DOM
-    // element to be to the right of the current for ArrowRight, which is
-    // never the case between columns here. `both` treats the keys as flat
-    // next/previous-focusable, which gives predictable wrap-around in DOM
-    // order for all four directions.
+    // Cap each column at `maxColumnWidth` and center the grid so it doesn't stretch
+    // to the far edge when the container is wider than the natural card width.
+    const gutterPx = gutter * remInPx;
+    const rawColumnWidth = (contentWidth - (columnCount - 1) * gutterPx) / columnCount;
+    const cappedColumnWidth = Math.min(rawColumnWidth, maxColumnWidth * remInPx);
+    const gridWidth = columnCount * cappedColumnWidth + (columnCount - 1) * gutterPx;
+
+    const ids = useMemo(() => items.map((item, index) => getId?.(item) ?? String(index)), [items, getId]);
+    const { rects, columnWidth, height, getTileRef, nodes } = useMasonryLayout({
+      ids,
+      columnCount,
+      containerWidth: gridWidth,
+      gutterPx,
+    });
+    useFlip({ nodes, ids, rects, enabled: true });
+
+    // Arrow-key navigation across tiles. Uses Tabster's `both` axis so all four
+    // arrows move focus through the items as flat next/previous-focusable, giving
+    // predictable wrap-around in DOM order.
     const arrowNavigationAttrs = useArrowNavigationGroup({
       axis: 'both',
       memorizeCurrent: true,
       tabbable: true,
     });
 
-    const TileAdapter = useMemo(() => {
-      const Adapter = ({ data, index }: { data: any; index: number }) => (
-        <div role='listitem' style={{ paddingBottom: `${gutter}rem` }}>
-          <Tile index={index} data={data} />
-        </div>
-      );
-      Adapter.displayName = 'Masonry.TileAdapter';
-      return Adapter;
-    }, [Tile, gutter]);
-
     if (width <= 0) {
       return null;
     }
 
-    // VirtuosoMasonry renders the scroller as a full-width flex row whose column children carry an
-    // inline `flexGrow: 1`. Capping each column at `maxColumnWidth` lets the columns grow to fill the
-    // row but stop at the natural card width; `justify-center` then distributes the remaining space as
-    // symmetric margins so the grid stays centered without the scroll container leaving the far edge.
     return (
       <ScrollArea.Viewport asChild>
-        <VirtuosoMasonry
+        <div
           {...composableProps(props, {
-            classNames: ['justify-center', '[&>div]:max-w-[var(--dx-masonry-column-max)]'],
-            style: { 'gap': `${gutter}rem`, '--dx-masonry-column-max': `${maxColumnWidth}rem` } as CSSProperties,
+            classNames: 'relative mx-auto',
+            style: { width: `${gridWidth}px`, height: `${height}px` },
           })}
           {...arrowNavigationAttrs}
-          ItemContent={TileAdapter}
-          columnCount={columnCount}
-          data={items as any[]}
-          // ref={forwardedRef}
-        />
+          role='list'
+          ref={forwardedRef}
+        >
+          {items.map((item, index) => {
+            const id = ids[index];
+            const rect = rects[index];
+            return (
+              <div
+                key={id}
+                ref={getTileRef(id)}
+                role='listitem'
+                style={{
+                  position: 'absolute',
+                  insetBlockStart: 0,
+                  insetInlineStart: 0,
+                  width: `${columnWidth}px`,
+                  transform: rect ? `translate(${rect.x}px, ${rect.y}px)` : undefined,
+                }}
+              >
+                <Tile index={index} data={item} />
+              </div>
+            );
+          })}
+        </div>
       </ScrollArea.Viewport>
     );
   },
 );
 
 MasonryViewportInner.displayName = 'Masonry.Viewport';
-
-/**
- * NOTE: Required in order for our Viewport to take over the scroll area.
- * https://github.com/petyosi/react-virtuoso/issues/1305
- */
-const VirtuosoMasonry = composable<HTMLDivElement, VirtuosoMasonryProps<any, any>>(({ ...props }, _forwardedRef) => {
-  return <NaturalVirtuosoMasonry {...props} />;
-});
 
 const MasonryViewport = MasonryViewportInner as <Item>(
   props: MasonryViewportProps<Item> & {

--- a/packages/ui/react-ui-masonry/src/layout.test.ts
+++ b/packages/ui/react-ui-masonry/src/layout.test.ts
@@ -1,0 +1,45 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { layout } from './layout';
+
+describe('layout', () => {
+  test('assigns each tile to the shortest column (not by index)', ({ expect }) => {
+    // With index-based placement item 2 would land in column 0; balancing puts it
+    // in column 1 because column 0 is still occupied by the tall first tile.
+    const { rects } = layout({ heights: [100, 10, 10, 10], columnCount: 2, containerWidth: 200, gutterPx: 0 });
+    expect(rects.map((rect) => rect.column)).toEqual([0, 1, 1, 1]);
+  });
+
+  test('breaks ties toward the lowest column index', ({ expect }) => {
+    const { rects } = layout({ heights: [10, 10], columnCount: 2, containerWidth: 200, gutterPx: 0 });
+    expect(rects.map((rect) => rect.column)).toEqual([0, 1]);
+  });
+
+  test('computes column width and x-offset accounting for the gutter', ({ expect }) => {
+    const { rects, columnWidth } = layout({ heights: [10, 10], columnCount: 2, containerWidth: 100, gutterPx: 10 });
+    expect(columnWidth).toBe(45); // (100 - 1 * 10) / 2
+    expect(rects[0]).toMatchObject({ x: 0, y: 0, column: 0 });
+    expect(rects[1]).toMatchObject({ x: 55, y: 0, column: 1 }); // 1 * (45 + 10)
+  });
+
+  test('stacks vertically in a single column and trims the trailing gutter', ({ expect }) => {
+    const { rects, height } = layout({ heights: [30, 20], columnCount: 1, containerWidth: 100, gutterPx: 10 });
+    expect(rects.map((rect) => rect.y)).toEqual([0, 40]); // 30 + 10 gutter
+    expect(height).toBe(60); // 30 + 10 + 20
+  });
+
+  test('handles an empty input', ({ expect }) => {
+    const { rects, height } = layout({ heights: [], columnCount: 3, containerWidth: 300, gutterPx: 8 });
+    expect(rects).toEqual([]);
+    expect(height).toBe(0);
+  });
+
+  test('clamps a non-positive column count to one', ({ expect }) => {
+    const { rects } = layout({ heights: [10, 10], columnCount: 0, containerWidth: 100, gutterPx: 0 });
+    expect(rects.map((rect) => rect.column)).toEqual([0, 0]);
+  });
+});

--- a/packages/ui/react-ui-masonry/src/layout.ts
+++ b/packages/ui/react-ui-masonry/src/layout.ts
@@ -1,0 +1,65 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export type Rect = {
+  /** Horizontal offset (px) of the tile's left edge. */
+  x: number;
+  /** Vertical offset (px) of the tile's top edge. */
+  y: number;
+  /** Column the tile was assigned to. */
+  column: number;
+};
+
+export type LayoutResult = {
+  /** Position of each tile, in input order. */
+  rects: Rect[];
+  /** Width (px) shared by every column. */
+  columnWidth: number;
+  /** Total content height (px), trailing gutter trimmed. */
+  height: number;
+};
+
+export type LayoutOptions = {
+  /** Measured tile heights (px), in item order. Unmeasured tiles pass 0. */
+  heights: readonly number[];
+  /** Number of columns to lay out across. */
+  columnCount: number;
+  /** Available content width (px), already net of any scrollbar allowance. */
+  containerWidth: number;
+  /** Space (px) between columns and between stacked tiles. */
+  gutterPx: number;
+};
+
+/**
+ * Lay tiles out into balanced columns using column-major greedy assignment: each
+ * tile is placed in the currently shortest column (ties resolve to the lowest
+ * index for stable ordering). Pure and synchronous so column balancing is unit
+ * testable without a DOM.
+ */
+export const layout = ({ heights, columnCount, containerWidth, gutterPx }: LayoutOptions): LayoutResult => {
+  const columns = Math.max(1, Math.floor(columnCount));
+  const columnWidth = (containerWidth - (columns - 1) * gutterPx) / columns;
+  const columnHeights = new Array<number>(columns).fill(0);
+
+  const rects: Rect[] = heights.map((tileHeight) => {
+    let target = 0;
+    for (let column = 1; column < columns; ++column) {
+      if (columnHeights[column] < columnHeights[target]) {
+        target = column;
+      }
+    }
+
+    const rect: Rect = {
+      x: target * (columnWidth + gutterPx),
+      y: columnHeights[target],
+      column: target,
+    };
+    columnHeights[target] += tileHeight + gutterPx;
+    return rect;
+  });
+
+  const tallest = columnHeights.reduce((max, value) => Math.max(max, value), 0);
+  const height = Math.max(0, tallest - gutterPx);
+  return { rects, columnWidth, height };
+};

--- a/packages/ui/react-ui-masonry/src/useFlip.ts
+++ b/packages/ui/react-ui-masonry/src/useFlip.ts
@@ -1,0 +1,82 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type RefObject, useLayoutEffect, useRef } from 'react';
+
+import { type Rect } from './layout';
+
+const DURATION = 200;
+const EASING = 'cubic-bezier(0.2, 0, 0, 1)';
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+export type UseFlipOptions = {
+  /** Tile wrappers by id, kept live by the layout hook. */
+  nodes: RefObject<Map<string, HTMLElement>>;
+  /** Item ids in render order (aligned with `rects`). */
+  ids: readonly string[];
+  /** Target positions (aligned with `ids`). */
+  rects: readonly Rect[];
+  /** Disable to snap without animating (also skipped under reduced-motion). */
+  enabled: boolean;
+};
+
+/**
+ * Animates tile position changes with FLIP: tiles that moved between layouts
+ * transition from their previous translate to the new one via the Web Animations
+ * API; freshly-added tiles fade/scale in. Respects `prefers-reduced-motion`.
+ */
+export const useFlip = ({ nodes, ids, rects, enabled }: UseFlipOptions): void => {
+  const previous = useRef(new Map<string, { x: number; y: number }>());
+
+  useLayoutEffect(() => {
+    const animate = enabled && !prefersReducedMotion();
+    const seen = new Set<string>();
+
+    ids.forEach((id, index) => {
+      const rect = rects[index];
+      const element = nodes.current.get(id);
+      if (!rect || !element) {
+        return;
+      }
+      seen.add(id);
+
+      const prior = previous.current.get(id);
+      previous.current.set(id, { x: rect.x, y: rect.y });
+
+      // Style already holds the target translate; snapping needs no animation.
+      if (!animate) {
+        return;
+      }
+
+      if (prior) {
+        if (prior.x !== rect.x || prior.y !== rect.y) {
+          element.animate(
+            [
+              { transform: `translate(${prior.x}px, ${prior.y}px)` },
+              { transform: `translate(${rect.x}px, ${rect.y}px)` },
+            ],
+            { duration: DURATION, easing: EASING },
+          );
+        }
+      } else {
+        element.animate(
+          [
+            { opacity: 0, transform: `translate(${rect.x}px, ${rect.y}px) scale(0.98)` },
+            { opacity: 1, transform: `translate(${rect.x}px, ${rect.y}px) scale(1)` },
+          ],
+          { duration: DURATION, easing: EASING },
+        );
+      }
+    });
+
+    // Forget positions for tiles no longer rendered.
+    for (const id of previous.current.keys()) {
+      if (!seen.has(id)) {
+        previous.current.delete(id);
+      }
+    }
+  }, [nodes, ids, rects, enabled]);
+};

--- a/packages/ui/react-ui-masonry/src/useMasonryLayout.ts
+++ b/packages/ui/react-ui-masonry/src/useMasonryLayout.ts
@@ -1,0 +1,124 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { type LayoutResult, layout } from './layout';
+
+/** Sub-pixel changes below this threshold (px) don't trigger a re-layout. */
+const HEIGHT_EPSILON = 0.5;
+
+export type MasonryLayout = LayoutResult & {
+  /** Stable ref callback for the tile wrapper of `id` (measures + registers it). */
+  getTileRef: (id: string) => (element: HTMLElement | null) => void;
+  /** Live map of currently-mounted tile wrappers by id (for FLIP positioning). */
+  nodes: RefObject<Map<string, HTMLElement>>;
+};
+
+export type UseMasonryLayoutOptions = {
+  /** Ids of the items to lay out, in render order. */
+  ids: readonly string[];
+  columnCount: number;
+  /** Available content width (px), net of scrollbar allowance. */
+  containerWidth: number;
+  gutterPx: number;
+};
+
+/**
+ * Measures tile heights via a shared ResizeObserver and computes balanced column
+ * positions. Heights are keyed by item id so reorders and removals reuse prior
+ * measurements; a version counter re-runs the pure layout when a height changes.
+ */
+export const useMasonryLayout = ({
+  ids,
+  columnCount,
+  containerWidth,
+  gutterPx,
+}: UseMasonryLayoutOptions): MasonryLayout => {
+  const heights = useRef(new Map<string, number>());
+  const nodes = useRef(new Map<string, HTMLElement>());
+  const elementIds = useRef(new WeakMap<Element, string>());
+  const refCallbacks = useRef(new Map<string, (element: HTMLElement | null) => void>());
+  const [version, setVersion] = useState(0);
+
+  const observer = useMemo(() => {
+    if (typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+
+    return new ResizeObserver((entries) => {
+      let changed = false;
+      for (const entry of entries) {
+        const id = elementIds.current.get(entry.target);
+        if (!id) {
+          continue;
+        }
+        // ResizeObserver types `target` as Element; we only ever observe HTMLElement tile wrappers,
+        // whose border-box height (offsetHeight) is what the layout stacks.
+        const height = (entry.target as HTMLElement).offsetHeight;
+        const previous = heights.current.get(id);
+        if (previous === undefined || Math.abs(previous - height) > HEIGHT_EPSILON) {
+          heights.current.set(id, height);
+          changed = true;
+        }
+      }
+      if (changed) {
+        setVersion((value) => value + 1);
+      }
+    });
+  }, []);
+
+  useEffect(() => () => observer?.disconnect(), [observer]);
+
+  const getTileRef = useCallback(
+    (id: string) => {
+      let callback = refCallbacks.current.get(id);
+      if (!callback) {
+        callback = (element: HTMLElement | null) => {
+          const previous = nodes.current.get(id);
+          if (previous === element) {
+            return;
+          }
+          if (previous) {
+            observer?.unobserve(previous);
+            elementIds.current.delete(previous);
+          }
+          if (element) {
+            nodes.current.set(id, element);
+            elementIds.current.set(element, id);
+            observer?.observe(element);
+          } else {
+            nodes.current.delete(id);
+          }
+        };
+        refCallbacks.current.set(id, callback);
+      }
+      return callback;
+    },
+    [observer],
+  );
+
+  const result = useMemo(() => {
+    // Prune measurements/callbacks for ids no longer present so the maps track the
+    // live item set.
+    const present = new Set(ids);
+    for (const id of heights.current.keys()) {
+      if (!present.has(id)) {
+        heights.current.delete(id);
+      }
+    }
+    for (const id of refCallbacks.current.keys()) {
+      if (!present.has(id)) {
+        refCallbacks.current.delete(id);
+      }
+    }
+
+    const tileHeights = ids.map((id) => heights.current.get(id) ?? 0);
+    return layout({ heights: tileHeights, columnCount, containerWidth, gutterPx });
+    // `version` re-runs layout when a measured height changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ids, columnCount, containerWidth, gutterPx, version]);
+
+  return { ...result, getTileRef, nodes };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -819,9 +819,6 @@ catalogs:
     '@valtown/codemirror-ts':
       specifier: ^2.3.1
       version: 2.3.1
-    '@virtuoso.dev/masonry':
-      specifier: ^1.4.2
-      version: 1.4.3
     '@vitejs/plugin-react':
       specifier: ^6.0.2
       version: 6.0.2
@@ -21895,9 +21892,6 @@ importers:
       '@radix-ui/react-context':
         specifier: 'catalog:'
         version: 1.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@virtuoso.dev/masonry':
-        specifier: 'catalog:'
-        version: 1.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-resize-detector:
         specifier: 'catalog:'
         version: 11.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -32650,18 +32644,6 @@ packages:
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
-
-  '@virtuoso.dev/gurx@1.2.3':
-    resolution: {integrity: sha512-zqIzVOQgJGEbrG+hvNiNHdrtM2G/9zBVgBSRUAW2yT8iUOouSHAsPIxpCU/xsAYEwicXURGhU6cxzgBPVjXL+g==}
-    peerDependencies:
-      react: ~19.2.7
-      react-dom: ~19.2.7
-
-  '@virtuoso.dev/masonry@1.4.3':
-    resolution: {integrity: sha512-3LxsW2TxlWn061NWZFSi8FhLVK0bwNfGZNPMMsKBg5uxhgVUo8j7XaEuOMgY9UO/EuIFMijAyHDc3DO3A5+KCA==}
-    peerDependencies:
-      react: ~19.2.7
-      react-dom: ~19.2.7
 
   '@vitejs/plugin-react-swc@4.3.1':
     resolution: {integrity: sha512-PaeokKjAGraNN+s5SIApgsktnJprIyt3zgEIu7awnEdfn29QiB2crTcCzyi2XGpX9rUnTc0cKU07Wm0N0g7H2w==}
@@ -55446,17 +55428,6 @@ snapshots:
       '@codemirror/view': 6.43.4
 
   '@vercel/oidc@3.1.0': {}
-
-  '@virtuoso.dev/gurx@1.2.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
-  '@virtuoso.dev/masonry@1.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@virtuoso.dev/gurx': 1.2.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@vitejs/plugin-react-swc@4.3.1(@swc/helpers@0.5.17)(vite@8.0.16(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -313,7 +313,6 @@ catalog:
   '@uiw/codemirror-theme-vscode': ^4.25.2
   '@valtown/codemirror-continue': ^2.3.1
   '@valtown/codemirror-ts': ^2.3.1
-  '@virtuoso.dev/masonry': ^1.4.2
   '@vitejs/plugin-react': ^6.0.2
   '@vitejs/plugin-react-swc': ^4.3.1
   '@vitest/browser': ^4.1.8


### PR DESCRIPTION
## What

Replaces the `@virtuoso.dev/masonry` dependency in `@dxos/react-ui-masonry` with a
self-contained layout engine. The public `Masonry.Root / Masonry.Content /
Masonry.Viewport` API is unchanged — a strict drop-in, so all 12 consumers compile
and render unmodified.

## Why

`VirtuosoMasonry` assigns items to columns **by index** (`item i → column i %
columnCount`), so a tall item leaves its column tall and short items never backfill
— columns visibly fail to balance. It also required a scroll-container takeover
workaround (`react-virtuoso#1305`) and forced a Tabster `axis: 'both'` navigation
compromise because it lays tiles out column-first in the DOM.

## How

- **`layout.ts`** — a pure, synchronous `layout({ heights, columnCount,
  containerWidth, gutterPx })` that places each tile in the currently **shortest**
  column (ties → lowest index). Fully unit-tested without a DOM.
- **`useMasonryLayout.ts`** — measures tile heights with a single shared
  `ResizeObserver` keyed by item id (reorders/removals reuse prior measurements),
  and re-runs `layout()` when a height changes past an epsilon.
- **`useFlip.ts`** — animates position changes with FLIP via the Web Animations
  API; new tiles fade/scale in. Respects `prefers-reduced-motion`.
- **`Masonry.tsx`** — `Viewport` now renders absolutely-positioned tiles
  (`translate(x, y)`) into a centered, max-width-capped grid. `Root`, `Content`,
  and `useColumnCount` (container width → column count) are unchanged.
- Removes `@virtuoso.dev/masonry` from the package and the pnpm catalog.

Design spec: `docs/superpowers/specs/2026-07-04-masonry-layout-engine-design.md`.

## Non-goals

- **Virtualization.** Phase 1 renders all items; the pure `layout()` seam allows a
  later windowing layer without touching the API. Acceptable for current consumer
  sizes (tens–low hundreds).
- No mobile-specific behavior; responsive column count already flows from width.

## Verification

- `react-ui-masonry:build`, `:lint` (0/0), `:test` (6 new pure layout cases:
  shortest-column assignment, tie-breaking, gutter geometry, single-column stack,
  empty input, column clamp) — green.
- All 12 consumers build unchanged (`plugin-masonry`, `plugin-space`,
  `plugin-crm`, `plugin-gallery`, `plugin-magazine`, `plugin-assistant`,
  `plugin-commerce`, stories-assistant, …).
- Manually verified in Storybook (`ui/react-ui-masonry/Masonry`): 36 person cards
  of varied height laid out into **4 evenly balanced columns** (9 per column),
  correct column width/centering, content height driving scroll — the ragged
  tall-column artifact is gone.
- Stories use the `@dxos/schema/testing` + `@dxos/random` Person generator with
  local enrichment (job/department/image/emails/notes) for varied card heights;
  no shared-schema generator annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refreshed the masonry experience with shortest-column-first placement and responsive tile reflow.
  * Added FLIP-style reflow animations for smoother transitions, with reduced-motion support that skips animations.
  * Updated the masonry demo to use person-based cards with richer, varied content.
* **Bug Fixes**
  * Improved handling of empty input, narrow/invalid widths, and unmeasured or zero-size tiles.
* **Tests**
  * Added unit coverage for column balancing and spacing/height calculations to prevent regressions.
* **Documentation**
  * Added a new design specification describing the masonry layout engine behavior and rollout risks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->