### PR TITLE
feat(echo): add Aggregate.dateBucket and wire Space Home activity graph

### DIFF
--- a/agents/superpowers/specs/activity-graph-aggregate.md
+++ b/agents/superpowers/specs/activity-graph-aggregate.md
@@ -1,0 +1,92 @@
+# Spec: Activity-graph aggregate query (`Aggregate.dateBucket`)
+
+## Goal
+
+Wire the Space Home activity matrix (`Dashboard.Activity`) to ECHO via an
+aggregate query that groups objects by their meta timestamp bucketed to a day
+and counts them, instead of materialising one `ActivityDatum` per object on the
+client.
+
+## Background
+
+The aggregate machinery already exists end-to-end: `Query.aggregate({...})` with
+`Aggregate.group | max | min | items | count`, serialisable AST
+(`QueryAST.GroupAggregate`), a planner `AggregateStep`, and two executors (host
+index-backed `QueryExecutor`, client `WorkingSetQueryExecutor`) sharing
+`GroupBy` (`packages/core/echo/echo-host/src/query/group-by.ts`).
+
+The single gap: `group` partitions by a raw scalar data property; there is no
+**time-bucketing** and no way to group by a **meta timestamp**
+(`createdAt`/`updatedAt`), which is not a data property.
+
+## API
+
+A dedicated aggregate constructor, mirroring the `field: 'createdAt' |
+'updatedAt'` naming already used by `Filter.updated/created` and the `timestamp`
+`Order`:
+
+```ts
+Query.select(Filter.everything()).aggregate({
+  day: Aggregate.dateBucket('updatedAt', { resolution: 'day' }),
+  count: Aggregate.count(),
+});
+```
+
+- `Aggregate.dateBucket(field, { resolution })` — a **grouping** aggregate (part
+  of the composite key, like `group`).
+  - `field: 'createdAt' | 'updatedAt'` — the meta timestamp.
+  - `resolution: 'hour' | 'day' | 'week' | 'month'` — the bucket size.
+  - Produces `number | null`: the bucket-start as unix ms (local-time floor),
+    or `null` when the object has no such timestamp.
+
+Chosen over the user's sketched `group('@meta.updatedAt', { resolution })`
+because (1) `field: 'createdAt'|'updatedAt'` matches the existing timestamp
+convention, (2) it keeps `group`'s `property: keyof T` typing clean, and (3) a
+distinct kind reads clearly at aggregate call sites.
+
+## Bucketing
+
+`GroupBy.bucketTimestamp(tsMs, resolution)` floors using **local** `Date`
+fields, matching `react-ui-dashboard`'s `buildCalendar` (local midnight, Monday-
+first weeks). Local-first: host and client share a timezone, so this is
+consistent with the UI. Weeks are Monday-first to match the calendar layout.
+
+## Changes
+
+Core AST / DSL:
+
+- `echo-protocol/.../query/ast.ts` — add `GroupAggregateDateBucket_` to the
+  `GroupAggregate_` union; extend the doc comment.
+- `echo/src/Aggregate.ts` — `TimeResolution` type, `date-bucket` `Spec` variant,
+  `dateBucket` constructor.
+- `echo/src/internal/Query/pretty.ts` — pretty-print `date-bucket`.
+
+Execution:
+
+- `echo-host/.../query/group-by.ts` — `TimeResolution` + `bucketTimestamp`;
+  `withGroupAggregates` stamps the group/date-bucket field value from the
+  pre-computed `groupKey` (add `groupKey?` to the item constraint) so bucketing
+  logic lives only in key computation.
+- `echo-host/.../query/query-executor.ts` — `QueryItem.getGroupKey` handles
+  `date-bucket` (reads `item.createdAt/updatedAt`, buckets).
+- `echo-client/.../query/working-set-executor.ts` — `_execAggregateStep` bails
+  (`return null`) when any aggregate is `date-bucket`; the client working set
+  has no meta-timestamp index, so the index-backed source serves it (same
+  fallback as `timestamp` filters/orders).
+- `echo-client/.../query/query-result.ts` — `_assembleGroups` treats
+  `date-bucket` like `group` (value spread from the source key);
+  `_computeAggregate` gets a `date-bucket` case.
+
+UI:
+
+- `plugin-space/.../SpaceHomeDashboard.tsx` — activity matrix from the aggregate
+  query (`{ date: new Date(row.day), value: row.count }`); derive `active-days`
+  from the row count. Other stats keep the full-object query (they need
+  per-object type info).
+
+## Tests
+
+- `Aggregate` / `pretty` round-trip for `dateBucket`.
+- `group-by` `bucketTimestamp` for each resolution.
+- Executor grouping-by-day count (client working-set bail + host grouping, or a
+  direct executor/e2e test).

