### PR TITLE
app-framework: document module activation ordering

### DIFF
--- a/.agents/skills/composer-plugins/SKILL.md
+++ b/.agents/skills/composer-plugins/SKILL.md
@@ -375,6 +375,30 @@ The main plugin file wires everything together using `Plugin.define(meta).pipe()
 
 See: `plugin-chess/src/ChessPlugin.tsx`
 
+### Module activation ordering
+
+Modules do **not** activate in registration order. Each module declares an
+event that triggers it (`activatesOn`), and ordering between modules is
+expressed through **shared activation events** — modules never reference each
+other directly. Two levers on `Plugin.addModule({...})`:
+
+- **`firesAfterActivation: [Event]`** — after this module's `activate` body
+  finishes, the framework fires `Event`; any module with `activatesOn: Event`
+  then runs. Use to publish "I'm ready" (e.g. `ClientEvents.ClientReady`).
+- **`firesBeforeActivation: [Event]`** — before this module's `activate` runs,
+  the framework activates `Event`'s contributors and **waits** for them. Use to
+  force a prerequisite (e.g. schema/migration setup) ahead of this module.
+
+To run module **B after** module A: A declares `firesAfterActivation: [E]`, B
+declares `activatesOn: E`. To force setup **before** B: B declares
+`firesBeforeActivation: [E]`. Combine events with `ActivationEvent.oneOf(...)`
+/ `allOf(...)`.
+
+Canonical example (idiom `org.dxos.app-framework.moduleActivationOrdering`):
+`plugin-client/src/ClientPlugin.ts` — the `Client` module fires
+`ClientEvents.ClientReady` after activating; `SchemaDefs`/`Migrations` listen on
+it and use `firesBeforeActivation` to sequence setup ahead of themselves.
+
 ## React Surface
 
 Surfaces are contributed via `Capability.contributes(Capabilities.ReactSurface, [...])` with `Surface.create()`.

--- a/packages/sdk/app-framework/src/core/plugin.ts
+++ b/packages/sdk/app-framework/src/core/plugin.ts
@@ -79,6 +79,18 @@ export const isPluginModule = (value: unknown): value is PluginModule => {
 /**
  * A unit of containment of modular functionality that can be provided to an application.
  * Activation of a module is async allowing for code to split and loaded lazily.
+ *
+ * Ordering between modules is expressed through shared activation events, not registration
+ * order: a module `activatesOn` an event, fires events *after* it activates via
+ * {@link PluginModule.firesAfterActivation} (publishing "I'm ready"), and forces prerequisites
+ * to complete *before* it activates via {@link PluginModule.firesBeforeActivation}. To run
+ * module B after module A, A declares `firesAfterActivation: [E]` and B declares
+ * `activatesOn: E`. See `plugin-client/src/ClientPlugin.ts` for a worked example.
+ *
+ * @idiom org.dxos.app-framework.moduleActivationOrdering
+ *   applies: sequencing one plugin module's activation before or after another
+ *   instead-of: assuming module registration order controls activation order
+ *   uses: {@link PluginModule.firesAfterActivation}, {@link PluginModule.firesBeforeActivation}
  */
 export interface PluginModule {
   readonly [PluginModuleTypeId]: PluginModuleTypeId;


### PR DESCRIPTION
## Summary

Documents how to sequence one plugin module's activation before/after another — a question that wasn't covered anywhere for agents or humans.

The plugin framework activates modules by **shared activation events**, not registration order. A module `activatesOn` an event, publishes readiness via `firesAfterActivation`, and forces prerequisites via `firesBeforeActivation`. This was implemented and JSDoc'd on the individual fields, but there was no named, discoverable entry point.

## Changes

- **`packages/sdk/app-framework/src/core/plugin.ts`** — add an `@idiom org.dxos.app-framework.moduleActivationOrdering` tag (+ summary prose) on the `PluginModule` interface, the symbol that owns the mechanism. Points to `plugin-client/src/ClientPlugin.ts` as the worked example.
- **`.agents/skills/composer-plugins/SKILL.md`** — add a "Module activation ordering" subsection under Plugin Definition covering the two levers, the before/after recipes, and the idiom slug.

## Notes

Docs-only: a Markdown skill file and a JSDoc comment — no executable code changes, so no changeset and no behavioral tests to add. The idiom will appear in `list_idioms` once the introspect index snapshot is next regenerated in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on controlling plugin module activation order using shared activation events.
  * Documented options for specifying modules that activate before or after others.
  * Clarified that registration order does not determine activation order.
  * Included examples for combining activation-order constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->