### PR TITLE
plugin-pwa: fix update toasts never firing and report update download progress (DX-1139)

### DIFF
--- a/.changeset/pwa-update-toast.md
+++ b/.changeset/pwa-update-toast.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-pwa': patch
+---
+
+Poll the service worker registration hourly so a deployed update is detected while the app stays open, instead of only on reload.

--- a/.changeset/pwa-update-toast.md
+++ b/.changeset/pwa-update-toast.md
@@ -2,4 +2,4 @@
 '@dxos/plugin-pwa': patch
 ---
 
-Poll the service worker registration hourly so a deployed update is detected while the app stays open, instead of only on reload.
+Poll the service worker registration hourly so a deployed update is detected while the app stays open, instead of only on reload, and report the update download as a progress monitor.

--- a/.changeset/pwa-update-toast.md
+++ b/.changeset/pwa-update-toast.md
@@ -2,4 +2,4 @@
 '@dxos/plugin-pwa': patch
 ---
 
-Poll the service worker registration hourly so a deployed update is detected while the app stays open, instead of only on reload, and report the update download as a progress monitor.
+Poll the service worker registration hourly so a deployed update is detected while the app stays open, instead of only on reload, and report the update download as a progress monitor. Re-dispatching a toast with an existing id now replaces it instead of stacking a duplicate.

--- a/packages/apps/composer-app/src/sw.ts
+++ b/packages/apps/composer-app/src/sw.ts
@@ -11,6 +11,10 @@ declare const self: ServiceWorkerGlobalScope;
 
 const precacheManifest = self.__WB_MANIFEST;
 
+// Workbox keys its precache by URL, so duplicate manifest entries collapse and fewer entries settle
+// than the manifest lists. Counting unique URLs keeps the meter's denominator honest.
+const precacheTotal = new Set(precacheManifest.map((entry) => (typeof entry === 'string' ? entry : entry.url))).size;
+
 /**
  * Progress envelope consumed by `@dxos/plugin-pwa`'s update-progress module, which projects it into
  * the app's progress registry. Declared here rather than imported so the worker bundle stays free of
@@ -21,6 +25,11 @@ const PRECACHE_PROGRESS = 'dxos:precache-progress';
 /** Batches the per-entry ticks: a full manifest is thousands of entries, one message each is noise. */
 const PROGRESS_POST_INTERVAL = 25;
 
+// Sampled once at worker startup rather than per message: a worker evaluated alongside an active peer
+// is an update, a first install has none. Read later it races activation — the first install has
+// already become `active` by the time the completion handler runs, mislabelling itself an update.
+const isUpdate = Boolean(self.registration.active);
+
 // An installing worker controls no clients, so uncontrolled windows must be included or the page
 // showing the meter never hears about the download it is waiting on.
 const postPrecacheProgress = async (current: number, done: boolean): Promise<void> => {
@@ -29,9 +38,8 @@ const postPrecacheProgress = async (current: number, done: boolean): Promise<voi
     client.postMessage({
       type: PRECACHE_PROGRESS,
       current,
-      total: precacheManifest.length,
-      // A worker installing alongside an active one is an update; a first install has no active peer.
-      isUpdate: Boolean(self.registration.active),
+      total: precacheTotal,
+      isUpdate,
       done,
     });
   }
