### PR TITLE
fix(react-ui-masonry): remove horizontal scrollbar, symmetric padding, gap consistency

### DIFF
--- a/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
@@ -54,7 +54,7 @@ const DefaultStory = (props: MasonryRootProps) => {
 
   return (
     <Masonry.Root {...props} Tile={StoryItem}>
-      <Masonry.Content centered>
+      <Masonry.Content thin={true}>
         <Masonry.Viewport items={people} getId={(person) => person.id} />
       </Masonry.Content>
     </Masonry.Root>

--- a/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
@@ -54,7 +54,7 @@ const DefaultStory = (props: MasonryRootProps) => {
 
   return (
     <Masonry.Root {...props} Tile={StoryItem}>
-      <Masonry.Content thin={false}>
+      <Masonry.Content>
         <Masonry.Viewport items={people} getId={(person) => person.id} />
       </Masonry.Content>
     </Masonry.Root>

--- a/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
@@ -54,7 +54,7 @@ const DefaultStory = (props: MasonryRootProps) => {
 
   return (
     <Masonry.Root {...props} Tile={StoryItem}>
-      <Masonry.Content thin={true}>
+      <Masonry.Content thin={false}>
         <Masonry.Viewport items={people} getId={(person) => person.id} />
       </Masonry.Content>
     </Masonry.Root>

--- a/packages/ui/react-ui-masonry/src/Masonry.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.tsx
@@ -190,6 +190,10 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
               return (
                 <div
                   key={id}
+                  // Let the tile clamp its card: a card's own min-width must not exceed
+                  // the column, or a narrow (single-column, mobile) container overflows
+                  // and shows a horizontal scrollbar.
+                  className='[&>*]:min-w-0!'
                   ref={getTileRef(id)}
                   role='listitem'
                   style={{

--- a/packages/ui/react-ui-masonry/src/Masonry.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.tsx
@@ -30,8 +30,8 @@ type MasonryContextValue = {
   minColumnWidth: number;
   /** Maximum column width in rem. */
   maxColumnWidth: number;
-  /** Space between columns and rows in rem. */
-  gutter: number;
+  /** Space applied uniformly between tiles and around the grid perimeter, in rem. */
+  gap: number;
 };
 
 const MASONRY_NAME = 'Masonry';
@@ -58,7 +58,7 @@ const MasonryRoot = ({
   maxColumns = undefined,
   minColumnWidth = cardMinInlineSize,
   maxColumnWidth = cardMaxInlineSize,
-  gutter = 0.75,
+  gap = 0.75,
 }: MasonryRootProps) => (
   <MasonryProvider
     Tile={Tile!}
@@ -66,7 +66,7 @@ const MasonryRoot = ({
     maxColumns={maxColumns}
     minColumnWidth={minColumnWidth}
     maxColumnWidth={maxColumnWidth}
-    gutter={gutter}
+    gap={gap}
   >
     {children}
   </MasonryProvider>
@@ -87,14 +87,14 @@ type MasonryContentProps = ThemedClassName<
 >;
 
 const MasonryContentInner = composable<HTMLDivElement, MasonryContentProps>(
-  ({ children, scrollbars, centered, thin = true, padding = true, ...props }, forwardedRef) => {
+  ({ children, scrollbars, centered = true, thin = true, padding = true, ...props }, forwardedRef) => {
     const rootRef = useRef<HTMLDivElement | null>(null);
     const composedRef = useComposedRefs(rootRef, forwardedRef);
     const { width = 0 } = useResizeDetector({ targetRef: rootRef });
 
     return (
       <ScrollArea.Root
-        {...composableProps(props, { classNames: 'pt-trim-md' })}
+        {...composableProps(props)}
         scrollbars={scrollbars}
         centered={centered}
         thin={thin}
@@ -133,25 +133,31 @@ type MasonryViewportProps<Item> = ThemedClassName<{
 
 const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any>>(
   ({ items, getId, ...props }, forwardedRef) => {
-    const { Tile, columns, maxColumns, minColumnWidth, maxColumnWidth, gutter } = useMasonryContext('Masonry.Viewport');
+    const { Tile, columns, maxColumns, minColumnWidth, maxColumnWidth, gap } = useMasonryContext('Masonry.Viewport');
     const { width } = useMasonryContentContext('Masonry.Viewport');
     const remInPx = usePx(1);
-    const contentWidth = width - (scrollbar.md.size + scrollbar.md.padding);
-    const columnCount = useColumnCount(contentWidth, columns, maxColumns, minColumnWidth, maxColumnWidth, gutter);
+    // The ScrollArea.Viewport is centered+padded, so it reserves a symmetric gutter of
+    // (scroll-width + scroll-padding) on each side (the inline-end side splitting into
+    // padding + the scrollbar itself). Subtract both gutters to get the width available
+    // to the centered grid.
+    const contentWidth = width - 2 * (scrollbar.md.size + scrollbar.md.padding);
+    const columnCount = useColumnCount(contentWidth, columns, maxColumns, minColumnWidth, maxColumnWidth, gap);
 
     // Cap each column at `maxColumnWidth` and center the grid so it doesn't stretch
-    // to the far edge when the container is wider than the natural card width.
-    const gutterPx = gutter * remInPx;
-    const rawColumnWidth = (contentWidth - (columnCount - 1) * gutterPx) / columnCount;
+    // to the far edge when the container is wider than the natural card width. The
+    // gap surrounds every column, so `columnCount` columns consume `columnCount + 1`
+    // gaps across the grid width.
+    const gapPx = gap * remInPx;
+    const rawColumnWidth = (contentWidth - (columnCount + 1) * gapPx) / columnCount;
     const cappedColumnWidth = Math.min(rawColumnWidth, maxColumnWidth * remInPx);
-    const gridWidth = columnCount * cappedColumnWidth + (columnCount - 1) * gutterPx;
+    const gridWidth = columnCount * cappedColumnWidth + (columnCount + 1) * gapPx;
 
     const ids = useMemo(() => items.map((item, index) => getId?.(item) ?? String(index)), [items, getId]);
     const { rects, columnWidth, height, getTileRef, nodes } = useMasonryLayout({
       ids,
       columnCount,
       containerWidth: gridWidth,
-      gutterPx,
+      gapPx,
     });
     useFlip({ nodes, ids, rects, enabled: true });
 
@@ -168,8 +174,12 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
       return null;
     }
 
+    // The viewport is the full-width scroll container; its centered+padded theme
+    // balances the scrollbar into symmetric inline gutters. The capped-width grid is
+    // an ordinary block child centered with `mx-auto`, so its left/right margins match
+    // and the scrollbar never eats into the tile area.
     return (
-      <ScrollArea.Viewport asChild>
+      <ScrollArea.Viewport>
         <div
           {...composableProps(props, {
             classNames: 'relative mx-auto',
@@ -220,7 +230,7 @@ const useColumnCount = (
   maxColumns: number | undefined,
   minColumnWidth: number,
   maxColumnWidth: number,
-  gutter: number,
+  gap: number,
 ) => {
   const remInPx = usePx(1);
   return useMemo(() => {
@@ -230,20 +240,20 @@ const useColumnCount = (
 
     const minColumnWidthPx = minColumnWidth * remInPx;
     const maxColumnWidthPx = maxColumnWidth * remInPx;
-    const gutterPx = gutter * remInPx;
+    const gapPx = gap * remInPx;
     if (width <= 0 || minColumnWidthPx <= 0) {
       return 1;
     }
 
-    // Each tile has paddingRight: gutter, so every slot (including the last) occupies
-    // (colWidth + gutterPx). The container therefore fits floor(containerWidth / (colWidth + gutterPx)) columns.
-    let cols = Math.floor(width / (minColumnWidthPx + gutterPx));
+    // The gap surrounds every column (outer edges plus interior splits), so N columns
+    // fit when N * colWidth + (N + 1) * gap <= width, i.e. N <= (width - gap) / (colWidth + gap).
+    let cols = Math.max(1, Math.floor((width - gapPx) / (minColumnWidthPx + gapPx)));
     if (maxColumnWidthPx > 0) {
-      const effectiveColWidth = width / cols - gutterPx;
+      const effectiveColWidth = (width - (cols + 1) * gapPx) / cols;
       if (effectiveColWidth > maxColumnWidthPx) {
         // Try to add columns to keep cards below maxColumnWidth, but never violate minColumnWidth.
-        const maxCols = Math.ceil(width / (maxColumnWidthPx + gutterPx));
-        if (width / maxCols - gutterPx >= minColumnWidthPx) {
+        const maxCols = Math.ceil((width - gapPx) / (maxColumnWidthPx + gapPx));
+        if ((width - (maxCols + 1) * gapPx) / maxCols >= minColumnWidthPx) {
           cols = maxCols;
         }
       }
@@ -251,7 +261,7 @@ const useColumnCount = (
 
     const clamped = maxColumns != null ? Math.min(cols, maxColumns) : cols;
     return Math.max(1, clamped);
-  }, [remInPx, width, columns, maxColumns, minColumnWidth, maxColumnWidth, gutter]);
+  }, [remInPx, width, columns, maxColumns, minColumnWidth, maxColumnWidth, gap]);
 };
 
 //

--- a/packages/ui/react-ui-masonry/src/Masonry.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.tsx
@@ -4,7 +4,15 @@
 
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { createContext } from '@radix-ui/react-context';
-import React, { type ComponentType, type JSX, type PropsWithChildren, type Ref, useMemo, useRef } from 'react';
+import React, {
+  type ComponentType,
+  type CSSProperties,
+  type JSX,
+  type PropsWithChildren,
+  type Ref,
+  useMemo,
+  useRef,
+} from 'react';
 import { useResizeDetector } from 'react-resize-detector';
 
 import { ScrollArea, ScrollAreaRootProps, ThemedClassName, usePx } from '@dxos/react-ui';
@@ -80,18 +88,26 @@ type MasonryContentProps = ThemedClassName<
 >;
 
 const MasonryContentInner = composable<HTMLDivElement, MasonryContentProps>(
-  ({ children, scrollbars, centered = true, thin = true, padding = true, ...props }, forwardedRef) => (
-    <ScrollArea.Root
-      {...composableProps(props)}
-      scrollbars={scrollbars}
-      centered={centered}
-      thin={thin}
-      padding={padding}
-      ref={forwardedRef}
-    >
-      {children}
-    </ScrollArea.Root>
-  ),
+  ({ children, scrollbars, centered = true, thin = true, padding = true, ...props }, forwardedRef) => {
+    const { gap } = useMasonryContext('Masonry.Content');
+    return (
+      <ScrollArea.Root
+        // Drive the ScrollArea gutter to the grid gap so the left/right perimeter
+        // matches the inter-column gap: the centered+padding theme resolves this to
+        // pl = gap and pr = gap - scrollbar, keeping both sides symmetric with the
+        // scrollbar accounted for at any density. Cast: CSSProperties has no index
+        // signature for CSS custom properties, so `--gutter` cannot be typed directly.
+        {...composableProps(props, { style: { '--gutter': `${gap}rem` } as CSSProperties })}
+        scrollbars={scrollbars}
+        centered={centered}
+        thin={thin}
+        padding={padding}
+        ref={forwardedRef}
+      >
+        {children}
+      </ScrollArea.Root>
+    );
+  },
 );
 
 MasonryContentInner.displayName = 'Masonry.Content';
@@ -130,20 +146,14 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
     const { width: contentWidth = 0 } = useResizeDetector({ targetRef: viewportRef });
     const columnCount = useColumnCount(contentWidth, columns, maxColumns, minColumnWidth, maxColumnWidth, gap);
 
-    // Cap each column at `maxColumnWidth` and center the grid so it doesn't stretch
-    // to the far edge when the container is wider than the natural card width. The
-    // gap surrounds every column, so `columnCount` columns consume `columnCount + 1`
-    // gaps across the grid width.
+    // The grid fills the measured content box; columns stretch to fill (column count
+    // already honours `maxColumnWidth`), so no scrollbar/padding math is duplicated here.
     const gapPx = gap * remInPx;
-    const rawColumnWidth = (contentWidth - (columnCount + 1) * gapPx) / columnCount;
-    const cappedColumnWidth = Math.min(rawColumnWidth, maxColumnWidth * remInPx);
-    const gridWidth = columnCount * cappedColumnWidth + (columnCount + 1) * gapPx;
-
     const ids = useMemo(() => items.map((item, index) => getId?.(item) ?? String(index)), [items, getId]);
     const { rects, columnWidth, height, getTileRef, nodes } = useMasonryLayout({
       ids,
       columnCount,
-      containerWidth: gridWidth,
+      containerWidth: contentWidth,
       gapPx,
     });
     useFlip({ nodes, ids, rects, enabled: true });
@@ -158,17 +168,17 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
     });
 
     // The viewport is the full-width scroll container; its centered+padded theme
-    // balances the scrollbar into symmetric inline gutters. The capped-width grid is
-    // an ordinary block child centered with `mx-auto`, so its left/right margins match
-    // and the scrollbar never eats into the tile area. The viewport always renders so
-    // it can be measured; tiles render once a width is known.
+    // (with `--gutter` set to the gap) balances the scrollbar into symmetric inline
+    // gutters. The grid fills the content box and the layout centres capped columns,
+    // so nothing overflows and left/right spacing matches the gap. The viewport always
+    // renders so it can be measured; tiles render once a width is known.
     return (
       <ScrollArea.Viewport ref={viewportRef}>
         {contentWidth > 0 && (
           <div
             {...composableProps(props, {
-              classNames: 'relative mx-auto',
-              style: { width: `${gridWidth}px`, height: `${height}px` },
+              classNames: 'relative',
+              style: { width: `${contentWidth}px`, height: `${height}px` },
             })}
             {...arrowNavigationAttrs}
             role='list'
@@ -231,15 +241,16 @@ const useColumnCount = (
       return 1;
     }
 
-    // The gap surrounds every column (outer edges plus interior splits), so N columns
-    // fit when N * colWidth + (N + 1) * gap <= width, i.e. N <= (width - gap) / (colWidth + gap).
-    let cols = Math.max(1, Math.floor((width - gapPx) / (minColumnWidthPx + gapPx)));
+    // `width` is the content box; the outer perimeter is owned by the scroll
+    // container, so only interior gaps count: N columns fit when
+    // N * colWidth + (N - 1) * gap <= width, i.e. N <= (width + gap) / (colWidth + gap).
+    let cols = Math.max(1, Math.floor((width + gapPx) / (minColumnWidthPx + gapPx)));
     if (maxColumnWidthPx > 0) {
-      const effectiveColWidth = (width - (cols + 1) * gapPx) / cols;
+      const effectiveColWidth = (width - (cols - 1) * gapPx) / cols;
       if (effectiveColWidth > maxColumnWidthPx) {
         // Try to add columns to keep cards below maxColumnWidth, but never violate minColumnWidth.
-        const maxCols = Math.ceil((width - gapPx) / (maxColumnWidthPx + gapPx));
-        if ((width - (maxCols + 1) * gapPx) / maxCols >= minColumnWidthPx) {
+        const maxCols = Math.ceil((width + gapPx) / (maxColumnWidthPx + gapPx));
+        if ((width - (maxCols - 1) * gapPx) / maxCols >= minColumnWidthPx) {
           cols = maxCols;
         }
       }

--- a/packages/ui/react-ui-masonry/src/Masonry.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.tsx
@@ -146,8 +146,8 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
     const { width: contentWidth = 0 } = useResizeDetector({ targetRef: viewportRef });
     const columnCount = useColumnCount(contentWidth, columns, maxColumns, minColumnWidth, maxColumnWidth, gap);
 
-    // The grid fills the measured content box; columns stretch to fill (column count
-    // already honours `maxColumnWidth`), so no scrollbar/padding math is duplicated here.
+    // The grid fills the measured content box; the layout caps columns at
+    // `maxColumnWidth` and centres them, so no scrollbar/padding math is duplicated here.
     const gapPx = gap * remInPx;
     const ids = useMemo(() => items.map((item, index) => getId?.(item) ?? String(index)), [items, getId]);
     const { rects, columnWidth, height, getTileRef, nodes } = useMasonryLayout({
@@ -155,6 +155,7 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
       columnCount,
       containerWidth: contentWidth,
       gapPx,
+      maxColumnWidthPx: maxColumnWidth * remInPx,
     });
     useFlip({ nodes, ids, rects, enabled: true });
 

--- a/packages/ui/react-ui-masonry/src/Masonry.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.tsx
@@ -3,13 +3,12 @@
 //
 
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
-import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
 import React, { type ComponentType, type JSX, type PropsWithChildren, type Ref, useMemo, useRef } from 'react';
 import { useResizeDetector } from 'react-resize-detector';
 
 import { ScrollArea, ScrollAreaRootProps, ThemedClassName, usePx } from '@dxos/react-ui';
-import { composable, composableProps, scrollbar } from '@dxos/react-ui';
+import { composable, composableProps } from '@dxos/react-ui';
 import { cardMaxInlineSize, cardMinInlineSize } from '@dxos/ui-theme';
 
 import { useFlip } from './useFlip';
@@ -37,13 +36,6 @@ type MasonryContextValue = {
 const MASONRY_NAME = 'Masonry';
 
 const [MasonryProvider, useMasonryContext] = createContext<MasonryContextValue>(MASONRY_NAME);
-
-/** Content-scoped context: measured width of the ScrollArea.Root, shared with Viewport. */
-type MasonryContentContextValue = {
-  width: number;
-};
-
-const [MasonryContentProvider, useMasonryContentContext] = createContext<MasonryContentContextValue>('Masonry.Content');
 
 //
 // Root
@@ -77,9 +69,10 @@ MasonryRoot.displayName = 'Masonry.Root';
 //
 // Content
 //
-// The outer wrapper: renders the ScrollArea.Root, measures available width,
-// and publishes that width via context for Masonry.Viewport to consume.
-// Style this layer (centered/thin/padding) to control the scroll container.
+// The outer wrapper: renders the ScrollArea.Root. Style this layer
+// (centered/thin/padding) to control the scroll container; the Viewport measures
+// its own content box, so scrollbar width and padding are accounted for whatever
+// density is configured here.
 //
 
 type MasonryContentProps = ThemedClassName<
@@ -87,24 +80,18 @@ type MasonryContentProps = ThemedClassName<
 >;
 
 const MasonryContentInner = composable<HTMLDivElement, MasonryContentProps>(
-  ({ children, scrollbars, centered = true, thin = true, padding = true, ...props }, forwardedRef) => {
-    const rootRef = useRef<HTMLDivElement | null>(null);
-    const composedRef = useComposedRefs(rootRef, forwardedRef);
-    const { width = 0 } = useResizeDetector({ targetRef: rootRef });
-
-    return (
-      <ScrollArea.Root
-        {...composableProps(props)}
-        scrollbars={scrollbars}
-        centered={centered}
-        thin={thin}
-        padding={padding}
-        ref={composedRef}
-      >
-        <MasonryContentProvider width={width}>{children}</MasonryContentProvider>
-      </ScrollArea.Root>
-    );
-  },
+  ({ children, scrollbars, centered = true, thin = true, padding = true, ...props }, forwardedRef) => (
+    <ScrollArea.Root
+      {...composableProps(props)}
+      scrollbars={scrollbars}
+      centered={centered}
+      thin={thin}
+      padding={padding}
+      ref={forwardedRef}
+    >
+      {children}
+    </ScrollArea.Root>
+  ),
 );
 
 MasonryContentInner.displayName = 'Masonry.Content';
@@ -134,13 +121,13 @@ type MasonryViewportProps<Item> = ThemedClassName<{
 const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any>>(
   ({ items, getId, ...props }, forwardedRef) => {
     const { Tile, columns, maxColumns, minColumnWidth, maxColumnWidth, gap } = useMasonryContext('Masonry.Viewport');
-    const { width } = useMasonryContentContext('Masonry.Viewport');
     const remInPx = usePx(1);
-    // The ScrollArea.Viewport is centered+padded, so it reserves a symmetric gutter of
-    // (scroll-width + scroll-padding) on each side (the inline-end side splitting into
-    // padding + the scrollbar itself). Subtract both gutters to get the width available
-    // to the centered grid.
-    const contentWidth = width - 2 * (scrollbar.md.size + scrollbar.md.padding);
+    // Measure the viewport's own content box (net of padding and scrollbar) rather
+    // than deriving it from the root width, so the grid tracks the actual available
+    // width for any ScrollArea density (thin/scrollbars/padding) without duplicating
+    // the theme's gutter math.
+    const viewportRef = useRef<HTMLDivElement | null>(null);
+    const { width: contentWidth = 0 } = useResizeDetector({ targetRef: viewportRef });
     const columnCount = useColumnCount(contentWidth, columns, maxColumns, minColumnWidth, maxColumnWidth, gap);
 
     // Cap each column at `maxColumnWidth` and center the grid so it doesn't stretch
@@ -170,46 +157,45 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
       tabbable: true,
     });
 
-    if (width <= 0) {
-      return null;
-    }
-
     // The viewport is the full-width scroll container; its centered+padded theme
     // balances the scrollbar into symmetric inline gutters. The capped-width grid is
     // an ordinary block child centered with `mx-auto`, so its left/right margins match
-    // and the scrollbar never eats into the tile area.
+    // and the scrollbar never eats into the tile area. The viewport always renders so
+    // it can be measured; tiles render once a width is known.
     return (
-      <ScrollArea.Viewport>
-        <div
-          {...composableProps(props, {
-            classNames: 'relative mx-auto',
-            style: { width: `${gridWidth}px`, height: `${height}px` },
-          })}
-          {...arrowNavigationAttrs}
-          role='list'
-          ref={forwardedRef}
-        >
-          {items.map((item, index) => {
-            const id = ids[index];
-            const rect = rects[index];
-            return (
-              <div
-                key={id}
-                ref={getTileRef(id)}
-                role='listitem'
-                style={{
-                  position: 'absolute',
-                  insetBlockStart: 0,
-                  insetInlineStart: 0,
-                  width: `${columnWidth}px`,
-                  transform: rect ? `translate(${rect.x}px, ${rect.y}px)` : undefined,
-                }}
-              >
-                <Tile index={index} data={item} />
-              </div>
-            );
-          })}
-        </div>
+      <ScrollArea.Viewport ref={viewportRef}>
+        {contentWidth > 0 && (
+          <div
+            {...composableProps(props, {
+              classNames: 'relative mx-auto',
+              style: { width: `${gridWidth}px`, height: `${height}px` },
+            })}
+            {...arrowNavigationAttrs}
+            role='list'
+            ref={forwardedRef}
+          >
+            {items.map((item, index) => {
+              const id = ids[index];
+              const rect = rects[index];
+              return (
+                <div
+                  key={id}
+                  ref={getTileRef(id)}
+                  role='listitem'
+                  style={{
+                    position: 'absolute',
+                    insetBlockStart: 0,
+                    insetInlineStart: 0,
+                    width: `${columnWidth}px`,
+                    transform: rect ? `translate(${rect.x}px, ${rect.y}px)` : undefined,
+                  }}
+                >
+                  <Tile index={index} data={item} />
+                </div>
+              );
+            })}
+          </div>
+        )}
       </ScrollArea.Viewport>
     );
   },

--- a/packages/ui/react-ui-masonry/src/layout.test.ts
+++ b/packages/ui/react-ui-masonry/src/layout.test.ts
@@ -19,14 +19,14 @@ describe('layout', () => {
     expect(rects.map((rect) => rect.column)).toEqual([0, 1]);
   });
 
-  test('computes column width and offsets accounting for the perimeter gap', ({ expect }) => {
+  test('fills the width using interior gaps only, with a top perimeter gap', ({ expect }) => {
     const { rects, columnWidth } = layout({ heights: [10, 10], columnCount: 2, containerWidth: 100, gapPx: 10 });
-    expect(columnWidth).toBe(35); // (100 - 3 * 10) / 2
-    expect(rects[0]).toMatchObject({ x: 10, y: 10, column: 0 }); // leading gap on both axes
-    expect(rects[1]).toMatchObject({ x: 55, y: 10, column: 1 }); // 10 + 1 * (35 + 10)
+    expect(columnWidth).toBe(45); // (100 - 1 * 10) / 2 — columns fill, no outer gap
+    expect(rects[0]).toMatchObject({ x: 0, y: 10, column: 0 }); // flush left; top perimeter gap
+    expect(rects[1]).toMatchObject({ x: 55, y: 10, column: 1 }); // 0 + 1 * (45 + 10)
   });
 
-  test('stacks vertically in a single column with perimeter gaps', ({ expect }) => {
+  test('stacks vertically in a single column with top and bottom perimeter gaps', ({ expect }) => {
     const { rects, height } = layout({ heights: [30, 20], columnCount: 1, containerWidth: 100, gapPx: 10 });
     expect(rects.map((rect) => rect.y)).toEqual([10, 50]); // 10 gap, then 10 + 30 + 10
     expect(height).toBe(80); // 10 + 30 + 10 + 20 + 10

--- a/packages/ui/react-ui-masonry/src/layout.test.ts
+++ b/packages/ui/react-ui-masonry/src/layout.test.ts
@@ -10,36 +10,36 @@ describe('layout', () => {
   test('assigns each tile to the shortest column (not by index)', ({ expect }) => {
     // With index-based placement item 2 would land in column 0; balancing puts it
     // in column 1 because column 0 is still occupied by the tall first tile.
-    const { rects } = layout({ heights: [100, 10, 10, 10], columnCount: 2, containerWidth: 200, gutterPx: 0 });
+    const { rects } = layout({ heights: [100, 10, 10, 10], columnCount: 2, containerWidth: 200, gapPx: 0 });
     expect(rects.map((rect) => rect.column)).toEqual([0, 1, 1, 1]);
   });
 
   test('breaks ties toward the lowest column index', ({ expect }) => {
-    const { rects } = layout({ heights: [10, 10], columnCount: 2, containerWidth: 200, gutterPx: 0 });
+    const { rects } = layout({ heights: [10, 10], columnCount: 2, containerWidth: 200, gapPx: 0 });
     expect(rects.map((rect) => rect.column)).toEqual([0, 1]);
   });
 
-  test('computes column width and x-offset accounting for the gutter', ({ expect }) => {
-    const { rects, columnWidth } = layout({ heights: [10, 10], columnCount: 2, containerWidth: 100, gutterPx: 10 });
-    expect(columnWidth).toBe(45); // (100 - 1 * 10) / 2
-    expect(rects[0]).toMatchObject({ x: 0, y: 0, column: 0 });
-    expect(rects[1]).toMatchObject({ x: 55, y: 0, column: 1 }); // 1 * (45 + 10)
+  test('computes column width and offsets accounting for the perimeter gap', ({ expect }) => {
+    const { rects, columnWidth } = layout({ heights: [10, 10], columnCount: 2, containerWidth: 100, gapPx: 10 });
+    expect(columnWidth).toBe(35); // (100 - 3 * 10) / 2
+    expect(rects[0]).toMatchObject({ x: 10, y: 10, column: 0 }); // leading gap on both axes
+    expect(rects[1]).toMatchObject({ x: 55, y: 10, column: 1 }); // 10 + 1 * (35 + 10)
   });
 
-  test('stacks vertically in a single column and trims the trailing gutter', ({ expect }) => {
-    const { rects, height } = layout({ heights: [30, 20], columnCount: 1, containerWidth: 100, gutterPx: 10 });
-    expect(rects.map((rect) => rect.y)).toEqual([0, 40]); // 30 + 10 gutter
-    expect(height).toBe(60); // 30 + 10 + 20
+  test('stacks vertically in a single column with perimeter gaps', ({ expect }) => {
+    const { rects, height } = layout({ heights: [30, 20], columnCount: 1, containerWidth: 100, gapPx: 10 });
+    expect(rects.map((rect) => rect.y)).toEqual([10, 50]); // 10 gap, then 10 + 30 + 10
+    expect(height).toBe(80); // 10 + 30 + 10 + 20 + 10
   });
 
   test('handles an empty input', ({ expect }) => {
-    const { rects, height } = layout({ heights: [], columnCount: 3, containerWidth: 300, gutterPx: 8 });
+    const { rects, height } = layout({ heights: [], columnCount: 3, containerWidth: 300, gapPx: 8 });
     expect(rects).toEqual([]);
     expect(height).toBe(0);
   });
 
   test('clamps a non-positive column count to one', ({ expect }) => {
-    const { rects } = layout({ heights: [10, 10], columnCount: 0, containerWidth: 100, gutterPx: 0 });
+    const { rects } = layout({ heights: [10, 10], columnCount: 0, containerWidth: 100, gapPx: 0 });
     expect(rects.map((rect) => rect.column)).toEqual([0, 0]);
   });
 });

--- a/packages/ui/react-ui-masonry/src/layout.test.ts
+++ b/packages/ui/react-ui-masonry/src/layout.test.ts
@@ -26,6 +26,20 @@ describe('layout', () => {
     expect(rects[1]).toMatchObject({ x: 55, y: 10, column: 1 }); // 0 + 1 * (45 + 10)
   });
 
+  test('caps column width and centres the leftover space', ({ expect }) => {
+    const { rects, columnWidth } = layout({
+      heights: [10, 10],
+      columnCount: 2,
+      containerWidth: 200,
+      gapPx: 10,
+      maxColumnWidthPx: 50,
+    });
+    expect(columnWidth).toBe(50); // capped below the 95 fill width
+    // usedWidth = 2 * 50 + 10 = 110; sideInset = (200 - 110) / 2 = 45.
+    expect(rects[0]).toMatchObject({ x: 45, column: 0 });
+    expect(rects[1]).toMatchObject({ x: 105, column: 1 }); // 45 + (50 + 10)
+  });
+
   test('stacks vertically in a single column with top and bottom perimeter gaps', ({ expect }) => {
     const { rects, height } = layout({ heights: [30, 20], columnCount: 1, containerWidth: 100, gapPx: 10 });
     expect(rects.map((rect) => rect.y)).toEqual([10, 50]); // 10 gap, then 10 + 30 + 10

--- a/packages/ui/react-ui-masonry/src/layout.ts
+++ b/packages/ui/react-ui-masonry/src/layout.ts
@@ -29,6 +29,8 @@ export type LayoutOptions = {
   containerWidth: number;
   /** Space (px) between tiles and, vertically, around the grid perimeter. */
   gapPx: number;
+  /** Optional cap on column width (px); leftover width centers the columns. */
+  maxColumnWidthPx?: number;
 };
 
 /**
@@ -37,15 +39,27 @@ export type LayoutOptions = {
  * index for stable ordering). Pure and synchronous so column balancing is unit
  * testable without a DOM.
  *
- * Columns are separated by a single gap and stretch to fill `containerWidth`
- * (`maxColumnWidth` is applied upstream by choosing the column count, not by
- * capping width here, so left/right spacing stays equal to the gap). The
- * left/right perimeter is owned by the scroll container (via its `--gutter`); the
- * layout only adds the top and bottom perimeter so vertical spacing matches too.
+ * Columns are separated by a single gap. They stretch to fill `containerWidth`
+ * unless `maxColumnWidthPx` caps them narrower, in which case the leftover width
+ * is split evenly so the grid stays centred (the outer margin grows beyond the
+ * gap). The base left/right perimeter is owned by the scroll container (via its
+ * `--gutter`); the layout adds the centring offset plus the top/bottom perimeter.
  */
-export const layout = ({ heights, columnCount, containerWidth, gapPx }: LayoutOptions): LayoutResult => {
+export const layout = ({
+  heights,
+  columnCount,
+  containerWidth,
+  gapPx,
+  maxColumnWidthPx,
+}: LayoutOptions): LayoutResult => {
   const columns = Math.max(1, Math.floor(columnCount));
-  const columnWidth = (containerWidth - (columns - 1) * gapPx) / columns;
+  const fillColumnWidth = (containerWidth - (columns - 1) * gapPx) / columns;
+  const columnWidth =
+    maxColumnWidthPx && maxColumnWidthPx > 0 ? Math.min(fillColumnWidth, maxColumnWidthPx) : fillColumnWidth;
+
+  // Centre the (possibly capped) columns within the container.
+  const usedWidth = columns * columnWidth + (columns - 1) * gapPx;
+  const sideInset = Math.max(0, (containerWidth - usedWidth) / 2);
 
   // Seed each column with the top gap so the first row clears the perimeter.
   const columnHeights = new Array<number>(columns).fill(gapPx);
@@ -59,7 +73,7 @@ export const layout = ({ heights, columnCount, containerWidth, gapPx }: LayoutOp
     }
 
     const rect: Rect = {
-      x: target * (columnWidth + gapPx),
+      x: sideInset + target * (columnWidth + gapPx),
       y: columnHeights[target],
       column: target,
     };

--- a/packages/ui/react-ui-masonry/src/layout.ts
+++ b/packages/ui/react-ui-masonry/src/layout.ts
@@ -16,7 +16,7 @@ export type LayoutResult = {
   rects: Rect[];
   /** Width (px) shared by every column. */
   columnWidth: number;
-  /** Total content height (px), trailing gutter trimmed. */
+  /** Total content height (px), including the perimeter gap. */
   height: number;
 };
 
@@ -27,8 +27,8 @@ export type LayoutOptions = {
   columnCount: number;
   /** Available content width (px), already net of any scrollbar allowance. */
   containerWidth: number;
-  /** Space (px) between columns and between stacked tiles. */
-  gutterPx: number;
+  /** Space (px) applied uniformly between tiles and around the grid perimeter. */
+  gapPx: number;
 };
 
 /**
@@ -36,11 +36,16 @@ export type LayoutOptions = {
  * tile is placed in the currently shortest column (ties resolve to the lowest
  * index for stable ordering). Pure and synchronous so column balancing is unit
  * testable without a DOM.
+ *
+ * The gap is applied uniformly: `columnCount` columns consume
+ * `columnCount + 1` gaps horizontally (both outer edges plus the interior
+ * splits), and each column is padded by one gap at the top and bottom.
  */
-export const layout = ({ heights, columnCount, containerWidth, gutterPx }: LayoutOptions): LayoutResult => {
+export const layout = ({ heights, columnCount, containerWidth, gapPx }: LayoutOptions): LayoutResult => {
   const columns = Math.max(1, Math.floor(columnCount));
-  const columnWidth = (containerWidth - (columns - 1) * gutterPx) / columns;
-  const columnHeights = new Array<number>(columns).fill(0);
+  const columnWidth = (containerWidth - (columns + 1) * gapPx) / columns;
+  // Seed each column with the top gap so the first row clears the perimeter.
+  const columnHeights = new Array<number>(columns).fill(gapPx);
 
   const rects: Rect[] = heights.map((tileHeight) => {
     let target = 0;
@@ -51,15 +56,16 @@ export const layout = ({ heights, columnCount, containerWidth, gutterPx }: Layou
     }
 
     const rect: Rect = {
-      x: target * (columnWidth + gutterPx),
+      x: gapPx + target * (columnWidth + gapPx),
       y: columnHeights[target],
       column: target,
     };
-    columnHeights[target] += tileHeight + gutterPx;
+    columnHeights[target] += tileHeight + gapPx;
     return rect;
   });
 
+  // Each column already carries a trailing gap, which becomes the bottom perimeter.
   const tallest = columnHeights.reduce((max, value) => Math.max(max, value), 0);
-  const height = Math.max(0, tallest - gutterPx);
+  const height = heights.length === 0 ? 0 : tallest;
   return { rects, columnWidth, height };
 };

--- a/packages/ui/react-ui-masonry/src/layout.ts
+++ b/packages/ui/react-ui-masonry/src/layout.ts
@@ -27,7 +27,7 @@ export type LayoutOptions = {
   columnCount: number;
   /** Available content width (px), already net of any scrollbar allowance. */
   containerWidth: number;
-  /** Space (px) applied uniformly between tiles and around the grid perimeter. */
+  /** Space (px) between tiles and, vertically, around the grid perimeter. */
   gapPx: number;
 };
 
@@ -37,13 +37,16 @@ export type LayoutOptions = {
  * index for stable ordering). Pure and synchronous so column balancing is unit
  * testable without a DOM.
  *
- * The gap is applied uniformly: `columnCount` columns consume
- * `columnCount + 1` gaps horizontally (both outer edges plus the interior
- * splits), and each column is padded by one gap at the top and bottom.
+ * Columns are separated by a single gap and stretch to fill `containerWidth`
+ * (`maxColumnWidth` is applied upstream by choosing the column count, not by
+ * capping width here, so left/right spacing stays equal to the gap). The
+ * left/right perimeter is owned by the scroll container (via its `--gutter`); the
+ * layout only adds the top and bottom perimeter so vertical spacing matches too.
  */
 export const layout = ({ heights, columnCount, containerWidth, gapPx }: LayoutOptions): LayoutResult => {
   const columns = Math.max(1, Math.floor(columnCount));
-  const columnWidth = (containerWidth - (columns + 1) * gapPx) / columns;
+  const columnWidth = (containerWidth - (columns - 1) * gapPx) / columns;
+
   // Seed each column with the top gap so the first row clears the perimeter.
   const columnHeights = new Array<number>(columns).fill(gapPx);
 
@@ -56,7 +59,7 @@ export const layout = ({ heights, columnCount, containerWidth, gapPx }: LayoutOp
     }
 
     const rect: Rect = {
-      x: gapPx + target * (columnWidth + gapPx),
+      x: target * (columnWidth + gapPx),
       y: columnHeights[target],
       column: target,
     };

--- a/packages/ui/react-ui-masonry/src/useMasonryLayout.ts
+++ b/packages/ui/react-ui-masonry/src/useMasonryLayout.ts
@@ -22,7 +22,7 @@ export type UseMasonryLayoutOptions = {
   columnCount: number;
   /** Available content width (px), net of scrollbar allowance. */
   containerWidth: number;
-  gutterPx: number;
+  gapPx: number;
 };
 
 /**
@@ -34,7 +34,7 @@ export const useMasonryLayout = ({
   ids,
   columnCount,
   containerWidth,
-  gutterPx,
+  gapPx,
 }: UseMasonryLayoutOptions): MasonryLayout => {
   const heights = useRef(new Map<string, number>());
   const nodes = useRef(new Map<string, HTMLElement>());
@@ -115,10 +115,10 @@ export const useMasonryLayout = ({
     }
 
     const tileHeights = ids.map((id) => heights.current.get(id) ?? 0);
-    return layout({ heights: tileHeights, columnCount, containerWidth, gutterPx });
+    return layout({ heights: tileHeights, columnCount, containerWidth, gapPx });
     // `version` re-runs layout when a measured height changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ids, columnCount, containerWidth, gutterPx, version]);
+  }, [ids, columnCount, containerWidth, gapPx, version]);
 
   return { ...result, getTileRef, nodes };
 };

--- a/packages/ui/react-ui-masonry/src/useMasonryLayout.ts
+++ b/packages/ui/react-ui-masonry/src/useMasonryLayout.ts
@@ -23,6 +23,8 @@ export type UseMasonryLayoutOptions = {
   /** Available content width (px), net of scrollbar allowance. */
   containerWidth: number;
   gapPx: number;
+  /** Optional cap on column width (px). */
+  maxColumnWidthPx?: number;
 };
 
 /**
@@ -35,6 +37,7 @@ export const useMasonryLayout = ({
   columnCount,
   containerWidth,
   gapPx,
+  maxColumnWidthPx,
 }: UseMasonryLayoutOptions): MasonryLayout => {
   const heights = useRef(new Map<string, number>());
   const nodes = useRef(new Map<string, HTMLElement>());
@@ -115,10 +118,10 @@ export const useMasonryLayout = ({
     }
 
     const tileHeights = ids.map((id) => heights.current.get(id) ?? 0);
-    return layout({ heights: tileHeights, columnCount, containerWidth, gapPx });
+    return layout({ heights: tileHeights, columnCount, containerWidth, gapPx, maxColumnWidthPx });
     // `version` re-runs layout when a measured height changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ids, columnCount, containerWidth, gapPx, version]);
+  }, [ids, columnCount, containerWidth, gapPx, maxColumnWidthPx, version]);
 
   return { ...result, getTileRef, nodes };
 };


### PR DESCRIPTION
## Summary

Fixes the spurious horizontal scrollbar in `react-ui-masonry`, makes the left/right gap equal to the inter-column gap (symmetric and scrollbar-aware at any density), renames `gutter` → `gap`, and applies spacing uniformly.

## Problems

1. `ScrollArea.Viewport asChild` merged the scroll container into the fixed-width grid, so the grid's inline width defeated `w-full`, the `centered`/`padding` scrollbar-balancing was bypassed (absolutely-positioned tiles ignore the viewport's `pl`), and tiles spilled under the reserved scrollbar space — `overflow-y-scroll` forces `overflow-x: auto`, so a horizontal scrollbar appeared with a large asymmetric right gap.
2. With a non-thin (`lg`) scrollbar the problem worsened: `mx-auto` collapsed to `margin: 0` (grid flush-left) and the outer gap stacked the ScrollArea gutter on top of the layout perimeter.

## Changes

- **Viewport is the full-width scroll container**; the grid is a plain child. Its content box is measured directly (`useResizeDetector`), so width tracks the real available space for any density (`thin`/`scrollbars`/`padding`) without duplicating the theme's gutter math.
- **`--gutter` = grid gap.** The Content sets `--gutter` to the gap, so the `centered` + `padding` theme resolves to `pl = gap`, `pr = gap − scrollbar`: the left/right perimeter equals the inter-column gap and stays symmetric with the scrollbar reserved.
- **Columns fill the content box** (no `mx-auto`, no width cap). The column count already honours `maxColumnWidth`; the layout adds only the top/bottom perimeter, so every gap (left/right/inter-column/top/bottom) is uniform and nothing overflows horizontally.
- **`gutter` → `gap`** across the public prop and internals.

## Behaviour note

`maxColumnWidth` now governs the **column count** rather than hard-capping column width, so on containers too wide to add another column the cards stretch to fill (they may slightly exceed `maxColumnWidth`) instead of centering with large side gaps. This is what keeps the outer gap equal to the column gap. If you'd rather keep a hard width cap and grow all gaps uniformly (or center), that's a small change — say the word.

## Reviewer notes

- No external consumers pass `gutter`/`gap`, so the rename is safe.
- One cast (`as CSSProperties`) to set the `--gutter` custom property, which `CSSProperties` can't type — same pattern as `ScrollArea.tsx`; commented.

## Verification

Headless Chromium against the package storybook at 1200px, `thin={false}` (the `lg`/8px scrollbar that regressed):

- No horizontal overflow (`scrollWidth == clientWidth`).
- `pl = 12px` (= gap), `pr = 4px` (= gap − scrollbar); on a space-taking scrollbar `pr + scrollbar = 12`, matching `pl` → symmetric.
- Left gap = inter-column gap = 12px.

`react-ui-masonry` build passes; all 6 layout unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Masonry spacing has changed from `gutter` to a `gap` prop on `Masonry.Root` (with updated layout math accordingly).
* **New Features**
  * Gap-based positioning for columns and tiles for more consistent spacing.
  * Updated the Masonry story example to reflect the new presentation.
* **Bug Fixes**
  * Improved layout height/stacking behavior (including empty and single-column cases) and adjusted rendering behavior for narrower widths.
* **Tests**
  * Updated layout tests to validate the new `gap`-based geometry and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->