### PR TITLE
plugin-connector: fix mailbox rename on reuse + missing cursor visibility on materialize

### DIFF
--- a/.changeset/mailbox-reuse-rename-and-materialize-cursor.md
+++ b/.changeset/mailbox-reuse-rename-and-materialize-cursor.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-connector': patch
+---
+
+Fix rebinding a target (e.g. a Mailbox) to an existing connection not renaming it after the connection's account, and fix the newly-created cursor for a target materialized alongside a brand-new connection not being immediately visible to the sync trigger UI.

--- a/packages/plugins/plugin-connector/src/capabilities/connector-coordinator/create-single-cursor.test.ts
+++ b/packages/plugins/plugin-connector/src/capabilities/connector-coordinator/create-single-cursor.test.ts
@@ -1,0 +1,109 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import * as ManagedRuntime from 'effect/ManagedRuntime';
+import { afterEach, beforeEach, describe, test } from 'vitest';
+
+import { Operation } from '@dxos/compute';
+import { Database, DXN, Filter, Obj, Ref } from '@dxos/echo';
+import { EchoTestBuilder } from '@dxos/echo-client/testing';
+import { EffectEx } from '@dxos/effect';
+import { invariant } from '@dxos/invariant';
+import { AccessToken, Cursor } from '@dxos/link';
+import { OperationInvoker } from '@dxos/operation';
+import { Expando } from '@dxos/schema';
+
+import { Connection, type ConnectorEntry, MaterializeTargetInput, MaterializeTargetOutput } from '#types';
+
+import { createSingleCursor } from './create-single-cursor';
+
+describe('createSingleCursor', () => {
+  let builder: EchoTestBuilder;
+
+  beforeEach(async () => {
+    builder = await new EchoTestBuilder().open();
+  });
+
+  afterEach(async () => {
+    await builder.close();
+  });
+
+  // Stand-in materialize operation: creates a fresh Expando named after the connection's
+  // access-token account (real connectors, e.g. Gmail, materialize a Mailbox the same way).
+  const MaterializeExampleTarget = Operation.make({
+    meta: { key: DXN.make('org.dxos.test.createSingleCursor.materialize') },
+    input: MaterializeTargetInput,
+    output: MaterializeTargetOutput,
+  });
+
+  const materializeHandler = MaterializeExampleTarget.pipe(
+    Operation.withHandler(
+      Effect.fnUntraced(function* ({ connection }) {
+        const connectionObj = connection.target;
+        invariant(connectionObj, 'connection ref must be hydrated');
+        const db = Obj.getDatabase(connectionObj);
+        invariant(db, 'connection must live in a database');
+        const accessToken = yield* Database.load(connectionObj.accessToken);
+        const created = db.add(Obj.make(Expando.Expando, { name: accessToken.account ?? 'Inbox' }));
+        return { target: Ref.make(created) };
+      }),
+    ),
+  );
+
+  const invoker = OperationInvoker.make(
+    () => Effect.succeed([materializeHandler]),
+    ManagedRuntime.make(Layer.empty) as unknown as ManagedRuntime.ManagedRuntime<any, any>,
+  );
+
+  const makeConnector = (overrides: Partial<ConnectorEntry> = {}): ConnectorEntry => ({
+    id: 'example',
+    source: 'example.com',
+    materializeTarget: MaterializeExampleTarget,
+    ...overrides,
+  });
+
+  const setup = async () => {
+    const { db, graph } = await builder.createDatabase();
+    graph.registry.add([Connection.Connection, Cursor.Cursor, AccessToken.AccessToken, Expando.Expando]);
+    const token = db.add(
+      Obj.make(AccessToken.AccessToken, { source: 'example.com', token: 'tok', account: 'me@example.com' }),
+    );
+    const connection = db.add(
+      Obj.make(Connection.Connection, { connectorId: 'example', accessToken: Ref.make(token) }),
+    );
+    return { db, connection };
+  };
+
+  const queryCursors = (db: Database.Database) =>
+    Database.query(Filter.type(Cursor.Cursor)).run.pipe(
+      Effect.provide(Database.layer(db)),
+      EffectEx.runAndForwardErrors,
+    );
+
+  test('materializing a target for a new connection creates a bound cursor', async ({ expect }) => {
+    const { db, connection } = await setup();
+
+    await createSingleCursor(invoker, db, makeConnector(), connection, undefined).pipe(EffectEx.runAndForwardErrors);
+
+    const cursors = await queryCursors(db);
+    expect(cursors).toHaveLength(1);
+    invariant(Cursor.isExternal(cursors[0]));
+    expect(cursors[0].spec.source.uri).toBe(connection.accessToken.uri);
+  });
+
+  test('binding an existingTarget renames it after the connection account', async ({ expect }) => {
+    const { db, connection } = await setup();
+    const mailbox = db.add(Obj.make(Expando.Expando, { name: 'Inbox' }));
+
+    await createSingleCursor(invoker, db, makeConnector(), connection, Ref.make(mailbox)).pipe(
+      EffectEx.runAndForwardErrors,
+    );
+
+    const cursors = await queryCursors(db);
+    expect(cursors).toHaveLength(1);
+    expect(Obj.getLabel(mailbox)).toBe('me@example.com');
+  });
+});