--- a/packages/core/echo/echo-client-e2e/src/query.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/query.test.ts
@@ -849,6 +849,31 @@ describe('Query', () => {
       expect(second).toBe(first);
       expect(second.atom).toBe(first.atom);
     });
+
+    test('dateBucket groups by the day objects were last touched, with per-day counts', async () => {
+      const { db } = await builder.createDatabase();
+      db.add(Obj.make(TestSchema.Expando, { value: 1 }));
+      db.add(Obj.make(TestSchema.Expando, { value: 2 }));
+      db.add(Obj.make(TestSchema.Expando, { value: 3 }));
+      await db.flush();
+
+      const rows = await db
+        .query(
+          Query.select(Filter.everything()).aggregate({
+            day: Aggregate.dateBucket('updatedAt', { resolution: 'day' }),
+            count: Aggregate.count(),
+          }),
+        )
+        .run();
+
+      // All three objects were touched "now", so they fall in a single day bucket.
+      expect(rows).to.have.length(1);
+      expect(rows[0].count).to.equal(3);
+      // The bucket key is the local-midnight unix ms for today.
+      const now = new Date();
+      const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+      expect(rows[0].day).to.equal(todayMidnight);
+    });
   });
 
   describe('Timestamp queries', () => {

--- a/packages/core/echo/echo-client/src/query/query-result.ts
+++ b/packages/core/echo/echo-client/src/query/query-result.ts
@@ -337,8 +337,8 @@ const _assembleGroups = (
     // Group-key fields are already keyed by their result-field name; spread them flat.
     const record: GroupResult = { ...keys.get(serializedKey)! };
     for (const aggregate of aggregates) {
-      if (aggregate.kind === 'group') {
-        continue; // Group-key fields come from the spread above.
+      if (aggregate.kind === 'group' || aggregate.kind === 'date-bucket') {
+        continue; // Grouping-key fields come from the spread above.
       }
       record[aggregate.name] = _computeAggregate(aggregate, groupMembers, counts.get(serializedKey)!);
     }
@@ -352,7 +352,8 @@ const _assembleGroups = (
 const _computeAggregate = (aggregate: QueryAST.GroupAggregate, members: readonly unknown[], count: number): unknown => {
   switch (aggregate.kind) {
     case 'group':
-      return undefined; // Group-key fields are assembled from the source key, not here.
+    case 'date-bucket':
+      return undefined; // Grouping-key fields are assembled from the source key, not here.
     case 'items':
       return aggregate.limit !== undefined ? members.slice(0, aggregate.limit) : members;
     case 'count':

--- a/packages/core/echo/echo-client/src/query/working-set-executor.ts
+++ b/packages/core/echo/echo-client/src/query/working-set-executor.ts
@@ -122,7 +122,13 @@ export class WorkingSetQueryExecutor {
     }
   }
 
-  private _execAggregateStep(step: QueryPlan.AggregateStep, ws: WorkingSetItem[]): WorkingSetItem[] {
+  private _execAggregateStep(step: QueryPlan.AggregateStep, ws: WorkingSetItem[]): WorkingSetItem[] | null {
+    // `date-bucket` groups by a system timestamp, which lives only in the index — the in-memory
+    // working set has no timestamps (see the `timestamp` order/filter bail-outs). Defer the whole
+    // aggregate to the index-backed source.
+    if (step.aggregates.some((aggregate) => aggregate.kind === 'date-bucket')) {
+      return null;
+    }
     const withKeys = ws.map((item) => ({ ...item, groupKey: WorkingSetItem.getGroupKey(item, step.aggregates) }));
     const partitioned = GroupBy.partitionByGroupKey(withKeys, (item) => GroupBy.serializeGroupKey(item.groupKey!));
     return GroupBy.withGroupAggregates(

--- a/packages/core/echo/echo-host/src/query/group-by.test.ts
+++ b/packages/core/echo/echo-host/src/query/group-by.test.ts
@@ -1,0 +1,41 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, test } from 'vitest';
+
+import { GroupBy } from './group-by';
+
+describe('GroupBy.bucketTimestamp', () => {
+  // A fixed local instant: 2026-03-18 (a Wednesday) at 14:37:12.
+  const timestamp = new Date(2026, 2, 18, 14, 37, 12).getTime();
+
+  test('null passes through', () => {
+    expect(GroupBy.bucketTimestamp(null, 'day')).to.equal(null);
+  });
+
+  test('hour floors to the start of the hour', () => {
+    expect(GroupBy.bucketTimestamp(timestamp, 'hour')).to.equal(new Date(2026, 2, 18, 14).getTime());
+  });
+
+  test('day floors to local midnight', () => {
+    expect(GroupBy.bucketTimestamp(timestamp, 'day')).to.equal(new Date(2026, 2, 18).getTime());
+  });
+
+  test('week floors to the preceding Monday', () => {
+    // 2026-03-18 is a Wednesday, so the week starts Monday 2026-03-16.
+    expect(GroupBy.bucketTimestamp(timestamp, 'week')).to.equal(new Date(2026, 2, 16).getTime());
+  });
+
+  test('month floors to the first of the month', () => {
+    expect(GroupBy.bucketTimestamp(timestamp, 'month')).to.equal(new Date(2026, 2, 1).getTime());
+  });
+
+  test('timestamps in the same day share a bucket; a different day does not', () => {
+    const morning = new Date(2026, 2, 18, 8).getTime();
+    const evening = new Date(2026, 2, 18, 22).getTime();
+    const nextDay = new Date(2026, 2, 19, 1).getTime();
+    expect(GroupBy.bucketTimestamp(morning, 'day')).to.equal(GroupBy.bucketTimestamp(evening, 'day'));
+    expect(GroupBy.bucketTimestamp(morning, 'day')).not.to.equal(GroupBy.bucketTimestamp(nextDay, 'day'));
+  });
+});

--- a/packages/core/echo/echo-host/src/query/group-by.ts
+++ b/packages/core/echo/echo-host/src/query/group-by.ts
@@ -180,10 +180,11 @@ export const GroupBy = Object.freeze({
   },
 
   /**
-   * Computes each group's scalar aggregates (`group`/`max`/`min`/`count`) and returns the same items
-   * with those values stamped on every member (all members of a group share them), so a following
-   * group-level `OrderStep` can order by them — including by a `group` field whose result name differs
-   * from its source property. The `items` aggregate is not stamped — it collects the members and is
+   * Computes each group's scalar aggregates (`group`/`date-bucket`/`max`/`min`/`count`) and returns
+   * the same items with those values stamped on every member (all members of a group share them), so
+   * a following group-level `OrderStep` can order by them — including by a `group`/`date-bucket` field
+   * whose result name differs from its source. The `items` aggregate is not stamped — it collects the
+   * members and is
    * materialised at result assembly. Assumes `items` are already partitioned into contiguous groups
    * (see {@link partitionByGroupKey}).
    */

--- a/packages/core/echo/echo-host/src/query/group-by.ts
+++ b/packages/core/echo/echo-host/src/query/group-by.ts
@@ -10,6 +10,9 @@ import { type QueryAST } from '@dxos/echo-protocol';
  */
 export type GroupKeyValue = Record<string, string | number | boolean | null>;
 
+/** Bucket size for a `date-bucket` aggregate; mirrors `Aggregate.TimeResolution`. */
+export type TimeResolution = 'hour' | 'day' | 'week' | 'month';
+
 /** Scalar result of a `max`/`min` aggregate (`null` when the group has no scalar values). */
 export type AggregateValue = string | number | boolean | null;
 
@@ -29,6 +32,31 @@ export const GroupBy = Object.freeze({
    */
   coerceKeyComponent: (value: unknown): string | number | boolean | null =>
     typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' ? value : null,
+
+  /**
+   * Floors a unix-ms timestamp to the start of its `resolution` bucket, returning the bucket-start
+   * unix ms (`null` passes through). Floored in local time — hour/day/month starts, weeks starting
+   * Monday — matching how a calendar view lays days out. `date-bucket` aggregates key on this.
+   */
+  bucketTimestamp: (timestampMs: number | null, resolution: TimeResolution): number | null => {
+    if (timestampMs == null) {
+      return null;
+    }
+    const date = new Date(timestampMs);
+    switch (resolution) {
+      case 'hour':
+        return new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours()).getTime();
+      case 'day':
+        return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+      case 'week': {
+        // Monday-first week start (matches the activity-calendar layout).
+        const mondayOffset = (date.getDay() + 6) % 7;
+        return new Date(date.getFullYear(), date.getMonth(), date.getDate() - mondayOffset).getTime();
+      }
+      case 'month':
+        return new Date(date.getFullYear(), date.getMonth(), 1).getTime();
+    }
+  },
 
   /**
    * Stable serialization of a composite group key (component order matters).
@@ -159,13 +187,14 @@ export const GroupBy = Object.freeze({
    * materialised at result assembly. Assumes `items` are already partitioned into contiguous groups
    * (see {@link partitionByGroupKey}).
    */
-  withGroupAggregates: <T extends { aggregates?: GroupAggregates }>(
+  withGroupAggregates: <T extends { aggregates?: GroupAggregates; groupKey?: GroupKeyValue }>(
     items: readonly T[],
     getKey: (item: T) => string,
     aggregates: readonly QueryAST.GroupAggregate[],
     getProperty: (item: T, property: string) => unknown,
   ): T[] => {
-    // Only group/max/min/count are stamped for ordering; `items` collects members at result assembly.
+    // Only group/date-bucket/max/min/count are stamped for ordering; `items` collects members at
+    // result assembly.
     if (!aggregates.some((aggregate) => aggregate.kind !== 'items')) {
       return items.slice();
     }
@@ -186,9 +215,10 @@ export const GroupBy = Object.freeze({
         computed[aggregate.name] =
           aggregate.kind === 'count'
             ? members.length
-            : aggregate.kind === 'group'
-              ? // All members of a group share the key, so read the group value off any member.
-                GroupBy.coerceKeyComponent(getProperty(members[0], aggregate.property))
+            : aggregate.kind === 'group' || aggregate.kind === 'date-bucket'
+              ? // Grouping keys carry the field value directly; all members share it, so read it off
+                // the already-computed group key rather than re-deriving from the source.
+                (members[0].groupKey?.[aggregate.name] ?? null)
               : GroupBy.reduceAggregate(
                   members.map((member) => coerceScalar(getProperty(member, aggregate.property))),
                   aggregate.kind,

--- a/packages/core/echo/echo-host/src/query/query-executor.ts
+++ b/packages/core/echo/echo-host/src/query/query-executor.ts
@@ -125,8 +125,9 @@ const QueryItem = Object.freeze({
   },
 
   /**
-   * Computes the composite group key for this item from the aggregate's `group`-kind entries, keyed
-   * by result field name. No `group` entries yields `{}` — a single group over the whole input.
+   * Computes the composite group key for this item from the aggregate's `group` and `date-bucket`
+   * entries, keyed by result field name. No such entries yields `{}` — a single group over the whole
+   * input.
    */
   getGroupKey: (item: QueryItem, aggregates: readonly QueryAST.GroupAggregate[]): GroupKeyValue => {
     const key: GroupKeyValue = {};

--- a/packages/core/echo/echo-host/src/query/query-executor.ts
+++ b/packages/core/echo/echo-host/src/query/query-executor.ts
@@ -133,6 +133,9 @@ const QueryItem = Object.freeze({
     for (const aggregate of aggregates) {
       if (aggregate.kind === 'group') {
         key[aggregate.name] = GroupBy.coerceKeyComponent(QueryItem.getProperty(item, [aggregate.property]));
+      } else if (aggregate.kind === 'date-bucket') {
+        const timestamp = aggregate.field === 'updatedAt' ? item.updatedAt : item.createdAt;
+        key[aggregate.name] = GroupBy.bucketTimestamp(timestamp, aggregate.resolution);
       }
     }
     return key;

--- a/packages/core/echo/echo-protocol/src/query/ast.ts
+++ b/packages/core/echo/echo-protocol/src/query/ast.ts
@@ -425,8 +425,11 @@ export const QuerySkipClause: Schema.Schema<QuerySkipClause> = QuerySkipClause_;
  * tagged union per kind — `property`/`limit` are present exactly when the kind uses them, so
  * read sites narrow by `kind` instead of guarding an unused optional field.
  * - `group` partitions members by a scalar `property`; its coerced key value is the field's value.
- *   Composite keys are formed from multiple `group` entries. A query with no `group` entries
- *   aggregates its entire input into a single row.
+ *   Composite keys are formed from multiple `group`/`date-bucket` entries. A query with no such
+ *   entries aggregates its entire input into a single row.
+ * - `date-bucket` partitions members by a system timestamp (`createdAt`/`updatedAt`) floored to a
+ *   `resolution` bucket; its key value is the bucket-start unix ms. Like `group`, it is a grouping
+ *   key rather than a reduction.
  * - `max`/`min` reduce a scalar member `property`.
  * - `items` collects the group's members, optionally capped to `limit`. Opt-in — a row carries no
  *   members otherwise.
@@ -436,6 +439,12 @@ const GroupAggregateGroup_ = Schema.Struct({
   name: Schema.String,
   kind: Schema.Literal('group'),
   property: Schema.String,
+});
+const GroupAggregateDateBucket_ = Schema.Struct({
+  name: Schema.String,
+  kind: Schema.Literal('date-bucket'),
+  field: Schema.Literal('createdAt', 'updatedAt'),
+  resolution: Schema.Literal('hour', 'day', 'week', 'month'),
 });
 const GroupAggregateMax_ = Schema.Struct({ name: Schema.String, kind: Schema.Literal('max'), property: Schema.String });
 const GroupAggregateMin_ = Schema.Struct({ name: Schema.String, kind: Schema.Literal('min'), property: Schema.String });
@@ -448,6 +457,7 @@ const GroupAggregateCount_ = Schema.Struct({ name: Schema.String, kind: Schema.L
 
 const GroupAggregate_ = Schema.Union(
   GroupAggregateGroup_,
+  GroupAggregateDateBucket_,
   GroupAggregateMax_,
   GroupAggregateMin_,
   GroupAggregateItems_,

--- a/packages/core/echo/echo-query/src/query-lite/query-lite.ts
+++ b/packages/core/echo/echo-query/src/query-lite/query-lite.ts
@@ -953,15 +953,16 @@ const prettyQuery = (query: QueryAST.Query): string => {
       return `${prettyQuery(query.query)}.skip(${query.skip})`;
     case 'aggregate': {
       const aggregates = query.aggregates.map((aggregate) => {
-        const arg =
-          aggregate.kind === 'items'
-            ? aggregate.limit !== undefined
-              ? `{ limit: ${aggregate.limit} }`
-              : ''
-            : aggregate.kind === 'count'
-              ? ''
-              : JSON.stringify(aggregate.property);
-        return `${JSON.stringify(aggregate.name)}: Aggregate.${aggregate.kind}(${arg})`;
+        switch (aggregate.kind) {
+          case 'items':
+            return `${JSON.stringify(aggregate.name)}: Aggregate.items(${aggregate.limit !== undefined ? `{ limit: ${aggregate.limit} }` : ''})`;
+          case 'count':
+            return `${JSON.stringify(aggregate.name)}: Aggregate.count()`;
+          case 'date-bucket':
+            return `${JSON.stringify(aggregate.name)}: Aggregate.dateBucket(${JSON.stringify(aggregate.field)}, { resolution: ${JSON.stringify(aggregate.resolution)} })`;
+          default:
+            return `${JSON.stringify(aggregate.name)}: Aggregate.${aggregate.kind}(${JSON.stringify(aggregate.property)})`;
+        }
       });
       return `${prettyQuery(query.query)}.aggregate({ ${aggregates.join(', ')} })`;
     }

--- a/packages/core/echo/echo/src/Aggregate.ts
+++ b/packages/core/echo/echo/src/Aggregate.ts
@@ -13,8 +13,12 @@ import type * as Query from './Query';
  * union per kind so `property`/`limit` are present exactly when the kind uses them (no unused
  * optional fields to guard against at read sites).
  */
+/** Bucket size for {@link dateBucket}: the timestamp is floored to the start of this interval. */
+export type TimeResolution = 'hour' | 'day' | 'week' | 'month';
+
 export type Spec =
   | { kind: 'group'; property: string }
+  | { kind: 'date-bucket'; field: 'createdAt' | 'updatedAt'; resolution: TimeResolution }
   | { kind: 'max'; property: string }
   | { kind: 'min'; property: string }
   | { kind: 'items'; limit?: number }
@@ -65,6 +69,18 @@ class AggregateClass<T, V> implements Aggregate<T, V> {
  */
 export const group = <T, K extends keyof T & string>(property: K): Aggregate<T, T[K] | null> =>
   new AggregateClass({ kind: 'group', property });
+
+/**
+ * Group members by a system timestamp (`createdAt`/`updatedAt`) floored to a `resolution` bucket —
+ * the GitHub-style activity-calendar shape (bucket by day, then {@link count}). Like {@link group},
+ * it is a grouping key: the record field named after it carries the bucket-start as unix ms, `null`
+ * for members with no such timestamp. Buckets are floored in local time (hour/day/month starts;
+ * weeks start Monday), matching how a calendar view lays days out.
+ */
+export const dateBucket = <T>(
+  field: 'createdAt' | 'updatedAt',
+  options: { resolution: TimeResolution },
+): Aggregate<T, number | null> => new AggregateClass({ kind: 'date-bucket', field, resolution: options.resolution });
 
 /**
  * Aggregate the maximum of a scalar property across the group's members.

--- a/packages/core/echo/echo/src/Query.test.ts
+++ b/packages/core/echo/echo/src/Query.test.ts
@@ -834,6 +834,22 @@ describe('query api', () => {
         Schema.validateSync(QueryAST.Query)(query.ast);
       });
 
+      test('dateBucket groups by a bucketed system timestamp', () => {
+        const query = Query.select(Filter.type(TestSchema.Person)).aggregate({
+          day: Aggregate.dateBucket('updatedAt', { resolution: 'day' }),
+          count: Aggregate.count(),
+        });
+
+        expect(query.ast).toMatchObject({
+          type: 'aggregate',
+          aggregates: [
+            { name: 'day', kind: 'date-bucket', field: 'updatedAt', resolution: 'day' },
+            { name: 'count', kind: 'count' },
+          ],
+        });
+        Schema.validateSync(QueryAST.Query)(query.ast);
+      });
+
       test('aggregate-everything (no group entries) is valid', () => {
         const query = Query.select(Filter.type(TestSchema.Person)).aggregate({ latest: Aggregate.max('name') });
 
@@ -929,6 +945,16 @@ describe('query api', () => {
           '.aggregate({ "email": Aggregate.group("email"), "latest": Aggregate.max("name"), "items": Aggregate.items({ limit: 20 }) })',
         );
         expect(pretty).toContain('.orderBy(Order.property("latest", "desc"))');
+      });
+
+      test('Query.pretty renders a dateBucket aggregate', () => {
+        const query = Query.select(Filter.type(TestSchema.Person)).aggregate({
+          day: Aggregate.dateBucket('updatedAt', { resolution: 'day' }),
+          count: Aggregate.count(),
+        });
+        expect(Query.pretty(query)).toContain(
+          '.aggregate({ "day": Aggregate.dateBucket("updatedAt", { resolution: "day" }), "count": Aggregate.count() })',
+        );
       });
 
       test('type-level: aggregates surface as flat top-level fields', () => {

--- a/packages/core/echo/echo/src/internal/Query/pretty.ts
+++ b/packages/core/echo/echo/src/internal/Query/pretty.ts
@@ -162,15 +162,16 @@ export const prettyQuery = (query: QueryAST.Query): string => {
       return `${prettyQuery(query.query)}.skip(${query.skip})`;
     case 'aggregate': {
       const aggregates = query.aggregates.map((aggregate) => {
-        const arg =
-          aggregate.kind === 'items'
-            ? aggregate.limit !== undefined
-              ? `{ limit: ${aggregate.limit} }`
-              : ''
-            : aggregate.kind === 'count'
-              ? ''
-              : JSON.stringify(aggregate.property);
-        return `${JSON.stringify(aggregate.name)}: Aggregate.${aggregate.kind}(${arg})`;
+        switch (aggregate.kind) {
+          case 'items':
+            return `${JSON.stringify(aggregate.name)}: Aggregate.items(${aggregate.limit !== undefined ? `{ limit: ${aggregate.limit} }` : ''})`;
+          case 'count':
+            return `${JSON.stringify(aggregate.name)}: Aggregate.count()`;
+          case 'date-bucket':
+            return `${JSON.stringify(aggregate.name)}: Aggregate.dateBucket(${JSON.stringify(aggregate.field)}, { resolution: ${JSON.stringify(aggregate.resolution)} })`;
+          default:
+            return `${JSON.stringify(aggregate.name)}: Aggregate.${aggregate.kind}(${JSON.stringify(aggregate.property)})`;
+        }
       });
       return `${prettyQuery(query.query)}.aggregate({ ${aggregates.join(', ')} })`;
     }

--- a/packages/plugins/plugin-space/src/containers/SpaceHomeDashboard/SpaceHomeDashboard.tsx
+++ b/packages/plugins/plugin-space/src/containers/SpaceHomeDashboard/SpaceHomeDashboard.tsx
@@ -6,7 +6,7 @@ import { useAtomValue } from '@effect-atom/atom-react';
 import React, { useMemo } from 'react';
 
 import { HomeSection, usePluginManager } from '@dxos/app-framework/ui';
-import { Collection, Filter, Obj, Query } from '@dxos/echo';
+import { Aggregate, Collection, Filter, Obj, Query } from '@dxos/echo';
 import { type Space, useMembers, useQuery } from '@dxos/react-client/echo';
 import { useTranslation } from '@dxos/react-ui';
 import { type ActivityDatum, Dashboard } from '@dxos/react-ui-dashboard';
@@ -26,8 +26,8 @@ type SpaceHomeDashboardProps = {
 
 /**
  * Space stats and activity matrix for the Home article. Stats are derived from the object graph
- * (counts of objects, distinct types, collections, members); the matrix buckets objects by the
- * day they were last touched (`updatedAt`, falling back to `createdAt`).
+ * (counts of objects, distinct types, collections, members); the matrix is an ECHO aggregate query
+ * that buckets objects by the day they were last touched (`updatedAt`) and counts them per day.
  *
  * NOTE: per-object `updatedAt` only reflects the latest change, so the matrix undercounts busy
  * days in the past.
@@ -40,7 +40,16 @@ type SpaceHomeDashboardProps = {
 export const SpaceHomeDashboard = ({ space, stats = STAT_IDS, onClose }: SpaceHomeDashboardProps) => {
   const { t } = useTranslation(meta.profile.key);
 
-  const query = useMemo(() => Query.select(Filter.everything()), []);
+  const statsQuery = useMemo(() => Query.select(Filter.everything()), []);
+  // Daily activity counts, aggregated in ECHO rather than materialising every object on the client.
+  const activityQuery = useMemo(
+    () =>
+      Query.select(Filter.everything()).aggregate({
+        day: Aggregate.dateBucket('updatedAt', { resolution: 'day' }),
+        count: Aggregate.count(),
+      }),
+    [],
+  );
   const members = useMembers(space?.key);
 
   const manager = usePluginManager();
@@ -48,13 +57,22 @@ export const SpaceHomeDashboard = ({ space, stats = STAT_IDS, onClose }: SpaceHo
   const enabled = useAtomValue(manager.enabled);
   const plugins = useMemo(() => enabled.filter((id) => !core.includes(id)).length, [core, enabled]);
 
-  // TODO(burdon): Can we caches this?
-  const objects = useQuery(space ? space.db : undefined, query);
-  const { activity, values } = useMemo(() => {
+  const activityRows = useQuery(space ? space.db : undefined, activityQuery);
+  const activity = useMemo<ActivityDatum[]>(() => {
+    const data: ActivityDatum[] = [];
+    for (const row of activityRows) {
+      if (row.day != null) {
+        data.push({ date: new Date(row.day), value: row.count });
+      }
+    }
+    return data;
+  }, [activityRows]);
+
+  // TODO(burdon): Can we cache this?
+  const objects = useQuery(space ? space.db : undefined, statsQuery);
+  const values = useMemo<Record<SpaceStatId, number>>(() => {
     const typenames = new Set<string>();
-    const days = new Set<string>();
     let collections = 0;
-    const activity: ActivityDatum[] = [];
     for (const object of objects) {
       const typename = Obj.getTypename(object);
       if (typename) {
@@ -63,26 +81,17 @@ export const SpaceHomeDashboard = ({ space, stats = STAT_IDS, onClose }: SpaceHo
       if (Obj.instanceOf(Collection.Collection, object)) {
         collections++;
       }
-      const objectMeta = Obj.getMeta(object);
-      const timestamp = objectMeta.updatedAt ?? objectMeta.createdAt;
-      if (timestamp) {
-        const date = new Date(timestamp);
-        days.add(date.toDateString());
-        activity.push({ date, value: 1 });
-      }
     }
 
-    const values: Record<SpaceStatId, number> = {
+    return {
       'objects': objects.length,
       'types': typenames.size,
       'collections': collections,
       'members': members.length,
-      'active-days': days.size,
+      'active-days': activity.length,
       'plugins': plugins,
     };
-
-    return { activity, values };
-  }, [objects, members, plugins]);
+  }, [objects, members, plugins, activity]);
 
   if (!space) {
     return null;


### PR DESCRIPTION
## Summary

Wires the Space Home activity matrix (`Dashboard.Activity`) to ECHO via an aggregate query, and extends the aggregate API with the time-bucketing it needs.

The aggregate machinery (`Query.aggregate` with `group`/`count`/`max`/`min`/`items`) already existed end-to-end. The single gap was grouping by a **meta timestamp** floored to a **time bucket** — `group` only partitions by a raw scalar data property. This adds a dedicated `dateBucket` grouping aggregate:

```ts
Query.select(Filter.everything()).aggregate({
  day: Aggregate.dateBucket('updatedAt', { resolution: 'day' }),
  count: Aggregate.count(),
})
```

`dateBucket(field, { resolution })` takes `field: 'createdAt' | 'updatedAt'` (matching the existing `Filter.updated/created` and `timestamp` `Order` naming) and `resolution: 'hour' | 'day' | 'week' | 'month'`, producing the bucket-start unix ms (or `null`). Chosen over the sketched `group('@meta.updatedAt', …)` because it matches the timestamp-field convention and keeps `group`'s `property: keyof T` typing clean.

## Changes

**Core AST / DSL**
- `echo-protocol` — add the `date-bucket` `GroupAggregate` AST variant.
- `echo/src/Aggregate.ts` — `Aggregate.dateBucket` + `TimeResolution`.
- Pretty-printers (`echo/internal/Query/pretty.ts`, `echo-query/query-lite`) render `date-bucket`.

**Execution**
- `echo-host/query/group-by.ts` — `GroupBy.bucketTimestamp` floors in local time (hour/day/month starts, Monday-first weeks), matching `react-ui-dashboard`'s calendar layout; `withGroupAggregates` now stamps grouping-key field values from the pre-computed group key so bucketing lives only in key computation.
- `echo-host/query/query-executor.ts` — `getGroupKey` computes the bucket from meta timestamps.
- `echo-client/query/working-set-executor.ts` — defers `date-bucket` aggregates to the index-backed source (the client working set has no timestamp index — same fallback as `timestamp` filters/orders).
- `echo-client/query/query-result.ts` — treats `date-bucket` like `group` at result assembly.

**UI**
- `plugin-space/SpaceHomeDashboard` — the activity matrix is sourced from the aggregate query (day buckets + counts) rather than materialising one `ActivityDatum` per object; `active-days` derives from the bucket count. Other stats keep the full-object query (they need per-object type info).

## Testing

- `echo` `Query.test.ts` — `dateBucket` AST + pretty round-trip.
- `echo-host` `group-by.test.ts` (new) — `bucketTimestamp` across all resolutions, null, and same-day/next-day behavior.
- `echo-client-e2e` `query.test.ts` — end-to-end `dateBucket` grouping over the host executor (per-day count + local-midnight bucket value).
- Full `echo`, `echo-client`, and `echo-client-e2e` suites pass; all touched packages build and lint clean. (An unrelated flaky automerge subduction network-sync test times out intermittently in this environment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGfjk4a3Qh5Ngo1L4G5jdK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGfjk4a3Qh5Ngo1L4G5jdK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `dateBucket` aggregation (hour/day/week/month) using created/updated timestamps, with local-time week bucketing (Monday-first).
  * Enabled proper grouping by date buckets in aggregate results.
  * Updated Space Home activity dashboard to derive “active days” from daily activity aggregates.
* **Bug Fixes**
  * Fixed client-side materialization and execution flow for `dateBucket` so bucket fields are handled correctly and computations use the intended execution path.
* **Tests**
  * Added coverage for AST/pretty rendering, bucketTimestamp behavior, and end-to-end aggregation counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->