### PR TITLE
ui-editor: markdown list formatting + outliner drag fixes

### DIFF
--- a/.changeset/ui-editor-list-formatting.md
+++ b/.changeset/ui-editor-list-formatting.md
@@ -1,0 +1,5 @@
+---
+'@dxos/ui-editor': patch
+---
+
+Fix markdown list formatting: toggling between bullet/task/ordered list styles now converts markers in place instead of nesting them, list markers align with the hanging indent, and the outliner block drag shows a full-width preview with a stable empty drop placeholder (no flicker when dragging items with children).

--- a/packages/ui/react-ui-editor/src/components/EditorToolbar/lists.ts
+++ b/packages/ui/react-ui-editor/src/components/EditorToolbar/lists.ts
@@ -5,7 +5,7 @@
 import { type EditorView } from '@codemirror/view';
 
 import { type ActionGroupBuilderFn, type ToolbarMenuActionGroupProperties } from '@dxos/react-ui-menu';
-import { List, addList, removeList } from '@dxos/ui-editor';
+import { List, toggleList } from '@dxos/ui-editor';
 
 import { translationKey } from '#translations';
 
@@ -45,11 +45,7 @@ export const addLists =
 
               const listType =
                 listStyle === 'ordered' ? List.Ordered : listStyle === 'bullet' ? List.Bullet : List.Task;
-              if (checked) {
-                removeList(listType)(view);
-              } else {
-                addList(listType)(view);
-              }
+              toggleList(listType)(view);
             },
           );
         }

--- a/packages/ui/ui-editor/src/extensions/language/markdown/formatting.test.ts
+++ b/packages/ui/ui-editor/src/extensions/language/markdown/formatting.test.ts
@@ -3,7 +3,7 @@
 //
 
 import { markdownLanguage } from '@codemirror/lang-markdown';
