### PR TITLE
fix(plugin-space): timeout and surface errors when creating a space

### DIFF
--- a/packages/plugins/plugin-space/src/containers/CreateSpaceDialog/CreateSpaceDialog.tsx
+++ b/packages/plugins/plugin-space/src/containers/CreateSpaceDialog/CreateSpaceDialog.tsx
@@ -4,11 +4,12 @@
 
 import * as Effect from 'effect/Effect';
 import type * as Schema from 'effect/Schema';
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { LayoutOperation, Paths } from '@dxos/app-toolkit';
 import { EffectEx } from '@dxos/effect';
+import { log } from '@dxos/log';
 import { Column, Dialog, useTranslation } from '@dxos/react-ui';
 import { Form } from '@dxos/react-ui-form';
 
@@ -25,28 +26,33 @@ const initialValues: FormValues = { edgeReplication: true };
 export const CreateSpaceDialog = () => {
   const closeRef = useRef<HTMLButtonElement | null>(null);
   const { t } = useTranslation(meta.profile.key);
-  const { invokePromise } = useOperationInvoker();
+  const { invoke } = useOperationInvoker();
 
   const inputSurfaceLookup = useInputSurfaceLookup();
+  const [error, setError] = useState<string | undefined>(undefined);
 
   const handleCreateSpace = useCallback(
-    async (data: FormValues) => {
-      const program = Effect.gen(function* () {
-        const { data: result } = yield* Effect.promise(() => invokePromise(SpaceOperation.Create, data));
-        if (result?.space) {
-          yield* Effect.promise(() =>
-            invokePromise(LayoutOperation.Open, {
-              subject: [Paths.getSpaceHomePath(result.space.id)],
-              workspace: Paths.getSpacePath(result.space.id),
-              navigation: 'immediate',
-            }),
-          );
-          yield* Effect.promise(() => invokePromise(LayoutOperation.UpdateDialog, { state: false }));
-        }
-      });
-      await EffectEx.runAndForwardErrors(program);
+    (data: FormValues) => {
+      setError(undefined);
+      return Effect.gen(function* () {
+        const { space } = yield* invoke(SpaceOperation.Create, data);
+        yield* invoke(LayoutOperation.Open, {
+          subject: [Paths.getSpaceHomePath(space.id)],
+          workspace: Paths.getSpacePath(space.id),
+          navigation: 'immediate',
+        });
+        yield* invoke(LayoutOperation.UpdateDialog, { state: false });
+      }).pipe(
+        Effect.catchAll((failure) =>
+          Effect.sync(() => {
+            log.catch(failure);
+            setError(t('create-space-dialog.error.message'));
+          }),
+        ),
+        EffectEx.runAndForwardErrors,
+      );
     },
-    [invokePromise],
+    [invoke, t],
   );
 
   return (
@@ -71,6 +77,7 @@ export const CreateSpaceDialog = () => {
           <Column.Center>
             <Form.Content>
               <Form.FieldSet />
+              <Form.Error>{error}</Form.Error>
               <Form.Submit />
             </Form.Content>
           </Column.Center>

--- a/packages/plugins/plugin-space/src/errors.ts
+++ b/packages/plugins/plugin-space/src/errors.ts
@@ -9,3 +9,9 @@ export class NoIdentityError extends BaseError.extend(
   'NoIdentityError',
   'A local identity is required to accept a space invitation.',
 ) {}
+
+/** The space's properties object never became available, so it cannot be safely used yet. */
+export class SpaceNotReadyError extends BaseError.extend(
+  'SpaceNotReadyError',
+  'Timed out waiting for the space to finish initializing.',
+) {}

--- a/packages/plugins/plugin-space/src/operations/create.ts
+++ b/packages/plugins/plugin-space/src/operations/create.ts
@@ -1,5 +1,6 @@
 // Copyright 2025 DXOS.org
 
+import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 
 import { Capability, Plugin } from '@dxos/app-framework';
@@ -13,9 +14,13 @@ import { EdgeReplicationSetting } from '@dxos/protocols/proto/dxos/echo/metadata
 import { iconValues } from '@dxos/react-ui-pickers/icons';
 import { hues } from '@dxos/ui-theme';
 
+import { SpaceNotReadyError } from '../errors';
 import { SpaceCapabilities, SpaceEvents } from '../types';
 import { SpaceOperation } from './definitions';
 import { SpaceOperationConfig } from './helpers';
+
+/** Bounds how long space creation waits for the new space's properties object to become available. */
+const SPACE_READY_TIMEOUT = Duration.seconds(10);
 
 const handler: Operation.WithHandler<typeof SpaceOperation.Create> = SpaceOperation.Create.pipe(
   Operation.withHandler(
@@ -33,7 +38,10 @@ const handler: Operation.WithHandler<typeof SpaceOperation.Create> = SpaceOperat
       if (edgeReplication) {
         yield* Effect.promise(() => space.internal.setEdgeReplicationPreference(EdgeReplicationSetting.ENABLED));
       }
-      yield* Effect.promise(() => space.waitUntilReady());
+      yield* Effect.tryPromise({
+        try: () => space.waitUntilReady(),
+        catch: SpaceNotReadyError.wrap(),
+      }).pipe(Effect.timeoutFail({ duration: SPACE_READY_TIMEOUT, onTimeout: () => new SpaceNotReadyError() }));
 
       const collection = Obj.make(Collection.Collection, { objects: [] });
       Obj.update(space.properties, (properties) => {

--- a/packages/plugins/plugin-space/src/translations.ts
+++ b/packages/plugins/plugin-space/src/translations.ts
@@ -218,6 +218,7 @@ export const translations = [
         'show-all.label': 'Show all',
         'no-sync-status.label': 'No space with missing objects.',
         'create-space-dialog.title': 'Create Space',
+        'create-space-dialog.error.message': 'Failed to create space. Please try again.',
         'create-object-dialog.title': 'Create {{object}}',
         'space-input.placeholder': 'Select space',
         'schema-input.placeholder': 'Select type',


### PR DESCRIPTION
## Summary
- The create-space dialog would freeze forever if the newly created space's properties object never became available: `space.waitUntilReady()` awaited an internal `warnAfterTimeout` that only logs a console warning after 5s but never rejects.
- `packages/plugins/plugin-space/src/operations/create.ts` now bounds that wait with a real timeout (`Effect.timeoutFail`) and fails with a new `SpaceNotReadyError` (`packages/plugins/plugin-space/src/errors.ts`) instead of hanging indefinitely. Scoped to the create-space flow only, matching the existing timeout pattern already used in `packages/devtools/cli-util/src/util/space-format.ts` for `waitUntilReady()`, rather than changing the shared `space-proxy.ts` used by ~70 other callers.
- `CreateSpaceDialog.tsx`'s save handler was rewritten to use the native Effect-returning `invoke` API directly (errors bubble through the Effect's own error channel) instead of `invokePromise` wrapped in `Effect.promise` with manual `{ data, error }` handling and a `try/catch` around the run call. Failures are now handled with `Effect.catchAll` piped before `EffectEx.runAndForwardErrors`, turning them into a `Form.Error` message. Because the handler's returned promise now always settles (instead of hanging), the form's own `saving`/`canSave` state re-enables the submit button automatically on failure.

## Test plan
- [x] `moon run plugin-space:build`
- [x] `moon run plugin-space:lint -- --fix`
- [x] `moon run plugin-space:test`
- [x] `pnpm format` (no diff)
- [ ] Manually verify: trigger the space-properties timeout and confirm the dialog shows an error and the Save button re-enables (not exercised live in this session — code-reviewed against the existing `CustomTokenDialog.tsx` sibling pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The space creation dialog now shows an inline error message when creation fails.
  * Space creation can now time out if initialization takes too long, improving feedback for stuck setups.

* **Bug Fixes**
  * Creation failures are now handled more gracefully, with errors logged and shown to the user.
  * Added a clearer message when a new space can’t be created: “Failed to create space. Please try again.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->