### PR TITLE
plugins: add headless harness tests mirroring Composer e2e flows

### DIFF
--- a/packages/plugins/plugin-comments/src/comment-flow.test.ts
+++ b/packages/plugins/plugin-comments/src/comment-flow.test.ts
@@ -1,0 +1,136 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { Obj, Query, Ref, Relation } from '@dxos/echo';
+import { EffectEx } from '@dxos/effect';
+import { ClientCapabilities, ClientEvents } from '@dxos/plugin-client';
+import { ClientPlugin, initializeIdentity } from '@dxos/plugin-client/testing';
+import { createComposerTestApp } from '@dxos/plugin-testing/harness';
+import { Text } from '@dxos/schema';
+import { AnchoredTo, Message, Thread } from '@dxos/types';
+
+// Headless coverage for the comment flows exercised by `composer-app/src/playwright/comments.spec.ts`.
+// In Composer a comment is a `Thread` (holding `Message` refs) attached to a document via an
+// `AnchoredTo` relation whose `anchor` encodes the selected text range. The Playwright tests drive
+// the thread sidebar UI; here we exercise the same data mutations — mirroring the `CommentOperation`
+// handlers (`Create` / `AddMessage` / `DeleteMessage` / `Delete` / `Restore`) — against a real ECHO
+// space from the composer test harness, without the anchoring editor or sidebar DOM.
+
+const setup = async () => {
+  const harness = await createComposerTestApp({ plugins: [ClientPlugin({})] });
+  const client = harness.get(ClientCapabilities.Client);
+  await client.addTypes([Text.Text, Thread.Thread, Message.Message, AnchoredTo.AnchoredTo]);
+  const { personalSpace } = await EffectEx.runAndForwardErrors(initializeIdentity(client));
+  await harness.waitForEvent(ClientEvents.SpacesReady);
+  return { harness, db: personalSpace.db };
+};
+
+type Db = Awaited<ReturnType<typeof setup>>['db'];
+
+const message = (text: string, role: 'user' | 'assistant' = 'user') =>
+  Message.make({ sender: { role }, blocks: [{ _tag: 'text', text }] });
+
+/** Create a document, a thread with its first message, and the anchor relation binding them. */
+const createComment = (db: Db, docText: string, commentText: string) => {
+  const subject = db.add(Text.make({ content: docText }));
+  const first = db.add(message(commentText));
+  const thread = db.add(Thread.make({ name: docText, status: 'active', messages: [Ref.make(first)] }));
+  const anchor = db.add(AnchoredTo.make({ [Relation.Source]: thread, [Relation.Target]: subject, anchor: '0:5' }));
+  return { subject, thread, anchor, first };
+};
+
+describe('comment flow', () => {
+  test('create a comment thread anchored to a document', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const { thread, anchor, subject } = createComment(db, 'Hello world!', 'world');
+
+    const threads = await db.query(Query.type(Thread.Thread)).run();
+    expect(threads.length).toBe(1);
+    expect(thread.messages.length).toBe(1);
+    // The anchor relation binds the thread (source) to the document (target).
+    expect(Relation.getSource(anchor)).toBe(thread);
+    expect(Relation.getTarget(anchor)).toBe(subject);
+  });
+
+  test('edit a comment message', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const { first } = createComment(db, 'Hello world!', 'Example');
+    expect(Message.extractText(first)).toBe('Example');
+
+    // Playwright `edit message`: replace the message body text.
+    Obj.update(first, (first) => {
+      first.blocks = [{ _tag: 'text', text: 'Edited' }];
+    });
+    expect(Message.extractText(first)).toBe('Edited');
+  });
+
+  test('add then delete a message', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const { thread } = createComment(db, 'lorem ipsum', 'first');
+    expect(thread.messages.length).toBe(1);
+
+    // Playwright `delete message`: add a second message, then delete it.
+    const second = db.add(message('second'));
+    Obj.update(thread, (thread) => {
+      thread.messages.push(Ref.make(second));
+    });
+    expect(thread.messages.length).toBe(2);
+
+    const index = thread.messages.findIndex((ref) => ref.target === second);
+    Obj.update(thread, (thread) => {
+      thread.messages.splice(index, 1);
+    });
+    db.remove(second);
+    expect(thread.messages.length).toBe(1);
+    expect(Obj.isDeleted(second)).toBe(true);
+  });
+
+  test('deleting the last message deletes the thread', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const { thread, anchor, first } = createComment(db, 'lorem ipsum', 'only message');
+    expect(thread.messages.length).toBe(1);
+
+    // Playwright `delete message`: deleting the final message removes the whole thread + its anchor
+    // (DeleteMessage delegates to Delete when the thread would be left empty).
+    Obj.update(thread, (thread) => {
+      thread.messages.splice(0, 1);
+    });
+    db.remove(first);
+    db.remove(anchor);
+    db.remove(thread);
+
+    const threads = await db.query(Query.type(Thread.Thread)).run();
+    expect(threads.length).toBe(0);
+    expect(Obj.isDeleted(thread)).toBe(true);
+  });
+
+  test('undo restores a deleted thread', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const { thread, anchor } = createComment(db, 'lorem ipsum', 'to be deleted');
+
+    // Playwright `delete thread`.
+    db.remove(anchor);
+    db.remove(thread);
+    expect((await db.query(Query.type(Thread.Thread)).run()).length).toBe(0);
+
+    // Playwright `undo delete thread`: Restore re-adds the thread and its anchor.
+    db.add(thread);
+    db.add(anchor);
+    const threads = await db.query(Query.type(Thread.Thread)).run();
+    expect(threads.length).toBe(1);
+    expect(threads[0].messages.length).toBe(1);
+  });
+});