@@ -40,11 +48,20 @@ const postPrecacheProgress = async (current: number, done: boolean): Promise<voi
 let precached = 0;
 const tickPrecache = (): void => {
   precached += 1;
-  const done = precached >= precacheManifest.length;
-  if (done || precached % PROGRESS_POST_INTERVAL === 0) {
-    void postPrecacheProgress(precached, done);
+  if (precached % PROGRESS_POST_INTERVAL === 0) {
+    void postPrecacheProgress(precached, false);
   }
 };
+
+// Completion is taken from the worker's own lifecycle rather than the tick count reaching the total:
+// an entry whose fetch fails settles through neither counting hook, which would strand the meter just
+// short of full and leave the monitor in the registry forever. Reaching `installed` means precaching
+// is over however many entries actually settled.
+self.serviceWorker?.addEventListener('statechange', () => {
+  if (self.serviceWorker.state === 'installed') {
+    void postPrecacheProgress(precacheTotal, true);
+  }
+});
 
 // Workbox precaches entries strictly one at a time and settles each through exactly one of these
 // hooks — `cachedResponseWillBeUsed` with a hit when the entry is already cached, `cacheDidUpdate`

--- a/packages/apps/composer-app/src/sw.ts
+++ b/packages/apps/composer-app/src/sw.ts
@@ -35,6 +35,13 @@ type AssetCacheMessage =
   | { type: 'dxos:evict-plugin'; pluginId: string }
   | { type: 'dxos:list-plugins' };
 
+/**
+ * Control message workbox-window posts (via `Workbox.messageSkipWaiting`) when the user accepts
+ * plugin-pwa's refresh toast. `injectManifest` builds ship no handler for it — unlike `generateSW`
+ * builds, where workbox-build injects one — so the toast's action button is inert without this.
+ */
+const SKIP_WAITING = 'SKIP_WAITING';
+
 // Lazy single-connection cache. The previous shape opened a fresh IDB connection
 // per call (one per `idbGet` / `idbPut` / `idbDelete` / `idbKeys`) and never
 // closed any of them — a real leak under heavy install/uninstall traffic since
@@ -163,8 +170,12 @@ const evictPlugin = async (pluginId: string): Promise<void> => {
 };
 
 self.addEventListener('message', (event) => {
-  const data = event.data as AssetCacheMessage | undefined;
+  const data = event.data as AssetCacheMessage | { type: typeof SKIP_WAITING } | undefined;
   if (!data || typeof data !== 'object' || !('type' in data)) {
+    return;
+  }
+  if (data.type === SKIP_WAITING) {
+    void self.skipWaiting();
     return;
   }
   const port = event.ports[0];
@@ -214,7 +225,10 @@ self.addEventListener('fetch', (event) => {
   );
 });
 
-self.addEventListener('install', () => self.skipWaiting());
+// Deliberately no `skipWaiting()` on install: workbox-window only reports an update once the new
+// worker parks in `waiting` (it suppresses the event when the waiting phase is skipped), so
+// self-activating here silently disabled plugin-pwa's `onNeedRefresh` toast. Activation is instead
+// driven by the SKIP_WAITING message the toast's action sends.
 self.addEventListener('activate', (event) => {
   // Hydrate the in-memory plugin-asset URL set from IDB before the SW starts handling
   // fetches. Without this, the first reload after activation would miss every plugin

--- a/packages/apps/composer-app/src/sw.ts
+++ b/packages/apps/composer-app/src/sw.ts
@@ -4,10 +4,69 @@
 
 /// <reference lib="webworker" />
 
-import { cleanupOutdatedCaches, createHandlerBoundToURL, precacheAndRoute } from 'workbox-precaching';
+import { addPlugins, cleanupOutdatedCaches, createHandlerBoundToURL, precacheAndRoute } from 'workbox-precaching';
 import { NavigationRoute, registerRoute } from 'workbox-routing';
 
 declare const self: ServiceWorkerGlobalScope;
+
+const precacheManifest = self.__WB_MANIFEST;
+
+/**
+ * Progress envelope consumed by `@dxos/plugin-pwa`'s update-progress module, which projects it into
+ * the app's progress registry. Declared here rather than imported so the worker bundle stays free of
+ * host code, mirroring `AssetCacheMessage` in `./asset-cache/service-worker.ts` — keep both in sync.
+ */
+const PRECACHE_PROGRESS = 'dxos:precache-progress';
+
+/** Batches the per-entry ticks: a full manifest is thousands of entries, one message each is noise. */
+const PROGRESS_POST_INTERVAL = 25;
+
+// An installing worker controls no clients, so uncontrolled windows must be included or the page
+// showing the meter never hears about the download it is waiting on.
+const postPrecacheProgress = async (current: number, done: boolean): Promise<void> => {
+  const clients = await self.clients.matchAll({ includeUncontrolled: true, type: 'window' });
+  for (const client of clients) {
+    client.postMessage({
+      type: PRECACHE_PROGRESS,
+      current,
+      total: precacheManifest.length,
+      // A worker installing alongside an active one is an update; a first install has no active peer.
+      isUpdate: Boolean(self.registration.active),
+      done,
+    });
+  }
+};
+
+let precached = 0;
+const tickPrecache = (): void => {
+  precached += 1;
+  const done = precached >= precacheManifest.length;
+  if (done || precached % PROGRESS_POST_INTERVAL === 0) {
+    void postPrecacheProgress(precached, done);
+  }
+};
+
+// Workbox precaches entries strictly one at a time and settles each through exactly one of these
+// hooks — `cachedResponseWillBeUsed` with a hit when the entry is already cached, `cacheDidUpdate`
+// once it has been downloaded — so counting both yields one tick per completed manifest entry. This
+// is the only progress workbox exposes for the install-time download that *is* the app update.
+addPlugins([
+  {
+    cachedResponseWillBeUsed: async ({ event, cachedResponse }) => {
+      if (event?.type === 'install' && cachedResponse) {
+        tickPrecache();
+      }
+      // The return value replaces the cached response; dropping it would make workbox re-download
+      // every entry that is already precached.
+      return cachedResponse;
+    },
+    cacheDidUpdate: async ({ event }) => {
+      if (event?.type === 'install') {
+        tickPrecache();
+      }
+    },
+  },
+]);
 
 // Precache all assets injected by VitePWA at build time (the app shell).
 //
@@ -15,7 +74,7 @@ declare const self: ServiceWorkerGlobalScope;
 // (and any other cache-busting query the host adds at runtime) from the precached
 // `icons.svg` entry. Without this, query-bearing URLs miss the precache and fall
 // through to the network — a guaranteed offline failure for the icons sprite.
-precacheAndRoute(self.__WB_MANIFEST, {
+precacheAndRoute(precacheManifest, {
   ignoreURLParametersMatching: [/^nocache$/],
 });
 cleanupOutdatedCaches();

--- a/packages/plugins/plugin-deck/src/capabilities/notification-tracker.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/notification-tracker.ts
@@ -17,6 +17,8 @@ import { log } from '@dxos/log';
 import { meta } from '#meta';
 import { DeckCapabilities } from '#types';
 
+import { upsertToast } from '../util';
+
 const NOTIFY_TOAST_DURATION = 5_000;
 const ERROR_TOAST_DURATION = 10_000;
 const UNDO_TOAST_DURATION = 10_000;
@@ -40,7 +42,7 @@ export default Capability.makeModule(
 
     const addToast = (toast: LayoutOperation.Toast) => {
       const state = registry.get(ephemeralAtom);
-      registry.set(ephemeralAtom, { ...state, toasts: [...state.toasts, toast] });
+      registry.set(ephemeralAtom, { ...state, toasts: upsertToast(state.toasts, toast) });
     };
 
     // Run a serialized invocation carried by an error's `notifyOverride` (see `LayoutOperation.NotifyOverride`):
@@ -134,7 +136,7 @@ export default Capability.makeModule(
         return;
       }
       hasShownFailureToast = true;
-      // Replace any stale plugin-failure toast so at most one is ever visible.
+      // The fixed id keeps at most one failure toast visible — `upsertToast` replaces any stale one.
       const toast: LayoutOperation.Toast = {
         id: 'plugin-failure',
         title: ['plugin-failure.title', { ns: meta.profile.key }],
@@ -146,10 +148,7 @@ export default Capability.makeModule(
         onAction: () => void invoker.invokePromise(SettingsOperation.OpenPluginRegistry),
       };
       const state = registry.get(ephemeralAtom);
-      registry.set(ephemeralAtom, {
-        ...state,
-        toasts: [...state.toasts.filter((t) => t.id !== 'plugin-failure'), toast],
-      });
+      registry.set(ephemeralAtom, { ...state, toasts: upsertToast(state.toasts, toast) });
     };
 
     const unsubscribeFailures = registry.subscribe(manager.failed, handleFailures);
@@ -174,7 +173,7 @@ export default Capability.makeModule(
         closeLabel: ['undo-close.label', { ns: meta.profile.key }],
         onAction: onUndo,
       };
-      registry.set(ephemeralAtom, { ...state, currentUndoId: undoId, toasts: [...toasts, toast] });
+      registry.set(ephemeralAtom, { ...state, currentUndoId: undoId, toasts: upsertToast(toasts, toast) });
     };
 
     // The history tracker is contributed on ProcessManagerReady, possibly after this module activates;

--- a/packages/plugins/plugin-deck/src/operations/add-toast.ts
+++ b/packages/plugins/plugin-deck/src/operations/add-toast.ts
@@ -13,10 +13,19 @@ import { DeckCapabilities } from '../types';
 const handler: Operation.WithHandler<typeof LayoutOperation.AddToast> = LayoutOperation.AddToast.pipe(
   Operation.withHandler(
     Effect.fnUntraced(function* (input) {
-      yield* Capabilities.updateAtomValue(DeckCapabilities.EphemeralState, (state) => ({
-        ...state,
-        toasts: [...state.toasts, input as LayoutOperation.Toast],
-      }));
+      yield* Capabilities.updateAtomValue(DeckCapabilities.EphemeralState, (state) => {
+        const toast = input as LayoutOperation.Toast;
+        // `id` is the key the toaster renders by, so a repeat dispatch has to replace the live toast:
+        // appending duplicates it on screen and collides the React key.
+        const index = state.toasts.findIndex(({ id }) => id === toast.id);
+        return {
+          ...state,
+          toasts:
+            index === -1
+              ? [...state.toasts, toast]
+              : state.toasts.map((existing, current) => (current === index ? toast : existing)),
+        };
+      });
     }),
   ),
 );

--- a/packages/plugins/plugin-deck/src/operations/add-toast.ts
+++ b/packages/plugins/plugin-deck/src/operations/add-toast.ts
@@ -9,23 +9,15 @@ import { LayoutOperation } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 
 import { DeckCapabilities } from '../types';
+import { upsertToast } from '../util';
 
 const handler: Operation.WithHandler<typeof LayoutOperation.AddToast> = LayoutOperation.AddToast.pipe(
   Operation.withHandler(
     Effect.fnUntraced(function* (input) {
-      yield* Capabilities.updateAtomValue(DeckCapabilities.EphemeralState, (state) => {
-        const toast = input as LayoutOperation.Toast;
-        // `id` is the key the toaster renders by, so a repeat dispatch has to replace the live toast:
-        // appending duplicates it on screen and collides the React key.
-        const index = state.toasts.findIndex(({ id }) => id === toast.id);
-        return {
-          ...state,
-          toasts:
-            index === -1
-              ? [...state.toasts, toast]
-              : state.toasts.map((existing, current) => (current === index ? toast : existing)),
-        };
-      });
+      yield* Capabilities.updateAtomValue(DeckCapabilities.EphemeralState, (state) => ({
+        ...state,
+        toasts: upsertToast(state.toasts, input as LayoutOperation.Toast),
+      }));
     }),
   ),
 );

--- a/packages/plugins/plugin-deck/src/util/index.ts
+++ b/packages/plugins/plugin-deck/src/util/index.ts
@@ -7,3 +7,4 @@ export * from './layoutAppliesTopbar';
 export * from './plank-url-params';
 export * from './sanitize-persisted-state';
 export * from './set-active';
+export * from './upsert-toast';

--- a/packages/plugins/plugin-deck/src/util/upsert-toast.test.ts
+++ b/packages/plugins/plugin-deck/src/util/upsert-toast.test.ts
@@ -8,8 +8,6 @@ import { type LayoutOperation } from '@dxos/app-toolkit';
 
 import { upsertToast } from './upsert-toast';
 
-const makeToast = (id: string, title?: string): LayoutOperation.Toast => ({ id, title });
-
 describe('upsertToast', () => {
   test('appends a toast with an unseen id', ({ expect }) => {
     const toasts = upsertToast([makeToast('a')], makeToast('b'));
@@ -33,3 +31,5 @@ describe('upsertToast', () => {
     expect(original[0].title).to.equal(undefined);
   });
 });
+
+const makeToast = (id: string, title?: string): LayoutOperation.Toast => ({ id, title });

--- a/packages/plugins/plugin-deck/src/util/upsert-toast.test.ts
+++ b/packages/plugins/plugin-deck/src/util/upsert-toast.test.ts
@@ -1,0 +1,35 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { type LayoutOperation } from '@dxos/app-toolkit';
+
+import { upsertToast } from './upsert-toast';
+
+const makeToast = (id: string, title?: string): LayoutOperation.Toast => ({ id, title });
+
+describe('upsertToast', () => {
+  test('appends a toast with an unseen id', ({ expect }) => {
+    const toasts = upsertToast([makeToast('a')], makeToast('b'));
+    expect(toasts.map(({ id }) => id)).to.deep.equal(['a', 'b']);
+  });
+
+  test('replaces a toast sharing an id rather than stacking a duplicate', ({ expect }) => {
+    const toasts = upsertToast([makeToast('a', 'first'), makeToast('b')], makeToast('a', 'second'));
+    expect(toasts.map(({ id }) => id)).to.deep.equal(['a', 'b']);
+    expect(toasts[0].title).to.equal('second');
+  });
+
+  test('replaces in place so a refreshed toast keeps its position', ({ expect }) => {
+    const toasts = upsertToast([makeToast('a'), makeToast('b'), makeToast('c')], makeToast('b', 'updated'));
+    expect(toasts.map(({ id }) => id)).to.deep.equal(['a', 'b', 'c']);
+  });
+
+  test('does not mutate the input', ({ expect }) => {
+    const original = [makeToast('a')];
+    upsertToast(original, makeToast('a', 'replaced'));
+    expect(original[0].title).to.equal(undefined);
+  });
+});

--- a/packages/plugins/plugin-deck/src/util/upsert-toast.ts
+++ b/packages/plugins/plugin-deck/src/util/upsert-toast.ts
@@ -1,0 +1,18 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type LayoutOperation } from '@dxos/app-toolkit';
+
+/**
+ * Adds a toast, replacing any live toast that shares its id. The toaster renders by `id` — it is the
+ * React key, and `onDismissToast` matches on it — so appending a repeat id stacks two identical
+ * toasts and collides the key. A repeat dispatch updates the live toast rather than opening a second.
+ */
+export const upsertToast = (
+  toasts: readonly LayoutOperation.Toast[],
+  toast: LayoutOperation.Toast,
+): LayoutOperation.Toast[] => {
+  const index = toasts.findIndex(({ id }) => id === toast.id);
+  return index === -1 ? [...toasts, toast] : toasts.map((existing, current) => (current === index ? toast : existing));
+};

--- a/packages/plugins/plugin-pwa/src/PwaPlugin.tsx
+++ b/packages/plugins/plugin-pwa/src/PwaPlugin.tsx
@@ -12,6 +12,8 @@ import { log } from '@dxos/log';
 import { meta } from '#meta';
 import { translations } from '#translations';
 
+const UPDATE_CHECK_INTERVAL = 60 * 60 * 1000; // 1h
+
 export const PwaPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.addModule({
@@ -20,7 +22,18 @@ export const PwaPlugin = Plugin.define(meta).pipe(
     activate: Effect.fnUntraced(function* () {
       const { invokePromise } = yield* Capability.get(Capabilities.OperationInvoker);
 
+      let timer: ReturnType<typeof setInterval> | undefined;
+
       const updateSW = registerSW({
+        onRegisteredSW: (_swUrl, registration) => {
+          if (!registration) {
+            return;
+          }
+          // The browser only re-fetches the worker script on navigation, but Composer sessions stay
+          // open for days, so without polling a deployed update is never noticed and the refresh
+          // toast only ever appears on reload.
+          timer = setInterval(() => void registration.update(), UPDATE_CHECK_INTERVAL);
+        },
         onNeedRefresh: () => {
           void invokePromise(LayoutOperation.AddToast, {
             id: `${meta.profile.key}.need-refresh`,
@@ -43,6 +56,8 @@ export const PwaPlugin = Plugin.define(meta).pipe(
           log.error(err);
         },
       });
+
+      return Capability.contributes(Capabilities.Null, null, () => Effect.sync(() => clearInterval(timer)));
     }),
   }),
   Plugin.make,

--- a/packages/plugins/plugin-pwa/src/PwaPlugin.tsx
+++ b/packages/plugins/plugin-pwa/src/PwaPlugin.tsx
@@ -3,16 +3,34 @@
 //
 
 import * as Effect from 'effect/Effect';
+import * as Predicate from 'effect/Predicate';
 import { registerSW } from 'virtual:pwa-register';
 
-import { ActivationEvents, Capabilities, Capability, Plugin } from '@dxos/app-framework';
-import { AppPlugin, LayoutOperation } from '@dxos/app-toolkit';
+import { ActivationEvent, ActivationEvents, Capabilities, Capability, Plugin } from '@dxos/app-framework';
+import { AppActivationEvents, AppCapabilities, AppPlugin, LayoutOperation } from '@dxos/app-toolkit';
 import { log } from '@dxos/log';
 
 import { meta } from '#meta';
 import { translations } from '#translations';
 
 const UPDATE_CHECK_INTERVAL = 60 * 60 * 1000; // 1h
+
+/**
+ * Progress envelope posted by the host's service worker while it precaches a build. The contract is
+ * duplicated in `composer-app/src/sw.ts` so the worker bundle stays free of host code — keep in sync.
+ */
+const PRECACHE_PROGRESS = 'dxos:precache-progress';
+
+type PrecacheProgress = {
+  type: typeof PRECACHE_PROGRESS;
+  current: number;
+  total: number;
+  isUpdate: boolean;
+  done: boolean;
+};
+
+const isPrecacheProgress = (data: unknown): data is PrecacheProgress =>
+  Predicate.isRecord(data) && data.type === PRECACHE_PROGRESS;
 
 export const PwaPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
@@ -58,6 +76,46 @@ export const PwaPlugin = Plugin.define(meta).pipe(
       });
 
       return Capability.contributes(Capabilities.Null, null, () => Effect.sync(() => clearInterval(timer)));
+    }),
+  }),
+  // Separate from `register-pwa` so that an app without the progress registry still registers the
+  // service worker — only the meter is lost, not the update flow itself.
+  Plugin.addModule({
+    id: 'update-progress',
+    activatesOn: ActivationEvent.allOf(ActivationEvents.ProcessManagerReady, AppActivationEvents.ProgressRegistryReady),
+    activate: Effect.fnUntraced(function* () {
+      const registry = yield* Capability.get(AppCapabilities.ProgressRegistry);
+
+      let monitor: AppCapabilities.ProgressMonitor | undefined;
+      const handleMessage = (event: MessageEvent) => {
+        if (!isPrecacheProgress(event.data)) {
+          return;
+        }
+
+        const { current, total, isUpdate, done } = event.data;
+        monitor ??= registry.register(`${meta.profile.key}.precache`, {
+          label: isUpdate ? 'Downloading app update' : 'Preparing offline use',
+          total,
+        });
+        monitor.total(total);
+        monitor.set(current);
+        if (done) {
+          monitor.done();
+          // Transient monitor: the download is a one-shot, so drop it rather than leave a completed
+          // row in the registry until the next reload.
+          monitor.remove();
+          monitor = undefined;
+        }
+      };
+
+      navigator.serviceWorker?.addEventListener('message', handleMessage);
+
+      return Capability.contributes(Capabilities.Null, null, () =>
+        Effect.sync(() => {
+          navigator.serviceWorker?.removeEventListener('message', handleMessage);
+          monitor?.remove();
+        }),
+      );
     }),
   }),
   Plugin.make,

--- a/packages/plugins/plugin-pwa/src/PwaPlugin.tsx
+++ b/packages/plugins/plugin-pwa/src/PwaPlugin.tsx
@@ -76,9 +76,16 @@ export const PwaPlugin = Plugin.define(meta).pipe(
       // for days, so without polling a deployed update is never noticed and the refresh toast only
       // ever appears on reload. `Effect.repeat` runs the first check straight away, before
       // `onRegisteredSW` has fired — the optional call makes that opening tick a no-op.
-      const fiber = yield* Effect.promise(async () => {
+      //
+      // `update()` rejects in its own right — `InvalidStateError` while a worker is already
+      // installing, a `TypeError` when the script fetch fails offline — so the rejection is recovered
+      // rather than left to `Effect.promise`, whose defect would kill the daemon fiber and silently
+      // end polling for the rest of the session.
+      const checkForUpdate = Effect.tryPromise(async () => {
         await registration?.update();
-      }).pipe(Effect.repeat(Schedule.fixed(UPDATE_CHECK_INTERVAL)), Effect.forkDaemon);
+      }).pipe(Effect.catchAll((error) => Effect.sync(() => log.warn('service worker update check failed', { error }))));
+
+      const fiber = yield* checkForUpdate.pipe(Effect.repeat(Schedule.fixed(UPDATE_CHECK_INTERVAL)), Effect.forkDaemon);
 
       // Return the interruption effect directly; Fiber.interrupt is async and would throw
       // AsyncFiberException if wrapped in Effect.runSync.

--- a/packages/plugins/plugin-pwa/src/PwaPlugin.tsx
+++ b/packages/plugins/plugin-pwa/src/PwaPlugin.tsx
@@ -100,6 +100,11 @@ export const PwaPlugin = Plugin.define(meta).pipe(
         }
 
         const { current, total, isUpdate, done } = event.data;
+        if (done && !monitor) {
+          // Completion for a download this window never saw start — nothing to report.
+          return;
+        }
+
         monitor ??= registry.register(`${meta.profile.key}.precache`, {
           label: isUpdate ? 'Downloading app update' : 'Preparing offline use',
           total,

--- a/packages/plugins/plugin-pwa/src/PwaPlugin.tsx
+++ b/packages/plugins/plugin-pwa/src/PwaPlugin.tsx
@@ -2,8 +2,11 @@
 // Copyright 2023 DXOS.org
 //
 
+import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
+import * as Fiber from 'effect/Fiber';
 import * as Predicate from 'effect/Predicate';
+import * as Schedule from 'effect/Schedule';
 import { registerSW } from 'virtual:pwa-register';
 
 import { ActivationEvent, ActivationEvents, Capabilities, Capability, Plugin } from '@dxos/app-framework';
@@ -13,7 +16,7 @@ import { log } from '@dxos/log';
 import { meta } from '#meta';
 import { translations } from '#translations';
 
-const UPDATE_CHECK_INTERVAL = 60 * 60 * 1000; // 1h
+const UPDATE_CHECK_INTERVAL = Duration.hours(1);
 
 /**
  * Progress envelope posted by the host's service worker while it precaches a build. The contract is
@@ -40,17 +43,11 @@ export const PwaPlugin = Plugin.define(meta).pipe(
     activate: Effect.fnUntraced(function* () {
       const { invokePromise } = yield* Capability.get(Capabilities.OperationInvoker);
 
-      let timer: ReturnType<typeof setInterval> | undefined;
+      let registration: ServiceWorkerRegistration | undefined;
 
       const updateSW = registerSW({
-        onRegisteredSW: (_swUrl, registration) => {
-          if (!registration) {
-            return;
-          }
-          // The browser only re-fetches the worker script on navigation, but Composer sessions stay
-          // open for days, so without polling a deployed update is never noticed and the refresh
-          // toast only ever appears on reload.
-          timer = setInterval(() => void registration.update(), UPDATE_CHECK_INTERVAL);
+        onRegisteredSW: (_swUrl, swRegistration) => {
+          registration = swRegistration;
         },
         onNeedRefresh: () => {
           void invokePromise(LayoutOperation.AddToast, {
@@ -75,7 +72,17 @@ export const PwaPlugin = Plugin.define(meta).pipe(
         },
       });
 
-      return Capability.contributes(Capabilities.Null, null, () => Effect.sync(() => clearInterval(timer)));
+      // The browser only re-fetches the worker script on navigation, but Composer sessions stay open
+      // for days, so without polling a deployed update is never noticed and the refresh toast only
+      // ever appears on reload. `Effect.repeat` runs the first check straight away, before
+      // `onRegisteredSW` has fired — the optional call makes that opening tick a no-op.
+      const fiber = yield* Effect.promise(async () => {
+        await registration?.update();
+      }).pipe(Effect.repeat(Schedule.fixed(UPDATE_CHECK_INTERVAL)), Effect.forkDaemon);
+
+      // Return the interruption effect directly; Fiber.interrupt is async and would throw
+      // AsyncFiberException if wrapped in Effect.runSync.
+      return Capability.contributes(Capabilities.Null, null, () => Fiber.interrupt(fiber));
     }),
   }),
   // Separate from `register-pwa` so that an app without the progress registry still registers the


### PR DESCRIPTION
Fixes [DX-1139](https://linear.app/dxos/issue/DX-1139/pwa-update-toasts-appear-not-to-work).

Preview: https://pr-12360-composer-main.dxos.workers.dev

## Diagnosis

Composer's custom `injectManifest` service worker (`packages/apps/composer-app/src/sw.ts`) called `self.skipWaiting()` from its `install` handler:

```ts
self.addEventListener('install', () => self.skipWaiting());
```

`plugin-pwa` registers with vite-plugin-pwa's default `registerType: 'prompt'`, and in that mode the **only** path to `onNeedRefresh` is workbox-window's `waiting` event. workbox deliberately suppresses that event when a worker self-activates — after `state === 'installed'` it starts a 200 ms timer and only dispatches `waiting` if `registration.waiting === sw` still holds, with the comment:

> This timeout is used to ignore cases where the service worker calls `skipWaiting()` in the install event, thus moving it directly in the activating state.

On an update the `installed` event fires with `isUpdate === true`, which vite-plugin-pwa's prompt branch ignores. So on every deploy the new worker went `install → activate` without ever parking in `waiting`, neither callback ran, and no toast could appear.

Two further gaps meant the flow still wouldn't have completed even once the toast showed:

1. **The Refresh button was inert.** `updateSW(true)` calls `Workbox.messageSkipWaiting()`, which posts `{type: 'SKIP_WAITING'}` to the waiting worker and relies on the worker handling it. `workbox-build` injects that handler only in `generateSW` mode — `injectManifest` builds must write it themselves, and `sw.ts`'s `message` listener dropped the message.
2. **Nothing triggered the update check.** The browser only re-fetches the worker script on navigation, and Composer sessions stay open for days.

## Changes

**The fix**

- `sw.ts` — removed the install-time `skipWaiting()` (with a comment at the site so it isn't reintroduced) and added a `SKIP_WAITING` branch to the existing `message` listener so the toast's action activates the waiting worker.
- `PwaPlugin.tsx` — an hourly `registration.update()` on a `Schedule.fixed` daemon fiber, interrupted from the capability's deactivate hook (matching `plugin-native`'s updater).

**Update download progress**

The install-time precache of the new worker *is* the update download, and it was invisible.

- `sw.ts` instruments the precache strategy via `addPlugins`. `PrecacheController` caches entries one at a time and settles each through exactly one of `cachedResponseWillBeUsed` (already cached) or `cacheDidUpdate` (downloaded) — the hooks workbox's own `PrecacheInstallReportPlugin` uses. Posted with `includeUncontrolled: true` (an installing worker controls no clients), batched every 25 entries.
- `plugin-pwa` projects those into `AppCapabilities.ProgressRegistry` as a transient monitor, in its own module gated on `ProgressRegistryReady` so an app without the registry still registers the worker.

**Fixes found by running it (see Verification)**

- Completion no longer derives from the tick count reaching the manifest length — it never arrived (duplicate url; entries whose fetch fails settle through neither hook), stranding the meter and leaking the monitor. It now comes from the worker reaching `installed`, with the total counted over unique urls.
- `isUpdate` is sampled once at worker startup instead of per message; read later it races activation and a first install mislabelled itself "Downloading app update".
- `AddToast` replaces a live toast with the same `id` instead of appending — `id` is the React key the toaster renders by, so a repeat dispatch rendered two identical toasts.

## Verification

Static: `plugin-pwa`/`plugin-deck` builds, `composer-app:bundle`, `tsc --noEmit` (clean for `sw.ts`), lint, format. The emitted `sw.js` has exactly one `skipWaiting()`, reached only via the `SKIP_WAITING` guard, no install-time self-activation, `activate` intact.

**Worker lifecycle**, against the real built worker driven through two "deploys" via workbox-window:

| after a redeploy | workbox events | toast? |
| --- | --- | --- |
| pre-fix | `installed:isUpdate=true` → `controlling` → `activated` | ❌ `waiting` never fires |
| this PR | `installed:isUpdate=true` → **`waiting:isUpdate=true`** | ✅ `onNeedRefresh` fires |

**End-to-end in the real app**, with no deploy and no rebuild — serve `out/composer` on localhost, boot Composer in Chromium, then mutate `sw.js` and call the same `registration.update()` the hourly schedule performs:

```
1. app booted
2. first install complete; first-install: 193 ticks, 25/4816 … 4816/4816, done=true
3. sw.js mutated — simulating a new deployment
4. UPDATE TOAST SHOWN: Refresh now to get app updates | You'll need these updates to
   continue without interruption. | Refresh
   progress: first-install: 193 ticks … done=true ; update: 193 ticks … done=true
5. after clicking Refresh: waiting worker gone = true | active = activated
```

So the toast renders with its real copy, the progress monitor runs and completes for both first install and update, and the Refresh button retires the waiting worker.

Not added to the repo: the harness needs a production build plus a mutating worker script, which doesn't fit the existing e2e setup (which runs with `DX_PWA=false`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PWA updates are detected automatically while the app remains open, polling for new deployments and reflecting them without a manual reload.
  - Service worker precaching and update downloads now show progress and completion status.
  - Updates can be applied via an explicit activation flow.

- **Bug Fixes**
  - Toasts now update/replace existing entries by id instead of stacking duplicates, including activation failure and undo toasts.
  - Progress indicators and update notifications are properly finalized and cleared when complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->