### PR TITLE
onboarding: single owner for invitation URL params, fix device-join hang

### DIFF
--- a/.changeset/device-invitation-single-owner.md
+++ b/.changeset/device-invitation-single-owner.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-client': patch
+---
+
+Fix device-invitation links hanging in apps with onboarding: invitation URL params are now consumed by a single owner (`invitationUrlHandler: false` disables the plugin-client/plugin-space navigation handlers so plugin-onboarding owns the flow), an invitation arriving with an existing identity opens the reset-and-join dialog instead of being dropped, navigation-handler failures surface as a toast instead of dying silently, and `dx halo share --open` always prints the invitation code.

--- a/.changeset/device-invitation-single-owner.md
+++ b/.changeset/device-invitation-single-owner.md
@@ -2,4 +2,4 @@
 '@dxos/plugin-client': patch
 ---
 
-Fix device-invitation links hanging in apps with onboarding: invitation URL params are now consumed by a single owner (`invitationUrlHandler: false` disables the plugin-client/plugin-space navigation handlers so plugin-onboarding owns the flow), an invitation arriving with an existing identity opens the reset-and-join dialog instead of being dropped, navigation-handler failures surface as a toast instead of dying silently, and `dx halo share --open` always prints the invitation code.
+Fix device-invitation links hanging in apps with onboarding: invitation URL params are now consumed by a single owner (`invitationUrlHandler: false` disables the plugin-client/plugin-space navigation handlers so plugin-onboarding owns the flow), an invitation arriving with an existing identity opens the reset-and-join dialog instead of being dropped, navigation-handler failures surface as a toast instead of dying silently, and `dx halo share --open` always prints the invitation code and reports browser-launch failures with the invitation URL.

