### PR TITLE
docs: document npm trusted publisher setup for new packages

### DIFF
--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -179,6 +179,21 @@ The filter consists of a series of filename pattern/level tuples separated by co
 The apps published are defined in [`.github/workflows/scripts/apps.sh`](https://github.com/dxos/dxos/blob/main/.github/workflows/scripts/apps.sh).
 In order to include a new app in the publish loop it needs to be added to the `APPS` list in this file.
 
+### New npm packages
+
+New packages are created with `"private": true` in their `package.json` (see [New Packages](./AGENTS.md#new-packages)). Publishing a package to npm for the first time requires an initial manual publish, since npm's OIDC trusted publishing (used by [`publish-all.yml`](https://github.com/dxos/dxos/blob/main/.github/workflows/publish-all.yml)) can only be configured for a package that already exists on the registry:
+
+1. Build the package and its dependencies: `moon run <package-name>:build` (this also builds upstream deps via `moon`'s task graph).
+2. Set the package's `version` to `0.0.0` and remove `"private": true` from its `package.json` at the same time — a private package cannot be published.
+3. From the package's directory, manually run `npm publish`. This must be a real public release (not `npm publish --tag ...` for staging), since the package needs to exist on npm before a trusted publisher can be configured for it.
+4. On npmjs.com, go to the package's **Settings → Trusted Publisher** and add GitHub Actions as a trusted publisher:
+   - Repository: `dxos/dxos`
+   - Workflow file: `publish-all.yml`
+   - Environment: leave blank unless the workflow specifies one.
+5. Revert the package's `version` back to align with the rest of the packages in the monorepo, now that the trusted publisher is configured and `publish-all.yml` will handle future releases.
+
+For bulk setup (roughly **10+ packages** at once), the [npm-trusted-publisher](https://github.com/wittjosiah/npm-trusted-publisher) Chrome extension automates step 4 across many packages. Below that threshold, doing it manually per package is faster.
+
 ## Dependencies
 
 Packages can be locked to a particular version as required by updating `pnpm.overrides` in `package.json`.

--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -190,6 +190,7 @@ New packages are created with `"private": true` in their `package.json` (see [Ne
    - Repository: `dxos/dxos`
    - Workflow file: `publish-all.yml`
    - Environment: leave blank unless the workflow specifies one.
+   - Allowed actions: `npm publish` only — do not enable `npm stage publish` (staged/review release flow that `publish-all.yml` does not use).
 5. Revert the package's `version` back to align with the rest of the packages in the monorepo, now that the trusted publisher is configured and `publish-all.yml` will handle future releases.
 
 For bulk setup (roughly **10+ packages** at once), the [npm-trusted-publisher](https://github.com/wittjosiah/npm-trusted-publisher) Chrome extension automates step 4 across many packages. Below that threshold, doing it manually per package is faster.


### PR DESCRIPTION
## Summary
- Adds a "New npm packages" subsection to `REPOSITORY_GUIDE.md`'s Publishing section, documenting the one-time manual steps needed to publish a new package to npm and configure GitHub Actions as an OIDC trusted publisher (via `publish-all.yml`).
- Links to the [npm-trusted-publisher](https://github.com/wittjosiah/npm-trusted-publisher) Chrome extension for bulk setup (10+ packages).

This is human-facing documentation only — no agent instructions (`AGENTS.md`/`CLAUDE.md`) were touched.

## Test plan
- [x] Docs-only change; no build/test impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for publishing new npm packages, including the initial manual publish process and how to set up trusted publishing for future releases.
  * Included steps for switching packages back to the normal release flow after setup.
  * Noted an optional bulk setup method for configuring multiple packages more quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->