--- a/packages/plugins/plugin-connector/src/capabilities/connector-coordinator/create-single-cursor.ts
+++ b/packages/plugins/plugin-connector/src/capabilities/connector-coordinator/create-single-cursor.ts
@@ -53,6 +53,9 @@ export const createSingleCursor = (
     // failure is not special-cased — a defect here is caught by this function's own outer
     // `catchAllDefect` below, same as any other step in this flow.
     yield* connector.onCursorCreated?.({ connection, cursor, target, db }) ?? Effect.void;
+    // Flush the index so a caller that queries cursors right after (e.g. the mailbox/calendar
+    // article this navigates to) observes the new binding immediately, matching `reconcileCursors`.
+    yield* Database.flush({ indexes: true });
   }).pipe(
     Effect.provide(Database.layer(db)),
     Effect.catchAll((error) => Effect.sync(() => log.warn('create single binding failed', { error }))),

--- a/packages/plugins/plugin-connector/src/util/connector-auth.test.ts
+++ b/packages/plugins/plugin-connector/src/util/connector-auth.test.ts
@@ -127,4 +127,29 @@ describe('connectorAuthActions', () => {
     expect(input.target.id).toBe(target.id);
     expect(input.cursor.id).toBe(cursors[0].id);
   });
+
+  test('reuse renames the existing target after the connection account', async ({ expect }) => {
+    const { db, graph } = await builder.createDatabase();
+    graph.registry.add([Connection.Connection, AccessToken.AccessToken, Cursor.Cursor]);
+    const token = db.add(
+      Obj.make(AccessToken.AccessToken, { source: 'b.example', token: 'tok', account: 'me@example.com' }),
+    );
+    const connection = db.add(Obj.make(Connection.Connection, { connectorId: 'b', accessToken: Ref.make(token) }));
+    const target = db.add(Obj.make(AccessToken.AccessToken, { source: 'target.example', token: 'tok' }));
+    const connector: ConnectorEntry = makeConnector('b');
+
+    const actions = connectorAuthActions({
+      connectorIds: ['b'],
+      db,
+      spaceId: db.spaceId,
+      existingTarget: Ref.make(target),
+      allConnectors: [connector],
+      allConnections: [connection],
+    });
+    const [reuse] = actions[0].actions ?? [];
+    invariant(Node.isAction(reuse));
+    await EffectEx.runAndForwardErrors(reuse.data());
+
+    expect(Obj.getLabel(target)).toBe('me@example.com');
+  });
 });

--- a/packages/plugins/plugin-connector/src/util/connector-auth.ts
+++ b/packages/plugins/plugin-connector/src/util/connector-auth.ts
@@ -6,7 +6,7 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppNode } from '@dxos/app-toolkit';
-import { Database, type Key, type Obj, type Ref } from '@dxos/echo';
+import { Database, type Key, Obj, type Ref } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
 import { Cursor } from '@dxos/link';
 import { type Node } from '@dxos/plugin-graph';
@@ -101,6 +101,11 @@ export const connectorAuthActions = ({
             return;
           }
           const target = yield* Database.load(existingTarget);
+          const accessToken = yield* Database.load(connection.accessToken);
+          const name = accessToken.account;
+          if (name) {
+            Obj.update(target, (target) => Obj.setLabel(target, name));
+          }
           const cursor = yield* Database.add(
             Cursor.makeExternal({ source: connection.accessToken, target: existingTarget }),
           );


### PR DESCRIPTION
## Summary

Two related bugs in the mailbox/connection binding flow (`packages/plugins/plugin-connector`):

1. **Binding a mailbox to an existing connection didn't rename it.** `reuseAction` in `connector-auth.ts` (the "reuse connection" menu entry — bind the currently-viewed target, e.g. an empty Mailbox, to an *already-existing* Connection) created the cursor but never renamed the target after the connection's access-token account. The parallel "bind an existing target to a *new* connection" path in `createSingleCursor` already did this rename; `reuseAction` was missing it (introduced in #12227, which added the cursor/`onCursorCreated` wiring here but didn't port over the rename).

2. **Materializing a fresh target for a new connection could leave its cursor invisible.** `createSingleCursor` (used for single-target connectors like Gmail/JMAP Mailbox) creates the `Cursor` binding the newly-materialized target to the new connection, but — unlike `reconcileCursors`, its multi-target sibling — never flushed the index afterwards. `reconcileCursors` explicitly does this "so a caller that queries cursors right after observes a state consistent with the returned counts." `createSingleCursor` is followed immediately by navigation to the new connection's page, which queries cursors, so the same reasoning applies there.

## Changes

- `connector-auth.ts`: `reuseAction` now loads the connection's access token and renames the bound target when an account is present, mirroring `createSingleCursor`'s `existingTarget` branch.
- `create-single-cursor.ts`: flush the index after creating the cursor (and running `onCursorCreated`), matching `reconcileCursors`.
- Added test coverage for both fixes, including new coverage for `createSingleCursor` (which previously had no dedicated test file).

## Test plan

- [x] Added `connector-auth.test.ts` case asserting the reused target is renamed after the connection's account.
- [x] Added `create-single-cursor.test.ts` covering both the materialize-a-new-target and bind-an-existingTarget paths.
- [ ] CI (`Check`) — network access to run `moon`/full workspace build was unavailable in this sandbox, so these tests could not be executed locally; relying on CI to confirm.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KmnRLzjnu2cTqLbXDhSTZ9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reusing an existing connection no longer incorrectly renames its target.
  - Target labels now update correctly based on the connection account.
  - Newly created cursors are immediately visible to synchronization status displays.
  - Cursor bindings are now reliably available immediately after creation.

- **Tests**
  - Added coverage for cursor creation, connection reuse, target relabeling, and immediate synchronization visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->