### PR TITLE
fix(plugin-client): suppress RpcClosedError race in fire-and-forget migrations

### DIFF
--- a/packages/plugins/plugin-client/src/capabilities/migrations.ts
+++ b/packages/plugins/plugin-client/src/capabilities/migrations.ts
@@ -5,6 +5,8 @@
 import * as Effect from 'effect/Effect';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
+import { log } from '@dxos/log';
+import { RpcClosedError } from '@dxos/protocols';
 
 import { ClientCapabilities } from '#types';
 
@@ -20,7 +22,13 @@ export default Capability.makeModule(
       (_migrations: any[]) => {
         const migrations = Array.from(new Set(_migrations.flat()));
         const spaces = client.spaces.get();
-        void Promise.all(spaces.map((space: any) => space.internal.db.runMigrations(migrations)));
+        // Migrations run fire-and-forget from the subscription callback; an in-flight flush can be
+        // interrupted when the client shuts down, which surfaces as a benign RpcClosedError race.
+        void Promise.all(spaces.map((space: any) => space.internal.db.runMigrations(migrations))).catch((err) => {
+          if (!(err instanceof RpcClosedError)) {
+            log.catch(err);
+          }
+        });
       },
       { immediate: true },
     );


### PR DESCRIPTION
## Problem

After the effect-rpc PR (#12127), tests became flaky with an unhandled rejection during teardown:

```
Unhandled Rejection
RpcClosedError: Request was terminated because the RPC endpoint is closed.
 ❯ ../../core/protocols/src/effect-runtime.ts:46:13
 ❯ EntityManager.flush ../../core/echo/echo-client/src/core-db/entity-manager.ts:572:7
 ❯ DatabaseImpl.runMigrations ../../core/echo/echo-client/src/proxy-db/database.ts:641:5
```

The test itself passes (`✓`), but Vitest reports `Errors 1 error` from the stray rejection, flaking runs such as `stories-assistant/src/test/startup.test.ts`.

## Root cause

The migrations capability subscribes with `immediate: true` and runs migrations **fire-and-forget**:

```ts
void Promise.all(spaces.map((space) => space.internal.db.runMigrations(migrations)));
```

`runMigrations` performs a `flush`, which issues an RPC via the new effect-rpc runtime. Since effect-rpc now surfaces interruption (connection closed underneath the call) as `RpcClosedError`, an in-flight flush that gets interrupted when the client shuts down (e.g. `client.destroy()` in test teardown) rejects the promise. Because the promise is `void`-discarded with no `.catch`, that rejection is unhandled.

## Fix

Attach a `.catch` to the fire-and-forget promise. Ignore the benign shutdown-race `RpcClosedError` (matching the established convention across the mesh/echo packages, where `RpcClosedError` from reconnection/shutdown is swallowed) and log any genuine migration failure via `log.catch` so real errors are still surfaced.

## Verification

- `moon run plugin-client:build` — passes
- `moon run plugin-client:lint -- --fix` — passes
- `moon run stories-assistant:test -- src/test/startup.test.ts` — passes with **no** unhandled-rejection / `Errors` section, across repeated runs
- Cast audit on the diff: no new casts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRKcTydAxi3jRktePikLGd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration reliability during shutdown by safely handling interrupted connections.
  * Added error reporting for unexpected migration failures while suppressing benign shutdown errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->