### PR TITLE
docs: replace conventional commits with scope: description

### DIFF
--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -109,7 +109,7 @@ For each failing check:
    - Format: `pnpm format`
 3. Apply the fix at the **root cause** — no casts, no `// @ts-ignore`, no `--no-verify`.
 4. Run the specific check locally to confirm the fix.
-5. Commit with a conventional commit message and push.
+5. Commit with a clear, descriptive message and push.
 
 **Prohibited shortcuts:**
 
@@ -261,7 +261,6 @@ This project uses:
 - `moon` for task running (`moon run <package>:task`)
 - `pnpm` for package management
 - `mcp__github__*` tools for all GitHub operations (no `gh` CLI in remote environments)
-- Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
 - TypeScript with strict linting
 - Single quotes, functional patterns, TailwindCSS
 

--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -109,7 +109,7 @@ For each failing check:
    - Format: `pnpm format`
 3. Apply the fix at the **root cause** — no casts, no `// @ts-ignore`, no `--no-verify`.
 4. Run the specific check locally to confirm the fix.
-5. Commit with a clear, descriptive message and push.
+5. Commit with a `scope: description` message (no type prefix — see `AGENTS.md`) and push.
 
 **Prohibited shortcuts:**
 
@@ -261,6 +261,7 @@ This project uses:
 - `moon` for task running (`moon run <package>:task`)
 - `pnpm` for package management
 - `mcp__github__*` tools for all GitHub operations (no `gh` CLI in remote environments)
+- `scope: description` commit/PR-title format (no type prefix — see `AGENTS.md`)
 - TypeScript with strict linting
 - Single quotes, functional patterns, TailwindCSS
 

--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -109,7 +109,7 @@ For each failing check:
    - Format: `pnpm format`
 3. Apply the fix at the **root cause** — no casts, no `// @ts-ignore`, no `--no-verify`.
 4. Run the specific check locally to confirm the fix.
-5. Commit with a `scope: description` message (no type prefix — see `AGENTS.md`) and push.
+5. Commit with a `scope: description` message (see `AGENTS.md`) and push.
 
 **Prohibited shortcuts:**
 
@@ -261,7 +261,7 @@ This project uses:
 - `moon` for task running (`moon run <package>:task`)
 - `pnpm` for package management
 - `mcp__github__*` tools for all GitHub operations (no `gh` CLI in remote environments)
-- `scope: description` commit/PR-title format (no type prefix — see `AGENTS.md`)
+- `scope: description` commit/PR-title format (see `AGENTS.md`)
 - TypeScript with strict linting
 - Single quotes, functional patterns, TailwindCSS
 

--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -109,7 +109,7 @@ For each failing check:
    - Format: `pnpm format`
 3. Apply the fix at the **root cause** — no casts, no `// @ts-ignore`, no `--no-verify`.
 4. Run the specific check locally to confirm the fix.
-5. Commit with a `scope: description` message (see `AGENTS.md`) and push.
+5. Commit with a `scope: description` message and push.
 
 **Prohibited shortcuts:**
 
@@ -261,7 +261,7 @@ This project uses:
 - `moon` for task running (`moon run <package>:task`)
 - `pnpm` for package management
 - `mcp__github__*` tools for all GitHub operations (no `gh` CLI in remote environments)
-- `scope: description` commit/PR-title format (see `AGENTS.md`)
+- `scope: description` commit/PR-title format
 - TypeScript with strict linting
 - Single quotes, functional patterns, TailwindCSS
 

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -29,10 +29,9 @@ runs in. To land (merge) an existing PR, use the `land` skill.
    for when one is needed, which package to name, and bump levels.
 7. **Push**, then verify `git status` shows a clean working tree. If anything
    remains, commit it or confirm before proceeding.