--- a/packages/plugins/plugin-markdown/src/document-flow.test.ts
+++ b/packages/plugins/plugin-markdown/src/document-flow.test.ts
@@ -1,0 +1,108 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import { describe, test } from 'vitest';
+
+import { Operation } from '@dxos/compute';
+import { Database, EID, Ref } from '@dxos/echo';
+import { EffectEx } from '@dxos/effect';
+import { ClientCapabilities, ClientEvents } from '@dxos/plugin-client';
+import { ClientPlugin, initializeIdentity } from '@dxos/plugin-client/testing';
+import { createComposerTestApp } from '@dxos/plugin-testing/harness';
+
+import { MarkdownPlugin } from '#plugin';
+
+import { Markdown, MarkdownOperation } from './types';
+
+// Headless coverage for the document flows exercised by `composer-app/src/playwright/basic.spec.ts`
+// (`create document`) and the editor content used by `comments.spec.ts`. The Playwright tests type
+// into a CodeMirror textbox; here we drive the same create/edit behaviour through the markdown
+// plugin's operations against a real ECHO space from the composer test harness — no editor DOM.
+
+const setup = async () => {
+  const harness = await createComposerTestApp({ plugins: [ClientPlugin({}), MarkdownPlugin()] });
+  const { personalSpace } = await EffectEx.runAndForwardErrors(
+    initializeIdentity(harness.get(ClientCapabilities.Client)),
+  );
+  await harness.waitForEvent(ClientEvents.SpacesReady);
+  return { harness, spaceId: personalSpace.id, db: personalSpace.db };
+};
+
+describe('markdown document flow', () => {
+  test('create a document with content', async ({ expect }) => {
+    const { harness, spaceId, db } = await setup();
+    await using _harness = harness;
+
+    await harness.runPromise(
+      Effect.gen(function* () {
+        const { id } = yield* Operation.invoke(
+          MarkdownOperation.Create,
+          { name: 'Welcome', content: 'Hello wold!' },
+          { spaceId },
+        );
+
+        const doc = yield* Database.resolve(EID.parse(id), Markdown.Document).pipe(Effect.provide(Database.layer(db)));
+        expect(doc.name).toBe('Welcome');
+
+        // Content lives in a referenced Text object (what the editor binds to).
+        const text = yield* Database.load(doc.content).pipe(Effect.provide(Database.layer(db)));
+        expect(text.content).toBe('Hello wold!');
+      }),
+    );
+  });
+
+  test('edit document content', async ({ expect }) => {
+    const { harness, spaceId, db } = await setup();
+    await using _harness = harness;
+
+    await harness.runPromise(
+      Effect.gen(function* () {
+        const { id } = yield* Operation.invoke(
+          MarkdownOperation.Create,
+          { name: 'Welcome', content: 'Hello wold!' },
+          { spaceId },
+        );
+        const doc = yield* Database.resolve(EID.parse(id), Markdown.Document).pipe(Effect.provide(Database.layer(db)));
+
+        // Playwright comments.spec `edit message` fixes the typo "wold" -> "world" in the editor.
+        const { newContent } = yield* Operation.invoke(
+          MarkdownOperation.Update,
+          { doc: Ref.make(doc), edits: [{ oldString: 'wold', newString: 'world' }] },
+          { spaceId },
+        );
+        expect(newContent).toBe('Hello world!');
+
+        const text = yield* Database.load(doc.content).pipe(Effect.provide(Database.layer(db)));
+        expect(text.content).toBe('Hello world!');
+      }),
+    );
+  });
+
+  test('append to document content', async ({ expect }) => {
+    const { harness, spaceId, db } = await setup();
+    await using _harness = harness;
+
+    await harness.runPromise(
+      Effect.gen(function* () {
+        const { id } = yield* Operation.invoke(
+          MarkdownOperation.Create,
+          { name: 'Notes', content: 'Line one.' },
+          { spaceId },
+        );
+        const doc = yield* Database.resolve(EID.parse(id), Markdown.Document).pipe(Effect.provide(Database.layer(db)));
+
+        // Omitting `oldString` appends (collaboration.spec appends parts to a shared document).
+        yield* Operation.invoke(
+          MarkdownOperation.Update,
+          { doc: Ref.make(doc), edits: [{ newString: ' Line two.' }] },
+          { spaceId },
+        );
+
+        const text = yield* Database.load(doc.content).pipe(Effect.provide(Database.layer(db)));
+        expect(text.content).toBe('Line one. Line two.');
+      }),
+    );
+  });
+});

