### PR TITLE
feat: SwarmTrace inbox module, scoped messaging tag subscriptions, multi-feed trace queries

### DIFF
--- a/packages/core/echo/echo-client/src/feed/feed.test.ts
+++ b/packages/core/echo/echo-client/src/feed/feed.test.ts
@@ -362,6 +362,28 @@ describe('Feed', () => {
     expect((traversed[0] as TestSchema.Person).name).toBe('alice');
   });
 
+  test('query unions items across multiple feeds', async ({ expect }) => {
+    await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
+    const db = await peer.createDatabase();
+    const testLayer = Database.layer(db);
+
+    // Duplicate same-kind feeds occur in production: writers race on feed creation (e.g. the
+    // edge's indexer-backed lookup missing a not-yet-indexed feed), so readers must be able to
+    // union items across all of a space's feeds in one query.
+    let feedA!: Feed.Feed;
+    let feedB!: Feed.Feed;
+    await Effect.gen(function* () {
+      feedA = yield* Database.add(Feed.make({ name: 'trace-a', namespace: 'trace' }));
+      feedB = yield* Database.add(Feed.make({ name: 'trace-b', namespace: 'trace' }));
+
+      yield* Feed.append(feedA, [Obj.make(TestSchema.Person, { name: 'alice' })]);
+      yield* Feed.append(feedB, [Obj.make(TestSchema.Person, { name: 'bob' })]);
+    }).pipe(Effect.provide(testLayer), EffectEx.runAndForwardErrors);
+
+    const results = await db.query(Query.type(TestSchema.Person).from([feedA, feedB])).run();
+    expect(results.map((person) => person.name).sort()).toEqual(['alice', 'bob']);
+  });
+
   describe('feed namespaces', () => {
     test('Feed.append assigns data and trace namespaces in feed store', async ({ expect }) => {
       await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });

--- a/packages/core/mesh/messaging/src/signal-manager/edge-signal-manager.test.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/edge-signal-manager.test.ts
@@ -117,6 +117,78 @@ describe('EdgeSignalManager broadcast (DX-1125)', () => {
     expect(subscriber.broadcasts).toHaveLength(1);
   });
 
+  test('one consumer unsubscribing does not clobber another consumer of the same tag', async ({ expect }) => {
+    const mesh = new TestEdgeMesh();
+    const topic = PublicKey.random();
+    const publisher = await setupPeer(mesh, topic, 'publisher');
+    const subscriber = await setupPeer(mesh, topic, 'subscriber');
+
+    // Two consumers on the same client share the manager's tag subscription (e.g. trace-progress
+    // and a story module both watching status updates). The bug (DX-1125): the first consumer's
+    // teardown wholesale-cleared the shared tag set, so the second consumer went silent.
+    await subscriber.manager.subscribeMessages(subscriber.peer, [TRACE_TAG]);
+    await subscriber.manager.subscribeMessages(subscriber.peer, [TRACE_TAG, 'space:test-space']);
+    await subscriber.manager.unsubscribeMessages(subscriber.peer, [TRACE_TAG, 'space:test-space']);
+
+    await publisher.manager.sendBroadcast(Context.default(), {
+      author: publisher.peer,
+      swarmKey: topic.toHex(),
+      tags: [TRACE_TAG],
+      payload: payload([5]),
+    });
+
+    // The first consumer's registration of TRACE_TAG survives; the released space tag does not.
+    expect(subscriber.broadcasts).toHaveLength(1);
+    expect([...subscriber.broadcasts[0].payload.value]).toEqual([5]);
+
+    await publisher.manager.sendBroadcast(Context.default(), {
+      author: publisher.peer,
+      swarmKey: topic.toHex(),
+      tags: ['space:test-space'],
+      payload: payload([6]),
+    });
+    expect(subscriber.broadcasts).toHaveLength(1);
+  });
+
+  test('releasing the last registration of a tag stops delivery', async ({ expect }) => {
+    const mesh = new TestEdgeMesh();
+    const topic = PublicKey.random();
+    const publisher = await setupPeer(mesh, topic, 'publisher');
+    const subscriber = await setupPeer(mesh, topic, 'subscriber');
+
+    await subscriber.manager.subscribeMessages(subscriber.peer, [TRACE_TAG]);
+    await subscriber.manager.unsubscribeMessages(subscriber.peer, [TRACE_TAG]);
+
+    await publisher.manager.sendBroadcast(Context.default(), {
+      author: publisher.peer,
+      swarmKey: topic.toHex(),
+      tags: [TRACE_TAG],
+      payload: payload([8]),
+    });
+
+    expect(subscriber.broadcasts).toHaveLength(0);
+  });
+
+  test('unsubscribe without tags clears the whole subscription (legacy)', async ({ expect }) => {
+    const mesh = new TestEdgeMesh();
+    const topic = PublicKey.random();
+    const publisher = await setupPeer(mesh, topic, 'publisher');
+    const subscriber = await setupPeer(mesh, topic, 'subscriber');
+
+    await subscriber.manager.subscribeMessages(subscriber.peer, [TRACE_TAG]);
+    await subscriber.manager.subscribeMessages(subscriber.peer, ['space:test-space']);
+    await subscriber.manager.unsubscribeMessages(subscriber.peer);
+
+    await publisher.manager.sendBroadcast(Context.default(), {
+      author: publisher.peer,
+      swarmKey: topic.toHex(),
+      tags: [TRACE_TAG, 'space:test-space'],
+      payload: payload([9]),
+    });
+
+    expect(subscriber.broadcasts).toHaveLength(0);
+  });
+
   test('still delivers point-to-point messages', async ({ expect }) => {
     const mesh = new TestEdgeMesh();
     const topic = PublicKey.random();

--- a/packages/core/mesh/messaging/src/signal-manager/edge-signal-manager.test.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/edge-signal-manager.test.ts
@@ -189,6 +189,26 @@ describe('EdgeSignalManager broadcast (DX-1125)', () => {
     expect(subscriber.broadcasts).toHaveLength(0);
   });
 
+  test('unsubscribe with an empty tags array is a no-op', async ({ expect }) => {
+    const mesh = new TestEdgeMesh();
+    const topic = PublicKey.random();
+    const publisher = await setupPeer(mesh, topic, 'publisher');
+    const subscriber = await setupPeer(mesh, topic, 'subscriber');
+
+    await subscriber.manager.subscribeMessages(subscriber.peer, [TRACE_TAG]);
+    await subscriber.manager.unsubscribeMessages(subscriber.peer, []);
+
+    await publisher.manager.sendBroadcast(Context.default(), {
+      author: publisher.peer,
+      swarmKey: topic.toHex(),
+      tags: [TRACE_TAG],
+      payload: payload([10]),
+    });
+
+    expect(subscriber.broadcasts).toHaveLength(1);
+    expect([...subscriber.broadcasts[0].payload.value]).toEqual([10]);
+  });
+
   test('still delivers point-to-point messages', async ({ expect }) => {
     const mesh = new TestEdgeMesh();
     const topic = PublicKey.random();

--- a/packages/core/mesh/messaging/src/signal-manager/edge-signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/edge-signal-manager.ts
@@ -199,9 +199,6 @@ export class EdgeSignalManager extends Resource implements SignalManager {
   }
 
   async subscribeMessages(peerInfo: PeerInfo, tags?: string[]): Promise<void> {
-    // #region DEBUG
-    log.info('[DEBUG H4] subscribeMessages', { tags, before: Array.from(this._subscribedTags.keys()) });
-    // #endregion DEBUG
     // Point-to-point delivery needs no registration (the edge relays targeted messages to this peer's
     // socket). Only tag broadcasts require a subscription registered on the swarm (DX-1125).
     if (!tags?.length) {
@@ -223,13 +220,6 @@ export class EdgeSignalManager extends Resource implements SignalManager {
   }
 
   async unsubscribeMessages(peerInfo: PeerInfo, tags?: string[]): Promise<void> {
-    // #region DEBUG
-    log.info('[DEBUG H5] unsubscribeMessages', {
-      tags,
-      before: Array.from(this._subscribedTags.keys()),
-      stack: new Error('unsubscribe caller').stack,
-    });
-    // #endregion DEBUG
     if (this._subscribedTags.size === 0) {
       return;
     }
@@ -264,12 +254,6 @@ export class EdgeSignalManager extends Resource implements SignalManager {
    */
   private async _sendSubscription(ctx: Context): Promise<void> {
     const swarmKeys = Array.from(this._swarmPeers.keys()).map((topic) => topic.toHex());
-    // #region DEBUG
-    log.info('[DEBUG H4] _sendSubscription', {
-      tags: Array.from(this._subscribedTags.keys()),
-      swarmCount: swarmKeys.length,
-    });
-    // #endregion DEBUG
     if (swarmKeys.length === 0) {
       return;
     }

--- a/packages/core/mesh/messaging/src/signal-manager/edge-signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/edge-signal-manager.ts
@@ -46,11 +46,13 @@ export class EdgeSignalManager extends Resource implements SignalManager {
   >(PublicKey.hash);
 
   /**
-   * OR-subscription tag set for broadcast messages (DX-1125). A single set is maintained across all
-   * joined swarms; the edge fans out any broadcast whose tags intersect this set. Re-sent on
+   * OR-subscription tag refcounts for broadcast messages (DX-1125). One count per distinct tag across
+   * all subscribers, so one consumer's unsubscribe releases only its own registration rather than
+   * clobbering another consumer's identical subscription. The effective tag set (the keys) is shared
+   * across all joined swarms; the edge fans out any broadcast whose tags intersect it. Re-sent on
    * reconnect and whenever a swarm is (re-)joined.
    */
-  private readonly _subscribedTags = new Set<string>();
+  private readonly _subscribedTags = new Map<string, number>();
 
   private readonly _edgeConnection: EdgeConnection;
 
@@ -197,15 +199,21 @@ export class EdgeSignalManager extends Resource implements SignalManager {
   }
 
   async subscribeMessages(peerInfo: PeerInfo, tags?: string[]): Promise<void> {
+    // #region DEBUG
+    log.info('[DEBUG H4] subscribeMessages', { tags, before: Array.from(this._subscribedTags.keys()) });
+    // #endregion DEBUG
     // Point-to-point delivery needs no registration (the edge relays targeted messages to this peer's
     // socket). Only tag broadcasts require a subscription registered on the swarm (DX-1125).
     if (!tags?.length) {
       return;
     }
     let changed = false;
-    for (const tag of tags) {
-      if (!this._subscribedTags.has(tag)) {
-        this._subscribedTags.add(tag);
+    // Dedupe so one call counts each tag once regardless of repeats in the input; the matching
+    // unsubscribe releases exactly one count per distinct tag.
+    for (const tag of new Set(tags)) {
+      const count = this._subscribedTags.get(tag) ?? 0;
+      this._subscribedTags.set(tag, count + 1);
+      if (count === 0) {
         changed = true;
       }
     }
@@ -214,13 +222,40 @@ export class EdgeSignalManager extends Resource implements SignalManager {
     }
   }
 
-  async unsubscribeMessages(peerInfo: PeerInfo): Promise<void> {
+  async unsubscribeMessages(peerInfo: PeerInfo, tags?: string[]): Promise<void> {
+    // #region DEBUG
+    log.info('[DEBUG H5] unsubscribeMessages', {
+      tags,
+      before: Array.from(this._subscribedTags.keys()),
+      stack: new Error('unsubscribe caller').stack,
+    });
+    // #endregion DEBUG
     if (this._subscribedTags.size === 0) {
       return;
     }
-    // TODO(dmaretskyi): Per-subscriber tag accounting; today a single set is cleared wholesale.
-    this._subscribedTags.clear();
-    await this._sendSubscription(this._ctx);
+    let changed = false;
+    if (tags?.length) {
+      // Release this subscriber's registration only; the tag stays live while other subscribers hold it.
+      for (const tag of new Set(tags)) {
+        const count = this._subscribedTags.get(tag);
+        if (count === undefined) {
+          continue;
+        }
+        if (count > 1) {
+          this._subscribedTags.set(tag, count - 1);
+        } else {
+          this._subscribedTags.delete(tag);
+          changed = true;
+        }
+      }
+    } else {
+      // Legacy wholesale clear (no tags supplied). Kept for callers that own the whole subscription.
+      this._subscribedTags.clear();
+      changed = true;
+    }
+    if (changed) {
+      await this._sendSubscription(this._ctx);
+    }
   }
 
   /**
@@ -229,6 +264,12 @@ export class EdgeSignalManager extends Resource implements SignalManager {
    */
   private async _sendSubscription(ctx: Context): Promise<void> {
     const swarmKeys = Array.from(this._swarmPeers.keys()).map((topic) => topic.toHex());
+    // #region DEBUG
+    log.info('[DEBUG H4] _sendSubscription', {
+      tags: Array.from(this._subscribedTags.keys()),
+      swarmCount: swarmKeys.length,
+    });
+    // #endregion DEBUG
     if (swarmKeys.length === 0) {
       return;
     }
@@ -243,7 +284,7 @@ export class EdgeSignalManager extends Resource implements SignalManager {
         payload: {
           action: SwarmRequestAction.SUBSCRIBE,
           swarmKeys,
-          subscribeTags: Array.from(this._subscribedTags),
+          subscribeTags: Array.from(this._subscribedTags.keys()),
         },
       }),
     );

--- a/packages/core/mesh/messaging/src/signal-manager/edge-signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/edge-signal-manager.ts
@@ -224,8 +224,13 @@ export class EdgeSignalManager extends Resource implements SignalManager {
       return;
     }
     let changed = false;
-    if (tags?.length) {
+    if (tags === undefined) {
+      // Legacy wholesale clear (no tags supplied). Kept for callers that own the whole subscription.
+      this._subscribedTags.clear();
+      changed = true;
+    } else {
       // Release this subscriber's registration only; the tag stays live while other subscribers hold it.
+      // An explicit empty array is a no-op (distinct from omitting tags).
       for (const tag of new Set(tags)) {
         const count = this._subscribedTags.get(tag);
         if (count === undefined) {
@@ -238,10 +243,6 @@ export class EdgeSignalManager extends Resource implements SignalManager {
           changed = true;
         }
       }
-    } else {
-      // Legacy wholesale clear (no tags supplied). Kept for callers that own the whole subscription.
-      this._subscribedTags.clear();
-      changed = true;
     }
     if (changed) {
       await this._sendSubscription(this._ctx);

--- a/packages/core/mesh/messaging/src/signal-methods.ts
+++ b/packages/core/mesh/messaging/src/signal-methods.ts
@@ -97,9 +97,12 @@ export interface SignalMethods {
   subscribeMessages: (peer: PeerInfo, tags?: string[]) => Promise<void>;
 
   /**
-   * Stop receiving messages from peer and clear any tag subscription.
+   * Stop receiving messages from peer. When `tags` are provided (DX-1125), release only this
+   * subscriber's registration of those tags — the transport keeps a tag refcount across subscribers,
+   * so another consumer's identical subscription stays live. Omitting `tags` clears the whole tag
+   * subscription (legacy behavior; avoid in new code — it clobbers concurrent subscribers).
    */
-  unsubscribeMessages: (peer: PeerInfo) => Promise<void>;
+  unsubscribeMessages: (peer: PeerInfo, tags?: string[]) => Promise<void>;
 }
 
 /**

--- a/packages/plugins/plugin-assistant/src/hooks/useTraceMessages.ts
+++ b/packages/plugins/plugin-assistant/src/hooks/useTraceMessages.ts
@@ -22,10 +22,12 @@ export const getTraceMessagesAtom = (space: Space): Atom.Atom<readonly Trace.Mes
     space.db.query(FeedTraceSink.query).atom,
     Atom.map(
       (feeds) =>
-        // TODO(dmaretskyi): Single query with limit(1) and feed traversal when query supports it.
+        // Query across ALL trace feeds: writers race on feed creation (the edge's indexer-backed
+        // lookup can miss a not-yet-indexed feed and create a duplicate), so a space may hold
+        // several trace feeds — reading only one would silently drop the others' events.
         space.db.query(
           feeds.length > 0
-            ? Query.type(Trace.Message).from(feeds[0])
+            ? Query.type(Trace.Message).from([...feeds])
             : (Query.select(Filter.nothing()) as Query.Query<never>),
         ).atom,
     ),

--- a/packages/plugins/plugin-client/src/capabilities/trace-progress.ts
+++ b/packages/plugins/plugin-client/src/capabilities/trace-progress.ts
@@ -27,6 +27,7 @@ export default Capability.makeModule(
 
     const progressSink = createProgressTraceSink(() => capabilityManager.getAll(AppCapabilities.ProgressRegistry)[0]);
 
+    // TODO(mykola): Possible bug source. Use `Effect.forkDaemon`.
     const fiber = processManagerRuntime.runFork(
       monitor.subscribeToTraceMessages({ type: Trace.StatusUpdate.key }).pipe(
         Stream.runForEach((message) =>

--- a/packages/sdk/client-services/src/packlets/network/network-service.ts
+++ b/packages/sdk/client-services/src/packlets/network/network-service.ts
@@ -120,10 +120,19 @@ export class NetworkServiceImpl implements NetworkService.Handlers {
         void this.signalManager.subscribeMessages(peer, tags);
       }
 
+      // This stream crosses the client-services RPC (protobufjs codec, e.g. dedicated worker → main
+      // thread). Its `Message.payload` is a `google.protobuf.Any` without `preserve_any`, and the
+      // codec refuses to encode an Any lacking '@type' — stamping the opaque form
+      // ('@type': 'google.protobuf.Any' + type_url/value) makes it pass through verbatim.
+      const encodableAny = (payload: Message['payload']): Message['payload'] => ({
+        ...payload,
+        '@type': 'google.protobuf.Any',
+      });
+
       // Point-to-point messages addressed to this peer.
       this.signalManager.onMessage.on(ctx, (message) => {
         if (message.recipient.peerKey === peer.peerKey) {
-          void emit.single(message);
+          void emit.single({ ...message, payload: encodableAny(message.payload) });
         }
       });
 
@@ -134,7 +143,7 @@ export class NetworkServiceImpl implements NetworkService.Handlers {
           void emit.single({
             author: broadcast.author,
             recipient: peer,
-            payload: broadcast.payload,
+            payload: encodableAny(broadcast.payload),
             tags: broadcast.tags,
           });
         }
@@ -142,7 +151,9 @@ export class NetworkServiceImpl implements NetworkService.Handlers {
 
       return Effect.promise(() => {
         if (tags.length > 0) {
-          void this.signalManager.unsubscribeMessages(peer);
+          // Release only this stream's tags (refcounted) — a bare unsubscribe would wholesale-clear
+          // every concurrent subscriber's tags on the edge (DX-1125).
+          void this.signalManager.unsubscribeMessages(peer, tags);
         }
         return ctx.dispose();
       });

--- a/packages/sdk/client-services/src/packlets/services/sqlite-storage.ts
+++ b/packages/sdk/client-services/src/packlets/services/sqlite-storage.ts
@@ -224,12 +224,23 @@ class SqliteRandomAccessFile extends BaseEventEmitter implements RandomAccessSto
   private async _saveToDb(): Promise<void> {
     const filePath = this.filePath;
     const data = this.#buffer;
-    await RuntimeProvider.runPromise(this.runtime)(
-      Effect.gen(function* () {
-        const sql = yield* SqlClient.SqlClient;
-        yield* sql`INSERT OR REPLACE INTO hypercore_files (path, data) VALUES (${filePath}, ${data})`;
-      }),
-    );
+    try {
+      await RuntimeProvider.runPromise(this.runtime)(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql`INSERT OR REPLACE INTO hypercore_files (path, data) VALUES (${filePath}, ${data})`;
+        }),
+      );
+    } catch (err) {
+      // Symmetric with `_loadFromDb`: a write racing teardown rejects (as `SqlError: Failed to
+      // execute statement` wrapping "connection is not open") when the shared SQL connection is
+      // torn down before this file's `#closed` flips. Persisting to a dead connection is moot
+      // during disposal, so swallow it; rethrow only a genuine failure against a live connection.
+      // An unswallowed rejection here surfaces as an unhandled rejection that fails the test worker.
+      if (!this.#closed && !isClosedConnectionError(err)) {
+        throw err;
+      }
+    }
   }
 
   write(offset: number, data: Buffer, cb: Callback<any>): void {

--- a/packages/sdk/client-services/src/packlets/space/space-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/space/space-protocol.ts
@@ -4,9 +4,9 @@
 
 import { type Event } from '@dxos/async';
 import { Context } from '@dxos/context';
-import { discoveryKey, subtleCrypto } from '@dxos/crypto';
+import { createIdFromSpaceKey } from '@dxos/echo-protocol';
 import { type FeedWrapper } from '@dxos/feed-store';
-import { PublicKey } from '@dxos/keys';
+import { PublicKey, SpaceId } from '@dxos/keys';
 import { log, logInfo } from '@dxos/log';
 import {
   MMSTTopology,
@@ -114,11 +114,11 @@ export class SpaceProtocol {
     this._onAuthFailure = onAuthFailure;
     this.blobSync = new BlobSync({ blobStore });
 
-    // TODO(burdon): Async race condition? Move to start?
-    this._topic = subtleCrypto
-      .digest('SHA-256', topic.asBuffer() as ArrayBufferView<ArrayBuffer>)
-      .then(discoveryKey)
-      .then(PublicKey.from);
+    // Space swarm topic contract (DX-1125): the SpaceId bytes (first 20 bytes of SHA-256(spaceKey)).
+    // Both peers and the edge must derive the identical swarm key; SpaceId is the only derivation
+    // computable on workerd (pure subtle-crypto — the previous hypercore `discoveryKey` needs keyed
+    // BLAKE2b, unavailable there). Edge counterpart: `TraceFeedWriter.getSpaceSwarmKey`.
+    this._topic = createIdFromSpaceKey(topic).then((spaceId) => PublicKey.from(SpaceId.decode(spaceId)));
 
     this._disableP2pReplication = disableP2pReplication ?? false;
   }

--- a/packages/stories/stories-inbox/src/modules/SwarmTraceModule.tsx
+++ b/packages/stories/stories-inbox/src/modules/SwarmTraceModule.tsx
@@ -1,0 +1,131 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import * as Fiber from 'effect/Fiber';
+import * as Stream from 'effect/Stream';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+import { Capabilities } from '@dxos/app-framework';
+import { useOptionalCapability } from '@dxos/app-framework/ui';
+import { Trace } from '@dxos/compute';
+import { Panel, Toolbar } from '@dxos/react-ui';
+import { JsonHighlighter } from '@dxos/react-ui-syntax-highlighter';
+import { type ModuleProps } from '@dxos/story-modules';
+
+/** Cap on retained events so a long-running story does not grow the list unbounded. */
+const MAX_EVENTS = 200;
+
+/** A flattened swarm trace event annotated with local receipt metadata for the trailing list. */
+type ReceivedEvent = Trace.FlatEvent & {
+  /** Monotonic local key for stable list rendering. */
+  readonly seq: number;
+  /** Local wall-clock time the event was received (ms). */
+  readonly receivedAt: number;
+};
+
+/**
+ * Renders a trailing (auto-scrolling) list of every ephemeral trace event broadcast by remote runtimes
+ * over the space swarm (DX-1125), consumed via the swarm-backed {@link Capabilities.RemoteTraceMonitor}.
+ * The monitor is subscribed with a space-scoped filter so it surfaces all swarm traffic for this space.
+ */
+export const SwarmTraceModule = ({ space }: ModuleProps) => {
+  const monitor = useOptionalCapability(Capabilities.RemoteTraceMonitor);
+  const runtime = useOptionalCapability(Capabilities.ProcessManagerRuntime);
+  const [events, setEvents] = useState<ReceivedEvent[]>([]);
+  const seqRef = useRef(0);
+
+  useEffect(() => {
+    if (!monitor || !runtime) {
+      return;
+    }
+
+    const fiber = runtime.runFork(
+      // A space-scoped filter yields a coarse `space:<id>` swarm subscription, so every remote
+      // trace message for this space is delivered and re-filtered client-side.
+      monitor.subscribeToTraceMessages({ space: space.id }).pipe(
+        Stream.runForEach((message) =>
+          Effect.sync(() => {
+            const receivedAt = Date.now();
+            const incoming = Trace.flatten(message).map((event) => ({
+              ...event,
+              seq: seqRef.current++,
+              receivedAt,
+            }));
+            setEvents((prev) => [...prev, ...incoming].slice(-MAX_EVENTS));
+          }),
+        ),
+      ),
+    );
+
+    return () => {
+      void runtime.runPromise(Fiber.interrupt(fiber));
+    };
+  }, [monitor, runtime, space.id]);
+
+  return (
+    <Panel.Root>
+      <Panel.Toolbar asChild>
+        <Toolbar.Root>
+          <Toolbar.Text>Swarm Trace</Toolbar.Text>
+          <Toolbar.Separator />
+          <Toolbar.Text>{events.length} events</Toolbar.Text>
+          <Toolbar.Separator />
+          <Toolbar.Button onClick={() => setEvents([])} disabled={events.length === 0}>
+            Clear
+          </Toolbar.Button>
+        </Toolbar.Root>
+      </Panel.Toolbar>
+      <Panel.Content className='overflow-hidden'>
+        {monitor ? <EventList events={events} /> : <div className='p-2 text-description'>No swarm trace source.</div>}
+      </Panel.Content>
+    </Panel.Root>
+  );
+};
+
+/** Auto-scrolling list of received events, newest at the bottom. */
+const EventList = ({ events }: { events: readonly ReceivedEvent[] }) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const pinnedRef = useRef(true);
+
+  // Only follow the tail while the user is already scrolled to the bottom, so manual
+  // scroll-up to inspect an earlier event is not yanked away by incoming traffic.
+  const handleScroll = () => {
+    const element = scrollRef.current;
+    if (!element) {
+      return;
+    }
+    pinnedRef.current = element.scrollHeight - element.scrollTop - element.clientHeight < 16;
+  };
+
+  useLayoutEffect(() => {
+    const element = scrollRef.current;
+    if (element && pinnedRef.current) {
+      element.scrollTop = element.scrollHeight;
+    }
+  }, [events]);
+
+  if (events.length === 0) {
+    return <div className='p-2 text-description'>Waiting for swarm trace events…</div>;
+  }
+
+  return (
+    <div ref={scrollRef} onScroll={handleScroll} className='flex flex-col gap-1 p-2 text-sm overflow-auto h-full'>
+      {events.map((event) => (
+        <div key={event.seq} className='flex flex-col gap-1 rounded border border-separator p-2'>
+          <div className='flex items-center gap-2 text-xs'>
+            <span className='text-description tabular-nums'>{formatTime(event.receivedAt)}</span>
+            <span className='font-mono truncate'>{event.type}</span>
+            {event.meta.runtimeName && <span className='text-description truncate'>{event.meta.runtimeName}</span>}
+            {event.meta.pid && <span className='text-description font-mono truncate'>pid:{event.meta.pid}</span>}
+          </div>
+          {event.data != null && <JsonHighlighter data={event.data} />}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const formatTime = (timestamp: number): string =>
+  new Date(timestamp).toLocaleTimeString(undefined, { hour12: false }) + `.${String(timestamp % 1000).padStart(3, '0')}`;

--- a/packages/stories/stories-inbox/src/modules/SwarmTraceModule.tsx
+++ b/packages/stories/stories-inbox/src/modules/SwarmTraceModule.tsx
@@ -128,4 +128,5 @@ const EventList = ({ events }: { events: readonly ReceivedEvent[] }) => {
 };
 
 const formatTime = (timestamp: number): string =>
-  new Date(timestamp).toLocaleTimeString(undefined, { hour12: false }) + `.${String(timestamp % 1000).padStart(3, '0')}`;
+  new Date(timestamp).toLocaleTimeString(undefined, { hour12: false }) +
+  `.${String(timestamp % 1000).padStart(3, '0')}`;

--- a/packages/stories/stories-inbox/src/modules/index.ts
+++ b/packages/stories/stories-inbox/src/modules/index.ts
@@ -9,6 +9,7 @@ export * from './FactsModule';
 export * from './MailboxModule';
 export * from './MessageModule';
 export * from './StatsModule';
+export * from './SwarmTraceModule';
 export * from './SyncStateModule';
 export * from './TopicsModule';
 export * from './TraceModule';

--- a/packages/stories/stories-inbox/src/stories/MailboxSync.stories.tsx
+++ b/packages/stories/stories-inbox/src/stories/MailboxSync.stories.tsx
@@ -97,6 +97,7 @@ const DefaultStory = () => (
       [Module.Archive, Module.Stats, Module.SyncState],
       [Module.Connector, Module.Triggers],
       [Module.Trace],
+      [Module.SwarmTrace],
     ]}
     compact
   />

--- a/packages/stories/stories-inbox/src/testing/modules.tsx
+++ b/packages/stories/stories-inbox/src/testing/modules.tsx
@@ -41,7 +41,7 @@ export const Module = {
   Stats: Role.make<Record<string, any>>('org.dxos.storybook.inbox.stats'),
   SyncState: Role.make<Record<string, any>>('org.dxos.storybook.inbox.syncState'),
   Trace: Role.make<Record<string, any>>('org.dxos.storybook.inbox.trace'),
-  SwarmTrace: Role.make<Record<string, any>>('org.dxos.storybook.inbox.swarmTrace'),
+  SwarmTrace: Role.make<Record<string, unknown>>('org.dxos.storybook.inbox.swarmTrace'),
   Triggers: Role.make<Record<string, any>>('org.dxos.storybook.inbox.triggers'),
 };
 

--- a/packages/stories/stories-inbox/src/testing/modules.tsx
+++ b/packages/stories/stories-inbox/src/testing/modules.tsx
@@ -18,6 +18,7 @@ import {
   MailboxModule,
   MessageModule,
   StatsModule,
+  SwarmTraceModule,
   SyncStateModule,
   TopicsModule,
   TraceModule,
@@ -40,6 +41,7 @@ export const Module = {
   Stats: Role.make<Record<string, any>>('org.dxos.storybook.inbox.stats'),
   SyncState: Role.make<Record<string, any>>('org.dxos.storybook.inbox.syncState'),
   Trace: Role.make<Record<string, any>>('org.dxos.storybook.inbox.trace'),
+  SwarmTrace: Role.make<Record<string, any>>('org.dxos.storybook.inbox.swarmTrace'),
   Triggers: Role.make<Record<string, any>>('org.dxos.storybook.inbox.triggers'),
 };
 
@@ -95,6 +97,11 @@ const moduleSurfaces: Surface.Definition[] = [
     id: 'inbox.trace',
     filter: Surface.makeFilter(Module.Trace),
     component: withModuleProps(TraceModule),
+  }),
+  Surface.create({
+    id: 'inbox.swarmTrace',
+    filter: Surface.makeFilter(Module.SwarmTrace),
+    component: withModuleProps(SwarmTraceModule),
   }),
   Surface.create({
     id: 'inbox.triggers',


### PR DESCRIPTION
- **feat: add SwarmTrace module to inbox stories and testing surfaces**
- **feat: enhance messaging system with refined tag subscription management and new feed query tests**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Swarm Trace panel to the inbox with live event streaming, auto-scrolling, timestamps, bounded history (max 200), event count, and a Clear action.
  - Trace queries now span all trace feeds for a space (instead of only the first feed).

- **Bug Fixes**
  - Improved tagged message subscription/unsubscription so one consumer won’t clobber others; legacy behavior remains when no tags are specified.
  - Updated message forwarding to wrap payloads as protobuf `Any`.
  - Improved space swarm topic derivation for better runtime compatibility.
  - Prevented teardown-time SQLite write failures when the shared connection is already closed.

- **Tests**
  - Added coverage for cross-feed query unions and tagged subscription lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->