-8. **Open the PR** with `gh`. Title uses `scope: description` (see
-   `AGENTS.md`). In the description, summarize the changes and the reasoning
-   behind major decisions, and link any Linear issue as `closes DX-123` or
-   `part of DX-123`.
+8. **Open the PR** with `gh`. Title uses `scope: description`. In the
+   description, summarize the changes and the reasoning behind major
+   decisions, and link any Linear issue as `closes DX-123` or `part of DX-123`.
 9. **Monitor CI every 5 minutes:**
    `gh run list --branch <branch> --limit 3 --workflow "Check"` and
    `pnpm -w gh-action --verify --watch`. Diagnose and, where possible, fix ALL

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -29,9 +29,10 @@ runs in. To land (merge) an existing PR, use the `land` skill.
    for when one is needed, which package to name, and bump levels.
 7. **Push**, then verify `git status` shows a clean working tree. If anything
    remains, commit it or confirm before proceeding.
-8. **Open the PR** with `gh`. Title clearly and concisely describes the change.
-   In the description, summarize the changes and the reasoning behind major
-   decisions, and link any Linear issue as `closes DX-123` or `part of DX-123`.
+8. **Open the PR** with `gh`. Title uses `scope: description` (no
+   `feat`/`fix`/`chore` type prefix — see `AGENTS.md`). In the description,
+   summarize the changes and the reasoning behind major decisions, and link
+   any Linear issue as `closes DX-123` or `part of DX-123`.
 9. **Monitor CI every 5 minutes:**
    `gh run list --branch <branch> --limit 3 --workflow "Check"` and
    `pnpm -w gh-action --verify --watch`. Diagnose and, where possible, fix ALL

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -23,17 +23,21 @@ runs in. To land (merge) an existing PR, use the `land` skill.
 5. **Account for every file.** `git status`; commit ALL modified/untracked files,
    including edits the user made in the shared worktree. Never leave changes
    behind silently — commit them or confirm exclusion with the user.
-6. **Push**, then verify `git status` shows a clean working tree. If anything
+6. **Changeset.** If the change is consumer-relevant, add a `.changeset/*.md`
+   and commit it with the rest — see
+   [`agents/instructions/changesets.md`](../../../agents/instructions/changesets.md)
+   for when one is needed, which package to name, and bump levels.
+7. **Push**, then verify `git status` shows a clean working tree. If anything
    remains, commit it or confirm before proceeding.
-7. **Open the PR** with `gh`. Title clearly and concisely describes the change.
+8. **Open the PR** with `gh`. Title clearly and concisely describes the change.
    In the description, summarize the changes and the reasoning behind major
    decisions, and link any Linear issue as `closes DX-123` or `part of DX-123`.
-8. **Monitor CI every 5 minutes:**
+9. **Monitor CI every 5 minutes:**
    `gh run list --branch <branch> --limit 3 --workflow "Check"` and
    `pnpm -w gh-action --verify --watch`. Diagnose and, where possible, fix ALL
    CI errors — even ones unrelated to this branch. Never merge around a red
    Check; fix the root cause with `gh run view <id> --log-failed`.
-9. **Address and RESPOND to every PR review comment.**
+10. **Address and RESPOND to every PR review comment.**
 
 ## Composer preview URL — always surface
 

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -25,10 +25,9 @@ runs in. To land (merge) an existing PR, use the `land` skill.
    behind silently — commit them or confirm exclusion with the user.
 6. **Push**, then verify `git status` shows a clean working tree. If anything
    remains, commit it or confirm before proceeding.
-7. **Open the PR** with `gh`. Title uses conventional-commit format
-   (`feat(scope): …`). In the description, summarize the changes and the
-   reasoning behind major decisions, and link any Linear issue as
-   `closes DX-123` or `part of DX-123`.
+7. **Open the PR** with `gh`. Title clearly and concisely describes the change.
+   In the description, summarize the changes and the reasoning behind major
+   decisions, and link any Linear issue as `closes DX-123` or `part of DX-123`.
 8. **Monitor CI every 5 minutes:**
    `gh run list --branch <branch> --limit 3 --workflow "Check"` and
    `pnpm -w gh-action --verify --watch`. Diagnose and, where possible, fix ALL

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -20,13 +20,14 @@ runs in. To land (merge) an existing PR, use the `land` skill.
 2. **Format.** Run `pnpm format` (oxfmt — CI checks `oxfmt --check`).
 3. **Lint.** `moon run :lint -- --fix` must succeed.
 4. **Test.** `moon run :test` must pass.
