### PR TITLE
repo: make session-start worktree/branch guards branch-first

### DIFF
--- a/.claude/hooks/guard-branch.sh
+++ b/.claude/hooks/guard-branch.sh
@@ -2,31 +2,25 @@
 #
 # Copyright 2026 DXOS.org
 #
-# PreToolUse guard: refuse Bash commands that create, rename, or add worktrees
-# or branches while the session is running inside a worktree. The Desktop UI
-# pairs a session to its worktree by the convention `branch == claude/<worktree
-# -dir-name>`; creating a side worktree or rebranching breaks that pairing and
-# makes the session invisible in the UI.
+# PreToolUse guard: refuse Bash commands that create, rename, or add worktrees or
+# branches. The harness owns this session's branch and worktree; the agent must
+# never create/rename/switch them. Enforced regardless of where the session runs
+# (worktree, primary checkout, or a mis-instantiated main-root session) — the
+# old gate keyed on CLAUDE_PROJECT_DIR containing /.claude/worktrees/, which left
+# this guard inert exactly in the main-root sessions where it matters most.
 #
-# Denies (in a worktree session only):
+# Denies:
 #   git worktree add ...        -> agent-created side worktree
 #   git checkout -b|-B ...       -> new branch (drifts off claude/<dir>)
 #   git switch  -c|-C ...        -> new branch
 #   git branch  -m|-M ...        -> branch rename
 #
 # Allows: file-level checkout (`git checkout -- path`, `git checkout <file>`),
-# toggling to an existing branch, and everything outside a worktree session.
+# toggling to an existing branch, and everything that is not one of the above.
 
 set -euo pipefail
 
 input=$(cat)
