### PR TITLE
fix(react-ui-mosaic): stabilize scrollbar during virtualized pagination

### DIFF
--- a/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.tsx
+++ b/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.tsx
@@ -10,13 +10,7 @@ import { DxAvatar } from '@dxos/lit-ui/react';
 import { type PaginationResult } from '@dxos/react-client/echo';
 import { Card, ScrollArea } from '@dxos/react-ui';
 import { composable, composableProps } from '@dxos/react-ui';
-import {
-  Focus,
-  Mosaic,
-  type MosaicTileProps,
-  useMosaicContainer,
-  useVirtualizerPagination,
-} from '@dxos/react-ui-mosaic';
+import { Focus, Mosaic, type MosaicTileProps, useMosaicContainer } from '@dxos/react-ui-mosaic';
 import { type Message } from '@dxos/types';
 
 import { useGmailTags } from '#hooks';
@@ -199,17 +193,6 @@ export const MessageStack = composable<HTMLDivElement, MessageStackProps>(
 
     const getItemId = useCallback((item: any) => item.conversationId ?? item.message?.id, []);
 
-    // Requests the next (older) page once the visible range approaches the loaded end, or the
-    // previous (newer) page once it approaches the loaded start, and preserves scroll position
-    // across the resulting `items` change (see `useVirtualizerPagination`). `pagination.getNext`/
-    // `getPrevious` are single-flight and a no-op once exhausted/at the head, so triggering them
-    // on every virtualizer change while near either edge is safe.
-    const { onChange: handleVirtualizerChange } = useVirtualizerPagination({
-      items,
-      getId: getItemId,
-      pagination,
-    });
-
     return (
       <Focus.Group asChild {...composableProps(props)} onKeyDown={handleKeyDown} ref={forwardedRef}>
         <Mosaic.Container
@@ -228,11 +211,11 @@ export const MessageStack = composable<HTMLDivElement, MessageStackProps>(
                 Tile={conversations ? (ConversationTile as any) : MessageTile}
                 items={items as any}
                 draggable={false}
-                getId={(item: any) => item.conversationId ?? item.message?.id}
+                getId={getItemId}
                 getScrollElement={() => viewport}
                 estimateSize={() => 150}
                 gap={4}
-                onChange={handleVirtualizerChange}
+                pagination={pagination}
               />
             </ScrollArea.Viewport>
           </ScrollArea.Root>

--- a/packages/ui/react-ui-mosaic/src/components/Mosaic/Stack.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/Mosaic/Stack.tsx
@@ -3,7 +3,7 @@
 //
 
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
-import { type ReactVirtualizerOptions, useVirtualizer } from '@tanstack/react-virtual';
+import { type ReactVirtualizerOptions, type Virtualizer, useVirtualizer } from '@tanstack/react-virtual';
 import React, {
   type FC,
   Fragment,
@@ -21,7 +21,7 @@ import { invariant } from '@dxos/invariant';
 import { type Axis, type ThemedClassName, composable, composableProps } from '@dxos/react-ui';
 import { mx } from '@dxos/ui-theme';
 
-import { useVisibleItems } from '../../hooks';
+import { type VirtualizerPaginationController, useVirtualizerPagination, useVisibleItems } from '../../hooks';
 import { useMosaicContainerContext } from './Container';
 import { MosaicPlaceholder, type MosaicPlaceholderProps } from './Placeholder';
 import { styles } from './styles';
@@ -179,7 +179,12 @@ type MosaicVirtualStackProps<TData = any> = MosaicStackProps<TData> &
   Pick<
     ReactVirtualizerOptions<HTMLElement, HTMLDivElement>,
     'estimateSize' | 'gap' | 'getScrollElement' | 'overscan' | 'onChange'
-  >;
+  > & {
+    /** Enables paginated loading; see `useVirtualizerPagination`. Requires `draggable={false}`. */
+    pagination?: VirtualizerPaginationController;
+    /** Rows from either loaded edge at which the adjacent page is requested. @default 12 */
+    paginationThreshold?: number;
+  };
 
 const MosaicVirtualStackInner = forwardRef<HTMLDivElement, MosaicVirtualStackProps>(
   (
@@ -193,6 +198,8 @@ const MosaicVirtualStackInner = forwardRef<HTMLDivElement, MosaicVirtualStackPro
       getScrollElement,
       overscan = 8,
       gap,
+      pagination,
+      paginationThreshold,
       onChange,
       draggable = true,
       debug,
@@ -212,14 +219,27 @@ const MosaicVirtualStackInner = forwardRef<HTMLDivElement, MosaicVirtualStackPro
       ? (index: number) => (index % 2 === 0 ? 0 : estimateSize(Math.floor(index / 2)))
       : estimateSize;
 
+    const { onChange: handlePaginationChange, leadingSpace } = useVirtualizerPagination({
+      items: visibleItems,
+      getId,
+      pagination,
+      threshold: paginationThreshold,
+    });
+    const handleChange = useCallback(
+      (nextVirtualizer: Virtualizer<any, any>, sync: boolean) => {
+        handlePaginationChange(nextVirtualizer);
+        onChange?.(nextVirtualizer, sync);
+      },
+      [handlePaginationChange, onChange],
+    );
+
     const virtualizer = useVirtualizer({
       // NOTE: When draggable we double the number of items to allow for placeholders.
       count: draggable ? visibleItems.length * 2 + 1 : visibleItems.length,
       estimateSize: wrappedEstimateSize,
       gap,
-      // Inset the stack from both ends by `gap` (matching the inter-item spacing). The virtualizer
-      // folds this into item offsets, getTotalSize(), and scrollToIndex, so no manual compensation.
-      paddingStart: gap,
+      // Inset by `gap` (inter-item spacing) plus any pagination spacer; see `useVirtualizerPagination`.
+      paddingStart: (gap ?? 0) + leadingSpace,
       paddingEnd: gap,
       // Key measurements by stable item ID so the size cache survives scrolling;
       // without this, measurements are indexed by position and are lost when items reorder.
@@ -228,7 +248,7 @@ const MosaicVirtualStackInner = forwardRef<HTMLDivElement, MosaicVirtualStackPro
         : (index) => getId(visibleItems![index]),
       getScrollElement,
       overscan,
-      onChange,
+      onChange: handleChange,
     });
 
     // Register scroll-to-item via virtualizer index lookup.

--- a/packages/ui/react-ui-mosaic/src/components/Mosaic/Stack.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/Mosaic/Stack.tsx
@@ -182,7 +182,7 @@ type MosaicVirtualStackProps<TData = any> = MosaicStackProps<TData> &
   > & {
     /** Enables paginated loading; see `useVirtualizerPagination`. Requires `draggable={false}`. */
     pagination?: VirtualizerPaginationController;
-    /** Rows from either loaded edge at which the adjacent page is requested. @default 12 */
+    /** Rows from either loaded edge at which the adjacent page is requested. @default 12. */
     paginationThreshold?: number;
   };
 
@@ -208,6 +208,7 @@ const MosaicVirtualStackInner = forwardRef<HTMLDivElement, MosaicVirtualStackPro
     forwardedRef,
   ) => {
     invariant(Tile);
+    invariant(!pagination || !draggable, 'pagination requires draggable={false}');
     const { id, dragging, currentId, selectedIds, registerScrollTo } =
       useMosaicContainerContext(MOSAIC_VIRTUAL_STACK_NAME);
     const visibleItems = useVisibleItems({ id, items, dragging: dragging?.source.data, getId });

--- a/packages/ui/react-ui-mosaic/src/components/Mosaic/VirtualStackPagination.stories.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/Mosaic/VirtualStackPagination.stories.tsx
@@ -15,7 +15,6 @@ import { withClientProvider } from '@dxos/react-client/testing';
 import { Button, Card, Input, Panel, ScrollArea, Select, Toolbar } from '@dxos/react-ui';
 import { Loading, withLayout, withTheme } from '@dxos/react-ui/testing';
 
-import { useVirtualizerPagination } from '../../hooks';
 import { Focus } from '../Focus';
 import { Mosaic } from './Mosaic';
 import { type MosaicTileProps } from './Tile';
@@ -24,8 +23,8 @@ const PAGE_SIZE = 50;
 const MAX_WINDOW_SIZE = PAGE_SIZE * 10;
 
 //
-// In-memory story (no ECHO): windows a plain array to show `useVirtualizerPagination` needs only a
-// `{ items, getNext, getPrevious }` shape.
+// In-memory story (no ECHO): windows a plain array to show `Mosaic.VirtualStack`'s `pagination`
+// prop needs only a `{ getNext, getPrevious }` shape.
 //
 
 /** Total size of the synthetic, in-memory data source. */
@@ -102,12 +101,6 @@ const VirtualStackPaginationStory = () => {
   const pagination = useMemo(() => ({ getNext, getPrevious, atHead }), [getNext, getPrevious, atHead]);
   const [viewport, setViewport] = useState<HTMLElement | null>(null);
 
-  const { onChange } = useVirtualizerPagination({
-    items,
-    getId: (item) => item.id,
-    pagination,
-  });
-
   const range = items.length > 0 ? `${items[0].index}–${items[items.length - 1].index}` : '–';
 
   return (
@@ -132,7 +125,7 @@ const VirtualStackPaginationStory = () => {
                   getScrollElement={() => viewport}
                   estimateSize={() => 56}
                   gap={4}
-                  onChange={onChange}
+                  pagination={pagination}
                 />
               </ScrollArea.Viewport>
             </ScrollArea.Root>
@@ -268,7 +261,6 @@ const FeedPaginationStory = () => {
   });
 
   const pagination = useMemo(() => ({ getNext, getPrevious, atHead }), [getNext, getPrevious, atHead]);
-  const { onChange } = useVirtualizerPagination({ items, getId: (item) => item.id, pagination });
 
   const handleAdd = useCallback(() => {
     if (!db || !feed || !counter || addCount <= 0) {
@@ -365,7 +357,7 @@ const FeedPaginationStory = () => {
                   getScrollElement={() => viewport}
                   estimateSize={() => 56}
                   gap={4}
-                  onChange={onChange}
+                  pagination={pagination}
                 />
               </ScrollArea.Viewport>
             </ScrollArea.Root>
@@ -389,10 +381,10 @@ export default meta;
 type Story = StoryObj;
 
 /**
- * `Mosaic.VirtualStack` paginated by `useVirtualizerPagination` over a plain in-memory array --
- * no ECHO query or `usePagination` involved. Scroll down to grow the window, then keep
- * scrolling past `MAX_WINDOW_SIZE` to see it slide (evicting the newest items); scroll back up to
- * slide it back toward the head without a visible jump.
+ * `Mosaic.VirtualStack`'s `pagination` prop over a plain in-memory array -- no ECHO query or
+ * `usePagination` involved. Scroll down to grow the window, then keep scrolling past
+ * `MAX_WINDOW_SIZE` to see it slide (evicting the newest items); scroll back up to slide it back
+ * toward the head without a visible jump.
  */
 export const Default: Story = {
   render: VirtualStackPaginationStory,
@@ -400,10 +392,10 @@ export const Default: Story = {
 
 /**
  * End-to-end pagination over a live ECHO feed: `usePagination` windows a feed seeded with 100
- * items (each a number + a random word), rendered through `useVirtualizerPagination` +
- * `Mosaic.VirtualStack`. Scroll to page toward older items (past `MAX_WINDOW_SIZE` to see the
- * window slide). Use the toolbar to append more items (they appear live at the head), and to sort
- * by natural/number/word in either direction.
+ * items (each a number + a random word), rendered through `Mosaic.VirtualStack`'s `pagination`
+ * prop. Scroll to page toward older items (past `MAX_WINDOW_SIZE` to see the window slide). Use
+ * the toolbar to append more items (they appear live at the head), and to sort by
+ * natural/number/word in either direction.
  */
 export const FeedBacked: Story = {
   render: FeedPaginationStory,

--- a/packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.ts
+++ b/packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.ts
@@ -51,16 +51,89 @@ export type UseVirtualizerPaginationResult = {
   leadingSpace: number;
 };
 
+//
+// Edge-trigger evaluation
+//
+
 /** A retained item's identity and pre-change offset. */
 type Anchor = { id: string; start: number };
 
+/** Position of the loaded window relative to the viewport, independent of what's rendered. */
+type EdgeGeometry = {
+  scrollOffset: number;
+  viewportHeight: number;
+  /** Index of the topmost/bottommost *rendered* row; undefined if nothing overlaps the viewport. */
+  firstVisibleIndex: number | undefined;
+  lastVisibleIndex: number | undefined;
+  /** Absolute start/end of the whole loaded window, defined even when nothing is rendered there. */
+  windowStart: number | undefined;
+  windowEnd: number | undefined;
+};
+
+const readEdgeGeometry = (virtualizer: Virtualizer<any, any>): EdgeGeometry => {
+  const virtualItems = virtualizer.getVirtualItems();
+  // `measurementsCache` covers the whole array even when nothing is rendered (deep in the spacer).
+  const measurements = virtualizer.measurementsCache;
+  return {
+    scrollOffset: virtualizer.scrollOffset ?? 0,
+    viewportHeight: virtualizer.scrollElement?.clientHeight ?? 0,
+    firstVisibleIndex: virtualItems.at(0)?.index,
+    lastVisibleIndex: virtualItems.at(-1)?.index,
+    windowStart: measurements[0]?.start,
+    windowEnd: measurements.at(-1)?.end,
+  };
+};
+
+const isNearBottomEdge = (geometry: EdgeGeometry, itemCount: number, threshold: number): boolean =>
+  geometry.lastVisibleIndex !== undefined
+    ? geometry.lastVisibleIndex >= nextPageIndexThreshold(itemCount, threshold)
+    : geometry.windowEnd != null && geometry.scrollOffset + geometry.viewportHeight > geometry.windowEnd;
+
+const isNearTopEdge = (geometry: EdgeGeometry, threshold: number): boolean =>
+  geometry.firstVisibleIndex !== undefined
+    ? geometry.firstVisibleIndex < threshold
+    : geometry.windowStart != null && geometry.scrollOffset < geometry.windowStart;
+
+/** Loaded content doesn't reach the viewport's top edge (e.g. scrolled into the leading spacer). */
+const isBlankAbove = (geometry: EdgeGeometry): boolean =>
+  geometry.windowStart != null && geometry.windowStart > geometry.scrollOffset;
+
+/** Loaded content doesn't reach the viewport's bottom edge. */
+const isBlankBelow = (geometry: EdgeGeometry): boolean =>
+  geometry.windowEnd != null && geometry.windowEnd < geometry.scrollOffset + geometry.viewportHeight;
+
 /** Per-direction dedup/throttle state for `evaluateTriggers`, independent of item type. */
 type TriggerState = {
-  lastNextRequestedItems: MutableRefObject<unknown>;
-  lastPreviousRequestedItems: MutableRefObject<unknown>;
-  lastGetNextScroll: MutableRefObject<number | null>;
-  lastGetPreviousScroll: MutableRefObject<number | null>;
-  pagination: MutableRefObject<VirtualizerPaginationController | undefined>;
+  lastNextRequestedItemsRef: MutableRefObject<unknown>;
+  lastPreviousRequestedItemsRef: MutableRefObject<unknown>;
+  lastGetNextScrollRef: MutableRefObject<number | null>;
+  lastGetPreviousScrollRef: MutableRefObject<number | null>;
+  paginationRef: MutableRefObject<VirtualizerPaginationController | undefined>;
+};
+
+/** Not fired at this exact scroll offset since the edge was last left, unless blank re-arms it. */
+const canRequestNext = (state: TriggerState, geometry: EdgeGeometry): boolean =>
+  state.lastGetNextScrollRef.current === null ||
+  geometry.scrollOffset !== state.lastGetNextScrollRef.current ||
+  isBlankBelow(geometry);
+
+const canRequestPrevious = (state: TriggerState, geometry: EdgeGeometry): boolean =>
+  state.lastGetPreviousScrollRef.current === null ||
+  geometry.scrollOffset !== state.lastGetPreviousScrollRef.current ||
+  isBlankAbove(geometry);
+
+const requestNext = (state: TriggerState, items: unknown, scrollOffset: number): void => {
+  state.lastNextRequestedItemsRef.current = items;
+  state.lastGetNextScrollRef.current = scrollOffset;
+  const getNext = state.paginationRef.current?.getNext;
+  queueMicrotask(() => getNext?.());
+};
+
+const requestPrevious = (state: TriggerState, items: unknown, scrollOffset: number): void => {
+  state.lastPreviousRequestedItemsRef.current = items;
+  state.lastGetPreviousScrollRef.current = scrollOffset;
+  const getPrevious = state.paginationRef.current?.getPrevious;
+  queueMicrotask(() => getPrevious?.());
 };
 
 type EvaluateTriggersOptions = {
@@ -73,76 +146,56 @@ type EvaluateTriggersOptions = {
 };
 
 /**
- * Requests `getNext`/`getPrevious` once the loaded window's edge (by row index, not scroll
- * position -- the spacer makes blank space scrollable too) nears the viewport. Deduped per
+ * Requests `getNext`/`getPrevious` once the loaded window's edge nears the viewport. Deduped per
  * direction and per `items` snapshot; re-armed while the viewport sits in blank space so a chain
  * of pages loads back-to-back without further user scrolling.
  */
 const evaluateTriggers = ({ virtualizer, items, pagination, itemCount, threshold, state }: EvaluateTriggersOptions) => {
+  const geometry = readEdgeGeometry(virtualizer);
   const scrollable = isScrollable(virtualizer);
-  const scrollOffset = virtualizer.scrollOffset ?? 0;
-  const viewportHeight = virtualizer.scrollElement?.clientHeight ?? 0;
-  const virtualItems = virtualizer.getVirtualItems();
-  const firstVisible = virtualItems.at(0);
-  const lastVisible = virtualItems.at(-1);
-  // `measurementsCache` covers the whole array even when nothing is rendered (deep in the spacer).
-  const measurements = virtualizer.measurementsCache;
-  const firstItemStart = measurements[0]?.start;
-  const lastItemEnd = measurements.at(-1)?.end;
-  const nextThreshold = nextPageIndexThreshold(itemCount, threshold);
   const smallWindow = itemCount <= threshold;
-  const nearBottomIndex = lastVisible
-    ? lastVisible.index >= nextThreshold
-    : !!(lastItemEnd != null && scrollOffset + viewportHeight > lastItemEnd);
-  const nearTopIndex = firstVisible
-    ? firstVisible.index < threshold
-    : !!(firstItemStart != null && scrollOffset < firstItemStart);
-  const blankAbove = !!(firstItemStart != null && firstItemStart > scrollOffset);
-  const blankBelow = !!(lastItemEnd != null && lastItemEnd < scrollOffset + viewportHeight);
-  const canGetNext =
-    state.lastGetNextScroll.current === null || scrollOffset !== state.lastGetNextScroll.current || blankBelow;
-  const canGetPrevious =
-    state.lastGetPreviousScroll.current === null || scrollOffset !== state.lastGetPreviousScroll.current || blankAbove;
-  const triggerNext = !!(
-    pagination?.getNext &&
+  const nearBottom = isNearBottomEdge(geometry, itemCount, threshold);
+  const nearTop = isNearTopEdge(geometry, threshold);
+
+  if (!nearBottom) {
+    state.lastGetNextScrollRef.current = null;
+  }
+  if (!nearTop) {
+    state.lastGetPreviousScrollRef.current = null;
+  }
+
+  const triggerNext =
+    !!pagination?.getNext &&
     !pagination.isLoading &&
     scrollable &&
-    nearBottomIndex &&
-    canGetNext &&
-    (!smallWindow || scrollOffset > 0)
-  );
-  const triggerPrev = !!(
-    pagination?.getPrevious &&
+    nearBottom &&
+    (!smallWindow || geometry.scrollOffset > 0) &&
+    canRequestNext(state, geometry);
+  const triggerPrevious =
+    !!pagination?.getPrevious &&
     !pagination.isLoading &&
     scrollable &&
-    canGetPrevious &&
-    nearTopIndex &&
-    pagination.atHead !== true
-  );
-  if (!nearBottomIndex) {
-    state.lastGetNextScroll.current = null;
-  }
-  if (!nearTopIndex) {
-    state.lastGetPreviousScroll.current = null;
-  }
+    nearTop &&
+    pagination.atHead !== true &&
+    canRequestPrevious(state, geometry);
+
   if (!triggerNext) {
-    state.lastNextRequestedItems.current = undefined;
+    state.lastNextRequestedItemsRef.current = undefined;
   }
-  if (!triggerPrev) {
-    state.lastPreviousRequestedItems.current = undefined;
+  if (!triggerPrevious) {
+    state.lastPreviousRequestedItemsRef.current = undefined;
   }
-  if (triggerNext && state.lastNextRequestedItems.current !== items) {
-    state.lastNextRequestedItems.current = items;
-    state.lastGetNextScroll.current = scrollOffset;
-    const getNext = state.pagination.current?.getNext;
-    queueMicrotask(() => getNext?.());
-  } else if (triggerPrev && state.lastPreviousRequestedItems.current !== items) {
-    state.lastPreviousRequestedItems.current = items;
-    state.lastGetPreviousScroll.current = scrollOffset;
-    const getPrevious = state.pagination.current?.getPrevious;
-    queueMicrotask(() => getPrevious?.());
+
+  if (triggerNext && state.lastNextRequestedItemsRef.current !== items) {
+    requestNext(state, items, geometry.scrollOffset);
+  } else if (triggerPrevious && state.lastPreviousRequestedItemsRef.current !== items) {
+    requestPrevious(state, items, geometry.scrollOffset);
   }
 };
+
+//
+// Front-edge (eviction/prepend) reconciliation
+//
 
 /** Total height (px) of `prevItems[0, oldIndexOfNewFirst)`, per its outgoing measurements. */
 const evictedPrefixHeight = (virtualizer: Virtualizer<any, any>, oldIndexOfNewFirst: number): number => {
@@ -171,6 +224,78 @@ const findRetainedAnchor = <TItem>(
   return null;
 };
 
+type FrontEdgeChange =
+  | { kind: 'none' }
+  | { kind: 'evicted'; evictedHeight: number }
+  | { kind: 'prepended'; anchor: Anchor | null };
+
+/**
+ * Classifies how `items` changed at the front, relative to `prevItems`, using only the outgoing
+ * window's own measurements (no need to wait for the incoming render). `'evicted'` covers both a
+ * prefix eviction (the window slid forward) and a pure append (the window grew) -- either way the
+ * item now at the front was already loaded, so its height is already known. `'prepended'` covers
+ * everything else (a `getPrevious` prepend, or a reset to a disjoint range).
+ */
+const classifyFrontEdgeChange = <TItem>(
+  prevItems: readonly TItem[] | TItem[] | undefined,
+  items: readonly TItem[] | TItem[] | undefined,
+  getId: GetId<TItem>,
+  virtualizer: Virtualizer<any, any> | null,
+): FrontEdgeChange => {
+  if (!virtualizer || !prevItems) {
+    return { kind: 'none' };
+  }
+  const firstNewId = items?.[0] != null ? getId(items[0]) : undefined;
+  const oldIndexOfNewFirst = firstNewId != null ? prevItems.findIndex((item) => getId(item) === firstNewId) : -1;
+  if (oldIndexOfNewFirst >= 0) {
+    return { kind: 'evicted', evictedHeight: evictedPrefixHeight(virtualizer, oldIndexOfNewFirst) };
+  }
+  const newIds = new Set(items?.map((item) => getId(item)));
+  return { kind: 'prepended', anchor: findRetainedAnchor(prevItems, newIds, getId, virtualizer) };
+};
+
+//
+// Prepend correction (deferred to a layout effect; see the hook's own doc comment for why)
+//
+
+type PrependCorrection =
+  | { kind: 'no-overlap' }
+  | { kind: 'pending' }
+  | { kind: 'absorbed'; nextSpace: number }
+  | { kind: 'snap'; nextSpace: number; scrollAdjust: number };
+
+/**
+ * `'no-overlap'`: the anchor isn't in the new `items` (e.g. a reset) -- the spacer no longer
+ * describes anything. `'pending'`: the incoming render hasn't measured the anchor yet. `'absorbed'`:
+ * the shift is fully absorbed by the spacer, no scroll rewrite needed. `'snap'`: growing past an
+ * empty spacer (or the `atHead` reset) leaves a remainder that has to move the scroll offset.
+ */
+const computePrependCorrection = <TItem>(
+  virtualizer: Virtualizer<any, any>,
+  items: readonly TItem[] | TItem[],
+  getId: GetId<TItem>,
+  anchor: Anchor,
+  currentSpace: number,
+  atHead: boolean,
+): PrependCorrection => {
+  const newIndex = items.findIndex((item) => getId(item) === anchor.id);
+  if (newIndex < 0) {
+    return { kind: 'no-overlap' };
+  }
+  const newStart = virtualizer.measurementsCache[newIndex]?.start;
+  if (newStart == null) {
+    return { kind: 'pending' };
+  }
+  const shift = newStart - anchor.start;
+  const nextSpace = atHead ? 0 : Math.max(0, currentSpace - shift);
+  const scrollAdjust = shift + (nextSpace - currentSpace);
+  return scrollAdjust === 0 ? { kind: 'absorbed', nextSpace } : { kind: 'snap', nextSpace, scrollAdjust };
+};
+
+//
+// Hook
+//
+
 /**
  * Wires a paginated data source into a `Mosaic.VirtualStack`: requests the next/previous page near
  * either loaded edge (`evaluateTriggers`), and keeps the scrollbar stable across the resulting
@@ -185,12 +310,13 @@ const findRetainedAnchor = <TItem>(
  * `paddingStart`) grows by exactly the evicted height and shrinks by exactly the prepended height,
  * so retained items keep their absolute position and the thumb only scales as the total grows.
  *
- * Eviction is corrected synchronously during the same render that observes the new `items`, since
- * the evicted height is already known from the outgoing window's own measurements -- deferring it
+ * Eviction (`classifyFrontEdgeChange`'s `'evicted'`) is corrected synchronously during the same
+ * render that observes the new `items`, since the evicted height is already known -- deferring it
  * would let the browser observe (and clamp `scrollTop` against) a momentary, too-short frame.
- * Prepending is corrected one render later, from a layout effect, since the prepended items'
- * heights aren't known until the incoming render measures them; that lag is safe because
- * prepending only ever grows content before the spacer shrinks to match.
+ * Prepending (`'prepended'`) is corrected one render later, from a layout effect
+ * (`computePrependCorrection`), since the prepended items' heights aren't known until the incoming
+ * render measures them; that lag is safe because prepending only ever grows content before the
+ * spacer shrinks to match.
  *
  * The layout effect also re-runs `evaluateTriggers`, because `@tanstack/react-virtual` only calls
  * `onChange` when the visible range changes, not merely when `items` does -- while the viewport
@@ -209,6 +335,12 @@ export const useVirtualizerPagination = <TItem = any>({
 
   const [leadingSpace, setLeadingSpace] = useState(0);
   const leadingSpaceRef = useRef(leadingSpace);
+  const setSpacer = useCallback((nextSpace: number) => {
+    if (nextSpace !== leadingSpaceRef.current) {
+      leadingSpaceRef.current = nextSpace;
+      setLeadingSpace(nextSpace);
+    }
+  }, []);
 
   const virtualizerRef = useRef<Virtualizer<any, any> | null>(null);
   const anchorRef = useRef<Anchor | null>(null);
@@ -217,38 +349,41 @@ export const useVirtualizerPagination = <TItem = any>({
   const restoringRef = useRef(false);
 
   const triggerState: TriggerState = {
-    lastNextRequestedItems: useRef<unknown>(undefined),
-    lastPreviousRequestedItems: useRef<unknown>(undefined),
-    lastGetNextScroll: useRef<number | null>(null),
-    lastGetPreviousScroll: useRef<number | null>(null),
-    pagination: useRef(pagination),
+    lastNextRequestedItemsRef: useRef<unknown>(undefined),
+    lastPreviousRequestedItemsRef: useRef<unknown>(undefined),
+    lastGetNextScrollRef: useRef<number | null>(null),
+    lastGetPreviousScrollRef: useRef<number | null>(null),
+    paginationRef: useRef(pagination),
   };
-  triggerState.pagination.current = pagination;
+  triggerState.paginationRef.current = pagination;
 
-  // Snapshots the front-edge change during render, before `Mosaic.VirtualStack` re-renders with
+  const rearmTriggers = useCallback(
+    (virtualizer: Virtualizer<any, any>) => {
+      evaluateTriggers({
+        virtualizer,
+        items,
+        pagination: triggerState.paginationRef.current,
+        itemCount,
+        threshold,
+        state: triggerState,
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [items, itemCount, threshold],
+  );
+
+  // Classifies the front-edge change during render, before `Mosaic.VirtualStack` re-renders with
   // the new `items` -- at this point `virtualizerRef.current` still reflects the outgoing array.
-  // The spacer/anchor computation itself is gated on `pagination` so a caller not using pagination
-  // never gets it for an unrelated `items` change (e.g. a sort or filter); `prevItemsRef` still
-  // tracks every change unconditionally so it isn't stale if `pagination` is attached later.
+  // Skipped entirely when `pagination` is unset, so a caller not using pagination never gets
+  // spacer/anchor bookkeeping for an unrelated `items` change (e.g. a sort or filter).
   if (prevItemsRef.current !== items) {
-    const virtualizer = virtualizerRef.current;
-    const prevItems = prevItemsRef.current;
     if (pagination) {
-      const firstNewId = items?.[0] != null ? getId(items[0]) : undefined;
-      const oldIndexOfNewFirst =
-        firstNewId != null ? (prevItems?.findIndex((item) => getId(item) === firstNewId) ?? -1) : -1;
-      if (virtualizer && oldIndexOfNewFirst >= 0) {
-        // Prefix eviction or pure append: correct now (see doc comment above).
-        const nextSpace = leadingSpaceRef.current + evictedPrefixHeight(virtualizer, oldIndexOfNewFirst);
-        if (nextSpace !== leadingSpaceRef.current) {
-          leadingSpaceRef.current = nextSpace;
-          setLeadingSpace(nextSpace);
-        }
+      const change = classifyFrontEdgeChange(prevItemsRef.current, items, getId, virtualizerRef.current);
+      if (change.kind === 'evicted') {
+        setSpacer(leadingSpaceRef.current + change.evictedHeight);
         anchorRef.current = null;
-      } else if (virtualizer && prevItems) {
-        // Prepend or a reset to a disjoint range: defer to the layout effect below.
-        const newIds = new Set(items?.map((item) => getId(item)));
-        anchorRef.current = findRetainedAnchor(prevItems, newIds, getId, virtualizer);
+      } else if (change.kind === 'prepended') {
+        anchorRef.current = change.anchor;
       }
     }
     prevItemsRef.current = items;
@@ -261,14 +396,11 @@ export const useVirtualizerPagination = <TItem = any>({
         restoringRef.current = false;
         return;
       }
-      evaluateTriggers({ virtualizer, items, pagination, itemCount, threshold, state: triggerState });
+      rearmTriggers(virtualizer);
     },
-    [items, pagination, itemCount, threshold],
+    [rearmTriggers],
   );
 
-  // Applies the prepend correction: the anchor's new offset (still under the OLD `leadingSpace`)
-  // minus its captured offset is the shift; the spacer absorbs it so item and scroll offsets both
-  // stay put. Only the remainder -- growing past the spacer while at the head -- moves the thumb.
   useLayoutEffect(() => {
     const virtualizer = virtualizerRef.current;
     const anchor = anchorRef.current;
@@ -276,53 +408,29 @@ export const useVirtualizerPagination = <TItem = any>({
     if (!virtualizer || !anchor || !items) {
       return;
     }
-    const newIndex = items.findIndex((item) => getId(item) === anchor.id);
-    const atHead = triggerState.pagination.current?.atHead === true;
-    if (newIndex < 0) {
-      // No overlap with the outgoing window (e.g. a reset to a fresh first page).
-      if (leadingSpaceRef.current !== 0) {
-        leadingSpaceRef.current = 0;
-        setLeadingSpace(0);
-      }
-      evaluateTriggers({
-        virtualizer,
-        items,
-        pagination: triggerState.pagination.current,
-        itemCount,
-        threshold,
-        state: triggerState,
-      });
-      return;
-    }
-    const newStart = virtualizer.measurementsCache[newIndex]?.start;
-    if (newStart == null) {
-      return;
-    }
-    const shift = newStart - anchor.start;
-    const previousSpace = leadingSpaceRef.current;
-    const nextSpace = atHead ? 0 : Math.max(0, previousSpace - shift);
-    const scrollAdjust = shift + (nextSpace - previousSpace);
-    if (nextSpace !== previousSpace) {
-      leadingSpaceRef.current = nextSpace;
-      setLeadingSpace(nextSpace);
-    }
-    if (scrollAdjust !== 0) {
-      // The head-reset snap: a one-shot move, not a chain, so skip re-evaluating triggers here --
-      // `virtualizer.scrollOffset` won't reflect it until the (suppressed) scroll event fires.
-      restoringRef.current = true;
-      virtualizer.scrollToOffset((virtualizer.scrollOffset ?? 0) + scrollAdjust);
-    } else {
-      evaluateTriggers({
-        virtualizer,
-        items,
-        pagination: triggerState.pagination.current,
-        itemCount,
-        threshold,
-        state: triggerState,
-      });
+    const atHead = triggerState.paginationRef.current?.atHead === true;
+    const correction = computePrependCorrection(virtualizer, items, getId, anchor, leadingSpaceRef.current, atHead);
+    switch (correction.kind) {
+      case 'pending':
+        return;
+      case 'no-overlap':
+        setSpacer(0);
+        rearmTriggers(virtualizer);
+        return;
+      case 'absorbed':
+        setSpacer(correction.nextSpace);
+        rearmTriggers(virtualizer);
+        return;
+      case 'snap':
+        // A one-shot move, not a chain, so `rearmTriggers` is skipped: `virtualizer.scrollOffset`
+        // won't reflect this until the (suppressed) scroll event fires.
+        setSpacer(correction.nextSpace);
+        restoringRef.current = true;
+        virtualizer.scrollToOffset((virtualizer.scrollOffset ?? 0) + correction.scrollAdjust);
+        return;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [items, getId]);
+  }, [items, getId, setSpacer, rearmTriggers]);
 
   return { onChange, leadingSpace };
 };

--- a/packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.ts
+++ b/packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.ts
@@ -3,7 +3,7 @@
 //
 
 import { type Virtualizer } from '@tanstack/react-virtual';
-import { useCallback, useLayoutEffect, useRef } from 'react';
+import { type MutableRefObject, useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 import { type GetId } from '../components';
 
@@ -17,10 +17,7 @@ const nextPageIndexThreshold = (itemCount: number, threshold: number): number =>
 /** True when loaded content exceeds the scroll viewport (user can actually scroll). */
 const isScrollable = (virtualizer: Virtualizer<any, any>): boolean => {
   const viewportHeight = virtualizer.scrollElement?.clientHeight ?? 0;
-  if (viewportHeight === 0) {
-    return false;
-  }
-  return virtualizer.getTotalSize() > viewportHeight + 1;
+  return viewportHeight > 0 && virtualizer.getTotalSize() > viewportHeight + 1;
 };
 
 export type VirtualizerPaginationController = {
@@ -48,69 +45,210 @@ export type UseVirtualizerPaginationProps<TItem = any> = {
   threshold?: number;
 };
 
+export type UseVirtualizerPaginationResult = {
+  onChange: (virtualizer: Virtualizer<any, any>) => void;
+  /** Extra scrollable space (px) to feed into the virtualizer's `paddingStart`. */
+  leadingSpace: number;
+};
+
+/** A retained item's identity and pre-change offset. */
+type Anchor = { id: string; start: number };
+
+/** Per-direction dedup/throttle state for `evaluateTriggers`, independent of item type. */
+type TriggerState = {
+  lastNextRequestedItems: MutableRefObject<unknown>;
+  lastPreviousRequestedItems: MutableRefObject<unknown>;
+  lastGetNextScroll: MutableRefObject<number | null>;
+  lastGetPreviousScroll: MutableRefObject<number | null>;
+  pagination: MutableRefObject<VirtualizerPaginationController | undefined>;
+};
+
+type EvaluateTriggersOptions = {
+  virtualizer: Virtualizer<any, any>;
+  items: unknown;
+  pagination: VirtualizerPaginationController | undefined;
+  itemCount: number;
+  threshold: number;
+  state: TriggerState;
+};
+
 /**
- * Wires a paginated data source into a `Mosaic.VirtualStack`: requests the next/previous page
- * once the visible range approaches either loaded edge, and preserves scroll position across the
- * resulting `items` change.
+ * Requests `getNext`/`getPrevious` once the loaded window's edge (by row index, not scroll
+ * position -- the spacer makes blank space scrollable too) nears the viewport. Deduped per
+ * direction and per `items` snapshot; re-armed while the viewport sits in blank space so a chain
+ * of pages loads back-to-back without further user scrolling.
+ */
+const evaluateTriggers = ({ virtualizer, items, pagination, itemCount, threshold, state }: EvaluateTriggersOptions) => {
+  const scrollable = isScrollable(virtualizer);
+  const scrollOffset = virtualizer.scrollOffset ?? 0;
+  const viewportHeight = virtualizer.scrollElement?.clientHeight ?? 0;
+  const virtualItems = virtualizer.getVirtualItems();
+  const firstVisible = virtualItems.at(0);
+  const lastVisible = virtualItems.at(-1);
+  // `measurementsCache` covers the whole array even when nothing is rendered (deep in the spacer).
+  const measurements = virtualizer.measurementsCache;
+  const firstItemStart = measurements[0]?.start;
+  const lastItemEnd = measurements.at(-1)?.end;
+  const nextThreshold = nextPageIndexThreshold(itemCount, threshold);
+  const smallWindow = itemCount <= threshold;
+  const nearBottomIndex = lastVisible
+    ? lastVisible.index >= nextThreshold
+    : !!(lastItemEnd != null && scrollOffset + viewportHeight > lastItemEnd);
+  const nearTopIndex = firstVisible
+    ? firstVisible.index < threshold
+    : !!(firstItemStart != null && scrollOffset < firstItemStart);
+  const blankAbove = !!(firstItemStart != null && firstItemStart > scrollOffset);
+  const blankBelow = !!(lastItemEnd != null && lastItemEnd < scrollOffset + viewportHeight);
+  const canGetNext =
+    state.lastGetNextScroll.current === null || scrollOffset !== state.lastGetNextScroll.current || blankBelow;
+  const canGetPrevious =
+    state.lastGetPreviousScroll.current === null || scrollOffset !== state.lastGetPreviousScroll.current || blankAbove;
+  const triggerNext = !!(
+    pagination?.getNext &&
+    !pagination.isLoading &&
+    scrollable &&
+    nearBottomIndex &&
+    canGetNext &&
+    (!smallWindow || scrollOffset > 0)
+  );
+  const triggerPrev = !!(
+    pagination?.getPrevious &&
+    !pagination.isLoading &&
+    scrollable &&
+    canGetPrevious &&
+    nearTopIndex &&
+    pagination.atHead !== true
+  );
+  if (!nearBottomIndex) {
+    state.lastGetNextScroll.current = null;
+  }
+  if (!nearTopIndex) {
+    state.lastGetPreviousScroll.current = null;
+  }
+  if (!triggerNext) {
+    state.lastNextRequestedItems.current = undefined;
+  }
+  if (!triggerPrev) {
+    state.lastPreviousRequestedItems.current = undefined;
+  }
+  if (triggerNext && state.lastNextRequestedItems.current !== items) {
+    state.lastNextRequestedItems.current = items;
+    state.lastGetNextScroll.current = scrollOffset;
+    const getNext = state.pagination.current?.getNext;
+    queueMicrotask(() => getNext?.());
+  } else if (triggerPrev && state.lastPreviousRequestedItems.current !== items) {
+    state.lastPreviousRequestedItems.current = items;
+    state.lastGetPreviousScroll.current = scrollOffset;
+    const getPrevious = state.pagination.current?.getPrevious;
+    queueMicrotask(() => getPrevious?.());
+  }
+};
+
+/** Total height (px) of `prevItems[0, oldIndexOfNewFirst)`, per its outgoing measurements. */
+const evictedPrefixHeight = (virtualizer: Virtualizer<any, any>, oldIndexOfNewFirst: number): number => {
+  const measurements = virtualizer.measurementsCache;
+  return (measurements[oldIndexOfNewFirst]?.start ?? 0) - (measurements[0]?.start ?? 0);
+};
+
+/**
+ * Finds an item retained across a prepend, anchored on its pre-change offset. Scans from the tail
+ * (the common case -- a prepend leaves the rest of the window untouched) and doesn't require the
+ * item to be currently rendered, since `measurementsCache` covers the whole array.
+ */
+const findRetainedAnchor = <TItem>(
+  prevItems: readonly TItem[],
+  newIds: Set<unknown>,
+  getId: GetId<TItem>,
+  virtualizer: Virtualizer<any, any>,
+): Anchor | null => {
+  for (let index = prevItems.length - 1; index >= 0; index--) {
+    const id = getId(prevItems[index]);
+    if (newIds.has(id)) {
+      const start = virtualizer.measurementsCache[index]?.start;
+      return start != null ? { id, start } : null;
+    }
+  }
+  return null;
+};
+
+/**
+ * Wires a paginated data source into a `Mosaic.VirtualStack`: requests the next/previous page near
+ * either loaded edge (`evaluateTriggers`), and keeps the scrollbar stable across the resulting
+ * `items` change by maintaining a leading spacer instead of rewriting the scroll offset.
  *
- * `@tanstack/react-virtual` keys items by stable id (measured sizes survive reordering), but it
- * recomputes every item's *pixel offset* from the current array order on each render, with no
- * built-in compensation for insertion/removal at the front -- so evicting the newest items or
- * prepending newer ones otherwise shifts all content under a scroll offset that itself never
- * moves, reading as a jump/flicker. This hook anchors on whichever item was first-visible just
- * before `items` changed and restores it to the same on-screen offset afterward.
+ * Called internally by `Mosaic.VirtualStack` when its `pagination` prop is set -- not normally
+ * called directly.
  *
- * Pass the returned `onChange` to `Mosaic.VirtualStack`'s `onChange` prop.
+ * `@tanstack/react-virtual` recomputes every item's pixel offset from the current array on each
+ * render, with no compensation for insertion/removal at the front -- rewriting the scroll offset
+ * to chase that shift visibly jumps the scrollbar thumb. Instead, `leadingSpace` (fed back into
+ * `paddingStart`) grows by exactly the evicted height and shrinks by exactly the prepended height,
+ * so retained items keep their absolute position and the thumb only scales as the total grows.
+ *
+ * Eviction is corrected synchronously during the same render that observes the new `items`, since
+ * the evicted height is already known from the outgoing window's own measurements -- deferring it
+ * would let the browser observe (and clamp `scrollTop` against) a momentary, too-short frame.
+ * Prepending is corrected one render later, from a layout effect, since the prepended items'
+ * heights aren't known until the incoming render measures them; that lag is safe because
+ * prepending only ever grows content before the spacer shrinks to match.
+ *
+ * The layout effect also re-runs `evaluateTriggers`, because `@tanstack/react-virtual` only calls
+ * `onChange` when the visible range changes, not merely when `items` does -- while the viewport
+ * sits in blank spacer space the range never changes, so relying on `onChange` alone would stall a
+ * catch-up chain after one page.
+ *
+ * Assumes the stack renders with `draggable={false}` (virtual indices map 1:1 onto `items`).
  */
 export const useVirtualizerPagination = <TItem = any>({
   items,
   getId,
   pagination,
   threshold = DEFAULT_THRESHOLD,
-}: UseVirtualizerPaginationProps<TItem>): { onChange: (virtualizer: Virtualizer<any, any>) => void } => {
+}: UseVirtualizerPaginationProps<TItem>): UseVirtualizerPaginationResult => {
   const itemCount = items?.length ?? 0;
 
-  // Tracks the live virtualizer instance (for imperative `scrollToOffset` calls) and the
-  // identity/on-screen offset of whichever item was first-visible just before `items` last
-  // changed.
-  const virtualizerRef = useRef<Virtualizer<any, any> | null>(null);
-  const anchorRef = useRef<{ id: string; offsetFromTop: number } | null>(null);
-  const prevItemsRef = useRef(items);
-  // Set right before the anchor-restoring `scrollToOffset` call below, consumed by the `onChange`
-  // it triggers (the resulting native `scroll` event fires asynchronously, so this can't be
-  // cleared synchronously after the call -- it has to survive until `onChange` actually observes
-  // it). Without this, restoring the anchor after a page-load can itself land within the
-  // next/previous-page threshold (the restore is only as accurate as the estimated size of
-  // not-yet-measured newly-revealed rows), and the resulting `onChange` would request another page
-  // as a side effect of our own correction rather than real user scrolling -- cascading into
-  // repeated loads/corrections while scrolling quickly.
-  const restoringRef = useRef(false);
-  // One page request per loaded `items` snapshot; cleared when the user scrolls away from both edges.
-  const lastRequestedItemsRef = useRef<typeof items>(undefined);
-  // Scroll offset when the last page request was issued; sync sources can deliver a new `items`
-  // snapshot without the user scrolling, which would otherwise re-trigger at the same edge.
-  const lastGetNextScrollRef = useRef<number | null>(null);
-  const lastGetPreviousScrollRef = useRef<number | null>(null);
-  const paginationRef = useRef(pagination);
-  paginationRef.current = pagination;
+  const [leadingSpace, setLeadingSpace] = useState(0);
+  const leadingSpaceRef = useRef(leadingSpace);
 
-  // Snapshot the anchor the moment `items` is about to change, during render rather than inside
-  // `onChange` or an effect. `@tanstack/react-virtual` calls `onChange` synchronously as part of
-  // consuming an updated `count`/`items` option on *every* render (`setOptions` runs
-  // unconditionally in the render body, not an effect) -- so by the time `onChange` fires for this
-  // render, it already sees the NEW `items`, making "first visible item in `items`"
-  // self-referential and the compensation below a permanent no-op. Right here, before the caller's
-  // `Mosaic.VirtualStack` has re-rendered with the new array, `virtualizerRef.current` still
-  // reflects the outgoing array's measurements/scroll offset, so indexing into
-  // `prevItemsRef.current` (the outgoing array) with it is accurate.
+  const virtualizerRef = useRef<Virtualizer<any, any> | null>(null);
+  const anchorRef = useRef<Anchor | null>(null);
+  const prevItemsRef = useRef(items);
+  // Suppresses trigger evaluation for the scroll event that our own correction below causes.
+  const restoringRef = useRef(false);
+
+  const triggerState: TriggerState = {
+    lastNextRequestedItems: useRef<unknown>(undefined),
+    lastPreviousRequestedItems: useRef<unknown>(undefined),
+    lastGetNextScroll: useRef<number | null>(null),
+    lastGetPreviousScroll: useRef<number | null>(null),
+    pagination: useRef(pagination),
+  };
+  triggerState.pagination.current = pagination;
+
+  // Snapshots the front-edge change during render, before `Mosaic.VirtualStack` re-renders with
+  // the new `items` -- at this point `virtualizerRef.current` still reflects the outgoing array.
+  // The spacer/anchor computation itself is gated on `pagination` so a caller not using pagination
+  // never gets it for an unrelated `items` change (e.g. a sort or filter); `prevItemsRef` still
+  // tracks every change unconditionally so it isn't stale if `pagination` is attached later.
   if (prevItemsRef.current !== items) {
     const virtualizer = virtualizerRef.current;
-    const firstVisible = virtualizer?.getVirtualItems().at(0);
-    if (virtualizer && firstVisible) {
-      const anchorItem = prevItemsRef.current?.[firstVisible.index];
-      const anchorId = anchorItem && getId(anchorItem);
-      if (anchorId) {
-        anchorRef.current = { id: anchorId, offsetFromTop: firstVisible.start - (virtualizer.scrollOffset ?? 0) };
+    const prevItems = prevItemsRef.current;
+    if (pagination) {
+      const firstNewId = items?.[0] != null ? getId(items[0]) : undefined;
+      const oldIndexOfNewFirst =
+        firstNewId != null ? (prevItems?.findIndex((item) => getId(item) === firstNewId) ?? -1) : -1;
+      if (virtualizer && oldIndexOfNewFirst >= 0) {
+        // Prefix eviction or pure append: correct now (see doc comment above).
+        const nextSpace = leadingSpaceRef.current + evictedPrefixHeight(virtualizer, oldIndexOfNewFirst);
+        if (nextSpace !== leadingSpaceRef.current) {
+          leadingSpaceRef.current = nextSpace;
+          setLeadingSpace(nextSpace);
+        }
+        anchorRef.current = null;
+      } else if (virtualizer && prevItems) {
+        // Prepend or a reset to a disjoint range: defer to the layout effect below.
+        const newIds = new Set(items?.map((item) => getId(item)));
+        anchorRef.current = findRetainedAnchor(prevItems, newIds, getId, virtualizer);
       }
     }
     prevItemsRef.current = items;
@@ -123,85 +261,68 @@ export const useVirtualizerPagination = <TItem = any>({
         restoringRef.current = false;
         return;
       }
-      const scrollable = isScrollable(virtualizer);
-      const scrollOffset = virtualizer.scrollOffset ?? 0;
-      const virtualItems = virtualizer.getVirtualItems();
-      const firstVisible = virtualItems.at(0);
-      const lastVisible = virtualItems.at(-1);
-      const nextThreshold = nextPageIndexThreshold(itemCount, threshold);
-      const smallWindow = itemCount <= threshold;
-      const nearBottomIndex = !!(lastVisible && lastVisible.index >= nextThreshold);
-      const canGetNext = lastGetNextScrollRef.current === null || scrollOffset !== lastGetNextScrollRef.current;
-      const canGetPrevious =
-        lastGetPreviousScrollRef.current === null || scrollOffset !== lastGetPreviousScrollRef.current;
-      const triggerNext = !!(
-        pagination?.getNext &&
-        !pagination.isLoading &&
-        scrollable &&
-        nearBottomIndex &&
-        canGetNext &&
-        (!smallWindow || scrollOffset > 0)
-      );
-      const triggerPrev = !!(
-        pagination?.getPrevious &&
-        !pagination.isLoading &&
-        scrollable &&
-        scrollOffset > 0 &&
-        canGetPrevious &&
-        firstVisible &&
-        firstVisible.index < threshold &&
-        pagination.atHead !== true
-      );
-      const alreadyRequestedForItems = lastRequestedItemsRef.current === items;
-      if (!nearBottomIndex) {
-        lastGetNextScrollRef.current = null;
-      }
-      if (!firstVisible || firstVisible.index >= threshold) {
-        lastGetPreviousScrollRef.current = null;
-      }
-      if (!triggerNext && !triggerPrev) {
-        lastRequestedItemsRef.current = undefined;
-        return;
-      }
-      if (alreadyRequestedForItems) {
-        return;
-      }
-      lastRequestedItemsRef.current = items;
-      if (triggerNext) {
-        lastGetNextScrollRef.current = scrollOffset;
-        const getNext = paginationRef.current?.getNext;
-        queueMicrotask(() => getNext?.());
-      } else if (triggerPrev) {
-        lastGetPreviousScrollRef.current = scrollOffset;
-        const getPrevious = paginationRef.current?.getPrevious;
-        queueMicrotask(() => getPrevious?.());
-      }
+      evaluateTriggers({ virtualizer, items, pagination, itemCount, threshold, state: triggerState });
     },
     [items, pagination, itemCount, threshold],
   );
 
-  // Restores the previously-first-visible item to the same on-screen offset it had before `items`
-  // changed. A no-op when the anchor item's index hasn't moved (e.g. appending at the end).
+  // Applies the prepend correction: the anchor's new offset (still under the OLD `leadingSpace`)
+  // minus its captured offset is the shift; the spacer absorbs it so item and scroll offsets both
+  // stay put. Only the remainder -- growing past the spacer while at the head -- moves the thumb.
   useLayoutEffect(() => {
     const virtualizer = virtualizerRef.current;
     const anchor = anchorRef.current;
+    anchorRef.current = null;
     if (!virtualizer || !anchor || !items) {
       return;
     }
     const newIndex = items.findIndex((item) => getId(item) === anchor.id);
+    const atHead = triggerState.pagination.current?.atHead === true;
     if (newIndex < 0) {
+      // No overlap with the outgoing window (e.g. a reset to a fresh first page).
+      if (leadingSpaceRef.current !== 0) {
+        leadingSpaceRef.current = 0;
+        setLeadingSpace(0);
+      }
+      evaluateTriggers({
+        virtualizer,
+        items,
+        pagination: triggerState.pagination.current,
+        itemCount,
+        threshold,
+        state: triggerState,
+      });
       return;
     }
-    const offset = virtualizer.getOffsetForIndex(newIndex, 'start');
-    if (!offset) {
+    const newStart = virtualizer.measurementsCache[newIndex]?.start;
+    if (newStart == null) {
       return;
     }
-    const target = offset[0] - anchor.offsetFromTop;
-    if (target !== virtualizer.scrollOffset) {
+    const shift = newStart - anchor.start;
+    const previousSpace = leadingSpaceRef.current;
+    const nextSpace = atHead ? 0 : Math.max(0, previousSpace - shift);
+    const scrollAdjust = shift + (nextSpace - previousSpace);
+    if (nextSpace !== previousSpace) {
+      leadingSpaceRef.current = nextSpace;
+      setLeadingSpace(nextSpace);
+    }
+    if (scrollAdjust !== 0) {
+      // The head-reset snap: a one-shot move, not a chain, so skip re-evaluating triggers here --
+      // `virtualizer.scrollOffset` won't reflect it until the (suppressed) scroll event fires.
       restoringRef.current = true;
-      virtualizer.scrollToOffset(target, { align: 'start' });
+      virtualizer.scrollToOffset((virtualizer.scrollOffset ?? 0) + scrollAdjust);
+    } else {
+      evaluateTriggers({
+        virtualizer,
+        items,
+        pagination: triggerState.pagination.current,
+        itemCount,
+        threshold,
+        state: triggerState,
+      });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items, getId]);
 
-  return { onChange };
+  return { onChange, leadingSpace };
 };

--- a/packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.ts
+++ b/packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.ts
@@ -41,7 +41,7 @@ export type UseVirtualizerPaginationProps<TItem = any> = {
   /** Load-next/load-previous callbacks. Both edges are inert while omitted. */
   pagination?: VirtualizerPaginationController;
 
-  /** Rows from either loaded edge at which the adjacent page is requested. @default 12 */
+  /** Rows from either loaded edge at which the adjacent page is requested. @default 12. */
   threshold?: number;
 };
 
@@ -384,6 +384,11 @@ export const useVirtualizerPagination = <TItem = any>({
         anchorRef.current = null;
       } else if (change.kind === 'prepended') {
         anchorRef.current = change.anchor;
+        if (!change.anchor) {
+          // No retained item to anchor on (a disjoint reset): the layout effect below never runs
+          // its own reset for this case, since it bails out early on a null anchor.
+          setSpacer(0);
+        }
       }
     }
     prevItemsRef.current = items;


### PR DESCRIPTION
## Summary

- `Mosaic.VirtualStack` paginated windows (via `useVirtualizerPagination`) previously rewrote the scroll offset to chase content shifted by evicted/prepended items, visibly jumping the scrollbar thumb. The hook now maintains a leading spacer instead, fed into the virtualizer's `paddingStart`, so the thumb only scales as the total loaded size grows/shrinks.
- Fixed two related bugs found while testing the fix:
  - `getNext`/`getPrevious` request dedup was shared across both directions, so an exhausted `getNext` at the tail of a dataset could permanently deadlock `getPrevious` for the same `items` snapshot.
  - `@tanstack/react-virtual` only invokes `onChange` when the *visible range* changes, not merely when `items` does. While the viewport sits in blank spacer space (e.g. after a large scroll-up fling), the range never changes, so a chain of catch-up page loads would silently stall after just one page.
- Simplified the public API: `useVirtualizerPagination` is now called internally by `Mosaic.VirtualStack` via a new `pagination` prop, rather than requiring callers to manually wire the hook's `onChange`/`leadingSpace` through to two separate props. `leadingSpace` is no longer exposed publicly.

## Test plan

- [x] `moon run react-ui-mosaic:build` / `:lint` / `:test` pass
- [x] `moon run plugin-inbox:build` / `:lint` / `:test` pass (123 tests)
- [x] Full-repo `moon run :lint -- --fix` passes (283 packages, 0 warnings/errors)
- [x] Full-repo `moon exec --on-failure continue :test` — only pre-existing, unrelated failures in AI/LLM packages (401s against live external APIs, no credentials in this environment); `react-ui-mosaic` and `plugin-inbox` both pass cleanly
- [x] Headless Playwright scroll-simulation against the `ui/react-ui-mosaic/Stack/Pagination` storybook stories: continuous scroll-to-end, a hard fling into blank spacer space (catch-up chain), and scroll-back-to-head — no scrollbar jumps/anomalies in any phase
- [x] Manually verified the live-ECHO `FeedBacked` story still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtualized lists now support paginated loading via a dedicated pagination controller, with an optional threshold for when paging triggers.
  * Virtual stacks now preserve stable scrolling behavior during incremental content loads.
* **Bug Fixes**
  * Reduced missed or repeated page loads near the top/bottom edges of long lists.
  * Improved scroll stability when items are inserted or evicted near the front.
* **Documentation**
  * Updated Storybook pagination examples to use the new pagination prop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->