-5. **Account for every file.** `git status`; commit ALL modified/untracked files,
-   including edits the user made in the shared worktree. Never leave changes
-   behind silently — commit them or confirm exclusion with the user.
-6. **Changeset.** If the change is consumer-relevant, add a `.changeset/*.md`
-   and commit it with the rest — see
+5. **Changeset.** If the change is consumer-relevant, add a `.changeset/*.md`
+   — see
    [`agents/instructions/changesets.md`](../../../agents/instructions/changesets.md)
    for when one is needed, which package to name, and bump levels.
+6. **Account for every file.** `git status`; commit ALL modified/untracked
+   files, including the changeset and edits the user made in the shared
+   worktree. Never leave changes behind silently — commit them or confirm
+   exclusion with the user.
 7. **Push**, then verify `git status` shows a clean working tree. If anything
    remains, commit it or confirm before proceeding.
 8. **Open the PR** with `gh`. Title uses `scope: description`. In the

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -29,10 +29,10 @@ runs in. To land (merge) an existing PR, use the `land` skill.
    for when one is needed, which package to name, and bump levels.
 7. **Push**, then verify `git status` shows a clean working tree. If anything
    remains, commit it or confirm before proceeding.
-8. **Open the PR** with `gh`. Title uses `scope: description` (no
-   `feat`/`fix`/`chore` type prefix — see `AGENTS.md`). In the description,
-   summarize the changes and the reasoning behind major decisions, and link
-   any Linear issue as `closes DX-123` or `part of DX-123`.
+8. **Open the PR** with `gh`. Title uses `scope: description` (see
+   `AGENTS.md`). In the description, summarize the changes and the reasoning
+   behind major decisions, and link any Linear issue as `closes DX-123` or
+   `part of DX-123`.
 9. **Monitor CI every 5 minutes:**
    `gh run list --branch <branch> --limit 3 --workflow "Check"` and
    `pnpm -w gh-action --verify --watch`. Diagnose and, where possible, fix ALL

--- a/.claude/agents/pr-merge-readiness-verifier.md
+++ b/.claude/agents/pr-merge-readiness-verifier.md
@@ -13,7 +13,7 @@ You will verify PR readiness by checking these factors IN ORDER. After making an
 
 1. **Git Commit Status**: Verify all changes are committed
    - Run `git status` to check for uncommitted changes
-   - If uncommitted changes exist, stage and commit them with a clear, descriptive message
+   - If uncommitted changes exist, stage and commit them with a `scope: description` message (no type prefix — see `AGENTS.md`)
    - Verify commit succeeded before proceeding
 
 2. **Pre-CI Checks**: Ensure `pnpm -w pre-ci` passes with exit code 0
@@ -109,6 +109,7 @@ This is a DXOS project using:
 - `moon` for task running
 - `pnpm` for package management
 - `gh` CLI for GitHub operations
+- `scope: description` commit/PR-title format (no type prefix — see `AGENTS.md`)
 - TypeScript with strict linting rules
 
 Align all fixes with DXOS code style: single quotes, inline type imports, functional patterns, and proper formatting.

--- a/.claude/agents/pr-merge-readiness-verifier.md
+++ b/.claude/agents/pr-merge-readiness-verifier.md
@@ -13,7 +13,7 @@ You will verify PR readiness by checking these factors IN ORDER. After making an
 
 1. **Git Commit Status**: Verify all changes are committed
    - Run `git status` to check for uncommitted changes
-   - If uncommitted changes exist, stage and commit them with a `scope: description` message (see `AGENTS.md`)
+   - If uncommitted changes exist, stage and commit them with a `scope: description` message
    - Verify commit succeeded before proceeding
 
 2. **Pre-CI Checks**: Ensure `pnpm -w pre-ci` passes with exit code 0
@@ -109,7 +109,7 @@ This is a DXOS project using:
 - `moon` for task running
 - `pnpm` for package management
 - `gh` CLI for GitHub operations
-- `scope: description` commit/PR-title format (see `AGENTS.md`)
+- `scope: description` commit/PR-title format
 - TypeScript with strict linting rules
 
 Align all fixes with DXOS code style: single quotes, inline type imports, functional patterns, and proper formatting.

