### PR TITLE
fix(plugin-wnfs): fix plugin activation race and unify backend id/storage

### DIFF
--- a/packages/plugins/plugin-file/PLUGIN.mdl
+++ b/packages/plugins/plugin-file/PLUGIN.mdl
@@ -44,17 +44,16 @@ type BackendDescriptor
     UI-facing descriptor for a registered storage option. Carries no upload/read behavior itself —
     that lives in the matching `BlobBackend` registered on the ECHO Hypergraph under `storage`.
   fields:
-    id: string                # stable backend id (e.g. 'inline', 'wnfs', 'edge'); used as the settings key
     name: string               # display label shown in settings
     description?: string       # description shown next to the backend in settings
-    storage: string             # Blob.fromBytes's `storage` option to use when this descriptor is selected
+    storage: string             # Blob.fromBytes's `storage` option; also the settings key (e.g. 'inline', 'wnfs', 'edge')
 ```
 
 ```mdl
 type Settings
   desc: Per-user plugin settings stored in the ECHO space.
   fields:
-    backend?: string         # active backend id; defaults to 'inline'
+    backend?: string         # active backend's storage name; defaults to 'inline'
 ```
 
 ## Components
@@ -282,7 +281,7 @@ test T-5: Preview PDF
 
 ```mdl
 test T-6: Backend fallback to inline
