### PR TITLE
chore(agents): rename task-planning $session sentinel to $project + add picker

### DIFF
--- a/.agents/projects/registry.yml
+++ b/.agents/projects/registry.yml
@@ -25,7 +25,7 @@ projects:
     summary: Rename the $session sentinel/concept to $project and add a numbered pick-to-resume table.
     tasks: .agents/skills/task-planning/TASKS.md
     design: .agents/skills/task-planning/SKILL.md
-    prs: []
-    resume: 'Rename + $project picker complete and hook-verified. Next: commit the 6-file change, then open a PR.'
+    prs: [12174]
+    resume: 'PR #12174 opened. Next: watch the Check workflow to green and address any review comments.'
 
 ended: []

--- a/.agents/projects/registry.yml
+++ b/.agents/projects/registry.yml
@@ -1,13 +1,14 @@
-# Session registry — every active work-stream, one entry each. Managed via the `task-planning` skill
-# ($session new/list/end; $resume/$hydrate key off it). Each session has a TASKS.md (ledger) and a
+# Project registry — every active work-stream, one entry each. Managed via the `task-planning` skill
+# ($project new/list/end; $resume/$hydrate key off it). Each project has a TASKS.md (ledger) and a
 # DESIGN.md (spec + decisions) — the `tasks`/`design` fields record where they live (a package file,
-# or .agents/sessions/<name>/{TASKS,DESIGN}.md). Keep this committed and current.
+# or .agents/projects/<name>/{TASKS,DESIGN}.md). Keep this committed and current.
 #
 # status: active | paused | blocked | ended
 
-sessions:
+projects:
   - name: mailbox-research
     status: active
+    user: burdon
     branch: claude/mailbox-research-d44635
     created: 2026-07-05
     summary: Open-weight vs premier model routing for the mailbox pipelines (labeling / summaries / drafts).
@@ -15,5 +16,16 @@ sessions:
     design: packages/stories/stories-brain/fixtures/REPORT.md
     prs: [12163, 12167]
     resume: 'REPORT §5 actionable items shipped in PR #12167 (classify-sender, isReplyable person-only, triage summarize, single enrichment pass, draft Instructions, model-policy map, topics fix). Next: run the private-corpus evals (classify-sender bootstrap→review, draft re-score) + design two-tier foreground/background latency.'
+
+  - name: task-planning-skill-update
+    status: active
+    user: burdon
+    branch: claude/task-planning-skill-update-dbeb64
+    created: 2026-07-12
+    summary: Rename the $session sentinel/concept to $project and add a numbered pick-to-resume table.
+    tasks: .agents/skills/task-planning/TASKS.md
+    design: .agents/skills/task-planning/SKILL.md
+    prs: []
+    resume: 'Rename + $project picker complete and hook-verified. Next: commit the 6-file change, then open a PR.'
 
 ended: []

--- a/.agents/skills/task-planning/SKILL.md
+++ b/.agents/skills/task-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-planning
-description: Use when work spans multiple steps, phases, or sessions, when resuming a task started earlier, when the user asks for a plan/roadmap/progress tracking, or when they use the `$track` / `track:`, `$hydrate`, `$resume`, or `$session` sentinel. Covers the session registry (`.agents/sessions/registry.yml`), maintaining a durable TASKS.md + DESIGN.md per work-stream, and checkpointing/reloading session state across sessions and PRs.
+description: Use when work spans multiple steps, phases, or sessions, when resuming a task started earlier, when the user asks for a plan/roadmap/progress tracking, or when they use the `$track` / `track:`, `$hydrate`, `$resume`, or `$project` sentinel. Covers the project registry (`.agents/projects/registry.yml`), maintaining a durable TASKS.md + DESIGN.md per work-stream, and checkpointing/reloading project state across sessions and PRs.
 ---
 
 # Task Planning
@@ -21,24 +21,25 @@ repo. Use your judgment about when a task warrants one — err toward creating i
 the work you're doing — that follow-up belongs in `TASKS.md`.** Task chips are
 only for genuinely separate work that should spin off into its own session.
 
-## Sessions (registry)
+## Projects (registry)
 
