### PR TITLE
shell,examples: fix vite bundle build failures

### DIFF
--- a/.changeset/shell-bundle-mkdir-fix.md
+++ b/.changeset/shell-bundle-mkdir-fix.md
@@ -1,0 +1,5 @@
+---
+'@dxos/shell': patch
+---
+
+Fix shell bundle build failing with ENOENT on a clean checkout.

--- a/packages/sdk/examples/stub.mjs
+++ b/packages/sdk/examples/stub.mjs
@@ -1,0 +1,7 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// Stubs for debugging.
+export {};
+export default {};

--- a/packages/sdk/examples/vite.config.ts
+++ b/packages/sdk/examples/vite.config.ts
@@ -47,9 +47,12 @@ export default defineConfig({
     target: [...browserTargets],
   },
   resolve: {
-    alias: {
-      'node-fetch': 'isomorphic-fetch',
-    },
+    // NOTE: Under Vite 8 / rolldown, string-keyed aliases are treated as prefix matches, so
+    // `tiktoken/lite` must use the regex form to avoid also matching deeper subpaths.
+    alias: [
+      { find: /^node-fetch$/, replacement: 'isomorphic-fetch' },
+      { find: /^tiktoken\/lite$/, replacement: path.resolve(dirname, 'stub.mjs') },
+    ],
   },
   worker: {
     format: 'es',

--- a/packages/sdk/shell/vite.config.ts
+++ b/packages/sdk/shell/vite.config.ts
@@ -92,7 +92,7 @@ export default defineConfig({
 
         const outDir = path.join(dirname, 'dist/bundle');
         if (!existsSync(outDir)) {
-          mkdirSync(outDir);
+          mkdirSync(outDir, { recursive: true });
         }
         writeFileSync(path.join(outDir, 'graph.json'), JSON.stringify(deps, null, 2));
       },


### PR DESCRIPTION
## Summary

Fixes the daily e2e job's `shell:bundle` failure (https://github.com/dxos/dxos/actions/runs/29718599620/job/88276599139), plus a second, latent failure in `examples:bundle` that the same job never reached (it aborts on first failure).

- **`shell`**: the `bundle-buddy` vite plugin's `buildEnd` hook did `mkdirSync('dist/bundle')` without `{ recursive: true }`. After the recent rolldown/vite bump, `buildEnd` now fires before Vite's write phase creates `dist/`, so on a clean checkout the mkdir threw `ENOENT: no such file or directory, mkdir '.../dist/bundle'`.
- **`examples`**: a transitive dependency chain (`@effect/ai-anthropic` → `@anthropic-ai/tokenizer` → `tiktoken/lite`, a wasm module with a top-level await) can't be `require()`'d synchronously by rolldown, causing a `REQUIRE_TLA` build error. Fixed by aliasing `tiktoken/lite` to a stub module — the same workaround `composer-app/vite.config.ts` already applies for this exact module.

## Test plan

- [x] `rm -rf dist out` in both packages (simulating a clean checkout) then `moon run shell:bundle` and `moon run examples:bundle` — both succeed.
- [x] Ran all 12 `bundle` tasks in the repo from clean output dirs (`cli`, `composer-app`, `composer-crx`, `devtools-extension`, `docs`, `examples`, `rpc-tunnel-e2e`, `shell`, `storybook-react`, `tasks`, `testbench-app`, `todomvc`) — all pass.
- [x] `pnpm format`, `moon run :lint -- --fix` — clean.
- [x] `moon run :test` — two unrelated timing flakes surfaced across two full runs (`ui-editor:test`, `plugin-client:test`), each reproduced as passing in isolation; neither touches files in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)