### PR TITLE
composer-app: skip flaky collaboration cursor e2e test

### DIFF
--- a/packages/apps/composer-app/src/playwright/collaboration.spec.ts
+++ b/packages/apps/composer-app/src/playwright/collaboration.spec.ts
@@ -80,7 +80,12 @@ test.describe('Collaboration tests', () => {
     }
   });
 
-  test("host and guest can see each others' cursors when same document is in focus", async () => {
+  // TODO(wittjosiah): Flaky -- depends on winning a race between the awareness gossip channel
+  //   becoming live and the peer's cursor-position broadcast, with no way from the test to
+  //   detect readiness (the presence indicator this used to rely on no longer exists at the
+  //   app level). Covered instead by a storybook interaction test exercising the CodeMirror
+  //   awareness extension against an in-memory two-peer transport.
+  test.skip("host and guest can see each others' cursors when same document is in focus", async () => {
     await host.createSpace();
     await host.createObject({ type: 'Document' });
 

--- a/packages/ui/react-ui-editor/src/stories/Automerge.stories.tsx
+++ b/packages/ui/react-ui-editor/src/stories/Automerge.stories.tsx
@@ -5,17 +5,17 @@
 import { Repo, initSubduction } from '@automerge/automerge-repo';
 import { BroadcastChannelNetworkAdapter } from '@automerge/automerge-repo-network-broadcastchannel';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { expect, waitFor } from 'storybook/test';
 
 import { Obj, Query, Ref } from '@dxos/echo';
 import { Doc } from '@dxos/echo-doc';
 import { TestSchema } from '@dxos/echo/testing';
-import { log } from '@dxos/log';
 import { type Messenger } from '@dxos/protocols';
-import { useQuery, useSpace } from '@dxos/react-client/echo';
+import { useQuery, useResolveRef, useSpace } from '@dxos/react-client/echo';
 import { type Identity, useIdentity } from '@dxos/react-client/halo';
 import { useClientStory, withMultiClientProvider } from '@dxos/react-client/testing';
-import { Button, useThemeContext } from '@dxos/react-ui';
+import { useThemeContext } from '@dxos/react-ui';
 import { Loading, withLayout, withTheme } from '@dxos/react-ui/testing';
 import { createBasicExtensions, createDataExtensions, createThemeExtensions } from '@dxos/ui-editor';
 
@@ -96,28 +96,16 @@ const EchoStory = () => {
   const identity = useIdentity();
   const space = useSpace(spaceId);
   const objects = useQuery(space?.db, Query.type(TestSchema.Expando, { type: 'test' }));
+  // NOTE: `objects[0]?.content.target` is not reactive to the ref loading; `useResolveRef`
+  // subscribes to the ref's load event so the editor mounts once the target arrives.
+  const content = useResolveRef(objects[0]?.content);
 
   const [source, setSource] = useState<Doc.Accessor>();
-  const init = useCallback(() => {
-    const content = objects[0]?.content.target;
-    if (!content) {
-      if (objects.length) {
-        // TODO(burdon): Initially ref isn't ready.
-        log.warn('no content', { index, objects: JSON.stringify(objects) });
-      }
-      return;
-    }
-
-    setSource(Doc.createAccessor(content, ['content']));
-  }, [objects]);
-
   useEffect(() => {
-    if (source) {
-      return;
+    if (!source && content) {
+      setSource(Doc.createAccessor(content, ['content']));
     }
-
-    init();
-  }, [objects, source]);
+  }, [content, source]);
 
   return (
     <div className='h-full w-full flex flex-col overflow-hidden'>
@@ -129,9 +117,7 @@ const EchoStory = () => {
           <Editor identity={identity} messenger={space} source={source} />
         </div>
       ) : (
-        <div className='p-2'>
-          <Button onClick={init}>Init</Button>
-        </div>
+        <Loading data={{ identity: !!identity, content: !!content }} />
       )}
     </div>
   );
@@ -156,13 +142,19 @@ export const Default: Story = {
   render: DefaultStory,
 };
 
-// TODO(burdon): Failing (doesn't sync)
+/**
+ * Two in-memory ECHO peers (no real networking, see `withMultiClientProvider`) sharing a
+ * document, exercising the `Space.postMessage`/`listen` gossip channel and the CodeMirror
+ * `awareness` extension end to end. This covers the same wiring as the (currently skipped,
+ * flaky) composer-app e2e collaboration cursor test, deterministically and without a browser.
+ */
 export const WithEcho: Story = {
   decorators: [
     withMultiClientProvider({
       numClients: 2,
       createIdentity: true,
       createSpace: true,
+      types: [TestSchema.Expando],
       onCreateSpace: async ({ space }) => {
         space.db.add(
           Obj.make(TestSchema.Expando, {
@@ -174,4 +166,34 @@ export const WithEcho: Story = {
     }),
   ],
   render: EchoStory,
+  play: async ({ canvasElement }) => {
+    // ECHO identity/space creation and invitation are async; wait for both peers to mount an editor.
+    const editors = await waitFor(
+      () => {
+        const found = Array.from(canvasElement.querySelectorAll<HTMLElement>('.cm-editor'));
+        void expect(found).toHaveLength(2);
+        return found;
+      },
+      { timeout: 15_000 },
+    );
+
+    const [contentA, contentB] = editors.map((editor) => editor.querySelector<HTMLElement>('.cm-content')!);
+
+    // Initial content replicated from the host's space to the guest.
+    await expect(contentA).toHaveTextContent(initialContent);
+    await expect(contentB).toHaveTextContent(initialContent);
+
+    // Focusing peer A broadcasts its cursor position over the gossip channel; peer B renders it
+    // as a `.cm-collab-selectionInfo` decoration.
+    contentA.focus();
+    await waitFor(() => expect(editors[1].querySelector('.cm-collab-selectionInfo')).toBeInTheDocument(), {
+      timeout: 10_000,
+    });
+
+    // And symmetrically in the other direction.
+    contentB.focus();
+    await waitFor(() => expect(editors[0].querySelector('.cm-collab-selectionInfo')).toBeInTheDocument(), {
+      timeout: 10_000,
+    });
+  },
 };


### PR DESCRIPTION
## Summary
- Skips the flaky `"host and guest can see each others' cursors when same document is in focus"` e2e test in `collaboration.spec.ts` — it depends on winning a race between the awareness gossip channel becoming live on both peers and the concurrent cursor-position broadcast triggered by the test's `Promise.all` focus calls, with no way from the test to detect readiness (the presence indicator it used to rely on no longer exists at the app level).
- Replaces that coverage with a storybook interaction test on `Automerge.stories.tsx`'s `WithEcho` story, which exercises the real `Space.postMessage`/`listen` gossip channel and the CodeMirror `awareness` extension end to end against an in-memory two-peer transport — deterministic, no browser.
- Fixing that story surfaced two pre-existing bugs blocking it from ever syncing:
  - `TestSchema.Expando` wasn't registered on the test clients, so `space.db.add(...)` threw for both peers.
  - The ref-to-content read wasn't reactive to the ref's load event (`objects[0]?.content.target`), so the editor never mounted once data did arrive — switched to `useResolveRef`.

## Test plan
- [x] `moon run react-ui-editor:test-storybook` — 50/50 passing, including the new `WithEcho` interaction test (stable across repeated runs)
- [x] `moon run composer-app:e2e` locally — 23 passed, 17 skipped (incl. the newly-skipped cursor test), 0 failed
- [x] `moon run react-ui-editor:lint -- --fix` / `moon run composer-app:lint -- --fix` — clean
- [ ] CI Check — monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved collaborative editor loading behavior with clearer loading feedback while shared content is being resolved.
  - Strengthened validation of shared document content and cursor synchronization between collaborators.

- **Tests**
  - Added more deterministic coverage for real-time content replication and cross-editor cursor visibility.
  - Isolated a known timing-sensitive cursor test to reduce unreliable test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->