### PR TITLE
docs: document the tag-clobber fix for floating deploy-pointer tags

### DIFF
--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -183,7 +183,9 @@ Because these tags are force-moved on every deploy, a plain `git pull`/`git fetc
 git config remote.origin.tagOpt --no-tags
 ```
 
-You can still pull a specific one on demand: `git fetch origin tag composer/labs`, or check without touching local refs at all: `git ls-remote --tags origin 'composer/*'`.
+You can still pull a specific one on demand: `git fetch origin tag composer/labs --force` (still needs
+`--force` — an explicit fetch doesn't skip the clobber check, only the automatic tag-following does), or
+check without touching local refs at all: `git ls-remote --tags origin 'composer/*'`.
 
 | Env            | Trigger                | Apps               | Notes                                    |
 | -------------- | ---------------------- | ------------------ | ---------------------------------------- |

--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -177,6 +177,14 @@ Packages ship as two lockstep groups — **A: Core/SDK** (`@dxos/echo`, `@dxos/c
 
 **Deploy apps.** One entry point: the **Deploy Apps** workflow (`deploy-apps.yml`) — pick an environment and the app set follows. Deploys go to Cloudflare Workers Static Assets, decoupled from npm; "what's deployed where" is tracked by floating `<app>/<env>` git tags. Deployable apps are listed in [`.github/workflows/scripts/apps.mjs`](./.github/workflows/scripts/apps.mjs); everything else — Worker name, bundle task, output dir, target environments — derives from each app's `wrangler.jsonc`.
 
+Because these tags are force-moved on every deploy, a plain `git pull`/`git fetch` will reject them once your local clone has a stale copy (`! [rejected] composer/labs -> composer/labs (would clobber existing tag)`). Turn off automatic tag-following once per clone so routine fetches stay quiet:
+
+```bash
+git config remote.origin.tagOpt --no-tags
+```
+
+You can still pull a specific one on demand: `git fetch origin tag composer/labs`, or check without touching local refs at all: `git ls-remote --tags origin 'composer/*'`.
+
 | Env            | Trigger                | Apps               | Notes                                    |
 | -------------- | ---------------------- | ------------------ | ---------------------------------------- |
 | **main**       | auto on push to `main` | all `main`-enabled | rolling preview; no native build         |


### PR DESCRIPTION
## Summary
- `deploy-apps.yml` force-moves the `<app>/<env>` deploy-pointer tags (e.g. `composer/labs`) on every deploy. A plain `git pull`/`git fetch` rejects them once a local clone already has the old tag: `! [rejected] composer/labs -> composer/labs (would clobber existing tag)`.
- Documents the fix in `REPOSITORY_GUIDE.md`'s Deploy apps section: turn off automatic tag-following once per clone (`git config remote.origin.tagOpt --no-tags`), with the on-demand commands to still fetch/inspect a specific tag when needed.

## Test plan
- [x] `oxfmt --check` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling force-moved deployment pointer tags during repository updates.
  * Included recommended Git commands to fetch specific pointer tags safely and to list matching remote tags without touching local refs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->