### PR TITLE
ci: sync the CI image's bun with .prototools

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -41,8 +41,12 @@ RUN npm install -g pnpm@10.13.1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Bun.
-# NOTE: Keep bun version in sync with .prototools
-ARG BUN_VERSION=1.3.4
+# NOTE: Keep bun version in sync with .prototools.
+#  Unlike node and pnpm, bun is not declared in .moon/toolchains.yml, so moon never installs it through
+#  proto and this is what a bare `bun` resolves to in CI. Drift is therefore silent, and it compiles the
+#  `dx` binary: 1.3.4 leaks `--smol` into `process.argv`, so the binary rejects its own arguments.
+#  The image tag tracks NODE_VERSION, so a change here does not move it — the image must be rebuilt.
+ARG BUN_VERSION=1.3.11
 RUN ARCH=$(uname -m) \
   && if [ "$ARCH" = "x86_64" ]; then ARCH="x64"; elif [ "$ARCH" = "aarch64" ]; then ARCH="aarch64"; else echo "Unsupported architecture: $ARCH"; exit 1; fi \
   && curl -fsSL https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-$ARCH.zip -o /tmp/bun.zip \

--- a/.prototools
+++ b/.prototools
@@ -3,6 +3,10 @@
 proto = "0.58.2"
 node = "24.11.1"
 pnpm = "10.28.0"
+# NOTE: Keep bun version in sync with `.github/Dockerfile`, and rebuild the image after changing it.
+#  Unlike node and pnpm, bun is not declared in `.moon/toolchains.yml`, so moon never installs it and a
+#  bare `bun` in CI resolves to the image's copy rather than this pin — bumping only this file leaves CI
+#  compiling with the old version, silently.
 # 1.3.4 leaks `--smol` into `process.argv` of every `--compile`d binary, which makes the published
 # `dx` reject its own arguments ("Invalid subcommand for dx").
 bun = "1.3.11"


### PR DESCRIPTION
One line: `.github/Dockerfile`'s `ARG BUN_VERSION` goes 1.3.4 → 1.3.11, matching the `.prototools` pin its own comment says to track. Split out of #12392 so the image can be rebuilt and landed on its own.

## Why the drift is silent

`bun` is the one toolchain version CI takes from the image rather than from `.prototools`:

- `.moon/toolchains.yml` declares `node: {}` and `pnpm: {}`, so **moon** installs those through proto and the pins are honoured.
- `bun` is declared nowhere, and `moonrepo/setup-toolchain` runs with `auto-install: false` (its default), so nothing installs it.
- With no `~/.proto/shims/bun`, a bare `bun` falls through PATH to `/usr/local/bin/bun` — this file's binary.

The clinching evidence is pnpm: this image bakes **10.13.1**, `.prototools` pins **10.28.0**, and CI reports **10.28.0**. Declared tools come from proto; undeclared ones come from the image. So `bun` alone drifted when #12379 moved the pin to 1.3.11.

## Why it matters

That bun compiles `@dxos/cli`'s binaries. 1.3.4 leaks `--smol` into `process.argv`, so the compiled `dx` rejects its own command line. Confirmed by installing the CI-built preview on another machine:

```
$ npm i https://pkg.pr.new/dxos/dxos/@dxos/cli-linux-x64@2d7f310
$ dx --version
Error: {"_tag":"CommandMismatch", … "Invalid subcommand for dx - use one of 'repl', 'reset', …"}
```

CI's own setup log agrees — right after `setup-toolchain`:

```
v24.11.1   ← node,  pinned ✅
10.28.0    ← pnpm,  pinned ✅
1.3.4      ← bun,   pinned is 1.3.11 ❌
```

## After this lands

The image needs rebuilding for the change to take effect — the tag tracks `NODE_VERSION`, so a bun bump alone doesn't move `ghcr.io/dxos/gh-actions:24.11.1`. `docker-image.yml` rebuilds on a push to `main` touching this file, so merging is sufficient.

Once the rebuilt image is in use, the interim workarounds in #12392 can come out: the `Install pinned bun` step in `.github/actions/setup`, and `proto run bun` in the CLI's `bundle` task. The version assertion in `scripts/build.ts` should stay — it's what turns a future drift into a build failure instead of a broken published binary.

## Verification

No behaviour to test here beyond the image build itself. 1.3.11 is the version every CLI build in #12392 was verified against, including the packed-and-installed smoke test and a run with the workspace's `node_modules` hidden.

---
_Generated by [Claude Code](https://claude.ai/code/session_012AK7sEUEE4nMJmpbFK8tMq)_