### PR TITLE
observability: send $survey_completed and fix feedback log uploads

### DIFF
--- a/.changeset/survey-completed-property.md
+++ b/.changeset/survey-completed-property.md
@@ -1,0 +1,5 @@
+---
+'@dxos/observability': patch
+---
+
+Send `$survey_completed` with captured user feedback so PostHog survey destinations trigger, and serialize errors logged as context to OTel instead of dropping them.

--- a/packages/apps/composer-app/src/functions/_worker.ts
+++ b/packages/apps/composer-app/src/functions/_worker.ts
@@ -47,7 +47,18 @@ const handleFeedbackLogs = async (request: Request, env: Env): Promise<Response>
     return new Response('Feedback logs storage not configured', { status: 503 });
   }
 
-  const contentLength = Number(request.headers.get('content-length') ?? 0);
+  // R2 only accepts a known-length stream, so Content-Length is required rather than advisory: it
+  // is both the size guard and what lets the body go straight to R2 unbuffered.
+  const contentLengthHeader = request.headers.get('content-length');
+  const contentLength = contentLengthHeader === null ? Number.NaN : Number(contentLengthHeader);
+  if (!Number.isInteger(contentLength) || contentLength < 0) {
+    return new Response('Content-Length required', { status: 411 });
+  }
+
+  if (contentLength === 0) {
+    return new Response('Empty body', { status: 400 });
+  }
+
   if (contentLength > FEEDBACK_LOGS_MAX_BODY_SIZE) {
     return new Response('Payload too large', { status: 413 });
   }
@@ -56,59 +67,19 @@ const handleFeedbackLogs = async (request: Request, env: Env): Promise<Response>
     return new Response('Empty body', { status: 400 });
   }
 
-  // Stream to R2 rather than buffering with `arrayBuffer()`: a multi-MB dump held whole in the
-  // isolate risks the Worker memory limit, which tears down the connection so the client sees a
-  // rejected `fetch` with no status instead of an error response.
-  let byteCount = 0;
-  let sizeExceeded = false;
-  let isEmpty = false;
-  const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>({
-    transform(chunk, controller) {
-      byteCount += chunk.byteLength;
-      // Enforce the cap even when Content-Length is absent or understates the body.
-      if (byteCount > FEEDBACK_LOGS_MAX_BODY_SIZE) {
-        sizeExceeded = true;
-        controller.error(new Error('Payload too large'));
-      } else {
-        controller.enqueue(chunk);
-      }
-    },
-    flush(controller) {
-      if (byteCount === 0) {
-        isEmpty = true;
-        controller.error(new Error('Empty body'));
-      }
-    },
-  });
-
-  // Never awaited: a rejecting put() can leave the pipe unsettled forever (it stops reading while
-  // the request body is still being written), and awaiting it would hang the request.
-  void request.body.pipeTo(writable).catch(() => {});
-
   const date = new Date().toISOString().slice(0, 10);
   const id = crypto.randomUUID();
   const key = `logs/${date}/${id}.ndjson`;
 
