### PR TITLE
plugin-simple-layout: declare @dxos/app-graph as a runtime dependency

### DIFF
--- a/packages/plugins/plugin-simple-layout/package.json
+++ b/packages/plugins/plugin-simple-layout/package.json
@@ -79,6 +79,7 @@
   ],
   "dependencies": {
     "@dxos/app-framework": "workspace:*",
+    "@dxos/app-graph": "workspace:*",
     "@dxos/app-toolkit": "workspace:*",
     "@dxos/async": "workspace:*",
     "@dxos/compute": "workspace:*",
@@ -100,7 +101,6 @@
     "@tauri-apps/plugin-deep-link": "catalog:"
   },
   "devDependencies": {
-    "@dxos/app-graph": "workspace:*",
     "@dxos/plugin-preview": "workspace:*",
     "@dxos/plugin-search": "workspace:*",
     "@dxos/plugin-space": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15859,6 +15859,9 @@ importers:
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
+      '@dxos/app-graph':
+        specifier: workspace:*
+        version: link:../../sdk/app-graph
       '@dxos/app-toolkit':
         specifier: workspace:*
         version: link:../../sdk/app-toolkit
@@ -15917,9 +15920,6 @@ importers:
         specifier: 'catalog:'
         version: 2.4.9
     devDependencies:
-      '@dxos/app-graph':
-        specifier: workspace:*
-        version: link:../../sdk/app-graph
       '@dxos/plugin-preview':
         specifier: workspace:*
         version: link:../plugin-preview


### PR DESCRIPTION
## Problem

`@dxos/plugin-simple-layout` publishes to npm (no `"private": true`), and `src/capabilities/url-handler.ts` uses `PathResolution` from `@dxos/app-graph` at runtime:

- `PathResolution.buildUrlKeyTable(builder)` — `url-handler.ts:72`
- `PathResolution.resolveUrl(builder, …)` — `url-handler.ts:96`
- `PathResolution.representNode(builder, state.active)` — `url-handler.ts:144`

But `@dxos/app-graph` was declared only in `devDependencies`. devDependencies are not installed transitively, so consumers installing the plugin from npm get no copy of `@dxos/app-graph` — the import resolved only by accident of hoisting in the monorepo. Sibling `@dxos/plugin-deck` already declares it in `dependencies`.

This is a pre-existing bug on `main`, not a regression from other in-flight work.

## Change

Moved `"@dxos/app-graph": "workspace:*"` from `devDependencies` to `dependencies`, and updated `pnpm-lock.yaml` to match.

I audited every other runtime import in `src` (excluding `*.test.*`, `*.stories.*`, and `testing/`) against the manifest — `@dxos/app-graph` was the only gap. `@dxos/react-ui`, `@dxos/ui-theme`, `effect`, and `react` are all covered by `peerDependencies`.

The lockfile diff is limited to the two importer hunks for this package. Regenerating produced unrelated `@effect/platform-bun` peer-resolution churn from pre-existing drift on `main`, which I dropped to keep the diff scoped; `pnpm install --frozen-lockfile` passes against the trimmed lockfile.

No changeset: the affected code has not shipped in a release, so this is an internal packaging correction with nothing consumer-visible to record in the changelog.

## Verification

- `pnpm install --frozen-lockfile` — passes, confirming lockfile/manifest consistency
- `moon run plugin-simple-layout:build` — 150 tasks completed, no failures
- `moon run plugin-simple-layout:lint` — clean
- `pnpm format` (oxfmt) — run and staged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to ensure a required application graph component is correctly included for the simple layout plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->