### PR TITLE
plugin-onboarding: surface passkey login failures (DX-1135)

### DIFF
--- a/.changeset/passkey-login-feedback.md
+++ b/.changeset/passkey-login-feedback.md
@@ -1,5 +1,5 @@
 ---
-'@dxos/plugin-markdown': patch
+'@dxos/plugin-client': patch
 ---
 
 Report passkey login failures on the welcome screen instead of silently doing nothing. `RedeemPasskey` now fails with `PasskeyDismissedError`, `PasskeyRejectedError`, or `PasskeyLoginError`, which `classifyPasskeyFailure` maps to a message.

--- a/.changeset/passkey-login-feedback.md
+++ b/.changeset/passkey-login-feedback.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-markdown': patch
+---
+
+Report passkey login failures on the welcome screen instead of silently doing nothing. `RedeemPasskey` now fails with `PasskeyDismissedError`, `PasskeyRejectedError`, or `PasskeyLoginError`, which `classifyPasskeyFailure` maps to a message.

--- a/packages/plugins/plugin-client/package.json
+++ b/packages/plugins/plugin-client/package.json
@@ -120,6 +120,7 @@
     "@dxos/echo-protocol": "workspace:*",
     "@dxos/edge-client": "workspace:*",
     "@dxos/effect": "workspace:*",
+    "@dxos/errors": "workspace:*",
     "@dxos/halo": "workspace:*",
     "@dxos/halo-adapter-client": "workspace:*",
     "@dxos/halo-react": "workspace:*",

--- a/packages/plugins/plugin-client/src/index.ts
+++ b/packages/plugins/plugin-client/src/index.ts
@@ -7,3 +7,10 @@ export { HaloServicesLayer } from './halo-services-layer';
 export * from './progress';
 export * from './types';
 export { ClientOperation } from './operations';
+export {
+  PasskeyDismissedError,
+  type PasskeyFailure,
+  PasskeyLoginError,
+  PasskeyRejectedError,
+  classifyPasskeyFailure,
+} from './operations/errors';

--- a/packages/plugins/plugin-client/src/operations/errors.test.ts
+++ b/packages/plugins/plugin-client/src/operations/errors.test.ts
@@ -1,0 +1,55 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  PasskeyDismissedError,
+  PasskeyLoginError,
+  PasskeyRejectedError,
+  classifyPasskeyFailure,
+  toPasskeyAssertionError,
+} from './errors';
+
+describe('passkey errors', () => {
+  describe('toPasskeyAssertionError', () => {
+    test('a dismissed prompt is not reported as a failure', () => {
+      const error = toPasskeyAssertionError(new DOMException('The operation either timed out.', 'NotAllowedError'));
+      expect(PasskeyDismissedError.is(error)).to.be.true;
+    });
+
+    test('an aborted ceremony is a dismissal', () => {
+      const error = toPasskeyAssertionError(new DOMException('Aborted.', 'AbortError'));
+      expect(PasskeyDismissedError.is(error)).to.be.true;
+    });
+
+    test('the native bridge rejects with a string, not a DOMException', () => {
+      const error = toPasskeyAssertionError('ASAuthorizationError: the operation was canceled');
+      expect(PasskeyDismissedError.is(error)).to.be.true;
+    });
+
+    test('anything else is a login failure', () => {
+      const error = toPasskeyAssertionError(new DOMException('Bad state.', 'InvalidStateError'));
+      expect(PasskeyLoginError.is(error)).to.be.true;
+    });
+
+    test('the original error is retained as the cause', () => {
+      const cause = new DOMException('Bad state.', 'InvalidStateError');
+      expect(toPasskeyAssertionError(cause).cause).to.eq(cause);
+    });
+  });
+
+  describe('classifyPasskeyFailure', () => {
+    test('each passkey error maps to its own message', () => {
+      expect(classifyPasskeyFailure(new PasskeyDismissedError())).to.eq('dismissed');
+      expect(classifyPasskeyFailure(new PasskeyRejectedError())).to.eq('rejected');
+      expect(classifyPasskeyFailure(new PasskeyLoginError())).to.eq('failed');
+    });
+
+    test('an unrecognized error is surfaced rather than swallowed', () => {
+      expect(classifyPasskeyFailure(new Error('boom'))).to.eq('failed');
+      expect(classifyPasskeyFailure(undefined)).to.eq('failed');
+    });
+  });
+});

--- a/packages/plugins/plugin-client/src/operations/errors.test.ts
+++ b/packages/plugins/plugin-client/src/operations/errors.test.ts
@@ -4,52 +4,24 @@
 
 import { describe, expect, test } from 'vitest';
 
