### PR TITLE
chore(deps): bump @effect/language-service 0.86.2 → 0.86.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,8 +178,8 @@ catalogs:
       specifier: 0.60.0
       version: 0.60.0
     '@effect/language-service':
-      specifier: ^0.86.2
-      version: 0.86.2
+      specifier: ^0.86.4
+      version: 0.86.4
     '@effect/opentelemetry':
       specifier: ^0.63.0
       version: 0.63.0
@@ -2038,7 +2038,7 @@ importers:
         version: link:tools/vite-plugin-log
       '@effect/language-service':
         specifier: 'catalog:'
-        version: 0.86.2
+        version: 0.86.4
       '@effect/vitest':
         specifier: 'catalog:'
         version: 0.29.0(effect@3.21.4)(vitest@4.1.8)
@@ -26238,8 +26238,8 @@ packages:
       lmdb:
         optional: true
 
-  '@effect/language-service@0.86.2':
-    resolution: {integrity: sha512-SaPln+8srOqDJDUwNTDmP5e+IYpEDr9+1epGznnsLqu8xvo6VnxyWARdeLpqvZJlb0Pgy9ca7ppqvvdWbHPXAg==}
+  '@effect/language-service@0.86.4':
+    resolution: {integrity: sha512-XzAPsbwCdm0gRh0E8wJu3wXECb00QraE3LnbObA4RgHn8u2TEbwAjmBadRnwSgOIElfzZjbsRqNR706/V54hDg==}
     hasBin: true
 
   '@effect/opentelemetry@0.63.0':
@@ -49045,7 +49045,7 @@ snapshots:
     optionalDependencies:
       ioredis: 5.3.2
 
-  '@effect/language-service@0.86.2': {}
+  '@effect/language-service@0.86.4': {}
 
   '@effect/opentelemetry@0.63.0(@effect/platform@0.96.2(effect@3.21.4))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@3.21.4)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,7 +81,7 @@ catalog:
   '@effect/cli': 0.75.2
   '@effect/cluster': 0.59.0
   '@effect/experimental': 0.60.0
-  '@effect/language-service': ^0.86.2
+  '@effect/language-service': ^0.86.4
   '@effect/opentelemetry': ^0.63.0
   '@effect/platform': 0.96.2
   '@effect/platform-browser': 0.76.0


### PR DESCRIPTION
## Summary

Periodic dependency update sweep — `effect` / `@effect/*` group.

| Package | Old | New | Kind |
|---------|-----|-----|------|
| `@effect/language-service` | ^0.86.2 | ^0.86.4 | patch |

Everything else in the family (`effect` core `3.21.4`, `@effect/platform` `0.96.2`, `@effect/ai*`, `@effect/sql*`, `@effect/rpc`, etc.) is already at latest.

### Investigated but not applied: `@effect/wa-sqlite` 0.1.2 → 0.2.1

Attempted this bump too, but `pnpm install` fails with a peer dependency conflict:

```
packages/common/sql-sqlite
└─┬ @effect/sql-sqlite-wasm 0.52.0
  └── ✕ unmet peer @effect/wa-sqlite@^0.1.2: found 0.2.1
```

`@effect/sql-sqlite-wasm` (already at its own latest, `0.52.0`) has not yet been updated to accept `wa-sqlite@0.2.x`. Reverted this part of the bump — will need to wait for a compatible `@effect/sql-sqlite-wasm` release before `wa-sqlite` can move past `0.1.x`.

## Validation

- `pnpm install` completed cleanly with only the `language-service` bump.
- **Note**: this automated sweep session could not run `moon` locally (its JS toolchain plugin fetch from `moonrepo/plugins` on GitHub is outside this session's repo-access scope). Relying on the `Check` CI workflow on this PR for build/lint/test validation.

## Classification

🟢 **Trivial** — single patch bump to a dev-only language service plugin, no source changes required.

---
🤖 Generated by an automated periodic dependency sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJx7WnSSGkYSSyVpM9haGU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workspace catalog version for `@effect/language-service` to the latest compatible release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->