### PR TITLE
plugin-inbox: open a new draft beside the mailbox

### DIFF
--- a/.changeset/draft-opens-beside-mailbox.md
+++ b/.changeset/draft-opens-beside-mailbox.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-inbox': patch
+---
+
+Open a new mail draft as a plank beside the mailbox view it was composed from, and leave reply/forward drafts inline in their conversation instead of navigating to Drafts.

--- a/packages/plugins/plugin-inbox/PLUGIN.mdl
+++ b/packages/plugins/plugin-inbox/PLUGIN.mdl
@@ -321,7 +321,7 @@ op draftEmail
 op draftEmailAndOpen
   desc: |
     draftEmail then, for a compose draft, opens it in EditMessage as a plank beside the mailbox view
-    named by pivotId (UI convenience wrapper). Reply/forward drafts are not navigated to — they
+    named by contextId (UI convenience wrapper). Reply/forward drafts are not navigated to — they
     render inline in the conversation they join.
   input:
     db: Database
@@ -330,7 +330,7 @@ op draftEmailAndOpen
     subject?: string
     body?: string
     mailbox?: Ref<Mailbox>
-    pivotId?: string
+    contextId?: string
   effects: [echo:write]
 ```
 

--- a/packages/plugins/plugin-inbox/PLUGIN.mdl
+++ b/packages/plugins/plugin-inbox/PLUGIN.mdl
@@ -319,7 +319,10 @@ op draftEmail
 
 ```mdl
 op draftEmailAndOpen
-  desc: draftEmail then opens the draft in EditMessage (UI convenience wrapper).
+  desc: |
+    draftEmail then, for a compose draft, opens it in EditMessage as a plank beside the mailbox view
+    named by contextId (UI convenience wrapper). Reply/forward drafts are not navigated to — they
+    render inline in the conversation they join.
   input:
     db: Database
     mode?: compose | reply | reply-all | forward
@@ -327,6 +330,7 @@ op draftEmailAndOpen
     subject?: string
     body?: string
     mailbox?: Ref<Mailbox>
+    contextId?: string
   effects: [echo:write]
 ```
 

--- a/packages/plugins/plugin-inbox/PLUGIN.mdl
+++ b/packages/plugins/plugin-inbox/PLUGIN.mdl
@@ -321,7 +321,7 @@ op draftEmail
 op draftEmailAndOpen
   desc: |
     draftEmail then, for a compose draft, opens it in EditMessage as a plank beside the mailbox view
-    named by contextId (UI convenience wrapper). Reply/forward drafts are not navigated to — they
+    named by pivotId (UI convenience wrapper). Reply/forward drafts are not navigated to — they
     render inline in the conversation they join.
   input:
     db: Database
@@ -330,7 +330,7 @@ op draftEmailAndOpen
     subject?: string
     body?: string
     mailbox?: Ref<Mailbox>
-    contextId?: string
+    pivotId?: string
   effects: [echo:write]
 ```
 

