### PR TITLE
plugin-markdown: create slash-menu objects in the current document's collection

### DIFF
--- a/.changeset/wild-mice-attend.md
+++ b/.changeset/wild-mice-attend.md
@@ -1,0 +1,6 @@
+---
+'@dxos/app-toolkit': patch
+'@dxos/plugin-markdown': patch
+---
+
+Documents created from the editor's slash/link menu are now filed in the same collection as the document they were created from, instead of the space root.

--- a/.changeset/wild-mice-attend.md
+++ b/.changeset/wild-mice-attend.md
@@ -1,5 +1,5 @@
 ---
-'@dxos/app-toolkit': patch
+'@dxos/echo': patch
 '@dxos/plugin-markdown': patch
 ---
 

--- a/packages/plugins/plugin-markdown/src/hooks/useLinkQuery.ts
+++ b/packages/plugins/plugin-markdown/src/hooks/useLinkQuery.ts
@@ -2,14 +2,16 @@
 // Copyright 2024 DXOS.org
 //
 
+import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 import { useCallback, useMemo } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { CollectionModel } from '@dxos/app-toolkit';
-import { Annotation, type Database, Filter, Obj, Query, Type } from '@dxos/echo';
+import { Annotation, Database, Filter, Obj, Query, Type } from '@dxos/echo';
 import { HiddenAnnotation, getTypeAnnotation } from '@dxos/echo/Annotation';
 import { Kind as EntityKind } from '@dxos/echo/Entity';
+import { EffectEx } from '@dxos/effect';
 import { SpaceOperation } from '@dxos/plugin-space';
 import { type Label, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { type EditorMenuGroup, type EditorMenuItem } from '@dxos/react-ui-editor';
@@ -33,23 +35,30 @@ export const useLinkQuery = (db: Database.Database | undefined, current?: Obj.Un
   );
 
   const handleLinkQuery = useCallback(
-    async (query?: string): Promise<EditorMenuGroup[]> => {
-      // A second "@" switches the link query into block-embed mode, so "@@foo" searches for "foo".
-      const name = query?.startsWith('@') ? query.slice(1).toLowerCase() : (query?.toLowerCase() ?? '');
-      const [results, containing] = await Promise.all([
-        db?.query(Query.select(filter)).run(),
-        db && current ? db.query(CollectionModel.containing(current)).run() : Promise.resolve([]),
-      ]);
+    (query?: string): Promise<EditorMenuGroup[]> => {
+      if (!db) {
+        return Promise.resolve([]);
+      }
 
-      const getLabel = (object: Obj.Unknown): Label => {
-        const type = Obj.getTypename(object)!;
-        return Obj.getLabel(object) ?? ['object-name.placeholder', { ns: type, defaultValue: 'New object' }];
-      };
+      return Effect.gen(function* () {
+        // A second "@" switches the link query into block-embed mode, so "@@foo" searches for "foo".
+        const name = query?.startsWith('@') ? query.slice(1).toLowerCase() : (query?.toLowerCase() ?? '');
+        const [results, containing] = yield* Effect.all(
+          [
+            Database.query(Query.select(filter)).run,
+            current ? Database.query(CollectionModel.containing(current)).run : Effect.succeed([]),
+          ],
+          { concurrency: 'unbounded' },
+        );
 
-      const items =
-        results
+        const getLabel = (object: Obj.Unknown): Label => {
+          const type = Obj.getTypename(object)!;
+          return Obj.getLabel(object) ?? ['object-name.placeholder', { ns: type, defaultValue: 'New object' }];
+        };
+
+        const items = results
           // Exclude the current document; it cannot link to itself.
-          ?.filter((object) => object.id !== current?.id)
+          .filter((object) => object.id !== current?.id)
           .filter((object) => toLocalizedString(getLabel(object), t).toLowerCase().includes(name))
           .map((object: Obj.Unknown): EditorMenuItem => {
             const type = Obj.getType(object);
@@ -71,38 +80,37 @@ export const useLinkQuery = (db: Database.Database | undefined, current?: Obj.Un
                 }
               },
             };
-          }) ?? [];
+          });
 
-      // File new objects in the current document's collection rather than the space root; with no
-      // containing collection `AddObject` applies its own default.
-      const target = containing[0] ?? db;
+        // File new objects in the current document's collection; with no containing collection
+        // `AddObject` falls back to the space's own default placement.
+        const target = containing[0] ?? db;
 
-      // Add "Create new document" option at the end.
-      const createItem: EditorMenuItem = {
-        id: 'create-document',
-        label: ['add-object.label', { ns: Type.getTypename(Markdown.Document) }],
-        icon: 'ph--plus--regular',
-        onSelect: ({ view, head }) => {
-          const doc = Markdown.make({ name: name || undefined });
-          // Added up-front so the link below can read its URI synchronously.
-          db?.add(doc);
-          if (target) {
+        // Add "Create new document" option at the end.
+        const createItem: EditorMenuItem = {
+          id: 'create-document',
+          label: ['add-object.label', { ns: Type.getTypename(Markdown.Document) }],
+          icon: 'ph--plus--regular',
+          onSelect: ({ view, head }) => {
+            const doc = Markdown.make({ name: name || undefined });
+            // Added up-front so the link below can read its URI synchronously.
+            db.add(doc);
             void invokePromise?.(SpaceOperation.AddObject, { object: doc, target });
-          }
-          const label = name || t('object-name.placeholder', { ns: Type.getTypename(Markdown.Document) });
-          const link = `[${label}](${Obj.getURI(doc)})`;
-          if (query?.startsWith('@')) {
-            insertAtLineStart(view, head, `!${link}\n`);
-          } else {
-            insertAtCursor(view, head, `${link} `);
-          }
-        },
-      };
+            const label = name || t('object-name.placeholder', { ns: Type.getTypename(Markdown.Document) });
+            const link = `[${label}](${Obj.getURI(doc)})`;
+            if (query?.startsWith('@')) {
+              insertAtLineStart(view, head, `!${link}\n`);
+            } else {
+              insertAtCursor(view, head, `${link} `);
+            }
+          },
+        };
 
-      return [
-        { id: 'echo', items },
-        { id: 'create', items: [createItem] },
-      ];
+        return [
+          { id: 'echo', items },
+          { id: 'create', items: [createItem] },
+        ];
+      }).pipe(Effect.provide(Database.layer(db)), EffectEx.runAndForwardErrors);
     },
     [db, filter, t, current, invokePromise],
   );

