### PR TITLE
echo: migrate Query/Filter/Order/Aggregate variance brands to TypeId constants

### DIFF
--- a/packages/core/echo/echo-query/src/query-lite/query-lite.ts
+++ b/packages/core/echo/echo-query/src/query-lite/query-lite.ts
@@ -25,19 +25,27 @@ import type { DXN, EID, EntityId, URI } from '@dxos/keys';
 
 // TODO(wittjosiah): The `export * as ...` syntax causes tsdown to genereate multiple files which breaks the sandbox.
 
-class OrderClass implements Order$.Any {
-  private static 'variance': Order$.Any['~Order'] = {} as Order$.Any['~Order'];
+// The TypeId brand keys mirror the constants in `@dxos/echo`. They are declared locally (typed by the
+// type-only imports) rather than imported as runtime values to keep this sandbox bundle free of the
+// `@dxos/echo` runtime graph.
+const OrderTypeId: Order$.OrderTypeId = '~@dxos/echo/Order';
+const FilterTypeId: Filter$.FilterTypeId = '~@dxos/echo/Filter';
+const QueryTypeId: Query$.QueryTypeId = '~@dxos/echo/Query';
 
-  static 'is'(value: unknown): value is Order$.Any {
-    return typeof value === 'object' && value !== null && '~Order' in value;
+class OrderClass implements Order$.Any {
+  private static 'variance': Order$.Any[typeof OrderTypeId] = {} as Order$.Any[typeof OrderTypeId];
+
+  static is(value: unknown): value is Order$.Any {
+    return typeof value === 'object' && value !== null && OrderTypeId in value;
   }
 
-  'constructor'(public readonly ast: QueryAST.Order) {}
+  constructor(public readonly ast: QueryAST.Order) {}
 
-  '~Order' = OrderClass.variance;
+  [OrderTypeId] = OrderClass.variance;
 }
 
 namespace Order1 {
+  export const OrderTypeId: Order$.OrderTypeId = '~@dxos/echo/Order';
   export const natural = (direction: QueryAST.OrderDirection = 'asc'): Order$.Order<any> =>
     new OrderClass({ kind: 'natural', direction });
   export const property = <T>(property: keyof T & string, direction: QueryAST.OrderDirection): Order$.Order<T> =>
@@ -154,17 +162,19 @@ const _filterMatchEntityLocal = (filter: QueryAST.Filter, entity: any): boolean 
 };
 
 class FilterClass implements Filter$.Any {
-  private static 'variance': Filter$.Any['~Filter'] = {} as Filter$.Any['~Filter'];
+  static 'FilterTypeId': Filter$.FilterTypeId = FilterTypeId;
 
-  static 'is'(value: unknown): value is Filter$.Any {
-    return typeof value === 'object' && value !== null && '~Filter' in value;
+  private static 'variance': Filter$.Any[typeof FilterTypeId] = {} as Filter$.Any[typeof FilterTypeId];
+
+  static is(value: unknown): value is Filter$.Any {
+    return typeof value === 'object' && value !== null && FilterTypeId in value;
   }
 
-  static 'fromAst'(ast: QueryAST.Filter): Filter$.Any {
+  static fromAst(ast: QueryAST.Filter): Filter$.Any {
     return new FilterClass(ast);
   }
 
-  static 'everything'(): FilterClass {
+  static everything(): FilterClass {
     return new FilterClass({
       type: 'object',
       typename: null,
@@ -172,7 +182,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'nothing'(): FilterClass {
+  static nothing(): FilterClass {
     return new FilterClass({
       type: 'not',
       filter: {
@@ -183,7 +193,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'relation'() {
+  static relation() {
     return new FilterClass({
       type: 'object',
       typename: null,
@@ -191,7 +201,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'id'(...ids: EntityId[]): Filter$.Any {
+  static id(...ids: EntityId[]): Filter$.Any {
     // assertArgument(
     //   ids.every((id) => EntityId.isValid(id)),
     //   'ids',
@@ -210,12 +220,12 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'type'<T extends Type$.AnyEntity>(
+  static type<T extends Type$.AnyEntity>(
     type: T,
     props?: Filter$.Props<Type$.InstanceType<T>>,
   ): Filter$.Filter<Type$.InstanceType<T>>;
-  static 'type'(schema: string, props?: Filter$.Props<unknown>): Filter$.Filter<any>;
-  static 'type'(schema: Type$.AnyEntity | string, props?: Filter$.Props<unknown>): Filter$.Filter<unknown> {
+  static type(schema: string, props?: Filter$.Props<unknown>): Filter$.Filter<any>;
+  static type(schema: Type$.AnyEntity | string, props?: Filter$.Props<unknown>): Filter$.Filter<unknown> {
     if (typeof schema !== 'string') {
       throw new TypeError('expected typename as the first paramter');
     }
@@ -226,7 +236,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'typename'(typename: string): Filter$.Any {
+  static typename(typename: string): Filter$.Any {
     return new FilterClass({
       type: 'object',
       typename: makeTypeDxn(typename),
@@ -234,7 +244,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'typeURI'(uri: URI.URI): Filter$.Any {
+  static typeURI(uri: URI.URI): Filter$.Any {
     return new FilterClass({
       type: 'object',
       typename: uri,
@@ -242,14 +252,14 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'tag'(tag: string): Filter$.Any {
+  static tag(tag: string): Filter$.Any {
     return new FilterClass({
       type: 'tag',
       tag,
     });
   }
 
-  static 'key'(key: string, options?: Filter$.KeyFilterOptions): Filter$.Any {
+  static key(key: string, options?: Filter$.KeyFilterOptions): Filter$.Any {
     return new FilterClass({
       type: 'object',
       typename: null,
@@ -259,7 +269,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'props'<T>(props: Filter$.Props<T>): Filter$.Filter<T> {
+  static props<T>(props: Filter$.Props<T>): Filter$.Filter<T> {
     return new FilterClass({
       type: 'object',
       typename: null,
@@ -267,7 +277,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'text'(text: string, options?: Filter$.TextSearchOptions): Filter$.Any {
+  static text(text: string, options?: Filter$.TextSearchOptions): Filter$.Any {
     return new FilterClass({
       type: 'text-search',
       text,
@@ -275,7 +285,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'foreignKeys'<S extends Type$.AnyEntity | string>(
+  static foreignKeys<S extends Type$.AnyEntity | string>(
     schema: S,
     keys: ForeignKey[],
   ): Filter$.Filter<S extends Type$.AnyEntity ? Type$.InstanceType<S> : unknown> {
@@ -289,7 +299,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'eq'<T>(value: T): Filter$.Filter<T | undefined> {
+  static eq<T>(value: T): Filter$.Filter<T | undefined> {
     if (!isRef(value) && typeof value === 'object' && value !== null) {
       throw new TypeError('Cannot use object as a value for eq filter');
     }
@@ -301,7 +311,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'neq'<T>(value: T): Filter$.Filter<T | undefined> {
+  static neq<T>(value: T): Filter$.Filter<T | undefined> {
     return new FilterClass({
       type: 'compare',
       operator: 'neq',
@@ -309,7 +319,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'gt'<T>(value: T): Filter$.Filter<T | undefined> {
+  static gt<T>(value: T): Filter$.Filter<T | undefined> {
     return new FilterClass({
       type: 'compare',
       operator: 'gt',
@@ -317,7 +327,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'gte'<T>(value: T): Filter$.Filter<T | undefined> {
+  static gte<T>(value: T): Filter$.Filter<T | undefined> {
     return new FilterClass({
       type: 'compare',
       operator: 'gte',
@@ -325,7 +335,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'lt'<T>(value: T): Filter$.Filter<T | undefined> {
+  static lt<T>(value: T): Filter$.Filter<T | undefined> {
     return new FilterClass({
       type: 'compare',
       operator: 'lt',
@@ -333,7 +343,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'lte'<T>(value: T): Filter$.Filter<T | undefined> {
+  static lte<T>(value: T): Filter$.Filter<T | undefined> {
     return new FilterClass({
       type: 'compare',
       operator: 'lte',
@@ -341,21 +351,21 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'in'<T>(...values: T[]): Filter$.Filter<T> {
+  static in<T>(...values: T[]): Filter$.Filter<T> {
     return new FilterClass({
       type: 'in',
       values,
     });
   }
 
-  static 'contains'<T>(value: T): Filter$.Filter<readonly T[] | undefined> {
+  static contains<T>(value: T): Filter$.Filter<readonly T[] | undefined> {
     return new FilterClass({
       type: 'contains',
       value,
     });
   }
 
-  static 'between'<T>(from: T, to: T): Filter$.Filter<T> {
+  static between<T>(from: T, to: T): Filter$.Filter<T> {
     return new FilterClass({
       type: 'range',
       from,
@@ -363,15 +373,15 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'updated'(range: { after?: Date | number; before?: Date | number }): Filter$.Any {
+  static updated(range: { after?: Date | number; before?: Date | number }): Filter$.Any {
     return FilterClass._timeRangeFilter('updatedAt', range);
   }
 
-  static 'created'(range: { after?: Date | number; before?: Date | number }): Filter$.Any {
+  static created(range: { after?: Date | number; before?: Date | number }): Filter$.Any {
     return FilterClass._timeRangeFilter('createdAt', range);
   }
 
-  static 'childOf'(parents: unknown | unknown[], options?: { transitive?: boolean }): Filter$.Any {
+  static childOf(parents: unknown | unknown[], options?: { transitive?: boolean }): Filter$.Any {
     const items = Array.isArray(parents) ? parents : [parents];
     const dxns = items.map((item) => {
       if (isEchoUriLike(item)) {
@@ -386,7 +396,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  private static '_timeRangeFilter'(
+  private static _timeRangeFilter(
     field: 'updatedAt' | 'createdAt',
     range: { after?: Date | number; before?: Date | number },
   ): Filter$.Any {
@@ -404,14 +414,14 @@ class FilterClass implements Filter$.Any {
     return filters.length === 1 ? filters[0] : FilterClass.and(...filters);
   }
 
-  static 'not'<F extends Filter$.Any>(filter: F): Filter$.Filter<Filter$.Type<F>> {
+  static not<F extends Filter$.Any>(filter: F): Filter$.Filter<Filter$.Type<F>> {
     return new FilterClass({
       type: 'not',
       filter: filter.ast,
     });
   }
 
-  static 'and'<Filters extends readonly Filter$.Any[]>(
+  static and<Filters extends readonly Filter$.Any[]>(
     ...filters: Filters
   ): Filter$.Filter<Filter$.Type<Filters[number]>> {
     return new FilterClass({
@@ -420,7 +430,7 @@ class FilterClass implements Filter$.Any {
     });
   }
 
-  static 'or'<Filters extends readonly Filter$.Any[]>(
+  static or<Filters extends readonly Filter$.Any[]>(
     ...filters: Filters
   ): Filter$.Filter<Filter$.Type<Filters[number]>> {
     return new FilterClass({
@@ -430,7 +440,7 @@ class FilterClass implements Filter$.Any {
   }
 
   /** Returns a human-readable string representation of a Filter AST. */
-  static 'pretty'(filter: Filter$.Any): string {
+  static pretty(filter: Filter$.Any): string {
     return prettyFilter(filter.ast);
   }
 
@@ -444,9 +454,9 @@ class FilterClass implements Filter$.Any {
     return _filterMatchEntityLocal(filter.ast, entityOrFilter);
   }) as typeof Filter$.toPredicate;
 
-  private 'constructor'(public readonly ast: QueryAST.Filter) {}
+  private constructor(public readonly ast: QueryAST.Filter) {}
 
-  '~Filter' = FilterClass.variance;
+  [FilterTypeId] = FilterClass.variance;
 }
 
 export const Filter1: typeof Filter$ = FilterClass;
@@ -504,24 +514,26 @@ const processPredicate = (predicate: any): QueryAST.Filter => {
 };
 
 class QueryClass implements Query$.Any {
-  private static 'variance': Query$.Any['~Query'] = {} as Query$.Any['~Query'];
+  static 'QueryTypeId': Query$.QueryTypeId = QueryTypeId;
 
-  static 'is'(value: unknown): value is Query$.Any {
-    return typeof value === 'object' && value !== null && '~Query' in value;
+  private static 'variance': Query$.Any[typeof QueryTypeId] = {} as Query$.Any[typeof QueryTypeId];
+
+  static is(value: unknown): value is Query$.Any {
+    return typeof value === 'object' && value !== null && QueryTypeId in value;
   }
 
-  static 'fromAst'(ast: QueryAST.Query): Query$.Any {
+  static fromAst(ast: QueryAST.Query): Query$.Any {
     return new QueryClass(ast);
   }
 
-  static 'select'<F extends Filter$.Any>(filter: F): Query$.Query<Filter$.Type<F>> {
+  static select<F extends Filter$.Any>(filter: F): Query$.Query<Filter$.Type<F>> {
     return new QueryClass({
       type: 'select',
       filter: filter.ast,
     });
   }
 
-  'select'(filter: Filter$.Any | Filter$.Props<any>): Query$.Any {
+  select(filter: Filter$.Any | Filter$.Props<any>): Query$.Any {
     if (FilterClass.is(filter)) {
       return new QueryClass({
         type: 'filter',
@@ -537,13 +549,13 @@ class QueryClass implements Query$.Any {
     }
   }
 
-  static 'type'<S extends Schema.Schema.All>(
+  static type<S extends Schema.Schema.All>(
     schema: S,
     predicates?: Filter$.Props<Schema.Schema.Type<S>>,
   ): Query$.Query<Schema.Schema.Type<S>>;
-  static 'type'(type: Type$.Type, predicates?: Filter$.Props<Obj$.Unknown>): Query$.Query<Obj$.Unknown>;
-  static 'type'(schema: string, predicates?: Filter$.Props<unknown>): Query$.Query<any>;
-  static 'type'(schema: Schema.Schema.All | Type$.Type | string, predicates?: Filter$.Props<unknown>): Query$.Any {
+  static type(type: Type$.Type, predicates?: Filter$.Props<Obj$.Unknown>): Query$.Query<Obj$.Unknown>;
+  static type(schema: string, predicates?: Filter$.Props<unknown>): Query$.Query<any>;
+  static type(schema: Schema.Schema.All | Type$.Type | string, predicates?: Filter$.Props<unknown>): Query$.Any {
     if (typeof schema !== 'string') {
       throw new TypeError('expected typename as the first paramter');
     }
@@ -553,7 +565,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  static 'all'(...queries: Query$.Any[]): Query$.Any {
+  static all(...queries: Query$.Any[]): Query$.Any {
     if (queries.length === 0) {
       throw new TypeError(
         'Query.all combines results of multiple queries, to query all objects use Query.select(Filter.everything())',
@@ -565,7 +577,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  static 'without'<T>(source: Query$.Query<T>, exclude: Query$.Query<T>): Query$.Query<T> {
+  static without<T>(source: Query$.Query<T>, exclude: Query$.Query<T>): Query$.Query<T> {
     return new QueryClass({
       type: 'set-difference',
       source: source.ast,
@@ -573,7 +585,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  static 'from'(...args: any[]): Query$.Any {
+  static from(...args: any[]): Query$.Any {
     const baseQuery: QueryAST.Query = {
       type: 'select',
       filter: FilterClass.everything().ast,
@@ -582,7 +594,7 @@ class QueryClass implements Query$.Any {
     return (wrapper.from as (...args: any[]) => Query$.Any)(...args);
   }
 
-  'from'(...args: any[]): Query$.Any {
+  from(...args: any[]): Query$.Any {
     // Variadic raw scopes: `.from(Scope.space(), Scope.registry())`.
     if (args.length > 1 && args.every((arg) => _isScopeLike(arg))) {
       return new QueryClass({
@@ -613,15 +625,15 @@ class QueryClass implements Query$.Any {
   }
 
   /** Returns a human-readable string representation of a Query AST. */
-  static 'pretty'(query: Query$.Any): string {
+  static pretty(query: Query$.Any): string {
     return prettyQuery(query.ast);
   }
 
-  'constructor'(public readonly ast: QueryAST.Query) {}
+  constructor(public readonly ast: QueryAST.Query) {}
 
-  '~Query' = QueryClass.variance;
+  [QueryTypeId] = QueryClass.variance;
 
-  'reference'(key: string): Query$.Any {
+  reference(key: string): Query$.Any {
     return new QueryClass({
       type: 'reference-traversal',
       anchor: this.ast,
@@ -629,7 +641,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'referencedBy'(target?: Type$.AnyEntity | string, key?: string): Query$.Any {
+  referencedBy(target?: Type$.AnyEntity | string, key?: string): Query$.Any {
     if (target !== undefined && typeof target !== 'string') {
       throw new TypeError('referencedBy requires a typename string in query-lite');
     }
@@ -642,7 +654,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'sourceOf'(
+  sourceOf(
     relation?: Type$.Relation<any, any, any, any> | string,
     predicates?: Filter$.Props<unknown> | undefined,
   ): Query$.Any {
@@ -659,7 +671,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'targetOf'(
+  targetOf(
     relation?: Type$.Relation<any, any, any, any> | string,
     predicates?: Filter$.Props<unknown> | undefined,
   ): Query$.Any {
@@ -676,7 +688,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'source'(): Query$.Any {
+  source(): Query$.Any {
     return new QueryClass({
       type: 'relation-traversal',
       anchor: this.ast,
@@ -684,7 +696,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'target'(): Query$.Any {
+  target(): Query$.Any {
     return new QueryClass({
       type: 'relation-traversal',
       anchor: this.ast,
@@ -692,7 +704,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'parent'(): Query$.Any {
+  parent(): Query$.Any {
     return new QueryClass({
       type: 'hierarchy-traversal',
       anchor: this.ast,
@@ -700,7 +712,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'children'(): Query$.Any {
+  children(): Query$.Any {
     return new QueryClass({
       type: 'hierarchy-traversal',
       anchor: this.ast,
@@ -708,7 +720,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'orderBy'(...order: Order$.Any[]): Query$.Any {
+  orderBy(...order: Order$.Any[]): Query$.Any {
     return new QueryClass({
       type: 'order',
       query: this.ast,
@@ -716,7 +728,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'limit'(limit: number): Query$.Any {
+  limit(limit: number): Query$.Any {
     return new QueryClass({
       type: 'limit',
       query: this.ast,
@@ -724,7 +736,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'skip'(skip: number): Query$.Any {
+  skip(skip: number): Query$.Any {
     return new QueryClass({
       type: 'skip',
       query: this.ast,
@@ -732,7 +744,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'aggregate'(aggregates: Record<string, Aggregate$.Any>): Query$.Any {
+  aggregate(aggregates: Record<string, Aggregate$.Any>): Query$.Any {
     return new QueryClass({
       type: 'aggregate',
       query: this.ast,
@@ -740,7 +752,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'options'(options: QueryAST.QueryOptions): Query$.Any {
+  options(options: QueryAST.QueryOptions): Query$.Any {
     return new QueryClass({
       type: 'options',
       query: this.ast,
@@ -748,7 +760,7 @@ class QueryClass implements Query$.Any {
     });
   }
 
-  'debugLabel'(label: string): Query$.Any {
+  debugLabel(label: string): Query$.Any {
     if (this.ast.type === 'options') {
       return new QueryClass({
         type: 'options',

--- a/packages/core/echo/echo-query/src/query-lite/query-lite.ts
+++ b/packages/core/echo/echo-query/src/query-lite/query-lite.ts
@@ -426,7 +426,7 @@ class FilterClass implements Filter$.Any {
   ): Filter$.Filter<Filter$.Type<Filters[number]>> {
     return new FilterClass({
       type: 'and',
-      filters: filters.map((f) => f.ast),
+      filters: filters.map((filter) => filter.ast),
     });
   }
 
@@ -435,7 +435,7 @@ class FilterClass implements Filter$.Any {
   ): Filter$.Filter<Filter$.Type<Filters[number]>> {
     return new FilterClass({
       type: 'or',
-      filters: filters.map((f) => f.ast),
+      filters: filters.map((filter) => filter.ast),
     });
   }
 
@@ -724,7 +724,7 @@ class QueryClass implements Query$.Any {
     return new QueryClass({
       type: 'order',
       query: this.ast,
-      order: order.map((o) => o.ast),
+      order: order.map((orderItem) => orderItem.ast),
     });
   }
 

--- a/packages/core/echo/echo-query/src/sandbox/query-sandbox.ts
+++ b/packages/core/echo/echo-query/src/sandbox/query-sandbox.ts
@@ -3,7 +3,7 @@
 //
 
 import { Resource } from '@dxos/context';
-import { Query, type QueryAST } from '@dxos/echo';
+import { Filter, Query, type QueryAST } from '@dxos/echo';
 import { trim } from '@dxos/util';
 import { type QuickJSRuntime, type QuickJSWASMModule, createQuickJS } from '@dxos/vendor-quickjs';
 
@@ -63,7 +63,7 @@ export class QuerySandbox extends Resource {
     unwrapResult(context, context.evalCode(globals)).dispose();
     using query = unwrapResult(context, context.evalCode(queryCode));
     const result = context.dump(query);
-    if ('~Filter' in result) {
+    if (Filter.FilterTypeId in result) {
       return Query.select(result).ast;
     } else {
       return result.ast;

--- a/packages/core/echo/echo/src/Aggregate.ts
+++ b/packages/core/echo/echo/src/Aggregate.ts
@@ -49,15 +49,15 @@ export type AggregationResult<A extends Record<string, Any>> = EffectTypes.Simpl
 >;
 
 class AggregateClass<T, V> implements Aggregate<T, V> {
-  private static 'variance': Aggregate<any, any>['~Aggregate'] = {} as Aggregate<any, any>['~Aggregate'];
+  private static 'variance': Aggregate<any, any>[AggregateTypeId] = {} as Aggregate<any, any>[AggregateTypeId];
 
-  static 'is'(value: unknown): value is Any {
-    return typeof value === 'object' && value !== null && '~Aggregate' in value;
+  static is(value: unknown): value is Any {
+    return typeof value === 'object' && value !== null && AggregateTypeId in value;
   }
 
-  'constructor'(public readonly spec: Spec) {}
+  constructor(public readonly spec: Spec) {}
 
-  '~Aggregate' = AggregateClass.variance as Aggregate<T, V>['~Aggregate'];
+  [AggregateTypeId] = AggregateClass.variance as Aggregate<T, V>[AggregateTypeId];
 }
 
 /**

--- a/packages/core/echo/echo/src/Aggregate.ts
+++ b/packages/core/echo/echo/src/Aggregate.ts
@@ -20,6 +20,9 @@ export type Spec =
   | { kind: 'items'; limit?: number }
   | { kind: 'count' };
 
+export const AggregateTypeId = '~@dxos/echo/Aggregate' as const;
+export type AggregateTypeId = typeof AggregateTypeId;
+
 /**
  * A per-group aggregate declaration, materialised as a top-level field on the flat result record
  * `Query.aggregate` produces and orderable via a following `orderBy(Order.property(name))`. Name it
@@ -30,10 +33,9 @@ export type Spec =
  * `group` entries aggregates the entire input into a single row.
  */
 export interface Aggregate<T, V> {
-  // TODO(dmaretskyi): See new effect-schema approach to variance.
-  '~Aggregate': { element: T; value: V };
+  readonly [AggregateTypeId]: { element: T; value: V };
 
-  'spec': Spec;
+  spec: Spec;
 }
 
 export type Any = Aggregate<any, any>;

--- a/packages/core/echo/echo/src/Filter.ts
+++ b/packages/core/echo/echo/src/Filter.ts
@@ -28,7 +28,7 @@ export interface Filter<T> {
   // TODO(dmaretskyi): See new effect-schema approach to variance.
   readonly [FilterTypeId]: { value: Types.Covariant<T> };
 
-  'ast': QueryAST.Filter;
+  ast: QueryAST.Filter;
 }
 
 export type Props<T> = {
@@ -41,15 +41,15 @@ export type Any = Filter<any>;
 export type Type<F extends Any> = F extends Filter<infer T> ? T : never;
 
 class FilterClass implements Any {
-  private static 'variance': Any['~Filter'] = {} as Any['~Filter'];
+  private static 'variance': Any[FilterTypeId] = {} as Any[FilterTypeId];
 
-  'constructor'(public readonly ast: QueryAST.Filter) {}
+  constructor(public readonly ast: QueryAST.Filter) {}
 
-  '~Filter' = FilterClass.variance;
+  [FilterTypeId] = FilterClass.variance;
 }
 
 export const is = (value: unknown): value is Any => {
-  return typeof value === 'object' && value !== null && '~Filter' in value;
+  return typeof value === 'object' && value !== null && FilterTypeId in value;
 };
 
 /** Construct a filter from an ast. */

--- a/packages/core/echo/echo/src/Filter.ts
+++ b/packages/core/echo/echo/src/Filter.ts
@@ -20,9 +20,13 @@ import type * as Obj from './Obj';
 import * as Ref from './Ref';
 // eslint-disable-next-line @dxos/rules/import-as-namespace
 import type * as Type$ from './Type';
+
+export const FilterTypeId = '~@dxos/echo/Filter' as const;
+export type FilterTypeId = typeof FilterTypeId;
+
 export interface Filter<T> {
   // TODO(dmaretskyi): See new effect-schema approach to variance.
-  '~Filter': { value: Types.Covariant<T> };
+  readonly [FilterTypeId]: { value: Types.Covariant<T> };
 
   'ast': QueryAST.Filter;
 }

--- a/packages/core/echo/echo/src/Order.ts
+++ b/packages/core/echo/echo/src/Order.ts
@@ -18,15 +18,15 @@ export interface Order<T> {
 export type Any = Order<any>;
 
 class OrderClass implements Order<any> {
-  private static 'variance': Order<any>['~Order'] = {} as Order<any>['~Order'];
+  private static 'variance': Order<any>[OrderTypeId] = {} as Order<any>[OrderTypeId];
 
-  static 'is'(value: unknown): value is Any {
-    return typeof value === 'object' && value !== null && '~Order' in value;
+  static is(value: unknown): value is Any {
+    return typeof value === 'object' && value !== null && OrderTypeId in value;
   }
 
-  'constructor'(public readonly ast: QueryAST.Order) {}
+  constructor(public readonly ast: QueryAST.Order) {}
 
-  '~Order' = OrderClass.variance;
+  [OrderTypeId] = OrderClass.variance;
 }
 
 /**

--- a/packages/core/echo/echo/src/Order.ts
+++ b/packages/core/echo/echo/src/Order.ts
@@ -6,11 +6,13 @@
 
 import { type QueryAST } from '@dxos/echo-protocol';
 
-export interface Order<T> {
-  // TODO(dmaretskyi): See new effect-schema approach to variance.
-  '~Order': { value: T };
+export const OrderTypeId = '~@dxos/echo/Order' as const;
+export type OrderTypeId = typeof OrderTypeId;
 
-  'ast': QueryAST.Order;
+export interface Order<T> {
+  readonly [OrderTypeId]: { value: T };
+
+  ast: QueryAST.Order;
 }
 
 export type Any = Order<any>;

--- a/packages/core/echo/echo/src/Query.ts
+++ b/packages/core/echo/echo/src/Query.ts
@@ -294,13 +294,13 @@ export type Any = Query<any>;
 export type Type<Q extends Any> = Q extends Query<infer T> ? T : never;
 
 class QueryClass implements Any {
-  private static 'variance': Any['~Query'] = {} as Any['~Query'];
+  private static 'variance': Any[QueryTypeId] = {} as Any[QueryTypeId];
 
-  'constructor'(public readonly ast: QueryAST.Query) {}
+  constructor(public readonly ast: QueryAST.Query) {}
 
-  '~Query' = QueryClass.variance;
+  [QueryTypeId] = QueryClass.variance;
 
-  'select'(filter: Filter.Any | Filter.Props<any>): Any {
+  select(filter: Filter.Any | Filter.Props<any>): Any {
     if (Filter.is(filter)) {
       return new QueryClass({
         type: 'filter',
@@ -316,7 +316,7 @@ class QueryClass implements Any {
     }
   }
 
-  'reference'(key: string): Any {
+  reference(key: string): Any {
     return new QueryClass({
       type: 'reference-traversal',
       anchor: this.ast,
@@ -324,7 +324,7 @@ class QueryClass implements Any {
     });
   }
 
-  'referencedBy'(target?: Type$.AnyEntity | URI.URI, key?: string): Any {
+  referencedBy(target?: Type$.AnyEntity | URI.URI, key?: string): Any {
     const uri = target !== undefined ? internal.getTypeURIFromSpecifier(target) : null;
     return new QueryClass({
       type: 'incoming-references',
@@ -334,7 +334,7 @@ class QueryClass implements Any {
     });
   }
 
-  'sourceOf'(relation?: Type$.AnyRelation | URI.URI, predicates?: Filter.Props<unknown> | undefined): Any {
+  sourceOf(relation?: Type$.AnyRelation | URI.URI, predicates?: Filter.Props<unknown> | undefined): Any {
     return new QueryClass({
       type: 'relation',
       anchor: this.ast,
@@ -343,7 +343,7 @@ class QueryClass implements Any {
     });
   }
 
-  'targetOf'(relation?: Type$.AnyRelation | URI.URI, predicates?: Filter.Props<unknown> | undefined): Any {
+  targetOf(relation?: Type$.AnyRelation | URI.URI, predicates?: Filter.Props<unknown> | undefined): Any {
     return new QueryClass({
       type: 'relation',
       anchor: this.ast,
@@ -352,7 +352,7 @@ class QueryClass implements Any {
     });
   }
 
-  'source'(): Any {
+  source(): Any {
     return new QueryClass({
       type: 'relation-traversal',
       anchor: this.ast,
@@ -360,7 +360,7 @@ class QueryClass implements Any {
     });
   }
 
-  'target'(): Any {
+  target(): Any {
     return new QueryClass({
       type: 'relation-traversal',
       anchor: this.ast,
@@ -368,7 +368,7 @@ class QueryClass implements Any {
     });
   }
 
-  'parent'(): Any {
+  parent(): Any {
     return new QueryClass({
       type: 'hierarchy-traversal',
       anchor: this.ast,
@@ -376,7 +376,7 @@ class QueryClass implements Any {
     });
   }
 
-  'children'(): Any {
+  children(): Any {
     return new QueryClass({
       type: 'hierarchy-traversal',
       anchor: this.ast,
@@ -384,7 +384,7 @@ class QueryClass implements Any {
     });
   }
 
-  'orderBy'(...order: Order.Any[]): Any {
+  orderBy(...order: Order.Any[]): Any {
     return new QueryClass({
       type: 'order',
       query: this.ast,
@@ -392,7 +392,7 @@ class QueryClass implements Any {
     });
   }
 
-  'aggregate'(aggregates: Record<string, Aggregate.Any>): Any {
+  aggregate(aggregates: Record<string, Aggregate.Any>): Any {
     return new QueryClass({
       type: 'aggregate',
       query: this.ast,
@@ -400,7 +400,7 @@ class QueryClass implements Any {
     });
   }
 
-  'limit'(limit: number): Any {
+  limit(limit: number): Any {
     return new QueryClass({
       type: 'limit',
       query: this.ast,
@@ -408,7 +408,7 @@ class QueryClass implements Any {
     });
   }
 
-  'skip'(skip: number): Any {
+  skip(skip: number): Any {
     return new QueryClass({
       type: 'skip',
       query: this.ast,
@@ -416,7 +416,7 @@ class QueryClass implements Any {
     });
   }
 
-  'from'(
+  from(
     ...args:
       | [
           (
@@ -555,7 +555,7 @@ class QueryClass implements Any {
     });
   }
 
-  'options'(options: QueryAST.QueryOptions): Any {
+  options(options: QueryAST.QueryOptions): Any {
     return new QueryClass({
       type: 'options',
       query: this.ast,
@@ -563,7 +563,7 @@ class QueryClass implements Any {
     });
   }
 
-  'debugLabel'(label: string): Any {
+  debugLabel(label: string): Any {
     if (this.ast.type === 'options') {
       return new QueryClass({
         type: 'options',
@@ -580,7 +580,7 @@ class QueryClass implements Any {
 }
 
 export const is = (value: unknown): value is Any => {
-  return typeof value === 'object' && value !== null && '~Query' in value;
+  return typeof value === 'object' && value !== null && QueryTypeId in value;
 };
 
 /** Construct a query from an ast. */

--- a/packages/core/echo/echo/src/Query.ts
+++ b/packages/core/echo/echo/src/Query.ts
@@ -57,12 +57,14 @@ export interface AggregateResult {
   readonly '~@dxos/echo/Query.AggregateResult': true;
 }
 
+export const QueryTypeId = '~@dxos/echo/Query' as const;
+export type QueryTypeId = typeof QueryTypeId;
+
 // TODO(burdon): Narrow T to Entity.Unknown?
 export interface Query<T> {
-  // TODO(dmaretskyi): See new effect-schema approach to variance.
-  '~Query': { value: T };
+  readonly [QueryTypeId]: { value: T };
 
-  'ast': QueryAST.Query;
+  ast: QueryAST.Query;
 
   /**
    * Filter the current selection based on a filter.


### PR DESCRIPTION
## Summary

Completes the in-progress refactor that replaces the phantom variance brand keys on the ECHO query interfaces with namespaced `TypeId` constants.

Previously `Query`, `Filter`, `Order`, and `Aggregate` each carried an ad-hoc, hand-written brand property (`~Query`, `~Filter`, `~Order`, `~Aggregate`) used only for variance and runtime `is()` checks. These are now keyed off exported `*TypeId` constants (`'~@dxos/echo/Query'`, etc.), matching the effect-schema TypeId convention.

## Changes

- **`packages/core/echo/echo`** — the WIP commit introduced the `*TypeId` constants and switched the interface declarations. This change finishes the migration by updating the class implementations (`variance` fields, computed brand members) and the `is()` guards in `Aggregate.ts`, `Filter.ts`, `Order.ts`, and `Query.ts`.
- **`packages/core/echo/echo-query`** — updated the light-weight query implementation (`query-lite.ts`) and the QuickJS query sandbox to key off the new constants. `query-lite` keeps its brand keys as locally-declared constants (typed by the type-only `@dxos/echo` imports) so the sandbox bundle stays free of the `@dxos/echo` runtime graph, and exposes the `*TypeId` values on its drop-in replacement namespaces/classes. The sandbox host uses the exported `Filter.FilterTypeId`.

Under the repo's `quoteProps: "consistent"` oxfmt rule, introducing computed `[TypeId]` members forces the surrounding class members to be unquoted for consistency — hence the incidental unquoting churn in the touched classes.

## Test plan

- `moon run echo:build` / `echo-query:build` — pass
- `moon run echo:test echo-query:test` — pass (451 + suite green)
- `moon run echo:lint echo-query:lint` — pass
- `oxfmt --check` on all touched files — clean

This is an internal (phantom, compile-time + in-memory) brand rename with no consumer-facing API surface, so no changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4NxJMYxiaVBjPKNK1gsm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved identification and type-guarding for queries, filters, ordering, and aggregates by switching to exported discriminator constants.
  * Updated lightweight query/filter/order typing to use consistent branded ID keys.
  * Standardized several query-building method declarations while preserving existing runtime behavior.
  * Enhanced sandbox evaluation to recognize filters using the shared filter discriminator constant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->