### PR TITLE
echo,plugins: resolve object database via Obj.getDatabase instead of getSpace

### DIFF
--- a/.changeset/getspace-object-database.md
+++ b/.changeset/getspace-object-database.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-assistant': patch
+---
+
+Resolve an object's database via `Obj.getDatabase(obj)` (and its space id via `db.spaceId`) instead of `getSpace(obj).db`/`.id` in plugin data-access sites, dropping the `@dxos/client`/`@dxos/react-client` dependency where the full space handle was not needed.

--- a/.changeset/getspace-object-database.md
+++ b/.changeset/getspace-object-database.md
@@ -1,5 +1,5 @@
 ---
-'@dxos/plugin-assistant': patch
+'@dxos/plugin-markdown': patch
 ---
 
 Resolve an object's database via `Obj.getDatabase(obj)` (and its space id via `db.spaceId`) instead of `getSpace(obj).db`/`.id` in plugin data-access sites, dropping the `@dxos/client`/`@dxos/react-client` dependency where the full space handle was not needed.

--- a/packages/core/echo/echo-react/MIGRATION.md
+++ b/packages/core/echo/echo-react/MIGRATION.md
@@ -54,3 +54,21 @@ data access:
 `useSpaces`/`useSpace` sites that exist only to reach `space.db` are left as-is:
 the space handle still comes from the client/space surface; only the ECHO query
 over `space.db` now runs through `@dxos/echo-react`.
+
+## Object-anchored space access (`getSpace` decomposition)
+
+`getSpace(obj)` returns the full client `Space` proxy just to reach the object's
+database or space id. When only those are needed, the object already carries
+both — no client required:
+
+- `getSpace(obj).db` → `Obj.getDatabase(obj)` — returns `Database.Database | undefined`
+  (which `extends Queryable`, so it drops straight into `useQuery`).
+- `getSpace(obj).id` → `Obj.getDatabase(obj)?.spaceId` — `Database` exposes `spaceId`.
+- Space metadata (name/state/members) by id → `useSpace(db.spaceId)` /
+  `useMembers(db.spaceId)` (`@dxos/halo-react`), or `Space.get(spaceId)` (Effect).
+
+A `getSpace(obj)` site is migrated only when the space value is used **solely**
+for `.db` and/or `.id`. Sites that need the full `Space` — `.properties`,
+`.members`, `.state`, `.membershipPolicy`, identity comparison, or passing the
+`Space` to a component/function/hook — stay on the client surface until those
+paths gain client-independent equivalents.

