### PR TITLE
fix: WebSocket message ordering & PostHog cross-subdomain cookie probe

### DIFF
--- a/packages/core/mesh/edge-client/src/edge-ws-connection.test.ts
+++ b/packages/core/mesh/edge-client/src/edge-ws-connection.test.ts
@@ -2,9 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-import { describe, expect, onTestFinished, test, vi } from 'vitest';
+import { describe, onTestFinished, test, vi } from 'vitest';
 
 import { Trigger } from '@dxos/async';
+import { invariant } from '@dxos/invariant';
 import { bufWkt } from '@dxos/protocols/buf';
 import { type Message, TextMessageSchema } from '@dxos/protocols/buf/dxos/edge/messenger_pb';
 
@@ -55,6 +56,69 @@ vi.mock('isomorphic-ws', () => ({ default: FakeWebSocket }));
 
 const { EdgeWsConnection } = await import('./edge-ws-connection');
 
+const testIdentity: EdgeIdentity = {
+  peerKey: 'test-peer-key',
+  identityDid: 'did:halo:test',
+  presentCredentials: async () => {
+    throw new Error('not implemented');
+  },
+};
+
+describe('EdgeWsConnection', () => {
+  test('reassembles segmented messages delivered as Blobs out of order', async ({ expect }) => {
+    const [chunksA, chunksB] = await buildSegmentedChunks([MESSAGE_A_CONTENT, MESSAGE_B_CONTENT]);
+    expect(chunksA).toHaveLength(2);
+    expect(chunksB).toHaveLength(4);
+
+    const { ws, received, allReceived } = await openTestConnection(2);
+
+    const deferredA = chunksA.map(deferredChunk);
+    const deferredB = chunksB.map(deferredChunk);
+
+    // Dispatch every chunk in correct wire order, as a real WebSocket would.
+    for (const { blob } of [...deferredA, ...deferredB]) {
+      ws.onmessage?.({ data: blob, type: 'message' });
+    }
+
+    // Resolve the underlying `arrayBuffer()` reads out of order, simulating the browser
+    // race where concurrent Blob reads do not complete in arrival order.
+    deferredA[0].resolve();
+    deferredB[0].resolve();
+    deferredB[1].resolve();
+    deferredA[1].resolve();
+    deferredB[2].resolve();
+    deferredB[3].resolve();
+
+    await allReceived.wait();
+    expect(received).toHaveLength(2);
+
+    const [messageA, messageB] = received;
+    invariant(messageA.payload);
+    invariant(messageB.payload);
+    expect(bufWkt.anyUnpack(messageA.payload, TextMessageSchema)?.message).toStrictEqual(MESSAGE_A_CONTENT);
+    expect(bufWkt.anyUnpack(messageB.payload, TextMessageSchema)?.message).toStrictEqual(MESSAGE_B_CONTENT);
+  });
+
+  test('reassembles segmented messages delivered as ArrayBuffers', async ({ expect }) => {
+    const [chunksA, chunksB] = await buildSegmentedChunks([MESSAGE_A_CONTENT, MESSAGE_B_CONTENT]);
+
+    const { ws, received, allReceived } = await openTestConnection(2);
+
+    for (const chunk of [...chunksA, ...chunksB]) {
+      ws.onmessage?.({ data: toArrayBuffer(chunk), type: 'message' });
+    }
+
+    await allReceived.wait();
+    expect(received).toHaveLength(2);
+
+    const [messageA, messageB] = received;
+    invariant(messageA.payload);
+    invariant(messageB.payload);
+    expect(bufWkt.anyUnpack(messageA.payload, TextMessageSchema)?.message).toStrictEqual(MESSAGE_A_CONTENT);
+    expect(bufWkt.anyUnpack(messageB.payload, TextMessageSchema)?.message).toStrictEqual(MESSAGE_B_CONTENT);
+  });
+});
+
 /**
  * A Blob whose `arrayBuffer()` resolves only when `resolve()` is called, so tests can
  * control the order in which concurrent `blob.arrayBuffer()` reads complete.
@@ -81,7 +145,7 @@ type DeferredChunk = {
 };
 
 const deferredChunk = (bytes: Uint8Array): DeferredChunk => {
-  let resolveResult!: (buffer: ArrayBuffer) => void;
+  let resolveResult: (buffer: ArrayBuffer) => void = () => {};
   const result = new Promise<ArrayBuffer>((res) => {
     resolveResult = res;
   });
@@ -125,14 +189,6 @@ const buildSegmentedChunks = async (contents: string[]): Promise<Uint8Array[][]>
   return chunksByMessage;
 };
 
-const testIdentity: EdgeIdentity = {
-  peerKey: 'test-peer-key',
-  identityDid: 'did:halo:test',
-  presentCredentials: async () => {
-    throw new Error('not implemented');
-  },
-};
-
 const openTestConnection = async (expectedMessages: number) => {
   const received: Message[] = [];
   const allReceived = new Trigger();
@@ -155,59 +211,9 @@ const openTestConnection = async (expectedMessages: number) => {
     await connection.close();
   });
 
-  const ws = FakeWebSocket.instances.at(-1)!;
+  const ws = FakeWebSocket.instances.at(-1);
+  invariant(ws, 'FakeWebSocket instance not created');
   ws.onopen?.();
 
   return { connection, ws, received, allReceived };
 };
-
-describe('EdgeWsConnection', () => {
-  test('reassembles segmented messages delivered as Blobs out of order', async () => {
-    const [chunksA, chunksB] = await buildSegmentedChunks([MESSAGE_A_CONTENT, MESSAGE_B_CONTENT]);
-    expect(chunksA).toHaveLength(2);
-    expect(chunksB).toHaveLength(4);
-
-    const { ws, received, allReceived } = await openTestConnection(2);
-
-    const deferredA = chunksA.map(deferredChunk);
-    const deferredB = chunksB.map(deferredChunk);
-
-    // Dispatch every chunk in correct wire order, as a real WebSocket would.
-    for (const { blob } of [...deferredA, ...deferredB]) {
-      ws.onmessage?.({ data: blob, type: 'message' });
-    }
-
-    // Resolve the underlying `arrayBuffer()` reads out of order, simulating the browser
-    // race where concurrent Blob reads do not complete in arrival order.
-    deferredA[0].resolve();
-    deferredB[0].resolve();
-    deferredB[1].resolve();
-    deferredA[1].resolve();
-    deferredB[2].resolve();
-    deferredB[3].resolve();
-
-    await allReceived.wait();
-    expect(received).toHaveLength(2);
-
-    const [messageA, messageB] = received;
-    expect(bufWkt.anyUnpack(messageA.payload!, TextMessageSchema)?.message).toStrictEqual(MESSAGE_A_CONTENT);
-    expect(bufWkt.anyUnpack(messageB.payload!, TextMessageSchema)?.message).toStrictEqual(MESSAGE_B_CONTENT);
-  });
-
-  test('reassembles segmented messages delivered as ArrayBuffers', async () => {
-    const [chunksA, chunksB] = await buildSegmentedChunks([MESSAGE_A_CONTENT, MESSAGE_B_CONTENT]);
-
-    const { ws, received, allReceived } = await openTestConnection(2);
-
-    for (const chunk of [...chunksA, ...chunksB]) {
-      ws.onmessage?.({ data: toArrayBuffer(chunk), type: 'message' });
-    }
-
-    await allReceived.wait();
-    expect(received).toHaveLength(2);
-
-    const [messageA, messageB] = received;
-    expect(bufWkt.anyUnpack(messageA.payload!, TextMessageSchema)?.message).toStrictEqual(MESSAGE_A_CONTENT);
-    expect(bufWkt.anyUnpack(messageB.payload!, TextMessageSchema)?.message).toStrictEqual(MESSAGE_B_CONTENT);
-  });
-});

--- a/packages/core/mesh/edge-client/src/edge-ws-connection.test.ts
+++ b/packages/core/mesh/edge-client/src/edge-ws-connection.test.ts
@@ -1,0 +1,213 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { describe, expect, onTestFinished, test, vi } from 'vitest';
+
+import { Trigger } from '@dxos/async';
+import { bufWkt } from '@dxos/protocols/buf';
+import { type Message, TextMessageSchema } from '@dxos/protocols/buf/dxos/edge/messenger_pb';
+
+import { protocol } from './defs';
+import { type EdgeIdentity } from './edge-identity';
+import { WebSocketMuxer } from './edge-ws-muxer';
+
+// Segmented-message chunk count depends on the protobuf envelope overhead, which is
+// determined empirically (see chunk-count assertions below) rather than assumed.
+const MAX_CHUNK_LENGTH = 64;
+const MESSAGE_A_CONTENT = 'a'.repeat(20);
+const MESSAGE_B_CONTENT = 'b'.repeat(120);
+
+// Replace isomorphic-ws's default export with a controllable fake so tests can drive
+// the connection's onmessage handler directly and inspect what it sends.
+const { FakeWebSocket } = vi.hoisted(() => {
+  class FakeWebSocket {
+    static instances: FakeWebSocket[] = [];
+
+    readyState = 1;
+    protocol = '';
+    binaryType = 'nodebuffer';
+    onopen: (() => void) | null = null;
+    onclose: ((event: { code?: number; reason?: string }) => void) | null = null;
+    onerror: ((event: { error?: unknown; message?: string }) => void) | null = null;
+    onmessage: ((event: { data: unknown; type: string }) => void) | null = null;
+    readonly sent: unknown[] = [];
+
+    constructor(
+      public readonly url: string,
+      public readonly protocols?: string[],
+      public readonly options?: unknown,
+    ) {
+      FakeWebSocket.instances.push(this);
+    }
+
+    send(data: unknown): void {
+      this.sent.push(data);
+    }
+
+    close(): void {}
+  }
+
+  return { FakeWebSocket };
+});
+
+vi.mock('isomorphic-ws', () => ({ default: FakeWebSocket }));
+
+const { EdgeWsConnection } = await import('./edge-ws-connection');
+
+/**
+ * A Blob whose `arrayBuffer()` resolves only when `resolve()` is called, so tests can
+ * control the order in which concurrent `blob.arrayBuffer()` reads complete.
+ */
+class DeferredBlob extends Blob {
+  readonly #result: Promise<ArrayBuffer>;
+
+  constructor(result: Promise<ArrayBuffer>) {
+    super();
+    this.#result = result;
+  }
+
+  override async arrayBuffer(): Promise<ArrayBuffer> {
+    // `await` (not a bare `return`) so the listener attaches to `#result` synchronously,
+    // during dispatch, rather than one microtask later — otherwise resolving out of
+    // dispatch order has no effect once every deferred promise is already settled.
+    return await this.#result;
+  }
+}
+
+type DeferredChunk = {
+  blob: DeferredBlob;
+  resolve: () => void;
+};
+
+const deferredChunk = (bytes: Uint8Array): DeferredChunk => {
+  let resolveResult!: (buffer: ArrayBuffer) => void;
+  const result = new Promise<ArrayBuffer>((res) => {
+    resolveResult = res;
+  });
+  // Copy so the returned ArrayBuffer starts at offset 0 and is independent of the source view.
+  const copy = new Uint8Array(bytes);
+  return { blob: new DeferredBlob(result), resolve: () => resolveResult(copy.buffer) };
+};
+
+const toArrayBuffer = (bytes: Uint8Array): ArrayBuffer => new Uint8Array(bytes).buffer;
+
+const textMessage = (message: string) =>
+  protocol.createMessage(TextMessageSchema, {
+    serviceId: 'test-service',
+    payload: { message },
+  });
+
+/**
+ * Sends each content string as a message on the same muxer/channel and returns the wire
+ * chunks grouped by message, mirroring how `WebSocketMuxer` splits segmented messages.
+ */
+const buildSegmentedChunks = async (contents: string[]): Promise<Uint8Array[][]> => {
+  const sentMessages: Uint8Array[] = [];
+  const muxer = new WebSocketMuxer(
+    { readyState: 1, send: (message: string) => sentMessages.push(Buffer.from(message)) },
+    { maxChunkLength: MAX_CHUNK_LENGTH },
+  );
+
+  const chunkCounts: number[] = [];
+  for (const content of contents) {
+    const before = sentMessages.length;
+    await muxer.send(textMessage(content));
+    chunkCounts.push(sentMessages.length - before);
+  }
+
+  const chunksByMessage: Uint8Array[][] = [];
+  let offset = 0;
+  for (const count of chunkCounts) {
+    chunksByMessage.push(sentMessages.slice(offset, offset + count));
+    offset += count;
+  }
+  return chunksByMessage;
+};
+
+const testIdentity: EdgeIdentity = {
+  peerKey: 'test-peer-key',
+  identityDid: 'did:halo:test',
+  presentCredentials: async () => {
+    throw new Error('not implemented');
+  },
+};
+
+const openTestConnection = async (expectedMessages: number) => {
+  const received: Message[] = [];
+  const allReceived = new Trigger();
+  const connection = new EdgeWsConnection(
+    testIdentity,
+    { url: new URL('ws://localhost:1234') },
+    {
+      onConnected: () => {},
+      onMessage: (message) => {
+        received.push(message);
+        if (received.length === expectedMessages) {
+          allReceived.wake();
+        }
+      },
+      onRestartRequired: () => {},
+    },
+  );
+  await connection.open();
+  onTestFinished(async () => {
+    await connection.close();
+  });
+
+  const ws = FakeWebSocket.instances.at(-1)!;
+  ws.onopen?.();
+
+  return { connection, ws, received, allReceived };
+};
+
+describe('EdgeWsConnection', () => {
+  test('reassembles segmented messages delivered as Blobs out of order', async () => {
+    const [chunksA, chunksB] = await buildSegmentedChunks([MESSAGE_A_CONTENT, MESSAGE_B_CONTENT]);
+    expect(chunksA).toHaveLength(2);
+    expect(chunksB).toHaveLength(4);
+
+    const { ws, received, allReceived } = await openTestConnection(2);
+
+    const deferredA = chunksA.map(deferredChunk);
+    const deferredB = chunksB.map(deferredChunk);
+
+    // Dispatch every chunk in correct wire order, as a real WebSocket would.
+    for (const { blob } of [...deferredA, ...deferredB]) {
+      ws.onmessage?.({ data: blob, type: 'message' });
+    }
+
+    // Resolve the underlying `arrayBuffer()` reads out of order, simulating the browser
+    // race where concurrent Blob reads do not complete in arrival order.
+    deferredA[0].resolve();
+    deferredB[0].resolve();
+    deferredB[1].resolve();
+    deferredA[1].resolve();
+    deferredB[2].resolve();
+    deferredB[3].resolve();
+
+    await allReceived.wait();
+    expect(received).toHaveLength(2);
+
+    const [messageA, messageB] = received;
+    expect(bufWkt.anyUnpack(messageA.payload!, TextMessageSchema)?.message).toStrictEqual(MESSAGE_A_CONTENT);
+    expect(bufWkt.anyUnpack(messageB.payload!, TextMessageSchema)?.message).toStrictEqual(MESSAGE_B_CONTENT);
+  });
+
+  test('reassembles segmented messages delivered as ArrayBuffers', async () => {
+    const [chunksA, chunksB] = await buildSegmentedChunks([MESSAGE_A_CONTENT, MESSAGE_B_CONTENT]);
+
+    const { ws, received, allReceived } = await openTestConnection(2);
+
+    for (const chunk of [...chunksA, ...chunksB]) {
+      ws.onmessage?.({ data: toArrayBuffer(chunk), type: 'message' });
+    }
+
+    await allReceived.wait();
+    expect(received).toHaveLength(2);
+
+    const [messageA, messageB] = received;
+    expect(bufWkt.anyUnpack(messageA.payload!, TextMessageSchema)?.message).toStrictEqual(MESSAGE_A_CONTENT);
+    expect(bufWkt.anyUnpack(messageB.payload!, TextMessageSchema)?.message).toStrictEqual(MESSAGE_B_CONTENT);
+  });
+});

