### PR TITLE
test(assistant-toolkit): remove schema-add test from database skill

### DIFF
--- a/packages/core/compute/assistant-toolkit/src/skills/database/skill.test.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/database/skill.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
 import { Operation, Skill } from '@dxos/compute';
-import { Database, Entity, Feed, Filter, Obj, Query, Ref, Relation, Scope, Tag, Type } from '@dxos/echo';
+import { Database, Entity, Feed, Filter, Obj, Query, Ref, Relation, Tag, Type } from '@dxos/echo';
 import { TestHelpers } from '@dxos/effect/testing';
 import { AgentService } from '@dxos/functions-runtime';
 import { AssistantTestLayer } from '@dxos/functions-runtime/testing';
@@ -42,29 +42,6 @@ describe('Database Skill', () => {
         });
         yield* agent.submitPrompt('List all available schemas. Tell me what typenames are available.');
         yield* agent.waitForCompletion();
-      },
-      Effect.provide(TestLayer),
-      TestHelpers.provideTestContext,
-    ),
-    { timeout: 60_000 },
-  );
-
-  it.effect(
-    'schema-add: add a new schema',
-    Effect.fnUntraced(
-      function* (_) {
-        const agent = yield* AgentService.createSession({
-          skills: [DatabaseSkill.make()],
-        });
-        yield* agent.submitPrompt(
-          'Add a new schema called "Project" with typename "com.example.type.project" and fields: name (string), description (string), and status (string).',
-        );
-        yield* agent.waitForCompletion();
-        const allTypes = yield* Database.query(
-          Query.select(Filter.type(Type.Type)).from(Scope.space(), Scope.registry()),
-        ).run;
-        const schemas = allTypes.filter((t) => Type.getTypename(t) === 'com.example.type.project');
-        expect(schemas.length).toBeGreaterThanOrEqual(1);
       },
       Effect.provide(TestLayer),
       TestHelpers.provideTestContext,


### PR DESCRIPTION
## Summary

Removes the `schema-add: add a new schema` test from the database skill test suite (`packages/core/compute/assistant-toolkit/src/skills/database/skill.test.ts`).

## Why

The test was structurally incapable of catching a broken `add-schema` operation:

- **The assertion never inspects the schema's fields.** It filtered created types by `typename` — a separate top-level tool arg from `jsonSchema` — and only checked `length >= 1`. As long as `makeObjectFromJsonSchema` produced *a* type with that typename without throwing, the test passed, even if the `jsonSchema` payload (the actual field definitions) was empty or malformed.
- **`jsonSchema` is typed `Schema.Any`**, so it undergoes no Effect-Schema decode at the boundary; a malformed value flows straight through unvalidated.
- **It runs against a memoized LLM fixture**, so it only ever exercises the wire format that already deserializes correctly and cannot surface serialization problems in schema creation.

The result was a green test over a feature that could be broken — worse than no test, since it signals coverage that isn't there.

## Changes

- Remove the `schema-add` test case.
- Drop the now-unused `Scope` import.

The `schema-list` test and all object/relation/tag/query/context tests are retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj3AjcySUTwunJTM5qzfMo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated database skill test coverage to match current behavior.
  * Removed an outdated schema-add test case and a now-unused import.
  * Existing coverage for schema listing and related database queries remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->