### PR TITLE
storybook,client,comments: fix react-ui-mosaic e2e (node-std alias) + comment attribution/reset-device races

### DIFF
--- a/.changeset/comments-identity-attribution-reset-reload.md
+++ b/.changeset/comments-identity-attribution-reset-reload.md
@@ -1,0 +1,6 @@
+---
+'@dxos/client': patch
+'@dxos/plugin-client': patch
+---
+
+Fix comment author attribution and reset-device reload. `useIdentity` now seeds its atom with the service's synchronous snapshot so the current identity is available on the first render instead of a transient `undefined` — a comment sent in that window was stamped with an empty sender and never matched its author, hiding the edit affordance. During `client.reset()` the worker-reconnect handler now reloads to the origin (fresh boot) rather than the stale current route, and `Client.resetting` exposes that state. SQLite hypercore storage drains in-flight writes on `close()` so a save racing reset teardown can't stall or reject against a torn-down connection.

--- a/packages/core/halo/halo-react/src/useIdentity.ts
+++ b/packages/core/halo/halo-react/src/useIdentity.ts
@@ -3,6 +3,7 @@
 //
 
 import { Atom, Result, useAtomValue } from '@effect-atom/atom-react';
+import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 import * as Stream from 'effect/Stream';
 import { useMemo } from 'react';
