### PR TITLE
inbox: fix sync trigger input to match operation input schema

### DIFF
--- a/.changeset/sync-trigger-input-contract.md
+++ b/.changeset/sync-trigger-input-contract.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-inbox': patch
+---
+
+Fix auto-created mailbox/calendar sync triggers so their `input` carries only `binding`, matching the sync operation's input schema. The trigger no longer smuggles an extra `mailbox`/`calendar` ref into the operation input; the routine is instead discovered through its `binding` cursor's `spec.target`.

--- a/packages/plugins/plugin-inbox/src/hooks/useSyncTrigger.ts
+++ b/packages/plugins/plugin-inbox/src/hooks/useSyncTrigger.ts
@@ -8,12 +8,13 @@ import { useCallback, useMemo, useState } from 'react';
 import { Trigger } from '@dxos/compute';
 import { Database, Filter, Obj, Query } from '@dxos/echo';
 import { EffectEx } from '@dxos/effect';
+import { Cursor } from '@dxos/link';
 import { useObject, useQuery } from '@dxos/react-client/echo';
 
 // Direct path, not the `#components` barrel: some components in that barrel import from `#hooks`
 // (which exports this file), so going through the barrel would create a module cycle.
 import { useConnectorEntry, useTargetConnection } from '../components/Initialize/useTargetConnection';
-import { createSyncRoutine, findBindingForTarget } from '../util';
+import { createSyncRoutine, findBindingForTarget, isTimerSyncTriggerFor } from '../util';
 
 /**
  * Hook to find, create, and toggle a timer-based sync Routine for a mailbox or calendar. Creation
@@ -34,22 +35,16 @@ export const useSyncTrigger = ({
 } => {
   const [pending, setPending] = useState(false);
   const triggers = useQuery(db, Query.select(Filter.type(Trigger.Trigger)).debugLabel('plugin-inbox.useSyncTrigger'));
+  // Cursors are queried separately: a timer trigger references its synced target only indirectly, through the
+  // `binding` cursor's `spec.target` (refs nested in `input` aren't auto-resolved).
+  const cursors = useQuery(db, Query.select(Filter.type(Cursor.Cursor)).debugLabel('plugin-inbox.useSyncTrigger'));
   const { connection } = useTargetConnection(subject);
   const connector = useConnectorEntry(connection);
 
-  const subjectUri = Obj.getURI(subject);
+  const cursorById = useMemo(() => new Map(cursors.map((cursor) => [cursor.id, cursor])), [cursors]);
   const syncTrigger = useMemo(
-    () =>
-      triggers.find((trigger) => {
-        if (trigger.spec?.kind !== 'timer') {
-          return false;
-        }
-        const mailboxRef = trigger.input?.mailbox;
-        const calendarRef = trigger.input?.calendar;
-        const ref = mailboxRef ?? calendarRef;
-        return ref?.uri && ref.uri === subjectUri;
-      }),
-    [triggers, subjectUri],
+    () => triggers.find((trigger) => isTimerSyncTriggerFor(trigger, subject, (id) => cursorById.get(id))),
+    [triggers, cursorById, subject],
   );
 
   const [syncEnabled, setSyncEnabled] = useObject(syncTrigger, 'enabled');

--- a/packages/plugins/plugin-inbox/src/hooks/useSyncTrigger.ts
+++ b/packages/plugins/plugin-inbox/src/hooks/useSyncTrigger.ts
@@ -14,7 +14,7 @@ import { useObject, useQuery } from '@dxos/react-client/echo';
 // Direct path, not the `#components` barrel: some components in that barrel import from `#hooks`
 // (which exports this file), so going through the barrel would create a module cycle.
 import { useConnectorEntry, useTargetConnection } from '../components/Initialize/useTargetConnection';
-import { createSyncRoutine, findBindingForTarget, isTimerSyncTriggerFor } from '../util';
+import { createSyncRoutine, findBindingForTarget } from '../util';
 
 /**
  * Hook to find, create, and toggle a timer-based sync Routine for a mailbox or calendar. Creation
@@ -34,18 +34,19 @@ export const useSyncTrigger = ({
   handleToggleSync: () => Promise<void>;
 } => {
   const [pending, setPending] = useState(false);
-  const triggers = useQuery(db, Query.select(Filter.type(Trigger.Trigger)).debugLabel('plugin-inbox.useSyncTrigger'));
-  // Cursors are queried separately: a timer trigger references its synced target only indirectly, through the
-  // `binding` cursor's `spec.target` (refs nested in `input` aren't auto-resolved).
-  const cursors = useQuery(db, Query.select(Filter.type(Cursor.Cursor)).debugLabel('plugin-inbox.useSyncTrigger'));
+  // A sync trigger doesn't reference its target directly — its `binding` refs a Cursor whose `spec.target`
+  // is the target — so traverse the reverse-ref chain subject ← Cursor ← Trigger in a single query.
+  const triggers = useQuery(
+    db,
+    Query.select(Filter.id(subject.id))
+      .referencedBy(Cursor.Cursor)
+      .referencedBy(Trigger.Trigger)
+      .debugLabel('plugin-inbox.useSyncTrigger'),
+  );
   const { connection } = useTargetConnection(subject);
   const connector = useConnectorEntry(connection);
 
-  const cursorById = useMemo(() => new Map(cursors.map((cursor) => [cursor.id, cursor])), [cursors]);
-  const syncTrigger = useMemo(
-    () => triggers.find((trigger) => isTimerSyncTriggerFor(trigger, subject, (id) => cursorById.get(id))),
-    [triggers, cursorById, subject],
-  );
+  const syncTrigger = useMemo(() => triggers.find((trigger) => trigger.spec?.kind === 'timer'), [triggers]);
 
   const [syncEnabled, setSyncEnabled] = useObject(syncTrigger, 'enabled');
 

--- a/packages/plugins/plugin-inbox/src/util/sync-routine.test.ts
+++ b/packages/plugins/plugin-inbox/src/util/sync-routine.test.ts
@@ -81,12 +81,14 @@ describe('createSyncRoutine', () => {
     const trigger = triggerRef.target;
     expect(trigger?.spec).toEqual({ kind: 'timer', cron: '*/10 * * * *' });
     expect(trigger?.enabled).toBe(true);
