### PR TITLE
ci: fix Deploy Apps json5 failure + Publish changelog timeout

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
-  "changelog": [
-    "@changesets/changelog-github",
-    {
-      "repo": "dxos/dxos"
-    }
-  ],
+  "changelog": "@changesets/changelog-git",
   "commit": false,
   "access": "public",
   "baseBranch": "main",

--- a/.github/RELEASE-SPEC.md
+++ b/.github/RELEASE-SPEC.md
@@ -36,7 +36,7 @@ Two fixed/lockstep groups plus deploy-only apps:
 - **`privatePackages: { version: true, tag: false }`** — version private group members (storybook, Composer) but never tag or publish them; deploy-only apps get no changeset, so never bump.
 - **`snapshot`** — the `@next` template (calculated base version + commit suffix, e.g. `0.10.0-next-<commit>`).
 - **`bumpVersionsWithWorkspaceProtocolOnly`** and **`onlyUpdatePeerDependentsWhenOutOfRange`** — part of the semver-cascade fix (below).
-- Otherwise standard: `@changesets/changelog-github`, `access: public`, `baseBranch: main`, `updateInternalDependencies: patch`.
+- Otherwise standard: `@changesets/changelog-git` (git-based, not GitHub API-based — `changelog-github` batches a GraphQL lookup across every unreleased changeset's commit in one query, which reliably timed out once the backlog grew past a few dozen changesets), `access: public`, `baseBranch: main`, `updateInternalDependencies: patch`.
 
 **Standard semver at every version.** At `0.x`, breaking rides the **minor** (`0.9.0 → 0.10.0`) and `major` is reserved for the deliberate `1.0.0` cut. A `minor` does **not** cascade the group to `1.0.0`. Bump-level rules live in the [authoring guide](../agents/instructions/changesets.md); the mechanism below is kept out of it.
 

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -227,6 +227,10 @@ jobs:
           lfs: true
           ref: ${{ needs.release.outputs.sha || github.sha }}
 
+      # Needed before "Check app targets this environment" — apps.mjs imports json5 from node_modules.
+      - name: Setup
+        uses: ./.github/actions/setup
+
       # Catches e.g. `app=storybook-react` on an environment it doesn't define (no env.staging/labs) —
       # before this existed, bundle-env.mjs/deploy-env.mjs silently no-op'd and the job still went green
       # with a false "deploying"/"succeeded" Discord ping despite deploying nothing. Runs before the
@@ -270,9 +274,6 @@ jobs:
           DX_POSTHOG_API_HOST: ${{ secrets.DX_POSTHOG_API_HOST }}
           IPDATA_API_KEY: ${{ secrets.IPDATA_API_KEY }}
           IPFS_API_SECRET: ${{ secrets.IPFS_API_SECRET }}
-
-      - name: Setup
-        uses: ./.github/actions/setup
 
       # Reuse the prebuilt Composer bundle when the prep job produced one — populating out/composer means
       # bundle-env.mjs reuses it instead of rebuilding.

--- a/agents/instructions/changesets.md
+++ b/agents/instructions/changesets.md
@@ -34,7 +34,7 @@ A `minor` does **not** cascade the group to `1.0.0` (the tooling keeps standard 
 
 ## Body + format
 
-`.changeset/<slug>.md` (any unique slug). One or two sentences, **changelog quality** — the body ships verbatim in `CHANGELOG.md` (via `@changesets/changelog-github`), so write it from the **consumer's** point of view and end with a period.
+`.changeset/<slug>.md` (any unique slug). One or two sentences, **changelog quality** — the body ships verbatim in `CHANGELOG.md` (via `@changesets/changelog-git`), so write it from the **consumer's** point of view and end with a period.
 
 ```md
 ---

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "vite-plugin-solid": "catalog:"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "catalog:",
+    "@changesets/changelog-git": "catalog:",
     "@changesets/cli": "catalog:",
     "@cloudflare/vitest-pool-workers": "catalog:",
     "@cloudflare/workers-types": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,9 @@ catalogs:
     '@ch-ui/icons':
       specifier: ^1.0.1
       version: 1.0.1
-    '@changesets/changelog-github':
-      specifier: ^0.7.0
-      version: 0.7.0
+    '@changesets/changelog-git':
+      specifier: ^0.2.1
+      version: 0.2.1
     '@changesets/cli':
       specifier: ^2.31.0
       version: 2.31.0
@@ -1994,9 +1994,9 @@ importers:
         specifier: 'catalog:'
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     devDependencies:
-      '@changesets/changelog-github':
+      '@changesets/changelog-git':
         specifier: 'catalog:'
-        version: 0.7.0
+        version: 0.2.1
       '@changesets/cli':
         specifier: 'catalog:'
         version: 2.31.0(@types/node@22.10.2)
@@ -26093,9 +26093,6 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/changelog-github@0.7.0':
-    resolution: {integrity: sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==}
-
   '@changesets/cli@2.31.0':
     resolution: {integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==}
     hasBin: true
@@ -26108,9 +26105,6 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.4':
     resolution: {integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==}
-
-  '@changesets/get-github-info@0.8.0':
-    resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
 
   '@changesets/get-release-plan@4.0.16':
     resolution: {integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==}
@@ -35940,9 +35934,6 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  dataloader@1.4.0:
-    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
-
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
@@ -36351,10 +36342,6 @@ packages:
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
-
-  dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
-    engines: {node: '>=10'}
 
   draco3d@1.5.7:
     resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
@@ -46285,14 +46272,6 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/changelog-github@0.7.0':
-    dependencies:
-      '@changesets/get-github-info': 0.8.0
-      '@changesets/types': 6.1.0
-      dotenv: 8.6.0
-    transitivePeerDependencies:
-      - encoding
-
   '@changesets/cli@2.31.0(@types/node@22.10.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
@@ -46345,13 +46324,6 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.8.1
-
-  '@changesets/get-github-info@0.8.0':
-    dependencies:
-      dataloader: 1.4.0
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
 
   '@changesets/get-release-plan@4.0.16':
     dependencies:
@@ -59005,8 +58977,6 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  dataloader@1.4.0: {}
-
   date-fns@3.6.0: {}
 
   dayjs@1.11.10: {}
@@ -59458,8 +59428,6 @@ snapshots:
       type-fest: 5.8.0
 
   dotenv@16.4.7: {}
-
-  dotenv@8.6.0: {}
 
   draco3d@1.5.7: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,7 +48,7 @@ catalog:
   '@ch-ui/icons': ^1.0.1
   '@ch-ui/tailwind-tokens': 2.8.1
   '@ch-ui/tokens': 3.0.1
-  '@changesets/changelog-github': ^0.7.0
+  '@changesets/changelog-git': ^0.2.1
   '@changesets/cli': ^2.31.0
   '@cloudflare/ai-chat': ^0.0.6
   '@cloudflare/vitest-pool-workers': ^0.18.6

--- a/tools/toolbox/src/toolbox.ts
+++ b/tools/toolbox/src/toolbox.ts
@@ -255,9 +255,7 @@ export class Toolbox {
 
     const config = {
       $schema: 'https://unpkg.com/@changesets/config@3.1.4/schema.json',
-      // git-based, not GitHub API-based: changelog-github batches a GraphQL lookup across every unreleased
-      // changeset's commit in one query, which reliably times out ("Timeout on validation of query") once
-      // the backlog grows past a few dozen changesets — see .github/RELEASE-SPEC.md.
+      // git-based, not GitHub API-based — see .github/RELEASE-SPEC.md for why.
       changelog: '@changesets/changelog-git',
       commit: false,
       access: 'public',

--- a/tools/toolbox/src/toolbox.ts
+++ b/tools/toolbox/src/toolbox.ts
@@ -255,7 +255,10 @@ export class Toolbox {
 
     const config = {
       $schema: 'https://unpkg.com/@changesets/config@3.1.4/schema.json',
-      changelog: ['@changesets/changelog-github', { repo: 'dxos/dxos' }],
+      // git-based, not GitHub API-based: changelog-github batches a GraphQL lookup across every unreleased
+      // changeset's commit in one query, which reliably times out ("Timeout on validation of query") once
+      // the backlog grows past a few dozen changesets — see .github/RELEASE-SPEC.md.
+      changelog: '@changesets/changelog-git',
       commit: false,
       access: 'public',
       baseBranch: 'main',


### PR DESCRIPTION
## Summary

Fixes two failing GitHub Actions runs on `main`:
- [Deploy Apps #189](https://github.com/dxos/dxos/actions/runs/30004508059/job/89197233674)
- [Publish #4998](https://github.com/dxos/dxos/actions/runs/30004507744/job/89197211295)

**Deploy Apps** — the `deploy` job's `Check app targets this environment` step runs `apps.mjs`, which imports `json5`. That step ran *before* the `Setup` step that does `pnpm install`, so `node_modules/json5` didn't exist yet, failing every run with `ERR_MODULE_NOT_FOUND`. Moved `Setup` to run right after checkout, before the validation step.

**Publish** — I checked the last 30 `Publish` runs going back 3+ days: every single one failed, all with `@changesets/get-github-info` hitting GitHub's GraphQL API for changelog metadata and getting `"Timeout on validation of query"`. This isn't network flakiness — `@changesets/changelog-github` batches a lookup across *every* unreleased changeset's commit into one query, and with the current ~75-changeset backlog that query reliably times out. Worse, it's a vicious cycle: the failed run means the version-bump PR never lands, so changesets keep piling up and the query keeps growing.

Switched `changelog` from `@changesets/changelog-github` to `@changesets/changelog-git`, which is git-only and makes zero network calls, eliminating the failure class entirely. Trade-off: changelog entries lose auto-linked PR numbers/author handles (just the changeset text + commit hash now). Updated `.github/RELEASE-SPEC.md` and `agents/instructions/changesets.md` to match, and swapped the dependency/catalog entry in `package.json` / `pnpm-workspace.yaml` (regenerated `pnpm-lock.yaml`). `.changeset/config.json` is generated by `tools/toolbox/src/toolbox.ts`, so the source-of-truth edit is there.

## Test plan

- [x] `pnpm install` — lockfile regenerates cleanly, postinstall toolbox script regenerates `.changeset/config.json` with the new `changelog` value
- [x] `moon run toolbox:build` / `moon run toolbox:lint` pass
- [x] `pnpm format` — no additional changes
- [x] Confirmed `@changesets/changelog-git` resolves from the project root (`require.resolve`) and its implementation does pure string formatting with no network calls
- [x] Ran `node .github/workflows/scripts/apps.mjs main all` locally to confirm it works once `node_modules` is present (mirrors the fixed step order)
- [ ] Actual CI run of both workflows (will monitor after this PR merges to `main`, since both only trigger on push to `main`)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01C3F7sG7Vkk2jRL2mbyZrFF

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3F7sG7Vkk2jRL2mbyZrFF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Changelogs now use a Git-based generator, preserving release notes directly from changeset entries.
  - Release tooling and documentation have been aligned with the updated changelog process.

- **Bug Fixes**
  - Deployment setup now runs before application and environment validation, ensuring required tooling is available during checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->