--- a/packages/plugins/plugin-space/src/collections.test.ts
+++ b/packages/plugins/plugin-space/src/collections.test.ts
@@ -1,0 +1,161 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { Collection, Obj, Ref } from '@dxos/echo';
+import { EffectEx } from '@dxos/effect';
+import { ClientCapabilities, ClientEvents } from '@dxos/plugin-client';
+import { ClientPlugin, initializeIdentity } from '@dxos/plugin-client/testing';
+import { createComposerTestApp } from '@dxos/plugin-testing/harness';
+import { Text } from '@dxos/schema';
+
+import { SpacePlugin } from '#plugin';
+
+// Headless coverage for the flows exercised by `composer-app/src/playwright/collections.spec.ts`
+// and the collection parts of `basic.spec.ts`. Those Playwright tests drive the navtree UI; here we
+// exercise the same data flows directly against a real ECHO space obtained from the composer test
+// harness. The delete/undo cases mirror `SpaceOperation.RemoveObjects` / `RestoreObjects` semantics
+// (splice the ref out of the parent collection + `db.remove`, then re-add) without the layout side
+// effects those operations perform, which require the browser-only deck plugin.
+
+const setup = async () => {
+  const harness = await createComposerTestApp({ plugins: [ClientPlugin({}), SpacePlugin({})] });
+  const { personalSpace } = await EffectEx.runAndForwardErrors(
+    initializeIdentity(harness.get(ClientCapabilities.Client)),
+  );
+  await harness.waitForEvent(ClientEvents.SpacesReady);
+  return { harness, db: personalSpace.db };
+};
+
+const objectIds = (collection: Collection.Collection): (string | undefined)[] =>
+  collection.objects.map((ref) => ref.target?.id);
+
+describe('collections', () => {
+  test('create a collection and add an object to it', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    // Playwright: `create collection` — a Collection object rendered in the tree.
+    const collection = db.add(Collection.make({ name: 'New collection' }));
+    expect(Collection.isCollection(collection)).toBe(true);
+    expect(collection.name).toBe('New collection');
+    expect(collection.objects.length).toBe(0);
+
+    // Playwright basic.spec: `create document` — documents are collection items.
+    const document = db.add(Text.make({ content: 'hello' }));
+    Obj.update(collection, (collection) => {
+      collection.objects.push(Ref.make(document));
+    });
+    expect(collection.objects.length).toBe(1);
+    expect(collection.objects[0].target?.id).toBe(document.id);
+  });
+
+  test('re-order sibling collections', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const root = db.add(Collection.make({ name: 'Root' }));
+    const first = db.add(Collection.make({ name: 'Collection 1' }));
+    const second = db.add(Collection.make({ name: 'Collection 2' }));
+    Obj.update(root, (root) => {
+      root.objects.push(Ref.make(first), Ref.make(second));
+    });
+    expect(objectIds(root)).toEqual([first.id, second.id]);
+
+    // Playwright `re-order collections`: dragging Collection 2 above Collection 1 reverses order.
+    Obj.update(root, (root) => {
+      const [moved] = root.objects.splice(1, 1);
+      root.objects.splice(0, 0, moved);
+    });
+    expect(objectIds(root)).toEqual([second.id, first.id]);
+  });
+
+  test('nest one collection inside another', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const root = db.add(Collection.make({ name: 'Root' }));
+    const outer = db.add(Collection.make({ name: 'Collection 2' }));
+    const inner = db.add(Collection.make({ name: 'Collection 1' }));
+    Obj.update(root, (root) => {
+      root.objects.push(Ref.make(outer), Ref.make(inner));
+    });
+
+    // Playwright `drag object into collection`: move `inner` out of root and into `outer`.
+    Obj.update(root, (root) => {
+      const index = root.objects.findIndex((ref) => ref.target === inner);
+      root.objects.splice(index, 1);
+    });
+    Obj.update(outer, (outer) => {
+      outer.objects.push(Ref.make(inner));
+    });
+
+    expect(objectIds(root)).toEqual([outer.id]);
+    expect(objectIds(outer)).toEqual([inner.id]);
+  });
+
+  test('deleting a collection removes it and its contents from the tree', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const root = db.add(Collection.make({ name: 'Root' }));
+    const parent = db.add(Collection.make({ name: 'Collection' }));
+    const child = db.add(Text.make({ content: 'nested' }));
+    Obj.update(parent, (parent) => {
+      parent.objects.push(Ref.make(child));
+    });
+    Obj.update(root, (root) => {
+      root.objects.push(Ref.make(parent));
+    });
+    expect(objectIds(root)).toEqual([parent.id]);
+
+    // Playwright `delete a collection`: deleting the containing collection leaves the tree empty —
+    // the child is no longer reachable from the root once its parent is gone.
+    Obj.update(root, (root) => {
+      const index = root.objects.findIndex((ref) => ref.target === parent);
+      root.objects.splice(index, 1);
+    });
+    db.remove(parent);
+    expect(root.objects.length).toBe(0);
+    expect(Obj.isDeleted(parent)).toBe(true);
+  });
+
+  test('undo restores a deleted collection and its contents', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const root = db.add(Collection.make({ name: 'Root' }));
+    const parent = db.add(Collection.make({ name: 'Collection' }));
+    const child = db.add(Collection.make({ name: 'Child' }));
+    const grandchild = db.add(Text.make({ content: 'leaf' }));
+    Obj.update(child, (child) => {
+      child.objects.push(Ref.make(grandchild));
+    });
+    Obj.update(parent, (parent) => {
+      parent.objects.push(Ref.make(child));
+    });
+    Obj.update(root, (root) => {
+      root.objects.push(Ref.make(parent));
+    });
+
+    // Remove (capturing the index for restore, exactly like RemoveObjects → RestoreObjects).
+    const index = root.objects.findIndex((ref) => ref.target === parent);
+    Obj.update(root, (root) => {
+      root.objects.splice(index, 1);
+    });
+    db.remove(parent);
+    expect(root.objects.length).toBe(0);
+
+    // Playwright `deletion undo restores collection`: undo re-adds the object at its old index and
+    // the full subtree (parent → child → grandchild) is reachable again.
+    const restored = db.add(parent);
+    Obj.update(root, (root) => {
+      root.objects.splice(index, 0, Ref.make(restored));
+    });
+    expect(objectIds(root)).toEqual([parent.id]);
+    expect(objectIds(parent)).toEqual([child.id]);
+    expect(objectIds(child)).toEqual([grandchild.id]);
+  });
+});

