### PR TITLE
release: push the Composer version bump as dxos-bot

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -51,7 +51,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write # Commit the Composer version bump to main + push version / deploy pointer tags.
+  contents: write # Push the per-app deploy pointer tags (the version bump to main uses dxos-bot's PAT).
 
 jobs:
   # Resolve the run into named booleans so downstream `if:` conditions stay readable. Outputs:
@@ -120,11 +120,14 @@ jobs:
       sha: ${{ steps.commit.outputs.sha }}
       version: ${{ steps.bump.outputs.version }}
     steps:
+      # dxos-bot's PAT, not GITHUB_TOKEN: main requires the merge queue and its push allow-list is empty, so
+      # only an admin identity (dxos-bot, with enforce_admins off) can land the bump.
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: main # A production release always cuts from main.
+          token: ${{ secrets.GH_DXOS_BOT_PAT }}
 
       # composer-app + composer-crx share the desktop/extension version line; bump-composer-version.mjs bumps
       # both in lockstep and prints the new version. sync-versions.mjs then stamps the derived files.
@@ -142,9 +145,25 @@ jobs:
           git config user.name 'dxos-bot'
           git config user.email 'bot@dxos.org'
           git add -A
-          git commit -m "chore(composer): release v${{ steps.bump.outputs.version }}"
+          # `[skip ci]` because a PAT push (unlike GITHUB_TOKEN) triggers workflows, and a Check + `main`
+          # deploy of a version-bump-only commit would race this run's production deploy.
+          git commit -m "chore(composer): release v${{ steps.bump.outputs.version }} [skip ci]"
+
+          # Rebase onto anything the merge queue landed while this run was bumping, rather than losing the
+          # release to a non-fast-forward rejection.
+          attempt=1
+          while ! git push origin HEAD:main; do
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::main moved under the release commit 3 times — rerun the workflow"
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+            git pull --rebase origin main
+          done
+
+          # Tagged after the push so the tag names the commit that actually landed (a rebase rewrites it).
           git tag "composer-v${{ steps.bump.outputs.version }}"
-          git push --follow-tags origin HEAD:main
+          git push origin "refs/tags/composer-v${{ steps.bump.outputs.version }}"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   # Build Composer's web bundle ONCE and share it as an artifact so the web deploy + native (Tauri) jobs

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -120,14 +120,14 @@ jobs:
       sha: ${{ steps.commit.outputs.sha }}
       version: ${{ steps.bump.outputs.version }}
     steps:
-      # dxos-bot's PAT, not GITHUB_TOKEN: main requires the merge queue and its push allow-list is empty, so
-      # only an admin identity (dxos-bot, with enforce_admins off) can land the bump.
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: main # A production release always cuts from main.
-          token: ${{ secrets.GH_DXOS_BOT_PAT }}
+          # Leave no credential in the workspace: persisted, it would be readable by the repo-controlled
+          # bump/sync scripts below, turning "can land a commit on main" into "can read dxos-bot's PAT".
+          persist-credentials: false
 
       # composer-app + composer-crx share the desktop/extension version line; bump-composer-version.mjs bumps
       # both in lockstep and prints the new version. sync-versions.mjs then stamps the derived files.
@@ -139,31 +139,36 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Composer -> $version"
 
+      # dxos-bot's PAT reaches only this step: main requires the merge queue and its push allow-list is
+      # empty, so only an admin identity (dxos-bot, with enforce_admins off) can land the bump.
       - name: Commit + tag on main
         id: commit
+        env:
+          GH_TOKEN: ${{ secrets.GH_DXOS_BOT_PAT }}
         run: |
           git config user.name 'dxos-bot'
           git config user.email 'bot@dxos.org'
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}"
           git add -A
           # `[skip ci]` because a PAT push (unlike GITHUB_TOKEN) triggers workflows, and a Check + `main`
           # deploy of a version-bump-only commit would race this run's production deploy.
-          git commit -m "chore(composer): release v${{ steps.bump.outputs.version }} [skip ci]"
+          git commit -m "composer: release v${{ steps.bump.outputs.version }} [skip ci]"
 
           # Rebase onto anything the merge queue landed while this run was bumping, rather than losing the
           # release to a non-fast-forward rejection.
           attempt=1
-          while ! git push origin HEAD:main; do
+          while ! git push "$remote" HEAD:main; do
             if [ "$attempt" -ge 3 ]; then
               echo "::error::main moved under the release commit 3 times — rerun the workflow"
               exit 1
             fi
             attempt=$((attempt + 1))
