### PR TITLE
repo: bump moon to 2.4.5 and proto to 0.58.2

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -28,8 +28,8 @@ runs:
     - uses: moonrepo/setup-toolchain@v0
       with:
         # IMPORTANT: Keep in-sync with .prototools
-        moon-version: '2.2.6'
-        proto-version: '0.57.3'
+        moon-version: '2.4.5'
+        proto-version: '0.58.2'
 
     - name: Log out debug info
       run: |

--- a/.prototools
+++ b/.prototools
@@ -1,6 +1,6 @@
 # https://moonrepo.dev/docs/proto/config
 
-proto = "0.57.3"
+proto = "0.58.2"
 node = "24.11.1"
 pnpm = "10.28.0"
 bun = "1.3.4"
@@ -10,7 +10,7 @@ bun = "1.3.4"
 #  This is only for compability purposes (i.e., supporting Cloudflare Pages deploys).
 #  It is expected that developers will be using moon via proto, but they should be kept in sync.
 # NOTE: Make sure those versions match!
-moon = "2.3.0"
+moon = "2.4.5"
 rust = "1.93.0"
 
 [settings]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,8 +289,8 @@ catalogs:
       specifier: ^1.0.8
       version: 1.0.8
     '@moonrepo/cli':
-      specifier: 2.3.0
-      version: 2.3.0
+      specifier: 2.4.5
+      version: 2.4.5
     '@ngneat/falso':
       specifier: ^7.1.1
       version: 7.1.1
@@ -2065,7 +2065,7 @@ importers:
         version: 0.29.0(effect@3.21.4)(vitest@4.1.10)
       '@moonrepo/cli':
         specifier: 'catalog:'
-        version: 2.3.0
+        version: 2.4.5
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
@@ -28424,46 +28424,46 @@ packages:
     peerDependencies:
       three: '>= 0.159.0'
 
-  '@moonrepo/cli@2.3.0':
-    resolution: {integrity: sha512-8Za9r9sLPvnzvaaDWqEBnoSRG1QRsHZHWZZmQBp2s/Fr6qAcqMS1sF3zZonqo3zL1lW4srOUICUR1JQUzhlBvQ==}
+  '@moonrepo/cli@2.4.5':
+    resolution: {integrity: sha512-AYdIBRpdTwhzfDgGcFzHexiIMEDxiQoUUmlwcajA64NaLglFM3D4pRv5ZmbR1cK+qMm+szwYCK6lnFJ1l57hOw==}
     hasBin: true
 
