### PR TITLE
fix(deploy): correct testbench-app's wrangler assets directory

### DIFF
--- a/packages/apps/testbench-app/wrangler.jsonc
+++ b/packages/apps/testbench-app/wrangler.jsonc
@@ -5,7 +5,7 @@
   "name": "testbench",
   "compatibility_date": "2024-11-01",
   "assets": {
-    "directory": "./out/testbench",
+    "directory": "./out/testbench-app",
     "not_found_handling": "single-page-application",
   },
   "env": {


### PR DESCRIPTION
## Summary
- `packages/apps/testbench-app/wrangler.jsonc`'s `assets.directory` was `./out/testbench`, but `vite.config.ts`'s actual build output is `out/testbench-app`.
- This broke the `main`-push `Deploy Apps` run introduced by #12106: `wrangler deploy` couldn't find the assets directory ([run 29252232708](https://github.com/dxos/dxos/actions/runs/29252232708/job/86823401838)).
- Root cause: a typo in the original `wrangler.toml` (authored as part of #12106's Pages→Workers migration), never caught because the `labs`/`staging` test environments only deploy `composer`(+`docs`) — `testbench` only deploys on `main`/`production`, and #12106's merge to `main` was the first real exercise of that path.

## Test plan
- [x] `apps.mjs` resolves the corrected path to `packages/apps/testbench-app/out/testbench-app`, matching vite's real output.
- [x] `oxfmt --check` clean on the changed file.
- [ ] CI green (Check + a `main`-push Deploy Apps run deploying `testbench` successfully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)