### PR TITLE
fix(plugin-assistant): hide new-chat button outside companion, fix toolbar order

### DIFF
--- a/packages/plugins/plugin-assistant/src/hooks/useChatToolbarActions.ts
+++ b/packages/plugins/plugin-assistant/src/hooks/useChatToolbarActions.ts
@@ -33,17 +33,17 @@ export const useChatToolbarActions = ({ chat, companionTo }: ChatToolbarActionsP
           ? get(db.query(Query.select(Filter.id(companionTo.id)).targetOf(Chat.CompanionTo).source()).atom)
           : [];
 
-      const builder = MenuBuilder.make()
-        .root({
-          label: ['chat-toolbar.title', { ns: meta.profile.key }],
-        })
-        .action(
+      const builder = MenuBuilder.make().root({
+        label: ['chat-toolbar.title', { ns: meta.profile.key }],
+      });
+
+      if (companionTo) {
+        builder.action(
           'new',
           {
             label: ['new-thread.button', { ns: meta.profile.key }],
             icon: 'ph--plus--regular',
             type: 'new',
-            disabled: !companionTo,
           },
           () => {
             invariant(companionTo);
@@ -52,6 +52,23 @@ export const useChatToolbarActions = ({ chat, companionTo }: ChatToolbarActionsP
               chat: undefined,
             }).pipe(EffectEx.runAndForwardErrors);
           },
+        );
+      }
+
+      builder
+        .action(
+          'branch',
+          {
+            label: ['branch-thread.menu', { ns: meta.profile.key }],
+            icon: 'ph--git-branch--regular',
+            type: 'branch',
+            disabled: !chat || !db,
+          },
+          () =>
+            Effect.gen(function* () {
+              invariant(chat);
+              yield* invoke(AssistantOperation.ForkChat, { chat, companionTo }, { spaceId: db?.spaceId });
+            }).pipe(EffectEx.runAndForwardErrors),
         )
         .action(
           'rename',
@@ -65,20 +82,6 @@ export const useChatToolbarActions = ({ chat, companionTo }: ChatToolbarActionsP
             Effect.gen(function* () {
               invariant(chat);
               yield* invoke(AssistantOperation.UpdateChatName, { chat }, { spaceId: db?.spaceId });
-            }).pipe(EffectEx.runAndForwardErrors),
-        )
-        .action(
-          'branch',
-          {
-            label: ['branch-thread.menu', { ns: meta.profile.key }],
-            icon: 'ph--git-branch--regular',
-            type: 'branch',
-            disabled: !chat || !db,
-          },
-          () =>
-            Effect.gen(function* () {
-              invariant(chat);
-              yield* invoke(AssistantOperation.ForkChat, { chat, companionTo }, { spaceId: db?.spaceId });
             }).pipe(EffectEx.runAndForwardErrors),
         );
 


### PR DESCRIPTION
## Summary
- Hide the plus (new chat) toolbar button entirely outside the companion context instead of rendering it disabled — it only makes sense when there's a `companionTo` object to attach a new chat to.
- Fix the AIChat toolbar action order: `plus → fork → rename` in the companion, `fork → rename` in the primary view.

## Test plan
- [x] `moon run plugin-assistant:lint -- --fix` passes clean
- [x] `moon run plugin-assistant:build` passes
- [ ] Manually verify in Composer: open a chat companion, confirm plus/fork/rename order; open primary chat view, confirm plus button is absent and fork/rename order is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated chat toolbar actions to show “New thread” only when applicable.
  * Reordered existing chat actions so “Branch thread” appears before “Rename thread.”

* **Bug Fixes**
  * Improved chat toolbar behavior by preventing unavailable actions from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->