### PR TITLE
react-ui-board: mount-centering + minimap viewport; masonry review follow-ups

### DIFF
--- a/.changeset/masonry-initial-render.md
+++ b/.changeset/masonry-initial-render.md
@@ -1,0 +1,5 @@
+---
+'@dxos/react-ui-masonry': minor
+---
+
+Masonry no longer flashes a bunched, overlapping stack on the initial render of a large set: unmeasured tiles now use an estimated height so the first layout is already spaced into columns, and the grid stays hidden until the layout settles before fading in (respecting `prefers-reduced-motion`). Reflow animation is limited to small add/remove edits — the initial render, bulk data swaps, and resizes snap instead of animating — and a new `animate` prop on `Masonry.Root` disables animation entirely.

--- a/packages/plugins/plugin-board/src/containers/BoardArticle/BoardArticle.tsx
+++ b/packages/plugins/plugin-board/src/containers/BoardArticle/BoardArticle.tsx
@@ -212,6 +212,8 @@ export const BoardArticle = ({ role, subject: board, attendableId }: BoardArticl
                   })}
                 </Board.Content>
               </Board.Viewport>
+              {/* Overview map (outlines the visible region), pinned to the corner over the board. */}
+              <Board.Map classNames='absolute bottom-2 right-2 z-10 w-40' />
             </Board.Container>
           </Panel.Content>
         </Panel.Root>

--- a/packages/plugins/plugin-mermaid/PLUGIN.mdl
+++ b/packages/plugins/plugin-mermaid/PLUGIN.mdl
@@ -14,11 +14,11 @@ Each extension is defined in the Appendix or resolved via its URI.
 
 | Term        | URI                           |
 |-------------|-------------------------------|
-| `type`      | `org.dxos.mdl.type@1.0`      |
-| `feat`      | `org.dxos.mdl.feat@1.0`      |
-| `test`      | `org.dxos.mdl.test@1.0`      |
-| `component` | `org.dxos.mdl.component@1.0` |
-| `op`        | `org.dxos.mdl.op@1.0`        |
+| `type`      | `org.dxos.mdl.type@1.0`       |
+| `feat`      | `org.dxos.mdl.feat@1.0`       |
+| `test`      | `org.dxos.mdl.test@1.0`       |
+| `component` | `org.dxos.mdl.component@1.0`  |
+| `op`        | `org.dxos.mdl.op@1.0`         |
 
 ## Types
 

--- a/packages/ui/react-ui-board/TASKS.md
+++ b/packages/ui/react-ui-board/TASKS.md
@@ -15,6 +15,13 @@
     from live board/viewport geometry. Wired into `plugin-board`'s `BoardArticle`
     as a corner overlay.
 
