### PR TITLE
agents: unify $project sentinel, harden session-start worktree safety

### DIFF
--- a/.agents/skills/task-planning/SKILL.md
+++ b/.agents/skills/task-planning/SKILL.md
@@ -89,7 +89,9 @@ user; if more than one is active, ask which (list them numbered) — never a gue
 > runs in a fresh harness-assigned worktree, and a project's original branch is
 > typically already merged to `main`, so there is nothing stable to match. On
 > resume, **never warn about a worktree/branch "mismatch"** — a fresh worktree is
-> the expected state — and **never leave the assigned worktree to chase the
+> the expected state. This waives only the project-vs-session comparison; the
+> AGENTS.md branch-safety gate (verify toplevel + branch, never edit on `main`)
+> still applies in full. And **never leave the assigned worktree to chase the
 > project's old one**: do not `cd` into, edit in, or adopt another worktree or
 > branch as a working directory. If unmerged prior work lives elsewhere, report
 > where it is and ask the user; continuing the work-stream always happens in
@@ -176,9 +178,12 @@ original doc). The two verbs are the explicit checkpoint/reload actions.
 
 ### `$project resume` — reload at the start of a session
 
-1. **Stay put** — resume continues the work-stream in **this session's assigned
-   worktree**; never `cd` into or adopt the project's previous worktree/branch.
-   If unmerged prior work lives elsewhere, report it and ask the user.
+1. **Stay put, on a safe branch** — first confirm the branch-safety gate
+   (`SESSION CONTEXT` verdict, or the AGENTS.md start-of-session check: non-`main`
+   branch → proceed, `main` → stop). Resume continues the work-stream in **this
+   session's assigned worktree**; never `cd` into or adopt the project's previous
+   worktree/branch. If unmerged prior work lives elsewhere, report it and ask
+   the user.
 2. **Read** the active `TASKS.md` (and any doc it links); memory is already
    loaded.
 3. **Check the tree** — `git status` + recent `git log`; surface uncommitted work

--- a/.agents/skills/task-planning/SKILL.md
+++ b/.agents/skills/task-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-planning
-description: Use when work spans multiple steps, phases, or sessions, when resuming a task started earlier, when the user asks for a plan/roadmap/progress tracking, or when they use the `$project` sentinel (any verb — list, new, end, track, hydrate, resume — or a legacy `$track`/`$hydrate`/`$resume` form). Covers the project registry (`.agents/projects/registry.yml`), maintaining a durable TASKS.md + DESIGN.md per work-stream, and checkpointing/reloading project state across sessions and PRs.
+description: Use when work spans multiple steps, phases, or sessions, when resuming a task started earlier, when the user asks for a plan/roadmap/progress tracking, or when they use the `$project` sentinel (any verb — list, new, end, track, hydrate, resume — or a legacy `$track`/`$hydrate`/`$checkpoint`/`$resume`/`$rehydrate` form). Covers the project registry (`.agents/projects/registry.yml`), maintaining a durable TASKS.md + DESIGN.md per work-stream, and checkpointing/reloading project state across sessions and PRs.
 ---
 
 # Task Planning

--- a/.agents/skills/task-planning/SKILL.md
+++ b/.agents/skills/task-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-planning
-description: Use when work spans multiple steps, phases, or sessions, when resuming a task started earlier, when the user asks for a plan/roadmap/progress tracking, or when they use the `$track` / `track:`, `$hydrate`, `$resume`, or `$project` sentinel. Covers the project registry (`.agents/projects/registry.yml`), maintaining a durable TASKS.md + DESIGN.md per work-stream, and checkpointing/reloading project state across sessions and PRs.
+description: Use when work spans multiple steps, phases, or sessions, when resuming a task started earlier, when the user asks for a plan/roadmap/progress tracking, or when they use the `$project` sentinel (any verb — list, new, end, track, hydrate, resume — or a legacy `$track`/`$hydrate`/`$resume` form). Covers the project registry (`.agents/projects/registry.yml`), maintaining a durable TASKS.md + DESIGN.md per work-stream, and checkpointing/reloading project state across sessions and PRs.
 ---
 
 # Task Planning
@@ -52,64 +52,57 @@ ended: []
 
 ### The `$project` sentinel
 
-- `$project` (bare) or `$project list` — render the active projects as a
+Desktop clients don't expose custom slash commands, so the **single** task-planning
+sentinel is `$project VERB [ARGS]` anywhere in a normal message. A
+`UserPromptSubmit` hook (`.claude/hooks/track.sh`) detects it and injects the
+matching directive; when you see one, follow it and confirm in one short line.
+
+- `$project` (bare) or `$project list [all]` — render the active projects as a
   **numbered markdown table**: the first column is a 1-based row number, followed
   by `name`, `status`, `user`, `host`, and a one-line summary. **By default show
