### PR TITLE
chat: stages 5–9 — agents in channels

### DIFF
--- a/.agents/projects/chat/DESIGN.md
+++ b/.agents/projects/chat/DESIGN.md
@@ -332,10 +332,14 @@ stages schedule its two phases.
 
 ### Risks / new pressure
 
-- **Feed budget** — the one genuinely new infrastructure pressure:
-  session-per-thread mints a feed per agent task against ~1000 feeds/space.
-  Session feeds need a retention/GC story (disposable once the task
-  concludes) or feed phases 3–4 headroom.
+- **Feed budget** — the one genuinely new infrastructure pressure: sessions
+  already live on feeds, but session-per-thread mints them at mention-cadence
+  — a feed per agent task against ~1000 feeds/space. Session feeds need a
+  retention/GC story (disposable once the task concludes); feed phase 3's
+  retention design is the natural home, extended to whole-feed GC/archival
+  rather than only within-feed compaction. Mirrored as constraints in
+  feed-live-objects DESIGN ("Agent sessions" workstream) + TASKS (phases
+  2–3).
 - **Thread deep-links** (stage-1 item, landed round 9) are a stage-7
   prerequisite: provenance links and "view session" need addressable threads
   and sessions (url-deck pair-chain grammar; plugin-projects shares the

--- a/.agents/projects/chat/DESIGN.md
+++ b/.agents/projects/chat/DESIGN.md
@@ -165,7 +165,8 @@ pattern; exact relation type chosen in stage 3). No per-thread relations.
   stage 3 replaces that with comment channels (`threadId = anchor`). Review
   and chat share only `@dxos/types` and `react-ui-thread` (no cross-imports).
 - Assistant `Chat` and inbox `Mailbox` follow the same feed-backed idiom;
-  convergence with Channel is deliberately deferred (see Open questions).
+  the `Chat`/`Channel` relationship is RESOLVED (2026-07-30): parallel types
+  over one substrate — see "Agents".
 
 ## Rollout
 
@@ -183,6 +184,22 @@ pattern; exact relation type chosen in stage 3). No per-thread relations.
    `document-revisions` (burdon), which is active in plugin-review.**
 4. **Post-stage-3 follow-ups**: notifications (subscription triggers) and
    presence/typing (ephemeral EDGE primitive).
+5. **Stage 5 — identity & attribution groundwork** (parallel to 2–4): sender
+   DIDs on user- and agent-authored messages; one live agent process per
+   conversation. Fixes latent bugs in the current single-user assistant.
+6. **Stage 6 — interface convergence** (after 2): the assistant chat surface
+   renders on the plugin-chat message kit, parameterized by a block-render
+   policy. One kit, per-surface policies — not a fork.
+7. **Stage 7 — agents in channels v1** (after 3 + 5 + 6): mentions, forced
+   threads, session-per-thread, provenance link + progress tile;
+   client-hosted interim placement.
+8. **Stage 8 — subscriptions & delivery** (extends 4): per-user thread
+   membership items; notification and agent delivery routes over one
+   subscription primitive.
+9. **Stage 9 — space-hosted sessions & live activity**: EDGE placement, real
+   agent identity, activity pulse.
+
+Detail for 5–9 in "Agents" below.
 
 **Ship gate:** prototype freely on the landed #12235 surface, but feed
 phase 1 (version/order axis) must land before chat ships to real users — v1
@@ -193,6 +210,145 @@ Inherited from feed phases with no plugin changes: read receipts/unread
 (phase 2 cursors), EDGE push replacing 1s polling (phase 2), history beyond
 device capacity (phases 3–4).
 
