### PR TITLE
ai: fix memoized LLM dynamic-value id remapping

### DIFF
--- a/.changeset/memoized-lm-id-remap.md
+++ b/.changeset/memoized-lm-id-remap.md
@@ -1,0 +1,5 @@
+---
+'@dxos/ai': patch
+---
+
+Fix memoized language model dynamic-value remapping: collect tokens over the normalized prompt so timestamp metadata cannot shift positional ids, and preserve per-pattern regex flags so uppercase-hex UUIDs match.

--- a/.changeset/memoized-lm-id-remap.md
+++ b/.changeset/memoized-lm-id-remap.md
@@ -1,5 +1,5 @@
 ---
-'@dxos/ai': patch
+'@dxos/echo': patch
 ---
 
 Fix memoized language model dynamic-value remapping: collect tokens over the normalized prompt so timestamp metadata cannot shift positional ids, and preserve per-pattern regex flags so uppercase-hex UUIDs match.

--- a/packages/core/compute/ai/DESIGN.md
+++ b/packages/core/compute/ai/DESIGN.md
@@ -74,3 +74,20 @@ fails on the old insertion-order collection and passes on the sorted collection.
   longer patterns first (`SPACE_ID_PATTERN` before `ENTITY_ID_PATTERN`).
 - **Snapshot growth.** The store appends and never prunes unused conversations (see the TODO in the
   source); large files should eventually be scoped per-test with last-used pruning.
+
+## Follow-up fixes
+
+- **Remap now collects over the normalized prompt.** `remapStoredResponse` previously collected
+  dynamic tokens from the **raw** prompt while matching compared the **timestamp/datetime-normalized**
+  prompt. A pattern that also matches normalized-away content (e.g. `ISO_TIMESTAMP_PATTERN` over the
+  ISO `timestamp` metadata) was collected on remap but not on match, so a duplicate-timestamp
+  asymmetry (stored dedups to one token, live to two) shifted every downstream positional index and
+  remapped a space key to a timestamp value. Remap now normalizes (timestamps/datetime only, dynamic
+  tokens left intact for the real→real mapping) before collecting, so its token count/order matches
+  what the match established.
+- **`buildDynamicMatcher` preserves per-pattern flags.** It combined only each pattern's `.source`
+  with a hard-coded `g`, silently dropping flags — notably `UUID_PATTERN`'s `i`, leaving
+  uppercase-hex UUIDs unmatched once combined. It now unions the input flags. Because JS flags are
+  whole-regex (a unioned `i` would apply to every alternative), patterns should still encode
+  case-sensitivity in their character class rather than relying on `i`; `UUID_PATTERN` now uses
+  `[0-9a-fA-F]` and drops the flag.

--- a/packages/core/compute/ai/src/testing/memoization/MemoizedLanguageModel.ts
+++ b/packages/core/compute/ai/src/testing/memoization/MemoizedLanguageModel.ts
@@ -119,7 +119,7 @@ export const ISO_TIMESTAMP_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}
  * such tools aren't otherwise memoizable since the value differs on every live execution.
  * @example 5baed323-7879-4fde-0441-c2cf954f2900
  */
-export const UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+export const UUID_PATTERN = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/;
 
 const dynamicPlaceholder = (index: number): string => `<memoized-dynamic-${index}>`;
 
@@ -135,7 +135,22 @@ const buildDynamicMatcher = (patterns: readonly RegExp[]): RegExp | undefined =>
     return undefined;
   }
 