-  only the current user's projects** (`user` == `whoami`); `$project list all`
-  (or `$project all`) lists every user. Then tell the user they can reply with a
-  row number to resume that project. **A lone number in the user's next message
-  means "resume the project at that row"** — run the "Project handoff" → resume
-  steps for that entry (equivalent to `$resume <that name>`).
+  only the current user's projects** (`user` == `whoami`); `list all` lists every
+  user. Then tell the user they can reply with a row number to resume that
+  project. **A lone number in the user's next message means "resume the project
+  at that row"** — run the "Project handoff" → resume steps for that entry.
 - `$project new <name> [summary]` — add an `active` entry (`user` = `whoami`,
   `host` = `hostname -s`); scaffold `.agents/projects/<name>/{TASKS.md,DESIGN.md}`
   unless the docs already live somewhere (record that path instead). Confirm in
   one line.
 - `$project end <name>` — move the entry to `ended`, recording the final PR/status.
+- `$project track <text>` — record `<text>` as a follow-up in the active
+  `TASKS.md` (never a background task chip).
+- `$project hydrate` (alias `checkpoint`) — **checkpoint** the project before
+  stopping or opening a PR (see "Project handoff").
+- `$project resume [name]` (alias `rehydrate`) — **reload** project state at the
+  start of a session (see "Project handoff").
 
-`$resume` / `$hydrate` (see "Project handoff") key off this registry: **which
-project** is resolved by name (`$resume <name>`) or by the row number from the
-most recent `$project` table. With no argument, fall back to the single `active`
-entry for the current user; if more than one is active, ask which (list them
-numbered) — never a guess.
+Legacy forms (`$track <text>` / `track:` lines, `$hydrate`, `$checkpoint`,
+`$resume`, `$rehydrate`) still map to the same directives; nudge toward the
+`$project <verb>` form once.
+
+`resume` / `hydrate` key off the registry: **which project** is resolved by name
+(`$project resume <name>`) or by the row number from the most recent `$project`
+table. With no argument, fall back to the single `active` entry for the current
+user; if more than one is active, ask which (list them numbered) — never a guess.
 
 > The registry deliberately does **not** record a branch/worktree. Each session
 > runs in a fresh harness-assigned worktree, and a project's original branch is
 > typically already merged to `main`, so there is nothing stable to match. On
 > resume, **never warn about a worktree/branch "mismatch"** — a fresh worktree is
-> the expected state; just continue the work-stream from it.
+> the expected state — and **never leave the assigned worktree to chase the
+> project's old one**: do not `cd` into, edit in, or adopt another worktree or
+> branch as a working directory. If unmerged prior work lives elsewhere, report
+> where it is and ask the user; continuing the work-stream always happens in
+> this session's own worktree.
 
 ## When to Use
 
 - Work spans **3+ distinct steps**, multiple files, or phases.
 - The task will likely outlive one session (you'll resume it later).
 - The user asks for a plan, roadmap, or to track progress.
-- The user uses the **`$track` / `track:` sentinel** (see below) — always record
-  the item, never a task chip.
+- The user uses **`$project track <text>`** — always record the item, never a
+  task chip.
 - You are resuming work — read the existing `TASKS.md` first to reload state.
-
-### The `$track` sentinel
-
-Desktop clients don't expose custom slash commands, so an explicit
-track request is a sentinel in a normal message:
-
-- `$track <text>` anywhere in a message, or
-- a line beginning `track: <text>`.
-
-A `UserPromptSubmit` hook (`.claude/hooks/track.sh`) detects it and injects a
-directive to append `<text>` to the active `TASKS.md`. When you see that
-directive, add the item and confirm in one line.
-
-### The `$hydrate` / `$resume` sentinels
-
-The same hook detects two project-handoff sentinels (see "Project handoff"
-below for what each does):
-
-- `$hydrate` (also `$checkpoint`) — **checkpoint** the project before you stop or
-  open a PR: reconcile `TASKS.md`, refresh the resume pointer, account for
-  uncommitted work.
-- `$resume` (also `$rehydrate`) — **reload** state at the start of a session:
-  read `TASKS.md` + any linked doc, check `git status`, report where things
-  stand, then continue.
 
 **When NOT to use:**
 
@@ -160,12 +153,12 @@ Short paragraph of context — what this phase delivers and why.
 5. **Commit it** — `TASKS.md` is committed alongside the work it tracks. Do not
    leave it as an uncommitted local edit (see "commit nothing silently").
 
-## Project handoff (`$hydrate` / `$resume`)
+## Project handoff (`$project hydrate` / `$project resume`)
 
 `TASKS.md` is the handoff medium — no separate `HANDOFF.md` (keep plans in the
-original doc). The two sentinels are the explicit checkpoint/reload verbs.
+original doc). The two verbs are the explicit checkpoint/reload actions.
 
