### PR TITLE
ci(deploy-apps): restore Discord notifications for labs/staging/production deploys

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -249,6 +249,18 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      # Notify on labs/staging/production only — main is the rolling auto-deploy-on-push preview and would
+      # be constant noise. Matches the "Update deploy pointer tags" gate below.
+      - name: Notify Discord — deploy started
+        if: env.DEPLOY_ENV != 'main'
+        env:
+          DX_DISCORD_WEBHOOK_URL: ${{ secrets.DX_DISCORD_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          payload=$(jq -nc --arg env "$DEPLOY_ENV" --arg app "$DEPLOY_APP" --arg url "$RUN_URL" \
+            '{content: (":rocket: Deploying **" + $app + "** to `" + $env + "`\nRun: " + $url)}')
+          curl -sS -X POST "$DX_DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "$payload"
+
       # Reuse the prebuilt Composer bundle when the prep job produced one — populating out/composer means
       # bundle-env.mjs reuses it instead of rebuilding.
       - name: Download Composer bundle
@@ -281,6 +293,26 @@ jobs:
             git tag -f "$tag" "$DEPLOY_REF"
             git push -f origin "refs/tags/$tag"
           done
+
+      - name: Notify Discord — deploy succeeded
+        if: success() && env.DEPLOY_ENV != 'main'
+        env:
+          DX_DISCORD_WEBHOOK_URL: ${{ secrets.DX_DISCORD_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          payload=$(jq -nc --arg env "$DEPLOY_ENV" --arg app "$DEPLOY_APP" --arg url "$RUN_URL" \
+            '{content: (":white_check_mark: Deployed **" + $app + "** to `" + $env + "`\nRun: " + $url)}')
+          curl -sS -X POST "$DX_DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "$payload"
+
+      - name: Notify Discord — deploy failed
+        if: failure() && env.DEPLOY_ENV != 'main'
+        env:
+          DX_DISCORD_WEBHOOK_URL: ${{ secrets.DX_DISCORD_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          payload=$(jq -nc --arg env "$DEPLOY_ENV" --arg app "$DEPLOY_APP" --arg url "$RUN_URL" \
+            '{content: (":x: Deploy of **" + $app + "** to `" + $env + "` failed\nRun: " + $url)}')
+          curl -sS -X POST "$DX_DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "$payload"
 
   # Desktop/mobile build for Composer, for the named environments (not `main` — a signed build per push is
   # too costly). CrabNebula channel is derived from the environment inside the reusable workflow; iOS → App

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -227,11 +227,6 @@ jobs:
           lfs: true
           ref: ${{ needs.release.outputs.sha || github.sha }}
 
-      # Fires before any setup/deploy work so every attempt gets a "started" message — including one that
-      # fails during env setup — pairing correctly with the "succeeded"/"failed" steps below. Notify on
-      # labs/staging/production only — main is the rolling auto-deploy-on-push preview and would be
-      # constant noise. continue-on-error: a webhook hiccup must never block the actual deploy or read as
-      # a deploy failure; --fail-with-body still surfaces a bad response in the log for debugging.
       - name: Notify Discord — deploy started
         if: env.DEPLOY_ENV != 'main'
         continue-on-error: true

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -227,6 +227,22 @@ jobs:
           lfs: true
           ref: ${{ needs.release.outputs.sha || github.sha }}
 
+      # Fires before any setup/deploy work so every attempt gets a "started" message — including one that
+      # fails during env setup — pairing correctly with the "succeeded"/"failed" steps below. Notify on
+      # labs/staging/production only — main is the rolling auto-deploy-on-push preview and would be
+      # constant noise. continue-on-error: a webhook hiccup must never block the actual deploy or read as
+      # a deploy failure; --fail-with-body still surfaces a bad response in the log for debugging.
+      - name: Notify Discord — deploy started
+        if: env.DEPLOY_ENV != 'main'
+        continue-on-error: true
+        env:
+          DX_DISCORD_WEBHOOK_URL: ${{ secrets.DX_DISCORD_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          payload=$(jq -nc --arg env "$DEPLOY_ENV" --arg app "$DEPLOY_APP" --arg url "$RUN_URL" \
+            '{content: (":rocket: Deploying **" + $app + "** to `" + $env + "`\nRun: " + $url)}')
+          curl -sS --fail-with-body -X POST "$DX_DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "$payload"
+
       # Select the env file by the DEPLOY environment (not the git branch) — environment is a deploy
       # parameter, so a production deploy running from main must still read env/production.
       - name: Set environment variables (Cloudflare creds, PostHog, …)
@@ -248,18 +264,6 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
-
-      # Notify on labs/staging/production only — main is the rolling auto-deploy-on-push preview and would
-      # be constant noise. Matches the "Update deploy pointer tags" gate below.
-      - name: Notify Discord — deploy started
-        if: env.DEPLOY_ENV != 'main'
-        env:
-          DX_DISCORD_WEBHOOK_URL: ${{ secrets.DX_DISCORD_WEBHOOK_URL }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          payload=$(jq -nc --arg env "$DEPLOY_ENV" --arg app "$DEPLOY_APP" --arg url "$RUN_URL" \
-            '{content: (":rocket: Deploying **" + $app + "** to `" + $env + "`\nRun: " + $url)}')
-          curl -sS -X POST "$DX_DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "$payload"
 
       # Reuse the prebuilt Composer bundle when the prep job produced one — populating out/composer means
       # bundle-env.mjs reuses it instead of rebuilding.
@@ -296,23 +300,25 @@ jobs:
 
       - name: Notify Discord — deploy succeeded
         if: success() && env.DEPLOY_ENV != 'main'
+        continue-on-error: true
         env:
           DX_DISCORD_WEBHOOK_URL: ${{ secrets.DX_DISCORD_WEBHOOK_URL }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           payload=$(jq -nc --arg env "$DEPLOY_ENV" --arg app "$DEPLOY_APP" --arg url "$RUN_URL" \
             '{content: (":white_check_mark: Deployed **" + $app + "** to `" + $env + "`\nRun: " + $url)}')
-          curl -sS -X POST "$DX_DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "$payload"
+          curl -sS --fail-with-body -X POST "$DX_DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "$payload"
 
       - name: Notify Discord — deploy failed
         if: failure() && env.DEPLOY_ENV != 'main'
+        continue-on-error: true
         env:
           DX_DISCORD_WEBHOOK_URL: ${{ secrets.DX_DISCORD_WEBHOOK_URL }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           payload=$(jq -nc --arg env "$DEPLOY_ENV" --arg app "$DEPLOY_APP" --arg url "$RUN_URL" \
             '{content: (":x: Deploy of **" + $app + "** to `" + $env + "` failed\nRun: " + $url)}')
-          curl -sS -X POST "$DX_DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "$payload"
+          curl -sS --fail-with-body -X POST "$DX_DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "$payload"
 
   # Desktop/mobile build for Composer, for the named environments (not `main` — a signed build per push is
   # too costly). CrabNebula channel is derived from the environment inside the reusable workflow; iOS → App


### PR DESCRIPTION
## Summary
- The old `deploy-apps.sh` (pre-Changesets-cutover) posted deploy start/success/failure to Discord (`DX_DISCORD_WEBHOOK_URL`), gated to `production`/`staging`/`labs`/`dev` — `main`/`dev` (the constant auto-deploying branch) was deliberately excluded to avoid noise.
- That notification was dropped when `deploy-apps.sh` was folded into `deploy-apps.yml` during the release-pipeline overhaul. This restores it as three steps in the `deploy` job — start, success, failure — gated the same way as the existing "Update deploy pointer tags" step (`env.DEPLOY_ENV != 'main'`), so `main`'s rolling preview deploys stay silent and `labs`/`staging`/`production` notify.
- Uses the same jq + curl Discord convention already established in `deploy-tauri.yaml`'s "Notify Discord on iOS build failure" step, rather than reviving the old bash `notifySuccess`/`notifyFailure` functions.

## Note — a separate, related gap
The old `publish-all.yml` (pre-Changesets) also posted npm-publish start/success/failure to Discord via a **different** secret, `DISCORD_NPM_PUBLISH_WEBHOOK` — ungated by environment (fired on every push-triggered publish attempt). That's not restored here since it's a distinct concern (different file, different secret, different trigger). Happy to add it as a follow-up if wanted.

## Test plan
- [x] YAML parses; step ordering verified (`Notify Discord — deploy started` right after `Setup`, before any bundling/deploy work; `succeeded`/`failed` after the pointer-tag step).
- [x] `oxfmt --check` clean.
- [ ] CI green.
- [ ] Manually verify on the next labs/staging/production dispatch that the Discord message actually posts (webhook secret is live in the org but untestable from this sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment status notifications for supported non-main environments.
  * Notifications are sent when deployments start, succeed, or fail, including the target environment, deployed apps, and a link to the workflow run.
  * Notification posting is resilient to webhook issues without blocking deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->