--- a/.claude/agents/pr-merge-readiness-verifier.md
+++ b/.claude/agents/pr-merge-readiness-verifier.md
@@ -13,7 +13,7 @@ You will verify PR readiness by checking these factors IN ORDER. After making an
 
 1. **Git Commit Status**: Verify all changes are committed
    - Run `git status` to check for uncommitted changes
-   - If uncommitted changes exist, stage and commit them with a `scope: description` message (no type prefix — see `AGENTS.md`)
+   - If uncommitted changes exist, stage and commit them with a `scope: description` message (see `AGENTS.md`)
    - Verify commit succeeded before proceeding
 
 2. **Pre-CI Checks**: Ensure `pnpm -w pre-ci` passes with exit code 0
@@ -109,7 +109,7 @@ This is a DXOS project using:
 - `moon` for task running
 - `pnpm` for package management
 - `gh` CLI for GitHub operations
-- `scope: description` commit/PR-title format (no type prefix — see `AGENTS.md`)
+- `scope: description` commit/PR-title format (see `AGENTS.md`)
 - TypeScript with strict linting rules
 
 Align all fixes with DXOS code style: single quotes, inline type imports, functional patterns, and proper formatting.

--- a/.claude/agents/pr-merge-readiness-verifier.md
+++ b/.claude/agents/pr-merge-readiness-verifier.md
@@ -13,7 +13,7 @@ You will verify PR readiness by checking these factors IN ORDER. After making an
 
 1. **Git Commit Status**: Verify all changes are committed
    - Run `git status` to check for uncommitted changes
-   - If uncommitted changes exist, stage and commit them with a descriptive conventional commit message
+   - If uncommitted changes exist, stage and commit them with a clear, descriptive message
    - Verify commit succeeded before proceeding
 
 2. **Pre-CI Checks**: Ensure `pnpm -w pre-ci` passes with exit code 0
@@ -109,7 +109,6 @@ This is a DXOS project using:
 - `moon` for task running
 - `pnpm` for package management
 - `gh` CLI for GitHub operations
-- Conventional Commits for commit messages
 - TypeScript with strict linting rules
 
 Align all fixes with DXOS code style: single quotes, inline type imports, functional patterns, and proper formatting.

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -19,7 +19,7 @@ If `FILES` is empty, report clean and stop.
 ## 2. Commit
 
 - Group changes into **one or more** logical commits when unrelated (e.g. separate features, separate packages).
-- Message format: `scope: description` (see `AGENTS.md`).
+- Message format: `scope: description`.
 - Stage **only** in-scope files; never stage excluded paths.
 - Create commits immediately — no review pass, no code changes.
 - **Do not push.**

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -19,7 +19,7 @@ If `FILES` is empty, report clean and stop.
 ## 2. Commit
 
 - Group changes into **one or more** logical commits when unrelated (e.g. separate features, separate packages).
-- Write a clear, descriptive message for each commit — no required format.
+- Message format: `scope: description` (no `feat`/`fix`/`chore` type prefix — see `AGENTS.md`).
 - Stage **only** in-scope files; never stage excluded paths.
 - Create commits immediately — no review pass, no code changes.
 - **Do not push.**

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -19,7 +19,7 @@ If `FILES` is empty, report clean and stop.
 ## 2. Commit
 
 - Group changes into **one or more** logical commits when unrelated (e.g. separate features, separate packages).
-- Use **conventional commits**: `feat(scope): …`, `fix(scope): …`, `refactor(scope): …`.
+- Write a clear, descriptive message for each commit — no required format.
 - Stage **only** in-scope files; never stage excluded paths.
 - Create commits immediately — no review pass, no code changes.
 - **Do not push.**

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -19,7 +19,7 @@ If `FILES` is empty, report clean and stop.
 ## 2. Commit
 
 - Group changes into **one or more** logical commits when unrelated (e.g. separate features, separate packages).
