### PR TITLE
refactor(effect): remove promiseWithCauseCapture workaround

### DIFF
--- a/packages/common/effect/src/EffectEx.ts
+++ b/packages/common/effect/src/EffectEx.ts
@@ -8,7 +8,6 @@ export { asyncTaskTaggingLayer } from './internal/async-task-tagging';
 export { contextFromScope } from './internal/context';
 export {
   causeToError,
-  promiseWithCauseCapture,
   runAndForwardErrors,
   runInRuntime,
   runPromise,

--- a/packages/common/effect/src/EffectEx.ts
+++ b/packages/common/effect/src/EffectEx.ts
@@ -6,12 +6,5 @@
 
 export { asyncTaskTaggingLayer } from './internal/async-task-tagging';
 export { contextFromScope } from './internal/context';
-export {
-  causeToError,
-  runAndForwardErrors,
-  runInRuntime,
-  runPromise,
-  throwCause,
-  unwrapExit,
-} from './internal/errors';
+export { causeToError, runAndForwardErrors, runInRuntime, runPromise, throwCause, unwrapExit } from './internal/errors';
 export { acquireReleaseResource } from './internal/resource';

--- a/packages/common/effect/src/internal/errors.ts
+++ b/packages/common/effect/src/internal/errors.ts
@@ -237,19 +237,3 @@ export const runInRuntime: {
     })();
   }
 };
-
-/**
- * Like `Effect.promise` but also caputes spans for defects.
- * Workaround for: https://github.com/Effect-TS/effect/issues/5436
- */
-export const promiseWithCauseCapture: <A>(evaluate: (signal: AbortSignal) => PromiseLike<A>) => Effect.Effect<A> = (
-  evaluate,
-) =>
-  Effect.promise(async (signal) => {
-    try {
-      const result = await evaluate(signal);
-      return Effect.succeed(result);
-    } catch (err) {
-      return Effect.die(err);
-    }
-  }).pipe(Effect.flatten);

--- a/packages/core/echo/echo/src/Database.ts
+++ b/packages/core/echo/echo/src/Database.ts
@@ -362,18 +362,18 @@ export const remove = <T extends Entity.Unknown>(obj: T): Effect.Effect<void, ne
  * @see {@link Database.appendToFeed}
  */
 export const appendToFeed = (feed: Feed.Feed, entities: Entity.Unknown[]): Effect.Effect<void, never, Service> =>
-  Service.pipe(
-    Effect.flatMap(({ db }) => Effect.promise(() => db.appendToFeed(feed, entities))),
-  ).pipe(Effect.withSpan('Database.appendToFeed'));
+  Service.pipe(Effect.flatMap(({ db }) => Effect.promise(() => db.appendToFeed(feed, entities)))).pipe(
+    Effect.withSpan('Database.appendToFeed'),
+  );
 
 /**
  * Removes entities from a feed.
  * @see {@link Database.deleteFromFeed}
  */
 export const deleteFromFeed = (feed: Feed.Feed, entities: Entity.Unknown[]): Effect.Effect<void, never, Service> =>