--- a/packages/core/mesh/edge-client/src/edge-ws-connection.ts
+++ b/packages/core/mesh/edge-client/src/edge-ws-connection.ts
@@ -184,16 +184,17 @@ export class EdgeWsConnection extends Resource {
         return;
       }
 
-      // Serialize processing so bytes reach `muxer.receiveData` in arrival order. The lock
-      // releases even if `_receiveMessage` throws, so a single bad message is logged and
-      // dropped instead of stalling every message queued after it.
-      void this._receiveMutex
-        .executeSynchronized(() => this._receiveMessage(event.data, muxer))
-        .catch((err) => log.catch(err));
+      // `_receiveMessage` serializes on `_receiveMutex`; `acquire` enqueues synchronously,
+      // so locks are taken in arrival order regardless of async conversion timing.
+      void this._receiveMessage(event.data, muxer).catch((err) => log.catch(err));
     };
   }
 
   private async _receiveMessage(data: WebSocket.Data, muxer: WebSocketMuxer): Promise<void> {
+    // Serialize processing so bytes reach `muxer.receiveData` in arrival order. The guard
+    // releases on scope exit even if processing throws, so a single bad message is logged
+    // and dropped instead of stalling every message queued after it.
+    using _guard = await this._receiveMutex.acquire();
     const bytes = await toUint8Array(data);
     this._recordBytes(0, bytes.byteLength);
     if (!this.isOpen) {

--- a/packages/core/mesh/edge-client/src/edge-ws-connection.ts
+++ b/packages/core/mesh/edge-client/src/edge-ws-connection.ts
@@ -48,6 +48,15 @@ export class EdgeWsConnection extends Resource {
   private _messagesSent = 0;
   private _messagesReceived = 0;
 
+  /**
+   * WebSocket frames arrive in order, but converting frame data to bytes is async
+   * (the `Blob` fallback path awaits `blob.arrayBuffer()`), and concurrent conversions
+   * are not guaranteed to complete in arrival order. Segmented-message reassembly in
+   * `WebSocketMuxer` requires chunks to reach `receiveData` in arrival order, so every
+   * message is processed by chaining onto this promise instead of running independently.
+   */
+  private _receiveChain: Promise<void> = Promise.resolve();
+
   constructor(
     private readonly _identity: EdgeIdentity,
     private readonly _connectionInfo: { url: URL; protocolHeader?: string; headers?: Record<string, string> },
@@ -123,6 +132,10 @@ export class EdgeWsConnection extends Resource {
         : [...baseProtocols],
       this._connectionInfo.headers ? { headers: this._connectionInfo.headers } : undefined,
     );
+    // Deliver frame data as `ArrayBuffer` rather than `Blob` so bytes are available
+    // synchronously; avoids the async `blob.arrayBuffer()` reads that can otherwise
+    // complete out of arrival order (see `_receiveChain`).
+    this._ws.binaryType = 'arraybuffer';
     const muxer = new WebSocketMuxer(this._ws);
     this._wsMuxer = muxer;
 
@@ -155,7 +168,7 @@ export class EdgeWsConnection extends Resource {
     /**
      * https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/data
      */
-    this._ws.onmessage = async (event: WebSocket.MessageEvent) => {
+    this._ws.onmessage = (event: WebSocket.MessageEvent) => {
       if (!this.isOpen) {
         log.verbose('message ignored on closed connection', { event: event.type });
         return;
@@ -170,23 +183,34 @@ export class EdgeWsConnection extends Resource {
         this._rescheduleHeartbeatTimeout();
         return;
       }
-      const bytes = await toUint8Array(event.data);
-      this._recordBytes(0, bytes.byteLength);
-      if (!this.isOpen) {
-        return;
-      }
 
-      this._messagesReceived++;
-
-      const message = this._ws?.protocol?.includes(EdgeWebsocketProtocol.V0)
-        ? buf.fromBinary(MessageSchema, bytes)
-        : muxer.receiveData(bytes);
-
-      if (message) {
-        log('received', { from: message.source, payload: protocol.getPayloadType(message) });
-        this._callbacks.onMessage(message);
-      }
+      // Chain each message onto the previous one so bytes reach `muxer.receiveData` in
+      // arrival order. Catching within the chained callback (rather than on
+      // `_receiveChain` itself) keeps `_receiveChain` resolved, so a single bad message
+      // is logged and dropped instead of stalling every message queued after it.
+      this._receiveChain = this._receiveChain.then(() =>
+        this._receiveMessage(event.data, muxer).catch((err) => log.catch(err)),
+      );
     };
+  }
+
+  private async _receiveMessage(data: WebSocket.Data, muxer: WebSocketMuxer): Promise<void> {
+    const bytes = await toUint8Array(data);
+    this._recordBytes(0, bytes.byteLength);
+    if (!this.isOpen) {
+      return;
+    }
+
+    this._messagesReceived++;
+
+    const message = this._ws?.protocol?.includes(EdgeWebsocketProtocol.V0)
+      ? buf.fromBinary(MessageSchema, bytes)
+      : muxer.receiveData(bytes);
+
+    if (message) {
+      log('received', { from: message.source, payload: protocol.getPayloadType(message) });
+      this._callbacks.onMessage(message);
+    }
   }
 
   protected override async _close(): Promise<void> {

--- a/packages/core/mesh/edge-client/src/edge-ws-connection.ts
+++ b/packages/core/mesh/edge-client/src/edge-ws-connection.ts
@@ -4,7 +4,7 @@
 
 import WebSocket from 'isomorphic-ws';
 
-import { scheduleTask, scheduleTaskInterval } from '@dxos/async';
+import { Mutex, scheduleTask, scheduleTaskInterval } from '@dxos/async';
 import { Context, Resource } from '@dxos/context';
 import { invariant } from '@dxos/invariant';
 import { log, logInfo } from '@dxos/log';
@@ -52,10 +52,10 @@ export class EdgeWsConnection extends Resource {
    * WebSocket frames arrive in order, but converting frame data to bytes is async
    * (the `Blob` fallback path awaits `blob.arrayBuffer()`), and concurrent conversions
    * are not guaranteed to complete in arrival order. Segmented-message reassembly in
-   * `WebSocketMuxer` requires chunks to reach `receiveData` in arrival order, so every
-   * message is processed by chaining onto this promise instead of running independently.
+   * `WebSocketMuxer` requires chunks to reach `receiveData` in arrival order, so message
+   * processing is serialized through this lock.
    */
-  private _receiveChain: Promise<void> = Promise.resolve();
+  private readonly _receiveMutex = new Mutex();
 
   constructor(
     private readonly _identity: EdgeIdentity,
@@ -184,13 +184,12 @@ export class EdgeWsConnection extends Resource {
         return;
       }
 
-      // Chain each message onto the previous one so bytes reach `muxer.receiveData` in
-      // arrival order. Catching within the chained callback (rather than on
-      // `_receiveChain` itself) keeps `_receiveChain` resolved, so a single bad message
-      // is logged and dropped instead of stalling every message queued after it.
-      this._receiveChain = this._receiveChain.then(() =>
-        this._receiveMessage(event.data, muxer).catch((err) => log.catch(err)),
-      );
+      // Serialize processing so bytes reach `muxer.receiveData` in arrival order. The lock
+      // releases even if `_receiveMessage` throws, so a single bad message is logged and
+      // dropped instead of stalling every message queued after it.
+      void this._receiveMutex
+        .executeSynchronized(() => this._receiveMessage(event.data, muxer))
+        .catch((err) => log.catch(err));
     };
   }
 

--- a/packages/core/mesh/edge-client/src/protocol.ts
+++ b/packages/core/mesh/edge-client/src/protocol.ts
@@ -97,9 +97,14 @@ export const toUint8Array = async (data: any): Promise<Uint8Array> => {
     return bufferToArray(data);
   }
 
-  // Browser.
+  // Browser with `binaryType = 'arraybuffer'`.
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  }
+
+  // Browser fallback (`binaryType = 'blob'`, the WebSocket default).
   if (data instanceof Blob) {
-    return new Uint8Array(await (data as Blob).arrayBuffer());
+    return new Uint8Array(await data.arrayBuffer());
   }
 
   throw new Error(`Unexpected datatype: ${data}`);

--- a/packages/sdk/observability/src/extensions/posthog/extension.ts
+++ b/packages/sdk/observability/src/extensions/posthog/extension.ts
@@ -104,6 +104,8 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
           api_host,
           mask_all_text: true,
           capture_exceptions: true,
+          // Cookies stay scoped to the exact host; the cross-subdomain dmn_chk_* probe fails on public-suffix hosts (e.g. *.pages.dev) and spams the console.
+          cross_subdomain_cookie: false,
           ...posthogConfig,
         });
         if (release || environment) {


### PR DESCRIPTION
## Summary

Two independent fixes surfaced while running Composer on a `*.pages.dev` preview deploy.

### `fix(edge-client)`: preserve WebSocket message arrival order during reassembly
WebSocket frames arrive in order, but converting frame data to bytes is async on the `Blob` fallback path (`blob.arrayBuffer()`), and concurrent conversions are not guaranteed to complete in arrival order. `WebSocketMuxer` segmented-message reassembly requires chunks to reach `receiveData` in arrival order, so out-of-order completion corrupts multi-chunk messages.

- Chain each message onto a `_receiveChain` promise so bytes reach `receiveData` in arrival order; a single bad message is caught and dropped rather than stalling the queue.
- Set `binaryType = 'arraybuffer'` so bytes are available synchronously, avoiding the async `blob.arrayBuffer()` read entirely on modern paths; `toUint8Array` gains an `ArrayBuffer` branch with the `Blob` path kept as fallback.
- Adds `edge-ws-connection.test.ts` covering both the out-of-order `Blob` race and the `ArrayBuffer` path.

### `fix(observability)`: disable PostHog cross-subdomain cookie probe
The PostHog `dmn_chk_*` cross-subdomain cookie probe fails on public-suffix hosts (e.g. `*.pages.dev` preview deploys) and spams the console. Set `cross_subdomain_cookie: false` to scope cookies to the exact host.

## Testing
- `moon run edge-client:test` — 35 passed (incl. new suite)
- `moon run edge-client:lint observability:lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebSocket receive handling to preserve ordered, contiguous segmented-message reassembly when frames are multiplexed and delivered asynchronously.
  - Standardized binary payload decoding for WebSocket messages provided as `ArrayBuffer` or `Blob`.
  - Ensured receive-path failures and malformed messages don’t block subsequent message processing.
  - Reduced PostHog console warnings by preventing cross-subdomain cookie probing.
- **Tests**
  - Added Vitest coverage for segmented protobuf message reassembly for both `ArrayBuffer` and `Blob` frame delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->