### PR TITLE
fix(assistant): restore space-level MCP server wiring to agent sessions

### DIFF
--- a/packages/core/compute/functions-runtime/src/agent-service/AgentService.test.ts
+++ b/packages/core/compute/functions-runtime/src/agent-service/AgentService.test.ts
@@ -21,7 +21,7 @@ import { getSession, hydrate } from '@dxos/compute/AgentService';
 import { Annotation, Feed, Filter, Obj, Ref } from '@dxos/echo';
 import { TestHelpers } from '@dxos/effect/testing';
 import { AssistantTestLayer } from '@dxos/functions-runtime/testing';
-import { DXN, EntityId } from '@dxos/keys';
+import { DXN, EID, EntityId, type SpaceId } from '@dxos/keys';
 import { Message, Organization } from '@dxos/types';
 
 import { ProcessManager } from '../index';
@@ -142,6 +142,26 @@ const StubDelegationStrategy: DelegationStrategy = {
 const DelegationTestLayer = AssistantTestLayer({
   ...assistantTestLayerOptions,
   agent: { delegationStrategy: StubDelegationStrategy },
+});
+
+//
+// Space MCP resolver fixtures.
+//
+
+/**
+ * Records the spaces the agent's MCP resolver is consulted for, proving the request seam invokes the
+ * space-scoped provider. Returns no servers — the wiring, not a live MCP connection, is under test.
+ */
+const mcpResolverHarness: { spaceIds: SpaceId[] } = { spaceIds: [] };
+
+const McpResolverTestLayer = AssistantTestLayer({
+  ...assistantTestLayerOptions,
+  agent: {
+    getMcpServers: (spaceId) => {
+      mcpResolverHarness.spaceIds.push(spaceId);
+      return Promise.resolve([]);
+    },
+  },
 });
 
 describe('Agent Service', () => {
@@ -519,5 +539,35 @@ describe('Agent Service', () => {
       Effect.provide(TestLayer()),
       TestHelpers.provideTestContext,
     ),
+  );
+
+  // Guards the regression from #11054: a refactor dropped the wiring that fed space-level MCP servers
+  // to agent sessions (the app-wide AgentService layer stopped providing `getMcpServers`), so servers
+  // configured via the chat MCP panel reached nothing. The request seam must consult the space-scoped
+  // resolver on each turn. The resolver is invoked before the model call, so a memoization miss would
+  // still fail elsewhere — the assertion below proves the wiring, not a live MCP connection.
+  // Placed last so the extra turn does not perturb the shared deterministic ID stream above.
+  // Reuses the existing memoized single-turn "capital of France" fixture, so no regeneration is
+  // needed; if this prompt changes, regenerate fixtures via the `regenerate-memoized-llm` skill.
+  it.effect(
+    'consults the space-scoped MCP server resolver on each turn',
+    Effect.fnUntraced(
+      function* (_) {
+        mcpResolverHarness.spaceIds = [];
+        const agent = yield* AgentService.createSession();
+
+        const parsed = EID.tryParse(Obj.getURI(agent.feed));
+        const expectedSpaceId = parsed ? EID.getSpaceId(parsed) : undefined;
+
+        yield* agent.submitPrompt('What is the capital of France? Reply with just the city name.');
+        yield* agent.waitForCompletion();
+
+        expect(expectedSpaceId).toBeDefined();
+        expect(mcpResolverHarness.spaceIds).toContain(expectedSpaceId);
+      },
+      Effect.provide(McpResolverTestLayer),
+      TestHelpers.provideTestContext,
+    ),
+    { timeout: MemoizedAiService.isGenerationEnabled() ? 60_000 : undefined },
   );
 });

--- a/packages/core/compute/functions-runtime/src/agent-service/AgentService.ts
+++ b/packages/core/compute/functions-runtime/src/agent-service/AgentService.ts
@@ -20,7 +20,7 @@ import {
 } from '@dxos/compute/AgentService';
 import { Annotation, Database, Feed, Obj, Ref, Registry } from '@dxos/echo';
 import { EffectEx } from '@dxos/effect';
-import { DXN, EID } from '@dxos/keys';
+import { DXN, EID, type SpaceId } from '@dxos/keys';
 import { log } from '@dxos/log';
 
 import { AGENT_PROCESS_KEY, AgentProcess } from './agent-process';
@@ -79,9 +79,11 @@ export interface AgentServiceOptions {
   provider?: DXN.DXN;
 
   /**
-   * Provider for space-level MCP server configs.
+   * Resolves the space-level MCP server configs for a given space. Invoked per request so that
+   * MCP servers added or toggled at runtime take effect without respawning the agent process.
+   * Space-scoped because a single application-wide service serves sessions across many spaces.
    */
-  getMcpServers?: () => McpServer.McpServer[];
+  getMcpServers?: (spaceId: SpaceId) => Promise<McpServer.McpServer[]>;
 
   /**
    * If true, long-running tool calls are moved to the background and the agent is notified
@@ -111,12 +113,13 @@ export const layer = (opts?: AgentServiceOptions): Layer.Layer<AgentService, nev
         { model: DXN.DXN | undefined; provider: DXN.DXN | undefined; handle: AgentHandle; session: Session }
       >();
 
-      const makeExecutable = (model?: DXN.DXN, provider?: DXN.DXN) =>
+      const makeExecutable = (model?: DXN.DXN, provider?: DXN.DXN, spaceId?: SpaceId) =>
         AgentProcess({
           systemPrompt: opts?.systemPrompt,
           model: model ?? opts?.model,
           provider: provider ?? opts?.provider,
-          getMcpServers: opts?.getMcpServers,
+          // Bind the session's space so the process can resolve that space's MCP servers at request time.
+          getMcpServers: spaceId !== undefined && opts?.getMcpServers ? () => opts.getMcpServers!(spaceId) : undefined,
           enableToolBackgrounding: opts?.enableToolBackgrounding,
           delegationStrategy: opts?.delegationStrategy,
         });
@@ -125,10 +128,12 @@ export const layer = (opts?: AgentServiceOptions): Layer.Layer<AgentService, nev
         // Handles cached before shutdown are suspended and no longer registered with the manager.
         sessionCache.clear();
 
-        const executable = makeExecutable();
         const agents = yield* processManager.list({ key: AGENT_PROCESS_KEY });
         log('agent hydrate', { count: agents.length });
         for (const agent of agents) {
+          // Rebind each restored agent to its own space (persisted on the handle's environment) so its
+          // MCP servers resolve after restart; getSession cannot rescope an already-live handle.
+          const executable = makeExecutable(undefined, undefined, agent.environment.space);
           yield* agent
             .hydrate(executable)
             .pipe(
@@ -166,7 +171,7 @@ export const layer = (opts?: AgentServiceOptions): Layer.Layer<AgentService, nev
             const target = Obj.getURI(feed);
             const parsedEchoUri = EID.tryParse(target);
             const spaceId = parsedEchoUri ? EID.getSpaceId(parsedEchoUri) : undefined;
-            const executable = makeExecutable(model, provider);
+            const executable = makeExecutable(model, provider, spaceId);
 
             // Reuse a still-running process for this feed only when there was no cached session
             // (e.g. after the UI remounted). After a model change we always spawn a fresh process,

--- a/packages/core/compute/functions-runtime/src/agent-service/agent-process.ts
+++ b/packages/core/compute/functions-runtime/src/agent-service/agent-process.ts
@@ -46,9 +46,10 @@ interface AgentProcessOptions {
   provider?: DXN.DXN;
 
   /**
-   * Provider for space-level MCP server configs, called on each turn.
+   * Resolves the space-level MCP server configs for this agent's space, called on each turn so
+   * that servers added or toggled at runtime take effect without respawning the process.
    */
-  getMcpServers?: () => McpServer.McpServer[];
+  getMcpServers?: () => Promise<McpServer.McpServer[]>;
 
   /**
    * If true, long-running tool calls are moved to the background after `backgroundThreshold`
@@ -264,6 +265,15 @@ export const AgentProcess = (options: AgentProcessOptions) =>
               log('begin request', { prompt });
               log('trace agent request begin');
               yield* Trace.write(AgentRequestBegin, {});
+              // Never let MCP resolution fail the turn: a rejected resolver falls back to no servers.
+              const mcpServers = options.getMcpServers
+                ? yield* Effect.tryPromise(() => options.getMcpServers!()).pipe(
+                    Effect.tapError((error) =>
+                      Effect.sync(() => log.warn('failed to resolve space MCP servers; continuing without', { error })),
+                    ),
+                    Effect.orElseSucceed(() => undefined),
+                  )
+                : undefined;
               yield* session
                 .createRequest({
                   prompt,
@@ -272,7 +282,7 @@ export const AgentProcess = (options: AgentProcessOptions) =>
                   // The alarm tools (set-alarm/get-current-date) now arrive as a bound blueprint whose
                   // operations reach this host's AlarmManager over HarnessService Tier B.
                   system: options.systemPrompt,
-                  mcpServers: options.getMcpServers?.(),
+                  mcpServers,
                 })
                 .pipe(
                   Effect.onExit((exit) =>

--- a/packages/plugins/plugin-assistant/src/capabilities/agent-service.ts
+++ b/packages/plugins/plugin-assistant/src/capabilities/agent-service.ts
@@ -6,10 +6,20 @@ import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
+import { McpServer } from '@dxos/assistant-toolkit';
+import { asyncTimeout } from '@dxos/async';
 import { AgentService, LayerSpec } from '@dxos/compute';
 import { ProcessManager } from '@dxos/compute-runtime';
+import { Filter } from '@dxos/echo';
 import { AgentService as AgentServiceRuntime } from '@dxos/functions-runtime';
+import { ClientCapabilities } from '@dxos/plugin-client';
 import { RoutineCapabilities } from '@dxos/plugin-routine';
+
+/**
+ * Upper bound on waiting for a space to become ready while resolving its MCP servers. The resolver
+ * runs on every agent turn, so it must not block indefinitely on a space that never readies.
+ */
+const MCP_RESOLVER_READY_TIMEOUT = 10_000;
 
 //
 // Capability Module
@@ -28,8 +38,28 @@ const AgentServiceSpec = LayerSpec.make(
       Effect.gen(function* () {
         // Optional supervisor behaviour, contributed by a plugin that knows the agent/plan model.
         const strategies = yield* Capability.getAll(RoutineCapabilities.AgentDelegationStrategy);
+        const client = yield* Capability.get(ClientCapabilities.Client).pipe(Effect.orDie);
         return AgentServiceRuntime.layer({
           delegationStrategy: strategies[0],
+          // Expose each space's runtime-configured MCP servers (added via the chat MCP panel) to that
+          // space's agent sessions. Resolved per request so servers added or toggled take effect live.
+          // Space-scoped because this single application-wide service serves sessions across all spaces.
+          getMcpServers: async (spaceId) => {
+            const space = client.spaces.get(spaceId);
+            if (!space) {
+              return [];
+            }
+            // Skip MCP for this turn if the space does not ready in time rather than stalling the turn.
+            try {
+              await asyncTimeout(space.waitUntilReady(), MCP_RESOLVER_READY_TIMEOUT);
+            } catch {
+              return [];
+            }
+            const servers = await space.db.query(Filter.type(McpServer.McpServer)).run();
+            return servers
+              .filter((server) => server.enabled !== false)
+              .map(({ url, protocol, apiKey }) => ({ url, protocol, apiKey }));
+          },
         });
       }),
     ),


### PR DESCRIPTION
## Summary

Space-level MCP server configs — `McpServer` ECHO objects added via the chat MCP panel — stopped reaching agent sessions, so a configured MCP server connected to nothing.

**Root cause.** The consumption wiring (a `getMcpServers` callback querying the space's enabled `McpServer` objects) originally lived in `plugin-automation`'s compute-runtime capability (#11044). The ProcessManager refactor (#11054) deleted that file, and the successor application-wide `AgentService` layer never re-provided the callback. The MCP panel and `McpServer` type survived; the wire that consumed them did not.

## Fix

Reconnect the wiring, now parameterized by `spaceId` — a single application-wide `AgentService` serves sessions across all spaces (unlike the original per-space layers), so the resolver must know which space a session belongs to:

- **`functions-runtime/agent-service/AgentService.ts`** — `getMcpServers` becomes `(spaceId) => Promise<McpServer[]>`; `getSession` binds the session's space (already derived from the feed URI) into the spawned process.
- **`functions-runtime/agent-service/agent-process.ts`** — resolves the space's MCP servers per request, so servers added or toggled at runtime take effect without respawning the process.
- **`plugin-assistant/capabilities/agent-service.ts`** — provides the resolver: looks up the space by id and returns its enabled `McpServer` configs. This is the layer permitted to depend on `assistant-toolkit`'s `McpServer` ECHO type, which keeps the dependency direction correct (the reason the resolver can't live down in `functions-runtime`).

Covers both interactive chat and the scheduled `AgentWorker`, since both spawn agent processes.

## Test

`AgentService.test.ts` gains a regression test that runs a turn with a spy resolver and asserts it is invoked with the session's `spaceId` — which never happened before this fix. It reuses an existing memoized conversation fixture, so it runs green without regeneration.

## Verification

- Full workspace build passes.
- `moon run :lint -- --fix`: 0 errors / 0 warnings, no files changed.
- `functions-runtime` agent-service suite passes (incl. the new test).
- No new type casts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent sessions now resolve MCP server settings per space, allowing different spaces to use different configured servers.
  * MCP server discovery is performed at request time and includes enabled-server filtering.

* **Bug Fixes**
  * Agent requests now re-resolve MCP servers on each turn for consistent behavior when switching spaces.
  * Restored sessions now retain space context so MCP resolution works after restart.
  * If a space isn’t ready or unavailable, the agent continues safely without MCP servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->