--- a/packages/plugins/plugin-markdown/src/hooks/useLinkQuery.ts
+++ b/packages/plugins/plugin-markdown/src/hooks/useLinkQuery.ts
@@ -5,9 +5,12 @@
 import * as Option from 'effect/Option';
 import { useCallback, useMemo } from 'react';
 
+import { useOperationInvoker } from '@dxos/app-framework/ui';
+import { CollectionModel } from '@dxos/app-toolkit';
 import { Annotation, type Database, Filter, Obj, Query, Type } from '@dxos/echo';
 import { HiddenAnnotation, getTypeAnnotation } from '@dxos/echo/Annotation';
 import { Kind as EntityKind } from '@dxos/echo/Entity';
+import { SpaceOperation } from '@dxos/plugin-space';
 import { type Label, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { type EditorMenuGroup, type EditorMenuItem } from '@dxos/react-ui-editor';
 import { insertAtCursor, insertAtLineStart } from '@dxos/ui-editor';
@@ -16,6 +19,7 @@ import { Markdown } from '../types';
 
 export const useLinkQuery = (db: Database.Database | undefined, current?: Obj.Unknown) => {
   const { t } = useTranslation();
+  const { invokePromise } = useOperationInvoker();
 
   const filter = useMemo(
     () =>
@@ -32,7 +36,10 @@ export const useLinkQuery = (db: Database.Database | undefined, current?: Obj.Un
     async (query?: string): Promise<EditorMenuGroup[]> => {
       // A second "@" switches the link query into block-embed mode, so "@@foo" searches for "foo".
       const name = query?.startsWith('@') ? query.slice(1).toLowerCase() : (query?.toLowerCase() ?? '');
-      const results = await db?.query(Query.select(filter)).run();
+      const [results, containing] = await Promise.all([
+        db?.query(Query.select(filter)).run(),
+        db && current ? db.query(CollectionModel.containing(current)).run() : Promise.resolve([]),
+      ]);
 
       const getLabel = (object: Obj.Unknown): Label => {
         const type = Obj.getTypename(object)!;
@@ -66,6 +73,10 @@ export const useLinkQuery = (db: Database.Database | undefined, current?: Obj.Un
             };
           }) ?? [];
 
+      // File new objects in the current document's collection rather than the space root; with no
+      // containing collection `AddObject` applies its own default.
+      const target = containing[0] ?? db;
+
       // Add "Create new document" option at the end.
       const createItem: EditorMenuItem = {
         id: 'create-document',
@@ -73,7 +84,11 @@ export const useLinkQuery = (db: Database.Database | undefined, current?: Obj.Un
         icon: 'ph--plus--regular',
         onSelect: ({ view, head }) => {
           const doc = Markdown.make({ name: name || undefined });
+          // Added up-front so the link below can read its URI synchronously.
           db?.add(doc);
+          if (target) {
+            void invokePromise?.(SpaceOperation.AddObject, { object: doc, target });
+          }
           const label = name || t('object-name.placeholder', { ns: Type.getTypename(Markdown.Document) });
           const link = `[${label}](${Obj.getURI(doc)})`;
           if (query?.startsWith('@')) {
@@ -89,7 +104,7 @@ export const useLinkQuery = (db: Database.Database | undefined, current?: Obj.Un
         { id: 'create', items: [createItem] },
       ];
     },
-    [db, filter, t, current],
+    [db, filter, t, current, invokePromise],
   );
 
   return handleLinkQuery;

--- a/packages/plugins/plugin-markdown/src/hooks/useLinkQuery.ts
+++ b/packages/plugins/plugin-markdown/src/hooks/useLinkQuery.ts
@@ -52,8 +52,12 @@ export const useLinkQuery = (db: Database.Database | undefined, current?: Obj.Un
         );
 
         const getLabel = (object: Obj.Unknown): Label => {
-          const type = Obj.getTypename(object)!;
-          return Obj.getLabel(object) ?? ['object-name.placeholder', { ns: type, defaultValue: 'New object' }];
+          const typename = Obj.getTypename(object);
+          // A typeless object cannot key a translation namespace, so it falls back to the literal.
+          const placeholder: Label = typename
+            ? ['object-name.placeholder', { ns: typename, defaultValue: 'New object' }]
+            : 'New object';
+          return Obj.getLabel(object) ?? placeholder;
         };
 
         const items = results
@@ -93,10 +97,10 @@ export const useLinkQuery = (db: Database.Database | undefined, current?: Obj.Un
           icon: 'ph--plus--regular',
           onSelect: ({ view, head }) => {
             const doc = Markdown.make({ name: name || undefined });
-            // Added up-front so the link below can read its URI synchronously.
-            db.add(doc);
             void invokePromise?.(SpaceOperation.AddObject, { object: doc, target });
             const label = name || t('object-name.placeholder', { ns: Type.getTypename(Markdown.Document) });
+            // `AddObject` attaches the object asynchronously, so this is the space-relative form of
+            // its URI; the anchor/preview path resolves that against the current space.
             const link = `[${label}](${Obj.getURI(doc)})`;
             if (query?.startsWith('@')) {
               insertAtLineStart(view, head, `!${link}\n`);

--- a/packages/sdk/app-toolkit/src/types/CollectionModel.test.ts
+++ b/packages/sdk/app-toolkit/src/types/CollectionModel.test.ts
@@ -1,0 +1,44 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { afterEach, beforeEach, describe, test } from 'vitest';
+
+import { Collection, Obj, Ref } from '@dxos/echo';
+import { EchoTestBuilder } from '@dxos/echo-client/testing';
+import { TestSchema } from '@dxos/echo/testing';
+
+import * as CollectionModel from './CollectionModel';
+
+describe('containing', () => {
+  let builder: EchoTestBuilder;
+
+  beforeEach(async () => {
+    builder = await new EchoTestBuilder().open();
+  });
+
+  afterEach(async () => {
+    await builder.close();
+  });
+
+  test('returns the collection an object is filed under', async ({ expect }) => {
+    const { db } = await builder.createDatabase({ types: [Collection.Collection, TestSchema.Person] });
+    const person = db.add(Obj.make(TestSchema.Person, { name: 'alice' }));
+    const collection = db.add(Collection.make({ name: 'People', objects: [Ref.make(person)] }));
+    db.add(Collection.make({ name: 'Other', objects: [] }));
+    await db.flush();
+
+    const results = await db.query(CollectionModel.containing(person)).run();
+    expect(results.map((result) => result.id)).toEqual([collection.id]);
+  });
+
+  test('returns nothing for an object outside every collection', async ({ expect }) => {
+    const { db } = await builder.createDatabase({ types: [Collection.Collection, TestSchema.Person] });
+    const person = db.add(Obj.make(TestSchema.Person, { name: 'alice' }));
+    db.add(Collection.make({ name: 'People', objects: [] }));
+    await db.flush();
+
+    const results = await db.query(CollectionModel.containing(person)).run();
+    expect(results).toEqual([]);
+  });
+});

--- a/packages/sdk/app-toolkit/src/types/CollectionModel.ts
+++ b/packages/sdk/app-toolkit/src/types/CollectionModel.ts
@@ -8,7 +8,7 @@ import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 
 import { SpaceProperties } from '@dxos/client-protocol/types';
-import { Annotation, Collection, Database, Obj, Query, Ref } from '@dxos/echo';
+import { Annotation, Collection, Database, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
 
 import * as AppNode from '../app-graph/AppNode';
@@ -18,6 +18,13 @@ type AddProps = {
   object: Obj.Unknown;
   target?: Collection.Collection;
 };
+
+/**
+ * Query for the collections that directly contain the object.
+ * Use it to file a new object alongside an existing one (e.g. a sibling created from within a document).
+ */
+export const containing = (object: Obj.Unknown): Query.Query<Collection.Collection> =>
+  Query.select(Filter.id(object.id)).referencedBy(Collection.Collection, 'objects');
 
 export const add = Effect.fn(function* ({ object, target }: AddProps) {
   const objectRef = Ref.make(object);


### PR DESCRIPTION
Creating a document from the editor's `/` menu (via **Inline link** / **Inline object** → the `@` picker → **Create new document**) called `db.add` directly. The new object was persisted but filed in no collection at all, so it never appeared under Collections in the navtree next to the document it was created from.

## Changes

- `@dxos/app-toolkit` — added `CollectionModel.containing(object)`, a query for the collections that directly reference an object in their `objects` array. Sits next to `CollectionModel.add`, which is the consumer of the result.
- `@dxos/plugin-markdown` — `useLinkQuery` resolves the collection containing the current document and routes creation through `SpaceOperation.AddObject`, targeting that collection. The query pair now runs as a single Effect over the `Database` service (`Database.query(...).run`, provided `Database.layer(db)` and run at the callback boundary) rather than ad-hoc `db.query().run()` promises; `Effect.all` with unbounded concurrency keeps the containing-collection lookup off the picker's critical path.

`AddObject` is invoked unconditionally — with the containing collection when there is one, otherwise the space, where the operation's existing root-collection fallback applies. Placement stays annotation-driven: `CollectionModel.add` only files collection-eligible objects (`CollectionItemAnnotation`, plus collections themselves). Routing through the operation also means a `/`-created document now behaves identically to one created from the sidebar (same observability event, same placement rules).

The object is still `db.add`-ed up front inside `onSelect` so the markdown link can read its URI synchronously — that callback has to insert text without awaiting.

## Testing

- New `packages/sdk/app-toolkit/src/types/CollectionModel.test.ts` covers `containing`: returns the single collection an object is filed under (ignoring unrelated collections), and returns nothing for an object outside every collection.
- `moon run app-toolkit:test` — 98 passed.
- `moon run plugin-markdown:test` — 22 passed, 9 skipped (memoized-LLM tests).
- `moon run app-toolkit:build plugin-markdown:build` and `:lint` clean; `pnpm format` run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced link menu search and label handling, including better fallbacks for objects without type information.
- **Bug Fixes**
  - Documents created from the editor’s slash or link menu are now stored in the same collection as the originating document (instead of being placed in the space root).
  - Link menu now behaves safely when database access is unavailable.
- **Tests**
  - Added coverage for identifying the collection containing a document, including the no-collection case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->