### PR TITLE
ui-editor: route widget updates by id so rehydrated tool state survives a remount

### DIFF
--- a/.changeset/xml-widget-state-remount.md
+++ b/.changeset/xml-widget-state-remount.md
@@ -1,0 +1,5 @@
+---
+'@dxos/ui-editor': patch
+---
+
+Fix XML tag widgets rendering blank after the document is replaced — widget state applied around the reset (for example tool call rows when returning to a chat) now reaches the mounted widget.

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/ChatThread.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/ChatThread.stories.tsx
@@ -7,6 +7,7 @@ import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
 import * as Layer from 'effect/Layer';
 import React, { useEffect, useMemo, useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { withPluginManager } from '@dxos/app-framework/testing';
 import { Database, Feed, Filter, Query } from '@dxos/echo';
@@ -17,6 +18,7 @@ import { PreviewPlugin } from '@dxos/plugin-preview/testing';
 import { StorybookPlugin, corePlugins } from '@dxos/plugin-testing';
 import { random } from '@dxos/random';
 import { useSpaces } from '@dxos/react-client/echo';
+import { Button } from '@dxos/react-ui';
 import { EditorPreviewProvider } from '@dxos/react-ui-editor';
 import { Loading, withLayout, withTheme } from '@dxos/react-ui/testing';
 import { Message, Organization, Person } from '@dxos/types';
@@ -30,9 +32,15 @@ random.seed(1);
 
 type MessageGenerator = Effect.Effect<void, never, Database.Service | Feed.ContextFeedService>;
 
-type StoryArgs = { generator?: MessageGenerator[]; delay?: number; wait?: boolean } & ChatThreadProps;
+type StoryArgs = {
+  generator?: MessageGenerator[];
+  delay?: number;
+  wait?: boolean;
+  /** Render a toggle that unmounts and remounts the thread, reproducing navigating away and back. */
+  remountable?: boolean;
+} & ChatThreadProps;
 
-const DefaultStory = ({ generator = [], delay = 0, wait, ...props }: StoryArgs) => {
+const DefaultStory = ({ generator = [], delay = 0, wait, remountable, ...props }: StoryArgs) => {
   const [space] = useSpaces();
   const feed = useMemo<Feed.Feed | undefined>(
     () => (space ? space.db.add(Feed.make({ name: 'chat' })) : undefined),
@@ -74,8 +82,29 @@ const DefaultStory = ({ generator = [], delay = 0, wait, ...props }: StoryArgs) 
 
   return (
     <EditorPreviewProvider onLookup={async ({ dxn, label }) => ({ label, text: dxn })}>
-      <ChatThread {...props} messages={messages} />
+      {remountable ? (
+        <RemountableThread {...props} messages={messages} />
+      ) : (
+        <ChatThread {...props} messages={messages} />
+      )}
     </EditorPreviewProvider>
+  );
+};
+
+/**
+ * Unmount/remount harness. Returning to a chat remounts the thread, which re-walks the messages and
+ * replaces the document — and a full replace clears accumulated widget props, so tool rows depend on
+ * the rehydration that follows it. Mounting fresh never exercises that path.
+ */
+const RemountableThread = (props: ChatThreadProps) => {
+  const [mounted, setMounted] = useState(true);
+  return (
+    <div className='flex flex-col h-full'>
+      <Button data-testid='story.toggleMount' onClick={() => setMounted((value) => !value)}>
+        {mounted ? 'Unmount' : 'Mount'}
+      </Button>
+      {mounted && <ChatThread {...props} />}
+    </div>
   );
 };
 
@@ -127,5 +156,41 @@ export const Delayed: Story = {
       typewriter: true,
       cursor: true,
     },
+  },
+};
+
+/**
+ * Tool rows must survive navigating away and back.
+ *
+ * They render from out-of-band widget state, not from the document: `blockToMarkdown` emits a
+ * `<toolCall id/>` placeholder and pushes the blocks via `updateWidget`; an empty state renders an
+ * empty row. On remount `MessageSyncer.reset` replaces the document, which fires `xmlTagResetEffect`
+ * and clears that state, then rehydrates it — and that rehydration used to be dropped, because the
+ * rebuild it triggers replaces the widget instances the editor was routing updates through
+ * (`xml-tags.test.ts`, "state reaches a mounted widget after a rebuild replaced its decoration
+ * instance").
+ */
+export const Remount: Story = {
+  args: {
+    generator: createMessageGenerator(),
+    wait: true,
+    remountable: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Streaming path: the tool rows render as the messages land.
+    await expect(canvas.findByText(/Calling search/, undefined, { timeout: 10_000 })).resolves.toBeTruthy();
+    await expect(canvas.findByText(/Calling create/, undefined, { timeout: 10_000 })).resolves.toBeTruthy();
+
+    // Away and back.
+    const toggle = await canvas.findByTestId('story.toggleMount');
+    await userEvent.click(toggle);
+    await waitFor(() => expect(canvas.queryByText(/Calling search/)).toBeNull());
+    await userEvent.click(toggle);
+
+    // Replay path: same rows, rebuilt from the messages rather than from streaming updates.
+    await expect(canvas.findByText(/Calling search/, undefined, { timeout: 10_000 })).resolves.toBeTruthy();
+    await expect(canvas.findByText(/Calling create/, undefined, { timeout: 10_000 })).resolves.toBeTruthy();
   },
 };

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/sync.test.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/sync.test.ts
@@ -5,7 +5,7 @@
 // @vitest-environment jsdom
 
 import { EditorView } from '@codemirror/view';
-import { describe, it } from '@effect/vitest';
+import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
 import { Obj } from '@dxos/echo';
@@ -286,6 +286,46 @@ describe('reducers', () => {
       const closeTagCount = (doc.content.match(/<\/reasoning>/g) ?? []).length;
       expect(openTagCount).toBe(1);
       expect(closeTagCount).toBe(1);
+    }),
+  );
+});
+
+describe('MessageSyncer tool widget rehydration', () => {
+  it.effect(
+    'restores tool widget state after reset replaces the document',
+    Effect.fnUntraced(function* (_) {
+      const updates: { id: string; value: any }[] = [];
+      class RecordingDocument extends TestDocument {
+        override updateWidget(id: string, value: any) {
+          updates.push({ id, value });
+        }
+      }
+
+      const document = new RecordingDocument();
+      const syncer = new MessageSyncer(document, createBlockRenderer('thinking'));
+      const messages = [
+        createMessage('assistant', [
+          { _tag: 'toolCall', toolCallId: 'abc', name: 'search', input: '{}', providerExecuted: false },
+        ]),
+        createMessage('user', [
+          { _tag: 'toolResult', toolCallId: 'abc', name: 'search', result: 'ok', providerExecuted: false },
+        ]),
+      ] as Message.Message[];
+
+      syncer.reset(messages);
+      // `reset` rehydrates in a promise continuation after `setContent`.
+      yield* Effect.promise(() => Promise.resolve());
+      yield* Effect.promise(() => Promise.resolve());
+
+      // Reduce the dispatches the way the widget state store does: each is either a value or a
+      // function of the previous state, applied in arrival order.
+      const forTool = updates.filter((update) => update.id === 'abc');
+      expect(forTool.length).toBeGreaterThan(0);
+      const state = forTool.reduce<{ blocks: ContentBlock.Any[] }>(
+        (previous, { value }) => (typeof value === 'function' ? value(previous) : value),
+        { blocks: [] },
+      );
+      expect(state.blocks.map((block) => block._tag)).toEqual(['toolCall', 'toolResult']);
     }),
   );
 });

