### PR TITLE
vite-plugin-log: preserve transform source maps (string + generated map)

### DIFF
--- a/tools/vite-plugin-log/src/plugin.ts
+++ b/tools/vite-plugin-log/src/plugin.ts
@@ -269,7 +269,15 @@ export function DxosLogPlugin(options: DxosLogPluginOptions = {}): Plugin {
         if (doWorkerInject) {
           ms.prepend(`import ${JSON.stringify(VITE_PLUGIN_LOG_RUNTIME_ID)};\n`);
         }
-        return { code: ms.toString() };
+        // Return a string + explicit source map (not the `RolldownMagicString` object): under the
+        // Vite pipeline the transform result's `code` must be a string, so returning the object leaks
+        // downstream as `[object Object]`. The map keeps dev breakpoints / stack traces aligned past
+        // the injected preamble `var __dxlog_file=…` line. (Returning the object only works in pure
+        // Rolldown / with `experimental.nativeMagicString`.)
+        return {
+          code: ms.toString(),
+          map: ms.generateMap({ hires: true, source: id, includeContent: false }).toString(),
+        };
       },
     } satisfies RolldownPlugin['transform'] as any;
   }


### PR DESCRIPTION
## Summary

The `DxosLogPlugin` Rolldown `transform` handler returned `ms.toString()` with no `map`, discarding the source map for the log-meta edits it applies. Because `computeLogMetaEdits` inserts a preamble line (`var __dxlog_file=…`), every subsequent line in the module shifts by 1–2, desyncing dev-server breakpoints and DevTools stack traces for the rest of the file.

This returns `ms.toString()` **plus** `ms.generateMap()` (serialized to a JSON string, which `SourceMapInput` accepts) so the map is emitted.

Note on the approach: the pure-Rolldown [Native MagicString](https://rolldown.rs/in-depth/native-magic-string) guideline is to return the `RolldownMagicString` object as `code`. That is **not** valid under the Vite/vitest transform pipeline used here (`vite@8` + `rolldown@1.1.5` without `experimental.nativeMagicString`): the object isn't stringified and leaks downstream as `[object Object]`, breaking `builtin:vite-resolve` for every module in storybook/vitest. Returning a string + explicit map is the correct Vite-compatible form.

Log line numbers themselves are unaffected — those come from the injected `L:<line>` literal, not the source map — so this only restores debugger/stack-trace fidelity.

## Changes

- `tools/vite-plugin-log/src/plugin.ts`: the `transform` handler now returns `{ code: ms.toString(), map: ms.generateMap({ hires: true, source: id, includeContent: false }).toString() }` instead of a mapless `{ code: ms.toString() }`.

## Testing

- `moon run vite-plugin-log:compile` — passes
- `moon run vite-plugin-log:test` — 20/20 pass
- `moon run vite-plugin-log:lint` — passes
- `vite build` on `tools/vite-plugin-log/example` (real Vite pipeline through `DxosLogPlugin`) — 455 modules transformed, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3QSBRmV9NoMK8Ca8X8hqi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debugging accuracy by preserving source maps after code transformation.
  * Breakpoints and stack traces now align correctly during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->