### PR TITLE
echo: test feed update-by-id returns single latest object

### DIFF
--- a/packages/core/echo/echo-client-e2e/src/feed.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/feed.test.ts
@@ -250,6 +250,43 @@ describe('feeds', () => {
     });
   });
 
+  describe('Update by id', () => {
+    test('appending an item with an existing id updates it in place', async ({ expect }) => {
+      await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
+      const db = await peer.createDatabase();
+      const feed = db.add(Feed.make({ name: 'people' }));
+
+      // Append the original object, then append a second object reusing the same id — this is an update.
+      const john = Obj.make(TestSchema.Person, { name: 'john' });
+      await db.appendToFeed(feed, [john]);
+      await db.appendToFeed(feed, [Obj.make(TestSchema.Person, { id: john.id, name: 'john v2' })]);
+
+      // The query collapses entries by id and returns a single object holding the latest state.
+      const result = await queryFeed(db, feed, Filter.everything()).run();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toEqual(john.id);
+      expect((result[0] as TestSchema.Person).name).toEqual('john v2');
+    });
+
+    test('the latest state survives indexing after flush', async ({ expect }) => {
+      await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
+      const db = await peer.createDatabase();
+      const feed = db.add(Feed.make({ name: 'people' }));
+
+      const john = Obj.make(TestSchema.Person, { name: 'john' });
+      await db.appendToFeed(feed, [john]);
+      await db.appendToFeed(feed, [Obj.make(TestSchema.Person, { id: john.id, name: 'john v2' })]);
+
+      // Flush so the query is served by the indexer rather than the in-memory feed handle.
+      await db.flush();
+
+      const result = await queryFeed(db, feed, Filter.everything()).run();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toEqual(john.id);
+      expect((result[0] as TestSchema.Person).name).toEqual('john v2');
+    });
+  });
+
   describe('Durability', () => {
     test('feed objects survive reload', async ({ expect }) => {
       await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });


### PR DESCRIPTION
## Summary

Adds e2e coverage in `echo-client-e2e` for feed update-by-id semantics: appending an item whose id matches an existing feed entry is an **update**, not a duplicate. The feed query collapses entries by id and returns a single object holding the latest state.

## Changes

Two tests under a new `Update by id` describe block in `feed.test.ts`:

- **`appending an item with an existing id updates it in place`** — appends `john`, then appends a second `Person` reusing `john.id` with a changed field; asserts the query returns exactly one object with the original id and the latest (`john v2`) state. Exercises the live in-memory feed-handle query path.
- **`the latest state survives indexing after flush`** — same scenario followed by `db.flush()`, so the query is served by the indexer rather than the in-memory handle; asserts the same single latest-state result.

## Testing

- `moon run echo-client-e2e:test` — both new tests pass (full suite green).
- `moon run echo-client-e2e:lint echo-client-e2e:build` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYFavn2kKrrSgcst2moAkC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYFavn2kKrrSgcst2moAkC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that updating a feed item by its ID replaces the previous entry rather than creating a duplicate.
  * Confirmed updated results remain correct after data is flushed and retrieved through the indexer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->