--- a/packages/ui/ui-editor/src/extensions/language/xml/stub.ts
+++ b/packages/ui/ui-editor/src/extensions/language/xml/stub.ts
@@ -15,6 +15,13 @@ export interface XmlWidgetNotifier {
   mounted(widget: XmlWidgetState): void;
   unmounted(id: string): void;
   /**
+   * Re-render the mounted widget for `id` with updated props. Keyed by id rather than by widget
+   * instance: a rebuild constructs fresh widgets, but `StubWidget.eq` (id equality) makes CodeMirror
+   * keep the previously-rendered DOM, so the instance in the decoration set is not the one holding
+   * the mounted root.
+   */
+  updated(id: string, widgetState: any): void;
+  /**
    * Drop any mounted widgets whose id is not in `liveIds`. Needed because CM reuses a widget's DOM
    * via `updateDOM` (without calling `destroy`) when a decoration's widget changes in place, so an
    * id that is no longer present — e.g. a position-keyed id after an edit shifted the node — would

--- a/packages/ui/ui-editor/src/extensions/language/xml/xml-tags.test.ts
+++ b/packages/ui/ui-editor/src/extensions/language/xml/xml-tags.test.ts
@@ -11,14 +11,17 @@ import { trim } from '@dxos/util';
 
 import { decorationSetToArray } from '../../../util';
 import { extendedMarkdown } from './extended-markdown';
+import { StubWidget } from './stub';
 import {
   type XmlWidgetDef,
   type XmlWidgetProps,
+  type XmlWidgetState,
   navigateNextEffect,
   navigatePreviousEffect,
   xmlTagRebuildEffect,
   xmlTagResetEffect,
   xmlTags,
+  xmlTagUpdateEffect,
 } from './xml-tags';
 
 //
@@ -392,5 +395,114 @@ describe('xmlTags decorations', () => {
       expect(view.state.selection.main.head).toBeLessThan(view.state.doc.length);
       view.destroy();
     });
+  });
+});
+
+//
+// Widget state.
+//
+// `xmlTags` documents that widget state may be updated BEFORE the widget mounts (a thread returning
+// from a remount replaces the document, then rehydrates each widget's state out-of-band). These lock
+// in that contract at the editor level: the effect must survive the reset, must not be dropped when it
+// shares a transaction, and must reach a widget that mounts afterwards.
+//
+
+describe('xmlTags widget state', () => {
+  const stateRegistry: Record<string, XmlWidgetDef> = {
+    toolCall: { block: true, Component: () => null },
+  };
+
+  const doc = trim`
+    <toolCall id="a" />
+
+    <toolCall id="b" />
+  `;
+
+  /** The live StubWidget for an id, as CodeMirror would render it. */
+  const stubWidget = (view: EditorView, id: string): StubWidget<XmlWidgetProps> => {
+    for (const source of view.state.facet(EditorView.decorations)) {
+      const set = typeof source === 'function' ? source(view) : source;
+      if (!set) {
+        continue;
+      }
+      for (const { value } of decorationSetToArray(set)) {
+        const widget = value.spec?.widget;
+        if (widget instanceof StubWidget && widget.id === id) {
+          return widget;
+        }
+      }
+    }
+
+    throw new Error(`no widget: ${id}`);
+  };
+
+  const widgetProps = (view: EditorView, id: string): XmlWidgetProps => stubWidget(view, id).props;
+
+  test('applies every widget update effect in a single transaction', async ({ expect }) => {
+    const view = createView(doc, { registry: stateRegistry });
+    await rebuild(view);
+    view.dispatch({
+      effects: [
+        xmlTagUpdateEffect.of({ id: 'a', value: { blocks: ['A'] } }),
+        xmlTagUpdateEffect.of({ id: 'b', value: { blocks: ['B'] } }),
+      ],
+    });
+    view.dispatch({ effects: xmlTagRebuildEffect.of(null) });
+    await flush();
+    expect(widgetProps(view, 'a').blocks).toEqual(['A']);
+    expect(widgetProps(view, 'b').blocks).toEqual(['B']);
+    view.destroy();
+  });
+
+  test('widget state survives the reset that replaces the document', async ({ expect }) => {
+    const view = createView('placeholder', { registry: stateRegistry });
+    await rebuild(view);
+
+    // What `setContent` dispatches on remount: replace the document and clear accumulated state.
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: doc },
+      effects: xmlTagResetEffect.of(null),
+    });
+    view.dispatch({ effects: xmlTagUpdateEffect.of({ id: 'a', value: { blocks: ['A'] } }) });
+    view.dispatch({ effects: xmlTagRebuildEffect.of(null) });
+    await flush();
+    expect(widgetProps(view, 'a').blocks).toEqual(['A']);
+    view.destroy();
+  });
+
+  test('state reaches a mounted widget after a rebuild replaced its decoration instance', async ({ expect }) => {
+    let mounted: XmlWidgetState[] = [];
+    const view = createView(doc, { registry: stateRegistry, setWidgets: (widgets) => (mounted = widgets) });
+    await rebuild(view);
+    stubWidget(view, 'a').toDOM(view);
+
+    // Replacing the document rebuilds decorations into fresh widget instances, but `StubWidget.eq`
+    // (id equality) makes CodeMirror keep the rendered DOM — so the rebuilt instance has no root and
+    // an update routed through the decoration set would find nothing to re-render.
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: doc },
+      effects: xmlTagResetEffect.of(null),
+    });
+    expect(stubWidget(view, 'a').root).toBeNull();
+
+    view.dispatch({ effects: xmlTagUpdateEffect.of({ id: 'a', value: { blocks: ['A'] } }) });
+    expect(mounted.find((state) => state.id === 'a')?.props.blocks).toEqual(['A']);
+    view.destroy();
+  });
+
+  test('a widget mounting after its state arrives receives that state', async ({ expect }) => {
+    let mounted: XmlWidgetState[] = [];
+    const view = createView(doc, { registry: stateRegistry, setWidgets: (widgets) => (mounted = widgets) });
+
+    // The one-shot parse-completion rebuild lands first and is never re-armed without a document
+    // change, so the state arriving afterwards cannot be picked up by another rebuild.
+    await rebuild(view);
+    view.dispatch({ effects: xmlTagUpdateEffect.of({ id: 'a', value: { blocks: ['A'] } }) });
+
+    // The widget mounts now — scrolled into CodeMirror's viewport, or portaled after the initial render.
+    const widget = stubWidget(view, 'a');
+    widget.toDOM(view);
+    expect(mounted.find((state) => state.id === 'a')?.props.blocks).toEqual(['A']);
+    view.destroy();
   });
 });

