### PR TITLE
stories-inbox: give CreateProject button wait a client-init-sized timeout

### DIFF
--- a/packages/stories/stories-inbox/src/stories/CreateProject.stories.tsx
+++ b/packages/stories/stories-inbox/src/stories/CreateProject.stories.tsx
@@ -128,7 +128,9 @@ export const Default: StoryType = {};
 export const Test: StoryType = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const button = await waitFor(() => canvas.getByRole('button', { name: /create project/i }));
+    // Client init (identity + space + indexed flush) gates the first render; waitFor's
+    // default 1s timeout is routinely exceeded on cold/loaded runners.
+    const button = await waitFor(() => canvas.getByRole('button', { name: /create project/i }), { timeout: 10_000 });
     // No projects initially.
     void expect(canvas.getByTestId('project-count').getAttribute('data-count')).toBe('0');
 


### PR DESCRIPTION
Fixes the `stories-inbox CreateProject > Test` storybook test, which fails on cold or loaded runners.

## Problem

The play function waited for the "Create Project" button with `waitFor`'s **default 1 s** timeout:

```ts
const button = await waitFor(() => canvas.getByRole('button', { name: /create project/i }));
```

But the story only renders that button after full client initialization — `initializeIdentity`, personal-space creation, and a `db.flush({ indexes: true })` — and renders a `Loading` placeholder until then. Locally that takes ~6–7 s cold, so the wait expires while the story is still booting and the test fails with `Unable to find role="button" and name /create project/i` (the printed DOM shows the empty `class="contents"` wrapper, i.e. still loading).

The same play function already allows 10 s for the assertion that follows, so the short wait was the outlier rather than a deliberate budget.

## Fix

Give the button wait the same 10 s budget, with a comment recording why it can't use the default.

## Verification

Failing before the change and passing after, via `moon run stories-inbox:test-storybook -- src/stories/CreateProject.stories.tsx`:

| | Result |
| --- | --- |
| Before | `× Test 2076ms` — `Unable to find role="button"` (also fails on retry) |
| After | `✓ Test 6802ms` — 2 passed (2) |

The 6.8 s pass time against the old 1 s budget is the whole story: nothing about the test was racy, the budget was simply too small for what it waits on.

## Notes

This was found while triaging CI on #12369 and originally committed there; it is unrelated to that PR's build-dependency change, so it ships separately here. Confirmed independent by reproducing the failure with #12369's resolution changes fully neutralized. No changeset — `stories-inbox` is a private stories package, not published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the “Create Project” story’s interaction test reliability by allowing more time for the button to appear in slower or cold-running environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->