### PR TITLE
protocols: delete redundant dxos.iframe.WorkerService protobuf service

### DIFF
--- a/.changeset/drop-iframe-worker-proto-service.md
+++ b/.changeset/drop-iframe-worker-proto-service.md
@@ -1,0 +1,6 @@
+---
+'@dxos/protocols': minor
+'@dxos/client-protocol': minor
+---
+
+Delete the redundant `dxos.iframe.WorkerService` protobuf service (and its `StartRequest` message) now that the tab→worker control channel is defined and served via effect-rpc (`WorkerService` in `@dxos/protocols/rpc`, over the app `MessagePort`). Also removes the now-unused `iframeServiceBundle` and `workerServiceBundle` exports from `@dxos/client-protocol` (they had no consumers). The `dxos.mesh.bridge.BridgeService` and `dxos.iframe.AppService`/`ShellService` protobuf definitions are retained — they are still used by the WebRTC transport bridge and the shell↔app iframe transport respectively.

--- a/packages/core/protocols/src/proto/dxos/iframe.proto
+++ b/packages/core/protocols/src/proto/dxos/iframe.proto
@@ -11,18 +11,6 @@ import "dxos/keys.proto";
 // TODO(burdon): Rename dxos.xxx.iframe?
 package dxos.iframe;
 
-message StartRequest {
-  string origin = 1;
-  /// Key for the iframe resource lock used to determine when the service is closing.
-  optional string lock_key = 2;
-}
-
-/// Iframe-to-worker RPCs.
-service WorkerService {
-  rpc Start(StartRequest) returns (google.protobuf.Empty);
-  rpc Stop(google.protobuf.Empty) returns (google.protobuf.Empty);
-}
-
 enum ShellDisplay {
   NONE = 0;
   FULLSCREEN = 1;

--- a/packages/sdk/client-protocol/src/service.ts
+++ b/packages/sdk/client-protocol/src/service.ts
@@ -19,8 +19,7 @@ import type {
 import type { DevtoolsHost } from '@dxos/protocols/proto/dxos/devtools/host';
 import type { QueryService } from '@dxos/protocols/proto/dxos/echo/query';
 import type { DataService } from '@dxos/protocols/proto/dxos/echo/service';
-import type { AppService, ShellService, WorkerService } from '@dxos/protocols/proto/dxos/iframe';
-import type { BridgeService } from '@dxos/protocols/proto/dxos/mesh/bridge';
+import type { AppService, ShellService } from '@dxos/protocols/proto/dxos/iframe';
 import { type ServiceBundle, createServiceBundle } from '@dxos/rpc';
 
 import { type ClientServicesRpc } from './service-rpc';
@@ -113,22 +112,6 @@ export const clientServiceBundle = createServiceBundle<ClientServices>({
   // TODO(burdon): Deprecated.
   DevtoolsHost: schema.getService('dxos.devtools.host.DevtoolsHost'),
 });
-
-export type IframeServiceBundle = {
-  BridgeService: BridgeService;
-};
-
-export const iframeServiceBundle: ServiceBundle<IframeServiceBundle> = {
-  BridgeService: schema.getService('dxos.mesh.bridge.BridgeService'),
-};
-
-export type WorkerServiceBundle = {
-  WorkerService: WorkerService;
-};
-
-export const workerServiceBundle: ServiceBundle<WorkerServiceBundle> = {
-  WorkerService: schema.getService('dxos.iframe.WorkerService'),
-};
 
 export type AppServiceBundle = {
   AppService: AppService;


### PR DESCRIPTION
## Summary

First protobuf **service definition** deleted as part of retiring the migrated proto service surface (follows #12190, #12201).

The tab→worker control channel (`start`/`stop`) is now defined and served over effect-rpc — `WorkerService` in `@dxos/protocols/rpc`, running over the app `MessagePort` (merged into `ClientServicesRpcs`). The protobuf `dxos.iframe.WorkerService` service and its `StartRequest` message were therefore redundant, and their only remaining consumer was the unused `workerServiceBundle`.

## Changes

- Delete `service WorkerService {}` + `message StartRequest` from `dxos/iframe.proto`.
- Remove the dead `iframeServiceBundle` / `workerServiceBundle` exports (and their types) from `@dxos/client-protocol` — neither had any consumer outside its own definition.

## Retained (deliberately)

- `dxos.mesh.bridge.BridgeService` — still used by the WebRTC transport bridge: its generated *type* backs `bridge-rpc.ts` / `rtc-transport-proxy.ts` / `worker-session.ts`, and its descriptor is used by network-manager tests.
- `dxos.iframe.AppService` / `ShellService` — still back the shell↔app iframe transport (`appServiceBundle` / `shellServiceBundle`).

## Context (remaining work)

The 13 client-service proto definitions (and `BridgeService`) remain, gated on migrating the three byte-transport bridges — `fromSocket` (devtools/remote websocket), `fromAgent` (CLI daemon), and the shell↔app iframe proxy — off protobuf `clientServiceBundle` onto the effect-rpc transport. That migration is bilateral and needs live CLI/devtools/shell verification, so it's tracked as follow-up.

## Test plan

- `moon run protocols:compile client-protocol:compile client:compile client-services:compile network-manager:compile` ✅ (proto regenerated without `WorkerService`; all downstream, incl. `BridgeService` consumers, still typecheck)
- `moon run protocols:test` ✅ · `moon run client-services:test` ✅ (155 passed)
- `moon run client-protocol:lint client-services:lint client:lint` ✅
- `pnpm format` (oxfmt) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7ebq3pfj9ykrSrpLG5ash

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7ebq3pfj9ykrSrpLG5ash)_