-  return new RegExp(patterns.map((pattern) => `(?:${pattern.source})`).join('|'), 'g');
+  // Only each pattern's `.source` is combined into the alternation, so per-pattern flags would be
+  // dropped. Union them (always adding `g`) so a pattern's flag is not silently lost — e.g. dropping
+  // UUID_PATTERN's case-insensitivity would leave uppercase-hex UUIDs unmatched. Regex flags are
+  // whole-regex in JS and cannot be scoped per-alternative, so encode case-sensitivity in the
+  // character class (as the exported patterns do) rather than relying on `i`, which a union would
+  // apply to every alternative. `y` (sticky) is excluded because it breaks alternation scanning.
+  const flags = new Set<string>(['g']);
+  for (const pattern of patterns) {
+    for (const flag of pattern.flags) {
+      if (flag !== 'y') {
+        flags.add(flag);
+      }
+    }
+  }
+
+  return new RegExp(patterns.map((pattern) => `(?:${pattern.source})`).join('|'), [...flags].join(''));
 };
 
 /**
@@ -210,8 +225,19 @@ const remapStoredResponse = (
     return storedResponse;
   }
 
-  const storedValues = collectDynamicValues(storedPrompt, matcher);
-  const liveValues = collectDynamicValues(livePrompt, matcher);
+  // Collect over the same timestamp/datetime-normalized form the matcher compared — but WITHOUT
+  // canonicalizing dynamic tokens, since we need the real values to build the stored→live mapping.
+  // Collecting over the raw prompt would pick up tokens the matcher had normalized away (e.g. ISO
+  // timestamps in `timestamp` metadata when ISO_TIMESTAMP_PATTERN is registered), diverging the
+  // token count/order from what the match established and misaligning the positional remap. See DESIGN.md.
+  const storedValues = collectDynamicValues(
+    normalizePromptForMemoization(cloneForMemoNormalization(storedPrompt)),
+    matcher,
+  );
+  const liveValues = collectDynamicValues(
+    normalizePromptForMemoization(cloneForMemoNormalization(livePrompt)),
+    matcher,
+  );
   const mapping = new Map<string, string>();
   for (let index = 0; index < storedValues.length; index++) {
     const live = liveValues[index];

--- a/packages/core/compute/ai/src/testing/memoization/memoization.test.ts
+++ b/packages/core/compute/ai/src/testing/memoization/memoization.test.ts
@@ -174,7 +174,7 @@ describe('memoization', () => {
 });
 
 describe('dynamic value matching', () => {
-  const { SPACE_ID_PATTERN, ENTITY_ID_PATTERN, __testing } = MemoizedLanguageModel;
+  const { SPACE_ID_PATTERN, ENTITY_ID_PATTERN, ISO_TIMESTAMP_PATTERN, UUID_PATTERN, __testing } = MemoizedLanguageModel;
 
   // Two structurally identical prompts that differ only in the (run-specific) space key.
   const SPACE_A = 'BA25QRC2FEWCSAMRP4RZL65LWJ7352CKE';
@@ -240,6 +240,47 @@ describe('dynamic value matching', () => {
     expect(serialized).not.toContain(SPACE_A);
     // Stable object id is preserved.
     expect(serialized).toContain(OBJECT_ID);
+  });
+
+  test('remap collects over the normalized prompt so timestamp tokens do not shift ids', ({ expect }) => {
+    // Regression: `timestamp` metadata is normalized away for matching but was collected raw during
+    // remap. With ISO_TIMESTAMP_PATTERN registered, a duplicate-timestamp asymmetry (stored dedups
+    // to one, live to two) shifted every downstream positional index, remapping the space key to a
+    // timestamp value instead of the live space key. See DESIGN.md / MemoizedLanguageModel remap.
+    const timestampedPrompt = (spaceId: string, timestamps: readonly string[]) => [
+      ...timestamps.map((timestamp) => ({ role: 'user', timestamp, content: [{ type: 'text', text: 'tick' }] })),
+      { role: 'user', content: [{ type: 'text', text: `Create an object in space echo://${spaceId}` }] },
+    ];
+
+    // Stored: both turns share one clock value (dedups to a single dynamic token before the space key).
+    const stored = timestampedPrompt(SPACE_A, ['2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z']);
+    // Live: the two turns have distinct clock values (two tokens) — the count diverges from stored.
+    const live = timestampedPrompt(SPACE_B, ['2026-01-01T00:00:01.000Z', '2026-01-01T00:00:02.000Z']);
+
+    // They still match: timestamps are normalized to a placeholder before canonicalization.
+    expect(__testing.normalizeForMatching(stored, [SPACE_ID_PATTERN, ISO_TIMESTAMP_PATTERN])).toEqual(
+      __testing.normalizeForMatching(live, [SPACE_ID_PATTERN, ISO_TIMESTAMP_PATTERN]),
+    );
+
+    const storedResponse = [{ type: 'text', text: `Created object in echo://${SPACE_A}.` }];
+    const remapped = __testing.remapResponse(stored, storedResponse, live, [SPACE_ID_PATTERN, ISO_TIMESTAMP_PATTERN]);
+
+    const serialized = JSON.stringify(remapped);
+    expect(serialized).toContain(SPACE_B);
+    expect(serialized).not.toContain(SPACE_A);
+  });
+
+  test('combined matcher preserves the uuid pattern case-insensitivity for uppercase hex', ({ expect }) => {
+    // Regression: buildDynamicMatcher combined only `.source` and dropped per-pattern flags, so
+    // UUID_PATTERN's uppercase-hex coverage was lost once combined.
+    const matcher = __testing.buildDynamicMatcher([UUID_PATTERN]);
+    expect(matcher).toBeDefined();
+    if (!matcher) {
+      return;
+    }
+    const uppercase = '5BAED323-7879-4FDE-0441-C2CF954F2900';
+    const tokens = [...`upload id=${uppercase}`.matchAll(matcher)].map((match) => match[0]);
+    expect(tokens).toEqual([uppercase]);
   });
 
   test('space-key pattern takes precedence over the entity-id pattern (no partial overlap)', ({ expect }) => {


### PR DESCRIPTION
## Summary

Audit of the memoized language model's run-specific **id replacement** logic (`packages/core/compute/ai/src/testing/memoization/MemoizedLanguageModel.ts`) surfaced two real bugs in the dynamic-value canonicalization/remap path. The core algorithm (positional canonicalization for matching + positional remap on hit) is sound; these are edge-case correctness fixes.

## Bug 1 — remap collected over the raw prompt, matching over the normalized prompt (correctness)

The remap invariant "i-th stored distinct token ↔ i-th live distinct token" relies on stored and live prompts having the same count/order of dynamic tokens. That is established only by `converstationMatches`, which compares the **timestamp/datetime-normalized** prompt. But `remapStoredResponse` collected dynamic tokens from the **raw** prompt.

With a pattern that also matches normalized-away content — e.g. `ISO_TIMESTAMP_PATTERN` over the ISO-8601 `timestamp` message metadata — tokens were collected on remap but not on match. A duplicate-timestamp asymmetry (stored dedups to one token, live to two) then shifted every downstream positional index, remapping a space key to a timestamp value.

**Fix:** collect over the same normalized form the matcher used (timestamps/datetime collapsed; dynamic tokens left intact so the real→real mapping is preserved).

## Bug 2 — `buildDynamicMatcher` dropped per-pattern regex flags (latent)

It combined only each pattern's `.source` with a hard-coded `g`, silently dropping flags — notably `UUID_PATTERN`'s `i`, so uppercase-hex UUIDs went unmatched once combined.

**Fix:** union the input flags. Since JS flags are whole-regex (a unioned `i` would apply to every alternative), `UUID_PATTERN` is made self-contained via `[0-9a-fA-F]` and drops the flag.

## Tests

Added two regression tests under the `dynamic value matching` suite; both were verified to fail on the pre-fix code and pass after the fix:
- remap collects over the normalized prompt so timestamp tokens do not shift ids;
- the combined matcher preserves UUID case-insensitivity for uppercase hex.

`DESIGN.md` updated with a "Follow-up fixes" section; `patch` changeset added for `@dxos/ai`.

## Test plan

- [x] New regression tests fail on pre-fix code, pass on fixed code (verified in isolation against the real module).
- [ ] Full `ai:test` suite green in CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bq12sGuDapC6FRxrTPXjd2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memoized AI replay determinism by remapping dynamic values using the same normalized prompt representation, avoiding positional shifts from timestamp normalization.
  * Preserved case-insensitive UUID matching for both uppercase and lowercase forms.
  * Improved dynamic-value matcher behavior by retaining regex flags from the provided patterns.
* **Documentation**
  * Added a “Follow-up fixes” note describing the behavioral corrections to the memoization/canonicalization pipeline.
* **Tests**
  * Added regression coverage for timestamp remapping and uppercase UUID extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->