### PR TITLE
inbox: fix mailbox paging stall and list blanking during sync

### DIFF
--- a/.agents/skills/code-style/SKILL.md
+++ b/.agents/skills/code-style/SKILL.md
@@ -3,7 +3,8 @@ name: dxos-code-style
 description: >-
   DXOS TypeScript authoring conventions. Use when writing or refactoring code —
   namespace-export packages, internal module imports, class member ordering,
-  options-bag types, function overloads, the no-cast rule, and test structure.
+  options-bag types, function overloads, the no-cast rule, the comment rule
+  (say why, once), and test structure.
 ---
 
 # DXOS Code Style
@@ -32,6 +33,36 @@ Do NOT cast to silence a build error; fix the type where it originates.
 - Casts accumulate fastest during large codemods — treat each as a deliberate
   decision, never an autopilot stopgap.
 - Use @dxos/util `trim` to create multi-line strings (e.g., prompts).
+
+## Comments — say why, once
+
+A comment earns its place by stating the _why_ the code can't — the constraint,
+the non-obvious consequence, the reason a reader would otherwise "fix" it wrong.
+The code already says _what_ it does; a comment that restates that is noise.
+
+- **One load-bearing clause.** Not a multi-sentence essay. If you're explaining a
+  mechanism, state the constraint in a sentence and stop — resist narrating each
+  step, the alternatives you rejected, or how it used to work. This applies
+  hardest to JSDoc on a new abstraction, where the instinct to over-explain peaks.
+- Never narrate history or the conversation ("previously X, now Y", "as
+  requested", "changed to…"). State the current invariant as if it always was.
+- Delete a comment that a competent reader gets from the code itself. Prefer a
+  clearer name or signature over a comment that compensates for an unclear one.
+- End with a period. JSDoc public functions.
+- **Before every commit/PR**, audit the comments in your diff:
+  `git diff origin/main | grep -nE '^\+\s*(//|\*|/\*)'`. Re-read each added line
+  and cut it to its load-bearing clause — or delete it. A verbose comment is the
+  autopilot default; conciseness is the deliberate pass. Do not defer to review.
+
+```ts
+// ✅ why the code can't be the obvious thing, in one clause:
+// Seeded across an identity change so the view refreshes in place, not to empty.
+
+// ❌ restates the code / multi-sentence narration / history:
+// Set displayItems to initialItems if it has items, otherwise the empty array.
+// We used to reset here but that flashed empty, so now we hold the previous page
+// and only replace it once the new query delivers its own results, which means…
+```
 
 ## Namespace-export packages
 

--- a/.changeset/mailbox-paging-sync-flash.md
+++ b/.changeset/mailbox-paging-sync-flash.md
@@ -1,0 +1,6 @@
+---
+'@dxos/react-ui-mosaic': patch
+'@dxos/plugin-inbox': patch
+---
+
+Fix mailbox paging and the list blanking during sync. `usePagination` now keeps the previously-shown page across a query-identity change instead of resetting to empty + loading, and the virtualizer pagination hook re-arms `getNext` after a page lands and no longer misreads a reordered item as an eviction. The mailbox renders a loading spinner in-flow at the end of the list rather than replacing the whole panel.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,9 +118,11 @@ Universal rules. Deeper conventions live in skills — see the pointers below.
 - Prefer named exports; avoid default exports. Use barrel imports.
 - **Never leave compatibility re-exports or shims when moving code.** Update
   every call site to the new location in the same change.
-- Comments state _why_ the code is necessary (the constraint it satisfies), end
-  with a period, and never narrate history or this conversation. JSDoc public
-  functions.
+- Comments state _why_ the code is necessary (the constraint it satisfies) in
+  **one load-bearing clause** — not a multi-sentence essay — end with a period,
+  and never narrate history or this conversation. Delete a comment the code
+  already makes obvious. Audit added comments in your diff before every commit,
+  same as casts. JSDoc public functions. Full rule → `code-style` skill.
 - Prefer ES `#private` over the TypeScript `private` keyword in new code
   (`_private` is fine to keep).
 - No single-letter variable names. Remove/update TODOs as you touch them.
@@ -129,9 +131,9 @@ Universal rules. Deeper conventions live in skills — see the pointers below.
 
 Deeper conventions:
 
-- No-cast rule, namespace-export packages, internal-module imports, class-member
-  ordering, options-bag types, overload syntax, and test structure →
-  `code-style` skill.
+- No-cast rule, comment rule (say why, once), namespace-export packages,
+  internal-module imports, class-member ordering, options-bag types, overload
+  syntax, and test structure → `code-style` skill.
 - ECHO objects, queries, schema, Ref/DXN → `echo` skill.
 - Effect-TS services, layers, and typed domain errors → `effect` skill.
 - React components, theme tokens, and Composer UI primitives → `composer-ui`

--- a/packages/core/echo/echo-react/src/usePagination.test.tsx
+++ b/packages/core/echo/echo-react/src/usePagination.test.tsx
@@ -308,6 +308,48 @@ describe('usePagination', () => {
     });
   });
 