-### `$hydrate` — checkpoint before stopping or opening a PR
+### `$project hydrate` — checkpoint before stopping or opening a PR
 
 1. **Reconcile `TASKS.md`** — check off what's done; add a one-line status note to
    each in-progress item (what's blocked, what's next).
@@ -181,14 +174,17 @@ original doc). The two sentinels are the explicit checkpoint/reload verbs.
 5. **Confirm** the checkpoint in one short block (done / in-progress / next /
    uncommitted).
 
-### `$resume` — reload at the start of a session
+### `$project resume` — reload at the start of a session
 
-1. **Read** the active `TASKS.md` (and any doc it links); memory is already
+1. **Stay put** — resume continues the work-stream in **this session's assigned
+   worktree**; never `cd` into or adopt the project's previous worktree/branch.
+   If unmerged prior work lives elsewhere, report it and ask the user.
+2. **Read** the active `TASKS.md` (and any doc it links); memory is already
    loaded.
-2. **Check the tree** — `git status` + recent `git log`; surface uncommitted work
+3. **Check the tree** — `git status` + recent `git log`; surface uncommitted work
    and the last commits.
-3. **Report** a concise state: done / in-progress / **next action** / uncommitted.
-4. **Continue** with the next action, or wait for direction if the user gave any.
+4. **Report** a concise state: done / in-progress / **next action** / uncommitted.
+5. **Continue** with the next action, or wait for direction if the user gave any.
 
 ## Viewing
 

--- a/.agents/skills/task-planning/TASKS.md
+++ b/.agents/skills/task-planning/TASKS.md
@@ -1,6 +1,6 @@
 # task-planning Skill — Tasks
 
-_Resume: commit the `$session`→`$project` rename + `$project` picker (5 files). Uncommitted: SKILL.md, TASKS.md, .claude/CLAUDE.md, .claude/hooks/track.sh, AGENTS.md, and the `.agents/sessions`→`.agents/projects` rename. Last: renamed the sentinel/concept and added the numbered pick-to-resume table._
+_Resume: test the skill in a new repo (see Follow-ups). Uncommitted: none. Last: unified all sentinels under `$project VERB [ARGS]` and hardened session-start safety._
 
 ## Sentinel rename + picker
 
@@ -17,6 +17,27 @@ resume from by row number.
 - [x] **`$project` picker** — bare `$project`/`$project list` renders a numbered
       markdown table; replying with a row number resumes that project (in-context, no
       bare-number hook). Verified hook fires on bare/`list`/`new`, silent on `$projects`.
+
+## Unified `$project VERB` sentinel + session-start hardening (2026-08-01)
+
+One sentinel for everything: `$project VERB [ARGS]` (list | new | end | track |
+hydrate | resume); legacy `$track`/`$hydrate`/`$resume` map with a nudge. Resume
+gained an explicit "stay in the assigned worktree" rule after a real session
+adopted another project's worktree via `$resume`.
+
+### Tasks
+
+- [x] **Unify sentinels under `$project`** — track.sh rewrite (verb dispatch,
+      punctuation-safe parsing, soft unknown-verb directive), SKILL.md,
+      .claude/CLAUDE.md. Verified all verbs + legacy forms + prose false-fire.
+- [x] **Resume never leaves the assigned worktree** — rule added to the registry
+      note, the resume steps, and the injected resume directive.
+- [x] **CPD fallback harmonized** — all four hook commands in
+      .claude/settings.json now fall back to `git rev-parse --show-toplevel`.
+- [x] **Global session-start layer** (`~/.claude/hooks/`, outside the repo) —
+      session-context.sh (SessionStart verdict injection), branch-beacon.sh
+      (silent-unless-drifted UserPromptSubmit), dxos-gated guard mirrors;
+      motivated by stub worktrees that load no project files at all.
 
 ## Follow-ups
 

--- a/.agents/skills/task-planning/TASKS.md
+++ b/.agents/skills/task-planning/TASKS.md
@@ -21,7 +21,8 @@ resume from by row number.
 ## Unified `$project VERB` sentinel + session-start hardening (2026-08-01)
 
 One sentinel for everything: `$project VERB [ARGS]` (list | new | end | track |
-hydrate | resume); legacy `$track`/`$hydrate`/`$resume` map with a nudge. Resume
+hydrate | resume); legacy `$track`/`$hydrate`/`$checkpoint`/`$resume`/`$rehydrate`
+map with a nudge. Resume
 gained an explicit "stay in the assigned worktree" rule after a real session
 adopted another project's worktree via `$resume`.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,17 +17,19 @@
 
 ## Task planning
 
