### PR TITLE
fix(plugin-assistant): force-close spans that time out without an end event

### DIFF
--- a/packages/plugins/plugin-assistant/src/containers/TracePanel/TracePanel.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/TracePanel/TracePanel.tsx
@@ -158,6 +158,11 @@ export const TracePanel = composable<HTMLDivElement, TracePanelProps>(
 // Stable ref.
 const atomEmpty = Atom.make(() => [] as const);
 
+// How often the graph re-checks for spans that timed out with no closing event.
+// Coarse-grained on purpose: `spanTimeoutMs` operates on a 20-minute scale, so there is no
+// benefit to re-deriving the graph more often than this just to catch the timeout crossing.
+const SPAN_TIMEOUT_CHECK_INTERVAL_MS = 60_000;
+
 type UseExecutionGraphOptions = {
   collapseCompletedSpans?: boolean;
   eventLimit?: number;
@@ -170,9 +175,19 @@ const useExecutionGraph = (
   const monitor = useCapability(Capabilities.ProcessMonitor);
   const processesAtom = monitor?.processTreeAtom ?? atomEmpty;
 
+  // Ticks periodically so spans that are still open purely because no new trace event has
+  // arrived (e.g. the runtime crashed before writing its `operationEnd`) eventually get
+  // force-closed by `buildExecutionGraph`'s `spanTimeoutMs` check, instead of staying stuck
+  // until unrelated trace activity happens to trigger a recompute.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), SPAN_TIMEOUT_CHECK_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
   const atom = useMemo(
-    () => getExecutionGraph(space, processesAtom, { collapseCompletedSpans, eventLimit }),
-    [space, processesAtom, collapseCompletedSpans, eventLimit],
+    () => getExecutionGraph(space, processesAtom, { collapseCompletedSpans, eventLimit, now }),
+    [space, processesAtom, collapseCompletedSpans, eventLimit, now],
   );
 
   return useAtomValue(atom);
@@ -181,7 +196,7 @@ const useExecutionGraph = (
 const getExecutionGraph = (
   space: Space,
   processesAtom: Atom.Atom<readonly Process.Info[]>,
-  { collapseCompletedSpans = true, eventLimit = 100 }: UseExecutionGraphOptions = {},
+  { collapseCompletedSpans = true, eventLimit = 100, now }: UseExecutionGraphOptions & { now: number },
 ): Atom.Atom<ExecutionGraph> => {
   const traceMessages = getTraceMessagesAtom(space);
 
@@ -204,6 +219,7 @@ const getExecutionGraph = (
       activeProcesses: get(activeProcesses),
       collapseCompletedSpans,
       eventLimit,
+      now,
     }),
   );
 };

--- a/packages/plugins/plugin-assistant/src/execution-graph/SPEC.md
+++ b/packages/plugins/plugin-assistant/src/execution-graph/SPEC.md
@@ -78,8 +78,8 @@ Optional input via `activeProcesses` (defaults to `[]`). Fields the builder read
 - `TracePanel`'s `getExecutionGraph` defaults `eventLimit = 300`
   (`TracePanel.tsx#L153`).
 - The cap targets `Timeline` rendering cost, not memory; see §11 for what it bounds.
-- `buildSpanTree` defaults `spanTimeoutMs = DEFAULT_SPAN_TIMEOUT_MS` (20 minutes) and
-  `now = Date.now()`; see §5.4 for the force-close behavior these gate.
+- `buildSpanTree` defaults `spanTimeoutMs = DEFAULT_SPAN_TIMEOUT_MS` (20 minutes); `now` has
+  no default and force-closing is skipped unless a caller passes it. See §5.4.
 
 ## 3. Outputs
 
@@ -232,9 +232,15 @@ across runs that share inputs. Test: `span-tree.test.ts#L120`.
 
 ### 5.4 Timeout-based force-close
 
-Runs after the linear scan, before children are sorted. Any span still in `openSpans`
-(no end event was ever recorded) whose **last** event is older than `now - spanTimeoutMs`
-is force-closed with a synthetic end event appended to `span.events`:
+Runs after the linear scan, before children are sorted, over `allSpans` — every span ever
+opened, not just the ones still in `openSpans`. This matters because a span superseded by a
+later same-pid begin event (§15 "interleaved same-pid begin/end pairs") is removed from
+`openSpans` but never receives an end event either; walking `allSpans` and checking each
+span's own last event (rather than map membership) reaches it too.
+
+Skipped entirely when `options.now` is omitted (see below). Otherwise, any span whose **last**
+event is not itself an end event (`isSpanEndEvent`) and is older than `now - spanTimeoutMs` is
+force-closed with a synthetic end event appended to `span.events`:
 
 - Span opened by `AgentRequestBegin` → synthetic `AgentRequestEnd` with
   `{ status: 'interrupted', error: SPAN_TIMEOUT_MESSAGE }`.
@@ -254,9 +260,12 @@ forever. Appending a synthetic end event makes it indistinguishable downstream f
 span that completed normally, except for the `outcome: 'failure'` / `status: 'interrupted'`
 result and the `SPAN_TIMEOUT_MESSAGE` text surfaced by `presentEvent` (§4.1).
 
-Both `spanTimeoutMs` (default `DEFAULT_SPAN_TIMEOUT_MS` = 20 minutes) and `now` (default
-`Date.now()`) are caller-configurable via `BuildSpanTreeOptions` — tests pass an explicit
-`now` for determinism (`span-tree.test.ts`, "force-closed" tests).
+`spanTimeoutMs` defaults to `DEFAULT_SPAN_TIMEOUT_MS` (20 minutes) when `now` is provided.
+`now` has **no default** — force-closing only runs when a caller explicitly passes it, so
+deterministic callers (tests, `TracePanel.stories.tsx`'s fixture snapshot) that pass fixture
+timestamps unrelated to wall-clock time are unaffected unless they opt in. `TracePanel` opts
+in by ticking a `now` state every 60s (`TracePanel.tsx`); `span-tree.test.ts`'s "force-closed"
+tests pass an explicit `now` for determinism.
 
 Only spans with **zero** events never happen (a span always has at least its begin
 event), so `span.events[span.events.length - 1]` is always defined when force-closing.
@@ -651,7 +660,9 @@ Each entry: **scenario → expected output → rationale**.
   spans per pid. If a process emits `B1 B2 E1 E2` interleaved, the second `B2`
   orphans the still-open `B1` (no `E1` ever closes the first span). The first
   span receives only its begin event; the second receives `B2 E1 E2`.
-  Outcome: incorrect. Not currently supported.
+  Outcome: incorrect. Not currently supported. `B1` is at least reachable by the
+  §5.4 timeout sweep (via `allSpans`) so it eventually force-closes rather than
+  hanging forever — but the interleaving itself is still not modeled correctly.
 - **Event types beyond `presentEvent`**: silently dropped from the commit
   stream but retained in `spanTree.events`. Consumers wanting the full event
   stream must read `spanTree`. Examples: `OperationInput`, `OperationOutput`,
@@ -671,7 +682,7 @@ Each entry: **scenario → expected output → rationale**.
 | ------------------------------------------------------- | ---------------------------------------------------------------------------- | ----------- |
 | `buildSpanTree`                                         | `packages/plugins/plugin-assistant/src/execution-graph/span-tree.ts`         | L112        |
 | `applyEventLimit`                                       | same                                                                         | L211        |
-| `makeTimeoutEndEvent` / `DEFAULT_SPAN_TIMEOUT_MS`        | same                                                                         | L252 / L13  |
+| `makeTimeoutEndEvent` / `DEFAULT_SPAN_TIMEOUT_MS`       | same                                                                         | L252 / L13  |
 | `ROOT_SPAN_ID`                                          | same                                                                         | L12         |
 | `BEGIN_EVENT_TYPES`/`END_EVENT_TYPES`                   | same                                                                         | L47         |
 | `walkSpanTree`/`flattenSpanTree`                        | same                                                                         | L245        |

--- a/packages/plugins/plugin-assistant/src/execution-graph/SPEC.md
+++ b/packages/plugins/plugin-assistant/src/execution-graph/SPEC.md
@@ -25,7 +25,8 @@ Out of scope:
 - Filtering / search of commits.
 - Mutating, ack-ing, or replaying trace events.
 
-Inputs: `traceMessages: Trace.Message[]`, `activeProcesses?: Process.Info[]`, `eventLimit?: number`.
+Inputs: `traceMessages: Trace.Message[]`, `activeProcesses?: Process.Info[]`, `eventLimit?: number`,
+`spanTimeoutMs?: number`, `now?: number`.
 Output: `ExecutionGraph = { branches, commits, spanTree, details }`.
 
 ## 2. Inputs
@@ -77,6 +78,8 @@ Optional input via `activeProcesses` (defaults to `[]`). Fields the builder read
 - `TracePanel`'s `getExecutionGraph` defaults `eventLimit = 300`
   (`TracePanel.tsx#L153`).
 - The cap targets `Timeline` rendering cost, not memory; see §11 for what it bounds.
+- `buildSpanTree` defaults `spanTimeoutMs = DEFAULT_SPAN_TIMEOUT_MS` (20 minutes) and
+  `now = Date.now()`; see §5.4 for the force-close behavior these gate.
 
 ## 3. Outputs
 
@@ -226,6 +229,39 @@ retains span boundaries') and `#L159` (regression for parent-child preservation)
 
 Sibling spans are sorted by `firstTimestamp` ascending so output is deterministic
 across runs that share inputs. Test: `span-tree.test.ts#L120`.
+
+### 5.4 Timeout-based force-close
+
+Runs after the linear scan, before children are sorted. Any span still in `openSpans`
+(no end event was ever recorded) whose **last** event is older than `now - spanTimeoutMs`
+is force-closed with a synthetic end event appended to `span.events`:
+
+- Span opened by `AgentRequestBegin` → synthetic `AgentRequestEnd` with
+  `{ status: 'interrupted', error: SPAN_TIMEOUT_MESSAGE }`.
+- Span opened by `Trace.OperationStart` → synthetic `Trace.OperationEnd` with
+  `{ key, name, icon, outcome: 'failure', error: SPAN_TIMEOUT_MESSAGE }` (fields copied
+  from the begin event's payload).
+
+The synthetic event's `timestamp` is `lastEvent.timestamp + spanTimeoutMs` (the exact
+moment the span crossed the threshold), not `now` — this keeps the emitted commit's
+position stable across repeated `buildSpanTree` calls with an advancing `now`, rather
+than jumping forward on every recompute.
+
+Rationale: the runtime may fail to write the closing event (crash, dropped connection,
+process killed) — see DX-1080. Without this, `isCompletedSpan` never returns `true` for
+that span (§7), so it never collapses and keeps rendering with the "in progress" shimmer
+forever. Appending a synthetic end event makes it indistinguishable downstream from a
+span that completed normally, except for the `outcome: 'failure'` / `status: 'interrupted'`
+result and the `SPAN_TIMEOUT_MESSAGE` text surfaced by `presentEvent` (§4.1).
+
+Both `spanTimeoutMs` (default `DEFAULT_SPAN_TIMEOUT_MS` = 20 minutes) and `now` (default
+`Date.now()`) are caller-configurable via `BuildSpanTreeOptions` — tests pass an explicit
+`now` for determinism (`span-tree.test.ts`, "force-closed" tests).
+
+Only spans with **zero** events never happen (a span always has at least its begin
+event), so `span.events[span.events.length - 1]` is always defined when force-closing.
+Nested children of a force-closed span are evaluated independently — a still-active
+child is not force-closed just because its parent timed out.
 
 ## 6. Span branch assignment (`branchOf`)
 
@@ -582,6 +618,16 @@ Each entry: **scenario → expected output → rationale**.
     - Logged via `log('invalid trace event', …)` and dropped. The event still
       occupies a position in `spanTree.events`.
 
+18. **Span open longer than `spanTimeoutMs` with no end event** (DX-1080)
+    - Force-closed with a synthetic failure/interrupted end event (§5.4); becomes
+      `isCompletedSpan` and collapses/renders like a normal completed span instead of
+      hanging with the shimmer effect forever. Test: `span-tree.test.ts`
+      ("an open operation span past the timeout is force-closed…").
+
+19. **Span open but still within `spanTimeoutMs`**
+    - Left untouched — stays open and continues to render as in-progress. Test:
+      `span-tree.test.ts` ("an open span within the timeout window stays open").
+
 ## 14. Performance & complexity
 
 - `buildSpanTree`: O(E log E) for the chronological sort, O(E) for the linear
@@ -625,6 +671,7 @@ Each entry: **scenario → expected output → rationale**.
 | ------------------------------------------------------- | ---------------------------------------------------------------------------- | ----------- |
 | `buildSpanTree`                                         | `packages/plugins/plugin-assistant/src/execution-graph/span-tree.ts`         | L112        |
 | `applyEventLimit`                                       | same                                                                         | L211        |
+| `makeTimeoutEndEvent` / `DEFAULT_SPAN_TIMEOUT_MS`        | same                                                                         | L252 / L13  |
 | `ROOT_SPAN_ID`                                          | same                                                                         | L12         |
 | `BEGIN_EVENT_TYPES`/`END_EVENT_TYPES`                   | same                                                                         | L47         |
 | `walkSpanTree`/`flattenSpanTree`                        | same                                                                         | L245        |

--- a/packages/plugins/plugin-assistant/src/execution-graph/execution-graph.ts
+++ b/packages/plugins/plugin-assistant/src/execution-graph/execution-graph.ts
@@ -93,6 +93,17 @@ export interface BuildExecutionGraphParams {
   activeProcesses?: readonly Process.Info[];
   collapseCompletedSpans?: boolean;
   eventLimit?: number;
+  /**
+   * Duration a span may sit open with no new events before it's force-closed with a synthetic
+   * end event. Only takes effect when `now` is also provided. Defaults to
+   * `DEFAULT_SPAN_TIMEOUT_MS`.
+   */
+  spanTimeoutMs?: number;
+  /**
+   * Reference time used to detect abandoned spans. Force-closing is skipped entirely when this
+   * is omitted.
+   */
+  now?: number;
 }
 
 /**
@@ -121,8 +132,10 @@ export const buildExecutionGraph = ({
   activeProcesses = [],
   collapseCompletedSpans = false,
   eventLimit = 500,
+  spanTimeoutMs,
+  now,
 }: BuildExecutionGraphParams): ExecutionGraph => {
-  const spanTree = buildSpanTree(traceMessages, { eventLimit });
+  const spanTree = buildSpanTree(traceMessages, { eventLimit, spanTimeoutMs, now });
   const toolCallContext = buildToolCallContext(traceMessages);
   const built = spanTreeToCommits(spanTree, activeProcesses, toolCallContext, collapseCompletedSpans);
   log('trace execution graph', {

--- a/packages/plugins/plugin-assistant/src/execution-graph/index.ts
+++ b/packages/plugins/plugin-assistant/src/execution-graph/index.ts
@@ -22,6 +22,7 @@ export {
 export {
   BEGIN_EVENT_TYPES,
   type BuildSpanTreeOptions,
+  DEFAULT_SPAN_TIMEOUT_MS,
   END_EVENT_TYPES,
   ROOT_SPAN_ID,
   type Span,

--- a/packages/plugins/plugin-assistant/src/execution-graph/span-tree.test.ts
+++ b/packages/plugins/plugin-assistant/src/execution-graph/span-tree.test.ts
@@ -9,7 +9,13 @@ import { describe, test } from 'vitest';
 import { AgentRequestBegin, AgentRequestEnd } from '@dxos/assistant';
 import { Trace } from '@dxos/compute';
 
-import { ROOT_SPAN_ID, buildSpanTree, collectSpanTreeEventsCategorically, flattenSpanTree } from './span-tree';
+import {
+  DEFAULT_SPAN_TIMEOUT_MS,
+  ROOT_SPAN_ID,
+  buildSpanTree,
+  collectSpanTreeEventsCategorically,
+  flattenSpanTree,
+} from './span-tree';
 import { collectTraceEvents, withMeta } from './testing';
 
 const NoteEvent = Trace.EventType('note', {
@@ -245,6 +251,63 @@ describe('buildSpanTree', () => {
     expect(order[1].meta.pid).toBe('agent-1');
     expect(order[2].meta.pid).toBe('op-1');
     expect(order).toHaveLength(3);
+  });
+
+  test('an open operation span past the timeout is force-closed with a synthetic failure end', ({ expect }) => {
+    const messages = collectTraceEvents(
+      withMeta({ pid: 'op-1' }, Trace.write(Trace.OperationStart, { key: 'reply', name: 'Reply' })),
+    );
+    // The single event lands at timestamp 1; `now` is well past the default timeout.
+    const tree = buildSpanTree(messages, { now: 1 + DEFAULT_SPAN_TIMEOUT_MS });
+    expect(tree.children).toHaveLength(1);
+    const span = tree.children[0];
+    expect(span.events).toHaveLength(2);
+    expect(span.events[1].type).toBe(Trace.OperationEnd.key);
+    expect(span.events[1].data).toMatchObject({ key: 'reply', name: 'Reply', outcome: 'failure' });
+  });
+
+  test('an open agent request span past the timeout is force-closed as interrupted', ({ expect }) => {
+    const messages = collectTraceEvents(withMeta({ pid: 'agent-1' }, Trace.write(AgentRequestBegin, {})));
+    const tree = buildSpanTree(messages, { now: 1 + DEFAULT_SPAN_TIMEOUT_MS });
+    const span = tree.children[0];
+    expect(span.events).toHaveLength(2);
+    expect(span.events[1].type).toBe(AgentRequestEnd.key);
+    expect(span.events[1].data).toMatchObject({ status: 'interrupted' });
+  });
+
+  test('an open span within the timeout window stays open', ({ expect }) => {
+    const messages = collectTraceEvents(
+      withMeta({ pid: 'op-1' }, Trace.write(Trace.OperationStart, { key: 'reply', name: 'Reply' })),
+    );
+    const tree = buildSpanTree(messages, { now: 1 + DEFAULT_SPAN_TIMEOUT_MS - 1 });
+    const span = tree.children[0];
+    expect(span.events).toHaveLength(1);
+  });
+
+  test('spanTimeoutMs is configurable', ({ expect }) => {
+    const messages = collectTraceEvents(
+      withMeta({ pid: 'op-1' }, Trace.write(Trace.OperationStart, { key: 'reply', name: 'Reply' })),
+    );
+    const closed = buildSpanTree(messages, { now: 100, spanTimeoutMs: 10 });
+    expect(closed.children[0].events).toHaveLength(2);
+
+    const stillOpen = buildSpanTree(messages, { now: 100, spanTimeoutMs: 1_000 });
+    expect(stillOpen.children[0].events).toHaveLength(1);
+  });
+
+  test('a completed span is unaffected by the timeout', ({ expect }) => {
+    const messages = collectTraceEvents(
+      withMeta(
+        { pid: 'op-1' },
+        Effect.gen(function* () {
+          yield* Trace.write(Trace.OperationStart, { key: 'reply', name: 'Reply' });
+          yield* Trace.write(Trace.OperationEnd, { key: 'reply', name: 'Reply', outcome: 'success' });
+        }),
+      ),
+    );
+    const tree = buildSpanTree(messages, { now: 1 + DEFAULT_SPAN_TIMEOUT_MS });
+    expect(tree.children[0].events).toHaveLength(2);
+    expect(tree.children[0].events[1].data).toMatchObject({ outcome: 'success' });
   });
 
   test('collectSpanTreeEventsCategorically emits begin, child subtrees, then remaining events', ({ expect }) => {

--- a/packages/plugins/plugin-assistant/src/execution-graph/span-tree.test.ts
+++ b/packages/plugins/plugin-assistant/src/execution-graph/span-tree.test.ts
@@ -295,6 +295,29 @@ describe('buildSpanTree', () => {
     expect(stillOpen.children[0].events).toHaveLength(1);
   });
 
+  test('a span superseded by a later same-pid begin event is force-closed too', ({ expect }) => {
+    // The first begin never gets an end (interleaved B1 B2 E1 pattern, §15) — `openSpans` only
+    // tracks the second span once it supersedes the first, so the sweep must reach both.
+    const messages = collectTraceEvents(
+      withMeta(
+        { pid: 'agent-1' },
+        Effect.gen(function* () {
+          yield* Trace.write(AgentRequestBegin, {});
+          yield* Trace.write(AgentRequestBegin, {});
+          yield* Trace.write(AgentRequestEnd, { status: 'success' });
+        }),
+      ),
+    );
+    const tree = buildSpanTree(messages, { now: 1 + DEFAULT_SPAN_TIMEOUT_MS });
+    expect(tree.children).toHaveLength(2);
+    const [superseded, current] = tree.children;
+    expect(superseded.events).toHaveLength(2);
+    expect(superseded.events[1].type).toBe(AgentRequestEnd.key);
+    expect(superseded.events[1].data).toMatchObject({ status: 'interrupted' });
+    expect(current.events).toHaveLength(2);
+    expect(current.events[1].data).toMatchObject({ status: 'success' });
+  });
+
   test('a completed span is unaffected by the timeout', ({ expect }) => {
     const messages = collectTraceEvents(
       withMeta(

--- a/packages/plugins/plugin-assistant/src/execution-graph/span-tree.ts
+++ b/packages/plugins/plugin-assistant/src/execution-graph/span-tree.ts
@@ -2,9 +2,18 @@
 // Copyright 2026 DXOS.org
 //
 
+import * as Option from 'effect/Option';
+import * as Schema from 'effect/Schema';
+
 import { AgentRequestBegin, AgentRequestEnd } from '@dxos/assistant';
 import { Trace } from '@dxos/compute';
 import { EID } from '@dxos/keys';
+
+/**
+ * Default duration a span may sit open with no new events before it's considered abandoned
+ * (the runtime crashed, lost connectivity, or otherwise never wrote the closing event).
+ */
+export const DEFAULT_SPAN_TIMEOUT_MS = 20 * 60 * 1_000;
 
 /**
  * Synthetic id assigned to the root span.
@@ -93,6 +102,20 @@ export interface BuildSpanTreeOptions {
    * and collapse them onto the root branch.
    */
   eventLimit?: number;
+
+  /**
+   * Duration a span may sit open with no new events before it's force-closed with a synthetic
+   * end event. Only takes effect when `now` is also provided. Defaults to
+   * `DEFAULT_SPAN_TIMEOUT_MS`.
+   */
+  spanTimeoutMs?: number;
+
+  /**
+   * Reference time used to detect abandoned spans. Force-closing is skipped entirely when this
+   * is omitted, so callers that don't pass it (tests, deterministic snapshots) keep the prior
+   * behavior of leaving unterminated spans open regardless of their fixture timestamps.
+   */
+  now?: number;
 }
 
 /**
@@ -196,6 +219,24 @@ export const buildSpanTree = (messages: readonly Trace.Message[], options: Build
     }
   }
 
+  // Force-close spans the runtime never reported the end of (crash, dropped connection, etc.) —
+  // otherwise they stay open forever and the UI renders them as stuck mid-flight. Skipped when
+  // `now` isn't supplied so callers that don't care about wall-clock staleness are unaffected.
+  if (options.now !== undefined) {
+    const now = options.now;
+    const spanTimeoutMs = options.spanTimeoutMs ?? DEFAULT_SPAN_TIMEOUT_MS;
+    for (const span of openSpans.values()) {
+      const lastEvent = span.events[span.events.length - 1]!;
+      const timeoutAt = lastEvent.timestamp + spanTimeoutMs;
+      if (now < timeoutAt) {
+        continue;
+      }
+      const endEvent = makeTimeoutEndEvent(span, timeoutAt);
+      span.events.push(endEvent);
+      noteTimestamp(span, endEvent.timestamp);
+    }
+  }
+
   // Sort children chronologically for deterministic output.
   const sortChildren = (span: MutableSpan): void => {
     span.children.sort((a, b) => a.firstTimestamp - b.firstTimestamp);
@@ -206,6 +247,48 @@ export const buildSpanTree = (messages: readonly Trace.Message[], options: Build
   sortChildren(root);
 
   return freezeSpan(root);
+};
+
+/**
+ * Message stamped on synthetic end events produced when a span times out.
+ */
+const SPAN_TIMEOUT_MESSAGE = 'No end event was recorded for this span; it was closed after a timeout.';
+
+/**
+ * Synthesizes the end event that closes an abandoned span, matching the event type its begin
+ * event opened it with (`OperationStart` → `OperationEnd`, `AgentRequestBegin` → `AgentRequestEnd`).
+ */
+const makeTimeoutEndEvent = (span: MutableSpan, timestamp: number): Trace.FlatEvent => {
+  const beginEvent = span.events[0]!;
+  if (beginEvent.type === AgentRequestBegin.key) {
+    return {
+      type: AgentRequestEnd.key,
+      timestamp,
+      meta: beginEvent.meta,
+      isEphemeral: false,
+      data: { status: 'interrupted', error: SPAN_TIMEOUT_MESSAGE },
+    };
+  }
+
+  // `beginEvent.data` is unvalidated wire data; decode defensively rather than trusting its shape.
+  const fallback: Schema.Schema.Type<typeof Trace.OperationStart.schema> = { key: 'unknown' };
+  const beginData = Option.getOrElse(
+    Schema.decodeUnknownOption(Trace.OperationStart.schema)(beginEvent.data),
+    () => fallback,
+  );
+  return {
+    type: Trace.OperationEnd.key,
+    timestamp,
+    meta: beginEvent.meta,
+    isEphemeral: false,
+    data: {
+      key: beginData.key,
+      name: beginData.name,
+      icon: beginData.icon,
+      outcome: 'failure',
+      error: SPAN_TIMEOUT_MESSAGE,
+    },
+  };
 };
 
 /**

--- a/packages/plugins/plugin-assistant/src/execution-graph/span-tree.ts
+++ b/packages/plugins/plugin-assistant/src/execution-graph/span-tree.ts
@@ -156,6 +156,12 @@ export const buildSpanTree = (messages: readonly Trace.Message[], options: Build
   // a sibling's released lane instead of forking off its parent.
   const lastSpanByPid = new Map<string, MutableSpan>();
 
+  // Every span ever opened, including ones later superseded by a same-pid begin event before
+  // getting an end event (§15 "interleaved same-pid begin/end pairs"). `openSpans` only tracks
+  // the *current* span per pid, so a superseded span — which will never receive an end event —
+  // would otherwise be unreachable by the timeout sweep below.
+  const allSpans: MutableSpan[] = [];
+
   let spanCounter = 0;
   const allocSpanId = (pid: string): string => {
     const id = `${pid}#${spanCounter}`;
@@ -188,6 +194,7 @@ export const buildSpanTree = (messages: readonly Trace.Message[], options: Build
       span.events.push(event);
       noteTimestamp(span, event.timestamp);
       parent.children.push(span);
+      allSpans.push(span);
       // The new span supersedes any previously-open span for this pid.
       openSpans.set(pid, span);
       lastSpanByPid.set(pid, span);
@@ -220,13 +227,18 @@ export const buildSpanTree = (messages: readonly Trace.Message[], options: Build
   }
 
   // Force-close spans the runtime never reported the end of (crash, dropped connection, etc.) —
-  // otherwise they stay open forever and the UI renders them as stuck mid-flight. Skipped when
-  // `now` isn't supplied so callers that don't care about wall-clock staleness are unaffected.
+  // otherwise they stay open forever and the UI renders them as stuck mid-flight. Walks every
+  // span ever opened (not just `openSpans`) so a span superseded by a later same-pid begin event
+  // — which never receives its own end event — is force-closed too. Skipped when `now` isn't
+  // supplied so callers that don't care about wall-clock staleness are unaffected.
   if (options.now !== undefined) {
     const now = options.now;
     const spanTimeoutMs = options.spanTimeoutMs ?? DEFAULT_SPAN_TIMEOUT_MS;
-    for (const span of openSpans.values()) {
+    for (const span of allSpans) {
       const lastEvent = span.events[span.events.length - 1]!;
+      if (isSpanEndEvent(lastEvent)) {
+        continue;
+      }
       const timeoutAt = lastEvent.timestamp + spanTimeoutMs;
       if (now < timeoutAt) {
         continue;


### PR DESCRIPTION
## Summary

- The runtime can fail to write the closing `operation.end` / `assistant.agentRequestEnd` trace event (crash, dropped connection, killed process). Previously such a span stayed open forever, rendering stuck with the "in progress" shimmer in the TracePanel timeline.
- `buildSpanTree` (and `buildExecutionGraph`) now accept optional `spanTimeoutMs` (default 20 minutes) and `now` options. When `now` is supplied, any span still open after `spanTimeoutMs` of inactivity is force-closed with a synthetic end event — `OperationEnd` with `outcome: 'failure'` for operation spans, `AgentRequestEnd` with `status: 'interrupted'` for agent-request spans — so it renders as terminated like any other completed span.
- Force-closing only activates when `now` is explicitly passed, so existing deterministic callers/tests (which use tiny synthetic fixture timestamps, not wall-clock time) are unaffected by default.
- `TracePanel` now ticks a `now` value every 60s and passes it through, so live spans that go stale purely from inactivity (no new trace events to otherwise trigger a recompute) still get force-closed.
- Updated `SPEC.md` (§5.4, edge cases §18–19) and added test coverage in `span-tree.test.ts`.

Closes DX-1080.

## Test plan

- [x] `oxlint` clean on all changed files.
- [x] `tsc --build` on `plugin-assistant`'s full dependency graph — no new type errors introduced (pre-existing unrelated errors elsewhere in the repo, e.g. missing `@dxos/protocols` proto codegen, are present on `main` too).
- [ ] `moon run plugin-assistant:test` — could not be run in this sandbox: `moon` failed to download its own `javascript_toolchain` plugin from `moonrepo/plugins` on GitHub, which this session's GitHub access is scoped away from (unrelated to `dxos/dxos`). Please run the suite in CI/locally to confirm `span-tree.test.ts` and `execution-graph.test.ts` pass.
- [ ] Manually exercise the TracePanel timeline with a span whose end event is deliberately withheld, to visually confirm it renders as terminated after the timeout.


---
_Generated by [Claude Code](https://claude.ai/code/session_019Zv6ejBa1ECEDeJgzjQbDV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trace views now periodically refresh even when no new events arrive, so stalled/incomplete traces can update automatically.
  * Abandoned trace spans are automatically force-closed after a timeout, improving clarity for incomplete recordings.

* **Bug Fixes**
  * Incomplete traces that never receive closing events no longer risk appearing to stay open indefinitely.
  * When spans are already completed, they remain unchanged during periodic refresh and timeout checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->