### PR TITLE
refactor(cli): address review feedback on `dx mcp`

### DIFF
--- a/packages/devtools/cli/src/commands/mcp/call.ts
+++ b/packages/devtools/cli/src/commands/mcp/call.ts
@@ -12,7 +12,7 @@ import * as Schema from 'effect/Schema';
 
 import { CommandConfig } from '@dxos/cli-util';
 
-import { initialize, request } from './client';
+import { McpProtocolError, ToolCallResult, initialize, request } from './client';
 import { requireSession, serverUrlOption } from './util';
 
 export const call = Command.make(
@@ -27,21 +27,32 @@ export const call = Command.make(
     url: serverUrlOption,
   },
   Effect.fn(function* ({ tool, input, url }) {
-    const { json, profile } = yield* CommandConfig;
+    const { profile } = yield* CommandConfig;
     const session = yield* requireSession(profile, url);
 
-    yield* Effect.tryPromise(() => initialize(session, { profile }));
-    const result = yield* Effect.tryPromise(() =>
-      request(session, 'tools/call', { name: tool, arguments: Option.getOrElse(input, () => ({})) }, { profile }),
-    );
+    const result = yield* Effect.tryPromise({
+      try: async () => {
+        await initialize(session, { profile });
+        return request(
+          session,
+          'tools/call',
+          { name: tool, arguments: Option.getOrElse(input, () => ({})) },
+          ToolCallResult,
+          { profile },
+        );
+      },
+      catch: (error) => new McpProtocolError({ message: `Tool ${tool} failed`, cause: error }),
+    });
 
     // A tool can fail without failing the RPC; surface that as a command error rather than
     // printing an error payload as if it were a result.
     if (result.isError) {
-      return yield* Effect.fail(new Error(`Tool ${tool} failed: ${JSON.stringify(result.content)}`));
+      return yield* Effect.fail(
+        new McpProtocolError({ message: `Tool ${tool} failed: ${JSON.stringify(result.content)}` }),
+      );
     }
 
-    const output = result.structuredContent ?? result.content;
-    yield* Console.log(json ? JSON.stringify(output, null, 2) : JSON.stringify(output, null, 2));
+    // Output is JSON either way: tool results are structured data, not a summary to format.
+    yield* Console.log(JSON.stringify(result.structuredContent ?? result.content, null, 2));
   }),
 ).pipe(Command.withDescription('Call a tool on a connected MCP server.'));

--- a/packages/devtools/cli/src/commands/mcp/client.ts
+++ b/packages/devtools/cli/src/commands/mcp/client.ts
@@ -2,11 +2,14 @@
 // Copyright 2026 DXOS.org
 //
 
+import * as Effect from 'effect/Effect';
+import * as Schema from 'effect/Schema';
 import { createHash, randomBytes } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
 import { DX_STATE, getProfilePath } from '@dxos/client-protocol';
+import { BaseError } from '@dxos/errors';
 
 /**
  * Minimal MCP client over Streamable HTTP with OAuth 2.1, used by the `dx mcp` commands.
@@ -17,30 +20,46 @@ import { DX_STATE, getProfilePath } from '@dxos/client-protocol';
  * challenge, only {@link authorize} changes.
  */
 
+export class McpProtocolError extends BaseError.extend('McpProtocolError', 'MCP protocol error') {}
+
 /** Persisted per profile, keyed by server origin, so subsequent commands reuse the session. */