-- Record a follow-up task with the `$track <text>` sentinel (anywhere in a
-  message) or a line beginning `track: <text>`.
-- Manage the project registry (`.agents/projects/registry.yml`) with
-  `$project new|list|end <name>`; each project has a `TASKS.md` + `DESIGN.md`.
-  Bare `$project` (or `$project list`) prints a numbered table of the current
-  user's projects (`list all` for everyone) — reply with a row number to resume.
-- Checkpoint project state with `$hydrate` (also `$checkpoint`) before stopping
-  or opening a PR; reload a project with `$resume [name]` (also `$rehydrate`) at
-  the start of a session — the registry resolves _which_ project (by name/row,
-  else the single active entry for the current user).
-- A `UserPromptSubmit` hook (`.claude/hooks/track.sh`) detects these and injects
-  the matching directive — append to the active `TASKS.md` (never a background
-  task chip), manage the registry, or run the hydrate/resume handoff. See the
-  `task-planning` skill for the file format, workflow, registry, and handoff steps.
+- One sentinel: `$project VERB [ARGS]` anywhere in a message; a
+  `UserPromptSubmit` hook (`.claude/hooks/track.sh`) detects it and injects the
+  matching directive.
+  - `$project` / `$project list [all]` — numbered table of the registry
+    (`.agents/projects/registry.yml`); reply with a row number to resume.
+  - `$project new <name> [summary]` / `$project end <name>` — manage entries;
+    each project has a `TASKS.md` + `DESIGN.md`.
+  - `$project track <text>` — record a follow-up in the active `TASKS.md`
+    (never a background task chip).
+  - `$project hydrate` (alias `checkpoint`) — checkpoint before stopping or
+    opening a PR.
+  - `$project resume [name]` — reload state at session start, always in the
+    session's assigned worktree.
+- Legacy `$track`/`$hydrate`/`$resume` forms map to the same directives.
+- See the `task-planning` skill for the file format, workflow, registry, and
+  handoff steps.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,6 +30,7 @@
     opening a PR.
   - `$project resume [name]` — reload state at session start, always in the
     session's assigned worktree.
-- Legacy `$track`/`$hydrate`/`$resume` forms map to the same directives.
+- Legacy `$track`/`$hydrate`/`$checkpoint`/`$resume`/`$rehydrate` forms map to
+  the same directives.
 - See the `task-planning` skill for the file format, workflow, registry, and
   handoff steps.

--- a/.claude/hooks/track.sh
+++ b/.claude/hooks/track.sh
@@ -2,15 +2,17 @@
 #
 # Copyright 2026 DXOS.org
 #
-# UserPromptSubmit hook for the task-planning sentinels.
+# UserPromptSubmit hook for the unified `$project` sentinel (task-planning skill).
 #
-# 1. `$track <text>` (anywhere) or a line beginning `track: <text>` — record <text>
-#    as a follow-up in the active TASKS.md (see the task-planning skill).
-# 2. `$hydrate` / `$checkpoint` — checkpoint the current project (reconcile TASKS.md,
-#    refresh the registry resume pointer, account for uncommitted work).
-# 3. `$resume [name]` / `$rehydrate` — reload a project (from the registry) and report.
-# 4. `$project [new|list|end …]` — manage the project registry; bare `$project`
-#    (or `list`) prints a numbered table you resume from by replying with a row number.
+# Grammar: `$project [VERB] [ARGS]` anywhere in the message.
+#   (bare) | list [all]   -> numbered table of the registry
+#   new <name> [summary]  -> add an active entry + scaffold docs
+#   end <name>            -> move the entry to ended
+#   track <text>          -> record <text> in the active TASKS.md
+#   hydrate | checkpoint  -> checkpoint the current project
+#   resume [name]         -> reload a project and report (rehydrate = alias)
+# Legacy sentinels ($track, $hydrate, $checkpoint, $resume, $rehydrate, and
+# `track:` lines) map to the same directives with a nudge toward the new form.
 # Stateless: emits one directive per matching sentinel and nothing otherwise.
 
 set -euo pipefail
@@ -18,40 +20,98 @@ set -euo pipefail
 input=$(cat)
 prompt=$(printf '%s' "$input" | jq -r '.prompt // empty' 2>/dev/null || printf '')
 
