### PR TITLE
fix(plugin-space): don't fail activation on edge replication timeout

### DIFF
--- a/packages/plugins/plugin-space/src/capabilities/spaces-ready.ts
+++ b/packages/plugins/plugin-space/src/capabilities/spaces-ready.ts
@@ -330,18 +330,28 @@ export default Capability.makeModule(
     subscriptions.add(() => viewingSub.unsubscribe());
 
     // Enable edge replication for all spaces.
-    try {
-      yield* Effect.tryPromise(() =>
-        Promise.all(
-          client.spaces
-            .get()
-            .map((space) => space.internal.setEdgeReplicationPreference(EdgeReplicationSetting.ENABLED)),
-        ),
-      );
-      registry.update(stateAtom, (current) => ({ ...current, enabledEdgeReplication: true }));
-    } catch (err) {
-      log.catch(err);
-    }
+    // Per-space failures (e.g. a timeout waiting for the property to propagate) must not
+    // block activation of the whole plugin, so each space is enabled independently.
+    yield* Effect.tryPromise(() =>
+      Promise.allSettled(
+        client.spaces
+          .get()
+          .filter((space) => space.internal.data.edgeReplication !== EdgeReplicationSetting.ENABLED)
+          .map((space) => space.internal.setEdgeReplicationPreference(EdgeReplicationSetting.ENABLED)),
+      ),
+    ).pipe(
+      Effect.tap((results) =>
+        Effect.sync(() => {
+          results.forEach((result) => {
+            if (result.status === 'rejected') {
+              log.catch(result.reason);
+            }
+          });
+        }),
+      ),
+      Effect.catchAll((err) => Effect.sync(() => log.catch(err))),
+    );
+    registry.update(stateAtom, (current) => ({ ...current, enabledEdgeReplication: true }));
 
     return Capability.contributes(Capabilities.Null, null, () =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- `spaces-ready.ts` enabled edge replication for all spaces inside a `try`/`catch`, but the failure came from `yield* Effect.tryPromise(...)` inside an `Effect.gen` — Effect failures propagate through Effect's own error channel, not as thrown JS exceptions, so the `catch` block never ran.
- `setEdgeReplicationPreference` waits up to 2s per space for the property to propagate (`space-proxy.ts`); if any single space in the `Promise.all([...])` timed out, the whole batch rejected and the `SpacesReady` capability failed, which surfaced as the fatal ResetDialog on startup.
- Switched to `Promise.allSettled` so one slow/timed-out space can't abort replication setup for the rest, added `Effect.catchAll`/`Effect.tap` so failures are actually logged instead of silently swallowed by a dead `catch`, and skip spaces that already have `edgeReplication` enabled.

## Test plan

- [x] `moon run plugin-space:build`
- [x] `moon run plugin-space:lint -- --fix`
- [ ] Manually reproduce the original timing (space created just before startup, replicator connection churn) to confirm activation no longer fails fatally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X9yuwLeNCjkGTjBmaxYRzZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Edge replication updates now continue even if one or more spaces fail to update.
  * Only spaces that still need the setting are processed, reducing unnecessary updates.
  * Plugin activation no longer waits on a full batch success, so the feature can be marked enabled after the attempt completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->