### PR TITLE
feat(echo): add access.spaceId field to automerge documents

### DIFF
--- a/packages/core/echo/echo-client/src/core-db/entity-manager.test.ts
+++ b/packages/core/echo/echo-client/src/core-db/entity-manager.test.ts
@@ -332,6 +332,7 @@ describe('DatabaseImpl', () => {
         await openAndClose(testBuilder);
         const { db } = await testBuilder.createDatabase();
         const rootDoc = db.getSpaceRootDocHandle().doc();
+        expect(rootDoc?.access?.spaceId).to.eq(db.spaceId);
         expect(rootDoc?.access?.spaceKey).to.be.a('string');
       });
 

--- a/packages/core/echo/echo-client/src/core-db/entity-manager.ts
+++ b/packages/core/echo/echo-client/src/core-db/entity-manager.ts
@@ -742,7 +742,7 @@ export class EntityManager implements IDatabaseBinding {
     const doc = existingDocHandle.doc();
     invariant(doc);
     invariant(doc.version === SpaceDocVersion.CURRENT);
-    if (doc.access == null) {
+    if (doc.access?.spaceId == null || doc.access?.spaceKey == null) {
       this._initDocAccess(existingDocHandle);
     }
     this._spaceRootDocHandle = existingDocHandle;
@@ -823,7 +823,8 @@ export class EntityManager implements IDatabaseBinding {
     invariant(this._spaceRootDocHandle, 'Database was not initialized with root object.');
     const spaceDocHandle = this._repoProxy.create<DatabaseDirectory>({
       version: SpaceDocVersion.CURRENT,
-      access: { spaceKey: this._spaceKey.toHex() },
+      // spaceKey is deprecated but still written so older clients can resolve the owning space.
+      access: { spaceId: this._spaceId, spaceKey: this._spaceKey.toHex() },
     });
     const creationPromise = spaceDocHandle
       .whenReady()
@@ -911,7 +912,9 @@ export class EntityManager implements IDatabaseBinding {
 
   private _initDocAccess(handle: DocHandleProxy<DatabaseDirectory>): void {
     handle.change((newDoc: DatabaseDirectory) => {
-      newDoc.access ??= { spaceKey: this._spaceKey.toHex() };
+      newDoc.access ??= {};
+      newDoc.access.spaceId = this._spaceId;
+      // spaceKey is deprecated but still written so older clients can resolve the owning space.
       newDoc.access.spaceKey = this._spaceKey.toHex();
     });
   }

--- a/packages/core/echo/echo-host/src/db-host/automerge-data-source.test.ts
+++ b/packages/core/echo/echo-host/src/db-host/automerge-data-source.test.ts
@@ -9,9 +9,10 @@ import { Context } from '@dxos/context';
 import { type DatabaseDirectory, EntityStructure, SpaceDocVersion } from '@dxos/echo-protocol';
 import { EffectEx } from '@dxos/effect';
 import { type IndexCursor } from '@dxos/index-core';
-import { DXN, SpaceId } from '@dxos/keys';
+import { DXN, PublicKey, SpaceId } from '@dxos/keys';
 
 import { AutomergeHost } from '../automerge';
+import { createIdFromSpaceKey } from '../common';
 import { createTestSqliteRuntime } from '../testing';
 import { AutomergeDataSource, headsCodec } from './automerge-data-source';
 
@@ -38,12 +39,12 @@ const setupAutomergeHost = async (): Promise<AutomergeHost> => {
  */
 const createDatabaseDirectory = async (
   host: AutomergeHost,
-  spaceKey: string,
+  spaceId: SpaceId,
   objects: Record<string, EntityStructure>,
 ): Promise<Awaited<ReturnType<typeof host.createDoc<DatabaseDirectory>>>> => {
   const handle = await host.createDoc<DatabaseDirectory>({
     version: SpaceDocVersion.CURRENT,
-    access: { spaceKey },
+    access: { spaceId },
     objects: {},
     links: {},
   });
@@ -83,9 +84,9 @@ describe('AutomergeDataSource', () => {
 
   test('returns new documents that have no cursor', async () => {
     const host = await setupAutomergeHost();
-    const spaceKey = SpaceId.random();
+    const spaceId = SpaceId.random();
 
-    const handle = await createDatabaseDirectory(host, spaceKey, {
+    const handle = await createDatabaseDirectory(host, spaceId, {
       'obj-1': EntityStructure.makeObject({ type: TEST_TYPE, data: { title: 'Test Document' } }),
     });
     await host.flush(Context.default());
@@ -104,12 +105,12 @@ describe('AutomergeDataSource', () => {
 
   test('returns documents with changed heads', async () => {
     const host = await setupAutomergeHost();
-    const spaceKey = SpaceId.random();
+    const spaceId = SpaceId.random();
 
-    const handle1 = await createDatabaseDirectory(host, spaceKey, {
+    const handle1 = await createDatabaseDirectory(host, spaceId, {
       'obj-1': EntityStructure.makeObject({ type: TEST_TYPE, data: { title: 'Doc 1' } }),
     });
-    const handle2 = await createDatabaseDirectory(host, spaceKey, {
+    const handle2 = await createDatabaseDirectory(host, spaceId, {
       'obj-2': EntityStructure.makeObject({ type: TEST_TYPE, data: { title: 'Doc 2' } }),
     });
     await host.flush(Context.default());
@@ -145,9 +146,9 @@ describe('AutomergeDataSource', () => {
 
   test('skips documents with unchanged heads', async () => {
     const host = await setupAutomergeHost();
-    const spaceKey = SpaceId.random();
+    const spaceId = SpaceId.random();
 
-    const handle = await createDatabaseDirectory(host, spaceKey, {
+    const handle = await createDatabaseDirectory(host, spaceId, {
       'obj-1': EntityStructure.makeObject({ type: TEST_TYPE, data: { title: 'Doc 1' } }),
     });
     await host.flush(Context.default());
@@ -173,11 +174,11 @@ describe('AutomergeDataSource', () => {
 
   test('respects limit option', async () => {
     const host = await setupAutomergeHost();
-    const spaceKey = SpaceId.random();
+    const spaceId = SpaceId.random();
 
     // Create 3 documents.
     for (let i = 1; i <= 3; i++) {
-      await createDatabaseDirectory(host, spaceKey, {
+      await createDatabaseDirectory(host, spaceId, {
         [`obj-${i}`]: EntityStructure.makeObject({ type: TEST_TYPE, data: { title: `Doc ${i}` } }),
       });
     }
@@ -194,9 +195,9 @@ describe('AutomergeDataSource', () => {
 
   test('extracts multiple objects from a document', async () => {
     const host = await setupAutomergeHost();
-    const spaceKey = SpaceId.random();
+    const spaceId = SpaceId.random();
 
-    await createDatabaseDirectory(host, spaceKey, {
+    await createDatabaseDirectory(host, spaceId, {
       'obj-1': EntityStructure.makeObject({ type: TEST_TYPE, data: { title: 'Object 1' } }),
       'obj-2': EntityStructure.makeObject({ type: OTHER_TYPE, data: { title: 'Object 2' } }),
     });
@@ -212,12 +213,12 @@ describe('AutomergeDataSource', () => {
 
   test('skips outdated documents', async () => {
     const host = await setupAutomergeHost();
-    const spaceKey = SpaceId.random();
+    const spaceId = SpaceId.random();
 
     // Create a document with outdated version.
     const handle = await host.createDoc<DatabaseDirectory>({
       version: 0 as SpaceDocVersion, // Outdated version.
-      access: { spaceKey },
+      access: { spaceId },
       objects: {},
       links: {},
     });
@@ -236,9 +237,9 @@ describe('AutomergeDataSource', () => {
 
   test('extracts object attributes correctly', async () => {
     const host = await setupAutomergeHost();
-    const spaceKey = SpaceId.random();
+    const spaceId = SpaceId.random();
 
-    await createDatabaseDirectory(host, spaceKey, {
+    await createDatabaseDirectory(host, spaceId, {
       'person-1': EntityStructure.makeObject({
         type: PERSON_TYPE,
         data: { name: 'Alice', age: 30 },
@@ -257,10 +258,10 @@ describe('AutomergeDataSource', () => {
     expect(obj.data.age).toBe(30);
   });
 
-  test('skips documents without spaceKey', async () => {
+  test('skips documents without space identifiers', async () => {
     const host = await setupAutomergeHost();
 
-    // Create a document without access.spaceKey.
+    // Create a document without access.spaceId/spaceKey.
     const handle = await host.createDoc<DatabaseDirectory>({
       version: SpaceDocVersion.CURRENT,
       objects: {},
@@ -277,5 +278,54 @@ describe('AutomergeDataSource', () => {
     const result = await EffectEx.runAndForwardErrors(dataSource.getChangedObjects(Context.default(), []));
 
     expect(result.objects).toHaveLength(0);
+  });
+
+  test('derives spaceId from documents that only carry the legacy spaceKey field', async () => {
+    const host = await setupAutomergeHost();
+    const spaceKey = PublicKey.random();
+
+    const handle = await host.createDoc<DatabaseDirectory>({
+      version: SpaceDocVersion.CURRENT,
+      access: { spaceKey: spaceKey.toHex() },
+      objects: {},
+      links: {},
+    });
+    handle.change((doc) => {
+      doc.objects = {
+        'obj-1': EntityStructure.makeObject({ type: TEST_TYPE, data: { title: 'Legacy Doc' } }),
+      };
+    });
+    await host.flush(Context.default());
+
+    const dataSource = new AutomergeDataSource(host);
+    const result = await EffectEx.runAndForwardErrors(dataSource.getChangedObjects(Context.default(), []));
+
+    expect(result.objects).toHaveLength(1);
+    expect(result.objects[0].spaceId).toBe(await createIdFromSpaceKey(spaceKey));
+  });
+
+  test('prefers access.spaceId over the legacy spaceKey field', async () => {
+    const host = await setupAutomergeHost();
+    const spaceId = SpaceId.random();
+    const spaceKey = PublicKey.random();
+
+    const handle = await host.createDoc<DatabaseDirectory>({
+      version: SpaceDocVersion.CURRENT,
+      access: { spaceId, spaceKey: spaceKey.toHex() },
+      objects: {},
+      links: {},
+    });
+    handle.change((doc) => {
+      doc.objects = {
+        'obj-1': EntityStructure.makeObject({ type: TEST_TYPE, data: { title: 'New Doc' } }),
+      };
+    });
+    await host.flush(Context.default());
+
+    const dataSource = new AutomergeDataSource(host);
+    const result = await EffectEx.runAndForwardErrors(dataSource.getChangedObjects(Context.default(), []));
+
+    expect(result.objects).toHaveLength(1);
+    expect(result.objects[0].spaceId).toBe(spaceId);
   });
 });

--- a/packages/core/echo/echo-host/src/db-host/automerge-data-source.ts
+++ b/packages/core/echo/echo-host/src/db-host/automerge-data-source.ts
@@ -10,11 +10,9 @@ import { type Context } from '@dxos/context';
 import { DatabaseDirectory, SpaceDocVersion } from '@dxos/echo-protocol';
 import { objectStructureToJson } from '@dxos/echo/internal';
 import { type DataSourceCursor, type IndexDataSource, type IndexerObject } from '@dxos/index-core';
-import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 
 import { type AutomergeHost } from '../automerge';
-import { createIdFromSpaceKey } from '../common';
 
 const HEADS_DELIMITER = '|';
 
@@ -105,14 +103,12 @@ export class AutomergeDataSource implements IndexDataSource {
             continue;
           }
 
-          // Extract spaceId from document.
-          const spaceKeyHex = DatabaseDirectory.getSpaceKey(doc);
-          if (!spaceKeyHex) {
-            // Skip documents without a space key.
+          // Extract spaceId from document, coalescing legacy space key fields.
+          const spaceId = yield* Effect.promise(() => DatabaseDirectory.getSpaceId(doc));
+          if (!spaceId) {
+            // Skip documents without a space identifier.
             continue;
           }
-          const spaceKey = PublicKey.fromHex(spaceKeyHex);
-          const spaceId = yield* Effect.promise(() => createIdFromSpaceKey(spaceKey));
 
           const existingCursor = cursorMap.get(documentId);
           const { changedObjectIds, updatedAt } = inspectDocChanges(doc, existingCursor);

--- a/packages/core/echo/echo-host/src/db-host/echo-host.ts
+++ b/packages/core/echo/echo-host/src/db-host/echo-host.ts
@@ -339,7 +339,8 @@ export class EchoHost extends Resource {
 
     const automergeRoot = await this._automergeHost.createDoc<DatabaseDirectory>({
       version: SpaceDocVersion.CURRENT,
-      access: { spaceKey: spaceKey.toHex() },
+      // spaceKey is deprecated but still written so older clients can resolve the owning space.
+      access: { spaceId, spaceKey: spaceKey.toHex() },
 
       // Better to initialize them right away to avoid merge conflicts and data loss that can occur if those maps get created on the fly.
       objects: {},

--- a/packages/core/echo/echo-protocol/src/document-structure.ts
+++ b/packages/core/echo/echo-protocol/src/document-structure.ts
@@ -31,9 +31,9 @@ export interface DatabaseDirectory {
 
   access?: {
     /**
-     * ID of the space that owns the document (multibase base-32 encoded).
+     * ID of the space that owns the document.
      */
-    spaceId?: string;
+    spaceId?: SpaceId;
 
     /**
      * @deprecated Use {@link spaceId}. Still written alongside `spaceId` so older clients
@@ -71,11 +71,9 @@ export const DatabaseDirectory = Object.freeze({
    * `experimental_spaceKey`), deriving the id from the key for documents that predate `spaceId`.
    */
   getSpaceId: async (doc: DatabaseDirectory): Promise<SpaceId | null> => {
-    // String(...) to handle RawString.
-    const rawSpaceId = doc.access?.spaceId != null ? String(doc.access.spaceId) : null;
-    if (rawSpaceId != null) {
-      invariant(SpaceId.isValid(rawSpaceId), 'Invalid space ID');
-      return rawSpaceId;
+    if (doc.access?.spaceId != null) {
+      invariant(SpaceId.isValid(doc.access.spaceId), 'Invalid space ID');
+      return doc.access.spaceId;
     }
 
     const spaceKeyHex = DatabaseDirectory.getSpaceKey(doc);

--- a/packages/core/echo/echo-protocol/src/document-structure.ts
+++ b/packages/core/echo/echo-protocol/src/document-structure.ts
@@ -3,13 +3,14 @@
 //
 
 import { invariant } from '@dxos/invariant';
-import type { EntityId, URI } from '@dxos/keys';
+import { type EntityId, PublicKey, SpaceId, type URI } from '@dxos/keys';
 import { visitValues } from '@dxos/util';
 
 import { type RawString } from './automerge';
 import type { ForeignKey } from './foreign-key';
 import { type EncodedReference, isEncodedReference } from './reference';
 import { type SpaceDocVersion } from './space-doc-version';
+import { createIdFromSpaceKey } from './space-id';
 
 export type SpaceState = {
   // Url of the root automerge document.
@@ -29,7 +30,19 @@ export interface DatabaseDirectory {
   version?: SpaceDocVersion;
 
   access?: {
-    spaceKey: string;
+    /**
+     * ID of the space that owns the document (multibase base-32 encoded).
+     */
+    spaceId?: string;
+
+    /**
+     * @deprecated Use {@link spaceId}. Still written alongside `spaceId` so older clients
+     * (and code paths that need the space public key, which cannot be recovered from the id)
+     * keep working.
+     *
+     * Space key of the owning space in hex format without the 0x prefix.
+     */
+    spaceKey?: string;
   };
   /**
    * Objects inlined in the current document.
@@ -53,6 +66,30 @@ export interface DatabaseDirectory {
 
 export const DatabaseDirectory = Object.freeze({
   /**
+   * @returns ID of the space that owns the document.
+   * Coalesces `access.spaceId` with the deprecated space key fields (`access.spaceKey`,
+   * `experimental_spaceKey`), deriving the id from the key for documents that predate `spaceId`.
+   */
+  getSpaceId: async (doc: DatabaseDirectory): Promise<SpaceId | null> => {
+    // String(...) to handle RawString.
+    const rawSpaceId = doc.access?.spaceId != null ? String(doc.access.spaceId) : null;
+    if (rawSpaceId != null) {
+      invariant(SpaceId.isValid(rawSpaceId), 'Invalid space ID');
+      return rawSpaceId;
+    }
+
+    const spaceKeyHex = DatabaseDirectory.getSpaceKey(doc);
+    if (spaceKeyHex == null) {
+      return null;
+    }
+
+    return createIdFromSpaceKey(PublicKey.fromHex(spaceKeyHex));
+  },
+
+  /**
+   * @deprecated Use {@link DatabaseDirectory.getSpaceId}. Only paths that require the space
+   * public key (which cannot be derived from the space id) should read the key.
+   *
    * @returns Space key in hex of the space that owns the document. In hex format. Without 0x prefix.
    */
   getSpaceKey: (doc: DatabaseDirectory): string | null => {
@@ -76,16 +113,22 @@ export const DatabaseDirectory = Object.freeze({
   },
 
   make: ({
+    spaceId,
     spaceKey,
     objects,
     links,
   }: {
-    spaceKey: string;
+    spaceId?: SpaceId;
+    /**
+     * @deprecated Provide {@link spaceId}. The key is still stamped for older clients.
+     */
+    spaceKey?: string;
     objects?: Record<string, EntityStructure>;
     links?: Record<string, RawString>;
   }): DatabaseDirectory => ({
     access: {
-      spaceKey,
+      ...(spaceId != null ? { spaceId } : {}),
+      ...(spaceKey != null ? { spaceKey } : {}),
     },
     objects: objects ?? {},
     links: links ?? {},

--- a/packages/core/echo/echo/src/testing/test-data.ts
+++ b/packages/core/echo/echo/src/testing/test-data.ts
@@ -3,18 +3,18 @@
 //
 
 import { DatabaseDirectory, EntityStructure } from '@dxos/echo-protocol';
-import { EID, EntityId, PublicKey } from '@dxos/keys';
+import { EID, EntityId, SpaceId } from '@dxos/keys';
 
 import { Type } from '../index';
 import { TestSchema } from './test-schema';
 
 // Lazy init: Cloudflare workers disallow non-determinism at module scope (e.g. random keys).
-let cachedSpaceKeyHex: string | undefined;
-const getSpaceKeyHex = (): string => {
-  if (cachedSpaceKeyHex === undefined) {
-    cachedSpaceKeyHex = PublicKey.random().toHex();
+let cachedSpaceId: SpaceId | undefined;
+const getSpaceId = (): SpaceId => {
+  if (cachedSpaceId === undefined) {
+    cachedSpaceId = SpaceId.random();
   }
-  return cachedSpaceKeyHex;
+  return cachedSpaceId;
 };
 
 let cachedPeopleAlice: DatabaseDirectory | undefined;
@@ -32,7 +32,7 @@ export const PEOPLE = {
   get alice(): DatabaseDirectory {
     if (cachedPeopleAlice === undefined) {
       cachedPeopleAlice = DatabaseDirectory.make({
-        spaceKey: getSpaceKeyHex(),
+        spaceId: getSpaceId(),
         objects: {
           [EntityId.random()]: EntityStructure.makeObject({
             type: Type.getURI(TestSchema.Person)!,
@@ -49,7 +49,7 @@ export const PEOPLE = {
   get bob(): DatabaseDirectory {
     if (cachedPeopleBob === undefined) {
       cachedPeopleBob = DatabaseDirectory.make({
-        spaceKey: getSpaceKeyHex(),
+        spaceId: getSpaceId(),
         objects: {
           [EntityId.random()]: EntityStructure.makeObject({
             type: Type.getURI(TestSchema.Person)!,
@@ -68,7 +68,7 @@ export const ORGS = {
   get dxos(): DatabaseDirectory {
     if (cachedOrgsDxos === undefined) {
       cachedOrgsDxos = DatabaseDirectory.make({
-        spaceKey: getSpaceKeyHex(),
+        spaceId: getSpaceId(),
         objects: {
           [EntityId.random()]: EntityStructure.makeObject({
             type: Type.getURI(TestSchema.Organization)!,
@@ -86,7 +86,7 @@ export const ORGS = {
   get cyberdyne(): DatabaseDirectory {
     if (cachedOrgsCyberdyne === undefined) {
       cachedOrgsCyberdyne = DatabaseDirectory.make({
-        spaceKey: getSpaceKeyHex(),
+        spaceId: getSpaceId(),
         objects: {
           [EntityId.random()]: EntityStructure.makeObject({
             type: Type.getURI(TestSchema.Organization)!,
@@ -106,7 +106,7 @@ export const WORKS_FOR = {
   get fredWorksForCyberdyne(): DatabaseDirectory {
     if (cachedWorksFredCyberdyne === undefined) {
       cachedWorksFredCyberdyne = DatabaseDirectory.make({
-        spaceKey: getSpaceKeyHex(),
+        spaceId: getSpaceId(),
         objects: {
           [EntityId.random()]: EntityStructure.makeRelation({
             type: Type.getURI(TestSchema.EmployedBy)!,
@@ -126,7 +126,7 @@ export const WORKS_FOR = {
   get aliceWorksForAperture(): DatabaseDirectory {
     if (cachedWorksAliceAperture === undefined) {
       cachedWorksAliceAperture = DatabaseDirectory.make({
-        spaceKey: getSpaceKeyHex(),
+        spaceId: getSpaceId(),
         objects: {
           [EntityId.random()]: EntityStructure.makeRelation({
             type: Type.getURI(TestSchema.EmployedBy)!,
@@ -148,7 +148,7 @@ export const TASKS = {
   get task1(): DatabaseDirectory {
     if (cachedTasksTask1 === undefined) {
       cachedTasksTask1 = DatabaseDirectory.make({
-        spaceKey: getSpaceKeyHex(),
+        spaceId: getSpaceId(),
         objects: {
           [EntityId.random()]: EntityStructure.makeObject({
             type: Type.getURI(TestSchema.Task)!,
@@ -169,7 +169,7 @@ export const TASKS = {
   get task2(): DatabaseDirectory {
     if (cachedTasksTask2 === undefined) {
       cachedTasksTask2 = DatabaseDirectory.make({
-        spaceKey: getSpaceKeyHex(),
+        spaceId: getSpaceId(),
         objects: {
           [EntityId.random()]: EntityStructure.makeObject({
             type: Type.getURI(TestSchema.Task)!,

--- a/packages/sdk/client-services/src/packlets/space-export/serialized-space-reader.ts
+++ b/packages/sdk/client-services/src/packlets/space-export/serialized-space-reader.ts
@@ -114,7 +114,7 @@ export const objJsonToObjectStructure = (obj: Obj.JSON): EntityStructure => {
 
 /**
  * Build a new {@link DatabaseDirectory} containing every object from the archive,
- * keyed by object id. The caller is responsible for stamping the `access.spaceKey`
+ * keyed by object id. The caller is responsible for stamping the `access` (space id/key)
  * and version fields after the document is created.
  */
 export const buildDatabaseDirectoryFromObjects = (objects: readonly Obj.JSON[]): DatabaseDirectory => {

--- a/packages/sdk/client-services/src/packlets/spaces/data-space.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space.ts
@@ -511,11 +511,14 @@ export class DataSpace {
         // Ensure only one root is processed at a time.
         using _guard = await this._epochProcessingMutex.acquire();
 
-        // Attaching space keys to legacy documents.
+        // Attaching space identifiers to legacy documents.
         const doc = handle.doc();
-        if (!doc.access?.spaceKey) {
-          handle.change((doc: any) => {
-            doc.access = { spaceKey: this.key.toHex() };
+        if (!doc.access?.spaceId || !doc.access?.spaceKey) {
+          handle.change((doc: DatabaseDirectory) => {
+            doc.access ??= {};
+            doc.access.spaceId ??= this.id;
+            // spaceKey is deprecated but still written so older clients can resolve the owning space.
+            doc.access.spaceKey ??= this.key.toHex();
           });
         }
 

--- a/packages/sdk/migrations/src/document-compaction.test.ts
+++ b/packages/sdk/migrations/src/document-compaction.test.ts
@@ -2,12 +2,15 @@
 // Copyright 2026 DXOS.org
 //
 
+import { type AnyDocumentId } from '@automerge/automerge-repo';
 import { describe, expect, test } from 'vitest';
 
 import { Client } from '@dxos/client';
 import { TestBuilder } from '@dxos/client/testing';
 import { Filter, Obj } from '@dxos/echo';
 import { TestSchema } from '@dxos/echo/testing';
+import { type DatabaseDirectory } from '@dxos/echo-protocol';
+import { invariant } from '@dxos/invariant';
 
 import { compactDocumentsEpochMigration } from './document-compaction';
 
@@ -39,6 +42,21 @@ describe('document compaction', () => {
 
       const epochsAfter = await space.internal.getEpochs();
       expect(epochsAfter.length).toBe(epochsBefore.length + 1);
+
+      // The re-created root and linked documents carry the space identifiers.
+      // Epoch credentials and root links store automerge URLs as plain strings, so the
+      // branded AnyDocumentId casts below are the only way to hand them back to the repo.
+      const repo = space.internal.db._repo;
+      const rootUrl = String(epochsAfter[epochsAfter.length - 1]?.subject.assertion.automergeRoot);
+      const rootHandle = repo.find<DatabaseDirectory>(rootUrl as AnyDocumentId);
+      await rootHandle.whenReady();
+      expect(rootHandle.doc()?.access?.spaceId).toBe(space.id);
+      const linkUrl = rootHandle.doc()?.links?.[object.id]?.toString();
+      invariant(linkUrl, 'Compacted object link missing from new root');
+      const linkedHandle = repo.find<DatabaseDirectory>(linkUrl as AnyDocumentId);
+      await linkedHandle.whenReady();
+      expect(linkedHandle.doc()?.access?.spaceId).toBe(space.id);
+      expect(linkedHandle.doc()?.access?.spaceKey).toBe(space.key.toHex());
     } finally {
       await client.destroy();
     }

--- a/packages/sdk/migrations/src/document-compaction.test.ts
+++ b/packages/sdk/migrations/src/document-compaction.test.ts
@@ -8,8 +8,8 @@ import { describe, expect, test } from 'vitest';
 import { Client } from '@dxos/client';
 import { TestBuilder } from '@dxos/client/testing';
 import { Filter, Obj } from '@dxos/echo';
-import { TestSchema } from '@dxos/echo/testing';
 import { type DatabaseDirectory } from '@dxos/echo-protocol';
+import { TestSchema } from '@dxos/echo/testing';
 import { invariant } from '@dxos/invariant';
 
 import { compactDocumentsEpochMigration } from './document-compaction';

--- a/packages/sdk/migrations/src/migration-builder.ts
+++ b/packages/sdk/migrations/src/migration-builder.ts
@@ -81,11 +81,7 @@ export class MigrationBuilder {
 
     const newState: DatabaseDirectory = {
       version: SpaceDocVersion.CURRENT,
-      access: {
-        spaceId: this._space.id,
-        // spaceKey is deprecated but still written so older clients can resolve the owning space.
-        spaceKey: this._space.key.toHex(),
-      },
+      access: this._makeAccess(),
       objects: {
         [id]: {
           system: {
@@ -139,6 +135,8 @@ export class MigrationBuilder {
 
       await oldHandle.whenReady();
       const materialized = toJS(oldHandle.doc()!) as DatabaseDirectory;
+      // Re-stamp access so documents that predate access.spaceId pick it up during compaction.
+      materialized.access = this._makeAccess();
       const newHandle = this._repo.create<DatabaseDirectory>(materialized);
       await newHandle.whenReady();
       invariant(newHandle.url, 'Compacted document URL not available after whenReady');
@@ -206,11 +204,7 @@ export class MigrationBuilder {
 
     this._newRoot = this._repo.create<DatabaseDirectory>({
       version: SpaceDocVersion.CURRENT,
-      access: {
-        spaceId: this._space.id,
-        // spaceKey is deprecated but still written so older clients can resolve the owning space.
-        spaceKey: this._space.key.toHex(),
-      },
+      access: this._makeAccess(),
       objects: this._rootDoc.objects,
       links,
     });
@@ -236,11 +230,7 @@ export class MigrationBuilder {
     core.setType(EncodedReference.fromURI(getSchemaURI(schema)!));
     const newHandle = this._repo.create<DatabaseDirectory>({
       version: SpaceDocVersion.CURRENT,
-      access: {
-        spaceId: this._space.id,
-        // spaceKey is deprecated but still written so older clients can resolve the owning space.
-        spaceKey: this._space.key.toHex(),
-      },
+      access: this._makeAccess(),
       objects: {
         [core.id]: core.getDoc() as EntityStructure,
       },
@@ -250,6 +240,14 @@ export class MigrationBuilder {
     this._addHandleToFlushList(newHandle.documentId!);
 
     return core;
+  }
+
+  private _makeAccess(): NonNullable<DatabaseDirectory['access']> {
+    return {
+      spaceId: this._space.id,
+      // spaceKey is deprecated but still written so older clients can resolve the owning space.
+      spaceKey: this._space.key.toHex(),
+    };
   }
 
   private _addHandleToFlushList(id: DocumentId): void {

--- a/packages/sdk/migrations/src/migration-builder.ts
+++ b/packages/sdk/migrations/src/migration-builder.ts
@@ -82,6 +82,8 @@ export class MigrationBuilder {
     const newState: DatabaseDirectory = {
       version: SpaceDocVersion.CURRENT,
       access: {
+        spaceId: this._space.id,
+        // spaceKey is deprecated but still written so older clients can resolve the owning space.
         spaceKey: this._space.key.toHex(),
       },
       objects: {
@@ -205,6 +207,8 @@ export class MigrationBuilder {
     this._newRoot = this._repo.create<DatabaseDirectory>({
       version: SpaceDocVersion.CURRENT,
       access: {
+        spaceId: this._space.id,
+        // spaceKey is deprecated but still written so older clients can resolve the owning space.
         spaceKey: this._space.key.toHex(),
       },
       objects: this._rootDoc.objects,
@@ -233,6 +237,8 @@ export class MigrationBuilder {
     const newHandle = this._repo.create<DatabaseDirectory>({
       version: SpaceDocVersion.CURRENT,
       access: {
+        spaceId: this._space.id,
+        // spaceKey is deprecated but still written so older clients can resolve the owning space.
         spaceKey: this._space.key.toHex(),
       },
       objects: {


### PR DESCRIPTION
## Summary

Automerge `DatabaseDirectory` documents identified their owning space only via `access.spaceKey`. This PR adds a new `access.spaceId` field, deprecates `access.spaceKey`, and coalesces the two on read.

## Changes

### Schema (`@dxos/echo-protocol`)

- `DatabaseDirectory.access` gains an optional `spaceId` field (multibase base-32 space ID).
- `access.spaceKey` is marked `@deprecated` (and is now optional in the type).
- New coalescing reader `DatabaseDirectory.getSpaceId(doc)`: prefers `access.spaceId`, and for documents that predate it derives the id from the legacy `access.spaceKey` / `experimental_spaceKey` fields via `createIdFromSpaceKey` (async, since the derivation is a SHA-256 hash).
- `DatabaseDirectory.make` accepts `spaceId` (with `spaceKey` kept as a deprecated option).

### Writers — now stamp `access.spaceId`

- `EchoHost.createSpaceRoot` (new space root documents).
- `EntityManager._createDocumentForObject` (new linked object documents) and `_initDocAccess` (stamping on load; the guard now also upgrades documents missing `spaceId`).
- `DataSpace._onNewAutomergeRoot` (legacy root stamping now fills in both identifiers).
- `MigrationBuilder` (epoch-migration documents).

**Note:** the deprecated `spaceKey` is still written alongside `spaceId`. The id is a one-way hash of the key, so older clients — and code paths that need the space *public key*, e.g. share-policy resolution in `AutomergeHost._getContainingSpaceForDocument` — cannot work from `spaceId` alone. Dropping the key write is a follow-up once those paths are id-based.

### Readers

- The indexer data source (`AutomergeDataSource`) now uses the coalescing `DatabaseDirectory.getSpaceId` instead of deriving the id from the key itself.
- `DatabaseDirectory.getSpaceKey` is marked deprecated, pointing consumers to `getSpaceId`.

### Tests

- `automerge-data-source.test.ts`: fixtures now write `access.spaceId` (they were previously stuffing a `SpaceId` into `spaceKey`); new cases cover deriving the id from legacy `spaceKey`-only documents and `spaceId` taking precedence when both are present.
- `entity-manager.test.ts`: asserts the root document is stamped with the database's `spaceId`.
- `@dxos/echo` test fixtures (`test-data.ts`) create directories with `spaceId`.

## Testing

- `moon run echo-protocol:build echo-host:build echo-client:build echo:build client-services:build migrations:build` — green.
- `moon run echo-host:test` (253 passed), `echo-client:test` (466 passed), `echo:test` (437 passed), `client-services:test` (123 passed), `migrations:test` — all green.
- Lint clean on all touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5QMTuxgDzQFHgjQRZaquN

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5QMTuxgDzQFHgjQRZaquN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a primary space identifier (`spaceId`) in document access metadata, while continuing to support the legacy key-based (`spaceKey`) format.

* **Bug Fixes**
  * Space access metadata is now consistently initialized and backfilled on root and object documents.
  * Document change detection now recognizes space identifiers when either is present, preferring `spaceId` when available.
  * Compaction and migrations now preserve/restamp space identifier info on recreated documents.

* **Tests**
  * Expanded automated coverage for legacy and `spaceId`/`spaceKey` interoperability, including additional derivation and compaction assertions.

* **Documentation**
  * Clarified guidance around stamping space access metadata in developer-facing comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->