+- [ ] **Overscroll mount-centering shift** (CodeRabbit PR #12321)
+  - With `overscroll`, `overscrollPad` is populated by a passive effect that runs
+    *after* the mount `useLayoutEffect` centre, so the board shifts by half the
+    viewport on first paint. Fix: commit the padding (measure viewport) before the
+    one-shot instant centre, or re-centre once after padding initialises — keeping
+    it mount-only. Overscroll-story only.
+
 - [ ] **Margin button to add a row/column**
   - Add a control (edge affordance / toolbar button) to grow the board by a
     row or column, extending the grid extent (relates to the `margin` prop and

--- a/packages/ui/react-ui-board/TASKS.md
+++ b/packages/ui/react-ui-board/TASKS.md
@@ -17,7 +17,7 @@
 
 - [ ] **Overscroll mount-centering shift** (CodeRabbit PR #12321)
   - With `overscroll`, `overscrollPad` is populated by a passive effect that runs
-    *after* the mount `useLayoutEffect` centre, so the board shifts by half the
+    _after_ the mount `useLayoutEffect` centre, so the board shifts by half the
     viewport on first paint. Fix: commit the padding (measure viewport) before the
     one-shot instant centre, or re-centre once after padding initialises — keeping
     it mount-only. Overscroll-story only.

--- a/packages/ui/react-ui-board/TASKS.md
+++ b/packages/ui/react-ui-board/TASKS.md
@@ -10,9 +10,12 @@
     any, otherwise holds the current viewport centre fixed. (Selection state now
     exists — added with the single/multi-select feature.)
 
-- [ ] **`Board.Map` renders empty**
-  - The overview map shows no tiles in use. Storybook render had 5 tile children
-    with `bg-accentSurface`, so likely the tile fill is invisible (contrast/token)
-    and/or it's empty in `plugin-board` (the map isn't wired there yet).
-  - Investigate the tile color token and add the map to `plugin-board`; consider
-    showing the current viewport rectangle too.
+- [x] **`Board.Map` overview** — done.
+  - Tiles render with `bg-separator` (visible); the viewport rectangle is drawn
+    from live board/viewport geometry. Wired into `plugin-board`'s `BoardArticle`
+    as a corner overlay.
+
+- [ ] **Margin button to add a row/column**
+  - Add a control (edge affordance / toolbar button) to grow the board by a
+    row or column, extending the grid extent (relates to the `margin` prop and
+    `bounds`).

--- a/packages/ui/react-ui-board/src/components/Board/Board.stories.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.stories.tsx
@@ -253,6 +253,18 @@ export const Overscroll: Story = {
   },
 };
 
+/** `margin: 1` — one cell of perimeter breathing room around the grid so tiles aren't flush to the
+ * board edges (the margin scales with the board when zooming). */
+export const Margin: Story = {
+  args: {
+    items: testItems,
+    layout: defaultLayout,
+    mode: 'float' satisfies GridMode,
+    margin: 1,
+    debug: true,
+  },
+};
+
 /** Single-select: clicking a card selects it (clicking it again clears); at most one is selected. */
 export const SingleSelect: Story = {
   args: {

--- a/packages/ui/react-ui-board/src/components/Board/Board.stories.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.stories.tsx
@@ -119,6 +119,9 @@ const DefaultStory = ({ layout: layoutProp, items: itemsProp, mode, zoom: zoomPr
                 label='Center board'
                 onClick={() => controller.current?.center()}
               />
+              <Toolbar.Button onClick={() => setZoom(1)} disabled={zoom === 1}>
+                100%
+              </Toolbar.Button>
             </Toolbar.Root>
           </Panel.Toolbar>
           <Panel.Content asChild>

--- a/packages/ui/react-ui-board/src/components/Board/Board.stories.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.stories.tsx
@@ -21,7 +21,7 @@ type TestItem = {
   image?: string;
 };
 
-const titles = ['Sales', 'Revenue', 'Users', 'Latency', 'Errors'];
+const titles = ['A', 'B', 'C', 'D', 'X'];
 
 const testItems: TestItem[] = titles.map((title, index) => ({ id: String(index), title }));
 

--- a/packages/ui/react-ui-board/src/components/Board/Board.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.tsx
@@ -718,10 +718,20 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
     const to = zoom;
     const duration = ANIMATION_DURATION;
     const apply = (scale: number) => {
+      const pad = padAt(scale);
       if (board) {
         board.style.transform = scale === 1 ? '' : `scale(${scale})`;
+        // Animate the footprint with the scale, not just the paint: a CSS transform leaves the
+        // scrollable area at the layout size, so without this the scroll area stays sized for the
+        // FINAL zoom while a frame's scroll target is computed for the (larger) intermediate scale —
+        // the target overflows the collapsed scroll area and clamps (worst once the board fits). The
+        // margins mirror Board.Viewport so the board lands exactly on React's values at the end.
+        board.style.marginLeft = `${pad.x}px`;
+        board.style.marginTop = `${pad.y}px`;
+        board.style.marginRight = `${pad.x - boardSize.width * (1 - scale)}px`;
+        board.style.marginBottom = `${pad.y - boardSize.height * (1 - scale)}px`;
       }
-      const { left, top } = anchoredScroll({ anchor, viewport, pad: padAt(scale), zoom: scale });
+      const { left, top } = anchoredScroll({ anchor, viewport, pad, zoom: scale });
       element.scrollLeft = left;
       element.scrollTop = top;
     };

--- a/packages/ui/react-ui-board/src/components/Board/Board.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.tsx
@@ -113,6 +113,8 @@ type BoardContextValue = {
   resizing: boolean;
   /** Scroll viewport element; set by `Board.Container`, used by the controller to center. */
   viewportRef: MutableRefObject<HTMLDivElement | null>;
+  /** Anchor captured before an incremental zoom (consumed by the zoom-anchor animation). */
+  pendingAnchor: MutableRefObject<{ x: number; y: number } | null>;
   /** Scroll the viewport to center the board, or a specific cell when its id is given. `smooth`
    * defaults to true; pass false to jump instantly (used for the flicker-free mount centering). */
   center: (cell?: string, smooth?: boolean) => void;
@@ -262,6 +264,12 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
     // Scroll viewport (set by Board.Container) + imperative centering, exposed via the Root ref.
     const viewportRef = useRef<HTMLDivElement | null>(null);
 
+    // Anchor (unscaled content point at the viewport centre) captured just before an incremental zoom.
+    // Captured here — before `onZoomChange` shrinks the board — because on a zoom-out commit the browser
+    // clamps scrollLeft to the smaller board, so an anchor read afterwards (in the zoom effect) would be
+    // taken from an already-shifted scroll and hold the wrong point.
+    const pendingAnchorRef = useRef<{ x: number; y: number } | null>(null);
+
     // Smooth scroll via rAF (instant per-frame assignment): the ScrollArea viewport ignores native
     // `scrollTo({ behavior: 'smooth' })`, so we animate the scroll ourselves.
     const scrollFrameRef = useRef(0);
@@ -359,15 +367,32 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
     );
     useImperativeHandle(forwardedRef, () => ({ center }), [center]);
 
+    // Capture the point currently at the viewport centre from the live (pre-zoom) scroll, so the
+    // zoom-anchor animation holds it across the incremental zoom (see pendingAnchorRef).
+    const captureAnchor = useCallback(() => {
+      const el = viewportRef.current;
+      if (!el) {
+        return;
+      }
+      const viewport = { width: el.clientWidth, height: el.clientHeight };
+      const pad = boardPad({ viewport, board: gridBounds(columns, rows, cellSizePx, gapPx), zoom, overscroll });
+      pendingAnchorRef.current = viewportCenterAnchor({
+        scroll: { left: el.scrollLeft, top: el.scrollTop },
+        viewport,
+        pad,
+        zoom,
+      });
+    }, [columns, rows, cellSizePx, gapPx, zoom, overscroll]);
+
     // Zoom stepping (clamped to [minZoom, 1]); the scale is controlled by the consumer via onZoomChange.
-    const zoomIn = useCallback(
-      () => onZoomChange?.(Math.min(1, Math.round((zoom + zoomStep) * 100) / 100)),
-      [onZoomChange, zoom, zoomStep],
-    );
-    const zoomOut = useCallback(
-      () => onZoomChange?.(Math.max(minZoom, Math.round((zoom - zoomStep) * 100) / 100)),
-      [onZoomChange, zoom, zoomStep, minZoom],
-    );
+    const zoomIn = useCallback(() => {
+      captureAnchor();
+      onZoomChange?.(Math.min(1, Math.round((zoom + zoomStep) * 100) / 100));
+    }, [captureAnchor, onZoomChange, zoom, zoomStep]);
+    const zoomOut = useCallback(() => {
+      captureAnchor();
+      onZoomChange?.(Math.max(minZoom, Math.round((zoom - zoomStep) * 100) / 100));
+    }, [captureAnchor, onZoomChange, zoom, zoomStep, minZoom]);
 
     // Selection (hand-rolled controlled/uncontrolled; Radix useControllableState mishandles clearing).
     const emptySelection = useMemo<ReadonlySet<string>>(() => new Set(), []);
@@ -511,6 +536,7 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
         previewLayout={previewLayout}
         resizing={!!resizePreview}
         viewportRef={viewportRef}
+        pendingAnchor={pendingAnchorRef}
         center={center}
         onAdd={readonly ? undefined : onAdd}
         onDelete={readonly ? undefined : onDelete}
@@ -588,7 +614,7 @@ const BOARD_CONTAINER_NAME = 'Board.Container';
 type BoardContainerProps = ThemedClassName<PropsWithChildren>;
 
 const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
-  const { viewportRef, center, resizing, zoom, selected, overscroll, layout, cellSize, gap } =
+  const { viewportRef, pendingAnchor, center, resizing, zoom, selected, overscroll, layout, cellSize, gap } =
     useBoardContext(BOARD_CONTAINER_NAME);
   const localRef = useRef<HTMLDivElement>(null);
   const ref = composeRefs(localRef, viewportRef);
@@ -640,8 +666,13 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
         sumY += rect.top + rect.height / 2;
       }
       anchor = { x: sumX / ids.length, y: sumY / ids.length };
+    } else if (pendingAnchor.current) {
+      // An incremental zoom captured the pre-zoom centre before the board (and scroll) shrank — use it
+      // rather than the now-clamped scroll.
+      anchor = pendingAnchor.current;
+      pendingAnchor.current = null;
     } else {
-      // Nothing selected: hold whatever is currently at the viewport centre.
+      // Fallback (e.g. a programmatic zoom): hold whatever is currently at the viewport centre.
       anchor = viewportCenterAnchor({
         scroll: { left: element.scrollLeft, top: element.scrollTop },
         viewport,

--- a/packages/ui/react-ui-board/src/components/Board/Board.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.tsx
@@ -1003,22 +1003,38 @@ const BOARD_MAP_NAME = 'Board.Map';
 type BoardMapProps = ThemedClassName<{}>;
 
 const BoardMap = ({ classNames }: BoardMapProps) => {
-  const { layout, columns, rows, cellSize, gap, selected, viewportRef, zoom, overscrollPad } =
-    useBoardContext(BOARD_MAP_NAME);
+  const { layout, columns, rows, cellSize, gap, selected, viewportRef } = useBoardContext(BOARD_MAP_NAME);
   // Match the grid's pixel aspect (not the viewport's), and place tiles by their exact rects so the
   // map is a faithful scale model of the board.
   const bounds = useMemo(() => gridBounds(columns, rows, cellSize, gap), [columns, rows, cellSize, gap]);
   const tiles = useMemo(() => Object.entries(layout.items), [layout.items]);
 
-  // Track the scroll position and size of the viewport so the map can outline the visible region.
+  // The visible region as a fraction of the board, derived purely from live DOM geometry (the scaled
+  // board rect vs the viewport rect). Reading the actual transform each update keeps the outline exact
+  // even mid-zoom — deriving it from scroll + the React zoom would lag the animation (scroll moves per
+  // frame while zoom is already at its final value) and the outline would jump.
   const [view, setView] = useState({ left: 0, top: 0, width: 0, height: 0 });
   useEffect(() => {
     const el = viewportRef.current;
     if (!el) {
       return;
     }
-    const update = () =>
-      setView({ left: el.scrollLeft, top: el.scrollTop, width: el.clientWidth, height: el.clientHeight });
+    const update = () => {
+      const boardEl = el.querySelector<HTMLElement>('[data-dx-board-viewport]');
+      if (!boardEl) {
+        return;
+      }
+      const vr = el.getBoundingClientRect();
+      const br = boardEl.getBoundingClientRect();
+      const scale = br.width / boardEl.offsetWidth || 1;
+      // Visible region in unscaled content coords, relative to the board's top-left.
+      setView({
+        left: (vr.left - br.left) / scale,
+        top: (vr.top - br.top) / scale,
+        width: vr.width / scale,
+        height: vr.height / scale,
+      });
+    };
     update();
     el.addEventListener('scroll', update, { passive: true });
     const observer = new ResizeObserver(update);
@@ -1029,20 +1045,11 @@ const BoardMap = ({ classNames }: BoardMapProps) => {
     };
   }, [viewportRef]);
 
-  // The visible region in unscaled content coords: undo the board's left/top pad (shared with the
-  // layout / scroll math) and the zoom scale so it maps onto the same coordinate space as the tile
-  // rects (percent of the board bounds).
-  const pad = boardPad({
-    viewport: { width: view.width, height: view.height },
-    board: bounds,
-    zoom,
-    overscroll: overscrollPad.x > 0 || overscrollPad.y > 0,
-  });
   const viewport = {
-    left: ((view.left - pad.x) / zoom / bounds.width) * 100,
-    top: ((view.top - pad.y) / zoom / bounds.height) * 100,
-    width: (view.width / zoom / bounds.width) * 100,
-    height: (view.height / zoom / bounds.height) * 100,
+    left: (view.left / bounds.width) * 100,
+    top: (view.top / bounds.height) * 100,
+    width: (view.width / bounds.width) * 100,
+    height: (view.height / bounds.height) * 100,
   };
 
   return (

--- a/packages/ui/react-ui-board/src/components/Board/Board.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.tsx
@@ -512,6 +512,14 @@ const BoardViewport = ({ classNames, children }: BoardViewportProps) => {
   const bounds = useMemo(() => gridBounds(columns, rows, cellSize, gap), [columns, rows, cellSize, gap]);
   const overscroll = overscrollPad.x > 0 || overscrollPad.y > 0;
 
+  // A CSS transform scales the paint but not the layout box, so at zoom < 1 the board keeps its full
+  // unscaled footprint and leaves a void to the right/below in the scroll area. Pull that extra extent
+  // back with negative right/bottom margins so the scrollable area matches the scaled board — without
+  // touching the transform, so Board.Container's scroll/zoom-anchor math (which maps a content point to
+  // `point * zoom` from the board's top-left) is unchanged.
+  const voidX = zoom < 1 ? bounds.width * (1 - zoom) : 0;
+  const voidY = zoom < 1 ? bounds.height * (1 - zoom) : 0;
+
   return (
     // `m-auto` centers the board within the (flex) scroll container when it fits, and stays fully
     // scrollable when it overflows (unlike justify-center, which would clip the top/left).
@@ -532,7 +540,12 @@ const BoardViewport = ({ classNames, children }: BoardViewportProps) => {
         // compensates scroll on zoom to keep the anchor (selected tile / current centre) fixed.
         transform: zoom !== 1 ? `scale(${zoom})` : undefined,
         transformOrigin: '0 0',
-        margin: overscroll ? `${overscrollPad.y}px ${overscrollPad.x}px` : undefined,
+        // Left/top keep `m-auto` (or the overscroll pad); right/bottom shed the unscaled void so the
+        // scroll extent matches the scaled board.
+        marginLeft: overscroll ? overscrollPad.x : undefined,
+        marginTop: overscroll ? overscrollPad.y : undefined,
+        marginRight: overscroll ? overscrollPad.x - voidX : voidX ? -voidX : undefined,
+        marginBottom: overscroll ? overscrollPad.y - voidY : voidY ? -voidY : undefined,
       }}
     >
       {children}

--- a/packages/ui/react-ui-board/src/components/Board/Board.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.tsx
@@ -20,7 +20,6 @@ import React, {
 } from 'react';
 
 import { invariant } from '@dxos/invariant';
-import { log } from '@dxos/log';
 import {
   IconButton,
   ScrollArea,
@@ -64,7 +63,7 @@ import {
 } from './geometry';
 
 /** Duration (ms) of the zoom-anchor and recenter scroll animations. */
-const ANIMATION_DURATION = 500;
+const ANIMATION_DURATION = 200;
 
 // TODO(burdon): Multi-select + keyboard move/resize.
 // TODO(burdon): Zoom/overview + toolbar (port from the previous Board — deferred).
@@ -285,10 +284,6 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
       const deltaLeft = left - startLeft;
       const deltaTop = top - startTop;
       const duration = ANIMATION_DURATION;
-      log.info('recenter begin', {
-        from: { left: Math.round(startLeft), top: Math.round(startTop) },
-        to: { left: Math.round(left), top: Math.round(top) },
-      });
       let startTime: number | undefined;
       const step = (time: number) => {
         startTime ??= time;
@@ -298,8 +293,6 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
         el.scrollTop = startTop + deltaTop * eased;
         if (t < 1) {
           scrollFrameRef.current = requestAnimationFrame(step);
-        } else {
-          log.info('recenter end', { at: { left: Math.round(el.scrollLeft), top: Math.round(el.scrollTop) } });
         }
       };
       scrollFrameRef.current = requestAnimationFrame(step);
@@ -694,22 +687,6 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
       });
     }
 
-    const target = anchoredScroll({ anchor, viewport, pad: padAt(zoom), zoom });
-    // Diagnostic: the full anchor computation for one zoom step. Enable in the browser with
-    // `localStorage.setItem('dxlog', 'info:react-ui-board/board')` (or check the default console).
-    log.info('zoom anchor begin', {
-      prevZoom,
-      zoom,
-      scrollBefore: { left: Math.round(element.scrollLeft), top: Math.round(element.scrollTop) },
-      viewport,
-      boardSize,
-      overscroll,
-      padPrev: padAt(prevZoom),
-      padNext: padAt(zoom),
-      anchor: { x: Math.round(anchor.x), y: Math.round(anchor.y) },
-      target,
-    });
-
     // Drive the zoom ourselves (scale + scroll together) each frame, so the anchor stays at the
     // viewport centre for the whole animation — the selected tiles are the focal point, not the
     // board's top-left. We set the scale imperatively (overriding React's inline transform for the
@@ -748,14 +725,6 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
       } else {
         // Settled: allow the next zoom to re-capture the anchor from the (now-stable) scroll.
         zooming.current = false;
-        // The actual scroll reached, and the content point now at the viewport centre — compare with
-        // `target` / `anchor` above to see whether the anchor held.
-        const scrollAfter = { left: Math.round(element.scrollLeft), top: Math.round(element.scrollTop) };
-        log.info('zoom anchor end', {
-          zoom,
-          scrollAfter,
-          achievedAnchor: viewportCenterAnchor({ scroll: scrollAfter, viewport, pad: padAt(zoom), zoom }),
-        });
       }
     };
     frame = requestAnimationFrame(step);

--- a/packages/ui/react-ui-board/src/components/Board/Board.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.tsx
@@ -89,6 +89,8 @@ type BoardContextValue = {
   overscroll: boolean;
   /** Overscroll padding in px (half the viewport on each axis), or 0 when disabled. */
   overscrollPad: { x: number; y: number };
+  /** Scroll viewport size in px (0 until measured); used to centre a board smaller than the viewport. */
+  viewportSize: { width: number; height: number };
   containerId: string;
   /** During an active drag, the layout the board would settle into — tiles animate to these
    * positions and spring back to `layout` when the drag ends without a drop. Undefined when idle. */
@@ -270,12 +272,12 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
       scrollFrameRef.current = requestAnimationFrame(step);
     }, []);
 
-    // Overscroll padding: half the viewport on each side, measured from the scroll element so the
-    // board can pad itself (see Board.Viewport) enough for any cell to reach the centre.
+    // Track the scroll viewport's size (always — used both for overscroll padding and for centering the
+    // board when it is smaller than the viewport, see Board.Viewport / `center`).
     const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 });
     useEffect(() => {
       const el = viewportRef.current;
-      if (!el || !overscroll) {
+      if (!el) {
         setViewportSize({ width: 0, height: 0 });
         return;
       }
@@ -284,7 +286,7 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
       const observer = new ResizeObserver(update);
       observer.observe(el);
       return () => observer.disconnect();
-    }, [overscroll]);
+    }, []);
     const overscrollPad = useMemo(
       () => (overscroll ? { x: viewportSize.width / 2, y: viewportSize.height / 2 } : { x: 0, y: 0 }),
       [overscroll, viewportSize.width, viewportSize.height],
@@ -314,11 +316,13 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
           anchorX = board.width / 2;
           anchorY = board.height / 2;
         }
-        // The board box sits at the overscroll padding offset and scales from its top-left
-        // (transform-origin 0 0), so a content point maps to `pad + point * zoom` on screen; place
-        // the anchor at the viewport centre.
-        const padX = overscroll ? el.clientWidth / 2 : 0;
-        const padY = overscroll ? el.clientHeight / 2 : 0;
+        // The board box sits at a left/top pad and scales from its top-left (transform-origin 0 0), so a
+        // content point maps to `pad + point * zoom` on screen; place the anchor at the viewport centre.
+        // The pad is half the viewport under overscroll, else the margin that centres a board smaller
+        // than the viewport (0 when it overflows) — matching Board.Viewport's margins.
+        const boardBox = gridBounds(columns, rows, cellSizePx, gapPx);
+        const padX = overscroll ? el.clientWidth / 2 : Math.max(0, (el.clientWidth - boardBox.width * zoom) / 2);
+        const padY = overscroll ? el.clientHeight / 2 : Math.max(0, (el.clientHeight - boardBox.height * zoom) / 2);
         const targetLeft = padX + anchorX * zoom - el.clientWidth / 2;
         const targetTop = padY + anchorY * zoom - el.clientHeight / 2;
         if (smooth) {
@@ -481,6 +485,7 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
         debug={debug}
         overscroll={overscroll}
         overscrollPad={overscrollPad}
+        viewportSize={viewportSize}
         containerId={containerId}
         previewLayout={previewLayout}
         resizing={!!resizePreview}
@@ -508,31 +513,31 @@ const BOARD_VIEWPORT_NAME = 'Board.Viewport';
 type BoardViewportProps = ThemedClassName<PropsWithChildren>;
 
 const BoardViewport = ({ classNames, children }: BoardViewportProps) => {
-  const { cellSize, gap, columns, rows, zoom, overscrollPad } = useBoardContext(BOARD_VIEWPORT_NAME);
+  const { cellSize, gap, columns, rows, zoom, overscrollPad, viewportSize } = useBoardContext(BOARD_VIEWPORT_NAME);
   const bounds = useMemo(() => gridBounds(columns, rows, cellSize, gap), [columns, rows, cellSize, gap]);
   const overscroll = overscrollPad.x > 0 || overscrollPad.y > 0;
 
   // A CSS transform scales the paint but not the layout box, so at zoom < 1 the board keeps its full
-  // unscaled footprint and leaves a void to the right/below in the scroll area. Pull that extra extent
-  // back with negative right/bottom margins so the scrollable area matches the scaled board — without
-  // touching the transform, so Board.Container's scroll/zoom-anchor math (which maps a content point to
-  // `point * zoom` from the board's top-left) is unchanged.
+  // unscaled footprint. `voidX/Y` is that extra extent (unscaled minus scaled).
   const voidX = zoom < 1 ? bounds.width * (1 - zoom) : 0;
   const voidY = zoom < 1 ? bounds.height * (1 - zoom) : 0;
+  // Left/top pad that centres a board smaller than the viewport (0 when it overflows). Computed
+  // explicitly rather than via `m-auto` so it stays symmetric — `m-auto` combined with the negative
+  // right margin (below) would shove the board to one side and leave a void on the left/top.
+  const padX = overscroll ? overscrollPad.x : Math.max(0, (viewportSize.width - bounds.width * zoom) / 2);
+  const padY = overscroll ? overscrollPad.y : Math.max(0, (viewportSize.height - bounds.height * zoom) / 2);
 
   return (
-    // `m-auto` centers the board within the (flex) scroll container when it fits, and stays fully
-    // scrollable when it overflows (unlike justify-center, which would clip the top/left).
+    // The board sits at `pad` (centring it when it fits, 0 + overscroll when it overflows) and sheds the
+    // unscaled void on the right/bottom so the scrollable area matches the scaled board.
     // A zoom < 1 gives a scaled overview; drag/resize are disabled in that mode (see BoardCell).
-    // With overscroll, an explicit margin (half the viewport) replaces `m-auto` so any cell can be
-    // scrolled to the centre.
     <div
       // `shrink-0`: as a flex item the board must keep its full width, else the row container shrinks
       // it and the right-hand overflow (incl. the overscroll margin) collapses.
       data-dx-board-viewport='true'
       // No CSS transform transition — Board.Container drives the zoom (scale + scroll together) per
       // frame so the focal point stays fixed while zooming.
-      className={mx('relative m-auto shrink-0', classNames)}
+      className={mx('relative shrink-0', classNames)}
       style={{
         width: bounds.width,
         height: bounds.height,
@@ -540,12 +545,10 @@ const BoardViewport = ({ classNames, children }: BoardViewportProps) => {
         // compensates scroll on zoom to keep the anchor (selected tile / current centre) fixed.
         transform: zoom !== 1 ? `scale(${zoom})` : undefined,
         transformOrigin: '0 0',
-        // Left/top keep `m-auto` (or the overscroll pad); right/bottom shed the unscaled void so the
-        // scroll extent matches the scaled board.
-        marginLeft: overscroll ? overscrollPad.x : undefined,
-        marginTop: overscroll ? overscrollPad.y : undefined,
-        marginRight: overscroll ? overscrollPad.x - voidX : voidX ? -voidX : undefined,
-        marginBottom: overscroll ? overscrollPad.y - voidY : voidY ? -voidY : undefined,
+        marginLeft: padX,
+        marginTop: padY,
+        marginRight: padX - voidX,
+        marginBottom: padY - voidY,
       }}
     >
       {children}
@@ -599,8 +602,15 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
     // fluctuating measurement mid-animation).
     const clientWidth = element.clientWidth;
     const clientHeight = element.clientHeight;
-    const padX = overscroll ? clientWidth / 2 : 0;
-    const padY = overscroll ? clientHeight / 2 : 0;
+    const board = element.querySelector<HTMLElement>('[data-dx-board-viewport]');
+    // Board's unscaled footprint (offsetWidth ignores the transform), used to derive its left/top
+    // offset in the scroll content at a given scale — matching Board.Viewport's margins: half the
+    // viewport under overscroll, else the margin that centres a board smaller than the viewport.
+    const boardW = board?.offsetWidth ?? 0;
+    const boardH = board?.offsetHeight ?? 0;
+    const padXAt = (scale: number) => (overscroll ? clientWidth / 2 : Math.max(0, (clientWidth - boardW * scale) / 2));
+    const padYAt = (scale: number) =>
+      overscroll ? clientHeight / 2 : Math.max(0, (clientHeight - boardH * scale) / 2);
 
     // Anchor point in unscaled, board-relative content coords.
     let anchorX: number;
@@ -620,15 +630,14 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
       anchorY = sumY / ids.length;
     } else {
       // Nothing selected: hold whatever is currently at the viewport centre.
-      anchorX = (element.scrollLeft + clientWidth / 2 - padX) / prevZoom;
-      anchorY = (element.scrollTop + clientHeight / 2 - padY) / prevZoom;
+      anchorX = (element.scrollLeft + clientWidth / 2 - padXAt(prevZoom)) / prevZoom;
+      anchorY = (element.scrollTop + clientHeight / 2 - padYAt(prevZoom)) / prevZoom;
     }
 
     // Drive the zoom ourselves (scale + scroll together) each frame, so the anchor stays at the
     // viewport centre for the whole animation — the selected tiles are the focal point, not the
     // board's top-left. We set the scale imperatively (overriding React's inline transform for the
     // ~duration); it lands on React's value at the end.
-    const board = element.querySelector<HTMLElement>('[data-dx-board-viewport]');
     const from = prevZoom;
     const to = zoom;
     const duration = 200;
@@ -636,8 +645,8 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
       if (board) {
         board.style.transform = scale === 1 ? '' : `scale(${scale})`;
       }
-      element.scrollLeft = padX + anchorX * scale - clientWidth / 2;
-      element.scrollTop = padY + anchorY * scale - clientHeight / 2;
+      element.scrollLeft = padXAt(scale) + anchorX * scale - clientWidth / 2;
+      element.scrollTop = padYAt(scale) + anchorY * scale - clientHeight / 2;
     };
 
     let frame = 0;
@@ -932,11 +941,14 @@ const BoardMap = ({ classNames }: BoardMapProps) => {
     };
   }, [viewportRef]);
 
-  // The visible region in unscaled content coords: undo the overscroll padding and the zoom scale so
-  // it maps onto the same coordinate space as the tile rects (percent of the board bounds).
+  // The visible region in unscaled content coords: undo the board's left/top pad (overscroll, or the
+  // margin that centres a board smaller than the viewport) and the zoom scale so it maps onto the same
+  // coordinate space as the tile rects (percent of the board bounds).
+  const padX = overscrollPad.x > 0 ? overscrollPad.x : Math.max(0, (view.width - bounds.width * zoom) / 2);
+  const padY = overscrollPad.y > 0 ? overscrollPad.y : Math.max(0, (view.height - bounds.height * zoom) / 2);
   const viewport = {
-    left: ((view.left - overscrollPad.x) / zoom / bounds.width) * 100,
-    top: ((view.top - overscrollPad.y) / zoom / bounds.height) * 100,
+    left: ((view.left - padX) / zoom / bounds.width) * 100,
+    top: ((view.top - padY) / zoom / bounds.height) * 100,
     width: (view.width / zoom / bounds.width) * 100,
     height: (view.height / zoom / bounds.height) * 100,
   };

--- a/packages/ui/react-ui-board/src/components/Board/Board.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.tsx
@@ -13,6 +13,7 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -96,8 +97,9 @@ type BoardContextValue = {
   resizing: boolean;
   /** Scroll viewport element; set by `Board.Container`, used by the controller to center. */
   viewportRef: MutableRefObject<HTMLDivElement | null>;
-  /** Scroll the viewport to center the board, or a specific cell when its id is given. */
-  center: (cell?: string) => void;
+  /** Scroll the viewport to center the board, or a specific cell when its id is given. `smooth`
+   * defaults to true; pass false to jump instantly (used for the flicker-free mount centering). */
+  center: (cell?: string, smooth?: boolean) => void;
   onAdd?: (position: GridPosition) => void;
   onDelete?: (id: string) => void;
   onResize: (id: string, size: { w: number; h: number }, constraints?: GridConstraints) => void;
@@ -289,7 +291,7 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
     );
 
     const center = useCallback(
-      (cell?: string) => {
+      (cell?: string, smooth = true) => {
         const el = viewportRef.current;
         if (!el) {
           return;
@@ -317,7 +319,16 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
         // the anchor at the viewport centre.
         const padX = overscroll ? el.clientWidth / 2 : 0;
         const padY = overscroll ? el.clientHeight / 2 : 0;
-        smoothScrollTo(el, padX + anchorX * zoom - el.clientWidth / 2, padY + anchorY * zoom - el.clientHeight / 2);
+        const targetLeft = padX + anchorX * zoom - el.clientWidth / 2;
+        const targetTop = padY + anchorY * zoom - el.clientHeight / 2;
+        if (smooth) {
+          smoothScrollTo(el, targetLeft, targetTop);
+        } else {
+          // Instant jump (no rAF animation) — the board must already be centered on the first paint.
+          cancelAnimationFrame(scrollFrameRef.current);
+          el.scrollLeft = targetLeft;
+          el.scrollTop = targetTop;
+        }
       },
       [layout, cellSizePx, gapPx, columns, rows, zoom, overscroll, smoothScrollTo],
     );
@@ -712,11 +723,13 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
     };
   }, []);
 