@@ -18,7 +19,16 @@ import { useHaloServices } from './HaloProvider';
 export const useIdentity = (): Identity.Info | undefined => {
   const services = useHaloServices();
   const atom = useMemo(
-    () => Atom.make(Identity.identity.pipe(Stream.provideContext(services), Stream.map(Option.getOrUndefined))),
+    () =>
+      Atom.make(Identity.identity.pipe(Stream.provideContext(services), Stream.map(Option.getOrUndefined)), {
+        // The stream emits the current identity, but only after its first (async) subscription
+        // tick — until then the atom would sit at `Result.Initial` and callers would see "no
+        // identity" for the first render(s) even when one already exists. Seed it with the
+        // service's synchronous snapshot so the current identity is available on the very first
+        // render; the stream's value takes over as soon as it arrives (and covers post-mount
+        // create/update).
+        initialValue: Option.getOrUndefined(Effect.runSync(Identity.getSnapshot.pipe(Effect.provide(services)))),
+      }),
     [services],
   );
   return Result.getOrElse(useAtomValue(atom), () => undefined);

--- a/packages/plugins/plugin-client/src/capabilities/client.ts
+++ b/packages/plugins/plugin-client/src/capabilities/client.ts
@@ -49,9 +49,21 @@ export default Capability.makeModule(
     // previous leader tab closes), its proxies are left in a broken state. Force a full reload to
     // re-establish a clean session until the reconnect flow can recover in place.
     // TODO(dmaretskyi): Remove once guest tabs recover from a leader handover without reloading.
+    //
+    // `client.reset()` also fires this event (its teardown reconnects this tab to a fresh worker),
+    // and reset must reload too, but to a different URL. `reload()` re-requests the *current* URL
+    // (path included); after a reset the current route (e.g. the Devices settings panel where reset
+    // was triggered) points at now-deleted data, so reopening it shows stale/broken UI. Navigating
+    // to `origin` instead drops the path and boots the app fresh — which is also what the app's own
+    // post-reset flow targets. The two branches differ only when the path isn't already `/`; a
+    // normal reconnect keeps the user where they were, a reset returns them to the root.
     client.services.reconnected?.on(() => {
       log.info('client reconnected, reloading to re-establish session');
-      window.location.reload();
+      if (client.resetting) {
+        window.location.href = window.location.origin;
+      } else {
+        window.location.reload();
+      }
     });
 
     let spacesReadyFired = false;

--- a/packages/sdk/client-services/src/packlets/services/sqlite-storage.ts
+++ b/packages/sdk/client-services/src/packlets/services/sqlite-storage.ts
@@ -161,7 +161,11 @@ class SqliteRandomAccessFile extends BaseEventEmitter implements RandomAccessSto
 
   #buffer: Buffer = Buffer.alloc(0);
   #loaded = false;
+  // The one-shot initial DB read (populates `#buffer`); set once, on first access.
   #loading: Promise<void> | null = null;
+  // The latest in-flight DB write (from `write`/`del`); replaced on each save, so it always
+  // tracks the most recent one. `close()` drains both before reporting closed.
+  #saving: Promise<void> | null = null;
 
   constructor(
     private readonly filePath: string,
@@ -244,7 +248,7 @@ class SqliteRandomAccessFile extends BaseEventEmitter implements RandomAccessSto
   }
 
   write(offset: number, data: Buffer, cb: Callback<any>): void {
-    this._ensureLoaded()
+    const saving = this._ensureLoaded()
       .then(() => {
         const end = offset + data.length;
         if (end > this.#buffer.length) {
@@ -255,8 +259,14 @@ class SqliteRandomAccessFile extends BaseEventEmitter implements RandomAccessSto
         data.copy(this.#buffer, offset);
         return this._saveToDb();
       })
-      .then(() => cb(null))
-      .catch((err) => cb(err));
+      .then(
+        () => cb(null),
+        (err) => cb(err),
+      );
+    // Track the in-flight save so `close()` can drain it before reporting closed — otherwise a
+    // write racing `close()` (e.g. a background sync write racing `client.reset()`'s teardown)
+    // keeps running against a connection the container may tear down immediately after.
+    this.#saving = saving.catch(() => {});
   }
 
   read(offset: number, size: number, cb: Callback<Buffer>): void {
@@ -276,7 +286,7 @@ class SqliteRandomAccessFile extends BaseEventEmitter implements RandomAccessSto
   }
 
   del(offset: number, size: number, cb: Callback<any>): void {
-    this._ensureLoaded()
+    const saving = this._ensureLoaded()
       .then(() => {
         const end = Math.min(offset + size, this.#buffer.length);
         if (offset < end) {
@@ -284,8 +294,12 @@ class SqliteRandomAccessFile extends BaseEventEmitter implements RandomAccessSto
         }
         return this._saveToDb();
       })
-      .then(() => cb(null))
-      .catch((err) => cb(err));
+      .then(
+        () => cb(null),
+        (err) => cb(err),
+      );
+    // See `write()`: track the in-flight save so `close()` can drain it before reporting closed.
+    this.#saving = saving.catch(() => {});
   }
 
   stat(cb: Callback<FileStat>): void {
@@ -298,9 +312,11 @@ class SqliteRandomAccessFile extends BaseEventEmitter implements RandomAccessSto
 
   close(cb: Callback<Error>): void {
     this.#closed = true;
-    // Drain any in-flight initial load before reporting closed, so a read never races a
-    // torn-down SQL connection (avoids "database connection is not open" unhandled rejections).
-    (this.#loading ?? Promise.resolve()).then(
+    // Drain any in-flight initial load and any in-flight write/del before reporting closed, so
+    // neither races a torn-down SQL connection (avoids "database connection is not open" errors,
+    // and the resulting stall in callers — e.g. `client.reset()`'s feed teardown — that wait on
+    // this file's `close()` to settle before tearing down the connection itself).
+    Promise.all([this.#loading ?? Promise.resolve(), this.#saving ?? Promise.resolve()]).then(
       () => cb(null),
       () => cb(null),
     );

--- a/packages/sdk/client/src/client/client.ts
+++ b/packages/sdk/client/src/client/client.ts
@@ -202,6 +202,16 @@ export class Client {
   }
 
   /**
+   * True while an in-progress {@link reset} is tearing down services. Consumers that react to
+   * service disconnect/reconnect (e.g. to force a reload) should check this before choosing a
+   * reload target — mid-reset, the current route is stale and reloading to it would reopen
+   * now-cleared UI, so navigate to the origin instead.
+   */
+  get resetting(): boolean {
+    return this._resetting;
+  }
+
+  /**
    * ECHO Spaces.
    */
   get spaces(): Echo {

--- a/tools/storybook-react/.storybook/main.ts
+++ b/tools/storybook-react/.storybook/main.ts
@@ -219,16 +219,27 @@ export const createConfig = ({
       {
         publicDir: staticDir,
         resolve: {
-          alias: {
-            'node-fetch': 'isomorphic-fetch',
-            'tiktoken/lite': resolve(__dirname, './stub.mjs'),
-            'node:util': '@dxos/node-std/util',
-            'util': '@dxos/node-std/util',
-            'node:crypto': '@dxos/node-std/crypto',
-            'crypto': '@dxos/node-std/crypto',
+          // NOTE: Under Vite 8 / rolldown, string-keyed aliases are treated as prefix matches, which means
+          // a bare `util` alias also rewrites `util/types` → `@dxos/node-std/util/types` (not exported).
+          // Use regex `find: /^util$/` (array form) to bind the bare module name only and let Vite's
+          // native node: polyfill layer handle subpaths like `node:util/types`.
+          alias: [
+            { find: /^node-fetch$/, replacement: 'isomorphic-fetch' },
+            { find: /^node:util$/, replacement: '@dxos/node-std/util' },
+            { find: /^util$/, replacement: '@dxos/node-std/util' },
+            { find: /^node:path$/, replacement: '@dxos/node-std/path' },
+            { find: /^path$/, replacement: '@dxos/node-std/path' },
+            { find: /^node:crypto$/, replacement: '@dxos/node-std/crypto' },
+            { find: /^crypto$/, replacement: '@dxos/node-std/crypto' },
+            { find: /^node:stream$/, replacement: '@dxos/node-std/stream' },
+            { find: /^stream$/, replacement: '@dxos/node-std/stream' },
+            { find: /^tiktoken\/lite$/, replacement: resolve(__dirname, './stub.mjs') },
             // Storybook builds from source; ensure worker entrypoints resolve without `dist/` artifacts.
-            '@dxos/client/opfs-worker': resolve(rootDir, 'packages/sdk/client/src/worker/opfs-worker.ts'),
-          },
+            {
+              find: /^@dxos\/client\/opfs-worker$/,
+              replacement: resolve(rootDir, 'packages/sdk/client/src/worker/opfs-worker.ts'),
+            },
+          ],
         },
         // `build.target` only lowers syntax for `storybook build`; the e2e tests run against
         // `storybook dev`, which otherwise serves source syntax untransformed straight to the


### PR DESCRIPTION
## Summary

Fixes the failing `react-ui-mosaic` e2e tests (the original report), plus two pre-existing `composer-app` e2e failures uncovered while verifying the fix in CI.

### 1. `storybook-react`: alias `node:path`/`node:stream` to `@dxos/node-std`
The shared storybook Vite config aliased only `node:util`/`node:crypto` to `@dxos/node-std`, but not `node:path`/`node:stream`. `Board.stories.tsx` transitively imports `teleport-extension-object-sync`'s `blob-store.ts`, which does `import path from 'node:path'` — without the alias the storybook dev server couldn't resolve it, breaking the whole module graph and timing out **every** react-ui-mosaic board test at `board-column` visibility. `composer-app` and `testbench-app` already had these aliases; storybook was the outlier. Also switched the alias map to the regex-array form those configs use (Vite 8/rolldown treats string-keyed aliases as prefix matches).

### 2. `client`/`plugin-client`: comment author attribution + reset-device reload
Two unrelated pre-existing composer-app e2e failures (`comments › edit message`, `basic › reset device`), fixed at root:

- **`useIdentity`** seeds its atom with the HALO service's synchronous snapshot via `initialValue`, so the current identity is available on the first render instead of a transient `undefined` while the stream's first (async) emission is still in flight. A comment message sent in that window was stamped with an empty `sender`, so its author never matched the local identity and the edit affordance never rendered.
- **`plugin-client`**: `client.reset()` fires the same worker-reconnect event whose interim fix reloads the tab. During a reset, reload to `origin` (fresh boot) rather than `reload()`-ing the now-stale current route (which pointed at reset-deleted data). Adds `Client.resetting` to signal this.
- **`client-services/sqlite-storage`**: `close()` now drains the latest in-flight write/del (`#saving`) alongside the initial read (`#loading`) before reporting closed, so a save racing `client.reset()` teardown can't stall on or reject against a torn-down connection.

## Testing

Full **Check** workflow (incl. all-browser e2e) green on this branch: run 29826562562. react-ui-mosaic (21 board tests, all 3 browsers), `comments › edit message`, and `basic › reset device` all pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Identity information is now available immediately during initial rendering, improving attribution for comments created during startup.
  - Reset flows now reload from the application’s origin instead of preserving a stale route.
  - Storage shutdown now safely waits for pending writes, preventing teardown-related failures or stalls.

- **New Features**
  - Added a way to detect when the client is actively resetting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->