-export type McpSession = {
-  serverUrl: string;
-  clientId: string;
-  accessToken: string;
-  refreshToken?: string;
-  identityKey: string;
-  spaceIds: string[];
-};
+export const McpSession = Schema.Struct({
+  serverUrl: Schema.String,
+  clientId: Schema.String,
+  accessToken: Schema.String,
+  refreshToken: Schema.optional(Schema.String),
+  identityKey: Schema.String,
+  spaceIds: Schema.Array(Schema.String),
+});
+export type McpSession = Schema.Schema.Type<typeof McpSession>;
+
+/** Token endpoint response; only the fields this client uses are modelled. */
+const TokenResponse = Schema.Struct({
+  access_token: Schema.String,
+  refresh_token: Schema.optional(Schema.String),
+});
+
+/** JSON-RPC envelope. MCP returns one object per request; Effect's RPC transport may batch. */
+const JsonRpcMessage = Schema.Struct({
+  result: Schema.optional(Schema.Unknown),
+  error: Schema.optional(Schema.Unknown),
+});
 
 const REDIRECT_URI = 'http://localhost:3000/callback';
 
+export const sessionDir = (profile: string): string => join(getProfilePath(DX_STATE, profile), 'mcp');
+
 const sessionPath = (profile: string, serverUrl: string): string => {
   const { host } = new URL(serverUrl);
-  return join(getProfilePath(DX_STATE, profile), 'mcp', `${host}.json`);
+  return join(sessionDir(profile), `${host}.json`);
 };
 
-export const loadSession = async (profile: string, serverUrl: string): Promise<McpSession | undefined> => {
-  try {
-    return JSON.parse(await readFile(sessionPath(profile, serverUrl), 'utf8'));
-  } catch {
-    return undefined;
-  }
-};
+export const loadSession = (profile: string, serverUrl: string): Effect.Effect<McpSession | undefined, never, never> =>
+  Effect.tryPromise(() => readFile(sessionPath(profile, serverUrl), 'utf8')).pipe(
+    Effect.flatMap((raw) => Schema.decodeUnknown(Schema.parseJson(McpSession))(raw)),
+    // A missing or corrupt session file is reported by the caller as "not connected".
+    Effect.orElseSucceed(() => undefined),
+  );
 
 export const saveSession = async (profile: string, session: McpSession): Promise<void> => {
   const path = sessionPath(profile, session.serverUrl);
@@ -61,7 +80,7 @@ export const authorize = async ({
 }: {
   serverUrl: string;
   identityKey: string;
-  spaceIds: string[];
+  spaceIds: readonly string[];
   haloSpaceId?: string;
 }): Promise<McpSession> => {
   const base = serverUrl.replace(/\/(mcp)?$/, '');
@@ -76,9 +95,13 @@ export const authorize = async ({
     }),
   });
   if (registerResponse.status !== 201) {
-    throw new Error(`Client registration failed (${registerResponse.status}): ${await registerResponse.text()}`);
+    throw new McpProtocolError({
+      message: `Client registration failed (${registerResponse.status}): ${await registerResponse.text()}`,
+    });
   }
-  const { client_id: clientId } = (await registerResponse.json()) as { client_id: string };
+  const { client_id: clientId } = Schema.decodeUnknownSync(Schema.Struct({ client_id: Schema.String }))(
+    await registerResponse.json(),
+  );
 
   const codeVerifier = randomBytes(32).toString('base64url');
   const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
