### PR TITLE
docs: add Trunk flaky-test quarantine guide + agent skill

### DIFF
--- a/.agents/skills/trunk-quarantine/SKILL.md
+++ b/.agents/skills/trunk-quarantine/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: trunk-quarantine
+description: >-
+  Use Trunk's CI Autopilot MCP server to investigate a failing CI run,
+  find/diagnose a flaky test, and quarantine it. Use when a CI run is red
+  and might be flaky, or when asked to quarantine/investigate a specific test.
+---
+
+# Trunk flaky-test quarantining
+
+CI already uploads test results to Trunk, which detects flaky tests
+statistically and quarantines (auto-skips) them instead of letting them block
+merges — no upload setup is needed. The `trunk` MCP server ("CI Autopilot") is
+already configured for this repo; each user just needs a one-time
+per-user authentication. See [REPOSITORY_GUIDE.md](../../../REPOSITORY_GUIDE.md#trunk-flaky-test-quarantining--ci-autopilot)
+for the auth steps if `trunk` tools aren't available yet.
+
+## Investigating a failing CI run
+
+Given a GitHub Actions workflow URL (e.g. from `gh run view` or a PR check),
+call `investigate-ci-failure` with that `workflowUrl`. It:
+
+- Pulls Trunk's parsed test-result bundles for that run.
+- Filters out tests already quarantined as known-flaky, so you only see real
+  failures.
+- Tells you if the job failed before tests ran (build/compile failure) — in
+  that case fall back to raw CI logs (`gh run view <id> --log-failed`).
+
+Prefer this over reading raw CI logs first when the repo has Trunk uploads
+configured — it does the flaky-vs-real triage for you.
+
+## Quarantining a specific flaky test
+
+Do this whenever you've identified a test as flaky (from `investigate-ci-failure`,
+a user report, or repeated unrelated CI failures) and want it stopped from
+blocking merges.
+
+1. **Find the test case ID**, if you don't already have one:
+   call `search-test` with a fuzzy `testNameSearch` and the `repoName`
+   (`owner/repo`).
+2. **Get evidence it's actually flaky** before quarantining — call
+   `fix-flaky-test` with the `testCaseId`:
+   - Omit `createNewInvestigation` to fetch the latest existing investigation
+     (ID, markdown summary, rendered facts).
+   - Pass `createNewInvestigation: true` to enqueue a fresh manual
+     investigation if there's no recent one, or if the failure looks
+     different from what's on file.
+   - If you already have an investigation ID, pass `investigationId` directly
+     instead of a test case ID.
+3. **Quarantine it.** No MCP tool performs this write — it's a dashboard-only
+   action, gated by the repo's Manual Quarantine Permissions (admins-only in
+   some repos). So:
+   - Check whether the `fix-flaky-test` result includes a direct link to the
+     test's Trunk dashboard page — surface it to the user.
+   - Tell the user (or, if you have permission and are asked to do it
+     yourself via a connected browser, do it) to open the test's details page
+     and click **Quarantine → Always**, add a required comment, and **Save**.
+     See [REPOSITORY_GUIDE.md](../../../REPOSITORY_GUIDE.md#manually-quarantining-a-test)
+     for the exact dashboard steps (details-page and table-row variants, plus
+     how to un-quarantine).
+   - Never report a test as "quarantined" until the user confirms the
+     dashboard action was completed — there's no way to verify or perform the
+     write through these tools.
+
+## Notes
+
+- `repoName` is always `owner/repo` (GitHub), not the Trunk org slug.
+- `orgSlug` is optional on most tools — only needed to disambiguate when the
+  authenticated user belongs to multiple Trunk orgs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,10 @@ Deeper conventions:
 - **Skills** (`.agents/skills/*`) — deep, task-specific how-to. Follow the
   relevant skill for the area you're working in (echo, effect, composer-ui,
   operations, testing, code-style, submit-pr, land, …).
