### PR TITLE
plugin-script: fix e2e task config path (vitest.config.ts -> vite.config.ts)

### DIFF
--- a/packages/plugins/plugin-script/moon.yml
+++ b/packages/plugins/plugin-script/moon.yml
@@ -8,9 +8,9 @@ tags:
   - storybook
 tasks:
   e2e:
-    command: vitest run -c vitest.config.ts --reporter=verbose --tagsFilter=functions-e2e src/e2e/*.test.ts
+    command: vitest run -c vite.config.ts --reporter=verbose --tagsFilter=functions-e2e src/e2e/*.test.ts
     deps:
       - ^:build
     inputs:
       - src/e2e/**
-      - vitest.config.ts
+      - vite.config.ts


### PR DESCRIPTION
## Summary

Fixes the daily scheduled **e2e** job on `main`, which has been failing consistently (07-20 through 07-23, e.g. [run 29981130479](https://github.com/dxos/dxos/actions/runs/29981130479)).

### Root cause

The `e2e` job runs `moon exec --on-failure continue :e2e`, which invokes every task named `e2e` across the workspace. `packages/plugins/plugin-script/moon.yml` defines one:

```yaml
e2e:
  command: vitest run -c vitest.config.ts --reporter=verbose --tagsFilter=functions-e2e src/e2e/*.test.ts
```

But plugin-script has **no `vitest.config.ts`** — its vitest config lives in `vite.config.ts` (`test: { node: true, storybook: true }`). So the task died at config load on every run:

```
plugin-script:e2e | failed to load config from .../plugin-script/vitest.config.ts
plugin-script:e2e | Error: Build failed with 1 error:
plugin-script:e2e | [UNRESOLVED_ENTRY] Cannot resolve entry module vitest.config.ts.
```

That made moon report `1 failed`, so `moon exec` exited non-zero. Because the task crashed before producing any JUnit report, the Trunk analytics-uploader (`junit-paths: test-results/playwright/report/*.xml`) found no results (`⚠️ No tests were found in the provided test results`), so its flaky/quarantine safety net couldn't override the non-zero exit — the step (and job) failed. The Playwright suites themselves only produced *flaky-but-recovered* tests (comments/inbox/todomvc), which are not the cause.

The broken task was introduced in #12246, matching the failure onset.

### Fix

Point the task command and its cache `inputs` entry at the config file that actually exists (`vite.config.ts`). The two e2e specs (`ai.test.ts`, `deploy.test.ts`) are both `describe.skip(...)`, so the task now loads the config, collects, skips, and exits 0.

## Test plan

- Reproduced the exact CI error locally with the old `-c vitest.config.ts`.
- With `-c vite.config.ts`, config resolution now succeeds; remaining local errors are only unbuilt workspace deps, which the task's `deps: [^:build]` provides in CI.
- Full end-to-end `moon run plugin-script:e2e` could not complete in the sandbox (toolchain download blocked by the proxy); the scheduled **e2e** job on this branch is the final verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHieSBuQafYukffAeMHFmW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated end-to-end test configuration to use the correct Vite configuration.
  * Ensured configuration changes correctly trigger end-to-end test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->