-A **session** is a work-stream — one coherent effort, usually one branch/worktree
+A **project** is a work-stream — one coherent effort, usually one branch/worktree
 — with its own `TASKS.md` (the ledger) and `DESIGN.md` (the _why_: spec +
-decisions). All sessions are listed in a committed registry so you and any future
+decisions). All projects are listed in a committed registry so you and any future
 session can see everything in flight and resume the right one.
 
-**Registry:** `.agents/sessions/registry.yml` — one entry per session, recording
+**Registry:** `.agents/projects/registry.yml` — one entry per project, recording
 where its docs and PRs live:
 
 ```yaml
-sessions:
+projects:
   - name: mailbox-research # stable slug
     status: active # active | paused | blocked | ended
+    user: burdon # owner (git/system username, e.g. `whoami`)
     branch: claude/mailboxsync-…
     created: 2026-07-05
     summary: One line — what this stream delivers.
-    tasks: path/to/TASKS.md # a package file, or .agents/sessions/<name>/TASKS.md
+    tasks: path/to/TASKS.md # a package file, or .agents/projects/<name>/TASKS.md
     design: path/to/DESIGN.md # spec + decisions (a REPORT.md counts)
     prs: [12163]
     resume: 'The single next action.'
@@ -46,20 +47,29 @@ ended: []
 ```
 
 - The registry records the **location** of each doc, so an existing effort points
-  at its package files and a brand-new session defaults to
-  `.agents/sessions/<name>/{TASKS.md,DESIGN.md}`. Keep it committed and current.
+  at its package files and a brand-new project defaults to
+  `.agents/projects/<name>/{TASKS.md,DESIGN.md}`. Keep it committed and current.
 
-### The `$session` sentinel
+### The `$project` sentinel
 
-- `$session new <name> [summary]` — add an `active` entry (branch = current);
-  scaffold `.agents/sessions/<name>/{TASKS.md,DESIGN.md}` unless the docs already
-  live somewhere (record that path instead). Confirm in one line.
-- `$session list` — print the active sessions from the registry.
-- `$session end <name>` — move the entry to `ended`, recording the final PR/status.
+- `$project` (bare) or `$project list` — render the active projects as a
+  **numbered markdown table**: the first column is a 1-based row number, followed
+  by `name`, `status`, `user`, `branch`, and a one-line summary. **By default show
+  only the current user's projects** (`user` == `whoami`); `$project list all`
+  (or `$project all`) lists every user. Then tell the user they can reply with a
+  row number to resume that project. **A lone number in the user's next message
+  means "resume the project at that row"** — run the "Project handoff" → resume
+  steps for that entry (equivalent to `$resume <that name>`).
+- `$project new <name> [summary]` — add an `active` entry (branch = current,
+  `user` = `whoami`); scaffold `.agents/projects/<name>/{TASKS.md,DESIGN.md}`
+  unless the docs already live somewhere (record that path instead). Confirm in
+  one line.
+- `$project end <name>` — move the entry to `ended`, recording the final PR/status.
 
-`$resume` / `$hydrate` (see "Session handoff") key off this registry: **which
-session** is resolved by name (`$resume <name>`) or, with no argument, by the
-entry whose `branch` matches the current one — never a guess.
+`$resume` / `$hydrate` (see "Project handoff") key off this registry: **which
+project** is resolved by name (`$resume <name>`), by the row number from the most
+recent `$project` table, or — with no argument — by the entry whose `branch`
+matches the current one. Never a guess.
 
 ## When to Use
 
@@ -84,10 +94,10 @@ directive, add the item and confirm in one line.
 
 ### The `$hydrate` / `$resume` sentinels
 