--- a/packages/plugins/plugin-table/src/table-flow.test.ts
+++ b/packages/plugins/plugin-table/src/table-flow.test.ts
@@ -50,7 +50,7 @@ const createTable = async (db: Db) => {
 };
 
 const rowCount = async (db: Db, type: Type.AnyEntity): Promise<number> =>
-  (await db.query(Filter.type(type)).run()).filter((row: Obj.Any) => !Obj.isDeleted(row)).length;
+  (await db.query(Filter.type(Type.assertObject(type))).run()).filter((row) => !Obj.isDeleted(row)).length;
 
 const makeProjection = (registry: Registry.Registry, view: View.View, type: Type.AnyEntity) =>
   new ProjectionModel({
@@ -93,7 +93,7 @@ describe('table flow', () => {
     }
     expect(await rowCount(db, type)).toBe(5);
 
-    const rows = await db.query(Filter.type(type)).run();
+    const rows = await db.query(Filter.type(Type.assertObject(type))).run();
     db.remove(rows[0]);
     db.remove(rows[1]);
     expect(await rowCount(db, type)).toBe(3);

--- a/packages/plugins/plugin-table/src/table-flow.test.ts
+++ b/packages/plugins/plugin-table/src/table-flow.test.ts
@@ -1,0 +1,146 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Registry } from '@effect-atom/atom-react';
+import { describe, test } from 'vitest';
+
+import { Filter, JsonSchema, Obj, Type, View } from '@dxos/echo';
+import { EffectEx, SchemaEx } from '@dxos/effect';
+import { invariant } from '@dxos/invariant';
+import { ClientCapabilities, ClientEvents } from '@dxos/plugin-client';
+import { ClientPlugin, initializeIdentity } from '@dxos/plugin-client/testing';
+import { createComposerTestApp } from '@dxos/plugin-testing/harness';
+import { Table } from '@dxos/react-ui-table/types';
+import { ProjectionModel, ViewModel, createEchoChangeCallback, getTypeURIFromQuery } from '@dxos/schema';
+
+import { TablePlugin } from '#plugin';
+
+// Headless coverage for the flows in `composer-app/src/playwright/tables.spec.ts` (currently skipped
+// in Playwright). Composer models a table as a `Table` object referencing a `View` that projects a
+// stored ECHO schema; rows are plain objects of that schema, columns are `View` fields backed by
+// schema properties. The Playwright tests drive the grid UI; here we exercise the same data flows
+// via `ViewModel` / `ProjectionModel` (what `TableOperation.Create` and `SpaceOperation.DeleteField`
+// use) against a real ECHO space from the composer test harness.
+
+const setup = async () => {
+  const harness = await createComposerTestApp({ plugins: [ClientPlugin({}), TablePlugin()] });
+  const client = harness.get(ClientCapabilities.Client);
+  // The view backing a table is a `View` object; register the schema so its projection can be mutated.
+  await client.addTypes([View.View]);
+  const { personalSpace } = await EffectEx.runAndForwardErrors(initializeIdentity(client));
+  await harness.waitForEvent(ClientEvents.SpacesReady);
+  return { harness, db: personalSpace.db };
+};
+
+type Db = Awaited<ReturnType<typeof setup>>['db'];
+
+/** Create a table + its view + a fresh stored schema (mirrors `TableOperation.Create`). */
+const createTable = async (db: Db) => {
+  const { view, jsonSchema } = await ViewModel.makeFromDatabase({ db });
+  const table = db.add(Table.make({ name: 'Contacts', view, jsonSchema }));
+
+  // Resolve the stored schema the view queries — rows are objects of this type.
+  const typeUri = getTypeURIFromQuery(view.query.ast);
+  invariant(typeUri);
+  const types = await db.query(Filter.type(Type.Type)).run();
+  const type = types.find((entity: Type.AnyEntity) => Type.getURI(entity) === typeUri);
+  invariant(type);
+  return { table, view, type };
+};
+
+const rowCount = async (db: Db, type: Type.AnyEntity): Promise<number> =>
+  (await db.query(Filter.type(type)).run()).filter((row: Obj.Any) => !Obj.isDeleted(row)).length;
+
+const makeProjection = (registry: Registry.Registry, view: View.View, type: Type.AnyEntity) =>
+  new ProjectionModel({
+    registry,
+    view,
+    baseSchema: JsonSchema.toJsonSchema(type),
+    change: createEchoChangeCallback(view, type),
+  });
+
+describe('table flow', () => {
+  test('create a table with one initial row', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const { table, type } = await createTable(db);
+    expect(Obj.instanceOf(Table.Table, table)).toBe(true);
+    // `makeFromDatabase` seeds one empty row, matching the single data row the grid shows on create.
+    expect(await rowCount(db, type)).toBe(1);
+  });
+
+  test('add rows', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const { type } = await createTable(db);
+    expect(await rowCount(db, type)).toBe(1);
+
+    db.add(Obj.make(Type.assertObject(type), {}));
+    db.add(Obj.make(Type.assertObject(type), {}));
+    expect(await rowCount(db, type)).toBe(3);
+  });
+
+  test('delete rows', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const { type } = await createTable(db);
+    for (let i = 0; i < 4; i++) {
+      db.add(Obj.make(Type.assertObject(type), {}));
+    }
+    expect(await rowCount(db, type)).toBe(5);
+
+    const rows = await db.query(Filter.type(type)).run();
+    db.remove(rows[0]);
+    db.remove(rows[1]);
+    expect(await rowCount(db, type)).toBe(3);
+  });
+
+  test('add a column', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const { view, type } = await createTable(db);
+    const projection = makeProjection(harness.registry, view, type);
+    const before = projection.getFields().length;
+
+    projection.createFieldProjection();
+    expect(projection.getFields().length).toBe(before + 1);
+  });
+
+  test('delete a column', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const { view, type } = await createTable(db);
+    const projection = makeProjection(harness.registry, view, type);
+
+    const field = projection.createFieldProjection();
+    const withNew = projection.getFields().length;
+    projection.deleteFieldProjection(field.id);
+    expect(projection.getFields().length).toBe(withNew - 1);
+  });
+
+  test('rename a column', async ({ expect }) => {
+    const { harness, db } = await setup();
+    await using _harness = harness;
+
+    const { view, type } = await createTable(db);
+    const projection = makeProjection(harness.registry, view, type);
+
+    // Rename an existing, schema-backed column (`title`) by pointing its projection at a new property.
+    const fieldId = projection.getFieldId('title');
+    invariant(fieldId);
+    const projected = projection.getFieldProjection(fieldId);
+    projection.setFieldProjection({
+      field: projected.field,
+      props: { ...projected.props, property: 'heading' as SchemaEx.JsonProp },
+    });
+
+    const renamed = projection.getFields().find((current) => current.id === fieldId);
+    expect(renamed?.path).toBe('heading');
+  });
+});


