### PR TITLE
chore: add Claude Code cloud setup script

### DIFF
--- a/.config/claude-code-setup.sh
+++ b/.config/claude-code-setup.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Environment bootstrap for Claude Code cloud agents working in this repo.
 # Installs the toolchain pinned in .prototools (node, pnpm, moon, …) and workspace deps.
+#
+# To wire this up, set your Claude Code cloud agent environment's setup/install command to:
+#   if [ -f .config/claude-code-setup.sh ]; then bash .config/claude-code-setup.sh; fi
+# It runs from the repo root, executes this script (propagating its exit code so real
+# failures surface), and no-ops where the file is absent — one line works across all repos.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/.config/claude-code-setup.sh
+++ b/.config/claude-code-setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Environment bootstrap for Claude Code cloud agents working in this repo.
+# Installs the toolchain pinned in .prototools (node, pnpm, moon, …) and workspace deps.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+export PROTO_HOME="${PROTO_HOME:-$HOME/.proto}"
+export PATH="$PROTO_HOME/shims:$PROTO_HOME/bin:$PATH"
+
+log() { printf '\033[1;34m[setup]\033[0m %s\n' "$*"; }
+
+# 1. proto — installs everything pinned in .prototools (auto-install is enabled).
+if ! command -v proto >/dev/null 2>&1; then
+  log "Installing proto"
+  curl -fsSL https://moonrepo.dev/install/proto.sh | bash -s -- --yes >/dev/null
+fi
+log "proto install"
+proto install
+
+# 2. moon workspace setup.
+log "moon setup"
+moon setup
+
+# 3. Workspace deps (non-interactive; skip husky hooks).
+log "pnpm install"
+CI=true HUSKY=0 pnpm install --prefer-offline
+
+log "Environment ready."


### PR DESCRIPTION
## Summary
- Adds `.config/claude-code-setup.sh` so Claude Code cloud agents can bootstrap this repo automatically.
- The script installs the proto-pinned toolchain (`node`, `pnpm`, `moon`) via `proto install`, runs `moon setup`, and installs workspace deps (`CI=true HUSKY=0 pnpm install`).
- Intended to be invoked by the agent environment config, which runs `.config/claude-code-setup.sh` if it exists (no-op otherwise).

## Test plan
- [ ] Fresh cloud agent env runs `.config/claude-code-setup.sh` and completes with node/pnpm/moon available and deps installed.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repository bootstrap script for cloud-based development agents.
  * Automatically configures environment settings and required tooling (including Proto and Moon) when missing.
  * Installs workspace dependencies in CI-friendly mode with Husky disabled.
  * Displays a confirmation message when the environment is ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->