### PR TITLE
feat(cli): add `dx mcp` command group (connect / tools / call)

### DIFF
--- a/packages/devtools/cli/src/bin.ts
+++ b/packages/devtools/cli/src/bin.ts
@@ -24,7 +24,7 @@ import { DEFAULT_PROFILE } from '@dxos/client-protocol';
 import { LogLevel, levels, log } from '@dxos/log';
 import { loadEnabledPlugins } from '@dxos/plugin-registry';
 
-import { admin, chat, debug, dx, fn, hub, mailbox, reflect, repl, reset } from './commands';
+import { admin, chat, debug, dx, fn, hub, mailbox, mcp, reflect, repl, reset } from './commands';
 import { getDefaults, getPlugins } from './commands/plugin-defs';
 import { setDispatcher } from './dispatcher';
 import { installStderrFilter } from './util';
@@ -88,6 +88,7 @@ const program = Effect.gen(function* () {
       chat,
       fn,
       mailbox,
+      mcp,
 
       // TODO(burdon): Admin-only. Where should these commands live?
       admin,

--- a/packages/devtools/cli/src/commands/index.ts
+++ b/packages/devtools/cli/src/commands/index.ts
@@ -10,5 +10,6 @@ export * from './reflect';
 export * from './function';
 export * from './hub';
 export * from './mailbox';
+export * from './mcp';
 export * from './repl';
 export * from './reset';

--- a/packages/devtools/cli/src/commands/mcp/call.ts
+++ b/packages/devtools/cli/src/commands/mcp/call.ts
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Args from '@effect/cli/Args';
+import * as Command from '@effect/cli/Command';
+import * as Options from '@effect/cli/Options';
+import * as Console from 'effect/Console';
+import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
+import * as Schema from 'effect/Schema';
+
+import { CommandConfig } from '@dxos/cli-util';
+
+import { initialize, request } from './client';
+import { requireSession, serverUrlOption } from './util';
+
+export const call = Command.make(
+  'call',
+  {
+    tool: Args.text({ name: 'tool' }).pipe(Args.withDescription('Tool name (see `dx mcp tools`).')),
+    input: Options.text('input').pipe(
+      Options.withDescription('Tool arguments as JSON.'),
+      Options.withSchema(Schema.parseJson(Schema.Unknown)),
+      Options.optional,
+    ),
+    url: serverUrlOption,
+  },
+  Effect.fn(function* ({ tool, input, url }) {
+    const { json, profile } = yield* CommandConfig;
+    const session = yield* requireSession(profile, url);
+
+    yield* Effect.tryPromise(() => initialize(session, { profile }));
+    const result = yield* Effect.tryPromise(() =>
+      request(session, 'tools/call', { name: tool, arguments: Option.getOrElse(input, () => ({})) }, { profile }),
+    );
+
+    // A tool can fail without failing the RPC; surface that as a command error rather than
+    // printing an error payload as if it were a result.
+    if (result.isError) {
+      return yield* Effect.fail(new Error(`Tool ${tool} failed: ${JSON.stringify(result.content)}`));
+    }
+
+    const output = result.structuredContent ?? result.content;
+    yield* Console.log(json ? JSON.stringify(output, null, 2) : JSON.stringify(output, null, 2));
+  }),
+).pipe(Command.withDescription('Call a tool on a connected MCP server.'));

--- a/packages/devtools/cli/src/commands/mcp/client.ts
+++ b/packages/devtools/cli/src/commands/mcp/client.ts
@@ -1,0 +1,207 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import { DX_STATE, getProfilePath } from '@dxos/client-protocol';
+
+/**
+ * Minimal MCP client over Streamable HTTP with OAuth 2.1, used by the `dx mcp` commands.
+ *
+ * The server (`@dxos/space-agent`) currently identifies the user with a dev-only form that takes
+ * an identity key and the space ids to bring into session context; this client fills that form
+ * from the active profile so nothing has to be pasted by hand. When the server moves to a signed
+ * challenge, only {@link authorize} changes.
+ */
+
+/** Persisted per profile, keyed by server origin, so subsequent commands reuse the session. */
+export type McpSession = {
+  serverUrl: string;
+  clientId: string;
+  accessToken: string;
+  refreshToken?: string;
+  identityKey: string;
+  spaceIds: string[];
+};
+
+const REDIRECT_URI = 'http://localhost:3000/callback';
+
+const sessionPath = (profile: string, serverUrl: string): string => {
+  const { host } = new URL(serverUrl);
+  return join(getProfilePath(DX_STATE, profile), 'mcp', `${host}.json`);
+};
+
+export const loadSession = async (profile: string, serverUrl: string): Promise<McpSession | undefined> => {
+  try {
+    return JSON.parse(await readFile(sessionPath(profile, serverUrl), 'utf8'));
+  } catch {
+    return undefined;
+  }
+};
+
+export const saveSession = async (profile: string, session: McpSession): Promise<void> => {
+  const path = sessionPath(profile, session.serverUrl);
+  await mkdir(dirname(path), { recursive: true });
+  // Tokens are bearer credentials: keep them readable only by the current user.
+  await writeFile(path, JSON.stringify(session, null, 2), { mode: 0o600 });
+};
+
+/**
+ * Runs the full OAuth 2.1 flow: RFC 7591 dynamic client registration, PKCE authorize (submitting
+ * the server's identity form), and the authorization-code exchange.
+ */
+export const authorize = async ({
+  serverUrl,
+  identityKey,
+  spaceIds,
+  haloSpaceId,
+}: {
+  serverUrl: string;
+  identityKey: string;
+  spaceIds: string[];
+  haloSpaceId?: string;
+}): Promise<McpSession> => {
+  const base = serverUrl.replace(/\/(mcp)?$/, '');
+
+  const registerResponse = await fetch(`${base}/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_name: 'dx mcp',
+      redirect_uris: [REDIRECT_URI],
+      token_endpoint_auth_method: 'none',
+    }),
+  });
+  if (registerResponse.status !== 201) {
+    throw new Error(`Client registration failed (${registerResponse.status}): ${await registerResponse.text()}`);
+  }
+  const { client_id: clientId } = (await registerResponse.json()) as { client_id: string };
+
+  const codeVerifier = randomBytes(32).toString('base64url');
+  const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+  const authorizeUrl = new URL(`${base}/authorize`);
+  authorizeUrl.searchParams.set('client_id', clientId);
+  authorizeUrl.searchParams.set('redirect_uri', REDIRECT_URI);
+  authorizeUrl.searchParams.set('response_type', 'code');
+  authorizeUrl.searchParams.set('code_challenge', codeChallenge);
+  authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+
+  const formResponse = await fetch(authorizeUrl);
+  const formHtml = await formResponse.text();
+  const nonce = formHtml.match(/name="nonce"\s+value="([^"]+)"/)?.[1];
+  if (!nonce) {
+    throw new Error(`Unexpected authorize page from ${base} (no nonce); is this an MCP server?`);
+  }
+
+  const submitResponse = await fetch(`${base}/authorize`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      nonce,
+      identity_key: identityKey,
+      space_ids: spaceIds.join(','),
+      // Falls back to the first space when the identity has no registered agent to look up.
+      halo_space_id: haloSpaceId ?? spaceIds[0] ?? '',
+    }).toString(),
+    redirect: 'manual',
+  });
+  if (submitResponse.status !== 302) {
+    throw new Error(`Authorization failed (${submitResponse.status}): ${await submitResponse.text()}`);
+  }
+  const code = new URL(submitResponse.headers.get('location')!).searchParams.get('code');
+  if (!code) {
+    throw new Error('Authorization did not return a code.');
+  }
+
+  const tokens = await exchange(base, {
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: REDIRECT_URI,
+    client_id: clientId,
+    code_verifier: codeVerifier,
+  });
+
+  return {
+    serverUrl: base,
+    clientId,
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    identityKey,
+    spaceIds,
+  };
+};
+
+const exchange = async (
+  base: string,
+  params: Record<string, string>,
+): Promise<{ access_token: string; refresh_token?: string }> => {
+  const response = await fetch(`${base}/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(params).toString(),
+  });
+  if (response.status !== 200) {
+    throw new Error(`Token exchange failed (${response.status}): ${await response.text()}`);
+  }
+  return (await response.json()) as { access_token: string; refresh_token?: string };
+};
+
+/**
+ * Issues a JSON-RPC request against the session's `/mcp` endpoint, refreshing the access token
+ * once on 401 so a stored session survives token expiry without re-authorizing.
+ */
+export const request = async (
+  session: McpSession,
+  method: string,
+  params: unknown,
+  options: { profile?: string } = {},
+): Promise<any> => {
+  const send = (token: string) =>
+    fetch(`${session.serverUrl}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ jsonrpc: '2.0', id: Date.now(), method, params }),
+    });
+
+  let response = await send(session.accessToken);
+  if (response.status === 401 && session.refreshToken) {
+    const tokens = await exchange(session.serverUrl, {
+      grant_type: 'refresh_token',
+      refresh_token: session.refreshToken,
+      client_id: session.clientId,
+    });
+    session.accessToken = tokens.access_token;
+    session.refreshToken = tokens.refresh_token ?? session.refreshToken;
+    if (options.profile) {
+      await saveSession(options.profile, session);
+    }
+    response = await send(session.accessToken);
+  }
+  if (response.status !== 200) {
+    throw new Error(`MCP ${method} failed (${response.status}): ${await response.text()}`);
+  }
+
+  const raw = await response.json();
+  // The Effect RPC transport batches; MCP Streamable HTTP returns a single object per request.
+  const message = (Array.isArray(raw) ? raw[0] : raw) as { result?: any; error?: unknown };
+  if (message.error) {
+    throw new Error(`MCP ${method} failed: ${JSON.stringify(message.error)}`);
+  }
+  return message.result;
+};
+
+/** MCP requires `initialize` before any other request on a connection. */
+export const initialize = async (session: McpSession, options: { profile?: string } = {}): Promise<any> =>
+  request(
+    session,
+    'initialize',
+    {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'dx-mcp', version: '0.1.0' },
+    },
+    options,
+  );

--- a/packages/devtools/cli/src/commands/mcp/connect.ts
+++ b/packages/devtools/cli/src/commands/mcp/connect.ts
@@ -1,0 +1,72 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Args from '@effect/cli/Args';
+import * as Command from '@effect/cli/Command';
+import * as Options from '@effect/cli/Options';
+import * as Console from 'effect/Console';
+import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
+
+import { CommandConfig, FormBuilder, print } from '@dxos/cli-util';
+import { ClientService } from '@dxos/client';
+
+import { authorize, initialize, saveSession } from './client';
+
+export const connect = Command.make(
+  'connect',
+  {
+    url: Args.text({ name: 'url' }).pipe(
+      Args.withDescription('MCP server URL (e.g. https://space-agent.dxos.workers.dev).'),
+    ),
+    spaceId: Options.text('space-id').pipe(
+      Options.withDescription('Space(s) to bring into the session context; repeatable. Defaults to the first space.'),
+      Options.repeated,
+    ),
+    haloSpaceId: Options.text('halo-space-id').pipe(
+      Options.withDescription('HALO space id. Only needed when the identity has no registered agent.'),
+      Options.optional,
+    ),
+  },
+  Effect.fn(function* ({ url, spaceId, haloSpaceId }) {
+    const { json, profile } = yield* CommandConfig;
+    const client = yield* ClientService;
+
+    const identity = client.halo.identity.get();
+    if (!identity) {
+      return yield* Effect.fail(new Error('Identity not available. Run `dx account login` first.'));
+    }
+
+    // The server scopes the session to these spaces; default to the profile's first space so the
+    // common case ("connect this space") needs no flags.
+    const spaceIds = spaceId.length > 0 ? [...spaceId] : client.spaces.get().map((space) => space.id);
+    if (spaceIds.length === 0) {
+      return yield* Effect.fail(new Error('No spaces available. Create one with `dx space create`.'));
+    }
+
+    const session = yield* Effect.tryPromise(() =>
+      authorize({
+        serverUrl: url,
+        identityKey: identity.identityKey.toHex(),
+        spaceIds,
+        haloSpaceId: Option.getOrUndefined(haloSpaceId),
+      }),
+    );
+    yield* Effect.tryPromise(() => initialize(session));
+    yield* Effect.promise(() => saveSession(profile, session));
+
+    if (json) {
+      yield* Console.log(
+        JSON.stringify({ serverUrl: session.serverUrl, identityKey: session.identityKey, spaceIds }, null, 2),
+      );
+    } else {
+      const builder = FormBuilder.make({ title: 'Connected' }).pipe(
+        FormBuilder.set('server', session.serverUrl),
+        FormBuilder.set('identity', session.identityKey.slice(0, 16)),
+        FormBuilder.set('spaces', spaceIds.join(', ')),
+      );
+      yield* Console.log(print(FormBuilder.build(builder)));
+    }
+  }),
+).pipe(Command.withDescription('Connect to an MCP server (OAuth 2.1 + PKCE) and store the session.'));

--- a/packages/devtools/cli/src/commands/mcp/index.ts
+++ b/packages/devtools/cli/src/commands/mcp/index.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Command from '@effect/cli/Command';
+
+import { call } from './call';
+import { connect } from './connect';
+import { tools } from './tools';
+
+export const mcp: Command.Command<any, any, any, any> = Command.make('mcp').pipe(
+  Command.withDescription('Interact with MCP servers (e.g. the DXOS space MCP server).'),
+  Command.withSubcommands([connect, tools, call]),
+);

--- a/packages/devtools/cli/src/commands/mcp/tools.ts
+++ b/packages/devtools/cli/src/commands/mcp/tools.ts
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Command from '@effect/cli/Command';
+import * as Console from 'effect/Console';
+import * as Effect from 'effect/Effect';
+
+import { CommandConfig, FormBuilder, print } from '@dxos/cli-util';
+
+import { initialize, request } from './client';
+import { requireSession, serverUrlOption } from './util';
+
+export const tools = Command.make(
+  'tools',
+  {
+    url: serverUrlOption,
+  },
+  Effect.fn(function* ({ url }) {
+    const { json, profile } = yield* CommandConfig;
+    const session = yield* requireSession(profile, url);
+
+    yield* Effect.tryPromise(() => initialize(session, { profile }));
+    const result = yield* Effect.tryPromise(() => request(session, 'tools/list', {}, { profile }));
+    const entries = (result.tools ?? []) as Array<{ name: string; description?: string }>;
+
+    if (json) {
+      yield* Console.log(JSON.stringify(entries, null, 2));
+    } else {
+      const builder = entries.reduce(
+        (acc, tool) => acc.pipe(FormBuilder.set(tool.name, tool.description ?? '')),
+        FormBuilder.make({ title: 'Tools' }),
+      );
+      yield* Console.log(print(FormBuilder.build(builder)));
+    }
+  }),
+).pipe(Command.withDescription('List the tools exposed by a connected MCP server.'));

--- a/packages/devtools/cli/src/commands/mcp/util.ts
+++ b/packages/devtools/cli/src/commands/mcp/util.ts
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Options from '@effect/cli/Options';
+import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
+
+import { type McpSession, loadSession } from './client';
+
+/**
+ * Server to act on. Optional: with a single stored session the commands pick it up automatically,
+ * which keeps the common case to `dx mcp tools` / `dx mcp call <tool>`.
+ */
+export const serverUrlOption = Options.text('url').pipe(
+  Options.withDescription('MCP server URL. Defaults to the most recently connected server.'),
+  Options.optional,
+);
+
+/** Resolves the stored session for a server, failing with actionable guidance when absent. */
+export const requireSession = (profile: string, url: Option.Option<string>): Effect.Effect<McpSession, Error, never> =>
+  Effect.gen(function* () {
+    const serverUrl = Option.getOrUndefined(url);
+    if (!serverUrl) {
+      const stored = yield* Effect.promise(() => lastSession(profile));
+      if (!stored) {
+        return yield* Effect.fail(new Error('No MCP session. Run `dx mcp connect <url>` first.'));
+      }
+      return stored;
+    }
+    const session = yield* Effect.promise(() => loadSession(profile, serverUrl));
+    if (!session) {
+      return yield* Effect.fail(new Error(`Not connected to ${serverUrl}. Run \`dx mcp connect ${serverUrl}\`.`));
+    }
+    return session;
+  });
+
+/** Most recently written session for the profile, or undefined when none exist. */
+const lastSession = async (profile: string): Promise<McpSession | undefined> => {
+  const { readdir, readFile, stat } = await import('node:fs/promises');
+  const { join } = await import('node:path');
+  const { DX_STATE, getProfilePath } = await import('@dxos/client-protocol');
+  const dir = join(getProfilePath(DX_STATE, profile), 'mcp');
+  try {
+    const files = await readdir(dir);
+    const stamped = await Promise.all(
+      files
+        .filter((file) => file.endsWith('.json'))
+        .map(async (file) => ({ file, mtime: (await stat(join(dir, file))).mtimeMs })),
+    );
+    const latest = stamped.sort((a, b) => b.mtime - a.mtime)[0];
+    return latest ? JSON.parse(await readFile(join(dir, latest.file), 'utf8')) : undefined;
+  } catch {
+    return undefined;
+  }
+};