-# `$track ...` (whitespace required after, so `$tracking`/`$tracked` don't match)
-# anywhere, or a line starting with `track: ...`.
+legacy_note=''
+
+emit_list() {
+  printf 'TASK-PLANNING PROJECT DIRECTIVE: `$project list` — args: "%s". Operate on .agents/projects/registry.yml per the task-planning skill. Render the active projects as a markdown table whose FIRST column is a 1-based row number (# | name | status | user | host | one-line summary). BY DEFAULT show only projects whose `user` matches the current user (run `whoami`); if none match, say so and show all. Args `all`: list every user. Then tell the user they can reply with a row number to resume that project — a lone number in their next message means "resume the project at that row" (same as `$project resume <name>`). Confirm in one short line.\n' "$1"
+}
+
+emit_new() {
+  printf 'TASK-PLANNING PROJECT DIRECTIVE: `$project new` — args: "%s". Per the task-planning skill, add an active entry to .agents/projects/registry.yml (user = `whoami`, host = `hostname -s`) and scaffold .agents/projects/<name>/{TASKS,DESIGN}.md unless the docs already live elsewhere (record that path instead). Confirm in one line.\n' "$1"
+}
+
+emit_end() {
+  printf 'TASK-PLANNING PROJECT DIRECTIVE: `$project end` — args: "%s". Per the task-planning skill, move the entry to `ended` in .agents/projects/registry.yml, recording the final PR/status. Confirm in one line.\n' "$1"
+}
+
+emit_track() {
+  printf 'TASK-PLANNING DIRECTIVE: `$project track`%s. Record this follow-up in the TASKS.md of the current unit of work (package or directory) per the task-planning skill — do NOT use a background task chip. Item: "%s". Confirm in one short line.\n' "$legacy_note" "$1"
+}
+
+emit_hydrate() {
+  printf 'TASK-PLANNING HYDRATE: `$project hydrate`%s. Follow the task-planning skill "Project handoff" -> hydrate: identify the CURRENT project (the single `active` .agents/projects/registry.yml entry for the current user; if more than one, ask which), reconcile its TASKS.md (check off done, note next step on in-progress items), update its `resume:` field + the doc resume pointer, push decisions into its DESIGN.md and durable direction to memory, run git status and account for EVERY uncommitted file, then confirm the checkpoint in one short block (done / in-progress / next / uncommitted).\n' "$legacy_note"
+}
+
+emit_resume() {
+  printf 'TASK-PLANNING RESUME: `$project resume`%s. Follow the task-planning skill "Project handoff" -> resume: pick the project from .agents/projects/registry.yml — %s. Stay in this session'\''s assigned worktree: NEVER cd into, edit in, or adopt another project'\''s worktree or branch — if the prior work lives on an unmerged branch elsewhere, report that and ask the user instead of following it. Read the project'\''s `tasks` (TASKS.md) + `design` doc (memory is already loaded), check git status + recent git log, report a concise state (done / in-progress / next action / uncommitted), then continue with the next action unless the user directed otherwise.\n' \
+    "$legacy_note" "$1"
+}
+
+# --- unified `$project` sentinel ---------------------------------------------
+
+raw=$(printf '%s\n' "$prompt" | grep -ioE '\$project([[:space:]]+[^[:cntrl:]]*)?' | head -1 || true)
+
+if [ -n "${raw:-}" ]; then
+  args=$(printf '%s' "$raw" | sed -E 's/^\$project[[:space:]]*//I')
+  verb=$(printf '%s' "$args" | awk '{print tolower($1)}' | tr -cd 'a-z')
+  rest=$(printf '%s' "$args" | sed -E 's/^[^[:space:]]+[[:space:]]*//')
+
+  case "$verb" in
+    '' | list)
+      emit_list "$(printf '%s' "$rest" | tr -cd 'a-zA-Z0-9 -')"
+      ;;
+    new)
+      emit_new "$rest"
+      ;;
+    end)
+      emit_end "$rest"
+      ;;
+    track)
+      emit_track "$rest"
+      ;;
+    hydrate | checkpoint)
+      emit_hydrate
+      ;;
+    resume | rehydrate)
+      name=$(printf '%s' "$rest" | grep -ioE '^[a-z0-9][a-z0-9-]*' || true)
+      if [ -n "${name:-}" ]; then
+        emit_resume "by name \"$name\""
+      else
+        emit_resume 'the single active entry for the current user (ask if more than one)'
+      fi
+      ;;
+    *)
+      printf 'TASK-PLANNING: `$project %s` — verb not recognized (valid: list | new <name> | end <name> | track <text> | hydrate | resume [name]). If the user intended a command, ask which; if the mention was just prose, ignore this directive.\n' "$verb"
+      ;;
+  esac
+fi
+
+# --- legacy sentinels (map to the unified grammar with a nudge) ---------------
+
+legacy_note=' (legacy sentinel — the current form is `$project <verb>`; mention this once)'
+
 task=$(printf '%s\n' "$prompt" \
   | grep -ioE '(\$track[[:space:]]+|^[[:space:]]*track:)[[:space:]]*.*' \
   | head -1 \
   | sed -E 's/^[[:space:]]*(\$track|track:)[[:space:]]*//I' || true)