+## Agents (stages 5–9)
+
+Decision (2026-07-30, josiah): assistant `Chat` and `Channel` stay separate
+types — **a session transcript is not a venue** — but converge on everything
+below the type: one `Message` schema, one feed idiom, one agent turn loop, one
+message-surface component kit. Resolves the former open question (was:
+"leaning parallel").
+
+### Venue vs. session transcript
+
+- In an assistant **chat**, the conversation IS the agent's working
+  transcript: the session reifies history from the chat feed, tool calls land
+  in it, context bindings live in it — the user stands inside the session.
+  `Chat` keeps its extras (`instructions`, `plan`, in-feed `AiContext`
+  bindings).
+- In a **channel**, the conversation is a venue. An agent participating in a
+  thread runs a session whose transcript is its own feed (a `Chat`); the
+  channel feed receives only its final messages. The private chat is the
+  degenerate case: venue == transcript, delivery == identity.
+
+The turn loop (`AiSession`/`AgentProcess`) is identical in both modes and
+never knows which one it is in. The differences are all at the edges:
+
+|            | chat                                                               | channel thread                                                                                                                                                                          |
+| ---------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| input      | harness writes the prompt `Message` straight into the session feed | the user's `Message` lands in the channel feed (an ordinary send); the agent's thread subscription delivers it (`enqueueMessage`); the session records a copy carrying a provenance ref |
+| output     | the assistant block appended to the session feed IS the reply      | posting is an **action**: append a `Message` (sender = agent DID, `threadId`) to the channel feed, recorded in the session feed like any tool call                                      |
+| visibility | tool calls, streaming, context chips render inline                 | final messages only; backstage reachable via the provenance link                                                                                                                        |
+
+### Rules
+
+- **Agent interactions force a thread.** An @-agent mention at channel level
+  mints the thread at compose time (`CreateThread` is idempotent; the
+  composer visibly switches to "starting a thread with X" before send — no
+  post-hoc re-parenting). Human-only messages stay nudged, never forced.
+- **Session per thread.** The mention spawns a session `Chat` bound to
+  `(channel, threadId)`; binding mechanism is a stage-7 design task
+  (thread-as-object makes `Chat → Thread` natural once cross-feed refs
+  resolve; otherwise a channel ref + `threadId` pair). Spawn-time context = a
+  window of channel/thread history bound via `AiContext.Binding` — data the
+  session reads, not transcript. Messages arriving after spawn are live turn
+  inputs via the subscription. A fresh mention elsewhere = a fresh,
+  concurrent session.
+- **Response policy:** respond-by-default while the session is the thread's
+  sole agent subscriber and no one else is addressed; mention-gated
+  otherwise. One rule everywhere — the private chat is the case where the
+  condition is always true.
+- **Echo suppression:** the delivery route drops messages whose
+  `sender.identityDid` is the agent's own. Identity-based, not role-based —
+  with several agents in a thread, `role === 'assistant'` cannot tell "me"
+  from another agent.
+- **Provenance:** an agent's venue messages link to the producing session;
+  "view session" opens it in the chat surface as its own plank (the stage-1
+  thread-plank pattern), read-only by default, joinable — anyone in the
+  thread can steer the running session, not just watch it.
+- **Progress is a render of the session feed.** The thread shows a
+  provisional tile at the reply's landing spot, folded from the session
+  feed's tail (turn started / tools begun / blocks completed). Derived state,
+  never a feed block — and it survives reload because the source blocks are
+  durable, which ephemeral typing-style signals cannot do. Token-level
+  liveness (the dormant `SwarmTraceSink` path) is optional polish. Progress
+  implies outcomes: the tile resolves to posted / failed / canceled, never
+  vanishes.
+
+### Subscription: one primitive, two delivery routes
+
+Per-user durable **thread membership** items (single-writer, folded at read —
+the `Reaction` shape): the join affordance writes one; first message
+auto-joins; "X joined" lines derive at render time, never message blocks.
+Written from day one so membership history is real when notification delivery
+lands. Delivery routes: human subscriber → notification trigger (the stage-4
+mechanism, filtered to joined threads); agent subscriber → session
+`enqueueMessage`. With EDGE hosting (stage 9) both routes become literally
+the same trigger machinery. Join ≠ read cursor (feed phase 2) — orthogonal
+per-user facts.
+
+### Placement is a property of the session, chosen by venue
+
+The session's whole interface is feed reads/writes plus subscription
+delivery — all replicated space data — so the loop is location-transparent by
+construction.
+
+- Private companion chat → **client-hosted** (works offline, streams tokens
+  locally, the user is present by definition). IndexedDB-backed process
+  manager, as today.
+- Channel/thread-bound sessions → **EDGE-hosted** (the task belongs to the
+  venue and must survive every laptop lid in the space). Same `AgentProcess`
+  — already a suspendible, alarm-driven process; the process-manager
+  capability layer is the seam where backends swap. Delivery = an EDGE
+  trigger on the channel feed — the plugin-routine machinery is the agent's
+  alarm clock.
+- Cancel-from-thread stays in the data plane: a control item on the session
+  feed that the host watches (inherits offline queueing), not an RPC path.
+- Later, not v1: promotion — hand a local session to EDGE ("keep going
+  without me"). State lives in the feed and the process suspends, so this is
+  close to suspend-here/resume-there.
+
+### Identity: attribution now, authority at EDGE
+
+Rides `agents/superpowers/specs/2026-07-21-agent-identity.md`; the chat
+stages schedule its two phases.
+
+- **Stage 5 (synthetic):** stamp `sender.identityDid` on user prompts —
+  `formatUserPrompt` writes a bare `role: 'user'` today, so two humans (or
+  two devices) in one feed are indistinguishable — and on agent messages via
+  `AgentIdentityService` reading `Agent.did`. Sufficient while writes happen
+  under the mentioning user's client authority. NOTE: a synthetic `sender`
+  DID is a **claim** — any space writer can stamp any DID — so it is
+  attribution, never authenticated provenance; build no permission checks on
+  it.
+- **Stage 9 (real):** an EDGE process must authenticate to write at all,
+  which forces the spec's real-identity phase: keypair-backed `did:halo:`,
+  agent as space member (`SpaceMember.Role` gates it; rosters and mention
+  autocomplete need no special case; the `resolveAuthor` agent-seeding shim
+  is deleted per the spec). Device model: the agent identity gets one or few
+  **long-lived EDGE runtime devices**, each hosting many sessions — devices
+  are laptops, not tabs. Considered and declined: device-per-session (heavy;
+  device admission permanently grows the append-only HALO credential graph);
+  shelved for its one virtue, per-session key revocation.
+
+### Risks / new pressure
+
+- **Feed budget** — the one genuinely new infrastructure pressure:
+  session-per-thread mints a feed per agent task against ~1000 feeds/space.
+  Session feeds need a retention/GC story (disposable once the task
+  concludes) or feed phases 3–4 headroom.
+- **Thread deep-links** (stage-1 item, landed round 9) are a stage-7
+  prerequisite: provenance links and "view session" need addressable threads
+  and sessions (url-deck pair-chain grammar; plugin-projects shares the
+  need).
+- **Cross-feed refs**: provenance refs (session ↔ channel messages) are not
+  known to resolve in either direction yet; v1 copies message content into
+  the session feed and carries the ref as metadata.
+- **Coordination**: stage 7 retires plugin-review's separate `agent-runner`
+  loop — a review agent becomes an agent subscribed to a comments channel —
+  under the same plugin-review sequencing constraint as stage 3. The
+  session-binding design overlaps plugin-projects' open context/artifact
+  decision; design them together.
+
 ## Open questions
 
 - Identical anchor range ⇒ same `threadId` ⇒ comments on the same selection
@@ -200,8 +356,10 @@ device capacity (phases 3–4).
 - Orphaned anchors (anchored text deleted): render-as-orphaned, as review
   does today.
 - `resolved` on the root message vs elsewhere — validate in stage 3.
-- Assistant `Chat` / `Channel` convergence (leaning: keep parallel; converge
-  only if the assistant needs channel features).
+- Who may cancel a running agent session from its thread: the mentioner or
+  any thread member (leaning: any member, per the team-steerable framing).
+- Session-feed retention/GC policy (see "Risks") — decide before stage 7
+  ships at any scale.
 - Per-thread read-state granularity: finer than the per-feed cursor feed
   phase 2 defines — feed phase 2 should not design out per-`threadId`
   high-water marks (flagged in feed-live-objects TASKS).

--- a/.agents/projects/chat/TASKS.md
+++ b/.agents/projects/chat/TASKS.md
@@ -14,6 +14,8 @@ harness (manual offline/propagation, two-client storybook); thread
 deep-linking, parked in stage 1, landed in round 9. Rounds 2–12 of jdw's
 review are folded in below, each marked with the round that asked for it;
 where a round revised an earlier decision the superseded entry says so.
+2026-07-30: stages 5–9 (agents in channels; josiah) added — model in
+DESIGN.md "Agents".
 NEXT: stage 2 — the `plugin-thread` → `plugin-chat` rename.
 
 ## Decisions log
@@ -29,6 +31,16 @@ NEXT: stage 2 — the `plugin-thread` → `plugin-chat` rename.
 - [x] Replies = `Message.parentMessage` refs.
 - [x] Presence/typing = ephemeral EDGE messaging, never feed blocks.
 - [x] Ship gate: feed phase 1 lands before chat ships to real users.
+- [x] Assistant `Chat`/`Channel`: parallel types over one substrate — a
+      session transcript is not a venue; `Message`, feed idiom, turn loop and
+      message-surface kit converge, the types do not (josiah, 2026-07-30).
+- [x] Agent interactions force a thread; one session per thread; the agent's
+      reply is an action on the venue, recorded in its session feed
+      (2026-07-30).
+- [x] Session placement by venue: private chat client-hosted, channel-bound
+      sessions EDGE-hosted; same `AgentProcess` (2026-07-30).
+- [x] Thread subscription = one primitive, two delivery routes: human →
+      notification, agent → session enqueue (2026-07-30).
 
 ## Stage 1 — prototype in plugin-thread
 
@@ -451,6 +463,110 @@ NEXT: stage 2 — the `plugin-thread` → `plugin-chat` rename.
       online roster); document the primitive — candidate for extraction, cf.
       plugin-calls swarm presence. Explicitly not feed-backed.
 