--- a/packages/apps/composer-app/src/plugin-defs.core.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.core.tsx
@@ -73,11 +73,19 @@ export const getCorePlugins = ({
       config,
       services,
       shareableLinkOrigin: origin,
+      // plugin-onboarding owns invitation URL params in Composer.
+      invitationUrlHandler: false,
       onReset: ({ target }) =>
         Effect.sync(() => {
           localStorage.clear();
           if (target === 'deviceInvitation') {
-            window.location.assign(new URL('/?deviceInvitationCode=', window.location.origin));
+            // Carry a pending invitation code across the reset so the join can complete.
+            const url = new URL('/', window.location.origin);
+            url.searchParams.set(
+              'deviceInvitationCode',
+              new URLSearchParams(window.location.search).get('deviceInvitationCode') ?? '',
+            );
+            window.location.assign(url);
           } else if (target === 'recoverIdentity') {
             window.location.assign(new URL('/?recoverIdentity=true', window.location.origin));
           } else {
@@ -102,6 +110,8 @@ export const getCorePlugins = ({
     SpacePlugin({
       observability: true,
       shareableLinkOrigin: origin,
+      // plugin-onboarding owns invitation URL params in Composer.
+      invitationUrlHandler: false,
     }),
     StatusBarPlugin(),
     ThemePlugin({

--- a/packages/plugins/plugin-client/src/ClientPlugin.ts
+++ b/packages/plugins/plugin-client/src/ClientPlugin.ts
@@ -29,8 +29,8 @@ import { type ClientPluginOptions } from '#types';
 
 export const ClientPlugin = Plugin.define<ClientPluginOptions>(meta).pipe(
   AppPlugin.addAppGraphModule({ activate: AppGraphBuilder }),
-  AppPlugin.addNavigationHandlerModule(({ invitationProp }) => ({
-    activate: () => NavigationHandler({ invitationProp }),
+  AppPlugin.addNavigationHandlerModule(({ invitationProp, invitationUrlHandler }) => ({
+    activate: () => NavigationHandler({ invitationProp, invitationUrlHandler }),
   })),
   AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
   AppPlugin.addReactContextModule({ activate: ReactContext }),

--- a/packages/plugins/plugin-client/src/capabilities/navigation-handler/navigation-handler.ts
+++ b/packages/plugins/plugin-client/src/capabilities/navigation-handler/navigation-handler.ts
@@ -5,9 +5,11 @@
 import * as Effect from 'effect/Effect';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
-import { AppCapabilities } from '@dxos/app-toolkit';
+import { AppCapabilities, LayoutOperation } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { log } from '@dxos/log';
+
+import { meta } from '#meta';
 
 import { ClientOperation } from '../../operations';
 
@@ -15,6 +17,8 @@ export type NavigationHandlerOptions = {
   invitationProp?: string;
   tokenProp?: string;
   tokenTypeProp?: string;
+  /** Set false when another plugin (e.g. plugin-onboarding) owns the invitation URL param. */
+  invitationUrlHandler?: boolean;
 };
 
 /**
@@ -26,6 +30,7 @@ export default Capability.makeModule(
     invitationProp = 'deviceInvitationCode',
     tokenProp = 'token',
     tokenTypeProp = 'type',
+    invitationUrlHandler = true,
   }: NavigationHandlerOptions = {}) {
     const capabilities = yield* Capability.Service;
     const operationService = yield* Capability.get(Capabilities.OperationInvoker);
@@ -34,7 +39,7 @@ export default Capability.makeModule(
       Effect.gen(function* () {
         const token = url.searchParams.get(tokenProp);
         const tokenType = url.searchParams.get(tokenTypeProp);
-        const invitationCode = url.searchParams.get(invitationProp);
+        const invitationCode = invitationUrlHandler ? url.searchParams.get(invitationProp) : null;
 
         if (token && tokenType === 'login') {
           log('login token received via navigation');
@@ -47,9 +52,21 @@ export default Capability.makeModule(
           yield* Operation.invoke(ClientOperation.JoinIdentity, { invitationCode });
         }
       }).pipe(
+        Effect.catchAll((error) =>
+          Effect.gen(function* () {
+            log.warn('navigation handler failed', { error });
+            yield* Operation.invoke(LayoutOperation.AddToast, {
+              id: `${meta.profile.key}/navigation-failed`,
+              title: ['navigation-failed-toast.title', { ns: meta.profile.key }],
+              description: ['navigation-failed-toast.description', { ns: meta.profile.key }],
+              icon: 'ph--warning--regular',
+            }).pipe(
+              Effect.catchAll((toastError) => Effect.sync(() => log.warn('failed to add toast', { toastError }))),
+            );
+          }),
+        ),
         Effect.provideService(Capability.Service, capabilities),
         Effect.provideService(Operation.Service, operationService),
-        Effect.orDie,
       );
 
     return Capability.contributes(AppCapabilities.NavigationHandler, handler);

--- a/packages/plugins/plugin-client/src/commands/halo/share/share.ts
+++ b/packages/plugins/plugin-client/src/commands/halo/share/share.ts
@@ -46,12 +46,16 @@ export const handler = Effect.fn(function* ({
             yield* Console.log(`\nSecret: ${authCode} (copied to clipboard)\n`);
           }
 
+          if (!json) {
+            yield* Console.log(`\nInvitation: ${invitationCode}\n`);
+          }
+
           if (open) {
             const url = new URL(host);
             url.searchParams.append('deviceInvitationCode', invitationCode);
-            yield* openBrowser(url.toString()).pipe(Effect.catchAll(() => Effect.void));
-          } else if (!json) {
-            yield* Console.log(`\nInvitation: ${invitationCode}\n`);
+            yield* openBrowser(url.toString()).pipe(
+              Effect.catchAll(() => Console.error(`Failed to open browser: ${url.toString()}`)),
+            );
           }
         }),
     },

--- a/packages/plugins/plugin-client/src/translations.ts
+++ b/packages/plugins/plugin-client/src/translations.ts
@@ -131,6 +131,8 @@ const pluginTranslations = [
         'reset-device.label': 'Reset storage',
         'reset-dialog.description': 'Reset storage',
         'reset-dialog.title': 'Reset storage',
+        'navigation-failed-toast.title': 'Link could not be processed',
+        'navigation-failed-toast.description': 'Something went wrong while handling this link. Please try again.',
       },
     },
   },

--- a/packages/plugins/plugin-client/src/types/schema.ts
+++ b/packages/plugins/plugin-client/src/types/schema.ts
@@ -114,6 +114,13 @@ export type ClientPluginOptions = ClientOptions & {
   invitationProp?: string;
 
   /**
+   * Whether the navigation handler consumes invitation codes from URL query params.
+   * Disable when another plugin (e.g. plugin-onboarding) owns the invitation URL flow.
+   * @default true
+   */
+  invitationUrlHandler?: boolean;
+
+  /**
    * Run after the client has been initialized.
    * Plugin context is provided so capabilities are accessible.
    */

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
@@ -1,0 +1,78 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, onTestFinished, test } from 'vitest';
+
+import { type Capabilities } from '@dxos/app-framework';
+import { Client } from '@dxos/client';
+import { TestBuilder } from '@dxos/client/testing';
+import { type Operation } from '@dxos/compute';
+import { ClientOperation } from '@dxos/plugin-client';
+
+import { OnboardingManager } from './onboarding-manager';
+
+const createClient = async () => {
+  const builder = new TestBuilder();
+  const client = new Client({ services: builder.createLocalClientServices() });
+  await client.initialize();
+  onTestFinished(async () => {
+    await client.destroy();
+    await builder.destroy();
+  });
+  return client;
+};
+
+const createInvoker = () => {
+  const calls: { key: string; input: unknown }[] = [];
+  const invokePromise: Capabilities.OperationInvoker['invokePromise'] = async (operation, ...args) => {
+    calls.push({ key: String(operation.meta.key), input: args[0] });
+    return {};
+  };
+  const getCalls = (operation: Operation.Definition.Any) =>
+    calls.filter((call) => call.key === String(operation.meta.key));
+  return { invokePromise, getCalls };
+};
+
+const createManager = async (options: { identity?: boolean; deviceInvitationCode?: string }) => {
+  const client = await createClient();
+  if (options.identity) {
+    await client.halo.createIdentity();
+  }
+  const { invokePromise, getCalls } = createInvoker();
+  const manager = new OnboardingManager({ invokePromise, client, deviceInvitationCode: options.deviceInvitationCode });
+  onTestFinished(() => manager.destroy());
+  return { manager, getCalls };
+};
+
+// No hubUrl is passed, so auth is skipped — the local/dev Composer configuration.
+describe('OnboardingManager', () => {
+  test('device invitation opens the join flow without auto-creating an identity', async ({ expect }) => {
+    const { manager, getCalls } = await createManager({ deviceInvitationCode: 'test-code' });
+    await manager.initialize();
+
+    expect(getCalls(ClientOperation.JoinIdentity)).toEqual([
+      expect.objectContaining({ input: { invitationCode: 'test-code' } }),
+    ]);
+    expect(getCalls(ClientOperation.CreateIdentity)).toHaveLength(0);
+  });
+
+  test('without a device invitation a fresh identity is created', async ({ expect }) => {
+    const { manager, getCalls } = await createManager({});
+    await manager.initialize();
+
+    expect(getCalls(ClientOperation.CreateIdentity)).toHaveLength(1);
+    expect(getCalls(ClientOperation.JoinIdentity)).toHaveLength(0);
+  });
+
+  test('device invitation with an existing identity opens the reset dialog', async ({ expect }) => {
+    const { manager, getCalls } = await createManager({ identity: true, deviceInvitationCode: 'test-code' });
+    await manager.initialize();
+
+    expect(getCalls(ClientOperation.ResetStorage)).toEqual([
+      expect.objectContaining({ input: { mode: 'join-new-identity' } }),
+    ]);
+    expect(getCalls(ClientOperation.JoinIdentity)).toHaveLength(0);
+    expect(getCalls(ClientOperation.CreateIdentity)).toHaveLength(0);
+  });
+});

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
@@ -12,39 +12,6 @@ import { ClientOperation } from '@dxos/plugin-client';
 
 import { OnboardingManager } from './onboarding-manager';
 
-const createClient = async () => {
-  const builder = new TestBuilder();
-  const client = new Client({ services: builder.createLocalClientServices() });
-  await client.initialize();
-  onTestFinished(async () => {
-    await client.destroy();
-    await builder.destroy();
-  });
-  return client;
-};
-
-const createInvoker = () => {
-  const calls: { key: string; input: unknown }[] = [];
-  const invokePromise: Capabilities.OperationInvoker['invokePromise'] = async (operation, ...args) => {
-    calls.push({ key: String(operation.meta.key), input: args[0] });
-    return {};
-  };
-  const getCalls = (operation: Operation.Definition.Any) =>
-    calls.filter((call) => call.key === String(operation.meta.key));
-  return { invokePromise, getCalls };
-};
-
-const createManager = async (options: { identity?: boolean; deviceInvitationCode?: string }) => {
-  const client = await createClient();
-  if (options.identity) {
-    await client.halo.createIdentity();
-  }
-  const { invokePromise, getCalls } = createInvoker();
-  const manager = new OnboardingManager({ invokePromise, client, deviceInvitationCode: options.deviceInvitationCode });
-  onTestFinished(() => manager.destroy());
-  return { manager, getCalls };
-};
-
 // No hubUrl is passed, so auth is skipped — the local/dev Composer configuration.
 describe('OnboardingManager', () => {
   test('device invitation opens the join flow without auto-creating an identity', async ({ expect }) => {
@@ -65,14 +32,50 @@ describe('OnboardingManager', () => {
     expect(getCalls(ClientOperation.JoinIdentity)).toHaveLength(0);
   });
 
-  test('device invitation with an existing identity opens the reset dialog', async ({ expect }) => {
-    const { manager, getCalls } = await createManager({ identity: true, deviceInvitationCode: 'test-code' });
+  test('device invitation with an existing identity opens the reset dialog and stops', async ({ expect }) => {
+    const { manager, calls } = await createManager({ identity: true, deviceInvitationCode: 'test-code' });
     await manager.initialize();
 
-    expect(getCalls(ClientOperation.ResetStorage)).toEqual([
-      expect.objectContaining({ input: { mode: 'join-new-identity' } }),
+    // The reset confirmation must be the only operation — no recovery/agent provisioning
+    // for an identity the user may be about to abandon.
+    expect(calls).toEqual([
+      expect.objectContaining({
+        key: String(ClientOperation.ResetStorage.meta.key),
+        input: { mode: 'join-new-identity' },
+      }),
     ]);
-    expect(getCalls(ClientOperation.JoinIdentity)).toHaveLength(0);
-    expect(getCalls(ClientOperation.CreateIdentity)).toHaveLength(0);
   });
 });
+
+const createClient = async () => {
+  const builder = new TestBuilder();
+  const client = new Client({ services: builder.createLocalClientServices() });
+  await client.initialize();
+  onTestFinished(async () => {
+    await client.destroy();
+    await builder.destroy();
+  });
+  return client;
+};
+
+const createInvoker = () => {
+  const calls: { key: string; input: unknown }[] = [];
+  const invokePromise: Capabilities.OperationInvoker['invokePromise'] = async (operation, ...args) => {
+    calls.push({ key: String(operation.meta.key), input: args[0] });
+    return {};
+  };
+  const getCalls = (operation: Operation.Definition.Any) =>
+    calls.filter((call) => call.key === String(operation.meta.key));
+  return { invokePromise, getCalls, calls };
+};
+
+const createManager = async (options: { identity?: boolean; deviceInvitationCode?: string }) => {
+  const client = await createClient();
+  if (options.identity) {
+    await client.halo.createIdentity();
+  }
+  const { invokePromise, getCalls, calls } = createInvoker();
+  const manager = new OnboardingManager({ invokePromise, client, deviceInvitationCode: options.deviceInvitationCode });
+  onTestFinished(() => manager.destroy());
+  return { manager, getCalls, calls };
+};

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
@@ -121,12 +121,11 @@ export class OnboardingManager {
     // a "no edge access" warning + request-access form).
     if (this._identity) {
       // A device invitation targets a different identity, so accepting it requires a storage
-      // reset; confirm via the reset dialog rather than dropping the invitation silently.
+      // reset; confirm via the reset dialog rather than dropping the invitation silently. Stop
+      // here — no recovery/agent provisioning for an identity the user may be about to abandon.
       if (this._deviceInvitationCode !== undefined) {
         await this._confirmJoinNewIdentity();
-        if (aborted()) {
-          return;
-        }
+        return;
       }
       // For users who already have a local identity but a fresh `?email=...`
       // URL param: hand it to the redeem endpoint, which is idempotent (the

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
@@ -91,21 +91,21 @@ export class OnboardingManager {
 
     this._identity = this._client.halo.identity.get();
 
-    this._subscriptions.add(
-      this._client.halo.identity.subscribe((identity) => {
-        if (this._destroyed) {
-          return;
-        }
-        const wasNull = this._identity === null;
-        this._identity = identity;
+    const subscription = this._client.halo.identity.subscribe((identity) => {
+      if (this._destroyed) {
+        return;
+      }
+      const wasNull = this._identity === null;
+      this._identity = identity;
 
-        // The gate is identity-presence: the moment a local identity exists, dismiss
-        // the welcome dialog. Account binding / activation can complete asynchronously.
-        if (identity && wasNull) {
-          void this._closeWelcome();
-        }
-      }).unsubscribe,
-    );
+      // The gate is identity-presence: the moment a local identity exists, dismiss
+      // the welcome dialog. Account binding / activation can complete asynchronously.
+      if (identity && wasNull) {
+        void this._closeWelcome();
+      }
+    });
+    // Bound closure: a detached `subscription.unsubscribe` loses its receiver and throws on dispose.
+    this._subscriptions.add(() => subscription.unsubscribe());
   }
 
   async initialize(): Promise<void> {
@@ -120,6 +120,14 @@ export class OnboardingManager {
     // is checked separately on the profile page (where users without an account see
     // a "no edge access" warning + request-access form).
     if (this._identity) {
+      // A device invitation targets a different identity, so accepting it requires a storage
+      // reset; confirm via the reset dialog rather than dropping the invitation silently.
+      if (this._deviceInvitationCode !== undefined) {
+        await this._confirmJoinNewIdentity();
+        if (aborted()) {
+          return;
+        }
+      }
       // For users who already have a local identity but a fresh `?email=...`
       // URL param: hand it to the redeem endpoint, which is idempotent (the
       // server may auto-bind, return a login token, or reject -- we swallow
@@ -359,6 +367,11 @@ export class OnboardingManager {
     }
 
     await this._invokePromise(ClientOperation.CreateAgent);
+  }
+
+  /** The invitation code stays in the URL so it survives the reset reload. */
+  private async _confirmJoinNewIdentity(): Promise<void> {
+    await this._invokePromise(ClientOperation.ResetStorage, { mode: 'join-new-identity' });
   }
 
   private async _openJoinIdentity(): Promise<void> {

--- a/packages/plugins/plugin-onboarding/src/util.ts
+++ b/packages/plugins/plugin-onboarding/src/util.ts
@@ -7,6 +7,9 @@ import { type Client } from '@dxos/react-client';
 import { type Credential } from '@dxos/react-client/halo';
 
 export const removeQueryParamByValue = (valueToRemove: string) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
   const url = new URL(window.location.href);
   const params = Array.from(url.searchParams.entries());
   const match = params.find(([_, value]) => value === valueToRemove);

--- a/packages/plugins/plugin-space/src/SpacePlugin.ts
+++ b/packages/plugins/plugin-space/src/SpacePlugin.ts
@@ -50,8 +50,8 @@ import pluginSpec from '../PLUGIN.mdl?raw';
 
 export const SpacePlugin = Plugin.define<SpacePluginOptions>(meta).pipe(
   AppPlugin.addCreateObjectModule({ activate: CreateObject }),
-  AppPlugin.addNavigationHandlerModule(({ invitationProp }) => ({
-    activate: () => NavigationHandler({ invitationProp }),
+  AppPlugin.addNavigationHandlerModule(({ invitationProp, invitationUrlHandler }) => ({
+    activate: () => NavigationHandler({ invitationProp, invitationUrlHandler }),
   })),
   AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
   AppPlugin.addReactRootModule({ activate: ReactRoot }),

--- a/packages/plugins/plugin-space/src/capabilities/navigation-handler/navigation-handler.ts
+++ b/packages/plugins/plugin-space/src/capabilities/navigation-handler/navigation-handler.ts
@@ -6,16 +6,20 @@ import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
-import { AppCapabilities } from '@dxos/app-toolkit';
+import { AppCapabilities, LayoutOperation } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { Identity } from '@dxos/halo';
 import { log } from '@dxos/log';
 import { HaloServicesLayer } from '@dxos/plugin-client';
 
+import { meta } from '#meta';
+
 import { SpaceOperation } from '../../operations';
 
 export type NavigationHandlerOptions = {
   invitationProp?: string;
+  /** Set false when another plugin (e.g. plugin-onboarding) owns the invitation URL param. */
+  invitationUrlHandler?: boolean;
 };
 
 /**
@@ -23,13 +27,16 @@ export type NavigationHandlerOptions = {
  * Handles ?spaceInvitationCode=X → join space via invitation.
  */
 export default Capability.makeModule(
-  Effect.fnUntraced(function* ({ invitationProp = 'spaceInvitationCode' }: NavigationHandlerOptions = {}) {
+  Effect.fnUntraced(function* ({
+    invitationProp = 'spaceInvitationCode',
+    invitationUrlHandler = true,
+  }: NavigationHandlerOptions = {}) {
     const capabilities = yield* Capability.Service;
     const operationService = yield* Capability.get(Capabilities.OperationInvoker);
 
     const handler: AppCapabilities.NavigationHandler = (url: URL) =>
       Effect.gen(function* () {
-        const invitationCode = url.searchParams.get(invitationProp);
+        const invitationCode = invitationUrlHandler ? url.searchParams.get(invitationProp) : null;
         if (!invitationCode) {
           return;
         }
@@ -44,9 +51,21 @@ export default Capability.makeModule(
         removeQueryParam(invitationProp);
         yield* Operation.invoke(SpaceOperation.Join, { invitationCode });
       }).pipe(
+        Effect.catchAll((error) =>
+          Effect.gen(function* () {
+            log.warn('navigation handler failed', { error });
+            yield* Operation.invoke(LayoutOperation.AddToast, {
+              id: `${meta.profile.key}/navigation-failed`,
+              title: ['navigation-failed-toast.title', { ns: meta.profile.key }],
+              description: ['navigation-failed-toast.description', { ns: meta.profile.key }],
+              icon: 'ph--warning--regular',
+            }).pipe(
+              Effect.catchAll((toastError) => Effect.sync(() => log.warn('failed to add toast', { toastError }))),
+            );
+          }),
+        ),
         Effect.provideService(Capability.Service, capabilities),
         Effect.provideService(Operation.Service, operationService),
-        Effect.orDie,
       );
 
     return Capability.contributes(AppCapabilities.NavigationHandler, handler);

--- a/packages/plugins/plugin-space/src/translations.ts
+++ b/packages/plugins/plugin-space/src/translations.ts
@@ -113,6 +113,8 @@ export const translations = [
       },
       [meta.profile.key]: {
         'plugin.name': 'Spaces',
+        'navigation-failed-toast.title': 'Link could not be processed',
+        'navigation-failed-toast.description': 'Something went wrong while handling this link. Please try again.',
         'add-object.label': 'Add object',
         'first-run.message': 'Nothing selected.',
         'create-space.label': 'Create space',

--- a/packages/plugins/plugin-space/src/types/types.ts
+++ b/packages/plugins/plugin-space/src/types/types.ts
@@ -56,6 +56,13 @@ export type SpacePluginOptions = {
   invitationProp?: string;
 
   /**
+   * Whether the navigation handler consumes invitation codes from URL query params.
+   * Disable when another plugin (e.g. plugin-onboarding) owns the invitation URL flow.
+   * @default true
+   */
+  invitationUrlHandler?: boolean;
+
+  /**
    * Whether to send observability events.
    */
   observability?: boolean;


### PR DESCRIPTION
## Summary

`?deviceInvitationCode=` was consumed by two competing components: plugin-client's navigation handler read the param and **stripped it from the URL** during deck startup, while plugin-onboarding's `OnboardingManager` read `window.location.search` at its (later) activation. In local/dev Composer this meant onboarding never saw the invitation, took its `!identity && skipAuth` branch, and **auto-created a fresh identity mid-join** — the join dialog span on "Connecting…" forever. With an existing identity the whole handler died silently via `Effect.orDie`.

## Changes

- **Single owner where onboarding is present.** New `invitationUrlHandler?: boolean` option on `ClientPluginOptions` and `SpacePluginOptions` gates the navigation-handler consumption of `deviceInvitationCode` / `spaceInvitationCode` (URL-generation via `invitationProp` is unaffected). Composer sets it to `false` for both, making plugin-onboarding the sole consumer; apps without onboarding keep the current behavior.
- **Existing-identity path.** `OnboardingManager.initialize()` now checks `deviceInvitationCode` before the early-return identity branch and opens the reset dialog (`ClientOperation.ResetStorage`, mode `join-new-identity`) instead of dropping the invitation silently. Composer's `onReset` now carries the pending invitation code across the reset reload so the join can complete.
- **No more silent death.** The plugin-client and plugin-space navigation handlers replace `Effect.orDie` with `catchAll` → `log.warn` + a user-visible toast.
- **CLI.** `dx halo share --open` always prints the invitation code, and a browser-launch failure prints a warning instead of being swallowed.
- **Latent teardown bug.** The manager stored a detached `subscription.unsubscribe`, which threw `Cannot read properties of undefined (reading '_state')` on every destroy; now wrapped in a bound closure (surfaced by the new tests).

## Tests

New `onboarding-manager.test.ts` (real `Client` via `TestBuilder`, recording invoker):
1. device invitation + no identity + skipAuth → `JoinIdentity` invoked, `CreateIdentity` **not** invoked (the regression);
2. no invitation + skipAuth → `CreateIdentity` still invoked;
3. device invitation + existing identity → `ResetStorage` (`join-new-identity`) invoked, no join/create.

Build, lint, and test suites for plugin-client / plugin-space / plugin-onboarding / composer-app are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device-invitation handling for existing identities, including reset-and-join flows that preserve invitation codes.
  * Invitation links are now consumed consistently, with onboarding controls to prevent unintended handling.
  * Navigation failures now display a warning notification instead of terminating silently.
  * Invitation codes are consistently shown when sharing, including when opening a browser.
  * Browser-opening failures now report the affected link.
* **Configuration**
  * Added options to enable or disable invitation URL handling for client and space experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->