### PR TITLE
plugin-deck: keep L0 reachable when `closed` persists across the lg breakpoint

### DIFF
--- a/.changeset/l0-sidebar-closed-at-lg.md
+++ b/.changeset/l0-sidebar-closed-at-lg.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-deck': patch
+---
+
+Fix the navigation sidebar disappearing permanently at desktop widths after a dismissal persisted from below the `lg` breakpoint.

--- a/packages/plugins/plugin-deck/src/containers/Deck/Deck.stories.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Deck/Deck.stories.tsx
@@ -6,6 +6,7 @@ import { Atom } from '@effect-atom/atom-react';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import * as Effect from 'effect/Effect';
 import React, { useEffect, useMemo, useRef } from 'react';
+import { expect, waitFor, within } from 'storybook/test';
 
 import { Capabilities, Capability, Plugin } from '@dxos/app-framework';
 import { withPluginManager } from '@dxos/app-framework/testing';
@@ -194,9 +195,11 @@ type DefaultStoryProps = {
   count?: number;
   /** Fold-transition variant to apply (see {@link FOLD_ANIMATIONS}). */
   foldAnimation?: FoldAnimation;
+  /** Navigation sidebar state to seed. `closed` is only reachable below `lg`. */
+  sidebarState?: StoredDeckState['sidebarState'];
 };
 
-const DefaultStory = ({ count = 0, foldAnimation = 'slide' }: DefaultStoryProps) => {
+const DefaultStory = ({ count = 0, foldAnimation = 'slide', sidebarState = 'closed' }: DefaultStoryProps) => {
   const settings = useAtomCapability(DeckCapabilities.Settings);
   const pluginManager = usePluginManager();
   const { graph } = useAppGraph();
@@ -221,12 +224,13 @@ const DefaultStory = ({ count = 0, foldAnimation = 'slide' }: DefaultStoryProps)
     const active = items.slice(0, count).map((item) => item.id);
     updateState((current) => ({
       ...current,
+      sidebarState,
       decks: {
         ...current.decks,
         [current.activeDeck]: { ...current.decks[current.activeDeck], active },
       },
     }));
-  }, [items, count, updateState]);
+  }, [items, count, sidebarState, updateState]);
 
   // `display: contents` so the wrapper carries `data-fold-anim` for the scoped CSS without affecting the
   // fullscreen layout of the deck beneath it.
@@ -276,3 +280,24 @@ export const TwoPlanks: Story = { args: { count: 2 } };
 // Six planks exceed the tiling threshold and render as a sliding, horizontally-scrolling deck.
 // Use the `foldAnimation` control to compare fold transitions.
 export const ManyPlanks: Story = { args: { count: 6, foldAnimation: 'slide' } };
+
+// A `closed` sidebar persisted from below `lg` (dismissing the drawer) must present as the L0 rail at
+// `lg`+, where `closed` would otherwise render L0 off-screen and inert with every control that could
+// reopen it either `lg:hidden` or inside L0 itself.
+export const SidebarClosedAtDesktop: Story = {
+  tags: ['test'],
+  args: { count: 1, sidebarState: 'closed' },
+  play: async ({ canvasElement }) => {
+    // The regression only exists at `lg`+, so a narrower canvas would make every assertion below pass
+    // vacuously.
+    await expect(window.innerWidth).toBeGreaterThanOrEqual(1024);
+
+    // The plugin manager activates asynchronously, so the deck mounts well after the story's first paint.
+    const sidebar = await within(canvasElement).findByTestId('deck.sidebar', {}, { timeout: 30_000 });
+    await waitFor(() => expect(sidebar).toHaveAttribute('data-state', 'collapsed'));
+    await expect(sidebar).not.toHaveAttribute('inert');
+
+    // `closed` parks the sidebar at `-start-[100vw]`; the rail has to be on screen to be usable.
+    await expect(sidebar.getBoundingClientRect().left).toBeGreaterThanOrEqual(0);
+  },
+};

--- a/packages/plugins/plugin-deck/src/containers/Deck/DeckRoot.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Deck/DeckRoot.tsx
@@ -3,13 +3,15 @@
 //
 
 import { createContext } from '@radix-ui/react-context';
-import React, { PropsWithChildren } from 'react';
+import React, { type PropsWithChildren, useMemo } from 'react';
 
 import { type PluginManager } from '@dxos/app-framework';
