### PR TITLE
plugin-projects: cascade-delete project routines by parenting them to the project

### DIFF
--- a/.changeset/project-routine-cascade.md
+++ b/.changeset/project-routine-cascade.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-projects': patch
+---
+
+Routines created from a project are now owned by it, so deleting the project deletes its routines (and their triggers) instead of leaving them behind.

--- a/packages/plugins/plugin-projects/src/containers/ProjectArticle/ProjectArticle.tsx
+++ b/packages/plugins/plugin-projects/src/containers/ProjectArticle/ProjectArticle.tsx
@@ -76,8 +76,8 @@ export const ProjectArticle = ({ role, subject, attendableId }: ProjectArticlePr
     [invokePromise, artifactsCollection],
   );
 
-  // Routines are linked, not owned: the ref is spliced here and `RemoveObjects` (no target) removes the
-  // object from the space's root collection, where the create flow filed it.
+  // Routines are owned by the project but filed in no collection, so `RemoveObjects` needs no target;
+  // the `routines` ref is spliced here since the cascade only follows parent edges.
   const handleDeleteRoutine = useCallback(
     (object: Obj.Unknown) => {
       updateProject((project) => {

--- a/packages/plugins/plugin-projects/src/operations/create-routine.ts
+++ b/packages/plugins/plugin-projects/src/operations/create-routine.ts
@@ -52,8 +52,10 @@ const handler: Operation.WithHandler<typeof ProjectOperation.CreateRoutine> = Pr
         seedProjectScope(yield* Database.load(instructionsRef));
       }
 
-      // A link, not ownership: the routine is a space object (it appears under Routines and may be
-      // triggered independently), and the project records that it was created in its scope.
+      // Owned AND linked, like template starter routines: the parent edge makes the routine (and its
+      // owned trigger) cascade-delete with the project, while the ref keeps gallery order — the
+      // Routines section lists by type query, so ownership does not hide it there.
+      Obj.setParent(object, project);
       Obj.update(project, (project) => {
         project.routines = [...project.routines, Ref.make(object)];
       });

--- a/packages/plugins/plugin-projects/src/operations/delete-project.test.ts
+++ b/packages/plugins/plugin-projects/src/operations/delete-project.test.ts
@@ -5,7 +5,7 @@
 import { afterEach, beforeEach, describe, test } from 'vitest';
 
 import { Chat } from '@dxos/assistant-toolkit';
-import { Instructions, Project } from '@dxos/compute';
+import { Instructions, Project, Routine } from '@dxos/compute';
 import { Collection, Feed, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { EchoTestBuilder } from '@dxos/echo-client/testing';
 import { Text } from '@dxos/schema';
@@ -29,7 +29,15 @@ describe('deleting a project', () => {
 
   const setup = async () => {
     const { db } = await builder.createDatabase({
-      types: [Project.Project, Instructions.Instructions, Collection.Collection, Chat.Chat, Feed.Feed, Text.Text],
+      types: [
+        Project.Project,
+        Instructions.Instructions,
+        Collection.Collection,
+        Chat.Chat,
+        Feed.Feed,
+        Text.Text,
+        Routine.Routine,
+      ],
     });
 
     // Mirrors the create-object capability: owned instructions + owned artifacts collection.
@@ -47,9 +55,16 @@ describe('deleting a project', () => {
     const feed = db.add(Feed.make());
     const chat = db.add(Chat.make({ name: 'Chat', feed: Ref.make(feed) }));
     Obj.setParent(chat, project);
+
+    // Mirrors ProjectOperation.CreateRoutine: owned by the parent edge AND linked for gallery order.
+    const routine = db.add(Routine.make({ name: 'Routine', triggers: [] }));
+    Obj.setParent(routine, project);
+    Obj.update(project, (project) => {
+      project.routines = [...project.routines, Ref.make(routine)];
+    });
     await db.flush();
 
-    return { db, project, instructions, artifacts, chat };
+    return { db, project, instructions, artifacts, chat, routine };
   };
 
   type TestDatabase = Awaited<ReturnType<typeof setup>>['db'];
@@ -80,12 +95,13 @@ describe('deleting a project', () => {
     return descendants;
   };
 
-  test('the owned instructions, artifacts collection and chats are removed with it', async ({ expect }) => {
+  test('the owned instructions, artifacts collection, chats and routines are removed with it', async ({ expect }) => {
     const { db, project } = await setup();
     expect(await countOf(db, Filter.type(Project.Project))).toEqual(1);
     expect(await countOf(db, Filter.type(Instructions.Instructions))).toEqual(1);
     expect(await countOf(db, Filter.type(Collection.Collection))).toEqual(1);
     expect(await countOf(db, Filter.type(Chat.Chat))).toEqual(1);
+    expect(await countOf(db, Filter.type(Routine.Routine))).toEqual(1);
 
     db.remove(project);
     await db.flush();
@@ -94,12 +110,13 @@ describe('deleting a project', () => {
     expect(await countOf(db, Filter.type(Instructions.Instructions))).toEqual(0);
     expect(await countOf(db, Filter.type(Collection.Collection))).toEqual(0);
     expect(await countOf(db, Filter.type(Chat.Chat))).toEqual(0);
+    expect(await countOf(db, Filter.type(Routine.Routine))).toEqual(0);
   });
 
   test('owned descendants are reachable transitively before removal, so their planks can be closed', async ({
     expect,
   }) => {
-    const { db, project, chat, instructions, artifacts } = await setup();
+    const { db, project, chat, instructions, artifacts, routine } = await setup();
 
     // Mirrors the walk `RemoveObjects` runs to decide which planks to close. Passing only the project
     // would leave the chat's plank open on a removed object; stopping at one level would miss the
@@ -108,6 +125,7 @@ describe('deleting a project', () => {
     expect(descendantIds).toContain(chat.id);
     expect(descendantIds).toContain(instructions.id);
     expect(descendantIds).toContain(artifacts.id);
+    expect(descendantIds).toContain(routine.id);
 
     const textId = instructions.text.target?.id;
     expect(textId).toBeTruthy();


### PR DESCRIPTION
## Summary

Routines created via `ProjectOperation.CreateRoutine` were only *linked* to the project (a `Ref` in `project.routines`), so deleting a project left its routines — and their live triggers — behind. The documented rationale ("the routine appears under Routines") doesn't require the link-only design: the Routines section lists by type query, so ownership doesn't hide a routine there, as template starter routines (already parented) demonstrate.

- `CreateRoutine` now sets the ECHO parent edge (`Obj.setParent(routine, project)`) in addition to the gallery-order ref, matching the inbox-research template's starter routines. The cascade in `SpaceOperation.RemoveObjects` then removes the routine and its owned instructions/trigger with the project, and closes their open planks.
- Extended `delete-project.test.ts` to pin that routines cascade and appear in the descendant walk.
- Corrected the stale `ProjectArticle` comment: routines are filed in no collection (no `CollectionItemAnnotation`), so per-routine delete needs no `RemoveObjects` target.

## Notes

- No dangling refs remain: routines are never filed into a collection, the Routines navtree is a reactive type query, and `project.routines` back-refs die with the project.
- Chats and the instructions/artifacts graph already cascaded via parent edges; this brings routines in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project-created routines are now owned by their project.
  * Deleting a project also deletes its routines and associated triggers.

* **Bug Fixes**
  * Prevented project routines from remaining after their project is removed.
  * Ensured routine descendants are correctly included in project deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->