### PR TITLE
scripts: add secrets.mjs to populate Cloudflare Worker secrets from 1Password

### DIFF
--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -211,17 +211,20 @@ gh run watch
 
 Handy as aliases — e.g. `gh alias set deploy-labs 'workflow run deploy-apps.yml -f environment=labs'`, then just `gh deploy-labs`.
 
-**Worker secrets.** `pnpm secrets` (`scripts/secrets.mjs`) populates a Cloudflare Worker's secrets (e.g. composer's `SIGNOZ_INGESTION_KEY`) from a 1Password item, matched by section label — a field under "shared" applies to every target, a field under a section named after the raw Worker name (e.g. `composer-main`) applies only there. Requires `CLOUDFLARE_ACCOUNT_ID` in the environment (same variable CI uses):
+**Worker secrets.** `pnpm secrets` (`scripts/secrets.mjs`) populates a Cloudflare Worker's secrets (e.g. composer's `SIGNOZ_INGESTION_KEY`) from a 1Password item, matched by section label — a field under "shared" applies to every target, a field under a section named after the raw Worker name (e.g. `composer-main`) applies only there. Defaults to the "dxos app worker secrets" item (pinned by UUID — stable even if the item is renamed); pass `--item` to target a different one. Requires `CLOUDFLARE_ACCOUNT_ID` in the environment (same variable CI uses):
 
 ```bash
 # Push secrets to the deployed composer-labs Worker.
-pnpm secrets remote labs --item "dxos app worker secrets"
+pnpm secrets remote labs
 
 # See what would be pushed without making any change.
-pnpm secrets remote main --item "dxos app worker secrets" --dry-run
+pnpm secrets remote main --dry-run
 
 # Write .dev.vars for local `wrangler dev`.
-pnpm secrets dev --item "dxos app worker secrets"
+pnpm secrets dev
+
+# Target a different 1Password item.
+pnpm secrets remote labs --item "some other item"
 ```
 
 ### New npm packages

--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -211,6 +211,19 @@ gh run watch
 
 Handy as aliases — e.g. `gh alias set deploy-labs 'workflow run deploy-apps.yml -f environment=labs'`, then just `gh deploy-labs`.
 