-  given: Settings.backend is 'wnfs' but no BackendDescriptor with id 'wnfs' is registered
+  given: Settings.backend is 'wnfs' but no BackendDescriptor with storage 'wnfs' is registered
   when: op:Create is invoked
   then: the inline backend is used and the file is stored inline
 ```

--- a/packages/plugins/plugin-file/src/capabilities/edge-backend.ts
+++ b/packages/plugins/plugin-file/src/capabilities/edge-backend.ts
@@ -19,7 +19,6 @@ export default Capability.makeModule(
     }
 
     return Capability.contributes(FileCapabilities.Backend, {
-      id: Blob.Storage.edge,
       name: 'Edge',
       description: 'Store files on the DXOS edge network. Scales beyond the inline size cap.',
       storage: Blob.Storage.edge,

--- a/packages/plugins/plugin-file/src/capabilities/inline-backend.ts
+++ b/packages/plugins/plugin-file/src/capabilities/inline-backend.ts
@@ -7,14 +7,13 @@ import * as Effect from 'effect/Effect';
 import { Capability } from '@dxos/app-framework';
 import { Blob } from '@dxos/echo';
 
-import { FileCapabilities, Settings } from '#types';
+import { FileCapabilities } from '#types';
 
 /**
  * Inline backend descriptor: file bytes are stored on the ECHO object itself.
  * Exported standalone for direct testing.
  */
 export const inlineBackend: FileCapabilities.Backend = {
-  id: Settings.DEFAULT_BACKEND_ID,
   name: 'Inline (ECHO)',
   description: 'Store the file bytes directly inside the ECHO document. Capped at 4MB; images, videos, and PDFs only.',
   storage: Blob.Storage.inline,

--- a/packages/plugins/plugin-file/src/containers/FileSettings/FileSettings.tsx
+++ b/packages/plugins/plugin-file/src/containers/FileSettings/FileSettings.tsx
@@ -20,12 +20,11 @@ export const FileSettings = ({ settings, onSettingsChange }: FileSettingsProps) 
   const client = useClient();
   const backends = useCapabilities(FileCapabilities.Backend);
   // No explicit choice defers to the Blob registry's own configured default (edge when
-  // configured, inline otherwise) — match by `storage`, not by the plugin's own default id, so
-  // the Select reflects what an upload will actually use.
-  const requested = settings.backend ? backends.find((b) => b.id === settings.backend) : undefined;
+  // configured, inline otherwise), so the Select reflects what an upload will actually use.
+  const requested = settings.backend ? backends.find((b) => b.storage === settings.backend) : undefined;
   const active = requested ?? backends.find((b) => b.storage === client.graph.defaultBlobStorage) ?? backends[0];
-  // Use the resolved backend id so the Select never shows a missing/stale value.
-  const activeId = active?.id ?? Settings.DEFAULT_BACKEND_ID;
+  // Use the resolved backend's storage name so the Select never shows a missing/stale value.
+  const activeStorage = active?.storage ?? Settings.DEFAULT_BACKEND_STORAGE;
 
   const handleChange = useCallback(
     (value: string) => onSettingsChange?.((current) => ({ ...current, backend: value })),
@@ -47,13 +46,13 @@ export const FileSettings = ({ settings, onSettingsChange }: FileSettingsProps) 
               label={t('settings.backend.label')}
               description={active?.description ?? t('settings.backend.description')}
             >
-              <Select.Root value={activeId} onValueChange={handleChange} disabled={!onSettingsChange}>
+              <Select.Root value={activeStorage} onValueChange={handleChange} disabled={!onSettingsChange}>
                 <Select.TriggerButton placeholder={t('settings.backend.placeholder')} />
                 <Select.Portal>
                   <Select.Content>
                     <Select.Viewport>
                       {backends.map((backend) => (
-                        <Select.Option key={backend.id} value={backend.id}>
+                        <Select.Option key={backend.storage} value={backend.storage}>
                           {backend.name}
                         </Select.Option>
                       ))}

--- a/packages/plugins/plugin-file/src/operations/create.test.ts
+++ b/packages/plugins/plugin-file/src/operations/create.test.ts
@@ -14,7 +14,7 @@ import { ClientPlugin, initializeIdentity } from '@dxos/plugin-client/testing';
 import { createComposerTestApp } from '@dxos/plugin-testing/harness';
 
 import { FilePlugin } from '#plugin';
-import { FileCapabilities, FileOperation, Settings } from '#types';
+import { FileCapabilities, FileOperation } from '#types';
 
 import { FileTooLargeError, UnsupportedFileTypeError } from './create';
 
@@ -67,7 +67,7 @@ describe('FileOperation.Create', () => {
     harness.capabilities.contribute({
       module: 'test',
       interface: FileCapabilities.Backend,
-      implementation: { id: 'mem', name: 'Mem', storage: 'mem' },
+      implementation: { name: 'Mem', storage: 'mem' },
     });
 
     try {
@@ -132,7 +132,7 @@ const setup = async () => {
   harness.capabilities.contribute({
     module: 'test',
     interface: FileCapabilities.Backend,
-    implementation: { id: Settings.DEFAULT_BACKEND_ID, name: 'Inline (ECHO)', storage: Blob.Storage.inline },
+    implementation: { name: 'Inline (ECHO)', storage: Blob.Storage.inline },
   });
 
   const { personalSpace } = await EffectEx.runAndForwardErrors(

--- a/packages/plugins/plugin-file/src/operations/create.ts
+++ b/packages/plugins/plugin-file/src/operations/create.ts
@@ -44,8 +44,8 @@ export class FileReadError extends Error {
 
 /**
  * Resolves the storage name to force for an upload:
- * - the id the user explicitly configured in Settings.backend, if it matches a registered
- *   {@link FileCapabilities.Backend} descriptor
+ * - the storage name the user explicitly configured in Settings.backend, if it matches a
+ *   registered {@link FileCapabilities.Backend} descriptor
  * - otherwise `undefined`, leaving `File.fromBytes`'s `storage` option unset so it falls through
  *   to the Blob registry's own configured default (edge when configured, inline otherwise)
  *   instead of hardcoding `inline`
@@ -65,7 +65,7 @@ export const resolveActiveStorage = Effect.gen(function* () {
   if (settingsAtomOpt._tag === 'Some' && registryOpt._tag === 'Some') {
     const settings = registryOpt.value.get(settingsAtomOpt.value) as Settings.Settings;
     if (settings.backend) {
-      const match = backends.find((b) => b.id === settings.backend);
+      const match = backends.find((b) => b.storage === settings.backend);
       if (match) {
         return match.storage;
       }

--- a/packages/plugins/plugin-file/src/types/FileCapabilities.ts
+++ b/packages/plugins/plugin-file/src/types/FileCapabilities.ts
@@ -18,13 +18,15 @@ import * as Settings from './Settings';
  * under `storage` (see `client.graph.registerBlobBackend`) — this type carries no behavior.
  */
 export type Backend = {
-  /** Stable backend id (e.g. 'inline', 'wnfs'). Used as the settings key. */
-  readonly id: string;
   /** Display label shown in the settings UI. */
   readonly name: string;
   /** Description shown next to the backend in settings. */
   readonly description?: string;
-  /** `Blob.fromBytes`'s `storage` option to use when this backend is selected. */
+  /**
+   * `Blob.fromBytes`'s `storage` option to use when this backend is selected. Also the settings
+   * key identifying this backend — one `BlobBackend` is registered per storage name, so the two
+   * concepts always coincide.
+   */
   readonly storage: string;
 };
 

--- a/packages/plugins/plugin-file/src/types/Settings.ts
+++ b/packages/plugins/plugin-file/src/types/Settings.ts
@@ -6,7 +6,7 @@
 
 import * as Schema from 'effect/Schema';
 
-export const DEFAULT_BACKEND_ID = 'inline';
+export const DEFAULT_BACKEND_STORAGE = 'inline';
 
 export const Settings = Schema.mutable(
   Schema.Struct({

--- a/packages/plugins/plugin-wnfs/PLUGIN.mdl
+++ b/packages/plugins/plugin-wnfs/PLUGIN.mdl
@@ -10,7 +10,7 @@ WNFS provides a content-addressed, end-to-end encrypted private file system usin
 structure. Files are stored as IPLD blocks referenced by CID, replicated to a DXOS edge blob service, and
 cached locally in IndexedDB. The plugin registers a `BlobBackend` (schemes: `['wnfs']`) on the ECHO Hypergraph
 via `client.graph.registerBlobBackend`, and contributes a matching `FileCapabilities.Backend` descriptor
-(`{ id: 'wnfs', storage: 'wnfs' }`) so `plugin-file` — and any plugin built on it, e.g. `plugin-gallery` — can
+(`{ storage: 'wnfs' }`) so `plugin-file` — and any plugin built on it, e.g. `plugin-gallery` — can
 upload files and resolve `wnfs://` URIs uniformly via the core `Blob.fromBytes`/`Blob.url`/`Blob.read` API,
 without knowing the underlying storage layer. Uploads are scoped to a DXOS Space; the private forest root CID
 is persisted on the space's ECHO properties and updated atomically on every write.

