### PR TITLE
tauri: drop the CrabNebula retry, keep the channel fix

### DIFF
--- a/.github/actions/cn-release/action.yml
+++ b/.github/actions/cn-release/action.yml
@@ -29,61 +29,8 @@ runs:
       with:
         environment: ${{ inputs.environment }}
 
-    # Resolved once so the three attempts below can't drift apart, and built in the shell from env rather
-    # than interpolated into the script.
-    - name: Resolve release command
-      id: command
-      shell: bash
-      env:
-        CN_COMMAND: ${{ inputs.command }}
-        CN_APPLICATION: ${{ inputs.application }}
-        CN_FRAMEWORK: ${{ inputs.framework }}
-        CN_CHANNEL: ${{ steps.release-channel.outputs.channel }}
-      run: |
-        command="release $CN_COMMAND $CN_APPLICATION --framework $CN_FRAMEWORK"
-        if [ -n "$CN_CHANNEL" ]; then
-          command="$command --channel $CN_CHANNEL"
-        fi
-        echo "value=$command" >> "$GITHUB_OUTPUT"
-
-    # The Cloud API intermittently 408s on `distribution.upload.finish` after every part has already
-    # transferred, and a single failure discards the macOS sign + notarize that precedes it (~30 min, with no
-    # remote cache on production), so each attempt is retried twice with backoff. The CLI exposes no retry or
-    # timeout flag, hence the retry lives here. `continue-on-error` is deliberately a literal — an
-    # `inputs`-based expression evaluates incorrectly inside a composite action (actions/runner#2418).
-    - name: Release (attempt 1 of 3)
-      id: attempt-1
-      continue-on-error: true
-      uses: FabianLars-crabnebula/cloud-release@e0bb6ccebcb78f71883ebde2320f76aae6b9eb92
+    - uses: FabianLars-crabnebula/cloud-release@e0bb6ccebcb78f71883ebde2320f76aae6b9eb92
       with:
-        command: ${{ steps.command.outputs.value }}
-        api-key: ${{ inputs.api-key }}
-        working-directory: ${{ inputs.working-directory }}
-
-    - name: Back off before attempt 2
-      if: steps.attempt-1.outcome == 'failure'
-      shell: bash
-      run: sleep 30
-
-    - name: Release (attempt 2 of 3)
-      id: attempt-2
-      if: steps.attempt-1.outcome == 'failure'
-      continue-on-error: true
-      uses: FabianLars-crabnebula/cloud-release@e0bb6ccebcb78f71883ebde2320f76aae6b9eb92
-      with:
-        command: ${{ steps.command.outputs.value }}
-        api-key: ${{ inputs.api-key }}
-        working-directory: ${{ inputs.working-directory }}
-
-    - name: Back off before attempt 3
-      if: steps.attempt-1.outcome == 'failure' && steps.attempt-2.outcome == 'failure'
-      shell: bash
-      run: sleep 60
-
-    - name: Release (attempt 3 of 3)
-      if: steps.attempt-1.outcome == 'failure' && steps.attempt-2.outcome == 'failure'
-      uses: FabianLars-crabnebula/cloud-release@e0bb6ccebcb78f71883ebde2320f76aae6b9eb92
-      with:
-        command: ${{ steps.command.outputs.value }}
+        command: release ${{ inputs.command }} ${{ inputs.application }} --framework ${{ inputs.framework }} --channel ${{ steps.release-channel.outputs.channel }}
         api-key: ${{ inputs.api-key }}
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/deploy-tauri.yaml
+++ b/.github/workflows/deploy-tauri.yaml
@@ -106,8 +106,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    # A production build (no remote cache) already runs ~30 min before the upload starts; the headroom is for
-    # the retries in cn-release, which must not be cut off mid-flight.
+    # A production build (no remote cache) already ran 27 min in the v0.10.2 release, close enough to the
+    # previous 45 that a slower runner would have been cut off mid-notarization.
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
Backs out the retry added in #12359, keeping everything else from it. Net **−57 / +4**.

## Why

**The record doesn't support it.** Of 23 dispatched `Deploy Apps` runs, 17 reached `build_tauri`, and exactly **one** failed in `Upload assets` — the 408 on [run 30304820989](https://github.com/dxos/dxos/actions/runs/30304820989). The other five `build_tauri` failures were all in `Build Tauri app`, clustered on 2026-07-13 while a build problem was being iterated on. It was a one-off.

**It probably wouldn't have helped.** Comparing that run against the labs verification run [30315586100](https://github.com/dxos/dxos/actions/runs/30315586100) — an *identical* 105-part payload:

| | failing (prod) | passing (labs) |
|---|---|---|
| parts uploaded | 105 | 105 |
| slowest part | **33.9s** | 4.8s |
| parts over 10s | **8** | 0 |
| `Upload assets` | ~150s → 408 | 27s → success |

Same work, ~7× worse per-part latency. The degradation spanned the whole 2.5-minute upload rather than being a blip, so a 30s backoff would have restarted all 105 parts into the same degraded backend.

**And it carried real risk.** The retry wrapped `draft` and `publish` as well as `upload`, where re-running after a partially applied call has undefined behaviour. `upload` was never established to be idempotent either — a retry after a server-side-completed `finish` could register duplicate assets on the draft. That's live downside against an unproven benefit on the release path.

## If it recurs

The fix isn't a better retry, it's artifact durability: persist the signed, notarized bundle as a GitHub artifact and upload from a separate job. A failure then costs minutes instead of ~30, no re-notarization, and a retry becomes cheap enough to be obviously correct.

## Kept from #12359

All exercised by run 30315586100, which was fully green:

- **environment-derived channel** — `--channel labs` confirmed in the build log; previously every environment collapsed to `main`, so labs prereleases landed on the channel production installs poll
- **removal of the dead `cn` CLI install** — the action downloads its own `cn` to the workspace root, confirmed in the same log
- **step and job timeouts** — the failing production build alone ran 27 min against the old 45-min cap, close enough that a slower runner would have been cut off mid-notarization

The `cn-release` command is byte-identical to what ran successfully tonight: `release upload dxos/composer --framework tauri --channel labs`.

## Testing

- `yaml.safe_load` on both files; `cn-release` asserted down to 2 steps with no `continue-on-error` residue
- `oxfmt --check` clean at the repo-pinned 0.60.0
- rendered command diffed against the successful run's log line

## Known gap, not addressed here

Per-branch channel isolation was lost in #12359. The old `ref_name` logic gave a branch dispatch its own throwaway channel; now any dispatch targets a real one, which makes testing tauri from a branch unsafe. Worth restoring separately — plausibly as `channel = environment` when dispatching from `main`, else the ref name.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwSo3su71aN5h52dEeomhv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the Cloud Release workflow to run the release command directly.
  * Removed automatic retry and backoff behavior from release publishing.
  * Updated production build timing guidance in the deployment workflow comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->