### PR TITLE
react-ui-masonry: fix initial-render bunching and gate reflow animation

### DIFF
--- a/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
@@ -5,22 +5,55 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React, { useMemo, useState } from 'react';
 
-import { Filter, Obj } from '@dxos/echo';
-import { useQuery } from '@dxos/echo-react';
 import { random } from '@dxos/random';
-import { useClientStory, withClientProvider } from '@dxos/react-client/testing';
 import { Card, Panel, Toolbar } from '@dxos/react-ui';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
-import { type ValueGenerator, createObjectFactory } from '@dxos/schema/testing';
-import { Person } from '@dxos/types';
 
 import { Masonry, type MasonryRootProps } from './Masonry';
 
 random.seed(1);
 
-const generator: ValueGenerator = random as any;
+/** Item counts the toolbar can switch between to exercise the layout under different loads. */
+const ITEM_COUNTS = [100, 200, 500] as const;
 
-const StoryItem = ({ data: person }: { data: Person.Person }) => {
+type PersonData = {
+  id: string;
+  fullName: string;
+  jobTitle?: string;
+  department?: string;
+  image?: string;
+  emails?: { value: string; label?: string }[];
+  notes?: string;
+};
+
+// Generate plain (non-ECHO) data so even the largest preset mounts instantly — the masonry is a
+// pure layout component, so seeding a database would only add unrelated cost. Variable notes and a
+// distinct image per person make cards differ in height and exercise the column-balancing layout.
+const createPeople = (count: number): PersonData[] =>
+  Array.from({ length: count }, (_, index) => {
+    const fullName = random.person.fullName();
+    const slug = fullName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '.')
+      .replace(/^\.+|\.+$/g, '');
+    return {
+      id: `person-${index}`,
+      fullName,
+      jobTitle: random.person.jobTitle(),
+      department: random.commerce.department(),
+      image: `https://picsum.photos/seed/${random.string.uuid()}/256/256`,
+      emails: [
+        { value: `${slug}@example.com` },
+        ...(index % 3 === 0 ? [{ label: 'work', value: `${slug}@work.example.com` }] : []),
+      ],
+      notes: index % 2 === 0 ? random.lorem.sentences(random.number.int({ min: 1, max: 4 })) : undefined,
+    };
+  });
+
+// Seed the largest preset once so switching counts is a cheap slice.
+const PEOPLE = createPeople(ITEM_COUNTS[ITEM_COUNTS.length - 1]);
+
+const StoryItem = ({ data: person }: { data: PersonData }) => {
   const { fullName, jobTitle, department, image, emails, notes } = person;
   const role = [jobTitle, department].filter(Boolean).join(' · ');
   return (
@@ -48,28 +81,25 @@ const StoryItem = ({ data: person }: { data: Person.Person }) => {
   );
 };
 
-// A slice of the seeded people is rendered so the toolbar can exercise both paths: the
-// full set snaps in (bulk render), while adding or removing one card animates the reflow.
+// A slice of the generated people is rendered so the toolbar can switch the item count (bulk
+// render under load) and add/remove single tiles (the small-edit reflow animation).
 const DefaultStory = (props: MasonryRootProps) => {
-  const { space } = useClientStory();
-  const people = useQuery(space?.db, Filter.type(Person.Person));
-  // Undefined tracks the full set even as the async query resolves; a number pins a slice.
-  const [limit, setLimit] = useState<number | undefined>(undefined);
-  const shown = limit ?? people.length;
-  const visible = useMemo(() => people.slice(0, shown), [people, shown]);
+  const [limit, setLimit] = useState<number>(ITEM_COUNTS[0]);
+  const visible = useMemo(() => PEOPLE.slice(0, limit), [limit]);
 
   return (
     <Panel.Root>
       <Panel.Toolbar asChild>
         <Toolbar.Root>
-          <Toolbar.Button onClick={() => setLimit((value) => Math.min(people.length, (value ?? people.length) + 1))}>
+          {ITEM_COUNTS.map((count) => (
+            <Toolbar.Button key={count} onClick={() => setLimit(count)}>
+              {count}
+            </Toolbar.Button>
+          ))}
+          <Toolbar.Button onClick={() => setLimit((value) => Math.min(PEOPLE.length, value + 1))}>
             Add one
           </Toolbar.Button>
-          <Toolbar.Button onClick={() => setLimit((value) => Math.max(0, (value ?? people.length) - 1))}>
-            Remove one
-          </Toolbar.Button>
-          <Toolbar.Button onClick={() => setLimit(0)}>Clear</Toolbar.Button>
-          <Toolbar.Button onClick={() => setLimit(people.length)}>Show all</Toolbar.Button>
+          <Toolbar.Button onClick={() => setLimit((value) => Math.max(0, value - 1))}>Remove one</Toolbar.Button>
         </Toolbar.Root>
       </Panel.Toolbar>
       <Panel.Content>
@@ -82,43 +112,6 @@ const DefaultStory = (props: MasonryRootProps) => {
     </Panel.Root>
   );
 };
-
-// Seed a space with `count` enriched people. Per-story (not on the meta) so each
-// variant gets an independently-sized dataset for exercising the layout under load.
-const withPeople = (count: number) =>
-  withClientProvider({
-    types: [Person.Person],
-    createIdentity: true,
-    createSpace: true,
-    onCreateSpace: async ({ space }) => {
-      const createObjects = createObjectFactory(space.db, generator);
-      const objects = await createObjects([{ type: Person.Person, count }]);
-
-      // The generator only populates fields with a GeneratorAnnotation and skips array fields;
-      // enrich each person (job data, distinct image, emails, variable-length notes) so cards vary
-      // in height and exercise the column-balancing layout.
-      objects
-        .filter((object): object is Person.Person => Obj.instanceOf(Person.Person, object))
-        .forEach((person, index) => {
-          Obj.update(person, (person: Obj.Mutable<Person.Person>) => {
-            person.jobTitle = random.person.jobTitle();
-            person.department = random.commerce.department();
-            person.image = `https://picsum.photos/seed/${random.string.uuid()}/256/256`;
-            const slug = (person.fullName ?? 'user')
-              .toLowerCase()
-              .replace(/[^a-z0-9]+/g, '.')
-              .replace(/^\.+|\.+$/g, '');
-            person.emails = [
-              { value: `${slug}@example.com` },
-              ...(index % 3 === 0 ? [{ label: 'work', value: `${slug}@work.example.com` }] : []),
-            ];
-            if (index % 2 === 0) {
-              person.notes = random.lorem.sentences(random.number.int({ min: 1, max: 4 }));
-            }
-          });
-        });
-    },
-  });
 
 const meta = {
   title: 'ui/react-ui-masonry/Masonry',
@@ -139,12 +132,4 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  decorators: [withPeople(36)],
-};
-
-// Seeds 200 tiles to exercise the bulk-render path under load: with `animate` on, the
-// initial render must snap into place (not animate every tile), which the layout gate handles.
-export const Stress: Story = {
-  decorators: [withPeople(200)],
-};
+export const Default: Story = {};

--- a/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
@@ -3,7 +3,7 @@
 //
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 
 import { random } from '@dxos/random';
 import { Card, Panel, Toolbar } from '@dxos/react-ui';
@@ -14,7 +14,17 @@ import { Masonry, type MasonryRootProps } from './Masonry';
 random.seed(1);
 
 /** Item counts the toolbar can switch between to exercise the layout under different loads. */
-const ITEM_COUNTS = [100, 200, 500] as const;
+const ITEM_COUNTS = [10, 100, 200, 500] as const;
+
+/** Fisher-Yates shuffle (seeded) so switching sets re-randomizes tile order. */
+const shuffle = <T,>(array: readonly T[]): T[] => {
+  const copy = [...array];
+  for (let index = copy.length - 1; index > 0; index--) {
+    const swap = random.number.int({ min: 0, max: index });
+    [copy[index], copy[swap]] = [copy[swap], copy[index]];
+  }
+  return copy;
+};
 
 type PersonData = {
   id: string;
@@ -81,25 +91,46 @@ const StoryItem = ({ data: person }: { data: PersonData }) => {
   );
 };
 
-// A slice of the generated people is rendered so the toolbar can switch the item count (bulk
-// render under load) and add/remove single tiles (the small-edit reflow animation).
+// A random subset of the generated people is rendered so the toolbar can switch the item count
+// (bulk render under load, re-shuffled each time) and add/remove single tiles (the small-edit
+// reflow animation).
 const DefaultStory = (props: MasonryRootProps) => {
-  const [limit, setLimit] = useState<number>(ITEM_COUNTS[0]);
-  const visible = useMemo(() => PEOPLE.slice(0, limit), [limit]);
+  const [visible, setVisible] = useState<PersonData[]>(() => shuffle(PEOPLE).slice(0, ITEM_COUNTS[0]));
+
+  const addOne = () =>
+    setVisible((current) => {
+      const shown = new Set(current.map((person) => person.id));
+      const candidates = PEOPLE.filter((person) => !shown.has(person.id));
+      if (candidates.length === 0) {
+        return current;
+      }
+      const person = candidates[random.number.int({ min: 0, max: candidates.length - 1 })];
+      const next = [...current];
+      next.splice(random.number.int({ min: 0, max: current.length }), 0, person);
+      return next;
+    });
+
+  const removeOne = () =>
+    setVisible((current) => {
+      if (current.length === 0) {
+        return current;
+      }
+      const index = random.number.int({ min: 0, max: current.length - 1 });
+      return current.filter((_, position) => position !== index);
+    });
 
   return (
     <Panel.Root>
       <Panel.Toolbar asChild>
         <Toolbar.Root>
           {ITEM_COUNTS.map((count) => (
-            <Toolbar.Button key={count} onClick={() => setLimit(count)}>
+            <Toolbar.Button key={count} onClick={() => setVisible(shuffle(PEOPLE).slice(0, count))}>
               {count}
             </Toolbar.Button>
           ))}
-          <Toolbar.Button onClick={() => setLimit((value) => Math.min(PEOPLE.length, value + 1))}>
-            Add one
-          </Toolbar.Button>
-          <Toolbar.Button onClick={() => setLimit((value) => Math.max(0, value - 1))}>Remove one</Toolbar.Button>
+          <Toolbar.Button onClick={addOne}>Add one</Toolbar.Button>
+          <Toolbar.Button onClick={removeOne}>Remove one</Toolbar.Button>
+          <Toolbar.Button onClick={() => setVisible([])}>Clear</Toolbar.Button>
         </Toolbar.Root>
       </Panel.Toolbar>
       <Panel.Content>

--- a/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
@@ -3,13 +3,13 @@
 //
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { Filter, Obj } from '@dxos/echo';
 import { useQuery } from '@dxos/echo-react';
 import { random } from '@dxos/random';
 import { useClientStory, withClientProvider } from '@dxos/react-client/testing';
-import { Card } from '@dxos/react-ui';
+import { Button, Card } from '@dxos/react-ui';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 import { type ValueGenerator, createObjectFactory } from '@dxos/schema/testing';
 import { Person } from '@dxos/types';
@@ -61,6 +61,37 @@ const DefaultStory = (props: MasonryRootProps) => {
   );
 };
 
+// Exercises the animate-only-on-small-edits behaviour: the full set snaps in (bulk),
+// while adding or removing one card animates the reflow.
+const InteractiveStory = (props: MasonryRootProps) => {
+  const { space } = useClientStory();
+  const people = useQuery(space?.db, Filter.type(Person.Person));
+  // Undefined tracks the full set even as the async query resolves; a number pins a slice.
+  const [limit, setLimit] = useState<number | undefined>(undefined);
+  const shown = limit ?? people.length;
+  const visible = useMemo(() => people.slice(0, shown), [people, shown]);
+
+  return (
+    <div className='flex flex-col grow bs-full min-is-0'>
+      <div className='flex gap-2 p-2'>
+        <Button onClick={() => setLimit((value) => Math.min(people.length, (value ?? people.length) + 1))}>
+          Add one
+        </Button>
+        <Button onClick={() => setLimit((value) => Math.max(0, (value ?? people.length) - 1))}>Remove one</Button>
+        <Button onClick={() => setLimit(0)}>Clear</Button>
+        <Button onClick={() => setLimit(people.length)}>Show all</Button>
+      </div>
+      <div className='flex grow min-bs-0'>
+        <Masonry.Root {...props} Tile={StoryItem}>
+          <Masonry.Content>
+            <Masonry.Viewport items={visible} getId={(person) => person.id} />
+          </Masonry.Content>
+        </Masonry.Root>
+      </div>
+    </div>
+  );
+};
+
 const meta = {
   title: 'ui/react-ui-masonry/Masonry',
   render: DefaultStory,
@@ -104,6 +135,12 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
+  argTypes: {
+    animate: { control: 'boolean' },
+  },
+  args: {
+    animate: true,
+  },
 } satisfies Meta<typeof DefaultStory>;
 
 export default meta;
@@ -111,3 +148,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const Interactive: Story = {
+  render: InteractiveStory,
+};

--- a/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
@@ -9,7 +9,7 @@ import { Filter, Obj } from '@dxos/echo';
 import { useQuery } from '@dxos/echo-react';
 import { random } from '@dxos/random';
 import { useClientStory, withClientProvider } from '@dxos/react-client/testing';
-import { Button, Card } from '@dxos/react-ui';
+import { Card, Panel, Toolbar } from '@dxos/react-ui';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 import { type ValueGenerator, createObjectFactory } from '@dxos/schema/testing';
 import { Person } from '@dxos/types';
@@ -48,22 +48,9 @@ const StoryItem = ({ data: person }: { data: Person.Person }) => {
   );
 };
 
+// A slice of the seeded people is rendered so the toolbar can exercise both paths: the
+// full set snaps in (bulk render), while adding or removing one card animates the reflow.
 const DefaultStory = (props: MasonryRootProps) => {
-  const { space } = useClientStory();
-  const people = useQuery(space?.db, Filter.type(Person.Person));
-
-  return (
-    <Masonry.Root {...props} Tile={StoryItem}>
-      <Masonry.Content>
-        <Masonry.Viewport items={people} getId={(person) => person.id} />
-      </Masonry.Content>
-    </Masonry.Root>
-  );
-};
-
-// Exercises the animate-only-on-small-edits behaviour: the full set snaps in (bulk),
-// while adding or removing one card animates the reflow.
-const InteractiveStory = (props: MasonryRootProps) => {
   const { space } = useClientStory();
   const people = useQuery(space?.db, Filter.type(Person.Person));
   // Undefined tracks the full set even as the async query resolves; a number pins a slice.
@@ -72,66 +59,71 @@ const InteractiveStory = (props: MasonryRootProps) => {
   const visible = useMemo(() => people.slice(0, shown), [people, shown]);
 
   return (
-    <div className='flex flex-col grow bs-full min-is-0'>
-      <div className='flex gap-2 p-2'>
-        <Button onClick={() => setLimit((value) => Math.min(people.length, (value ?? people.length) + 1))}>
-          Add one
-        </Button>
-        <Button onClick={() => setLimit((value) => Math.max(0, (value ?? people.length) - 1))}>Remove one</Button>
-        <Button onClick={() => setLimit(0)}>Clear</Button>
-        <Button onClick={() => setLimit(people.length)}>Show all</Button>
-      </div>
-      <div className='flex grow min-bs-0'>
+    <Panel.Root>
+      <Panel.Toolbar asChild>
+        <Toolbar.Root>
+          <Toolbar.Button onClick={() => setLimit((value) => Math.min(people.length, (value ?? people.length) + 1))}>
+            Add one
+          </Toolbar.Button>
+          <Toolbar.Button onClick={() => setLimit((value) => Math.max(0, (value ?? people.length) - 1))}>
+            Remove one
+          </Toolbar.Button>
+          <Toolbar.Button onClick={() => setLimit(0)}>Clear</Toolbar.Button>
+          <Toolbar.Button onClick={() => setLimit(people.length)}>Show all</Toolbar.Button>
+        </Toolbar.Root>
+      </Panel.Toolbar>
+      <Panel.Content>
         <Masonry.Root {...props} Tile={StoryItem}>
           <Masonry.Content>
             <Masonry.Viewport items={visible} getId={(person) => person.id} />
           </Masonry.Content>
         </Masonry.Root>
-      </div>
-    </div>
+      </Panel.Content>
+    </Panel.Root>
   );
 };
+
+// Seed a space with `count` enriched people. Per-story (not on the meta) so each
+// variant gets an independently-sized dataset for exercising the layout under load.
+const withPeople = (count: number) =>
+  withClientProvider({
+    types: [Person.Person],
+    createIdentity: true,
+    createSpace: true,
+    onCreateSpace: async ({ space }) => {
+      const createObjects = createObjectFactory(space.db, generator);
+      const objects = await createObjects([{ type: Person.Person, count }]);
+
+      // The generator only populates fields with a GeneratorAnnotation and skips array fields;
+      // enrich each person (job data, distinct image, emails, variable-length notes) so cards vary
+      // in height and exercise the column-balancing layout.
+      objects
+        .filter((object): object is Person.Person => Obj.instanceOf(Person.Person, object))
+        .forEach((person, index) => {
+          Obj.update(person, (person: Obj.Mutable<Person.Person>) => {
+            person.jobTitle = random.person.jobTitle();
+            person.department = random.commerce.department();
+            person.image = `https://picsum.photos/seed/${random.string.uuid()}/256/256`;
+            const slug = (person.fullName ?? 'user')
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '.')
+              .replace(/^\.+|\.+$/g, '');
+            person.emails = [
+              { value: `${slug}@example.com` },
+              ...(index % 3 === 0 ? [{ label: 'work', value: `${slug}@work.example.com` }] : []),
+            ];
+            if (index % 2 === 0) {
+              person.notes = random.lorem.sentences(random.number.int({ min: 1, max: 4 }));
+            }
+          });
+        });
+    },
+  });
 
 const meta = {
   title: 'ui/react-ui-masonry/Masonry',
   render: DefaultStory,
-  decorators: [
-    withTheme(),
-    withLayout({ layout: 'fullscreen' }),
-    withClientProvider({
-      types: [Person.Person],
-      createIdentity: true,
-      createSpace: true,
-      onCreateSpace: async ({ space }) => {
-        const createObjects = createObjectFactory(space.db, generator);
-        const objects = await createObjects([{ type: Person.Person, count: 36 }]);
-
-        // The generator only populates fields with a GeneratorAnnotation and skips array fields;
-        // enrich each person (job data, distinct image, emails, variable-length notes) so cards vary
-        // in height and exercise the column-balancing layout.
-        objects
-          .filter((object): object is Person.Person => Obj.instanceOf(Person.Person, object))
-          .forEach((person, index) => {
-            Obj.update(person, (person: Obj.Mutable<Person.Person>) => {
-              person.jobTitle = random.person.jobTitle();
-              person.department = random.commerce.department();
-              person.image = `https://picsum.photos/seed/${random.string.uuid()}/256/256`;
-              const slug = (person.fullName ?? 'user')
-                .toLowerCase()
-                .replace(/[^a-z0-9]+/g, '.')
-                .replace(/^\.+|\.+$/g, '');
-              person.emails = [
-                { value: `${slug}@example.com` },
-                ...(index % 3 === 0 ? [{ label: 'work', value: `${slug}@work.example.com` }] : []),
-              ];
-              if (index % 2 === 0) {
-                person.notes = random.lorem.sentences(random.number.int({ min: 1, max: 4 }));
-              }
-            });
-          });
-      },
-    }),
-  ],
+  decorators: [withTheme(), withLayout({ layout: 'fullscreen' })],
   parameters: {
     layout: 'fullscreen',
   },
@@ -147,8 +139,12 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  decorators: [withPeople(36)],
+};
 
-export const Interactive: Story = {
-  render: InteractiveStory,
+// Seeds 200 tiles to exercise the bulk-render path under load: with `animate` on, the
+// initial render must snap into place (not animate every tile), which the layout gate handles.
+export const Stress: Story = {
+  decorators: [withPeople(200)],
 };

--- a/packages/ui/react-ui-masonry/src/Masonry.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.tsx
@@ -11,8 +11,10 @@ import React, {
   type MouseEvent,
   type PropsWithChildren,
   type Ref,
+  useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import { useResizeDetector } from 'react-resize-detector';
 
@@ -174,7 +176,7 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
     // `maxColumnWidth` and centres them, so no scrollbar/padding math is duplicated here.
     const gapPx = gap * remInPx;
     const ids = useMemo(() => items.map((item, index) => getId?.(item) ?? String(index)), [items, getId]);
-    const { rects, columnWidth, height, getTileRef, nodes } = useMasonryLayout({
+    const { rects, columnWidth, height, getTileRef, nodes, measured } = useMasonryLayout({
       ids,
       columnCount,
       containerWidth: contentWidth,
@@ -182,6 +184,15 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
       maxColumnWidthPx: maxColumnWidth * remInPx,
     });
     useFlip({ nodes, ids, rects, columnCount, containerWidth: contentWidth, enabled: animate });
+
+    // Hide the grid until the first layout is measured so the initial all-heights-zero stack
+    // (every tile bunched at the top) never flashes; latch on so later edits never re-hide it.
+    const [revealed, setRevealed] = useState(false);
+    useEffect(() => {
+      if (measured) {
+        setRevealed(true);
+      }
+    }, [measured]);
 
     // Arrow-key navigation across tiles. Uses Tabster's `both` axis so all four
     // arrows move focus through the items as flat next/previous-focusable, giving
@@ -203,7 +214,12 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
           <div
             {...composableProps(props, {
               classNames: 'relative',
-              style: { width: `${contentWidth}px`, height: `${height}px` },
+              style: {
+                width: `${contentWidth}px`,
+                height: `${height}px`,
+                opacity: revealed ? 1 : 0,
+                transition: animate ? 'opacity 200ms cubic-bezier(0.2, 0, 0, 1)' : undefined,
+              },
             })}
             {...arrowNavigationAttrs}
             role='list'

--- a/packages/ui/react-ui-masonry/src/Masonry.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.tsx
@@ -40,6 +40,11 @@ type MasonryContextValue = {
   maxColumnWidth: number;
   /** Space applied uniformly between tiles and around the grid perimeter, in rem. */
   gap: number;
+  /**
+   * Animate reflow when a small number of tiles are added or removed. Disabled, or on a
+   * bulk change (initial render, data swap) or resize, tiles snap to position instead.
+   */
+  animate: boolean;
 };
 
 const MASONRY_NAME = 'Masonry';
@@ -60,6 +65,7 @@ const MasonryRoot = ({
   minColumnWidth = cardMinInlineSize,
   maxColumnWidth = cardMaxInlineSize,
   gap = 0.75,
+  animate = true,
 }: MasonryRootProps) => (
   <MasonryProvider
     Tile={Tile!}
@@ -68,6 +74,7 @@ const MasonryRoot = ({
     minColumnWidth={minColumnWidth}
     maxColumnWidth={maxColumnWidth}
     gap={gap}
+    animate={animate}
   >
     {children}
   </MasonryProvider>
@@ -146,7 +153,8 @@ type MasonryViewportProps<Item> = ThemedClassName<{
 
 const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any>>(
   ({ items, getId, selectedIds, onSelect, ...props }, forwardedRef) => {
-    const { Tile, columns, maxColumns, minColumnWidth, maxColumnWidth, gap } = useMasonryContext('Masonry.Viewport');
+    const { Tile, columns, maxColumns, minColumnWidth, maxColumnWidth, gap, animate } =
+      useMasonryContext('Masonry.Viewport');
     const remInPx = usePx(1);
     // Measure the viewport's own content box (net of padding and scrollbar) rather
     // than deriving it from the root width, so the grid tracks the actual available
@@ -173,7 +181,7 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
       gapPx,
       maxColumnWidthPx: maxColumnWidth * remInPx,
     });
-    useFlip({ nodes, ids, rects, enabled: true });
+    useFlip({ nodes, ids, rects, columnCount, containerWidth: contentWidth, enabled: animate });
 
     // Arrow-key navigation across tiles. Uses Tabster's `both` axis so all four
     // arrows move focus through the items as flat next/previous-focusable, giving

--- a/packages/ui/react-ui-masonry/src/Masonry.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.tsx
@@ -25,6 +25,12 @@ import { cardMaxInlineSize, cardMinInlineSize } from '@dxos/ui-theme';
 import { useFlip } from './useFlip';
 import { useMasonryLayout } from './useMasonryLayout';
 
+/** Reveal the grid once the layout has been stable for this long (the initial reflow has settled). */
+const REVEAL_SETTLE_MS = 80;
+
+/** Reveal the grid no later than this after mount, so churning content never hides it indefinitely. */
+const REVEAL_DEADLINE_MS = 1200;
+
 //
 // Context
 //
@@ -185,14 +191,23 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
     });
     useFlip({ nodes, ids, rects, columnCount, containerWidth: contentWidth, enabled: animate });
 
-    // Hide the grid until the first layout is measured so the initial all-heights-zero stack
-    // (every tile bunched at the top) never flashes; latch on so later edits never re-hide it.
+    // Hide the grid until the layout stops changing, then fade in; latch on so later edits never
+    // re-hide it. Revealing on the first measurement is not enough: tiles mount collapsed (their
+    // poster reserves height a frame later), so the first pass stacks them bunched at the top and
+    // only settles over the next few reflows. Debounce on `rects` identity — which changes on every
+    // relayout — and reveal once it has been stable for a beat, with a hard deadline as a backstop.
     const [revealed, setRevealed] = useState(false);
     useEffect(() => {
-      if (measured) {
-        setRevealed(true);
+      if (revealed || !measured) {
+        return;
       }
-    }, [measured]);
+      const timer = setTimeout(() => setRevealed(true), REVEAL_SETTLE_MS);
+      return () => clearTimeout(timer);
+    }, [revealed, measured, rects]);
+    useEffect(() => {
+      const deadline = setTimeout(() => setRevealed(true), REVEAL_DEADLINE_MS);
+      return () => clearTimeout(deadline);
+    }, []);
 
     // Arrow-key navigation across tiles. Uses Tabster's `both` axis so all four
     // arrows move focus through the items as flat next/previous-focusable, giving

--- a/packages/ui/react-ui-masonry/src/useFlip.test.ts
+++ b/packages/ui/react-ui-masonry/src/useFlip.test.ts
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { shouldAnimateReflow } from './useFlip';
+
+describe('shouldAnimateReflow', () => {
+  test('animates a small add', ({ expect }) => {
+    expect(shouldAnimateReflow({ added: 1, removed: 0, resized: false })).toBe(true);
+  });
+
+  test('animates a small remove', ({ expect }) => {
+    expect(shouldAnimateReflow({ added: 0, removed: 2, resized: false })).toBe(true);
+  });
+
+  test('snaps the initial bulk render', ({ expect }) => {
+    expect(shouldAnimateReflow({ added: 36, removed: 0, resized: false })).toBe(false);
+  });
+
+  test('snaps a height-settling reflow (no add/remove)', ({ expect }) => {
+    expect(shouldAnimateReflow({ added: 0, removed: 0, resized: false })).toBe(false);
+  });
+
+  test('snaps on resize even for a small delta', ({ expect }) => {
+    expect(shouldAnimateReflow({ added: 1, removed: 0, resized: true })).toBe(false);
+  });
+
+  test('snaps at the delta boundary and animates just below it', ({ expect }) => {
+    expect(shouldAnimateReflow({ added: 4, removed: 4, resized: false, maxDelta: 8 })).toBe(true);
+    expect(shouldAnimateReflow({ added: 5, removed: 4, resized: false, maxDelta: 8 })).toBe(false);
+  });
+});

--- a/packages/ui/react-ui-masonry/src/useFlip.ts
+++ b/packages/ui/react-ui-masonry/src/useFlip.ts
@@ -9,8 +9,34 @@ import { type Rect } from './layout';
 const DURATION = 200;
 const EASING = 'cubic-bezier(0.2, 0, 0, 1)';
 
+/**
+ * Above this many tiles added/removed in a single layout, snap instead of animate.
+ * Reflows this large are the initial bulk render or a data swap, not an incremental
+ * edit, and animating dozens of tiles at once is the source of the perf/bunching jank.
+ */
+const ANIMATE_MAX_DELTA = 8;
+
 const prefersReducedMotion = () =>
   typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+/**
+ * Decide whether a layout transition should animate. Animate only genuine small
+ * incremental edits on a stable container: a resize snaps (the whole grid moves),
+ * and a zero add/remove delta means either the initial bulk render's height-settling
+ * pass or a pure resize — both snap so the grid never animates into place from the
+ * degenerate all-heights-zero layout.
+ */
+export const shouldAnimateReflow = ({
+  added,
+  removed,
+  resized,
+  maxDelta = ANIMATE_MAX_DELTA,
+}: {
+  added: number;
+  removed: number;
+  resized: boolean;
+  maxDelta?: number;
+}): boolean => !resized && added + removed > 0 && added + removed <= maxDelta;
 
 export type UseFlipOptions = {
   /** Tile wrappers by id, kept live by the layout hook. */
@@ -19,7 +45,11 @@ export type UseFlipOptions = {
   ids: readonly string[];
   /** Target positions (aligned with `ids`). */
   rects: readonly Rect[];
-  /** Disable to snap without animating (also skipped under reduced-motion). */
+  /** Current column count; a change marks a resize, which snaps rather than animates. */
+  columnCount: number;
+  /** Current content width (px); a change marks a resize, which snaps rather than animates. */
+  containerWidth: number;
+  /** Disable to snap without animating (also skipped under reduced-motion and on bulk reflows). */
   enabled: boolean;
 };
 
@@ -28,11 +58,32 @@ export type UseFlipOptions = {
  * transition from their previous translate to the new one via the Web Animations
  * API; freshly-added tiles fade/scale in. Respects `prefers-reduced-motion`.
  */
-export const useFlip = ({ nodes, ids, rects, enabled }: UseFlipOptions): void => {
+export const useFlip = ({ nodes, ids, rects, columnCount, containerWidth, enabled }: UseFlipOptions): void => {
   const previous = useRef(new Map<string, { x: number; y: number }>());
+  const previousLayout = useRef<{ columnCount: number; containerWidth: number } | null>(null);
 
   useLayoutEffect(() => {
-    const animate = enabled && !prefersReducedMotion();
+    // Classify the reflow before recording new positions: added/removed relative to
+    // the last rendered id set, and whether the container dimensions changed (resize).
+    const idSet = new Set(ids);
+    let added = 0;
+    for (const id of ids) {
+      if (!previous.current.has(id)) {
+        added += 1;
+      }
+    }
+    let removed = 0;
+    for (const id of previous.current.keys()) {
+      if (!idSet.has(id)) {
+        removed += 1;
+      }
+    }
+    const resized =
+      previousLayout.current !== null &&
+      (previousLayout.current.columnCount !== columnCount || previousLayout.current.containerWidth !== containerWidth);
+    previousLayout.current = { columnCount, containerWidth };
+
+    const animate = enabled && !prefersReducedMotion() && shouldAnimateReflow({ added, removed, resized });
     const seen = new Set<string>();
 
     ids.forEach((id, index) => {
@@ -78,5 +129,5 @@ export const useFlip = ({ nodes, ids, rects, enabled }: UseFlipOptions): void =>
         previous.current.delete(id);
       }
     }
-  }, [nodes, ids, rects, enabled]);
+  }, [nodes, ids, rects, columnCount, containerWidth, enabled]);
 };

--- a/packages/ui/react-ui-masonry/src/useMasonryLayout.ts
+++ b/packages/ui/react-ui-masonry/src/useMasonryLayout.ts
@@ -10,6 +10,8 @@ import { type LayoutResult, layout } from './layout';
 const HEIGHT_EPSILON = 0.5;
 
 export type MasonryLayout = LayoutResult & {
+  /** True once every tile has reported a height, so positions are final (not the all-zero stack). */
+  measured: boolean;
   /** Stable ref callback for the tile wrapper of `id` (measures + registers it). */
   getTileRef: (id: string) => (element: HTMLElement | null) => void;
   /** Live map of currently-mounted tile wrappers by id (for FLIP positioning). */
@@ -118,7 +120,10 @@ export const useMasonryLayout = ({
     }
 
     const tileHeights = ids.map((id) => heights.current.get(id) ?? 0);
-    return layout({ heights: tileHeights, columnCount, containerWidth, gapPx, maxColumnWidthPx });
+    // Positions are final only once every tile has contributed a height; before that the
+    // unmeasured tiles all stack at the top, so consumers hide the grid until this is true.
+    const measured = ids.every((id) => heights.current.has(id));
+    return { ...layout({ heights: tileHeights, columnCount, containerWidth, gapPx, maxColumnWidthPx }), measured };
     // `version` re-runs layout when a measured height changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ids, columnCount, containerWidth, gapPx, maxColumnWidthPx, version]);

--- a/packages/ui/react-ui-masonry/src/useMasonryLayout.ts
+++ b/packages/ui/react-ui-masonry/src/useMasonryLayout.ts
@@ -9,6 +9,9 @@ import { type LayoutResult, layout } from './layout';
 /** Sub-pixel changes below this threshold (px) don't trigger a re-layout. */
 const HEIGHT_EPSILON = 0.5;
 
+/** Assumed tile height (px) before any real measurement exists, so the first layout is spaced out. */
+const ESTIMATED_TILE_HEIGHT = 280;
+
 export type MasonryLayout = LayoutResult & {
   /** True once every tile has reported a height, so positions are final (not the all-zero stack). */
   measured: boolean;
@@ -119,9 +122,16 @@ export const useMasonryLayout = ({
       }
     }
 
-    const tileHeights = ids.map((id) => heights.current.get(id) ?? 0);
-    // Positions are final only once every tile has contributed a height; before that the
-    // unmeasured tiles all stack at the top, so consumers hide the grid until this is true.
+    // Unmeasured tiles fall back to an estimate — the running average of measured tiles, else a
+    // default — so the first layout spaces every tile out instead of stacking them all at y≈0 (the
+    // source of the initial bunched/overlapping flash). Real heights replace the estimate as they
+    // arrive, and the estimate tracks the actual card size, so the correcting reflow stays small.
+    const measuredValues = [...heights.current.values()];
+    const estimate = measuredValues.length
+      ? measuredValues.reduce((sum, value) => sum + value, 0) / measuredValues.length
+      : ESTIMATED_TILE_HEIGHT;
+    const tileHeights = ids.map((id) => heights.current.get(id) ?? estimate);
+    // Positions are final only once every tile has contributed a real height.
     const measured = ids.every((id) => heights.current.has(id));
     return { ...layout({ heights: tileHeights, columnCount, containerWidth, gapPx, maxColumnWidthPx }), measured };
     // `version` re-runs layout when a measured height changes.

--- a/packages/ui/react-ui/src/components/Panel/Panel.stories.tsx
+++ b/packages/ui/react-ui/src/components/Panel/Panel.stories.tsx
@@ -24,11 +24,24 @@ const List = composable<HTMLDivElement, ScrollAreaRootProps>((props, forwardedRe
   );
 });
 
+/**
+ * Panel is the standard full-height surface layout: a CSS grid whose `auto 1fr auto`
+ * rows pin a toolbar and statusbar while the content region absorbs the remaining
+ * height, so a scroll container inside it scrolls rather than growing the page. Each
+ * region takes `asChild` to merge its grid slot onto a `Toolbar.Root` / `ScrollArea`
+ * instead of nesting an extra wrapper element.
+ *
+ * @idiom org.dxos.react-ui.panelLayout
+ *   applies: Any full-height pane with a fixed toolbar/statusbar and a scrolling body
+ *   instead-of: Hand-wiring flex columns with min-height:0 and a bespoke scroll container
+ *   uses: {@link Panel.Root}, {@link Panel.Toolbar}, {@link Panel.Content}, {@link Panel.Statusbar}
+ *   related: org.dxos.react-ui-menu.toolbarMenu
+ */
 const DefaultStory = () => {
   return (
     <Panel.Root className='dx-document'>
       <Panel.Toolbar asChild>
-        <Toolbar.Root classNames='gap-2'>
+        <Toolbar.Root>
           <Toolbar.IconButton icon='ph--plus--regular' variant='primary' label='Add' />
           <Input.Root>
             <Input.TextInput placeholder='Search' />


### PR DESCRIPTION
## What

Fixes the masonry grid's initial-render flicker (tiles bunched/overlapping at the top of a large set), makes reflow animation cheap and purposeful, and turns the storybook into a proper load bench.

### Core changes (`@dxos/react-ui-masonry`)
- **Estimate unmeasured tile heights.** The layout gave unmeasured tiles a height of `0`, so before the `ResizeObserver` reported real heights every tile stacked at y≈0 — the heavy bunched/overlapping flash on a large initial render. Unmeasured tiles now fall back to an estimate (running average of measured tiles, else a default), so the first layout is already spaced into columns; real heights replace it as they arrive.
- **Gate the FLIP reflow animation to small edits.** Animating the whole grid on the initial bulk render (or a resize) was expensive and janky. `useFlip` now animates only genuine small add/remove edits on a stable container; the initial render, data swaps, resizes, and height-settling reflows snap instead. Added an `animate` prop (default `true`) on `Masonry.Root` to disable animation entirely.
- **Reveal on settle.** The grid stays hidden until the layout stops changing (debounced, with a deadline backstop), then fades in — so the initial reflow is never shown.

### Storybook (`react-ui-masonry` + `react-ui`)
- Rebuilt the story as a load bench: a toolbar switches item count between **10 / 100 / 200 / 500** (re-shuffled each switch), plus **Add one** (random insert), **Remove one** (random tile), and **Clear**.
- Generates plain in-memory data instead of seeding ECHO — the masonry is a pure layout component, and seeding 500 reactive objects made the story take minutes to mount; plain data renders every preset instantly.
- Wrapped the controls in `Panel.Root` / `Panel.Toolbar` (asChild → `Toolbar.Root`) / `Panel.Content` so the grid scrolls.
- Documented the Panel layout `@idiom` on the Panel default story.

## Why

Large card sets (inbox, search results) rendered with a visible bunched flash and a heavy simultaneous animation. The estimate fix removes the flash at the source; the animation gate keeps reflows cheap and meaningful.

## Reviewer notes
- Not virtualized: N items still mount N Card subtrees. The estimate makes unmeasured tiles cheap to *place*, not to *mount*. Progressive paging / virtualization is a deliberate follow-up (feel the cost via the **500** preset).
- The animation threshold (`ANIMATE_MAX_DELTA = 8`) and reveal timings are internal constants.
- Verified in storybook: 10/100/200/500 switching, random add/remove/clear, reshuffle on switch, and a clean spaced initial layout with no bunching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional masonry animations with smoother tile reflow transitions.
  * Improved initial masonry rendering by preventing layout flashes while measurements settle.
  * Added estimated spacing for tiles before their actual heights are measured.
  * Added Storybook controls for enabling or disabling masonry animations.

* **Bug Fixes**
  * Large updates and resize-driven layout changes now snap into place instead of producing distracting animations.
  * Improved masonry layout stability during initial rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->