### PR TITLE
plugin-inbox: fix mailbox flash of wrong empty-state during load

### DIFF
--- a/.changeset/mailbox-loading-state.md
+++ b/.changeset/mailbox-loading-state.md
@@ -1,0 +1,6 @@
+---
+'@dxos/echo-react': patch
+'@dxos/plugin-inbox': patch
+---
+
+`usePagination`'s `isLoading` now reflects genuine query settlement instead of clearing on the next microtask regardless of delivery, so consumers can reliably distinguish "still loading" from "loaded and empty" even for async, feed-backed queries. The mailbox article uses this to fix a bug where it could briefly flash the wrong empty-state message (e.g. "No connections configured") while a large mailbox's messages were still loading.

--- a/packages/core/echo/echo-react/src/usePagination.test.tsx
+++ b/packages/core/echo/echo-react/src/usePagination.test.tsx
@@ -408,6 +408,66 @@ describe('usePagination', () => {
     ]);
   });
 
+  test('isLoading is true while the first page loads, then false once it settles', async () => {
+    await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
+    const db = await peer.createDatabase();
+    const feed = db.add(Feed.make({ name: 'windowed' }));
+    await appendPeople(feed, db, 5);
+
+    const query = Query.select(Filter.type(TestSchema.Person)).from(feed).orderBy(Order.natural('desc')).limit(3);
+    const loadingStates: boolean[] = [];
+    const { result } = renderHook(() => {
+      const paginated = usePagination(db, query);
+      loadingStates.push(paginated.isLoading);
+      return paginated;
+    });
+
+    // The async feed query is in flight from the first render until its first result lands.
+    expect(loadingStates[0]).toBe(true);
+    await waitFor(() => expect(result.current.items).toHaveLength(3));
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  test('isLoading settles to false for an empty feed (never sticks)', async () => {
+    // Regression: an async feed query with zero results still receives a first response from the
+    // host, so `isLoading` must clear on that delivery rather than hang forever waiting for a row.
+    await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
+    const db = await peer.createDatabase();
+    const feed = db.add(Feed.make({ name: 'empty' }));
+
+    const query = Query.select(Filter.type(TestSchema.Person)).from(feed).orderBy(Order.natural('desc')).limit(3);
+    const { result } = renderHook(() => usePagination(db, query));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  test('isLoading goes true again while getNext loads the next page', async () => {
+    await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
+    const db = await peer.createDatabase();
+    const feed = db.add(Feed.make({ name: 'windowed' }));
+    await appendPeople(feed, db, 10);
+
+    const query = Query.select(Filter.type(TestSchema.Person)).from(feed).orderBy(Order.natural('desc')).limit(3);
+    const loadingStates: boolean[] = [];
+    const { result } = renderHook(() => {
+      const paginated = usePagination(db, query);
+      loadingStates.push(paginated.isLoading);
+      return paginated;
+    });
+
+    await waitFor(() => expect(result.current.items).toHaveLength(3));
+    expect(result.current.isLoading).toBe(false);
+
+    loadingStates.length = 0;
+    result.current.getNext();
+    await waitFor(() => expect(result.current.items).toHaveLength(6));
+
+    // The next range was in flight between the request and its delivery, then settled.
+    expect(loadingStates.some((loading) => loading)).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
   test('throws when the query does not carry a limit', async () => {
     await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
     const db = await peer.createDatabase();

--- a/packages/core/echo/echo-react/src/usePagination.test.tsx
+++ b/packages/core/echo/echo-react/src/usePagination.test.tsx
@@ -429,8 +429,7 @@ describe('usePagination', () => {
   });
 
   test('isLoading settles to false for an empty feed (never sticks)', async () => {
-    // Regression: an async feed query with zero results still receives a first response from the
-    // host, so `isLoading` must clear on that delivery rather than hang forever waiting for a row.
+    // An empty async feed still delivers a first response, so isLoading must clear on it.
     await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
     const db = await peer.createDatabase();
     const feed = db.add(Feed.make({ name: 'empty' }));

--- a/packages/core/echo/echo-react/src/usePagination.ts
+++ b/packages/core/echo/echo-react/src/usePagination.ts
@@ -28,11 +28,7 @@ export type PaginationResult<T> = {
   getPrevious: () => void;
   /** Whether older items remain beyond what is currently loaded. Inferred from the last page's size. */
   hasMore: boolean;
-  /**
-   * Whether a range query is in flight -- true from when a range is requested until it delivers its
-   * first result (including the initial load), false once settled (even if the result is empty).
-   * Lets a consumer distinguish "still loading" from "loaded and empty".
-   */
+  /** True until the current range delivers its first result, even an empty one. */
   isLoading: boolean;
   /** False once eviction has detached the window from the live head (i.e. skip > 0). */
   atHead: boolean;
@@ -76,20 +72,12 @@ const createPaginationStore = <Q extends Query.Any, O>(
   let maxWindowSize = initialMaxWindowSize;
   let skip = 0;
   let limit = pageSize;
-  // Single-flight latch coalescing a synchronous burst of `getNext`/`getPrevious` into one range
-  // change: a virtualizer's `onChange` fires once per newly-rendered row, so one "scrolled near the
-  // edge" gesture can invoke the callback many times before React re-renders with the new range.
-  // Set and checked synchronously within the call (so the whole burst sees it, no dependency on a
-  // render in between) and cleared on the next microtask, so a later genuine gesture isn't blocked.
-  // Purely about coalescing re-entrant calls -- whether the query has delivered is `isLoading`'s job.
+  // Single-flight latch coalescing a burst of synchronous `getNext`/`getPrevious` calls (a
+  // virtualizer's `onChange` fires once per rendered row) into one range change.
   let rangeChangePending = false;
   let innerUnsubscribe: (() => void) | undefined;
-  // Whether a range query is in flight: true from the moment a range is (re)pointed until that range
-  // delivers its first result (including the initial load), then false. Cleared on genuine delivery
-  // (in the subscribe callback), never on a timer: async sources (feeds served by the index) stay
-  // `true` until the host's first response lands, and since even an empty feed notifies, this settles
-  // rather than sticking. A real "still loading" signal, so consumers can tell "loading" apart from
-  // "loaded and empty". Initialised to whether there is a resource to load at all.
+  // Cleared only on the range's first delivery (never on a timer), so it never sticks true even for
+  // an empty async feed.
   let isLoading = resource !== undefined;
   // The items currently shown. Held across a range change until the new range delivers its own
   // results, so the list never flickers to empty while a new (possibly async) range loads.
@@ -127,14 +115,8 @@ const createPaginationStore = <Q extends Query.Any, O>(
     const nextQueryResult = resource.query(effectiveQuery);
     isLoading = true;
 
-    // Publish the new range's results only once they exist, and clear `isLoading` on that first
-    // delivery. `subscribe({ fire: true })` invokes the callback synchronously for synchronous
-    // sources (authoritative results, possibly empty) and defers it until the first response for
-    // asynchronous sources (e.g. a feed served by the index) -- that first response always arrives,
-    // even for an empty feed, so `isLoading` clears on genuine delivery without ever sticking. Until
-    // then `displayItems` keeps showing the previous range, so the list never flickers to empty while
-    // a new range loads. The callback also fires on every later change (keeping the window live);
-    // those later fires leave the already-false `isLoading` untouched.
+    // Publish results and clear `isLoading` only on delivery -- deferred for an async source (a feed
+    // served by the index) until its first response, which arrives even when that response is empty.
     innerUnsubscribe = nextQueryResult.subscribe(
       () => {
         displayItems = nextQueryResult.results as O[];
@@ -144,14 +126,8 @@ const createPaginationStore = <Q extends Query.Any, O>(
       { fire: true },
     );
 
-    // Reflect the in-flight state without clobbering `displayItems` (which still holds the previous
-    // range for async sources; synchronous sources have already replaced it, and cleared `isLoading`,
-    // above).
     notify();
-    // Clear the re-entrancy latch on the next microtask: long enough to coalesce a synchronous burst
-    // within one tick, but not tied to delivery -- `isLoading` (cleared only on delivery) is what
-    // guards against requesting the next range before this one lands, so a later gesture on a settled
-    // window can proceed once the latch lifts.
+    // The re-entrancy latch only needs to survive one tick, not the query's actual delivery.
     queueMicrotask(() => {
       rangeChangePending = false;
     });

--- a/packages/core/echo/echo-react/src/usePagination.ts
+++ b/packages/core/echo/echo-react/src/usePagination.ts
@@ -28,6 +28,11 @@ export type PaginationResult<T> = {
   getPrevious: () => void;
   /** Whether older items remain beyond what is currently loaded. Inferred from the last page's size. */
   hasMore: boolean;
+  /**
+   * Whether a range query is in flight -- true from when a range is requested until it delivers its
+   * first result (including the initial load), false once settled (even if the result is empty).
+   * Lets a consumer distinguish "still loading" from "loaded and empty".
+   */
   isLoading: boolean;
   /** False once eviction has detached the window from the live head (i.e. skip > 0). */
   atHead: boolean;
@@ -71,15 +76,21 @@ const createPaginationStore = <Q extends Query.Any, O>(
   let maxWindowSize = initialMaxWindowSize;
   let skip = 0;
   let limit = pageSize;
-  // Guards `getNext`/`getPrevious` against a burst of synchronous re-entrant calls within the
-  // same tick (a virtualizer's `onChange` can fire once per newly-rendered row, so a single
-  // "scrolled near the edge" event may invoke the callback many times before the first one's new
-  // range has delivered a result). Plain closure state, checked and set synchronously inside the
-  // call itself, so the rest of the burst sees it immediately -- no dependency on a render
-  // happening in between.
-  let pending = false;
+  // Single-flight latch coalescing a synchronous burst of `getNext`/`getPrevious` into one range
+  // change: a virtualizer's `onChange` fires once per newly-rendered row, so one "scrolled near the
+  // edge" gesture can invoke the callback many times before React re-renders with the new range.
+  // Set and checked synchronously within the call (so the whole burst sees it, no dependency on a
+  // render in between) and cleared on the next microtask, so a later genuine gesture isn't blocked.
+  // Purely about coalescing re-entrant calls -- whether the query has delivered is `isLoading`'s job.
+  let rangeChangePending = false;
   let innerUnsubscribe: (() => void) | undefined;
-  let isLoading = false;
+  // Whether a range query is in flight: true from the moment a range is (re)pointed until that range
+  // delivers its first result (including the initial load), then false. Cleared on genuine delivery
+  // (in the subscribe callback), never on a timer: async sources (feeds served by the index) stay
+  // `true` until the host's first response lands, and since even an empty feed notifies, this settles
+  // rather than sticking. A real "still loading" signal, so consumers can tell "loading" apart from
+  // "loaded and empty". Initialised to whether there is a resource to load at all.
+  let isLoading = resource !== undefined;
   // The items currently shown. Held across a range change until the new range delivers its own
   // results, so the list never flickers to empty while a new (possibly async) range loads.
   let displayItems: O[] = EMPTY_ARRAY;
@@ -116,31 +127,33 @@ const createPaginationStore = <Q extends Query.Any, O>(
     const nextQueryResult = resource.query(effectiveQuery);
     isLoading = true;
 
-    // Publish the new range's results only once they exist. `subscribe({ fire: true })` invokes the
-    // callback synchronously for synchronous sources (authoritative results, possibly empty) and
-    // defers it until the first real result for asynchronous sources (e.g. a feed served by the
-    // index). Until then `displayItems` keeps showing the previous range, so the list never flickers
-    // to empty while a new range loads. The callback also fires on every later change, keeping the
-    // window live.
+    // Publish the new range's results only once they exist, and clear `isLoading` on that first
+    // delivery. `subscribe({ fire: true })` invokes the callback synchronously for synchronous
+    // sources (authoritative results, possibly empty) and defers it until the first response for
+    // asynchronous sources (e.g. a feed served by the index) -- that first response always arrives,
+    // even for an empty feed, so `isLoading` clears on genuine delivery without ever sticking. Until
+    // then `displayItems` keeps showing the previous range, so the list never flickers to empty while
+    // a new range loads. The callback also fires on every later change (keeping the window live);
+    // those later fires leave the already-false `isLoading` untouched.
     innerUnsubscribe = nextQueryResult.subscribe(
       () => {
         displayItems = nextQueryResult.results as O[];
+        isLoading = false;
         notify();
       },
       { fire: true },
     );
 
-    // Reflect the pending state without clobbering `displayItems` (which still holds the previous
-    // range for async sources; synchronous sources have already replaced it above). `isLoading`/
-    // `pending` gate this tick's re-entrancy and a "just requested a new range" signal, not "the
-    // query is provably settled", so resolving them on the next microtask keeps them from getting
-    // stuck while still blocking every synchronous call within the same burst (a virtualizer's
-    // `onChange` can fire many times per tick for one user gesture, all before a microtask elapses).
+    // Reflect the in-flight state without clobbering `displayItems` (which still holds the previous
+    // range for async sources; synchronous sources have already replaced it, and cleared `isLoading`,
+    // above).
     notify();
+    // Clear the re-entrancy latch on the next microtask: long enough to coalesce a synchronous burst
+    // within one tick, but not tied to delivery -- `isLoading` (cleared only on delivery) is what
+    // guards against requesting the next range before this one lands, so a later gesture on a settled
+    // window can proceed once the latch lifts.
     queueMicrotask(() => {
-      isLoading = false;
-      pending = false;
-      notify();
+      rangeChangePending = false;
     });
   };
 
@@ -163,10 +176,10 @@ const createPaginationStore = <Q extends Query.Any, O>(
       maxWindowSize = value;
     },
     getNext: () => {
-      if (pending || snapshot.items.length < limit) {
+      if (isLoading || rangeChangePending || snapshot.items.length < limit) {
         return;
       }
-      pending = true;
+      rangeChangePending = true;
       const nextLimit = limit + pageSize;
       if (nextLimit <= maxWindowSize) {
         limit = nextLimit;
@@ -177,10 +190,10 @@ const createPaginationStore = <Q extends Query.Any, O>(
       pointAtRange();
     },
     getPrevious: () => {
-      if (pending || skip === 0) {
+      if (isLoading || rangeChangePending || skip === 0) {
         return;
       }
-      pending = true;
+      rangeChangePending = true;
       // Slides the window toward the head at constant size (limit unchanged) -- decreasing skip
       // while holding limit fixed both reveals newer items at the front and drops an equal count
       // of the oldest loaded items, mirroring getNext's own "slide" branch (taken once it hits
@@ -189,7 +202,7 @@ const createPaginationStore = <Q extends Query.Any, O>(
       pointAtRange();
     },
     jumpToHead: () => {
-      pending = false;
+      rangeChangePending = false;
       skip = 0;
       limit = pageSize;
       pointAtRange();

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.stories.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.stories.tsx
@@ -73,13 +73,7 @@ type StoryArgs = {
   conversations?: boolean;
   /** Seed the realistic `SAMPLE_MESSAGES` corpus instead of the lorem builder, for the `SearchFilter` play test. */
   seedSearchTerm?: boolean;
-  /**
-   * Seed a sync binding (AccessToken → Connection → Cursor → Mailbox) for an otherwise-empty mailbox,
-   * exercising `InitializeMailbox`'s connection-derived copy: bound shows "Mailbox empty", unbound
-   * (the default) shows "No connections configured". `MailboxArticle`'s own loading vs. empty branch
-   * is driven by `usePagination`'s `isLoading` instead (real query-settlement, not fakeable via the
-   * cursor), so there is no separate "loading" binding to demonstrate as a stable story.
-   */
+  /** Seeds a sync binding (AccessToken → Connection → Cursor) so `InitializeMailbox` shows "Mailbox empty" instead of "No connections configured". */
   bound?: boolean;
 };
 
@@ -166,9 +160,6 @@ const meta = {
               } else {
                 const mailbox = yield* Effect.promise(() => initializeMailbox(personalSpace, count, threads));
                 if (bound) {
-                  // Seed a sync binding (AccessToken → Connection → Cursor → Mailbox) so
-                  // `InitializeMailbox` resolves a `Connection` and shows "Mailbox empty" instead of
-                  // the unbound "No connections configured" state.
                   const accessToken = personalSpace.db.add(
                     AccessToken.make({ source: 'imap.example.com', account: 'user@example.com', token: 'story-token' }),
                   );
@@ -217,15 +208,12 @@ export const Flat: Story = {
   },
 };
 
-// Empty, unbound mailbox: no sync cursor exists, so the article shows the "No connections configured" panel.
 export const NoConnection: Story = {
   args: {
     count: 0,
   },
 };
 
-// Empty mailbox bound to a connection (cursor + access token seeded, no messages): shows the "Mailbox
-// empty" panel rather than "No connections configured".
 export const Empty: Story = {
   args: {
     count: 0,

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.stories.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.stories.tsx
@@ -14,10 +14,12 @@ import { withPluginManager } from '@dxos/app-framework/testing';
 import { useCapability } from '@dxos/app-framework/ui';
 import { AppActivationEvents, AppPlugin, LayoutOperation } from '@dxos/app-toolkit';
 import { Operation, OperationHandlerSet } from '@dxos/compute';
-import { Database, Feed, Filter } from '@dxos/echo';
+import { Database, Feed, Filter, Ref } from '@dxos/echo';
 import { DXN } from '@dxos/keys';
+import { AccessToken, Cursor } from '@dxos/link';
 import { ClientPlugin } from '@dxos/plugin-client/testing';
 import { initializeIdentity } from '@dxos/plugin-client/testing';
+import { Connection } from '@dxos/plugin-connector';
 import { PreviewPlugin } from '@dxos/plugin-preview/testing';
 import { SAMPLE_MESSAGES, StorybookPlugin, corePlugins } from '@dxos/plugin-testing';
 import { useQuery, useSpaces } from '@dxos/react-client/echo';
@@ -71,6 +73,14 @@ type StoryArgs = {
   conversations?: boolean;
   /** Seed the realistic `SAMPLE_MESSAGES` corpus instead of the lorem builder, for the `SearchFilter` play test. */
   seedSearchTerm?: boolean;
+  /**
+   * Seed a sync binding (AccessToken → Connection → Cursor → Mailbox) for an otherwise-empty mailbox,
+   * exercising `InitializeMailbox`'s connection-derived copy: bound shows "Mailbox empty", unbound
+   * (the default) shows "No connections configured". `MailboxArticle`'s own loading vs. empty branch
+   * is driven by `usePagination`'s `isLoading` instead (real query-settlement, not fakeable via the
+   * cursor), so there is no separate "loading" binding to demonstrate as a stable story.
+   */
+  bound?: boolean;
 };
 
 const DefaultStory = ({ conversations }: StoryArgs) => {
@@ -98,12 +108,20 @@ const meta = {
   render: DefaultStory,
   decorators: [
     withLayout({ layout: 'column' }),
-    withPluginManager<StoryArgs>(({ args: { count = 0, threads = 10, seedSearchTerm = false } }) => ({
+    withPluginManager<StoryArgs>(({ args: { count = 0, threads = 10, seedSearchTerm = false, bound = false } }) => ({
       setupEvents: [AppActivationEvents.SetupSettings],
       plugins: [
         ...corePlugins(),
         ClientPlugin({
-          types: [Feed.Feed, Mailbox.Mailbox, Message.Message, Person.Person],
+          types: [
+            Feed.Feed,
+            Mailbox.Mailbox,
+            Message.Message,
+            Person.Person,
+            AccessToken.AccessToken,
+            Connection.Connection,
+            Cursor.Cursor,
+          ],
           onClientInitialized: ({ client }) =>
             Effect.gen(function* () {
               const { personalSpace } = yield* initializeIdentity(client);
@@ -146,7 +164,21 @@ const meta = {
                   );
                 }
               } else {
-                yield* Effect.promise(() => initializeMailbox(personalSpace, count, threads));
+                const mailbox = yield* Effect.promise(() => initializeMailbox(personalSpace, count, threads));
+                if (bound) {
+                  // Seed a sync binding (AccessToken → Connection → Cursor → Mailbox) so
+                  // `InitializeMailbox` resolves a `Connection` and shows "Mailbox empty" instead of
+                  // the unbound "No connections configured" state.
+                  const accessToken = personalSpace.db.add(
+                    AccessToken.make({ source: 'imap.example.com', account: 'user@example.com', token: 'story-token' }),
+                  );
+                  const connection = personalSpace.db.add(
+                    Connection.make({ name: 'Story Mail', accessToken: Ref.make(accessToken) }),
+                  );
+                  personalSpace.db.add(
+                    Cursor.makeExternal({ source: connection.accessToken, target: Ref.make(mailbox) }),
+                  );
+                }
               }
               yield* Effect.promise(() => personalSpace.db.flush({ indexes: true }));
             }),
@@ -176,19 +208,28 @@ export const Default: Story = {
   },
 };
 
-export const Conversations: Story = {
+// TODO(wittjosiah): Remove? Conversation grouping is on by default now, so `Default` already covers
+// it — this exists only to exercise the flat/ungrouped fallback (`conversations: false`).
+export const Flat: Story = {
   args: {
     count: 500,
-    // A thread pool comfortably larger than the page size (10 conversations) so scrolling
-    // exercises group-level pagination — with the default pool of 10 everything fits on one page.
-    threads: 100,
-    conversations: true,
+    conversations: false,
   },
 };
 
+// Empty, unbound mailbox: no sync cursor exists, so the article shows the "No connections configured" panel.
+export const NoConnection: Story = {
+  args: {
+    count: 0,
+  },
+};
+
+// Empty mailbox bound to a connection (cursor + access token seeded, no messages): shows the "Mailbox
+// empty" panel rather than "No connections configured".
 export const Empty: Story = {
   args: {
     count: 0,
+    bound: true,
   },
 };
 

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -188,10 +188,7 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
   // Flat message list backing keyboard navigation and message-id lookups in action handlers.
   const messages = useMemo(() => items.flatMap((item) => (isMessageGroup(item) ? item.messages : [item])), [items]);
 
-  // `usePagination`'s `isLoading` reflects the underlying query settling, not a message-count guess --
-  // it stays true until the (possibly async, feed-backed) query delivers its first result, including
-  // when that result is empty. Gating on it (rather than on `messages.length`) means the empty-mailbox
-  // panel only ever renders once the query has genuinely settled with nothing, never mid-load.
+  // Gates on the query settling, not on `messages.length`, so the empty-mailbox panel never renders mid-load.
   const loading = !feed || pagination.isLoading;
 
   const handleClear = useCallback(() => {
@@ -333,8 +330,7 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
       </ElevationProvider>
       <Panel.Content asChild>
         {loading ? (
-          // The spinner stays hidden for 1s (the fade-in animation only reveals after its delay) so a
-          // fast (sub-second) load never flashes it -- it should be a rare sight in practice.
+          // Fade-in delayed 1s so a fast load never flashes the spinner.
           <div className='grid place-items-center bs-full is-full'>
             <Icon
               icon='ph--spinner-gap--regular'
@@ -356,8 +352,6 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
             onAction={handleAction}
           />
         ) : (
-          // Settled with no messages: genuinely empty. `InitializeMailbox` looks up the mailbox's own
-          // sync cursor/connection to choose between "No connections configured" and "Mailbox empty".
           <InitializeMailbox mailbox={mailbox} />
         )}
       </Panel.Content>

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -21,7 +21,7 @@ import { type EntityId } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { useActionRunner } from '@dxos/plugin-graph';
 import { AtomState, useAtomState } from '@dxos/react-hooks';
-import { ElevationProvider, Panel } from '@dxos/react-ui';
+import { ElevationProvider, Icon, Panel } from '@dxos/react-ui';
 import { linkedSegment, useArticleKeyboardNavigation, useSelection } from '@dxos/react-ui-attention';
 import { type EditorController } from '@dxos/react-ui-editor';
 import {
@@ -188,22 +188,11 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
   // Flat message list backing keyboard navigation and message-id lookups in action handlers.
   const messages = useMemo(() => items.flatMap((item) => (isMessageGroup(item) ? item.messages : [item])), [items]);
 
-  // TODO(burdon): Actual test should be if we have synced; not number of messages.
-  // Show the message list as soon as any messages are present; only fall back to the empty state
-  // after a brief delay of genuinely having none (prevents an initial-load flicker). Keyed on the
-  // COUNT, not the query-result identity: keying on `messages` (which changes on every update) plus
-  // an always-delayed setter meant that during a sync the timeout was cleared before it ever fired,
-  // latching the empty state `true` while messages streamed in — the mailbox showed empty for the
-  // whole burst and only revealed messages once updates slowed past the 1s window.
-  const [isEmpty, setEmpty] = useState<boolean>(false);
-  useEffect(() => {
-    if (messages.length > 0) {
-      setEmpty(false);
-      return;
-    }
-    const t = setTimeout(() => setEmpty(true), 1_000);
-    return () => clearTimeout(t);
-  }, [messages.length]);
+  // `usePagination`'s `isLoading` reflects the underlying query settling, not a message-count guess --
+  // it stays true until the (possibly async, feed-backed) query delivers its first result, including
+  // when that result is empty. Gating on it (rather than on `messages.length`) means the empty-mailbox
+  // panel only ever renders once the query has genuinely settled with nothing, never mid-load.
+  const loading = !feed || pagination.isLoading;
 
   const handleClear = useCallback(() => {
     setFilterText(filterProp ?? '');
@@ -343,9 +332,17 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
         </Menu.Root>
       </ElevationProvider>
       <Panel.Content asChild>
-        {isEmpty ? (
-          <InitializeMailbox mailbox={mailbox} />
-        ) : (
+        {loading ? (
+          // The spinner stays hidden for 1s (the fade-in animation only reveals after its delay) so a
+          // fast (sub-second) load never flashes it -- it should be a rare sight in practice.
+          <div className='grid place-items-center bs-full is-full'>
+            <Icon
+              icon='ph--spinner-gap--regular'
+              size={6}
+              classNames='text-subdued [animation:spin_1s_linear_infinite,fade-in_200ms_ease-out_1s_backwards]'
+            />
+          </div>
+        ) : messages.length > 0 ? (
           <MessageStack
             id={id}
             items={items}
@@ -358,6 +355,10 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
             searchQuery={searchQuery}
             onAction={handleAction}
           />
+        ) : (
+          // Settled with no messages: genuinely empty. `InitializeMailbox` looks up the mailbox's own
+          // sync cursor/connection to choose between "No connections configured" and "Mailbox empty".
+          <InitializeMailbox mailbox={mailbox} />
         )}
       </Panel.Content>
       {progress && (progress.status === 'running' || progress.status === 'error') && (


### PR DESCRIPTION
## Summary

- `MailboxArticle` guessed "still loading" from message count with a 1s timeout, so a bound mailbox with no messages loaded yet could briefly flash the wrong empty-state panel (e.g. "No connections configured") before settling. It now derives loading directly from `usePagination`'s `isLoading`; `InitializeMailbox`'s existing cursor/connection lookup still distinguishes "No connections configured" from "Mailbox empty" once the query genuinely settles empty.
- That exposed a real bug in `usePagination` itself: `isLoading` cleared on the next microtask regardless of whether the (possibly async, feed-backed) query had actually delivered a result — so it could read `false` while a page was still loading, making it useless as a "still loading" signal. It now clears only on genuine delivery from the query's subscribe callback, which is safe even for an empty result set (the host always sends a first response, even for zero results, so it never hangs). The single-flight re-entrancy guard for `getNext`/`getPrevious` bursts is split into its own state (`rangeChangePending`), no longer conflated with real loading.
- `MailboxArticle.stories.tsx`: renamed `Conversations` → `Flat` (conversation grouping is the default now, so this exercises the ungrouped fallback instead; flagged with a `TODO(wittjosiah): Remove?`), and added a bound-but-empty `Empty` story alongside the existing unbound `NoConnection` one.

## Test plan

- [x] `moon run echo-react:test` — 36/36 passing, including 3 new `usePagination` tests covering the `isLoading` fix (initial load, empty-feed settlement, `getNext` in-flight)
- [x] `moon run plugin-inbox:test` — 203/203 passing
- [x] `moon run plugin-inbox:test-storybook` — full Storybook play-function suite green
- [x] `moon exec --on-failure continue :test -- --no-file-parallelism` (full repo) — 775 tasks, 1 failure (`phoenix:test`, a detached-watchdog test that fails identically on an unmodified `origin/main` tree in this sandbox — confirmed pre-existing/environment-specific, unrelated to this change)
- [x] `moon run :lint -- --fix` (full repo) — clean
- [x] `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loading indicators for mailbox message feeds, including initial loads, empty mailboxes, and pagination.
  - Prevented transient “Mailbox empty” messaging from appearing while messages are still loading.
  - Updated pagination loading behavior to better reflect in-flight range queries, including empty-result settlement and subsequent page loads.
- **Tests**
  - Added coverage for `usePagination` loading state transitions (initial load, empty feeds, and `getNext()` pagination).
- **Documentation**
  - Clarified `usePagination` loading semantics in the in-app documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->