+## Stage 5 — identity & attribution groundwork (parallel to stages 2–4)
+
+Rides the "today" (synthetic) phase of
+`agents/superpowers/specs/2026-07-21-agent-identity.md`. Fixes latent bugs in
+the current single-user assistant, independent of agents-in-channels.
+
+- [ ] Stamp `sender.identityDid` on user-authored prompts — `formatUserPrompt`
+      (`assistant/src/request/format.ts`) writes `sender: { role: 'user' }`
+      today, so two humans (or two of one user's devices) in one chat feed
+      are indistinguishable.
+- [ ] Provide `AgentIdentityService` from the session layer (spec scope items
+      1–2) and stamp agent-authored messages with `Agent.did`; retire
+      plugin-review's hardcoded `DEFAULT_AGENT_IDENTITY` ("Kai", name only).
+- [ ] Document the boundary: synthetic `sender` DIDs are claims, not
+      authenticated provenance — no permission checks on `sender`.
+- [ ] One live agent process per conversation: `AgentService`'s per-client
+      in-memory session cache lets two clients double-spawn loops on one feed
+      (interleaved double replies). Minimum-viable claim/coordination now;
+      remote host addressing is stage 9.
+
+## Stage 6 — interface convergence (after stage 2)
+
+- [ ] The assistant chat surface renders on the plugin-chat message kit
+      (tiles, hover controls, composer), parameterized by a **block-render
+      policy**: assistant surface shows tool calls / streaming partials /
+      context chips; channel surface renders finalized content blocks only.
+      One kit, per-surface policies — not a fork.
+- [ ] `Chat` keeps its type and extras (`instructions`, `plan`, in-feed
+      context bindings); `Message`, the feed idiom, and the UI converge.
+- [ ] Stage-1 message affordances (reactions, quote-reply, edit, delete)
+      light up in assistant chats via the shared kit — verify they don't
+      fight the assistant's streaming tiles.
+
+## Stage 7 — agents in channels v1 (after stages 3, 5, 6)
+
+- [ ] Wire `mention()` autocomplete (`ui-editor` completion extension —
+      exists, unwired) into the channel composer: space members + enabled
+      `Agent`s.
+- [ ] Forced thread: an @-agent mention at channel level mints the thread at
+      compose time (composer shows "starting a thread with X" before send;
+      `CreateThread` is already idempotent). Human-only messages stay
+      nudged, never forced.
+- [ ] Session per thread: the mention spawns a session `Chat` bound to
+      `(channel, threadId)` — design the binding (thread-as-object makes
+      `Chat → Thread` natural once cross-feed refs resolve; else channel ref + `threadId`). Spawn-time context = channel-history window via
+      `AiContext.Binding`.
+- [ ] Delivery: thread messages route into the live session via harness
+      `enqueueMessage`; echo suppression keyed on own `sender.identityDid`,
+      not `role`.
+- [ ] Output action: a post-to-thread operation appends the `Message`
+      (sender = agent DID, `threadId`) to the channel feed and records the
+      action in the session feed.
+- [ ] Response policy: respond-by-default while sole agent subscriber and no
+      one else is addressed; mention-gated otherwise.
+- [ ] Provenance: agent venue-messages link to the producing session; "view
+      session" opens it as its own plank (read-only default, joinable for
+      steering).
+- [ ] Progress tile: provisional tile in the thread folded from the session
+      feed's tail; resolves to posted / failed / canceled; derived state,
+      never feed blocks.
+- [ ] Retire plugin-review's `agent-runner`: a review agent = an agent
+      subscribed to the document's comments channel (after stage 3;
+      coordinate with document-revisions, same constraint as stage 3).
+- [ ] Interim placement: client-hosted in the mentioner's client, explicitly
+      marked scaffolding for stage 9.
+- [ ] Prerequisite: session deep-links for provenance and "view session" —
+      threads are URL-addressable since round 9; sessions (companion chats)
+      are not (the plugin-projects UrlBinding gap; same fix serves both).
+
+## Stage 8 — subscriptions & delivery (extends stage 4)
+
+- [ ] Thread membership items (per-user, single-writer, folded at read — the
+      `Reaction` shape): join affordance writes one; first message
+      auto-joins; "X joined" derives at render, never a message block. Write
+      these from day one so notification history is real.
+- [ ] Notification delivery filtered to joined threads (the stage-4 trigger
+      mechanism).
+- [ ] Agent delivery route = the same subscription primitive with delivery =
+      session enqueue; with EDGE (stage 9) both routes are the same trigger
+      machinery.
+- [ ] Keep join distinct from feed-phase-2 read cursors — orthogonal
+      per-user facts; a non-joined reviewer still gets a read cursor.
+
+## Stage 9 — space-hosted sessions & live activity
+
+- [ ] EDGE-hosted `AgentProcess` for channel-bound sessions: same process
+      code over an EDGE-backed process manager; wake-up = EDGE trigger on
+      the channel feed (plugin-routine machinery).
+- [ ] Real agent identity (the spec's "future" phase — EDGE forces it):
+      keypair-backed `did:halo:`, agent as space member; one/few long-lived
+      EDGE runtime devices each hosting many sessions. Declined:
+      device-per-session (credential-graph bloat); shelved for its one
+      virtue, per-session key revocation.
+- [ ] Remote control in the data plane: cancel = control item on the session
+      feed watched by the host; decide who may cancel (open question —
+      leaning any thread member).
+- [ ] Activity pulse: coarse status folded from the replicated session feed
+      first; token-level liveness via the dormant `SwarmTraceSink` publish
+      side only if wanted.
+- [ ] Session-feed retention/GC — a feed per agent task vs ~1000 feeds/space;
+      or gate scale on feed phases 3–4.
+- [ ] Later, not v1: session promotion local → EDGE ("keep going without
+      me").
+
 ## Blocked / needs a separate fix
 
 - [x] `plugin-onboarding:build-exemplar` was failing on `main`
@@ -467,7 +583,8 @@ NEXT: stage 2 — the `plugin-thread` → `plugin-chat` rename.
       `EID.getEntityId(EID.tryParse(ref.uri)!)`, most with the banned non-null
       assertion, and this change added two more local copies. Core-API
       addition, so it needs Josiah's sign-off before it rides along.
-- [ ] Assistant `Chat`/`Channel` convergence decision (leaning: parallel).
+- [x] Assistant `Chat`/`Channel` convergence — DECIDED 2026-07-30: parallel
+      types over one substrate (DESIGN.md "Agents"); executed via stage 6.
 - [ ] Per-thread read-state: feed phase 2 cursor design must not preclude
       per-`threadId` high-water marks (mirrored in feed-live-objects TASKS).
 - [ ] Channel management polish: sidebar grouping, membership display

--- a/.agents/projects/feed-live-objects/DESIGN.md
+++ b/.agents/projects/feed-live-objects/DESIGN.md
@@ -130,7 +130,18 @@ swap rather than a rewrite.
   via live objects (#12235), notifications via subscription triggers, read
   state via phase 2, scale via phases 3–4. Needs one new primitive — an
   ephemeral presence/typing channel over EDGE messaging, explicitly not feed
-  blocks. Becomes its own project when work starts.
+  blocks. Became the `chat` project (see `.agents/projects/chat/`).
+- **Agent sessions** (chat stages 5–9; see chat DESIGN.md "Agents"). Agent
+  sessions already live on feeds (every assistant `Chat` has one); what
+  changes is the minting rate — an agent responding in a channel thread gets
+  a session per task, so feeds are created at mention-cadence rather than one
+  per deliberately-created chat. Two touch points: (1) phase 2's
+  trigger/cursor machinery gains a second consumer — agent wake-up (delivery =
+  enqueue into an EDGE-hosted session process), the same subscription
+  primitive as notifications with a different delivery route; (2) pressure on
+  the ~1000 feeds/space budget — concluded session feeds are disposable, so
+  phase 3's retention design should cover whole-feed GC / archival, not only
+  within-feed compaction. Constraints mirrored in TASKS.
 - **Large-source ingestion** (e.g. whole Discord servers): source-cursor
   pipeline (the external cursor, e.g. last snowflake per channel, lives in a
   small ECHO object) emitting signals; add a capped-retention feed buffer only

--- a/.agents/projects/feed-live-objects/TASKS.md
+++ b/.agents/projects/feed-live-objects/TASKS.md
@@ -142,6 +142,10 @@ flagged the default-off guarantee). Also the chat ship gate.
       mechanism to replace `FeedHandle`'s 1s polling; keep polling fallback.
 - [ ] Constraint from chat: do NOT design out per-`threadId` high-water marks
       (per-thread unread); cursor model should permit keyed sub-cursors later.
+- [ ] Constraint from chat stages 5–9: the trigger/subscription machinery
+      gains a second consumer — agent session wake-up (delivery = enqueue
+      into an EDGE-hosted session process, not a notification op); keep the
+      dispatch target pluggable.
 
 ### Phase 3 — retention + epoch chaining
 
@@ -154,6 +158,10 @@ flagged the default-off guarantee). Also the chat ship gate.
       use.
 - [ ] Interaction check: retention vs tombstones (a tombstone must not be
       compacted away while any replica could still hold the live object).
+- [ ] Constraint from chat stages 5–9: agent session-per-thread mints feeds at
+      mention-cadence against the ~1000 feeds/space budget, and concluded
+      session feeds are disposable — retention design should cover whole-feed
+      GC/archival, not only within-feed compaction.
 
 ### Phase 4 — sparse feeds (email-scale partial history)
 


### PR DESCRIPTION
## Summary

Docs-only extension of the first-party chat plan (stacked on #12393), adding stages 5–9 to `.agents/projects/chat/{DESIGN,TASKS}.md` — the agent-integration design worked out in the multi-user agent exploration with @wittjosiah.

### Decisions recorded

- **Assistant `Chat` / `Channel` convergence RESOLVED** (was an open question, leaning parallel): parallel types over one substrate — *a session transcript is not a venue*. `Message`, the feed idiom, the agent turn loop, and the message-surface component kit converge; the types do not.
- **Venue vs. session split**: in a chat the conversation *is* the agent's transcript; in a channel the agent runs a backstage session (its own feed) and replying is an **action** on the venue, recorded in the session feed like a tool call. Same turn loop in both modes; all differences live at the edges (input delivery, output routing, block-render policy).
- **Agent interactions force a thread**; one session per thread (thread = task); response policy = respond-by-default while sole agent subscriber and nobody else addressed, mention-gated otherwise — the private chat is the degenerate case where that's always true.
- **Provenance + progress**: agent venue-messages link to the producing session ("view session" opens it as a plank, joinable for steering); in-thread progress is a provisional tile folded from the session feed's tail — derived state, never feed blocks.
- **Subscription = one primitive, two delivery routes**: per-user thread-membership items (single-writer, Reaction shape); human → notification trigger, agent → session `enqueueMessage`.
- **Placement by venue**: private chat stays client-hosted; channel-bound sessions are EDGE-hosted (same suspendible `AgentProcess`; EDGE trigger on the channel feed as the wake-up).
- **Identity ladder**: stage 5 rides the agent-identity spec's synthetic phase (attribution: `sender.identityDid` on user + agent messages); stage 9's EDGE hosting forces the real-identity phase (agent as space member; long-lived EDGE runtime devices, *not* device-per-session — considered and declined).

### Stages added

5. Identity & attribution groundwork (parallel to 2–4; fixes latent single-user bugs — unstamped senders, per-client agent double-spawn)
6. Interface convergence (assistant chat renders on the plugin-chat kit via block-render policies)
7. Agents in channels v1 (mentions, forced threads, session-per-thread, provenance, progress tile; retires plugin-review's separate `agent-runner`; client-hosted interim)
8. Subscriptions & delivery (extends stage 4)
9. Space-hosted sessions & live activity (EDGE placement, real agent identity, activity pulse, session-feed retention)

Risks recorded: session-per-thread feed budget (~1000 feeds/space), cross-feed ref resolution, session deep-links (the plugin-projects UrlBinding gap), plugin-review/plugin-projects coordination.

No package code touched; registry intentionally untouched to avoid churn against the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArWVpPJztBYyWU1KiTs9mn

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArWVpPJztBYyWU1KiTs9mn)_