### PR TITLE
ci: stop pushes to main cancelling the nightly, and report e2e outcomes

### DIFF
--- a/.github/actions/test-report/send-test-report.sh
+++ b/.github/actions/test-report/send-test-report.sh
@@ -14,20 +14,29 @@ RED=16711680
 GH_BUILD_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
 if [ -z "${DISCORD_TEST_REPORT_WEBHOOK:-}" ]; then
-  echo "::warning title=Test report not sent::DISCORD_TEST_REPORT_WEBHOOK is unset ($NAME: $RESULT)"
-  exit 0
+  echo "::error title=Test report not sent::DISCORD_TEST_REPORT_WEBHOOK is unset ($NAME: $RESULT)"
+  exit 1
 fi
 
-# `--fail-with-body` turns a non-2xx webhook response into a non-zero exit so the step goes red.
+# Discord answers 204 with an empty body. Anything else — including a 3xx from a stale or proxied webhook
+# URL, which curl reports as success since redirects are not followed — means nobody was told.
 function notify() {
-  local message
+  local message response status body
   message=$(
     printf '{ "content": %s, "embeds": [{ "title": %s, "description": %s, "color": %s }] }' \
       "\"$1\"" "\"$2: $NAME\"" "\"$GH_BUILD_URL\"" "$3"
   )
   echo "$message"
-  curl --fail-with-body --silent --show-error -H "Content-Type: application/json" \
-    -d "$message" "$DISCORD_TEST_REPORT_WEBHOOK"
+  response=$(
+    curl --silent --show-error --write-out '\n%{http_code}' -H "Content-Type: application/json" \
+      -d "$message" "$DISCORD_TEST_REPORT_WEBHOOK"
+  )
+  status=${response##*$'\n'}
+  body=${response%$'\n'*}
+  if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+    echo "::error title=Test report not delivered::Discord webhook returned $status ($NAME: $RESULT) $body"
+    return 1
+  fi
 }
 
 case "$RESULT" in

--- a/.github/actions/test-report/send-test-report.sh
+++ b/.github/actions/test-report/send-test-report.sh
@@ -1,26 +1,45 @@
 #!/bin/bash
 
+# Fail loudly: a report that cannot be delivered has to surface as a red step, otherwise the nightly
+# looks reported when nobody was told.
+set -euo pipefail
+
+NAME="${1:-unknown}"
+RESULT="${2:-unknown}"
+
 ROLE_ID=1166483404066402414
 GREEN=4783872
+ORANGE=16744192
 RED=16711680
 GH_BUILD_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
-function notifySuccess() {
-  if [ -z "$DISCORD_TEST_REPORT_WEBHOOK" ]; then return; fi
-  MESSAGE='{ "content": "🌈✨✅", "embeds": [{ "title": "Daily testing successful: '$1'", "description": "'$GH_BUILD_URL'", "color": '$GREEN' }] }'
-  echo "$MESSAGE"
-  curl -H "Content-Type: application/json" -d "${MESSAGE}" "$DISCORD_TEST_REPORT_WEBHOOK"
-}
-
-function notifyFailure() {
-  if [ -z "$DISCORD_TEST_REPORT_WEBHOOK" ]; then return; fi
-  MESSAGE='{ "content": "⚠️ <@&'$ROLE_ID'>", "embeds": [{ "title": "Daily testing failed: '$1'", "description": "'$GH_BUILD_URL'", "color": '$RED' }] }'
-  echo "$MESSAGE"
-  curl -H "Content-Type: application/json" -d "${MESSAGE}" "$DISCORD_TEST_REPORT_WEBHOOK"
-}
-
-if [ "$2" = "success" ]; then
-  notifySuccess "$1"
-else
-  notifyFailure "$1"
+if [ -z "${DISCORD_TEST_REPORT_WEBHOOK:-}" ]; then
+  echo "::warning title=Test report not sent::DISCORD_TEST_REPORT_WEBHOOK is unset ($NAME: $RESULT)"
+  exit 0
 fi
+
+# `--fail-with-body` turns a non-2xx webhook response into a non-zero exit so the step goes red.
+function notify() {
+  local message
+  message=$(
+    printf '{ "content": %s, "embeds": [{ "title": %s, "description": %s, "color": %s }] }' \
+      "\"$1\"" "\"$2: $NAME\"" "\"$GH_BUILD_URL\"" "$3"
+  )
+  echo "$message"
+  curl --fail-with-body --silent --show-error -H "Content-Type: application/json" \
+    -d "$message" "$DISCORD_TEST_REPORT_WEBHOOK"
+}
+
+case "$RESULT" in
+  success)
+    notify "🌈✨✅" "Daily testing successful" "$GREEN"
+    ;;
+  # A cancelled job means the run never produced a verdict (job timeout, or the run was cancelled), so it
+  # must not read as a test failure — nothing was proven either way.
+  cancelled | skipped)
+    notify "⏹️ <@&$ROLE_ID>" "Daily testing did not complete ($RESULT)" "$ORANGE"
+    ;;
+  *)
+    notify "⚠️ <@&$ROLE_ID>" "Daily testing failed" "$RED"
+    ;;
+esac