+import { useMediaQuery } from '@dxos/react-ui';
 
 import { type Settings } from '#types';
 
 import { type DeckStateHook } from '../../hooks/useDeckState';
+import { resolveSidebarState } from '../../util';
 
 const DECK_NAME = 'Deck';
 const DECK_ROOT_NAME = 'DeckRoot';
@@ -36,8 +38,21 @@ export type DeckRootProps = PropsWithChildren<DeckContextValue>;
 /**
  * Headless root that provides Deck context.
  */
-export const DeckRoot = ({ children, ...context }: DeckRootProps) => {
-  return <DeckProvider {...context}>{children}</DeckProvider>;
+export const DeckRoot = ({ children, state, ...context }: DeckRootProps) => {
+  const [isLg] = useMediaQuery('lg');
+
+  // Resolved here rather than at each consumer so the sidebar width, `Main.Root` and the navtree all
+  // read one value; the persisted `closed` is left intact because it still applies below `lg`.
+  const resolvedState = useMemo(
+    () => ({ ...state, sidebarState: resolveSidebarState(state.sidebarState, isLg) }),
+    [state, isLg],
+  );
+
+  return (
+    <DeckProvider {...context} state={resolvedState}>
+      {children}
+    </DeckProvider>
+  );
 };
 
 DeckRoot.displayName = DECK_ROOT_NAME;

--- a/packages/plugins/plugin-deck/src/containers/Sidebar/Sidebar.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Sidebar/Sidebar.tsx
@@ -28,6 +28,7 @@ export const Sidebar = () => {
 
   return (
     <Main.NavigationSidebar
+      data-testid='deck.sidebar'
       label={label}
       classNames={['grid', topbar && 'top-[calc(env(safe-area-inset-top)+var(--dx-rail-size))]']}
     >

--- a/packages/plugins/plugin-deck/src/util/index.ts
+++ b/packages/plugins/plugin-deck/src/util/index.ts
@@ -5,5 +5,6 @@
 export * from './companion-view-state';
 export * from './layoutAppliesTopbar';
 export * from './migrate-persisted-state';
+export * from './resolve-sidebar-state';
 export * from './serialize-deck-url';
 export * from './set-active';

--- a/packages/plugins/plugin-deck/src/util/resolve-sidebar-state.test.ts
+++ b/packages/plugins/plugin-deck/src/util/resolve-sidebar-state.test.ts
@@ -1,0 +1,24 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, test } from 'vitest';
+
+import { resolveSidebarState } from './resolve-sidebar-state';
+
+describe('resolveSidebarState', () => {
+  test('closed presents as collapsed at lg so L0 stays reachable', () => {
+    expect(resolveSidebarState('closed', true)).toBe('collapsed');
+  });
+
+  test('closed is preserved below lg where the drawer can be dismissed', () => {
+    expect(resolveSidebarState('closed', false)).toBe('closed');
+  });
+
+  test('collapsed and expanded are unchanged at either breakpoint', () => {
+    expect(resolveSidebarState('collapsed', true)).toBe('collapsed');
+    expect(resolveSidebarState('collapsed', false)).toBe('collapsed');
+    expect(resolveSidebarState('expanded', true)).toBe('expanded');
+    expect(resolveSidebarState('expanded', false)).toBe('expanded');
+  });
+});

--- a/packages/plugins/plugin-deck/src/util/resolve-sidebar-state.ts
+++ b/packages/plugins/plugin-deck/src/util/resolve-sidebar-state.ts
@@ -1,0 +1,18 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type StoredDeckState } from '#types';
+
+export type SidebarState = StoredDeckState['sidebarState'];
+
+/**
+ * Resolves the navigation sidebar state for the current breakpoint.
+ *
+ * `closed` only describes the dismissed drawer below `lg`: at `lg`+ it renders L0 zero-width and
+ * inert while every control that could restore it is either `lg:hidden` or inside L0 itself, so a
+ * `closed` value written below the breakpoint (e.g. while resizing across it) would otherwise
+ * persist into desktop widths and leave no affordance to bring L0 back.
+ */
+export const resolveSidebarState = (state: SidebarState, isLg: boolean): SidebarState =>
+  isLg && state === 'closed' ? 'collapsed' : state;


### PR DESCRIPTION
Fixes [DX-1141](https://linear.app/dxos/issue/DX-1141/l0-sidebar-disappears-permanently-after-rapid-horizontal-window-resize) — L0 sidebar disappears permanently after rapid horizontal window resize.

Preview: https://pr-12374-composer-main.dxos.workers.dev

## Problem

`sidebarState` has three values, and `closed` is unrecoverable at `lg` and above:

1. **`closed` hides L0 entirely.** At `lg`+, `packages/ui/ui-theme/src/css/layout/main.css` gives `[data-side='is'][data-state='collapsed']` a `w-(--dx-l0-size) start-0`, but `closed` gets neither — L0 stays at the base `-start-[100vw]`. `Main.tsx` also marks it `inert`.
2. **Every escape hatch is out of reach.** The floating toggles carry `lg:hidden` (`DeckViewport.tsx`), and the L0/complementary toggles live *inside* the sidebar that is off-screen and inert.
3. **It persists.** `sidebarState` is part of `StoredDeckState`, written through `createKvsStore` to localStorage, so a reload restores the broken state.

Both writers of `closed` are gated on a per-component `useMediaQuery('lg')` in `NavTreeContainer` — activating a nav item, or re-clicking the active L0 tab, while below `lg`. Resizing across 1024px mid-interaction persists `closed`, and widening back removes the only control that could undo it.

## Fix

`closed` only ever means "the small-breakpoint drawer is dismissed", so it is resolved to `collapsed` at `lg`+:

- `util/resolve-sidebar-state.ts` — the rule as a pure, unit-tested function.
- `containers/Deck/DeckRoot.tsx` — applies it to the context it provides, the single point feeding both `Main.Root` (via `DeckContent`) and `--main-sidebar-width` (via `DeckViewport`), so the width, the sidebar element and the navtree can't disagree.

This **derives** rather than rewrites the persisted value, deliberately:

- Below `lg`, `closed` is the only state that makes the off-screen drawer `inert` — `collapsed` also sits at `-start-[100vw]` there but stays focusable. Rewriting `closed → collapsed` on the way up to desktop would therefore leave a hidden-but-keyboard-reachable sidebar after a rotation back down.
- A reactive derivation self-heals whenever a stale `useMediaQuery` subscription writes `closed` mid-resize, whereas a one-shot repair effect races it.
- Below `lg`, `closed` stays meaningful and persisted, which is the existing (correct) behaviour.

Every remaining reader of the raw persisted value — `ToggleSidebarButton`, the `app-graph-builder` toggle action, and `layoutAtom` — treats `closed` as "not expanded" and toggles to `expanded`, so none of them get stuck.

### Resulting behaviour

Measured in the app (`data-state` / `inert` / sidebar x-position):

| step | viewport | `data-state` | `inert` | x |
| --- | --- | --- | --- | --- |
| drawer open below `lg` | 800 | `expanded` | no | +8 (on screen) |
| dismiss it | 800 | `closed` | yes | −800 |
| widen to desktop | 1280 | `collapsed` | no | 0, width 72 (L0 rail) |
| back below `lg` | 800 | `closed` | yes | −800 (still dismissed) |

The round trip is idempotent: desktop always gets the rail back, and the dismissal is preserved below `lg` because the persisted value is never rewritten.

## Testing

Both tiers were verified against a reverted `DeckRoot` and fail there, so neither passes vacuously.

- **Unit** — 3 tests for `resolveSidebarState`. `plugin-deck:test`: 44/44.
- **Storybook** — a `SidebarClosedAtDesktop` story (`tags: ['test']`) whose `play` function asserts the sidebar is `collapsed`, not `inert`, and on screen. Without the fix it fails with `data-state="closed"`. `plugin-deck:test-storybook`: 14/14.
  - `sidebarState` is now a story arg, so the deck stories can render each sidebar presentation. The stories previously hard-coded `closed`, which at desktop meant they rendered with no sidebar at all.
  - Adds a `deck.sidebar` testid for the assertion.
- `plugin-deck:build` and `plugin-deck:lint` clean; `pnpm format` applied.

The change is contained to `plugin-deck` — no composer-app-level e2e, since the invariant is a layout concern the story tier can hold.

Includes a patch changeset for `@dxos/plugin-deck`.