@@ -93,7 +116,9 @@ export const authorize = async ({
   const formHtml = await formResponse.text();
   const nonce = formHtml.match(/name="nonce"\s+value="([^"]+)"/)?.[1];
   if (!nonce) {
-    throw new Error(`Unexpected authorize page from ${base} (no nonce); is this an MCP server?`);
+    throw new McpProtocolError({
+      message: `Unexpected authorize page from ${base} (no nonce); is this an MCP server?`,
+    });
   }
 
   const submitResponse = await fetch(`${base}/authorize`, {
@@ -109,11 +134,17 @@ export const authorize = async ({
     redirect: 'manual',
   });
   if (submitResponse.status !== 302) {
-    throw new Error(`Authorization failed (${submitResponse.status}): ${await submitResponse.text()}`);
+    throw new McpProtocolError({
+      message: `Authorization failed (${submitResponse.status}): ${await submitResponse.text()}`,
+    });
   }
-  const code = new URL(submitResponse.headers.get('location')!).searchParams.get('code');
+  const location = submitResponse.headers.get('location');
+  if (!location) {
+    throw new McpProtocolError({ message: 'Authorization redirect did not include a Location header.' });
+  }
+  const code = new URL(location).searchParams.get('code');
   if (!code) {
-    throw new Error('Authorization did not return a code.');
+    throw new McpProtocolError({ message: 'Authorization did not return a code.' });
   }
 
   const tokens = await exchange(base, {
@@ -130,35 +161,38 @@ export const authorize = async ({
     accessToken: tokens.access_token,
     refreshToken: tokens.refresh_token,
     identityKey,
-    spaceIds,
+    spaceIds: [...spaceIds],
   };
 };
 
 const exchange = async (
   base: string,
   params: Record<string, string>,
-): Promise<{ access_token: string; refresh_token?: string }> => {
+): Promise<Schema.Schema.Type<typeof TokenResponse>> => {
   const response = await fetch(`${base}/token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams(params).toString(),
   });
   if (response.status !== 200) {
-    throw new Error(`Token exchange failed (${response.status}): ${await response.text()}`);
+    throw new McpProtocolError({ message: `Token exchange failed (${response.status}): ${await response.text()}` });
   }
-  return (await response.json()) as { access_token: string; refresh_token?: string };
+  return Schema.decodeUnknownSync(TokenResponse)(await response.json());
 };
 
 /**
  * Issues a JSON-RPC request against the session's `/mcp` endpoint, refreshing the access token
  * once on 401 so a stored session survives token expiry without re-authorizing.
+ *
+ * The result is decoded against `schema`, so callers get a typed value rather than `any`.
  */
-export const request = async (
+export const request = async <A, I>(
   session: McpSession,
   method: string,
   params: unknown,
+  schema: Schema.Schema<A, I>,
   options: { profile?: string } = {},
-): Promise<any> => {
+): Promise<A> => {
   const send = (token: string) =>
     fetch(`${session.serverUrl}/mcp`, {
       method: 'POST',
@@ -173,29 +207,32 @@ export const request = async (
       refresh_token: session.refreshToken,
       client_id: session.clientId,
     });
-    session.accessToken = tokens.access_token;
-    session.refreshToken = tokens.refresh_token ?? session.refreshToken;
+    const refreshed: McpSession = {
+      ...session,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token ?? session.refreshToken,
+    };
     if (options.profile) {
-      await saveSession(options.profile, session);
+      await saveSession(options.profile, refreshed);
     }
+    session = refreshed;
     response = await send(session.accessToken);
   }
   if (response.status !== 200) {
-    throw new Error(`MCP ${method} failed (${response.status}): ${await response.text()}`);
+    throw new McpProtocolError({ message: `MCP ${method} failed (${response.status}): ${await response.text()}` });
   }
 
   const raw = await response.json();
-  // The Effect RPC transport batches; MCP Streamable HTTP returns a single object per request.
-  const message = (Array.isArray(raw) ? raw[0] : raw) as { result?: any; error?: unknown };
-  if (message.error) {
-    throw new Error(`MCP ${method} failed: ${JSON.stringify(message.error)}`);
+  const message = Schema.decodeUnknownSync(JsonRpcMessage)(Array.isArray(raw) ? raw[0] : raw);
+  if (message.error !== undefined) {
+    throw new McpProtocolError({ message: `MCP ${method} failed: ${JSON.stringify(message.error)}` });
   }
-  return message.result;
+  return Schema.decodeUnknownSync(schema)(message.result);
 };
 
 /** MCP requires `initialize` before any other request on a connection. */
-export const initialize = async (session: McpSession, options: { profile?: string } = {}): Promise<any> =>
-  request(
+export const initialize = async (session: McpSession, options: { profile?: string } = {}): Promise<void> => {
+  await request(
     session,
     'initialize',
     {
@@ -203,5 +240,19 @@ export const initialize = async (session: McpSession, options: { profile?: strin
       capabilities: {},
       clientInfo: { name: 'dx-mcp', version: '0.1.0' },
     },
+    Schema.Unknown,
     options,
   );
+};
+
+/** `tools/list` result. */
+export const ToolsListResult = Schema.Struct({
+  tools: Schema.Array(Schema.Struct({ name: Schema.String, description: Schema.optional(Schema.String) })),
+});
+
+/** `tools/call` result; `structuredContent` is present when the tool declares an output schema. */
+export const ToolCallResult = Schema.Struct({
+  isError: Schema.optional(Schema.Boolean),
+  content: Schema.optional(Schema.Unknown),
+  structuredContent: Schema.optional(Schema.Unknown),
+});

--- a/packages/devtools/cli/src/commands/mcp/connect.ts
+++ b/packages/devtools/cli/src/commands/mcp/connect.ts
@@ -62,13 +62,16 @@ export const connect = Command.make(
         }),
       catch: (error) => new McpConnectError({ message: `Authorization failed for ${url}`, cause: error }),
     });
-    yield* Effect.tryPromise({
-      try: () => initialize(session),
-      catch: (error) => new McpConnectError({ message: `MCP initialize failed for ${url}`, cause: error }),
-    });
+    // Persist before initializing: `initialize` may refresh the token internally, and passing
+    // `{ profile }` lets that refresh be stored. Saving afterwards would write the pre-refresh
+    // session back over it, leaving a consumed refresh token on disk.
     yield* Effect.tryPromise({
       try: () => saveSession(profile, session),
       catch: (error) => new McpConnectError({ message: 'Failed to store the MCP session', cause: error }),
+    });
+    yield* Effect.tryPromise({
+      try: () => initialize(session, { profile }),
+      catch: (error) => new McpConnectError({ message: `MCP initialize failed for ${url}`, cause: error }),
     });
 
     if (json) {

--- a/packages/devtools/cli/src/commands/mcp/connect.ts
+++ b/packages/devtools/cli/src/commands/mcp/connect.ts
@@ -11,8 +11,11 @@ import * as Option from 'effect/Option';
 
 import { CommandConfig, FormBuilder, print } from '@dxos/cli-util';
 import { ClientService } from '@dxos/client';
+import { BaseError } from '@dxos/errors';
 
 import { authorize, initialize, saveSession } from './client';
+
+class McpConnectError extends BaseError.extend('McpConnectError', 'MCP connect failed') {}
 
 export const connect = Command.make(
   'connect',
@@ -35,26 +38,38 @@ export const connect = Command.make(
 
     const identity = client.halo.identity.get();
     if (!identity) {
-      return yield* Effect.fail(new Error('Identity not available. Run `dx account login` first.'));
+      return yield* Effect.fail(
+        new McpConnectError({ message: 'Identity not available. Run `dx account login` first.' }),
+      );
     }
 
-    // The server scopes the session to these spaces; default to the profile's first space so the
+    // The server scopes the session to these spaces; default to the profile's spaces so the
     // common case ("connect this space") needs no flags.
     const spaceIds = spaceId.length > 0 ? [...spaceId] : client.spaces.get().map((space) => space.id);
     if (spaceIds.length === 0) {
-      return yield* Effect.fail(new Error('No spaces available. Create one with `dx space create`.'));
+      return yield* Effect.fail(
+        new McpConnectError({ message: 'No spaces available. Create one with `dx space create`.' }),
+      );
     }
 
-    const session = yield* Effect.tryPromise(() =>
-      authorize({
-        serverUrl: url,
-        identityKey: identity.identityKey.toHex(),
-        spaceIds,
-        haloSpaceId: Option.getOrUndefined(haloSpaceId),
-      }),
-    );
-    yield* Effect.tryPromise(() => initialize(session));
-    yield* Effect.promise(() => saveSession(profile, session));
+    const session = yield* Effect.tryPromise({
+      try: () =>
+        authorize({
+          serverUrl: url,
+          identityKey: identity.identityKey.toHex(),
+          spaceIds,
+          haloSpaceId: Option.getOrUndefined(haloSpaceId),
+        }),
+      catch: (error) => new McpConnectError({ message: `Authorization failed for ${url}`, cause: error }),
+    });
+    yield* Effect.tryPromise({
+      try: () => initialize(session),
+      catch: (error) => new McpConnectError({ message: `MCP initialize failed for ${url}`, cause: error }),
+    });
+    yield* Effect.tryPromise({
+      try: () => saveSession(profile, session),
+      catch: (error) => new McpConnectError({ message: 'Failed to store the MCP session', cause: error }),
+    });
 
     if (json) {
       yield* Console.log(

--- a/packages/devtools/cli/src/commands/mcp/index.ts
+++ b/packages/devtools/cli/src/commands/mcp/index.ts
@@ -8,7 +8,7 @@ import { call } from './call';
 import { connect } from './connect';
 import { tools } from './tools';
 
-export const mcp: Command.Command<any, any, any, any> = Command.make('mcp').pipe(
+export const mcp = Command.make('mcp').pipe(
   Command.withDescription('Interact with MCP servers (e.g. the DXOS space MCP server).'),
   Command.withSubcommands([connect, tools, call]),
 );

--- a/packages/devtools/cli/src/commands/mcp/tools.ts
+++ b/packages/devtools/cli/src/commands/mcp/tools.ts
@@ -8,7 +8,7 @@ import * as Effect from 'effect/Effect';
 
 import { CommandConfig, FormBuilder, print } from '@dxos/cli-util';
 
-import { initialize, request } from './client';
+import { McpProtocolError, ToolsListResult, initialize, request } from './client';
 import { requireSession, serverUrlOption } from './util';
 
 export const tools = Command.make(
@@ -20,14 +20,18 @@ export const tools = Command.make(
     const { json, profile } = yield* CommandConfig;
     const session = yield* requireSession(profile, url);
 
-    yield* Effect.tryPromise(() => initialize(session, { profile }));
-    const result = yield* Effect.tryPromise(() => request(session, 'tools/list', {}, { profile }));
-    const entries = (result.tools ?? []) as Array<{ name: string; description?: string }>;
+    const result = yield* Effect.tryPromise({
+      try: async () => {
+        await initialize(session, { profile });
+        return request(session, 'tools/list', {}, ToolsListResult, { profile });
+      },
+      catch: (error) => new McpProtocolError({ message: `Failed to list tools on ${session.serverUrl}`, cause: error }),
+    });
 
     if (json) {
-      yield* Console.log(JSON.stringify(entries, null, 2));
+      yield* Console.log(JSON.stringify(result.tools, null, 2));
     } else {
-      const builder = entries.reduce(
+      const builder = result.tools.reduce(
         (acc, tool) => acc.pipe(FormBuilder.set(tool.name, tool.description ?? '')),
         FormBuilder.make({ title: 'Tools' }),
       );

--- a/packages/devtools/cli/src/commands/mcp/util.ts
+++ b/packages/devtools/cli/src/commands/mcp/util.ts
@@ -55,17 +55,26 @@ const lastSession = (profile: string): Effect.Effect<McpSession | undefined, Mcp
     const dir = sessionDir(profile);
     const files = yield* Effect.tryPromise({
       try: () => readdir(dir),
-      // No session directory yet is the normal first-run state, not an error.
-      catch: () => new McpSessionError({ message: `No stored sessions in ${dir}.` }),
-    }).pipe(Effect.orElseSucceed(() => [] as string[]));
-
-    const stamped = yield* Effect.promise(() =>
-      Promise.all(
-        files
-          .filter((file) => file.endsWith('.json'))
-          .map(async (file) => ({ file, mtime: (await stat(join(dir, file))).mtimeMs })),
+      catch: (error) => new McpSessionError({ message: `Failed to read session directory ${dir}`, cause: error }),
+    }).pipe(
+      // Only a missing directory is normal (first run); permission and I/O errors must surface.
+      Effect.catchIf(
+        (error) => (error.cause as NodeJS.ErrnoException | undefined)?.code === 'ENOENT',
+        () => Effect.succeed([] as string[]),
       ),
     );
+
+    // A session file can disappear between `readdir` and `stat`; fail typed rather than letting
+    // the rejection become an unrecoverable defect.
+    const stamped = yield* Effect.tryPromise({
+      try: () =>
+        Promise.all(
+          files
+            .filter((file) => file.endsWith('.json'))
+            .map(async (file) => ({ file, mtime: (await stat(join(dir, file))).mtimeMs })),
+        ),
+      catch: (error) => new McpSessionError({ message: `Failed to inspect sessions in ${dir}`, cause: error }),
+    });
     const latest = stamped.sort((left, right) => right.mtime - left.mtime)[0];
     if (!latest) {
       return undefined;

--- a/packages/devtools/cli/src/commands/mcp/util.ts
+++ b/packages/devtools/cli/src/commands/mcp/util.ts
@@ -5,8 +5,13 @@
 import * as Options from '@effect/cli/Options';
 import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
+import * as Schema from 'effect/Schema';
 
-import { type McpSession, loadSession } from './client';
+import { BaseError } from '@dxos/errors';
+
+import { type McpSession, McpSession as McpSessionSchema, loadSession, sessionDir } from './client';
+
+export class McpSessionError extends BaseError.extend('McpSessionError', 'MCP session error') {}
 
 /**
  * Server to act on. Optional: with a single stored session the commands pick it up automatically,
@@ -18,39 +23,69 @@ export const serverUrlOption = Options.text('url').pipe(
 );
 
 /** Resolves the stored session for a server, failing with actionable guidance when absent. */
-export const requireSession = (profile: string, url: Option.Option<string>): Effect.Effect<McpSession, Error, never> =>
+export const requireSession = (
+  profile: string,
+  url: Option.Option<string>,
+): Effect.Effect<McpSession, McpSessionError, never> =>
   Effect.gen(function* () {
     const serverUrl = Option.getOrUndefined(url);
     if (!serverUrl) {
-      const stored = yield* Effect.promise(() => lastSession(profile));
+      const stored = yield* lastSession(profile);
       if (!stored) {
-        return yield* Effect.fail(new Error('No MCP session. Run `dx mcp connect <url>` first.'));
+        return yield* Effect.fail(
+          new McpSessionError({ message: 'No MCP session. Run `dx mcp connect <url>` first.' }),
+        );
       }
       return stored;
     }
-    const session = yield* Effect.promise(() => loadSession(profile, serverUrl));
+    const session = yield* loadSession(profile, serverUrl);
     if (!session) {
-      return yield* Effect.fail(new Error(`Not connected to ${serverUrl}. Run \`dx mcp connect ${serverUrl}\`.`));
+      return yield* Effect.fail(
+        new McpSessionError({ message: `Not connected to ${serverUrl}. Run \`dx mcp connect ${serverUrl}\`.` }),
+      );
     }
     return session;
   });
 
 /** Most recently written session for the profile, or undefined when none exist. */
-const lastSession = async (profile: string): Promise<McpSession | undefined> => {
-  const { readdir, readFile, stat } = await import('node:fs/promises');
-  const { join } = await import('node:path');
-  const { DX_STATE, getProfilePath } = await import('@dxos/client-protocol');
-  const dir = join(getProfilePath(DX_STATE, profile), 'mcp');
-  try {
-    const files = await readdir(dir);
-    const stamped = await Promise.all(
-      files
-        .filter((file) => file.endsWith('.json'))
-        .map(async (file) => ({ file, mtime: (await stat(join(dir, file))).mtimeMs })),
+const lastSession = (profile: string): Effect.Effect<McpSession | undefined, McpSessionError, never> =>
+  Effect.gen(function* () {
+    const { readdir, readFile, stat } = yield* Effect.promise(() => import('node:fs/promises'));
+    const { join } = yield* Effect.promise(() => import('node:path'));
+    const dir = sessionDir(profile);
+    const files = yield* Effect.tryPromise({
+      try: () => readdir(dir),
+      // No session directory yet is the normal first-run state, not an error.
+      catch: () => new McpSessionError({ message: `No stored sessions in ${dir}.` }),
+    }).pipe(Effect.orElseSucceed(() => [] as string[]));
+
+    const stamped = yield* Effect.promise(() =>
+      Promise.all(
+        files
+          .filter((file) => file.endsWith('.json'))
+          .map(async (file) => ({ file, mtime: (await stat(join(dir, file))).mtimeMs })),
+      ),
     );
-    const latest = stamped.sort((a, b) => b.mtime - a.mtime)[0];
-    return latest ? JSON.parse(await readFile(join(dir, latest.file), 'utf8')) : undefined;
-  } catch {
-    return undefined;
-  }
-};
+    const latest = stamped.sort((left, right) => right.mtime - left.mtime)[0];
+    if (!latest) {
+      return undefined;
+    }
+
+    const raw = yield* Effect.tryPromise({
+      try: () => readFile(join(dir, latest.file), 'utf8'),
+      catch: (error) => new McpSessionError({ message: `Failed to read session ${latest.file}`, cause: error }),
+    });
+    return yield* decodeSession(raw, latest.file);
+  });
+
+/** Persisted sessions are decoded rather than trusted: the file is user-editable state. */
+export const decodeSession = (raw: string, label: string): Effect.Effect<McpSession, McpSessionError, never> =>
+  Schema.decodeUnknown(Schema.parseJson(McpSessionSchema))(raw).pipe(
+    Effect.mapError(
+      (error) =>
+        new McpSessionError({
+          message: `Stored session ${label} is invalid; re-run \`dx mcp connect\`.`,
+          cause: error,
+        }),
+    ),
+  );


### PR DESCRIPTION
Follow-up to #12351. That PR merged from the queue before these review fixes landed on the branch, so they ship separately. All seven CodeRabbit findings on #12351 are addressed here.

- **No `any` in the RPC layer.** `request` is now `request<A, I>(session, method, params, schema, options)` and decodes the JSON-RPC result against a caller-supplied schema; `ToolsListResult` / `ToolCallResult` give `tools.ts` and `call.ts` typed values.
- **Validated persisted state.** `McpSession` (and the token response) are Effect Schemas; stored sessions are decoded via `Schema.parseJson(McpSession)` in both `loadSession` and `lastSession` rather than trusted — the session file is user-editable.
- **Tagged errors.** `McpProtocolError`, `McpSessionError`, `McpConnectError` via `BaseError.extend`, replacing raw `Error` in Effect error channels (matching `admin/util.ts`).
- **No non-null assertion** on the authorize redirect's `Location` header, which would otherwise throw an opaque `TypeError` from `new URL(null)`.
- **`Effect.tryPromise`** for session persistence and the authorize/initialize calls.
- **Dropped `Command.Command<any, any, any, any>`** — inference works. (The existing `halo` command group still carries this annotation, which is where I copied it from.)

Build and lint pass; re-verified against the deployed dev stack that `dx mcp call createDocument` still creates a document in a real space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized MCP error handling across connect and call flows with clearer, actionable messages.
  * Improved handling of missing, corrupt, or expired session files (including typed validation) and safer session discovery.
  * Strengthened runtime validation of MCP OAuth/token and JSON-RPC results; tool and request failures are now surfaced consistently.
  * Simplified tool output formatting to always emit JSON content.

* **Improvements**
  * More reliable session restoration by selecting the most recently saved session for a profile.
  * Tool listing/execution now uses a more consistent request sequence and error wrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->