--- a/.github/actions/test-report/send-test-report.sh
+++ b/.github/actions/test-report/send-test-report.sh
@@ -13,8 +13,15 @@ ORANGE=16744192
 RED=16711680
 GH_BUILD_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
+# Workflow commands are newline-delimited, so an unescaped webhook response could forge annotations.
+function escape() {
+  local value=${1//'%'/'%25'}
+  value=${value//$'\r'/'%0D'}
+  printf '%s' "${value//$'\n'/'%0A'}"
+}
+
 if [ -z "${DISCORD_TEST_REPORT_WEBHOOK:-}" ]; then
-  echo "::error title=Test report not sent::DISCORD_TEST_REPORT_WEBHOOK is unset ($NAME: $RESULT)"
+  echo "::error title=Test report not sent::DISCORD_TEST_REPORT_WEBHOOK is unset ($(escape "$NAME"): $(escape "$RESULT"))"
   exit 1
 fi
 
@@ -28,13 +35,13 @@ function notify() {
   )
   echo "$message"
   response=$(
-    curl --silent --show-error --write-out '\n%{http_code}' -H "Content-Type: application/json" \
-      -d "$message" "$DISCORD_TEST_REPORT_WEBHOOK"
+    curl --silent --show-error --connect-timeout 10 --max-time 30 --write-out '\n%{http_code}' \
+      -H "Content-Type: application/json" -d "$message" "$DISCORD_TEST_REPORT_WEBHOOK"
   )
   status=${response##*$'\n'}
   body=${response%$'\n'*}
   if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
-    echo "::error title=Test report not delivered::Discord webhook returned $status ($NAME: $RESULT) $body"
+    echo "::error title=Test report not delivered::Discord webhook returned $status ($(escape "$NAME"): $(escape "$RESULT")) $(escape "$body")"
     return 1
   fi
 }

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -514,24 +514,32 @@ jobs:
       credentials:
         username: dxos-bot
         password: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
+      # Each report is `always()` so an undelivered one cannot suppress the rest — without it a failing
+      # first report skips the e2e report, silencing the very signal this job exists to send. A failed
+      # step still fails the job.
       - name: Send test report
+        if: always()
         uses: ./.github/actions/test-report
         with:
           name: test-24.11.1
           result: ${{ needs.test.result }}
       - name: Send storybook report
+        if: always()
         uses: ./.github/actions/test-report
         with:
           name: storybook-24.11.1
           result: ${{ needs.storybook.result }}
       - name: Send workerd report
+        if: always()
         uses: ./.github/actions/test-report
         with:
           name: workerd-24.11.1
           result: ${{ needs.workerd.result }}
       - name: Send e2e report
+        if: always()
         uses: ./.github/actions/test-report
         with:
           name: e2e

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -441,12 +441,14 @@ jobs:
       - name: Install Playwright
         run: pnpm run install-playwright
 
+      # A manual `e2e` dispatch takes the "All" path on any branch: affected-scoping resolves to nothing
+      # when the diff touches no project (e.g. a CI-only change), which would bundle and test nothing.
       - name: Bundle Affected
-        if: ${{ steps.extract_branch.outputs.branch != 'main' }}
+        if: ${{ steps.extract_branch.outputs.branch != 'main' && !inputs.e2e }}
         run: moon run :bundle --affected remote
 
       - name: Bundle All
-        if: ${{ steps.extract_branch.outputs.branch == 'main' }}
+        if: ${{ steps.extract_branch.outputs.branch == 'main' || inputs.e2e }}
         run: moon run :bundle
 
       # `@dxos/cli` ships as prebuilt platform binaries, so its failure modes live in the packed
@@ -464,7 +466,7 @@ jobs:
         run: rm -rf test-results
 
       - name: Test Affected
-        if: ${{ steps.extract_branch.outputs.branch != 'main' }}
+        if: ${{ steps.extract_branch.outputs.branch != 'main' && !inputs.e2e }}
         timeout-minutes: 45
         uses: trunk-io/analytics-uploader@v1
         env:
@@ -477,11 +479,14 @@ jobs:
           run: moon run :e2e --affected remote --concurrency=1
 
       - name: Test All
-        if: ${{ steps.extract_branch.outputs.branch == 'main' }}
+        if: ${{ steps.extract_branch.outputs.branch == 'main' || inputs.e2e }}
         timeout-minutes: 45
         uses: trunk-io/analytics-uploader@v1
         env:
           PLAYWRIGHT_BROWSER: all
+          # A manual dispatch must execute the suite: re-running the same commit otherwise replays a remote
+          # cache hit in seconds, which reports green without running a test and emits no JUnit XML.
+          MOON_CACHE: ${{ inputs.e2e && 'off' || 'read-write' }}
         with:
           junit-paths: 'test-results/playwright/report/*.xml'
           org-slug: dxos

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -430,6 +430,7 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
+          persist-credentials: false
 
       - name: Extract branch
         id: extract_branch
@@ -516,7 +517,11 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 10
     steps:
+      # This job only runs a repository-local action, so it never needs git auth; leaving the token in
+      # `.git/config` would expose it to anything in the checked-out tree.
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       # Each report is `always()` so an undelivered one cannot suppress the rest — without it a failing
       # first report skips the e2e report, silencing the very signal this job exists to send. A failed
       # step still fails the job.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,8 +36,10 @@ env:
   TRUNK_TOKEN: ${{ secrets.TRUNK_TOKEN }}
 
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
+# The event is part of the key because on a schedule `github.ref` is `refs/heads/main`: without it the
+# nightly shares a group with pushes to main and the next push cancels it mid-e2e.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # https://moonrepo.dev/docs/guides/ci
@@ -408,7 +410,9 @@ jobs:
       credentials:
         username: dxos-bot
         password: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 60
+    # Headroom over the 45m test cap plus ~10m of bundling: the step timeout fails the job cleanly with
+    # traces attached, whereas hitting this cap cancels it and proves nothing.
+    timeout-minutes: 75
     env:
       DX_ENVIRONMENT: ci
       DX_EDGE_BASE_URL: 'wss://edge-main.dxos.workers.dev/'
@@ -493,15 +497,11 @@ jobs:
           path: test-results/playwright
           retention-days: 7
 
-      - name: Send test report
-        if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
-        uses: ./.github/actions/test-report
-        with:
-          name: ${{ github.job }}
-          result: ${{ job.status }}
-
+  # Reports every nightly job from one place. e2e is in `needs` so a cancelled e2e is still reported (its
+  # former in-job step used `success() || failure()`, which skips on cancellation) and so the other three
+  # reports can no longer go out green while e2e is still running.
   report:
-    needs: [test, storybook, workerd]
+    needs: [test, storybook, workerd, e2e]
     if: always() && github.event_name == 'schedule'
     runs-on: depot-ubuntu-24.04-8
     container:
@@ -526,6 +526,11 @@ jobs:
         with:
           name: workerd-24.11.1
           result: ${{ needs.workerd.result }}
+      - name: Send e2e report
+        uses: ./.github/actions/test-report
+        with:
+          name: e2e
+          result: ${{ needs.e2e.result }}
 
   # Advisory changeset reminder (NOT a gate): when a PR changes publishable source but has no
   # `.changeset/*.md`, post/update a single sticky comment; remove it once a changeset is added.


### PR DESCRIPTION
## Why

Last night's nightly ([run 30423928161](https://github.com/dxos/dxos/actions/runs/30423928161), 07-29 05:02 UTC) ended `cancelled` with **no failure notification** — and worse, it sent three *green* reports.

Two independent bugs:

**1. A push to main cancels the nightly.** On a `schedule` event `github.ref` is `refs/heads/main`, so the nightly shared the concurrency group `Check-refs/heads/main` with pushes to main. The push of `4bb7e3b4` created its run at `05:16:52`; the nightly was cancelled at `05:16:56` — 14 minutes in, with e2e still in `Test All`.

**2. Cancellation was unreportable, and the summary went out early.** In the cancelled e2e job:

| step | condition | outcome |
|---|---|---|
| `Upload Traces` | `always()` | success |
| `Send test report` | `(success() \|\| failure())` | **skipped** |

Meanwhile the `report` job depended only on `[test, storybook, workerd]`, so it ran at `05:11` — before e2e was killed at `05:16` — and sent three "🌈✨✅ Daily testing successful" messages. The nightly reported success while its e2e signal was silently discarded.

## What changed

- **`concurrency`** is keyed on `github.event_name`, so scheduled runs stand alone. Pushes still cancel each other; PR and `merge_group` dedupe behaviour is unchanged (their refs were already distinct).
- **`report` now depends on `e2e`** and reports `needs.e2e.result`, replacing the in-job step. The green reports can no longer be sent before e2e has a verdict, and a `cancelled` e2e (job timeout) is reported. Each report step is `always()` so an undelivered report cannot suppress the ones after it.
- **`send-test-report.sh`** distinguishes `cancelled`/`skipped` (orange, "did not complete") from a genuine test failure (red), and fails the step when a report is not delivered — unset webhook, non-2xx, or a 3xx that never reached Discord. The request is bounded (`--connect-timeout 10 --max-time 30`) and the webhook response is escaped before it reaches a `::error` annotation.
- **e2e `timeout-minutes: 60` → `75`**, so the 45m test cap trips first and fails the job cleanly with traces attached instead of the job cap cancelling it. The 07-28 run finished at 54m — uncomfortably close to the old cap.
- **A manual `e2e: true` dispatch now actually runs the suite** — see below.
- **`persist-credentials: false`** on the `report` and `e2e` checkouts, the last two in this workflow without it (zizmor: artipacked). Neither needs git auth.

## Manual e2e verification was impossible

Dispatching `e2e: true` to check the suite by hand could not produce a real result:

- On a branch the job takes the affected path, and `--affected remote` resolves to nothing when the diff touches no moon project — a CI-only change bundles and tests nothing.
- On main it replays the remote cache. [Run 30445909226](https://github.com/dxos/dxos/actions/runs/30445909226) finished `Test All` in **1m51s** with `291 completed (290 cached)`, reporting green without executing a test and leaving no JUnit XML, so Trunk logged `No tests were found in the provided test results`.

The dispatch now routes down the "All" path on any branch and runs with `MOON_CACHE=off`, so a manual verification run executes rather than replays.

## On the test failures

The 07-28 nightly ([run 30330425113](https://github.com/dxos/dxos/actions/runs/30330425113)) was a genuine, near-total e2e regression from `5585ec89` (#12273, deck URL pair-chain) — everything after `basic.spec.ts:31` hit the 60s test timeout, burning the full 45m cap. Because the step was killed mid-run, Playwright never printed a summary, which is why those logs carry no error detail.

**It was already repaired** by `ebb6383b` (#12362, "repair the browser-e2e suite") later the same day, so no test changes are needed here.

Confirmed by a genuine uncached run on this branch ([run 30447844243](https://github.com/dxos/dxos/actions/runs/30447844243)), `Test All` in **39m16s**:

```
📚 Test Report
   Total: 255   Pass: 254   Fail: 0   Quarantined: 1   Pass Ratio: 99.6%
❤️‍🩹  1 test failed and was quarantined
🎉 All test failures were quarantined, overriding exit code to be exit_success (0)
```

The mass regression is gone. Note the step's green is a Trunk quarantine override, not a clean sweep: `comments.spec.ts:161 › Comments tests › selecting comment highlights thread and vice versa` failed all three attempts on chromium (and failed-then-passed on webkit). It is already quarantined, so it does not fail CI — pre-existing, and the same test whose helper carries the `waitForTimeout(1_000)` TODO in `playwright/plugins/markdown.ts`.

## Testing

`.github/workflows/check.yml` parses; `report` resolves to `needs: [test, storybook, workerd, e2e]` with four `always()` report steps; all seven checkouts set `persist-credentials: false`; and the e2e job routes `Bundle All` + `Test All` under a manual dispatch (verified in run 30447844243, where both `*Affected` steps skipped and the run executed rather than replaying cache).

`send-test-report.sh` was exercised against a local stub webhook:

| case | behaviour | exit |
|---|---|---|
| `success` | 🌈✨✅ Daily testing successful | 0 |
| `failure` / unknown | ⚠️ Daily testing failed (role ping) | 0 |
| `cancelled` / `skipped` | ⏹️ Daily testing did not complete (role ping) | 0 |
| webhook returns 500 | `::error`, step fails | 1 |
| webhook returns 302 | `::error`, step fails | 1 |
| webhook unset | `::error`, step fails | 1 |
| connection refused | curl error propagates | 7 |

Injection is covered too: a stub body of `bad\n::error title=FORGED::pwned\n100% broken` yields a single `::error` line with the payload inert as `%0A::error…`.

## Residual gaps

- If a scheduled run is cancelled while `report` is still queued, no notification is sent — GitHub cancels queued jobs regardless of `always()`. The concurrency fix removes the only observed cause; a manual cancel is deliberate and does not need to page.
- An uncached manual dispatch used 39m16s of the 45m step cap, so headroom is thin. If the suite grows, raise the cap rather than let a manual verification die on timeout.
- A moon cache hit materialises no JUnit XML, so Trunk records zero tests for that run. Pre-existing, untouched here.
- With `retries: 2` and a 60s test timeout, a systemic e2e break exhausts the 45m cap before Playwright prints a summary. A CI `maxFailures` would fail fast and preserve it, but that changes test policy and interacts with the Trunk quarantine flow, so I have not touched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B49TKbC9bu3ydEo6bQ3dGf