-  let stored = false;
   try {
-    await env.FEEDBACK_LOGS.put(key, readable, {
+    // Hand R2 the request body itself: `arrayBuffer()` would hold the whole dump in the isolate,
+    // near its memory limit, and a Worker torn down that way resets the connection — the client
+    // then sees a rejected `fetch` with no status rather than an error response.
+    await env.FEEDBACK_LOGS.put(key, request.body, {
       httpMetadata: { contentType: 'application/x-ndjson' },
     });
-    stored = true;
   } catch {
-    // put() rejects both when the transform errors the stream above and when R2 itself fails; the
-    // flags distinguish the two, and a resolved put() means the body was fully read.
-  }
-
-  if (sizeExceeded) {
-    return new Response('Payload too large', { status: 413 });
-  }
-
-  if (isEmpty) {
-    return new Response('Empty body', { status: 400 });
-  }
-
-  if (!stored) {
+    // R2 rejects a body that does not match Content-Length, as well as its own failures.
     return new Response('Failed to store feedback logs', { status: 502 });
   }
 

--- a/packages/apps/composer-app/src/functions/_worker.ts
+++ b/packages/apps/composer-app/src/functions/_worker.ts
@@ -5,7 +5,7 @@
 // Import from the focused constants module rather than the `../util` barrel: the barrel re-exports
 // modules (config/halo/storage) that pull Automerge's wasm into this Cloudflare Worker bundle, which
 // esbuild cannot load. The Worker only needs this one constant.
-import { FEEDBACK_LOGS_MAX_SIZE } from '../util/constants';
+import { LOG_STORE_MAX_BYTES } from '../util/constants';
 
 type Env = {
   ASSETS: Fetcher;
@@ -16,7 +16,7 @@ type Env = {
 };
 
 const OTEL_MAX_BODY_SIZE = 800 * 1024 * 1024; // 800MB.
-const FEEDBACK_LOGS_MAX_BODY_SIZE = FEEDBACK_LOGS_MAX_SIZE;
+const FEEDBACK_LOGS_MAX_BODY_SIZE = LOG_STORE_MAX_BYTES;
 
 const ALLOWED_ORIGINS = new Set([
   'https://composer.space',

--- a/packages/apps/composer-app/src/functions/_worker.ts
+++ b/packages/apps/composer-app/src/functions/_worker.ts
@@ -52,22 +52,65 @@ const handleFeedbackLogs = async (request: Request, env: Env): Promise<Response>
     return new Response('Payload too large', { status: 413 });
   }
 
-  const bodyBuffer = await request.arrayBuffer();
-  if (bodyBuffer.byteLength === 0) {
+  if (!request.body) {
     return new Response('Empty body', { status: 400 });
   }
 
-  if (bodyBuffer.byteLength > FEEDBACK_LOGS_MAX_BODY_SIZE) {
-    return new Response('Payload too large', { status: 413 });
-  }
+  // Stream to R2 rather than buffering with `arrayBuffer()`: a multi-MB dump held whole in the
+  // isolate risks the Worker memory limit, which tears down the connection so the client sees a
+  // rejected `fetch` with no status instead of an error response.
+  let byteCount = 0;
+  let sizeExceeded = false;
+  let isEmpty = false;
+  const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      byteCount += chunk.byteLength;
+      // Enforce the cap even when Content-Length is absent or understates the body.
+      if (byteCount > FEEDBACK_LOGS_MAX_BODY_SIZE) {
+        sizeExceeded = true;
+        controller.error(new Error('Payload too large'));
+      } else {
+        controller.enqueue(chunk);
+      }
+    },
+    flush(controller) {
+      if (byteCount === 0) {
+        isEmpty = true;
+        controller.error(new Error('Empty body'));
+      }
+    },
+  });
+
+  // Never awaited: a rejecting put() can leave the pipe unsettled forever (it stops reading while
+  // the request body is still being written), and awaiting it would hang the request.
+  void request.body.pipeTo(writable).catch(() => {});
 
   const date = new Date().toISOString().slice(0, 10);
   const id = crypto.randomUUID();
   const key = `logs/${date}/${id}.ndjson`;
 
-  await env.FEEDBACK_LOGS.put(key, bodyBuffer, {
-    httpMetadata: { contentType: 'application/x-ndjson' },
-  });
+  let stored = false;
+  try {
+    await env.FEEDBACK_LOGS.put(key, readable, {
+      httpMetadata: { contentType: 'application/x-ndjson' },
+    });
+    stored = true;
+  } catch {
+    // put() rejects both when the transform errors the stream above and when R2 itself fails; the
+    // flags distinguish the two, and a resolved put() means the body was fully read.
+  }
+
+  if (sizeExceeded) {
+    return new Response('Payload too large', { status: 413 });
+  }
+
+  if (isEmpty) {
+    return new Response('Empty body', { status: 400 });
+  }
+
+  if (!stored) {
+    return new Response('Failed to store feedback logs', { status: 502 });
+  }
 
   return new Response(JSON.stringify({ key }), {
     status: 200,

--- a/packages/apps/composer-app/src/recovery/download-logs.ts
+++ b/packages/apps/composer-app/src/recovery/download-logs.ts
@@ -4,11 +4,11 @@
 
 import { IdbLogStore } from '@dxos/log-store-idb';
 
-import { LOG_STORE_DB_NAME, exportManualLogDownload, triggerNdjsonDownload } from '../util';
+import { LOG_STORE_DB_NAME, LOG_STORE_MAX_BYTES, exportManualLogDownload, triggerNdjsonDownload } from '../util';
 
 /** Export NDJSON logs from the IDB log collector and trigger a browser download. */
 export const downloadRecoveryLogs = async (): Promise<{ byteLength: number }> => {
-  const logStore = new IdbLogStore({ dbName: LOG_STORE_DB_NAME });
+  const logStore = new IdbLogStore({ dbName: LOG_STORE_DB_NAME, maxBytes: LOG_STORE_MAX_BYTES });
   try {
     const blob = await exportManualLogDownload(logStore);
     triggerNdjsonDownload(blob);

--- a/packages/apps/composer-app/src/util/config.ts
+++ b/packages/apps/composer-app/src/util/config.ts
@@ -12,7 +12,7 @@ import { type IdbLogStore } from '@dxos/log-store-idb';
 import { Observability, ObservabilityExtension, ObservabilityProvider } from '@dxos/observability';
 import { getHostPlatform } from '@dxos/util';
 
-import { FEEDBACK_LOGS_MAX_SIZE } from './constants';
+import { FEEDBACK_LOG_UPLOAD_MAX_SIZE } from './constants';
 
 export const PARAM_PROFILER = 'profiler';
 export const PARAM_SAFE_MODE = 'safe';
@@ -97,7 +97,7 @@ export const initializeObservability = async (
         release: DXOS_VERSION,
         environment: config.values.runtime?.app?.env?.DX_ENVIRONMENT ?? 'unknown',
         logStore,
-        feedbackLogMaxSize: FEEDBACK_LOGS_MAX_SIZE,
+        feedbackLogMaxSize: FEEDBACK_LOG_UPLOAD_MAX_SIZE,
         posthog: observabilityDisabled ? POSTHOG_DISABLED_CONFIG : undefined,
       }),
     ),

--- a/packages/apps/composer-app/src/util/config.ts
+++ b/packages/apps/composer-app/src/util/config.ts
@@ -12,7 +12,7 @@ import { type IdbLogStore } from '@dxos/log-store-idb';
 import { Observability, ObservabilityExtension, ObservabilityProvider } from '@dxos/observability';
 import { getHostPlatform } from '@dxos/util';
 
-import { FEEDBACK_LOG_UPLOAD_MAX_SIZE } from './constants';
+import { LOG_STORE_MAX_BYTES } from './constants';
 
 export const PARAM_PROFILER = 'profiler';
 export const PARAM_SAFE_MODE = 'safe';
@@ -97,7 +97,7 @@ export const initializeObservability = async (
         release: DXOS_VERSION,
         environment: config.values.runtime?.app?.env?.DX_ENVIRONMENT ?? 'unknown',
         logStore,
-        feedbackLogMaxSize: FEEDBACK_LOG_UPLOAD_MAX_SIZE,
+        feedbackLogMaxSize: LOG_STORE_MAX_BYTES,
         posthog: observabilityDisabled ? POSTHOG_DISABLED_CONFIG : undefined,
       }),
     ),

--- a/packages/apps/composer-app/src/util/constants.ts
+++ b/packages/apps/composer-app/src/util/constants.ts
@@ -18,7 +18,7 @@ export const LOG_STORE_DB_NAME = 'composer-logs';
  * limit would discard logs the circular buffer deliberately retained. Passed explicitly to every
  * `IdbLogStore` rather than relying on the package default, so the two cannot drift.
  */
-export const LOG_STORE_MAX_BYTES = 50 * 1024 * 1024; // 50 MB
+export const LOG_STORE_MAX_BYTES = 50 * 1024 * 1024;
 
 /** Recovery mode entry point (minimal client, export, debug port). */
 export const RECOVERY_PATH = '/recovery.html';

--- a/packages/apps/composer-app/src/util/constants.ts
+++ b/packages/apps/composer-app/src/util/constants.ts
@@ -12,19 +12,13 @@ export const APP_KEY = 'composer.dxos.org';
 export const LOG_STORE_DB_NAME = 'composer-logs';
 
 /**
- * Hard ceiling the Cloudflare worker (`_worker.ts`) enforces on a feedback log upload.
- * Deliberately well above {@link FEEDBACK_LOG_UPLOAD_MAX_SIZE} — it is a server-side abuse
- * guard, not the size clients aim for.
+ * Retention cap for the log store, and therefore the size of a feedback log upload: the client
+ * trims its export to this, and the Cloudflare worker (`_worker.ts`) enforces the same ceiling.
+ * One constant for both so a feedback report carries everything the store kept — a smaller upload
+ * limit would discard logs the circular buffer deliberately retained. Passed explicitly to every
+ * `IdbLogStore` rather than relying on the package default, so the two cannot drift.
  */
-export const FEEDBACK_LOGS_MAX_SIZE = 50 * 1024 * 1024; // 50 MB
-
-/**
- * Byte size the feedback dialog trims the exported log store to before uploading.
- * Kept far below the log store's own 50 MB retention cap: exporting the full store produced
- * uploads large enough to fail at the transport layer (the browser only sees a rejected
- * `fetch`, with no status), and a few MB of recent lines is what a bug report actually needs.
- */
-export const FEEDBACK_LOG_UPLOAD_MAX_SIZE = 8 * 1024 * 1024; // 8 MB
+export const LOG_STORE_MAX_BYTES = 50 * 1024 * 1024; // 50 MB
 
 /** Recovery mode entry point (minimal client, export, debug port). */
 export const RECOVERY_PATH = '/recovery.html';

--- a/packages/apps/composer-app/src/util/constants.ts
+++ b/packages/apps/composer-app/src/util/constants.ts
@@ -12,11 +12,19 @@ export const APP_KEY = 'composer.dxos.org';
 export const LOG_STORE_DB_NAME = 'composer-logs';
 
 /**
- * Maximum byte size for a feedback log upload.
- * Must match the limit enforced in the Cloudflare worker (`_worker.ts`).
- * Export trims to this size so the upload never exceeds the worker's cap.
+ * Hard ceiling the Cloudflare worker (`_worker.ts`) enforces on a feedback log upload.
+ * Deliberately well above {@link FEEDBACK_LOG_UPLOAD_MAX_SIZE} — it is a server-side abuse
+ * guard, not the size clients aim for.
  */
 export const FEEDBACK_LOGS_MAX_SIZE = 50 * 1024 * 1024; // 50 MB
+
+/**
+ * Byte size the feedback dialog trims the exported log store to before uploading.
+ * Kept far below the log store's own 50 MB retention cap: exporting the full store produced
+ * uploads large enough to fail at the transport layer (the browser only sees a rejected
+ * `fetch`, with no status), and a few MB of recent lines is what a bug report actually needs.
+ */
+export const FEEDBACK_LOG_UPLOAD_MAX_SIZE = 8 * 1024 * 1024; // 8 MB
 
 /** Recovery mode entry point (minimal client, export, debug port). */
 export const RECOVERY_PATH = '/recovery.html';

--- a/packages/apps/composer-app/src/workers/dedicated-worker.ts
+++ b/packages/apps/composer-app/src/workers/dedicated-worker.ts
@@ -7,9 +7,9 @@ import { log } from '@dxos/log';
 import { IdbLogStore } from '@dxos/log-store-idb';
 import { isTauri } from '@dxos/util';
 
-import { LOG_STORE_DB_NAME, initializeObservability } from '../util';
+import { LOG_STORE_DB_NAME, LOG_STORE_MAX_BYTES, initializeObservability } from '../util';
 
-const logStore = new IdbLogStore({ dbName: LOG_STORE_DB_NAME });
+const logStore = new IdbLogStore({ dbName: LOG_STORE_DB_NAME, maxBytes: LOG_STORE_MAX_BYTES });
 log.addProcessor(logStore.processor);
 
 runDedicatedWorker({

--- a/packages/sdk/observability/src/extensions/otel/logs.test.ts
+++ b/packages/sdk/observability/src/extensions/otel/logs.test.ts
@@ -1,0 +1,39 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { stringifyValues } from './logs';
+
+describe('stringifyValues', () => {
+  test('serializes errors via stack', ({ expect }) => {
+    const error = new Error('upload exploded');
+    const result = stringifyValues({ error }, 'ctx_');
+    expect(result.ctx_error).toContain('upload exploded');
+  });
+
+  test('falls back to name and message when stack is absent', ({ expect }) => {
+    const error = new Error('no stack here');
+    error.stack = undefined;
+    expect(stringifyValues({ error })).toEqual({ error: 'Error: no stack here' });
+  });
+
+  test('serializes errors nested past the flatten depth', ({ expect }) => {
+    const result = stringifyValues({ outer: { inner: { error: new Error('deep') } } });
+    expect(Object.values(result).join()).toContain('deep');
+  });
+
+  test('flattens plain objects and stringifies arrays', ({ expect }) => {
+    expect(stringifyValues({ status: 502, nested: { count: 1 }, list: [1, 2] })).toEqual({
+      status: '502',
+      nested_count: '1',
+      list: '[1,2]',
+    });
+  });
+
+  test('skips undefined values and handles a missing object', ({ expect }) => {
+    expect(stringifyValues({ present: 'yes', absent: undefined })).toEqual({ present: 'yes' });
+    expect(stringifyValues(undefined)).toEqual({});
+  });
+});

--- a/packages/sdk/observability/src/extensions/otel/logs.ts
+++ b/packages/sdk/observability/src/extensions/otel/logs.ts
@@ -101,16 +101,19 @@ const convertLevel = (level: LogLevel): SeverityNumber => {
   }
 };
 
+const errorToString = (error: Error): string => error.stack ?? `${error.name}: ${error.message}`;
+
 const safeStringify = (value: unknown): string => {
   try {
-    return JSON.stringify(value);
+    // Replace errors as they are encountered; `JSON.stringify` alone renders them as `{}`.
+    return JSON.stringify(value, (_key, nested) => (nested instanceof Error ? errorToString(nested) : nested));
   } catch {
     return '[Circular]';
   }
 };
 
 // TODO(wittjosiah): Reconcile logging utils w/ EDGE.
-const stringifyValues = (object: object | undefined, keyPrefix?: string, depth: number = 1) => {
+export const stringifyValues = (object: object | undefined, keyPrefix?: string, depth: number = 1) => {
   if (!object) {
     return {};
   }
@@ -121,7 +124,11 @@ const stringifyValues = (object: object | undefined, keyPrefix?: string, depth: 
     }
     const newKey = keyPrefix ? `${keyPrefix}${key}` : key;
     if (typeof value === 'object') {
-      if (!value || Array.isArray(value) || depth > FLATTEN_DEPTH) {
+      if (value instanceof Error) {
+        // `message`/`stack` are non-enumerable, so the flatten path below would silently
+        // reduce a logged error to nothing.
+        result[newKey] = errorToString(value);
+      } else if (!value || Array.isArray(value) || depth > FLATTEN_DEPTH) {
         result[newKey] = safeStringify(value);
       } else {
         const flattened = stringifyValues(value, `${newKey}_`, depth + 1);

--- a/packages/sdk/observability/src/extensions/posthog/extension.ts
+++ b/packages/sdk/observability/src/extensions/posthog/extension.ts
@@ -183,6 +183,8 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
                     $survey_id: survey.id,
                     $survey_questions: [{ id: question.id, question: question.question }],
                     [`$survey_response_${question.id}`]: form.message,
+                    // Survey destinations (Slack/webhook notifications) filter on `$survey_completed = true`, so responses without it are dropped.
+                    $survey_completed: true,
                     debug_log_dump_key: debugLogDumpKey,
                   });
                   resolve(result?.uuid);


### PR DESCRIPTION
Fixes two independent reasons Composer feedback wasn't landing as expected in PostHog.

## 1. Notifications never fired — `$survey_completed` was missing

PostHog survey destinations carry an implicit trigger filter on `$survey_completed = true`. Composer's survey is API type (we capture `survey sent` ourselves), and we sent `$survey_id`, `$survey_questions`, and the response — but not `$survey_completed`. Every event was skipped before it reached the "Only notify when" filters, so no Slack/webhook notification ever fired.

Added the property in `posthog/extension.ts`.

## 2. `debug_log_dump_key` was always `'failed'`

SigNoz shows 6 records over 7 days, all from `extension.ts:51` — the `catch` branch of `uploadLogs`, never the `!response.ok` branch. So the `fetch` **rejected**; there was no HTTP status at all.

Ruled out the competing explanation (the SPA fallback swallowing `/api/*`, which would also land in that catch via a non-JSON 200): production sets `DX_OTEL_ENDPOINT=/api/otel`, and those same-origin browser OTel records are arriving in SigNoz, so `run_worker_first: ["/api/*"]` demonstrably works and the POST does reach the Worker.

That points at the request itself, and the Worker was buffering the whole body with `await request.arrayBuffer()` before handing it to R2 — up to 50 MB held in an isolate limited to 128 MB. A Worker torn down that way resets the connection, which is exactly what the client sees.

Changes:

- Hand `request.body` straight to `env.FEEDBACK_LOGS.put()` so the body never lands in isolate memory. R2 accepts it because a request body carries a known length from `Content-Length`.
- Require `Content-Length` (411 without it): it is both the size guard and what makes the unbuffered put legal.
- Return 502 when R2 fails, rather than letting it escape as an unhandled exception.

### An earlier attempt in this PR was wrong

The first version piped the body through a byte-counting `TransformStream` into R2. That **failed every upload with a 502** — R2 will not accept a value whose length it cannot determine, and a `TransformStream` readable has none. A fake-R2 unit check couldn't model that constraint; the PR preview did, with `main.composer.space` on the same bucket returning 200 as a control. The committed version is simpler as a result: no transform, no orphaned pipe.

## 3. Why this was hard to diagnose — logged errors were being dropped

`log.warn('feedback log upload error', { error: err })` reached SigNoz with no `ctx_error` attribute. `stringifyValues` walks `Object.entries(...)` and falls back to `JSON.stringify` — and an `Error` has non-enumerable `message`/`stack`, so both paths reduce it to nothing. Errors are now serialized via their stack at any nesting depth, so the next occurrence names its own cause.

## Upload cap is tied to log retention

The upload limit and the log store's retention cap were both 50 MB, but only coincidentally — composer hardcoded its own constant while the store fell back to the package default, and either could have moved independently. They're now one constant, `LOG_STORE_MAX_BYTES`, used as the store's `maxBytes` (passed explicitly at every `IdbLogStore` site instead of relying on the default), the client's export trim, and the Worker ceiling. A feedback report therefore carries everything the circular buffer retained.

`maxBytes` is a soft cap in the store — eviction drops whole chunks and always keeps the newest — but `export({ maxSize })` hard-trims to an exact UTF-8 byte count, so an upload is always within the cap and the Worker's check never trips on a legitimate one.

## Testing

- `moon run observability:test` — 60 passed, 1 skipped. Includes a new `logs.test.ts` covering error serialization (it caught a real hole in the first attempt: errors nested past the flatten depth still went through `JSON.stringify`).
- `moon run observability:build`, `observability:lint`, `composer-app:lint` — clean.
- `pnpm build:functions` bundles the worker.
- Endpoint exercised end-to-end against the PR preview (dev-tier bucket), which is what caught the R2 stream-length bug above:

  | Body | Result |
  | --- | --- |
  | small NDJSON | 200 + key |
  | 8 MB | 200, 5/5 attempts |
  | 52,428,800 B (exactly the cap) | 200 + key |
  | 52,428,801 B (cap + 1) | 413 Payload too large |
  | `GET` | 405 |

  So an at-cap upload — the realistic worst case now that the client trims to the retention cap — completes, and going over is refused with a status rather than a reset connection.
- The pre-existing `src/functions/tsconfig.json` `rootDir` errors are unchanged from the baseline (verified against a stash); that config can't reach `../util/constants`, and CI only esbuild-bundles the worker.

Note: the root-cause claim for #2 is inferred, not captured — the actual error text was destroyed by the logging bug in #3, so the memory argument is a plausible mechanism rather than a demonstrated one. With #3 fixed, any recurrence will report its own cause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Survey feedback submissions now include the required completion indicator so responses reach configured destinations.
  * Observability feedback and error serialization improvements ensure richer event payloads.

* **Bug Fixes**
  * Feedback and recovery logs now enforce a consistent 50 MB storage limit across upload and export flows.
  * Feedback-log uploads validate `Content-Length`, reject empty/invalid/oversized requests, and improve error responses.

* **Tests**
  * Added a test suite covering log value stringification, including correct `Error` handling and flattening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->