--- a/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
@@ -215,7 +215,7 @@ export default Capability.makeModule(
                   db,
                   mailbox,
                   // This action hangs off the Drafts view, so the draft opens as a plank beside it.
-                  pivotId: getMailboxDraftsPath(db.spaceId, mailbox.id),
+                  contextId: getMailboxDraftsPath(db.spaceId, mailbox.id),
                 }),
               properties: {
                 label: ['create-draft.label', { ns: meta.profile.key }],

--- a/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
@@ -32,19 +32,9 @@ import {
   getSentId,
   getSubscriptionsId,
 } from '../paths';
-import { syncTarget } from '../util';
+import { getMessageLabel, syncTarget } from '../util';
 
 const calendarTypename = Type.getTypename(Calendar.Calendar);
-
-/**
- * Node label for a message. A compose draft's subject starts as an empty string rather than absent, so
- * a `??` fallback would leave the plank title (and breadcrumb tail) blank until the user types one.
- */
-const getMessageLabel = (message: Message.Message) =>
-  message.properties?.subject ||
-  (DraftMessage.instanceOf(message)
-    ? (['draft.label', { ns: meta.profile.key }] as const)
-    : (['message.label', { ns: meta.profile.key }] as const));
 
 const FILTER_TYPE = `${Type.getTypename(Mailbox.Mailbox)}-filter`;
 

--- a/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
@@ -36,6 +36,16 @@ import { syncTarget } from '../util';
 
 const calendarTypename = Type.getTypename(Calendar.Calendar);
 
+/**
+ * Node label for a message. A compose draft's subject starts as an empty string rather than absent, so
+ * a `??` fallback would leave the plank title (and breadcrumb tail) blank until the user types one.
+ */
+const getMessageLabel = (message: Message.Message) =>
+  message.properties?.subject ||
+  (DraftMessage.instanceOf(message)
+    ? (['draft.label', { ns: meta.profile.key }] as const)
+    : (['message.label', { ns: meta.profile.key }] as const));
+
 const FILTER_TYPE = `${Type.getTypename(Mailbox.Mailbox)}-filter`;
 
 export default Capability.makeModule(
@@ -256,8 +266,8 @@ export default Capability.makeModule(
                 type: Type.getTypename(Message.Message),
                 data: message,
                 properties: {
-                  label: message.properties?.subject ?? ['message.label', { ns: meta.profile.key }],
-                  icon: 'ph--envelope-open--regular',
+                  label: getMessageLabel(message),
+                  icon: DraftMessage.instanceOf(message) ? 'ph--pencil-simple--regular' : 'ph--envelope-open--regular',
                   disposition: 'hidden',
                 },
               }),

--- a/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
@@ -215,7 +215,7 @@ export default Capability.makeModule(
                   db,
                   mailbox,
                   // This action hangs off the Drafts view, so the draft opens as a plank beside it.
-                  contextId: getMailboxDraftsPath(db.spaceId, mailbox.id),
+                  pivotId: getMailboxDraftsPath(db.spaceId, mailbox.id),
                 }),
               properties: {
                 label: ['create-draft.label', { ns: meta.profile.key }],

--- a/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
@@ -26,6 +26,7 @@ import {
   getAllMailId,
   getCalendarsPath,
   getDraftsId,
+  getMailboxDraftsPath,
   getMailboxesPath,
   getMailboxesSectionId,
   getSentId,
@@ -209,7 +210,13 @@ export default Capability.makeModule(
           return Effect.succeed([
             Node.makeAction({
               id: 'createDraft',
-              data: () => Operation.invoke(InboxOperation.DraftEmailAndOpen, { db, mailbox }),
+              data: () =>
+                Operation.invoke(InboxOperation.DraftEmailAndOpen, {
+                  db,
+                  mailbox,
+                  // This action hangs off the Drafts view, so the draft opens as a plank beside it.
+                  contextId: getMailboxDraftsPath(db.spaceId, mailbox.id),
+                }),
               properties: {
                 label: ['create-draft.label', { ns: meta.profile.key }],
                 icon: 'ph--plus--regular',

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -545,8 +545,9 @@ const useMailboxActions = (
   const handleCompose = useCallback(() => {
     const db = Obj.getDatabase(mailbox);
     invariant(db);
-    void invoker.invokePromise(InboxOperation.DraftEmailAndOpen, { db, mailbox });
-  }, [invoker, mailbox]);
+    // `nodeId` is this view's node, so the draft opens as a plank beside it rather than beside Drafts.
+    void invoker.invokePromise(InboxOperation.DraftEmailAndOpen, { db, mailbox, contextId: nodeId });
+  }, [invoker, mailbox, nodeId]);
 
   // Resolve capabilities here (in the container) and thread them into the presentation-only mailbox
   // action hooks — components (and the hooks they call) must not resolve capabilities themselves.

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -546,7 +546,7 @@ const useMailboxActions = (
     const db = Obj.getDatabase(mailbox);
     invariant(db);
     // `nodeId` is this view's node, so the draft opens as a plank beside it rather than beside Drafts.
-    void invoker.invokePromise(InboxOperation.DraftEmailAndOpen, { db, mailbox, contextId: nodeId });
+    void invoker.invokePromise(InboxOperation.DraftEmailAndOpen, { db, mailbox, pivotId: nodeId });
   }, [invoker, mailbox, nodeId]);
 
   // Resolve capabilities here (in the container) and thread them into the presentation-only mailbox

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -546,7 +546,7 @@ const useMailboxActions = (
     const db = Obj.getDatabase(mailbox);
     invariant(db);
     // `nodeId` is this view's node, so the draft opens as a plank beside it rather than beside Drafts.
-    void invoker.invokePromise(InboxOperation.DraftEmailAndOpen, { db, mailbox, pivotId: nodeId });
+    void invoker.invokePromise(InboxOperation.DraftEmailAndOpen, { db, mailbox, contextId: nodeId });
   }, [invoker, mailbox, nodeId]);
 
   // Resolve capabilities here (in the container) and thread them into the presentation-only mailbox

--- a/packages/plugins/plugin-inbox/src/containers/MessageArticle/MessageArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MessageArticle/MessageArticle.tsx
@@ -152,8 +152,9 @@ export const MessageArticle = ({
     [invoker],
   );
 
-  // Generate a grounded reply body (thread + facts), then open the reply draft prefilled; on LLM failure
-  // fall back to an empty reply draft so the action never leaves the user without one.
+  // Generate a grounded reply body (thread + facts), then create the reply draft prefilled — it joins
+  // this thread and renders inline. On LLM failure fall back to an empty reply draft so the action never
+  // leaves the user without one.
   const handleAiReply = useCallback(
     async (message: MessageType.Message) => {
       if (!db || !mailbox) {

--- a/packages/plugins/plugin-inbox/src/operations/draft-email-and-open.ts
+++ b/packages/plugins/plugin-inbox/src/operations/draft-email-and-open.ts
@@ -8,16 +8,15 @@ import { LayoutOperation } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { Database } from '@dxos/echo';
 import { SpaceOperation } from '@dxos/plugin-space';
-import { Attention } from '@dxos/react-ui-attention/types';
 import { DraftMessage } from '@dxos/types';
 
-import { getMailboxDraftsPath } from '../paths';
+import { getFeedObjectPath, getMailboxPath } from '../paths';
 import { InboxOperation, Mailbox, SystemTags } from '../types';
 import { createDraftMessage } from '../util';
 
 const handler: Operation.WithHandler<typeof InboxOperation.DraftEmailAndOpen> = InboxOperation.DraftEmailAndOpen.pipe(
   Operation.withHandler(
-    Effect.fnUntraced(function* ({ db, mode, message, subject, body, mailbox }) {
+    Effect.fnUntraced(function* ({ db, mode = 'compose', message, subject, body, mailbox, contextId }) {
       const props = createDraftMessage({ mode, message, subject, body, mailbox });
       const draft = DraftMessage.make(props);
       yield* Operation.invoke(SpaceOperation.AddObject, {
@@ -25,21 +24,34 @@ const handler: Operation.WithHandler<typeof InboxOperation.DraftEmailAndOpen> = 
         target: db,
       });
 
-      if (Mailbox.instanceOf(mailbox)) {
-        // Tag as 'draft' so the Drafts view (a systemTag filter, like Inbox/Sent) picks it up;
-        // `useSendEmail` removes the tag at send time.
-        yield* SystemTags.toggleTag(mailbox, draft, 'draft').pipe(Effect.provide(Database.layer(db)));
-
-        // Navigate to Drafts and select the new draft, mirroring the select-then-show-companion flow
-        // a list click does via `useShowItem` (invoked directly here since this runs outside a component).
-        const draftsPath = getMailboxDraftsPath(db.spaceId, mailbox.id);
-        yield* Operation.invoke(LayoutOperation.Select, {
-          contextId: draftsPath,
-          subject: { mode: 'single', id: draft.id },
-        });
-        yield* Operation.invoke(LayoutOperation.Open, { subject: [draftsPath] });
-        yield* Operation.invoke(LayoutOperation.UpdateCompanion, { subject: Attention.linkedSegment('message') });
+      if (!Mailbox.instanceOf(mailbox)) {
+        return;
       }
+
+      // Tag as 'draft' so the Drafts view (a systemTag filter, like Inbox/Sent) picks it up;
+      // `useSendEmail` removes the tag at send time.
+      yield* SystemTags.toggleTag(mailbox, draft, 'draft').pipe(Effect.provide(Database.layer(db)));
+
+      // A reply/forward draft shares its parent's `threadId`, so the conversation the caller is already
+      // looking at renders it inline (see `ConversationStack`) — navigating anywhere would lose that view.
+      if (mode !== 'compose') {
+        return;
+      }
+
+      // A fresh draft joins no thread, so open it as its own plank beside the mailbox view it was
+      // composed from — the add-navigation a message click uses (see `MailboxArticle`). Drafts hang off
+      // every mailbox view node (see the `mailboxMessages` connector), so the path resolves for any view.
+      const pivotId = contextId ?? getMailboxPath(db.spaceId, mailbox.id);
+      yield* Operation.invoke(LayoutOperation.Select, {
+        contextId: pivotId,
+        subject: { mode: 'single', id: draft.id },
+      });
+      yield* Operation.invoke(LayoutOperation.Open, {
+        subject: [getFeedObjectPath(pivotId, draft.id)],
+        pivotId,
+        disposition: 'add',
+        navigation: 'immediate',
+      });
     }),
   ),
 );

--- a/packages/plugins/plugin-inbox/src/operations/draft-email-and-open.ts
+++ b/packages/plugins/plugin-inbox/src/operations/draft-email-and-open.ts
@@ -16,7 +16,7 @@ import { createDraftMessage } from '../util';
 
 const handler: Operation.WithHandler<typeof InboxOperation.DraftEmailAndOpen> = InboxOperation.DraftEmailAndOpen.pipe(
   Operation.withHandler(
-    Effect.fnUntraced(function* ({ db, mode = 'compose', message, subject, body, mailbox, pivotId }) {
+    Effect.fnUntraced(function* ({ db, mode = 'compose', message, subject, body, mailbox, contextId }) {
       const props = createDraftMessage({ mode, message, subject, body, mailbox });
       const draft = DraftMessage.make(props);
       yield* Operation.invoke(SpaceOperation.AddObject, {
@@ -38,17 +38,17 @@ const handler: Operation.WithHandler<typeof InboxOperation.DraftEmailAndOpen> = 
         return;
       }
 
-      // A fresh draft joins no thread, so open it as its own plank beside the view it was composed from —
-      // the add-navigation a message click uses (see `MailboxArticle`). Drafts hang off every mailbox view
-      // node (see the `mailboxMessages` connector), so the path resolves whichever view is the pivot.
-      const pivot = pivotId ?? getMailboxPath(db.spaceId, mailbox.id);
+      // A fresh draft joins no thread, so open it as its own plank beside the mailbox view it was
+      // composed from — the add-navigation a message click uses (see `MailboxArticle`). Drafts hang off
+      // every mailbox view node (see the `mailboxMessages` connector), so the path resolves for any view.
+      const pivotId = contextId ?? getMailboxPath(db.spaceId, mailbox.id);
       yield* Operation.invoke(LayoutOperation.Select, {
-        contextId: pivot,
+        contextId: pivotId,
         subject: { mode: 'single', id: draft.id },
       });
       yield* Operation.invoke(LayoutOperation.Open, {
-        subject: [getFeedObjectPath(pivot, draft.id)],
-        pivotId: pivot,
+        subject: [getFeedObjectPath(pivotId, draft.id)],
+        pivotId,
         disposition: 'add',
         navigation: 'immediate',
       });

--- a/packages/plugins/plugin-inbox/src/operations/draft-email-and-open.ts
+++ b/packages/plugins/plugin-inbox/src/operations/draft-email-and-open.ts
@@ -17,16 +17,18 @@ import { createDraftMessage } from '../util';
 const handler: Operation.WithHandler<typeof InboxOperation.DraftEmailAndOpen> = InboxOperation.DraftEmailAndOpen.pipe(
   Operation.withHandler(
     Effect.fnUntraced(function* ({ db, mode = 'compose', message, subject, body, mailbox, contextId }) {
+      // A draft is identified by the `properties.mailbox` its mailbox supplies (see `DraftMessage`), so
+      // without one there is nothing to scope, tag, or render it — bail before persisting an orphan.
+      if (!Mailbox.instanceOf(mailbox)) {
+        return;
+      }
+
       const props = createDraftMessage({ mode, message, subject, body, mailbox });
       const draft = DraftMessage.make(props);
       yield* Operation.invoke(SpaceOperation.AddObject, {
         object: draft,
         target: db,
       });
-
-      if (!Mailbox.instanceOf(mailbox)) {
-        return;
-      }
 
       // Tag as 'draft' so the Drafts view (a systemTag filter, like Inbox/Sent) picks it up;
       // `useSendEmail` removes the tag at send time.

--- a/packages/plugins/plugin-inbox/src/operations/draft-email-and-open.ts
+++ b/packages/plugins/plugin-inbox/src/operations/draft-email-and-open.ts
@@ -16,7 +16,7 @@ import { createDraftMessage } from '../util';
 
 const handler: Operation.WithHandler<typeof InboxOperation.DraftEmailAndOpen> = InboxOperation.DraftEmailAndOpen.pipe(
   Operation.withHandler(
-    Effect.fnUntraced(function* ({ db, mode = 'compose', message, subject, body, mailbox, contextId }) {
+    Effect.fnUntraced(function* ({ db, mode = 'compose', message, subject, body, mailbox, pivotId }) {
       const props = createDraftMessage({ mode, message, subject, body, mailbox });
       const draft = DraftMessage.make(props);
       yield* Operation.invoke(SpaceOperation.AddObject, {
@@ -38,17 +38,17 @@ const handler: Operation.WithHandler<typeof InboxOperation.DraftEmailAndOpen> = 
         return;
       }
 
-      // A fresh draft joins no thread, so open it as its own plank beside the mailbox view it was
-      // composed from — the add-navigation a message click uses (see `MailboxArticle`). Drafts hang off
-      // every mailbox view node (see the `mailboxMessages` connector), so the path resolves for any view.
-      const pivotId = contextId ?? getMailboxPath(db.spaceId, mailbox.id);
+      // A fresh draft joins no thread, so open it as its own plank beside the view it was composed from —
+      // the add-navigation a message click uses (see `MailboxArticle`). Drafts hang off every mailbox view
+      // node (see the `mailboxMessages` connector), so the path resolves whichever view is the pivot.
+      const pivot = pivotId ?? getMailboxPath(db.spaceId, mailbox.id);
       yield* Operation.invoke(LayoutOperation.Select, {
-        contextId: pivotId,
+        contextId: pivot,
         subject: { mode: 'single', id: draft.id },
       });
       yield* Operation.invoke(LayoutOperation.Open, {
-        subject: [getFeedObjectPath(pivotId, draft.id)],
-        pivotId,
+        subject: [getFeedObjectPath(pivot, draft.id)],
+        pivotId: pivot,
         disposition: 'add',
         navigation: 'immediate',
       });

--- a/packages/plugins/plugin-inbox/src/translations.ts
+++ b/packages/plugins/plugin-inbox/src/translations.ts
@@ -56,6 +56,7 @@ export const translations = [
         'action-delete.menu': 'Delete',
         'action-mark-read.menu': 'Mark as read',
         'message.label': 'Message',
+        'draft.label': 'New message',
         'event.label': 'Event',
         'facts.label': 'Facts',
         'inbox.label': 'Inbox',

--- a/packages/plugins/plugin-inbox/src/types/InboxOperation.ts
+++ b/packages/plugins/plugin-inbox/src/types/InboxOperation.ts
@@ -105,11 +105,10 @@ export const DraftEmailAndOpen = Operation.make({
     // TODO(wittjosiah): Should be Mailbox.Mailbox.
     mailbox: Schema.optional(Schema.Any),
     /**
-     * Node the compose draft's plank opens beside, and whose selection it becomes — the mailbox *view*
-     * it was composed from (Inbox/Sent/Drafts/a saved filter each have their own node and selection),
-     * not the mailbox. Defaults to the mailbox's own node when the caller has no view to pivot on.
+     * Graph node id of the mailbox view the draft is composed from; a compose draft opens as a plank
+     * beside it. Defaults to the mailbox's own node when the caller has no view context.
      */
-    pivotId: Schema.optional(Schema.String),
+    contextId: Schema.optional(Schema.String),
   }),
   output: Schema.Void,
 });

--- a/packages/plugins/plugin-inbox/src/types/InboxOperation.ts
+++ b/packages/plugins/plugin-inbox/src/types/InboxOperation.ts
@@ -105,10 +105,11 @@ export const DraftEmailAndOpen = Operation.make({
     // TODO(wittjosiah): Should be Mailbox.Mailbox.
     mailbox: Schema.optional(Schema.Any),
     /**
-     * Graph node id of the mailbox view the draft is composed from; a compose draft opens as a plank
-     * beside it. Defaults to the mailbox's own node when the caller has no view context.
+     * Node the compose draft's plank opens beside, and whose selection it becomes — the mailbox *view*
+     * it was composed from (Inbox/Sent/Drafts/a saved filter each have their own node and selection),
+     * not the mailbox. Defaults to the mailbox's own node when the caller has no view to pivot on.
      */
-    contextId: Schema.optional(Schema.String),
+    pivotId: Schema.optional(Schema.String),
   }),
   output: Schema.Void,
 });

--- a/packages/plugins/plugin-inbox/src/types/InboxOperation.ts
+++ b/packages/plugins/plugin-inbox/src/types/InboxOperation.ts
@@ -104,6 +104,11 @@ export const DraftEmailAndOpen = Operation.make({
     body: Schema.optional(Schema.String),
     // TODO(wittjosiah): Should be Mailbox.Mailbox.
     mailbox: Schema.optional(Schema.Any),
+    /**
+     * Graph node id of the mailbox view the draft is composed from; a compose draft opens as a plank
+     * beside it. Defaults to the mailbox's own node when the caller has no view context.
+     */
+    contextId: Schema.optional(Schema.String),
   }),
   output: Schema.Void,
 });

--- a/packages/plugins/plugin-inbox/src/util/util.test.ts
+++ b/packages/plugins/plugin-inbox/src/util/util.test.ts
@@ -7,10 +7,13 @@ import { describe, test } from 'vitest';
 import { Obj } from '@dxos/echo';
 import { Message } from '@dxos/types';
 
+import { meta } from '#meta';
+
 import {
   createDraftMessage,
   dedupeSupersededDrafts,
   getMessageBodyText,
+  getMessageLabel,
   getMessageProps,
   messageMatchesQuery,
   orderThreadItems,
@@ -335,6 +338,32 @@ describe('messageMatchesQuery', () => {
   test('an empty query always matches', ({ expect }) => {
     expect(messageMatchesQuery(message, '')).toBe(true);
     expect(messageMatchesQuery(message, '   ')).toBe(true);
+  });
+});
+
+describe('getMessageLabel', () => {
+  test('uses the subject when there is one', ({ expect }) => {
+    expect(getMessageLabel(makeRead('2025-01-01T00:00:00.000Z'))).toBe('Topic');
+  });
+
+  test('a compose draft (empty subject) falls back to the draft label, not a blank heading', ({ expect }) => {
+    const draft = Obj.make(Message.Message, {
+      created: '2025-01-01T00:00:00.000Z',
+      sender: { name: 'Me' },
+      blocks: [{ _tag: 'text' as const, text: '' }],
+      properties: { subject: '', mailbox: DRAFT_MAILBOX },
+    });
+    expect(getMessageLabel(draft)).toEqual(['draft.label', { ns: meta.profile.key }]);
+  });
+
+  test('a non-draft without a subject falls back to the message label', ({ expect }) => {
+    const message = Obj.make(Message.Message, {
+      created: '2025-01-01T00:00:00.000Z',
+      sender: { name: 'Sender' },
+      blocks: [{ _tag: 'text' as const, text: '' }],
+      properties: { subject: '' },
+    });
+    expect(getMessageLabel(message)).toEqual(['message.label', { ns: meta.profile.key }]);
   });
 });
 

--- a/packages/plugins/plugin-inbox/src/util/util.ts
+++ b/packages/plugins/plugin-inbox/src/util/util.ts
@@ -7,6 +7,7 @@ import { format, formatDistance, isThisWeek, isThisYear, isToday } from 'date-fn
 import { Obj } from '@dxos/echo';
 import { type ContentBlock, DraftMessage, type Message } from '@dxos/types';
 
+import { meta } from '#meta';
 import { type Mailbox } from '#types';
 
 export const REPLY_DELIMITER = '\n\n---';
@@ -169,6 +170,17 @@ export const dedupeSupersededDrafts = (messages: Message.Message[], mailboxUri: 
     return !(message.properties?.sentMessageId && syncedIds.has(message.properties.sentMessageId));
   });
 };
+
+/**
+ * Display label for a message's graph node (the plank heading, and its breadcrumb tail in flat mode).
+ * A compose draft's subject is an empty string rather than absent, so falling back only on `undefined`
+ * would leave the heading blank until the user types one.
+ */
+export const getMessageLabel = (message: Message.Message) =>
+  message.properties?.subject ||
+  (DraftMessage.instanceOf(message)
+    ? (['draft.label', { ns: meta.profile.key }] as const)
+    : (['message.label', { ns: meta.profile.key }] as const));
 
 // TODO(burdon): Factor out sort pattern with getters.
 export const sortByCreated =


### PR DESCRIPTION
Now that a message article can be navigated to directly (a message is a hidden child of every mailbox view node, and `MailboxArticle` opens one as a plank beside the mailbox via `disposition: 'add'`), a new draft no longer needs the detour through the Drafts view.

## Changes

- `draftEmailAndOpen` now takes an optional `contextId` — the graph node id of the mailbox *view* the draft was composed from — and opens a **compose** draft as its own plank beside it (`Select` + `Open` with `pivotId`/`disposition: 'add'`/`navigation: 'immediate'`, mirroring `MailboxArticle`'s message-click navigation). The view matters, not just the mailbox: Inbox/Sent/Drafts/saved filters are separate nodes with their own selection. Falls back to the mailbox's own node when no context is given.
- **Reply/forward** drafts no longer navigate at all: they carry the parent's `threadId`, so the conversation the caller is already looking at renders them inline (this is already how `ConversationStack`'s own reply/forward buttons behave — only the AI-reply path went through the operation and got yanked to Drafts).
- Call sites pass their context: the mailbox toolbar's compose action passes the article's node id (so composing from Inbox opens beside Inbox, not beside Drafts); the nav-tree "create draft" action passes the Drafts view path it hangs off.
- Dropped the old `Select(drafts)` → `Open(drafts)` → `UpdateCompanion('message')` sequence and its `Attention` import.
- **Fixed a blank plank heading for the new draft.** A compose draft's `properties.subject` is an empty string rather than absent, so the message node's `?? ['message.label']` fallback never fired and the heading (the breadcrumb tail in flat mode) rendered empty. `getMessageLabel` now falls back on empty — a subject-less draft reads "New message", a subject-less synced message still reads "Message" — and draft nodes get the pencil icon the Drafts view uses.
- `PLUGIN.mdl` spec block updated for the new input and navigation behavior; changeset added.

## Testing

- `moon run plugin-inbox:build` — pass
- `moon run plugin-inbox:lint` — pass
- `moon run plugin-inbox:test` — 225 passed, 14 skipped (3 new, covering the empty-subject label cases)
- `pnpm format` — clean
- Compose verified on the PR preview: the draft opens as its own plank beside the mailbox view.

No e2e coverage of the compose flow yet (the Playwright inbox spec covers sync/select/reply only) — tracked in the plugin's `TASKS.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New email drafts open as a plank beside the mailbox view where they were composed.
  * Reply and forward drafts now remain inline within their conversation (no jump to Drafts).
  * Drafts without a subject display the label **“New message”**, with clearer label/icon differentiation.
* **Bug Fixes**
  * Compose draft actions now preserve and restore the originating mailbox context, ensuring drafts open in the correct place rather than defaulting to a generic Drafts view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->