-
 if [ -n "${task:-}" ]; then
-  printf 'TASK-PLANNING DIRECTIVE: the user used the track sentinel. Record this follow-up in the TASKS.md of the current unit of work (package or directory) per the task-planning skill — do NOT use a background task chip. Item: "%s". Confirm in one short line.\n' "$task"
+  emit_track "$task"
 fi
 
-# `$project [new|list|end …]` — bare `$project` (or `$project list`) lists the
-# registry; capture any verb + args (empty for a bare list).
-if printf '%s\n' "$prompt" | grep -iqE '\$project([[:space:]]|$)'; then
-  project_args=$(printf '%s\n' "$prompt" \
-    | grep -ioE '\$project[[:space:]]+[^[:space:]].*' \
-    | head -1 \
-    | sed -E 's/^.*\$project[[:space:]]+//I' || true)
-  printf 'TASK-PLANNING PROJECT DIRECTIVE: the user used the $project sentinel — args: "%s". Per the task-planning skill "Projects (registry)", operate on .agents/projects/registry.yml. Empty args or `list`: render the active projects as a markdown table whose FIRST column is a 1-based row number (# | name | status | user | host | one-line summary). BY DEFAULT show only projects whose `user` matches the current user (run `whoami`); if none match, say so and show all. `list all` (or `all`) lists every user. Then tell the user they can reply with a row number to resume that project — a lone number in their next message means "resume the project at that row", which runs the "Project handoff" → resume steps for that entry (same as $resume <name>). `new <name> [summary]`: add an active entry (user = `whoami`, host = `hostname -s`) and scaffold .agents/projects/<name>/{TASKS,DESIGN}.md unless the docs already live elsewhere. `end <name>`: move it to ended with the final PR/status. Confirm in one short line.\n' "$project_args"
-fi
-
-# Session-handoff sentinels (require the `$` prefix + a word boundary so the plain
-# words "hydrate"/"resume" in prose don't trigger).
 if printf '%s\n' "$prompt" | grep -iqE '\$(hydrate|checkpoint)([[:space:]]|$)'; then
-  printf 'TASK-PLANNING HYDRATE: the user used the $hydrate sentinel. Follow the task-planning skill "Project handoff" → hydrate: identify the CURRENT project (the single `active` .agents/projects/registry.yml entry for the current user; if more than one, ask which), reconcile its TASKS.md (check off done, note next step on in-progress items), update its `resume:` field + the doc resume pointer, push decisions into its DESIGN.md and durable direction to memory, run git status and account for EVERY uncommitted file, then confirm the checkpoint in one short block (done / in-progress / next / uncommitted).\n'
+  emit_hydrate
 fi
-
-# `$resume [name]` — optional project name argument.
-resume_name=$(printf '%s\n' "$prompt" \
-  | grep -ioE '\$(resume|rehydrate)[[:space:]]+[a-z0-9][a-z0-9-]*' \
-  | head -1 \
-  | sed -E 's/^.*\$(resume|rehydrate)[[:space:]]+//I' || true)
 
 if printf '%s\n' "$prompt" | grep -iqE '\$(resume|rehydrate)([[:space:]]|$)'; then
-  printf 'TASK-PLANNING RESUME: the user used the $resume sentinel. Follow the task-planning skill "Project handoff" → resume: pick the project from .agents/projects/registry.yml — %s. Read its `tasks` (TASKS.md) + `design` doc (memory is already loaded), check git status + recent git log, report a concise state (done / in-progress / next action / uncommitted), then continue with the next action unless the user directed otherwise.\n' \
-    "$( [ -n "${resume_name:-}" ] && printf 'by name "%s"' "$resume_name" || printf 'the single active entry for the current user (ask if more than one)' )"
+  resume_name=$(printf '%s\n' "$prompt" \
+    | grep -ioE '\$(resume|rehydrate)[[:space:]]+[a-z0-9][a-z0-9-]*' \
+    | head -1 \
+    | sed -E 's/^.*\$(resume|rehydrate)[[:space:]]+//I' || true)
+  if [ -n "${resume_name:-}" ]; then
+    emit_resume "by name \"$resume_name\""
+  else
+    emit_resume 'the single active entry for the current user (ask if more than one)'
+  fi
 fi
