### PR TITLE
ci: run Setup before apps.mjs in deploy job so json5 resolves

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -227,6 +227,11 @@ jobs:
           lfs: true
           ref: ${{ needs.release.outputs.sha || github.sha }}
 
+      # Install first: the validate step below runs apps.mjs, which imports json5 (parsing wrangler.jsonc),
+      # so dependencies must be resolvable before any script runs.
+      - name: Setup
+        uses: ./.github/actions/setup
+
       # Catches e.g. `app=storybook-react` on an environment it doesn't define (no env.staging/labs) —
       # before this existed, bundle-env.mjs/deploy-env.mjs silently no-op'd and the job still went green
       # with a false "deploying"/"succeeded" Discord ping despite deploying nothing. Runs before the
@@ -270,9 +275,6 @@ jobs:
           DX_POSTHOG_API_HOST: ${{ secrets.DX_POSTHOG_API_HOST }}
           IPDATA_API_KEY: ${{ secrets.IPDATA_API_KEY }}
           IPFS_API_SECRET: ${{ secrets.IPFS_API_SECRET }}
-
-      - name: Setup
-        uses: ./.github/actions/setup
 
       # Reuse the prebuilt Composer bundle when the prep job produced one — populating out/composer means
       # bundle-env.mjs reuses it instead of rebuilding.


### PR DESCRIPTION
## Problem

The **Deploy Apps** workflow's web `deploy` job fails with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'json5' imported from /__w/dxos/dxos/.github/workflows/scripts/apps.mjs
```

This breaks **every** web deploy (labs / staging / production). It is unrelated to app code.

## Root cause

`.github/workflows/scripts/apps.mjs` does `import JSON5 from 'json5'` to parse each app's `wrangler.jsonc` (which uses JSONC syntax — comments, trailing commas, and URL string values, so plain `JSON.parse` is not viable).

The `deploy` job's first invocation of `apps.mjs` is in its **"Check app targets this environment"** validate step, which ran *before* the `Setup` step (`./.github/actions/setup` → `pnpm install`). With no `node_modules` yet, `json5` was unresolvable.

The original break was introduced by #12106 (Changesets / Cloudflare Workers deploy cutover), which added `apps.mjs` with the json5 import but no dependency. #12158 later added `"json5": "catalog:"` to the root `package.json`, but that alone does not help the `deploy` job because its validate step still runs the script before dependencies are installed. `build-bundle` and `tauri` never hit this because they only run the script after `Setup`.

## Fix

Move the `Setup` step to run immediately after `Checkout`, before the validate step. `json5` is already a declared dependency, so installing before the first script invocation resolves it. This keeps the cheap fail-fast validate ahead of the Discord "started" notification (its original purpose), and `Setup` needs only the checkout — none of the Cloudflare/PostHog env vars set later.

No dependency or lockfile changes are required.

## Verification

- `node .github/workflows/scripts/apps.mjs production all` → resolves and prints the app names (exit 0).
- YAML parses; exactly one `Setup` step remains in the `deploy` job.

This unblocks all web deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment workflow reliability by preparing required dependencies before application validation.
  * Added clarification to the deployment process to help prevent validation failures caused by unresolved configuration parsing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->