### PR TITLE
composer-app: idle memory profiling harness for DX-1134

### DIFF
--- a/packages/apps/composer-app/src/playwright/idle-memory.profile.spec.ts
+++ b/packages/apps/composer-app/src/playwright/idle-memory.profile.spec.ts
@@ -13,8 +13,8 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { AppManager } from './app-manager';
-import { Markdown } from './plugins';
 import { here } from './harness-helpers';
+import { Markdown } from './plugins';
 
 const DURATION_MS = Number(process.env.DX_IDLE_DURATION_MS ?? 8 * 60_000);
 const INTERVAL_MS = Number(process.env.DX_IDLE_INTERVAL_MS ?? 30_000);

--- a/packages/apps/composer-app/src/playwright/idle-memory.profile.spec.ts
+++ b/packages/apps/composer-app/src/playwright/idle-memory.profile.spec.ts
@@ -1,0 +1,90 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// Investigative script for DX-1134 (idle memory leak). Not part of the
+// regular e2e suite — run manually with:
+//   pnpm exec playwright test src/playwright/idle-memory.profile.spec.ts --config=src/playwright/playwright.config.ts
+// Delete once the investigation concludes, or promote to a real regression
+// spec if the leak is confirmed and worth guarding against.
+
+import { type CDPSession, expect, test } from '@playwright/test';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { AppManager } from './app-manager';
+import { Markdown } from './plugins';
+import { here } from './harness-helpers';
+
+const DURATION_MS = Number(process.env.DX_IDLE_DURATION_MS ?? 8 * 60_000);
+const INTERVAL_MS = Number(process.env.DX_IDLE_INTERVAL_MS ?? 30_000);
+
+type Sample = {
+  label: string;
+  elapsedMs: number;
+  JSHeapUsedSize?: number;
+  JSHeapTotalSize?: number;
+  Nodes?: number;
+  Documents?: number;
+  JSEventListeners?: number;
+  LayoutObjects?: number;
+  Frames?: number;
+  ScriptDuration?: number;
+  TaskDuration?: number;
+};
+
+test.describe.serial('DX-1134 idle memory profiling', () => {
+  test('idle memory growth with a document open', async ({ browser }) => {
+    test.setTimeout(DURATION_MS + 5 * 60_000);
+
+    const host = new AppManager(browser, false);
+    await host.init();
+
+    await host.createSpace();
+    await host.createObject({ type: 'Document' });
+    const plank = host.deck.plank();
+    await expect(Markdown.getMarkdownTextboxWithLocator(plank.locator)).toBeEditable();
+
+    const cdp: CDPSession = await host.page.context().newCDPSession(host.page);
+    await cdp.send('Performance.enable');
+
+    const sample = async (label: string, elapsedMs: number): Promise<Sample> => {
+      await cdp.send('HeapProfiler.enable').catch(() => {});
+      await cdp.send('HeapProfiler.collectGarbage').catch(() => {});
+      const { metrics } = await cdp.send('Performance.getMetrics');
+      const byName = Object.fromEntries(metrics.map((metric) => [metric.name, metric.value]));
+      return {
+        label,
+        elapsedMs,
+        JSHeapUsedSize: byName.JSHeapUsedSize,
+        JSHeapTotalSize: byName.JSHeapTotalSize,
+        Nodes: byName.Nodes,
+        Documents: byName.Documents,
+        JSEventListeners: byName.JSEventListeners,
+        LayoutObjects: byName.LayoutObjects,
+        Frames: byName.Frames,
+        ScriptDuration: byName.ScriptDuration,
+        TaskDuration: byName.TaskDuration,
+      };
+    };
+
+    const samples: Sample[] = [];
+    samples.push(await sample('baseline', 0));
+
+    const start = Date.now();
+    while (Date.now() - start < DURATION_MS) {
+      await host.page.waitForTimeout(INTERVAL_MS);
+      const elapsed = Date.now() - start;
+      samples.push(await sample(`t+${Math.round(elapsed / 1000)}s`, elapsed));
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(samples.at(-1)));
+    }
+
+    const outDir = path.join(here, '..', '..', '..', '..', '..', 'test-results', 'composer-app');
+    mkdirSync(outDir, { recursive: true });
+    const outFile = path.join(outDir, 'idle-memory.json');
+    writeFileSync(outFile, `${JSON.stringify(samples, null, 2)}\n`);
+    // eslint-disable-next-line no-console
+    console.log(`wrote ${samples.length} samples to ${outFile}`);
+  });
+});


### PR DESCRIPTION
## Summary
- Investigating [DX-1134](https://linear.app/dxos/issue/DX-1134/composer-memory-leak), a reported idle memory leak in Composer.
- Adds `src/playwright/idle-memory.profile.spec.ts`: a manual (not part of the regular e2e suite) Playwright harness that opens a space with a document, then uses a CDP session to force GC and sample `Performance.getMetrics` (JS heap size, DOM node/listener/document/layout-object counts) at intervals over an idle period.
- Not wired into CI — run manually via `pnpm exec playwright test src/playwright/idle-memory.profile.spec.ts --config=src/playwright/playwright.config.ts` (see comment at top of the file), with `DX_IDLE_DURATION_MS` / `DX_IDLE_INTERVAL_MS` env vars to size the run.

## Findings so far
Ran a 30-minute idle session (space + one Markdown doc open, no interaction), sampling every 60s:
- DOM node count (15,220), document count (4), layout object count (2,573), and frame count (3) stayed completely flat for the full 30 minutes — no evidence of a DOM-node or detached-listener leak in this scenario.
- JS heap climbed for roughly the first 10 minutes (consistent with lazy-loaded chunks/caches/ECHO index warm-up), then plateaued and oscillated in a ~0.5–1 MB noise band; the second half of the run trended under 1 MB/hour.
- This specific scenario does not reproduce an unbounded leak in 30 minutes. It doesn't rule out: much slower leaks only visible over hours, leaks tied to space/document switching or WASM modules (`@dxos/wa-sqlite`, `manifold-3d`) not exercised here, or leaks that need multiple collaborators/peers.

This PR is to preserve the harness for further investigation, not a fix — no root cause identified yet.

## Test plan
- [x] `pnpm exec playwright test src/playwright/idle-memory.profile.spec.ts` run manually (30 min, see findings above)
- [ ] Longer/varied-scenario runs (multi-space, multi-doc, hours-long) to pin down whether the residual sub-1MB/hr trend is real


---
_Generated by [Claude Code](https://claude.ai/code/session_01PA1oZRznR48B9ifaugVFux)_