-import {
-  PasskeyDismissedError,
-  PasskeyLoginError,
-  PasskeyRejectedError,
-  classifyPasskeyFailure,
-  toPasskeyAssertionError,
-} from './errors';
+import { PasskeyDismissedError, classifyPasskeyFailure, toPasskeyAssertionError } from './errors';
 
 describe('passkey errors', () => {
-  describe('toPasskeyAssertionError', () => {
-    test('a dismissed prompt is not reported as a failure', () => {
-      const error = toPasskeyAssertionError(new DOMException('The operation either timed out.', 'NotAllowedError'));
-      expect(PasskeyDismissedError.is(error)).to.be.true;
-    });
+  // The native (Tauri) bridge rejects with a plain string rather than a DOMException, and
+  // ASAuthorization spells it "canceled" while the web spells it "cancelled".
+  test.each(['ASAuthorizationError: the operation was canceled', 'Prompt cancelled by user'])(
+    'a native dismissal is recognised without a DOMException (%s)',
+    (rejection) => {
+      expect(PasskeyDismissedError.is(toPasskeyAssertionError(rejection))).to.be.true;
+    },
+  );
 
-    test('an aborted ceremony is a dismissal', () => {
-      const error = toPasskeyAssertionError(new DOMException('Aborted.', 'AbortError'));
-      expect(PasskeyDismissedError.is(error)).to.be.true;
-    });
-
-    test('the native bridge rejects with a string, not a DOMException', () => {
-      const error = toPasskeyAssertionError('ASAuthorizationError: the operation was canceled');
-      expect(PasskeyDismissedError.is(error)).to.be.true;
-    });
-
-    test('anything else is a login failure', () => {
-      const error = toPasskeyAssertionError(new DOMException('Bad state.', 'InvalidStateError'));
-      expect(PasskeyLoginError.is(error)).to.be.true;
-    });
-
-    test('the original error is retained as the cause', () => {
-      const cause = new DOMException('Bad state.', 'InvalidStateError');
-      expect(toPasskeyAssertionError(cause).cause).to.eq(cause);
-    });
-  });
-
-  describe('classifyPasskeyFailure', () => {
-    test('each passkey error maps to its own message', () => {
-      expect(classifyPasskeyFailure(new PasskeyDismissedError())).to.eq('dismissed');
-      expect(classifyPasskeyFailure(new PasskeyRejectedError())).to.eq('rejected');
-      expect(classifyPasskeyFailure(new PasskeyLoginError())).to.eq('failed');
-    });
-
-    test('an unrecognized error is surfaced rather than swallowed', () => {
-      expect(classifyPasskeyFailure(new Error('boom'))).to.eq('failed');
-      expect(classifyPasskeyFailure(undefined)).to.eq('failed');
-    });
-  });
+  // The bug this guards: a failure the classifier doesn't recognise must still reach the user.
+  // A `switch` on the error tag without a default would regress to silence.
+  test.each([new Error('Recovery key not registered.'), 'plain string', undefined, null])(
+    'an unrecognised failure is still reported (%s)',
+    (error) => {
+      expect(classifyPasskeyFailure(error)).to.eq('failed');
+    },
+  );
 });

--- a/packages/plugins/plugin-client/src/operations/errors.ts
+++ b/packages/plugins/plugin-client/src/operations/errors.ts
@@ -1,0 +1,47 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { BaseError } from '@dxos/errors';
+
+/**
+ * The platform prompt produced no assertion. WebAuthn reports a dismissed prompt and
+ * "this device has no passkey for this site" identically, so the two cannot be told apart.
+ */
+export class PasskeyDismissedError extends BaseError.extend('PasskeyDismissedError', 'No passkey was presented') {}
+
+/** The assertion was refused: the passkey is not registered as a recovery credential for any identity. */
+export class PasskeyRejectedError extends BaseError.extend('PasskeyRejectedError', 'Passkey was not accepted') {}
+
+/** Passkey login failed before an assertion could be checked (service unreachable, unusable authenticator response). */
+export class PasskeyLoginError extends BaseError.extend('PasskeyLoginError', 'Passkey login failed') {}
+
+/**
+ * Classify a rejection from the authenticator. WebAuthn reports a dismissed prompt and
+ * "no credential for this site" as the same `NotAllowedError`, so both map to dismissal;
+ * the native (Tauri) bridge rejects with a plain string rather than a `DOMException`.
+ */
+export const toPasskeyAssertionError = (error: unknown): PasskeyDismissedError | PasskeyLoginError => {
+  const name = error instanceof DOMException ? error.name : undefined;
+  if (name === 'NotAllowedError' || name === 'AbortError' || /cancell?ed/i.test(String(error))) {
+    return new PasskeyDismissedError({ cause: error });
+  }
+  return new PasskeyLoginError({ cause: error });
+};
+
+/** Discriminates a passkey login failure so callers can pick a message without matching on error names. */
+export type PasskeyFailure = 'dismissed' | 'rejected' | 'failed';
+
+/**
+ * Classify an error returned by the `RedeemPasskey` operation.
+ * Anything unrecognized is reported as a generic failure rather than swallowed.
+ */
+export const classifyPasskeyFailure = (error: unknown): PasskeyFailure => {
+  if (PasskeyDismissedError.is(error)) {
+    return 'dismissed';
+  }
+  if (PasskeyRejectedError.is(error)) {
+    return 'rejected';
+  }
+  return 'failed';
+};

--- a/packages/plugins/plugin-client/src/operations/index.ts
+++ b/packages/plugins/plugin-client/src/operations/index.ts
@@ -5,6 +5,7 @@
 import { OperationHandlerSet } from '@dxos/compute';
 
 export * as ClientOperation from './definitions';