-  // Center the board once on mount only. Deliberately NOT re-centering when the layout/size changes,
-  // so the viewport doesn't jump after a drag or resize (`center` now closes over `layout`, so it is
-  // intentionally excluded from the deps — this must run a single time).
-  useEffect(() => {
-    center();
+  // Center the board once on mount, before the first paint and without animation, so it starts
+  // centered rather than scrolling into place from the top-left. A layout effect + instant jump
+  // avoids the flicker the smooth scroll (used for later, explicit centering) would show here.
+  // Deliberately NOT re-centering when the layout/size changes, so the viewport doesn't jump after a
+  // drag or resize (`center` closes over `layout`, so it is intentionally excluded from the deps).
+  useLayoutEffect(() => {
+    center(undefined, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -880,11 +893,40 @@ const BOARD_MAP_NAME = 'Board.Map';
 type BoardMapProps = ThemedClassName<{}>;
 
 const BoardMap = ({ classNames }: BoardMapProps) => {
-  const { layout, columns, rows, cellSize, gap, selected } = useBoardContext(BOARD_MAP_NAME);
+  const { layout, columns, rows, cellSize, gap, selected, viewportRef, zoom, overscrollPad } =
+    useBoardContext(BOARD_MAP_NAME);
   // Match the grid's pixel aspect (not the viewport's), and place tiles by their exact rects so the
   // map is a faithful scale model of the board.
   const bounds = useMemo(() => gridBounds(columns, rows, cellSize, gap), [columns, rows, cellSize, gap]);
   const tiles = useMemo(() => Object.entries(layout.items), [layout.items]);
+
+  // Track the scroll position and size of the viewport so the map can outline the visible region.
+  const [view, setView] = useState({ left: 0, top: 0, width: 0, height: 0 });
+  useEffect(() => {
+    const el = viewportRef.current;
+    if (!el) {
+      return;
+    }
+    const update = () =>
+      setView({ left: el.scrollLeft, top: el.scrollTop, width: el.clientWidth, height: el.clientHeight });
+    update();
+    el.addEventListener('scroll', update, { passive: true });
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => {
+      el.removeEventListener('scroll', update);
+      observer.disconnect();
+    };
+  }, [viewportRef]);
+
+  // The visible region in unscaled content coords: undo the overscroll padding and the zoom scale so
+  // it maps onto the same coordinate space as the tile rects (percent of the board bounds).
+  const viewport = {
+    left: ((view.left - overscrollPad.x) / zoom / bounds.width) * 100,
+    top: ((view.top - overscrollPad.y) / zoom / bounds.height) * 100,
+    width: (view.width / zoom / bounds.width) * 100,
+    height: (view.height / zoom / bounds.height) * 100,
+  };
 
   return (
     <div
@@ -907,6 +949,18 @@ const BoardMap = ({ classNames }: BoardMapProps) => {
           />
         );
       })}
+      {/* The current viewport, outlined over the board (clips to the map when it extends past bounds). */}
+      {view.width > 0 && (
+        <div
+          className='pointer-events-none absolute rounded-[1px] border border-accent-bg'
+          style={{
+            left: `${viewport.left}%`,
+            top: `${viewport.top}%`,
+            width: `${viewport.width}%`,
+            height: `${viewport.height}%`,
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/packages/ui/react-ui-board/src/components/Board/Board.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.tsx
@@ -93,6 +93,8 @@ type BoardContextValue = {
   /** Cell size and gap in px (converted from the `cellSize`/`gap` props, which are in rem). */
   cellSize: GridCellSize;
   gap: number;
+  /** Perimeter breathing room around the grid, in cell units (see the `margin` prop). */
+  margin: number;
   /** Column/row extent to render (the backdrop shows at least this; grows with content). */
   columns: number;
   rows: number;
@@ -183,6 +185,9 @@ type BoardRootProps = PropsWithChildren<{
   cellSize?: GridCellSize;
   /** Gap between cells in rem. */
   gap?: number;
+  /** Perimeter breathing room around the grid, in cell units, so tiles aren't flush to the board
+   * edges (0 = none). Part of the scaled board, so it zooms with the content. */
+  margin?: number;
   /** Render each backdrop cell's `x,y` coordinate (debugging aid). Off by default. */
   debug?: boolean;
   /**
@@ -225,6 +230,7 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
       onSelectedChange,
       cellSize = defaultCellSize,
       gap = defaultGap,
+      margin = 0,
       debug = false,
       overscroll = false,
       settleDelay = 500,
@@ -334,18 +340,24 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
             { x: position.x, y: position.y, w: position.w ?? 1, h: position.h ?? 1 },
             cellSizePx,
             gapPx,
+            margin,
           );
           anchorX = rect.left + rect.width / 2;
           anchorY = rect.top + rect.height / 2;
         } else {
-          const board = gridBounds(columns, rows, cellSizePx, gapPx);
+          const board = gridBounds(columns, rows, cellSizePx, gapPx, margin);
           anchorX = board.width / 2;
           anchorY = board.height / 2;
         }
         // Place the anchor at the viewport centre. The board sits at `pad` and scales from its top-left
         // (transform-origin 0 0), so a content point maps to `pad + point * zoom` on screen.
         const viewport = { width: el.clientWidth, height: el.clientHeight };
-        const pad = boardPad({ viewport, board: gridBounds(columns, rows, cellSizePx, gapPx), zoom, overscroll });
+        const pad = boardPad({
+          viewport,
+          board: gridBounds(columns, rows, cellSizePx, gapPx, margin),
+          zoom,
+          overscroll,
+        });
         const { left: targetLeft, top: targetTop } = anchoredScroll({
           anchor: { x: anchorX, y: anchorY },
           viewport,
@@ -373,7 +385,7 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
         return;
       }
       const viewport = { width: el.clientWidth, height: el.clientHeight };
-      const pad = boardPad({ viewport, board: gridBounds(columns, rows, cellSizePx, gapPx), zoom, overscroll });
+      const pad = boardPad({ viewport, board: gridBounds(columns, rows, cellSizePx, gapPx, margin), zoom, overscroll });
       pendingAnchorRef.current = viewportCenterAnchor({
         scroll: { left: el.scrollLeft, top: el.scrollTop },
         viewport,
@@ -532,6 +544,7 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
         zoomOut={zoomOut}
         cellSize={cellSizePx}
         gap={gapPx}
+        margin={margin}
         columns={columns}
         rows={rows}
         debug={debug}
@@ -567,8 +580,12 @@ const BOARD_VIEWPORT_NAME = 'Board.Viewport';
 type BoardViewportProps = ThemedClassName<PropsWithChildren>;
 
 const BoardViewport = ({ classNames, children }: BoardViewportProps) => {
-  const { cellSize, gap, columns, rows, zoom, overscrollPad, viewportSize } = useBoardContext(BOARD_VIEWPORT_NAME);
-  const bounds = useMemo(() => gridBounds(columns, rows, cellSize, gap), [columns, rows, cellSize, gap]);
+  const { cellSize, gap, margin, columns, rows, zoom, overscrollPad, viewportSize } =
+    useBoardContext(BOARD_VIEWPORT_NAME);
+  const bounds = useMemo(
+    () => gridBounds(columns, rows, cellSize, gap, margin),
+    [columns, rows, cellSize, gap, margin],
+  );
   const overscroll = overscrollPad.x > 0 || overscrollPad.y > 0;
 
   // A CSS transform scales the paint but not the layout box, so at zoom < 1 the board keeps its full
@@ -621,8 +638,20 @@ const BOARD_CONTAINER_NAME = 'Board.Container';
 type BoardContainerProps = ThemedClassName<PropsWithChildren>;
 
 const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
-  const { viewportRef, pendingAnchor, zooming, center, resizing, zoom, selected, overscroll, layout, cellSize, gap } =
-    useBoardContext(BOARD_CONTAINER_NAME);
+  const {
+    viewportRef,
+    pendingAnchor,
+    zooming,
+    center,
+    resizing,
+    zoom,
+    selected,
+    overscroll,
+    layout,
+    cellSize,
+    gap,
+    margin,
+  } = useBoardContext(BOARD_CONTAINER_NAME);
   const localRef = useRef<HTMLDivElement>(null);
   const ref = composeRefs(localRef, viewportRef);
 
@@ -632,8 +661,8 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
 
   // Latest state read from refs so the zoom-anchor effect depends only on `zoom` (so selecting a tile
   // at a constant zoom does NOT move the board).
-  const anchorState = useRef({ selected, overscroll, layout, cellSize, gap });
-  anchorState.current = { selected, overscroll, layout, cellSize, gap };
+  const anchorState = useRef({ selected, overscroll, layout, cellSize, gap, margin });
+  anchorState.current = { selected, overscroll, layout, cellSize, gap, margin };
 
   // Keep the board anchored while zooming: animate the scale AND the scroll together each frame so the
   // anchor stays at the viewport centre for the whole animation (no post-animation shift). The anchor
@@ -650,7 +679,7 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
       return;
     }
 
-    const { selected, overscroll, layout, cellSize, gap } = anchorState.current;
+    const { selected, overscroll, layout, cellSize, gap, margin } = anchorState.current;
     // Capture the viewport size once — stable during the animation in a real pane (and avoids a
     // fluctuating measurement mid-animation).
     const viewport = { width: element.clientWidth, height: element.clientHeight };
@@ -668,7 +697,12 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
       let sumY = 0;
       for (const id of ids) {
         const position = layout.items[id];
-        const rect = cellRect({ x: position.x, y: position.y, w: position.w ?? 1, h: position.h ?? 1 }, cellSize, gap);
+        const rect = cellRect(
+          { x: position.x, y: position.y, w: position.w ?? 1, h: position.h ?? 1 },
+          cellSize,
+          gap,
+          margin,
+        );
         sumX += rect.left + rect.width / 2;
         sumY += rect.top + rect.height / 2;
       }
@@ -865,13 +899,14 @@ const BOARD_BACKDROP_NAME = 'Board.Backdrop';
 type BoardBackdropProps = {};
 
 const BoardBackdrop = (_props: BoardBackdropProps) => {
-  const { cellSize, gap, columns, rows, debug, containerId, readonly, onAdd } = useBoardContext(BOARD_BACKDROP_NAME);
+  const { cellSize, gap, margin, columns, rows, debug, containerId, readonly, onAdd } =
+    useBoardContext(BOARD_BACKDROP_NAME);
 
   const cells = useMemo(() => {
     const cells: { position: { x: number; y: number }; rect: Rect }[] = [];
     for (let y = 0; y < rows; y++) {
       for (let x = 0; x < columns; x++) {
-        cells.push({ position: { x, y }, rect: cellRect({ x, y, w: 1, h: 1 }, cellSize, gap) });
+        cells.push({ position: { x, y }, rect: cellRect({ x, y, w: 1, h: 1 }, cellSize, gap, margin) });
       }
     }
 
@@ -982,10 +1017,13 @@ const BOARD_MAP_NAME = 'Board.Map';
 type BoardMapProps = ThemedClassName<{}>;
 
 const BoardMap = ({ classNames }: BoardMapProps) => {
-  const { layout, columns, rows, cellSize, gap, selected, viewportRef } = useBoardContext(BOARD_MAP_NAME);
+  const { layout, columns, rows, cellSize, gap, margin, selected, viewportRef } = useBoardContext(BOARD_MAP_NAME);
   // Match the grid's pixel aspect (not the viewport's), and place tiles by their exact rects so the
   // map is a faithful scale model of the board.
-  const bounds = useMemo(() => gridBounds(columns, rows, cellSize, gap), [columns, rows, cellSize, gap]);
+  const bounds = useMemo(
+    () => gridBounds(columns, rows, cellSize, gap, margin),
+    [columns, rows, cellSize, gap, margin],
+  );
   const tiles = useMemo(() => Object.entries(layout.items), [layout.items]);
 
   // The visible region as a fraction of the board, derived purely from live DOM geometry (the scaled
@@ -1037,7 +1075,12 @@ const BoardMap = ({ classNames }: BoardMapProps) => {
       style={{ aspectRatio: `${bounds.width} / ${bounds.height}` }}
     >
       {tiles.map(([id, position]) => {
-        const rect = cellRect({ x: position.x, y: position.y, w: position.w ?? 1, h: position.h ?? 1 }, cellSize, gap);
+        const rect = cellRect(
+          { x: position.x, y: position.y, w: position.w ?? 1, h: position.h ?? 1 },
+          cellSize,
+          gap,
+          margin,
+        );
         return (
           <div
             key={id}

--- a/packages/ui/react-ui-board/src/components/Board/Board.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.tsx
@@ -115,6 +115,8 @@ type BoardContextValue = {
   viewportRef: MutableRefObject<HTMLDivElement | null>;
   /** Anchor captured before an incremental zoom (consumed by the zoom-anchor animation). */
   pendingAnchor: MutableRefObject<{ x: number; y: number } | null>;
+  /** True while a zoom animation is in flight; the animation clears it when it settles. */
+  zooming: MutableRefObject<boolean>;
   /** Scroll the viewport to center the board, or a specific cell when its id is given. `smooth`
    * defaults to true; pass false to jump instantly (used for the flicker-free mount centering). */
   center: (cell?: string, smooth?: boolean) => void;
@@ -267,8 +269,11 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
     // Anchor (unscaled content point at the viewport centre) captured just before an incremental zoom.
     // Captured here — before `onZoomChange` shrinks the board — because on a zoom-out commit the browser
     // clamps scrollLeft to the smaller board, so an anchor read afterwards (in the zoom effect) would be
-    // taken from an already-shifted scroll and hold the wrong point.
+    // taken from an already-shifted scroll and hold the wrong point. `zooming` gates re-capture: while a
+    // zoom animation is in flight the live scroll is mid-transition, so a rapid second zoom must reuse
+    // the in-flight anchor rather than read the (still-moving) scroll.
     const pendingAnchorRef = useRef<{ x: number; y: number } | null>(null);
+    const zoomingRef = useRef(false);
 
     // Smooth scroll via rAF (instant per-frame assignment): the ScrollArea viewport ignores native
     // `scrollTo({ behavior: 'smooth' })`, so we animate the scroll ourselves.
@@ -385,12 +390,20 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
     }, [columns, rows, cellSizePx, gapPx, zoom, overscroll]);
 
     // Zoom stepping (clamped to [minZoom, 1]); the scale is controlled by the consumer via onZoomChange.
+    // Capture the anchor only when no zoom is in flight (a rapid second zoom reuses the in-flight anchor,
+    // since the live scroll is mid-animation); mark zooming so the animation-end handler can clear it.
     const zoomIn = useCallback(() => {
-      captureAnchor();
+      if (!zoomingRef.current) {
+        captureAnchor();
+      }
+      zoomingRef.current = true;
       onZoomChange?.(Math.min(1, Math.round((zoom + zoomStep) * 100) / 100));
     }, [captureAnchor, onZoomChange, zoom, zoomStep]);
     const zoomOut = useCallback(() => {
-      captureAnchor();
+      if (!zoomingRef.current) {
+        captureAnchor();
+      }
+      zoomingRef.current = true;
       onZoomChange?.(Math.max(minZoom, Math.round((zoom - zoomStep) * 100) / 100));
     }, [captureAnchor, onZoomChange, zoom, zoomStep, minZoom]);
 
@@ -537,6 +550,7 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
         resizing={!!resizePreview}
         viewportRef={viewportRef}
         pendingAnchor={pendingAnchorRef}
+        zooming={zoomingRef}
         center={center}
         onAdd={readonly ? undefined : onAdd}
         onDelete={readonly ? undefined : onDelete}
@@ -614,7 +628,7 @@ const BOARD_CONTAINER_NAME = 'Board.Container';
 type BoardContainerProps = ThemedClassName<PropsWithChildren>;
 
 const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
-  const { viewportRef, pendingAnchor, center, resizing, zoom, selected, overscroll, layout, cellSize, gap } =
+  const { viewportRef, pendingAnchor, zooming, center, resizing, zoom, selected, overscroll, layout, cellSize, gap } =
     useBoardContext(BOARD_CONTAINER_NAME);
   const localRef = useRef<HTMLDivElement>(null);
   const ref = composeRefs(localRef, viewportRef);
@@ -668,9 +682,8 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
       anchor = { x: sumX / ids.length, y: sumY / ids.length };
     } else if (pendingAnchor.current) {
       // An incremental zoom captured the pre-zoom centre before the board (and scroll) shrank — use it
-      // rather than the now-clamped scroll.
+      // rather than the now-clamped scroll. Kept (not cleared) so a rapid follow-up zoom reuses it.
       anchor = pendingAnchor.current;
-      pendingAnchor.current = null;
     } else {
       // Fallback (e.g. a programmatic zoom): hold whatever is currently at the viewport centre.
       anchor = viewportCenterAnchor({
@@ -723,6 +736,8 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
       if (t < 1) {
         frame = requestAnimationFrame(step);
       } else {
+        // Settled: allow the next zoom to re-capture the anchor from the (now-stable) scroll.
+        zooming.current = false;
         // The actual scroll reached, and the content point now at the viewport centre — compare with
         // `target` / `anchor` above to see whether the anchor held.
         const scrollAfter = { left: Math.round(element.scrollLeft), top: Math.round(element.scrollTop) };

--- a/packages/ui/react-ui-board/src/components/Board/Board.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/Board.tsx
@@ -20,6 +20,7 @@ import React, {
 } from 'react';
 
 import { invariant } from '@dxos/invariant';
+import { log } from '@dxos/log';
 import {
   IconButton,
   ScrollArea,
@@ -50,7 +51,20 @@ import {
   type Layout,
   pushToFit,
 } from './engine';
-import { type GridCellSize, type Rect, cellRect, getColumnCount, getRowCount, gridBounds } from './geometry';
+import {
+  type GridCellSize,
+  type Rect,
+  anchoredScroll,
+  boardPad,
+  cellRect,
+  getColumnCount,
+  getRowCount,
+  gridBounds,
+  viewportCenterAnchor,
+} from './geometry';
+
+/** Duration (ms) of the zoom-anchor and recenter scroll animations. */
+const ANIMATION_DURATION = 500;
 
 // TODO(burdon): Multi-select + keyboard move/resize.
 // TODO(burdon): Zoom/overview + toolbar (port from the previous Board — deferred).
@@ -257,7 +271,11 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
       const startTop = el.scrollTop;
       const deltaLeft = left - startLeft;
       const deltaTop = top - startTop;
-      const duration = 200;
+      const duration = ANIMATION_DURATION;
+      log.info('recenter begin', {
+        from: { left: Math.round(startLeft), top: Math.round(startTop) },
+        to: { left: Math.round(left), top: Math.round(top) },
+      });
       let startTime: number | undefined;
       const step = (time: number) => {
         startTime ??= time;
@@ -267,6 +285,8 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
         el.scrollTop = startTop + deltaTop * eased;
         if (t < 1) {
           scrollFrameRef.current = requestAnimationFrame(step);
+        } else {
+          log.info('recenter end', { at: { left: Math.round(el.scrollLeft), top: Math.round(el.scrollTop) } });
         }
       };
       scrollFrameRef.current = requestAnimationFrame(step);
@@ -316,15 +336,16 @@ const BoardRoot = forwardRef<BoardController, BoardRootProps>(
           anchorX = board.width / 2;
           anchorY = board.height / 2;
         }
-        // The board box sits at a left/top pad and scales from its top-left (transform-origin 0 0), so a
-        // content point maps to `pad + point * zoom` on screen; place the anchor at the viewport centre.
-        // The pad is half the viewport under overscroll, else the margin that centres a board smaller
-        // than the viewport (0 when it overflows) — matching Board.Viewport's margins.
-        const boardBox = gridBounds(columns, rows, cellSizePx, gapPx);
-        const padX = overscroll ? el.clientWidth / 2 : Math.max(0, (el.clientWidth - boardBox.width * zoom) / 2);
-        const padY = overscroll ? el.clientHeight / 2 : Math.max(0, (el.clientHeight - boardBox.height * zoom) / 2);
-        const targetLeft = padX + anchorX * zoom - el.clientWidth / 2;
-        const targetTop = padY + anchorY * zoom - el.clientHeight / 2;
+        // Place the anchor at the viewport centre. The board sits at `pad` and scales from its top-left
+        // (transform-origin 0 0), so a content point maps to `pad + point * zoom` on screen.
+        const viewport = { width: el.clientWidth, height: el.clientHeight };
+        const pad = boardPad({ viewport, board: gridBounds(columns, rows, cellSizePx, gapPx), zoom, overscroll });
+        const { left: targetLeft, top: targetTop } = anchoredScroll({
+          anchor: { x: anchorX, y: anchorY },
+          viewport,
+          pad,
+          zoom,
+        });
         if (smooth) {
           smoothScrollTo(el, targetLeft, targetTop);
         } else {
@@ -522,10 +543,9 @@ const BoardViewport = ({ classNames, children }: BoardViewportProps) => {
   const voidX = zoom < 1 ? bounds.width * (1 - zoom) : 0;
   const voidY = zoom < 1 ? bounds.height * (1 - zoom) : 0;
   // Left/top pad that centres a board smaller than the viewport (0 when it overflows). Computed
-  // explicitly rather than via `m-auto` so it stays symmetric — `m-auto` combined with the negative
-  // right margin (below) would shove the board to one side and leave a void on the left/top.
-  const padX = overscroll ? overscrollPad.x : Math.max(0, (viewportSize.width - bounds.width * zoom) / 2);
-  const padY = overscroll ? overscrollPad.y : Math.max(0, (viewportSize.height - bounds.height * zoom) / 2);
+  // explicitly (shared with the scroll/zoom-anchor math) rather than via `m-auto`, which — combined
+  // with the negative right margin below — would shove the board to one side and void the left/top.
+  const { x: padX, y: padY } = boardPad({ viewport: viewportSize, board: bounds, zoom, overscroll });
 
   return (
     // The board sits at `pad` (centring it when it fits, 0 + overscroll when it overflows) and sheds the
@@ -600,21 +620,14 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
     const { selected, overscroll, layout, cellSize, gap } = anchorState.current;
     // Capture the viewport size once — stable during the animation in a real pane (and avoids a
     // fluctuating measurement mid-animation).
-    const clientWidth = element.clientWidth;
-    const clientHeight = element.clientHeight;
+    const viewport = { width: element.clientWidth, height: element.clientHeight };
     const board = element.querySelector<HTMLElement>('[data-dx-board-viewport]');
-    // Board's unscaled footprint (offsetWidth ignores the transform), used to derive its left/top
-    // offset in the scroll content at a given scale — matching Board.Viewport's margins: half the
-    // viewport under overscroll, else the margin that centres a board smaller than the viewport.
-    const boardW = board?.offsetWidth ?? 0;
-    const boardH = board?.offsetHeight ?? 0;
-    const padXAt = (scale: number) => (overscroll ? clientWidth / 2 : Math.max(0, (clientWidth - boardW * scale) / 2));
-    const padYAt = (scale: number) =>
-      overscroll ? clientHeight / 2 : Math.max(0, (clientHeight - boardH * scale) / 2);
+    // Board's unscaled footprint (offsetWidth ignores the transform), used to derive its pad at a scale.
+    const boardSize = { width: board?.offsetWidth ?? 0, height: board?.offsetHeight ?? 0 };
+    const padAt = (scale: number) => boardPad({ viewport, board: boardSize, zoom: scale, overscroll });
 
     // Anchor point in unscaled, board-relative content coords.
-    let anchorX: number;
-    let anchorY: number;
+    let anchor: { x: number; y: number };
     const ids = [...selected].filter((id) => layout.items[id]);
     if (ids.length > 0) {
       // Centre of mass of the selected tiles' centres.
@@ -626,13 +639,32 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
         sumX += rect.left + rect.width / 2;
         sumY += rect.top + rect.height / 2;
       }
-      anchorX = sumX / ids.length;
-      anchorY = sumY / ids.length;
+      anchor = { x: sumX / ids.length, y: sumY / ids.length };
     } else {
       // Nothing selected: hold whatever is currently at the viewport centre.
-      anchorX = (element.scrollLeft + clientWidth / 2 - padXAt(prevZoom)) / prevZoom;
-      anchorY = (element.scrollTop + clientHeight / 2 - padYAt(prevZoom)) / prevZoom;
+      anchor = viewportCenterAnchor({
+        scroll: { left: element.scrollLeft, top: element.scrollTop },
+        viewport,
+        pad: padAt(prevZoom),
+        zoom: prevZoom,
+      });
     }
+
+    const target = anchoredScroll({ anchor, viewport, pad: padAt(zoom), zoom });
+    // Diagnostic: the full anchor computation for one zoom step. Enable in the browser with
+    // `localStorage.setItem('dxlog', 'info:react-ui-board/board')` (or check the default console).
+    log.info('zoom anchor begin', {
+      prevZoom,
+      zoom,
+      scrollBefore: { left: Math.round(element.scrollLeft), top: Math.round(element.scrollTop) },
+      viewport,
+      boardSize,
+      overscroll,
+      padPrev: padAt(prevZoom),
+      padNext: padAt(zoom),
+      anchor: { x: Math.round(anchor.x), y: Math.round(anchor.y) },
+      target,
+    });
 
     // Drive the zoom ourselves (scale + scroll together) each frame, so the anchor stays at the
     // viewport centre for the whole animation — the selected tiles are the focal point, not the
@@ -640,13 +672,14 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
     // ~duration); it lands on React's value at the end.
     const from = prevZoom;
     const to = zoom;
-    const duration = 200;
+    const duration = ANIMATION_DURATION;
     const apply = (scale: number) => {
       if (board) {
         board.style.transform = scale === 1 ? '' : `scale(${scale})`;
       }
-      element.scrollLeft = padXAt(scale) + anchorX * scale - clientWidth / 2;
-      element.scrollTop = padYAt(scale) + anchorY * scale - clientHeight / 2;
+      const { left, top } = anchoredScroll({ anchor, viewport, pad: padAt(scale), zoom: scale });
+      element.scrollLeft = left;
+      element.scrollTop = top;
     };
 
     let frame = 0;
@@ -658,6 +691,15 @@ const BoardContainer = composable<HTMLDivElement>(({ children, ...props }, forwa
       apply(from + (to - from) * eased);
       if (t < 1) {
         frame = requestAnimationFrame(step);
+      } else {
+        // The actual scroll reached, and the content point now at the viewport centre — compare with
+        // `target` / `anchor` above to see whether the anchor held.
+        const scrollAfter = { left: Math.round(element.scrollLeft), top: Math.round(element.scrollTop) };
+        log.info('zoom anchor end', {
+          zoom,
+          scrollAfter,
+          achievedAnchor: viewportCenterAnchor({ scroll: scrollAfter, viewport, pad: padAt(zoom), zoom }),
+        });
       }
     };
     frame = requestAnimationFrame(step);
@@ -941,14 +983,18 @@ const BoardMap = ({ classNames }: BoardMapProps) => {
     };
   }, [viewportRef]);
 
-  // The visible region in unscaled content coords: undo the board's left/top pad (overscroll, or the
-  // margin that centres a board smaller than the viewport) and the zoom scale so it maps onto the same
-  // coordinate space as the tile rects (percent of the board bounds).
-  const padX = overscrollPad.x > 0 ? overscrollPad.x : Math.max(0, (view.width - bounds.width * zoom) / 2);
-  const padY = overscrollPad.y > 0 ? overscrollPad.y : Math.max(0, (view.height - bounds.height * zoom) / 2);
+  // The visible region in unscaled content coords: undo the board's left/top pad (shared with the
+  // layout / scroll math) and the zoom scale so it maps onto the same coordinate space as the tile
+  // rects (percent of the board bounds).
+  const pad = boardPad({
+    viewport: { width: view.width, height: view.height },
+    board: bounds,
+    zoom,
+    overscroll: overscrollPad.x > 0 || overscrollPad.y > 0,
+  });
   const viewport = {
-    left: ((view.left - padX) / zoom / bounds.width) * 100,
-    top: ((view.top - padY) / zoom / bounds.height) * 100,
+    left: ((view.left - pad.x) / zoom / bounds.width) * 100,
+    top: ((view.top - pad.y) / zoom / bounds.height) * 100,
     width: (view.width / zoom / bounds.width) * 100,
     height: (view.height / zoom / bounds.height) * 100,
   };

--- a/packages/ui/react-ui-board/src/components/Board/BoardCell.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/BoardCell.tsx
@@ -58,6 +58,7 @@ export const BoardCell = ({
   const {
     cellSize,
     gap,
+    margin,
     columns,
     zoom,
     selectionMode,
@@ -239,7 +240,7 @@ export const BoardCell = ({
   // to where it will land (cell-to-cell) during the drag and is already there on drop, rather than
   // snapping back from its original cell. The cursor-following clone is the "picked up" copy.
   const effectiveLayout = previewLayout ? (previewLayout.items[item.id] ?? layout) : layout;
-  const rect = cellRect(span(effectiveLayout), cellSize, gap);
+  const rect = cellRect(span(effectiveLayout), cellSize, gap, margin);
 
   // While this tile is dragged, outline the FULL w×h footprint it will occupy at the target cell
   // (not just the 1x1 cell under the cursor) so the landing area reads as one blue-bordered region.
@@ -248,7 +249,7 @@ export const BoardCell = ({
       ? dragging.target.data.location
       : undefined;
   const moveGhost = moveTarget
-    ? cellRect({ x: moveTarget.x, y: moveTarget.y, w: layout.w ?? 1, h: layout.h ?? 1 }, cellSize, gap)
+    ? cellRect({ x: moveTarget.x, y: moveTarget.y, w: layout.w ?? 1, h: layout.h ?? 1 }, cellSize, gap, margin)
     : undefined;
 
   return (

--- a/packages/ui/react-ui-board/src/components/Board/BoardCell.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/BoardCell.tsx
@@ -313,14 +313,14 @@ export const BoardCell = ({
 
       {/* Move outline: the full footprint the tile will occupy at the target cell. */}
       {moveGhost && (
-        <div className='pointer-events-none absolute z-10 rounded-sm ring-2 ring-accent-bg' style={moveGhost} />
+        <div className='pointer-events-none absolute z-10 rounded-md ring-2 ring-accent-bg' style={moveGhost} />
       )}
 
       {/* Resize outline: previews the target size while dragging the handle; the tile snaps to whole
           cells only on release (see the resize draggable's onDrop). */}
       {resizeGhost && (
         <div
-          className='pointer-events-none absolute z-10 rounded-sm ring-2 ring-accent-bg'
+          className='pointer-events-none absolute z-10 rounded-md ring-2 ring-accent-bg'
           style={{ left: rect.left, top: rect.top, width: resizeGhost.width, height: resizeGhost.height }}
         />
       )}

--- a/packages/ui/react-ui-board/src/components/Board/geometry.test.ts
+++ b/packages/ui/react-ui-board/src/components/Board/geometry.test.ts
@@ -1,0 +1,70 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { anchoredScroll, boardPad, viewportCenterAnchor } from './geometry';
+
+const viewport = { width: 1000, height: 800 };
+const board = { width: 3000, height: 2400 };
+
+describe('boardPad', () => {
+  test('overscroll pads by half the viewport', ({ expect }) => {
+    expect(boardPad({ viewport, board, zoom: 1, overscroll: true })).toEqual({ x: 500, y: 400 });
+  });
+
+  test('overflowing board gets no pad', ({ expect }) => {
+    // At zoom 1 the 3000px board overflows the 1000px viewport.
+    expect(boardPad({ viewport, board, zoom: 1, overscroll: false })).toEqual({ x: 0, y: 0 });
+  });
+
+  test('a board smaller than the viewport is centred by the pad', ({ expect }) => {
+    // At zoom 0.25 the board is 750×600, smaller than 1000×800.
+    expect(boardPad({ viewport, board, zoom: 0.25, overscroll: false })).toEqual({ x: 125, y: 100 });
+  });
+});
+
+describe('anchor round-trip', () => {
+  test('anchoredScroll and viewportCenterAnchor are inverses', ({ expect }) => {
+    const zoom = 0.5;
+    const pad = boardPad({ viewport, board, zoom, overscroll: false });
+    const anchor = { x: 1234, y: 567 };
+    const scroll = anchoredScroll({ anchor, viewport, pad, zoom });
+    expect(viewportCenterAnchor({ scroll, viewport, pad, zoom })).toEqual(anchor);
+  });
+});
+
+describe('zoom keeps the anchor centred', () => {
+  const overscroll = false;
+
+  // Zooming should hold whatever content point is at the viewport centre. Recover the anchor from the
+  // pre-zoom scroll, then compute the post-zoom scroll and confirm the same point is still centred.
+  const zoomAndCheckAnchor = (expect: any, from: number, to: number, scroll: { left: number; top: number }) => {
+    const padFrom = boardPad({ viewport, board, zoom: from, overscroll });
+    const anchor = viewportCenterAnchor({ scroll, viewport, pad: padFrom, zoom: from });
+    const padTo = boardPad({ viewport, board, zoom: to, overscroll });
+    const next = anchoredScroll({ anchor, viewport, pad: padTo, zoom: to });
+    // The same content point is centred after the zoom.
+    expect(viewportCenterAnchor({ scroll: next, viewport, pad: padTo, zoom: to })).toEqual(anchor);
+    return { anchor, next };
+  };
+
+  test('zooming out holds the board centre', ({ expect }) => {
+    // Centred on the board centre (1500, 1200) at zoom 1 (overflowing, pad 0).
+    const scroll = { left: 1500 - viewport.width / 2, top: 1200 - viewport.height / 2 };
+    const { anchor } = zoomAndCheckAnchor(expect, 1, 0.5, scroll);
+    expect(anchor).toEqual({ x: 1500, y: 1200 });
+  });
+
+  test('zooming out holds an off-centre point', ({ expect }) => {
+    const scroll = { left: 400, top: 300 };
+    zoomAndCheckAnchor(expect, 1, 0.5, scroll);
+  });
+
+  test('zooming across the overflow→fit boundary holds the anchor', ({ expect }) => {
+    // 0.5 overflows (1500>1000), 0.25 fits (750<1000) — the pad changes from 0 to 125.
+    const scroll = { left: 700, top: 500 };
+    zoomAndCheckAnchor(expect, 0.5, 0.25, scroll);
+  });
+});

--- a/packages/ui/react-ui-board/src/components/Board/geometry.test.ts
+++ b/packages/ui/react-ui-board/src/components/Board/geometry.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, test } from 'vitest';
 
-import { anchoredScroll, boardPad, viewportCenterAnchor } from './geometry';
+import { type Point, type Scroll, anchoredScroll, boardPad, viewportCenterAnchor } from './geometry';
 
 const viewport = { width: 1000, height: 800 };
 const board = { width: 3000, height: 2400 };
@@ -36,35 +36,42 @@ describe('anchor round-trip', () => {
 });
 
 describe('zoom keeps the anchor centred', () => {
-  const overscroll = false;
-
-  // Zooming should hold whatever content point is at the viewport centre. Recover the anchor from the
-  // pre-zoom scroll, then compute the post-zoom scroll and confirm the same point is still centred.
-  const zoomAndCheckAnchor = (expect: any, from: number, to: number, scroll: { left: number; top: number }) => {
-    const padFrom = boardPad({ viewport, board, zoom: from, overscroll });
-    const anchor = viewportCenterAnchor({ scroll, viewport, pad: padFrom, zoom: from });
-    const padTo = boardPad({ viewport, board, zoom: to, overscroll });
-    const next = anchoredScroll({ anchor, viewport, pad: padTo, zoom: to });
-    // The same content point is centred after the zoom.
-    expect(viewportCenterAnchor({ scroll: next, viewport, pad: padTo, zoom: to })).toEqual(anchor);
-    return { anchor, next };
-  };
-
   test('zooming out holds the board centre', ({ expect }) => {
     // Centred on the board centre (1500, 1200) at zoom 1 (overflowing, pad 0).
     const scroll = { left: 1500 - viewport.width / 2, top: 1200 - viewport.height / 2 };
-    const { anchor } = zoomAndCheckAnchor(expect, 1, 0.5, scroll);
+    const { anchor, centredAfter } = zoomAnchor(1, 0.5, scroll);
     expect(anchor).toEqual({ x: 1500, y: 1200 });
+    expect(centredAfter).toEqual(anchor);
   });
 
   test('zooming out holds an off-centre point', ({ expect }) => {
-    const scroll = { left: 400, top: 300 };
-    zoomAndCheckAnchor(expect, 1, 0.5, scroll);
+    const { anchor, centredAfter } = zoomAnchor(1, 0.5, { left: 400, top: 300 });
+    expect(centredAfter).toEqual(anchor);
   });
 
   test('zooming across the overflow→fit boundary holds the anchor', ({ expect }) => {
     // 0.5 overflows (1500>1000), 0.25 fits (750<1000) — the pad changes from 0 to 125.
-    const scroll = { left: 700, top: 500 };
-    zoomAndCheckAnchor(expect, 0.5, 0.25, scroll);
+    const { anchor, centredAfter } = zoomAnchor(0.5, 0.25, { left: 700, top: 500 });
+    expect(centredAfter).toEqual(anchor);
+  });
+
+  test('a fitting board centres — the ideal offset goes negative and the pad recentres', ({ expect }) => {
+    // The point held at 0.5 (content 1000) can't be centred once the 0.25 board (750px) fits the 1000px
+    // viewport: anchoredScroll returns a negative offset (below), which the browser clamps to 0, and the
+    // pad margin then centres the board. This is the intended clamped fallback.
+    const { next } = zoomAnchor(0.5, 0.25, { left: 0, top: 0 });
+    expect(next.left).toBeLessThan(0);
+    expect(boardPad({ viewport, board, zoom: 0.25, overscroll: false })).toEqual({ x: 125, y: 100 });
   });
 });
+
+// Recover the anchor from the pre-zoom scroll, then compute the post-zoom scroll and the point it
+// re-centres (helpers live below the suites so tests read top-down).
+const zoomAnchor = (from: number, to: number, scroll: Scroll): { anchor: Point; next: Scroll; centredAfter: Point } => {
+  const padFrom = boardPad({ viewport, board, zoom: from, overscroll: false });
+  const anchor = viewportCenterAnchor({ scroll, viewport, pad: padFrom, zoom: from });
+  const padTo = boardPad({ viewport, board, zoom: to, overscroll: false });
+  const next = anchoredScroll({ anchor, viewport, pad: padTo, zoom: to });
+  const centredAfter = viewportCenterAnchor({ scroll: next, viewport, pad: padTo, zoom: to });
+  return { anchor, next, centredAfter };
+};

--- a/packages/ui/react-ui-board/src/components/Board/geometry.ts
+++ b/packages/ui/react-ui-board/src/components/Board/geometry.ts
@@ -17,24 +17,29 @@ export const cellRect = (
   { x, y, w, h }: { x: number; y: number; w: number; h: number },
   cellSize: GridCellSize,
   gap: number,
+  // Perimeter breathing room around the grid, in cell units (a cell = its size + one gap). Offsets
+  // every cell so the grid isn't flush to the board edges; 0 leaves the grid flush.
+  margin = 0,
 ): Rect => ({
-  left: gap + x * (cellSize.width + gap),
-  top: gap + y * (cellSize.height + gap),
+  left: margin * (cellSize.width + gap) + gap + x * (cellSize.width + gap),
+  top: margin * (cellSize.height + gap) + gap + y * (cellSize.height + gap),
   width: w * cellSize.width + Math.max(0, w - 1) * gap,
   height: h * cellSize.height + Math.max(0, h - 1) * gap,
 });
 
 /**
- * Overall pixel size of a grid with the given column/row count.
+ * Overall pixel size of a grid with the given column/row count, plus `margin` cells of perimeter
+ * breathing room on each side (see {@link cellRect}).
  */
 export const gridBounds = (
   columns: number,
   rows: number,
   cellSize: GridCellSize,
   gap: number,
+  margin = 0,
 ): { width: number; height: number } => ({
-  width: columns * (cellSize.width + gap) + gap,
-  height: rows * (cellSize.height + gap) + gap,
+  width: (columns + 2 * margin) * (cellSize.width + gap) + gap,
+  height: (rows + 2 * margin) * (cellSize.height + gap) + gap,
 });
 
 type Size = { width: number; height: number };

--- a/packages/ui/react-ui-board/src/components/Board/geometry.ts
+++ b/packages/ui/react-ui-board/src/components/Board/geometry.ts
@@ -84,7 +84,12 @@ export const viewportCenterAnchor = ({
   y: (scroll.top + viewport.height / 2 - pad.y) / zoom,
 });
 
-/** Scroll offset that places the unscaled content point `anchor` at the viewport centre. */
+/**
+ * Scroll offset that places the unscaled content point `anchor` at the viewport centre. The result
+ * may fall outside the scroll range (e.g. negative once the scaled board fits the viewport and an
+ * off-centre anchor can no longer be scrolled to the middle); the browser clamps it and the `pad`
+ * margin then centres the fitting board — the intended fallback.
+ */
 export const anchoredScroll = ({
   anchor,
   viewport,

--- a/packages/ui/react-ui-board/src/components/Board/geometry.ts
+++ b/packages/ui/react-ui-board/src/components/Board/geometry.ts
@@ -37,6 +37,64 @@ export const gridBounds = (
   height: rows * (cellSize.height + gap) + gap,
 });
 
+type Size = { width: number; height: number };
+export type Point = { x: number; y: number };
+export type Scroll = { left: number; top: number };
+
+/**
+ * The board's top-left offset (px) within the scroll content. Under overscroll it is half the
+ * viewport (so any cell can reach the centre); otherwise it is the margin that centres a board
+ * smaller than the viewport, and 0 once the scaled board overflows. Board.Viewport applies this as
+ * the board's margin, and the scroll/zoom math below assumes a content point maps to
+ * `pad + point * zoom`, so all three must use this single definition to stay consistent.
+ */
+export const boardPad = ({
+  viewport,
+  board,
+  zoom,
+  overscroll,
+}: {
+  viewport: Size;
+  board: Size;
+  zoom: number;
+  overscroll: boolean;
+}): Point => ({
+  x: overscroll ? viewport.width / 2 : Math.max(0, (viewport.width - board.width * zoom) / 2),
+  y: overscroll ? viewport.height / 2 : Math.max(0, (viewport.height - board.height * zoom) / 2),
+});
+
+/** The unscaled content point currently at the viewport centre (inverse of {@link anchoredScroll}). */
+export const viewportCenterAnchor = ({
+  scroll,
+  viewport,
+  pad,
+  zoom,
+}: {
+  scroll: Scroll;
+  viewport: Size;
+  pad: Point;
+  zoom: number;
+}): Point => ({
+  x: (scroll.left + viewport.width / 2 - pad.x) / zoom,
+  y: (scroll.top + viewport.height / 2 - pad.y) / zoom,
+});
+
+/** Scroll offset that places the unscaled content point `anchor` at the viewport centre. */
+export const anchoredScroll = ({
+  anchor,
+  viewport,
+  pad,
+  zoom,
+}: {
+  anchor: Point;
+  viewport: Size;
+  pad: Point;
+  zoom: number;
+}): Scroll => ({
+  left: pad.x + anchor.x * zoom - viewport.width / 2,
+  top: pad.y + anchor.y * zoom - viewport.height / 2,
+});
+
 /** A tile position (span optional, defaulting to 1×1) as stored in a layout keyed by id. */
 type Position = { x: number; y: number; w?: number; h?: number };
 

--- a/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
@@ -36,9 +36,13 @@ type PersonData = {
   notes?: string;
 };
 
+// A small fixed pool of image URLs, cycled by index, so even the 500 preset issues only a handful
+// of (cacheable) requests instead of one per person — keeping the bench fast and offline-friendly.
+const IMAGE_POOL = Array.from({ length: 12 }, (_, index) => `https://picsum.photos/seed/masonry-${index}/256/256`);
+
 // Generate plain (non-ECHO) data so even the largest preset mounts instantly — the masonry is a
 // pure layout component, so seeding a database would only add unrelated cost. Variable notes and a
-// distinct image per person make cards differ in height and exercise the column-balancing layout.
+// cycled image make cards differ in height and exercise the column-balancing layout.
 const createPeople = (count: number): PersonData[] =>
   Array.from({ length: count }, (_, index) => {
     const fullName = random.person.fullName();
@@ -51,7 +55,7 @@ const createPeople = (count: number): PersonData[] =>
       fullName,
       jobTitle: random.person.jobTitle(),
       department: random.commerce.department(),
-      image: `https://picsum.photos/seed/${random.string.uuid()}/256/256`,
+      image: IMAGE_POOL[index % IMAGE_POOL.length],
       emails: [
         { value: `${slug}@example.com` },
         ...(index % 3 === 0 ? [{ label: 'work', value: `${slug}@work.example.com` }] : []),

--- a/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.stories.tsx
@@ -36,9 +36,27 @@ type PersonData = {
   notes?: string;
 };
 
-// A small fixed pool of image URLs, cycled by index, so even the 500 preset issues only a handful
-// of (cacheable) requests instead of one per person — keeping the bench fast and offline-friendly.
-const IMAGE_POOL = Array.from({ length: 12 }, (_, index) => `https://picsum.photos/seed/masonry-${index}/256/256`);
+// A small fixed pool of inline (data-URI) images, cycled by index, so the bench is fully
+// self-contained — even the 500 preset issues zero network requests. Distinct hues keep cards varied.
+const IMAGE_POOL = [
+  '#e11d48',
+  '#db2777',
+  '#c026d3',
+  '#9333ea',
+  '#7c3aed',
+  '#4f46e5',
+  '#2563eb',
+  '#0891b2',
+  '#059669',
+  '#65a30d',
+  '#ca8a04',
+  '#ea580c',
+].map(
+  (color) =>
+    `data:image/svg+xml,${encodeURIComponent(
+      `<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256'><rect width='256' height='256' fill='${color}'/></svg>`,
+    )}`,
+);
 
 // Generate plain (non-ECHO) data so even the largest preset mounts instantly — the masonry is a
 // pure layout component, so seeding a database would only add unrelated cost. Variable notes and a

--- a/packages/ui/react-ui-masonry/src/Masonry.tsx
+++ b/packages/ui/react-ui-masonry/src/Masonry.tsx
@@ -22,7 +22,7 @@ import { ScrollArea, ScrollAreaRootProps, ThemedClassName, usePx } from '@dxos/r
 import { composable, composableProps } from '@dxos/react-ui';
 import { cardMaxInlineSize, cardMinInlineSize } from '@dxos/ui-theme';
 
-import { useFlip } from './useFlip';
+import { prefersReducedMotion, useFlip } from './useFlip';
 import { useMasonryLayout } from './useMasonryLayout';
 
 /** Reveal the grid once the layout has been stable for this long (the initial reflow has settled). */
@@ -233,7 +233,10 @@ const MasonryViewportInner = composable<HTMLDivElement, MasonryViewportProps<any
                 width: `${contentWidth}px`,
                 height: `${height}px`,
                 opacity: revealed ? 1 : 0,
-                transition: animate ? 'opacity 200ms cubic-bezier(0.2, 0, 0, 1)' : undefined,
+                // Hidden (not just transparent) before reveal so the settling tiles are neither
+                // focusable nor hit-testable; the opacity fade only runs when motion is allowed.
+                visibility: revealed ? 'visible' : 'hidden',
+                transition: animate && !prefersReducedMotion() ? 'opacity 200ms cubic-bezier(0.2, 0, 0, 1)' : undefined,
               },
             })}
             {...arrowNavigationAttrs}

--- a/packages/ui/react-ui-masonry/src/useFlip.ts
+++ b/packages/ui/react-ui-masonry/src/useFlip.ts
@@ -16,7 +16,7 @@ const EASING = 'cubic-bezier(0.2, 0, 0, 1)';
  */
 const ANIMATE_MAX_DELTA = 8;
 
-const prefersReducedMotion = () =>
+export const prefersReducedMotion = () =>
   typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
 
 /**
@@ -63,6 +63,9 @@ export const useFlip = ({ nodes, ids, rects, columnCount, containerWidth, enable
   const previousLayout = useRef<{ columnCount: number; containerWidth: number } | null>(null);
 
   useLayoutEffect(() => {
+    // Without committed positions this is the first non-empty layout — snap it (the initial
+    // render), even for a small set that would otherwise read as a handful of added tiles.
+    const hasPriorPositions = previous.current.size > 0;
     // Classify the reflow before recording new positions: added/removed relative to
     // the last rendered id set, and whether the container dimensions changed (resize).
     const idSet = new Set(ids);
@@ -83,7 +86,8 @@ export const useFlip = ({ nodes, ids, rects, columnCount, containerWidth, enable
       (previousLayout.current.columnCount !== columnCount || previousLayout.current.containerWidth !== containerWidth);
     previousLayout.current = { columnCount, containerWidth };
 
-    const animate = enabled && !prefersReducedMotion() && shouldAnimateReflow({ added, removed, resized });
+    const animate =
+      hasPriorPositions && enabled && !prefersReducedMotion() && shouldAnimateReflow({ added, removed, resized });
     const seen = new Set<string>();
 
     ids.forEach((id, index) => {


### PR DESCRIPTION
Follow-up work after #12316 merged (its CodeRabbit review fixes weren't in that merge), plus new `@dxos/react-ui-board` fixes.

## react-ui-board
- **Center on mount without a flicker.** The board centered via a 200ms smooth scroll in a post-paint effect, so it painted at the top-left and visibly scrolled to center. It now centers in a `useLayoutEffect` with an instant jump (new internal `smooth` flag on `center`), so it paints centered. Verified: scroll sits at the centered offset from the first frame.
- **Minimap shows the current viewport.** `Board.Map` now outlines the visible region relative to the canvas — it tracks the viewport's scroll position and size (undoing the zoom scale and overscroll padding) and draws an accent rectangle over the tile map.
- **Match the drag/resize outline radius to the tiles.** The footprint outlines were `rounded-sm`; tiles are `rounded-md`. They now match.

## react-ui-masonry — review follow-ups from #12316
- **Snap the first non-empty layout.** With no committed positions yet, a small initial set was read as added tiles and animated; `useFlip` now requires prior positions before animating, so the initial render always snaps.
- **Hide the pre-reveal grid with `visibility:hidden`** (not just `opacity: 0`) so settling tiles aren't focusable/hit-testable, and gate the opacity fade on `prefers-reduced-motion`.
- **Offline story images**: cycle a small fixed image pool instead of one remote URL per person.
- Adds the `@dxos/react-ui-masonry` changeset that #12316 shipped without.

## Also
- `plugin-mermaid/PLUGIN.mdl`: whitespace-only alignment of the extension URI table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Board now shows a live visible-region indicator as you pan and resize.
  - Board centering now supports smooth scrolling or instant jumps.
  - Masonry adds an `animate` option to disable animations.
- **Bug Fixes**
  - Masonry improved large-dataset initial rendering to prevent initial overlapping stacks and uses reduced-motion-safe reveal behavior.
  - First meaningful layout now snaps reliably to avoid unexpected reflow animation.
  - Board viewport sizing/centering is more accurate (uses improved measurement) and reduces initial flicker.
- **Style**
  - Board drag/resize outlines use a softer rounded radius.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->