+
+exit 0

--- a/.claude/hooks/track.sh
+++ b/.claude/hooks/track.sh
@@ -23,7 +23,7 @@ prompt=$(printf '%s' "$input" | jq -r '.prompt // empty' 2>/dev/null || printf '
 legacy_note=''
 
 emit_list() {
-  printf 'TASK-PLANNING PROJECT DIRECTIVE: `$project list` — args: "%s". Operate on .agents/projects/registry.yml per the task-planning skill. Render the active projects as a markdown table whose FIRST column is a 1-based row number (# | name | status | user | host | one-line summary). BY DEFAULT show only projects whose `user` matches the current user (run `whoami`); if none match, say so and show all. Args `all`: list every user. Then tell the user they can reply with a row number to resume that project — a lone number in their next message means "resume the project at that row" (same as `$project resume <name>`). Confirm in one short line.\n' "$1"
+  printf 'TASK-PLANNING PROJECT DIRECTIVE: `$project list` — args: "%s". Operate on .agents/projects/registry.yml per the task-planning skill. Render the active projects as a markdown table whose FIRST column is a 1-based row number (# | name | status | user | host | one-line summary). BY DEFAULT show only projects whose `user` matches the current user (run `whoami`); if none match, say so and mention `$project list all` — do not show other users unasked. Args `all`: list every user. Then tell the user they can reply with a row number to resume that project — a lone number in their next message means "resume the project at that row" (same as `$project resume <name>`). Confirm in one short line.\n' "$1"
 }
 
 emit_new() {
@@ -49,7 +49,9 @@ emit_resume() {
 
 # --- unified `$project` sentinel ---------------------------------------------
 
-raw=$(printf '%s\n' "$prompt" | grep -ioE '\$project([[:space:]]+[^[:cntrl:]]*)?' | head -1 || true)
+# Boundary rule: `$project` must not be followed by an identifier char, so
+# `$projects` is prose, while `$project`, `$project list`, and `($project)` fire.
+raw=$(printf '%s\n' "$prompt" | grep -ioE '\$project($|[^a-zA-Z0-9_][^[:cntrl:]]*)' | head -1 || true)
 
 if [ -n "${raw:-}" ]; then
   args=$(printf '%s' "$raw" | sed -E 's/^\$project[[:space:]]*//I')
@@ -98,11 +100,13 @@ if [ -n "${task:-}" ]; then
   emit_track "$task"
 fi
 
-if printf '%s\n' "$prompt" | grep -iqE '\$(hydrate|checkpoint)([[:space:]]|$)'; then
+# Same boundary rule as `$project`: punctuation after the word is fine
+# (`$hydrate,`), identifier continuations are not (`$hydrated`).
+if printf '%s\n' "$prompt" | grep -iqE '\$(hydrate|checkpoint)($|[^a-zA-Z0-9_])'; then
   emit_hydrate
 fi
 
-if printf '%s\n' "$prompt" | grep -iqE '\$(resume|rehydrate)([[:space:]]|$)'; then
+if printf '%s\n' "$prompt" | grep -iqE '\$(resume|rehydrate)($|[^a-zA-Z0-9_])'; then
   resume_name=$(printf '%s\n' "$prompt" \
     | grep -ioE '\$(resume|rehydrate)[[:space:]]+[a-z0-9][a-z0-9-]*' \
     | head -1 \

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-branch.sh\"",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}/.claude/hooks/guard-branch.sh\"",
             "statusMessage": "Checking branch/worktree safety"
           }
         ]
@@ -37,11 +37,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/response-mode.sh\""
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}/.claude/hooks/response-mode.sh\""
           },
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/track.sh\""
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}/.claude/hooks/track.sh\""
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,31 +8,22 @@ This file is the shared, harness-agnostic entrypoint for coding agents.
 
 ## Start of session
 
-- **MANDATORY FIRST ACTION — check the branch before any file op. The branch, not
-  the directory, decides whether editing is safe.** The harness assigns this
-  session a branch and a worktree, but ~10% of the time it mis-instantiates them:
-  the assigned `claude/…` branch gets checked out at the _primary checkout_ while
-  the worktree path is left an empty `.claude`/`.moon` stub. Editing at the primary
-  checkout is still safe **as long as HEAD is your assigned branch** — your commits
-  land there, not on `main`. The bare-root path does NOT by itself mean `main`.
-  Before reading, editing, or running anything, run:
+- On the Claude harness, a global `SessionStart` hook injects a `SESSION CONTEXT`
+  block (cwd, toplevel, branch, verdict) — trust it and follow its directive. If
+  no such block is present (other harnesses), run this before any file op:
   ```
   git rev-parse --show-toplevel && git branch --show-current
   ```