--- a/packages/ui/ui-editor/src/extensions/language/xml/xml-tags.ts
+++ b/packages/ui/ui-editor/src/extensions/language/xml/xml-tags.ts
@@ -223,21 +223,21 @@ const widgetContextStateField = StateField.define<any>({
 const widgetStateMapStateField = StateField.define<XmlWidgetStateMap>({
   create: () => ({}),
   update: (map, tr) => {
+    // Reduce over every effect: a transaction may carry several updates (or a reset followed by them),
+    // and returning on the first would silently drop the rest.
+    let next = map;
     for (const effect of tr.effects) {
       if (effect.is(xmlTagResetEffect)) {
-        return {};
-      }
-
-      if (effect.is(xmlTagUpdateEffect)) {
+        next = {};
+      } else if (effect.is(xmlTagUpdateEffect)) {
         // Update accumulated widget props by id.
         const { id, value } = effect.value;
         log('widget updated', { id, value });
-        const state = typeof value === 'function' ? value(map[id]) : value;
-        return { ...map, [id]: state };
+        next = { ...next, [id]: typeof value === 'function' ? value(next[id]) : value };
       }
     }
 
-    return map;
+    return next;
   },
 });
 
@@ -285,6 +285,21 @@ const createParseCompletionPlugin = () => {
 };
 
 /**
+ * Re-applies the accumulated widget state at mount time.
+ *
+ * A widget's props are baked when its decoration is built, but state can be dispatched before the
+ * widget mounts — rehydration after a document reset targets widgets that are still outside
+ * CodeMirror's viewport, and `xmlTagUpdateEffect` alone rebuilds no decorations. Such a widget would
+ * otherwise mount with the stale props it was built with, since `StubWidget.eq` (id equality) stops a
+ * later rebuild from replacing the instance.
+ */
+const withCurrentWidgetState = (state: XmlWidgetState): XmlWidgetState => {
+  const view: EditorView | undefined = state.props?.view;
+  const widgetState = view?.state.field(widgetStateMapStateField, false)?.[state.id];
+  return widgetState ? { ...state, props: { ...state.props, ...widgetState } } : state;
+};
+
+/**
  * Manages the collection of widgets.
  */
 const createWidgetMap = (setWidgets?: (widgets: XmlWidgetState[]) => void, debug = false): XmlWidgetNotifier => {
@@ -292,13 +307,23 @@ const createWidgetMap = (setWidgets?: (widgets: XmlWidgetState[]) => void, debug
 
   // TODO(burdon): Batch updates?
   const notifier = {
-    mounted: (state: XmlWidgetState) => {
+    mounted: (rawState: XmlWidgetState) => {
+      const state = withCurrentWidgetState(rawState);
       const isNew = !widgets.has(state.id);
       widgets.set(state.id, state);
       // Only a genuinely new id changes the portal set (blank-frame culprit); re-parents just re-notify.
       if (debug && isNew) {
         log.info('widget-map: mounted', { id: state.id, count: widgets.size });
       }
+      setWidgets?.([...widgets.values()]);
+    },
+    updated: (id: string, widgetState: any) => {
+      const current = widgets.get(id);
+      if (!current || !widgetState) {
+        return;
+      }
+
+      widgets.set(id, { ...current, props: { ...current.props, ...widgetState } });
       setWidgets?.([...widgets.values()]);
     },
     unmounted: (id: string) => {
@@ -447,22 +472,11 @@ const createWidgetUpdatePlugin = (
           notifier.reconcile(liveIds);
         }
 
-        // Check for widget update effects and re-render widgets.
+        // Re-render widgets whose state changed. Widgets not yet mounted pick their state up at mount
+        // time instead (see `withCurrentWidgetState`).
         for (const effect of update.transactions.flatMap((tr) => tr.effects)) {
           if (effect.is(xmlTagUpdateEffect)) {
-            const widgetState = widgetStateMap[effect.value.id];
-
-            // Find and render widget.
-            for (const range of decorationSetToArray(decorations)) {
-              const deco = range.value;
-              const widget = deco?.spec?.widget;
-
-              // NOTE: If the widget has not yet been mounted, then the root will be null.
-              if (widget && widget instanceof StubWidget && widget.id === effect.value.id && widget.root) {
-                const props = { ...widget.props, ...widgetState };
-                notifier.mounted({ id: widget.id, props, root: widget.root, Component: widget.Component });
-              }
-            }
+            notifier.updated(effect.value.id, widgetStateMap[effect.value.id]);
           }
         }
       }


### PR DESCRIPTION
Tool call rows in a chat rendered blank after navigating away and back — the text survived, the rows came back empty. This predates the branch it was found on and affects any chat with tool calls.

## Root cause

Tool rows render from out-of-band widget state, not from the document: `blockToMarkdown` emits a `<toolCall id/>` placeholder and the blocks go out via `updateWidget`, so an empty state renders an empty row. On remount `MessageSyncer.reset` replaces the document — clearing that state via `xmlTagResetEffect` — and rehydrates it. The rehydration never reached the portals.

The update plugin resolved each `xmlTagUpdateEffect` by scanning the decoration set for a `StubWidget` with a non-null `root`. The reset rebuilds decorations into **fresh** widget instances, while `StubWidget.eq` (id equality) makes CodeMirror keep the previously rendered DOM. So the instance holding the mounted root and the instance in the decoration set are different objects, and every candidate the scan found had `root === null`. Instrumenting the story showed exactly that — `1234:false, 4567:false` on each rehydration effect, with the widgets mounted and rendering `blocks=0`.

Updates are now routed through the notifier's id-keyed map of mounted widgets, which is authoritative regardless of which instance the decoration set holds. It also drops an O(decorations) scan per effect.

## Two further defects, fixed along the way

- `widgetStateMapStateField` returned on the first matching effect, so a transaction carrying several `xmlTagUpdateEffect`s kept only the first.
- A widget's props are baked when its decoration is built, so state arriving *before* a widget mounts (a widget outside CodeMirror's viewport) was never picked up. The accumulated state is now merged at mount time.

## Ruled out

Two plausible theories were tested and disproven rather than assumed:

- **Dispatches dropped because the view did not exist yet.** Instrumentation showed `view=true` at every single `updateWidget` call. A buffer-and-replay fix was implemented, observed never to fire, and reverted.
- **The state field losing updates across the reset.** It does not; the test `widget state survives the reset that replaces the document` passes without any fix and pins that down.

## Tests

Four editor-level regression tests in `xml-tags.test.ts` (no browser needed), plus the end-to-end `ChatThread` **Remount** story and the syncer's `sync.test.ts` rehydration case.

Verified non-vacuous: reverting only the routing fix fails exactly `state reaches a mounted widget after a rebuild replaced its decoration instance`, and the other two failed before their respective fixes.

```
ui-editor           346 passed | 1 expected fail
plugin-assistant    41/41 storybook
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed blank XML tag widgets after documents are replaced or chat threads are remounted.
  - Preserved tool-call and tool-result widget state across navigation, streaming updates, and document rebuilds.
  - Ensured widget updates are applied whether they arrive before or after a widget mounts.
- **Tests**
  - Added coverage for widget state restoration, multiple updates, remounting, and rebuilt editor decorations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->