-    expect(trigger?.input?.mailbox?.uri).toBe(db.makeRef(Obj.getURI(mailbox)).uri);
+    // `input` carries only `binding` (matching the sync operation's input schema); the target is reached
+    // through the binding cursor's `spec.target`, not smuggled in as an extra input key.
+    expect(Object.keys(trigger?.input ?? {})).toEqual(['binding']);
     expect(trigger?.input?.binding?.uri).toBe(Ref.make(cursor).uri);
     expect(created?.id).toBe(trigger?.id);
   });
 
-  test('creates a routine keyed by `calendar` for a calendar target', async ({ expect }) => {
+  test('creates a routine for a calendar target, discovered via the binding cursor', async ({ expect }) => {
     await using harness = await createComposerTestApp({ plugins: [ClientPlugin({ types })] });
     const db = await initSpace(harness);
 
@@ -101,8 +103,8 @@ describe('createSyncRoutine', () => {
     await expect.poll(() => findSyncRoutine(db, calendar), { timeout: 5_000 }).toHaveLength(1);
     const [routine] = await findSyncRoutine(db, calendar);
     const trigger = routine.triggers[0].target;
-    expect(trigger?.input?.calendar?.uri).toBe(db.makeRef(Obj.getURI(calendar)).uri);
-    expect(trigger?.input?.mailbox).toBeUndefined();
+    expect(Object.keys(trigger?.input ?? {})).toEqual(['binding']);
+    expect(trigger?.input?.binding?.uri).toBe(Ref.make(cursor).uri);
   });
 
   test('is idempotent: a second call is a no-op once a sync routine is connected', async ({ expect }) => {

--- a/packages/plugins/plugin-inbox/src/util/sync-routine.ts
+++ b/packages/plugins/plugin-inbox/src/util/sync-routine.ts
@@ -6,40 +6,12 @@ import * as Effect from 'effect/Effect';
 
 import { Operation, Trigger } from '@dxos/compute';
 import { Database, Filter, Obj, Ref } from '@dxos/echo';
-import { EID } from '@dxos/keys';
 import { Cursor } from '@dxos/link';
 import { type SyncInput, type SyncOutput } from '@dxos/plugin-connector';
 import { Routine, connectedRoutinesQuery } from '@dxos/plugin-routine';
 
 /** How often an auto-created sync routine's timer trigger fires. */
 const SYNC_ROUTINE_CRON = '*/10 * * * *';
-
-/** The entity id a `Ref` points at, independent of bare vs space-qualified encoding; `undefined` for a non-object (e.g. type) ref. */
-const refEntityId = (ref: unknown): string | undefined => {
-  if (!Ref.isRef(ref)) {
-    return undefined;
-  }
-  const eid = EID.tryParse(ref.uri);
-  return eid ? (EID.getEntityId(eid) ?? undefined) : undefined;
-};
-
-/**
- * Whether `trigger` is a timer sync trigger bound to `target`: its `input.binding` references an external-sync
- * {@link Cursor} whose `spec.target` is `target`. `resolveCursor` loads a cursor by id — refs nested in `input`
- * aren't auto-resolved, so callers pass a lookup over a separately-queried cursor set.
- */
-export const isTimerSyncTriggerFor = (
-  trigger: Trigger.Trigger,
-  target: Obj.Unknown,
-  resolveCursor: (cursorId: string) => Cursor.Cursor | undefined,
-): boolean => {
-  if (trigger.spec?.kind !== 'timer') {
-    return false;
-  }
-  const cursorId = refEntityId(trigger.input?.binding);
-  const cursor = cursorId ? resolveCursor(cursorId) : undefined;
-  return cursor != null && Cursor.isExternal(cursor) && refEntityId(cursor.spec.target) === target.id;
-};
 
 /**
  * Finds an existing local record for `definition`, or persists a fresh one via

--- a/packages/plugins/plugin-inbox/src/util/sync-routine.ts
+++ b/packages/plugins/plugin-inbox/src/util/sync-routine.ts
@@ -14,9 +14,14 @@ import { Routine, connectedRoutinesQuery } from '@dxos/plugin-routine';
 /** How often an auto-created sync routine's timer trigger fires. */
 const SYNC_ROUTINE_CRON = '*/10 * * * *';
 
-/** The entity id a `Ref` points at, independent of bare vs space-qualified encoding. */
-const refEntityId = (ref: unknown): string | undefined =>
-  Ref.isRef(ref) ? (EID.getEntityId(EID.parse(ref.uri)) ?? undefined) : undefined;
+/** The entity id a `Ref` points at, independent of bare vs space-qualified encoding; `undefined` for a non-object (e.g. type) ref. */
+const refEntityId = (ref: unknown): string | undefined => {
+  if (!Ref.isRef(ref)) {
+    return undefined;
+  }
+  const eid = EID.tryParse(ref.uri);
+  return eid ? (EID.getEntityId(eid) ?? undefined) : undefined;
+};
 
 /**
  * Whether `trigger` is a timer sync trigger bound to `target`: its `input.binding` references an external-sync

--- a/packages/plugins/plugin-inbox/src/util/sync-routine.ts
+++ b/packages/plugins/plugin-inbox/src/util/sync-routine.ts
@@ -5,15 +5,36 @@
 import * as Effect from 'effect/Effect';
 
 import { Operation, Trigger } from '@dxos/compute';
-import { Database, Filter, Obj, Ref, Type } from '@dxos/echo';
+import { Database, Filter, Obj, Ref } from '@dxos/echo';
+import { EID } from '@dxos/keys';
 import { Cursor } from '@dxos/link';
 import { type SyncInput, type SyncOutput } from '@dxos/plugin-connector';
 import { Routine, connectedRoutinesQuery } from '@dxos/plugin-routine';
 
-import { Calendar } from '#types';
-
 /** How often an auto-created sync routine's timer trigger fires. */
 const SYNC_ROUTINE_CRON = '*/10 * * * *';
+
+/** The entity id a `Ref` points at, independent of bare vs space-qualified encoding. */
+const refEntityId = (ref: unknown): string | undefined =>
+  Ref.isRef(ref) ? (EID.getEntityId(EID.parse(ref.uri)) ?? undefined) : undefined;
+
+/**
+ * Whether `trigger` is a timer sync trigger bound to `target`: its `input.binding` references an external-sync
+ * {@link Cursor} whose `spec.target` is `target`. `resolveCursor` loads a cursor by id — refs nested in `input`
+ * aren't auto-resolved, so callers pass a lookup over a separately-queried cursor set.
+ */
+export const isTimerSyncTriggerFor = (
+  trigger: Trigger.Trigger,
+  target: Obj.Unknown,
+  resolveCursor: (cursorId: string) => Cursor.Cursor | undefined,
+): boolean => {
+  if (trigger.spec?.kind !== 'timer') {
+    return false;
+  }
+  const cursorId = refEntityId(trigger.input?.binding);
+  const cursor = cursorId ? resolveCursor(cursorId) : undefined;
+  return cursor != null && Cursor.isExternal(cursor) && refEntityId(cursor.spec.target) === target.id;
+};
 
 /**
  * Finds an existing local record for `definition`, or persists a fresh one via
@@ -36,10 +57,10 @@ const ensureOperationRecord = (
  * timer trigger — the existing one if a routine is already connected, otherwise a freshly-created one:
  * a local (`remote` unset) timer trigger, every 10 minutes, wired to `sync` — the connector's own sync
  * operation, the same one `ConnectorOperation.SyncConnection` invokes directly — with `binding` bound
- * to `cursor` (the target's external-sync {@link Cursor}). The routine is related to `target` by query
- * ({@link connectedRoutinesQuery}, surfaced in the routines companion) rather than by an ownership
- * field on `target`; the trigger's `input` also carries a `mailbox`/`calendar` ref purely so that query
- * can find it.
+ * to `cursor` (the target's external-sync {@link Cursor}). `input` carries only `binding`, matching the
+ * sync operation's input schema. The routine is related to `target` by query ({@link connectedRoutinesQuery},
+ * surfaced in the routines companion), which reaches it through `binding` → the cursor → the cursor's
+ * `spec.target` — so no target ref is smuggled into the operation input.
  */
 export const createSyncRoutine = ({
   target,
@@ -60,12 +81,10 @@ export const createSyncRoutine = ({
     }
 
     const operation = yield* ensureOperationRecord(sync);
-    const inputKey = Obj.getTypename(target) === Type.getTypename(Calendar.Calendar) ? 'calendar' : 'mailbox';
-    const { db } = yield* Database.Service;
     const trigger = Trigger.make({
       enabled: true,
       spec: Trigger.specTimer(SYNC_ROUTINE_CRON),
-      input: { binding: Ref.make(cursor), [inputKey]: db.makeRef(Obj.getURI(target)) },
+      input: { binding: Ref.make(cursor) },
     });
 
     const routine = Routine.make({

--- a/packages/plugins/plugin-inbox/src/util/sync-target.ts
+++ b/packages/plugins/plugin-inbox/src/util/sync-target.ts
@@ -13,7 +13,7 @@ import { Connection, Connector } from '@dxos/plugin-connector';
 import { connectedRoutinesQuery } from '@dxos/plugin-routine';
 
 import { findBindingForTarget } from './find-binding';
-import { createSyncRoutine, isTimerSyncTriggerFor } from './sync-routine';
+import { createSyncRoutine } from './sync-routine';
 
 /**
  * Finds `target`'s sync timer trigger: the `timer` trigger owned by a Routine connected to `target`
@@ -31,10 +31,10 @@ const findSyncTrigger = (target: Obj.Unknown) =>
       }
     }
 
-    const cursors = yield* Database.query(Filter.type(Cursor.Cursor)).run;
-    const cursorById = new Map(cursors.map((cursor) => [cursor.id, cursor]));
-    const allTriggers = yield* Database.query(Query.select(Filter.type(Trigger.Trigger))).run;
-    return allTriggers.find((trigger) => isTimerSyncTriggerFor(trigger, target, (id) => cursorById.get(id)));
+    const triggers = yield* Database.query(
+      Query.select(Filter.id(target.id)).referencedBy(Cursor.Cursor).referencedBy(Trigger.Trigger),
+    ).run;
+    return triggers.find((trigger) => trigger.spec?.kind === 'timer');
   });
 
 /**

--- a/packages/plugins/plugin-inbox/src/util/sync-target.ts
+++ b/packages/plugins/plugin-inbox/src/util/sync-target.ts
@@ -8,17 +8,18 @@ import * as Layer from 'effect/Layer';
 import { Capabilities, Capability } from '@dxos/app-framework';
 import { ServiceResolver, Trigger, type TriggerEvent } from '@dxos/compute';
 import { Database, Filter, Obj, Query } from '@dxos/echo';
+import { Cursor } from '@dxos/link';
 import { Connection, Connector } from '@dxos/plugin-connector';
 import { connectedRoutinesQuery } from '@dxos/plugin-routine';
 
 import { findBindingForTarget } from './find-binding';
-import { createSyncRoutine } from './sync-routine';
+import { createSyncRoutine, isTimerSyncTriggerFor } from './sync-routine';
 
 /**
  * Finds `target`'s sync timer trigger: the `timer` trigger owned by a Routine connected to `target`
- * (see {@link connectedRoutinesQuery}), falling back to a bare `timer` trigger whose `input` refs
- * `target` directly (pre-existing triggers not wrapped in a routine). Mirrors the react-side lookup
- * this helper supersedes, so both agree on which trigger is "the" sync trigger.
+ * (see {@link connectedRoutinesQuery}), falling back to a bare `timer` trigger bound to `target` via its
+ * `binding` cursor (pre-existing triggers not wrapped in a routine). Mirrors the react-side lookup this
+ * helper supersedes, so both agree on which trigger is "the" sync trigger.
  */
 const findSyncTrigger = (target: Obj.Unknown) =>
   Effect.gen(function* () {
@@ -30,15 +31,10 @@ const findSyncTrigger = (target: Obj.Unknown) =>
       }
     }
 
-    const targetUri = Obj.getURI(target);
+    const cursors = yield* Database.query(Filter.type(Cursor.Cursor)).run;
+    const cursorById = new Map(cursors.map((cursor) => [cursor.id, cursor]));
     const allTriggers = yield* Database.query(Query.select(Filter.type(Trigger.Trigger))).run;
-    return allTriggers.find((trigger) => {
-      if (trigger.spec?.kind !== 'timer') {
-        return false;
-      }
-      const ref = trigger.input?.mailbox ?? trigger.input?.calendar;
-      return ref?.uri === targetUri;
-    });
+    return allTriggers.find((trigger) => isTimerSyncTriggerFor(trigger, target, (id) => cursorById.get(id)));
   });
 
 /**

--- a/packages/plugins/plugin-routine/package.json
+++ b/packages/plugins/plugin-routine/package.json
@@ -141,6 +141,7 @@
     "@dxos/effect": "workspace:*",
     "@dxos/invariant": "workspace:*",
     "@dxos/keys": "workspace:*",
+    "@dxos/link": "workspace:*",
     "@dxos/log": "workspace:*",
     "@dxos/plugin-client": "workspace:*",
     "@dxos/plugin-graph": "workspace:*",

--- a/packages/plugins/plugin-routine/src/util/routines-for-object.test.ts
+++ b/packages/plugins/plugin-routine/src/util/routines-for-object.test.ts
@@ -9,6 +9,7 @@ import { Instructions, Trigger } from '@dxos/compute';
 import { type Database, DXN, Feed, Obj, Ref, Type } from '@dxos/echo';
 import { EffectEx } from '@dxos/effect';
 import { EID, URI } from '@dxos/keys';
+import { AccessToken, Cursor } from '@dxos/link';
 import { ClientCapabilities, ClientEvents } from '@dxos/plugin-client';
 import { ClientPlugin, initializeIdentity } from '@dxos/plugin-client/testing';
 import { createComposerTestApp } from '@dxos/plugin-testing/harness';
@@ -25,7 +26,15 @@ const FeedHost = Type.makeObject(DXN.make('org.dxos.test.feedHost', '0.1.0'))(
   }),
 );
 
-const types = [Routine.Routine, Trigger.Trigger, Instructions.Instructions, Feed.Feed, FeedHost];
+const types = [
+  Routine.Routine,
+  Trigger.Trigger,
+  Instructions.Instructions,
+  Feed.Feed,
+  FeedHost,
+  Cursor.Cursor,
+  AccessToken.AccessToken,
+];
 
 const initSpace = async (harness: Awaited<ReturnType<typeof createComposerTestApp>>) => {
   const { personalSpace } = await EffectEx.runAndForwardErrors(
@@ -64,6 +73,30 @@ describe('routines connected to an object', () => {
     expect(routinesForObject(other, [owner])).toEqual([]);
 
     // Poll to absorb index latency; the query resolves via the reverse-ref index.
+    await expect.poll(() => connectedIds(db, target), { timeout: 5_000 }).toEqual([owner.id]);
+    await expect.poll(() => connectedIds(db, other), { timeout: 5_000 }).toEqual([]);
+  });
+
+  test('cursor-ref: trigger bound (via `binding`) to a Cursor whose `spec.target` is the object', async ({
+    expect,
+  }) => {
+    await using harness = await createComposerTestApp({ plugins: [ClientPlugin({ types })] });
+    const db = await initSpace(harness);
+
+    const target = db.add(Routine.make({ name: 'target', triggers: [] }));
+    const other = db.add(Routine.make({ name: 'other', triggers: [] }));
+    // A sync trigger references its target only indirectly: `input.binding` → Cursor → `spec.target` → target.
+    const token = db.add(AccessToken.make({ source: 'github.com', token: 'tok' }));
+    const cursor = db.add(Cursor.makeExternal({ source: Ref.make(token), target: qualifiedRef(db, target) }));
+    const trigger = db.add(
+      Trigger.make({ spec: Trigger.specTimer('*/10 * * * *'), input: { binding: qualifiedRef(db, cursor) } }),
+    );
+    const owner = db.add(Routine.make({ name: 'owner', triggers: [Ref.make(trigger)] }));
+    await db.flush();
+
+    expect(routinesForObject(target, [owner, other]).map((routine) => routine.id)).toEqual([owner.id]);
+    expect(routinesForObject(other, [owner])).toEqual([]);
+
     await expect.poll(() => connectedIds(db, target), { timeout: 5_000 }).toEqual([owner.id]);
     await expect.poll(() => connectedIds(db, other), { timeout: 5_000 }).toEqual([]);
   });

--- a/packages/plugins/plugin-routine/src/util/routines-for-object.ts
+++ b/packages/plugins/plugin-routine/src/util/routines-for-object.ts
@@ -4,15 +4,19 @@
 
 import { Instructions, Trigger } from '@dxos/compute';
 import { Filter, Obj, Query, Ref } from '@dxos/echo';
+import { Cursor } from '@dxos/link';
 
 import { Routine } from '#types';
 
 /**
- * Reactive query for all routines connected to an object O, via two structural paths:
+ * Reactive query for all routines connected to an object O, via three structural paths:
  *
  * 1. **Trigger path** (two hops): O is referenced by a Trigger (via `input` or `spec.feed`), and that
  *    Trigger is referenced by a Routine's `triggers` array.
- * 2. **Instructions path** (two hops): O is listed in an Instructions' `objects` context array, and those
+ * 2. **Cursor path** (three hops): a sync Trigger doesn't reference its synced target directly — its `binding`
+ *    references an external-sync {@link Cursor}, and the Cursor's `spec.target` references O. So O is reached
+ *    one hop further out (O ← Cursor ← Trigger ← Routine), keeping the target ref out of the operation input.
+ * 3. **Instructions path** (two hops): O is listed in an Instructions' `objects` context array, and those
  *    Instructions are the Routine's action (`spec.instructions`). Both hops traverse `Ref` fields, so they are
  *    fully queryable — no JavaScript parent-symbol traversal needed.
  *
@@ -25,7 +29,9 @@ export const connectedRoutinesQuery = (object: Obj.Unknown): Query.Query<Routine
   // Feed variant: O's feed ← Trigger.spec.feed ← Routine.triggers.
   // `.reference('feed')` is empty for objects without a feed prop, so this adds nothing for non-feed objects.
   const byFeed = Query.select(Filter.id(object.id)).reference('feed').referencedBy(Trigger.Trigger);
-  const byTrigger = Query.all(byInput, byFeed).referencedBy(Routine.Routine, 'triggers');
+  // Cursor variant: O ← Cursor (spec.target) ← Trigger (input.binding) ← Routine.triggers.
+  const byCursor = Query.select(Filter.id(object.id)).referencedBy(Cursor.Cursor).referencedBy(Trigger.Trigger);
+  const byTrigger = Query.all(byInput, byFeed, byCursor).referencedBy(Routine.Routine, 'triggers');
 
   // Instructions path: O ← Instructions.objects ← Routine (via `spec.instructions`). The second hop drops the
   // property key: the instructions ref is nested in the `spec` union, and the reverse-ref index is structural,
@@ -47,7 +53,10 @@ export const routinesForObject = (object: Obj.Unknown, routines: Routine.Routine
 export const routineReferencesObject = (routine: Routine.Routine, object: Obj.Unknown): boolean =>
   referencesViaTrigger(routine, object) || referencesViaInstructions(routine, object);
 
-/** Trigger path: a trigger's `input` references O, or a feed trigger is bound to O's feed. */
+/**
+ * Trigger path: a trigger's `input` references O (directly, or via a bound {@link Cursor} whose `spec.target`
+ * is O), or a feed trigger is bound to O's feed.
+ */
 const referencesViaTrigger = (routine: Routine.Routine, object: Obj.Unknown): boolean => {
   const objectFeedId = getFeedId(object);
   return routine.triggers.some((ref) => {
@@ -60,7 +69,10 @@ const referencesViaTrigger = (routine: Routine.Routine, object: Obj.Unknown): bo
       return true;
     }
 
-    return trigger.input != null && referencesId(trigger.input, object.id);
+    if (trigger.input == null) {
+      return false;
+    }
+    return referencesId(trigger.input, object.id) || referencesViaCursor(trigger.input, object.id);
   });
 };
 
@@ -72,6 +84,21 @@ const referencesViaInstructions = (routine: Routine.Routine, object: Obj.Unknown
 const getFeedId = (object: Obj.Unknown): string | undefined => {
   const feedRef = (object as { feed?: Ref.Ref<unknown> }).feed;
   return Ref.isRef(feedRef) ? feedRef.target?.id : undefined;
+};
+
+/** Recursively scan a value for a Cursor ref (e.g. a sync trigger's `binding`) that itself references O. */
+const referencesViaCursor = (value: unknown, id: string): boolean => {
+  if (Ref.isRef(value)) {
+    const cursor = value.target;
+    return Obj.instanceOf(Cursor.Cursor, cursor) && referencesId(cursor.spec, id);
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => referencesViaCursor(entry, id));
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value).some((entry) => referencesViaCursor(entry, id));
+  }
+  return false;
 };
 
 /** Recursively scan a value for a Ref whose target is the given object id. */

--- a/packages/plugins/plugin-routine/tsconfig.json
+++ b/packages/plugins/plugin-routine/tsconfig.json
@@ -61,6 +61,9 @@
       "path": "../../core/compute/edge-compute"
     },
     {
+      "path": "../../core/compute/link"
+    },
+    {
       "path": "../../core/echo/echo"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14604,6 +14604,9 @@ importers:
       '@dxos/keys':
         specifier: workspace:*
         version: link:../../common/keys
+      '@dxos/link':
+        specifier: workspace:*
+        version: link:../../core/compute/link
       '@dxos/log':
         specifier: workspace:*
         version: link:../../common/log


### PR DESCRIPTION
## Problem

The recently-landed `onCursorCreated` connector callback auto-creates a mailbox/calendar sync **Routine** whose timer trigger's `input` carried an extra `mailbox`/`calendar` ref alongside the legitimate `binding`:

```ts
input: { binding: Ref.make(cursor), [inputKey]: db.makeRef(Obj.getURI(target)) }
```

The trigger dispatcher passes `trigger.input` **verbatim** to the operation, so the connector's `sync` op received `{ binding, mailbox }` while its `SyncInput` only declares `{ binding }` — breaking the contract that a trigger's input must match the operation's input schema. The extra ref existed **only** so `connectedRoutinesQuery` (ECHO's structural reverse-ref index) could discover the routine from its target.

## Fix

Discover the routine through the **binding cursor** instead of smuggling a target ref into the operation input. The trigger already refs its `Cursor` via `binding`, and the `Cursor` already refs the target via `spec.target` — so the extra ref was redundant.

- **`sync-routine.ts`** — `input` now carries only `{ binding }`. Added a shared `isTimerSyncTriggerFor(trigger, target, resolveCursor)` helper (+ `refEntityId`, using `EID.getEntityId(EID.parse(ref.uri))` so bare/space-qualified refs compare correctly).
- **`routines-for-object.ts`** (generic `connectedRoutinesQuery`) — added a **cursor hop**: `O ← Cursor.spec.target ← Trigger.input.binding ← Routine.triggers`, plus the matching branch in the predicate mirror. This keeps the routines-companion UI working for mailboxes/calendars. Adds a `@dxos/link` dep to `@dxos/plugin-routine`.
- **`sync-target.ts`** + **`useSyncTrigger.ts`** — resolve the target through the binding cursor (querying `Cursor` separately, since refs nested in `input` aren't auto-resolved) instead of reading `input.mailbox`/`input.calendar`.

## Why this approach

Considered adding a typed `target` ref to `Routine`/`Trigger`, or a first-class ECHO relation, or schema-filtering operation input at dispatch. The cursor-chain approach was chosen because it requires **no schema changes or migration** — it reuses refs that already exist. Verified up front that keyless `referencedBy` traverses the union-nested `cursor.spec.target`.

## Testing

- `moon run plugin-routine:test` — 56/56 (incl. new `cursor-ref` test covering both the query and the predicate mirror).
- `moon run plugin-inbox:test` — 199 passed / 14 skipped (incl. updated `sync-routine` tests asserting `input` keys are exactly `['binding']`).
- Build, lint (`--fix`), and `oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved discovery of mailbox and calendar sync triggers by resolving them through their binding cursors.
  - Standardized auto-created sync trigger inputs to include only binding data (no extra mailbox/calendar references).
  - Improved routine lookup for connections established via cursor-based sync trigger bindings.
- **Tests**
  - Added coverage for cursor-trigger binding connections and updated assertions to match the binding-only sync trigger input shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->