-  - **On a `claude/…` (or any non-`main`) branch → proceed.** Edits are data-safe
-    even if `--show-toplevel` is the primary checkout instead of
-    `.../.claude/worktrees/<name>`. If the path is not the assigned worktree, say
-    so once: that only affects whether the Desktop UI tracks the session
-    (recoverable), not data safety. Do NOT run `git worktree add <path> <branch>`
-    to "fix" it — the branch is already checked out, so that command fails (and the
-    `git worktree add` guard denies it anyway). If UI pairing matters, ask the user
-    to work-in-place or restart the session; do not halt the task over it.
-  - **On `main` → STOP, write nothing, tell the user.** Only here do edits pollute
-    the shared branch irreversibly. Do not create a worktree or branch to escape
-    (the harness owns those) — ask the user how to proceed.
-- Confirm you understand these instructions and list the guidance files you are
-  aware of (this file, `.claude/CLAUDE.md`, relevant `.agents/skills/*`).
-- State the branch and the `--show-toplevel` path you are operating on.
+- **The branch, not the directory, decides whether editing is safe:**
+  - Non-`main` branch (normally `claude/…`) → proceed — even if the toplevel is
+    the primary checkout instead of the assigned worktree (a known harness
+    mis-instantiation; say so once — it affects only Desktop UI pairing, never
+    data safety). Never run `git worktree add` to "fix" it.
+  - `main` → STOP, write nothing, tell the user. Never create a worktree or
+    branch to escape — the harness owns those.
+- First reply: confirm these instructions, state the branch + toplevel path, and
+  list the guidance files in play (this file, `.claude/CLAUDE.md`, relevant
+  `.agents/skills/*`).
 - When asking a question, make it yes/no or give numbered options — never an
   unnumbered a-or-b.
 - If unsure how to implement something, ask rather than guess.


### PR DESCRIPTION
## What

Session-startup discipline (branch/worktree rules, start-of-session reporting) kept failing because it relied on prose instructions competing for the model's first action. This PR converts the failing behavioral asks into deterministic mechanisms and unifies the task-planning sentinels.

- **`.claude/hooks/track.sh`** — rewritten around a single sentinel: `$project VERB [ARGS]` (`list | new | end | track | hydrate | resume`, with `checkpoint`/`rehydrate` aliases). Punctuation-safe parsing (a prose mention like `$project list)` no longer emits a command directive), unknown verbs get a soft "ask or ignore" directive, and legacy `$track`/`$hydrate`/`$resume` forms map to the same directives with a one-time nudge.
- **Resume never leaves the assigned worktree** — a real session followed `$resume` into a different project's worktree as an "additional working directory", breaking the Desktop UI's session pairing. The rule is now explicit in the skill's registry note, the resume steps, and the injected resume directive.
- **`.claude/settings.json`** — all four hook commands now fall back to `git rev-parse --show-toplevel` when `CLAUDE_PROJECT_DIR` is empty (previously only guard-worktree had the fallback; the other three would silently no-op).
- **`AGENTS.md`** — start-of-session section slimmed; on the Claude harness it defers to a `SESSION CONTEXT` block injected by a global SessionStart hook, with the manual git check kept as the fallback for other harnesses.
- **`.agents/skills/task-planning/SKILL.md`**, **`.claude/CLAUDE.md`** — document the unified grammar.

## Why

Audit findings: mis-instantiated stub worktrees (confirmed on-disk: some contain only `.moon` or `packages`) load **no** project instructions or hooks at all, so repo-level mitigations were invisible exactly in the failing sessions. The complementary fix — global `~/.claude` hooks (SessionStart context injection, a silent-unless-drifted per-prompt beacon, and dxos-gated guard mirrors) — lives outside the repo in the user's machine config; this PR contains the repo-side half.

## Reviewer notes

- Hook behavior was exercised directly: all verbs, legacy forms, the prose false-fire case, and deny paths for the guards.
- No package code touched; no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified `$project VERB [ARGS]` workflow for listing, creating, tracking, checkpointing, hydrating, and resuming projects.
  * Added support for legacy command aliases with migration guidance.
* **Bug Fixes**
  * Improved resume behavior to preserve the current worktree and branch.
  * Improved project-directory detection and branch-based editing safety.
* **Documentation**
  * Updated task-planning and session-start guidance for the unified workflow and safer branch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->