### PR DESCRIPTION
Adds a scriptable MCP client to the CLI so a DXOS space can be driven from the terminal, not only from Claude Desktop. Counterpart to the MCP server work in [dxos/edge#757](https://github.com/dxos/edge/pull/757).

## Commands

```bash
dx mcp connect https://space-agent.dxos.workers.dev --space-id <spaceId>
dx mcp tools
dx mcp call createDocument --input '{"name":"Notes","content":"# Notes"}'
```

- **`connect`** — RFC 7591 dynamic client registration, PKCE authorize, token exchange. The identity key and space context come from the active profile's HALO, so nothing is pasted by hand.
- **`tools`** / **`call`** — `tools/list` and `tools/call` over MCP Streamable HTTP. A tool that returns `isError` fails the command rather than printing an error payload as a result.

## Notes

- Sessions persist per profile under `DX_STATE`, keyed by server origin, written `0600` since they hold bearer tokens. They refresh once on 401, and `tools`/`call` default to the most recently connected server so `--url` is rarely needed.
- The MCP server's identity step is currently a dev-only form; when it moves to a signed challenge (edge DESIGN §4.1) only `authorize()` in `client.ts` changes.

## Verification

Run against the deployed dev stack with a real identity and space: `connect`, `tools` (8 tools listed) and `call createDocument` all succeed — the document is created in the space.

`readDocument` currently fails with `EntityNotFoundError` because of [dxos/edge#758](https://github.com/dxos/edge/issues/758) (server-side writes are orphaned from the space root on deployed infrastructure — unrelated to this PR, and reproducible with two curls against compute-intrinsics). The CLI surfaces it as a clean command error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP support to the developer CLI through `dx mcp`.
  * Connect to MCP servers with OAuth authentication and persist sessions.
  * List available server tools with `dx mcp tools`.
  * Invoke tools with JSON input using `dx mcp call`.
  * Supports formatted and JSON output, plus automatic session token refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->