### PR TITLE
storybook: name the story generators `prebuild` so the tag deps reach them

### DIFF
--- a/packages/ui/react-ui-experimental/moon.yml
+++ b/packages/ui/react-ui-experimental/moon.yml
@@ -9,8 +9,9 @@ tags:
 tasks:
   build:
     deps:
-      - glsl
-  glsl:
+      - prebuild
+  # Named `prebuild` so storybook's `#storybook:prebuild` reaches it; the gen dir does not exist until it runs.
+  prebuild:
     command: pnpm run --silent glsl
     inputs:
       - src/shaders/glsl/*.*

--- a/packages/ui/react-ui-gameboard/moon.yml
+++ b/packages/ui/react-ui-gameboard/moon.yml
@@ -9,8 +9,9 @@ tags:
 tasks:
   build:
     deps:
-      - gen-pieces
-  gen-pieces:
+      - prebuild
+  # Named `prebuild` so storybook's `#storybook:prebuild` reaches it; `src/gen` does not exist until it runs.
+  prebuild:
     command: pnpm run --silent gen:pieces
     inputs:
       - assets/*.*

--- a/scripts/migrate-to-vite-build.mjs
+++ b/scripts/migrate-to-vite-build.mjs
@@ -84,7 +84,7 @@ const parseEntryPoints = (moonYmlText) => {
 /**
  * Rewrite moon.yml: swap `ts-build` → `ts-vite-build`, drop the `compile` task block,
  * and inject a `build` override that re-declares the dropped compile-task deps
- * (e.g. `prebuild`, `glsl`, `gen-pieces`) so the new build still waits on them.
+ * (e.g. `prebuild`) so the new build still waits on them.
  */
 const rewriteMoonYml = (text, buildExtraDeps = []) => {
   const lines = text.split('\n');

--- a/tools/storybook-react/moon.yml
+++ b/tools/storybook-react/moon.yml
@@ -15,13 +15,10 @@ tasks:
       # Vendor bundles (e.g. `@dxos/vendor-hyperformula`) use the `vendor` tag, not `ts-build`/
       # `ts-compile`, so they are not covered above; without their dist Vite's dep-scan aborts.
       - '#vendor:build'
-      # See `serve` — plugin-sketch static assets must exist before storybook builds.
-      - plugin-sketch:prebuild
-      # Stories that import a *generated* source file. Storybook resolves every other package straight
-      # from source, but these two only exist after their generator runs, and both carry `ts-vite-build`
-      # rather than `ts-build`/`ts-compile`, so the tag deps above never build them.
-      - react-ui-gameboard:gen-pieces
-      - react-ui-experimental:glsl
+      # Storybook resolves packages straight from source, so anything *generated* — assets, sprites,
+      # compiled shaders — is missing until its producer runs. Each such package exposes it as `prebuild`;
+      # depending on their `build` instead would drag in ts-vite-build's recursive `^:build`.
+      - '#storybook:prebuild'
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts
@@ -44,13 +41,9 @@ tasks:
       # Vendor bundles (e.g. `@dxos/vendor-hyperformula`) use the `vendor` tag, not `ts-build`/
       # `ts-compile`; their dist is what the dep-scan above needs.
       - '#vendor:build'
-      # `.storybook/main.ts` serves `plugin-sketch/dist/assets` as a staticDir; storybook aborts if it
-      # is missing. It hangs off plugin-sketch's `build`, which the tag deps above do not run, so a
-      # fresh worktree has no assets. Generate them explicitly.
-      - plugin-sketch:prebuild
-      # See `bundle` — stories importing generated sources, which the tag deps above never build.
-      - react-ui-gameboard:gen-pieces
-      - react-ui-experimental:glsl
+      # See `bundle` — generated sources and static assets, which hang off each package's `build` and so
+      # are absent in a fresh worktree.
+      - '#storybook:prebuild'
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts
@@ -71,10 +64,8 @@ tasks:
       - '#ts-build:build'
       - '#ts-compile:build'
       - '#vendor:build'
-      - plugin-sketch:prebuild
-      # See `bundle` — stories importing generated sources, which the tag deps above never build.
-      - react-ui-gameboard:gen-pieces
-      - react-ui-experimental:glsl
+      # See `bundle` — generated sources and static assets the tag deps above never produce.
+      - '#storybook:prebuild'
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts

--- a/tools/storybook-react/moon.yml
+++ b/tools/storybook-react/moon.yml
@@ -17,6 +17,11 @@ tasks:
       - '#vendor:build'
       # See `serve` — plugin-sketch static assets must exist before storybook builds.
       - plugin-sketch:prebuild
+      # Stories that import a *generated* source file. Storybook resolves every other package straight
+      # from source, but these two only exist after their generator runs, and both carry `ts-vite-build`
+      # rather than `ts-build`/`ts-compile`, so the tag deps above never build them.
+      - react-ui-gameboard:gen-pieces
+      - react-ui-experimental:glsl
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts
@@ -43,6 +48,9 @@ tasks:
       # is missing. It hangs off plugin-sketch's `build`, which the tag deps above do not run, so a
       # fresh worktree has no assets. Generate them explicitly.
       - plugin-sketch:prebuild
+      # See `bundle` — stories importing generated sources, which the tag deps above never build.
+      - react-ui-gameboard:gen-pieces
+      - react-ui-experimental:glsl
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts
@@ -64,6 +72,9 @@ tasks:
       - '#ts-compile:build'
       - '#vendor:build'
       - plugin-sketch:prebuild
+      # See `bundle` — stories importing generated sources, which the tag deps above never build.
+      - react-ui-gameboard:gen-pieces
+      - react-ui-experimental:glsl
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts


### PR DESCRIPTION
The v0.10.1 production deploy failed bundling `storybook-react` ([run 30296255492](https://github.com/dxos/dxos/actions/runs/30296255492/job/90080865382)):

```
[UNRESOLVED_IMPORT] Could not resolve '../../gen/pieces/chess/alpha'
  in packages/ui/react-ui-gameboard/src/components/Chessboard/chess.ts
```

## Root cause

Storybook resolves packages straight from source (via `importSource`), so it never builds them. That works for every package except one whose source imports a **generated** file: `react-ui-gameboard`'s `src/gen/pieces` is gitignored and produced by its own generator, which only that package's `build` depends on. Storybook's tag deps cover `#ts-build` (9 packages repo-wide), `#ts-compile` and `#vendor` — and `react-ui-gameboard` carries `ts-vite-build`, like all its siblings.

## Why CI never caught it

Two independent gaps:

- The only CI step that builds a storybook bundle is `moon run :bundle` in the **`e2e`** job, which runs on pushes to `main` and the Changesets PR — skipped on ordinary PRs.
- `main`-push deploys do bundle it and pass, but for the wrong reason. On `env=main`, `plan` sets `bundle=false`, so `build-bundle` is skipped and `deploy` builds composer in-job — and `plugin-chess` depends on `react-ui-gameboard`, so its generator runs incidentally. On a named env, `build-bundle` runs and `deploy` downloads the composer artifact, shrinking the graph to `storybook-react` + `docs`. Confirmed in the failed log: only those two bundle tasks, zero occurrences of the generator.

So the build-sharing optimisation is what removed the incidental dependency.

## Fix

Rename `react-ui-gameboard`'s `gen-pieces` and `react-ui-experimental`'s `glsl` to **`prebuild`** — the name `plugin-sketch` already uses for exactly this — and depend on `#storybook:prebuild`. The owning package keeps the knowledge of how to prepare its own sources, storybook names no individual package, and a third such package needs no storybook change. This also subsumes the previous explicit `plugin-sketch:prebuild` dep.

`scripts/migrate-to-vite-build.mjs` already grouped all three as one class (`prebuild`, `glsl`, `gen-pieces`); its comment is updated to match.

Two alternatives were measured and rejected:

- **Depend on each package's `build`.** `ts-vite-build`'s `build` carries a recursive `^:build` plus tsgo `.d.ts`, so this would drag a large closure and dist artifacts storybook never reads into every bundle.
- **`^:prebuild`.** A no-op: `storybook-react` declares only 7 `@dxos` deps (`log`, `storybook-addon-logger`, `storybook-utils`, `ui-theme`, three vite plugins) and discovers stories by **glob** across 121 packages. There is no dependency edge for `^` to walk. Making those edges real is a worthwhile change on its own, but it would mark `storybook-react` affected on most `packages/**` PRs and bundle storybook each time — a repo-wide CI cost that deserves its own PR.

## Validation

Verified against moon 2.2.6 on `main` with `moon action-graph '#storybook:prebuild'`: the tag-scoped target resolves without error, so moon **skips** tagged projects that lack the task — 109 projects carry `storybook`, and only `plugin-sketch` and `composer-app` define `prebuild` today. The one extra expansion versus naming packages explicitly is `composer-app:prebuild`, which is a `copy:assets` script whose own `^:prebuild` closure (protobuf, lezer) is already in storybook's graph via `#ts-build:build`.

`Preview Build / build` exercises the rename directly: it builds the composer bundle, and `plugin-chess` depends on `react-ui-gameboard`, so a dangling generator reference would fail there.

Note that **`Check` passing does not exercise the storybook bundle** — `e2e` is skipped on PRs. The end-to-end check is a `production` deploy with `app=storybook-react`, which sets `release=false` and `bundle=false` (no version bump) and reproduces the exact graph that failed.

Follow-up, not in this PR: v0.10.1 is tagged on `main` but never deployed, since `deploy` died before the deploy step. Re-dispatching production will bump to v0.10.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)