### PR TITLE
assistant: chat-scoped instructions ref, project artifact skill, live system eval

### DIFF
--- a/.agents/projects/plugin-projects/TASKS.md
+++ b/.agents/projects/plugin-projects/TASKS.md
@@ -49,10 +49,40 @@ Initial priority (user, 2026-07-24):
 - [ ] **"/" completion of commands (and "@", "$")** — unify chat-prompt completion triggers.
 - [ ] **inbox naming sweep** — action id 'create-topic' + Attention.linkedSegment('topic') → 'project' (verify companion segment resolution after rename).
 
+## Phase 3 / milestone 3: project chats
+
+Start a chat session from a project with the project already in scope, and see that
+session in the navtree under its project. Design: the "Milestone 3: project chats"
+section of the design spec. Decisions (user, 2026-07-27): ECHO parent edge (no schema
+change), new chat opens as a deck plank, toolbar scoped to chat creation only, bindings
+applied once at creation.
+
+### Tasks
+
+- [ ] **`bindings` input on `AssistantOperation.CreateChat`** — optional
+      `{ skills?, objects? }` passed to the binder it already constructs.
+- [ ] **`ProjectOperation.CreateChat`** — invoke `AssistantOperation.CreateChat` with
+      `Project.contextBindings(project)` + the project ref, `Obj.setParent(chat, project)`,
+      `LayoutOperation.Open`. No `SpaceOperation.AddObject` (would file it in the root
+      collection).
+- [ ] **`projectChats` graph extension** — `children()` query → `AppNode.makeObject` per
+      chat; `url` reuses the `chat` key with a parent-resolving dynamic path.
+- [ ] **Exclude project chats from the top-level Chats section** — plugin-assistant's
+      section query, alongside the existing `CompanionTo` exclusion.
+- [ ] **`ProjectArticle` toolbar** — `Panel.Toolbar` + `IconButton`; same action on the
+      project's navtree node (`list-item-primary`).
+- [ ] **Tests** — unit (enumeration, parenting + binding pass-through), story play test
+      (toolbar creates a chat, appears in the list), live verify (instructions reach the
+      system prompt in a standalone plank; navtree children survive a cold deep link).
+- [ ] **Watch item** — if `children()` does not re-emit in the graph connector when a chat
+      is newly parented, fall back to a `chats: Ref<Collection>` field on Project
+      (0.2.0 → 0.3.0 bump + migration); only the enumeration source changes.
+
 ## Follow-ups / deferred (design reviews)
 
 - [ ] **Possibly move Project type from @dxos/compute to plugin-projects at end** — revisit once the plugin's shape settles.