+  test('holds the previous page across a query-identity change instead of blanking', async () => {
+    // Regression test for the mailbox "flash to loading during sync" bug. The Inbox/Sent view
+    // selects by an explicit id set (`Filter.id(...ids)`); each message tagged mid-sync grows that
+    // set, which is a new query identity and rebuilds the internal store. The rebuilt store must
+    // seed from the page already on screen -- keeping it visible with `isLoading` false -- rather
+    // than resetting to empty + loading and blanking the whole list on every sync batch.
+    await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
+    const db = await peer.createDatabase();
+    const feed = db.add(Feed.make({ name: 'tagged' }));
+    await appendPeople(feed, db, 5);
+
+    // Resolve the feed's object ids (newest-first) to build a growing id-set filter, as the mailbox
+    // system-tag view does from its `TagIndex`.
+    const all = await db
+      .query(Query.select(Filter.type(TestSchema.Person)).from(feed).orderBy(Order.natural('desc')))
+      .run();
+    const ids = all.map((person) => person.id);
+
+    const queryFor = (selected: string[]) =>
+      Query.select(Filter.and(Filter.type(TestSchema.Person), Filter.id(...selected)))
+        .from(feed)
+        .orderBy(Order.natural('desc'))
+        .limit(10);
+
+    const { result, rerender } = renderHook(({ query }) => usePagination(db, query), {
+      initialProps: { query: queryFor(ids.slice(0, 3)) },
+    });
+
+    await waitFor(() => expect(result.current.items).toHaveLength(3));
+    expect(result.current.isLoading).toBe(false);
+
+    // A new message gets tagged: the id set grows -> new query identity -> internal store rebuild.
+    rerender({ query: queryFor(ids.slice(0, 5)) });
+
+    // The previously-shown page stays on screen (never empties) and no loading state is surfaced for
+    // this background refresh -- the whole point of the fix. (Pre-fix: items [] and isLoading true.)
+    expect(result.current.items.length).toBeGreaterThan(0);
+    expect(result.current.isLoading).toBe(false);
+
+    await waitFor(() => expect(result.current.items).toHaveLength(5));
+  });
+
   test('pages over whole groups for a grouped query', async () => {
     await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
     const db = await peer.createDatabase();

--- a/packages/core/echo/echo-react/src/usePagination.ts
+++ b/packages/core/echo/echo-react/src/usePagination.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-import { useMemo, useSyncExternalStore } from 'react';
+import { useMemo, useRef, useSyncExternalStore } from 'react';
 
 import { type Database, type Entity, Query } from '@dxos/echo';
 
@@ -68,6 +68,11 @@ const createPaginationStore = <Q extends Query.Any, O>(
   innerAst: Parameters<typeof Query.fromAst>[0],
   pageSize: number,
   initialMaxWindowSize: number,
+  // The page shown by the previous store, handed over when the query *identity* changes (see the
+  // hook's `previousItemsRef`). A live filter whose id set grows -- e.g. a mailbox's system-tag view
+  // gaining members as sync tags them -- rebuilds the store on every batch; seeding from the prior
+  // page keeps that page on screen until the new query delivers, instead of flashing empty + loading.
+  initialItems: O[],
 ) => {
   let maxWindowSize = initialMaxWindowSize;
   let skip = 0;
@@ -76,12 +81,14 @@ const createPaginationStore = <Q extends Query.Any, O>(
   // virtualizer's `onChange` fires once per rendered row) into one range change.
   let rangeChangePending = false;
   let innerUnsubscribe: (() => void) | undefined;
-  // Cleared only on the range's first delivery (never on a timer), so it never sticks true even for
-  // an empty async feed.
-  let isLoading = resource !== undefined;
   // The items currently shown. Held across a range change until the new range delivers its own
-  // results, so the list never flickers to empty while a new (possibly async) range loads.
-  let displayItems: O[] = EMPTY_ARRAY;
+  // results, so the list never flickers to empty while a new (possibly async) range loads. Seeded
+  // from the previous store's page so a query-identity change refreshes in place, not to empty.
+  let displayItems: O[] = initialItems.length > 0 ? initialItems : EMPTY_ARRAY;
+  // Cleared only on the range's first delivery (never on a timer), so it never sticks true even for
+  // an empty async feed. Starts false when seeded: we already have a page to show, so this is a
+  // background refresh, not a first load that should blank the view.
+  let isLoading = resource !== undefined && displayItems.length === 0;
   let snapshot: Snapshot<O> = { items: displayItems, skip, limit, isLoading };
   const listeners = new Set<() => void>();
 
@@ -92,12 +99,16 @@ const createPaginationStore = <Q extends Query.Any, O>(
     }
   };
 
-  // (Re)points the query at the current skip/limit.
+  // (Re)points the query at the current skip/limit. `markLoading` flags a range the user navigated
+  // to (initial load, `getNext`/`getPrevious`, `jumpToHead`) -- one worth surfacing a loading state
+  // for. A seeded background refresh (a query-identity change that handed over a page to show)
+  // passes `false`: the previous page stays visible and `isLoading` stays put, so consumers don't
+  // blank the view for a refresh the user never asked for.
   //
   // TODO(wittjosiah): For feeds, this re-fetches/decodes the whole feed on every range change --
   // only what's rendered is bounded, not what's fetched. Needs index-backed keyset pagination to
   // fix properly.
-  const pointAtRange = () => {
+  const pointAtRange = (markLoading: boolean) => {
     innerUnsubscribe?.();
     innerUnsubscribe = undefined;
 
@@ -113,7 +124,9 @@ const createPaginationStore = <Q extends Query.Any, O>(
     // selection/filter/type -- the entity type this query selects is unchanged from `Q`.
     const effectiveQuery = Query.fromAst(innerAst).skip(skip).limit(limit) as Q;
     const nextQueryResult = resource.query(effectiveQuery);
-    isLoading = true;
+    if (markLoading) {
+      isLoading = true;
+    }
 
     // Publish results and clear `isLoading` only on delivery -- deferred for an async source (a feed
     // served by the index) until its first response, which arrives even when that response is empty.
@@ -137,7 +150,8 @@ const createPaginationStore = <Q extends Query.Any, O>(
     subscribe: (onStoreChange: () => void) => {
       listeners.add(onStoreChange);
       if (listeners.size === 1) {
-        pointAtRange();
+        // Seeded (background identity refresh) → don't surface loading; otherwise it's a first load.
+        pointAtRange(displayItems.length === 0);
       }
       return () => {
         listeners.delete(onStoreChange);
@@ -163,7 +177,7 @@ const createPaginationStore = <Q extends Query.Any, O>(
         limit = maxWindowSize;
         skip += pageSize;
       }
-      pointAtRange();
+      pointAtRange(true);
     },
     getPrevious: () => {
       if (isLoading || rangeChangePending || skip === 0) {
@@ -175,13 +189,13 @@ const createPaginationStore = <Q extends Query.Any, O>(
       // of the oldest loaded items, mirroring getNext's own "slide" branch (taken once it hits
       // maxWindowSize) in the opposite direction.
       skip = Math.max(0, skip - pageSize);
-      pointAtRange();
+      pointAtRange(true);
     },
     jumpToHead: () => {
       rangeChangePending = false;
       skip = 0;
       limit = pageSize;
-      pointAtRange();
+      pointAtRange(true);
     },
   };
 };
@@ -194,8 +208,10 @@ const createPaginationStore = <Q extends Query.Any, O>(
  * The query's `.orderBy(...)` is otherwise untouched, and applies to any query the underlying
  * `Database.Queryable` supports -- e.g. `Order.natural('desc')` for feed insertion order.
  *
- * Keeps showing the previous page while a new one loads: `items` only resets to empty when the
- * query's filter/order/page-size/resource identity changes, not when `skip`/`limit` move.
+ * Keeps showing the previous page while a new one loads -- across both a `skip`/`limit` move and a
+ * query-identity change (filter/order/page-size/resource). The latter rebuilds the internal store;
+ * the last page is handed to the new store as its seed so the view refreshes in place instead of
+ * flashing empty, and `isLoading` stays put (a background refresh isn't a load the user asked for).
  *
  * @example
  * ```tsx
@@ -221,11 +237,24 @@ export const usePagination = <Q extends Query.Any>(
   const innerAstKey = JSON.stringify(innerAst);
   const maxWindowSize = options?.maxWindowSize ?? pageSize * 10;
 
-  // A new store -- and thus a reset to empty -- is only built when "what" is being shown changes:
-  // filter/order (`innerAstKey`), page size, or `resource` (matching `useQuery`, which likewise
-  // keys its memo on `resource` directly rather than just its truthiness).
+  // The page shown right now, carried across store rebuilds so the new store can seed from it (a
+  // query-identity change hands over the visible page rather than resetting to empty). Written on
+  // every render just after the snapshot is read, so the next render's `useMemo` below sees the
+  // page the previous render displayed.
+  const previousItemsRef = useRef<PaginationElement<Q>[]>(EMPTY_ARRAY);
+
+  // A new store is built when "what" is being shown changes: filter/order (`innerAstKey`), page
+  // size, or `resource` (matching `useQuery`, which likewise keys its memo on `resource` directly
+  // rather than just its truthiness). It is seeded from the previous store's page (see above).
   const store = useMemo(
-    () => createPaginationStore<Q, PaginationElement<Q>>(resource, innerAst, pageSize, maxWindowSize),
+    () =>
+      createPaginationStore<Q, PaginationElement<Q>>(
+        resource,
+        innerAst,
+        pageSize,
+        maxWindowSize,
+        previousItemsRef.current,
+      ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [resource, innerAstKey, pageSize],
   );
@@ -235,6 +264,7 @@ export const usePagination = <Q extends Query.Any>(
   store.setMaxWindowSize(maxWindowSize);
 
   const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot);
+  previousItemsRef.current = snapshot.items;
 
   // Stable across renders that don't change `snapshot` (`store`'s own methods are already stable
   // per store identity) -- callers can pass this straight through to a memoized child (e.g. a

--- a/packages/core/echo/echo-react/src/usePagination.ts
+++ b/packages/core/echo/echo-react/src/usePagination.ts
@@ -68,10 +68,8 @@ const createPaginationStore = <Q extends Query.Any, O>(
   innerAst: Parameters<typeof Query.fromAst>[0],
   pageSize: number,
   initialMaxWindowSize: number,
-  // The page shown by the previous store, handed over when the query *identity* changes (see the
-  // hook's `previousItemsRef`). A live filter whose id set grows -- e.g. a mailbox's system-tag view
-  // gaining members as sync tags them -- rebuilds the store on every batch; seeding from the prior
-  // page keeps that page on screen until the new query delivers, instead of flashing empty + loading.
+  // Seed for the visible page, handed over when a query-identity change rebuilds the store, so the
+  // view refreshes in place instead of flashing empty + loading (see the hook's `previousItemsRef`).
   initialItems: O[],
 ) => {
   let maxWindowSize = initialMaxWindowSize;
@@ -81,13 +79,11 @@ const createPaginationStore = <Q extends Query.Any, O>(
   // virtualizer's `onChange` fires once per rendered row) into one range change.
   let rangeChangePending = false;
   let innerUnsubscribe: (() => void) | undefined;
-  // The items currently shown. Held across a range change until the new range delivers its own
-  // results, so the list never flickers to empty while a new (possibly async) range loads. Seeded
-  // from the previous store's page so a query-identity change refreshes in place, not to empty.
+  // Held across a range change (and seeded across an identity change) until the new range delivers,
+  // so the list never flickers to empty while a new (possibly async) range loads.
   let displayItems: O[] = initialItems.length > 0 ? initialItems : EMPTY_ARRAY;
-  // Cleared only on the range's first delivery (never on a timer), so it never sticks true even for
-  // an empty async feed. Starts false when seeded: we already have a page to show, so this is a
-  // background refresh, not a first load that should blank the view.
+  // Cleared on the range's first delivery, never on a timer, so it can't stick true on an empty feed.
+  // False when seeded: a page is already shown, so this is a background refresh, not a first load.
   let isLoading = resource !== undefined && displayItems.length === 0;
   let snapshot: Snapshot<O> = { items: displayItems, skip, limit, isLoading };
   const listeners = new Set<() => void>();
@@ -99,11 +95,9 @@ const createPaginationStore = <Q extends Query.Any, O>(
     }
   };
 
-  // (Re)points the query at the current skip/limit. `markLoading` flags a range the user navigated
-  // to (initial load, `getNext`/`getPrevious`, `jumpToHead`) -- one worth surfacing a loading state
-  // for. A seeded background refresh (a query-identity change that handed over a page to show)
-  // passes `false`: the previous page stays visible and `isLoading` stays put, so consumers don't
-  // blank the view for a refresh the user never asked for.
+  // (Re)points the query at the current skip/limit. `markLoading` is true for a range the user
+  // navigated to (initial load, `getNext`/`getPrevious`, `jumpToHead`); a seeded background refresh
+  // passes false so the previous page stays visible and consumers don't blank on it.
   //
   // TODO(wittjosiah): For feeds, this re-fetches/decodes the whole feed on every range change --
   // only what's rendered is bounded, not what's fetched. Needs index-backed keyset pagination to
@@ -237,10 +231,8 @@ export const usePagination = <Q extends Query.Any>(
   const innerAstKey = JSON.stringify(innerAst);
   const maxWindowSize = options?.maxWindowSize ?? pageSize * 10;
 
-  // The page shown right now, carried across store rebuilds so the new store can seed from it (a
-  // query-identity change hands over the visible page rather than resetting to empty). Written on
-  // every render just after the snapshot is read, so the next render's `useMemo` below sees the
-  // page the previous render displayed.
+  // The page shown right now, carried across a store rebuild to seed the new store. Written just
+  // after the snapshot below, so the next render's `useMemo` sees the previously-displayed page.
   const previousItemsRef = useRef<PaginationElement<Q>[]>(EMPTY_ARRAY);
 
   // A new store is built when "what" is being shown changes: filter/order (`innerAstKey`), page

--- a/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.tsx
+++ b/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.tsx
@@ -8,7 +8,7 @@ import React, { type KeyboardEvent, type MouseEvent, forwardRef, useCallback, us
 
 import type { PaginationResult } from '@dxos/echo-react';
 import { DxAvatar } from '@dxos/lit-ui/react';
-import { Card, ScrollArea } from '@dxos/react-ui';
+import { Card, Icon, ScrollArea } from '@dxos/react-ui';
 import { composable, composableProps } from '@dxos/react-ui';
 import { Focus, Mosaic, type MosaicTileProps, useMosaicContainer } from '@dxos/react-ui-mosaic';
 import { Highlighted, buildSnippet } from '@dxos/react-ui-search';
@@ -85,6 +85,12 @@ export type MessageStackProps = {
    */
   pagination?: PaginationResult<unknown>;
   /**
+   * Renders a spinner in the scroll flow after the last item while a page loads, instead of the
+   * caller blanking the whole list. On an empty list (height 0) it sits at the top — the only thing
+   * shown during a first load — so the list container never gets replaced by a full-panel loader.
+   */
+  loading?: boolean;
+  /**
    * Show the "Ignore sender" tile menu item. Off by default — only the mailbox view handles the
    * `ignore-sender` action, so other consumers (e.g. drafts) must not render a no-op menu item.
    */
@@ -108,6 +114,7 @@ export const MessageStack = composable<HTMLDivElement, MessageStackProps>(
       selectedIds,
       starredAtom,
       pagination,
+      loading,
       enableIgnoreSender,
       enableCreateTopic,
       searchQuery,
@@ -229,6 +236,15 @@ export const MessageStack = composable<HTMLDivElement, MessageStackProps>(
                 gap={4}
                 pagination={pagination}
               />
+              {loading && (
+                <div role='status' className='grid place-items-center pli-2 plb-3'>
+                  <Icon
+                    icon='ph--spinner-gap--regular'
+                    size={5}
+                    classNames='text-subdued [animation:spin_1s_linear_infinite]'
+                  />
+                </div>
+              )}
             </ScrollArea.Viewport>
           </ScrollArea.Root>
         </Mosaic.Container>

--- a/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.tsx
+++ b/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.tsx
@@ -84,11 +84,7 @@ export type MessageStackProps = {
    * destructuring and re-bundling it themselves, which would defeat its referential stability.
    */
   pagination?: PaginationResult<unknown>;
-  /**
-   * Renders a spinner in the scroll flow after the last item while a page loads, instead of the
-   * caller blanking the whole list. On an empty list (height 0) it sits at the top — the only thing
-   * shown during a first load — so the list container never gets replaced by a full-panel loader.
-   */
+  /** Renders a spinner after the last item while a page loads (at the top when the list is empty). */
   loading?: boolean;
   /**
    * Show the "Ignore sender" tile menu item. Off by default — only the mailbox view handles the

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -23,7 +23,7 @@ import { type EntityId } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { useActionRunner } from '@dxos/plugin-graph';
 import { AtomState, useAtomState } from '@dxos/react-hooks';
-import { ElevationProvider, Icon, Panel } from '@dxos/react-ui';
+import { ElevationProvider, Panel } from '@dxos/react-ui';
 import { linkedSegment, useArticleKeyboardNavigation, useSelection } from '@dxos/react-ui-attention';
 import { type EditorController } from '@dxos/react-ui-editor';
 import {
@@ -235,9 +235,14 @@ export const MailboxArticle = ({
   // Flat message list backing keyboard navigation and message-id lookups in action handlers.
   const messages = useMemo(() => items.flatMap((item) => (isMessageGroup(item) ? item.messages : [item])), [items]);
 
-  // Gates on the query settling, not on `messages.length`, so the empty-mailbox panel never renders
-  // mid-load. `source` is only undefined for a free-text view whose feed hasn't resolved yet.
+  // `source` is only undefined for a free-text view whose feed hasn't resolved yet. `isLoading`
+  // covers a page fetch in flight (initial load, paging). It drives an in-flow spinner in the list,
+  // NOT a full-panel fallback: a subsequent-page load — or a background query-identity refresh as
+  // sync tags messages (`usePagination` holds the prior page across it) — must never blank the list.
   const loading = !source || pagination.isLoading;
+  // The empty-mailbox panel shows only once the query has genuinely settled with nothing — never
+  // mid-load — so it can't flash in before the first page (or a refresh) delivers.
+  const showEmptyState = !loading && messages.length === 0;
 
   const handleClear = useCallback(() => {
     setFilterText(filterProp ?? '');
@@ -384,16 +389,12 @@ export const MailboxArticle = ({
         </Menu.Root>
       </ElevationProvider>
       <Panel.Content asChild>
-        {loading ? (
-          // Fade-in delayed 1s so a fast load never flashes the spinner.
-          <div className='grid place-items-center bs-full is-full'>
-            <Icon
-              icon='ph--spinner-gap--regular'
-              size={6}
-              classNames='text-subdued [animation:spin_1s_linear_infinite,fade-in_200ms_ease-out_1s_backwards]'
-            />
-          </div>
-        ) : messages.length > 0 ? (
+        {showEmptyState ? (
+          <InitializeMailbox mailbox={mailbox} />
+        ) : (
+          // Always keep the list mounted (even with no items yet); `loading` renders an in-flow
+          // spinner at the end of the list rather than replacing the whole panel — so a page fetch
+          // or a mid-sync refresh never blanks what's already shown.
           <MessageStack
             id={id}
             items={items}
@@ -401,13 +402,12 @@ export const MailboxArticle = ({
             tagsAtom={tagsAtom}
             starredAtom={starredAtom}
             pagination={pagination}
+            loading={loading}
             enableIgnoreSender
             enableCreateTopic
             searchQuery={searchQuery}
             onAction={handleAction}
           />
-        ) : (
-          <InitializeMailbox mailbox={mailbox} />
         )}
       </Panel.Content>
       {progress && (progress.status === 'running' || progress.status === 'error') && (

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -235,13 +235,10 @@ export const MailboxArticle = ({
   // Flat message list backing keyboard navigation and message-id lookups in action handlers.
   const messages = useMemo(() => items.flatMap((item) => (isMessageGroup(item) ? item.messages : [item])), [items]);
 
-  // `source` is only undefined for a free-text view whose feed hasn't resolved yet. `isLoading`
-  // covers a page fetch in flight (initial load, paging). It drives an in-flow spinner in the list,
-  // NOT a full-panel fallback: a subsequent-page load — or a background query-identity refresh as
-  // sync tags messages (`usePagination` holds the prior page across it) — must never blank the list.
+  // Drives an in-flow spinner in the list, never a full-panel fallback — a page fetch or a
+  // background refresh must not blank the list. `source` is undefined until a free-text feed resolves.
   const loading = !source || pagination.isLoading;
-  // The empty-mailbox panel shows only once the query has genuinely settled with nothing — never
-  // mid-load — so it can't flash in before the first page (or a refresh) delivers.
+  // Show the empty-mailbox panel only once the query has settled with nothing, never mid-load.
   const showEmptyState = !loading && messages.length === 0;
 
   const handleClear = useCallback(() => {

--- a/packages/ui/react-ui-mosaic/package.json
+++ b/packages/ui/react-ui-mosaic/package.json
@@ -87,6 +87,7 @@
     "@dxos/types": "workspace:*",
     "@dxos/ui-theme": "workspace:*",
     "@effect-atom/atom-react": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "effect": "catalog:",

--- a/packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.test.tsx
+++ b/packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.test.tsx
@@ -1,0 +1,105 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Virtualizer } from '@tanstack/react-virtual';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { type VirtualizerPaginationController, useVirtualizerPagination } from './useVirtualizerPagination';
+
+type Item = { id: string };
+
+const getId = (item: Item) => item.id;
+const makeItems = (ids: number[]): Item[] => ids.map((id) => ({ id: String(id) }));
+
+const ROW_HEIGHT = 60;
+const VIEWPORT_HEIGHT = 340;
+
+/**
+ * Minimal fake covering only the fields the hook actually reads off a real `Virtualizer` -- a
+ * genuine type-boundary mock; there's no typed alternative short of driving real DOM layout.
+ */
+const makeVirtualizer = (itemCount: number, lastVisibleIndex: number): Virtualizer<any, any> =>
+  ({
+    getVirtualItems: () => [{ index: lastVisibleIndex }],
+    measurementsCache: Array.from({ length: itemCount }, (_, i) => ({
+      start: i * ROW_HEIGHT,
+      end: i * ROW_HEIGHT + (ROW_HEIGHT - 4),
+    })),
+    scrollOffset: lastVisibleIndex * ROW_HEIGHT,
+    scrollElement: { clientHeight: VIEWPORT_HEIGHT },
+    getTotalSize: () => itemCount * ROW_HEIGHT,
+    scrollToOffset: vi.fn(),
+  }) as unknown as Virtualizer<any, any>;
+
+describe('useVirtualizerPagination', () => {
+  test('chains getNext across a page landing with no further onChange', async () => {
+    // Regression test: once the loaded window's tail is fully rendered and the scrollbar sits at
+    // its physical max, `@tanstack/react-virtual` stops calling `onChange` -- its `maybeNotify` only
+    // fires on `[isScrolling, startIndex, endIndex]` changes, and neither moves just because `items`
+    // did. A `getNext` chain (e.g. a mailbox window sliding once it hits its max size, appending a
+    // page while evicting an equal-sized one from the front) must keep going purely off the `items`
+    // prop changing -- with no further onChange -- or it stalls forever right where it landed.
+    let items = makeItems([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const getNext = vi.fn(() => {
+      items = makeItems([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+    });
+    const pagination: VirtualizerPaginationController = { getNext, atHead: true };
+
+    const { result, rerender } = renderHook(
+      (props: { items: Item[] }) => useVirtualizerPagination({ items: props.items, getId, pagination }),
+      { initialProps: { items } },
+    );
+
+    // The one onChange tanstack fires as the user scrolls to the loaded window's tail: near the
+    // bottom edge, last row visible, and tall enough (10 rows) to exceed the viewport so the
+    // hook's own `isScrollable` check passes.
+    act(() => {
+      result.current.onChange(makeVirtualizer(10, 9));
+    });
+    // `requestNext`'s own `getNext()` call is deferred to a microtask.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getNext).toHaveBeenCalledTimes(1);
+
+    // The data layer resolved and slid the window -- re-render with the new page, but WITHOUT any
+    // further onChange call (tanstack wouldn't fire one: the rendered range hasn't moved).
+    rerender({ items });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The chain must continue on its own: the window is still the same size, so the same geometry
+    // is still "near the bottom" -- the layout effect's re-arm should have requested another page.
+    expect(getNext).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not misclassify a mid-list item reordered to the head as an eviction', () => {
+    // Regression test: a conversation-grouped mailbox bumps an existing (already-loaded) thread to
+    // the head when a new reply lands during sync. A bare `findIndex` match on the new head's id
+    // used to be enough to classify this as an 'evicted' prefix -- reading the bumped item's old
+    // mid-list offset as "evicted" height and growing the leading spacer by a bogus amount that's
+    // never reversed, which is what produced the flashing/jumping during sync.
+    const items = makeItems([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const pagination: VirtualizerPaginationController = {};
+
+    const { result, rerender } = renderHook(
+      (props: { items: Item[] }) => useVirtualizerPagination({ items: props.items, getId, pagination }),
+      { initialProps: { items } },
+    );
+
+    act(() => {
+      result.current.onChange(makeVirtualizer(10, 4));
+    });
+    expect(result.current.leadingSpace).toBe(0);
+
+    // Item '5' (previously mid-list, at index 5) is bumped to the head; everything else keeps its
+    // prior relative order -- exactly the shape a conversation re-sort produces.
+    const reordered = [items[5], ...items.slice(0, 5), ...items.slice(6)];
+    rerender({ items: reordered });
+
+    expect(result.current.leadingSpace).toBe(0);
+  });
+});

--- a/packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.ts
+++ b/packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.ts
@@ -204,11 +204,9 @@ const evictedPrefixHeight = (virtualizer: Virtualizer<any, any>, oldIndexOfNewFi
 };
 
 /**
- * True when `items` is exactly `prevItems` sliced from `oldIndexOfNewFirst`, optionally with new
- * items appended after it -- the shape a genuine slide/eviction/append actually produces. False for
- * anything that reorders retained items (e.g. a conversation bumped to the head by a new reply
- * arriving mid-sync): the bumped item's old mid-list offset would otherwise be misread as "evicted"
- * height, growing the leading spacer by a bogus amount that's never reversed.
+ * True when `items` is `prevItems` sliced from `oldIndexOfNewFirst` (a genuine slide/eviction/append).
+ * False for a reorder -- e.g. a conversation bumped to the head by a mid-sync reply -- whose old
+ * mid-list offset would otherwise be misread as evicted height and grow the spacer for good.
  */
 const isContiguousSlide = <TItem>(
   prevItems: readonly TItem[],
@@ -442,9 +440,8 @@ export const useVirtualizerPagination = <TItem = any>({
       return;
     }
     if (!anchor) {
-      // Evicted/appended (a `getNext` page, or eviction sliding the window), or a caller-driven
-      // `items` change with no front-edge classification (pagination unset) -- no prepend to
-      // correct, but still re-arm: see the hook's own doc comment for why this can't be skipped.
+      // Evicted/appended (a `getNext` page or a slide), or an unclassified change -- no prepend to
+      // correct, but still re-arm (see the hook doc for why this can't be skipped).
       rearmTriggers(virtualizer);
       return;
     }

--- a/packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.ts
+++ b/packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.ts
@@ -204,6 +204,28 @@ const evictedPrefixHeight = (virtualizer: Virtualizer<any, any>, oldIndexOfNewFi
 };
 
 /**
+ * True when `items` is exactly `prevItems` sliced from `oldIndexOfNewFirst`, optionally with new
+ * items appended after it -- the shape a genuine slide/eviction/append actually produces. False for
+ * anything that reorders retained items (e.g. a conversation bumped to the head by a new reply
+ * arriving mid-sync): the bumped item's old mid-list offset would otherwise be misread as "evicted"
+ * height, growing the leading spacer by a bogus amount that's never reversed.
+ */
+const isContiguousSlide = <TItem>(
+  prevItems: readonly TItem[],
+  items: readonly TItem[],
+  oldIndexOfNewFirst: number,
+  getId: GetId<TItem>,
+): boolean => {
+  const overlap = Math.min(items.length, prevItems.length - oldIndexOfNewFirst);
+  for (let index = 0; index < overlap; index++) {
+    if (getId(items[index]) !== getId(prevItems[oldIndexOfNewFirst + index])) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
  * Finds an item retained across a prepend, anchored on its pre-change offset. Scans from the tail
  * (the common case -- a prepend leaves the rest of the window untouched) and doesn't require the
  * item to be currently rendered, since `measurementsCache` covers the whole array.
@@ -233,8 +255,11 @@ type FrontEdgeChange =
  * Classifies how `items` changed at the front, relative to `prevItems`, using only the outgoing
  * window's own measurements (no need to wait for the incoming render). `'evicted'` covers both a
  * prefix eviction (the window slid forward) and a pure append (the window grew) -- either way the
- * item now at the front was already loaded, so its height is already known. `'prepended'` covers
- * everything else (a `getPrevious` prepend, or a reset to a disjoint range).
+ * item now at the front was already loaded, so its height is already known, *and* the retained
+ * items keep their old relative order (`isContiguousSlide`). `'prepended'` covers everything else:
+ * a `getPrevious` prepend, a reset to a disjoint range, or an existing item reordered to the head
+ * (e.g. conversation grouping bumping a thread on a new reply) -- despite the new head having been
+ * loaded before, nothing was actually evicted.
  */
 const classifyFrontEdgeChange = <TItem>(
   prevItems: readonly TItem[] | TItem[] | undefined,
@@ -247,7 +272,7 @@ const classifyFrontEdgeChange = <TItem>(
   }
   const firstNewId = items?.[0] != null ? getId(items[0]) : undefined;
   const oldIndexOfNewFirst = firstNewId != null ? prevItems.findIndex((item) => getId(item) === firstNewId) : -1;
-  if (oldIndexOfNewFirst >= 0) {
+  if (oldIndexOfNewFirst >= 0 && items && isContiguousSlide(prevItems, items, oldIndexOfNewFirst, getId)) {
     return { kind: 'evicted', evictedHeight: evictedPrefixHeight(virtualizer, oldIndexOfNewFirst) };
   }
   const newIds = new Set(items?.map((item) => getId(item)));
@@ -318,10 +343,12 @@ const computePrependCorrection = <TItem>(
  * render measures them; that lag is safe because prepending only ever grows content before the
  * spacer shrinks to match.
  *
- * The layout effect also re-runs `evaluateTriggers`, because `@tanstack/react-virtual` only calls
- * `onChange` when the visible range changes, not merely when `items` does -- while the viewport
- * sits in blank spacer space the range never changes, so relying on `onChange` alone would stall a
- * catch-up chain after one page.
+ * The layout effect also re-runs `evaluateTriggers` on every `items` change, evicted/appended or
+ * prepended alike -- `@tanstack/react-virtual` only calls `onChange` when the visible range (or
+ * `isScrolling`) changes, not merely when `items` does. Once the loaded window's tail is already
+ * fully rendered and the scrollbar sits at its physical max, further scrolling can't move that
+ * range at all, so `onChange` stops firing -- relying on it alone would permanently stall a
+ * `getNext` chain right after its own page lands, before the user scrolls again.
  *
  * Assumes the stack renders with `draggable={false}` (virtual indices map 1:1 onto `items`).
  */
@@ -385,8 +412,9 @@ export const useVirtualizerPagination = <TItem = any>({
       } else if (change.kind === 'prepended') {
         anchorRef.current = change.anchor;
         if (!change.anchor) {
-          // No retained item to anchor on (a disjoint reset): the layout effect below never runs
-          // its own reset for this case, since it bails out early on a null anchor.
+          // No retained item to anchor on (a disjoint reset): the layout effect below still
+          // re-arms triggers for this case, but its own correction/reset is anchor-driven, so
+          // clear the spacer here instead of waiting on it.
           setSpacer(0);
         }
       }
@@ -410,7 +438,14 @@ export const useVirtualizerPagination = <TItem = any>({
     const virtualizer = virtualizerRef.current;
     const anchor = anchorRef.current;
     anchorRef.current = null;
-    if (!virtualizer || !anchor || !items) {
+    if (!virtualizer || !items) {
+      return;
+    }
+    if (!anchor) {
+      // Evicted/appended (a `getNext` page, or eviction sliding the window), or a caller-driven
+      // `items` change with no front-edge classification (pagination unset) -- no prepend to
+      // correct, but still re-arm: see the hook's own doc comment for why this can't be skipped.
+      rearmTriggers(virtualizer);
       return;
     }
     const atHead = triggerState.paginationRef.current?.atHead === true;

--- a/packages/ui/react-ui-mosaic/vite.config.ts
+++ b/packages/ui/react-ui-mosaic/vite.config.ts
@@ -12,5 +12,5 @@ export default defineConfig({
     translations: 'src/translations.ts',
   },
   jsx: 'react',
-  test: { node: true, storybook: true },
+  test: { node: { environment: 'jsdom' }, storybook: true },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2347,7 +2347,7 @@ importers:
         version: 2.3.0(rollup@3.30.0)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vite-plugin-inspect:
         specifier: 'catalog:'
-        version: 12.0.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 12.0.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vite-plugin-top-level-await:
         specifier: 'catalog:'
         version: 1.6.0(@swc/helpers@0.5.17)(rollup@3.30.0)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -2359,7 +2359,7 @@ importers:
         version: 6.1.1(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wait-on:
         specifier: 'catalog:'
         version: 8.0.3
@@ -3930,7 +3930,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/common/effect-zod:
     dependencies:
@@ -3949,7 +3949,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/common/errors: {}
 
@@ -4647,7 +4647,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/common/web-context-solid:
     dependencies:
@@ -4724,7 +4724,7 @@ importers:
         version: 0.29.0(effect@3.21.4)(vitest@4.1.10)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/ai:
     dependencies:
@@ -5048,7 +5048,7 @@ importers:
         version: 0.19.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/assistant-toolkit:
     dependencies:
@@ -5197,7 +5197,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/compute-hyperformula:
     dependencies:
@@ -5328,7 +5328,7 @@ importers:
         version: 0.29.0(effect@3.21.4)(vitest@4.1.10)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/conductor:
     dependencies:
@@ -5453,7 +5453,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/edge-compute:
     dependencies:
@@ -5532,7 +5532,7 @@ importers:
         version: 0.29.0(effect@3.21.4)(vitest@4.1.10)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/extractor:
     dependencies:
@@ -5597,7 +5597,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/functions-runtime-cloudflare:
     dependencies:
@@ -5746,7 +5746,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/mcp-client:
     dependencies:
@@ -5770,7 +5770,7 @@ importers:
         version: 0.36.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.21.4
         version: 3.21.4
@@ -5817,7 +5817,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline:
     dependencies:
@@ -5839,7 +5839,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline-discord:
     dependencies:
@@ -5894,7 +5894,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline-email:
     dependencies:
@@ -5958,7 +5958,7 @@ importers:
         version: 0.16.1
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline-rdf:
     dependencies:
@@ -6031,7 +6031,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline-transcription:
     dependencies:
@@ -6095,7 +6095,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/echo/echo:
     dependencies:
@@ -6609,7 +6609,7 @@ importers:
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/echo/feed:
     dependencies:
@@ -7603,7 +7603,7 @@ importers:
         version: 0.96.2(effect@3.21.4)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/printer':
         specifier: 'catalog:'
         version: 0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4)
@@ -7685,7 +7685,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/devtools/cli-util:
     dependencies:
@@ -7733,7 +7733,7 @@ importers:
         version: 0.96.2(effect@3.21.4)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/printer':
         specifier: 'catalog:'
         version: 0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4)
@@ -7752,7 +7752,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/devtools/devtools:
     dependencies:
@@ -9280,7 +9280,7 @@ importers:
         version: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-brain:
     dependencies:
@@ -10429,7 +10429,7 @@ importers:
         version: 0.75.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@tauri-apps/api':
         specifier: 'catalog:'
         version: 2.11.1
@@ -10593,7 +10593,7 @@ importers:
         version: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-crx:
     dependencies:
@@ -10663,7 +10663,7 @@ importers:
         version: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-debug:
     dependencies:
@@ -14472,7 +14472,7 @@ importers:
         version: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-pwa:
     dependencies:
@@ -14993,7 +14993,7 @@ importers:
         version: 0.29.0(effect@3.21.4)(vitest@4.1.10)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-script:
     dependencies:
@@ -18307,7 +18307,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/reflect/introspect:
     dependencies:
@@ -18350,7 +18350,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/reflect/introspect-mcp:
     dependencies:
@@ -18371,7 +18371,7 @@ importers:
         version: link:../../common/util
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.21.4
         version: 3.21.4
@@ -18390,7 +18390,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/reflect/introspect-tools:
     dependencies:
@@ -18415,7 +18415,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/sdk/app-framework:
     dependencies:
@@ -19850,7 +19850,7 @@ importers:
         version: link:../../common/typings
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/sdk/worker-framework:
     dependencies:
@@ -22756,7 +22756,7 @@ importers:
         version: link:../ui-theme
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.21.4
         version: 3.21.4
@@ -23112,7 +23112,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/ui/react-ui-menu:
     dependencies:
@@ -23304,6 +23304,9 @@ importers:
       '@effect-atom/atom-react':
         specifier: 'catalog:'
         version: 0.5.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)(react@19.2.7)(scheduler@0.27.0)
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ~19.2.17
         version: 19.2.17
@@ -24751,7 +24754,7 @@ importers:
         version: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   tools/vite-plugin-log/example:
     devDependencies:
@@ -28526,6 +28529,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -44038,6 +44042,7 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
+      vite: '>=8.1.4'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -46330,7 +46335,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 4.20260714.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wrangler: 4.112.0(@cloudflare/workers-types@5.20260719.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -49482,11 +49487,11 @@ snapshots:
       gonzales-pe: 4.3.0
       node-source-walk: 7.0.1
 
-  '@devframes/hub@0.6.0(devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3))':
+  '@devframes/hub@0.6.0(devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3))':
     dependencies:
       birpc: 4.0.0
       destr: 2.0.5
-      devframe: 0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3)
+      devframe: 0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3)
       nostics: 1.1.4
       pathe: 2.0.3
       perfect-debounce: 2.1.0
@@ -49682,7 +49687,7 @@ snapshots:
       effect: 3.21.4
       multipasta: 0.2.7
 
-  '@effect/platform-bun@0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)':
+  '@effect/platform-bun@0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)':
     dependencies:
       '@effect/cluster': 0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/platform': 0.96.2(effect@3.21.4)
@@ -49787,7 +49792,7 @@ snapshots:
   '@effect/vitest@0.29.0(effect@3.21.4)(vitest@4.1.10)':
     dependencies:
       effect: 3.21.4
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@effect/wa-sqlite@0.1.2': {}
 
@@ -50929,7 +50934,7 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.2)
       ajv: 8.18.0
@@ -54119,7 +54124,7 @@ snapshots:
       '@vitest/browser': 4.1.10(patch_hash=a986f87598d00b4753574afb9fcad1a84d9b0145eaf80189a0b49d32b7af569a)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/browser-playwright': 4.1.10(playwright@1.57.0)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/runner': 4.1.10
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -55696,10 +55701,10 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitejs/devtools-kit@0.4.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/devtools-kit@0.4.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@devframes/hub': 0.6.0(devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3))
-      devframe: 0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3)
+      '@devframes/hub': 0.6.0(devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3))
+      devframe: 0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3)
       mlly: 1.8.2
       nostics: 1.1.4
       vite: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -55732,7 +55737,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -55745,7 +55750,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -55762,7 +55767,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -55779,7 +55784,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -55800,9 +55805,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(patch_hash=a986f87598d00b4753574afb9fcad1a84d9b0145eaf80189a0b49d32b7af569a)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(patch_hash=a986f87598d00b4753574afb9fcad1a84d9b0145eaf80189a0b49d32b7af569a)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.10)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -55881,7 +55886,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -56843,7 +56848,7 @@ snapshots:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@cloudflare/ai-chat': 0.0.6(agents@0.3.10)(ai@6.0.97(zod@4.3.6))(react@19.2.7)(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 6.0.97(zod@4.3.6)
       cron-schedule: 6.0.0
       escape-html: 1.0.3
@@ -59189,7 +59194,7 @@ snapshots:
 
   devalue@5.6.3: {}
 
-  devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3):
+  devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3):
     dependencies:
       '@valibot/to-json-schema': 1.7.1(valibot@1.4.2(typescript@6.0.3))
       birpc: 4.0.0
@@ -59203,7 +59208,7 @@ snapshots:
       ufo: 1.6.4
       valibot: 1.4.2(typescript@6.0.3)
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
     transitivePeerDependencies:
       - srvx
       - typescript
@@ -69014,9 +69019,9 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-inspect@12.0.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-plugin-inspect@12.0.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      '@vitejs/devtools-kit': 0.4.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitejs/devtools-kit': 0.4.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ansis: 4.3.1
       error-stack-parser-es: 2.0.1
       obug: 2.1.3
@@ -69187,7 +69192,7 @@ snapshots:
     optionalDependencies:
       vite: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -69218,20 +69223,9 @@ snapshots:
       happy-dom: 20.7.0
       jsdom: 29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
-  vitest@4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
+  vitest@4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -69262,18 +69256,7 @@ snapshots:
       happy-dom: 20.7.0
       jsdom: 29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   void-elements@3.1.0: {}
 


### PR DESCRIPTION
Closes DX-1132.

## Problem

Two symptoms from the ticket:
1. **Mailbox paging stops working** — scrolling to the end of the loaded window never loads more.
2. **The list flashes/blanks during sync** — while messages stream in, the whole message list disappears for stretches (confirmed via a screen recording of the real Inbox).

## Root causes & fixes

**`usePagination` reset to empty + loading on every query-identity change** (`packages/core/echo/echo-react/src/usePagination.ts`)
A regular sync churns the mailbox query identity, which rebuilt the internal store and reset it to `isLoading: true` + empty — blanking the list on every sync batch. The rebuilt store is now **seeded from the previously-shown page** (keep-previous-data) and treats the rebuild as a background refresh, so the view refreshes in place instead of flashing empty. This is the core fix for the recording.

**`useVirtualizerPagination` never re-armed `getNext`** (`packages/ui/react-ui-mosaic/src/hooks/useVirtualizerPagination.ts`)
Once the loaded window's tail was rendered, `@tanstack/react-virtual` stops firing `onChange`, and only the prepend/`getPrevious` path re-armed triggers on an `items` change. The evicted/append (`getNext`) path now re-arms too, so pagination keeps chaining.

**`useVirtualizerPagination` misclassified a reorder as an eviction** (same file)
A thread bumped to the head by a new reply mid-sync was read as a prefix eviction, growing the leading spacer by a bogus, never-reversed amount (a cumulative downward drift). Eviction now requires the retained items to be contiguous with the prior window (`isContiguousSlide`); a reorder falls through to the correct prepend path.

**`MailboxArticle` blanked the whole panel on `isLoading`** (`packages/plugins/plugin-inbox/...`)
A subsequent-page load (or a background refresh) replaced the entire panel with a spinner. It now keeps the list mounted and renders a spinner **in-flow at the end of the list** (which sits at the top when the list is empty); the empty-mailbox panel shows only once the query has genuinely settled empty (`showEmptyState`). `MessageStack` gained a `loading` prop for the in-flow footer spinner.

## Tests

- `echo-react`: new test that a query-identity change holds the previous page instead of blanking.
- `react-ui-mosaic`: new tests for the `getNext` re-arm and the reorder-not-eviction cases (added jsdom env + `@testing-library/react` to the package's test project — it had no unit tests before).
- Each regression test was verified to fail without its fix.
- Full suites pass locally: echo-react 37, react-ui-mosaic 2, plugin-inbox 216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mailbox paging during synchronization no longer flashes an empty state; the previously displayed messages remain visible across query identity changes.
  * Inline loading now appears within the virtualized message area (including when the list is empty) and the mailbox panel is no longer unmounted/replaced during page fetches or mid-sync refreshes.
  * Virtualized pagination/scrolling is more resilient to reordered items and maintains smooth “load next” behavior at scroll limits.
* **Tests**
  * Added regression coverage for pagination behavior during query refreshes, pagination chaining, and reordering edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->