### PR TITLE
chore(deps): bump @types/react-test-renderer 17 → 19

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -739,8 +739,8 @@ catalogs:
       specifier: ^15.5.13
       version: 15.5.13
     '@types/react-test-renderer':
-      specifier: ^17.0.2
-      version: 17.0.9
+      specifier: ^19.1.0
+      version: 19.1.0
     '@types/react-virtualized':
       specifier: ^9.22.3
       version: 9.22.3
@@ -20972,7 +20972,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@types/react-test-renderer':
         specifier: 'catalog:'
-        version: 17.0.9
+        version: 19.1.0
       chai:
         specifier: 'catalog:'
         version: 4.4.1
@@ -32224,8 +32224,8 @@ packages:
   '@types/react-syntax-highlighter@15.5.13':
     resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
 
-  '@types/react-test-renderer@17.0.9':
-    resolution: {integrity: sha512-bOfxcu5oZ+KxvACScbkTwZ4eGCtZFTz4VZCOVAIfGbThxqiXSIGipKVG8ubaYBXquUSQROzNIUzviWdSnnAlzg==}
+  '@types/react-test-renderer@19.1.0':
+    resolution: {integrity: sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==}
 
   '@types/react-virtualized@9.22.3':
     resolution: {integrity: sha512-UKRWeBIrECaKhE4O//TSFhlgwntMwyiEIOA7WZoVkr52Jahv0dH6YIOorqc358N2V3oKFclsq5XxPmx2PiYB5A==}
@@ -55021,7 +55021,7 @@ snapshots:
     dependencies:
       '@types/react': 19.2.17
 
-  '@types/react-test-renderer@17.0.9':
+  '@types/react-test-renderer@19.1.0':
     dependencies:
       '@types/react': 19.2.17
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -286,7 +286,7 @@ catalog:
   '@types/react': ~19.2.17
   '@types/react-dom': ~19.2.3
   '@types/react-syntax-highlighter': ^15.5.13
-  '@types/react-test-renderer': ^17.0.2
+  '@types/react-test-renderer': ^19.1.0
   '@types/react-virtualized': ^9.22.3
   '@types/readable-stream': ^2.3.9
   '@types/reveal.js': ^5.0.3


### PR DESCRIPTION
## Summary

Periodic dependency update sweep — `react` group.

| Package | Old | New | Kind |
|---------|-----|-----|------|
| `@types/react-test-renderer` | ^17.0.2 | ^19.1.0 | major (types-only) |

The runtime `react-test-renderer` package is already at `~19.2.7`; the types package had been left behind at the `17.x` line. Aligning the type package with the runtime major version.

`react`, `react-dom`, `react-is`, `react-test-renderer`, `@types/react`, `@types/react-dom`, and all `@testing-library/*` packages are already at their latest versions — no changes needed.

`@types/react-test-renderer` is declared only in `packages/ui/react-ui-editor/package.json` and is not actually imported anywhere in that package's source or tests, so blast radius is effectively zero.

## Validation

- `pnpm install` completed cleanly.
- Confirmed `@types/react-test-renderer` / `react-test-renderer` have no source usages in the repo (`grep -rn "react-test-renderer|ReactTestRenderer"` under `packages/ui/react-ui-editor/src` returns nothing).
- **Note**: this automated sweep session could not run `moon` locally (its JS toolchain plugin fetch from `moonrepo/plugins` on GitHub is outside this session's repo-access scope). Relying on the `Check` CI workflow on this PR for build/lint/test validation.

## Classification

🟢 **Trivial** — types-only major bump for a package with zero actual usage in source.

---
🤖 Generated by an automated periodic dependency sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJx7WnSSGkYSSyVpM9haGU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a workspace dependency version for React test renderer type support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->