-import { EditorState, type StateCommand } from '@codemirror/state';
+import { EditorSelection, EditorState, type StateCommand } from '@codemirror/state';
 import { describe, expect, test } from 'vitest';
 
 import {
@@ -414,6 +414,20 @@ describe('toggleList', () => {
   testCommand('removes only the tasks of a mixed list', '- [x] {one\n- two}', removeList(List.Task), 'one\n- two');
 
   testCommand("doesn't remove plain bullets after a task item", '- [x] one\n- {two}', removeList(List.Task), null);
+
+  // Disjoint multi-cursor ranges in the same ordered list: renumbering from the first range must not
+  // produce specs overlapping the second range's marker edits (state.changes rejects overlaps);
+  // resulting numbering is best-effort.
+  test('handles disjoint ranges in the same ordered list', () => {
+    let state = EditorState.create({
+      doc: '1. a\n2. b\n3. c\n4. d',
+      selection: EditorSelection.create([EditorSelection.cursor(3), EditorSelection.cursor(13)]),
+      extensions: [markdownLanguage, EditorState.allowMultipleSelections.of(true)],
+    });
+    const status = removeList(List.Ordered)({ state, dispatch: (tr) => (state = tr.state) });
+    expect(status).to.equal(true);
+    expect(state.doc.toString()).to.equal('a\n1. b\nc\n3. d');
+  });
 });
 
 describe('addBlockquote', () => {

--- a/packages/ui/ui-editor/src/extensions/language/markdown/formatting.test.ts
+++ b/packages/ui/ui-editor/src/extensions/language/markdown/formatting.test.ts
@@ -22,6 +22,7 @@ import {
   removeList,
   removeStyle,
   setHeading,
+  toggleList,
 } from './formatting';
 
 export const emptyFormatting: Formatting = {
@@ -310,6 +311,8 @@ describe('removeList', () => {
 
   testCommand('can remove a task list', '- [x] Hi{}', removeList(List.Task), 'Hi');
 
+  testCommand('can remove a task list with an uppercase check', '- [X] Hi{}', removeList(List.Task), 'Hi');
+
   testCommand(
     'can remove a bullet list from multiple blocks',
     '- {One\n\n- # Two\n\n- Three}',
@@ -340,6 +343,56 @@ describe('removeList', () => {
     '1. one\n\n2. {two\n\n3. three}\n\n4. four\n\n5. five',
     ordered,
     '1. one\n\ntwo\n\nthree\n\n1. four\n\n2. five',
+  );
+});
+
+describe('toggleList', () => {
+  testCommand('can add a bullet list', 'Hi{}', toggleList(List.Bullet), '- Hi');
+
+  testCommand('can remove a bullet list', '- Hi{}', toggleList(List.Bullet), 'Hi');
+
+  testCommand('can remove a task list', '- [ ] Hi{}', toggleList(List.Task), 'Hi');
+
+  testCommand('converts a bullet list to a task list', '- Hi{}', toggleList(List.Task), '- [ ] Hi');
+
+  testCommand('converts a task list to a bullet list', '- [ ] Hi{}', toggleList(List.Bullet), '- Hi');
+
+  testCommand('converts a checked task list to a bullet list', '- [x] Hi{}', toggleList(List.Bullet), '- Hi');
+
+  testCommand('converts an ordered list to a bullet list', '1. Hi{}', toggleList(List.Bullet), '- Hi');
+
+  testCommand('converts an ordered list to a task list', '1. Hi{}', toggleList(List.Task), '- [ ] Hi');
+
+  testCommand('converts a bullet list to an ordered list', '- Hi{}', toggleList(List.Ordered), '1. Hi');
+
+  testCommand(
+    'converts multiple bullet items to a task list',
+    '- {one\n- two}',
+    toggleList(List.Task),
+    '- [ ] one\n- [ ] two',
+  );
+
+  testCommand('converts an empty bullet item to a task item', '- {}', toggleList(List.Task), '- [ ] ');
+
+  testCommand(
+    'reindents continuation lines when converting a multi-line item',
+    '- [ ] Hello this\n      is wrapped{}',
+    toggleList(List.Bullet),
+    '- Hello this\n  is wrapped',
+  );
+
+  testCommand(
+    'numbers items when converting to an ordered list',
+    '- {one\n- two\n- three}',
+    toggleList(List.Ordered),
+    '1. one\n2. two\n3. three',
+  );
+
+  testCommand(
+    'renumbers following items when converting from an ordered list',
+    '1. {one}\n2. two\n3. three',
+    toggleList(List.Bullet),
+    '- one\n1. two\n2. three',
   );
 });
 

--- a/packages/ui/ui-editor/src/extensions/language/markdown/formatting.test.ts
+++ b/packages/ui/ui-editor/src/extensions/language/markdown/formatting.test.ts
@@ -15,6 +15,7 @@ import {
   addLink,
   addList,
   addStyle,
+  convertList,
   getFormatting,
   removeBlockquote,
   removeCodeblock,
@@ -394,6 +395,25 @@ describe('toggleList', () => {
     toggleList(List.Bullet),
     '- one\n1. two\n2. three',
   );
+
+  // Mixed lists resolve task-ness per item, independent of document order.
+  testCommand(
+    'converts only the plain bullets of a mixed list to tasks',
+    '- [x] {one\n- two\n- three}',
+    convertList(List.Bullet, List.Task),
+    '- [x] one\n- [ ] two\n- [ ] three',
+  );
+
+  testCommand(
+    'converts only the tasks of a mixed list to bullets',
+    '- {one\n- [ ] two\n- three}',
+    convertList(List.Task, List.Bullet),
+    '- one\n- two\n- three',
+  );
+
+  testCommand('removes only the tasks of a mixed list', '- [x] {one\n- two}', removeList(List.Task), 'one\n- two');
+
+  testCommand("doesn't remove plain bullets after a task item", '- [x] one\n- {two}', removeList(List.Task), null);
 });
 
 describe('addBlockquote', () => {

--- a/packages/ui/ui-editor/src/extensions/language/markdown/formatting.ts
+++ b/packages/ui/ui-editor/src/extensions/language/markdown/formatting.ts
@@ -770,7 +770,7 @@ export const removeList = (type: List): StateCommand => {
           } else if (name === 'ListItem' && stack[stack.length - 1] === targetNodeType && node.from !== lastBlock) {
             lastBlock = node.from;
             let line = state.doc.lineAt(node.from);
-            const mark = /^\s*(\d+[.)] |[-*+] (\[[ x]\] )?)/.exec(line.text.slice(node.from - line.from));
+            const mark = /^\s*(\d+[.)] |[-*+] (\[[ xX]\] )?)/.exec(line.text.slice(node.from - line.from));
             if (!mark) {
               return false;
             }
@@ -813,7 +813,96 @@ export const toggleList = (type: List): StateCommand => {
     const formatting = getFormatting(target.state);
     const active =
       formatting.listStyle === (type === List.Bullet ? 'bullet' : type === List.Ordered ? 'ordered' : 'task');
-    return (active ? removeList(type) : addList(type))(target);
+    if (active) {
+      return removeList(type)(target);
+    }
+    if (formatting.listStyle) {
+      const current =
+        formatting.listStyle === 'bullet' ? List.Bullet : formatting.listStyle === 'ordered' ? List.Ordered : List.Task;
+      return convertList(current, type)(target);
+    }
+    return addList(type)(target);
+  };
+};
+
+/**
+ * Convert list items from one style to another by rewriting markers in place;
+ * removing and re-adding would merge adjacent items into a single paragraph,
+ * while adding on top of an existing list would nest markers (e.g. `- - [ ] item`).
+ */
+export const convertList = (from: List, to: List): StateCommand => {
+  return ({ state, dispatch }) => {
+    let lastBlock = -1;
+    const changes: ChangeSpec[] = [];
+    const stack: string[] = [];
+    const counters: number[] = [];
+    const sourceNodeType = from === List.Ordered ? 'OrderedList' : from === List.Bullet ? 'BulletList' : 'TaskList';
+    for (const range of state.selection.ranges) {
+      syntaxTree(state).iterate({
+        from: range.from,
+        to: range.to,
+        enter: (node) => {
+          const { name } = node;
+          if (name === 'BulletList' || name === 'OrderedList' || name === 'Blockquote') {
+            // Maintain block context.
+            stack.push(name);
+            counters.push(1);
+          } else if (name === 'Task' && stack[stack.length - 1] === 'BulletList') {
+            stack[stack.length - 1] = 'TaskList';
+          }
+        },
+        leave: (node) => {
+          const { name } = node;
+          if (name === 'BulletList' || name === 'OrderedList' || name === 'Blockquote') {
+            stack.pop();
+            counters.pop();
+          } else if (name === 'ListItem' && stack[stack.length - 1] === sourceNodeType && node.from !== lastBlock) {
+            lastBlock = node.from;
+            let line = state.doc.lineAt(node.from);
+            const mark = /^\s*(\d+[.)] |[-*+] (\[[ xX]\] )?)/.exec(line.text.slice(node.from - line.from));
+            if (!mark) {
+              return;
+            }
+            const newMark =
+              to === List.Ordered ? `${counters[counters.length - 1]++}. ` : to === List.Task ? '- [ ] ' : '- ';
+            changes.push({ from: node.from, to: node.from + mark[0].length, insert: newMark });
+            // Adjust continuation-line indentation to match the new marker width.
+            const delta = newMark.length - mark[0].length;
+            const column = node.from - line.from;
+            while (line.to < node.to) {
+              line = state.doc.lineAt(line.to + 1);
+              const open = /^[\s>]*/.exec(line.text)![0].length;
+              if (open <= column) {
+                continue;
+              }
+              if (delta > 0) {
+                changes.push({ from: line.from + column, insert: ' '.repeat(delta) });
+              } else if (delta < 0) {
+                changes.push({ from: line.from + column, to: line.from + Math.min(column - delta, open) });
+              }
+            }
+            if (from === List.Ordered && node.to >= range.to) {
+              renumberListItems(node.node.nextSibling, 1, changes, state.doc);
+            }
+          }
+        },
+      });
+    }
+
+    if (!changes.length) {
+      return false;
+    }
+
+    const changeSet = state.changes(changes);
+    dispatch(
+      state.update({
+        changes: changeSet,
+        selection: state.selection.map(changeSet, 1),
+        userEvent: 'format.list.convert',
+        scrollIntoView: true,
+      }),
+    );
+    return true;
   };
 };
 

--- a/packages/ui/ui-editor/src/extensions/language/markdown/formatting.ts
+++ b/packages/ui/ui-editor/src/extensions/language/markdown/formatting.ts
@@ -675,7 +675,7 @@ export const addList = (type: List): StateCommand => {
       return false;
     }
 
-    const changes: ChangeSpec[] = [];
+    const changes: SimpleChange[] = [];
     for (let i = 0; i < blocks.length; i++) {
       const { node, counter, parentColumn } = blocks[i];
       const nodeFrom = node.name === 'CodeBlock' ? node.from - 4 : node.from;
@@ -811,9 +811,28 @@ const forEachListItem = (state: EditorState, type: List, callback: (item: ListIt
   }
 };
 
+type SimpleChange = { from: number; to?: number; insert?: string };
+
+/**
+ * Changes from `candidates` that overlap neither `changes` nor an earlier kept candidate.
+ * Renumbering walks siblings on the original doc, so disjoint multi-cursor ranges in the same
+ * ordered list can otherwise produce overlapping specs, which `state.changes` rejects.
+ */
+const nonOverlappingChanges = (candidates: SimpleChange[], changes: SimpleChange[]): SimpleChange[] => {
+  const kept: SimpleChange[] = [];
+  const overlaps = (a: SimpleChange, b: SimpleChange) => a.from < (b.to ?? b.from) && b.from < (a.to ?? a.from);
+  for (const candidate of candidates) {
+    if (![...changes, ...kept].some((change) => overlaps(candidate, change))) {
+      kept.push(candidate);
+    }
+  }
+  return kept;
+};
+
 export const removeList = (type: List): StateCommand => {
   return ({ state, dispatch }) => {
-    const changes: ChangeSpec[] = [];
+    const changes: SimpleChange[] = [];
+    const renumbers: SimpleChange[] = [];
     forEachListItem(state, type, ({ node, line: startLine, markLength, endOfRange }) => {
       const column = node.from - startLine.from;
       // Delete the marker on the first line.
@@ -828,7 +847,7 @@ export const removeList = (type: List): StateCommand => {
         }
       }
       if (endOfRange) {
-        renumberListItems(node.nextSibling, 1, changes, state.doc);
+        renumberListItems(node.nextSibling, 1, renumbers, state.doc);
       }
     });
     if (!changes.length) {
@@ -837,7 +856,7 @@ export const removeList = (type: List): StateCommand => {
 
     dispatch(
       state.update({
-        changes,
+        changes: [...changes, ...nonOverlappingChanges(renumbers, changes)],
         userEvent: 'format.list.remove',
         scrollIntoView: true,
       }),
@@ -870,7 +889,8 @@ export const toggleList = (type: List): StateCommand => {
  */
 export const convertList = (from: List, to: List): StateCommand => {
   return ({ state, dispatch }) => {
-    const changes: ChangeSpec[] = [];
+    const changes: SimpleChange[] = [];
+    const renumbers: SimpleChange[] = [];
     forEachListItem(state, from, ({ node, line: startLine, markLength, ordinal, endOfRange }) => {
       const newMark = to === List.Ordered ? `${ordinal}. ` : to === List.Task ? '- [ ] ' : '- ';
       changes.push({ from: node.from, to: node.from + markLength, insert: newMark });
@@ -891,7 +911,7 @@ export const convertList = (from: List, to: List): StateCommand => {
         }
       }
       if (from === List.Ordered && endOfRange) {
-        renumberListItems(node.nextSibling, 1, changes, state.doc);
+        renumberListItems(node.nextSibling, 1, renumbers, state.doc);
       }
     });
 
@@ -899,7 +919,7 @@ export const convertList = (from: List, to: List): StateCommand => {
       return false;
     }
 
-    const changeSet = state.changes(changes);
+    const changeSet = state.changes([...changes, ...nonOverlappingChanges(renumbers, changes)]);
     dispatch(
       state.update({
         changes: changeSet,
@@ -912,7 +932,7 @@ export const convertList = (from: List, to: List): StateCommand => {
   };
 };
 
-const renumberListItems = (item: SyntaxNode | null, counter: number, changes: ChangeSpec[], doc: Text) => {
+const renumberListItems = (item: SyntaxNode | null, counter: number, changes: SimpleChange[], doc: Text) => {
   for (; item; item = item.nextSibling) {
     if (item.name === 'ListItem') {
       const number = /(\s*)(\d+)[.)]/.exec(doc.sliceString(item.from, item.from + 10));

--- a/packages/ui/ui-editor/src/extensions/language/markdown/formatting.ts
+++ b/packages/ui/ui-editor/src/extensions/language/markdown/formatting.ts
@@ -743,56 +743,94 @@ export const addList = (type: List): StateCommand => {
   };
 };
 
+type ListItemContext = {
+  node: SyntaxNode;
+  /** The item's first line. */
+  line: Line;
+  /** Length of the matched marker (leading whitespace + list mark, including any task marker). */
+  markLength: number;
+  /** 1-based position among the matched items of the containing list. */
+  ordinal: number;
+  /** Whether this is the last matched item of its selection range (following siblings may need renumbering). */
+  endOfRange: boolean;
+};
+
+/**
+ * Invokes `callback` for each list item in the selection whose style matches `type`. Task-ness is
+ * resolved per item (an item is a task when it carries its own task marker), so mixed bullet/task
+ * siblings match independently of document order. Shared by `removeList` and `convertList`.
+ */
+const forEachListItem = (state: EditorState, type: List, callback: (item: ListItemContext) => void): void => {
+  let lastBlock = -1;
+  const stack: string[] = [];
+  const ordinals: number[] = [];
+  for (const { from, to } of state.selection.ranges) {
+    syntaxTree(state).iterate({
+      from,
+      to,
+      enter: (node) => {
+        const { name } = node;
+        if (name === 'BulletList' || name === 'OrderedList' || name === 'Blockquote') {
+          // Maintain block context.
+          stack.push(name);
+          ordinals.push(0);
+        }
+      },
+      leave: (node) => {
+        const { name } = node;
+        if (name === 'BulletList' || name === 'OrderedList' || name === 'Blockquote') {
+          stack.pop();
+          ordinals.pop();
+        } else if (name === 'ListItem' && node.from !== lastBlock) {
+          const context = stack[stack.length - 1];
+          const isTask = node.node.getChild('Task') != null;
+          const matches =
+            type === List.Ordered
+              ? context === 'OrderedList'
+              : context === 'BulletList' && (type === List.Task) === isTask;
+          if (!matches) {
+            return;
+          }
+          lastBlock = node.from;
+          const line = state.doc.lineAt(node.from);
+          const mark = /^\s*(\d+[.)] |[-*+] (\[[ xX]\] )?)/.exec(line.text.slice(node.from - line.from));
+          if (!mark) {
+            return;
+          }
+          ordinals[ordinals.length - 1]++;
+          callback({
+            node: node.node,
+            line,
+            markLength: mark[0].length,
+            ordinal: ordinals[ordinals.length - 1],
+            endOfRange: node.to >= to,
+          });
+        }
+      },
+    });
+  }
+};
+
 export const removeList = (type: List): StateCommand => {
   return ({ state, dispatch }) => {
-    let lastBlock = -1;
     const changes: ChangeSpec[] = [];
-    const stack: string[] = [];
-    const targetNodeType = type === List.Ordered ? 'OrderedList' : type === List.Bullet ? 'BulletList' : 'TaskList';
-    // Scan the syntax tree to locate list items that can be unwrapped.
-    for (const { from, to } of state.selection.ranges) {
-      syntaxTree(state).iterate({
-        from,
-        to,
-        enter: (node) => {
-          const { name } = node;
-          if (name === 'BulletList' || name === 'OrderedList' || name === 'Blockquote') {
-            // Maintain block context.
-            stack.push(name);
-          } else if (name === 'Task' && stack[stack.length - 1] === 'BulletList') {
-            stack[stack.length - 1] = 'TaskList';
-          }
-        },
-        leave: (node) => {
-          const { name } = node;
-          if (name === 'BulletList' || name === 'OrderedList' || name === 'Blockquote') {
-            stack.pop();
-          } else if (name === 'ListItem' && stack[stack.length - 1] === targetNodeType && node.from !== lastBlock) {
-            lastBlock = node.from;
-            let line = state.doc.lineAt(node.from);
-            const mark = /^\s*(\d+[.)] |[-*+] (\[[ xX]\] )?)/.exec(line.text.slice(node.from - line.from));
-            if (!mark) {
-              return false;
-            }
-            const column = node.from - line.from;
-            // Delete the marker on the first line.
-            changes.push({ from: node.from, to: node.from + mark[0].length });
-            // and indentation on subsequent lines.
-            while (line.to < node.to) {
-              line = state.doc.lineAt(line.to + 1);
-              const open = /^[\s>]*/.exec(line.text)![0].length;
-              if (open > column) {
-                changes.push({ from: line.from + column, to: line.from + Math.min(column + mark[0].length, open) });
-              }
-            }
-            if (node.to >= to) {
-              renumberListItems(node.node.nextSibling, 1, changes, state.doc);
-            }
-            return false;
-          }
-        },
-      });
-    }
+    forEachListItem(state, type, ({ node, line: startLine, markLength, endOfRange }) => {
+      const column = node.from - startLine.from;
+      // Delete the marker on the first line.
+      changes.push({ from: node.from, to: node.from + markLength });
+      // and indentation on subsequent lines.
+      let line = startLine;
+      while (line.to < node.to) {
+        line = state.doc.lineAt(line.to + 1);
+        const open = /^[\s>]*/.exec(line.text)![0].length;
+        if (open > column) {
+          changes.push({ from: line.from + column, to: line.from + Math.min(column + markLength, open) });
+        }
+      }
+      if (endOfRange) {
+        renumberListItems(node.nextSibling, 1, changes, state.doc);
+      }
+    });
     if (!changes.length) {
       return false;
     }
@@ -832,62 +870,30 @@ export const toggleList = (type: List): StateCommand => {
  */
 export const convertList = (from: List, to: List): StateCommand => {
   return ({ state, dispatch }) => {
-    let lastBlock = -1;
     const changes: ChangeSpec[] = [];
-    const stack: string[] = [];
-    const counters: number[] = [];
-    const sourceNodeType = from === List.Ordered ? 'OrderedList' : from === List.Bullet ? 'BulletList' : 'TaskList';
-    for (const range of state.selection.ranges) {
-      syntaxTree(state).iterate({
-        from: range.from,
-        to: range.to,
-        enter: (node) => {
-          const { name } = node;
-          if (name === 'BulletList' || name === 'OrderedList' || name === 'Blockquote') {
-            // Maintain block context.
-            stack.push(name);
-            counters.push(1);
-          } else if (name === 'Task' && stack[stack.length - 1] === 'BulletList') {
-            stack[stack.length - 1] = 'TaskList';
-          }
-        },
-        leave: (node) => {
-          const { name } = node;
-          if (name === 'BulletList' || name === 'OrderedList' || name === 'Blockquote') {
-            stack.pop();
-            counters.pop();
-          } else if (name === 'ListItem' && stack[stack.length - 1] === sourceNodeType && node.from !== lastBlock) {
-            lastBlock = node.from;
-            let line = state.doc.lineAt(node.from);
-            const mark = /^\s*(\d+[.)] |[-*+] (\[[ xX]\] )?)/.exec(line.text.slice(node.from - line.from));
-            if (!mark) {
-              return;
-            }
-            const newMark =
-              to === List.Ordered ? `${counters[counters.length - 1]++}. ` : to === List.Task ? '- [ ] ' : '- ';
-            changes.push({ from: node.from, to: node.from + mark[0].length, insert: newMark });
-            // Adjust continuation-line indentation to match the new marker width.
-            const delta = newMark.length - mark[0].length;
-            const column = node.from - line.from;
-            while (line.to < node.to) {
-              line = state.doc.lineAt(line.to + 1);
-              const open = /^[\s>]*/.exec(line.text)![0].length;
-              if (open <= column) {
-                continue;
-              }
-              if (delta > 0) {
-                changes.push({ from: line.from + column, insert: ' '.repeat(delta) });
-              } else if (delta < 0) {
-                changes.push({ from: line.from + column, to: line.from + Math.min(column - delta, open) });
-              }
-            }
-            if (from === List.Ordered && node.to >= range.to) {
-              renumberListItems(node.node.nextSibling, 1, changes, state.doc);
-            }
-          }
-        },
-      });
-    }
+    forEachListItem(state, from, ({ node, line: startLine, markLength, ordinal, endOfRange }) => {
+      const newMark = to === List.Ordered ? `${ordinal}. ` : to === List.Task ? '- [ ] ' : '- ';
+      changes.push({ from: node.from, to: node.from + markLength, insert: newMark });
+      // Adjust continuation-line indentation to match the new marker width.
+      const delta = newMark.length - markLength;
+      const column = node.from - startLine.from;
+      let line = startLine;
+      while (line.to < node.to) {
+        line = state.doc.lineAt(line.to + 1);
+        const open = /^[\s>]*/.exec(line.text)![0].length;
+        if (open <= column) {
+          continue;
+        }
+        if (delta > 0) {
+          changes.push({ from: line.from + column, insert: ' '.repeat(delta) });
+        } else if (delta < 0) {
+          changes.push({ from: line.from + column, to: line.from + Math.min(column - delta, open) });
+        }
+      }
+      if (from === List.Ordered && endOfRange) {
+        renumberListItems(node.nextSibling, 1, changes, state.doc);
+      }
+    });
 
     if (!changes.length) {
       return false;

--- a/packages/ui/ui-editor/src/extensions/language/markdown/styles.ts
+++ b/packages/ui/ui-editor/src/extensions/language/markdown/styles.ts
@@ -30,7 +30,9 @@ export const formattingStyles = EditorView.theme({
    */
   '& .cm-list-item': {},
   '& .cm-list-mark': {
-    display: 'inline',
+    // Must be inline-block so the fixed width applies and the first-line text start matches the
+    // hanging indent (`text-indent: -width`) set on `.cm-list-item`.
+    display: 'inline-block',
     textAlign: 'right',
     paddingRight: '0.5em',
     fontVariant: 'tabular-nums',

--- a/packages/ui/ui-editor/src/extensions/structure/blocks/drag.ts
+++ b/packages/ui/ui-editor/src/extensions/structure/blocks/drag.ts
@@ -228,6 +228,12 @@ class PlaceholderWidget extends WidgetType {
     );
   }
 
+  // Without this the height map assumes a default-height widget until the async measure pass corrects
+  // it, and the correction can shift scroll bookkeeping for a frame at drag start.
+  override get estimatedHeight(): number {
+    return this.totalHeight;
+  }
+
   override toDOM(): HTMLElement {
     const element = document.createElement('div');
     element.className = 'cm-blockDropPlaceholder';
@@ -793,6 +799,12 @@ const dragTheme = EditorView.theme({
   },
   '.cm-scroller.cm-blockDragging': {
     cursor: 'grabbing',
+  },
+  // Hide the static overlay grips synchronously at drag start (they are children of the scroller; the
+  // preview grip rides on `view.dom`): the overlay only removes them in the async measure pass, which
+  // would leave both grips visible for a frame.
+  '.cm-scroller.cm-blockDragging .cm-blockDragHandle': {
+    display: 'none',
   },
   '.cm-scroller.cm-blockDragging .cm-content': {
     userSelect: 'none',

--- a/packages/ui/ui-editor/src/extensions/structure/blocks/drag.ts
+++ b/packages/ui/ui-editor/src/extensions/structure/blocks/drag.ts
@@ -803,9 +803,9 @@ const dragTheme = EditorView.theme({
     pointerEvents: 'none',
   },
   // Left/width are set inline per drop (they track the drop level so the box aligns with the content).
+  // Unpainted: the drop slot reads as empty space matching the anticipated dropped block.
   '.cm-blockDropPlaceholderBox': {
     boxSizing: 'border-box',
-    backgroundColor: 'color-mix(in oklch, var(--color-accent-text, #3b82f6) 25%, transparent)',
   },
   '.cm-blockDragPreview': {
     position: 'absolute',

--- a/packages/ui/ui-editor/src/extensions/structure/blocks/drag.ts
+++ b/packages/ui/ui-editor/src/extensions/structure/blocks/drag.ts
@@ -636,13 +636,20 @@ const createDragPlugin = (
       }
 
       // The slot the pointer is over: the first non-source block whose vertical midpoint is below the
-      // pointer. The dragged (collapsed) blocks are skipped, so the drop gap — and thus the placeholder —
-      // always lands on a visible block, above or below the pointer, never inside the lifted group.
+      // pointer. The dragged (collapsed) blocks are skipped — including blocks inside a dragged extent
+      // (a parent's children share its collapse but are not source indices) — so the drop gap, and thus
+      // the placeholder, always lands on a visible block, never inside the lifted group where the
+      // collapse decoration would absorb it.
       #dropIndexAt(clientY: number): number {
         const blocks = getBlocks(this.view.state);
         const sources = new Set(this.#sourceIndices ?? []);
+        const extents = [...sources]
+          .map((sourceIndex) => this.#extentOf(sourceIndex))
+          .filter((extent): extent is Block => extent != null);
+        const collapsed = (block: Block) =>
+          extents.some((extent) => block.from >= extent.from && block.from <= extent.to);
         for (let index = 0; index < blocks.length; index++) {
-          if (sources.has(index)) {
+          if (sources.has(index) || collapsed(blocks[index])) {
             continue;
           }
           const top = this.view.coordsAtPos(blocks[index].from);
@@ -744,13 +751,14 @@ const createDragPlugin = (
           return;
         }
 
-        // A side:-1 block widget sitting at a collapse's END is absorbed by the block-replace and renders
-        // nothing (dropping onto the block right after a source). Snap such positions to that collapse's
-        // START, which renders before it — the source's own slot, a no-op drop, so the position is right.
+        // A side:-1 block widget sitting inside a collapse (including at its end) is absorbed by the
+        // block-replace and renders nothing — the gap would vanish for that update. Snap such positions
+        // to that collapse's START, which renders before it — the source's own slot, a no-op drop, so
+        // the position is right.
         let placeholderPos = dropIndex < blocks.length ? blocks[dropIndex].from : this.view.state.doc.length;
-        const atCollapseEnd = collapses.find((range) => range.to === placeholderPos);
-        if (atCollapseEnd) {
-          placeholderPos = atCollapseEnd.from;
+        const atCollapse = collapses.find((range) => placeholderPos > range.from && placeholderPos <= range.to);
+        if (atCollapse) {
+          placeholderPos = atCollapse.from;
         }
         // The drop level (quantized to indent units) shifts the placeholder so it aligns with the content.
         const indentOffset = this.#dropIndent?.offset ?? 0;

--- a/packages/ui/ui-editor/src/extensions/structure/outliner/dnd.ts
+++ b/packages/ui/ui-editor/src/extensions/structure/outliner/dnd.ts
@@ -86,12 +86,18 @@ export const getDropIndent = (
   const items = flattenItems(state);
   const count = items.length;
   const unit = getIndentUnit(state);
-  const sourceIndent = indentAt(state, items[sourceIndices[0]].lineRange.from);
+  const sourceItem = items[sourceIndices[0]];
+  const sourceIndent = indentAt(state, sourceItem.lineRange.from);
 
-  // The item directly above the drop slot, skipping the dragged item.
-  const sources = new Set(sourceIndices);
+  // The item directly above the drop slot, skipping the dragged subtree (the source's children are
+  // collapsed with it, so they cannot serve as the indent reference).
+  const [sourceFrom, sourceTo] = getRange(state.facet(treeFacet), sourceItem);
   let aboveIndex = dropIndex - 1;
-  while (aboveIndex >= 0 && sources.has(aboveIndex)) {
+  while (
+    aboveIndex >= 0 &&
+    items[aboveIndex].lineRange.from >= sourceFrom &&
+    items[aboveIndex].lineRange.from <= sourceTo
+  ) {
     aboveIndex--;
   }
   const above = aboveIndex >= 0 ? items[aboveIndex] : null;

--- a/packages/ui/ui-editor/src/extensions/structure/outliner/outliner.ts
+++ b/packages/ui/ui-editor/src/extensions/structure/outliner/outliner.ts
@@ -169,5 +169,15 @@ const decorations = () => [
     '.cm-list-item-current': {
       borderColor: 'var(--color-focus-ring-subtle)',
     },
+
+    // The drag preview clones the selected rows, whose content is shifted horizontally to preview the
+    // drop indent — so the highlight must come from the (full-width) container, not the cloned lines,
+    // to span the editor width regardless of the indent level.
+    '.cm-blockDragPreview': {
+      backgroundImage: 'linear-gradient(var(--color-cm-highlight-surface), var(--color-cm-highlight-surface))',
+    },
+    '.cm-blockDragPreview .cm-list-item-selected': {
+      backgroundColor: 'transparent',
+    },
   }),
 ];


### PR DESCRIPTION
## Summary

Four fixes to markdown list formatting and the outliner block drag, all in `@dxos/ui-editor` (+ toolbar wiring in `@dxos/react-ui-editor`).

### List toggle conversion
- `toggleList` on a different active list style nested markers (`- one` + task → `- - [ ] one`). A new `convertList` rewrites markers in place — remove-then-add would merge adjacent items into a single paragraph — reindenting continuation lines and renumbering ordered neighbors. The `EditorToolbar` list group now routes through `toggleList`.
- `removeList` accepts uppercase `[X]` task checks.

### List marker hanging indent
- `.cm-list-mark` had regressed from `inline-block` to `inline` (#12168), so its fixed width (24px bullet / 36px ordered) was ignored and first-line text no longer aligned with the continuation indent. Restored `inline-block`; the tall-line issue that motivated the change stays fixed by the existing `vertical-align: top` + `line-height: inherit`.

### Outliner drag preview
- The drag preview highlight now comes from the (full-editor-width) preview container instead of the cloned selected rows, which shift horizontally with the drop-indent preview.
- The drop placeholder is unpainted empty space matching the anticipated block, rather than an accent-colored box.

### Drag-start flicker
- The static grip is hidden synchronously via CSS at drag start (previously removed a frame late in the async measure pass, overlapping the preview grip).
- `PlaceholderWidget` reports `estimatedHeight` so the height map doesn't briefly assume a default-height widget.
- **Dragging an item with children**: the drop scan could resolve a hidden child (children share the parent's collapse but are not source indices) — the placeholder then sat inside the collapse decoration, was absorbed, and rendered nothing, so the gap vanished and content jumped (the reported flicker). The scan now skips blocks inside any dragged extent, placeholder positions inside a collapse snap to its start, and `getDropIndent` skips the dragged subtree when picking the indent-reference item.

## Testing

- `formatting.test.ts` extended with 15 toggle/conversion cases (continuation reindent, ordered renumbering, uppercase `[X]`); 316 ui-editor tests green.
- Verified live in storybook: marker/continuation alignment measured per-list-type; scripted grip drags confirmed the full-width preview, transparent placeholder, synchronous grip hide, and a 29-position pointer sweep over a collapsed subtree with the placeholder stable throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor list toolbar actions now convert directly between bullet, task, and ordered lists.
  * List conversions preserve marker type, indentation, task checked state, and ordered numbering.

* **Bug Fixes**
  * Improved handling of uppercase task markers.
  * Fixed list marker conversion behavior (including wrapped lines and renumbering after toggles).
  * Refined block/outliner drag reordering to reduce flicker and improve placeholder sizing, snapping, absorption behavior, and preview highlighting.

* **Style**
  * Improved list-marker alignment with hanging indents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->