-- [ ] **Review CompanionTo reuse for project chats** — vs a dedicated relation; decide agent-roster linkage alongside.
+- [x] **Review CompanionTo reuse for project chats** — resolved in milestone 3: companion chat keeps `CompanionTo`; owned sessions use the ECHO parent edge. Agent-roster linkage still open.
+- [ ] **Unify project-context binding** across companion and standalone chats (shared hook keyed on the chat's parent) — closes the late-added-skills gap.
 - [ ] **Remove plugin-sidekick** — obviated (AUDIT.md notes it); deletion is a separate change.
 - [ ] **Consider merging plugin-routine into plugin-projects** — boundary is thin post-Routine-move.
 - [ ] **Editor.View accent focus defaults** — removed on this branch; NotebookCell opted back in; audit remaining call sites if focus affordances look off elsewhere.

--- a/.agents/projects/plugin-projects/TASKS.md
+++ b/.agents/projects/plugin-projects/TASKS.md
@@ -1,6 +1,6 @@
 # plugin-projects — Tasks
 
-_Resume: PR #12335 GREEN + preview live (pr-12335-composer-main.dxos.workers.dev), awaiting review; 3 MS2 commits LOCAL/unpushed (8bf145dd40, bb45d4e472, f45f055760 — cold-load fix, instructions→system-prompt, stub labels) pending PR-strategy decision (grow #12335 vs follow-up PR). Next: commands-authoring UI in InstructionsEditor, then outliner skill design._
+_Resume: PR #12335 MERGED (2026-07-25, squash f7d7735615) — it carried milestone 1 **plus** the three MS2 commits (cold-load fix, instructions→system-prompt, stub labels), so nothing is left unpushed. Fresh worktree at main tip, clean. Next: commands-authoring UI in InstructionsEditor, then outliner skill design._
 
 ## Phase 1: Core plugin + Project type (milestone 1) — DONE
 
@@ -31,7 +31,7 @@ Initial priority (user, 2026-07-24):
 3. Use with outliner skill to manage tasks (project + task outline artifact + skill binding).
 4. Define and use commands (authoring UI + commands rendered into the session prompt).
 
-- [x] **Open PR** — #12335 GREEN; preview https://pr-12335-composer-main.dxos.workers.dev; awaiting review.
+- [x] **Open PR** — #12335 MERGED 2026-07-25 (squash f7d7735615); carried milestone 1 + the three MS2 commits below.
 - [x] **P2: instructions reach the model** — formatSystemPrompt renders bound Instructions inline (## Instructions: text + sentinel-command directives), out of the tool-load stub list; unit tests (format.test.ts 2/2). User-verified "basically working" in-app.
 - [x] **P1 partial: create/edit verified live** in Composer via serve-min (this worktree); cold-load fix: ProjectArticle resolves owned instructions reactively (useObject + Obj.getReactiveOrUndefined — sync .target never resolves on deep link).
 - [x] **Context-stub labels** — object stubs in the system prompt carry `<label>` so the model doesn't tool-load just to identify a binding.
@@ -39,7 +39,7 @@ Initial priority (user, 2026-07-24):
 - [x] **Minimal plugin set** — Projects/Routine/Outliner in plugin-defs.minimal.tsx + defaults + vite optimizeDeps glob.
 - [x] **Live-AI story** — stories/stories-assistant/Projects ("Voyage": AHOY marker + $track command; Default manual + InstructionsTest play, !test-tagged).
 - [ ] **P1 remaining: delete flow** — verify navtree ⋮ delete for projects; ALSO: intermittent "first click into empty deck attends but opens no plank" (repro needed).
-- [ ] **PR strategy decision (user)** — push the 3 local MS2 commits onto #12335 vs land #12335 first and follow up. Default: keep local until #12335 lands.
+- [x] **PR strategy decision** — moot: the three MS2 commits shipped inside #12335's squash; verified present on main (ProjectArticle `getReactiveOrUndefined`, format.ts `## Instructions` + `<label>`, Projects.stories.tsx, minimal plugin set).
 - [ ] **PLUGIN.mdl for plugin-projects** — as-built record now that implementation settled.
 - [ ] **Commands-authoring UI** — InstructionsEditor edits text/skills/objects only; `commands` currently data-only despite autocomplete shipping.
 - [ ] **In-article routine creation**; project-scoped chat list UI.

--- a/.agents/projects/registry.yml
+++ b/.agents/projects/registry.yml
@@ -12,10 +12,10 @@ projects:
     host: burdon-studio-2022
     created: 2026-07-24
     summary: New core plugin for interactive long-running processes (Routines, Agents, artifacts); Project type succeeds Topic; obviates plugin-sidekick.
-    tasks: .agents/projects/plugin-projects/TASKS.md
-    design: agents/superpowers/specs/2026-07-24-plugin-projects-design.md
+    tasks: packages/plugins/plugin-projects/TASKS.md
+    design: packages/plugins/plugin-projects/DESIGN.md
     prs: [12335]
-    resume: 'PR #12335 MERGED (squash f7d7735615) — carried milestone 1 plus all three MS2 commits (cold-load fix, instructions->system-prompt, stub labels); nothing unpushed. Next: commands-authoring UI in InstructionsEditor, outliner skill design, delete-flow verify.'
+    resume: 'Docs now live in the package (DESIGN.md + TASKS.md at packages/plugins/plugin-projects/). PR #12335 MERGED (squash f7d7735615) carried milestones 1-2; nothing unpushed. Milestone 3 (project chats: article toolbar -> chat scoped to project, chats parented to the Project and shown as navtree children) is DESIGNED AND APPROVED, not implemented. NEXT: first Phase 3 task — optional bindings input on AssistantOperation.CreateChat — then ProjectOperation.CreateChat, projectChats graph extension, Chats-section exclusion, toolbar. Watch: if Query.children() does not re-emit in the graph connector, fall back to a chats Collection field.'
 
   - name: sketch-scene-dsl
     status: active

--- a/.agents/projects/registry.yml
+++ b/.agents/projects/registry.yml
@@ -26,7 +26,7 @@ projects:
     tasks: packages/plugins/plugin-projects/TASKS.md
     design: packages/plugins/plugin-projects/DESIGN.md
     prs: [12335, 12365]
-    resume: 'Phase 3 instructions-channel arc COMPLETE + system eval GREEN: Chat.instructions typed ref -> explicit formatSystemPrompt param (typename partition deleted; bound Instructions are now plain context stubs), agent-process boundary via Process.InstructionsAnnotation, ProjectSkill (artifact add/list, 4/4 unit tests), projects.eval.ts PASSED LIVE 100% (created/filed/bound, opus-4-8). PR #12365 OPEN, Check in progress. REMAINING Phase 3 UI: ProjectOperation.CreateChat, projectChats graph extension (children() re-emit watch item), Chats-section exclusion, ProjectArticle toolbar. Then: commands-authoring UI, outliner skill, Agent/Project convergence review.'
+    resume: 'PR #12365 CI GREEN, review round addressed — USER LANDS IT HIMSELF (do not merge). Decisions 2026-07-28: reconciliation phases A+B are NEXT (before Phase 3 UI); phase C shape decided = relay pattern (Routine feed-trigger -> RelayFunction: cheap-model qualify -> submitInput onto the durable process input queue; multiplexing + filtering; AgentWorker/Qualifier retire; agent.feed dissolves; backpressure = accepted gap, intermediary-feed hatch). Plan: packages/plugins/plugin-projects/PLAN.md. NEXT SESSION: fresh worktree after #12365 merges -> phase A (Agent.instructions -> Ref<Instructions>) then phase B (Chat.agent inversion), each its own PR. Then Phase 3 UI (CreateChat op, navtree children, Chats exclusion, toolbar).'
 
   - name: sketch-scene-dsl
     status: active

--- a/.agents/projects/registry.yml
+++ b/.agents/projects/registry.yml
@@ -25,8 +25,8 @@ projects:
     summary: New core plugin for interactive long-running processes (Routines, Agents, artifacts); Project type succeeds Topic; obviates plugin-sidekick.
     tasks: packages/plugins/plugin-projects/TASKS.md
     design: packages/plugins/plugin-projects/DESIGN.md
-    prs: [12335]
-    resume: 'Phase 3 instructions-channel arc COMPLETE + system eval GREEN: Chat.instructions typed ref -> explicit formatSystemPrompt param (typename partition deleted; bound Instructions are now plain context stubs), agent-process boundary via Process.InstructionsAnnotation, ProjectSkill (artifact add/list, 4/4 unit tests), projects.eval.ts PASSED LIVE 100% (created/filed/bound, opus-4-8). PR being opened from this worktree (submit-pr in flight). REMAINING Phase 3 UI: ProjectOperation.CreateChat, projectChats graph extension (children() re-emit watch item), Chats-section exclusion, ProjectArticle toolbar, ChatCompanion sets chat.instructions + lazy backfill. Then: commands-authoring UI, outliner skill, Agent/Project convergence review.'
+    prs: [12335, 12365]
+    resume: 'Phase 3 instructions-channel arc COMPLETE + system eval GREEN: Chat.instructions typed ref -> explicit formatSystemPrompt param (typename partition deleted; bound Instructions are now plain context stubs), agent-process boundary via Process.InstructionsAnnotation, ProjectSkill (artifact add/list, 4/4 unit tests), projects.eval.ts PASSED LIVE 100% (created/filed/bound, opus-4-8). PR #12365 OPEN, Check in progress. REMAINING Phase 3 UI: ProjectOperation.CreateChat, projectChats graph extension (children() re-emit watch item), Chats-section exclusion, ProjectArticle toolbar, ChatCompanion sets chat.instructions + lazy backfill. Then: commands-authoring UI, outliner skill, Agent/Project convergence review.'
 
   - name: sketch-scene-dsl
     status: active

--- a/.agents/projects/registry.yml
+++ b/.agents/projects/registry.yml
@@ -9,13 +9,13 @@ projects:
   - name: plugin-projects
     status: active
     user: burdon
-    host: burdon-mbp-2092
+    host: burdon-studio-2022
     created: 2026-07-24
     summary: New core plugin for interactive long-running processes (Routines, Agents, artifacts); Project type succeeds Topic; obviates plugin-sidekick.
     tasks: .agents/projects/plugin-projects/TASKS.md
     design: agents/superpowers/specs/2026-07-24-plugin-projects-design.md
     prs: [12335]
-    resume: 'PR #12335 GREEN + preview live, awaiting review. MS2 underway: instructions->system-prompt + stub labels + cold-load fix done (3 commits LOCAL/unpushed pending PR-strategy decision); create/edit verified live. Next: commands-authoring UI in InstructionsEditor, outliner skill design, delete-flow verify.'
+    resume: 'PR #12335 MERGED (squash f7d7735615) — carried milestone 1 plus all three MS2 commits (cold-load fix, instructions->system-prompt, stub labels); nothing unpushed. Next: commands-authoring UI in InstructionsEditor, outliner skill design, delete-flow verify.'
 
   - name: sketch-scene-dsl
     status: active

--- a/.agents/projects/registry.yml
+++ b/.agents/projects/registry.yml
@@ -26,7 +26,7 @@ projects:
     tasks: packages/plugins/plugin-projects/TASKS.md
     design: packages/plugins/plugin-projects/DESIGN.md
     prs: [12335]
-    resume: 'Docs now live in the package (DESIGN.md + TASKS.md at packages/plugins/plugin-projects/). PR #12335 MERGED (squash f7d7735615) carried milestones 1-2; nothing unpushed. Milestone 3 (project chats: article toolbar -> chat scoped to project, chats parented to the Project and shown as navtree children) is DESIGNED AND APPROVED, not implemented. NEXT: first Phase 3 task — optional bindings input on AssistantOperation.CreateChat — then ProjectOperation.CreateChat, projectChats graph extension, Chats-section exclusion, toolbar. Watch: if Query.children() does not re-emit in the graph connector, fall back to a chats Collection field.'
+    resume: 'Phase 3 instructions-channel arc COMPLETE + system eval GREEN: Chat.instructions typed ref -> explicit formatSystemPrompt param (typename partition deleted; bound Instructions are now plain context stubs), agent-process boundary via Process.InstructionsAnnotation, ProjectSkill (artifact add/list, 4/4 unit tests), projects.eval.ts PASSED LIVE 100% (created/filed/bound, opus-4-8). PR being opened from this worktree (submit-pr in flight). REMAINING Phase 3 UI: ProjectOperation.CreateChat, projectChats graph extension (children() re-emit watch item), Chats-section exclusion, ProjectArticle toolbar, ChatCompanion sets chat.instructions + lazy backfill. Then: commands-authoring UI, outliner skill, Agent/Project convergence review.'
 
   - name: sketch-scene-dsl
     status: active

--- a/.agents/projects/registry.yml
+++ b/.agents/projects/registry.yml
@@ -26,7 +26,7 @@ projects:
     tasks: packages/plugins/plugin-projects/TASKS.md
     design: packages/plugins/plugin-projects/DESIGN.md
     prs: [12335, 12365]
-    resume: 'Phase 3 instructions-channel arc COMPLETE + system eval GREEN: Chat.instructions typed ref -> explicit formatSystemPrompt param (typename partition deleted; bound Instructions are now plain context stubs), agent-process boundary via Process.InstructionsAnnotation, ProjectSkill (artifact add/list, 4/4 unit tests), projects.eval.ts PASSED LIVE 100% (created/filed/bound, opus-4-8). PR #12365 OPEN, Check in progress. REMAINING Phase 3 UI: ProjectOperation.CreateChat, projectChats graph extension (children() re-emit watch item), Chats-section exclusion, ProjectArticle toolbar, ChatCompanion sets chat.instructions + lazy backfill. Then: commands-authoring UI, outliner skill, Agent/Project convergence review.'
+    resume: 'Phase 3 instructions-channel arc COMPLETE + system eval GREEN: Chat.instructions typed ref -> explicit formatSystemPrompt param (typename partition deleted; bound Instructions are now plain context stubs), agent-process boundary via Process.InstructionsAnnotation, ProjectSkill (artifact add/list, 4/4 unit tests), projects.eval.ts PASSED LIVE 100% (created/filed/bound, opus-4-8). PR #12365 OPEN, Check in progress. REMAINING Phase 3 UI: ProjectOperation.CreateChat, projectChats graph extension (children() re-emit watch item), Chats-section exclusion, ProjectArticle toolbar. Then: commands-authoring UI, outliner skill, Agent/Project convergence review.'
 
   - name: sketch-scene-dsl
     status: active

--- a/.changeset/chat-instructions-ref.md
+++ b/.changeset/chat-instructions-ref.md
@@ -1,0 +1,6 @@
+---
+'@dxos/echo': minor
+'@dxos/plugin-assistant': minor
+---
+
+Chats carry a typed `instructions` ref rendered into the system prompt at request time (replacing typename-based inlining of bound Instructions objects, which now bind as ordinary context objects), and the new Project skill lets the assistant file created objects into a project's artifacts collection and list them.

--- a/agents/superpowers/plans/2026-07-24-plugin-projects.md
+++ b/agents/superpowers/plans/2026-07-24-plugin-projects.md
@@ -8,8 +8,8 @@
 
 **Tech Stack:** TypeScript, Effect Schema, ECHO (`@dxos/echo`), moon tasks, React + `@dxos/react-ui*`, CodeMirror (`@codemirror/autocomplete`), Storybook.
 
-**Spec:** `agents/superpowers/specs/2026-07-24-plugin-projects-design.md`
-**Tracker:** `.agents/projects/plugin-projects/TASKS.md`
+**Spec:** `packages/plugins/plugin-projects/DESIGN.md`
+**Tracker:** `packages/plugins/plugin-projects/TASKS.md`
 
 ## Global Constraints
 
@@ -826,13 +826,13 @@ pnpm format && git add -A && git commit -m "assistant: sentinel-command autocomp
 
 - Modify: `packages/plugins/AUDIT.md`
 - Create: `.changeset/plugin-projects.md`
-- Modify: `.agents/projects/plugin-projects/TASKS.md`, `.agents/projects/registry.yml`
+- Modify: `packages/plugins/plugin-projects/TASKS.md`, `.agents/projects/registry.yml`
 
 **Interfaces:** none (documentation + verification).
 
 - [ ] **Step 1: AUDIT note**
 
-Add/update the plugin-sidekick row/section in `packages/plugins/AUDIT.md` (read its format first): note "obviated by plugin-projects (see agents/superpowers/specs/2026-07-24-plugin-projects-design.md); removal tracked separately." Add a plugin-projects entry if the file lists all plugins.
+Add/update the plugin-sidekick row/section in `packages/plugins/AUDIT.md` (read its format first): note "obviated by plugin-projects (see packages/plugins/plugin-projects/DESIGN.md); removal tracked separately." Add a plugin-projects entry if the file lists all plugins.
 
 - [ ] **Step 2: Changeset**
 
@@ -850,7 +850,7 @@ Expected: all green; no unformatted files. Audit the diff for stray casts and na
 
 - [ ] **Step 4: Update tracker + commit**
 
-Update `.agents/projects/plugin-projects/TASKS.md` (check off milestone-1 tasks, note deferred items) and the registry `resume` line.
+Update `packages/plugins/plugin-projects/TASKS.md` (check off milestone-1 tasks, note deferred items) and the registry `resume` line.
 
 ```bash
 git status && git add -A && git commit -m "plugin-projects: finalize milestone 1 (audit note, changeset)"

--- a/agents/superpowers/specs/2026-07-24-plugin-projects-design.md
+++ b/agents/superpowers/specs/2026-07-24-plugin-projects-design.md
@@ -86,11 +86,15 @@ non-AI project concept:
 `@dxos/assistant-toolkit` depends on `@dxos/compute`, so `Project` cannot hold
 typed refs to `Chat` or `Agent`.
 
-- **Chats**: linked via the existing `CompanionTo` relation
+- **Chats**: two distinct linkages, resolved in milestone 3 (see
+  [Project chats](#milestone-3-project-chats)). A project's _companion_ chat
+  stays on the existing `CompanionTo` relation
   (`org.dxos.relation.assistant.companionTo`, source `Chat` → target
-  `Obj.Unknown`), consistent with `Agent`'s chat wiring. plugin-projects queries
-  chats by relation target. **Review flagged** (tracked): revisit vs a dedicated
-  relation once the design is exercised.
+  `Obj.Unknown`), consistent with `Agent`'s chat wiring. A project's _own_ chat
+  sessions are instead **parented** to the Project in the ECHO hierarchy
+  (`Obj.setParent`) and enumerated with `Query…children()` — the relation is
+  single-current by construction (`state.currentChat[objectUri]`) and carries no
+  ownership edge, so it cannot express "N sessions belonging to this project".
 - **Agents**: explicit linkage deferred. MVP: agents participate via project
   chats and routines (an instructions-routine already runs in the agent
   harness). A project-scoped agent roster (relation or parenting) comes later,
@@ -184,10 +188,108 @@ linked via `routines`).
 - **Dev loop**: Projects/Routine/Outliner plugins are part of the composer-app
   minimal set (`serve-min`).
 
+## Milestone 3: project chats
+
+Goal: start a chat session from a project, with the project already in scope, and
+see that session in the navtree under its project.
+
+### Ownership: the ECHO parent edge
+
+A project chat is parented to its Project (`Obj.setParent(chat, project)`) and
+enumerated with `Query.select(Filter.id(project.id)).children()` narrowed to
+`Chat.Chat`. No `Project` schema change, so no version bump and no migration of
+existing project objects.
+
+Rejected alternatives: a `chats: Ref<Collection>` field mirroring `artifacts`
+(buys sibling ordering and drag-rearrange, costs a 0.2.0 → 0.3.0 bump); and
+reusing `CompanionTo` (conflates the single-current companion chat with N owned
+sessions, and yields no ownership edge).
+
+The one risk this takes on: a hierarchy-traversal query driving a graph connector
+is less exercised than a ref-array read. If `children()` does not re-emit when a
+chat is newly parented, fall back to the Collection field — the rest of the
+design is unchanged, only the enumeration source moves.
+
+### Creation: `ProjectOperation.CreateChat`
+
+`ProjectOperation.CreateChat({ project })`, handled in plugin-projects:
+
+1. Invoke `AssistantOperation.CreateChat({ db, bindings })` — chat + feed, with
+   the assistant's default skills already bound.
+2. `Obj.setParent(chat, project)`.
+3. Open it with `LayoutOperation.Open` (a plank in the deck, matching the Chats
+   section's own create action).
+
+`SpaceOperation.AddObject` is deliberately **not** called: it would file the chat
+in the space's root collection, surfacing it under Collections as well. DB
+membership alone (`addToSpace: true`) is what a parented chat needs.
+
+### Context binding: an optional `bindings` input on `CreateChat`
+
+`AssistantOperation.CreateChat` gains an optional
+`bindings: { skills?, objects? }`, passed straight to the `AiContext.Binder` it
+already constructs for the default skills. plugin-projects supplies
+`Project.contextBindings(project)` plus a ref to the project itself, and needs no
+`AiContext` plumbing of its own.
+
+Bindings persist in the conversation feed, and `Instructions` are bound **by
+ref** — so later edits to instruction text or commands reach the model at
+prompt-format time without re-binding. Known gap, accepted: a skill added to the
+instructions _after_ the chat exists does not reach that chat. `ChatCompanion`
+avoids this by re-binding reactively; unifying the two paths (extract its binding
+logic into a shared hook keyed on `Obj.getParent(chat)`) is a follow-up, not this
+milestone.
+
+### Navtree: chats as children of the project node
+
+Projects are leaf nodes today — `TypeSection.createTypeSectionExtension` emits
+`AppNode.makeObject` with no children. A new `projectChats` extension in
+plugin-projects contributes them:
+
+- `match`: nodes whose `data` is a `Project.Project`.
+- `connector`: the `children()` query above → `AppNode.makeObject` per chat.
+- `url`: reuses the `chat` key with a data-dependent `path` that resolves the
+  chat's parent project. Sharing one key across extensions is supported and
+  intended — plugin-space's `object` key spans both collection connectors for
+  exactly this reason (`@dxos/app-graph` `path-resolution.ts`), so a chat is
+  addressed the same way wherever it sits.
+
+**Consequence in plugin-assistant**: the Chats type-section query already
+excludes `CompanionTo` sources; it must also exclude project-parented chats, or
+every project chat appears twice — once under its project, once at the top level.
+
+### Toolbar: `ProjectArticle`
+
+`ProjectArticle` has no toolbar today. Add `Panel.Toolbar asChild` +
+`Toolbar.Root` with a single `IconButton` invoking
+`ProjectOperation.CreateChat`. The same action is contributed to the project's
+navtree node (`disposition: 'list-item-primary'`) so `+` works from the tree.
+
+Scope held to chat creation: in-article routine and artifact creation are already
+their own TASKS.md items.
+
+### Dependencies
+
+plugin-projects gains `@dxos/assistant-toolkit` (the `Chat` type) and
+`@dxos/plugin-assistant` (`AssistantOperation`, via its `./types` export). No
+cycle — plugin-assistant does not depend on plugin-projects.
+
+### Testing
+
+- Unit: the `children()`-based chat enumeration, and `CreateChat` parenting +
+  binding pass-through (in-memory db).
+- Story + play test: `ProjectArticle` toolbar creates a chat and it appears in
+  the project's chat list.
+- Live: create a project chat in Composer, confirm the project's instructions
+  reach the system prompt in a _standalone plank_ (not just the companion) and
+  that the chat shows under the project in the navtree, including after a cold
+  deep-link load.
+
 ## Deferred / follow-ups (tracked in TASKS.md)
 
 - Possibly move Project type from `@dxos/compute` into the plugin at end.
-- Review CompanionTo reuse for project chats (vs dedicated relation).
+- Unify project-context binding across companion and standalone chats (shared
+  hook keyed on the chat's parent), closing the late-added-skills gap.
 - Remove plugin-sidekick (this pass: AUDIT.md note only).
 - Consider merging plugin-routine into plugin-projects.
 - In-article routine creation; project agent roster; artifact provenance;

--- a/packages/core/compute/agent-runtime/src/agent-service/AgentService.test.ts
+++ b/packages/core/compute/agent-runtime/src/agent-service/AgentService.test.ts
@@ -511,7 +511,6 @@ describe.skipIf(!runMemoizedTests())('Agent Service', () => {
       TestHelpers.provideTestContext,
     ),
   );
-
 });
 
 // Control-plane coverage (no LLM turn), so it runs ungated in CI unlike the replay suite above.

--- a/packages/core/compute/agent-runtime/src/agent-service/AgentService.test.ts
+++ b/packages/core/compute/agent-runtime/src/agent-service/AgentService.test.ts
@@ -16,12 +16,13 @@ import { expect } from 'vitest';
 
 import { MemoizedAiService } from '@dxos/ai/testing';
 import { PartialBlock, SessionLink } from '@dxos/assistant';
-import { Operation, OperationHandlerSet, Process, ServiceResolver, Skill, Trace } from '@dxos/compute';
+import { Instructions, Operation, OperationHandlerSet, Process, ServiceResolver, Skill, Trace } from '@dxos/compute';
 import { ProcessManager } from '@dxos/compute-runtime';
 import { getSession, hydrate } from '@dxos/compute/AgentService';
-import { Annotation, Feed, Filter, Obj, Ref } from '@dxos/echo';
+import { Annotation, Database, Feed, Filter, Obj, Ref } from '@dxos/echo';
 import { TestHelpers } from '@dxos/effect/testing';
 import { DXN, EntityId } from '@dxos/keys';
+import { Text } from '@dxos/schema';
 import { Message, Organization } from '@dxos/types';
 
 import { AssistantTestLayer, runMemoizedTests } from '../testing';
@@ -85,7 +86,7 @@ const ResearchSkill = Skill.make({
 });
 
 const assistantTestLayerOptions = {
-  types: [Organization.Organization, Feed.Feed, Skill.Skill],
+  types: [Organization.Organization, Feed.Feed, Skill.Skill, Instructions.Instructions, Text.Text],
   tracing: 'pretty' as const,
   aiServicePreset: 'edge-remote' as const,
   operationHandlers: [handlers],
@@ -505,6 +506,69 @@ describe.skipIf(!runMemoizedTests())('Agent Service', () => {
         expect(handle.status.state).not.toBe(Process.State.TERMINATED);
 
         yield* handle.terminate();
+      },
+      Effect.provide(TestLayer()),
+      TestHelpers.provideTestContext,
+    ),
+  );
+
+});
+
+// Control-plane coverage (no LLM turn), so it runs ungated in CI unlike the replay suite above.
+describe('Agent Service (control plane)', () => {
+  // Exercises the instruction-aware reuse identity on both paths — the session cache and the
+  // remount (rediscovered process) path.
+  it.scoped(
+    'session reuse tracks the steering-instructions ref',
+    Effect.fnUntraced(
+      function* (_) {
+        const processManager = yield* ProcessManager.ProcessManagerService;
+
+        const instructionsA = yield* Database.add(Instructions.make({ text: 'Steering A.' }));
+        const instructionsB = yield* Database.add(Instructions.make({ text: 'Steering B.' }));
+        const feed = yield* Database.add(Feed.make());
+        yield* Database.flush();
+        const target = Obj.getURI(feed);
+
+        const isActive = (state: Process.State) =>
+          state !== Process.State.SUCCEEDED && state !== Process.State.FAILED && state !== Process.State.TERMINATED;
+        const activePids = Effect.gen(function* () {
+          const processes = yield* processManager.list({ target, key: AGENT_PROCESS_KEY });
+          return processes.filter((process) => isActive(process.status.state));
+        });
+
+        // Spawn with A: the ref URI is stamped as a spawn annotation.
+        const sessionA = yield* getSession(feed, { instructions: Ref.make(instructionsA) });
+        const [handleA] = yield* activePids;
+        const pidA = String(handleA.pid);
+        expect(
+          Option.getOrNull(Annotation.getDictionary(handleA.params.annotations, Process.InstructionsAnnotation)),
+        ).toBe(Ref.make(instructionsA).uri);
+
+        // Unchanged ref: the cached session (and process) is reused.
+        const sessionAgain = yield* getSession(feed, { instructions: Ref.make(instructionsA) });
+        expect(sessionAgain).toBe(sessionA);
+        expect((yield* activePids).map((handle) => String(handle.pid))).toEqual([pidA]);
+
+        // Repointed ref: the process is torn down and respawned with the new annotation.
+        yield* getSession(feed, { instructions: Ref.make(instructionsB) });
+        const [handleB] = yield* activePids;
+        expect(String(handleB.pid)).not.toBe(pidA);
+        expect(
+          Option.getOrNull(Annotation.getDictionary(handleB.params.annotations, Process.InstructionsAnnotation)),
+        ).toBe(Ref.make(instructionsB).uri);
+
+        // Remount path (cache cleared by hydrate): present-to-absent also respawns, since the
+        // rediscovered process's spawn annotation no longer matches the request.
+        yield* hydrate();
+        yield* getSession(feed);
+        const [handleNone] = yield* activePids;
+        expect(String(handleNone.pid)).not.toBe(String(handleB.pid));
+        expect(
+          Option.getOrNull(Annotation.getDictionary(handleNone.params.annotations, Process.InstructionsAnnotation)),
+        ).toBeNull();
+
+        yield* handleNone.terminate();
       },
       Effect.provide(TestLayer()),
       TestHelpers.provideTestContext,

--- a/packages/core/compute/agent-runtime/src/agent-service/AgentService.ts
+++ b/packages/core/compute/agent-runtime/src/agent-service/AgentService.ts
@@ -189,6 +189,9 @@ export const layer = (opts?: AgentServiceOptions): Layer.Layer<AgentService, nev
                 // lookup (set once at spawn, immutable — the identity plane).
                 annotations: Annotation.buildDictionary((dictionary) => {
                   Annotation.setDictionary(dictionary, Process.HarnessHostAnnotation, true);
+                  if (options?.instructions) {
+                    Annotation.setDictionary(dictionary, Process.InstructionsAnnotation, options.instructions.uri);
+                  }
                 }),
                 environment: {
                   ...(spaceId !== undefined ? { space: spaceId } : {}),

--- a/packages/core/compute/agent-runtime/src/agent-service/AgentService.ts
+++ b/packages/core/compute/agent-runtime/src/agent-service/AgentService.ts
@@ -7,6 +7,7 @@
 import * as Cause from 'effect/Cause';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
+import * as Option from 'effect/Option';
 
 import { AiContext } from '@dxos/assistant';
 import { McpServer, Process, Skill } from '@dxos/compute';
@@ -106,12 +107,18 @@ export const layer = (opts?: AgentServiceOptions): Layer.Layer<AgentService, nev
     AgentService,
     Effect.gen(function* () {
       const processManager = yield* ProcessManager.Service;
-      // The agent's model is bound to its process at spawn time, so the cache tracks the model
-      // each session was created with. Requesting a different model for the same feed tears down
-      // the old process and spawns a fresh one (see below).
+      // The agent's model and steering instructions are bound to its process at spawn time, so the
+      // cache tracks what each session was created with. Requesting a different model or a repointed
+      // instructions ref for the same feed tears down the old process and spawns a fresh one (see below).
       const sessionCache = new Map<
         string,
-        { model: DXN.DXN | undefined; provider: DXN.DXN | undefined; handle: AgentHandle; session: Session }
+        {
+          model: DXN.DXN | undefined;
+          provider: DXN.DXN | undefined;
+          instructions: string | undefined;
+          handle: AgentHandle;
+          session: Session;
+        }
       >();
 
       const makeExecutable = (model?: DXN.DXN, provider?: DXN.DXN) =>
@@ -147,20 +154,24 @@ export const layer = (opts?: AgentServiceOptions): Layer.Layer<AgentService, nev
           Effect.gen(function* () {
             const model = options?.model ?? opts?.model;
             const provider = options?.provider ?? opts?.provider;
+            const instructions = options?.instructions?.uri;
             const cached = sessionCache.get(feed.id);
             if (cached) {
               if (
                 cached.model === model &&
                 cached.provider === provider &&
+                cached.instructions === instructions &&
                 !isTerminalProcess(cached.handle.status.state)
               ) {
                 return cached.session;
               }
 
               if (!isTerminalProcess(cached.handle.status.state)) {
-                // Model or provider changed (e.g. the user toggled online/offline): terminate the
+                // Model, provider, or steering instructions changed (e.g. the user toggled
+                // online/offline, or the chat's instructions ref was repointed): terminate the
                 // existing process so the conversation continues on a fresh process bound to the new
-                // model. Conversation history is preserved via the feed, which the new process replays.
+                // configuration. Conversation history is preserved via the feed, which the new
+                // process replays.
                 yield* cached.handle.terminate();
               }
               sessionCache.delete(feed.id);
@@ -175,7 +186,19 @@ export const layer = (opts?: AgentServiceOptions): Layer.Layer<AgentService, nev
             // (e.g. after the UI remounted). After a model change we always spawn a fresh process,
             // since the process key does not encode the model.
             const processes = yield* processManager.list({ target, key: executable.key });
-            const activeProcess = processes.find((process) => !isTerminalProcess(process.status.state));
+            let activeProcess = processes.find((process) => !isTerminalProcess(process.status.state));
+
+            // Spawn annotations are immutable, so a running process found via the remount path may
+            // carry stale instructions; terminate it and respawn with the requested ref.
+            if (activeProcess) {
+              const processInstructions = Option.getOrUndefined(
+                Annotation.getDictionary(activeProcess.params.annotations, Process.InstructionsAnnotation),
+              );
+              if (processInstructions !== instructions) {
+                yield* activeProcess.terminate();
+                activeProcess = undefined;
+              }
+            }
 
             let handle: AgentHandle;
             if (activeProcess) {
@@ -207,7 +230,7 @@ export const layer = (opts?: AgentServiceOptions): Layer.Layer<AgentService, nev
               sessionCache.delete(feed.id);
             };
             const session = makeSession(handle, feed, releaseSession);
-            sessionCache.set(feed.id, { model, provider, handle, session });
+            sessionCache.set(feed.id, { model, provider, instructions, handle, session });
             return session;
           }),
         hydrate: hydrateAgents,

--- a/packages/core/compute/agent-runtime/src/agent-service/agent-process.ts
+++ b/packages/core/compute/agent-runtime/src/agent-service/agent-process.ts
@@ -39,8 +39,10 @@ import { trim } from '@dxos/util';
 import { type DelegationStrategy } from './delegation-strategy';
 
 interface AgentProcessOptions {
+  // TODO(burdon): Instructions?
   systemPrompt?: string;
 
+  /** Model identifier. */
   model?: DXN.DXN;
 
   /**

--- a/packages/core/compute/agent-runtime/src/agent-service/agent-process.ts
+++ b/packages/core/compute/agent-runtime/src/agent-service/agent-process.ts
@@ -40,22 +40,20 @@ import { type DelegationStrategy } from './delegation-strategy';
 
 interface AgentProcessOptions {
   systemPrompt?: string;
+
   model?: DXN.DXN;
-  // The catalog's shared model ids are served by several providers, so resolution needs the provider
-  // alongside the id; without it a local model id cannot be claimed by any resolver.
-  provider?: DXN.DXN;
 
   /**
-   * Provider for space-level MCP server configs, called on each turn.
+   * The catalog's shared model ids are served by several providers, so resolution needs the provider
+   * alongside the id; without it a local model id cannot be claimed by any resolver.
    */
-  getMcpServers?: () => McpServer.McpServer[];
+  provider?: DXN.DXN;
 
   /**
    * If true, long-running tool calls are moved to the background after `backgroundThreshold`
    * and the agent is notified asynchronously when they complete.
    *
    * Currently unstable — disabled by default.
-   *
    * @default false
    */
   enableToolBackgrounding?: boolean;
@@ -66,6 +64,11 @@ interface AgentProcessOptions {
    * (the default) the process behaves as a plain conversational agent.
    */
   delegationStrategy?: DelegationStrategy;
+
+  /**
+   * Provider for space-level MCP server configs, called on each turn.
+   */
+  getMcpServers?: () => McpServer.McpServer[];
 }
 
 export const AGENT_PROCESS_KEY = 'org.dxos.testing.process.agent';

--- a/packages/core/compute/agent-runtime/src/agent-service/agent-process.ts
+++ b/packages/core/compute/agent-runtime/src/agent-service/agent-process.ts
@@ -25,7 +25,7 @@ import {
   makeToolExecutionService,
   makeToolResolverFromOperations,
 } from '@dxos/assistant';
-import { Credential, McpServer, Operation, Trace } from '@dxos/compute';
+import { Credential, Instructions, McpServer, Operation, Trace } from '@dxos/compute';
 import { Process } from '@dxos/compute';
 import { ProcessManager } from '@dxos/compute-runtime';
 import * as StorageService from '@dxos/compute/StorageService';
@@ -103,8 +103,20 @@ export const AgentProcess = (options: AgentProcessOptions) =>
           return yield* Effect.die(new Error('Agent executable requires spawn options.target set to a queue DXN.'));
         }
         const feed = yield* Database.resolve(feedDxn, Feed.Feed).pipe(Effect.orDie);
+        // Steering instructions travel as a spawn annotation (the session is feed-centric and cannot
+        // reach its Chat); a broken ref degrades to an unsteered session rather than failing the process.
+        const instructionsDxn = Annotation.getDictionary(ctx.params.annotations, Process.InstructionsAnnotation).pipe(
+          Option.getOrUndefined,
+        );
+        const instructions = instructionsDxn
+          ? yield* Database.resolve(instructionsDxn, Instructions.Instructions).pipe(
+              Effect.orElseSucceed(() => undefined),
+            )
+          : undefined;
         const runtime = yield* Effect.runtime<Database.Service>();
-        const session = yield* EffectEx.acquireReleaseResource(() => new AiSession.Session({ feed, runtime }));
+        const session = yield* EffectEx.acquireReleaseResource(
+          () => new AiSession.Session({ feed, runtime, instructions: instructions ? [instructions] : [] }),
+        );
         let inputQueue: AgentEvent[] = [...(yield* AgentEventsCell.get)];
         const storageService = yield* StorageService.StorageService;
         const toolCallManager = new ToolCallManager(storageService);

--- a/packages/core/compute/assistant-evals/src/evals/projects.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/projects.eval.ts
@@ -1,0 +1,117 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import * as Schema from 'effect/Schema';
+import { evalite } from 'evalite';
+
+import { AiContext } from '@dxos/assistant';
+import { Chat, ProjectSkill } from '@dxos/assistant-toolkit';
+import { Project } from '@dxos/compute';
+import { Collection, Database, Feed, Filter, Obj, Ref } from '@dxos/echo';
+import { EID } from '@dxos/keys';
+import { Markdown } from '@dxos/plugin-markdown';
+import { MarkdownPlugin } from '@dxos/plugin-markdown/plugin';
+import { trim } from '@dxos/util';
+
+import { findObject } from '../assertions';
+import { createEvalRunner } from '../runner';
+import { getDefaultSkills } from '../skills';
+
+// The plugin-projects system test: a Chat runs in a Project's context (the project's own
+// Instructions, passed by reference) and the model is directed to create a markdown document.
+// Graded on DB effects: the document exists, is bound into the session context, and is filed
+// into the project's artifacts collection (the ProjectSkill add-artifact tool) — binding alone
+// proves the session saw the object; only the collection check proves the project owns it.
+
+const PROJECT_NAME = 'Voyage';
+
+/** Entity id underlying a ref or object URI, so space-qualified and local URIs compare equal. */
+const entityId = (uri: string): string => {
+  const eid = EID.tryParse(uri);
+  return (eid && EID.getEntityId(eid)) ?? uri;
+};
+
+const task = createEvalRunner({
+  instructions: trim`
+    You manage the "${PROJECT_NAME}" project (its reference is bound into this chat).
+    Create a markdown document titled "Trip Notes" with a short packing list (3 items).
+    Then add the document to the chat context, and file it into the project's artifacts.
+  `,
+  input: Schema.Unknown,
+  output: Schema.Unknown,
+  skills: [...getDefaultSkills(), Ref.make(ProjectSkill.make())],
+  plugins: [MarkdownPlugin()],
+  types: [Project.Project, Collection.Collection],
+  // Multi-tool scenario (create + context-add + artifact-add), so allow more round-trips.
+  timeout: 150_000,
+  seed: ({ instructions }) =>
+    Effect.gen(function* () {
+      const collection = yield* Database.add(Collection.make());
+      const project = yield* Database.add(
+        Project.make({
+          name: PROJECT_NAME,
+          instructions: Ref.make(instructions),
+          artifacts: Ref.make(collection),
+        }),
+      );
+      Obj.setParent(collection, project);
+
+      // The chat mirrors ProjectOperation.CreateChat: parented to the project, steering
+      // instructions passed by reference (the project's own Instructions object).
+      const feed = yield* Database.add(Feed.make());
+      const chat = yield* Database.add(
+        Chat.make({ name: `${PROJECT_NAME} Chat`, feed: Ref.make(feed), instructions: Ref.make(instructions) }),
+      );
+      Obj.setParent(chat, project);
+      yield* Database.flush();
+
+      return { objects: [Ref.make(project)], chat: Ref.make(chat) };
+    }),
+  dbQuery: () =>
+    Effect.gen(function* () {
+      const document = yield* findObject(Markdown.Document, () => true);
+      const project = yield* findObject(Project.Project, (project) => project.name === PROJECT_NAME);
+      if (!document || !project?.artifacts) {
+        return { documentCreated: !!document, filed: false, bound: false };
+      }
+      const documentId = entityId(Obj.getURI(document));
+
+      const artifacts = yield* Database.load(project.artifacts);
+      const filed = artifacts.objects.some((ref) => entityId(ref.uri) === documentId);
+
+      // Bound = a Binding record in the chat feed added the document to the session context.
+      const chat = yield* findObject(Chat.Chat, () => true);
+      let bound = false;
+      if (chat) {
+        const feed = yield* Database.load(chat.feed);
+        const bindings = yield* Feed.query(feed, Filter.type(AiContext.Binding)).run;
+        bound = bindings.some((binding) => binding.objects.added.some((ref) => entityId(ref.uri) === documentId));
+      }
+
+      return { documentCreated: true, filed, bound };
+    }),
+});
+
+evalite('Projects — project chat creates and files an artifact', {
+  data: [{ input: null }],
+  task,
+  scorers: [
+    {
+      name: 'document-created',
+      description: 'A Markdown Document exists in the DB after the run.',
+      scorer: ({ output }) => (output.dbQuery.documentCreated ? 1 : 0),
+    },
+    {
+      name: 'document-filed',
+      description: "The document is in the project's artifacts collection (add-artifact tool).",
+      scorer: ({ output }) => (output.dbQuery.filed ? 1 : 0),
+    },
+    {
+      name: 'document-bound',
+      description: 'A Binding record in the chat feed added the document to the session context.',
+      scorer: ({ output }) => (output.dbQuery.bound ? 1 : 0),
+    },
+  ],
+});

--- a/packages/core/compute/assistant-evals/src/runner.ts
+++ b/packages/core/compute/assistant-evals/src/runner.ts
@@ -18,7 +18,7 @@ import { AppActivationEvents } from '@dxos/app-toolkit';
 import { Chat, RunInstructions } from '@dxos/assistant-toolkit';
 import { Instructions, Operation, ServiceResolver, type Skill } from '@dxos/compute';
 import { FeedTraceSink } from '@dxos/compute-runtime';
-import { Database, Feed, Ref, Tag } from '@dxos/echo';
+import { Database, Feed, Obj, Ref, Tag, type Type } from '@dxos/echo';
 import { EffectEx } from '@dxos/effect';
 import { DXN, type SpaceId } from '@dxos/keys';
 import { AssistantPlugin } from '@dxos/plugin-assistant/plugin';
@@ -65,9 +65,19 @@ const makeAiServiceMiddleware = (): Promise<(_upstream: AiService.Service) => Ai
     EffectEx.runAndForwardErrors,
   );
 
-const createDefaultPlugins = async (options: { plugins?: Plugin.Plugin[] }): Promise<Plugin.Plugin[]> => [
+const createDefaultPlugins = async (options: {
+  plugins?: Plugin.Plugin[];
+  types?: Type.AnyEntity[];
+}): Promise<Plugin.Plugin[]> => [
   ClientPlugin({
-    types: [Organization.Organization, Person.Person, Employer.Employer, Tag.Tag, Mailbox.Mailbox],
+    types: [
+      Organization.Organization,
+      Person.Person,
+      Employer.Employer,
+      Tag.Tag,
+      Mailbox.Mailbox,
+      ...(options.types ?? []),
+    ],
   }),
   AssistantPlugin({
     aiServiceMiddleware: await makeAiServiceMiddleware(),
@@ -94,13 +104,14 @@ const runInstructions = <I>(
   spaceId: SpaceId,
   input: I,
   sessionChat?: boolean,
+  seededChat?: Ref.Ref<Chat.Chat>,
 ) =>
   harness.runPromise(
     Effect.gen(function* () {
       yield* seedInstructions(instructions);
 
-      let chatRef: Ref.Ref<Chat.Chat> | undefined;
-      if (sessionChat) {
+      let chatRef: Ref.Ref<Chat.Chat> | undefined = seededChat;
+      if (!chatRef && sessionChat) {
         const feed = yield* Database.add(Feed.make());
         const chat = yield* Database.add(Chat.make({ feed: Ref.make(feed), name: 'Eval Chat' }));
         yield* Database.flush();
@@ -147,7 +158,28 @@ export interface CreateEvalRunnerOptions<I, O> {
    * @default 60_000
    */
   timeout?: number;
+  /**
+   * Additional ECHO types the scenario's seed/dbQuery touch, registered with the harness client.
+   */
+  types?: Type.AnyEntity[];
+  /**
+   * Seeds the space before the run (e.g. a Project the scenario operates on). Runs inside the
+   * harness with `Database.Service` provided; receives the run's `Instructions` object so seeded
+   * entities can reference it (it is added to the DB after seeding). Returned `objects` are bound
+   * into the session context alongside the instructions' own; a returned `chat` is used as the
+   * session chat (taking precedence over `sessionChat`).
+   */
+  seed?: (context: {
+    spaceId: SpaceId;
+    instructions: Instructions.Instructions;
+  }) => Effect.Effect<SeedResult, unknown, Database.Service>;
 }
+
+/** Entities a {@link CreateEvalRunnerOptions.seed} hook contributes to the run. */
+export type SeedResult = {
+  objects?: Ref.Ref<Obj.Unknown>[];
+  chat?: Ref.Ref<Chat.Chat>;
+};
 
 /** A deterministic DB-state assertion run after the agent completes, before the harness is disposed. */
 export type DbQuery<I, D> = (
@@ -222,8 +254,27 @@ export function createEvalRunner<I, O, D>(
           EffectEx.runAndForwardErrors(initializeIdentity(harness.get(ClientCapabilities.Client))),
         );
 
+        let seeded: SeedResult = {};
+        const seedFn = options.seed;
+        if (seedFn) {
+          seeded = yield* Effect.promise(() =>
+            harness.runPromise(
+              seedFn({ spaceId: personalSpace.id, instructions }).pipe(
+                Effect.provide(ServiceResolver.provide({ space: personalSpace.id }, Database.Service)),
+              ),
+            ),
+          );
+          if (seeded.objects?.length) {
+            const objects = seeded.objects;
+            Obj.update(instructions, (instructions) => {
+              instructions.objects = [...(instructions.objects ?? []), ...objects];
+            });
+          }
+        }
+
         const agentOutput = yield* Effect.tryPromise({
-          try: () => runInstructions(harness, instructions, model, personalSpace.id, input, options.sessionChat),
+          try: () =>
+            runInstructions(harness, instructions, model, personalSpace.id, input, options.sessionChat, seeded.chat),
           catch: (cause) => new AgentRunFailure({ cause }),
         });
 

--- a/packages/core/compute/assistant-toolkit/package.json
+++ b/packages/core/compute/assistant-toolkit/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@dxos/client-protocol": "workspace:*",
+    "@dxos/echo-client": "workspace:*",
     "@dxos/plugin-markdown": "workspace:*",
     "@dxos/ui-theme": "workspace:*",
     "effect": "catalog:",

--- a/packages/core/compute/assistant-toolkit/src/skills/index.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/index.ts
@@ -15,4 +15,5 @@ export * from './discord';
 export * from './linear';
 export * from './memory';
 export * from './planning';
+export * from './project';
 export * from './websearch';

--- a/packages/core/compute/assistant-toolkit/src/skills/project/index.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/project/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export { default as ProjectSkill } from './skill';
+export { ProjectHandlers, ProjectOperations } from './operations';

--- a/packages/core/compute/assistant-toolkit/src/skills/project/operations/artifact-add.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/project/operations/artifact-add.ts
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Operation } from '@dxos/compute';
+import { Collection, Database, Obj, Ref } from '@dxos/echo';
+import { EID } from '@dxos/keys';
+
+import { ArtifactAdd } from './definitions';
+
+/** Compare refs by entity id when possible — space-qualified and local URIs may name the same object. */
+const refKey = (ref: Ref.Ref<Obj.Unknown>): string => {
+  const eid = EID.tryParse(ref.uri);
+  return (eid && EID.getEntityId(eid)) ?? ref.uri;
+};
+
+const handler: Operation.WithHandler<typeof ArtifactAdd> = ArtifactAdd.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ project: projectRef, object: objectRef }) {
+      const project = yield* Database.load(projectRef);
+
+      // Projects normally own an artifacts collection from creation; materialize one for those that don't.
+      let collection: Collection.Collection;
+      if (project.artifacts) {
+        collection = yield* Database.load(project.artifacts);
+      } else {
+        collection = yield* Database.add(Collection.make());
+        Obj.setParent(collection, project);
+        Obj.update(project, (project) => {
+          project.artifacts = Ref.make(collection);
+        });
+      }
+
+      if (!collection.objects.some((ref) => refKey(ref) === refKey(objectRef))) {
+        Obj.update(collection, (collection) => {
+          collection.objects.push(objectRef);
+        });
+      }
+
+      yield* Database.flush();
+    }),
+  ),
+);
+
+export default handler;

--- a/packages/core/compute/assistant-toolkit/src/skills/project/operations/artifact-list.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/project/operations/artifact-list.ts
@@ -1,0 +1,38 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Operation } from '@dxos/compute';
+import { Database, Obj } from '@dxos/echo';
+
+import { ArtifactList } from './definitions';
+
+const handler: Operation.WithHandler<typeof ArtifactList> = ArtifactList.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ project: projectRef }) {
+      const project = yield* Database.load(projectRef);
+      if (!project.artifacts) {
+        return { artifacts: [] };
+      }
+
+      const collection = yield* Database.load(project.artifacts);
+      const artifacts = yield* Effect.forEach(collection.objects, (ref) =>
+        Database.load(ref).pipe(
+          Effect.map((object) => ({
+            dxn: Obj.getURI(object),
+            typename: Obj.getTypename(object),
+            label: Obj.getLabel(object),
+          })),
+          // A broken ref yields a placeholder row rather than failing the whole listing.
+          Effect.orElseSucceed(() => ({ dxn: ref.uri, typename: undefined, label: undefined })),
+        ),
+      );
+
+      return { artifacts };
+    }),
+  ),
+);
+
+export default handler;

--- a/packages/core/compute/assistant-toolkit/src/skills/project/operations/artifact-list.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/project/operations/artifact-list.ts
@@ -25,8 +25,11 @@ const handler: Operation.WithHandler<typeof ArtifactList> = ArtifactList.pipe(
             typename: Obj.getTypename(object),
             label: Obj.getLabel(object),
           })),
-          // A broken ref yields a placeholder row rather than failing the whole listing.
-          Effect.orElseSucceed(() => ({ dxn: ref.uri, typename: undefined, label: undefined })),
+          // A broken ref yields a placeholder row rather than failing the whole listing; other
+          // load failures (transport, decoding) still propagate.
+          Effect.catchTag('EntityNotFoundError', () =>
+            Effect.succeed({ dxn: ref.uri, typename: undefined, label: undefined }),
+          ),
         ),
       );
 

--- a/packages/core/compute/assistant-toolkit/src/skills/project/operations/definitions.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/project/operations/definitions.ts
@@ -1,0 +1,63 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+
+import { Operation, Project } from '@dxos/compute';
+import { Database, Obj, Ref, Type } from '@dxos/echo';
+import { DXN } from '@dxos/keys';
+import { trim } from '@dxos/util';
+
+export const ArtifactAdd = Operation.make({
+  meta: {
+    key: DXN.make('org.dxos.function.project.artifactAdd'),
+    name: 'Add project artifact',
+    icon: 'ph--stack-plus--regular',
+    description: trim`
+      Files an object into a project's artifacts collection.
+      Use this after creating an object (document, outline, sheet, contact, …) while working in a
+      project's context, so the project owns it and it appears in the project's artifacts list.
+      Adding the same object twice is a no-op.
+    `,
+  },
+  input: Schema.Struct({
+    project: Ref.Ref(Project.Project).annotations({
+      description: 'The project to file into (its reference is in the chat context).',
+    }),
+    object: Ref.Ref(Obj.Unknown).annotations({
+      description: 'The object to file as an artifact.',
+    }),
+  }),
+  output: Schema.Void,
+  services: [Database.Service],
+});
+
+/** One artifact row: enough to identify and load the object, without inlining its content. */
+export const ArtifactInfo = Schema.Struct({
+  dxn: Schema.String,
+  typename: Schema.optional(Schema.String),
+  label: Schema.optional(Schema.String),
+});
+
+export const ArtifactList = Operation.make({
+  meta: {
+    key: DXN.make('org.dxos.function.project.artifactList'),
+    name: 'List project artifacts',
+    icon: 'ph--stack--regular',
+    description: trim`
+      Lists the objects in a project's artifacts collection (DXN, type, and label per artifact).
+      Use this to find what the project already holds before searching the whole space; load an
+      artifact's content with the load tool when needed.
+    `,
+  },
+  input: Schema.Struct({
+    project: Ref.Ref(Project.Project).annotations({
+      description: 'The project whose artifacts to list (its reference is in the chat context).',
+    }),
+  }),
+  output: Schema.Struct({
+    artifacts: Schema.Array(ArtifactInfo),
+  }),
+  services: [Database.Service],
+});

--- a/packages/core/compute/assistant-toolkit/src/skills/project/operations/definitions.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/project/operations/definitions.ts
@@ -5,7 +5,7 @@
 import * as Schema from 'effect/Schema';
 
 import { Operation, Project } from '@dxos/compute';
-import { Database, Obj, Ref, Type } from '@dxos/echo';
+import { Database, Obj, Ref } from '@dxos/echo';
 import { DXN } from '@dxos/keys';
 import { trim } from '@dxos/util';
 

--- a/packages/core/compute/assistant-toolkit/src/skills/project/operations/index.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/project/operations/index.ts
@@ -1,0 +1,12 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { OperationHandlerSet } from '@dxos/compute';
+
+export * as ProjectOperations from './definitions';
+
+export const ProjectHandlers = OperationHandlerSet.lazy(
+  () => import('./artifact-add'),
+  () => import('./artifact-list'),
+);

--- a/packages/core/compute/assistant-toolkit/src/skills/project/skill.test.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/project/skill.test.ts
@@ -1,0 +1,76 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, it } from '@effect/vitest';
+import * as Effect from 'effect/Effect';
+
+import { Instructions, Project } from '@dxos/compute';
+import { Collection, Database, Ref } from '@dxos/echo';
+import { TestDatabaseLayer } from '@dxos/echo-client/testing';
+import { Text } from '@dxos/schema';
+
+import artifactAdd from './operations/artifact-add';
+import artifactList from './operations/artifact-list';
+
+const testLayer = () =>
+  TestDatabaseLayer({
+    types: [Project.Project, Instructions.Instructions, Collection.Collection, Text.Text],
+  });
+
+describe('project skill operations', () => {
+  it.effect('artifact-add files into the project collection; adding twice is a no-op', () =>
+    Effect.gen(function* () {
+      const collection = yield* Database.add(Collection.make());
+      const project = yield* Database.add(Project.make({ name: 'Voyage', artifacts: Ref.make(collection) }));
+      const doc = yield* Database.add(Text.make({ content: 'notes' }));
+      yield* Database.flush();
+
+      yield* artifactAdd.handler({ project: Ref.make(project), object: Ref.make(doc) });
+      expect(collection.objects).toHaveLength(1);
+
+      yield* artifactAdd.handler({ project: Ref.make(project), object: Ref.make(doc) });
+      expect(collection.objects).toHaveLength(1);
+    }).pipe(Effect.provide(testLayer())),
+  );
+
+  it.effect('artifact-add materializes a collection for a project without one', () =>
+    Effect.gen(function* () {
+      const project = yield* Database.add(Project.make({ name: 'Bare' }));
+      const doc = yield* Database.add(Text.make({ content: 'notes' }));
+      yield* Database.flush();
+
+      yield* artifactAdd.handler({ project: Ref.make(project), object: Ref.make(doc) });
+      const artifactsRef = project.artifacts;
+      expect(artifactsRef).toBeDefined();
+      if (!artifactsRef) {
+        throw new Error('unreachable');
+      }
+      const collection = yield* Database.load(artifactsRef);
+      expect(collection.objects).toHaveLength(1);
+    }).pipe(Effect.provide(testLayer())),
+  );
+
+  it.effect('artifact-list returns dxn, typename, and label per artifact', () =>
+    Effect.gen(function* () {
+      const doc = yield* Database.add(Text.make({ content: 'notes' }));
+      const collection = yield* Database.add(Collection.make({ objects: [Ref.make(doc)] }));
+      const project = yield* Database.add(Project.make({ name: 'Voyage', artifacts: Ref.make(collection) }));
+      yield* Database.flush();
+
+      const { artifacts } = yield* artifactList.handler({ project: Ref.make(project) });
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0].typename).toBe('org.dxos.type.text');
+    }).pipe(Effect.provide(testLayer())),
+  );
+
+  it.effect('artifact-list is empty for a project without a collection', () =>
+    Effect.gen(function* () {
+      const project = yield* Database.add(Project.make({ name: 'Bare' }));
+      yield* Database.flush();
+
+      const { artifacts } = yield* artifactList.handler({ project: Ref.make(project) });
+      expect(artifacts).toEqual([]);
+    }).pipe(Effect.provide(testLayer())),
+  );
+});

--- a/packages/core/compute/assistant-toolkit/src/skills/project/skill.test.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/project/skill.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
 import { Instructions, Project } from '@dxos/compute';
-import { Collection, Database, Ref } from '@dxos/echo';
+import { Collection, Database, Obj, Ref } from '@dxos/echo';
 import { TestDatabaseLayer } from '@dxos/echo-client/testing';
 import { Text } from '@dxos/schema';
 
@@ -60,7 +60,9 @@ describe('project skill operations', () => {
 
       const { artifacts } = yield* artifactList.handler({ project: Ref.make(project) });
       expect(artifacts).toHaveLength(1);
+      expect(artifacts[0].dxn).toBe(Obj.getURI(doc));
       expect(artifacts[0].typename).toBe('org.dxos.type.text');
+      expect(artifacts[0].label).toBe(Obj.getLabel(doc));
     }).pipe(Effect.provide(testLayer())),
   );
 

--- a/packages/core/compute/assistant-toolkit/src/skills/project/skill.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/project/skill.ts
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Skill } from '@dxos/compute';
+import { Ref } from '@dxos/echo';
+import { Text } from '@dxos/schema';
+import { trim } from '@dxos/util';
+
+import { ArtifactAdd, ArtifactList } from './operations/definitions';
+
+const SKILL_KEY = 'org.dxos.skill.project';
+
+const instructions = trim`
+  You are working in the context of a project (its reference is bound into this chat).
+  The project owns a collection of artifacts: the durable work products of this project.
+  When you create an object the user asked for (a document, outline, sheet, contact, …), file it
+  into the project's artifacts with the add-artifact tool so the project owns it.
+  When looking for the project's existing material, list its artifacts first rather than searching
+  the whole space.
+`;
+
+const make = () =>
+  Skill.make({
+    key: SKILL_KEY,
+    name: 'Project',
+    description: "Manage a project's artifacts: file created objects and find existing ones.",
+    agentCanEnable: true,
+    instructions: {
+      source: Ref.make(Text.make({ content: instructions })),
+    },
+    tools: Skill.toolDefinitions({
+      operations: [ArtifactAdd, ArtifactList],
+    }),
+  });
+
+const skill: Skill.Definition = {
+  key: SKILL_KEY,
+  make,
+};
+
+export default skill;

--- a/packages/core/compute/assistant-toolkit/src/types/Agent.ts
+++ b/packages/core/compute/assistant-toolkit/src/types/Agent.ts
@@ -49,6 +49,7 @@ export class Agent extends Type.makeObject<Agent>(DXN.make('org.dxos.type.agent'
     /**
      * Instructions for the agent.
      */
+    // TODO(burdon): Instructions.Instructions
     instructions: Ref.Ref(Text.Text).pipe(
       Format.FormatAnnotation.set(Format.TypeFormat.Markdown),
       Schema.annotations({ title: 'Instructions' }),
@@ -57,14 +58,7 @@ export class Agent extends Type.makeObject<Agent>(DXN.make('org.dxos.type.agent'
     /**
      * Primary chat for the agent.
      */
-    // TODO(dmaretskyi): Multiple chats; RB: branching hierarchy.
     chat: Schema.optional(Ref.Ref(Chat.Chat).pipe(FormInputAnnotation.set(false))),
-
-    /**
-     * Input feed for subscriptions.
-     * @deprecated Subscriptions will write directly to the agent.
-     */
-    feed: Schema.optional(Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false))),
 
     // TODO(burdon): Currently Memory.Memory objects are global to the space; make them artifacts?
     artifacts: Schema.Array(
@@ -93,6 +87,12 @@ export class Agent extends Type.makeObject<Agent>(DXN.make('org.dxos.type.agent'
       title: 'Cron',
       description: 'Cron expression for a timer trigger that invokes the agent on a schedule.',
     }),
+
+    /**
+     * Input feed for subscriptions.
+     * @deprecated Subscriptions will write directly to the agent.
+     */
+    feed: Schema.optional(Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false))),
 
     /**
      * Allow the agent to filter events.

--- a/packages/core/compute/assistant-toolkit/src/types/Agent.ts
+++ b/packages/core/compute/assistant-toolkit/src/types/Agent.ts
@@ -49,7 +49,7 @@ export class Agent extends Type.makeObject<Agent>(DXN.make('org.dxos.type.agent'
     /**
      * Instructions for the agent.
      */
-    // TODO(burdon): Instructions.Instructions
+    // TODO(burdon): Migrate to Ref<Instructions.Instructions> — plugin-projects PLAN.md phase A.
     instructions: Ref.Ref(Text.Text).pipe(
       Format.FormatAnnotation.set(Format.TypeFormat.Markdown),
       Schema.annotations({ title: 'Instructions' }),

--- a/packages/core/compute/assistant-toolkit/src/types/Agent.ts
+++ b/packages/core/compute/assistant-toolkit/src/types/Agent.ts
@@ -60,6 +60,12 @@ export class Agent extends Type.makeObject<Agent>(DXN.make('org.dxos.type.agent'
     // TODO(dmaretskyi): Multiple chats; RB: branching hierarchy.
     chat: Schema.optional(Ref.Ref(Chat.Chat).pipe(FormInputAnnotation.set(false))),
 
+    /**
+     * Input feed for subscriptions.
+     * @deprecated Subscriptions will write directly to the agent.
+     */
+    feed: Schema.optional(Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false))),
+
     // TODO(burdon): Currently Memory.Memory objects are global to the space; make them artifacts?
     artifacts: Schema.Array(
       Schema.Struct({
@@ -87,12 +93,6 @@ export class Agent extends Type.makeObject<Agent>(DXN.make('org.dxos.type.agent'
       title: 'Cron',
       description: 'Cron expression for a timer trigger that invokes the agent on a schedule.',
     }),
-
-    /**
-     * Input feed for subscriptions.
-     * @deprecated Subscriptions will write directly to the agent.
-     */
-    feed: Schema.optional(Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false))),
 
     /**
      * Allow the agent to filter events.

--- a/packages/core/compute/assistant-toolkit/src/types/Chat.ts
+++ b/packages/core/compute/assistant-toolkit/src/types/Chat.ts
@@ -8,6 +8,7 @@ import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 
 import { Harness } from '@dxos/assistant';
+import { Instructions } from '@dxos/compute';
 import { Annotation, Database, DXN, Feed, Filter, Obj, Ref, Type } from '@dxos/echo';
 import { FormInputAnnotation, LabelAnnotation } from '@dxos/echo/Annotation';
 import { type EntityNotFoundError } from '@dxos/echo/Err';
@@ -24,6 +25,12 @@ export class Chat extends Type.makeObject<Chat>(DXN.make('org.dxos.type.assistan
     name: Schema.String.pipe(Schema.optional),
     feed: Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false)),
     viewType: Schema.String.pipe(Schema.optional),
+
+    /**
+     * Instructions steering this conversation, rendered into the system prompt at request time.
+     * Held by reference (never copied), so a project's chats follow edits to its instructions.
+     */
+    instructions: Schema.optional(Ref.Ref(Instructions.Instructions).pipe(FormInputAnnotation.set(false))),
 
     /**
      * Session plan for tracking task progress within this conversation.

--- a/packages/core/compute/assistant-toolkit/src/types/Chat.ts
+++ b/packages/core/compute/assistant-toolkit/src/types/Chat.ts
@@ -18,6 +18,7 @@ import * as Plan from './Plan';
 /**
  * AI chat.
  */
+// TODO(burdon): This is badly named.
 export class Chat extends Type.makeObject<Chat>(DXN.make('org.dxos.type.assistant.chat', '0.1.0'))(
   Schema.Struct({
     name: Schema.String.pipe(Schema.optional),

--- a/packages/core/compute/assistant-toolkit/src/types/Chat.ts
+++ b/packages/core/compute/assistant-toolkit/src/types/Chat.ts
@@ -36,6 +36,7 @@ export class Chat extends Type.makeObject<Chat>(DXN.make('org.dxos.type.assistan
      * Session plan for tracking task progress within this conversation.
      * Created lazily when the first task is recorded.
      */
+    // TODO(burdon): Generalize to artifact associated with a skill?
     plan: Schema.optional(Ref.Ref(Plan.Plan).pipe(FormInputAnnotation.set(false))),
   }).pipe(
     LabelAnnotation.set(['name']),

--- a/packages/core/compute/assistant-toolkit/tsconfig.json
+++ b/packages/core/compute/assistant-toolkit/tsconfig.json
@@ -60,6 +60,9 @@
       "path": "../../echo/echo"
     },
     {
+      "path": "../../echo/echo-client"
+    },
+    {
       "path": "../../echo/echo-protocol"
     },
     {

--- a/packages/core/compute/assistant/docs/agent.drawio.svg
+++ b/packages/core/compute/assistant/docs/agent.drawio.svg
@@ -1,1139 +1,879 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent; color-scheme: light dark;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="981px" height="1161px" viewBox="-0.5 -0.5 981 1161" content="&lt;mxfile&gt;&lt;diagram id=&quot;johfjf3ioz4qrdwLIx9m&quot; name=&quot;Page-1&quot;&gt;5V1Lc+MoEP41rto9zJTQ20fHTnb3kNpUPFU7OSoysTUrSx49Emd//aIY9AAc6wlkkksshCT08XXT3TRoZiz3xz8S77C7jTcwnOna5jgzVjNdB5bhoH9FyeupxJ6DU8E2CTa4UlWwDv6DuFDDpXmwgWmjYhbHYRYcmoV+HEXQzxplXpLEL81qT3HYfOrB2+InalXB2vdCyFT7J9hku1Opa9Vq/wmD7Y48GWj4zN4jlXFBuvM28UutyLieGcskjrPTr/1xCcMCPILL6bqbM2fLhiUwylpdYOGuePbCHL8dbln2Sl43ifNoA4srtJlx9bILMrg+eH5x9gV1MCrbZfsQHQH08ykIw2Ucxgk6juIIVbrCT4BJBo9n2wnKt0e0gfEeZskrqoIvsDFemDAuOX6p4AcE010NetPEhR7u8m156woV9AMDwwfJ0LpgBC5jtPHSXVn3LGAMOhwMzwLmaE3EDK0lYmAMxCwGH7hBEoQP8VvWAIHHIPte+/1QcO2rhY9WR0y9t4NXfHAWpDTOEx8/FndU5iVbiGsZp6KiQe8CmcDQy4LnpsgPAUVnWPT3449CPY0mbzPdcFfL1c2iKI+jrFauvf2h8jRL4n9h7YxlzxfL1Tis02nW6SzrXJ6YjsA5WxXOGSznTFmcMxjOfUuC7RYmvxDpSpJJIB3QXVVoZ3JUnSWLdyar6w4wQc+Io5luh6h9V4+Ig/Y2K1/vl+BiaW9I4KIyTHRYJuqyiMiatzcQMWsQ40bgiStRZZldeRJtFoXThA790EvTwD8V3gThRUTqtACcgdGRxQvAjozLnTfQFhuBGF8kKhDQ2YSqmIFPVrTQemqYJuB+njyXB+1YZglg2dul6NW911qFQxxEWVq7811RcNaHNWnX/P3qhqlRfXl6ftWz5Yu062yLEYBbLwgf46NyMmByfNepZKAMzEw5itbk5vp+70WvrOREqN3fq1sVhw/1c9WN3446jc/AZUVkdK+YT2qqZ4FDddmpSfiiqte6ippBCQ8VBhssPMSe6cwSrR9LuNq1d1+TehJCIJ1tD4JbidVDHaozuGHZAQ3JqQTpjOxclsrBYxOvM6aRvNYSQyTRHldCjL7eiPbVqXc1aCsi50zTKfpsGnuC0WKACmwwA9xI2pJ+jPu+YcI0yx2ZOvNRlMRg5vSmB5AWYiatqRl1iy2M1HNrdJEmHWBA+StKsyT3i3BUOgwbpaJPXwBt94iEmfWor9CvQxIM5Z/aGJcTZiIw7jyqXrRpWmk5MrnSMFykxW5Ia2pMW0OkwovYsmQ950ici+DEOu/hzxym8tU/A4srDhajr6/WzaMn/npvn2MqA9YgGTLKB8Qu2J0TB8QM1ky4X69RgRITBkxMjJMBM5kEsbN5az8JDurpFZFjMbmHqBjQIDfF4ETFyTAqY/IF9MWuQxyoNzBAn8tCxmCj8ndJ7CPrhp02v/Uib3AmxwhCaEtM+nH6BhR7husHCaHDm5qSRjXnnQkgbSGdVfSAZwt0ZR0RuWSjsYqTbuFKi/A7rBNSsWpgps8UrBLoiDgiEnRGY9WcMy4SV2rqwDed0WfrFPxnAt89rH7ynoonCInUfm5fw1YGT4mma/JUWr4taY7qdBKo9lwx8ZeR6CQqD4Ieh6bTcO5nzAEXqi8/kg/ijp4S3o7g5XqkCQjOOjKfgOACNTgAiqjwvlH2Zre3kpNyyWbDsNCmkZ6ugXPrzOhxLnLO1B852acEqzH1FBbvRAetbvLIz1SYqWNGYIEjBiAZIp9KoHiWuqICRUYreQLFmYz6aAIldIT6SBG7kvVNUZAWCS7b85FnHWyBU39AYzNQ3gFEzR0BbM40zXQ7AgDN6Sqh46QulXLVEDayk4gEYSsb+S4QTXGaYjUeVwkBaSuGy376AFldQnUN4NnWaqZ1OUJtaDHTKYLyutrJLFm7q6QNTeVnORfSuej6o9vQgE1bWoaBCtnwTHBMYDIX4Cz8VGONAG3RWSKXPpM9nlprk8HrinSOXTL+xFUvUbYpfo69OAz0Xh0mQnf37z5gyNvPQGfNJ2VCA7Rki1yWAgxlNiMr8ycaqTryFouR5tRzdZDFXWx+OIgxSk2c0FuSCY3zGspsSlbmRDS4J8/b4+SUfwLuiQyJGmwm3l0S7xXM2hc6HFgiZutbiiTPhCAvKUMmWRPiPs6zIBpXJp3lylncdJFJc7WwHWcc8tET6a5ImSQ3qSEcNJYi09H2377B/QH1M/xdutTSTqtY4Nj5sEeyuHjgCu4JoAGaSIfeZM24IDrkGYdNa38H9556XJqLDKiabEIc0nIfCzCgCR0zRaQrtBszTV4E1JS3ks1k7dgRomlKjZj0mgmxip+NVvoIBHiUb8YyMglEBixNdgr6oilxzORrMlcmmebq6DHOqi1guvL0GOstKrEfqivTUGB3U1JiMQcdVhAKCvnISQ0U5KDIjzG7Ug0k1j3xkix48nwFvBMGGZHOicU6J2n+mL5tHzF8960J0BE6iFusdfMzh/nAeMsUqIgcpi3WtBnX2R/0KSIaGl2o9mWHpGGATPO5JpMOsrX9XlMZneuAEjqsPph1mo2uPjtmXP8P&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="981px" height="1161px" viewBox="-0.5 -0.5 981 1161" content="&lt;mxfile&gt;&lt;diagram id=&quot;johfjf3ioz4qrdwLIx9m&quot; name=&quot;Page-1&quot;&gt;5V1bc9soFP41ntl9aEfo7kfXbrr7kNlM3JltHhWZ2mplydUlcfbXL4pBF8C2rkCavMQgLKGP7xzOORzwzFjuj18S77C7jTcwnOna5jgzVjNdB4bloH9FzcupZu66p4ptEmxwo6piHfwHcaWGa/NgA9NGwyyOwyw4NCv9OIqgnzXqvCSJn5vNvsdh86kHb4ufqFUVa98LIdPs32CT7U61rlVr/RcMtjvyZKDhK3uPNMYV6c7bxM+1KuPzzFgmcZydPu2PSxgW4BFcTt+7OXO17FgCo6zVF8hQPHlhjt8O9yx7Ia+bxHm0gcU3tJnx6XkXZHB98Pzi6jMaYFS3y/YhKgH08XsQhss4jBNUjuIINfrEdgr38wkmGTzWqnAnv8B4D7PkBTXBV22MFyaMS8rPFfyAYLqrQW+auNLDQ74tb12hgj5gYPggGVoXjMB1jDZeuivbTgOYozURM7SWiIExELMYfOAGSRAu4resAQKPQfat9vmh4NpHC5dWR0y918ILLpwFKY3zxMePxQOVeckW4lbGqaro0EUgExh6WfDUFPkhoOgMi/55/FGop9HkbaYb7mq5ulkU9XGU1eq11z9Un2ZJ/BPWrlj2fLFcjcM6nWadzrLO5YnpCJyzVeGcwXLOlMU5g+Hc1yTYbmHyG5GuJJkE0gHdVYV2JkfVWbJ4Z7K67gAT9Iw4mul2iPr36RFx0N5m5ev9Flws7Q0JXFSGiQ7LRF0WEVnz9gYiZg1i3Ag8cSWqLLMrT6LNonCaUNEPvTQN/FPlTRBeRaROC8CZGB1ZvADszLjceQNtsRGI8UGiAgGdTaiKGfhiRQutp4ZpAu7nyVNZaMcySwDLXr+KXt17qTU4xEGUpbU73xUVZ31Yk3bNLzc3TI0ay9Pzq5EtX6TdYFuMANx6QfgYH5WTAZPju04lA2VgZspZtCY3n+/3XvTCSk6E+v2tulVRfKhfq278Wuo0PwOXFZHRvWI+qamRBQ41ZKcu4S9Vo9ZV1AxKeKgw2GDhIfZMZ5Zo/VjC1a69x5q0kxAC6Wx7ENxKrB7qUJ3BDcsOaEhOJUhnZOe6VA6em3iDMY3ktZYYIon2uBJi9PVGtI9OfahBWxE5Z5pOMWbT2BOMFgNUYIOZ4EbSlvRj3MuGCdMtd2TqzEdREoOZ05seQFqImfSmZtQttjBSz63RRZp0gAHl7yjNktwvwlHpMGyUij59ALTdIxJm1qNe/yyk6TfGt1wsE4Fv5xn1qj3TSsORhZWG0SItbkN6U2cZROq7iCtL1nGOxHUITpzzHv7KYSpf9TOwuOJgMfr6ad28eeKr9/Y3pjJeDZIdo3ww7IrNOXEwzGBNhPv1GlUosVjAxMM42S+TSRC7krf2k+Cgnl4ROReTe4iK/wxyUQxORJxMozIWXkBf7DrEgHoDA/S5LGQMNiJ/l8Q+sm7YJfNbL/IGZ3GMIIS2xIQfp28wsWeofpAQOrxlKWlUcy4s/mgL6ayiJzxboBvriMgjG41VnFQLV1p032GdkIpVA7N8pmCVQEfEEZGcMxqr5px5kbhSUwe96Ww+W6fgPxP07mH1k/dUPDlIpPZz+xq2MnhKNF2Tp9JybUl3VKeTQLXniom/jEQnUTkQ9Dw0nYZz32P+t1B9+ZZ8EHf0dPB2BC/3Ik1AcNaReQcEF6jBAVBEhfeNsjeHvZWclNs1G4aFNo30dA2cW2dmj3ORc6b9yIk+JViNpaeweCc6aHWTR36mwkodMwMLnDEAyQ55VwLFs9QVFSgyW8kTKM5i1FsTKKEz1FuK2JWsb4qCtEhw2Z+3vOpgC1z6AxqbgXIBEDVPA7A5yzTTnQYANKerhI6TulTKVUPYyCkiEoSt7ORFIJriNMVOPK4SAtJ2C5fj9AayuoTqGsCzrdVM63KE2tBillME5XW1k1myb1dJG5rKz3KupHPR7Ue3oQGbtrQMAxUy4ZngmMBkLsDZ9KnG/gDaorNEbnsm5zu11iaD9xTpHLtk/IWrXqJsU/wce2MY6L0zTITu7j98wJB3loHOmk/KhAZoyRa5JQUYyhxEVuZPNFJ15G0UI92p5+ogi7s4+HAQY5RaOKGPIxMa5zWUOZCszIlocE+et8fJKX8H3BMZEjXYTLy7JN4rmLUvdDqwRKzWtxRJnglBXlKGTLImxH2cZ0E0rkw6y5WzuOkik+ZqYTvOOOSjF9JdkTJJblJDOGhsQ6aj7X98hfsDGmf4p3SppZ1WscCx62GP6NMhIY6MUtAATaRDb7JmXBAd8ozDprW/g3tPPS7NRQZUTTYhDmm5twUY0ITOmSLSFdrNmSYvAmrK28lmsnbsCNE0pWZMes+EWMXPRit9BAI8yjdjGZkEIgOWJrsEfdWUOGbyNZkrk0xzdfQYZ9cWMF15eoz1FpU4C9WVaSiwJykpsZmDDisIBYX8wEkNFOSgyI8xu1INJNY98ZIs+O75CngnDDIinROLdU7S/DF9PT5i+MlbE6AjdBK3WOvmVw7zgfGWKVAROU1brGmjkLNPQ6ML1b7slDQMkGlyDU06yNb2t5rK6FwHlFCx+rGs02p09ZNjxuf/AQ==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <g>
-            <rect x="220" y="720" width="120" height="440" fill="none" stroke="#000000" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="860" y="160" width="120" height="140" rx="18" ry="18" fill="none" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <path d="M 440 200 L 473.63 200" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 478.88 200 L 471.88 203.5 L 473.63 200 L 471.88 196.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="360" y="180" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all" style="fill: light-dark(rgb(141, 205, 250), rgb(24, 79, 118)); stroke: light-dark(rgb(86, 154, 205), rgb(65, 123, 167));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 361px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ededed); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Object
-                                </div>
+        <rect x="220" y="720" width="120" height="440" fill="none" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="860" y="160" width="120" height="140" rx="18" ry="18" fill="none" stroke="rgb(0, 0, 0)" stroke-dasharray="3 3" pointer-events="all"/>
+        <path d="M 440 200 L 473.63 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 478.88 200 L 471.88 203.5 L 473.63 200 L 471.88 196.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="360" y="180" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 361px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Object
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="400" y="204" fill="#000000" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Object
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="400" y="204" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Object
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 560 200 L 593.63 200" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 598.88 200 L 591.88 203.5 L 593.63 200 L 591.88 196.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="480" y="180" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all" style="fill: light-dark(rgb(141, 205, 250), rgb(24, 79, 118)); stroke: light-dark(rgb(86, 154, 205), rgb(65, 123, 167));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 481px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ededed); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Trigger
-                                </div>
+        <path d="M 560 200 L 593.63 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 598.88 200 L 591.88 203.5 L 593.63 200 L 591.88 196.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="480" y="180" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 481px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Trigger
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="520" y="204" fill="#000000" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Trigger
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="520" y="204" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Trigger
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 680 200 L 753.63 200" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 758.88 200 L 751.88 203.5 L 753.63 200 L 751.88 196.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="600" y="180" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all" style="fill: light-dark(rgb(141, 205, 250), rgb(24, 79, 118)); stroke: light-dark(rgb(86, 154, 205), rgb(65, 123, 167));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 601px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ededed); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Operation
-                                    <br/>
-                                </div>
+        <path d="M 680 200 L 753.63 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 758.88 200 L 751.88 203.5 L 753.63 200 L 751.88 196.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="600" y="180" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 601px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Operation
+                                <br/>
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="640" y="204" fill="#000000" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Operation
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="640" y="204" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Operation
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 320 200 L 353.63 200" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 358.88 200 L 351.88 203.5 L 353.63 200 L 351.88 196.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="240" y="180" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 241px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Feed
-                                </div>
+        <path d="M 320 200 L 353.63 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 358.88 200 L 351.88 203.5 L 353.63 200 L 351.88 196.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="240" y="180" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 241px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Feed
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="280" y="204" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Feed
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="280" y="204" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Feed
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 200 200 L 233.63 200" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 238.88 200 L 231.88 203.5 L 233.63 200 L 231.88 196.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="120" y="180" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 121px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Chat
-                                </div>
+        <path d="M 200 200 L 233.63 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 238.88 200 L 231.88 203.5 L 233.63 200 L 231.88 196.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="120" y="180" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 121px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Chat
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="160" y="204" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Chat
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="160" y="204" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Chat
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 200 280 L 220 280 L 220 200 L 240 200" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="120" y="260" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 280px; margin-left: 121px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Mailbox
-                                </div>
+        <path d="M 200 280 L 220 280 L 220 200 L 240 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="120" y="260" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 280px; margin-left: 121px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Mailbox
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="160" y="284" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Mailbox
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="160" y="284" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Mailbox
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 200 80 L 510 80 Q 520 80 520 90 L 520 180" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 524 180 L 520 172 L 516 180" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <path d="M 120 80 L 80 80" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <path d="M 160 60 L 160 20 L 80 20" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 80 24 L 88 20 L 80 16" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <path d="M 180 100 L 180 140 L 280 140 L 280 173.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 280 178.88 L 276.5 171.88 L 280 173.63 L 283.5 171.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <path d="M 160 100 L 160 173.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 160 178.88 L 156.5 171.88 L 160 173.63 L 163.5 171.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="120" y="60" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 80px; margin-left: 121px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Agent
-                                </div>
+        <path d="M 200 80 L 510 80 Q 520 80 520 90 L 520 180" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 524 180 L 520 172 L 516 180" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 120 80 L 80 80" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 160 60 L 160 20 L 80 20" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 80 24 L 88 20 L 80 16" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 180 100 L 180 140 L 280 140 L 280 173.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 280 178.88 L 276.5 171.88 L 280 173.63 L 283.5 171.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 160 100 L 160 173.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 160 178.88 L 156.5 171.88 L 160 173.63 L 163.5 171.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="120" y="60" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 80px; margin-left: 121px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Agent
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="160" y="84" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Agent
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="160" y="84" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Agent
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="0" y="60" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all" style="fill: light-dark(rgb(141, 205, 250), rgb(24, 79, 118)); stroke: light-dark(rgb(86, 154, 205), rgb(65, 123, 167));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 80px; margin-left: 1px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ededed); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Instructions
-                                </div>
+        <rect x="0" y="60" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 80px; margin-left: 1px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Instructions
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="40" y="84" fill="#000000" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Instructions
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="40" y="84" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Instructions
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="0" y="0" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all" style="fill: light-dark(rgb(141, 205, 250), rgb(24, 79, 118)); stroke: light-dark(rgb(86, 154, 205), rgb(65, 123, 167));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 20px; margin-left: 1px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ededed); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Blueprint
-                                </div>
+        <rect x="0" y="0" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 20px; margin-left: 1px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Skill
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="40" y="24" fill="#000000" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Blueprint
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="40" y="24" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Skill
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 920 220 L 920 240" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 924 240 L 920 232 L 916 240" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="880" y="180" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 881px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Session
-                                </div>
+        <path d="M 920 220 L 920 240" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 924 240 L 920 232 L 916 240" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="880" y="180" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 881px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Session
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="920" y="204" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Session
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="920" y="204" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Session
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="880" y="240" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 260px; margin-left: 881px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Request
-                                </div>
+        <rect x="880" y="240" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 260px; margin-left: 881px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Request
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="920" y="264" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Request
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="920" y="264" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Request
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 200 340 L 220 340 L 220 200 L 233.63 200" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 238.88 200 L 231.88 203.5 L 233.63 200 L 231.88 196.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="120" y="320" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 340px; margin-left: 121px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    RSS Feed
-                                </div>
+        <path d="M 200 340 L 220 340 L 220 200 L 233.63 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 238.88 200 L 231.88 203.5 L 233.63 200 L 231.88 196.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="120" y="320" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 340px; margin-left: 121px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                RSS Feed
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="160" y="344" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        RSS Feed
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="160" y="344" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    RSS Feed
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="880" y="0" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 20px; margin-left: 881px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Script
-                                </div>
+        <rect x="880" y="0" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 20px; margin-left: 881px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Script
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="920" y="24" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Script
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="920" y="24" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Script
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 760 200 L 873.63 200" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 878.88 200 L 871.88 203.5 L 873.63 200 L 871.88 196.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <path d="M 800 180 L 800 106.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 800 101.12 L 803.5 108.12 L 800 106.37 L 796.5 108.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="760" y="180" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 761px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Process
-                                    <br/>
-                                    Manager
-                                </div>
+        <path d="M 760 200 L 873.63 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 878.88 200 L 871.88 203.5 L 873.63 200 L 871.88 196.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 800 180 L 800 106.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 800 101.12 L 803.5 108.12 L 800 106.37 L 796.5 108.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="760" y="180" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 200px; margin-left: 761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Process
+                                <br/>
+                                Manager
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="800" y="204" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Process...
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="800" y="204" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Process...
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 200 480 L 233.63 480" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 238.88 480 L 231.88 483.5 L 233.63 480 L 231.88 476.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="120" y="460" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 480px; margin-left: 121px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Mailbox A
-                                </div>
+        <path d="M 200 480 L 233.63 480" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 238.88 480 L 231.88 483.5 L 233.63 480 L 231.88 476.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="120" y="460" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 480px; margin-left: 121px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Mailbox A
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="160" y="484" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Mailbox A
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="160" y="484" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Mailbox A
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 200 560 L 233.63 560" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 238.88 560 L 231.88 563.5 L 233.63 560 L 231.88 556.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="120" y="540" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 560px; margin-left: 121px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Mailbox B
-                                </div>
+        <path d="M 200 560 L 233.63 560" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 238.88 560 L 231.88 563.5 L 233.63 560 L 231.88 556.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="120" y="540" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 560px; margin-left: 121px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Mailbox B
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="160" y="564" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Mailbox B
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="160" y="564" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Mailbox B
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 320 480 L 353.63 480" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 358.88 480 L 351.88 483.5 L 353.63 480 L 351.88 476.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="240" y="460" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 480px; margin-left: 241px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Feed
-                                </div>
+        <path d="M 320 480 L 353.63 480" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 358.88 480 L 351.88 483.5 L 353.63 480 L 351.88 476.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="240" y="460" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 480px; margin-left: 241px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Feed
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="280" y="484" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Feed
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="280" y="484" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Feed
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 320 560 L 353.63 560" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 358.88 560 L 351.88 563.5 L 353.63 560 L 351.88 556.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="240" y="540" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 560px; margin-left: 241px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Feed
-                                </div>
+        <path d="M 320 560 L 353.63 560" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 358.88 560 L 351.88 563.5 L 353.63 560 L 351.88 556.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="240" y="540" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 560px; margin-left: 241px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Feed
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="280" y="564" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Feed
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="280" y="564" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Feed
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 560 480 L 593.63 480" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 598.88 480 L 591.88 483.5 L 593.63 480 L 591.88 476.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="480" y="460" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all" style="fill: light-dark(rgb(141, 205, 250), rgb(24, 79, 118)); stroke: light-dark(rgb(86, 154, 205), rgb(65, 123, 167));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 480px; margin-left: 481px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ededed); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Trigger
-                                </div>
+        <path d="M 560 480 L 593.63 480" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 598.88 480 L 591.88 483.5 L 593.63 480 L 591.88 476.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="480" y="460" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 480px; margin-left: 481px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Trigger
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="520" y="484" fill="#000000" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Trigger
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="520" y="484" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Trigger
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 560 560 L 593.63 560" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 598.88 560 L 591.88 563.5 L 593.63 560 L 591.88 556.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="480" y="540" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all" style="fill: light-dark(rgb(141, 205, 250), rgb(24, 79, 118)); stroke: light-dark(rgb(86, 154, 205), rgb(65, 123, 167));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 560px; margin-left: 481px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ededed); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Trigger
-                                </div>
+        <path d="M 560 560 L 593.63 560" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 598.88 560 L 591.88 563.5 L 593.63 560 L 591.88 556.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="480" y="540" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 560px; margin-left: 481px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Trigger
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="520" y="564" fill="#000000" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Trigger
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="520" y="564" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Trigger
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 680 480 L 700 480 L 700 520 L 753.63 520" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 758.88 520 L 751.88 523.5 L 753.63 520 L 751.88 516.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="600" y="460" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 480px; margin-left: 601px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Relay
-                                    <br/>
-                                    Function
-                                </div>
+        <path d="M 680 480 L 700 480 L 700 520 L 753.63 520" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 758.88 520 L 751.88 523.5 L 753.63 520 L 751.88 516.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="600" y="460" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 480px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Relay
+                                <br/>
+                                Function
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="640" y="484" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Relay...
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="640" y="484" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Relay...
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 680 560 L 700 560 L 700 520 L 753.63 520" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 758.88 520 L 751.88 523.5 L 753.63 520 L 751.88 516.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="600" y="540" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 560px; margin-left: 601px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Relay
-                                    <br/>
-                                    Function
-                                </div>
+        <path d="M 680 560 L 700 560 L 700 520 L 753.63 520" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 758.88 520 L 751.88 523.5 L 753.63 520 L 751.88 516.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="600" y="540" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 560px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Relay
+                                <br/>
+                                Function
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="640" y="564" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Relay...
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="640" y="564" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Relay...
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 840 520 L 873.63 520" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 878.88 520 L 871.88 523.5 L 873.63 520 L 871.88 516.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="760" y="500" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 520px; margin-left: 761px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Process
-                                    <br/>
-                                    Manager
-                                </div>
+        <path d="M 840 520 L 873.63 520" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 878.88 520 L 871.88 523.5 L 873.63 520 L 871.88 516.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="760" y="500" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 520px; margin-left: 761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Process
+                                <br/>
+                                Manager
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="800" y="524" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Process...
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="800" y="524" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Process...
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="860" y="480" width="120" height="140" rx="18" ry="18" fill="none" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <path d="M 920 540 L 920 560" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 924 560 L 920 552 L 916 560" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <path d="M 800 500 L 800 426.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 800 421.12 L 803.5 428.12 L 800 426.37 L 796.5 428.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="880" y="500" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 520px; margin-left: 881px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Session
-                                </div>
+        <rect x="860" y="480" width="120" height="140" rx="18" ry="18" fill="none" stroke="rgb(0, 0, 0)" stroke-dasharray="3 3" pointer-events="all"/>
+        <path d="M 920 540 L 920 560" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 924 560 L 920 552 L 916 560" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 800 500 L 800 426.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 800 421.12 L 803.5 428.12 L 800 426.37 L 796.5 428.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="880" y="500" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 520px; margin-left: 881px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Session
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="920" y="524" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Session
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="920" y="524" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Session
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="880" y="560" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 580px; margin-left: 881px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Request
-                                </div>
+        <rect x="880" y="560" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 580px; margin-left: 881px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Request
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="920" y="584" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Request
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="920" y="584" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Request
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 680 640 L 720 640 L 720 520 L 753.63 520" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 758.88 520 L 751.88 523.5 L 753.63 520 L 751.88 516.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="600" y="620" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 640px; margin-left: 601px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Client
-                                </div>
+        <path d="M 680 640 L 720 640 L 720 520 L 753.63 520" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 758.88 520 L 751.88 523.5 L 753.63 520 L 751.88 516.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="600" y="620" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 640px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Client
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="640" y="644" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Client
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="640" y="644" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Client
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="760" y="380" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 400px; margin-left: 761px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Agent
-                                </div>
+        <rect x="760" y="380" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 400px; margin-left: 761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Agent
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="800" y="404" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Agent
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="800" y="404" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Agent
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 800 60 L 800 20 L 873.63 20" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 878.88 20 L 871.88 23.5 L 873.63 20 L 871.88 16.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <path d="M 840 80 L 873.63 80" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 878.88 80 L 871.88 83.5 L 873.63 80 L 871.88 76.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="760" y="60" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 80px; margin-left: 761px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Function
-                                </div>
+        <path d="M 800 60 L 800 20 L 873.63 20" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 878.88 20 L 871.88 23.5 L 873.63 20 L 871.88 16.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 840 80 L 873.63 80" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 878.88 80 L 871.88 83.5 L 873.63 80 L 871.88 76.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="760" y="60" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 80px; margin-left: 761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Function
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="800" y="84" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Function
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="800" y="84" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Function
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 440 480 L 473.63 480" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 478.88 480 L 471.88 483.5 L 473.63 480 L 471.88 476.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="360" y="460" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all" style="fill: light-dark(rgb(141, 205, 250), rgb(24, 79, 118)); stroke: light-dark(rgb(86, 154, 205), rgb(65, 123, 167));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 480px; margin-left: 361px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ededed); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Message
-                                </div>
+        <path d="M 440 480 L 473.63 480" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 478.88 480 L 471.88 483.5 L 473.63 480 L 471.88 476.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="360" y="460" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 480px; margin-left: 361px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Message
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="400" y="484" fill="#000000" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Message
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="400" y="484" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Message
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 440 560 L 473.63 560" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 478.88 560 L 471.88 563.5 L 473.63 560 L 471.88 556.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="360" y="540" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all" style="fill: light-dark(rgb(141, 205, 250), rgb(24, 79, 118)); stroke: light-dark(rgb(86, 154, 205), rgb(65, 123, 167));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 560px; margin-left: 361px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ededed); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Message
-                                </div>
+        <path d="M 440 560 L 473.63 560" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 478.88 560 L 471.88 563.5 L 473.63 560 L 471.88 556.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="360" y="540" width="80" height="40" fill="#8dcdfa" stroke="#569acd" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 560px; margin-left: 361px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Message
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="400" y="564" fill="#000000" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Message
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="400" y="564" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Message
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="880" y="60" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 80px; margin-left: 881px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Prompt
-                                </div>
+        <rect x="880" y="60" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 80px; margin-left: 881px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Prompt
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="920" y="84" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Prompt
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="920" y="84" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Prompt
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 560 760 L 593.63 760" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 598.88 760 L 591.88 763.5 L 593.63 760 L 591.88 756.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="480" y="740" width="80" height="40" fill="#7cd7af" stroke="#4da677" pointer-events="all" style="fill: light-dark(rgb(124, 215, 175), rgb(12, 91, 56)); stroke: light-dark(rgb(77, 166, 119), rgb(56, 133, 92));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 760px; margin-left: 481px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ededed); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Routine
-                                </div>
+        <path d="M 560 760 L 593.63 760" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 598.88 760 L 591.88 763.5 L 593.63 760 L 591.88 756.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="480" y="740" width="80" height="40" fill="#7cd7af" stroke="#4da677" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 760px; margin-left: 481px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Routine
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="520" y="764" fill="#000000" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Routine
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="520" y="764" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Routine
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="600" y="740" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 760px; margin-left: 601px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    instructions
-                                    <br/>
-                                    (Template)
-                                </div>
+        <rect x="600" y="740" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 760px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                instructions
+                                <br/>
+                                (Template)
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="640" y="764" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        instructions...
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="640" y="764" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    instructions...
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="600" y="920" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 940px; margin-left: 601px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    blueprints
-                                </div>
+        <rect x="600" y="920" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 940px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                blueprints
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="640" y="944" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        blueprints
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="640" y="944" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    blueprints
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="600" y="800" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 820px; margin-left: 601px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    input
-                                    <br/>
-                                    (Schema)
-                                </div>
+        <rect x="600" y="800" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 820px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                input
+                                <br/>
+                                (Schema)
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="640" y="824" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        input...
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="640" y="824" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    input...
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="600" y="860" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 880px; margin-left: 601px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    output
-                                    <br/>
-                                    (Schema)
-                                </div>
+        <rect x="600" y="860" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 880px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                output
+                                <br/>
+                                (Schema)
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="640" y="884" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        output...
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="640" y="884" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    output...
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 200 760 L 233.63 760" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 238.88 760 L 231.88 763.5 L 233.63 760 L 231.88 756.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="120" y="740" width="80" height="40" fill="#7cd7af" stroke="#4da677" pointer-events="all" style="fill: light-dark(rgb(124, 215, 175), rgb(12, 91, 56)); stroke: light-dark(rgb(77, 166, 119), rgb(56, 133, 92));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 760px; margin-left: 121px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ededed); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Agent
-                                </div>
+        <path d="M 200 760 L 233.63 760" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 238.88 760 L 231.88 763.5 L 233.63 760 L 231.88 756.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="120" y="740" width="80" height="40" fill="#7cd7af" stroke="#4da677" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 760px; margin-left: 121px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Agent
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="160" y="764" fill="#000000" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Agent
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="160" y="764" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Agent
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="600" y="980" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 1000px; margin-left: 601px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    context
-                                </div>
+        <rect x="600" y="980" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 1000px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                context
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="640" y="1004" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        context
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="640" y="1004" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    context
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="240" y="740" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 760px; margin-left: 241px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    instructions
-                                    <br/>
-                                    (Text)
-                                </div>
+        <rect x="240" y="740" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 760px; margin-left: 241px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                instructions
+                                <br/>
+                                (Text)
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="280" y="764" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        instructions...
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="280" y="764" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    instructions...
+                </text>
+            </switch>
         </g>
-        <g>
-            <path d="M 320 820 L 353.63 820" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 358.88 820 L 351.88 823.5 L 353.63 820 L 351.88 816.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="240" y="800" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 820px; margin-left: 241px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Chat
-                                </div>
+        <path d="M 320 820 L 353.63 820" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 358.88 820 L 351.88 823.5 L 353.63 820 L 351.88 816.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="240" y="800" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 820px; margin-left: 241px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Chat
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="280" y="824" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Chat
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="280" y="824" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Chat
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="360" y="800" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 820px; margin-left: 361px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    Feed
-                                </div>
+        <rect x="360" y="800" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 820px; margin-left: 361px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Feed
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="400" y="824" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Feed
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="400" y="824" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Feed
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="240" y="860" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 880px; margin-left: 241px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    plan
-                                </div>
+        <rect x="240" y="860" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 880px; margin-left: 241px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                plan
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="280" y="884" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        plan
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="280" y="884" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    plan
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="240" y="920" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 940px; margin-left: 241px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    artifacts
-                                </div>
+        <rect x="240" y="920" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 940px; margin-left: 241px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                artifacts
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="280" y="944" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        artifacts
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="280" y="944" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    artifacts
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="240" y="980" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 1000px; margin-left: 241px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    subscriptions
-                                </div>
+        <rect x="240" y="980" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 1000px; margin-left: 241px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                subscriptions
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="280" y="1004" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        subscriptions
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="280" y="1004" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    subscriptions
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="240" y="1040" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 1060px; margin-left: 241px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    queue
-                                </div>
+        <rect x="240" y="1040" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 1060px; margin-left: 241px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                queue
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="280" y="1064" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        queue
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="280" y="1064" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    queue
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="240" y="1100" width="80" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 1120px; margin-left: 241px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    blueprints
-                                </div>
+        <rect x="240" y="1100" width="80" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 1120px; margin-left: 241px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                blueprints
                             </div>
                         </div>
-                    </foreignObject>
-                    <text x="280" y="1124" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        blueprints
-                    </text>
-                </switch>
-            </g>
+                    </div>
+                </foreignObject>
+                <text x="280" y="1124" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    blueprints
+                </text>
+            </switch>
         </g>
-        <g>
-            <rect x="580" y="720" width="120" height="320" fill="none" stroke="#000000" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
+        <rect x="580" y="720" width="120" height="320" fill="none" stroke="rgb(0, 0, 0)" pointer-events="all"/>
     </g>
     <switch>
         <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
-        <a transform="translate(0,-5)" xlink:href="https://www.drawio.com/doc/faq/svg-export-text-problems" target="_blank">
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
             <text text-anchor="middle" font-size="10px" x="50%" y="100%">
                 Text is not SVG - cannot display
             </text>

--- a/packages/core/compute/assistant/docs/project.drawio.svg
+++ b/packages/core/compute/assistant/docs/project.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="721px" height="337px" viewBox="-0.5 -0.5 721 337" content="&lt;mxfile&gt;&lt;diagram id=&quot;NXkKOAojmEnQiF92G5a8&quot; name=&quot;Page-1&quot;&gt;5Vrfd9ogFP5rfN0RMNE8dv7o9rCznvqw7ZEl1LBi8BCsur9+RMAkRm2aptg1PijcXBL4+PLdC9hD4+X2VuBV/I1HhPVgP9r20KQHoe8H6jsz7LQhGI20YSFopE0gN8zpX2KM0FjXNCJpyVFyziRdlY0hTxISypINC8E3ZbcHzspPXeEFqRjmIWZV6w8ayVhbR14/t38hdBHbJ4O+ubLE1tkY0hhHfFMwoWkPjQXnUpeW2zFhGXYWF91udubqoWOCJLJOA890Q+7s2EikhmqqCU/Uz+dYLpmqAVUkWyp/qnL/k2dqvwpXJtkE921lZytJdJOBrqrT+yVOdto2o4wZjweeyBleUpY1ma9wSFSfbgWXJH1Ul3Ufs46dHaUxpXwtQuNluCKxWBDjNTggrJhJ+JJIsVMugjAs6VP57thwZHHwy2FUBYPkaVQPs1sX1mcASNUgpMXQtN7bChg+j3JrMILAFY6wFXr2L9KzXexDhtOUhiXwQZvgazcX4OtbPGG2Nje9E/xPJqfHcyL4OolIZMDYxFQSjSOabJT+H1FdYTLmjIt9W4SgD5X662ko2Gf7zx5rwR9J4QoI0MS7qasaT0RIsr2MeRVM2yAwIOyO6ptc9QNfm+KC4A9Gr4d/1JD6oEj8w2vwrDKbG5YVo8R9rphwxP0a0tUa75Ej2qMK7b8mioPrUFKepN3hPkL+1bg/bCz7w/q6X0O034Tbg/a5vW+qBoN3BYcVp4lMC3e+ywz5BEN/UJpgW5+d8Ueji/6qoHuQz/BhKLUmPWgl1l9ORVsK5q544TvSPND0hXtJsHnPedYJ7IHnCPxBJeCMY9zhJAvazQAHgcavYH/HcNJd7A8a7wB74CLDfc+iA/pV1XG1Q2GfXWD+zSLrbGeobyl8BdUBqOvMt5u2xXgLXVF/0DTR/MDou1pdA78p+C/I8v838F+dajZa/3nD8gIfmdOVttZzdqTFEEPnRGHJ282w1Bs9QcMXhZkpmMHaBw+vCjMeLMcZl9sosLHSfZDtc3teWNo/dyZ18AT/xwotsm03zXrX/PeH5RWGS/4DrzIDM6JA7kyOe7yH6zTJDSrg3/O1pEoBOoP/4Ira3/Rk/3prjHaPrU/kWc6kH1ZTH0VARvZnSN2h//HukuW6C/pXj/G+/+7W4fVx5H079FU1/8eSXinkf/tC038=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="721px" height="337px" viewBox="-0.5 -0.5 721 337" content="&lt;mxfile&gt;&lt;diagram id=&quot;NXkKOAojmEnQiF92G5a8&quot; name=&quot;Page-1&quot;&gt;5Vpdd5sgGP41ud0RiUYvu3x0u9hZT3Ox7ZIpjbREcpA0cb9+GCF+pak1lnSzF6m8vig8PDzvCziC0/X+lqNN9I2FmI5sK9yP4Gxk257nyt/MkOYG3/Nyw4qTMDeBwrAkf7Ay2sq6JSFOKo6CMSrIpmoMWBzjQFRsiHO2q7o9MFp96watcMOwDBBtWn+QUESqW45V2L9gsor0m4Gl7qyRdlaGJEIh25VMcD6CU86YyK/W+ymmGXYal7ze4oW7x4ZxHIs2FRzVDJHqvuFQdlUVYxbLf58jsaayBOQl3hPxU15bnxxV+lW6M8sG2NKFVBfi8CYDXRbn92sUp7ltQShVHg8sFgu0JjSrstygAMs23XImcPIkb+dtzBr2Yi+VKWFbHigvxRWB+Aorr/ERYclMzNZY8FS6cEyRIM/VpyPFkdXRr4BRXigkT6N6HN22sL4CQCI7ITSGqvbBVsLwdZR7gxH4pnC0e6GndZae/WIfUJQkJKiAD/oEP3czAX7+iGdEt+qhd5w9ZnJaHxPOtnGIQwXGLiIC5zjC2U7qf43qEpMpo4wf6kJouzIeqGEo2ReHvwPWnD3h0h3gw5lz01Y1njEXeH8e8yaYuoKvQEhr5V2h+r6KZVFJ8Mfe5fB7HakPysQ/ToNXlVk9sKoYFe4zyYQa91tIV2+8h4ZoDxu0/xpLDm4DQVicDIf7ELpX4/6ks+xP2ut+C9F+F26P++f2oarsDEpLDhtGYpGUnnyXGYoBtt1xZYB1efGCP/TO+suLvAXFCB+70mrQ/V5i/flUtKdgbooXriHNA10n3FuCzUfOs05gDxxD4I8bAWcaoQEnWbbeDDAQaNwG9ncUxcPF/qjxBrAHJjLcjyw6wGqqjqkdCv3uEvNvVlljB0N9TeErqA6AQ2e+3rQtx1vbFPXHXRPN/xh9U6tr4HYF/w1Z/r8G/sWpZqf1nzOpLvChOl3paz2ne1oOMWSJJZas3wxLzugZnLwpzMzBwm598HBRmHHsapwxuY1ywT7KtSZbr0cX+riwsn1uak3deQP3emcX7w++sTBjn9CeqQQL7/tNcT+09riT6urOpPYApzECCyxBHsz6or5/bnSB4TfAv2dbQaQADAb/8RXjbtevKq63vuv3k4ETOa4x6bebaackIMWH87vh0L++s6e5boL+zSPU77+H9eFAPfKaRL+5p718ymb0YMF/x8gri8W3evkaufjgEc7/Ag==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <path d="M 192 144 L 192 192" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
@@ -125,8 +125,10 @@
                 </text>
             </switch>
         </g>
-        <path d="M 672 96 L 672 54.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 672 49.12 L 675.5 56.12 L 672 54.37 L 668.5 56.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 672 144 L 672 192" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 676 192 L 672 184 L 668 192" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 672 96 L 672 48" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 668 48 L 672 56 L 676 48" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <rect x="624" y="96" width="96" height="48" fill="#214d37" stroke="#1e1f20" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
@@ -211,6 +213,23 @@
                 </foreignObject>
                 <text x="672" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
                     Object
+                </text>
+            </switch>
+        </g>
+        <rect x="624" y="192" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 216px; margin-left: 625px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Skill
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="672" y="220" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Skill
                 </text>
             </switch>
         </g>

--- a/packages/core/compute/assistant/docs/project.drawio.svg
+++ b/packages/core/compute/assistant/docs/project.drawio.svg
@@ -1,10 +1,12 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="721px" height="337px" viewBox="-0.5 -0.5 721 337" content="&lt;mxfile&gt;&lt;diagram id=&quot;NXkKOAojmEnQiF92G5a8&quot; name=&quot;Page-1&quot;&gt;5Vnfd5sgFP5r8rojEk187JLY7WHn9DQP2x45SiOrSg6SJu6vHwZQiU2bH450sw8pfFwQvvt5L+AIzrLdPUPr5BuNcTpynXg3gvOR6/o+FL8VUEogmE4lsGIklhBogCX5jRXoKnRDYlwYhpzSlJO1CUY0z3HEDQwxRrem2RNNzaeu0Qp3gGWE0i76ncQ8kejUcxr8CyarRD8ZOKolQ9pYAUWCYrptQXAxgjNGKZelbDfDacWd5kX2C4+01hNjOOendPDUNHip14ZjsVRVzWku/n1OeJaKGhBFvCP8hyg7nzxV+9lqmVcOdnSl1JU8vqtIF9XFY4byUmIhSVNl8URzHqKMpFWX5RpFWMzpnlGOi2fRLOdYTezoKhVU0A2LlJXSCkdshZXVuGZYKBPTDHNWChOGU8TJizk6UhpZ1XYNjaKgmHyd1dq719HqvEnrO6QVYuFc866euMdavL/vmd6oB4Et7uUQLyjdqEEfGP1VRYFDlzC6yWMcq5VuE8KxpBHOtyJsmR56EpzMaErZvi+Eru+KoCW90MLD/d+eakafcasFBHDu3Z0q9hfMON69zXmXTN0hUCSUB/VtE6wCX0JJK06Np9fTP71Q+aCt+/oteDegqAFN0RrSp0IJB9IHFkMOtCR72JH911xocBNxQvNiONqH0L+Z9icXR/3J6WG/Jf4oRUVBIkP/f03b4/61ve8qFoPKlsGakpwXrZEfKqBxsOuPDQfrenjEHk7ftBcFOYPGw/VSTnJ6YGEHdWYuv7UufEsxD1z6wp2TbPrdZh1zTW/cA88S+eNOwpklaMCbLFefYS0kGr/D/UOK8uFyX8d4C9wDGzvcjxx0gNONOrYO1vrZLeXfrarJDkb6WsI3iDoADl35+q6xnW9dW9IfX7rR/I/Zt3W6Bv6l5J+xy//XyL96q3nR+c+bmAd8qD4K9HWe0yttpxiyxIJL2u8OS7zRczg5K80sQOiefF9+VZrxXDPP2LxG0V95DA/MxJLxrt9E/6E94E9ud4kLvI4HQixIHswu6/AW0eo2K+iQ/0g3nIiAPxj+Dw94muv+6RfV5murTBfNJ2u4+AM=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="721px" height="337px" viewBox="-0.5 -0.5 721 337" content="&lt;mxfile&gt;&lt;diagram id=&quot;NXkKOAojmEnQiF92G5a8&quot; name=&quot;Page-1&quot;&gt;5Vrfd9ogFP5rfN0RMNE8dv7o9rCznvqw7ZEl1LBi8BCsur9+RMAkRm2aptg1PijcXBL4+PLdC9hD4+X2VuBV/I1HhPVgP9r20KQHoe8H6jsz7LQhGI20YSFopE0gN8zpX2KM0FjXNCJpyVFyziRdlY0hTxISypINC8E3ZbcHzspPXeEFqRjmIWZV6w8ayVhbR14/t38hdBHbJ4O+ubLE1tkY0hhHfFMwoWkPjQXnUpeW2zFhGXYWF91udubqoWOCJLJOA890Q+7s2EikhmqqCU/Uz+dYLpmqAVUkWyp/qnL/k2dqvwpXJtkE921lZytJdJOBrqrT+yVOdto2o4wZjweeyBleUpY1ma9wSFSfbgWXJH1Ul3Ufs46dHaUxpXwtQuNluCKxWBDjNTggrJhJ+JJIsVMugjAs6VP57thwZHHwy2FUBYPkaVQPs1sX1mcASNUgpMXQtN7bChg+j3JrMILAFY6wFXr2L9KzXexDhtOUhiXwQZvgazcX4OtbPGG2Nje9E/xPJqfHcyL4OolIZMDYxFQSjSOabJT+H1FdYTLmjIt9W4SgD5X662ko2Gf7zx5rwR9J4QoI0MS7qasaT0RIsr2MeRVM2yAwIOyO6ptc9QNfm+KC4A9Gr4d/1JD6oEj8w2vwrDKbG5YVo8R9rphwxP0a0tUa75Ej2qMK7b8mioPrUFKepN3hPkL+1bg/bCz7w/q6X0O034Tbg/a5vW+qBoN3BYcVp4lMC3e+ywz5BEN/UJpgW5+d8Ueji/6qoHuQz/BhKLUmPWgl1l9ORVsK5q544TvSPND0hXtJsHnPedYJ7IHnCPxBJeCMY9zhJAvazQAHgcavYH/HcNJd7A8a7wB74CLDfc+iA/pV1XG1Q2GfXWD+zSLrbGeobyl8BdUBqOvMt5u2xXgLXVF/0DTR/MDou1pdA78p+C/I8v838F+dajZa/3nD8gIfmdOVttZzdqTFEEPnRGHJ282w1Bs9QcMXhZkpmMHaBw+vCjMeLMcZl9sosLHSfZDtc3teWNo/dyZ18AT/xwotsm03zXrX/PeH5RWGS/4DrzIDM6JA7kyOe7yH6zTJDSrg3/O1pEoBOoP/4Ira3/Rk/3prjHaPrU/kWc6kH1ZTH0VARvZnSN2h//HukuW6C/pXj/G+/+7W4fVx5H079FU1/8eSXinkf/tC038=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <path d="M 192 144 L 192 192" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 196 192 L 192 184 L 188 192" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 192 96 L 192 48" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 188 48 L 192 56 L 196 48" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 144 120 L 96 120" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 96 124 L 104 120 L 96 116" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 192 96 L 192 54.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 192 49.12 L 195.5 56.12 L 192 54.37 L 188.5 56.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <rect x="144" y="96" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
@@ -123,6 +125,8 @@
                 </text>
             </switch>
         </g>
+        <path d="M 672 96 L 672 54.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 672 49.12 L 675.5 56.12 L 672 54.37 L 668.5 56.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <rect x="624" y="96" width="96" height="48" fill="#214d37" stroke="#1e1f20" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
@@ -157,11 +161,11 @@
                 </text>
             </switch>
         </g>
-        <rect x="144" y="0" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <rect x="0" y="96" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 145px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 120px; margin-left: 1px;">
                         <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Routine
@@ -169,8 +173,44 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="192" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                <text x="48" y="124" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
                     Routine
+                </text>
+            </switch>
+        </g>
+        <path d="M 240 24 L 624 24" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 624 20 L 616 24 L 624 28" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="144" y="0" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 145px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Collection
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="192" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Collection
+                </text>
+            </switch>
+        </g>
+        <rect x="624" y="0" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 625px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Object
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="672" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Object
                 </text>
             </switch>
         </g>

--- a/packages/core/compute/assistant/docs/project.drawio.svg
+++ b/packages/core/compute/assistant/docs/project.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="721px" height="241px" viewBox="-0.5 -0.5 721 241" content="&lt;mxfile&gt;&lt;diagram id=&quot;NXkKOAojmEnQiF92G5a8&quot; name=&quot;Page-1&quot;&gt;5VlNc9sgEP01vnaEsBT7mPqj7aEzmfrQ9shIxKJB4EE4tvrru4rAAqtJnEQhae2DLR7L19vHssIjPCv3nxTZFF9lTvkojvL9CM9HcTyNMHw3QG2AyaQF1orlLYQ6YMV+UwPGBt2ynFaeoZaSa7bxwUwKQTPtYUQpufPNriX3R92QNe0Bq4zwPvqd5bpo0UkSdfhnytaFHRlFpqYk1tgAVUFyuXMgvBjhmZJSt0/lfkZ5w53lpW23vKf2MDFFhT6lQWKmoWu7NprDUk1RSAE/HwtdcigheKR7pn/Ac/QhMaWfTs28cXBkC7UtiPyyIR2Ki28lEXWLLRnnxuJaCr0kJeNNk9WGZBTm9ElJTasbqG7n2Ezs3lUaqJJblRkroxVN1Joaq/GBYVAmlSXVqgYTRTnR7NbvnRiNrA92HY3wYJj8O6tm6FvCt6bTKyV/NUo8ZlvJrchpbnjYFUzTdv14voOt45N/DYzNJJfqri3GcRrDxmnpc/Dl3QfwSit5Q50aNMXz5PJUwm+p0nT/MOV9Mm2DqSGhPirvug0zTVuocPbKePJy+ifPFDVyJN0J/FFRmw59SVegO20tJCjBYsYGBZQ9DiR73JP9FwEa3GaaSVGdj/YxTt9M+xeDaD8+WfwZJ1XFMk//r6bt8fDavmsKiyG1Y7CRTOjK6fmqARwHT8aeg3EUHfmo7bHz2GFqJzlxGuBU9gKU6dINUO/Mz2mgGIaG2UAP759HSBvINYNxj5JA5I97B8isIGecNMX2vSjAwZH2uL/iRJwv94cYH4B7FCJjfc9BB0X9qBPqZc2O7Sj/ct1M9mykbyX8BlEH4XNXvr2/cs/bOJT0x89NNP9j9kO9LaP0ueQ/Icv/18gPlmrawd2oz1YUlieHTXpgk83xxZMi/wIt45OvRV8U+ZPYD/0hbyrsZb7ngRksme6HPXvftQfSi7e7J0VJzwNLCiSfTeJzLP9XzHyg2P2r014JdX+N4cUf&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="721px" height="241px" viewBox="-0.5 -0.5 721 241" content="&lt;mxfile&gt;&lt;diagram id=&quot;NXkKOAojmEnQiF92G5a8&quot; name=&quot;Page-1&quot;&gt;5Vldk9ogFP01vnZCMFEft2q2feiMUx/aPjIJa+gScAiupr++NxswsNkP13XjtvoiHC5fh8O9QAZ4WuyuFVnn32RG+SAMst0AzwZhiMJgAn81UhkkCHGDrBTLDNYCS/aH2qoG3bCMlp6hlpJrtvbBVApBU+1hRCm59c1uJPd7XZMV7QDLlPAu+oNlOm/QcRS0+BfKVrntGQWmpCDW2ABlTjK5dSA8H+CpklI3qWI3pbxmz/LS1EueKN0PTFGhD6kQmWHoys6NZjBVkxVSwN/nXBcccgiSdMf0T0gHnyKT++WUzOolDmymshmRXdWkQ3b+vSCiarCEcW4sbqTQCSkYr6ss1ySlMKZrJTUtb6G4GWM9sCdnaaBSblRqrIxWNFEraqyGe4ZBm1QWVKsKTBTlRLM7v3ViNLLa27U0QsIw+Tirpus7wjem0YWSv2slPmRbyY3IaGZ42OZM02b+eLaFzeOTfwOMTSWX6r4uxmEcjseGPgdP7n+Al1rJW+qUoAmeRVeHEn5Hlaa75ynvkmkrTAwJ1YP8tt0wk7iBcmevDMdvp398pKiRI+lW4C+K2jToS7oE3WlrIUEJFjM2qEfZ455kjzuy/ypAg5tUMynKy9E+xvHZtD862qGPXI8eHCr+lJOyZKmn/3fT9vD02r6vCpMhlWOwlkzo0ml5UQPtAofx0Ftgm0+esMfjZ+0h0YygXeH9VA5a9EkPUdxzaKZJ16F9MF3EPfk8dOyGe02weYG0Ey3NybhHUU/kDzsBZ5qTCz5k1SPtK9DEHe4XnIjL5X7v43vgHvVxwv3ITgcFXa/T1+XO9u0o/2pVD/ZipG8lfAavg/ClK9++d7nxNuxL+sNjD5r/Mft93a5RfCz5rzjl/2vkv/moedT9Lxr5F3xsHqZPdZ+zM3VDDFtS4FKe9oQFO3qGR68KM3OUhAe/2b4pzEShH2f6fEaxXxq8FZjClOnutIH+Q69APDrfIy6KOiuQUCD5Yk5ZD18R3/GYBdn2k1Pjr9ovd3j+Fw==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <path d="M 192 48 L 192 96" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
@@ -39,12 +39,12 @@
                 </text>
             </switch>
         </g>
-        <path d="M 240 108 L 326 108 Q 336 108 336 98 L 336 54.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 216 96 L 216 82 Q 216 72 226 72 L 326 72 Q 336 72 336 63.18 L 336 54.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 336 49.12 L 339.5 56.12 L 336 54.37 L 332.5 56.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <path d="M 192 144 L 192 185.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 192 190.88 L 188.5 183.88 L 192 185.63 L 195.5 183.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 240 120 L 473.63 120" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 478.88 120 L 471.88 123.5 L 473.63 120 L 471.88 116.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 240 120 L 281.63 120" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 286.88 120 L 279.88 123.5 L 281.63 120 L 279.88 116.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <rect x="144" y="96" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
@@ -102,8 +102,8 @@
         <path d="M 622.88 24 L 615.88 27.5 L 617.63 24 L 615.88 20.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <path d="M 480 24 L 390.37 24" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 385.12 24 L 392.12 20.5 L 390.37 24 L 392.12 27.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 528 48 L 528 89.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 528 94.88 L 524.5 87.88 L 528 89.63 L 531.5 87.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 528 48 L 528 110 Q 528 120 518 120 L 390.37 120" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 385.12 120 L 392.12 116.5 L 390.37 120 L 392.12 123.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <rect x="480" y="0" width="96" height="48" fill="#214d37" stroke="#1e1f20" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
@@ -138,11 +138,11 @@
                 </text>
             </switch>
         </g>
-        <rect x="480" y="96" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <rect x="288" y="96" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 120px; margin-left: 481px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 120px; margin-left: 289px;">
                         <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Feed
@@ -150,7 +150,7 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="528" y="124" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                <text x="336" y="124" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
                     Feed
                 </text>
             </switch>

--- a/packages/core/compute/assistant/docs/project.drawio.svg
+++ b/packages/core/compute/assistant/docs/project.drawio.svg
@@ -1,0 +1,167 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="721px" height="241px" viewBox="-0.5 -0.5 721 241" content="&lt;mxfile&gt;&lt;diagram id=&quot;NXkKOAojmEnQiF92G5a8&quot; name=&quot;Page-1&quot;&gt;5VlNc9sgEP01vnaEsBT7mPqj7aEzmfrQ9shIxKJB4EE4tvrru4rAAqtJnEQhae2DLR7L19vHssIjPCv3nxTZFF9lTvkojvL9CM9HcTyNMHw3QG2AyaQF1orlLYQ6YMV+UwPGBt2ynFaeoZaSa7bxwUwKQTPtYUQpufPNriX3R92QNe0Bq4zwPvqd5bpo0UkSdfhnytaFHRlFpqYk1tgAVUFyuXMgvBjhmZJSt0/lfkZ5w53lpW23vKf2MDFFhT6lQWKmoWu7NprDUk1RSAE/HwtdcigheKR7pn/Ac/QhMaWfTs28cXBkC7UtiPyyIR2Ki28lEXWLLRnnxuJaCr0kJeNNk9WGZBTm9ElJTasbqG7n2Ezs3lUaqJJblRkroxVN1Joaq/GBYVAmlSXVqgYTRTnR7NbvnRiNrA92HY3wYJj8O6tm6FvCt6bTKyV/NUo8ZlvJrchpbnjYFUzTdv14voOt45N/DYzNJJfqri3GcRrDxmnpc/Dl3QfwSit5Q50aNMXz5PJUwm+p0nT/MOV9Mm2DqSGhPirvug0zTVuocPbKePJy+ifPFDVyJN0J/FFRmw59SVegO20tJCjBYsYGBZQ9DiR73JP9FwEa3GaaSVGdj/YxTt9M+xeDaD8+WfwZJ1XFMk//r6bt8fDavmsKiyG1Y7CRTOjK6fmqARwHT8aeg3EUHfmo7bHz2GFqJzlxGuBU9gKU6dINUO/Mz2mgGIaG2UAP759HSBvINYNxj5JA5I97B8isIGecNMX2vSjAwZH2uL/iRJwv94cYH4B7FCJjfc9BB0X9qBPqZc2O7Sj/ct1M9mykbyX8BlEH4XNXvr2/cs/bOJT0x89NNP9j9kO9LaP0ueQ/Icv/18gPlmrawd2oz1YUlieHTXpgk83xxZMi/wIt45OvRV8U+ZPYD/0hbyrsZb7ngRksme6HPXvftQfSi7e7J0VJzwNLCiSfTeJzLP9XzHyg2P2r014JdX+N4cUf&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 192 48 L 192 96" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 196 96 L 192 88 L 188 96" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="144" y="0" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 145px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Project
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="192" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Project
+                </text>
+            </switch>
+        </g>
+        <path d="M 243 24 L 288 24" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <ellipse cx="240" cy="24" rx="3" ry="3" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="288" y="0" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 289px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Instructions
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="336" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Instructions
+                </text>
+            </switch>
+        </g>
+        <path d="M 240 108 L 326 108 Q 336 108 336 98 L 336 54.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 336 49.12 L 339.5 56.12 L 336 54.37 L 332.5 56.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 192 144 L 192 185.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 192 190.88 L 188.5 183.88 L 192 185.63 L 195.5 183.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 240 120 L 473.63 120" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 478.88 120 L 471.88 123.5 L 473.63 120 L 471.88 116.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="144" y="96" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 120px; margin-left: 145px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Chat
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="192" y="124" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Chat
+                </text>
+            </switch>
+        </g>
+        <rect x="144" y="192" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 216px; margin-left: 145px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Plan
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="192" y="220" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Plan
+                </text>
+            </switch>
+        </g>
+        <path d="M 96 120 L 137.63 120" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 142.88 120 L 135.88 123.5 L 137.63 120 L 135.88 116.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="0" y="96" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 120px; margin-left: 1px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Agent
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="48" y="124" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Agent
+                </text>
+            </switch>
+        </g>
+        <path d="M 576 24 L 617.63 24" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 622.88 24 L 615.88 27.5 L 617.63 24 L 615.88 20.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 480 24 L 390.37 24" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 385.12 24 L 392.12 20.5 L 390.37 24 L 392.12 27.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 528 48 L 528 89.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 528 94.88 L 524.5 87.88 L 528 89.63 L 531.5 87.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="480" y="0" width="96" height="48" fill="#214d37" stroke="#1e1f20" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 481px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                AiSession
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="528" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    AiSession
+                </text>
+            </switch>
+        </g>
+        <rect x="624" y="0" width="96" height="48" fill="#214d37" stroke="#1e1f20" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 625px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                AiContext
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="672" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    AiContext
+                </text>
+            </switch>
+        </g>
+        <rect x="480" y="96" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 120px; margin-left: 481px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Feed
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="528" y="124" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Feed
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/packages/core/compute/assistant/docs/project.drawio.svg
+++ b/packages/core/compute/assistant/docs/project.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="721px" height="337px" viewBox="-0.5 -0.5 721 337" content="&lt;mxfile&gt;&lt;diagram id=&quot;NXkKOAojmEnQiF92G5a8&quot; name=&quot;Page-1&quot;&gt;5Vpdd5sgGP41ud0RiUYvu3x0u9hZT3Ox7ZIpjbREcpA0cb9+GCF+pak1lnSzF6m8vig8PDzvCziC0/X+lqNN9I2FmI5sK9yP4Gxk257nyt/MkOYG3/Nyw4qTMDeBwrAkf7Ay2sq6JSFOKo6CMSrIpmoMWBzjQFRsiHO2q7o9MFp96watcMOwDBBtWn+QUESqW45V2L9gsor0m4Gl7qyRdlaGJEIh25VMcD6CU86YyK/W+ymmGXYal7ze4oW7x4ZxHIs2FRzVDJHqvuFQdlUVYxbLf58jsaayBOQl3hPxU15bnxxV+lW6M8sG2NKFVBfi8CYDXRbn92sUp7ltQShVHg8sFgu0JjSrstygAMs23XImcPIkb+dtzBr2Yi+VKWFbHigvxRWB+Aorr/ERYclMzNZY8FS6cEyRIM/VpyPFkdXRr4BRXigkT6N6HN22sL4CQCI7ITSGqvbBVsLwdZR7gxH4pnC0e6GndZae/WIfUJQkJKiAD/oEP3czAX7+iGdEt+qhd5w9ZnJaHxPOtnGIQwXGLiIC5zjC2U7qf43qEpMpo4wf6kJouzIeqGEo2ReHvwPWnD3h0h3gw5lz01Y1njEXeH8e8yaYuoKvQEhr5V2h+r6KZVFJ8Mfe5fB7HakPysQ/ToNXlVk9sKoYFe4zyYQa91tIV2+8h4ZoDxu0/xpLDm4DQVicDIf7ELpX4/6ks+xP2ut+C9F+F26P++f2oarsDEpLDhtGYpGUnnyXGYoBtt1xZYB1efGCP/TO+suLvAXFCB+70mrQ/V5i/flUtKdgbooXriHNA10n3FuCzUfOs05gDxxD4I8bAWcaoQEnWbbeDDAQaNwG9ncUxcPF/qjxBrAHJjLcjyw6wGqqjqkdCv3uEvNvVlljB0N9TeErqA6AQ2e+3rQtx1vbFPXHXRPN/xh9U6tr4HYF/w1Z/r8G/sWpZqf1nzOpLvChOl3paz2ne1oOMWSJJZas3wxLzugZnLwpzMzBwm598HBRmHHsapwxuY1ywT7KtSZbr0cX+riwsn1uak3deQP3emcX7w++sTBjn9CeqQQL7/tNcT+09riT6urOpPYApzECCyxBHsz6or5/bnSB4TfAv2dbQaQADAb/8RXjbtevKq63vuv3k4ETOa4x6bebaackIMWH87vh0L++s6e5boL+zSPU77+H9eFAPfKaRL+5p718ymb0YMF/x8gri8W3evkaufjgEc7/Ag==&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="865px" height="337px" viewBox="-0.5 -0.5 865 337" content="&lt;mxfile&gt;&lt;diagram id=&quot;NXkKOAojmEnQiF92G5a8&quot; name=&quot;Page-1&quot;&gt;5VpLc9sgEP41nmkvHSEsWT4mfqQ9dJqJD22PRCIWDRYehGOrv77IQm/HkWUFO1UODqwWBN9+7C6gAZysdnccrf3vzMN0YBrebgCnA9McQ0v+xoIoEQDDhIlkyYmnZLlgQf5iJTSVdEM8HJYUBWNUkHVZ6LIgwK4oyRDnbFtWe2K0/NY1Wqo3Grlg4SKKa2o/iSf8ROpYBe2vmCz99M3AUE9WKFVWgtBHHtsWRHA2gBPOmEhKq90E0xi8FJek3fyVp9nAOA5EkwbKEqGI0rlhT05VVQMWyH+3vlhRWQOyiHdE/JJl44ular8LT6axhY20EqWVwLuJQZfV2cMKBVEimxNKlcYTC8QcrQiNmyzWyMVyTHecCRw+y8fJGOOBvTpLJQrZhrtKS3FFIL7ESmuYISypidkKCx5JFY4pEuSl3DtSHFlmejmMsqCQPIxqZt2msL4BQCgnIVIMVeu9rIDh2yh3BiMY68LR7ISexlF6dou9S1EYErcEPugS/ERNB/hJFy+IblSn95z9id1p1SacbQIPewqMrU8ETnCE060MABWqS0wmjDK+bwuhaZuOo8xQkM/3f3usOXvGhSdgDKfWTVOv8YK5wLvjmNfBTBuMFQhRpb7Nvf7YTkR+weEPnfPhd1pSHxSJny2DNz2z6rDsMUrcZ5IJFe43cF2d8R5qoj2s0f5bIDm4cQVhQdgf7kNoX4z7o9Zuf9Tc7zdw2u/C7WH33N43lZNBUUFhzUggwkLP97EgN7BpD0sGTuvzV/Shc1RfFpIR5BbOptLI6ONOYv3xVLSjYK6LF7YmnwfaLrhTgs0151kHsAeWJvCHtYAz8ZFcdzaVI7l95LK0jEufFljOmAWf+xODqvlXPFJdMciumeWeoqC/2GfuXwP2QEfye83+CBh1h6Tr8CJ9d4H5N8t4sL2hfkrhC3gdAPvO/PQ8txiKTV3UH7bNQf9j9HVtvIHdFvwTNgAfDfyzs9BWW0NrVN77Q3Xx0tVWL51pMcQQld52Gmbkip7C0UlhZgbmZuM7ibPCjGWW44zOE5aTj1iu+IYivRUsnZKfu3VutW6c6pGK8mldrZvWh8KXuw95f0vrik9aDqjk7HmU5XNxpZBSxNW82b72IeLaAatdJq6N0ovZ94pr5oG4NpGmwbtut09XHdfsUfnkQGdcA1bNAnMsQe7N3rV6baN18zqugf/ANoJId9Mb/IcXzOnafsxzubODbr9UObB/0pcd1Lc0koAU76+N+0P/6qlxynUd9K/f3P947Nf3KtXIqxP9+n3J4jle0b0B3wG2JvBlNf9CNElT8+9s4ewf&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <path d="M 192 144 L 192 192" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
@@ -57,12 +57,14 @@
                         <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Chat
+                                <br/>
+                                (Session)
                             </div>
                         </div>
                     </div>
                 </foreignObject>
                 <text x="192" y="220" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
-                    Chat
+                    Chat...
                 </text>
             </switch>
         </g>
@@ -125,10 +127,12 @@
                 </text>
             </switch>
         </g>
-        <path d="M 672 144 L 672 192" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 676 192 L 672 184 L 668 192" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 720 120 L 806 120 Q 816 120 816 110 L 816 48" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 812 48 L 816 56 L 820 48" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <path d="M 672 96 L 672 48" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 668 48 L 672 56 L 676 48" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 672 144 L 672 206 Q 672 216 662 216 L 390.37 216" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 385.12 216 L 392.12 212.5 L 390.37 216 L 392.12 219.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <rect x="624" y="96" width="96" height="48" fill="#214d37" stroke="#1e1f20" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
@@ -216,11 +220,11 @@
                 </text>
             </switch>
         </g>
-        <rect x="624" y="192" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <rect x="768" y="0" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 216px; margin-left: 625px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 769px;">
                         <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Skill
@@ -228,7 +232,7 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="672" y="220" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                <text x="816" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
                     Skill
                 </text>
             </switch>

--- a/packages/core/compute/assistant/docs/project.drawio.svg
+++ b/packages/core/compute/assistant/docs/project.drawio.svg
@@ -1,50 +1,10 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="721px" height="241px" viewBox="-0.5 -0.5 721 241" content="&lt;mxfile&gt;&lt;diagram id=&quot;NXkKOAojmEnQiF92G5a8&quot; name=&quot;Page-1&quot;&gt;5Vldk9ogFP01vnZCMFEft2q2feiMUx/aPjIJa+gScAiupr++NxswsNkP13XjtvoiHC5fh8O9QAZ4WuyuFVnn32RG+SAMst0AzwZhiMJgAn81UhkkCHGDrBTLDNYCS/aH2qoG3bCMlp6hlpJrtvbBVApBU+1hRCm59c1uJPd7XZMV7QDLlPAu+oNlOm/QcRS0+BfKVrntGQWmpCDW2ABlTjK5dSA8H+CpklI3qWI3pbxmz/LS1EueKN0PTFGhD6kQmWHoys6NZjBVkxVSwN/nXBcccgiSdMf0T0gHnyKT++WUzOolDmymshmRXdWkQ3b+vSCiarCEcW4sbqTQCSkYr6ss1ySlMKZrJTUtb6G4GWM9sCdnaaBSblRqrIxWNFEraqyGe4ZBm1QWVKsKTBTlRLM7v3ViNLLa27U0QsIw+Tirpus7wjem0YWSv2slPmRbyY3IaGZ42OZM02b+eLaFzeOTfwOMTSWX6r4uxmEcjseGPgdP7n+Al1rJW+qUoAmeRVeHEn5Hlaa75ynvkmkrTAwJ1YP8tt0wk7iBcmevDMdvp398pKiRI+lW4C+K2jToS7oE3WlrIUEJFjM2qEfZ455kjzuy/ypAg5tUMynKy9E+xvHZtD862qGPXI8eHCr+lJOyZKmn/3fT9vD02r6vCpMhlWOwlkzo0ml5UQPtAofx0Ftgm0+esMfjZ+0h0YygXeH9VA5a9EkPUdxzaKZJ16F9MF3EPfk8dOyGe02weYG0Ey3NybhHUU/kDzsBZ5qTCz5k1SPtK9DEHe4XnIjL5X7v43vgHvVxwv3ITgcFXa/T1+XO9u0o/2pVD/ZipG8lfAavg/ClK9++d7nxNuxL+sNjD5r/Mft93a5RfCz5rzjl/2vkv/moedT9Lxr5F3xsHqZPdZ+zM3VDDFtS4FKe9oQFO3qGR68KM3OUhAe/2b4pzEShH2f6fEaxXxq8FZjClOnutIH+Q69APDrfIy6KOiuQUCD5Yk5ZD18R3/GYBdn2k1Pjr9ovd3j+Fw==&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="721px" height="337px" viewBox="-0.5 -0.5 721 337" content="&lt;mxfile&gt;&lt;diagram id=&quot;NXkKOAojmEnQiF92G5a8&quot; name=&quot;Page-1&quot;&gt;5Vnfd5sgFP5r8rojEk187JLY7WHn9DQP2x45SiOrSg6SJu6vHwZQiU2bH450sw8pfFwQvvt5L+AIzrLdPUPr5BuNcTpynXg3gvOR6/o+FL8VUEogmE4lsGIklhBogCX5jRXoKnRDYlwYhpzSlJO1CUY0z3HEDQwxRrem2RNNzaeu0Qp3gGWE0i76ncQ8kejUcxr8CyarRD8ZOKolQ9pYAUWCYrptQXAxgjNGKZelbDfDacWd5kX2C4+01hNjOOendPDUNHip14ZjsVRVzWku/n1OeJaKGhBFvCP8hyg7nzxV+9lqmVcOdnSl1JU8vqtIF9XFY4byUmIhSVNl8URzHqKMpFWX5RpFWMzpnlGOi2fRLOdYTezoKhVU0A2LlJXSCkdshZXVuGZYKBPTDHNWChOGU8TJizk6UhpZ1XYNjaKgmHyd1dq719HqvEnrO6QVYuFc866euMdavL/vmd6oB4Et7uUQLyjdqEEfGP1VRYFDlzC6yWMcq5VuE8KxpBHOtyJsmR56EpzMaErZvi+Eru+KoCW90MLD/d+eakafcasFBHDu3Z0q9hfMON69zXmXTN0hUCSUB/VtE6wCX0JJK06Np9fTP71Q+aCt+/oteDegqAFN0RrSp0IJB9IHFkMOtCR72JH911xocBNxQvNiONqH0L+Z9icXR/3J6WG/Jf4oRUVBIkP/f03b4/61ve8qFoPKlsGakpwXrZEfKqBxsOuPDQfrenjEHk7ftBcFOYPGw/VSTnJ6YGEHdWYuv7UufEsxD1z6wp2TbPrdZh1zTW/cA88S+eNOwpklaMCbLFefYS0kGr/D/UOK8uFyX8d4C9wDGzvcjxx0gNONOrYO1vrZLeXfrarJDkb6WsI3iDoADl35+q6xnW9dW9IfX7rR/I/Zt3W6Bv6l5J+xy//XyL96q3nR+c+bmAd8qD4K9HWe0yttpxiyxIJL2u8OS7zRczg5K80sQOiefF9+VZrxXDPP2LxG0V95DA/MxJLxrt9E/6E94E9ud4kLvI4HQixIHswu6/AW0eo2K+iQ/0g3nIiAPxj+Dw94muv+6RfV5murTBfNJ2u4+AM=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <path d="M 192 48 L 192 96" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 196 96 L 192 88 L 188 96" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="144" y="0" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 145px;">
-                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Project
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="192" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
-                    Project
-                </text>
-            </switch>
-        </g>
-        <path d="M 243 24 L 288 24" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <ellipse cx="240" cy="24" rx="3" ry="3" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
-        <rect x="288" y="0" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 289px;">
-                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Instructions
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="336" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
-                    Instructions
-                </text>
-            </switch>
-        </g>
-        <path d="M 216 96 L 216 82 Q 216 72 226 72 L 326 72 Q 336 72 336 63.18 L 336 54.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 336 49.12 L 339.5 56.12 L 336 54.37 L 332.5 56.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 192 144 L 192 185.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 192 190.88 L 188.5 183.88 L 192 185.63 L 195.5 183.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 240 120 L 281.63 120" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 286.88 120 L 279.88 123.5 L 281.63 120 L 279.88 116.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 192 144 L 192 192" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 196 192 L 192 184 L 188 192" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 192 96 L 192 48" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 188 48 L 192 56 L 196 48" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <rect x="144" y="96" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
@@ -52,92 +12,18 @@
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 120px; margin-left: 145px;">
                         <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Chat
+                                Project
                             </div>
                         </div>
                     </div>
                 </foreignObject>
                 <text x="192" y="124" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
-                    Chat
+                    Project
                 </text>
             </switch>
         </g>
-        <rect x="144" y="192" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 216px; margin-left: 145px;">
-                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Plan
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="192" y="220" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
-                    Plan
-                </text>
-            </switch>
-        </g>
-        <path d="M 96 120 L 137.63 120" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 142.88 120 L 135.88 123.5 L 137.63 120 L 135.88 116.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="0" y="96" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 120px; margin-left: 1px;">
-                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Agent
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="48" y="124" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
-                    Agent
-                </text>
-            </switch>
-        </g>
-        <path d="M 576 24 L 617.63 24" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 622.88 24 L 615.88 27.5 L 617.63 24 L 615.88 20.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 480 24 L 390.37 24" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 385.12 24 L 392.12 20.5 L 390.37 24 L 392.12 27.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 528 48 L 528 110 Q 528 120 518 120 L 390.37 120" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 385.12 120 L 392.12 116.5 L 390.37 120 L 392.12 123.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="480" y="0" width="96" height="48" fill="#214d37" stroke="#1e1f20" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 481px;">
-                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                AiSession
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="528" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
-                    AiSession
-                </text>
-            </switch>
-        </g>
-        <rect x="624" y="0" width="96" height="48" fill="#214d37" stroke="#1e1f20" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 625px;">
-                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                AiContext
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="672" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
-                    AiContext
-                </text>
-            </switch>
-        </g>
+        <path d="M 243 120 L 288 120" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <ellipse cx="240" cy="120" rx="3" ry="3" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
         <rect x="288" y="96" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
@@ -145,13 +31,146 @@
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 120px; margin-left: 289px;">
                         <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Feed
+                                Instructions
                             </div>
                         </div>
                     </div>
                 </foreignObject>
                 <text x="336" y="124" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Instructions
+                </text>
+            </switch>
+        </g>
+        <path d="M 216 192 L 216 178 Q 216 168 226 168 L 326 168 Q 336 168 336 159.18 L 336 150.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 336 145.12 L 339.5 152.12 L 336 150.37 L 332.5 152.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 192 240 L 192 281.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 192 286.88 L 188.5 279.88 L 192 281.63 L 195.5 279.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 240 216 L 281.63 216" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 286.88 216 L 279.88 219.5 L 281.63 216 L 279.88 212.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="144" y="192" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 216px; margin-left: 145px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Chat
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="192" y="220" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Chat
+                </text>
+            </switch>
+        </g>
+        <rect x="144" y="288" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 312px; margin-left: 145px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Plan
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="192" y="316" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Plan
+                </text>
+            </switch>
+        </g>
+        <path d="M 96 216 L 137.63 216" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 142.88 216 L 135.88 219.5 L 137.63 216 L 135.88 212.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="0" y="192" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 216px; margin-left: 1px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Agent
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="48" y="220" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Agent
+                </text>
+            </switch>
+        </g>
+        <path d="M 576 120 L 617.63 120" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 622.88 120 L 615.88 123.5 L 617.63 120 L 615.88 116.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 480 120 L 390.37 120" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 385.12 120 L 392.12 116.5 L 390.37 120 L 392.12 123.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 528 144 L 528 206 Q 528 216 518 216 L 390.37 216" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 385.12 216 L 392.12 212.5 L 390.37 216 L 392.12 219.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="480" y="96" width="96" height="48" fill="#214d37" stroke="#1e1f20" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 120px; margin-left: 481px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                AiSession
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="528" y="124" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    AiSession
+                </text>
+            </switch>
+        </g>
+        <rect x="624" y="96" width="96" height="48" fill="#214d37" stroke="#1e1f20" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 120px; margin-left: 625px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                AiContext
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="672" y="124" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    AiContext
+                </text>
+            </switch>
+        </g>
+        <rect x="288" y="192" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 216px; margin-left: 289px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Feed
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="336" y="220" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
                     Feed
+                </text>
+            </switch>
+        </g>
+        <rect x="144" y="0" width="96" height="48" fill="#326288" stroke="#193d5a" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 24px; margin-left: 145px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Space Grotesk&quot;; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Routine
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="192" y="28" fill="#FFFFFF" font-family="Space Grotesk" font-size="12px" text-anchor="middle">
+                    Routine
                 </text>
             </switch>
         </g>

--- a/packages/core/compute/assistant/src/request/AiRequest.ts
+++ b/packages/core/compute/assistant/src/request/AiRequest.ts
@@ -26,7 +26,7 @@ import {
   callTool,
   withoutToolCallParising,
 } from '@dxos/ai';
-import { Operation, type Skill, Trace } from '@dxos/compute';
+import { type Instructions, Operation, type Skill, Trace } from '@dxos/compute';
 import { Database, Obj, Registry } from '@dxos/echo';
 import { log } from '@dxos/log';
 import { ContentBlock, Message } from '@dxos/types';
@@ -76,6 +76,8 @@ export type RunProps<R = never> = {
   history?: Message.Message[];
   objects?: Obj.Unknown[];
   skills?: readonly Skill.Skill[];
+  /** Rendered inline into the system prompt; passed explicitly rather than inferred from `objects`. */
+  instructions?: readonly Instructions.Instructions[];
   toolkit?: OpaqueToolkit.OpaqueToolkit<R>;
 };
 
@@ -85,6 +87,7 @@ export type BeginProps = {
   history?: Message.Message[];
   objects?: Obj.Unknown[];
   skills?: readonly Skill.Skill[];
+  instructions?: readonly Instructions.Instructions[];
 };
 
 export type TurnProps<R = never> = {
@@ -191,13 +194,14 @@ export class Request {
     history = [],
     skills = [],
     objects = [],
+    instructions = [],
   }: BeginProps): Effect.Effect<void, RunError, RunRequirements> =>
     Effect.gen(this, function* () {
       this._started = Date.now();
       this._history = [...history];
       this._pending = [];
 
-      const systemPrompt = yield* formatSystemPrompt({ system, skills, objects }).pipe(Effect.orDie);
+      const systemPrompt = yield* formatSystemPrompt({ system, skills, objects, instructions }).pipe(Effect.orDie);
 
       if (this._options.summarizationThreshold !== undefined) {
         const tokenCount = yield* AiPreprocessor.estimateTokens(
@@ -345,12 +349,15 @@ export class Request {
     history = [],
     objects = [],
     skills = [],
+    instructions = [],
     toolkit,
   }: RunProps<R>): Effect.Effect<Message.Message[], RunError, RunRequirements | R> =>
     Effect.gen(this, function* () {
-      yield* this.begin({ prompt, system: systemTemplate, history, objects, skills });
+      yield* this.begin({ prompt, system: systemTemplate, history, objects, skills, instructions });
 
-      const system = yield* formatSystemPrompt({ system: systemTemplate, skills, objects }).pipe(Effect.orDie);
+      const system = yield* formatSystemPrompt({ system: systemTemplate, skills, objects, instructions }).pipe(
+        Effect.orDie,
+      );
 
       do {
         const { done, finishReason } = yield* this.runAgentTurn({ system, toolkit });

--- a/packages/core/compute/assistant/src/request/format.test.ts
+++ b/packages/core/compute/assistant/src/request/format.test.ts
@@ -23,7 +23,7 @@ const testLayer = () =>
   );
 
 describe('formatSystemPrompt', () => {
-  it.effect('renders bound Instructions inline (text + commands), not as object stubs', () =>
+  it.effect('renders Instructions inline (text + commands), not as object stubs', () =>
     Effect.gen(function* () {
       const instructions = yield* Database.add(
         Instructions.make({
@@ -35,7 +35,7 @@ describe('formatSystemPrompt', () => {
         }),
       );
 
-      const prompt = yield* formatSystemPrompt({ system: 'Base prompt.', objects: [instructions] });
+      const prompt = yield* formatSystemPrompt({ system: 'Base prompt.', instructions: [instructions] });
       expect(prompt).toContain('Base prompt.');
       expect(prompt).toContain('## Instructions');
       expect(prompt).toContain('Answer like a pirate.');
@@ -59,10 +59,23 @@ describe('formatSystemPrompt', () => {
         instructions.text = Ref.fromURI(URI.make('dxn:echo:@:missing-text'));
       });
 
-      const prompt = yield* formatSystemPrompt({ objects: [instructions] });
+      const prompt = yield* formatSystemPrompt({ instructions: [instructions] });
       expect(prompt).toContain('## Instructions');
       expect(prompt).toContain('`$go`: Go.');
       expect(prompt).not.toContain('unreachable');
+    }).pipe(Effect.provide(testLayer())),
+  );
+
+  it.effect('treats a bound Instructions object as an ordinary context stub', () =>
+    Effect.gen(function* () {
+      // Steering is declared by the `instructions` parameter, so a bound Instructions object is
+      // subject matter (e.g. "help me edit these") rather than something the session must obey.
+      const instructions = yield* Database.add(Instructions.make({ name: 'Draft', text: 'Answer like a pirate.' }));
+      const prompt = yield* formatSystemPrompt({ objects: [instructions] });
+      expect(prompt).toContain('## Context Objects');
+      expect(prompt).toContain('<label>Draft</label>');
+      expect(prompt).not.toContain('## Instructions');
+      expect(prompt).not.toContain('Answer like a pirate.');
     }).pipe(Effect.provide(testLayer())),
   );
 

--- a/packages/core/compute/assistant/src/request/format.ts
+++ b/packages/core/compute/assistant/src/request/format.ts
@@ -6,7 +6,7 @@ import * as Effect from 'effect/Effect';
 import * as Function from 'effect/Function';
 import * as Option from 'effect/Option';
 
-import { type FunctionNotFoundError, Instructions, type Operation, Template } from '@dxos/compute';
+import { type FunctionNotFoundError, type Operation, Template } from '@dxos/compute';
 import { Database, Obj, type Registry } from '@dxos/echo';
 import { ObjectVersion } from '@dxos/echo-client';
 import { type EntityNotFoundError } from '@dxos/echo/Err';

--- a/packages/core/compute/assistant/src/request/format.ts
+++ b/packages/core/compute/assistant/src/request/format.ts
@@ -27,7 +27,8 @@ export const formatSystemPrompt = ({
   system,
   skills = [],
   objects = [],
-}: Pick<AiRequest.RunProps, 'system' | 'skills' | 'objects'>): Effect.Effect<
+  instructions = [],
+}: Pick<AiRequest.RunProps, 'system' | 'skills' | 'objects' | 'instructions'>): Effect.Effect<
   string,
   FunctionNotFoundError | EntityNotFoundError,
   Database.Service | Registry.Service | Operation.Service
@@ -50,15 +51,10 @@ export const formatSystemPrompt = ({
       Effect.map((skills) => (skills.length > 0 ? ['## Skills Definitions', ...skills].join('\n\n') : undefined)),
     );
 
-    // Bound Instructions steer the session: their text (and sentinel commands) belongs in the system
+    // Instructions steer the session, so their text (and sentinel commands) belongs in the system
     // prompt itself — a context-object stub would force the model to tool-load them and follow nothing.
-    const instructionObjects = objects.filter((object): object is Instructions.Instructions =>
-      Obj.instanceOf(Instructions.Instructions, object),
-    );
-    const contextObjects = objects.filter((object) => !Obj.instanceOf(Instructions.Instructions, object));
-
     const instructionDefs = yield* Function.pipe(
-      instructionObjects,
+      instructions,
       Effect.forEach((instructions) =>
         Effect.gen(function* () {
           // A broken text ref degrades to commands-only rather than failing the whole prompt.
@@ -85,7 +81,7 @@ export const formatSystemPrompt = ({
     );
 
     const objectDefs = yield* Function.pipe(
-      contextObjects,
+      objects,
       Effect.forEach((object) => {
         // Carry the label so the model only tool-loads an object when it needs the contents,
         // not just to learn what the reference is.

--- a/packages/core/compute/assistant/src/session/AiSession.ts
+++ b/packages/core/compute/assistant/src/session/AiSession.ts
@@ -68,12 +68,14 @@ const SUMMARY_THRESHOLD = 80_000;
  * Executes tools based on AI responses and supports cancellation of in-progress requests.
  */
 export class Session extends Resource {
+  private readonly _feed: Feed.Feed;
+  private readonly _runtime: Runtime.Runtime<Database.Service>;
+
   /**
    * Skills and objects bound to the session.
    */
   private readonly _binder: AiContext.Binder;
-  private readonly _feed: Feed.Feed;
-  private readonly _runtime: Runtime.Runtime<Database.Service>;
+
   private readonly _sessionLoader = new SessionLoader();
 
   public constructor(options: Options) {

--- a/packages/core/compute/assistant/src/session/AiSession.ts
+++ b/packages/core/compute/assistant/src/session/AiSession.ts
@@ -14,7 +14,7 @@ import * as Record from 'effect/Record';
 import * as Runtime from 'effect/Runtime';
 
 import { type OpaqueToolkit, type ToolExecutionService, type ToolResolverService } from '@dxos/ai';
-import { McpServer, Operation, type Skill, Trace } from '@dxos/compute';
+import { type Instructions, McpServer, Operation, type Skill, Trace } from '@dxos/compute';
 import { Resource } from '@dxos/context';
 import { Database, Feed, Filter, Obj, Registry } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
@@ -55,6 +55,11 @@ export type Options = {
   runtime: Runtime.Runtime<Database.Service>;
   /** @effect-atom/atom-react Registry for reactive state. */
   registry?: AtomRegistry.Registry;
+  /**
+   * Instructions steering the conversation (typically the owning `Chat`'s), rendered into the system
+   * prompt on every turn. The session is feed-centric and cannot reach its chat, so these are passed in.
+   */
+  instructions?: readonly Instructions.Instructions[];
 };
 
 /**
@@ -70,6 +75,7 @@ const SUMMARY_THRESHOLD = 80_000;
 export class Session extends Resource {
   private readonly _feed: Feed.Feed;
   private readonly _runtime: Runtime.Runtime<Database.Service>;
+  private readonly _instructions: readonly Instructions.Instructions[];
 
   /**
    * Skills and objects bound to the session.
@@ -82,6 +88,7 @@ export class Session extends Resource {
     super();
     this._feed = options.feed;
     this._runtime = options.runtime;
+    this._instructions = options.instructions ?? [];
     invariant(this._feed);
     invariant(this._runtime);
     this._binder = new AiContext.Binder({
@@ -163,6 +170,7 @@ export class Session extends Resource {
         history,
         skills,
         objects,
+        instructions: this._instructions,
         prompt: params.prompt,
         system: params.system,
       });
@@ -191,6 +199,7 @@ export class Session extends Resource {
           system: params.system,
           skills: currentSkills,
           objects: this.context.getObjects(),
+          instructions: this._instructions,
         }).pipe(Effect.orDie);
 
         const { done, finishReason } = yield* request.runAgentTurn({ system, toolkit });

--- a/packages/core/compute/assistant/src/session/AiSession.ts
+++ b/packages/core/compute/assistant/src/session/AiSession.ts
@@ -75,7 +75,7 @@ const SUMMARY_THRESHOLD = 80_000;
 export class Session extends Resource {
   private readonly _feed: Feed.Feed;
   private readonly _runtime: Runtime.Runtime<Database.Service>;
-  private readonly _instructions: readonly Instructions.Instructions[];
+  readonly #instructions: readonly Instructions.Instructions[];
 
   /**
    * Skills and objects bound to the session.
@@ -88,7 +88,7 @@ export class Session extends Resource {
     super();
     this._feed = options.feed;
     this._runtime = options.runtime;
-    this._instructions = options.instructions ?? [];
+    this.#instructions = options.instructions ?? [];
     invariant(this._feed);
     invariant(this._runtime);
     this._binder = new AiContext.Binder({
@@ -170,7 +170,7 @@ export class Session extends Resource {
         history,
         skills,
         objects,
-        instructions: this._instructions,
+        instructions: this.#instructions,
         prompt: params.prompt,
         system: params.system,
       });
@@ -199,7 +199,7 @@ export class Session extends Resource {
           system: params.system,
           skills: currentSkills,
           objects: this.context.getObjects(),
-          instructions: this._instructions,
+          instructions: this.#instructions,
         }).pipe(Effect.orDie);
 
         const { done, finishReason } = yield* request.runAgentTurn({ system, toolkit });

--- a/packages/core/compute/compute/src/AgentService.ts
+++ b/packages/core/compute/compute/src/AgentService.ts
@@ -13,6 +13,7 @@ import { DXN } from '@dxos/keys';
 import type { ContentBlock } from '@dxos/types';
 
 import type * as Trace from './Trace';
+import type * as Instructions from './types/Instructions';
 
 /**
  * Service interface for the agent session manager.
@@ -88,4 +89,10 @@ export interface GetSessionOptions {
   // the model into the agent process — the id alone does not identify a resolver.
   readonly provider?: DXN.DXN;
   readonly systemPrompt?: string;
+  /**
+   * Instructions steering the conversation (typically the Chat's `instructions` ref), persisted as a
+   * spawn annotation so a re-hydrated process recovers it. Read at spawn only: repointing requires a
+   * process restart (same staleness model as `model`/`provider`).
+   */
+  readonly instructions?: Ref.Ref<Instructions.Instructions>;
 }

--- a/packages/core/compute/compute/src/AgentService.ts
+++ b/packages/core/compute/compute/src/AgentService.ts
@@ -13,7 +13,7 @@ import { DXN } from '@dxos/keys';
 import type { ContentBlock } from '@dxos/types';
 
 import type * as Trace from './Trace';
-import type * as Instructions from './types/Instructions';
+import { Instructions } from './types';
 
 /**
  * Service interface for the agent session manager.

--- a/packages/core/compute/compute/src/Process.ts
+++ b/packages/core/compute/compute/src/Process.ts
@@ -174,6 +174,15 @@ export const NotifyAnnotation = Annotation.make({
 });
 
 /**
+ * URI of the Instructions object steering the process's conversation. Persisted at spawn (like
+ * {@link TargetAnnotation}) so a re-hydrated process recovers its steering without reaching the Chat.
+ */
+export const InstructionsAnnotation = Annotation.make({
+  id: 'org.dxos.process.instructions',
+  schema: URI.Schema,
+});
+
+/**
  * Marks a process as the harness host for its conversation (discovery substrate).
  */
 export const HarnessHostAnnotation = Annotation.make({

--- a/packages/core/compute/compute/src/types/Project.test.ts
+++ b/packages/core/compute/compute/src/types/Project.test.ts
@@ -23,7 +23,7 @@ describe('Project', () => {
     expect(project.routines).toEqual([]);
   });
 
-  test('contextBindings exposes instructions, skills, and objects', ({ expect }) => {
+  test('contextBindings exposes skills and objects, not the instructions object itself', ({ expect }) => {
     const skillRef = Ref.fromURI(URI.make('dxn:echo:@:skill-1'));
     const doc = Obj.make(TestObject, {});
     const instructions = Instructions.make({ text: 'Test', skills: [skillRef], objects: [Ref.make(doc)] });
@@ -35,7 +35,8 @@ describe('Project', () => {
 
     const bindings = Project.contextBindings(project);
     expect(bindings.skills.map((ref) => ref.uri)).toEqual([skillRef.uri]);
-    expect(bindings.objects.length).toBe(2);
+    // Instructions text reaches the prompt via Chat.instructions, not a binding.
+    expect(bindings.objects.map((ref) => ref.uri)).toEqual([Ref.make(doc).uri]);
   });
 
   test('contextBindings returns empty bindings when instructions is unresolved', ({ expect }) => {

--- a/packages/core/compute/compute/src/types/Project.ts
+++ b/packages/core/compute/compute/src/types/Project.ts
@@ -52,9 +52,11 @@ export type ContextBindings = {
 };
 
 /**
- * Bindings a chat session should receive when running in this project's context:
- * the instructions object itself (so its text/commands are visible), its skills, and its context objects.
- * Requires the instructions ref to be resolved (`.target`); unresolved refs contribute nothing.
+ * Bindings a chat session should receive when running in this project's context: the instructions'
+ * skills and context objects. The instructions object itself is NOT bound — its text/commands reach
+ * the system prompt through the chat's `instructions` ref, and a bound Instructions object would
+ * render as an inert context stub. Requires the instructions ref to be resolved (`.target`);
+ * unresolved refs contribute nothing.
  */
 export const contextBindings = (project: Project): ContextBindings => {
   const instructionsRef = project.instructions;
@@ -73,6 +75,6 @@ export const contextBindings = (project: Project): ContextBindings => {
   // and re-wrapping would drop the registry DXN of skills that have no space-DB identity.
   return {
     skills: [...instructions.skills],
-    objects: [instructionsRef, ...(instructions.objects ?? [])],
+    objects: [...(instructions.objects ?? [])],
   };
 };

--- a/packages/plugins/AUDIT.md
+++ b/packages/plugins/AUDIT.md
@@ -16,5 +16,5 @@ Cross-plugin capability contracts: where one plugin defines a capability interfa
 ## Notes
 
 - `plugin-sidekick` is obviated by `plugin-projects` (see
-  `agents/superpowers/specs/2026-07-24-plugin-projects-design.md`); removal is
+  `packages/plugins/plugin-projects/DESIGN.md`); removal is
   tracked separately.

--- a/packages/plugins/plugin-assistant/src/capabilities/skill-definition.ts
+++ b/packages/plugins/plugin-assistant/src/capabilities/skill-definition.ts
@@ -26,6 +26,8 @@ import {
   MemorySkill,
   PlanningHandlers,
   PlanningSkill,
+  ProjectHandlers,
+  ProjectSkill,
   SkillManagerHandlers,
   SkillManagerSkill,
   WebSearchHandlers,
@@ -53,6 +55,7 @@ const skillDefinition = () =>
     Capability.contributes(AppCapabilities.SkillDefinition, AgentWizardSkill),
     Capability.contributes(AppCapabilities.SkillDefinition, DelegationSkill),
     Capability.contributes(AppCapabilities.SkillDefinition, AlarmSkill),
+    Capability.contributes(AppCapabilities.SkillDefinition, ProjectSkill),
 
     Capability.contributes(Capabilities.OperationHandler, AgentHandlers),
     Capability.contributes(Capabilities.OperationHandler, AgentSkillHandlers),
@@ -63,6 +66,7 @@ const skillDefinition = () =>
     Capability.contributes(Capabilities.OperationHandler, DelegationHandlers),
     Capability.contributes(Capabilities.OperationHandler, PlanningHandlers),
     Capability.contributes(Capabilities.OperationHandler, AlarmHandlers),
+    Capability.contributes(Capabilities.OperationHandler, ProjectHandlers),
 
     // Run the conversational agent as a supervisor: delegate in-progress plan tasks to sub-agents
     // and fold their results back into the conversation (consumed by the AgentService LayerSpec).

--- a/packages/plugins/plugin-assistant/src/containers/ChatCompanion/ChatCompanion.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatCompanion/ChatCompanion.tsx
@@ -3,7 +3,7 @@
 //
 
 import * as Option from 'effect/Option';
-import React, { forwardRef, useCallback, useMemo } from 'react';
+import React, { forwardRef, useCallback, useEffect, useMemo } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { AppAnnotation } from '@dxos/app-toolkit';
@@ -98,10 +98,24 @@ const useSkills = ({ subject: chat, companionTo }: Pick<ChatCompanionProps, 'sub
   );
 
   // Subscribe so a project's instructions ref resolving after the project object itself (e.g. loading
-  // over the wire) re-triggers the bind below, mirroring the `feedSnapshot` subscription above.
+  // over the wire) re-triggers the effects below, mirroring the `feedSnapshot` subscription above.
   const [instructionsSnapshot] = useObject(
     Obj.instanceOf(Project.Project, companionTo) ? companionTo.instructions : undefined,
   );
+
+  // Steer the chat with the project's instructions BY REFERENCE (chat.instructions → system prompt at
+  // request time). Also the lazy backfill: pre-existing project chats without the field pick it up here.
+  useEffect(() => {
+    if (!chat || chat.instructions || !Obj.instanceOf(Project.Project, companionTo)) {
+      return;
+    }
+    const instructionsRef = companionTo.instructions;
+    if (instructionsRef) {
+      Obj.update(chat, (chat) => {
+        chat.instructions = instructionsRef;
+      });
+    }
+  }, [chat, companionTo, instructionsSnapshot]);
 
   useAsyncEffect(async () => {
     if (!binder?.isOpen) {
@@ -131,7 +145,8 @@ const useSkills = ({ subject: chat, companionTo }: Pick<ChatCompanionProps, 'sub
       await binder.bind({ objects: [Ref.make(companionTo)] });
     }
 
-    // Bind the project's instructions, skills, and context objects into the session.
+    // Bind the project's skills and context objects into the session (instructions text travels
+    // via chat.instructions, set above).
     if (Obj.instanceOf(Project.Project, companionTo)) {
       const bindings = Project.contextBindings(companionTo);
       if (bindings.skills.length > 0) {

--- a/packages/plugins/plugin-assistant/src/processor/processor.ts
+++ b/packages/plugins/plugin-assistant/src/processor/processor.ts
@@ -310,6 +310,7 @@ export class AiChatProcessor {
         const session = yield* AgentService.getSession(this._feed, {
           model: this._options.model,
           provider: this._options.provider,
+          instructions: this._options.chat?.target?.instructions,
         });
         const ephemeralStream = session.subscribeEphemeral();
         yield* ephemeralStream.pipe(

--- a/packages/plugins/plugin-assistant/src/processor/processor.ts
+++ b/packages/plugins/plugin-assistant/src/processor/processor.ts
@@ -25,8 +25,15 @@ import {
   formatSystemPrompt,
 } from '@dxos/assistant';
 import { type Chat } from '@dxos/assistant-toolkit';
-import { AgentService, type Credential, Operation, type ServiceNotAvailableError, Trace } from '@dxos/compute';
-import { type Database, Feed, Obj, Ref, type Registry } from '@dxos/echo';
+import {
+  AgentService,
+  type Credential,
+  type Instructions,
+  Operation,
+  type ServiceNotAvailableError,
+  Trace,
+} from '@dxos/compute';
+import { Database, Feed, Obj, Ref, type Registry } from '@dxos/echo';
 import { UsageQuotaExceededError } from '@dxos/edge-client';
 import { EffectEx } from '@dxos/effect';
 import { DXN } from '@dxos/keys';
@@ -249,10 +256,11 @@ export class AiChatProcessor {
       Effect.gen(this, function* () {
         const skills = this.context.getSkills();
         const objects = this.context.getObjects();
+        const instructions = yield* this._getInstructions();
         // Tier A only: system-prompt formatting runs operations that read the conversation context;
         // the live-host Tier B control surface is not reachable from this fiber.
         const runtime = yield* Effect.runtime<Database.Service>();
-        return yield* formatSystemPrompt({ system: this._options.system, skills, objects }).pipe(
+        return yield* formatSystemPrompt({ system: this._options.system, skills, objects, instructions }).pipe(
           Effect.provideService(
             Harness.HarnessService,
             Harness.fromBinder({ feed: this._feed, runtime, binder: this.context }),
@@ -260,6 +268,22 @@ export class AiChatProcessor {
         );
       }).pipe(Effect.provide(this._spaceLayer), Effect.orDie),
     );
+  }
+
+  /**
+   * Resolves the chat's steering instructions, if any. The session is feed-centric and cannot reach
+   * its chat, so the ref is resolved here and handed down.
+   */
+  private _getInstructions(): Effect.Effect<Instructions.Instructions[], never, Database.Service> {
+    return Effect.gen(this, function* () {
+      const instructionsRef = this._options.chat?.target?.instructions;
+      if (!instructionsRef) {
+        return [];
+      }
+
+      const instructions = yield* Database.load(instructionsRef).pipe(Effect.orElseSucceed(() => undefined));
+      return instructions ? [instructions] : [];
+    });
   }
 
   /**

--- a/packages/plugins/plugin-assistant/src/processor/processor.ts
+++ b/packages/plugins/plugin-assistant/src/processor/processor.ts
@@ -256,7 +256,7 @@ export class AiChatProcessor {
       Effect.gen(this, function* () {
         const skills = this.context.getSkills();
         const objects = this.context.getObjects();
-        const instructions = yield* this._getInstructions();
+        const instructions = yield* this.#getInstructions();
         // Tier A only: system-prompt formatting runs operations that read the conversation context;
         // the live-host Tier B control surface is not reachable from this fiber.
         const runtime = yield* Effect.runtime<Database.Service>();
@@ -274,7 +274,7 @@ export class AiChatProcessor {
    * Resolves the chat's steering instructions, if any. The session is feed-centric and cannot reach
    * its chat, so the ref is resolved here and handed down.
    */
-  private _getInstructions(): Effect.Effect<Instructions.Instructions[], never, Database.Service> {
+  #getInstructions(): Effect.Effect<Instructions.Instructions[], never, Database.Service> {
     return Effect.gen(this, function* () {
       const instructionsRef = this._options.chat?.target?.instructions;
       if (!instructionsRef) {

--- a/packages/plugins/plugin-projects/DESIGN.md
+++ b/packages/plugins/plugin-projects/DESIGN.md
@@ -301,18 +301,22 @@ so `+` works from the tree.
 
 ### System test (live against a real model, out of CI)
 
-One scenario exercising the whole loop, graded on database effects rather than on
-model wording:
+`@dxos/assistant-evals` `src/evals/projects.eval.ts` — one scenario exercising
+the whole loop, graded on database effects rather than on model wording:
 
-1. Create a Project with instructions.
-2. Create a Chat under it — own feed, `instructions` pointing at the project's.
+1. Seed a Project with instructions and an artifacts Collection.
+2. Seed a Chat under it — own feed, `instructions` pointing at the project's
+   own object, parented to the project (mirrors `ProjectOperation.CreateChat`).
 3. Prompt the model to create a markdown document.
-4. Assert the document is bound into the session context **and** present in the
-   project's artifacts Collection.
+4. Assert the document is bound into the session context (a `Binding` record in
+   the chat feed) **and** present in the project's artifacts Collection.
 
 Step 4 is the real assertion: binding alone proves only that the session saw the
 object, not that the project owns it, so this is the test that would catch the
-project skill failing to file. It runs against a live model and stays out of CI.
+project skill failing to file. It runs against a live model
+(`DX_ANTHROPIC_API_KEY`) and stays out of CI. The eval runner gained `seed`
+(space setup returning context objects + the session chat) and `types` (extra
+ECHO types for the harness client) to host it.
 
 ## Open questions
 

--- a/packages/plugins/plugin-projects/DESIGN.md
+++ b/packages/plugins/plugin-projects/DESIGN.md
@@ -273,6 +273,131 @@ chat appears twice, once under its project and once at the space level.
 contributed to the project's navtree node (`disposition: 'list-item-primary'`)
 so `+` works from the tree.
 
+## Agent ↔ Project convergence (analysis, decision pending)
+
+`Agent` (`org.dxos.type.agent@0.1.0`, assistant-toolkit) accreted most of what
+`Project` now owns. This section documents how each overlapping property is
+actually used, proposes the target split, and analyzes the impact of refactoring
+`Agent` down to it.
+
+### Agent's current surface, and where each field is used
+
+| Field           | Shape                           | Used by                                                                                                                                            |
+| --------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`          | `string`                        | labels                                                                                                                                             |
+| `did`           | `IdentityDid`                   | attribution of agent-authored content (e.g. suggestion branches); minted at runtime-identity provision, not creation                               |
+| `enabled`       | `boolean`                       | `sync-triggers` propagates it to every trigger it manages                                                                                          |
+| `instructions`  | `Ref<Text>` (raw markdown)      | `get-context` (returned to the model), `qualifier` (event filtering)                                                                               |
+| `chat`          | `Ref<Chat>` (primary chat)      | `AgentWorker` (resolves the feed to run in), `qualifier`, `resetChatHistory`, planning/delegation tests; `makeInitialized` also adds `CompanionTo` |
+| `artifacts`     | inline `{name, data: Ref}[]`    | `add-artifact` op (model files from chat context), `get-context` (lists them back to the model)                                                    |
+| `subscriptions` | `Ref[]` (objects with a feed)   | `sync-triggers` → one qualifier trigger per subscription feed                                                                                      |
+| `cron`          | `string`                        | `sync-triggers` → a timer trigger invoking `AgentWorker` directly                                                                                  |
+| `feed`          | `Ref<Feed>` <em>deprecated</em> | input feed for subscriptions                                                                                                                       |
+| `filterEvents`  | `boolean` <em>deprecated</em>   | qualifier opt-out                                                                                                                                  |
+
+Overlap with `Project`: **instructions** (Project: `Ref<Instructions>`, typed,
+with skills/objects/commands; Agent: raw `Ref<Text>`), **artifacts** (Project:
+owned `Collection`, addressed by `ProjectSkill`; Agent: a private inline array
+with its own `add-artifact` op), **chats** (Project: parented children + a
+`CompanionTo` companion; Agent: a single owned `chat` ref _plus_ `CompanionTo`),
+and **automation** (Project: `routines`; Agent: `cron` + `subscriptions` wired
+imperatively by `sync-triggers`). Four parallel mechanisms for the same four
+concepts.
+
+### Target split
+
+- **Agent** — an _identity_: `did`, a skill set, later permissions. A
+  personality, not a container: it carries **no history** beyond the Chats it
+  has participated in, and owns nothing.
+- **Project** — the _container and chat factory_: artifacts, routines, and
+  chats. A project spawns chats with different skill sets — or different Agent
+  identities.
+- **Chat** — the _conversational instance_: history (feed), bindings
+  (artifacts, skills), steering `instructions`; **optionally references an
+  Agent** as an alternative to hand-picking skills — the agent is a preset.
+
+Use cases this must serve:
+
+1. Ad-hoc: user starts a bare Chat, uses skills, skills create artifacts.
+2. Scoped: user creates a Project; many related Chats share its artifacts.
+3. Preset: user creates an Agent and applies it to a Chat (or as a project's
+   default) — one pick configures identity + skills + instructions.
+
+### Refactoring impact, field by field
+
+**Remove `artifacts`.** Filing moves to `ProjectSkill.artifact-add` against a
+Project's Collection; the agent skill's `add-artifact` op and the artifacts
+half of `get-context` retire. An agent that needs durable work products gets a
+Project (use case 3 composes with 2). Existing agents' inline `{name, data}`
+arrays migrate into a Collection on a Project created per agent. The inline
+`name` field is the one loss — Collection rows use the object's own label —
+which is also the correction: naming lived on the wrong object.
+
+**Remove `cron` (and `subscriptions`).** Both are trigger _sources_ that
+`sync-triggers` compiles imperatively into `Trigger` objects. A `Routine`
+(instructions + trigger) is exactly this, declaratively: cron becomes a Routine
+with a timer trigger; each subscription becomes a Routine with a feed trigger
+(the qualifier folds into the routine's instructions or stays as its runnable's
+first stage). `enabled` stays as the agent-level master switch only if routines
+gain an owner reference to gate on — otherwise it moves to the Routine.
+`sync-triggers` shrinks to a migration shim, then deletes.
+
+**`instructions: Ref<Text>` → `Ref<Instructions>`.** The typed object carries
+`skills`, `objects`, and `commands` — which is precisely the "skill set" the
+target Agent needs, so this one change gives Agent its whole preset payload.
+`makeInitialized` wraps its markdown into `Instructions.make({ text })`;
+`get-context` and `qualifier` load `instructions.text` instead of the Text ref.
+And it aligns with `Chat.instructions`: applying an agent to a chat is then
+`chat.instructions = agent.instructions` — the same channel projects use, no
+new plumbing.
+
+**Invert `chat` → `Chat.agent?: Ref<Agent>`.** Today the trigger input carries
+the agent and `AgentWorker` resolves `agent.chat` to find its feed. Inverted,
+whatever invokes a run holds the Chat (this is already true everywhere else —
+see the call-site table above) and reads `chat.agent` for identity/attribution.
+"The agent's chats" becomes a query
+(`Query.select(Filter.type(Chat)).where(chat.agent === …)` or the existing
+`CompanionTo` relation), which also fixes the current single-chat limitation —
+the `TODO(dmaretskyi): Multiple chats` on the field. `resetChatHistory` becomes
+a Chat helper (rebuild the feed), not an Agent one.
+
+### Where current Agent functionality lands
+
+| Today (Agent)                                                            | After                                                                                                                                            |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `makeInitialized` (agent + chat + binder + CompanionTo)                  | create Agent (identity + instructions); chat creation is the chat factory's job (`ProjectOperation.CreateChat` or ad-hoc), with `chat.agent` set |
+| model files an artifact (`add-artifact`)                                 | `ProjectSkill.artifact-add` into the owning project's Collection                                                                                 |
+| model reads its context (`get-context`)                                  | instructions via the system prompt (`chat.instructions`); artifacts via `ProjectSkill.artifact-list`; plan via the chat, unchanged               |
+| scheduled run (`cron` → `sync-triggers` → timer trigger → `AgentWorker`) | Routine (timer trigger) whose run targets a chat carrying `chat.agent`                                                                           |
+| subscription run (qualifier trigger per feed)                            | Routine (feed trigger); qualifier folds into the routine                                                                                         |
+| `resetChatHistory`                                                       | Chat helper; the agent is untouched                                                                                                              |
+| chat attribution (`did`)                                                 | unchanged — the one thing that was always identity-shaped                                                                                        |
+
+Sequences for the three use cases, post-refactor:
+
+1. **Ad-hoc chat**: `AssistantOperation.CreateChat` → skills bound → model
+   creates artifacts; nothing owns them unless the user files them.
+2. **Project chat**: `ProjectOperation.CreateChat` → `chat.instructions` =
+   project's, `ProjectSkill` bound → artifacts filed into the shared Collection.
+3. **Agent as preset**: pick an Agent at chat creation → `chat.agent` = ref,
+   `chat.instructions` = `agent.instructions` (skills come along inside it) →
+   authored content attributed to `agent.did`. In a project, the project
+   remains the container; the agent only flavors the session.
+
+### Recommendation
+
+Factor by **removal, not extraction**: don't introduce a shared
+"artifact-holder" abstraction — make Project the only container and shrink
+Agent to `name`, `did`, `instructions: Ref<Instructions>` (+ future
+permissions). Sequence: (1) `instructions` typing (small, unlocks the preset
+path), (2) `Chat.agent` inversion (mechanical; `AgentWorker` takes a chat),
+(3) cron/subscriptions → Routines (deletes `sync-triggers`), (4) artifacts →
+Project + migration. Each step ships independently; a schema bump
+(0.1.0 → 0.2.0) with migration lands with step 4, when the deprecated
+`feed`/`filterEvents` fields also drop.
+
+Phased implementation plan (files, verification, risks): [`./PLAN.md`](./PLAN.md).
+
 ## UI conventions
 
 - **Owned refs resolve reactively in articles**: a sync `.target` read never

--- a/packages/plugins/plugin-projects/DESIGN.md
+++ b/packages/plugins/plugin-projects/DESIGN.md
@@ -184,12 +184,14 @@ plus a persisted spawn annotation beside `Process.TargetAnnotation`. Executable
 options do not survive re-hydration (`hydrateAgents` rebuilds with a bare
 `makeExecutable()`), which is why the feed itself travels as the process target.
 
-**Known staleness**: spawn annotations are the immutable identity plane, so
-editing the instructions _text_ reaches a running process (the ref resolves fresh
-each turn) but _repointing_ `chat.instructions` at a different object does not,
-until the process is terminated — the same behavior a model change already has.
-The fix, if it ever bites: compare the ref against the `sessionCache` entry and
-terminate/respawn, exactly as the model/provider comparison does.
+**Repointing**: spawn annotations are immutable, so editing the instructions
+_text_ reaches a running process (the ref resolves fresh each turn), while
+_repointing_ `chat.instructions` at a different object requires a process
+restart. `AgentService.getSession` handles this the way it already handles a
+model change: the instructions URI is part of the session-reuse identity (both
+in the `sessionCache` comparison and against a rediscovered process's spawn
+annotation on the remount path), and a mismatch terminates and respawns — the
+feed replays, so history is preserved.
 
 ## Artifacts and the project skill
 

--- a/packages/plugins/plugin-projects/DESIGN.md
+++ b/packages/plugins/plugin-projects/DESIGN.md
@@ -1,8 +1,8 @@
 # plugin-projects — Design
 
-Date: 2026-07-24
+Date: 2026-07-24 (milestone 3 design added 2026-07-27)
 Status: approved (brainstorm 1×1 with burdon)
-Tracker: `.agents/projects/plugin-projects/TASKS.md`
+Tracker: `./TASKS.md`
 
 ## Concept
 

--- a/packages/plugins/plugin-projects/DESIGN.md
+++ b/packages/plugins/plugin-projects/DESIGN.md
@@ -338,11 +338,17 @@ which is also the correction: naming lived on the wrong object.
 **Remove `cron` (and `subscriptions`).** Both are trigger _sources_ that
 `sync-triggers` compiles imperatively into `Trigger` objects. A `Routine`
 (instructions + trigger) is exactly this, declaratively: cron becomes a Routine
-with a timer trigger; each subscription becomes a Routine with a feed trigger
-(the qualifier folds into the routine's instructions or stays as its runnable's
-first stage). `enabled` stays as the agent-level master switch only if routines
-gain an owner reference to gate on — otherwise it moves to the Routine.
-`sync-triggers` shrinks to a migration shim, then deletes.
+with a timer trigger; each subscription becomes a Routine with a feed trigger.
+The conversion is substrate-preserving — `AgentWorker` already runs an ephemeral
+`AiSession`, the same substrate as `RunInstructions`, never the durable
+`AgentProcess`. Two caveats from tracing the fired path: the `filterEvents`
+pipeline stages qualified events through `agent.feed` (the "deprecated" field is
+load-bearing), and the qualifier is a deliberately cheap pre-filter whose
+replacement needs a real decision (see PLAN.md phase C) — folding it into the
+routine's instructions would put filtering on the expensive model. `enabled`
+stays as the agent-level master switch only if routines gain an owner reference
+to gate on — otherwise it moves to the Routine. `sync-triggers` shrinks to a
+migration shim, then deletes.
 
 **`instructions: Ref<Text>` → `Ref<Instructions>`.** The typed object carries
 `skills`, `objects`, and `commands` — which is precisely the "skill set" the

--- a/packages/plugins/plugin-projects/DESIGN.md
+++ b/packages/plugins/plugin-projects/DESIGN.md
@@ -17,6 +17,29 @@ plugin-projects is a **seminal core plugin**: it unifies existing concepts
 to extend it (via artifacts, templates) or use projects directly. It will be one
 of the core aspects of Composer.
 
+## Background: Agent, Chat, and the AiSession lifecycle
+
+An **`Agent`** (`org.dxos.type.agent@0.1.0`, `@dxos/assistant-toolkit`) is a
+durable named actor — its own identity DID for attributing content it authors,
+markdown instructions, a primary `chat`, artifacts, subscriptions, and an
+`enabled` master switch over its triggers — whereas a **`Chat`**
+(`org.dxos.type.assistant.chat@0.1.0`) is deliberately thin: essentially a `name`
+plus a ref to a **`Feed`**, the durable append-only log that _is_ the
+conversation (messages, plus `Binding` records of the skills and objects bound to
+it), with the feed parented to its chat and a `CompanionTo` relation attaching the
+chat to whatever object it accompanies. That split is why the runtime is
+**feed-centric rather than chat-centric**: `AiSession.Session` is constructed from
+`{ feed, runtime }` and knows nothing of `Chat`; it owns an `AiContext.Binder`
+that projects the feed's `Binding` records into live skill/object sets, and
+`createRequest` replays history from the feed, formats the system prompt, then
+loops turns — recomputing the toolkit and system prompt each turn so dynamically
+enabled skills take effect — appending every message back to the feed. In the app
+that request does not run in-process: `AgentService.getSession(feed)` spawns (or
+re-hydrates) a durable `AgentProcess` whose process _target_ is the feed's DXN,
+so a restart recovers the whole conversation by replaying the feed — and so
+anything the session needs beyond the feed has to be handed to it explicitly,
+which is the constraint milestone 3's instructions ref is designed around.
+
 ## Types
 
 ### `Project` (`@dxos/compute`)
@@ -135,8 +158,9 @@ revisit once plugin-projects settles (tracked).
 
 - Companion chat surface on `Project` (as plugin-assistant provides for other
   types).
-- On session start the project binds via `AiContext`: instructions text,
-  skills, context objects, and commands flow into the system prompt.
+- On session start the project binds via `AiContext`: skills and context objects.
+  Instructions text and commands reach the system prompt through the
+  `Chat.instructions` ref (milestone 3), not through a binding.
 - Commands autocomplete: plugin-assistant `ChatPrompt` extension reads
   `commands` from the bound project's Instructions and offers sentinel
   completion.
@@ -171,7 +195,9 @@ linked via `routines`).
 
 ## Milestone 2 decisions (as-built addenda)
 
-- **Instructions reach the model via the prompt formatter, not stubs**: bound
+- **Instructions reach the model via the prompt formatter, not stubs** —
+  _superseded in milestone 3 by the `Chat.instructions` ref; the inline rendering
+  stays, the typename-based recovery from `objects` goes._ Bound
   `Instructions` objects are rendered inline by `formatSystemPrompt`
   (`@dxos/assistant` request/format.ts) as a `## Instructions` section — resolved
   markdown text plus sentinel-command directives — and are excluded from the
@@ -214,31 +240,81 @@ design is unchanged, only the enumeration source moves.
 
 `ProjectOperation.CreateChat({ project })`, handled in plugin-projects:
 
-1. Invoke `AssistantOperation.CreateChat({ db, bindings })` — chat + feed, with
-   the assistant's default skills already bound.
+1. Invoke `AssistantOperation.CreateChat({ db, instructions })` — chat + feed,
+   with the assistant's default skills already bound.
 2. `Obj.setParent(chat, project)`.
-3. Open it with `LayoutOperation.Open` (a plank in the deck, matching the Chats
+3. Bind `instructions.skills` (see below — skills still travel by binding).
+4. Open it with `LayoutOperation.Open` (a plank in the deck, matching the Chats
    section's own create action).
+
+The project passes its instructions **by reference** — `chat.instructions` points
+at the project's own `Instructions` object, never a copy, so editing the project's
+instructions steers every chat under it.
 
 `SpaceOperation.AddObject` is deliberately **not** called: it would file the chat
 in the space's root collection, surfacing it under Collections as well. DB
 membership alone (`addToSpace: true`) is what a parented chat needs.
 
-### Context binding: an optional `bindings` input on `CreateChat`
+### Instructions: a typed ref on `Chat`, read when the request is built
 
-`AssistantOperation.CreateChat` gains an optional
-`bindings: { skills?, objects? }`, passed straight to the `AiContext.Binder` it
-already constructs for the default skills. plugin-projects supplies
-`Project.contextBindings(project)` plus a ref to the project itself, and needs no
-`AiContext` plumbing of its own.
+`Chat` gains `instructions?: Ref.Ref<Instructions>` (assistant-toolkit → compute,
+so the typed ref is legal). Whoever builds the session resolves it and passes it
+down; `formatSystemPrompt` takes an explicit `instructions` parameter.
 
-Bindings persist in the conversation feed, and `Instructions` are bound **by
-ref** — so later edits to instruction text or commands reach the model at
-prompt-format time without re-binding. Known gap, accepted: a skill added to the
-instructions _after_ the chat exists does not reach that chat. `ChatCompanion`
-avoids this by re-binding reactively; unifying the two paths (extract its binding
-logic into a shared hook keyed on `Obj.getParent(chat)`) is a follow-up, not this
-milestone.
+This **replaces** the milestone-2 mechanism, where the instructions ref rode in
+the context-object bindings and `formatSystemPrompt` recovered it by filtering
+`objects` for `Obj.instanceOf(Instructions.Instructions, …)`. That worked, but
+dispatch was by typename rather than intent: _any_ bound `Instructions` object
+steered the session, so an Instructions object could never be bound as subject
+matter (e.g. "help me edit these"). Rejected alternatives: an `instructions` slot
+on the `Binding` feed message (schema bump on a type written into every
+conversation feed, and it leaves the ref unqueryable); and walking
+`Obj.getParent(feed)` to reach the chat (needs a compute-level accessor, since
+neither `@dxos/assistant` nor `@dxos/agent-runtime` may import `Chat` —
+`assistant-toolkit` already depends on `agent-runtime`).
+
+The ref is available at every session-construction site, so nothing needs to
+resolve it structurally:
+
+| Site                    | Feed from        | Chat in hand                                                                                     |
+| ----------------------- | ---------------- | ------------------------------------------------------------------------------------------------ |
+| `useChatProcessor`      | `chat.feed`      | yes                                                                                              |
+| `run-instructions`      | `chat.feed`      | yes (routines pass their own `system` text; path unaffected)                                     |
+| agent skill `agent.ts`  | `chatFeed`       | yes                                                                                              |
+| cli `chat/processor.ts` | chat             | yes                                                                                              |
+| `agent-process`         | spawn target DXN | no — but its spawner, `AgentService.getSession`, is called by `processor.ts`, which holds `chat` |
+
+So: `AiSession.Options.instructions` → `RunProps` → `formatSystemPrompt`. For the
+durable agent process, `GetSessionOptions.instructions` plus a persisted spawn
+annotation next to `Process.TargetAnnotation` — executable options do not survive
+re-hydration (`hydrateAgents` rebuilds with a bare `makeExecutable()`), which is
+why the feed itself travels as the process target. `@dxos/agent-runtime` already
+depends on `@dxos/compute`, so it carries an `Instructions` ref without naming
+`Chat`.
+
+**Accepted staleness** (decided 2026-07-27): spawn annotations are the immutable
+identity plane, so editing the instructions _text_ reaches a running process (the
+ref resolves fresh each turn) but _repointing_ `chat.instructions` at a different
+object does not, until the process is terminated. This is the same behavior a
+model change already has. If it ever bites, compare the ref against the
+`sessionCache` entry and terminate/respawn, exactly as the model/provider
+comparison does.
+
+Consequences:
+
+- `Project.contextBindings` drops the instructions ref from `objects`, keeping
+  `skills` and `instructions.objects`. **Skills still travel by binding** — a ref
+  on the Chat can put text in the prompt but cannot put skills in the toolkit.
+- `formatSystemPrompt`'s `instructionObjects` / `contextObjects` partition is
+  deleted. A bound `Instructions` object then renders as an ordinary context
+  stub, which is the point.
+- `ChatCompanion` stops binding project instructions; companion-chat creation
+  sets `chat.instructions` instead, so companion and standalone chats share one
+  path and that hook gets smaller.
+- Chats predating the field have no instructions and would silently lose their
+  steering. Lazy backfill: when a chat opens whose parent (or `CompanionTo`
+  target) is a Project and `chat.instructions` is unset, set it.
+- `format.test.ts`'s three instruction tests move to the explicit parameter.
 
 ### Navtree: chats as children of the project node
 
@@ -276,13 +352,16 @@ cycle — plugin-assistant does not depend on plugin-projects.
 
 ### Testing
 
-- Unit: the `children()`-based chat enumeration, and `CreateChat` parenting +
-  binding pass-through (in-memory db).
+- Unit: `formatSystemPrompt` renders the explicit `instructions` parameter and no
+  longer inlines a bound `Instructions` object; the `children()`-based chat
+  enumeration; `CreateChat` parenting + instructions-ref pass-through (in-memory
+  db).
 - Story + play test: `ProjectArticle` toolbar creates a chat and it appears in
   the project's chat list.
 - Live: create a project chat in Composer, confirm the project's instructions
-  reach the system prompt in a _standalone plank_ (not just the companion) and
-  that the chat shows under the project in the navtree, including after a cold
+  reach the system prompt in a _standalone plank_ (not just the companion) — the
+  end-to-end check that the ref survives the agent-process boundary — and that
+  the chat shows under the project in the navtree, including after a cold
   deep-link load.
 
 ## Deferred / follow-ups (tracked in TASKS.md)

--- a/packages/plugins/plugin-projects/DESIGN.md
+++ b/packages/plugins/plugin-projects/DESIGN.md
@@ -336,19 +336,19 @@ arrays migrate into a Collection on a Project created per agent. The inline
 which is also the correction: naming lived on the wrong object.
 
 **Remove `cron` (and `subscriptions`).** Both are trigger _sources_ that
-`sync-triggers` compiles imperatively into `Trigger` objects. A `Routine`
-(instructions + trigger) is exactly this, declaratively: cron becomes a Routine
-with a timer trigger; each subscription becomes a Routine with a feed trigger.
-The conversion is substrate-preserving — `AgentWorker` already runs an ephemeral
-`AiSession`, the same substrate as `RunInstructions`, never the durable
-`AgentProcess`. Two caveats from tracing the fired path: the `filterEvents`
-pipeline stages qualified events through `agent.feed` (the "deprecated" field is
-load-bearing), and the qualifier is a deliberately cheap pre-filter whose
-replacement needs a real decision (see PLAN.md phase C) — folding it into the
-routine's instructions would put filtering on the expensive model. `enabled`
-stays as the agent-level master switch only if routines gain an owner reference
-to gate on — otherwise it moves to the Routine. `sync-triggers` shrinks to a
-migration shim, then deletes.
+`sync-triggers` compiles imperatively into `Trigger` objects. Each becomes a
+Routine — timer trigger for cron, feed trigger per subscription — whose runnable
+is a **relay**: qualify the event with a cheap model, and when relevant forward
+it to the agent's durable process via `AgentService`/ProcessManager (decided
+burdon × Dima; see PLAN.md phase C). The relay gives multiplexing (many feeds →
+one process) and filtering in one construct, retires `AgentWorker`'s ephemeral
+path, and dissolves `agent.feed` — today's "deprecated" but load-bearing staging
+queue between qualifier and worker — into the process's durable input queue.
+Accepted gap: no backpressure (relays push as triggers fire); the escape hatch
+is an intermediary feed the process drains at its own pace. `enabled` stays as
+the agent-level master switch only if routines gain an owner reference to gate
+on — otherwise it moves to the Routine. `sync-triggers` shrinks to a migration
+shim, then deletes.
 
 **`instructions: Ref<Text>` → `Ref<Instructions>`.** The typed object carries
 `skills`, `objects`, and `commands` — which is precisely the "skill set" the

--- a/packages/plugins/plugin-projects/DESIGN.md
+++ b/packages/plugins/plugin-projects/DESIGN.md
@@ -15,6 +15,13 @@ to be one of the core aspects of Composer.
 
 ## Background: Project, Agent, Chat, AiSession
 
+**Agent**: a durable named actor (`org.dxos.type.agent@0.1.0`,
+`@dxos/assistant-toolkit`) — its own identity DID for attributing content it
+authors, markdown instructions, a primary `chat`, artifacts, subscriptions, and
+an `enabled` master switch over its triggers. Where a project is scope, an agent
+is a participant: it is the thing that acts on a schedule or a trigger rather
+than in response to a user turn.
+
 **Project**: the user's unit of long-running work and the _scope_ a session runs
 in. It owns the instructions that steer its chats (text, sentinel commands, and
 the skills those chats get), the routines that automate it, a collection of
@@ -22,13 +29,6 @@ artifacts, and the chat sessions parented to it. It is inert on its own — a
 project does nothing until a chat or routine runs in its context — so its whole
 job is to supply that context, and every design question below is about how its
 instructions, skills, and objects reach a running session.
-
-**Agent**: a durable named actor (`org.dxos.type.agent@0.1.0`,
-`@dxos/assistant-toolkit`) — its own identity DID for attributing content it
-authors, markdown instructions, a primary `chat`, artifacts, subscriptions, and
-an `enabled` master switch over its triggers. Where a project is scope, an agent
-is a participant: it is the thing that acts on a schedule or a trigger rather
-than in response to a user turn.
 
 **Chat**: a conversation (`org.dxos.type.assistant.chat@0.1.0`), deliberately
 thin — essentially a `name`, a ref to a **`Feed`**, and (per this design) a ref to

--- a/packages/plugins/plugin-projects/DESIGN.md
+++ b/packages/plugins/plugin-projects/DESIGN.md
@@ -1,52 +1,59 @@
 # plugin-projects — Design
 
-Date: 2026-07-24 (milestone 3 design added 2026-07-27)
-Status: approved (brainstorm 1×1 with burdon)
 Tracker: `./TASKS.md`
 
 ## Concept
 
 `Project` is a user-facing container for interactive, long-running work, loosely
 modeled on Claude Desktop projects: instructions (with skills and sentinel
-commands), routines, artifacts, and AI chat sessions that run in project
-context. It is the successor to `Topic` (`@dxos/compute`) and obviates the
-stalled plugin-sidekick.
+commands), routines, artifacts, and AI chat sessions that run in project context.
 
-plugin-projects is a **seminal core plugin**: it unifies existing concepts
-(topics, sidekick ambitions, automation scoping) and other plugins are expected
-to extend it (via artifacts, templates) or use projects directly. It will be one
-of the core aspects of Composer.
+plugin-projects is a **seminal core plugin**: it unifies subject-matter grouping,
+automation scoping, and project-scoped assistance, and other plugins are expected
+to extend it (via artifacts, templates) or use projects directly. It is intended
+to be one of the core aspects of Composer.
 
-## Background: Agent, Chat, and the AiSession lifecycle
+## Background: Project, Agent, Chat, AiSession
 
-An **`Agent`** (`org.dxos.type.agent@0.1.0`, `@dxos/assistant-toolkit`) is a
-durable named actor — its own identity DID for attributing content it authors,
-markdown instructions, a primary `chat`, artifacts, subscriptions, and an
-`enabled` master switch over its triggers — whereas a **`Chat`**
-(`org.dxos.type.assistant.chat@0.1.0`) is deliberately thin: essentially a `name`
-plus a ref to a **`Feed`**, the durable append-only log that _is_ the
-conversation (messages, plus `Binding` records of the skills and objects bound to
-it), with the feed parented to its chat and a `CompanionTo` relation attaching the
-chat to whatever object it accompanies. That split is why the runtime is
-**feed-centric rather than chat-centric**: `AiSession.Session` is constructed from
-`{ feed, runtime }` and knows nothing of `Chat`; it owns an `AiContext.Binder`
-that projects the feed's `Binding` records into live skill/object sets, and
-`createRequest` replays history from the feed, formats the system prompt, then
-loops turns — recomputing the toolkit and system prompt each turn so dynamically
-enabled skills take effect — appending every message back to the feed. In the app
-that request does not run in-process: `AgentService.getSession(feed)` spawns (or
-re-hydrates) a durable `AgentProcess` whose process _target_ is the feed's DXN,
-so a restart recovers the whole conversation by replaying the feed — and so
-anything the session needs beyond the feed has to be handed to it explicitly,
-which is the constraint milestone 3's instructions ref is designed around.
+**Project**: the user's unit of long-running work and the _scope_ a session runs
+in. It owns the instructions that steer its chats (text, sentinel commands, and
+the skills those chats get), the routines that automate it, a collection of
+artifacts, and the chat sessions parented to it. It is inert on its own — a
+project does nothing until a chat or routine runs in its context — so its whole
+job is to supply that context, and every design question below is about how its
+instructions, skills, and objects reach a running session.
+
+**Agent**: a durable named actor (`org.dxos.type.agent@0.1.0`,
+`@dxos/assistant-toolkit`) — its own identity DID for attributing content it
+authors, markdown instructions, a primary `chat`, artifacts, subscriptions, and
+an `enabled` master switch over its triggers. Where a project is scope, an agent
+is a participant: it is the thing that acts on a schedule or a trigger rather
+than in response to a user turn.
+
+**Chat**: a conversation (`org.dxos.type.assistant.chat@0.1.0`), deliberately
+thin — essentially a `name`, a ref to a **`Feed`**, and (per this design) a ref to
+the `Instructions` that steer it. The feed is the durable append-only log that
+_is_ the conversation: messages, plus `Binding` records of the skills and objects
+bound to it. The feed is parented to its chat, and a `CompanionTo` relation
+attaches a chat to whatever object it accompanies.
+
+**AiSession**: the runtime, and it is **feed-centric rather than chat-centric**.
+`AiSession.Session` is constructed from `{ feed, runtime }` and knows nothing of
+`Chat`; it owns an `AiContext.Binder` that projects the feed's `Binding` records
+into live skill/object sets, and `createRequest` replays history from the feed,
+formats the system prompt, then loops turns — recomputing the toolkit and system
+prompt each turn so dynamically enabled skills take effect — appending every
+message back to the feed. In the app that request does not run in-process:
+`AgentService.getSession(feed)` spawns (or re-hydrates) a durable `AgentProcess`
+whose process _target_ is the feed's DXN, so a restart recovers the whole
+conversation by replaying the feed. The consequence that shapes this design:
+anything a session needs beyond its feed has to be handed to it explicitly.
 
 ## Types
 
 ### `Project` (`@dxos/compute`)
 
-Evolved in place from `Topic.ts` (Topic is deleted; no shims). Typename
-`org.dxos.type.project@0.2.0` — 0.2.0 disambiguates from stored instances of the
-name-squatting `@dxos/types` Project at 0.1.0.
+`org.dxos.type.project@0.2.0`:
 
 ```text
 name?: string
@@ -56,185 +63,155 @@ routines: Ref(Routine)[]             // routines created in project scope
 artifacts?: Ref(Collection)          // owned child Collection (documents, outliners, tables, …)
 ```
 
-- Placement decision: core type in `@dxos/compute` (next to Instructions, Skill,
-  Trigger) so brain/inbox/EDGE-side code can reference it without a plugin
-  dependency. Follow-up (tracked): possibly move the type into the plugin once
-  its shape settles.
-- Artifacts use a `Collection` (core, `@dxos/echo`) to reuse existing collection
-  UI/drag-drop. Artifact provenance (which routine/agent produced what) is
-  deferred.
+The type lives in `@dxos/compute` (next to Instructions, Skill, Trigger) so
+brain/inbox/EDGE-side code can reference it without a plugin dependency.
+Artifacts use a `Collection` (core, `@dxos/echo`) to reuse existing collection
+UI and drag-drop.
 
-### `Routine` schema moves to `@dxos/compute`
+Chats are **not** a field: they are parented to the Project in the ECHO
+hierarchy — see [Project chats](#project-chats).
 
-`Routine` (`org.dxos.type.routine@0.2.0`) moves from
-`plugin-routine/src/types/Routine.ts` to `@dxos/compute` types, with its pure
-helpers (`instanceOf`, `instructionsRef`, `runnableRef`). This lets `Project`
-hold `Ref(Routine)`.
+### `Routine` (`@dxos/compute`)
 
-`wireTriggers` and the wiring `make` (instructions/trigger parenting +
-`runInstructionsRef`) **stay in plugin-routine**: they depend on
-`RunInstructions` from `@dxos/assistant-toolkit`, which itself depends on
-`@dxos/compute` — moving them would create a cycle.
+`Routine` (`org.dxos.type.routine@0.2.0`) lives in `@dxos/compute` with its pure
+helpers (`instanceOf`, `instructionsRef`, `runnableRef`), so `Project` can hold
+`Ref(Routine)`. Its wiring — `wireTriggers` and the wiring `make`
+(instructions/trigger parenting + `runInstructionsRef`) — stays in plugin-routine
+because it depends on `RunInstructions` from `@dxos/assistant-toolkit`, which
+itself depends on `@dxos/compute`.
 
 ### `Instructions.commands` (structured sentinel commands)
 
-`Instructions` (`@dxos/compute`) gains an optional structured field:
+`Instructions` (`@dxos/compute`) carries an optional structured field:
 
 ```text
 commands?: Array<{ sentinel: string; description?: string; prompt: string }>
 ```
 
 Project instructions define sentinel commands (e.g. `$track …`) that chat
-sessions in project context can reference; they surface as autocomplete in the
-chat prompt from day one (no free-text-only MVP). Living on `Instructions`
-(not `Project`) means routines and agents get commands too.
+sessions in project context can invoke, surfaced as autocomplete in the chat
+prompt. Living on `Instructions` rather than `Project` means routines and agents
+get commands too.
 
-### `ExternalProject` rename (`@dxos/types`)
+### `Chat.instructions` (`@dxos/assistant-toolkit`)
 
-The existing `@dxos/types` `Project` ({name, description, image}) is a separate
-GH/Linear-style concept name-squatting the typename. It is renamed (possibly
-temporarily) for later use syncing remote services with a lightweight,
-non-AI project concept:
+`Chat` carries `instructions?: Ref.Ref<Instructions>` — the instructions that
+steer that conversation. A project chat's ref points at the **project's own**
+`Instructions` object, never a copy, so editing the project's instructions
+steers every chat under it.
 
-- Type + file: `Project` → `ExternalProject`; all call sites updated
-  (plugin-github/plugin-linear sync + materialize-target, plugin-space,
-  onboarding exemplar script, stories/tests); no compatibility shims.
-- DXN: → `org.dxos.type.externalProject@0.1.0` (frees the typename in the data
-  layer; acceptable because the type is not actively exercised).
-- plugin-space create menu: **entry removed** (sync plugins materialize it;
-  hand-creation would collide with the new Project entry).
+## Layering constraints
 
-### Chats and Agents (layering)
+These are load-bearing and easy to trip over:
 
-`@dxos/assistant-toolkit` depends on `@dxos/compute`, so `Project` cannot hold
-typed refs to `Chat` or `Agent`.
-
-- **Chats**: two distinct linkages, resolved in milestone 3 (see
-  [Project chats](#milestone-3-project-chats)). A project's _companion_ chat
-  stays on the existing `CompanionTo` relation
-  (`org.dxos.relation.assistant.companionTo`, source `Chat` → target
-  `Obj.Unknown`), consistent with `Agent`'s chat wiring. A project's _own_ chat
-  sessions are instead **parented** to the Project in the ECHO hierarchy
-  (`Obj.setParent`) and enumerated with `Query…children()` — the relation is
-  single-current by construction (`state.currentChat[objectUri]`) and carries no
-  ownership edge, so it cannot express "N sessions belonging to this project".
-- **Agents**: explicit linkage deferred. MVP: agents participate via project
-  chats and routines (an instructions-routine already runs in the agent
-  harness). A project-scoped agent roster (relation or parenting) comes later,
-  decided alongside the CompanionTo review.
+- `@dxos/assistant-toolkit` depends on `@dxos/compute`, so `Project` cannot hold
+  typed refs to `Chat` or `Agent` — but `Chat` can hold a typed ref to
+  `Instructions`.
+- `@dxos/assistant-toolkit` depends on `@dxos/agent-runtime`, so neither
+  `@dxos/assistant` nor `@dxos/agent-runtime` may import `Chat`. Both may import
+  `@dxos/compute`, so an `Instructions` ref can travel through them.
+- plugin-projects depends on `@dxos/assistant-toolkit` (the `Chat` type) and
+  `@dxos/plugin-assistant` (`AssistantOperation`, via its `./types` export).
+  plugin-assistant does not depend on plugin-projects.
 
 ## Plugin
 
-New `packages/plugins/plugin-projects` (`"private": true`), standard core-plugin
+`packages/plugins/plugin-projects` (`"private": true`), standard core-plugin
 shape:
 
 - `meta`, `types/` (`ProjectOperation`, capabilities, events), `translations`.
-- `capabilities/`: `create-object` (navtree "+ Project": creates Project with
-  owned Instructions + empty artifacts Collection), `app-graph-builder`
-  (Project node with children: artifacts collection, routines),
+- `capabilities/`: `create-object` (navtree "+ Project": creates a Project with
+  owned Instructions + empty artifacts Collection), `app-graph-builder`,
   `navigation-resolver`, `react-surface`, `operation-handler`.
-- `containers/ProjectArticle/`: reworked from plugin-brain's `TopicArticle`
-  (which moves here and is deleted from plugin-brain): header
-  (name/description), instructions editor (Form + markdown text), routines
-  list, artifacts collection section. Storybook story + play test.
+- `containers/ProjectArticle/`: header (name/description), instructions editor
+  (Form + markdown text), routines list, artifacts collection section, and a
+  toolbar. Storybook story + play test.
 
 ### Extension points (seminal-plugin posture)
 
-1. **Artifacts**: any plugin's objects can be project artifacts — the
-   Collection accepts `Obj.Unknown`; no coupling required.
-2. **Direct use**: types/operations exported so other plugins can create/target
-   projects (`ProjectOperation.Create`, …).
-3. **Templates (phase 2)**: a capability for plugins to contribute project
-   templates (instructions + skills + starter routines), mirroring the
-   existing `automation-templates` pattern.
-
-### plugin-routine merge (deferred)
-
-Considered merging plugin-routine into plugin-projects. Decision: not in this
-pass — the Routine schema move to `@dxos/compute` already thins the boundary;
-revisit once plugin-projects settles (tracked).
+1. **Artifacts**: any plugin's objects can be project artifacts — the Collection
+   accepts `Obj.Unknown`; no coupling required.
+2. **Direct use**: types and operations are exported so other plugins can create
+   or target projects (`ProjectOperation.Create`, …).
+3. **Templates**: a capability for plugins to contribute project templates
+   (instructions + skills + starter routines), mirroring `automation-templates`.
 
 ## Chat integration
 
-- Companion chat surface on `Project` (as plugin-assistant provides for other
-  types).
-- On session start the project binds via `AiContext`: skills and context objects.
-  Instructions text and commands reach the system prompt through the
-  `Chat.instructions` ref (milestone 3), not through a binding.
-- Commands autocomplete: plugin-assistant `ChatPrompt` extension reads
-  `commands` from the bound project's Instructions and offers sentinel
-  completion.
+A project's chats reach the model through two distinct channels, and the split
+matters: **a ref on the Chat can put text in the prompt but cannot put skills in
+the toolkit.**
 
-## Call-site migrations
+- **Instructions text and commands** travel via `Chat.instructions`. Whoever
+  builds the session resolves the ref and passes it down —
+  `AiSession.Options.instructions` → `RunProps` → an explicit `instructions`
+  parameter on `formatSystemPrompt`, which renders a `## Instructions` section
+  (resolved markdown plus sentinel-command directives).
+- **Skills and context objects** travel via `AiContext` bindings.
+  `Project.contextBindings` supplies `instructions.skills` and
+  `instructions.objects`; bindings persist as `Binding` records in the feed.
+- **Commands autocomplete**: a plugin-assistant `ChatPrompt` extension reads
+  `commands` from the chat's instructions and offers sentinel completion.
+- Context-object stubs in the system prompt carry a `<label>`, so the model
+  tool-loads a bound object only for its contents, never to identify it.
 
-- **plugin-brain**: drops Topic surfaces (create-object, navigation-resolver,
-  app-graph-builder, react-surface entries, translations); `TopicArticle`
-  moves to plugin-projects.
-- **plugin-inbox**: `create-topic-from-message` produces a `Project`; operation
-  renamed `CreateProjectFromMessage`; labels updated.
-- **stories-brain / stories-inbox / assistant fixtures**: updated to `Project`.
-- **plugin-github / plugin-linear / plugin-space / onboarding script**:
-  `ExternalProject` rename.
+### Why instructions are a typed ref, not a binding
 
-## Milestone 1 scope (approved)
+Instructions could ride in the context-object bindings, with
+`formatSystemPrompt` recovering them by filtering `objects` for
+`Obj.instanceOf(Instructions.Instructions, …)`. That dispatches on typename
+rather than intent: _any_ bound `Instructions` object would steer the session, so
+an Instructions object could never be bound as subject matter (e.g. "help me edit
+these"). Two other options were considered and rejected: an `instructions` slot
+on the `Binding` feed message (a schema bump on a type written into every
+conversation feed, and the ref stays unqueryable), and walking
+`Obj.getParent(feed)` to reach the chat (needs a compute-level accessor, since
+the session layers may not import `Chat`).
 
-Full loop: `Project` type + create-object; `ProjectArticle`; companion chat
-bound via `AiContext` (instructions + skills + commands); commands autocomplete
-in the chat prompt; all call-site migrations above. Routine creation _within_
-the article is deferred to milestone 2 (create via existing routine flows;
-linked via `routines`).
+The ref is available at every session-construction site, so nothing has to
+resolve it structurally:
 
-## Testing
+| Site                    | Feed from        | Chat in hand                                                                                     |
+| ----------------------- | ---------------- | ------------------------------------------------------------------------------------------------ |
+| `useChatProcessor`      | `chat.feed`      | yes                                                                                              |
+| `run-instructions`      | `chat.feed`      | yes (routines pass their own `system` text, so this path is unaffected)                          |
+| agent skill `agent.ts`  | `chatFeed`       | yes                                                                                              |
+| cli `chat/processor.ts` | chat             | yes                                                                                              |
+| `agent-process`         | spawn target DXN | no — but its spawner, `AgentService.getSession`, is called by `processor.ts`, which holds `chat` |
 
-- Type tests: Project/Routine schema round-trip, commands field, ExternalProject
-  rename fallout.
-- Migration-touched suites: plugin-routine, plugin-inbox, plugin-brain,
-  plugin-linear, plugin-github sync.
-- `ProjectArticle` story + play test; chat-binding story in stories-assistant.
-- Verify: `moon` build/test/lint + storybook from the worktree on an alt port.
+For the durable agent process the ref travels as `GetSessionOptions.instructions`
+plus a persisted spawn annotation beside `Process.TargetAnnotation`. Executable
+options do not survive re-hydration (`hydrateAgents` rebuilds with a bare
+`makeExecutable()`), which is why the feed itself travels as the process target.
 
-## Milestone 2 decisions (as-built addenda)
+**Known staleness**: spawn annotations are the immutable identity plane, so
+editing the instructions _text_ reaches a running process (the ref resolves fresh
+each turn) but _repointing_ `chat.instructions` at a different object does not,
+until the process is terminated — the same behavior a model change already has.
+The fix, if it ever bites: compare the ref against the `sessionCache` entry and
+terminate/respawn, exactly as the model/provider comparison does.
 
-- **Instructions reach the model via the prompt formatter, not stubs** —
-  _superseded in milestone 3 by the `Chat.instructions` ref; the inline rendering
-  stays, the typename-based recovery from `objects` goes._ Bound
-  `Instructions` objects are rendered inline by `formatSystemPrompt`
-  (`@dxos/assistant` request/format.ts) as a `## Instructions` section — resolved
-  markdown text plus sentinel-command directives — and are excluded from the
-  `## Context Objects` stub list. This is the load-bearing half of "use project
-  instructions in chat"; binding alone only produced a tool-loadable stub.
-- **Context stubs carry labels** (`<label>`), so the model tool-loads bound
-  objects only for contents, not identification.
-- **Owned refs resolve reactively in articles**: `.target` sync reads never
-  resolve on cold/deep-link loads; use `useObject(ref)` +
-  `Obj.getReactiveOrUndefined` (ProjectArticle instructions).
-- **Instructions typename labels**: plugin-assistant's legacy "Routine" labels
-  for `org.dxos.type.instructions` corrected to "Instructions"; project
-  creation names the owned Instructions object.
-- **Dev loop**: Projects/Routine/Outliner plugins are part of the composer-app
-  minimal set (`serve-min`).
+## Project chats
 
-## Milestone 3: project chats
-
-Goal: start a chat session from a project, with the project already in scope, and
+Goal: start a chat session from a project with the project already in scope, and
 see that session in the navtree under its project.
 
 ### Ownership: the ECHO parent edge
 
 A project chat is parented to its Project (`Obj.setParent(chat, project)`) and
 enumerated with `Query.select(Filter.id(project.id)).children()` narrowed to
-`Chat.Chat`. No `Project` schema change, so no version bump and no migration of
-existing project objects.
+`Chat.Chat`. This needs no `Project` schema field, and the parent edge is the
+ownership statement.
 
 Rejected alternatives: a `chats: Ref<Collection>` field mirroring `artifacts`
-(buys sibling ordering and drag-rearrange, costs a 0.2.0 → 0.3.0 bump); and
-reusing `CompanionTo` (conflates the single-current companion chat with N owned
-sessions, and yields no ownership edge).
+(buys sibling ordering and drag-rearrange, costs a schema version bump); and
+reusing `CompanionTo` for owned sessions (that relation is single-current by
+construction, via `state.currentChat[objectUri]`, and carries no ownership edge).
+`CompanionTo` still links the project's _companion_ chat.
 
-The one risk this takes on: a hierarchy-traversal query driving a graph connector
-is less exercised than a ref-array read. If `children()` does not re-emit when a
-chat is newly parented, fall back to the Collection field — the rest of the
-design is unchanged, only the enumeration source moves.
+**Risk**: a hierarchy-traversal query driving a graph connector is less exercised
+than a ref-array read. If `children()` does not re-emit when a chat is newly
+parented, fall back to the Collection field — only the enumeration source moves.
 
 ### Creation: `ProjectOperation.CreateChat`
 
@@ -243,133 +220,74 @@ design is unchanged, only the enumeration source moves.
 1. Invoke `AssistantOperation.CreateChat({ db, instructions })` — chat + feed,
    with the assistant's default skills already bound.
 2. `Obj.setParent(chat, project)`.
-3. Bind `instructions.skills` (see below — skills still travel by binding).
-4. Open it with `LayoutOperation.Open` (a plank in the deck, matching the Chats
-   section's own create action).
-
-The project passes its instructions **by reference** — `chat.instructions` points
-at the project's own `Instructions` object, never a copy, so editing the project's
-instructions steers every chat under it.
+3. Bind `instructions.skills`.
+4. Open it with `LayoutOperation.Open` (a plank in the deck).
 
 `SpaceOperation.AddObject` is deliberately **not** called: it would file the chat
 in the space's root collection, surfacing it under Collections as well. DB
 membership alone (`addToSpace: true`) is what a parented chat needs.
 
-### Instructions: a typed ref on `Chat`, read when the request is built
-
-`Chat` gains `instructions?: Ref.Ref<Instructions>` (assistant-toolkit → compute,
-so the typed ref is legal). Whoever builds the session resolves it and passes it
-down; `formatSystemPrompt` takes an explicit `instructions` parameter.
-
-This **replaces** the milestone-2 mechanism, where the instructions ref rode in
-the context-object bindings and `formatSystemPrompt` recovered it by filtering
-`objects` for `Obj.instanceOf(Instructions.Instructions, …)`. That worked, but
-dispatch was by typename rather than intent: _any_ bound `Instructions` object
-steered the session, so an Instructions object could never be bound as subject
-matter (e.g. "help me edit these"). Rejected alternatives: an `instructions` slot
-on the `Binding` feed message (schema bump on a type written into every
-conversation feed, and it leaves the ref unqueryable); and walking
-`Obj.getParent(feed)` to reach the chat (needs a compute-level accessor, since
-neither `@dxos/assistant` nor `@dxos/agent-runtime` may import `Chat` —
-`assistant-toolkit` already depends on `agent-runtime`).
-
-The ref is available at every session-construction site, so nothing needs to
-resolve it structurally:
-
-| Site                    | Feed from        | Chat in hand                                                                                     |
-| ----------------------- | ---------------- | ------------------------------------------------------------------------------------------------ |
-| `useChatProcessor`      | `chat.feed`      | yes                                                                                              |
-| `run-instructions`      | `chat.feed`      | yes (routines pass their own `system` text; path unaffected)                                     |
-| agent skill `agent.ts`  | `chatFeed`       | yes                                                                                              |
-| cli `chat/processor.ts` | chat             | yes                                                                                              |
-| `agent-process`         | spawn target DXN | no — but its spawner, `AgentService.getSession`, is called by `processor.ts`, which holds `chat` |
-
-So: `AiSession.Options.instructions` → `RunProps` → `formatSystemPrompt`. For the
-durable agent process, `GetSessionOptions.instructions` plus a persisted spawn
-annotation next to `Process.TargetAnnotation` — executable options do not survive
-re-hydration (`hydrateAgents` rebuilds with a bare `makeExecutable()`), which is
-why the feed itself travels as the process target. `@dxos/agent-runtime` already
-depends on `@dxos/compute`, so it carries an `Instructions` ref without naming
-`Chat`.
-
-**Accepted staleness** (decided 2026-07-27): spawn annotations are the immutable
-identity plane, so editing the instructions _text_ reaches a running process (the
-ref resolves fresh each turn) but _repointing_ `chat.instructions` at a different
-object does not, until the process is terminated. This is the same behavior a
-model change already has. If it ever bites, compare the ref against the
-`sessionCache` entry and terminate/respawn, exactly as the model/provider
-comparison does.
-
-Consequences:
-
-- `Project.contextBindings` drops the instructions ref from `objects`, keeping
-  `skills` and `instructions.objects`. **Skills still travel by binding** — a ref
-  on the Chat can put text in the prompt but cannot put skills in the toolkit.
-- `formatSystemPrompt`'s `instructionObjects` / `contextObjects` partition is
-  deleted. A bound `Instructions` object then renders as an ordinary context
-  stub, which is the point.
-- `ChatCompanion` stops binding project instructions; companion-chat creation
-  sets `chat.instructions` instead, so companion and standalone chats share one
-  path and that hook gets smaller.
-- Chats predating the field have no instructions and would silently lose their
-  steering. Lazy backfill: when a chat opens whose parent (or `CompanionTo`
-  target) is a Project and `chat.instructions` is unset, set it.
-- `format.test.ts`'s three instruction tests move to the explicit parameter.
+Companion chats take the same instructions path: companion-chat creation sets
+`chat.instructions` from the project rather than binding it, so companion and
+standalone chats behave identically.
 
 ### Navtree: chats as children of the project node
 
-Projects are leaf nodes today — `TypeSection.createTypeSectionExtension` emits
-`AppNode.makeObject` with no children. A new `projectChats` extension in
-plugin-projects contributes them:
+A `projectChats` extension in plugin-projects contributes the children (the
+`TypeSection` extension that emits Project nodes makes them leaves):
 
 - `match`: nodes whose `data` is a `Project.Project`.
 - `connector`: the `children()` query above → `AppNode.makeObject` per chat.
 - `url`: reuses the `chat` key with a data-dependent `path` that resolves the
   chat's parent project. Sharing one key across extensions is supported and
   intended — plugin-space's `object` key spans both collection connectors for
-  exactly this reason (`@dxos/app-graph` `path-resolution.ts`), so a chat is
+  exactly this reason (`@dxos/app-graph` `path-resolution.ts`) — so a chat is
   addressed the same way wherever it sits.
 
-**Consequence in plugin-assistant**: the Chats type-section query already
-excludes `CompanionTo` sources; it must also exclude project-parented chats, or
-every project chat appears twice — once under its project, once at the top level.
+The Chats type-section query in plugin-assistant excludes both `CompanionTo`
+sources and project-parented chats; without the second exclusion every project
+chat appears twice, once under its project and once at the space level.
 
-### Toolbar: `ProjectArticle`
+### Toolbar
 
-`ProjectArticle` has no toolbar today. Add `Panel.Toolbar asChild` +
-`Toolbar.Root` with a single `IconButton` invoking
-`ProjectOperation.CreateChat`. The same action is contributed to the project's
-navtree node (`disposition: 'list-item-primary'`) so `+` works from the tree.
+`ProjectArticle` has a `Panel.Toolbar` (`asChild` + `Toolbar.Root`) whose
+`IconButton` invokes `ProjectOperation.CreateChat`. The same action is
+contributed to the project's navtree node (`disposition: 'list-item-primary'`)
+so `+` works from the tree.
 
-Scope held to chat creation: in-article routine and artifact creation are already
-their own TASKS.md items.
+## UI conventions
 
-### Dependencies
+- **Owned refs resolve reactively in articles**: a sync `.target` read never
+  resolves on a cold or deep-link load, leaving the section permanently missing.
+  Use `useObject(ref)` + `Obj.getReactiveOrUndefined` (see `ProjectArticle`'s
+  instructions).
+- **Dev loop**: Projects, Routine, and Outliner are part of the composer-app
+  minimal plugin set (`serve-min`); keep the plugin list in sync with the
+  `optimizeDeps` brace glob in `vite.config.ts`.
 
-plugin-projects gains `@dxos/assistant-toolkit` (the `Chat` type) and
-`@dxos/plugin-assistant` (`AssistantOperation`, via its `./types` export). No
-cycle — plugin-assistant does not depend on plugin-projects.
+## Testing
 
-### Testing
-
-- Unit: `formatSystemPrompt` renders the explicit `instructions` parameter and no
-  longer inlines a bound `Instructions` object; the `children()`-based chat
-  enumeration; `CreateChat` parenting + instructions-ref pass-through (in-memory
-  db).
-- Story + play test: `ProjectArticle` toolbar creates a chat and it appears in
-  the project's chat list.
-- Live: create a project chat in Composer, confirm the project's instructions
-  reach the system prompt in a _standalone plank_ (not just the companion) — the
+- Type tests: `Project`/`Routine` schema round-trip, the `commands` field,
+  `Project.contextBindings`.
+- Unit: `formatSystemPrompt` renders the explicit `instructions` parameter and
+  does not inline a bound `Instructions` object; the `children()`-based chat
+  enumeration; `CreateChat` parenting and instructions-ref pass-through.
+- Storybook: `ProjectArticle` story + play test (including the toolbar creating a
+  chat that appears in the project's chat list); chat-binding story in
+  stories-assistant.
+- Live: create a project chat in Composer and confirm the project's instructions
+  reach the system prompt in a _standalone plank_, not just the companion — the
   end-to-end check that the ref survives the agent-process boundary — and that
-  the chat shows under the project in the navtree, including after a cold
-  deep-link load.
+  the chat shows under its project in the navtree after a cold deep-link load.
 
-## Deferred / follow-ups (tracked in TASKS.md)
+## Open questions
 
-- Possibly move Project type from `@dxos/compute` into the plugin at end.
-- Unify project-context binding across companion and standalone chats (shared
-  hook keyed on the chat's parent), closing the late-added-skills gap.
-- Remove plugin-sidekick (this pass: AUDIT.md note only).
-- Consider merging plugin-routine into plugin-projects.
-- In-article routine creation; project agent roster; artifact provenance;
-  project templates capability.
+- Move the `Project` type from `@dxos/compute` into this plugin, once its shape
+  settles.
+- Merge plugin-routine into plugin-projects — the boundary is thin now that
+  `Routine` lives in `@dxos/compute`.
+- Project-scoped agent roster (relation or parenting), and artifact provenance
+  (which routine or agent produced what).
+- Remove plugin-sidekick, which this plugin obviates.
+
+Task-level follow-ups live in `./TASKS.md`.

--- a/packages/plugins/plugin-projects/DESIGN.md
+++ b/packages/plugins/plugin-projects/DESIGN.md
@@ -191,6 +191,24 @@ until the process is terminated — the same behavior a model change already has
 The fix, if it ever bites: compare the ref against the `sessionCache` entry and
 terminate/respawn, exactly as the model/provider comparison does.
 
+## Artifacts and the project skill
+
+The artifacts Collection is only useful if the model can both **file** into it and
+**find** from it. A `ProjectSkill`, bound into every project chat, owns that:
+
+- **Add** an object ref to the project's artifacts Collection.
+- **List** the collection, so the model can find what the project already holds
+  without falling back to a space-wide search.
+
+Filing is explicit rather than automatic: the skill's instructions tell the model
+to file what it creates, and the tool call is visible in the conversation. The
+alternative — intercepting object creation during a project chat and filing
+everything automatically — needs a creation hook and silently captures scratch
+objects, so it is not the default.
+
+Creating artifacts of other types from a project chat (Outline, Sheet,
+Organization/Contact) builds on the same skill and is tracked separately.
+
 ## Project chats
 
 Goal: start a chat session from a project with the project already in scope, and
@@ -275,10 +293,26 @@ so `+` works from the tree.
 - Storybook: `ProjectArticle` story + play test (including the toolbar creating a
   chat that appears in the project's chat list); chat-binding story in
   stories-assistant.
-- Live: create a project chat in Composer and confirm the project's instructions
-  reach the system prompt in a _standalone plank_, not just the companion — the
-  end-to-end check that the ref survives the agent-process boundary — and that
-  the chat shows under its project in the navtree after a cold deep-link load.
+- Live (manual, in Composer): create a project chat and confirm the project's
+  instructions reach the system prompt in a _standalone plank_, not just the
+  companion — the end-to-end check that the ref survives the agent-process
+  boundary — and that the chat shows under its project in the navtree after a
+  cold deep-link load.
+
+### System test (live against a real model, out of CI)
+
+One scenario exercising the whole loop, graded on database effects rather than on
+model wording:
+
+1. Create a Project with instructions.
+2. Create a Chat under it — own feed, `instructions` pointing at the project's.
+3. Prompt the model to create a markdown document.
+4. Assert the document is bound into the session context **and** present in the
+   project's artifacts Collection.
+
+Step 4 is the real assertion: binding alone proves only that the session saw the
+object, not that the project owns it, so this is the test that would catch the
+project skill failing to file. It runs against a live model and stays out of CI.
 
 ## Open questions
 

--- a/packages/plugins/plugin-projects/PLAN.md
+++ b/packages/plugins/plugin-projects/PLAN.md
@@ -116,6 +116,24 @@ substrate-preserving, not a downgrade. `AgentWorker`'s identity mechanism
       pass of `projects.eval.ts` (unchanged expectations prove the container
       path was already agent-free).
 
+## Phase E (optional) — rename the session host
+
+`agent-process.ts` (the durable process behind interactive chats) never
+references the `Agent` type — its identity is a feed, and its machinery (input
+queue, alarms, tool-call manager, delegation supervisor, end-request hooks,
+HarnessControl) is per-conversation, configured by layer options. Once "Agent"
+means the identity/preset type, the name `AgentProcess` actively misleads.
+
+- [ ] Rename `AgentProcess`/`AgentEvent`/`AgentService` toward
+      "session host" vocabulary (e.g. `SessionProcess`, `SessionHost`) — naming
+      only, no behavior.
+- [ ] `AGENT_PROCESS_KEY` is `org.dxos.testing.process.agent` — a `testing`
+      namespace in a production identifier, and the **hydration key** for
+      persisted process records; changing it needs a compat alias (hydrate by
+      old key, spawn by new) or a record migration, not a find-and-replace.
+- [ ] Can land any time — zero coupling to phases A–D (verified: the file has
+      no `Agent`-type reference).
+
 ## Non-goals
 
 - Permissions on Agent (tracked, later).
@@ -132,7 +150,8 @@ substrate-preserving, not a downgrade. `AgentWorker`'s identity mechanism
   ephemeral `AiSession`s. This plan preserves that split — C converts within
   the ephemeral substrate — but any future "agent alarms survive restarts for
   triggered runs" requirement pulls C onto the durable substrate instead;
-  decide before C, not after.
+  decide before C, not after. (The durable process itself is Agent-type-free —
+  see phase E — so either choice leaves it untouched.)
 - **Memoized-LLM tests** encode current tool surfaces (`add-artifact`,
   `get-context` artifacts); D re-records them.
 - `enabled` semantics during C: don't strand existing disabled agents —

--- a/packages/plugins/plugin-projects/PLAN.md
+++ b/packages/plugins/plugin-projects/PLAN.md
@@ -68,34 +68,45 @@ appended to `agent.feed` (the nominally-deprecated field is this pipeline's
 staging queue) → second trigger on `agent.feed` → `AgentWorker`. Without
 `filterEvents`, the subscription trigger invokes `AgentWorker` directly; `cron`
 always does. `AgentWorker` builds an **ephemeral `AiSession` on the chat feed**
-(hardcoded model, retry ×2) — it never touches the durable `AgentProcess`, so
-triggered runs already share `RunInstructions`' substrate and the conversion is
-substrate-preserving, not a downgrade. `AgentWorker`'s identity mechanism
-(assert exactly one Agent bound in the chat context) is replaced by B's
-`chat.agent`.
+(hardcoded model, retry ×2) — it never touches the durable `AgentProcess`.
+`AgentWorker`'s identity mechanism (assert exactly one Agent bound in the chat
+context) is replaced by B's `chat.agent`.
 
-- [ ] Agent wizard: creating a schedule/subscription creates a `Routine`
-      (timer / feed trigger) whose runnable is `RunInstructions` over the
-      agent's instructions, input carrying the target chat (per B).
-- [ ] **Qualifier stage — decide, don't fold blindly.** Folding relevance
-      filtering into the routine's instructions makes the expensive model do
-      the cheap model's job. Options: (a) a qualifier/filter option on the
-      `Trigger` spec or Routine (a pre-stage runnable + model), preserving the
-      cost profile; (b) a two-routine chain, which still needs an intermediate
-      feed (keeps `agent.feed`'s role, just relocated); (c) drop qualification
-      for v1 and deliver events unfiltered. Leaning (a); decide with usage
-      data from the wizard's existing subscriptions.
+**Decided shape (burdon × Dima, re-confirmed 2026-07-28): the relay pattern.**
+Each subscription becomes a Routine (feed trigger) whose runnable is a
+**`RelayFunction`** — it qualifies the event with a cheap model and, when
+relevant, forwards it to the agent's **durable process** via
+`AgentService`/ProcessManager (`Handle.submitInput`, or the `enqueueMessage`
+Tier B RPC — both persist onto the process's durable input queue). This gives
+multiplexing (N feed routines → one process) and filtering in one construct,
+and resolves the substrate fork: **triggered runs move onto the durable
+process**; `AgentWorker`'s ephemeral path retires and `agent.feed` dissolves
+into the process input queue (fulfilling its own deprecation note,
+"subscriptions will write directly to the agent"). `RelayFunction` does not
+exist yet — the delivery surfaces do.
+
+Known gap, accepted: **no backpressure** — events are durable once delivered,
+but relays push as fast as triggers fire, so a hot feed grows the input queue
+unboundedly. Escape hatch if it bites: reintroduce an intermediary feed the
+process drains at its own pace (at the cost of the visible extra feed).
+
+- [ ] `RelayFunction` (assistant-toolkit): input `{ agent | chat, event }`;
+      qualify (cheap model, reusing the Qualifier prompt) → on relevant,
+      `AgentService.getSession(chatFeed, { instructions }).submitPrompt(event)`.
+      Instructions reach the durable process via the existing spawn-annotation
+      path — no separate ephemeral-path work needed.
+- [ ] Agent wizard: a subscription creates a Routine (feed trigger →
+      `RelayFunction`); `cron` creates a Routine (timer trigger) that submits a
+      wake prompt through the same relay path.
 - [ ] `enabled`: routines gain an owner gate or the flag moves onto each
       Routine; `sync-triggers` reduces to a migration shim (existing
       cron/subscription fields → Routines on first open), then deletes.
-- [ ] Triggered runs gain instructions: `RunInstructions` (or the interim
-      `AgentWorker`) passes the agent's instructions via `RunProps` — the
-      spawn-annotation path covers only the durable interactive process, not
-      this ephemeral path.
-- [ ] Verify: agent-wizard `sync-triggers` tests become routine-creation
-      tests; trigger-dispatch memoized tests; a two-stage subscription fixture
-      keeps its filtering behavior (or its removal is explicit per the
-      qualifier decision).
+- [ ] Retire `AgentWorker` + `Qualifier` ops (the relay subsumes both);
+      `get-context`'s chat/plan reads move per B.
+- [ ] Verify: agent-wizard tests become routine-creation tests;
+      trigger-dispatch memoized tests; a subscription fixture proves filtering
+      (irrelevant event never reaches the process queue) and multiplexing (two
+      feeds, one process).
 
 ## Phase D — remove `artifacts`; schema bump + migration
 
@@ -105,10 +116,11 @@ substrate-preserving, not a downgrade. `AgentWorker`'s identity mechanism
       entries → a Collection on a Project created per agent (named after it);
       `agent.chat` (kept readable through B/C) reparented under that Project;
       drop `feed` / `filterEvents` and the transitional `chat`. NOTE:
-      `feed`/`filterEvents` are deprecated in name only — they are the
+      `feed`/`filterEvents` are deprecated in name only — they are the current
       qualifier pipeline's staging queue and its switch — so dropping them is
-      **gated on C's qualifier decision**, not an independent cleanup
-      (`AgentArticle.tsx` also backfills `agent.feed` today).
+      **gated on C landing** (the relay dissolves the staging queue into the
+      process input queue); `AgentArticle.tsx` also backfills `agent.feed`
+      today.
 - [ ] `makeInitialized` slims to identity + instructions (+ optional first
       chat via the chat factory).
 - [ ] Verify: Agent.test round-trip at 0.2.0, migration test (0.1.0 fixture →
@@ -145,13 +157,13 @@ means the identity/preset type, the name `AgentProcess` actively misleads.
 
 - **Durable processes** hydrate from spawn annotations; B/C change what
   trigger inputs carry, so shims must accept both shapes for one release.
-- **Two execution substrates.** Interactive chats run on the durable
-  `AgentProcess` (input queue, alarms, delegation); triggered runs on
-  ephemeral `AiSession`s. This plan preserves that split — C converts within
-  the ephemeral substrate — but any future "agent alarms survive restarts for
-  triggered runs" requirement pulls C onto the durable substrate instead;
-  decide before C, not after. (The durable process itself is Agent-type-free —
-  see phase E — so either choice leaves it untouched.)
+- **Substrate unification (resolved 2026-07-28).** C moves triggered runs onto
+  the durable process via the relay pattern, ending the ephemeral/durable
+  split for agents; the relay is the only new moving part. The durable process
+  itself is Agent-type-free (see phase E) and unchanged.
+- **Queue growth without backpressure** (see phase C): a hot subscribed feed
+  can grow the process input queue faster than turns drain it; the
+  intermediary-feed escape hatch is the mitigation.
 - **Memoized-LLM tests** encode current tool surfaces (`add-artifact`,
   `get-context` artifacts); D re-records them.
 - `enabled` semantics during C: don't strand existing disabled agents —

--- a/packages/plugins/plugin-projects/PLAN.md
+++ b/packages/plugins/plugin-projects/PLAN.md
@@ -1,0 +1,104 @@
+# Agent ↔ Project reconciliation — Plan
+
+Proposal: shrink `Agent` to an identity/preset (`name`, `did`,
+`instructions: Ref<Instructions>`, future permissions) and make `Project` the
+only container (artifacts, routines, chats). Rationale and field-by-field
+analysis: [DESIGN.md § Agent ↔ Project convergence](./DESIGN.md).
+
+Target model:
+
+- **Agent** = identity + skill set (via its typed Instructions), no history.
+- **Project** = chat factory + container; spawns chats with different skill
+  sets or Agent identities.
+- **Chat** = instance + history; `instructions` steers it; `agent?` attributes
+  it. An agent is a _preset_, applied at chat creation.
+
+Each phase ships as its own PR, keeps main green, and is independently
+revertible. Order matters: A unlocks the preset channel, B removes the wrong
+direction dependency, C and D delete the duplicate machinery.
+
+## Phase A — `Agent.instructions: Ref<Text>` → `Ref<Instructions>`
+
+The typed object carries `skills`/`objects`/`commands`, which _is_ the preset
+payload; after this phase "apply agent to chat" is one assignment.
+
+- [ ] Schema: `instructions: Ref(Instructions.Instructions)`
+      (`types/Agent.ts`); keep `@0.1.0` — field shape changes but old data is
+      migrated in D's bump (until then, `makeInitialized`-created agents are
+      the only writers).
+- [ ] `makeInitialized`: `Instructions.make({ text: props.instructions })`
+      (owned: `Obj.setParent(instructions, agent)`); move `props.skills` into
+      `instructions.skills` instead of raw binder args.
+- [ ] Call sites that load the ref as Text: `get-context.ts` (returns
+      `instructions.text` content), `qualifier.ts`, `skill.test.ts` helper.
+- [ ] Verify: assistant-toolkit unit + agent skill memoized tests.
+
+## Phase B — invert `Agent.chat` → `Chat.agent?: Ref<Agent>`
+
+Whoever invokes a run already holds the Chat (see the call-site table in
+DESIGN.md); the agent should not own conversation state.
+
+- [ ] `Chat` gains `agent?: Ref<Agent>` — same file, no layering change (both
+      types live in assistant-toolkit).
+- [ ] `AgentWorker` (`skills/agent/operations/agent.ts`): input becomes
+      `{ chat }` (or `{ agent, chat }` during transition); resolve feed from
+      the chat, identity from `chat.agent`.
+- [ ] `qualifier.ts`: receives the chat in its trigger input rather than
+      `agent.chat`.
+- [ ] `resetChatHistory` → `Chat.resetHistory(chat)` (feed rebuild is
+      chat-shaped); agent variant delegates until D.
+- [ ] "The agent's chats" = query on `Chat.agent` (or the existing
+      `CompanionTo`); removes the single-chat limitation
+      (`TODO(dmaretskyi): Multiple chats`).
+- [ ] `makeInitialized`: still creates a first chat (UX unchanged) but sets
+      `chat.agent` and stops writing `agent.chat`; keep the field readable
+      until D so hydrated processes don't break mid-migration.
+- [ ] Verify: planning / delegation / agent skill tests (they anchor on
+      `agent.chat` today — port to `chat.agent` or `CompanionTo`).
+
+## Phase C — `cron` + `subscriptions` → Routines
+
+`sync-triggers` compiles these imperatively into `Trigger` objects; a Routine
+(instructions + trigger) is the same thing declaratively, shared with projects.
+
+- [ ] Agent wizard: creating a schedule/subscription creates a `Routine`
+      (timer / feed trigger) whose runnable is `RunInstructions` over the
+      agent's instructions, input carrying the target chat (per B).
+- [ ] Qualifier folds into the subscription-routine (first stage of its
+      runnable or its instructions).
+- [ ] `enabled`: routines gain an owner gate or the flag moves onto each
+      Routine; `sync-triggers` reduces to a migration shim (existing
+      cron/subscription fields → Routines on first open), then deletes.
+- [ ] Verify: agent-wizard `sync-triggers` tests become routine-creation
+      tests; trigger-dispatch memoized tests.
+
+## Phase D — remove `artifacts`; schema bump + migration
+
+- [ ] Delete `Agent.artifacts`, `add-artifact` op, and the artifacts half of
+      `get-context`; the model files via `ProjectSkill.artifact-add`.
+- [ ] Bump `org.dxos.type.agent` → `0.2.0`; migration: inline `{name, data}`
+      entries → a Collection on a Project created per agent (named after it);
+      `agent.chat` (kept readable through B/C) reparented under that Project;
+      drop deprecated `feed` / `filterEvents` and the transitional `chat`.
+- [ ] `makeInitialized` slims to identity + instructions (+ optional first
+      chat via the chat factory).
+- [ ] Verify: Agent.test round-trip at 0.2.0, migration test (0.1.0 fixture →
+      0.2.0), full assistant-toolkit + plugin-assistant suites, and a live
+      pass of `projects.eval.ts` (unchanged expectations prove the container
+      path was already agent-free).
+
+## Non-goals
+
+- Permissions on Agent (tracked, later).
+- Multi-agent rosters per project (decided alongside the deferred
+  agent-roster item).
+- UI redesign of the agent wizard beyond what C forces.
+
+## Risks
+
+- **Durable processes** hydrate from spawn annotations; B/C change what
+  trigger inputs carry, so shims must accept both shapes for one release.
+- **Memoized-LLM tests** encode current tool surfaces (`add-artifact`,
+  `get-context` artifacts); D re-records them.
+- `enabled` semantics during C: don't strand existing disabled agents —
+  migration copies the flag onto generated Routines.

--- a/packages/plugins/plugin-projects/PLAN.md
+++ b/packages/plugins/plugin-projects/PLAN.md
@@ -61,16 +61,41 @@ DESIGN.md); the agent should not own conversation state.
 `sync-triggers` compiles these imperatively into `Trigger` objects; a Routine
 (instructions + trigger) is the same thing declaratively, shared with projects.
 
+The as-is runtime this replaces (traced 2026-07-27): with `filterEvents`
+(default) a subscription is a **two-stage pipeline** — feed trigger →
+`Qualifier` (cheap model, `concurrency: 5`, relevance check) → qualified event
+appended to `agent.feed` (the nominally-deprecated field is this pipeline's
+staging queue) → second trigger on `agent.feed` → `AgentWorker`. Without
+`filterEvents`, the subscription trigger invokes `AgentWorker` directly; `cron`
+always does. `AgentWorker` builds an **ephemeral `AiSession` on the chat feed**
+(hardcoded model, retry ×2) — it never touches the durable `AgentProcess`, so
+triggered runs already share `RunInstructions`' substrate and the conversion is
+substrate-preserving, not a downgrade. `AgentWorker`'s identity mechanism
+(assert exactly one Agent bound in the chat context) is replaced by B's
+`chat.agent`.
+
 - [ ] Agent wizard: creating a schedule/subscription creates a `Routine`
       (timer / feed trigger) whose runnable is `RunInstructions` over the
       agent's instructions, input carrying the target chat (per B).
-- [ ] Qualifier folds into the subscription-routine (first stage of its
-      runnable or its instructions).
+- [ ] **Qualifier stage — decide, don't fold blindly.** Folding relevance
+      filtering into the routine's instructions makes the expensive model do
+      the cheap model's job. Options: (a) a qualifier/filter option on the
+      `Trigger` spec or Routine (a pre-stage runnable + model), preserving the
+      cost profile; (b) a two-routine chain, which still needs an intermediate
+      feed (keeps `agent.feed`'s role, just relocated); (c) drop qualification
+      for v1 and deliver events unfiltered. Leaning (a); decide with usage
+      data from the wizard's existing subscriptions.
 - [ ] `enabled`: routines gain an owner gate or the flag moves onto each
       Routine; `sync-triggers` reduces to a migration shim (existing
       cron/subscription fields → Routines on first open), then deletes.
+- [ ] Triggered runs gain instructions: `RunInstructions` (or the interim
+      `AgentWorker`) passes the agent's instructions via `RunProps` — the
+      spawn-annotation path covers only the durable interactive process, not
+      this ephemeral path.
 - [ ] Verify: agent-wizard `sync-triggers` tests become routine-creation
-      tests; trigger-dispatch memoized tests.
+      tests; trigger-dispatch memoized tests; a two-stage subscription fixture
+      keeps its filtering behavior (or its removal is explicit per the
+      qualifier decision).
 
 ## Phase D — remove `artifacts`; schema bump + migration
 
@@ -79,7 +104,11 @@ DESIGN.md); the agent should not own conversation state.
 - [ ] Bump `org.dxos.type.agent` → `0.2.0`; migration: inline `{name, data}`
       entries → a Collection on a Project created per agent (named after it);
       `agent.chat` (kept readable through B/C) reparented under that Project;
-      drop deprecated `feed` / `filterEvents` and the transitional `chat`.
+      drop `feed` / `filterEvents` and the transitional `chat`. NOTE:
+      `feed`/`filterEvents` are deprecated in name only — they are the
+      qualifier pipeline's staging queue and its switch — so dropping them is
+      **gated on C's qualifier decision**, not an independent cleanup
+      (`AgentArticle.tsx` also backfills `agent.feed` today).
 - [ ] `makeInitialized` slims to identity + instructions (+ optional first
       chat via the chat factory).
 - [ ] Verify: Agent.test round-trip at 0.2.0, migration test (0.1.0 fixture →
@@ -98,6 +127,12 @@ DESIGN.md); the agent should not own conversation state.
 
 - **Durable processes** hydrate from spawn annotations; B/C change what
   trigger inputs carry, so shims must accept both shapes for one release.
+- **Two execution substrates.** Interactive chats run on the durable
+  `AgentProcess` (input queue, alarms, delegation); triggered runs on
+  ephemeral `AiSession`s. This plan preserves that split — C converts within
+  the ephemeral substrate — but any future "agent alarms survive restarts for
+  triggered runs" requirement pulls C onto the durable substrate instead;
+  decide before C, not after.
 - **Memoized-LLM tests** encode current tool surfaces (`add-artifact`,
   `get-context` artifacts); D re-records them.
 - `enabled` semantics during C: don't strand existing disabled agents —

--- a/packages/plugins/plugin-projects/PLAN.md
+++ b/packages/plugins/plugin-projects/PLAN.md
@@ -13,9 +13,13 @@ Target model:
 - **Chat** = instance + history; `instructions` steers it; `agent?` attributes
   it. An agent is a _preset_, applied at chat creation.
 
-Each phase ships as its own PR, keeps main green, and is independently
-revertible. Order matters: A unlocks the preset channel, B removes the wrong
-direction dependency, C and D delete the duplicate machinery.
+Each phase ships as its own PR and keeps main green. Phases that change
+persisted shapes (A, B) are revertible only within an explicit
+**dual-read/dual-write window**: A dual-reads the old shape and B dual-writes
+the old field until D's migration closes the window — reverting after D means
+restoring from the migration, not flipping a switch. Order matters: A unlocks
+the preset channel, B removes the wrong-direction dependency, C and D delete
+the duplicate machinery.
 
 ## Phase A — `Agent.instructions: Ref<Text>` → `Ref<Instructions>`
 
@@ -23,9 +27,13 @@ The typed object carries `skills`/`objects`/`commands`, which _is_ the preset
 payload; after this phase "apply agent to chat" is one assignment.
 
 - [ ] Schema: `instructions: Ref(Instructions.Instructions)`
-      (`types/Agent.ts`); keep `@0.1.0` — field shape changes but old data is
-      migrated in D's bump (until then, `makeInitialized`-created agents are
-      the only writers).
+      (`types/Agent.ts`); keep `@0.1.0` — old data migrates in D's bump.
+- [ ] **Dual-read until D**: a shared resolve helper accepts both shapes
+      (target is `Text` → treat as instructions text; target is
+      `Instructions` → typed), used by every reader below — existing agents
+      keep working unmigrated, and reverting A cannot strand new-shape
+      records unread (old readers loaded the ref as Text, which a dual-read
+      helper subsumes).
 - [ ] `makeInitialized`: `Instructions.make({ text: props.instructions })`
       (owned: `Obj.setParent(instructions, agent)`); move `props.skills` into
       `instructions.skills` instead of raw binder args.
@@ -50,9 +58,10 @@ DESIGN.md); the agent should not own conversation state.
 - [ ] "The agent's chats" = query on `Chat.agent` (or the existing
       `CompanionTo`); removes the single-chat limitation
       (`TODO(dmaretskyi): Multiple chats`).
-- [ ] `makeInitialized`: still creates a first chat (UX unchanged) but sets
-      `chat.agent` and stops writing `agent.chat`; keep the field readable
-      until D so hydrated processes don't break mid-migration.
+- [ ] `makeInitialized`: still creates a first chat (UX unchanged), sets
+      `chat.agent` **and dual-writes `agent.chat`** until D — legacy readers
+      (hydrated processes, un-migrated call sites, a reverted B) keep working;
+      D's migration drops the field and ends the window.
 - [ ] Verify: planning / delegation / agent skill tests (they anchor on
       `agent.chat` today — port to `chat.agent` or `CompanionTo`).
 
@@ -90,14 +99,18 @@ but relays push as fast as triggers fire, so a hot feed grows the input queue
 unboundedly. Escape hatch if it bites: reintroduce an intermediary feed the
 process drains at its own pace (at the cost of the visible extra feed).
 
-- [ ] `RelayFunction` (assistant-toolkit): input `{ agent | chat, event }`;
-      qualify (cheap model, reusing the Qualifier prompt) → on relevant,
-      `AgentService.getSession(chatFeed, { instructions }).submitPrompt(event)`.
-      Instructions reach the durable process via the existing spawn-annotation
-      path — no separate ephemeral-path work needed.
+- [ ] `RelayFunction` (assistant-toolkit): input `{ chat: Ref<Chat>, event }`
+      — the concrete contract, mirroring `RunInstructions.chat`: the chat is
+      what carries history (feed), bound context, and the typed
+      `instructions: Ref<Instructions>` (set from the agent's per B). Qualify
+      (cheap model, reusing the Qualifier prompt) → on relevant,
+      `AgentService.getSession(chat.feed, { instructions: chat.instructions })
+      .submitPrompt(event)`. Instructions reach the durable process via the
+      existing spawn-annotation path — no separate ephemeral-path work needed.
 - [ ] Agent wizard: a subscription creates a Routine (feed trigger →
-      `RelayFunction`); `cron` creates a Routine (timer trigger) that submits a
-      wake prompt through the same relay path.
+      `RelayFunction` with the agent's chat ref); `cron` creates a Routine
+      (timer trigger) that submits a wake prompt through the same relay path
+      (same `chat` input, synthetic event).
 - [ ] `enabled`: routines gain an owner gate or the flag moves onto each
       Routine; `sync-triggers` reduces to a migration shim (existing
       cron/subscription fields → Routines on first open), then deletes.
@@ -123,10 +136,14 @@ process drains at its own pace (at the cost of the visible extra feed).
       today.
 - [ ] `makeInitialized` slims to identity + instructions (+ optional first
       chat via the chat factory).
-- [ ] Verify: Agent.test round-trip at 0.2.0, migration test (0.1.0 fixture →
-      0.2.0), full assistant-toolkit + plugin-assistant suites, and a live
-      pass of `projects.eval.ts` (unchanged expectations prove the container
-      path was already agent-free).
+- [ ] Verify: Agent.test round-trip at 0.2.0; a migration test (0.1.0 fixture
+      → 0.2.0) asserting each inline artifact lands in the created project's
+      Collection **and** is returned by `ProjectSkill.artifact-list`, and that
+      the reparented chat still resolves its feed and instructions; full
+      assistant-toolkit + plugin-assistant suites; and a live pass of
+      `projects.eval.ts`, whose scorers already assert the replacement
+      workflow end-to-end (artifact created → filed into the project
+      Collection via `artifact-add` → bound into chat context).
 
 ## Phase E (optional) — rename the session host
 

--- a/packages/plugins/plugin-projects/PLAN.md
+++ b/packages/plugins/plugin-projects/PLAN.md
@@ -103,9 +103,9 @@ process drains at its own pace (at the cost of the visible extra feed).
       — the concrete contract, mirroring `RunInstructions.chat`: the chat is
       what carries history (feed), bound context, and the typed
       `instructions: Ref<Instructions>` (set from the agent's per B). Qualify
-      (cheap model, reusing the Qualifier prompt) → on relevant,
-      `AgentService.getSession(chat.feed, { instructions: chat.instructions })
-      .submitPrompt(event)`. Instructions reach the durable process via the
+      (cheap model, reusing the Qualifier prompt); on relevant, get the durable
+      session for `chat.feed` (passing `chat.instructions`) and submit the
+      event as a prompt. Instructions reach the durable process via the
       existing spawn-annotation path — no separate ephemeral-path work needed.
 - [ ] Agent wizard: a subscription creates a Routine (feed trigger →
       `RelayFunction` with the agent's chat ref); `cron` creates a Routine

--- a/packages/plugins/plugin-projects/TASKS.md
+++ b/packages/plugins/plugin-projects/TASKS.md
@@ -1,6 +1,6 @@
 # plugin-projects — Tasks
 
-_Resume: Phase 3 instructions-channel arc COMPLETE, shipped as PR #12365 (Check monitoring in progress); system eval passed live at 100%. Next: remaining Phase 3 UI (ProjectOperation.CreateChat, projectChats graph extension, Chats-section exclusion, ProjectArticle toolbar, ChatCompanion sets chat.instructions + lazy backfill). Uncommitted: none._
+_Resume: Phase 3 instructions-channel arc COMPLETE, shipped as PR #12365 (Check monitoring in progress); system eval passed live at 100%. Next: remaining Phase 3 UI (ProjectOperation.CreateChat, projectChats graph extension, Chats-section exclusion, ProjectArticle toolbar). Uncommitted: none._
 
 Design: [`./DESIGN.md`](./DESIGN.md) — Tasks ledger: this file.
 

--- a/packages/plugins/plugin-projects/TASKS.md
+++ b/packages/plugins/plugin-projects/TASKS.md
@@ -70,9 +70,11 @@ repoint.
       `processor.getSystemPrompt` resolves `chat.instructions`. assistant 43 tests green
       (format.test.ts 4/4, incl. a new case asserting a bound Instructions object is now an
       ordinary context stub); assistant-toolkit + plugin-assistant build clean.
-- [ ] **Agent-process boundary** — `GetSessionOptions.instructions` + a persisted spawn
-      annotation beside `Process.TargetAnnotation`; `processor.ts` passes
-      `chat.instructions`. Executable options don't survive `hydrateAgents`.
+- [x] **Agent-process boundary** — `Process.InstructionsAnnotation` (URI, persisted at spawn
+      beside `TargetAnnotation`); `AgentService.getSession` stamps it from
+      `GetSessionOptions.instructions`; `agent-process` resolves it into
+      `AiSession.Options.instructions` (broken ref degrades to unsteered);
+      `processor.request` passes `chat.instructions`. compute 46 tests green, builds clean.
 - [ ] **`Project.contextBindings` drops the instructions ref** — keeps `skills` +
       `instructions.objects`. Skills must stay on the binding path (toolkit, not prompt).
 - [ ] **`ChatCompanion` stops binding project instructions** — companion-chat creation
@@ -95,19 +97,30 @@ repoint.
       play test (toolbar creates a chat, appears in the list), live verify (instructions
       reach the system prompt in a standalone plank — proves the ref survives the
       agent-process boundary; navtree children survive a cold deep link).
-- [ ] **`ProjectSkill` — artifact management** — tools to add an object ref to the project's
-      artifacts Collection and to list the collection, so the model can file and find
-      artifacts without a space-wide search. Bound into every project chat. Filing is
-      explicit (skill instructions tell the model to file what it creates), not an
-      interception of object creation. Prerequisite for the system test below.
-- [ ] **System test (live model, out of CI)** — Project with instructions → Chat under it
-      (own feed, project's instructions) → prompt the model to create a markdown document →
-      assert the document is both bound into the session context AND in the project's
-      artifacts Collection. Graded on DB effects, not model wording. Placement TBD
-      (`@dxos/assistant-evals` eval vs a `!test`-tagged live-AI story alongside the existing
-      `Projects.stories.tsx`).
+- [x] **`ProjectSkill` — artifact management** — `assistant-toolkit/src/skills/project/`:
+      `artifact-add` (dedupes by entity id; materializes a missing collection) and
+      `artifact-list` (dxn/typename/label rows; broken ref → placeholder). Registered in
+      plugin-assistant `skill-definition`. 4/4 handler tests green (TestDatabaseLayer).
+- [x] **System test (live model, out of CI)** — `assistant-evals/src/evals/projects.eval.ts`
+      (placement decided: evals, not a story): seeded Project + Chat (project's instructions
+      by ref, chat parented), model creates "Trip Notes" markdown doc; scorers document-created
+      / document-filed (artifacts collection) / document-bound (Binding record in the chat
+      feed). Runner gained `seed` + `types` options. PASSED LIVE at 100% (all three scorers,
+      opus-4-8, 32s, 2026-07-27).
 - [ ] **Create other artifact types from a project chat** — Outline, Sheet,
       Organization/Contact objects; builds on `ProjectSkill`.
+- [ ] **Agent artifacts: factor out commonality with Project** — `Agent.artifacts` is an
+      inline `{name, data}` array while `Project.artifacts` is an owned Collection; converge
+      on one artifact-holder shape so `ProjectSkill`'s add/list tools (and provenance later)
+      work for both.
+- [ ] **Agent cron: generalize to Routine** — Agent's cron/trigger scheduling should be
+      expressed as a Routine (instructions + trigger) rather than agent-specific wiring, so
+      projects and agents share one automation model.
+- [ ] **Agent ↔ Project convergence review** — the two share Chat, Artifacts, Instructions,
+      and Routines (Agent: subscriptions/cron); factor the commonality (one artifact-holder
+      shape, one automation model, one instructions channel) and sharpen the remaining
+      distinction (Agent = actor with identity/DID; Project = scope/container). Subsumes the
+      two items above; design pass before more per-type features accrete.
 - [ ] **Watch item** — if `children()` does not re-emit in the graph connector when a chat
       is newly parented, fall back to a `chats: Ref<Collection>` field on Project
       (0.2.0 → 0.3.0 bump + migration); only the enumeration source changes.

--- a/packages/plugins/plugin-projects/TASKS.md
+++ b/packages/plugins/plugin-projects/TASKS.md
@@ -109,18 +109,12 @@ repoint.
       opus-4-8, 32s, 2026-07-27).
 - [ ] **Create other artifact types from a project chat** — Outline, Sheet,
       Organization/Contact objects; builds on `ProjectSkill`.
-- [ ] **Agent artifacts: factor out commonality with Project** — `Agent.artifacts` is an
-      inline `{name, data}` array while `Project.artifacts` is an owned Collection; converge
-      on one artifact-holder shape so `ProjectSkill`'s add/list tools (and provenance later)
-      work for both.
-- [ ] **Agent cron: generalize to Routine** — Agent's cron/trigger scheduling should be
-      expressed as a Routine (instructions + trigger) rather than agent-specific wiring, so
-      projects and agents share one automation model.
-- [ ] **Agent ↔ Project convergence review** — the two share Chat, Artifacts, Instructions,
-      and Routines (Agent: subscriptions/cron); factor the commonality (one artifact-holder
-      shape, one automation model, one instructions channel) and sharpen the remaining
-      distinction (Agent = actor with identity/DID; Project = scope/container). Subsumes the
-      two items above; design pass before more per-type features accrete.
+- [x] **Agent ↔ Project convergence review** — analysis + proposal written: DESIGN.md
+      "Agent ↔ Project convergence" (field-by-field usage, target split, migration table)
+      and [`./PLAN.md`](./PLAN.md) (4 phases: instructions typing → Chat.agent inversion →
+      cron/subscriptions→Routines → artifacts→Project + 0.2.0 migration). Recommendation:
+      removal, not extraction. Subsumed the separate "Agent artifacts" and "Agent cron"
+      items. Execution pending user go-ahead, phase by phase.
 - [ ] **Watch item** — if `children()` does not re-emit in the graph connector when a chat
       is newly parented, fall back to a `chats: Ref<Collection>` field on Project
       (0.2.0 → 0.3.0 bump + migration); only the enumeration source changes.

--- a/packages/plugins/plugin-projects/TASKS.md
+++ b/packages/plugins/plugin-projects/TASKS.md
@@ -1,6 +1,6 @@
 # plugin-projects — Tasks
 
-_Resume: milestone 3 (project chats) is DESIGNED AND APPROVED, not yet implemented — start at the first Phase 3 task (`bindings` input on `AssistantOperation.CreateChat`). PR #12335 MERGED (2026-07-25, squash f7d7735615) carried milestones 1–2; nothing unpushed from those. This worktree branches from main tip; local commits are docs only. Uncommitted: none._
+_Resume: Phase 3 instructions-channel arc COMPLETE, shipped as PR #12365 (Check monitoring in progress); system eval passed live at 100%. Next: remaining Phase 3 UI (ProjectOperation.CreateChat, projectChats graph extension, Chats-section exclusion, ProjectArticle toolbar, ChatCompanion sets chat.instructions + lazy backfill). Uncommitted: none._
 
 Design: [`./DESIGN.md`](./DESIGN.md) — Tasks ledger: this file.
 

--- a/packages/plugins/plugin-projects/TASKS.md
+++ b/packages/plugins/plugin-projects/TASKS.md
@@ -1,6 +1,6 @@
 # plugin-projects — Tasks
 
-_Resume: Phase 3 instructions-channel arc COMPLETE, shipped as PR #12365 (Check monitoring in progress); system eval passed live at 100%. Next: remaining Phase 3 UI (ProjectOperation.CreateChat, projectChats graph extension, Chats-section exclusion, ProjectArticle toolbar). Uncommitted: none._
+_Resume: PR #12365 green + review-addressed — user lands it himself. Next (decided 2026-07-28): reconciliation phase A (Agent.instructions typed ref) then B (Chat.agent inversion) per ./PLAN.md, each its own PR from a fresh worktree; Phase 3 UI follows. Phase C shape decided: relay pattern onto the durable process (see PLAN.md). Uncommitted: none._
 
 Design: [`./DESIGN.md`](./DESIGN.md) — Tasks ledger: this file.
 

--- a/packages/plugins/plugin-projects/TASKS.md
+++ b/packages/plugins/plugin-projects/TASKS.md
@@ -54,27 +54,45 @@ Initial priority (user, 2026-07-24):
 
 Start a chat session from a project with the project already in scope, and see that
 session in the navtree under its project. Design: the "Milestone 3: project chats"
-section of [`./DESIGN.md`](./DESIGN.md). Decisions (user, 2026-07-27): ECHO parent edge (no schema
-change), new chat opens as a deck plank, toolbar scoped to chat creation only, bindings
-applied once at creation.
+section of [`./DESIGN.md`](./DESIGN.md). Decisions (user, 2026-07-27): ECHO parent edge (no
+Project schema change), new chat opens as a deck plank, toolbar scoped to chat creation
+only; instructions reach the session through a typed `Chat.instructions` ref passed at
+session construction (NOT via context bindings), accepting spawn-time staleness on
+repoint.
 
 ### Tasks
 
-- [ ] **`bindings` input on `AssistantOperation.CreateChat`** — optional
-      `{ skills?, objects? }` passed to the binder it already constructs.
-- [ ] **`ProjectOperation.CreateChat`** — invoke `AssistantOperation.CreateChat` with
-      `Project.contextBindings(project)` + the project ref, `Obj.setParent(chat, project)`,
-      `LayoutOperation.Open`. No `SpaceOperation.AddObject` (would file it in the root
-      collection).
+- [ ] **`Chat.instructions?: Ref<Instructions>`** — typed ref on the Chat schema
+      (assistant-toolkit → compute).
+- [ ] **Explicit `instructions` through the request path** — `formatSystemPrompt` takes it
+      as a parameter and its `instructionObjects`/`contextObjects` partition is deleted;
+      threaded via `AiSession.Options` → `RunProps`. Update all four
+      `formatSystemPrompt` call sites (AiRequest ×2, AiSession, plugin-assistant processor).
+- [ ] **Agent-process boundary** — `GetSessionOptions.instructions` + a persisted spawn
+      annotation beside `Process.TargetAnnotation`; `processor.ts` passes
+      `chat.instructions`. Executable options don't survive `hydrateAgents`.
+- [ ] **`Project.contextBindings` drops the instructions ref** — keeps `skills` +
+      `instructions.objects`. Skills must stay on the binding path (toolkit, not prompt).
+- [ ] **`ChatCompanion` stops binding project instructions** — companion-chat creation
+      sets `chat.instructions` instead, unifying companion and standalone.
+- [ ] **Lazy backfill for pre-existing chats** — chat opens, parent (or `CompanionTo`
+      target) is a Project, `chat.instructions` unset → set it. Without this, chats created
+      before this milestone silently lose their steering.
+- [ ] **`ProjectOperation.CreateChat`** — invoke `AssistantOperation.CreateChat` with the
+      project's instructions ref (by reference, never a copy), `Obj.setParent(chat, project)`,
+      bind `instructions.skills`, `LayoutOperation.Open`. No `SpaceOperation.AddObject`
+      (would file it in the root collection).
 - [ ] **`projectChats` graph extension** — `children()` query → `AppNode.makeObject` per
       chat; `url` reuses the `chat` key with a parent-resolving dynamic path.
 - [ ] **Exclude project chats from the top-level Chats section** — plugin-assistant's
       section query, alongside the existing `CompanionTo` exclusion.
 - [ ] **`ProjectArticle` toolbar** — `Panel.Toolbar` + `IconButton`; same action on the
       project's navtree node (`list-item-primary`).
-- [ ] **Tests** — unit (enumeration, parenting + binding pass-through), story play test
-      (toolbar creates a chat, appears in the list), live verify (instructions reach the
-      system prompt in a standalone plank; navtree children survive a cold deep link).
+- [ ] **Tests** — unit (`formatSystemPrompt` renders the explicit param and no longer
+      inlines a bound Instructions object; enumeration; parenting + ref pass-through), story
+      play test (toolbar creates a chat, appears in the list), live verify (instructions
+      reach the system prompt in a standalone plank — proves the ref survives the
+      agent-process boundary; navtree children survive a cold deep link).
 - [ ] **Watch item** — if `children()` does not re-emit in the graph connector when a chat
       is newly parented, fall back to a `chats: Ref<Collection>` field on Project
       (0.2.0 → 0.3.0 bump + migration); only the enumeration source changes.

--- a/packages/plugins/plugin-projects/TASKS.md
+++ b/packages/plugins/plugin-projects/TASKS.md
@@ -62,12 +62,14 @@ repoint.
 
 ### Tasks
 
-- [ ] **`Chat.instructions?: Ref<Instructions>`** — typed ref on the Chat schema
+- [x] **`Chat.instructions?: Ref<Instructions>`** — typed ref on the Chat schema
       (assistant-toolkit → compute).
-- [ ] **Explicit `instructions` through the request path** — `formatSystemPrompt` takes it
-      as a parameter and its `instructionObjects`/`contextObjects` partition is deleted;
-      threaded via `AiSession.Options` → `RunProps`. Update all four
-      `formatSystemPrompt` call sites (AiRequest ×2, AiSession, plugin-assistant processor).
+- [x] **Explicit `instructions` through the request path** — `formatSystemPrompt` takes it
+      as a parameter, the `instructionObjects`/`contextObjects` partition is deleted, and it
+      is threaded via `AiSession.Options` → `RunProps` → `begin`/`run`;
+      `processor.getSystemPrompt` resolves `chat.instructions`. assistant 43 tests green
+      (format.test.ts 4/4, incl. a new case asserting a bound Instructions object is now an
+      ordinary context stub); assistant-toolkit + plugin-assistant build clean.
 - [ ] **Agent-process boundary** — `GetSessionOptions.instructions` + a persisted spawn
       annotation beside `Process.TargetAnnotation`; `processor.ts` passes
       `chat.instructions`. Executable options don't survive `hydrateAgents`.
@@ -93,6 +95,19 @@ repoint.
       play test (toolbar creates a chat, appears in the list), live verify (instructions
       reach the system prompt in a standalone plank — proves the ref survives the
       agent-process boundary; navtree children survive a cold deep link).
+- [ ] **`ProjectSkill` — artifact management** — tools to add an object ref to the project's
+      artifacts Collection and to list the collection, so the model can file and find
+      artifacts without a space-wide search. Bound into every project chat. Filing is
+      explicit (skill instructions tell the model to file what it creates), not an
+      interception of object creation. Prerequisite for the system test below.
+- [ ] **System test (live model, out of CI)** — Project with instructions → Chat under it
+      (own feed, project's instructions) → prompt the model to create a markdown document →
+      assert the document is both bound into the session context AND in the project's
+      artifacts Collection. Graded on DB effects, not model wording. Placement TBD
+      (`@dxos/assistant-evals` eval vs a `!test`-tagged live-AI story alongside the existing
+      `Projects.stories.tsx`).
+- [ ] **Create other artifact types from a project chat** — Outline, Sheet,
+      Organization/Contact objects; builds on `ProjectSkill`.
 - [ ] **Watch item** — if `children()` does not re-emit in the graph connector when a chat
       is newly parented, fall back to a `chats: Ref<Collection>` field on Project
       (0.2.0 → 0.3.0 bump + migration); only the enumeration source changes.

--- a/packages/plugins/plugin-projects/TASKS.md
+++ b/packages/plugins/plugin-projects/TASKS.md
@@ -1,10 +1,11 @@
 # plugin-projects — Tasks
 
-_Resume: PR #12335 MERGED (2026-07-25, squash f7d7735615) — it carried milestone 1 **plus** the three MS2 commits (cold-load fix, instructions→system-prompt, stub labels), so nothing is left unpushed. Fresh worktree at main tip, clean. Next: commands-authoring UI in InstructionsEditor, then outliner skill design._
+_Resume: milestone 3 (project chats) is DESIGNED AND APPROVED, not yet implemented — start at the first Phase 3 task (`bindings` input on `AssistantOperation.CreateChat`). PR #12335 MERGED (2026-07-25, squash f7d7735615) carried milestones 1–2; nothing unpushed from those. This worktree branches from main tip; local commits are docs only. Uncommitted: none._
+
+Design: [`./DESIGN.md`](./DESIGN.md) — Tasks ledger: this file.
 
 ## Phase 1: Core plugin + Project type (milestone 1) — DONE
 
-Design: agents/superpowers/specs/2026-07-24-plugin-projects-design.md
 Plan: agents/superpowers/plans/2026-07-24-plugin-projects.md (all 10 tasks complete, per-task + final reviews clean)
 
 ### Tasks
@@ -42,8 +43,8 @@ Initial priority (user, 2026-07-24):
 - [x] **PR strategy decision** — moot: the three MS2 commits shipped inside #12335's squash; verified present on main (ProjectArticle `getReactiveOrUndefined`, format.ts `## Instructions` + `<label>`, Projects.stories.tsx, minimal plugin set).
 - [ ] **PLUGIN.mdl for plugin-projects** — as-built record now that implementation settled.
 - [ ] **Commands-authoring UI** — InstructionsEditor edits text/skills/objects only; `commands` currently data-only despite autocomplete shipping.
-- [ ] **In-article routine creation**; project-scoped chat list UI.
-- [ ] **App-graph Project node children** — artifacts collection + routines child nodes (spec sketch; current TypeSection port is flat).
+- [ ] **In-article routine creation** — (the project-scoped chat list moved to Phase 3).
+- [ ] **App-graph Project node children: artifacts + routines** — Phase 3 adds the chat children and the branch-node plumbing; these two reuse it.
 - [ ] **ProjectOperation.Create + operation-handler/events** — extension point 2 (other plugins create/target projects).
 - [ ] **Project templates capability** — plugins contribute instructions+skills+routines presets (mirrors automation-templates).
 - [ ] **"/" completion of commands (and "@", "$")** — unify chat-prompt completion triggers.
@@ -53,7 +54,7 @@ Initial priority (user, 2026-07-24):
 
 Start a chat session from a project with the project already in scope, and see that
 session in the navtree under its project. Design: the "Milestone 3: project chats"
-section of the design spec. Decisions (user, 2026-07-27): ECHO parent edge (no schema
+section of [`./DESIGN.md`](./DESIGN.md). Decisions (user, 2026-07-27): ECHO parent edge (no schema
 change), new chat opens as a deck plank, toolbar scoped to chat creation only, bindings
 applied once at creation.
 

--- a/packages/plugins/plugin-projects/TASKS.md
+++ b/packages/plugins/plugin-projects/TASKS.md
@@ -75,13 +75,13 @@ repoint.
       `GetSessionOptions.instructions`; `agent-process` resolves it into
       `AiSession.Options.instructions` (broken ref degrades to unsteered);
       `processor.request` passes `chat.instructions`. compute 46 tests green, builds clean.
-- [ ] **`Project.contextBindings` drops the instructions ref** — keeps `skills` +
-      `instructions.objects`. Skills must stay on the binding path (toolkit, not prompt).
-- [ ] **`ChatCompanion` stops binding project instructions** — companion-chat creation
-      sets `chat.instructions` instead, unifying companion and standalone.
-- [ ] **Lazy backfill for pre-existing chats** — chat opens, parent (or `CompanionTo`
-      target) is a Project, `chat.instructions` unset → set it. Without this, chats created
-      before this milestone silently lose their steering.
+- [x] **`Project.contextBindings` drops the instructions ref** — keeps `skills` +
+      `instructions.objects` (test updated to assert the exclusion). Skills stay on the
+      binding path (toolkit, not prompt).
+- [x] **`ChatCompanion` stops binding project instructions** — a `useEffect` sets
+      `chat.instructions` from the project when unset; Projects story mirrors it.
+- [x] **Lazy backfill for pre-existing chats** — same effect: any project companion chat
+      without the field picks it up on open.
 - [ ] **`ProjectOperation.CreateChat`** — invoke `AssistantOperation.CreateChat` with the
       project's instructions ref (by reference, never a copy), `Obj.setParent(chat, project)`,
       bind `instructions.skills`, `LayoutOperation.Open`. No `SpaceOperation.AddObject`

--- a/packages/plugins/plugin-projects/TASKS.md
+++ b/packages/plugins/plugin-projects/TASKS.md
@@ -53,8 +53,8 @@ Initial priority (user, 2026-07-24):
 ## Phase 3 / milestone 3: project chats
 
 Start a chat session from a project with the project already in scope, and see that
-session in the navtree under its project. Design: the "Milestone 3: project chats"
-section of [`./DESIGN.md`](./DESIGN.md). Decisions (user, 2026-07-27): ECHO parent edge (no
+session in the navtree under its project. Design: the "Project chats" and "Chat
+integration" sections of [`./DESIGN.md`](./DESIGN.md). Decisions (user, 2026-07-27): ECHO parent edge (no
 Project schema change), new chat opens as a deck plank, toolbar scoped to chat creation
 only; instructions reach the session through a typed `Chat.instructions` ref passed at
 session construction (NOT via context bindings), accepting spawn-time staleness on

--- a/packages/stories/stories-assistant/src/stories/Projects.stories.tsx
+++ b/packages/stories/stories-assistant/src/stories/Projects.stories.tsx
@@ -73,10 +73,17 @@ const decorators = createDecorators({
     space.db.add(project);
     await space.db.flush({ indexes: true });
   },
-  // Mirror ChatCompanion's project binding: the project itself plus its instructions/skills/objects.
-  onChatCreated: async ({ space, binder }) => {
+  // Mirror ChatCompanion's project wiring: instructions steer via the chat's ref; skills and
+  // context objects (plus the project itself) travel via bindings.
+  onChatCreated: async ({ space, chat, binder }) => {
     const { Project } = await import('@dxos/compute');
     const [project] = await space.db.query(Filter.type(Project.Project)).run();
+    if (!chat.instructions && project.instructions) {
+      const instructionsRef = project.instructions;
+      Obj.update(chat, (chat) => {
+        chat.instructions = instructionsRef;
+      });
+    }
     const bindings = Project.contextBindings(project);
     if (bindings.skills.length > 0) {
       await binder.bind({ skills: [...bindings.skills] });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2341,7 +2341,7 @@ importers:
         version: 2.3.0(rollup@3.30.0)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vite-plugin-inspect:
         specifier: 'catalog:'
-        version: 12.0.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 12.0.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vite-plugin-top-level-await:
         specifier: 'catalog:'
         version: 1.6.0(@swc/helpers@0.5.17)(rollup@3.30.0)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -2353,7 +2353,7 @@ importers:
         version: 6.1.1(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wait-on:
         specifier: 'catalog:'
         version: 8.0.3
@@ -3930,7 +3930,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/common/effect-zod:
     dependencies:
@@ -3949,7 +3949,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/common/errors: {}
 
@@ -4647,7 +4647,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/common/web-context-solid:
     dependencies:
@@ -4724,7 +4724,7 @@ importers:
         version: 0.29.0(effect@3.21.4)(vitest@4.1.10)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/ai:
     dependencies:
@@ -4988,7 +4988,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/assistant-evals:
     dependencies:
@@ -5067,7 +5067,7 @@ importers:
         version: 0.19.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/assistant-toolkit:
     dependencies:
@@ -5150,6 +5150,9 @@ importers:
         specifier: 'catalog:'
         version: 1.7.0
     devDependencies:
+      '@dxos/echo-client':
+        specifier: workspace:*
+        version: link:../../echo/echo-client
       '@dxos/plugin-markdown':
         specifier: workspace:*
         version: link:../../../plugins/plugin-markdown
@@ -5219,7 +5222,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/compute-hyperformula:
     dependencies:
@@ -5350,7 +5353,7 @@ importers:
         version: 0.29.0(effect@3.21.4)(vitest@4.1.10)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/conductor:
     dependencies:
@@ -5475,7 +5478,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/edge-compute:
     dependencies:
@@ -5554,7 +5557,7 @@ importers:
         version: 0.29.0(effect@3.21.4)(vitest@4.1.10)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/extractor:
     dependencies:
@@ -5619,7 +5622,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/functions-runtime-cloudflare:
     dependencies:
@@ -5768,7 +5771,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/mcp-client:
     dependencies:
@@ -5792,7 +5795,7 @@ importers:
         version: 0.36.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.21.4
         version: 3.21.4
@@ -5839,7 +5842,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline:
     dependencies:
@@ -5861,7 +5864,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline-discord:
     dependencies:
@@ -5916,7 +5919,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline-email:
     dependencies:
@@ -5980,7 +5983,7 @@ importers:
         version: 0.16.1
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline-rdf:
     dependencies:
@@ -6053,7 +6056,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline-transcription:
     dependencies:
@@ -6117,7 +6120,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/echo/echo:
     dependencies:
@@ -6631,7 +6634,7 @@ importers:
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/echo/feed:
     dependencies:
@@ -7591,7 +7594,7 @@ importers:
         version: 0.96.2(effect@3.21.4)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/printer':
         specifier: 'catalog:'
         version: 0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4)
@@ -7673,7 +7676,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/devtools/cli-util:
     dependencies:
@@ -7721,7 +7724,7 @@ importers:
         version: 0.96.2(effect@3.21.4)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/printer':
         specifier: 'catalog:'
         version: 0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4)
@@ -7740,7 +7743,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/devtools/devtools:
     dependencies:
@@ -9268,7 +9271,7 @@ importers:
         version: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-brain:
     dependencies:
@@ -10260,7 +10263,7 @@ importers:
         version: 0.75.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@tauri-apps/api':
         specifier: 'catalog:'
         version: 2.11.1
@@ -10424,7 +10427,7 @@ importers:
         version: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-crx:
     dependencies:
@@ -10494,7 +10497,7 @@ importers:
         version: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-debug:
     dependencies:
@@ -14312,7 +14315,7 @@ importers:
         version: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-projects:
     dependencies:
@@ -15072,7 +15075,7 @@ importers:
         version: 0.29.0(effect@3.21.4)(vitest@4.1.10)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-script:
     dependencies:
@@ -18389,7 +18392,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/reflect/introspect:
     dependencies:
@@ -18432,7 +18435,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/reflect/introspect-mcp:
     dependencies:
@@ -18453,7 +18456,7 @@ importers:
         version: link:../../common/util
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.21.4
         version: 3.21.4
@@ -18472,7 +18475,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/reflect/introspect-tools:
     dependencies:
@@ -18497,7 +18500,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/sdk/app-framework:
     dependencies:
@@ -19932,7 +19935,7 @@ importers:
         version: link:../../common/typings
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/sdk/worker-framework:
     dependencies:
@@ -23005,7 +23008,7 @@ importers:
         version: link:../ui-theme
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 3.21.4
         version: 3.21.4
@@ -23361,7 +23364,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/ui/react-ui-menu:
     dependencies:
@@ -25006,7 +25009,7 @@ importers:
         version: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   tools/vite-plugin-log/example:
     devDependencies:
@@ -28775,6 +28778,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -44284,6 +44288,7 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
+      vite: '>=8.1.4'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -46561,7 +46566,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 4.20260714.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wrangler: 4.112.0(@cloudflare/workers-types@5.20260719.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -49713,11 +49718,11 @@ snapshots:
       gonzales-pe: 4.3.0
       node-source-walk: 7.0.1
 
-  '@devframes/hub@0.6.0(devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3))':
+  '@devframes/hub@0.6.0(devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3))':
     dependencies:
       birpc: 4.0.0
       destr: 2.0.5
-      devframe: 0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3)
+      devframe: 0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3)
       nostics: 1.1.4
       pathe: 2.0.3
       perfect-debounce: 2.1.0
@@ -49913,7 +49918,7 @@ snapshots:
       effect: 3.21.4
       multipasta: 0.2.7
 
-  '@effect/platform-bun@0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)':
+  '@effect/platform-bun@0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)':
     dependencies:
       '@effect/cluster': 0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/platform': 0.96.2(effect@3.21.4)
@@ -50018,7 +50023,7 @@ snapshots:
   '@effect/vitest@0.29.0(effect@3.21.4)(vitest@4.1.10)':
     dependencies:
       effect: 3.21.4
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@effect/wa-sqlite@0.1.2': {}
 
@@ -51160,7 +51165,7 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.2)
       ajv: 8.18.0
@@ -54335,7 +54340,7 @@ snapshots:
       '@vitest/browser': 4.1.10(patch_hash=a986f87598d00b4753574afb9fcad1a84d9b0145eaf80189a0b49d32b7af569a)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/browser-playwright': 4.1.10(playwright@1.57.0)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/runner': 4.1.10
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -55912,10 +55917,10 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitejs/devtools-kit@0.4.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/devtools-kit@0.4.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@devframes/hub': 0.6.0(devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3))
-      devframe: 0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3)
+      '@devframes/hub': 0.6.0(devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3))
+      devframe: 0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3)
       mlly: 1.8.2
       nostics: 1.1.4
       vite: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -55948,7 +55953,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -55961,7 +55966,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -55978,7 +55983,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -55995,7 +56000,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -56016,9 +56021,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(patch_hash=a986f87598d00b4753574afb9fcad1a84d9b0145eaf80189a0b49d32b7af569a)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(patch_hash=a986f87598d00b4753574afb9fcad1a84d9b0145eaf80189a0b49d32b7af569a)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.10)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -56097,7 +56102,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -57059,7 +57064,7 @@ snapshots:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@cloudflare/ai-chat': 0.0.6(agents@0.3.10)(ai@6.0.97(zod@4.3.6))(react@19.2.7)(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 6.0.97(zod@4.3.6)
       cron-schedule: 6.0.0
       escape-html: 1.0.3
@@ -59403,7 +59408,7 @@ snapshots:
 
   devalue@5.6.3: {}
 
-  devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3):
+  devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3):
     dependencies:
       '@valibot/to-json-schema': 1.7.1(valibot@1.4.2(typescript@6.0.3))
       birpc: 4.0.0
@@ -59417,7 +59422,7 @@ snapshots:
       ufo: 1.6.4
       valibot: 1.4.2(typescript@6.0.3)
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
     transitivePeerDependencies:
       - srvx
       - typescript
@@ -69226,9 +69231,9 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-inspect@12.0.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-plugin-inspect@12.0.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      '@vitejs/devtools-kit': 0.4.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitejs/devtools-kit': 0.4.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ansis: 4.3.1
       error-stack-parser-es: 2.0.1
       obug: 2.1.3
@@ -69399,7 +69404,7 @@ snapshots:
     optionalDependencies:
       vite: 8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -69430,20 +69435,9 @@ snapshots:
       happy-dom: 20.7.0
       jsdom: 29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
-  vitest@4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
+  vitest@4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -69474,18 +69468,7 @@ snapshots:
       happy-dom: 20.7.0
       jsdom: 29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   void-elements@3.1.0: {}
 


### PR DESCRIPTION
## Summary

Milestone 3 (instructions channel) of the plugin-projects work-stream: a chat's steering instructions become first-class, queryable state on the `Chat` object, passed by reference through the whole request path — plus the `ProjectSkill` that lets the assistant manage a project's artifacts, verified end-to-end by a live-model eval.

### Instructions as a typed ref (replaces typename dispatch)

- `Chat.instructions?: Ref<Instructions>` — a project chat points at the **project's own** Instructions object (never a copy), so editing the project steers every chat under it.
- `formatSystemPrompt` takes an explicit `instructions` parameter; the previous behavior — recovering instructions by filtering bound context objects with `Obj.instanceOf(Instructions, …)` — is deleted. Dispatch was by typename rather than intent: any bound Instructions object steered the session, so one could never be bound as *subject matter* (e.g. "help me edit these"). Bound Instructions now render as ordinary context stubs.
- Threaded via `AiSession.Options` → `RunProps` → `begin`/`run`; recomputed each turn.
- **Agent-process boundary**: the session is feed-centric and durable (`hydrateAgents` rebuilds with a bare executable), so the ref travels as a persisted spawn annotation (`Process.InstructionsAnnotation`, beside `TargetAnnotation`) via `GetSessionOptions.instructions`; `plugin-assistant`'s processor passes `chat.instructions`. Accepted staleness: repointing the ref needs a process restart — same model as a model/provider change. A broken ref degrades to an unsteered session.

### ProjectSkill (assistant-toolkit)

`org.dxos.skill.project`: `artifact-add` (files an object ref into the project's artifacts Collection; dedupes by entity id; materializes a missing collection) and `artifact-list` (dxn/typename/label rows). Registered in plugin-assistant's skill definitions. Filing is explicit — the skill's instructions tell the model to file what it creates — not an interception of object creation.

### System eval (live model, out of CI)

`assistant-evals/src/evals/projects.eval.ts`: seeds a Project (instructions + artifacts Collection) and a Chat mirroring the milestone-3 shape (parented to the project, `instructions` by ref), directs the model to create a markdown document, and grades **DB effects**: document created, **filed into the project's Collection**, and bound into the session context (a `Binding` record in the chat feed). The filing assertion is the load-bearing one — binding alone proves the session saw the object, not that the project owns it. **Passed live at 100%** (all three scorers, opus-4-8, 32s). The eval runner gained `seed` (space setup returning context objects + the session chat) and `types` options.

### Docs

`packages/plugins/plugin-projects/{DESIGN,TASKS}.md` consolidated into the package and rewritten as living documents; DESIGN.md records the layering constraints, the two-channel split (ref → prompt text; bindings → toolkit skills), and the rejected alternatives.

## Testing

- assistant 43 ✓ (format tests moved to the explicit parameter + new stub-behavior case), compute 46 ✓, agent-runtime 21 ✓, assistant-toolkit 30 ✓ (4 new ProjectSkill handler tests), plugin-assistant 136 ✓.
- Live eval: 100% (document-created / document-filed / document-bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chats and requests can now include typed, project-specific instructions that are rendered into the system prompt on each request.
  * Added project assistant capabilities to create and manage project artifacts (add and list) via new Project tools/skill.
  * Existing project chats automatically backfill missing instructions.
* **Bug Fixes**
  * Improved agent session/process rehydration and caching so instruction changes take effect correctly, without instructions showing up as duplicate context objects.
* **Documentation**
  * Updated plugin-projects design, plan, audit notes, and milestone task tracking.
* **Tests**
  * Added/extended eval and unit coverage for project artifact filing/listing and instruction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->