### PR TITLE
feat: verify all public packages are published to npm

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Check publish config
         run: pnpm run check-publish-config
 
+      - name: Check public packages are published
+        run: pnpm run check-packages-published
+
       - name: Check package.json paths
         run: pnpm run pkg-lint
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "moon run :build",
     "changed-packages": "scripts/changed",
     "check-cycles": "node scripts/check-cycles.mjs",
+    "check-packages-published": "node scripts/check-packages-published.mjs",
     "check-public-dependencies": "node scripts/check-public-dependencies.mjs",
     "check-publish-config": "node scripts/check-publish-config.mjs",
     "create-worktree": "./scripts/create-worktree",

--- a/scripts/check-packages-published.mjs
+++ b/scripts/check-packages-published.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'fs';
+import { globby } from 'globby';
+
+const NPM_REGISTRY = 'https://registry.npmjs.org';
+const CONCURRENCY = 10;
+const RETRIES = 2;
+
+const files = await globby(['{packages,tools,vendor}/**/package.json', 'docs/package.json'], {
+  ignore: ['**/node_modules/**', '**/__fixtures__/**', '**/dist/**', '**/build/**', '**/out/**'],
+});
+
+const publicPackages = [];
+
+for (const file of files) {
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    continue;
+  }
+
+  if (!pkg.name || pkg.private) {
+    continue;
+  }
+
+  publicPackages.push({ file, name: pkg.name });
+}
+
+// npm does not expose whether trusted publishing (OIDC) is configured for a package through any
+// public API — that setting only lives in npmjs.com's UI. We can only check whether a package has
+// ever been published. Per repo policy (see AGENTS.md), new packages stay `private: true` until
+// their first publish, at which point trusted publishing is set up alongside it — so "published"
+// is treated here as a stand-in for "trusted publishing is configured".
+const fetchPublished = async (name) => {
+  const url = `${NPM_REGISTRY}/${encodeURIComponent(name)}`;
+  for (let attempt = 0; ; attempt++) {
+    const response = await fetch(url, { headers: { Accept: 'application/vnd.npm.install-v1+json' } });
+    if (response.status === 404) {
+      return false;
+    }
+    if (response.ok) {
+      return true;
+    }
+    if (attempt >= RETRIES) {
+      throw new Error(`unexpected status ${response.status} fetching ${url}`);
+    }
+  }
+};
+
+const results = new Array(publicPackages.length);
+let cursor = 0;
+
+const worker = async () => {
+  while (cursor < publicPackages.length) {
+    const index = cursor++;
+    const entry = publicPackages[index];
+    results[index] = { ...entry, published: await fetchPublished(entry.name) };
+  }
+};
+
+try {
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+} catch (error) {
+  console.error(`ERROR: failed to query the npm registry: ${error.message}`);
+  process.exit(1);
+}
+
+const unpublished = results.filter((entry) => !entry.published);
+
+if (unpublished.length > 0) {
+  console.error('ERROR: The following publishable packages have never been published to npm.');
+  console.error('Publish them and set up npm trusted publishing (OIDC) for each package.');
+  console.error('');
+  for (const { name, file } of unpublished.sort((a, b) => a.name.localeCompare(b.name))) {
+    console.error(`  ${name} (${file})`);
+  }
+  process.exit(1);
+}
+
+console.log(`OK: all ${publicPackages.length} publishable packages are published to npm.`);


### PR DESCRIPTION
## Summary

- Add `scripts/check-packages-published.mjs`, which scans all workspace `package.json` files and errors if any publishable (non-`private`) package has never been published to npm.
- Wire it up as `pnpm check-packages-published` and run it in the `Check` CI workflow, right after the existing `check-publish-config` step.
- npm has no public API to verify whether trusted publishing (OIDC) is configured for a package — that lives only in npmjs.com's UI. This check verifies publish status only, with a comment explaining the assumption: per repo policy (AGENTS.md), new packages stay `private: true` until their first publish, at which point trusted publishing is set up alongside it — so "published" is a stand-in for "trusted publishing is configured".

Follow-up to #12103, which added the sibling `check-public-dependencies` check.

**Expected: this check will currently fail** — `@dxos/extractor-lib`, `@dxos/pipeline`, `@dxos/pipeline-transcription`, and `@dxos/react-ui-dashboard` were recently made public but haven't been published to npm yet. They need to be published (with trusted publishing configured) before this check goes green.

## Test plan

- [x] `node scripts/check-packages-published.mjs` run locally — correctly errors listing the 4 unpublished packages, verified independently against the npm registry (404s)
- [x] `pnpm oxfmt --check scripts/check-packages-published.mjs` passes
- [x] `check-cycles`, `check-public-dependencies`, `check-publish-config` still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated package publication check to the CI pipeline.
  * Included a new project script to verify package release status and fail the build if any publishable package has not been released yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->