### PR TITLE
protocols: migrate QueryService RPC off protobuf to Effect schemas

### DIFF
--- a/.changeset/query-service-effect-schema.md
+++ b/.changeset/query-service-effect-schema.md
@@ -1,0 +1,5 @@
+---
+'@dxos/protocols': patch
+---
+
+Fix corruption of large query results containing emoji or other astral characters. The `QueryService` RPC now encodes its payloads with Effect schemas instead of protobuf, avoiding a `@protobufjs/utf8` bug that injected a lone surrogate into string fields larger than 8KB and broke object hydration.

--- a/packages/core/protocols/src/QueryService.test.ts
+++ b/packages/core/protocols/src/QueryService.test.ts
@@ -8,11 +8,6 @@ import { describe, expect, test } from 'vitest';
 import * as QueryService from './QueryService.ts';
 import { protoMessage } from './service-rpc.ts';
 
-// A 4-byte (astral) character at char offset 8191 makes protobufjs's `utf8.read` overshoot its 8192-unit
-// flush boundary, then a later block spreads a stale, reused `chunk` slot — injecting a lone low-surrogate
-// (`\udfe9` for U+1F7E9) and shifting every following code unit. The corrupted string then breaks JSON.parse.
-const buildLargeString = (): string => 'a'.repeat(8191) + '\u{1F7E9}' + 'b'.repeat(8192) + 'TAIL';
-
 describe('QueryService wire schema', () => {
   test('round-trips a >8KB documentJson containing an astral character', () => {
     const documentJson = buildLargeString();
@@ -63,3 +58,8 @@ describe('QueryService wire schema', () => {
     expect(decoded.results?.[0]?.documentJson).not.toEqual(documentJson);
   });
 });
+
+// A 4-byte (astral) character at char offset 8191 makes protobufjs's `utf8.read` overshoot its 8192-unit
+// flush boundary, then a later block spreads a stale, reused `chunk` slot — injecting a lone low-surrogate
+// (`\udfe9` for U+1F7E9) and shifting every following code unit. The corrupted string then breaks JSON.parse.
+const buildLargeString = (): string => 'a'.repeat(8191) + '\u{1F7E9}' + 'b'.repeat(8192) + 'TAIL';

--- a/packages/core/protocols/src/QueryService.test.ts
+++ b/packages/core/protocols/src/QueryService.test.ts
@@ -1,0 +1,65 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+import { describe, expect, test } from 'vitest';
+
+import * as QueryService from './QueryService.ts';
+import { protoMessage } from './service-rpc.ts';
+
+// A 4-byte (astral) character at char offset 8191 makes protobufjs's `utf8.read` overshoot its 8192-unit
+// flush boundary, then a later block spreads a stale, reused `chunk` slot — injecting a lone low-surrogate
+// (`\udfe9` for U+1F7E9) and shifting every following code unit. The corrupted string then breaks JSON.parse.
+const buildLargeString = (): string => 'a'.repeat(8191) + '\u{1F7E9}' + 'b'.repeat(8192) + 'TAIL';
+
+describe('QueryService wire schema', () => {
+  test('round-trips a >8KB documentJson containing an astral character', () => {
+    const documentJson = buildLargeString();
+    const response: QueryService.QueryResponse = {
+      queryId: 'q1',
+      results: [{ id: 'obj1', spaceId: 'space1', rank: 0, documentJson }],
+    };
+
+    const encode = Schema.encodeSync(QueryService.QueryResponse);
+    const decode = Schema.decodeSync(QueryService.QueryResponse);
+    const decoded = decode(encode(response));
+
+    const decodedJson = decoded.results?.[0]?.documentJson;
+    expect(decodedJson?.length).toEqual(documentJson.length);
+    expect(decodedJson).toEqual(documentJson);
+  });
+
+  test('round-trips a >8KB JSON payload with an astral character (JSON.parse succeeds)', () => {
+    // Emoji at absolute offset 8191 inside the JSON string; `{"body":"` is 9 chars, so 8182 leading `a`s.
+    const documentJson = '{"body":"' + 'a'.repeat(8182) + '\u{1F7E9}' + 'b'.repeat(8192) + '"}';
+    const response: QueryService.QueryResponse = {
+      results: [{ id: 'obj1', spaceId: 'space1', rank: 0, documentJson }],
+    };
+
+    const decoded = Schema.decodeSync(QueryService.QueryResponse)(
+      Schema.encodeSync(QueryService.QueryResponse)(response),
+    );
+
+    // Downstream index hydration does JSON.parse on this field; a lone surrogate would break it.
+    expect(() => JSON.parse(decoded.results?.[0]?.documentJson ?? '')).not.toThrow();
+  });
+
+  // Documents the root cause the inline Effect schema replaces: the protobuf codec that previously backed
+  // the query wire corrupts the same payload via `@protobufjs/utf8.read`. The bug surfaces only on the JS
+  // Reader path (a plain Uint8Array, as arrives over the browser worker MessagePort), not Node's native
+  // BufferReader — which is why it broke the browser mailbox story but not Node tests. Guards against
+  // regressing the wire encoding back to protobuf.
+  test('protobuf codec corrupts the same payload on the browser Reader path (root cause)', () => {
+    const documentJson = buildLargeString();
+    const message = protoMessage('dxos.echo.query.QueryResponse');
+    const encoded = Schema.encodeSync(message)({
+      results: [{ id: 'obj1', spaceId: 'space1', rank: 0, documentJson }],
+    });
+
+    // A plain (non-Buffer) Uint8Array forces protobufjs's JS Reader (utf8.read) instead of Node's
+    // native BufferReader, matching the structured-clone bytes delivered over the worker MessagePort.
+    const decoded = Schema.decodeSync(message)(new Uint8Array(encoded));
+    expect(decoded.results?.[0]?.documentJson).not.toEqual(documentJson);
+  });
+});

--- a/packages/core/protocols/src/QueryService.ts
+++ b/packages/core/protocols/src/QueryService.ts
@@ -5,21 +5,110 @@
 import * as Rpc from '@effect/rpc/Rpc';
 import type * as RpcClient from '@effect/rpc/RpcClient';
 import * as RpcGroup from '@effect/rpc/RpcGroup';
+import * as Schema from 'effect/Schema';
 
-import { protoMessage, serviceError } from './service-rpc.ts';
+import { serviceError } from './service-rpc.ts';
+import { mutableArray } from './service-schemas.ts';
+
+//
+// RPC message schemas.
+//
+// These are hand-authored Effect schemas rather than `protoMessage(...)` wrappers: encoding the query
+// wire through the protobuf codec routes large string fields (notably `QueryResult.documentJson`) through
+// `@protobufjs/utf8.read`, which corrupts >8KB strings containing astral characters (emoji, some CJK) by
+// injecting a lone surrogate. Effect schemas carry strings verbatim over the structured-clone transport.
+// See QueryService.test.ts.
+//
+
+/**
+ * Index match strategy (`dxos.echo.indexing.IndexKind.Kind`).
+ */
+export const IndexKindKind = Schema.Enums({
+  SCHEMA_MATCH: 0,
+  FIELD_MATCH: 1,
+  FULL_TEXT: 2,
+  VECTOR: 3,
+  GRAPH: 4,
+});
+export type IndexKindKind = Schema.Schema.Type<typeof IndexKindKind>;
+
+export const IndexKind = Schema.Struct({
+  kind: IndexKindKind,
+  field: Schema.optional(Schema.String),
+});
+export interface IndexKind extends Schema.Schema.Type<typeof IndexKind> {}
+
+export const IndexConfig = Schema.Struct({
+  indexes: Schema.optional(mutableArray(IndexKind)),
+  /**
+   * Is indexing enabled (FEATURE FLAG).
+   * If not set, the default is false.
+   */
+  enabled: Schema.optional(Schema.Boolean),
+});
+export interface IndexConfig extends Schema.Schema.Type<typeof IndexConfig> {}
+
+/**
+ * Query result delivery mode (`dxos.echo.query.QueryReactivity`).
+ */
+export const QueryReactivity = Schema.Enums({
+  /** Returns a single result. */
+  ONE_SHOT: 0,
+  /** Returns the initial result and then incremental reactive updates when the data source changes. */
+  REACTIVE: 1,
+});
+export type QueryReactivity = Schema.Schema.Type<typeof QueryReactivity>;
+
+export const QueryRequest = Schema.Struct({
+  queryId: Schema.optional(Schema.String),
+  reactivity: QueryReactivity,
+  /**
+   * JSON-encoded `QueryAST.Query`.
+   */
+  query: Schema.String,
+});
+export interface QueryRequest extends Schema.Schema.Type<typeof QueryRequest> {}
+
+export const QueryResult = Schema.Struct({
+  id: Schema.String,
+  spaceId: Schema.String,
+  documentId: Schema.optional(Schema.String),
+  queueId: Schema.optional(Schema.String),
+  queueNamespace: Schema.optional(Schema.String),
+  rank: Schema.Number,
+  /**
+   * In the ECHO JSON object format.
+   */
+  documentJson: Schema.optional(Schema.String),
+  /**
+   * JSON-encoded group key (an object keyed by the aggregate's group-field names). Present iff the query has an aggregate clause.
+   */
+  groupKey: Schema.optional(Schema.String),
+  /**
+   * Number of records in this record's group within the result set. Present iff the query has an aggregate clause.
+   */
+  groupCount: Schema.optional(Schema.Number),
+});
+export interface QueryResult extends Schema.Schema.Type<typeof QueryResult> {}
+
+export const QueryResponse = Schema.Struct({
+  queryId: Schema.optional(Schema.String),
+  results: Schema.optional(mutableArray(QueryResult)),
+});
+export interface QueryResponse extends Schema.Schema.Type<typeof QueryResponse> {}
 
 /**
  * Effect RPC definitions for `dxos.echo.query.QueryService`.
- * Shared proto types remain protobuf-encoded on the wire.
+ * Payloads use hand-authored Effect schemas (not protobuf) so large string fields survive the wire intact.
  */
 export class Rpcs extends RpcGroup.make(
   Rpc.make('setConfig', {
-    payload: protoMessage('dxos.echo.indexing.IndexConfig'),
+    payload: IndexConfig,
     error: serviceError,
   }),
   Rpc.make('execQuery', {
-    payload: protoMessage('dxos.echo.query.QueryRequest'),
-    success: protoMessage('dxos.echo.query.QueryResponse'),
+    payload: QueryRequest,
+    success: QueryResponse,
     error: serviceError,
     stream: true,
   }),


### PR DESCRIPTION
## Problem

Protobuf string fields larger than ~8 KB that contain an astral character (emoji, some CJK) get corrupted when decoded: exactly **one extra UTF-16 code unit is inserted** (a lone low-surrogate), which breaks any downstream `JSON.parse`.

The read path was still affected: `QueryService.execQuery` encoded its `QueryResponse` (and `QueryRequest`/`IndexConfig`) via `protoMessage(...)`, so `QueryResult.documentJson` — the JSON-encoded object payload — was decoded through the buggy `@protobufjs/utf8.read`, then `JSON.parse`d during index hydration. Any indexed object >8 KB with an emoji failed to hydrate (e.g. GitHub PR-notification emails embedding CI-status square emoji 🟩/🟦), surfacing as `SyntaxError: … is not valid JSON` in the mailbox sync story.

## Root cause

`@protobufjs/utf8@1.1.0`'s `utf8.read` reuses a `chunk` array across its 8192-unit flush boundary without truncating it. A 4-byte character can push `i` from `8191 → 8193`, leaving `chunk.length = 8193`; a later block that flushes at exactly `i = 8192` then spreads a stale `chunk[8192]` (a leftover low-surrogate), injecting +1 code unit mid-string.

The bug only manifests on protobufjs's JS `Reader` path — a plain `Uint8Array`, as arrives over the browser worker `MessagePort` via structured clone — not Node's native `BufferReader`. That is why it broke the browser but passed Node tests.

## Fix

Migrate `QueryService` off protobuf entirely (following the `FeedService` precedent from #12158). `QueryRequest`, `QueryResponse`, `QueryResult`, `IndexConfig`, and their enums are now hand-authored Effect `Schema.Struct`s in `QueryService.ts`, so payloads travel as plain objects/strings over the structured-clone transport and never touch the protobuf codec. Deprecated/unused wire fields (`filter`, `spaceKey`, `documentAutomerge`, `objects`) are dropped from the inline schemas.

Handlers and consumers (`echo-host`, `echo-client`, `functions-runtime-cloudflare`, `client`, `blade-runner`) keep importing the generated proto types — they remain structurally compatible at the RPC boundary, so no call-site churn.

## Test

Per the task, started with a reproduction. `packages/core/protocols/src/QueryService.test.ts`:

- Round-trips a >8 KB `documentJson` with an astral character at offset 8191 through the new `QueryService.QueryResponse` schema and asserts fidelity (and that `JSON.parse` succeeds).
- A root-cause test that decodes the same payload through the protobuf codec via a plain `Uint8Array` (forcing the browser Reader path) and asserts it corrupts — reproducing the bug and guarding against regressing the wire encoding back to protobuf.

## Verification

- `moon run protocols:test` — 16 passed (including the 3 new tests).
- `moon run {echo-host,echo-client,client-protocol,client,functions-runtime-cloudflare,blade-runner,plugin-transcription}:compile` — all green (structural compatibility confirmed).
- `moon run echo-client:test` (478 passed) and `moon run echo-host:test` (258 passed).
- `moon run protocols:lint` and `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSpgUcjq8LubTGVJ37FnFh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed corruption of large query results containing emoji and other special Unicode characters.
  * Improved reliability when handling query payloads larger than 8KB.
  * Prevented malformed JSON from breaking result hydration.

* **Tests**
  * Added regression coverage for large Unicode-containing query responses and payload validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->