### PR DESCRIPTION
## Summary

Audit of the Composer Playwright e2e suite (`packages/apps/composer-app/src/playwright`) and a first batch of **headless** tests that reproduce the same data flows without a browser, using the composer testing harness (`createComposerTestApp` + `initializeIdentity`). Tests run in the `node` vitest project and are spread across the plugins that own each flow.

## What the Playwright suite covers today

| Spec | Flows | Portable headless? |
| --- | --- | --- |
| `basic.spec.ts` | default space on identity, create space, create document (editable), reset device | data flows ✅ (space/doc); reset/device ❌ (browser/storage) |
| `collections.spec.ts` | create collection, re-order, drag-into (nest), delete (cascade), undo | ✅ |
| `comments.spec.ts` | create comment thread, edit/delete message, delete thread, undo, highlight sync | ✅ (CRUD); cm decoration highlight ❌ (editor DOM) |
| `tables.spec.ts` (skipped) | create table, add/delete rows, add/delete/rename columns | ✅ |
| `collaboration.spec.ts` | two-peer replication, cursors, presence | ❌ (WebRTC/awareness; chromium-only) |
| `halo.spec.ts` | device invitation, space deletion replicates across devices | ❌ (multi-device replication) |
| `startup.spec.ts` / `dev-startup.spec.ts` / `welcome-focus.spec.ts` / `first-run.spec.ts` | boot timing, bundle/profiler benchmarks, welcome focus, joyride | ❌ (perf/paint/focus — inherently browser) |

