### PR TITLE
ci: give storybook vitest teardown more time before declaring a hung close

### DIFF
--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -357,6 +357,11 @@ export const createConfig = (options: ConfigOptions): ViteUserConfig => {
     test: {
       ...resolveReporterConfig(dirname),
       tags: TEST_TAGS,
+      // Closing a storybook project's chromium instance (ECHO/WASM-SQLite teardown, many
+      // mounted components) occasionally exceeds vitest's 10s default, logging "close timed
+      // out" and force-exiting — CI sees this as a failed task despite every test passing.
+      // Give it more real time before giving up.
+      teardownTimeout: 30_000,
       projects: [nodeProject, storybookProject, ...browserProjects, workerdProject].filter(
         (project): project is UserWorkspaceConfig => project !== undefined,
       ),
@@ -807,6 +812,11 @@ const buildTestConfig = (
     // node tests, WebSocket birpc errors from the storybook runner) — these surface as
     // non-zero exits with no actual test failures and turn the entire job red.
     dangerouslyIgnoreUnhandledErrors: true,
+    // Closing a storybook project's chromium instance (ECHO/WASM-SQLite teardown, many
+    // mounted components) occasionally exceeds vitest's 10s default, logging "close timed
+    // out" and force-exiting — CI sees this as a failed task despite every test passing.
+    // Give it more real time before giving up.
+    teardownTimeout: 30_000,
     projects: [nodeProject, storybookProject, ...browserProjects, workerdProject].filter(
       (project): project is UserWorkspaceConfig => project !== undefined,
     ),


### PR DESCRIPTION
## Summary

The `storybook` job of the `Check` workflow [failed on `main`](https://github.com/dxos/dxos/actions/runs/29938055452) even though every story test passed (Trunk's own report: 194/194, 100%).

## Root cause

- `stories-inbox:test-storybook` logged vitest's `close timed out after 10000ms` / `Tests closed successfully but something prevents the main process from exiting`, and the task exited non-zero — reddening the whole `storybook` job despite zero failing assertions.
- This is a **pre-existing, intermittent flake**, not a regression from the merged commit (`inbox: keep threadless messages in the mailbox and fix the reply e2e helper`, #12306). The [immediately preceding `main` run](https://github.com/dxos/dxos/actions/runs/29920457897) hit the *identical* `close timed out after 10000ms` hang, for both `stories-inbox` **and** `stories-assistant` — it just stayed hidden there because a separate, real bug (`MailboxArticle › Search Filter`) also failed that run, which #12306 correctly fixed. With that real bug gone, this teardown flake is now the only thing left, and it's enough on its own to fail the job.
- Neither of the affected packages' code changed in #12306, and moon's own task retries (`retryCount: 2`, confirmed working — a different package flaked and recovered on retry in the same run) never got a chance to kick in for this failure mode.
- This flake sits in the same family as two mitigations already in `vite.base.config.ts`'s storybook project config (`retry: 1` for a dying chromium session, `dangerouslyIgnoreUnhandledErrors: true` for WebSocket birpc teardown rejections) — it's a third variant not yet covered.

## Fix

Raise vitest's `teardownTimeout` (default 10s) for the storybook/browser test config so a slow-but-harmless chromium close (ECHO/WASM-SQLite teardown, many mounted components) has more real time before vitest gives up and force-exits. Applied in both `buildTestConfig` (the current `defineConfig` path used by `stories-inbox`, `stories-assistant`, and all other affected packages) and the legacy `createConfig` shim, for consistency.

## Testing

- `pnpm format` — clean, no additional changes.
- Ad-hoc `tsc` pass over the touched file shows no new type errors (pre-existing errors are unrelated environment/path-resolution noise from running outside `moon`'s build graph).
- Could not reproduce the hang locally in this sandbox (network-restricted; `moon`'s build graph and browser dependencies aren't available), so this is a config-level mitigation based on the reproduced log signature across two separate `main` runs rather than a locally-verified fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYn5rNbvoavvUjHxmGtAb1


---
_Generated by [Claude Code](https://claude.ai/code/session_01EYn5rNbvoavvUjHxmGtAb1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the Storybook test teardown timeout to help prevent false failures in CI when cleanup takes longer than expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->