--- a/packages/plugins/plugin-assistant/src/containers/ChatCompanion/ChatCompanion.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatCompanion/ChatCompanion.tsx
@@ -27,22 +27,22 @@ export type ChatCompanionProps = AppSurface.ArticleProps<Chat.Chat, {}, Obj.Unkn
 export const ChatCompanion = forwardRef<HTMLDivElement, ChatCompanionProps>(
   ({ role = 'article', subject: chat, companionTo, attendableId }, forwardedRef) => {
     const { invokePromise } = useOperationInvoker();
-    const space = getSpace(companionTo);
+    const db = Obj.getDatabase(companionTo);
     useSkills({ subject: chat, companionTo });
 
     // Persist (and flush) a transient chat before the first request so the agent can resolve
     // the now-durable conversation feed; subsequent submits are a no-op once persisted.
     const handleSubmit = useCallback(async () => {
-      if (!space || !chat || Obj.getDatabase(chat)) {
+      if (!db || !chat || Obj.getDatabase(chat)) {
         return;
       }
 
       await invokePromise(SpaceOperation.AddObject, {
         object: chat,
-        target: space.db,
+        target: db,
       });
       await invokePromise(SpaceOperation.AddRelation, {
-        db: space.db,
+        db,
         schema: Chat.CompanionTo,
         source: chat,
         target: companionTo,
@@ -51,8 +51,8 @@ export const ChatCompanion = forwardRef<HTMLDivElement, ChatCompanionProps>(
         companionTo,
         chat,
       });
-      await space.db.flush();
-    }, [space, chat, companionTo, invokePromise]);
+      await db.flush();
+    }, [db, chat, companionTo, invokePromise]);
 
     return (
       <ChatArticle

--- a/packages/plugins/plugin-code/src/containers/CodeArticle/CodeArticle.tsx
+++ b/packages/plugins/plugin-code/src/containers/CodeArticle/CodeArticle.tsx
@@ -8,7 +8,7 @@ import React, { forwardRef, useCallback, useEffect, useMemo, useState } from 're
 
 import { useAtomCapabilityState, useOperationInvoker } from '@dxos/app-framework/ui';
 import { type AppSurface } from '@dxos/app-toolkit/ui';
-import { Ref } from '@dxos/echo';
+import { Obj, Ref } from '@dxos/echo';
 import { Doc } from '@dxos/echo-doc';
 import { useObject } from '@dxos/echo-react';
 import { useIdentity } from '@dxos/halo-react';
@@ -75,8 +75,8 @@ export const CodeArticle = forwardRef<HTMLDivElement, CodeArticleProps>(
     // The handlers run with `Database.Service` in scope, so the invoker must be
     // given the project's space id — that's how the process manager resolves
     // the right database into the Effect environment.
-    const space = getSpace(project);
-    const spaceId = space?.id;
+    const db = Obj.getDatabase(project);
+    const spaceId = db?.spaceId;
 
     const handleBuild = useCallback(async () => {
       if (!spaceId) {

--- a/packages/plugins/plugin-commerce/src/containers/SearchArticle/SearchArticle.tsx
+++ b/packages/plugins/plugin-commerce/src/containers/SearchArticle/SearchArticle.tsx
@@ -9,7 +9,6 @@ import { LayoutOperation } from '@dxos/app-toolkit';
 import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { Filter, Obj, Query, Tag } from '@dxos/echo';
 import { useObject, useQuery } from '@dxos/echo-react';
-import { getSpace } from '@dxos/react-client/echo';
 import { Panel, useTranslation } from '@dxos/react-ui';
 import { useSelection } from '@dxos/react-ui-attention';
 import { Empty } from '@dxos/react-ui-list';
@@ -42,7 +41,7 @@ export const SearchArticle = ({ role, subject, attendableId }: SearchArticleProp
   // Result filter: all vs starred-only (ephemeral view state).
   const [view, setView] = useState<'all' | 'starred'>('all');
 
-  const db = getSpace(search)?.db;
+  const db = Obj.getDatabase(search);
 
   // Results are immutable entries in the Search's feed queue.
   const echoFeed = search.feed?.target;

--- a/packages/plugins/plugin-commerce/src/operations/run-provider-search.ts
+++ b/packages/plugins/plugin-commerce/src/operations/run-provider-search.ts
@@ -4,7 +4,6 @@
 
 import * as Effect from 'effect/Effect';
 
-import { getSpace } from '@dxos/client/echo';
 import { Operation } from '@dxos/compute';
 import { Database, Feed, Filter, Obj, Ref } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
@@ -82,9 +81,9 @@ const handler: Operation.WithHandler<typeof SearchOperation.RunProviderSearch> =
       // listings (identity = url); a matched listing keeps its original snapshot, and its `starred`
       // tag (keyed by Result id on the Search) survives because the Result object is never recreated.
       const feed = yield* Database.load(search.feed);
-      const space = getSpace(search);
-      invariant(space, 'Search is not in a space.');
-      const databaseLayer = Database.layer(space.db);
+      const db = Obj.getDatabase(search);
+      invariant(db, 'Search is not in a space.');
+      const databaseLayer = Database.layer(db);
       const existing = yield* Feed.query(feed, Filter.type(Result.Result)).run.pipe(Effect.provide(databaseLayer));
       const seen = new Set(existing.map((result) => result.url));
 

--- a/packages/plugins/plugin-inbox/src/components/ConversationStack/useExtractorActions.tsx
+++ b/packages/plugins/plugin-inbox/src/components/ConversationStack/useExtractorActions.tsx
@@ -3,9 +3,9 @@
 //
 
 import { type Capabilities } from '@dxos/app-framework';
+import { Obj } from '@dxos/echo';
 import { type ObjectExtractor } from '@dxos/extractor';
 import { log } from '@dxos/log';
-import { getSpace } from '@dxos/react-client/echo';
 
 import { isAiServiceUnavailable } from '../../operations/extractor/ai-gate';
 import { InboxOperation, Mailbox } from '../../types';
@@ -43,15 +43,15 @@ export const buildExtractActions = (
   const matching = extractors;
 
   const runOne = (extractorId: string) => {
-    const space = getSpace(message);
-    if (!space) {
+    const db = Obj.getDatabase(message);
+    if (!db) {
       return Promise.resolve();
     }
 
     // NOTE: `spaceId` scopes the spawned operation process so its space-affinity services
     // (e.g. `AiService`) can materialize.
     return invoker
-      .invokePromise(InboxOperation.ExtractMessage, { source: message, extractorId }, { spaceId: space.id })
+      .invokePromise(InboxOperation.ExtractMessage, { source: message, extractorId }, { spaceId: db.spaceId })
       .catch((err) => {
         // Distinguish the startup race where the assistant plugin's `AiService` LayerSpec is not
         // yet in the process-manager runtime: surface an actionable message instead of an opaque

--- a/packages/plugins/plugin-script/src/skills/functions/deploy.ts
+++ b/packages/plugins/plugin-script/src/skills/functions/deploy.ts
@@ -13,7 +13,6 @@ import { Database, Obj } from '@dxos/echo';
 import { FunctionsServiceClient, incrementSemverPatch } from '@dxos/edge-compute';
 import { bundleFunction, initializeBundler } from '@dxos/edge-compute/bundler';
 import { FunctionRuntimeKind } from '@dxos/protocols';
-import { getSpace } from '@dxos/react-client/echo';
 
 import { Deploy } from './definitions';
 
@@ -27,8 +26,8 @@ export default Deploy.pipe(
       }
       const script = (yield* Database.load(loaded.source)) as Script.Script;
 
-      const space = getSpace(loaded);
-      if (!space || !script.source?.target?.content) {
+      const db = Obj.getDatabase(loaded);
+      if (!db || !script.source?.target?.content) {
         return yield* Effect.fail(new Error('Script source or space not available'));
       }
 

--- a/packages/plugins/plugin-transcription/src/hooks/useTranscriptionRecording.ts
+++ b/packages/plugins/plugin-transcription/src/hooks/useTranscriptionRecording.ts
@@ -10,7 +10,6 @@ import { Database, Feed, Obj } from '@dxos/echo';
 import { EffectEx } from '@dxos/effect';
 import { useIdentity } from '@dxos/halo-react';
 import { log } from '@dxos/log';
-import { getSpace } from '@dxos/react-client/echo';
 import { useAudioTrack, useTranscriber } from '@dxos/react-ui-transcription';
 import { Message, type Transcript } from '@dxos/types';
 
@@ -27,7 +26,7 @@ export type TranscriptionRecording = {
  * recording flag and a toggle callback for the caller to wire to UI.
  */
 export const useTranscriptionRecording = (transcript: Transcript.Transcript): TranscriptionRecording => {
-  const space = getSpace(transcript);
+  const db = Obj.getDatabase(transcript);
   const identity = useIdentity();
   const feed = transcript.feed.target;
 
@@ -40,7 +39,7 @@ export const useTranscriptionRecording = (transcript: Transcript.Transcript): Tr
   // extraction is enabled) with references to known entities mentioned in the transcript.
   const handleSegments = useCallback(
     async (blocks: Message.Message['blocks']) => {
-      if (!space || !feed || blocks.length === 0) {
+      if (!db || !feed || blocks.length === 0) {
         return;
       }
       const sender = identity ? { identityDid: identity.did, name: identity.displayName } : {};
@@ -56,7 +55,7 @@ export const useTranscriptionRecording = (transcript: Transcript.Transcript): Tr
         const { data, error } = await invokePromise(
           TranscriptOperation.EnrichMessage,
           { message },
-          { spaceId: space.id },
+          { spaceId: db.spaceId },
         );
         if (error) {
           log.warn('entity extraction failed; using raw transcript', { error });
@@ -65,9 +64,9 @@ export const useTranscriptionRecording = (transcript: Transcript.Transcript): Tr
         }
       }
 
-      await Feed.append(feed, [message]).pipe(Effect.provide(Database.layer(space.db)), EffectEx.runAndForwardErrors);
+      await Feed.append(feed, [message]).pipe(Effect.provide(Database.layer(db)), EffectEx.runAndForwardErrors);
     },
-    [space, feed, identity, invokePromise, settings],
+    [db, feed, identity, invokePromise, settings],
   );
 
   // Drive the transcriber lifecycle off the recording flag + audio track.

--- a/packages/plugins/plugin-trip/src/containers/BookingSearch/BookingSearch.tsx
+++ b/packages/plugins/plugin-trip/src/containers/BookingSearch/BookingSearch.tsx
@@ -7,7 +7,6 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useCapabilities, useOperationInvoker } from '@dxos/app-framework/ui';
 import { PluginRegistryButton } from '@dxos/app-toolkit/ui';
 import { Obj, Ref } from '@dxos/echo';
-import { getSpace } from '@dxos/react-client/echo';
 import { Message, Select, Separator, useTranslation } from '@dxos/react-ui';
 import { Form } from '@dxos/react-ui-form';
 import { Empty } from '@dxos/react-ui-list';
@@ -150,11 +149,11 @@ export const BookingSearch = ({ segment }: BookingSearchProps) => {
       if (offer._tag !== 'flight') {
         return;
       }
-      const space = getSpace(segment);
-      if (!space) {
+      const db = Obj.getDatabase(segment);
+      if (!db) {
         return;
       }
-      const booking = space.db.add(Booking.make(offerToBookingProps(offer)));
+      const booking = db.add(Booking.make(offerToBookingProps(offer)));
       const details = offerToFlightDetails(offer);
       Obj.update(segment, (segment) => {
         // Mutate the (flight) details in place: a whole-object assignment would require the

--- a/packages/plugins/plugin-trip/src/containers/TripArticle/TripArticle.tsx
+++ b/packages/plugins/plugin-trip/src/containers/TripArticle/TripArticle.tsx
@@ -13,7 +13,6 @@ import { useObject, useObjects } from '@dxos/echo-react';
 import { log } from '@dxos/log';
 import { MapInline } from '@dxos/plugin-map';
 import { MapCapabilities } from '@dxos/plugin-map/types';
-import { getSpace } from '@dxos/react-client/echo';
 import { Panel } from '@dxos/react-ui';
 import { linkedSegment, useArticleKeyboardNavigation, useSelection } from '@dxos/react-ui-attention';
 import { Calendar as NaturalCalendar } from '@dxos/react-ui-calendar';
@@ -144,13 +143,13 @@ export const TripArticle = ({ role, subject, attendableId, defaultShowGlobe }: T
 
   const handleAddSegment = useCallback(
     (kind: Segment.Kind) => {
-      const space = getSpace(subject);
-      if (!space) {
+      const db = Obj.getDatabase(subject);
+      if (!db) {
         return;
       }
       // The chronologically-last leg, used to chain the new segment's origin from where it ended.
       const previous = segments.at(-1);
-      const segment = space.db.add(Segment.makeDefault(kind));
+      const segment = db.add(Segment.makeDefault(kind));
       Trip.addSegment(subject, segment);
       // Pre-fill the start (and end, for a range) from the current calendar selection.
       if (calendarSelection?.from) {


### PR DESCRIPTION
## Summary

Third track of the consumer migration off `@dxos/client` (after HALO #12229 and the ECHO hooks #12278). This targets the **object-anchored `getSpace(obj)` pattern**: where a consumer called `getSpace(obj)` only to reach the object's **database** or **space id**, the object already carries both — no client needed.

| legacy (client `Space` proxy) | client-independent replacement |
|---|---|
| `getSpace(obj).db` | `Obj.getDatabase(obj)` |
| `getSpace(obj).id` | `Obj.getDatabase(obj)?.spaceId` |

`Obj.getDatabase(obj)` (from `@dxos/echo`) returns `Database.Database \| undefined`, and `interface Database extends Queryable`, so it drops straight into `useQuery(db, …)` with no cast. `Database` exposes `spaceId`, covering the id case.

## What changed

**9 sites migrated** across 7 plugins; the space value at each was used *solely* for `.db` and/or `.id`:

- `plugin-assistant` — ChatCompanion (`.db`)
- `plugin-code` — CodeArticle (`.id`)
- `plugin-commerce` — SearchArticle (`.db`), run-provider-search (`.db`)
- `plugin-inbox` — useExtractorActions (`.id`)
- `plugin-script` — skills/functions/deploy (truthiness)
- `plugin-transcription` — useTranscriptionRecording (`.id` + `.db`)
- `plugin-trip` — BookingSearch (`.db`), TripArticle (`.db`)

Four of these files drop `@dxos/client` / `@dxos/react-client` entirely.

## What was deliberately NOT migrated

Sites where the space value is used as a full client `Space` — `.properties`, `.members`, `.state`, `.membershipPolicy`, identity comparison (`=== space`), or passing the `Space` to a component/function/hook (`messenger: space`, `<X space={…}/>`, `useContextBinder(space, …)`) — stay on the client surface until those paths gain client-independent equivalents. `getSpace` count: **34 → 27 files**, **46 → 37 call-sites**.

Full recipe documented in `packages/core/echo/echo-react/MIGRATION.md`.

## Test plan

- `moon run :build` on all 7 affected packages (+ deps): **193 tasks, exit 0**.
- `moon run :lint` on all 7 (cache-off): **green**.
- `oxfmt --check` on all changed files: **clean**.
- No `as`/`!` casts introduced; `Obj.getDatabase(obj)` returns the same `Database` object `space.db` did, so `.add`/`.flush`/query behavior and the truthiness guards are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017SPKaYp1L1eLXz9tJkuqU8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability across chats, bookings, trips, searches, transcripts, scripts, and code projects by resolving Echo databases via object-based access instead of space access.
  * Ensured transient chat data is flushed before follow-up persistence actions.
  * Improved behavior when required storage context is missing during deployments and message extraction (including clearer failure/guarding).
* **Documentation**
  * Updated migration guidance for replacing database-only `getSpace(obj)` usage with object database access, while keeping cases that require full space context unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->