-- Message format: `scope: description` (no `feat`/`fix`/`chore` type prefix — see `AGENTS.md`).
+- Message format: `scope: description` (see `AGENTS.md`).
 - Stage **only** in-scope files; never stage excluded paths.
 - Create commits immediately — no review pass, no code changes.
 - **Do not push.**

--- a/.opencode.yaml
+++ b/.opencode.yaml
@@ -10,6 +10,7 @@ instructions: |
   - When reaching a natural stopping point, run the linter for impacted packages
   - Create a new branch before starting work
   - Use `gh pr create` to create a pull request
+  - Commit messages and PR titles use `scope: description` (no feat/fix/chore type prefix) — scope is the package or area most affected
   - Consumer-relevant changes need a `.changeset/*.md` before opening the PR — see agents/instructions/changesets.md
   - Ask for confirmation to ensure all work is complete and if so check that all packages build and pass linting and fix any problems that come up
   - Composer is the main product; it is made up from a set of plugins (in packages/plugins); each plugin has a `meta.ts` file

--- a/.opencode.yaml
+++ b/.opencode.yaml
@@ -10,7 +10,6 @@ instructions: |
   - When reaching a natural stopping point, run the linter for impacted packages
   - Create a new branch before starting work
   - Use `gh pr create` to create a pull request
-  - Use "Conventional Commits" for PR titles
   - Ask for confirmation to ensure all work is complete and if so check that all packages build and pass linting and fix any problems that come up
   - Composer is the main product; it is made up from a set of plugins (in packages/plugins); each plugin has a `meta.ts` file
   - Use single quotes for strings in Typescript

--- a/.opencode.yaml
+++ b/.opencode.yaml
@@ -10,7 +10,7 @@ instructions: |
   - When reaching a natural stopping point, run the linter for impacted packages
   - Create a new branch before starting work
   - Use `gh pr create` to create a pull request
-  - Commit messages and PR titles use `scope: description` (no feat/fix/chore type prefix) — scope is the package or area most affected
+  - Commit messages and PR titles use `scope: description` — scope is the package or area most affected
   - Consumer-relevant changes need a `.changeset/*.md` before opening the PR — see agents/instructions/changesets.md
   - Ask for confirmation to ensure all work is complete and if so check that all packages build and pass linting and fix any problems that come up
   - Composer is the main product; it is made up from a set of plugins (in packages/plugins); each plugin has a `meta.ts` file

--- a/.opencode.yaml
+++ b/.opencode.yaml
@@ -10,6 +10,7 @@ instructions: |
   - When reaching a natural stopping point, run the linter for impacted packages
   - Create a new branch before starting work
   - Use `gh pr create` to create a pull request
+  - Consumer-relevant changes need a `.changeset/*.md` before opening the PR — see agents/instructions/changesets.md
   - Ask for confirmation to ensure all work is complete and if so check that all packages build and pass linting and fix any problems that come up
   - Composer is the main product; it is made up from a set of plugins (in packages/plugins); each plugin has a `meta.ts` file
   - Use single quotes for strings in Typescript

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,9 @@ Deeper conventions:
 - Commit hygiene → see "Commit nothing silently" in Non-negotiables.
 - Creating or landing a PR is a procedure — use the `submit-pr` and `land`
   skills. Always surface the Composer preview URL next to the PR link.
+- Consumer-relevant changes need a `.changeset/*.md` before opening the PR —
+  see [`agents/instructions/changesets.md`](agents/instructions/changesets.md)
+  for when to add one, which package to name, and bump levels.
 
 ## Where things live
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,11 @@ Deeper conventions:
 
 ## Git & PR workflow
 
