### PR TITLE
tauri: retry CrabNebula release commands and derive the channel from the environment

### DIFF
--- a/.github/actions/cn-channel/action.yml
+++ b/.github/actions/cn-channel/action.yml
@@ -1,6 +1,11 @@
 name: Crab Nebula Channel
 description: Compute the channel for a Crab Nebula release
 
+inputs:
+  environment:
+    description: Target environment (labs | staging | production).
+    required: true
+
 outputs:
   channel:
     description: 'Crab Nebula channel'
@@ -10,6 +15,18 @@ runs:
   using: 'composite'
   steps:
     - id: release-channel
-      # Replace all slashes with dashes.
-      run: echo "channel=$(echo "${{ github.ref_name }}" | sed 's|/|-|g')" >> $GITHUB_OUTPUT
       shell: bash
+      env:
+        ENVIRONMENT: ${{ inputs.environment }}
+      run: |
+        if [ -z "$ENVIRONMENT" ]; then
+          echo 'cn-channel: environment input is required' >&2
+          exit 1
+        fi
+        # Production keeps the `main` channel it has always shipped on: every build bakes its channel into the
+        # updater endpoint, so moving it to the primary channel would strand installs still polling `main`.
+        if [ "$ENVIRONMENT" = 'production' ]; then
+          echo 'channel=main' >> "$GITHUB_OUTPUT"
+        else
+          echo "channel=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/cn-config/action.yml
+++ b/.github/actions/cn-config/action.yml
@@ -5,6 +5,9 @@ inputs:
   version:
     description: 'Version'
     required: true