-  '@moonrepo/core-linux-arm64-gnu@2.3.0':
-    resolution: {integrity: sha512-mXB5y58BihYwafRGY8K+LRsEYcB6qmBh30J+0bE3sYNPum1eT2QAuG+fQhhbLhTos1REP1eUJgjSAZ2pIjrQmA==}
+  '@moonrepo/core-linux-arm64-gnu@2.4.5':
+    resolution: {integrity: sha512-pvcANFo5cYvRlT4pFkwd3qaB536mLoTkaXH+PQeGj+Ox0be3Nfk3xZ9tlisD/OENLsy17vLHifqbJaRY28kkTQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@moonrepo/core-linux-arm64-musl@2.3.0':
-    resolution: {integrity: sha512-gCw9fL/XqEGGqjUxCs0awCY5QZIm4V7UJIZ8eHm0OlospNmjMXJbCzAOgp+XYIns4kezINcs+bmm4cUl7VaszA==}
+  '@moonrepo/core-linux-arm64-musl@2.4.5':
+    resolution: {integrity: sha512-s+HIrTMgUt6ekQSmOSJRzDguTxWWYmceMZOGe01wEx6U5a/cka8qJKWjKet2Wgs3sub0GGHguLZcCCVyPW79LA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@moonrepo/core-linux-x64-gnu@2.3.0':
-    resolution: {integrity: sha512-vZmzqSJbzqIwdkAROlbkb5OIXL+pFWbu96P4hc3SG7iu3e9TQ8JnuL21i2Jd1mULbqA4zfcu25gbzECdSXPpOA==}
+  '@moonrepo/core-linux-x64-gnu@2.4.5':
+    resolution: {integrity: sha512-ZOR9EbKuFA40xZeJ4wIAAJRpjin/Vz9uxNDAywYvPw3Uzx1K+m4VeZVuc/0V8x/jWd+UeXB4yKUCDPZG/7UPnQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@moonrepo/core-linux-x64-musl@2.3.0':
-    resolution: {integrity: sha512-5oA4/q3/ryI7YCYbKEKZ0ZWGyU7KoKqi60Eqe2HfAXvkMiJCfUtsAmdZ8ybsWFQlQcbnKUPbqDCiacm67fcmdA==}
+  '@moonrepo/core-linux-x64-musl@2.4.5':
+    resolution: {integrity: sha512-ocJQvGay5A47pxnM+gY9u//UQWHuLVh1h+mQwOU6gFIY49vyJvPuth6e7Tz3kxnnzTE7Fq1N7AbUV5XpN59JTA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@moonrepo/core-macos-arm64@2.3.0':
-    resolution: {integrity: sha512-QZaqPABNid8pDBfQFp6I/G78qY2vTjQrpoAjhB936LXt4GrQAGJTDQSzdyIkuzLZaHrkw7jeLAD3ktVtgI/94w==}
+  '@moonrepo/core-macos-arm64@2.4.5':
+    resolution: {integrity: sha512-D4EBmxvISKzeR42wzLFfU9Kl0Eg3f8XDxRo9IdQn7cwFx3s4IMhEdoIm0MWmy9w9hYvRCwNIDTZT7U+fuFqOVg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@moonrepo/core-macos-x64@2.3.0':
-    resolution: {integrity: sha512-UP8P0y0VyXTy2PwLOnC5LXasV5OQYlmZIVaGFyDZK60SAtBjJ8pcq8L2P+gBYYjkbseejs8GJiL0peM/B621vg==}
+  '@moonrepo/core-macos-x64@2.4.5':
+    resolution: {integrity: sha512-Ovt7YFiTLWdy+s3RL/PEQxVOMsMgk+f8AIKoJT++aA3HiyM+R46jJ9LgGVq0IjcMOlgAoI07bKRRS0Gd2YFeMQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@moonrepo/core-windows-x64-msvc@2.3.0':
-    resolution: {integrity: sha512-4is1mItYa/zYHDkSkFZZfVsqg0gIHZGzMpjRT9XRn4XZ+SOILCqGX2tDtdOecuI+jHYKZ1V5ElnFsX7a3L6Nwg==}
+  '@moonrepo/core-windows-x64-msvc@2.4.5':
+    resolution: {integrity: sha512-4GS+vVCpBuOCAai+G2vIOM13AmIHAMJ7rFRhodanYBuZqfQgPzxEJd1q4nGac25gsbtv85kGy2idaf93D2v6Jg==}
     cpu: [x64]
     os: [win32]
 
@@ -50847,37 +50847,37 @@ snapshots:
       promise-worker-transferable: 1.0.4
       three: 0.178.0
 
-  '@moonrepo/cli@2.3.0':
+  '@moonrepo/cli@2.4.5':
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      '@moonrepo/core-linux-arm64-gnu': 2.3.0
-      '@moonrepo/core-linux-arm64-musl': 2.3.0
-      '@moonrepo/core-linux-x64-gnu': 2.3.0
-      '@moonrepo/core-linux-x64-musl': 2.3.0
-      '@moonrepo/core-macos-arm64': 2.3.0
-      '@moonrepo/core-macos-x64': 2.3.0
-      '@moonrepo/core-windows-x64-msvc': 2.3.0
+      '@moonrepo/core-linux-arm64-gnu': 2.4.5
+      '@moonrepo/core-linux-arm64-musl': 2.4.5
+      '@moonrepo/core-linux-x64-gnu': 2.4.5
+      '@moonrepo/core-linux-x64-musl': 2.4.5
+      '@moonrepo/core-macos-arm64': 2.4.5
+      '@moonrepo/core-macos-x64': 2.4.5
+      '@moonrepo/core-windows-x64-msvc': 2.4.5
 
-  '@moonrepo/core-linux-arm64-gnu@2.3.0':
+  '@moonrepo/core-linux-arm64-gnu@2.4.5':
     optional: true
 
-  '@moonrepo/core-linux-arm64-musl@2.3.0':
+  '@moonrepo/core-linux-arm64-musl@2.4.5':
     optional: true
 
-  '@moonrepo/core-linux-x64-gnu@2.3.0':
+  '@moonrepo/core-linux-x64-gnu@2.4.5':
     optional: true
 
-  '@moonrepo/core-linux-x64-musl@2.3.0':
+  '@moonrepo/core-linux-x64-musl@2.4.5':
     optional: true
 
-  '@moonrepo/core-macos-arm64@2.3.0':
+  '@moonrepo/core-macos-arm64@2.4.5':
     optional: true
 
-  '@moonrepo/core-macos-x64@2.3.0':
+  '@moonrepo/core-macos-x64@2.4.5':
     optional: true
 
-  '@moonrepo/core-windows-x64-msvc@2.3.0':
+  '@moonrepo/core-windows-x64-msvc@2.4.5':
     optional: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -129,7 +129,7 @@ catalog:
   '@lezer/xml': ^1.0.6
   '@lit/react': ^1.0.8
   '@modelcontextprotocol/sdk': ^1.27.1
-  '@moonrepo/cli': 2.3.0
+  '@moonrepo/cli': 2.4.5
   '@ngneat/falso': ^7.1.1
   '@observablehq/plot': ^0.6.11
   '@obsidize/tar-browserify': ^5.2.0


### PR DESCRIPTION
## Summary

Bumps the build toolchain to the latest releases:
- **moon** `2.3.0` → `2.4.5`
- **proto** `0.57.3` → `0.58.2`

## Pins updated (kept in sync)

- `.prototools` — `moon` and `proto`.
- `pnpm-workspace.yaml` — the `@moonrepo/cli` catalog entry (`2.3.0` → `2.4.5`), plus the corresponding `pnpm-lock.yaml` update. The lockfile diff is scoped to `@moonrepo/cli` + its `@moonrepo/core-*` platform packages only.
- `.github/actions/setup/action.yml` — the CI `setup-toolchain` action's `moon-version` (`2.2.6` → `2.4.5`) and `proto-version` (`0.57.3` → `0.58.2`), which the file comments require to match `.prototools`.

## Verification

The proto/moon shim's GitHub release download is blocked by this environment's egress policy, but the npm `@moonrepo/cli@2.4.5` binary (installed via its `@moonrepo/core-*` optional deps) runs locally. Under moon 2.4.5:
- `moon query projects` — loads every project config, exit 0, no errors or deprecation warnings.
- `moon task keys:build` — task graph resolves, exit 0.

No changeset: this is a dev-toolchain bump with no consumer-facing package change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TdP7LbMziBLe1YVcuuRsY2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s development tooling to newer Moon and Proto versions.
  * Aligned local, workspace, and automated setup configurations for consistent tool versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->