### PR TITLE
config: default edge replication to subduction replicator

### DIFF
--- a/.changeset/subduction-default-replicator.md
+++ b/.changeset/subduction-default-replicator.md
@@ -1,0 +1,5 @@
+---
+'@dxos/config': minor
+---
+
+Default edge replication to the Subduction sedimentree transport: the built-in client config now enables `edgeFeatures.subductionReplicator` instead of `edgeFeatures.echoReplicator`. Set `subductionReplicator: false` (and `echoReplicator: true`) to restore the previous Automerge edge replicator.

--- a/packages/apps/composer-app/dx-env.yml
+++ b/packages/apps/composer-app/dx-env.yml
@@ -31,6 +31,10 @@ DX_EDGE_ECHO_REPLICATOR:
   path: runtime.client.edgeFeatures.echoReplicator
   type: boolean
 
+DX_EDGE_SUBDUCTION_REPLICATOR:
+  path: runtime.client.edgeFeatures.subductionReplicator
+  type: boolean
+
 DX_EDGE_FEED_REPLICATOR:
   path: runtime.client.edgeFeatures.feedReplicator
   type: boolean

--- a/packages/apps/composer-app/dx.yml
+++ b/packages/apps/composer-app/dx.yml
@@ -6,7 +6,7 @@ runtime:
       persistent: true
     edgeFeatures:
       signaling: true
-      echoReplicator: true
+      subductionReplicator: true
       feedReplicator: true
       agents: true
 

--- a/packages/apps/testbench-app/dx.yml
+++ b/packages/apps/testbench-app/dx.yml
@@ -6,7 +6,7 @@ runtime:
       dataStore: 1
     edgeFeatures:
       signaling: true
-      echoReplicator: true
+      subductionReplicator: true
       feedReplicator: true
       agents: true
     disableP2pReplication: true

--- a/packages/devtools/cli/config/config-dev.yml
+++ b/packages/devtools/cli/config/config-dev.yml
@@ -3,7 +3,7 @@ version: 1
 runtime:
   client:
     edgeFeatures:
-      echoReplicator: true
+      subductionReplicator: true
       feedReplicator: true
       signaling: true
       agents: true

--- a/packages/devtools/cli/config/config-local.yml
+++ b/packages/devtools/cli/config/config-local.yml
@@ -3,7 +3,7 @@ version: 1
 runtime:
   client:
     edgeFeatures:
-      echoReplicator: true
+      subductionReplicator: true
       feedReplicator: true
       signaling: true
       agents: true