+  environment:
+    description: Target environment (labs | staging | production) — selects the updater channel.
+    required: true
   ios-bundle-version:
     description: >-
       Optional override for bundle.iOS.bundleVersion (Apple's CFBundleVersion, which must be plain digits
@@ -19,8 +22,9 @@ runs:
   using: 'composite'
   steps:
     - uses: ./.github/actions/cn-channel
-      if: github.ref_name != 'production'
       id: release-channel
+      with:
+        environment: ${{ inputs.environment }}
 
     - name: Find tauri.conf.json
       id: find-tauri-config
@@ -34,7 +38,6 @@ runs:
       shell: bash
 
     - name: Update endpoints in tauri.conf.json
-      if: github.ref_name != 'production'
       run: |
         jq \
           --arg channel "${{ steps.release-channel.outputs.channel }}" \

--- a/.github/actions/cn-release/action.yml
+++ b/.github/actions/cn-release/action.yml
@@ -11,6 +11,9 @@ inputs:
   application:
     description: 'Cloud Release application name'
     required: true
+  environment:
+    description: Target environment (labs | staging | production) — selects the channel.
+    required: true
   framework:
     description: 'Cloud Release framework'
     default: 'tauri'
@@ -22,11 +25,12 @@ runs:
   using: 'composite'
   steps:
     - uses: ./.github/actions/cn-channel
-      if: github.ref_name != 'production'
       id: release-channel
+      with:
+        environment: ${{ inputs.environment }}
 
-    # Resolved once so the three attempts below can't drift apart; built in the shell from env rather than
-    # interpolated into the script, since `github.ref_name` reaches the channel and is attacker-chosen.
+    # Resolved once so the three attempts below can't drift apart, and built in the shell from env rather
+    # than interpolated into the script.
     - name: Resolve release command
       id: command
       shell: bash
@@ -34,7 +38,7 @@ runs:
         CN_COMMAND: ${{ inputs.command }}
         CN_APPLICATION: ${{ inputs.application }}
         CN_FRAMEWORK: ${{ inputs.framework }}
-        CN_CHANNEL: ${{ github.ref_name != 'production' && steps.release-channel.outputs.channel || '' }}
+        CN_CHANNEL: ${{ steps.release-channel.outputs.channel }}
       run: |
         command="release $CN_COMMAND $CN_APPLICATION --framework $CN_FRAMEWORK"
         if [ -n "$CN_CHANNEL" ]; then

--- a/.github/actions/cn-release/action.yml
+++ b/.github/actions/cn-release/action.yml
@@ -25,8 +25,61 @@ runs:
       if: github.ref_name != 'production'
       id: release-channel
 
-    - uses: FabianLars-crabnebula/cloud-release@e0bb6ccebcb78f71883ebde2320f76aae6b9eb92
+    # Resolved once so the three attempts below can't drift apart; built in the shell from env rather than
+    # interpolated into the script, since `github.ref_name` reaches the channel and is attacker-chosen.
+    - name: Resolve release command
+      id: command
+      shell: bash
+      env:
+        CN_COMMAND: ${{ inputs.command }}
+        CN_APPLICATION: ${{ inputs.application }}
+        CN_FRAMEWORK: ${{ inputs.framework }}
+        CN_CHANNEL: ${{ github.ref_name != 'production' && steps.release-channel.outputs.channel || '' }}
+      run: |
+        command="release $CN_COMMAND $CN_APPLICATION --framework $CN_FRAMEWORK"
+        if [ -n "$CN_CHANNEL" ]; then
+          command="$command --channel $CN_CHANNEL"
+        fi
+        echo "value=$command" >> "$GITHUB_OUTPUT"
+
+    # The Cloud API intermittently 408s on `distribution.upload.finish` after every part has already
+    # transferred, and a single failure discards the macOS sign + notarize that precedes it (~30 min, with no
+    # remote cache on production), so each attempt is retried twice with backoff. The CLI exposes no retry or
+    # timeout flag, hence the retry lives here. `continue-on-error` is deliberately a literal — an
+    # `inputs`-based expression evaluates incorrectly inside a composite action (actions/runner#2418).
+    - name: Release (attempt 1 of 3)
+      id: attempt-1
+      continue-on-error: true
+      uses: FabianLars-crabnebula/cloud-release@e0bb6ccebcb78f71883ebde2320f76aae6b9eb92
       with:
-        command: release ${{ inputs.command }} ${{ inputs.application }} --framework ${{ inputs.framework }}${{ github.ref_name != 'production' && format(' --channel {0}', steps.release-channel.outputs.channel) || '' }}
+        command: ${{ steps.command.outputs.value }}
+        api-key: ${{ inputs.api-key }}
+        working-directory: ${{ inputs.working-directory }}
+
+    - name: Back off before attempt 2
+      if: steps.attempt-1.outcome == 'failure'
+      shell: bash
+      run: sleep 30
+
+    - name: Release (attempt 2 of 3)
+      id: attempt-2
+      if: steps.attempt-1.outcome == 'failure'
+      continue-on-error: true
+      uses: FabianLars-crabnebula/cloud-release@e0bb6ccebcb78f71883ebde2320f76aae6b9eb92
+      with:
+        command: ${{ steps.command.outputs.value }}
+        api-key: ${{ inputs.api-key }}
+        working-directory: ${{ inputs.working-directory }}
+
+    - name: Back off before attempt 3
+      if: steps.attempt-1.outcome == 'failure' && steps.attempt-2.outcome == 'failure'
+      shell: bash
+      run: sleep 60
+
+    - name: Release (attempt 3 of 3)
+      if: steps.attempt-1.outcome == 'failure' && steps.attempt-2.outcome == 'failure'
+      uses: FabianLars-crabnebula/cloud-release@e0bb6ccebcb78f71883ebde2320f76aae6b9eb92
+      with:
+        command: ${{ steps.command.outputs.value }}
         api-key: ${{ inputs.api-key }}
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/deploy-tauri.yaml
+++ b/.github/workflows/deploy-tauri.yaml
@@ -56,16 +56,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq
 
-      - name: Install CrabNebula CLI
-        run: |
-          # Download the latest cn CLI for Linux
-          curl -L -o cn https://cdn.crabnebula.app/download/crabnebula/cn-cli/latest/cn_linux
-          chmod +x cn
-          sudo mv cn /usr/local/bin/
-
-          # Verify installation
-          cn --version
-
       - name: Compute Tauri version
         id: bump-version
         run: |
@@ -114,7 +104,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: 45
+    # A production build (no remote cache) already runs ~30 min before the upload starts; the headroom is for
+    # the retries in cn-release, which must not be cut off mid-flight.
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v5
@@ -285,12 +277,28 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
       - name: Upload assets
+        timeout-minutes: 30
         uses: ./.github/actions/cn-release
         with:
           api-key: ${{ secrets.CN_API_KEY }}
           application: ${{ env.CN_APPLICATION }}
           command: upload
           working-directory: ./packages/apps/composer-app/src-tauri/
+
+      # The web deploy is a sibling job that ships independently, so a red run here reads as "the release
+      # failed" when only the desktop half did — announce which half, as build_tauri_ios already does.
+      - name: Notify Discord on desktop build failure
+        if: failure() || cancelled()
+        env:
+          DX_DISCORD_WEBHOOK_URL: ${{ secrets.DX_DISCORD_WEBHOOK_URL }}
+          REF_NAME: ${{ inputs.environment }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          payload=$(jq -nc --arg ref "$REF_NAME" --arg url "$RUN_URL" \
+            '{content: (":warning: **build_tauri** failed on `" + $ref + "` — the web deploy is unaffected.\nRun: " + $url)}')
+          curl -sS -X POST "$DX_DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$payload"
 
   build_tauri_ios:
     needs: draft_tauri

--- a/.github/workflows/deploy-tauri.yaml
+++ b/.github/workflows/deploy-tauri.yaml
@@ -60,7 +60,7 @@ jobs:
         id: bump-version
         run: |
           # composer-app/package.json is the source of truth for the version: bumped by deploy-apps' release
-          # job for a production release, current otherwise. Production ships the clean version to the primary
+          # job for a production release, current otherwise. Production ships the clean version to the `main`
           # CrabNebula channel; labs/staging get a unique per-commit prerelease tagged with the env name
           # (which selects its channel).
           BASE=$(jq -r '.version' packages/apps/composer-app/package.json)
@@ -79,6 +79,7 @@ jobs:
       - name: Update tauri.conf.json
         uses: ./.github/actions/cn-config
         with:
+          environment: ${{ inputs.environment }}
           version: ${{ steps.bump-version.outputs.version }}
           ios-bundle-version: ${{ steps.bump-version.outputs.ios_bundle_version }}
           working-directory: ./packages/apps/composer-app/src-tauri/
@@ -86,6 +87,7 @@ jobs:
       - name: Create draft non-production release
         uses: ./.github/actions/cn-release
         with:
+          environment: ${{ inputs.environment }}
           api-key: ${{ secrets.CN_API_KEY }}
           application: ${{ env.CN_APPLICATION }}
           command: draft
@@ -129,6 +131,7 @@ jobs:
       - name: Update tauri.conf.json
         uses: ./.github/actions/cn-config
         with:
+          environment: ${{ inputs.environment }}
           version: ${{ needs.draft_tauri.outputs.version }}
           ios-bundle-version: ${{ needs.draft_tauri.outputs.ios_bundle_version }}
           working-directory: ./packages/apps/composer-app/src-tauri/
@@ -280,6 +283,7 @@ jobs:
         timeout-minutes: 30
         uses: ./.github/actions/cn-release
         with:
+          environment: ${{ inputs.environment }}
           api-key: ${{ secrets.CN_API_KEY }}
           application: ${{ env.CN_APPLICATION }}
           command: upload
@@ -323,6 +327,7 @@ jobs:
       - name: Update tauri.conf.json
         uses: ./.github/actions/cn-config
         with:
+          environment: ${{ inputs.environment }}
           version: ${{ needs.draft_tauri.outputs.version }}
           ios-bundle-version: ${{ needs.draft_tauri.outputs.ios_bundle_version }}
           working-directory: ./packages/apps/composer-app/src-tauri/
@@ -425,6 +430,7 @@ jobs:
         timeout-minutes: 30
         uses: ./.github/actions/cn-release
         with:
+          environment: ${{ inputs.environment }}
           api-key: ${{ secrets.CN_API_KEY }}
           application: ${{ env.CN_APPLICATION }}
           command: upload
@@ -480,6 +486,7 @@ jobs:
       - name: Update tauri.conf.json
         uses: ./.github/actions/cn-config
         with:
+          environment: ${{ inputs.environment }}
           version: ${{ needs.draft_tauri.outputs.version }}
           ios-bundle-version: ${{ needs.draft_tauri.outputs.ios_bundle_version }}
           working-directory: ./packages/apps/composer-app/src-tauri/
@@ -487,6 +494,7 @@ jobs:
       - name: Publish release
         uses: ./.github/actions/cn-release
         with:
+          environment: ${{ inputs.environment }}
           api-key: ${{ secrets.CN_API_KEY }}
           application: ${{ env.CN_APPLICATION }}
           command: publish


### PR DESCRIPTION
## Problem

Composer v0.10.2 desktop was built, codesigned and **notarized (Apple accepted)** — then the publish threw it all away:

```
Notarizing Finished with status Accepted for id fa958dd9-… (Processing complete)
Put part 53 of size 1924516, took 16.974s
Failed to finish upload: HTTP status client error (408 Request Timeout)
  for url (https://api.crabnebula.app/directory/rspc/distribution.upload.finish)
```

[Run 30304820989](https://github.com/dxos/dxos/actions/runs/30304820989), job `build_tauri (depot-macos-latest)`. Everything expensive succeeded; the failure is the final `upload.finish` call after all 53 parts (~265 MB) had already transferred. `publish_tauri` depends on `build_tauri`, so it was skipped and the v0.10.2 CrabNebula release is still a draft.

**Transient, not systematic.** Across the last ~30 `Deploy Apps` runs this is the only `build_tauri` failure. The other recent red run ([30288042687](https://github.com/dxos/dxos/actions/runs/30288042687)) failed in `release` on the protected-branch push, already fixed by #12356. Individual part PUTs in the failing upload took up to 30s, so the backend was clearly struggling — but only on that run.

## 1. Survive a transient upload failure

- **Retry each `cn release` command up to 3 times with backoff** (30s, 60s) inside the `cn-release` composite action, so `draft` / `upload` / `publish` all benefit from one place. The CrabNebula CLI exposes no retry or timeout flag, so the retry has to live at the step level. `continue-on-error` is written as a literal rather than an input-driven expression, which evaluates incorrectly inside composite actions ([actions/runner#2418](https://github.com/actions/runner/issues/2418)).
- **Resolve the release command once into a step output** instead of repeating the long interpolation per attempt, so the three attempts cannot drift apart. It is assembled in the shell from `env` rather than interpolated into the script.
- **Drop the `Install CrabNebula CLI` step.** Nothing ever invoked `cn` — every command goes through the pinned `cloud-release` action. This also retires the unpinned `.../cn-cli/latest/cn_linux` download rather than pinning a binary that was dead weight.
- **Bound the upload step at 30 min and raise the `build_tauri` job cap 45 → 60 min**, so the retries cannot be cut off mid-flight (a production build already runs ~30 min before the upload starts, since the remote cache is deliberately disabled there).
- **Notify Discord when `build_tauri` fails**, mirroring `build_tauri_ios`, so a desktop failure is announced instead of only surfacing as a red run whose web deploy actually succeeded.

## 2. Fix the channel derivation

Found while reading the same code. `cn-channel`, `cn-config` and `cn-release` all gated on `github.ref_name != 'production'`, but `ref_name` is the branch the deploy was dispatched from — always `main`, never an environment name. So the condition was permanently true and **every environment published to the `main` channel**, meaning a labs prerelease `0.10.3-labs.abc1234` lands on the channel a production install polls and outranks the release it is running.

The `environment` input is now threaded through all three actions and maps straight to the channel — which is what `deploy-tauri.yaml`'s header comment already claimed was happening.

| environment | channel before | channel after |
|---|---|---|
| labs | `main` | `labs` |
| staging | `main` | `staging` |
| production | `main` | `main` (unchanged) |

**Production deliberately stays on `main`** rather than moving to the primary channel. Every shipped build bakes its channel into `plugins.updater.endpoints`, so every existing install is polling `?channel=main`; moving production to the primary channel would strand them with no auto-update. Production's resolved command and endpoint are byte-identical to before — only labs and staging move.

## Why the run is still allowed to go red

Marking `build_tauri` `continue-on-error` would turn the run green, but `publish_tauri` would then publish a release missing the macOS bundle — strictly worse than a red run. The run genuinely did fail: half the release did not ship. What was misleading was the *reporting*, so the fix is the failure notification above; the web deploy already announces its own success separately.

## Testing

CI-only change, so no unit test covers it — the real proof is the next `Deploy Apps` run exercising these actions.

- All four files parse as YAML (`yaml.safe_load`); every `cn-config` / `cn-release` call site asserted to pass `environment`.
- `oxfmt --check` clean at the repo-pinned 0.60.0.
- Command construction verified against the original expression: `release upload dxos/composer --framework tauri --channel main` for production, matching today's output exactly.
- Channel mapping exercised for `labs` / `staging` / `production`, plus the empty-input guard.
- Retry conditions traced through all paths: attempts 2 and 3 are `skipped` (not `failure`) when an earlier attempt succeeds, and attempt 3 carries no `continue-on-error`, so a genuine outage still fails the job.

## Follow-ups not in this PR

- The two orphaned CrabNebula drafts (v0.10.1, v0.10.2) need clearing in the Cloud dashboard — needs credentials not available here.
- The stale `storybook/production` tag (`e0e1a9fa43`, superseded by `storybook-react/production`) still needs deleting; ref deletion is blocked from this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment Improvements**
  - Deployment workflows now consistently target the selected environment and release channel across desktop and iOS builds.
  - Production releases use the main channel, while staging and labs releases remain isolated.
  - Build and upload operations have improved timeout handling and clearer failure notifications.
  - Release retries continue to be supported for greater deployment resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->