-  Service.pipe(
-    Effect.flatMap(({ db }) => Effect.promise(() => db.deleteFromFeed(feed, entities))),
-  ).pipe(Effect.withSpan('Database.deleteFromFeed'));
+  Service.pipe(Effect.flatMap(({ db }) => Effect.promise(() => db.deleteFromFeed(feed, entities)))).pipe(
+    Effect.withSpan('Database.deleteFromFeed'),
+  );
 
 /**
  * Flushes pending changes to disk.

--- a/packages/core/echo/echo/src/Database.ts
+++ b/packages/core/echo/echo/src/Database.ts
@@ -9,7 +9,6 @@ import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as Schema from 'effect/Schema';
 
-import { EffectEx } from '@dxos/effect';
 import { invariant } from '@dxos/invariant';
 import { type SpaceId, type URI } from '@dxos/keys';
 
@@ -296,7 +295,7 @@ export const resolve: {
   Effect.gen(function* () {
     const { db } = yield* Service;
     const dxn = typeof ref === 'string' ? ref : ref.uri;
-    const object = yield* EffectEx.promiseWithCauseCapture(() =>
+    const object = yield* Effect.promise(() =>
       db.graph
         .createRefResolver({
           context: {
@@ -327,7 +326,7 @@ export const resolve: {
  */
 export const load: <T>(ref: Ref<T>) => Effect.Effect<T, Err.EntityNotFoundError, never> = Effect.fn('Database.load')(
   function* (ref) {
-    const object = yield* EffectEx.promiseWithCauseCapture(() => ref.tryLoad());
+    const object = yield* Effect.promise(() => ref.tryLoad());
     if (!object) {
       return yield* Effect.fail(new Err.EntityNotFoundError(ref.uri));
     }
@@ -347,7 +346,7 @@ export const add = <T extends Entity.Unknown>(obj: T & RejectTypeEntity<T>): Eff
  * @see {@link Database.addType}
  */
 export const addType = <T extends Type.AnyEntity>(type: T): Effect.Effect<T, never, Service> =>
-  Service.pipe(Effect.flatMap(({ db }) => EffectEx.promiseWithCauseCapture(() => db.addType(type)))).pipe(
+  Service.pipe(Effect.flatMap(({ db }) => Effect.promise(() => db.addType(type)))).pipe(
     Effect.withSpan('Database.addType'),
   );
 
@@ -364,7 +363,7 @@ export const remove = <T extends Entity.Unknown>(obj: T): Effect.Effect<void, ne
  */
 export const appendToFeed = (feed: Feed.Feed, entities: Entity.Unknown[]): Effect.Effect<void, never, Service> =>
   Service.pipe(
-    Effect.flatMap(({ db }) => EffectEx.promiseWithCauseCapture(() => db.appendToFeed(feed, entities))),
+    Effect.flatMap(({ db }) => Effect.promise(() => db.appendToFeed(feed, entities))),
   ).pipe(Effect.withSpan('Database.appendToFeed'));
 
 /**
@@ -373,7 +372,7 @@ export const appendToFeed = (feed: Feed.Feed, entities: Entity.Unknown[]): Effec
  */
 export const deleteFromFeed = (feed: Feed.Feed, entities: Entity.Unknown[]): Effect.Effect<void, never, Service> =>
   Service.pipe(
-    Effect.flatMap(({ db }) => EffectEx.promiseWithCauseCapture(() => db.deleteFromFeed(feed, entities))),
+    Effect.flatMap(({ db }) => Effect.promise(() => db.deleteFromFeed(feed, entities))),
   ).pipe(Effect.withSpan('Database.deleteFromFeed'));
 
 /**
@@ -381,7 +380,7 @@ export const deleteFromFeed = (feed: Feed.Feed, entities: Entity.Unknown[]): Eff
  * @see {@link Database.flush}
  */
 export const flush = (opts?: FlushOptions) =>
-  Service.pipe(Effect.flatMap(({ db }) => EffectEx.promiseWithCauseCapture(() => db.flush(opts)))).pipe(
+  Service.pipe(Effect.flatMap(({ db }) => Effect.promise(() => db.flush(opts)))).pipe(
     Effect.withSpan('Database.flush'),
   );
 

--- a/packages/core/echo/echo/src/internal/Query/query-result-effect.ts
+++ b/packages/core/echo/echo/src/internal/Query/query-result-effect.ts
@@ -6,8 +6,6 @@ import * as Effect from 'effect/Effect';
 import * as Effectable from 'effect/Effectable';
 import * as Option from 'effect/Option';
 
-import { EffectEx } from '@dxos/effect';
-
 import type * as QueryResult from '../../QueryResult';
 
 /**
@@ -19,9 +17,9 @@ export const makeQueryResultEffect = <T, E, R>(
   eff: Effect.Effect<QueryResult.QueryResult<T>, E, R>,
 ): QueryResult.QueryResultEffect<T, E, R> => {
   return {
-    run: Effect.flatMap(eff, (result) => EffectEx.promiseWithCauseCapture(() => result.run())),
+    run: Effect.flatMap(eff, (result) => Effect.promise(() => result.run())),
     first: Effect.flatMap(eff, (result) =>
-      EffectEx.promiseWithCauseCapture(async () => Option.fromNullable(await result.firstOrUndefined())),
+      Effect.promise(async () => Option.fromNullable(await result.firstOrUndefined())),
     ),
 
     // Effect internals: the result is itself an Effect, so it carries the commit prototype.

--- a/scripts/migrate-effect-namespaces.mjs
+++ b/scripts/migrate-effect-namespaces.mjs
@@ -12,7 +12,6 @@ const EFFECT_EX_SYMBOLS = new Set([
   'unwrapExit',
   'runAndForwardErrors',
   'runInRuntime',
-  'promiseWithCauseCapture',
   'acquireReleaseResource',
   'contextFromScope',
   'asyncTaskTaggingLayer',


### PR DESCRIPTION
## Summary

Removes the `promiseWithCauseCapture` helper, which existed as a workaround for [Effect-TS/effect#5436](https://github.com/Effect-TS/effect/issues/5436) (defects originating inside `Effect.promise` didn't capture spans).

That issue is now fixed in the version of Effect we depend on (3.21.4): `Effect.promise` routes rejections through `core.die`, which captures the current fiber span via `currentSpanFromFiber`. The helper's flatten-an-inner-`Effect.die` trick is therefore redundant.

## Changes

- Delete `promiseWithCauseCapture` from `packages/common/effect/src/internal/errors.ts` and its re-export in `EffectEx.ts`.
- Replace all call sites (`Database.ts`, `query-result-effect.ts`) with plain `Effect.promise` — same signature, so a direct swap.
- Drop the now-unused `EffectEx` imports.
- Remove the stale entry from the one-off `migrate-effect-namespaces.mjs` symbol set.

## Verification

- `moon run effect:build echo:build` — pass
- `moon run effect:lint echo:lint` — pass
- `moon run effect:test echo:test` — pass (451 passed, 9 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kzsBxspMV1fYnXcwmq73a

---
_Generated by [Claude Code](https://claude.ai/code/session_019kzsBxspMV1fYnXcwmq73a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved promise handling and error propagation across database operations and query results.
  * Updated asynchronous operations to use the standard effect-based promise handling.
* **Refactor**
  * Removed the deprecated promise error-capture utility from the public effect API.
  * Updated effect namespace migration behavior to reflect the API change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->