--- a/packages/devtools/devtools/src/containers/SubductionSelector.tsx
+++ b/packages/devtools/devtools/src/containers/SubductionSelector.tsx
@@ -20,7 +20,10 @@ export const SubductionSelector = () => {
     const existing = await Storage();
     await SaveConfig(
       merge({}, existing, {
-        runtime: { client: { edgeFeatures: { subductionReplicator: checked } } },
+        // The two edge transports are mutually exclusive: flipping subduction off re-enables the
+        // legacy echo replicator, so replication never silently stops (neither flag set selects no
+        // edge replicator in the service context).
+        runtime: { client: { edgeFeatures: { subductionReplicator: checked, echoReplicator: !checked } } },
       }),
     );
     window.location.reload();

--- a/packages/e2e/blade-runner/src/spec/edge-sync.ts
+++ b/packages/e2e/blade-runner/src/spec/edge-sync.ts
@@ -66,7 +66,7 @@ export class EdgeSync implements TestPlan<EdgeTestSpec, EdgeSyncResult> {
         runtime: {
           client: {
             edgeFeatures: {
-              echoReplicator: true,
+              subductionReplicator: true,
               signaling: true,
               feedReplicator: true,
               agents: true,
@@ -93,10 +93,10 @@ export class EdgeSync implements TestPlan<EdgeTestSpec, EdgeSyncResult> {
     // Config.
     //
     const configEnabledEdgeSync = structuredClone(params.spec.config);
-    configEnabledEdgeSync.runtime!.client!.edgeFeatures!.echoReplicator = true;
+    configEnabledEdgeSync.runtime!.client!.edgeFeatures!.subductionReplicator = true;
 
     const configDisabledEdgeSync = structuredClone(params.spec.config);
-    configDisabledEdgeSync.runtime!.client!.edgeFeatures!.echoReplicator = false;
+    configDisabledEdgeSync.runtime!.client!.edgeFeatures!.subductionReplicator = false;
 
     //
     // Spawn replicant and setup.

--- a/packages/sdk/client/test/e2e/edge-recovery.test.ts
+++ b/packages/sdk/client/test/e2e/edge-recovery.test.ts
@@ -29,7 +29,7 @@ const createEdgeConfig = () =>
       },
       client: {
         edgeFeatures: {
-          echoReplicator: true,
+          subductionReplicator: true,
           feedReplicator: true,
           signaling: true,
           agents: true,

--- a/packages/sdk/client/test/e2e/sync.test.ts
+++ b/packages/sdk/client/test/e2e/sync.test.ts
@@ -30,7 +30,7 @@ describe('sync', { timeout: 120_000, retry: 0, tags: ['sync-e2e'] }, async () =>
         },
         client: {
           edgeFeatures: {
-            echoReplicator: true,
+            subductionReplicator: true,
             feedReplicator: true,
           },
           storage: {

--- a/packages/sdk/config/src/config-service.ts
+++ b/packages/sdk/config/src/config-service.ts
@@ -19,7 +19,7 @@ export const memoryConfig = new Config({
   runtime: {
     client: {
       edgeFeatures: {
-        echoReplicator: true,
+        subductionReplicator: true,
         feedReplicator: true,
         signaling: true,
         agents: true,
@@ -32,7 +32,7 @@ export const defaultConfig = new Config({
   runtime: {
     client: {
       edgeFeatures: {
-        echoReplicator: true,
+        subductionReplicator: true,
         feedReplicator: true,
         signaling: true,
         agents: true,
@@ -101,7 +101,7 @@ const profileBuiltinDefaults = (profile: string) => {
     runtime: {
       client: {
         edgeFeatures: {
-          echoReplicator: true,
+          subductionReplicator: true,
           feedReplicator: true,
           signaling: true,
           agents: true,

--- a/packages/sdk/config/src/preset.ts
+++ b/packages/sdk/config/src/preset.ts
@@ -45,7 +45,7 @@ export const configPreset = ({ edge = 'main', sandbox }: ConfigPresetOptions = {
       client: {
         edgeFeatures: {
           signaling: true,
-          echoReplicator: true,
+          subductionReplicator: true,
           feedReplicator: true,
         },
       },

--- a/packages/sdk/observability/test/e2e/tracing-invitation.test.ts
+++ b/packages/sdk/observability/test/e2e/tracing-invitation.test.ts
@@ -42,7 +42,7 @@ const createEdgeConfig = () =>
       },
       client: {
         edgeFeatures: {
-          echoReplicator: true,
+          subductionReplicator: true,
           feedReplicator: true,
           signaling: true,
           agents: true,


### PR DESCRIPTION
## What

Make **Subduction** the default edge replication transport for the client. Everywhere the built-in config previously defaulted `edgeFeatures.echoReplicator: true`, it now sets `edgeFeatures.subductionReplicator: true` instead.

The selector in `service-context.ts` already prefers `subductionReplicator` (and drives `useSubduction` on the `EchoHost`), so this is purely a config-default flip — no runtime selection logic changed.

## Changes

**SDK config (`@dxos/config`)**
- `config-service.ts` — `memoryConfig`, `defaultConfig`, `profileBuiltinDefaults`
- `preset.ts` — `configPreset`

**Shipping app configs**
- `composer-app/dx.yml` — production Composer now defaults to Subduction
- `testbench-app/dx.yml`
- `composer-app/dx-env.yml` — added `DX_EDGE_SUBDUCTION_REPLICATOR` env toggle (kept `DX_EDGE_ECHO_REPLICATOR` for ops parity)

**CLI dev/local configs**
- `devtools/cli/config/config-dev.yml`, `config-local.yml`

**Test / e2e specs**
- `blade-runner/src/spec/edge-sync.ts` (base spec + enabled/disabled runtime configs)
- `client/test/e2e/sync.test.ts`, `client/test/e2e/edge-recovery.test.ts`, `observability/test/e2e/tracing-invitation.test.ts`

**Devtools config-view switch fix**
- `SubductionSelector.tsx` now flips **both** flags mutually-exclusively: `subductionReplicator: checked, echoReplicator: !checked`.

## Why the devtools fix is needed

With the base config no longer setting `echoReplicator`, the old one-flag switch was broken: toggling subduction **off** left `subductionReplicator: false` with `echoReplicator` absent, so the selector fell through to `Layer.empty` — **no edge replicator at all**. Writing both flags makes the switch a proper transport toggle where exactly one of the two is always active (subduction on → echo off, and vice-versa). Verified end-to-end through the config-source precedence (`Storage()` is the top-priority arg to `defaultsDeep`, and a saved `false` is preserved rather than back-filled from the `dx.yml` defaults).

## Reverting to the legacy replicator

Set `edgeFeatures.subductionReplicator: false` and `edgeFeatures.echoReplicator: true` (or, in Composer, `DX_EDGE_SUBDUCTION_REPLICATOR=false` + `DX_EDGE_ECHO_REPLICATOR=true`).

## Notes

- Left intentionally on echo: the `service-context.ts` selector fallback (still honors `echoReplicator` if a config sets it), `boot-client.ts`'s deliberate `echoReplicator: false` in recovery, and three storybook configs that opt into the echo path for their scenarios.
- Changeset: `@dxos/config: minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switched the default edge replication mechanism to Subduction for improved replication support.
  * Added configuration controls for enabling or disabling Subduction replication.
  * Updated development tools, test environments, and built-in configurations to use the new default.

* **Bug Fixes**
  * Prevented replication from being unintentionally disabled when changing the replication setting.

* **Documentation**
  * Documented how to restore the previous replication behavior using the compatibility configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->