### PR TITLE
tauri: update @tauri-apps/plugin-dialog

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,8 +583,8 @@ catalogs:
       specifier: ^2.4.9
       version: 2.4.9
     '@tauri-apps/plugin-dialog':
-      specifier: ^2.7.1
-      version: 2.7.1
+      specifier: ^2.7.2
+      version: 2.7.2
     '@tauri-apps/plugin-fs':
       specifier: ^2.5.1
       version: 2.5.1
@@ -13424,7 +13424,7 @@ importers:
         version: 2.11.1
       '@tauri-apps/plugin-dialog':
         specifier: 'catalog:'
-        version: 2.7.1
+        version: 2.7.2
       '@tauri-apps/plugin-fs':
         specifier: 'catalog:'
         version: 2.5.1
@@ -32641,8 +32641,8 @@ packages:
   '@tauri-apps/plugin-deep-link@2.4.9':
     resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
 
-  '@tauri-apps/plugin-dialog@2.7.1':
-    resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
+  '@tauri-apps/plugin-dialog@2.7.2':
+    resolution: {integrity: sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg==}
 
   '@tauri-apps/plugin-fs@2.5.1':
     resolution: {integrity: sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==}
@@ -54935,7 +54935,7 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.1
 
-  '@tauri-apps/plugin-dialog@2.7.1':
+  '@tauri-apps/plugin-dialog@2.7.2':
     dependencies:
       '@tauri-apps/api': 2.11.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -232,7 +232,7 @@ catalog:
   '@tauri-apps/api': ^2.11.1
   '@tauri-apps/cli': ^2.11.4
   '@tauri-apps/plugin-deep-link': ^2.4.9
-  '@tauri-apps/plugin-dialog': ^2.7.1
+  '@tauri-apps/plugin-dialog': ^2.7.2
   '@tauri-apps/plugin-fs': ^2.5.1
   '@tauri-apps/plugin-haptics': ^2.3.2
   '@tauri-apps/plugin-opener': ^2.5.4


### PR DESCRIPTION
## Summary

Bumps the one `@tauri-apps/*` package with a newer version available. All others (`api`, `cli`, `plugin-deep-link`, `plugin-fs`, `plugin-haptics`, `plugin-opener`, `plugin-os`, `plugin-process`, `plugin-shell`, `plugin-updater`) are already at latest.

## Versions

| Package | Old | New |
|---|---|---|
| @tauri-apps/plugin-dialog | ^2.7.1 | ^2.7.2 |

## Validation

- **Build:** ✅ green (`moon exec --on-failure continue --quiet :build`, exit 0)
- **Lint:** ✅ green (298/298 tasks)
- **Tests:** full-suite run shows only the known baseline-noise failures (56 packages, matching the pattern documented on dxos/dxos#11229) — no `tauri`-specific failures.

## Classification: trivial

Single patch bump, build+lint green, no regressions. Enabling auto-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KUaiuHoT5A36GgBSkpahWZ)_