+**Worker secrets.** `pnpm secrets` (`scripts/secrets.mjs`) populates a Cloudflare Worker's secrets (e.g. composer's `SIGNOZ_INGESTION_KEY`) from a 1Password item, matched by section label — a field under "shared" applies to every target, a field under a section named after the raw Worker name (e.g. `composer-main`) applies only there. Requires `CLOUDFLARE_ACCOUNT_ID` in the environment (same variable CI uses):
+
+```bash
+# Push secrets to the deployed composer-labs Worker.
+pnpm secrets remote labs --item "dxos app worker secrets"
+
+# See what would be pushed without making any change.
+pnpm secrets remote main --item "dxos app worker secrets" --dry-run
+
+# Write .dev.vars for local `wrangler dev`.
+pnpm secrets dev --item "dxos app worker secrets"
+```
+
 ### New npm packages
 
 New packages are created with `"private": true` in their `package.json` (see [New Packages](./AGENTS.md#new-packages)). Publishing a package to npm for the first time requires an initial manual publish, since npm's OIDC trusted publishing (used by [`publish-all.yml`](https://github.com/dxos/dxos/blob/main/.github/workflows/publish-all.yml)) can only be configured for a package that already exists on the registry:

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "prepare": "[ \"$HUSKY\" != \"0\" ] && husky install || true",
     "publish-package": "node scripts/publish-package.mjs",
     "query-logs": "node scripts/query-logs.mjs",
+    "secrets": "node scripts/secrets.mjs",
     "test": "moon run :test -- --no-file-parallelism",
     "test-browser": "MOON_CONCURRENCY=4 moon run :test-browser -- --no-file-parallelism",
     "test-storybook": "MOON_CONCURRENCY=4 moon run :test-storybook -- --no-file-parallelism",

--- a/scripts/secrets.mjs
+++ b/scripts/secrets.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+//
+// Copyright 2026 DXOS.org
+//
+
+// Populate Cloudflare Worker secrets (e.g. composer's SIGNOZ_INGESTION_KEY) from a 1Password item, for
+// either local dev (`.dev.vars`, read by `wrangler dev`) or a deployed Worker (`wrangler secret put`).
+//
+// The 1Password item's fields are matched by section label: a field in a section named "shared" applies to
+// every target; a field in a section matching the raw Cloudflare Worker name (e.g. "composer-main", from
+// wrangler.jsonc's `env.<env>.name`) applies only there. Production's Worker is currently the bare
+// "composer" (the legacy Pages-era name, retired once that project goes away), so a "composer-production"
+// 1Password section won't match anything until then. Only CONCEALED fields are read.
+//
+// Requires `CLOUDFLARE_ACCOUNT_ID` in the environment (same variable CI uses) — the account associated
+// with this token has more than one account, so wrangler can't disambiguate non-interactively without it.
+//
+// Usage:
+//   secrets.mjs dev    --item <1password-item> [--config <wrangler.jsonc>]
+//   secrets.mjs remote <env> --item <1password-item> [--config <wrangler.jsonc>] [--dry-run]
+//
+// <config> is a path to a wrangler.jsonc (default packages/apps/composer-app/wrangler.jsonc — the only
+// app with secrets today). <env> must be one of that config's `env.*` keys (e.g. main, labs, staging,
+// production). `--dry-run` lists what would be pushed without calling `wrangler secret put`.
+//
+// Examples:
+//   node scripts/secrets.mjs dev --item "dxos app worker secrets"
+//   node scripts/secrets.mjs remote main --item "dxos app worker secrets"
+
+import JSON5 from 'json5';
+import { execFileSync, execSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DEFAULT_CONFIG = 'packages/apps/composer-app/wrangler.jsonc';
+
+const args = process.argv.slice(2);
+const mode = args[0];
+if (mode !== 'dev' && mode !== 'remote') {
+  console.error('usage: secrets.mjs <dev|remote> [env] --item <1password-item> [--config <wrangler.jsonc>]');
+  process.exit(1);
+}
+
+const flagValue = (name) => {
+  const i = args.indexOf(`--${name}`);
+  return i === -1 ? undefined : args[i + 1];
+};
+
+const item = flagValue('item');
+if (!item) {
+  console.error('usage: secrets.mjs <dev|remote> [env] --item <1password-item> [--config <wrangler.jsonc>]');
+  process.exit(1);
+}
+const configPath = flagValue('config') ?? DEFAULT_CONFIG;
+
+// Positional env, only for `remote` (skip over a leading `--flag value` pair if `mode` is the only positional).
+const env = mode === 'remote' ? args[1] : undefined;
+if (mode === 'remote' && (!env || env.startsWith('--'))) {
+  console.error('usage: secrets.mjs remote <env> --item <1password-item> [--config <wrangler.jsonc>]');
+  process.exit(1);
+}
+
+const root = execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+const absConfigPath = join(root, configPath);
+if (!existsSync(absConfigPath)) {
+  console.error(`Config not found: ${configPath}`);
+  process.exit(1);
+}
+const wranglerConf = JSON5.parse(readFileSync(absConfigPath, 'utf8'));
+
+// The 1Password section label is matched against the raw Cloudflare Worker name (production's is currently
+// the bare "composer" — the legacy Pages-era name, retired once that project goes away — so it won't match
+// a "composer-production" section until then; every other env's name already matches its section exactly).
+let workerName;
+if (mode === 'remote') {
+  workerName = wranglerConf.env?.[env]?.name;
+  if (!workerName) {
+    const valid = Object.keys(wranglerConf.env ?? {}).join(', ') || '(none defined)';
+    console.error(`No env.${env} in ${configPath}. Valid envs: ${valid}`);
+    process.exit(1);
+  }
+} else {
+  workerName = wranglerConf.name;
+}
+
+console.log(`Fetching secrets from 1Password item "${item}" (section: "shared" or "${workerName}")`);
+let itemJson;
+try {
+  itemJson = JSON.parse(execFileSync('op', ['item', 'get', item, '--format', 'json'], { encoding: 'utf8' }));
+} catch (err) {
+  console.error(`Failed to read 1Password item "${item}": ${err.stderr?.toString().trim() || err.message}`);
+  process.exit(1);
+}
+const secrets = itemJson.fields.filter(
+  (field) =>
+    field.type === 'CONCEALED' &&
+    field.value !== undefined &&
+    (field.section?.label === 'shared' || field.section?.label === workerName),
+);
+
+if (secrets.length === 0) {
+  console.log(`No matching CONCEALED fields (section "shared" or "${workerName}") — nothing to do.`);
+  process.exit(0);
+}
+
+if (mode === 'dev') {
+  const devVarsPath = join(root, configPath, '..', '.dev.vars');
+  console.log(`Writing ${devVarsPath}`);
+  const lines = secrets.map((field) => `${field.label}=${field.value}`);
+  writeFileSync(devVarsPath, lines.join('\n') + '\n');
+  for (const field of secrets) {
+    console.log(`  ${field.label}`);
+  }
+  console.log('Done.');
+} else {
+  // A name already declared as a `vars` entry for this env can't also be `secret put` under the same
+  // binding name.
+  const targetVars = wranglerConf.env?.[env]?.vars ?? wranglerConf.vars ?? {};
+  const skipLabels = new Set(Object.keys(targetVars));
+  const dryRun = args.includes('--dry-run');
+
+  if (!dryRun) {
+    try {
+      execFileSync('pnpm', ['exec', 'wrangler', 'deployments', 'list', '--config', absConfigPath, '--env', env], {
+        stdio: 'pipe',
+      });
+    } catch (err) {
+      const stderr = err.stderr?.toString() ?? '';
+      if (/could not find|does not exist/i.test(stderr)) {
+        console.error(`Worker "${workerName}" does not exist — deploy it first (Deploy Apps) before pushing secrets.`);
+      } else {
+        console.error(`Could not verify worker "${workerName}" exists:\n${stderr || err.message}`);
+      }
+      process.exit(1);
+    }
+  }
+
+  console.log(`${dryRun ? '[dry-run] Would push' : 'Pushing'} secrets to "${workerName}" (env=${env})`);
+  const failed = [];
+  for (const field of secrets) {
+    if (skipLabels.has(field.label)) {
+      console.log(`  skip ${field.label} (already a wrangler var for this env)`);
+      continue;
+    }
+    console.log(`  ${field.label}`);
+    if (dryRun) {
+      continue;
+    }
+    try {
+      execFileSync(
+        'pnpm',
+        ['exec', 'wrangler', 'secret', 'put', field.label, '--config', absConfigPath, '--env', env],
+        { input: field.value, stdio: ['pipe', 'inherit', 'inherit'] },
+      );
+    } catch (err) {
+      console.error(`  failed: ${field.label}: ${err.message}`);
+      failed.push(field.label);
+    }
+  }
+
+  if (failed.length > 0) {
+    console.error(`Failed to push ${failed.length} secret(s): ${failed.join(', ')}`);
+    process.exit(1);
+  }
+  console.log('Done.');
+}

--- a/scripts/secrets.mjs
+++ b/scripts/secrets.mjs
@@ -16,16 +16,20 @@
 // with this token has more than one account, so wrangler can't disambiguate non-interactively without it.
 //
 // Usage:
-//   secrets.mjs dev    --item <1password-item> [--config <wrangler.jsonc>]
-//   secrets.mjs remote <env> --item <1password-item> [--config <wrangler.jsonc>] [--dry-run]
+//   secrets.mjs dev    [--item <1password-item-or-uuid>] [--config <wrangler.jsonc>]
+//   secrets.mjs remote <env> [--item <1password-item-or-uuid>] [--config <wrangler.jsonc>] [--dry-run]
+//
+// `--item` defaults to the "dxos app worker secrets" item's UUID — pinned rather than its display name,
+// since the name can be renamed/retitled in 1Password but the UUID never changes. Pass `--item` to target
+// a different item.
 //
 // <config> is a path to a wrangler.jsonc (default packages/apps/composer-app/wrangler.jsonc — the only
 // app with secrets today). <env> must be one of that config's `env.*` keys (e.g. main, labs, staging,
 // production). `--dry-run` lists what would be pushed without calling `wrangler secret put`.
 //
 // Examples:
-//   node scripts/secrets.mjs dev --item "dxos app worker secrets"
-//   node scripts/secrets.mjs remote main --item "dxos app worker secrets"
+//   node scripts/secrets.mjs dev
+//   node scripts/secrets.mjs remote main
 
 import JSON5 from 'json5';
 import { execFileSync, execSync } from 'node:child_process';
@@ -33,11 +37,13 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const DEFAULT_CONFIG = 'packages/apps/composer-app/wrangler.jsonc';
+// 1Password item "dxos app worker secrets" — referenced by UUID (stable) rather than name (renamable).
+const DEFAULT_ITEM = 'x5yuqygiiomwsd2fikbzvwpd6i';
 
 const args = process.argv.slice(2);
 const mode = args[0];
 if (mode !== 'dev' && mode !== 'remote') {
-  console.error('usage: secrets.mjs <dev|remote> [env] --item <1password-item> [--config <wrangler.jsonc>]');
+  console.error('usage: secrets.mjs <dev|remote> [env] [--item <1password-item>] [--config <wrangler.jsonc>]');
   process.exit(1);
 }
 
@@ -46,17 +52,13 @@ const flagValue = (name) => {
   return i === -1 ? undefined : args[i + 1];
 };
 
-const item = flagValue('item');
-if (!item) {
-  console.error('usage: secrets.mjs <dev|remote> [env] --item <1password-item> [--config <wrangler.jsonc>]');
-  process.exit(1);
-}
+const item = flagValue('item') ?? DEFAULT_ITEM;
 const configPath = flagValue('config') ?? DEFAULT_CONFIG;
 
 // Positional env, only for `remote` (skip over a leading `--flag value` pair if `mode` is the only positional).
 const env = mode === 'remote' ? args[1] : undefined;
 if (mode === 'remote' && (!env || env.startsWith('--'))) {
-  console.error('usage: secrets.mjs remote <env> --item <1password-item> [--config <wrangler.jsonc>]');
+  console.error('usage: secrets.mjs remote <env> [--item <1password-item>] [--config <wrangler.jsonc>]');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- New `scripts/secrets.mjs`, mirroring `edge/scripts/secrets.mjs` (fetch CONCEALED fields from a 1Password item, matched by section label) but fitting this repo's own wrangler-script family style (`deploy-env.mjs`, `apps.mjs`, `bundle-env.mjs` — plain `node:child_process` + JSON5, no zx/yargs) and its per-app `wrangler.jsonc` `env.*` layout.
- Two modes: `dev` (writes `<app>/.dev.vars` for local `wrangler dev`) and `remote <env>` (`wrangler secret put` against the deployed Worker, skipping any label already declared as a wrangler `vars` entry for that env). `--dry-run` lists what would be pushed without executing anything.
- Matching is by 1Password section label against the raw Cloudflare Worker name (e.g. `composer-main`) — production is currently the bare `composer` (the legacy Pages-era name, retired once that project goes away), so a `composer-production` section won't match until then; every other env already matches exactly.
- Requires `CLOUDFLARE_ACCOUNT_ID` in the environment (same variable CI already uses) — the token here has more than one account, so wrangler can't disambiguate non-interactively without it.

## Test plan
- [x] Verified end-to-end against the real `dxos app worker secrets` 1Password item: `--dry-run` against `main`/`labs`/`staging` all resolved the expected `SIGNOZ_INGESTION_KEY` field correctly.
- [x] Ran for real against `composer-main` and `composer-labs` — both had been 503ing `/api/otel/v1/logs` with `OTel proxy not configured` (missing secret); both now return `200`, matching production.
- [x] `oxfmt --check` clean; `node --check` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line utility to sync Cloudflare Worker secrets from 1Password.
  * Supports remote secret publishing, local `.dev.vars` generation, alternate items, environment targeting, and dry runs.
  * Filters secrets by shared or worker-specific sections and avoids conflicts with existing configuration variables.

* **Documentation**
  * Added setup instructions, required environment variables, usage examples, and troubleshooting guidance for secret management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->