-The same hook detects two session-handoff sentinels (see "Session handoff"
+The same hook detects two project-handoff sentinels (see "Project handoff"
 below for what each does):
 
-- `$hydrate` (also `$checkpoint`) — **checkpoint** the session before you stop or
+- `$hydrate` (also `$checkpoint`) — **checkpoint** the project before you stop or
   open a PR: reconcile `TASKS.md`, refresh the resume pointer, account for
   uncommitted work.
 - `$resume` (also `$rehydrate`) — **reload** state at the start of a session:
@@ -143,7 +153,7 @@ Short paragraph of context — what this phase delivers and why.
 5. **Commit it** — `TASKS.md` is committed alongside the work it tracks. Do not
    leave it as an uncommitted local edit (see "commit nothing silently").
 
-## Session handoff (`$hydrate` / `$resume`)
+## Project handoff (`$hydrate` / `$resume`)
 
 `TASKS.md` is the handoff medium — no separate `HANDOFF.md` (keep plans in the
 original doc). The two sentinels are the explicit checkpoint/reload verbs.

--- a/.agents/skills/task-planning/TASKS.md
+++ b/.agents/skills/task-planning/TASKS.md
@@ -1,5 +1,23 @@
 # task-planning Skill — Tasks
 
+_Resume: commit the `$session`→`$project` rename + `$project` picker (5 files). Uncommitted: SKILL.md, TASKS.md, .claude/CLAUDE.md, .claude/hooks/track.sh, AGENTS.md, and the `.agents/sessions`→`.agents/projects` rename. Last: renamed the sentinel/concept and added the numbered pick-to-resume table._
+
+## Sentinel rename + picker
+
+Renamed the `$session` sentinel and "session" work-stream concept to `$project`
+(full rename), and made bare `$project` list the registry as a numbered table you
+resume from by row number.
+
+### Tasks
+
+- [x] **Rename `$session`→`$project` (full concept rename)** — SKILL.md,
+  registry (`.agents/sessions`→`.agents/projects`, `sessions:`→`projects:`),
+  track.sh, .claude/CLAUDE.md, AGENTS.md. "session" kept only where it means a
+  Claude conversation.
+- [x] **`$project` picker** — bare `$project`/`$project list` renders a numbered
+  markdown table; replying with a row number resumes that project (in-context, no
+  bare-number hook). Verified hook fires on bare/`list`/`new`, silent on `$projects`.
+
 ## Follow-ups
 
 ### Tasks

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,11 +19,13 @@
 
 - Record a follow-up task with the `$track <text>` sentinel (anywhere in a
   message) or a line beginning `track: <text>`.
-- Manage the session registry (`.agents/sessions/registry.yml`) with
-  `$session new|list|end <name>`; each session has a `TASKS.md` + `DESIGN.md`.
-- Checkpoint session state with `$hydrate` (also `$checkpoint`) before stopping
-  or opening a PR; reload a session with `$resume [name]` (also `$rehydrate`) at
-  the start of a session — the registry resolves _which_ session (by name, else
+- Manage the project registry (`.agents/projects/registry.yml`) with
+  `$project new|list|end <name>`; each project has a `TASKS.md` + `DESIGN.md`.
+  Bare `$project` (or `$project list`) prints a numbered table of the current
+  user's projects (`list all` for everyone) — reply with a row number to resume.
+- Checkpoint project state with `$hydrate` (also `$checkpoint`) before stopping
+  or opening a PR; reload a project with `$resume [name]` (also `$rehydrate`) at
+  the start of a session — the registry resolves _which_ project (by name, else
   by the entry whose branch matches HEAD).
 - A `UserPromptSubmit` hook (`.claude/hooks/track.sh`) detects these and injects
   the matching directive — append to the active `TASKS.md` (never a background

--- a/.claude/hooks/track.sh
+++ b/.claude/hooks/track.sh
@@ -6,10 +6,11 @@
 #
 # 1. `$track <text>` (anywhere) or a line beginning `track: <text>` — record <text>
 #    as a follow-up in the active TASKS.md (see the task-planning skill).
-# 2. `$hydrate` / `$checkpoint` — checkpoint the current session (reconcile TASKS.md,
+# 2. `$hydrate` / `$checkpoint` — checkpoint the current project (reconcile TASKS.md,
 #    refresh the registry resume pointer, account for uncommitted work).
-# 3. `$resume [name]` / `$rehydrate` — reload a session (from the registry) and report.
-# 4. `$session new|list|end …` — manage the session registry.
+# 3. `$resume [name]` / `$rehydrate` — reload a project (from the registry) and report.
+# 4. `$project [new|list|end …]` — manage the project registry; bare `$project`
+#    (or `list`) prints a numbered table you resume from by replying with a row number.
 # Stateless: emits one directive per matching sentinel and nothing otherwise.
 
 set -euo pipefail
@@ -28,29 +29,29 @@ if [ -n "${task:-}" ]; then
   printf 'TASK-PLANNING DIRECTIVE: the user used the track sentinel. Record this follow-up in the TASKS.md of the current unit of work (package or directory) per the task-planning skill — do NOT use a background task chip. Item: "%s". Confirm in one short line.\n' "$task"
 fi
 
-# `$session new|list|end …` — capture the verb + rest.
-session=$(printf '%s\n' "$prompt" \
-  | grep -ioE '\$session[[:space:]]+.*' \
-  | head -1 \
-  | sed -E 's/^.*\$session[[:space:]]+//I' || true)
-
-if [ -n "${session:-}" ]; then
-  printf 'TASK-PLANNING SESSION DIRECTIVE: the user used the $session sentinel — "%s". Per the task-planning skill "Sessions (registry)", operate on .agents/sessions/registry.yml: `new <name> [summary]` adds an active entry (branch = current) and scaffolds .agents/sessions/<name>/{TASKS,DESIGN}.md unless the docs already live elsewhere; `list` prints active sessions; `end <name>` moves it to ended with the final PR/status. Confirm in one short line.\n' "$session"
+# `$project [new|list|end …]` — bare `$project` (or `$project list`) lists the
+# registry; capture any verb + args (empty for a bare list).
+if printf '%s\n' "$prompt" | grep -iqE '\$project([[:space:]]|$)'; then
+  project_args=$(printf '%s\n' "$prompt" \
+    | grep -ioE '\$project[[:space:]]+[^[:space:]].*' \
+    | head -1 \
+    | sed -E 's/^.*\$project[[:space:]]+//I' || true)
+  printf 'TASK-PLANNING PROJECT DIRECTIVE: the user used the $project sentinel — args: "%s". Per the task-planning skill "Projects (registry)", operate on .agents/projects/registry.yml. Empty args or `list`: render the active projects as a markdown table whose FIRST column is a 1-based row number (# | name | status | user | branch | one-line summary). BY DEFAULT show only projects whose `user` matches the current user (run `whoami`); if none match, say so and show all. `list all` (or `all`) lists every user. Then tell the user they can reply with a row number to resume that project — a lone number in their next message means "resume the project at that row", which runs the "Project handoff" → resume steps for that entry (same as $resume <name>). `new <name> [summary]`: add an active entry (branch = current, user = `whoami`) and scaffold .agents/projects/<name>/{TASKS,DESIGN}.md unless the docs already live elsewhere. `end <name>`: move it to ended with the final PR/status. Confirm in one short line.\n' "$project_args"
 fi
 
 # Session-handoff sentinels (require the `$` prefix + a word boundary so the plain
 # words "hydrate"/"resume" in prose don't trigger).
 if printf '%s\n' "$prompt" | grep -iqE '\$(hydrate|checkpoint)([[:space:]]|$)'; then
-  printf 'TASK-PLANNING HYDRATE: the user used the $hydrate sentinel. Follow the task-planning skill "Session handoff" → hydrate: identify the CURRENT session (the .agents/sessions/registry.yml entry whose branch matches HEAD), reconcile its TASKS.md (check off done, note next step on in-progress items), update its `resume:` field + the doc resume pointer, push decisions into its DESIGN.md and durable direction to memory, run git status and account for EVERY uncommitted file, then confirm the checkpoint in one short block (done / in-progress / next / uncommitted).\n'
+  printf 'TASK-PLANNING HYDRATE: the user used the $hydrate sentinel. Follow the task-planning skill "Project handoff" → hydrate: identify the CURRENT project (the .agents/projects/registry.yml entry whose branch matches HEAD), reconcile its TASKS.md (check off done, note next step on in-progress items), update its `resume:` field + the doc resume pointer, push decisions into its DESIGN.md and durable direction to memory, run git status and account for EVERY uncommitted file, then confirm the checkpoint in one short block (done / in-progress / next / uncommitted).\n'
 fi
 
-# `$resume [name]` — optional session name argument.
+# `$resume [name]` — optional project name argument.
 resume_name=$(printf '%s\n' "$prompt" \
   | grep -ioE '\$(resume|rehydrate)[[:space:]]+[a-z0-9][a-z0-9-]*' \
   | head -1 \
   | sed -E 's/^.*\$(resume|rehydrate)[[:space:]]+//I' || true)
 
 if printf '%s\n' "$prompt" | grep -iqE '\$(resume|rehydrate)([[:space:]]|$)'; then
-  printf 'TASK-PLANNING RESUME: the user used the $resume sentinel. Follow the task-planning skill "Session handoff" → resume: pick the session from .agents/sessions/registry.yml — %s. Read its `tasks` (TASKS.md) + `design` doc (memory is already loaded), check git status + recent git log, report a concise state (done / in-progress / next action / uncommitted), then continue with the next action unless the user directed otherwise.\n' \
+  printf 'TASK-PLANNING RESUME: the user used the $resume sentinel. Follow the task-planning skill "Project handoff" → resume: pick the project from .agents/projects/registry.yml — %s. Read its `tasks` (TASKS.md) + `design` doc (memory is already loaded), check git status + recent git log, report a concise state (done / in-progress / next action / uncommitted), then continue with the next action unless the user directed otherwise.\n' \
     "$( [ -n "${resume_name:-}" ] && printf 'by name "%s"' "$resume_name" || printf 'the entry whose branch matches HEAD' )"
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ Deeper conventions:
 ## Where things live
 
 - **`.agents/` vs `agents/`** — `.agents/` (dot) holds agent **control state**
-  (skills, the session registry); `agents/` (no dot) holds **user-visible
+  (skills, the project registry); `agents/` (no dot) holds **user-visible
   artifacts** (instructions, prompts, superpowers specs/plans/handoffs).
 - **Superpowers artifacts** — brainstorming specs, writing-plans plans, and
   handoffs live in **`agents/superpowers/{specs,plans,handoffs}/`**, NEVER


### PR DESCRIPTION
## What

Renames the task-planning **work-stream** concept from *session* to *project* and adds a picker to the `$project` sentinel.

### Rename (full concept)
- `$session` → `$project` (`new|list|end`); `Sessions (registry)` → `Projects (registry)`; `Session handoff` → `Project handoff`.
- `.agents/sessions/` → `.agents/projects/` (`registry.yml`; `sessions:` → `projects:`).
- "session" is kept **only** where it means a Claude conversation.

### Picker + ownership
- Bare `$project` (or `$project list`) renders a **numbered markdown table**; replying with a row number resumes that project.
- New `user` field on registry records (git/system username via `whoami`); `list` defaults to the current user's projects, `$project list all` shows everyone.

## Why

The sentinel that manages the registry was named `$session`, which collided with the notion of a Claude *conversation* session — confusing in the skill prose and the handoff verbs. "Project" is the durable work-stream; "session" is the conversation. The picker makes resuming a registered project a one-keystroke reply instead of recalling its slug.

## Reviewer notes

- The number-reply is handled **in-context** (the model just rendered the table), **not** by a hook. A hook catching lone numbers would misfire against this repo's heavy use of numbered-option prompts — deliberate omission.
- `track.sh` now fires on **bare** `$project` (previously required a verb) via `\$project([[:space:]]|$)`; verified it stays silent on `$projects`.
- Docs/hooks-only change (Markdown, shell, YAML) — no TypeScript, nothing for the test suite to exercise.

## Files
- `.agents/skills/task-planning/SKILL.md`
- `.agents/sessions/registry.yml` → `.agents/projects/registry.yml`
- `.claude/hooks/track.sh`
- `.claude/CLAUDE.md`
- `AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced project-based task planning with project creation, listing, resuming, and ending workflows.
  * Added numbered project selection for quickly resuming work.
  * Added durable project tracking through `TASKS.md` and `DESIGN.md` files.
  * Updated hydration and resume workflows to load the appropriate project automatically.

* **Documentation**
  * Updated task-planning guidance and repository documentation to use project terminology and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->