-project_dir="${CLAUDE_PROJECT_DIR:-}"
-
-# Only enforce inside a worktree session (path contains /.claude/worktrees/).
-case "$project_dir" in
-  */.claude/worktrees/*) ;;
-  *) exit 0 ;;
-esac
 
 command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
 [ -z "$command" ] && exit 0
@@ -43,19 +37,19 @@ deny() {
 
 # git worktree add — creating a side worktree.
 if printf '%s' "$normalized" | grep -Eq '(^|[;&|[:space:]])git[[:space:]]+worktree[[:space:]]+add([[:space:]]|$)'; then
-  deny "Refusing to create a worktree: this session already runs in the assigned worktree '$project_dir'. Creating another breaks the Desktop UI's session/worktree pairing. Work in the assigned directory; if you need a different branch, ask the user."
+  deny "Refusing to create a worktree: the harness owns this session's worktree. Creating another breaks the Desktop UI's session/worktree pairing. Work on the assigned branch; if you need a different branch, ask the user."
 fi
 
 # git checkout -b|-B / git switch -c|-C — creating a new branch. The suffix
 # accepts any char (not just whitespace) so combined forms like `-bq`/`-cname`
 # cannot bypass the guard; newlines are already normalized to spaces above.
 if printf '%s' "$normalized" | grep -Eq '(^|[;&|[:space:]])git[[:space:]]+(checkout[[:space:]]+-[bB]|switch[[:space:]]+-[cC])(.|$)'; then
-  deny "Refusing to create a new branch: the assigned branch must stay 'claude/<worktree-dir-name>' so the Desktop UI can pair this session to its worktree. Do not create branches unless the user explicitly asks."
+  deny "Refusing to create a new branch: the harness assigns this session's branch (the Desktop UI pairs it to the worktree via a claude/… convention). Do not create branches unless the user explicitly asks."
 fi
 
 # git branch -m|-M — renaming a branch (combined form `-mnewname` also caught).
 if printf '%s' "$normalized" | grep -Eq '(^|[;&|[:space:]])git[[:space:]]+branch[[:space:]]+-[mM](.|$)'; then
-  deny "Refusing to rename the branch: the assigned branch must stay 'claude/<worktree-dir-name>' so the Desktop UI can pair this session to its worktree. Do not rename the branch."
+  deny "Refusing to rename the branch: the harness assigns this session's branch and the Desktop UI pairs it to the worktree. Do not rename the branch."
 fi
 
 exit 0

--- a/.claude/hooks/guard-worktree.sh
+++ b/.claude/hooks/guard-worktree.sh
@@ -2,82 +2,62 @@
 #
 # Copyright 2026 DXOS.org
 #
-# PreToolUse guard: refuse Edit/Write/MultiEdit/NotebookEdit that target the
-# MAIN checkout while the session is running inside a worktree. Catches the
-# failure mode where an absolute path is built from the repo root instead of
-# the assigned worktree, silently landing edits on `main`.
+# PreToolUse guard for Edit/Write/MultiEdit/NotebookEdit. The hazard is editing
+# while HEAD is on `main` — that pollutes the shared branch irreversibly. The
+# decisive signal is the BRANCH, not the directory: the harness sometimes checks
+# the assigned `claude/…` branch out at the primary checkout and leaves the
+# worktree path an empty stub. Editing there is safe because HEAD is the assigned
+# branch, so the old path-based "primary checkout == main" rule produced false
+# halts. This guard instead asks git for the branch of the target's working tree.
 #
-# Allows: edits inside the worktree, and anything outside the repo (e.g. the
-# auto-memory directory under ~/.claude). Enforces only in worktree sessions.
+# Denies: an edit whose target lives in a working tree whose HEAD is `main`.
+# Allows: edits on any feature branch (including the mis-instantiated case where
+# the feature branch sits at the primary checkout), detached HEAD, and anything
+# outside a git repo (e.g. the auto-memory dir under ~/.claude). Needs no
+# CLAUDE_PROJECT_DIR — the old dependency on it was the hole that once let a full
+# feature land on `main`.
 
 set -euo pipefail
 
 input=$(cat)
-project_dir="${CLAUDE_PROJECT_DIR:-}"
-
-# Fallback chain: CLAUDE_PROJECT_DIR can be UNSET (or point at the bare repo root),
-# which used to silently disable this guard — the exact hole that once let a full
-# feature land on `main`. When it does not name a worktree, derive the worktree
-# context from the hook's cwd, then from the git worktree root.
-case "$project_dir" in
-  */.claude/worktrees/*) ;;
-  *)
-    cwd="$(pwd)"
-    case "$cwd" in
-      */.claude/worktrees/*) project_dir="$cwd" ;;
-      *)
-        gitwt="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-        case "$gitwt" in
-          */.claude/worktrees/*) project_dir="$gitwt" ;;
-        esac
-        ;;
-    esac
-    ;;
-esac
-
-# Only enforce when a worktree context could be identified. A genuine main-checkout
-# session (no worktree in env, cwd, or git root) is left untouched.
-case "$project_dir" in
-  */.claude/worktrees/*) ;;
-  *) exit 0 ;;
-esac
-
-# Derive the main checkout root (everything before /.claude/worktrees/).
-main_root="${project_dir%%/.claude/worktrees/*}"
 
 # Target path: file_path for Edit/Write/MultiEdit, notebook_path for NotebookEdit.
 path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')
 [ -z "$path" ] && exit 0
 
-# Resolve relative paths against the worktree (the session cwd).
+# Resolve a directory to query git from — the file may not exist yet (Write), so
+# walk up to the nearest existing ancestor.
+case "$path" in
+  /*) probe=$(dirname "$path") ;;
+  *)  probe="$(pwd)" ;;
+esac
+while [ ! -d "$probe" ] && [ "$probe" != "/" ]; do
+  probe=$(dirname "$probe")
+done
+
+branch=$(git -C "$probe" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+[ "$branch" = "main" ] || exit 0
+
+# On `main`: fence edits that land inside this repo's working tree. Edits outside
+# the repo (e.g. ~/.claude memory) are allowed even though HEAD reads `main`.
+repo_root=$(git -C "$probe" rev-parse --show-toplevel 2>/dev/null || true)
+[ -z "$repo_root" ] && exit 0
+
 case "$path" in
   /*) abs="$path" ;;
-  *) abs="$project_dir/$path" ;;
+  *)  abs="$(pwd)/$path" ;;
 esac
 
-# Canonicalize to collapse `..`/`.` segments before the string boundary checks, so a path like
-# "$project_dir/../foo" can't textually match the worktree prefix and escape it. Uses purely
-# lexical normalization (no filesystem/symlink resolution needed): python3 `normpath` is portable
-# across macOS/Linux; `realpath -m` (GNU) is a fallback; raw value as a last resort.
-canonicalize() {
-  python3 -c 'import os,sys; print(os.path.normpath(sys.argv[1]))' "$1" 2>/dev/null ||
-    realpath -m "$1" 2>/dev/null ||
-    printf '%s' "$1"
-}
-abs=$(canonicalize "$abs")
-project_dir=$(canonicalize "$project_dir")
-main_root=$(canonicalize "$main_root")
+# Lexically collapse `..`/`.` before the boundary check so a path cannot escape
+# the repo prefix textually. python3 normpath is portable; realpath -m is a GNU
+# fallback; raw value as last resort.
+abs=$(python3 -c 'import os,sys; print(os.path.normpath(sys.argv[1]))' "$abs" 2>/dev/null ||
+  realpath -m "$abs" 2>/dev/null ||
+  printf '%s' "$abs")
 
-# Allow anything inside the worktree.
 case "$abs" in
-  "$project_dir"/* | "$project_dir") exit 0 ;;
-esac
-
-# Deny edits that land inside the main checkout but outside the worktree.
-case "$abs" in
-  "$main_root"/*)
-    suffix="${abs#"$main_root"/}"
-    reason="Refusing to edit the MAIN checkout: '$abs'. This session's worktree is '$project_dir'. Re-issue the edit against the worktree path: '$project_dir/$suffix'."
+  "$repo_root"/* | "$repo_root")
+    reason="Refusing to edit '$abs': HEAD is on 'main', so this edit would pollute the shared main branch. This session's work belongs on its assigned 'claude/…' branch. If you are on main because the worktree was mis-instantiated, STOP and ask the user — do not create a worktree or branch to escape."
     jq -n --arg r "$reason" \
       '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
     exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,25 +8,31 @@ This file is the shared, harness-agnostic entrypoint for coding agents.
 
 ## Start of session
 
-- **MANDATORY FIRST ACTION — verify the worktree before any file op.** The harness
-  fails to instantiate the assigned worktree roughly 10% of the time, leaving an
-  empty stub whose git resolves up to the bare repo root — so edits silently land
-  on `main`. Before reading, editing, or running anything, run:
+- **MANDATORY FIRST ACTION — check the branch before any file op. The branch, not
+  the directory, decides whether editing is safe.** The harness assigns this
+  session a branch and a worktree, but ~10% of the time it mis-instantiates them:
+  the assigned `claude/…` branch gets checked out at the _primary checkout_ while
+  the worktree path is left an empty `.claude`/`.moon` stub. Editing at the primary
+  checkout is still safe **as long as HEAD is your assigned branch** — your commits
+  land there, not on `main`. The bare-root path does NOT by itself mean `main`.
+  Before reading, editing, or running anything, run:
   ```
   git rev-parse --show-toplevel && git branch --show-current
   ```
-  The toplevel MUST equal the environment's assigned worktree path
-  (`.../.claude/worktrees/<name>`). If it instead resolves to the bare repo root
-  `/Users/burdon/Code/dxos/dxos`, or the assigned path is missing/empty/absent from
-  `git worktree list`, the worktree was never created: **STOP, write nothing, and
-  tell the user.** Do not `cd` to the bare repo root and do not build absolute
-  paths from it — every path must start with the assigned worktree root. (Only on
-  the user's explicit instruction, recover with
-  `git -C <bare-root> checkout main` then
-  `git worktree add <assigned-path> <branch>`.)
+  - **On a `claude/…` (or any non-`main`) branch → proceed.** Edits are data-safe
+    even if `--show-toplevel` is the primary checkout instead of
+    `.../.claude/worktrees/<name>`. If the path is not the assigned worktree, say
+    so once: that only affects whether the Desktop UI tracks the session
+    (recoverable), not data safety. Do NOT run `git worktree add <path> <branch>`
+    to "fix" it — the branch is already checked out, so that command fails (and the
+    `git worktree add` guard denies it anyway). If UI pairing matters, ask the user
+    to work-in-place or restart the session; do not halt the task over it.
+  - **On `main` → STOP, write nothing, tell the user.** Only here do edits pollute
+    the shared branch irreversibly. Do not create a worktree or branch to escape
+    (the harness owns those) — ask the user how to proceed.
 - Confirm you understand these instructions and list the guidance files you are
   aware of (this file, `.claude/CLAUDE.md`, relevant `.agents/skills/*`).
-- State the worktree you are operating in (the verified `--show-toplevel` path).
+- State the branch and the `--show-toplevel` path you are operating on.
 - When asking a question, make it yes/no or give numbered options — never an
   unnumbered a-or-b.
 - If unsure how to implement something, ask rather than guess.
@@ -74,11 +80,13 @@ Treat the user as an expensive, intermittent resource — minimize round-trips.
   out-of-range on any bump and would cascade the fixed publish group to a
   spurious major. Do not "simplify" it to `*`. Why it matters:
   `.github/RELEASE-SPEC.md`.
-- **Never edit the main checkout.** All file edits (and `cd` targets) use the
-  assigned worktree path, never the bare repo root or another worktree. Do NOT
-  rely on `guard-worktree.sh` to catch this — when `CLAUDE_PROJECT_DIR` is unset
-  the hook is a no-op. Self-verify per the Start-of-session check: if
-  `git rev-parse --show-toplevel` is the bare repo root, you are on `main` — stop.
+- **Never edit while on the `main` branch.** The safety signal is the branch, not
+  the directory: run `git branch --show-current` before your first edit. If it is
+  `main`, stop — edits pollute the shared branch. Editing the primary checkout
+  directory is fine when HEAD is your assigned `claude/…` branch (the ~10%
+  mis-instantiation case in Start-of-session); the bare-root path does **not**
+  imply `main`. `guard-worktree.sh` fences edits whose target working tree is on
+  `main`, but treat it as a backstop, not a guarantee — self-verify the branch.
 - **Commit nothing silently.** Before any commit/push, `git status` and account
   for every modified/untracked file — including the user's own edits in the
   shared worktree. Commit them or explicitly confirm exclusion.


### PR DESCRIPTION
## Problem

Claude Code Desktop frequently gets confused at session start about the
worktree/branch to use. Root cause, observed live via reflog during the session
that produced this change:

```
HEAD: main → claude/e2e-tests-5daa3c → HEAD (detached)
```

The harness sometimes checks a session's branch out **at the shared primary
checkout** instead of populating the isolated worktree, then detaches it. The
prior guidance used the **directory** as its safety signal ("primary checkout ⟹
you are on `main` ⟹ STOP"), which is false: the primary checkout is often on the
correct feature branch, so data-safe sessions were forced to halt and write
nothing. The transcript that motivated this had an agent burn its first turn on
an unwarranted STOP off a plain "fix e2e tests" prompt.

## Fix — make the branch, not the directory, the decisive signal

- **`AGENTS.md`** — branch-first start-of-session: on any non-`main` branch,
  proceed (even at the primary checkout); STOP only when HEAD is `main`. A path
  that isn't the assigned worktree is a UI-pairing caveat (recoverable), not a
  data-safety halt. Rewrote the "never edit main checkout" non-negotiable to
  "never edit while on `main`" and removed the false "bare-root ⟹ main" claim.
- **`.claude/hooks/guard-worktree.sh`** — fences an edit whose target working
  tree's HEAD is `main` (asks git for the branch); dropped the
  `CLAUDE_PROJECT_DIR` dependency that left it a no-op in exactly the main-root
  sessions where it mattered.
- **`.claude/hooks/guard-branch.sh`** — denies branch/worktree creation
  regardless of path (previously inert when `CLAUDE_PROJECT_DIR` was unset).

## Verification

Validated the hooks against throwaway git repos: `guard-worktree.sh` denies a
main-branch edit and allows feature-branch, detached-HEAD, and outside-repo
edits; `guard-branch.sh` denies `worktree add` / `checkout -b` / `switch -c` /
`branch -m` and allows `status`, file checkout, and read-only git loops.

## Known follow-up (not in this PR)

The global `~/.claude/settings.json` rule `Bash(git worktree add*)` over-fires on
compound commands (it tripped three times while preparing this change on
commands merely containing the token "worktree"). Narrowing it is a separate,
user-config change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safeguards against creating branches or worktrees through restricted Git operations.
  * Prevented edits when the target repository is on the `main` branch.
  * Improved handling of edit targets and misconfigured worktree sessions.

* **Documentation**
  * Updated session-start and editing guidance to prioritize the active Git branch when determining whether work may proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->