The **data-behavior** flows port cleanly to the harness; the replication, timing, and focus/DOM specs do not and stay in Playwright (or are covered by `echo-client-e2e` / `halo-e2e` at a lower level).

## Tests added

- **`plugin-space/src/collections.test.ts`** — `collections.spec` + the collection parts of `basic.spec`: create collection, add object, re-order siblings, nest, cascade delete, undo restore (mirrors `SpaceOperation.RemoveObjects`/`RestoreObjects` minus the deck/layout side effects).
- **`plugin-markdown/src/document-flow.test.ts`** — `basic.spec` create-document and the editor content edited in `comments.spec`, driven through the markdown `Create`/`Update` operations; asserts the referenced `Text` content.
- **`plugin-comments/src/comment-flow.test.ts`** — `comments.spec`: create an `AnchoredTo` thread, add/edit/delete message, delete-last-message-deletes-thread, delete + undo restore. Net-new coverage (comment CRUD had no headless test).
- **`plugin-table/src/table-flow.test.ts`** — `tables.spec` (currently skipped in Playwright): create table, add/delete rows, add/delete/rename columns via `ViewModel` / `ProjectionModel`.

## Test plan

All four suites pass in the node vitest project:

- `moon run plugin-space:test -- src/collections.test.ts` — 5 passed
- `moon run plugin-markdown:test -- src/document-flow.test.ts` — 3 passed
- `moon run plugin-comments:test -- src/comment-flow.test.ts` — 5 passed
- `moon run plugin-table:test -- src/table-flow.test.ts` — 6 passed

Lint and oxfmt clean on all four files. No changeset — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5LNCu1jUsLV3HfF6FYTbr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added headless Vitest coverage for comment threads and messages, including create/edit/delete and undo restoration.
  * Added headless Vitest coverage for markdown document flow, covering create, update, and append operations.
  * Added headless Vitest coverage for space collections, including create, nest, reorder, delete, and undo delete.
  * Added headless Vitest coverage for table flow, including row lifecycle and dynamic column behavior (create, delete, rename).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->