+- **Commit messages and PR titles: `scope: description`** — no type prefix
+  (`feat`/`fix`/`chore`/…). Scope is the package or area most affected (e.g.
+  `echo`, `plugin-markdown`, `release`), description is a concise, imperative
+  summary. Not CI-enforced — a convention, not a gate. ([Why not Conventional
+  Commits?](https://sumnerevans.com/posts/software-engineering/stop-using-conventional-commits/))
 - **CI is one workflow, "Check"** — build, test, lint, fmt. A red Check is your
   failure, not pre-existing; fix the root cause on the branch, never merge
   around it. Inspect: `gh run list --branch <branch> --workflow "Check"`, then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,6 @@ Deeper conventions:
 
 ## Git & PR workflow
 
-- **PR titles use conventional-commit format**, scope when relevant:
-  `feat(echo): add group aggregates`, `fix: resolve subscription leak`,
-  `refactor: simplify error handling`, `docs: update Space API`.
 - **CI is one workflow, "Check"** — build, test, lint, fmt. A red Check is your
   failure, not pre-existing; fix the root cause on the branch, never merge
   around it. Inspect: `gh run list --branch <branch> --workflow "Check"`, then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,11 +111,9 @@ Deeper conventions:
 
 ## Git & PR workflow
 
-- **Commit messages and PR titles: `scope: description`** — no type prefix
-  (`feat`/`fix`/`chore`/…). Scope is the package or area most affected (e.g.
-  `echo`, `plugin-markdown`, `release`), description is a concise, imperative
-  summary. Not CI-enforced — a convention, not a gate. ([Why not Conventional
-  Commits?](https://sumnerevans.com/posts/software-engineering/stop-using-conventional-commits/))
+- **Commit messages and PR titles: `scope: description`.** Scope is the
+  package or area most affected (e.g. `echo`, `plugin-markdown`, `release`);
+  description is a concise, imperative summary.
 - **CI is one workflow, "Check"** — build, test, lint, fmt. A red Check is your
   failure, not pre-existing; fix the root cause on the branch, never merge
   around it. Inspect: `gh run list --branch <branch> --workflow "Check"`, then

--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -158,7 +158,7 @@ DXOS is **trunk-based**: `main` is the only long-lived integration branch.
 
 - Work happens on feature branches that merge to `main` via PRs; the **Check** workflow (build, test, lint, fmt) must pass. External contributors fork and PR from their fork.
 - Feature branches are **squashed** on merge, keeping `main` linear.
-- Consumer-relevant changes carry a `.changeset/*.md` — see the [changeset authoring guide](./agents/instructions/changesets.md). (There is no longer a CI-enforced conventional-commit PR-title check; conventional PR titles remain a documented convention — see the PR Naming Convention in `AGENTS.md`.)
+- Consumer-relevant changes carry a `.changeset/*.md` — see the [changeset authoring guide](./agents/instructions/changesets.md). PR titles and commit messages have no required format — write them clear and descriptive.
 - `labs` / `staging` / `production` are **deploy environments**, not long-lived branches — you deploy a chosen commit to one via the Deploy Apps workflow, and "what's deployed where" is tracked by floating `<app>/<environment>` git tags.
 
 Full design (versioning policy, publish groups, cross-repo contract): [`.github/RELEASE-SPEC.md`](./.github/RELEASE-SPEC.md).

--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -158,7 +158,7 @@ DXOS is **trunk-based**: `main` is the only long-lived integration branch.
 
 - Work happens on feature branches that merge to `main` via PRs; the **Check** workflow (build, test, lint, fmt) must pass. External contributors fork and PR from their fork.
 - Feature branches are **squashed** on merge, keeping `main` linear.
-- Consumer-relevant changes carry a `.changeset/*.md` — see the [changeset authoring guide](./agents/instructions/changesets.md). PR titles and commit messages use `scope: description` (no `feat`/`fix`/`chore` type prefix) — see `AGENTS.md`.
+- Consumer-relevant changes carry a `.changeset/*.md` — see the [changeset authoring guide](./agents/instructions/changesets.md). PR titles and commit messages use `scope: description` — see `AGENTS.md`.
 - `labs` / `staging` / `production` are **deploy environments**, not long-lived branches — you deploy a chosen commit to one via the Deploy Apps workflow, and "what's deployed where" is tracked by floating `<app>/<environment>` git tags.
 
 Full design (versioning policy, publish groups, cross-repo contract): [`.github/RELEASE-SPEC.md`](./.github/RELEASE-SPEC.md).

--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -158,7 +158,7 @@ DXOS is **trunk-based**: `main` is the only long-lived integration branch.
 
 - Work happens on feature branches that merge to `main` via PRs; the **Check** workflow (build, test, lint, fmt) must pass. External contributors fork and PR from their fork.
 - Feature branches are **squashed** on merge, keeping `main` linear.
-- Consumer-relevant changes carry a `.changeset/*.md` — see the [changeset authoring guide](./agents/instructions/changesets.md). PR titles and commit messages use `scope: description` — see `AGENTS.md`.
+- Consumer-relevant changes carry a `.changeset/*.md` — see the [changeset authoring guide](./agents/instructions/changesets.md). PR titles and commit messages use `scope: description`.
 - `labs` / `staging` / `production` are **deploy environments**, not long-lived branches — you deploy a chosen commit to one via the Deploy Apps workflow, and "what's deployed where" is tracked by floating `<app>/<environment>` git tags.
 
 Full design (versioning policy, publish groups, cross-repo contract): [`.github/RELEASE-SPEC.md`](./.github/RELEASE-SPEC.md).

--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -158,7 +158,7 @@ DXOS is **trunk-based**: `main` is the only long-lived integration branch.
 
 - Work happens on feature branches that merge to `main` via PRs; the **Check** workflow (build, test, lint, fmt) must pass. External contributors fork and PR from their fork.
 - Feature branches are **squashed** on merge, keeping `main` linear.
-- Consumer-relevant changes carry a `.changeset/*.md` — see the [changeset authoring guide](./agents/instructions/changesets.md). PR titles and commit messages have no required format — write them clear and descriptive.
+- Consumer-relevant changes carry a `.changeset/*.md` — see the [changeset authoring guide](./agents/instructions/changesets.md). PR titles and commit messages use `scope: description` (no `feat`/`fix`/`chore` type prefix) — see `AGENTS.md`.
 - `labs` / `staging` / `production` are **deploy environments**, not long-lived branches — you deploy a chosen commit to one via the Deploy Apps workflow, and "what's deployed where" is tracked by floating `<app>/<environment>` git tags.
 
 Full design (versioning policy, publish groups, cross-repo contract): [`.github/RELEASE-SPEC.md`](./.github/RELEASE-SPEC.md).


### PR DESCRIPTION
## Summary

Two related changes to agent-instruction docs:

1. **Removed conventional-commit mandates.** The conventional-commit PR-title CI gate (`validate-pr-title.yaml`) was already removed in #12106 when the release pipeline moved to Changesets, which doesn't parse commit history at all — no PR title or commit message carries any release-automation weight anymore. Several docs still told agents to use conventional-commit format; dropped those mandates (the style itself isn't prohibited, just no longer required).
2. **Replaced it with `scope: description`.** Per [this post](https://sumnerevans.com/posts/software-engineering/stop-using-conventional-commits/), Conventional Commits elevates type (`feat`/`fix`/`chore`) over scope and makes scope optional — but scope is what's actually useful when scanning history or debugging an area. Linux, FreeBSD, Git, and Go all use the simpler `scope: description` instead, e.g. `i2c: virtio: mark device ready before registering the adapter`. Not CI-enforced — a convention, not a gate.

## Changed

- `AGENTS.md` (canonical, symlinked as `CLAUDE.md`/`GEMINI.md`): the Git & PR workflow section now states the `scope: description` rule once; every other doc below points there instead of repeating it.
- `REPOSITORY_GUIDE.md`, `.opencode.yaml`: updated to match.
- `.agents/skills/submit-pr/SKILL.md`: PR-title step + new changeset step (a PR was missing a pointer to the changeset authoring guide).
- `.agents/skills/land/SKILL.md`, `.claude/commands/commit.md`, `.claude/agents/pr-merge-readiness-verifier.md`: commit-message guidance updated to match.

## Left untouched (historical/task-specific, not living instructions)

`CHANGELOG.md`'s auto-generated 2023 entry, and dated plan docs under `plans/` and `agents/superpowers/plans/` that reference conventional commits as part of a specific already-scoped task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated contribution and workflow guidance to require `scope: description` for commit messages and pull request titles (removing Conventional Commits references).
  - Added a required **Changeset** step for consumer-relevant updates before opening a pull request.
  - Refreshed PR submission, review, and CI-repair instructions to match the new title/message format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->