-            git pull --rebase origin main
+            git pull --rebase "$remote" main
           done
 
           # Tagged after the push so the tag names the commit that actually landed (a rebase rewrites it).
           git tag "composer-v${{ steps.bump.outputs.version }}"
-          git push origin "refs/tags/composer-v${{ steps.bump.outputs.version }}"
+          git push "$remote" "refs/tags/composer-v${{ steps.bump.outputs.version }}"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   # Build Composer's web bundle ONCE and share it as an artifact so the web deploy + native (Tauri) jobs

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -51,7 +51,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write # Push the per-app deploy pointer tags (the version bump to main uses dxos-bot's PAT).
+  contents: read # Only `deploy` writes (its pointer tags); the version bump to main uses dxos-bot's PAT.
 
 jobs:
   # Resolve the run into named booleans so downstream `if:` conditions stay readable. Outputs:
@@ -227,6 +227,8 @@ jobs:
     needs: [plan, release, build-bundle]
     # Run once the prep jobs succeeded or were skipped (main / static-only); skip only on a failure.
     if: ${{ !cancelled() && needs.plan.result == 'success' && needs.release.result != 'failure' && needs.build-bundle.result != 'failure' }}
+    permissions:
+      contents: write # Force-updates the per-app `<app>/<env>` deploy pointer tags.
     runs-on: depot-ubuntu-24.04-4
     container:
       image: ghcr.io/dxos/gh-actions:24.11.1


### PR DESCRIPTION
Production release v0.10.1 was blocked: the `release` job in `deploy-apps.yml` commits Composer's version bump and pushes it to `main`, and `main`'s protection rejects that push outright ([run 30288042687](https://github.com/dxos/dxos/actions/runs/30288042687)):

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through the merge queue
remote: - You're not authorized to push to this branch.
```

The merge queue + linear-history setup that RELEASE-SPEC §5 lists as pending human setup is now enabled, and it fenced out the one path that writes to `main`. Two reasons the push can't succeed as written: the push allow-list is on with **no** entries (nobody may push), and the merge queue is required. The job authenticates as `github-actions[bot]` via `GITHUB_TOKEN` — `git config user.name 'dxos-bot'` only sets commit authorship, so the `bypass_pull_request_allowances` entry that already exists for `dxos-bot` never applied.

## Fix

Authenticate the `release` checkout with `secrets.GH_DXOS_BOT_PAT`, so the push identity is `dxos-bot` — a repo admin, with `enforce_admins` off, which bypasses both the merge queue and the push allow-list. This keeps the design in RELEASE-SPEC §5 intact (bump commit on `main` + `composer-v<x>` tag, one dispatch, no local command sequence). The secret already exists on the repo and was previously unused.

Two consequences handled alongside it:

- **`[skip ci]` on the bump commit.** Unlike `GITHUB_TOKEN`, a PAT push *does* trigger workflows — without this, every release spawns a redundant Check plus a `main` deploy racing the production deploy from the same run.
- **Rebase-retry on the push.** The job checks out `main` at run start; a merge landing while it bumps would reject the push as non-fast-forward and lose the release. Retries up to 3 times, rebasing in between. The tag is now created *after* the push so it names the commit that actually landed, rather than a pre-rebase SHA.

Alternatives considered and rejected: a tag-only release (leaves `composer-app/package.json` on `main` permanently stale, so every non-production build reports the wrong version); a PR-based release (conformant, but puts a human merge in the middle of a single-dispatch flow); loosening `main`'s protection (weakens the branch for every workflow holding `GITHUB_TOKEN`, not just this one).

## Verification

Nothing partially landed from the failed run — `main` is unchanged at `bf055c8b5a`, no `composer-v0.10.1` tag on the remote, and `build-bundle`/`deploy`/`tauri` all skipped. Tag pushes were never the problem (`composer/staging`, `tasks/production` push fine with `GITHUB_TOKEN`; no workflow triggers on tags).

The real proof is the next production dispatch. One residual risk I can't check from here: `GH_DXOS_BOT_PAT`'s scopes and expiry are opaque to CI config — if it's stale the release fails the same way and the PAT needs rotating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production release reliability when multiple changes are merged concurrently.
  * Ensured release tags reference the commit that was successfully published.
  * Prevented automated release commits from triggering unnecessary CI runs.
  * Improved deployment updates by explicitly enabling required write access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->