### PR TITLE
deck: plank toolbar breadcrumbs

### DIFF
--- a/.changeset/deck-plank-breadcrumbs.md
+++ b/.changeset/deck-plank-breadcrumbs.md
@@ -1,0 +1,6 @@
+---
+'@dxos/plugin-deck': minor
+'@dxos/react-ui': patch
+---
+
+Deck plank toolbars now render an ancestor breadcrumb trail (derived from the plank's qualified graph path) with navigable crumbs, and the Breadcrumb primitive lays out as a single horizontally-scrolling row.

--- a/packages/plugins/plugin-deck/src/components/Plank/Plank.stories.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/Plank.stories.tsx
@@ -18,6 +18,7 @@ import { withAttention } from '@dxos/react-ui-attention/testing';
 import { Syntax } from '@dxos/react-ui-syntax-highlighter';
 import { Loading, withLayout, withTheme } from '@dxos/react-ui/testing';
 import { Organization, Person } from '@dxos/types';
+import { mx } from '@dxos/ui-theme';
 
 import { DeckState, OperationHandler } from '#capabilities';
 import { meta as pluginMeta } from '#meta';
@@ -85,6 +86,41 @@ const DefaultStory = () => {
   );
 };
 
+// A plank whose toolbar renders an ancestor breadcrumb trail; click a crumb to navigate.
+const BreadcrumbsStory = () => {
+  const [organization] = useMemo(() => [Organization.make({ name: random.company.name() })], []);
+  const organizationNode = useNode(organization, 'ph--building-office--regular');
+  const breadcrumbs = useMemo<Node.Node[]>(
+    () => [
+      {
+        id: 'root/registry',
+        type: 'test',
+        data: null,
+        properties: { label: 'Plugins', icon: 'ph--squares-four--regular' },
+      },
+      {
+        id: 'root/registry/companies',
+        type: 'test',
+        data: null,
+        properties: { label: 'Companies', icon: 'ph--buildings--regular' },
+      },
+      organizationNode,
+    ],
+    [organizationNode],
+  );
+
+  return (
+    <div className='flex h-full gap-3 p-3 bg-deck-surface'>
+      <Plank
+        node={organizationNode}
+        breadcrumbs={breadcrumbs}
+        onNavigate={(id) => console.log('navigate', id)}
+        classNames={mx(PLANK_CLASSNAMES, 'is-[40rem]')}
+      />
+    </div>
+  );
+};
+
 const meta: Meta = {
   title: 'plugins/plugin-deck/components/Plank',
   decorators: [
@@ -101,3 +137,5 @@ export default meta;
 type Story = StoryObj;
 
 export const Default: Story = { render: () => <DefaultStory /> };
+
+export const Breadcrumbs: Story = { render: () => <BreadcrumbsStory /> };

--- a/packages/plugins/plugin-deck/src/components/Plank/Plank.stories.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/Plank.stories.tsx
@@ -85,9 +85,24 @@ const Story = ({ breadcrumbs }: StoryArgs) => {
   // Synthetic ancestor chain (structural nodes carry no data); the ECHO object is the leaf.
   const trail = useMemo<Node.Node[]>(
     () => [
-      { id: 'root/registry', type: 'test', data: null, properties: { label: 'Plugins', icon: 'ph--squares-four--regular' } },
-      { id: 'root/registry/companies', type: 'test', data: null, properties: { label: 'Companies', icon: 'ph--buildings--regular' } },
-      { id: 'root/registry/companies/west-coast', type: 'test', data: null, properties: { label: 'West Coast Region', icon: 'ph--map-pin--regular' } },
+      {
+        id: 'root/registry',
+        type: 'test',
+        data: null,
+        properties: { label: 'Plugins', icon: 'ph--squares-four--regular' },
+      },
+      {
+        id: 'root/registry/companies',
+        type: 'test',
+        data: null,
+        properties: { label: 'Companies', icon: 'ph--buildings--regular' },
+      },
+      {
+        id: 'root/registry/companies/west-coast',
+        type: 'test',
+        data: null,
+        properties: { label: 'West Coast Region', icon: 'ph--map-pin--regular' },
+      },
       organizationNode,
     ],
     [organizationNode],

--- a/packages/plugins/plugin-deck/src/components/Plank/Plank.stories.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/Plank.stories.tsx
@@ -69,8 +69,12 @@ const useNode = (data: Obj.Any, icon: string): Node.Node =>
     [data, icon],
   );
 
-// Two planks side by side; focus either to move attention (sigil/title take the accent color).
-const DefaultStory = () => {
+type StoryArgs = {
+  /** Render the leaf plank's toolbar as an ancestor breadcrumb trail (narrowed to demonstrate scrolling). */
+  breadcrumbs?: boolean;
+};
+
+const Story = ({ breadcrumbs }: StoryArgs) => {
   const [organization, person] = useMemo(
     () => [Organization.make({ name: random.company.name() }), Person.make({ fullName: random.person.fullName() })],
     [],
@@ -78,6 +82,34 @@ const DefaultStory = () => {
   const organizationNode = useNode(organization, 'ph--building-office--regular');
   const personNode = useNode(person, 'ph--user--regular');
 
+  // Synthetic ancestor chain (structural nodes carry no data); the ECHO object is the leaf.
+  const trail = useMemo<Node.Node[]>(
+    () => [
+      { id: 'root/registry', type: 'test', data: null, properties: { label: 'Plugins', icon: 'ph--squares-four--regular' } },
+      { id: 'root/registry/companies', type: 'test', data: null, properties: { label: 'Companies', icon: 'ph--buildings--regular' } },
+      { id: 'root/registry/companies/west-coast', type: 'test', data: null, properties: { label: 'West Coast Region', icon: 'ph--map-pin--regular' } },
+      organizationNode,
+    ],
+    [organizationNode],
+  );
+
+  // Narrow plank so the trail overflows and the toolbar scrolls horizontally.
+  if (breadcrumbs) {
+    return (
+      <div className='flex h-full gap-3 p-3 bg-deck-surface'>
+        <div className='flex h-full shrink-0' style={{ inlineSize: 320 }}>
+          <Plank
+            node={organizationNode}
+            breadcrumbs={trail}
+            onNavigate={(id) => console.log('navigate', id)}
+            classNames={mx(PLANK_CLASSNAMES, 'grow')}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // Two planks side by side; focus either to move attention (sigil/title take the accent color).
   return (
     <div className='flex h-full gap-3 p-3 bg-deck-surface'>
       <Plank node={organizationNode} classNames={PLANK_CLASSNAMES} />
@@ -86,43 +118,9 @@ const DefaultStory = () => {
   );
 };
 
-// A plank whose toolbar renders an ancestor breadcrumb trail; click a crumb to navigate.
-const BreadcrumbsStory = () => {
-  const [organization] = useMemo(() => [Organization.make({ name: random.company.name() })], []);
-  const organizationNode = useNode(organization, 'ph--building-office--regular');
-  const breadcrumbs = useMemo<Node.Node[]>(
-    () => [
-      {
-        id: 'root/registry',
-        type: 'test',
-        data: null,
-        properties: { label: 'Plugins', icon: 'ph--squares-four--regular' },
-      },
-      {
-        id: 'root/registry/companies',
-        type: 'test',
-        data: null,
-        properties: { label: 'Companies', icon: 'ph--buildings--regular' },
-      },
-      organizationNode,
-    ],
-    [organizationNode],
-  );
-
-  return (
-    <div className='flex h-full gap-3 p-3 bg-deck-surface'>
-      <Plank
-        node={organizationNode}
-        breadcrumbs={breadcrumbs}
-        onNavigate={(id) => console.log('navigate', id)}
-        classNames={mx(PLANK_CLASSNAMES, 'is-[40rem]')}
-      />
-    </div>
-  );
-};
-
-const meta: Meta = {
+const meta: Meta<StoryArgs> = {
   title: 'plugins/plugin-deck/components/Plank',
+  render: (args) => <Story {...args} />,
   decorators: [
     withPluginManager({ plugins: [...corePlugins(), TestPlugin()], capabilities: [TestExtension] }),
     withAttention(),
@@ -134,8 +132,12 @@ const meta: Meta = {
 
 export default meta;
 
-type Story = StoryObj;
+type StoryObject = StoryObj<StoryArgs>;
 
-export const Default: Story = { render: () => <DefaultStory /> };
+export const Default: StoryObject = {
+  args: { breadcrumbs: false },
+};
 
-export const Breadcrumbs: Story = { render: () => <BreadcrumbsStory /> };
+export const Breadcrumbs: StoryObject = {
+  args: { breadcrumbs: true },
+};

--- a/packages/plugins/plugin-deck/src/components/Plank/Plank.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/Plank.tsx
@@ -74,14 +74,14 @@ const PlankBreadcrumbs = ({ nodes, attendableId, related, onNavigate }: PlankBre
   const label = (node: Node.Node) => toLocalizedString(node.properties?.label ?? '', t);
   const current = nodes[nodes.length - 1];
   return (
-    <Breadcrumb.Root aria-label={label(current)} classNames='min-w-0 grow overflow-hidden'>
-      <Breadcrumb.List classNames='flex items-center gap-1 min-w-0 grow'>
+    <Breadcrumb.Root aria-label={label(current)} classNames='ps-2'>
+      <Breadcrumb.List classNames='flex items-center gap-1'>
         {nodes.slice(0, -1).map((node) => (
           <Fragment key={node.id}>
-            <Breadcrumb.ListItem classNames='min-w-0'>
+            <Breadcrumb.ListItem asChild>
               <button
                 type='button'
-                className='truncate text-description hover:text-base-fg'
+                className='shrink-0 whitespace-nowrap text-description hover:text-base-fg'
                 onClick={() => onNavigate?.(node.id)}
               >
                 {label(node)}
@@ -90,8 +90,8 @@ const PlankBreadcrumbs = ({ nodes, attendableId, related, onNavigate }: PlankBre
             <Breadcrumb.Separator />
           </Fragment>
         ))}
-        <Breadcrumb.ListItem classNames='min-w-0'>
-          <Pane.Title attendableId={attendableId} related={related}>
+        <Breadcrumb.ListItem>
+          <Pane.Title attendableId={attendableId} related={related} classNames='w-auto grow-0'>
             {label(current)}
           </Pane.Title>
         </Breadcrumb.ListItem>

--- a/packages/plugins/plugin-deck/src/components/Plank/Plank.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/Plank.tsx
@@ -14,7 +14,7 @@ import React, {
 import { Surface } from '@dxos/app-framework/ui';
 import { AppSurface, AttentionSigil, type AttentionSigilAction } from '@dxos/app-toolkit/ui';
 import { type Node } from '@dxos/plugin-graph';
-import { Icon, Popover, type ThemedClassName, toLocalizedString, useTranslation } from '@dxos/react-ui';
+import { Breadcrumb, Icon, Popover, type ThemedClassName, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { useAttentionAttributes } from '@dxos/react-ui-attention';
 
 import { meta } from '#meta';
@@ -25,11 +25,15 @@ type SurfaceProps = ComponentProps<typeof Surface.Surface>;
 
 export type PlankProps = ThemedClassName<{
   node: Node.Node;
+  /** Ancestor chain (outermost → leaf); when it has more than one entry the title renders as breadcrumbs. */
+  breadcrumbs?: Node.Node[];
   /** Attendable id; defaults to the node id. */
   attendableId?: string;
   /** Grouped sigil menu actions; when present the sigil opens a menu, otherwise it is a plain button. */
   actions?: AttentionSigilAction[][];
   onAction?: (action: AttentionSigilAction) => void;
+  /** Navigate to an ancestor breadcrumb. */
+  onNavigate?: (id: string) => void;
   /** Toolbar controls rendered after the title (e.g. close/solo/fullscreen). */
   controls?: ReactNode;
   /** Toolbar content rendered between the title and the controls (e.g. a NavbarEnd surface). */
@@ -54,6 +58,48 @@ export type PlankProps = ThemedClassName<{
   onKeyDown?: KeyboardEventHandler<HTMLDivElement>;
 }>;
 
+type PlankBreadcrumbsProps = {
+  nodes: Node.Node[];
+  attendableId: string;
+  related?: boolean;
+  onNavigate?: (id: string) => void;
+};
+
+/**
+ * Renders the ancestor chain as a breadcrumb trail: every node but the last is a link that navigates
+ * to that ancestor; the last (the plank's own node) is the current, non-interactive crumb.
+ */
+const PlankBreadcrumbs = ({ nodes, attendableId, related, onNavigate }: PlankBreadcrumbsProps) => {
+  const { t } = useTranslation(meta.profile.key);
+  const label = (node: Node.Node) => toLocalizedString(node.properties?.label ?? '', t);
+  const current = nodes[nodes.length - 1];
+  return (
+    <Breadcrumb.Root aria-label={label(current)} classNames='min-w-0 grow overflow-hidden'>
+      <Breadcrumb.List classNames='flex items-center gap-1 min-w-0 grow'>
+        {nodes.slice(0, -1).map((node) => (
+          <Fragment key={node.id}>
+            <Breadcrumb.ListItem classNames='min-w-0'>
+              <button
+                type='button'
+                className='truncate text-description hover:text-base-fg'
+                onClick={() => onNavigate?.(node.id)}
+              >
+                {label(node)}
+              </button>
+            </Breadcrumb.ListItem>
+            <Breadcrumb.Separator />
+          </Fragment>
+        ))}
+        <Breadcrumb.ListItem classNames='min-w-0'>
+          <Pane.Title attendableId={attendableId} related={related}>
+            {label(current)}
+          </Pane.Title>
+        </Breadcrumb.ListItem>
+      </Breadcrumb.List>
+    </Breadcrumb.Root>
+  );
+};
+
 /**
  * A higher-level deck pane bound to a graph {@link Node}: renders the node's sigil, title and content
  * Surface inside a {@link Pane}, and makes itself the node's attendable region. Toolbar controls
@@ -65,9 +111,11 @@ export const Plank = forwardRef<HTMLDivElement, PlankProps>(
     {
       classNames,
       node,
+      breadcrumbs,
       attendableId = node.id,
       actions,
       onAction,
+      onNavigate,
       controls,
       navbarEnd,
       sigilFooter,
@@ -124,9 +172,18 @@ export const Plank = forwardRef<HTMLDivElement, PlankProps>(
                 </Pane.Sigil>
               )}
             </ActionRoot>
-            <Pane.Title attendableId={attendableId} related={related} classNames={pending && 'text-description'}>
-              {label}
-            </Pane.Title>
+            {breadcrumbs && breadcrumbs.length > 1 ? (
+              <PlankBreadcrumbs
+                nodes={breadcrumbs}
+                attendableId={attendableId}
+                related={related}
+                onNavigate={onNavigate}
+              />
+            ) : (
+              <Pane.Title attendableId={attendableId} related={related} classNames={pending && 'text-description'}>
+                {label}
+              </Pane.Title>
+            )}
             {navbarEnd}
             {controls}
           </Pane.Toolbar>

--- a/packages/plugins/plugin-deck/src/containers/Deck/DeckPlank.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Deck/DeckPlank.tsx
@@ -42,6 +42,7 @@ export const DeckPlank = memo(
     const rootRef = useRef<HTMLDivElement>(null);
     const {
       node,
+      breadcrumbs,
       companions,
       resolvedCompanionId,
       hasCompanion,
@@ -51,6 +52,7 @@ export const DeckPlank = memo(
       popoverAnchorId,
       scrollIntoView,
       onAction,
+      onNavigate,
       onAdjust,
       onScrollIntoView,
       onUpdateCompanion,
@@ -149,10 +151,12 @@ export const DeckPlank = memo(
           <Plank
             ref={rootRef}
             node={node}
+            breadcrumbs={breadcrumbs}
             attendableId={id}
             related={part === 'complementary'}
             actions={sigilActions}
             onAction={onAction}
+            onNavigate={onNavigate}
             popoverAnchorId={popoverAnchorId}
             articleData={articleData}
             controls={controls}

--- a/packages/plugins/plugin-deck/src/containers/Deck/useDeckPlank.ts
+++ b/packages/plugins/plugin-deck/src/containers/Deck/useDeckPlank.ts
@@ -11,7 +11,14 @@ import { useAppGraph } from '@dxos/app-toolkit/ui';
 import { Graph, Node, useActionRunner, useActions, useNode } from '@dxos/plugin-graph';
 import { getLinkedVariant, useAttention } from '@dxos/react-ui-attention';
 
-import { useBreakpoints, useCompanions, useDeckState, useSelectedCompanion, useSelectedCompanionVariant } from '#hooks';
+import {
+  useBreadcrumbs,
+  useBreakpoints,
+  useCompanions,
+  useDeckState,
+  useSelectedCompanion,
+  useSelectedCompanionVariant,
+} from '#hooks';
 import { meta } from '#meta';
 import { DeckOperation, type LayoutMode, PLANK_COMPANION_TYPE, type ResolvedPart } from '#types';
 
@@ -42,6 +49,8 @@ export type UseDeckPlankOptions = {
 
 export type DeckPlank = {
   node: Node.Node | undefined;
+  /** Ancestor chain (outermost → leaf) for the plank's toolbar breadcrumbs. */
+  breadcrumbs: Node.Node[];
   companions: Node.Node[];
   resolvedCompanionId: string | undefined;
   currentCompanion: Node.Node | undefined;
@@ -54,6 +63,8 @@ export type DeckPlank = {
   popoverAnchorId?: string;
   scrollIntoView?: string;
   onAction: (action: AttentionSigilAction) => void;
+  /** Navigate to an ancestor breadcrumb, opening it in the main content area. */
+  onNavigate: (id: string) => void;
   onAdjust: (type: DeckOperation.PartAdjustment) => void;
   onResize: (size: number) => void;
   onScrollIntoView: (subject?: string) => void;
@@ -79,6 +90,7 @@ export const useDeckPlank = ({
   const runAction = useActionRunner();
   const breakpoint = useBreakpoints();
   const node = useNode(graph, id);
+  const breadcrumbs = useBreadcrumbs(graph, id);
   // Subscribe reactively to the node's actions: they are loaded asynchronously by `Graph.expand`
   // below, and the node atom does not re-emit when action edges arrive, so a one-shot read would
   // leave a freshly-created plank's sigil menu empty until an unrelated re-render.
@@ -164,6 +176,11 @@ export const useDeckPlank = ({
     [node, runAction],
   );
 
+  const onNavigate = useCallback(
+    (navId: string) => invokePromise(LayoutOperation.Open, { subject: [navId] }),
+    [invokePromise],
+  );
+
   const onAdjust = useCallback(
     (type: DeckOperation.PartAdjustment) => {
       if (type === 'close') {
@@ -201,6 +218,7 @@ export const useDeckPlank = ({
 
   return {
     node,
+    breadcrumbs,
     companions,
     resolvedCompanionId,
     currentCompanion,
@@ -211,6 +229,7 @@ export const useDeckPlank = ({
     popoverAnchorId: state.popoverAnchorId,
     scrollIntoView: state.scrollIntoView,
     onAction,
+    onNavigate,
     onAdjust,
     onResize,
     onScrollIntoView,

--- a/packages/plugins/plugin-deck/src/hooks/index.ts
+++ b/packages/plugins/plugin-deck/src/hooks/index.ts
@@ -2,6 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
+export * from './useBreadcrumbs';
 export * from './useBreakpoints';
 export * from './useCompanions';
 export * from './useCompanionSplit';

--- a/packages/plugins/plugin-deck/src/hooks/useBreadcrumbs.ts
+++ b/packages/plugins/plugin-deck/src/hooks/useBreadcrumbs.ts
@@ -1,0 +1,39 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Atom, useAtomValue } from '@effect-atom/atom-react';
+import * as Option from 'effect/Option';
+import { useMemo } from 'react';
+
+import { Graph, Node, getParentId } from '@dxos/plugin-graph';
+import { isNonNullable } from '@dxos/util';
+
+/**
+ * Resolve the ancestor chain for a plank from the graph.
+ *
+ * Plank ids are fully-qualified graph paths (`root/<workspace>/…/<leaf>`), so the ancestor chain is
+ * recovered by decomposing the id rather than walking edges — this reflects the exact path that was
+ * opened (no DAG ambiguity over which parent the plank was reached from). The root segment is omitted
+ * and unresolved ancestors (not yet materialized in the graph) are skipped.
+ *
+ * @returns Ordered nodes from the outermost ancestor to the leaf (the plank itself).
+ */
+export const useBreadcrumbs = (graph: Graph.ReadableGraph, id: string): Node.Node[] => {
+  const atom = useMemo(
+    () =>
+      Atom.make((get) => {
+        const ids: string[] = [];
+        let current: string | undefined = id;
+        while (current && current !== Node.RootId) {
+          ids.unshift(current);
+          current = getParentId(current);
+        }
+
+        return ids.map((nodeId) => Option.getOrElse(get(graph.node(nodeId)), () => undefined)).filter(isNonNullable);
+      }),
+    [graph, id],
+  );
+
+  return useAtomValue(atom);
+};

--- a/packages/ui/react-ui/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/ui/react-ui/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -5,35 +5,37 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
-import { withTheme } from '../../testing';
+import { withLayout, withTheme } from '../../testing';
 import { Button } from '../Button';
 import { Breadcrumb, type BreadcrumbRootProps } from './Breadcrumb';
 
 const DefaultStory = (props: BreadcrumbRootProps) => {
   return (
-    <Breadcrumb.Root {...props}>
-      <Breadcrumb.List>
-        <Breadcrumb.ListItem>
-          <Breadcrumb.Link asChild>
-            <Button variant='ghost' classNames='px-0 text-base-fg font-normal'>
-              Grocery
-            </Button>
-          </Breadcrumb.Link>
-          <Breadcrumb.Separator />
-        </Breadcrumb.ListItem>
-        <Breadcrumb.ListItem>
-          <Breadcrumb.Link href='#'>Produce</Breadcrumb.Link>
-          <Breadcrumb.Separator />
-        </Breadcrumb.ListItem>
-        <Breadcrumb.ListItem>
-          <Breadcrumb.Link href='#'>Veggies</Breadcrumb.Link>
-          <Breadcrumb.Separator />
-        </Breadcrumb.ListItem>
-        <Breadcrumb.ListItem>
-          <Breadcrumb.Current>Peppers</Breadcrumb.Current>
-        </Breadcrumb.ListItem>
-      </Breadcrumb.List>
-    </Breadcrumb.Root>
+    <div>
+      <Breadcrumb.Root {...props}>
+        <Breadcrumb.List>
+          <Breadcrumb.ListItem>
+            <Breadcrumb.Link>
+              <Button variant='ghost' classNames='px-0 text-base-fg font-normal'>
+                Home
+              </Button>
+            </Breadcrumb.Link>
+            <Breadcrumb.Separator />
+          </Breadcrumb.ListItem>
+          <Breadcrumb.ListItem>
+            <Breadcrumb.Link href='#'>Mailbox</Breadcrumb.Link>
+            <Breadcrumb.Separator />
+          </Breadcrumb.ListItem>
+          <Breadcrumb.ListItem>
+            <Breadcrumb.Link href='#'>Work</Breadcrumb.Link>
+            <Breadcrumb.Separator />
+          </Breadcrumb.ListItem>
+          <Breadcrumb.ListItem>
+            <Breadcrumb.Current>All</Breadcrumb.Current>
+          </Breadcrumb.ListItem>
+        </Breadcrumb.List>
+      </Breadcrumb.Root>
+    </div>
   );
 };
 
@@ -41,7 +43,7 @@ const meta = {
   title: 'ui/react-ui-core/components/Breadcrumb',
   component: Breadcrumb.Root as any,
   render: DefaultStory,
-  decorators: [withTheme()],
+  decorators: [withTheme(), withLayout({ layout: 'column' })],
 } satisfies Meta<typeof DefaultStory>;
 
 export default meta;

--- a/packages/ui/react-ui/src/components/Breadcrumb/Breadcrumb.theme.ts
+++ b/packages/ui/react-ui/src/components/Breadcrumb/Breadcrumb.theme.ts
@@ -7,15 +7,17 @@ import { type ComponentFunction, type Theme } from '@dxos/ui-types';
 
 export type breadcrumbStyleProps = {};
 
-const root: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) => mx('shrink-0 flex items-center', ...etc);
+const root: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) =>
+  mx('flex items-center grow overflow-hidden', ...etc);
 
-const list: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) => mx('contents', ...etc);
+const list: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) =>
+  mx('flex items-center min-w-0 grow overflow-x-auto scrollbar-none', ...etc);
 
-const listItem: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) => mx('contents', ...etc);
+const listItem: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) => mx('flex items-center shrink-0', ...etc);
 
-const current: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) => mx(...etc);
+const current: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) => mx('whitespace-nowrap', ...etc);
 
-const separator: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) => mx('opacity-50', ...etc);
+const separator: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) => mx('shrink-0 opacity-50', ...etc);
 
 export const breadcrumbTheme: Theme<breadcrumbStyleProps> = {
   root,

--- a/packages/ui/react-ui/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/ui/react-ui/src/components/Breadcrumb/Breadcrumb.tsx
@@ -75,7 +75,7 @@ BreadcrumbCurrent.displayName = 'Breadcrumb.Current';
 
 type BreadcrumbSeparatorProps = ThemedClassName<ComponentPropsWithoutRef<typeof Primitive.span>>;
 
-function BreadcrumbSeparator({ children, classNames, ...props }: BreadcrumbSeparatorProps) {
+function BreadcrumbSeparator({ classNames, children, ...props }: BreadcrumbSeparatorProps) {
   const { tx } = useThemeContext();
   return (
     <Primitive.span
@@ -84,7 +84,7 @@ function BreadcrumbSeparator({ children, classNames, ...props }: BreadcrumbSepar
       {...props}
       className={tx('breadcrumb.separator', {}, classNames)}
     >
-      {children ?? <Icon icon='ph--dot--bold' />}
+      {children ?? <Icon icon='ph--caret-double-right--regular' />}
     </Primitive.span>
   );
 }


### PR DESCRIPTION
## Summary

Adds an **ancestor breadcrumb trail** to deck plank toolbars, so a plank opened from a list (e.g. a plugin opened from the Registry) shows where it was navigated from and offers one-click navigation back up the chain — the navtree can't do this today because such planks are often hidden children.

## Demo

<img width="1386" height="1521" alt="Screenshot 2026-07-22 at 9 24 55 PM" src="https://github.com/user-attachments/assets/49914640-9aaf-403a-9e9e-754d4b061ee1" />

## How it works

- Plank ids are already **fully-qualified graph paths** (`root/<workspace>/…/<leaf>`), so the ancestor chain is recovered by decomposing the id via `getParentId` and resolving each prefix node reactively — no separate navtree state, and it reflects the exact path opened (no DAG ambiguity).
- New `useBreadcrumbs(graph, id)` hook (plugin-deck) returns the resolved ancestor nodes; `useDeckPlank` exposes them plus an `onNavigate` that invokes `LayoutOperation.Open`.
- `Plank` renders the trail in `Pane.Toolbar` (replacing the plain title when there's ≥1 ancestor): ancestors as navigable crumbs, the leaf as the current title.

## `@dxos/react-ui` Breadcrumb changes

- Removed `display: contents` from `listItem`/`current` — it negated consumer classNames when combined with `asChild`.
- Reworked the theme so the trail is a single **horizontally-scrolling** row: crumbs keep their natural width (`shrink-0`) and the list scrolls (`overflow-x-auto`) rather than truncating.

## Verified

- Storybook (`plugin-deck/components/Plank` → `Breadcrumbs`, and `react-ui-core/components/Breadcrumb`): trail renders, ancestor click fires `onNavigate(<ancestorId>)`, and the toolbar scrolls horizontally when the trail overflows.
- `react-ui` + `plugin-deck` build & lint clean.

## Notes / follow-ups (not in this PR)

- Determining which ancestors are navigable (registry root vs. structural group/section/space nodes) — discussed; the current cut renders all resolved ancestors.
- Carrying an intermediate **category** context (`Plugins › Labs › Assistant`) — the category isn't in the graph path; would need extra plumbing.
- Auto-scroll the trail to the current crumb on mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigable ancestor breadcrumbs to Deck plank toolbars.
  * Selecting a breadcrumb opens the corresponding ancestor plank.
  * Breadcrumb trails now support horizontal scrolling for long paths.

* **UI Improvements**
  * Updated breadcrumb separators and spacing for improved readability.
  * Added Storybook examples covering breadcrumb-enabled planks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->