+- **Flaky test quarantining** — investigating a flaky/red CI run or setting up
+  Trunk test uploads → `trunk-quarantine` skill
+  (`.agents/skills/trunk-quarantine/SKILL.md`); adding the Trunk MCP server →
+  `REPOSITORY_GUIDE.md`.
 - **`REPOSITORY_GUIDE.md`** — toolchain setup, prerequisites, and how to run
   apps/services (Composer, Tasks, Docs).
 - **`OPS_GUIDE.md`** / **`TROUBLESHOOTING.md`** — operations and common issues.

--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -301,6 +301,40 @@ Examples:
 
 See [CI docs](./.github/workflows/README.md).
 
+## Trunk (flaky test quarantining / CI Autopilot)
+
+CI already uploads test results to [Trunk](https://trunk.io), which detects
+flaky tests and quarantines (auto-skips) them instead of letting them block
+merges. The org-wide Trunk MCP server ("CI Autopilot") is already configured
+for this repo — it just needs a one-time per-user authentication:
+
+```bash
+claude mcp add --transport http trunk https://mcp.trunk.io/mcp --scope project
+```
+
+Then run `claude .`, run `/mcp`, select `trunk`, and hit Enter to authenticate
+with your own Trunk account.
+
+For how an agent should use the server's tools (investigating a CI failure,
+looking up a flaky test), see the `trunk-quarantine` agent skill
+(`.agents/skills/trunk-quarantine/SKILL.md`).
+
+### Manually quarantining a test
+
+Quarantining is a dashboard-only action — there's no CLI or config-file way to
+do it, and it's gated by each repo's **Manual Quarantine Permissions** setting
+(**Settings → Repositories → [repo] → Flaky Tests**), so admins may need to do
+this step.
+
+- **From a test's details page:** click **Quarantine**, choose **Always** in
+  the quarantine-status control, add a required comment, then **Save**.
+- **From the Flaky Tests table:** open the row's **⋮** actions menu and select
+  **Quarantine test**.
+
+To reverse it, use the same controls: **Remove Quarantine** on the details
+page, or **Unquarantine test** from the table's actions menu. Every override
+is logged in the test's **Events** tab (author, timestamp, comment).
+
 ## Patching third-party repos
 
 1. Clone and fork the third-party repo then maked edits and build


### PR DESCRIPTION
## Summary

- **`REPOSITORY_GUIDE.md`**: documents that the Trunk MCP server ("CI Autopilot") is already connected org-wide and only needs a one-time per-user auth (`claude mcp add ... && /mcp`), plus concise steps for **manually quarantining a test** via the Trunk dashboard (test-details page and Flaky Tests table variants, and how to un-quarantine).
- **`.agents/skills/trunk-quarantine/SKILL.md`** (new): agent-facing instructions for using the `trunk` MCP tools — investigating a failing CI run (`investigate-ci-failure`), finding a test (`search-test`), gathering flakiness evidence (`fix-flaky-test`), and then quarantining it. Explicitly calls out that quarantining itself is a dashboard-only write with no MCP tool to perform it, so the agent should surface the dashboard link/steps to the user and never claim a test is quarantined without confirmation.
- **`AGENTS.md`**: pointer to the new skill under "Where things live".

## Why

We didn't have any repo guidance on Trunk flaky-test quarantining — neither how to connect to the already-configured MCP server nor how to manually quarantine a test from the dashboard. This also gives agents clear, accurate instructions instead of assuming a quarantine action can be done through MCP tools (it can't — quarantining is dashboard-only and permission-gated).

## Test plan

- [x] Docs-only change — no build/test/lint impact.
- [ ] Reviewer sanity-check: dashboard steps and MCP tool names match current Trunk behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for investigating CI failures and quarantining flaky tests.
  * Documented Trunk CI Autopilot setup, authentication, and dashboard workflows.
  * Added instructions for manually quarantining and restoring tests.
  * Added repository pointers to the new flaky-test handling documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->