### PR TITLE
fix: e2e test failures (phoenix watchdog, edge-client reconnect race)

### DIFF
--- a/.changeset/fix-phoenix-watchdog-import.md
+++ b/.changeset/fix-phoenix-watchdog-import.md
@@ -1,0 +1,5 @@
+---
+'@dxos/phoenix': patch
+---
+
+Fix the daemon watchdog failing to start with `ERR_MODULE_NOT_FOUND` after the vite/rolldown build migration by importing from the correct `dist/lib` entrypoint.

--- a/packages/common/phoenix/bin/watchdog.mjs
+++ b/packages/common/phoenix/bin/watchdog.mjs
@@ -6,7 +6,7 @@
 
 import { log } from '@dxos/log';
 
-import { WatchDog } from '../dist/lib/node-esm/index.mjs';
+import { WatchDog } from '../dist/lib/index.mjs';
 
 const params = JSON.parse(process.argv[2]);
 

--- a/packages/common/phoenix/moon.yml
+++ b/packages/common/phoenix/moon.yml
@@ -5,7 +5,7 @@ tags:
   - ts-test
   - pack
 tasks:
-  # `bin/watchdog.mjs` imports from `../dist/lib/node-esm/index.mjs`, so the
+  # `bin/watchdog.mjs` imports from `../dist/lib/index.mjs`, so the
   # package's own dist must exist before tests run. The inherited `:test` task
   # only depends on the upstream build (`^:build`), not the package's own.
   test:

--- a/packages/core/mesh/edge-client/src/testing/test-utils.ts
+++ b/packages/core/mesh/edge-client/src/testing/test-utils.ts
@@ -62,7 +62,11 @@ export const createTestEdgeWsServer = async (port = DEFAULT_PORT, params?: TestE
     });
 
     ws.on('close', () => {
-      connection = undefined;
+      // During a reconnect the new connection may be admitted before the old
+      // socket's close event fires; only clear if this socket is still current.
+      if (connection?.ws === ws) {
+        connection = undefined;
+      }
       closeTrigger.wake();
     });
   });


### PR DESCRIPTION
## Summary

Fixes two failures surfaced by the full test suite (`ALLOW_LLM_GENERATION=1 MOON_CONCURRENCY=4 moon run :test -- --no-file-parallelism`).

### 1. `phoenix` — watchdog import path (`da64a40474`)

The vite/rolldown build migration (#11319) changed the package's build output from `dist/lib/node-esm/index.mjs` → `dist/lib/index.mjs`, but `bin/watchdog.mjs` still hardcoded the old path. The detached watchdog process crashed with `ERR_MODULE_NOT_FOUND`, so the daemon never wrote its pid file and the `start/stop detached watchdog` test timed out.

This is a real consumer-facing bug: any consumer spawning the phoenix daemon hits the same crash. Changeset added (`@dxos/phoenix` patch).

### 2. `edge-client` — reconnect race in mock ws server (`70e403ea20`)

The test WebSocket server's per-socket `close` handler unconditionally cleared the shared `connection` reference. During a reconnect (`setIdentity` → WS reconnect), the new socket could be admitted before the old socket's `close` event fired, so the stale close wiped out the live connection and `sendMessage` dereferenced `undefined`. This surfaced as a flaky `echo-host` failure (`EchoEdgeSubductionReplicator > reconnects`) under full-suite concurrency. Now only clears the reference when the closing socket is still current.

## Testing

- `moon run phoenix:test` — green (was 1 failed).
- `moon run echo-host:test` — green (was 1 failed).
- Full suite `ALLOW_LLM_GENERATION=1 MOON_CONCURRENCY=4 moon run :test -- --no-file-parallelism` — 531 tasks completed, exit 0.

## Notes for reviewer

`ai:test` was investigated and is **not** broken — it passes standalone and in the full run. The `SyntaxError: Unexpected token ')'` seen in its output is an **expected** assertion (`tools.test.ts:126` verifies the calculator tool's error path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Phoenix daemon watchdog startup failures caused by an invalid module path.
  * Improved WebSocket reconnection handling so older connection closures no longer disrupt newer active connections.
* **Documentation**
  * Updated watchdog configuration guidance to reflect the correct module path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->