### PR TITLE
storybook: pin @babel/parser to 7.x + guard chunk repair (follow-up to #12234)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: ^7.18.13
       version: 7.28.0
     '@babel/parser':
-      specifier: ^8.0.4
-      version: 8.0.4
+      specifier: ^7.29.0
+      version: 7.29.0
     '@babel/preset-typescript':
       specifier: ^7.27.1
       version: 7.27.1
@@ -24480,7 +24480,7 @@ importers:
     dependencies:
       '@babel/parser':
         specifier: 'catalog:'
-        version: 8.0.4
+        version: 7.29.0
       vite-plugin-top-level-await:
         specifier: 'catalog:'
         version: 1.6.0(@swc/helpers@0.5.17)(rollup@3.30.0)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -25402,17 +25402,9 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@8.0.0':
-    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@8.0.4':
-    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
@@ -25429,11 +25421,6 @@ packages:
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@8.0.4':
-    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.7':
@@ -25901,10 +25888,6 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/types@8.0.4':
-    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babylonjs/core@7.54.3':
     resolution: {integrity: sha512-P5ncXVd8GEUJLhwloP9V0oVwQYIrvZztguVeLlvd5Rx+9aQnenKjpV8auJ6SRsUlAmNZU4pFTKzwF6o2EUfhAw==}
@@ -46416,11 +46399,7 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
-  '@babel/helper-string-parser@8.0.0': {}
-
   '@babel/helper-validator-identifier@7.28.5': {}
-
-  '@babel/helper-validator-identifier@8.0.4': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -46441,10 +46420,6 @@ snapshots:
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@babel/parser@8.0.4':
-    dependencies:
-      '@babel/types': 8.0.4
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.7(@babel/core@7.28.0)':
     dependencies:
@@ -47038,11 +47013,6 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-
-  '@babel/types@8.0.4':
-    dependencies:
-      '@babel/helper-string-parser': 8.0.0
-      '@babel/helper-validator-identifier': 8.0.4
 
   '@babylonjs/core@7.54.3': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
   '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.40
   '@automerge/automerge-subduction': 0.16.0
   '@babel/core': ^7.18.13
-  '@babel/parser': ^8.0.4
+  '@babel/parser': ^7.29.0
   '@babel/preset-typescript': ^7.27.1
   '@babel/runtime': ^7.9.6
   '@babylonjs/core': ^7.52.5

--- a/tools/storybook-react/.storybook/main.ts
+++ b/tools/storybook-react/.storybook/main.ts
@@ -115,7 +115,15 @@ const repairTopLevelAwait = async (code: string): Promise<string | null> => {
     return null;
   }
   const { parse } = await import('@babel/parser');
-  const ast = parse(code, { sourceType: 'module', errorRecovery: true });
+  // `errorRecovery` still throws on unrecoverable syntax; a single such chunk must not
+  // fail the whole build, so leave it unmodified rather than propagating out of renderChunk.
+  let program: unknown;
+  try {
+    program = parse(code, { sourceType: 'module', errorRecovery: true }).program;
+  } catch (error) {
+    console.warn('[dxos:repair-top-level-await] Skipping unparseable chunk.', error);
+    return null;
+  }
   const positions: number[] = [];
   const walk = (node: AstNode) => {
     if (FUNCTION_NODES.has(node.type) && node.async === false && typeof node.start === 'number' && ownsAwait(node)) {
@@ -133,8 +141,8 @@ const repairTopLevelAwait = async (code: string): Promise<string | null> => {
       }
     }
   };
-  if (isAstNode(ast.program)) {
-    walk(ast.program);
+  if (isAstNode(program)) {
+    walk(program);
   }
   if (positions.length === 0) {
     return null;


### PR DESCRIPTION
## Summary

Follow-up to #12234 (the top-level-await build repair), addressing the two CodeRabbit review findings that couldn't be pushed before that PR entered the merge queue.

1. **Pin `@babel/parser` to `^7.29.0`** (was `^8.0.4`). Babel 8 requires Node
   `^22.18.0 || >=24.11.0`, which is incompatible with the repo's declared
   `engines.node` (`^24.0.0`) — Node 24.0–24.10 would fail the build. 7.x has no
   such floor, is already in the tree, and produces the same AST for the repair
   step in `.storybook/main.ts`.

2. **Guard the parser against unrecoverable syntax.** `errorRecovery` can still
   throw; a single unparseable chunk would otherwise propagate out of
   `renderChunk` and fail the whole `storybook build`. Now it falls back to the
   unmodified chunk (warn + skip) so one bad chunk can't take down the build.

## Notes for reviewers

- Pure robustness follow-up; no behavior change on the success path. Verified a
  local `storybook build` still produces **0 malformed chunks** with the 7.x
  parser.
- Known limitation (not addressed here): stories that boot a full DXOS client
  (ECHO/Automerge WASM) still hang in the production bundle — rolldown's
  top-level-await *sequencing* is broken more deeply than the syntax this repair
  patches. Simple stories render; dev is unaffected. Tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build resilience when code parsing fails during Storybook processing.
  * Affected code chunks are now left unchanged instead of causing the entire build to fail.

* **Chores**
  * Updated the Babel parser version used by the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->