+export * from './errors';
 
 export const ClientOperationHandlerSet = OperationHandlerSet.lazy(
   () => import('./create-agent'),

--- a/packages/plugins/plugin-client/src/operations/redeem-passkey.ts
+++ b/packages/plugins/plugin-client/src/operations/redeem-passkey.ts
@@ -13,69 +13,99 @@ import { invariant } from '@dxos/invariant';
 
 import { ClientCapabilities } from '../types';
 import { RedeemPasskey } from './definitions';
+import { PasskeyDismissedError, PasskeyLoginError, PasskeyRejectedError, toPasskeyAssertionError } from './errors';
+
+/** Signed challenge presented to EDGE in exchange for admitting this device. */
+type Assertion = {
+  lookupKey: PublicKey;
+  signature: Buffer;
+  clientDataJson: Buffer;
+  authenticatorData: Buffer;
+};
+
+const nativeAssertion = (challenge: string): Effect.Effect<Assertion, PasskeyDismissedError | PasskeyLoginError> =>
+  Effect.gen(function* () {
+    const result = yield* Effect.tryPromise({
+      try: () => NativePasskey.loginNativePasskey({ challenge: Uint8Array.from(Buffer.from(challenge, 'base64')) }),
+      catch: toPasskeyAssertionError,
+    });
+    if (!result?.user_handle || !result.signature) {
+      return yield* Effect.fail(new PasskeyLoginError({ message: 'Native passkey login returned no assertion.' }));
+    }
+
+    return {
+      lookupKey: PublicKey.from(NativePasskey.decodeUrlSafeBase64(result.user_handle)),
+      signature: Buffer.from(NativePasskey.decodeUrlSafeBase64(result.signature)),
+      clientDataJson: Buffer.from(NativePasskey.decodeUrlSafeBase64(result.client_data_json)),
+      authenticatorData: Buffer.from(NativePasskey.decodeUrlSafeBase64(result.authenticator_data)),
+    };
+  });
+
+const webAssertion = (challenge: string): Effect.Effect<Assertion, PasskeyDismissedError | PasskeyLoginError> =>
+  Effect.gen(function* () {
+    if (typeof PublicKeyCredential === 'undefined') {
+      return yield* Effect.fail(new PasskeyLoginError({ message: 'WebAuthn is not available in this browser.' }));
+    }
+
+    const credential = yield* Effect.tryPromise({
+      try: () =>
+        navigator.credentials.get({
+          publicKey: {
+            challenge: Buffer.from(challenge, 'base64'),
+            rpId: location.hostname,
+            userVerification: 'required',
+          },
+        }),
+      catch: toPasskeyAssertionError,
+    });
+    // A null credential means the authenticator resolved without presenting one; same signal as a dismissal.
+    if (
+      !(credential instanceof PublicKeyCredential) ||
+      !(credential.response instanceof AuthenticatorAssertionResponse)
+    ) {
+      return yield* Effect.fail(new PasskeyDismissedError({ message: 'No passkey assertion was returned.' }));
+    }
+
+    const { signature, clientDataJSON, authenticatorData, userHandle } = credential.response;
+    // The user handle carries the lookup key; a passkey created without a resident key has none.
+    if (!userHandle) {
+      return yield* Effect.fail(new PasskeyLoginError({ message: 'Passkey assertion has no user handle.' }));
+    }
+
+    return {
+      lookupKey: PublicKey.from(new Uint8Array(userHandle)),
+      signature: Buffer.from(signature),
+      clientDataJson: Buffer.from(clientDataJSON),
+      authenticatorData: Buffer.from(authenticatorData),
+    };
+  });
 
 const handler: Operation.WithHandler<typeof RedeemPasskey> = RedeemPasskey.pipe(
   Operation.withHandler(
     Effect.fnUntraced(function* () {
       const client = yield* Capability.get(ClientCapabilities.Client);
-      invariant(client.services.services.IdentityService, 'IdentityService not available');
-      const { deviceKey, controlFeedKey, challenge } = yield* Effect.promise(() =>
-        client.services.services.IdentityService!.requestRecoveryChallenge(),
+      const identityService = client.services.services.IdentityService;
+      invariant(identityService, 'IdentityService not available');
+
+      const { deviceKey, controlFeedKey, challenge } = yield* Effect.tryPromise({
+        try: () => identityService.requestRecoveryChallenge(),
+        catch: PasskeyLoginError.wrap({ message: 'Failed to request a recovery challenge.' }),
+      });
+
+      const assertion = yield* Match.value(NativePasskey.supportsNativePasskeys()).pipe(
+        Match.when(true, () => nativeAssertion(challenge)),
+        Match.orElse(() => webAssertion(challenge)),
       );
 
-      const { lookupKey, signature, clientDataJson, authenticatorData } = yield* Match.value(
-        NativePasskey.supportsNativePasskeys(),
-      ).pipe(
-        Match.when(true, () =>
-          Effect.gen(function* () {
-            const result = yield* Effect.promise(() =>
-              NativePasskey.loginNativePasskey({ challenge: Uint8Array.from(Buffer.from(challenge, 'base64')) }),
-            );
-            invariant(result, 'Native passkey login returned no result');
-            return {
-              lookupKey: PublicKey.from(NativePasskey.decodeUrlSafeBase64(result.user_handle)),
-              signature: Buffer.from(NativePasskey.decodeUrlSafeBase64(result.signature)),
-              clientDataJson: Buffer.from(NativePasskey.decodeUrlSafeBase64(result.client_data_json)),
-              authenticatorData: Buffer.from(NativePasskey.decodeUrlSafeBase64(result.authenticator_data)),
-            };
-          }),
-        ),
-        Match.orElse(() =>
-          Effect.gen(function* () {
-            const credential = yield* Effect.promise(() =>
-              navigator.credentials.get({
-                publicKey: {
-                  challenge: Buffer.from(challenge, 'base64'),
-                  rpId: location.hostname,
-                  userVerification: 'required',
-                },
-              }),
-            );
-            return {
-              lookupKey: PublicKey.from(new Uint8Array((credential as any).response.userHandle)),
-              signature: Buffer.from((credential as any).response.signature),
-              clientDataJson: Buffer.from((credential as any).response.clientDataJSON),
-              authenticatorData: Buffer.from((credential as any).response.authenticatorData),
-            };
-          }),
-        ),
-      );
-
-      yield* Effect.promise(() =>
-        client.services.services.IdentityService!.recoverIdentity(
-          {
-            external: {
-              lookupKey,
-              deviceKey,
-              controlFeedKey,
-              signature,
-              clientDataJson,
-              authenticatorData,
-            },
-          },
-          { timeout: RECOVER_IDENTITY_RPC_TIMEOUT },
-        ),
-      );
+      // EDGE refuses the assertion when the passkey isn't registered as a recovery credential.
+      yield* Effect.tryPromise({
+        try: () =>
+          identityService.recoverIdentity(
+            { external: { ...assertion, deviceKey, controlFeedKey } },
+            { timeout: RECOVER_IDENTITY_RPC_TIMEOUT },
+          ),
+        catch: PasskeyRejectedError.wrap(),
+      });
     }),
   ),
 );

--- a/packages/plugins/plugin-client/tsconfig.json
+++ b/packages/plugins/plugin-client/tsconfig.json
@@ -28,6 +28,9 @@
       "path": "../../common/effect"
     },
     {
+      "path": "../../common/errors"
+    },
+    {
       "path": "../../common/invariant"
     },
     {

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.stories.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.stories.tsx
@@ -56,7 +56,7 @@ export const Default: Story = {
 export const PasskeyRejected: Story = {
   decorators: [withClientProvider()],
   args: {
-    passkeyError: 'rejected',
+    error: 'passkey-rejected',
     onPasskey: () => console.log('passkey'),
     onJoinIdentity: () => console.log('join identity'),
     onRecoverIdentity: () => console.log('recover identity'),

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.stories.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.stories.tsx
@@ -52,6 +52,17 @@ export const Default: Story = {
   },
 };
 
+/** Passkey login failed because the credential isn't a recovery credential for any account. */
+export const PasskeyRejected: Story = {
+  decorators: [withClientProvider()],
+  args: {
+    passkeyError: 'rejected',
+    onPasskey: () => console.log('passkey'),
+    onJoinIdentity: () => console.log('join identity'),
+    onRecoverIdentity: () => console.log('recover identity'),
+  },
+};
+
 /** Email is the primary login method (no passkey handler). Used by welcome-focus.spec.ts. */
 export const EmailPrimary: Story = {
   decorators: [withClientProvider()],

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.tsx
@@ -24,7 +24,7 @@ import { mx } from '@dxos/ui-theme';
 
 import { meta } from '../../meta';
 import { hero } from './hero-image';
-import { type PasskeyFailure, type WelcomeScreenProps, WelcomeState, validEmail, validInvitationCode } from './types';
+import { type WelcomeError, type WelcomeScreenProps, WelcomeState, validEmail, validInvitationCode } from './types';
 
 const supportsPasskeys =
   (navigator.credentials && 'create' in navigator.credentials) || NativePasskey.supportsNativePasskeys();
@@ -32,10 +32,12 @@ const supportsPasskeys =
 /** OAuth provider backing the "Atmosphere account" option (atproto / Bluesky). */
 const ATMOSPHERE_PROVIDER = 'atproto';
 
-const passkeyErrorKeys: Record<PasskeyFailure, string> = {
-  dismissed: 'passkey-dismissed-error.message',
-  rejected: 'passkey-rejected-error.message',
-  failed: 'passkey-failed-error.message',
+const errorMessageKeys: Record<WelcomeError, string> = {
+  'email': 'email-error.message',
+  'oauth': 'oauth-error.message',
+  'passkey-dismissed': 'passkey-dismissed-error.message',
+  'passkey-rejected': 'passkey-rejected-error.message',
+  'passkey-failed': 'passkey-failed-error.message',
 };
 
 export const OVERLAY_CLASSES = 'dark bg-neutral-950! bg-no-repeat bg-center';
@@ -61,7 +63,6 @@ type SignupStep = 'collect' | 'auth';
 export const Welcome = ({
   state,
   error,
-  passkeyError,
   identity,
   onEmailLogin,
   onPasskey,
@@ -321,8 +322,7 @@ export const Welcome = ({
                   emailValue={email}
                   setEmailValue={setEmail}
                   emailRef={emailRef}
-                  emailError={error}
-                  passkeyError={passkeyError}
+                  error={error}
                   pending={pending}
                   onPasskey={onPasskey ? handlePasskey : undefined}
                   onSendSignInLink={handleSendSignInLink}
@@ -397,7 +397,7 @@ export const Welcome = ({
                       submitLabel={t('continue-button.label')}
                       submitDisabled={!validEmail(email) || pending}
                       onSubmit={handleCreateAccount}
-                      validation={error ? t('email-error.message') : null}
+                      validation={error === 'email' ? t(errorMessageKeys.email) : null}
                     />
                     {onCreateAccountWithOAuth && (
                       <>
@@ -428,6 +428,7 @@ export const Welcome = ({
                                 loginHint: atmosphereHandle,
                               })
                             }
+                            validation={error === 'oauth' ? t(errorMessageKeys.oauth) : null}
                           />
                         </div>
                       </>
@@ -501,8 +502,7 @@ type LoginTabProps = {
   emailValue: string;
   setEmailValue: (value: string) => void;
   emailRef: React.Ref<HTMLInputElement>;
-  emailError?: boolean;
-  passkeyError?: PasskeyFailure | null;
+  error?: WelcomeError | null;
   pending: boolean;
   onPasskey?: () => unknown;
   onSendSignInLink: () => void;
@@ -527,8 +527,7 @@ const LoginTab = ({
   emailValue,
   setEmailValue,
   emailRef,
-  emailError,
-  passkeyError,
+  error,
   pending,
   onPasskey,
   onSendSignInLink,
@@ -654,10 +653,10 @@ const LoginTab = ({
             <Icon icon='ph--key--regular' size={5} />
             <span>{pending ? t('passkey-pending.label') : t('sign-in-with-passkey-button.label')}</span>
           </Button>
-          {passkeyError && (
-            <p role='alert' className='px-2 text-sm text-error-text'>
-              {t(passkeyErrorKeys[passkeyError])}
-            </p>
+          {error?.startsWith('passkey-') && (
+            <Input.Root>
+              <ValidationMessage>{t(errorMessageKeys[error])}</ValidationMessage>
+            </Input.Root>
           )}
         </div>
       )}
@@ -675,7 +674,7 @@ const LoginTab = ({
             submitLabel={t('send-link-button.label')}
             submitDisabled={!validEmail(emailValue) || pending}
             onSubmit={onSendSignInLink}
-            validation={emailError ? t('email-error.message') : null}
+            validation={error === 'email' ? t(errorMessageKeys.email) : null}
           />
         </div>
       )}
@@ -697,6 +696,7 @@ const LoginTab = ({
             submitLabel={t('continue-button.label')}
             submitDisabled={!atmosphereHandle || pending}
             onSubmit={() => onRecoverWithOAuth(ATMOSPHERE_PROVIDER, atmosphereHandle)}
+            validation={error === 'oauth' ? t(errorMessageKeys.oauth) : null}
           />
         </div>
       )}
@@ -782,14 +782,21 @@ const InlineForm = ({
           {submitLabel}
         </Button>
       </div>
-      {validation && (
-        <Input.DescriptionAndValidation>
-          <Input.Validation classNames='flex px-2 pt-2 text-error-text'>{validation}</Input.Validation>
-        </Input.DescriptionAndValidation>
-      )}
+      {validation && <ValidationMessage>{validation}</ValidationMessage>}
     </Input.Root>
   );
 };
+
+/**
+ * Error text under a login control. Shared with {@link InlineForm} so a failure reads the same
+ * whether it came from a field (email, invitation code) or a button (passkey). Callers outside
+ * `InlineForm` must supply their own `Input.Root` — it is context only and renders no markup.
+ */
+const ValidationMessage = ({ children }: PropsWithChildren) => (
+  <Input.DescriptionAndValidation>
+    <Input.Validation classNames='flex px-2 pt-2 text-error-text'>{children}</Input.Validation>
+  </Input.DescriptionAndValidation>
+);
 
 /** Horizontal "or" separator between alternative auth methods. */
 const OrDivider = ({ children }: PropsWithChildren) => (

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.tsx
@@ -24,13 +24,19 @@ import { mx } from '@dxos/ui-theme';
 
 import { meta } from '../../meta';
 import { hero } from './hero-image';
-import { type WelcomeScreenProps, WelcomeState, validEmail, validInvitationCode } from './types';
+import { type PasskeyFailure, type WelcomeScreenProps, WelcomeState, validEmail, validInvitationCode } from './types';
 
 const supportsPasskeys =
   (navigator.credentials && 'create' in navigator.credentials) || NativePasskey.supportsNativePasskeys();
 
 /** OAuth provider backing the "Atmosphere account" option (atproto / Bluesky). */
 const ATMOSPHERE_PROVIDER = 'atproto';
+
+const passkeyErrorKeys: Record<PasskeyFailure, string> = {
+  dismissed: 'passkey-dismissed-error.message',
+  rejected: 'passkey-rejected-error.message',
+  failed: 'passkey-failed-error.message',
+};
 
 export const OVERLAY_CLASSES = 'dark bg-neutral-950! bg-no-repeat bg-center';
 export const OVERLAY_STYLE = { backgroundImage: `url(${hero})` };
@@ -55,6 +61,7 @@ type SignupStep = 'collect' | 'auth';
 export const Welcome = ({
   state,
   error,
+  passkeyError,
   identity,
   onEmailLogin,
   onPasskey,
@@ -115,6 +122,19 @@ export const Welcome = ({
   //
   // Login handlers
   //
+
+  // Holds `pending` for the whole WebAuthn ceremony so a second click can't open a duplicate prompt.
+  const handlePasskey = useCallback(async () => {
+    if (pending) {
+      return;
+    }
+    setPending(true);
+    try {
+      await onPasskey?.();
+    } finally {
+      setPending(false);
+    }
+  }, [pending, onPasskey]);
 
   const handleSendSignInLink = useCallback(async () => {
     if (!validEmail(email)) {
@@ -302,8 +322,9 @@ export const Welcome = ({
                   setEmailValue={setEmail}
                   emailRef={emailRef}
                   emailError={error}
+                  passkeyError={passkeyError}
                   pending={pending}
-                  onPasskey={onPasskey}
+                  onPasskey={onPasskey ? handlePasskey : undefined}
                   onSendSignInLink={handleSendSignInLink}
                   onEmailKeyDown={handleEmailKeyDown}
                   onJoinIdentity={onJoinIdentity}
@@ -481,6 +502,7 @@ type LoginTabProps = {
   setEmailValue: (value: string) => void;
   emailRef: React.Ref<HTMLInputElement>;
   emailError?: boolean;
+  passkeyError?: PasskeyFailure | null;
   pending: boolean;
   onPasskey?: () => unknown;
   onSendSignInLink: () => void;
@@ -506,6 +528,7 @@ const LoginTab = ({
   setEmailValue,
   emailRef,
   emailError,
+  passkeyError,
   pending,
   onPasskey,
   onSendSignInLink,
@@ -621,10 +644,22 @@ const LoginTab = ({
       <h2 className='text-2xl'>{identity ? t('existing-identity.title') : t('welcome-back.title')}</h2>
       {/* Primary method */}
       {primary === 'passkey' && supportsPasskeys && onPasskey && (
-        <Button variant='primary' classNames='w-full justify-center gap-2' onClick={onPasskey}>
-          <Icon icon='ph--key--regular' size={5} />
-          <span>{t('sign-in-with-passkey-button.label')}</span>
-        </Button>
+        <div className='flex flex-col gap-2'>
+          <Button
+            variant='primary'
+            classNames='w-full justify-center gap-2 disabled:bg-neutral-800'
+            disabled={pending}
+            onClick={onPasskey}
+          >
+            <Icon icon='ph--key--regular' size={5} />
+            <span>{pending ? t('passkey-pending.label') : t('sign-in-with-passkey-button.label')}</span>
+          </Button>
+          {passkeyError && (
+            <p role='alert' className='px-2 text-sm text-error-text'>
+              {t(passkeyErrorKeys[passkeyError])}
+            </p>
+          )}
+        </div>
       )}
       {primary === 'email' && (
         <div className='flex flex-col gap-2'>

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/types.ts
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/types.ts
@@ -3,7 +3,10 @@
 //
 
 import type { Identity } from '@dxos/client/halo';
+import { type PasskeyFailure } from '@dxos/plugin-client';
 import { type MaybePromise } from '@dxos/util';
+
+export type { PasskeyFailure };
 
 export enum WelcomeState {
   INIT = 0,
@@ -17,6 +20,8 @@ export type WelcomeScreenProps = {
   state: WelcomeState;
   identity?: Identity | null;
   error?: boolean;
+  /** Why the last passkey login attempt failed; cleared when a new attempt starts. */
+  passkeyError?: PasskeyFailure | null;
 
   // Login tab.
   /** Existing-account email login. Server returns a recovery token inline (dev)

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/types.ts
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/types.ts
@@ -6,7 +6,13 @@ import type { Identity } from '@dxos/client/halo';
 import { type PasskeyFailure } from '@dxos/plugin-client';
 import { type MaybePromise } from '@dxos/util';
 
-export type { PasskeyFailure };
+/**
+ * Which failure the screen is currently reporting. Only one login method is on screen at a time, so
+ * one field is enough; the reason selects both the message and the control it renders under.
+ */
+export type WelcomeError = 'email' | 'oauth' | `passkey-${PasskeyFailure}`;
+
+export const passkeyError = (failure: PasskeyFailure): WelcomeError => `passkey-${failure}`;
 
 export enum WelcomeState {
   INIT = 0,
@@ -19,9 +25,8 @@ export enum WelcomeState {
 export type WelcomeScreenProps = {
   state: WelcomeState;
   identity?: Identity | null;
-  error?: boolean;
-  /** Why the last passkey login attempt failed; cleared when a new attempt starts. */
-  passkeyError?: PasskeyFailure | null;
+  /** Failure from the last login/sign-up attempt; cleared when a new attempt starts. */
+  error?: WelcomeError | null;
 
   // Login tab.
   /** Existing-account email login. Server returns a recovery token inline (dev)

--- a/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
@@ -9,7 +9,7 @@ import { LayoutOperation } from '@dxos/app-toolkit';
 import { createDidFromIdentityKey } from '@dxos/credentials';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
-import { ClientOperation, type PasskeyFailure, classifyPasskeyFailure } from '@dxos/plugin-client';
+import { ClientOperation, classifyPasskeyFailure } from '@dxos/plugin-client';
 import { useClient } from '@dxos/react-client';
 import { useIdentity } from '@dxos/react-client/halo';
 import { ThemeProvider, defaultTx } from '@dxos/react-ui';
@@ -19,7 +19,7 @@ import { useForceDarkTheme } from '../hooks';
 import { meta } from '../meta';
 import { OnboardingOperation } from '../operations';
 import { translations } from '../translations';
-import { Welcome, WelcomeState } from './Welcome';
+import { Welcome, type WelcomeError, WelcomeState, passkeyError } from './Welcome';
 
 export const WELCOME_SCREEN = `${meta.profile.key}.component.welcome-screen`;
 
@@ -28,8 +28,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
   const identity = useIdentity();
   const { invokePromise } = useOperationInvoker();
   const [state, setState] = useState<WelcomeState>(WelcomeState.INIT);
-  const [error, setError] = useState(false);
-  const [passkeyError, setPasskeyError] = useState<PasskeyFailure | null>(null);
+  const [error, setError] = useState<WelcomeError | null>(null);
   const pendingRef = useRef(false);
 
   // The welcome screen always renders dark, regardless of the system theme.
@@ -42,7 +41,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
       }
 
       if (error) {
-        setError(false);
+        setError(null);
       }
 
       try {
@@ -88,7 +87,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
         setState(WelcomeState.LOGIN_SENT);
       } catch (err) {
         log.catch(err);
-        setError(true);
+        setError('email');
       } finally {
         pendingRef.current = false;
       }
@@ -99,12 +98,12 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
   // `invokePromise` resolves with `{ error }` rather than rejecting, so a failed redemption is
   // invisible unless the result is inspected.
   const handlePasskey = useCallback(async () => {
-    setPasskeyError(null);
+    setError(null);
     // On success the onboarding manager dismisses this dialog off the back of the new identity.
     const { error: redeemError } = await invokePromise(ClientOperation.RedeemPasskey);
     if (redeemError) {
       log.catch(redeemError);
-      setPasskeyError(classifyPasskeyFailure(redeemError));
+      setError(passkeyError(classifyPasskeyFailure(redeemError)));
     }
   }, [invokePromise]);
 
@@ -122,7 +121,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
         return;
       }
       if (error) {
-        setError(false);
+        setError(null);
       }
       pendingRef.current = true;
       try {
@@ -136,7 +135,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
         }
       } catch (err) {
         log.catch(err);
-        setError(true);
+        setError('oauth');
       } finally {
         pendingRef.current = false;
       }
@@ -162,7 +161,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
         return;
       }
       if (error) {
-        setError(false);
+        setError(null);
       }
       pendingRef.current = true;
       try {
@@ -193,7 +192,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
         await invokePromise(LayoutOperation.UpdateDialog, { state: false });
       } catch (err) {
         log.catch(err);
-        setError(true);
+        setError('email');
       } finally {
         pendingRef.current = false;
       }
@@ -207,7 +206,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
         return;
       }
       if (error) {
-        setError(false);
+        setError(null);
       }
       pendingRef.current = true;
       try {
@@ -228,7 +227,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
         }
       } catch (err) {
         log.catch(err);
-        setError(true);
+        setError('oauth');
       } finally {
         pendingRef.current = false;
       }
@@ -265,7 +264,6 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
       <Welcome
         state={state}
         error={error}
-        passkeyError={passkeyError}
         identity={identity}
         onEmailLogin={handleLogin}
         onPasskey={!identity ? handlePasskey : undefined}

--- a/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
@@ -9,7 +9,7 @@ import { LayoutOperation } from '@dxos/app-toolkit';
 import { createDidFromIdentityKey } from '@dxos/credentials';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
-import { ClientOperation } from '@dxos/plugin-client';
+import { ClientOperation, type PasskeyFailure, classifyPasskeyFailure } from '@dxos/plugin-client';
 import { useClient } from '@dxos/react-client';
 import { useIdentity } from '@dxos/react-client/halo';
 import { ThemeProvider, defaultTx } from '@dxos/react-ui';
@@ -29,6 +29,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
   const { invokePromise } = useOperationInvoker();
   const [state, setState] = useState<WelcomeState>(WelcomeState.INIT);
   const [error, setError] = useState(false);
+  const [passkeyError, setPasskeyError] = useState<PasskeyFailure | null>(null);
   const pendingRef = useRef(false);
 
   // The welcome screen always renders dark, regardless of the system theme.
@@ -95,8 +96,16 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
     [hubUrl, client, invokePromise, error],
   );
 
+  // `invokePromise` resolves with `{ error }` rather than rejecting, so a failed redemption is
+  // invisible unless the result is inspected.
   const handlePasskey = useCallback(async () => {
-    await invokePromise(ClientOperation.RedeemPasskey);
+    setPasskeyError(null);
+    // On success the onboarding manager dismisses this dialog off the back of the new identity.
+    const { error: redeemError } = await invokePromise(ClientOperation.RedeemPasskey);
+    if (redeemError) {
+      log.catch(redeemError);
+      setPasskeyError(classifyPasskeyFailure(redeemError));
+    }
   }, [invokePromise]);
 
   const handleJoinIdentity = useCallback(async () => {
@@ -256,6 +265,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
       <Welcome
         state={state}
         error={error}
+        passkeyError={passkeyError}
         identity={identity}
         onEmailLogin={handleLogin}
         onPasskey={!identity ? handlePasskey : undefined}

--- a/packages/plugins/plugin-onboarding/src/translations.ts
+++ b/packages/plugins/plugin-onboarding/src/translations.ts
@@ -32,6 +32,12 @@ export const translations = [
         'signup-tab.label': 'Sign Up',
         'welcome-back.title': 'Welcome back!',
         'sign-in-with-passkey-button.label': 'Log in with passkey',
+        'passkey-pending.label': 'Waiting for passkey…',
+        'passkey-dismissed-error.message':
+          'No passkey was used. The prompt was dismissed, or this device has no passkey for Composer.',
+        'passkey-rejected-error.message':
+          "That passkey isn't linked to an account. Try another passkey, or log in with email or another device.",
+        'passkey-failed-error.message': 'Passkey login failed. Please try again or use another way to log in.',
         'more-ways-to-sign-in.label': 'More ways to log in',
         'login-passkey.label': 'Passkey',
         'login-passkey.description': 'The simplest way to access your data on new devices.',

--- a/packages/plugins/plugin-onboarding/src/translations.ts
+++ b/packages/plugins/plugin-onboarding/src/translations.ts
@@ -20,6 +20,7 @@ export const translations = [
         'request-access-email.description':
           "A confirmation link has been sent to your inbox. If it doesn't arrive in the next three minutes please check your spam folder.",
         'email-error.message': 'Failed to send verification email.',
+        'oauth-error.message': 'Could not connect to that account. Please try again.',
 
         'email-input.label': 'Email',
         'email-input.placeholder': 'Your email',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9744,6 +9744,9 @@ importers:
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../common/effect
+      '@dxos/errors':
+        specifier: workspace:*
+        version: link:../../common/errors
       '@dxos/halo':
         specifier: workspace:*
         version: link:../../core/halo/halo


### PR DESCRIPTION
Fixes [DX-1135](https://linear.app/dxos/issue/DX-1135/invalid-passkeys-provide-no-feedback).

## Diagnosis

`Operation.invokePromise` resolves with `{ data?, error? }` — it never rejects ([`ProcessOperationInvoker.ts:323`](https://github.com/dxos/dxos/blob/main/packages/core/compute/compute-runtime/src/ProcessOperationInvoker.ts#L323)). `WelcomeScreen.handlePasskey` discarded that result entirely:

```ts
const handlePasskey = useCallback(async () => {
  await invokePromise(ClientOperation.RedeemPasskey);
}, [invokePromise]);
```

So when EDGE refuses an assertion — the passkey isn't registered as a recovery credential for any identity, which is exactly the "invalid passkey" case — `recoverIdentity` rejected, the operation failed, and the welcome dialog just sat there: no error, no state change, no way to tell the click had registered at all. The sibling OAuth handler right below it does check (`if (result.error) throw result.error`); the passkey one never did.

The screenshot on DX-1135 is precisely this: `operation invocation failed {opKey: '…operation.redeemPasskey', cause: 'Error: Recovery key not registered.'}` in the console, and nothing on screen. The error was never lost — just never rendered.

Two things compounded it:

- The handler used `Effect.promise` throughout, turning every rejection into an untyped defect, so even a caller that *did* inspect the error had nothing to discriminate on.
- `(credential as any).response.userHandle` meant a null credential or a passkey without a resident key produced a `TypeError` deep in the handler rather than a diagnosable failure.

## Changes

**`@dxos/plugin-client`**

- New `operations/errors.ts`: `PasskeyDismissedError`, `PasskeyRejectedError`, `PasskeyLoginError` (via `BaseError.extend`), plus `toPasskeyAssertionError` and `classifyPasskeyFailure`.
- `redeem-passkey.ts` uses `Effect.tryPromise` at each boundary so failures are typed rather than defects. Dismissal is separated from real failure — WebAuthn reports both a dismissed prompt and "no passkey for this site" as `NotAllowedError`, so they share the dismissed reason and a message naming both possibilities; the native Tauri bridge rejects with a plain string, matched separately.
- The `as any` casts are replaced with `PublicKeyCredential` / `AuthenticatorAssertionResponse` narrowing, which also gives the null-credential and missing-user-handle guards for free.

**`@dxos/plugin-onboarding`**

- A single `error?: WelcomeError | null` field replaces the previous separate email/passkey fields. Reasons are `'email' | 'oauth' | 'passkey-${PasskeyFailure}'`; only one login method is on screen at a time, so the reason selects both the message and the control it renders under, and nothing leaks across controls when the user switches method.
- The passkey error renders through the same `Input.Validation` slot as the email and invitation-code errors, via a shared `ValidationMessage`.
- The passkey button holds `pending` for the whole ceremony, so a second click can't open a duplicate WebAuthn prompt.

**Beyond the ticket** — flagged for review, and cleanly revertible if you'd rather keep the diff tight:

- Both Atmosphere (atproto) forms gained the validation slot they were missing. `handleRecoverWithOAuth` and `handleCreateAccountWithOAuth` already set `error`, but neither form rendered it — the same silent-failure shape as the passkey bug, on a different control.

The success path is untouched: the onboarding manager already dismisses the dialog off the back of the new identity appearing.

## Testing

- `packages/plugins/plugin-client/src/operations/errors.test.ts` — 6 cases across two properties that aren't just a restatement of the classifier: native dismissals arrive as a plain string rather than a `DOMException` (and "canceled"/"cancelled" both count), and an unrecognised failure still reaches the user rather than being swallowed.
- `moon run plugin-client:build plugin-onboarding:build composer-app:build` — green.
- `moon run plugin-client:lint plugin-onboarding:lint` — clean. `pnpm format` applied.

Not covered by automated tests, stated plainly: the WebAuthn ceremony needs a real authenticator, and there is no live home for a test asserting the UI reacts to a failed operation — plugin-onboarding runs node-only vitest with no DOM project, and the existing `welcome-focus.spec.ts` that drives these stories is `test.describe.skip`. The rendered messages were checked through the `PasskeyRejected` story instead.