--- a/packages/plugins/plugin-wnfs/src/WnfsPlugin.tsx
+++ b/packages/plugins/plugin-wnfs/src/WnfsPlugin.tsx
@@ -2,16 +2,14 @@
 // Copyright 2024 DXOS.org
 //
 
-import * as Effect from 'effect/Effect';
-
-import { Capability, Plugin } from '@dxos/app-framework';
+import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { ClientEvents } from '@dxos/plugin-client';
 
-import { BlobBackend, Blockstore } from '#capabilities';
+import { BlobBackend, Dependencies } from '#capabilities';
 import { meta } from '#meta';
 import { translations } from '#translations';
-import { WnfsCapabilities } from '#types';
+import { WnfsEvents } from '#types';
 
 // eslint-disable-next-line import/no-relative-packages
 import pluginSpec from '../PLUGIN.mdl?raw';
@@ -19,22 +17,14 @@ import pluginSpec from '../PLUGIN.mdl?raw';
 export const WnfsPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.addModule({
-    id: 'blockstore',
+    id: 'dependencies',
     activatesOn: ClientEvents.ClientReady,
-    activate: Blockstore,
-  }),
-  Plugin.addModule({
-    id: 'instances',
-    activatesOn: ClientEvents.ClientReady,
-    activate: () =>
-      Effect.sync(() => {
-        const instances: WnfsCapabilities.Instances = {};
-        return Capability.contributes(WnfsCapabilities.Instances, instances);
-      }),
+    firesAfterActivation: [WnfsEvents.DependenciesReady],
+    activate: Dependencies,
   }),
   Plugin.addModule({
     id: 'blob-backend',
-    activatesOn: ClientEvents.ClientReady,
+    activatesOn: WnfsEvents.DependenciesReady,
     activate: BlobBackend,
   }),
   AppPlugin.addPluginAssetModule({

--- a/packages/plugins/plugin-wnfs/src/capabilities/blob-backend.ts
+++ b/packages/plugins/plugin-wnfs/src/capabilities/blob-backend.ts
@@ -82,10 +82,9 @@ export const createWnfsBlobBackend = ({ client, blockstore, instances }: CreateW
 
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
-    const capabilities = yield* Capability.Service;
     const client = yield* Capability.get(ClientCapabilities.Client);
     const blockstore = yield* Capability.get(WnfsCapabilities.Blockstore);
-    const instances = capabilities.get(WnfsCapabilities.Instances);
+    const instances = yield* Capability.get(WnfsCapabilities.Instances);
 
     const cleanup = client.graph.registerBlobBackend(
       WnfsCapabilities.WNFS_BACKEND,
@@ -95,7 +94,6 @@ export default Capability.makeModule(
     return Capability.contributes(
       FileCapabilities.Backend,
       {
-        id: WnfsCapabilities.WNFS_BACKEND,
         name: 'WNFS',
         description: 'Decentralized, end-to-end encrypted storage via Web Native File System.',
         storage: WnfsCapabilities.WNFS_BACKEND,

--- a/packages/plugins/plugin-wnfs/src/capabilities/dependencies.ts
+++ b/packages/plugins/plugin-wnfs/src/capabilities/dependencies.ts
@@ -18,6 +18,11 @@ export default Capability.makeModule(
     const blockstore = Blockstore.create(apiHost);
     yield* Effect.tryPromise(() => blockstore.open());
 
-    return Capability.contributes(WnfsCapabilities.Blockstore, blockstore);
+    const instances: WnfsCapabilities.Instances = {};
+
+    return [
+      Capability.contributes(WnfsCapabilities.Blockstore, blockstore),
+      Capability.contributes(WnfsCapabilities.Instances, instances),
+    ];
   }),
 );

--- a/packages/plugins/plugin-wnfs/src/capabilities/index.ts
+++ b/packages/plugins/plugin-wnfs/src/capabilities/index.ts
@@ -6,4 +6,4 @@ import { Capability } from '@dxos/app-framework';
 
 export const BlobBackend = Capability.lazy('BlobBackend', () => import('./blob-backend'));
 
-export const Blockstore = Capability.lazy('Blockstore', () => import('./blockstore'));
+export const Dependencies = Capability.lazy('Dependencies', () => import('./dependencies'));

--- a/packages/plugins/plugin-wnfs/src/types/WnfsEvents.ts
+++ b/packages/plugins/plugin-wnfs/src/types/WnfsEvents.ts
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// @import-as-namespace
+
+import { ActivationEvent } from '@dxos/app-framework';
+
+import { meta } from '#meta';
+
+/**
+ * Fired by the `dependencies` module (via `firesAfterActivation`) once it finishes contributing
+ * `WnfsCapabilities.Blockstore`/`Instances`. `blob-backend` activates on this event rather than
+ * `ClientEvents.ClientReady` directly — `dependencies` also activates on `ClientReady`, and
+ * modules activating on the same event load concurrently with capabilities invisible to each
+ * other until the whole batch settles, so `blob-backend` couldn't otherwise be guaranteed to run
+ * after `dependencies`.
+ */
+export const DependenciesReady = ActivationEvent.make(`${meta.profile.key}.event.dependenciesReady`);

--- a/packages/plugins/plugin-wnfs/src/types/index.ts
+++ b/packages/plugins/plugin-wnfs/src/types/index.ts
@@ -3,3 +3,4 @@
 //
 
 export * as WnfsCapabilities from './WnfsCapabilities';
+export * as WnfsEvents from './WnfsEvents';


### PR DESCRIPTION
## Summary

Follow-up fixes to #12090 (ECHO Blob API), found while smoke-testing the WNFS backend in Composer after that PR landed.

- **plugin-wnfs failed to activate at runtime** (`invariant violation: No capability found for org.dxos.plugin.wnfs.capability.blockstore`). Root cause: `blob-backend`'s module eagerly resolved `WnfsCapabilities.Blockstore`/`Instances` during its own activation body, but those capabilities are contributed by sibling modules (`blockstore`, `instances`) activating on the *same* `ClientEvents.ClientReady` event. Modules activating on the same event load concurrently (`Effect.allWith({ concurrency: 'unbounded' })`), and their capability contributions aren't visible to each other until the whole batch settles — this was a guaranteed structural failure, not a flaky timing race.

  Fixed by:
  - Merging `blockstore` + `instances` into a single `dependencies` module (contributing both capabilities together).
  - Having `dependencies` declare `firesAfterActivation: [WnfsEvents.DependenciesReady]` (new dedicated event).
  - Having `blob-backend` activate on `WnfsEvents.DependenciesReady` instead of `ClientEvents.ClientReady` directly.
  
  This mirrors the existing `SchemaDefs`/`AppActivationEvents.SetupSchema` pattern already used in `plugin-client/src/ClientPlugin.ts` for the same class of problem.

- **`FileCapabilities.Backend.id` was redundant with `.storage`** — every registered backend (inline/edge/wnfs) always set both fields to the same value. Removed `id` entirely; `storage` is now the sole identifying key used throughout (settings UI dropdown, `resolveActiveStorage`, tests).

## Test plan
- [x] `moon run plugin-wnfs:build` / `moon run plugin-file:build` — clean
- [x] `moon run plugin-wnfs:test --force` (8/8) / `moon run plugin-file:test --force` (5/5) — clean
- [x] `moon run plugin-wnfs:lint -- --fix` / `moon run plugin-file:lint -- --fix` — 0 warnings/errors
- [x] Diff audited for new type casts — none found
- [ ] Manual verification in Composer: confirm plugin-wnfs activates without error and file upload/settings backend selection works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backend selection now uses the storage name shown in the UI, making the chosen upload backend match what is actually used.
  * WNFS-related startup and backend registration now follow a clearer initialization flow.

* **Bug Fixes**
  * Improved fallback behavior so the inline backend is used when the selected storage backend isn’t available.
  * Updated backend matching to avoid mismatches between displayed labels and configured storage values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->