### PR TITLE
app-toolkit: factor WithProperties test helper out of plugin-markdown

### DIFF
--- a/.changeset/with-properties-testing.md
+++ b/.changeset/with-properties-testing.md
@@ -1,0 +1,6 @@
+---
+'@dxos/app-toolkit': minor
+'@dxos/plugin-markdown': minor
+---
+
+Move the `WithProperties` test helper from `@dxos/plugin-markdown/testing` to a new `@dxos/app-toolkit/testing` subpath export.

--- a/packages/core/compute/assistant-toolkit/src/skills/browser/skill.test.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/browser/skill.test.ts
@@ -8,6 +8,7 @@ import * as Effect from 'effect/Effect';
 import { AgentService } from '@dxos/agent-runtime';
 import { AssistantTestLayerWithTriggers } from '@dxos/agent-runtime/testing';
 import { MemoizedAiService } from '@dxos/ai/testing';
+import { WithProperties } from '@dxos/app-toolkit/testing';
 import { SpaceProperties } from '@dxos/client-protocol';
 import { OperationHandlerSet, Skill } from '@dxos/compute';
 import { Collection, Database, Feed, Query } from '@dxos/echo';
@@ -17,7 +18,6 @@ import { log } from '@dxos/log';
 import { MarkdownSkill } from '@dxos/plugin-markdown';
 import { Markdown } from '@dxos/plugin-markdown';
 import { MarkdownOperationHandlerSet } from '@dxos/plugin-markdown/plugin';
-import { WithProperties } from '@dxos/plugin-markdown/testing';
 import { Person } from '@dxos/types';
 
 import { DatabaseHandlers, DatabaseSkill } from '../database';

--- a/packages/plugins/plugin-markdown/src/operations/accept-change.test.ts
+++ b/packages/plugins/plugin-markdown/src/operations/accept-change.test.ts
@@ -7,6 +7,7 @@ import * as Effect from 'effect/Effect';
 
 import { AssistantTestLayer } from '@dxos/agent-runtime/testing';
 import { CollaborationOperation } from '@dxos/app-toolkit';
+import { WithProperties } from '@dxos/app-toolkit/testing';
 import { SpaceProperties } from '@dxos/client-protocol';
 import { Operation } from '@dxos/compute';
 import { Collection, Database, Feed, Ref } from '@dxos/echo';
@@ -16,8 +17,6 @@ import { TestHelpers } from '@dxos/effect/testing';
 import { invariant } from '@dxos/invariant';
 import { Text } from '@dxos/schema';
 import { HasSubject } from '@dxos/types';
-
-import { WithProperties } from '#testing';
 
 import { Markdown, MarkdownOperation } from '../types';
 import { MarkdownOperationHandlerSet } from './index';

--- a/packages/plugins/plugin-markdown/src/operations/create.test.ts
+++ b/packages/plugins/plugin-markdown/src/operations/create.test.ts
@@ -5,13 +5,14 @@
 import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
+import { WithProperties } from '@dxos/app-toolkit/testing';
 import { Operation } from '@dxos/compute';
 import { Database, EID } from '@dxos/echo';
 import { TestHelpers } from '@dxos/effect/testing';
 import { EntityId } from '@dxos/keys';
 import { Markdown } from '@dxos/plugin-markdown';
 
-import { OperationTestLayer, WithProperties } from '#testing';
+import { OperationTestLayer } from '#testing';
 
 import { MarkdownOperation } from '../types';
 

--- a/packages/plugins/plugin-markdown/src/operations/open.test.ts
+++ b/packages/plugins/plugin-markdown/src/operations/open.test.ts
@@ -5,13 +5,14 @@
 import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
+import { WithProperties } from '@dxos/app-toolkit/testing';
 import { Operation } from '@dxos/compute';
 import { Database, Ref } from '@dxos/echo';
 import { TestHelpers } from '@dxos/effect/testing';
 import { EntityId } from '@dxos/keys';
 import { Markdown } from '@dxos/plugin-markdown';
 
-import { OperationTestLayer, WithProperties } from '#testing';
+import { OperationTestLayer } from '#testing';
 
 import { MarkdownOperation } from '../types';
 

--- a/packages/plugins/plugin-markdown/src/operations/reject-change.test.ts
+++ b/packages/plugins/plugin-markdown/src/operations/reject-change.test.ts
@@ -7,6 +7,7 @@ import * as Effect from 'effect/Effect';
 
 import { AssistantTestLayer } from '@dxos/agent-runtime/testing';
 import { CollaborationOperation } from '@dxos/app-toolkit';
+import { WithProperties } from '@dxos/app-toolkit/testing';
 import { SpaceProperties } from '@dxos/client-protocol';
 import { Operation } from '@dxos/compute';
 import { Collection, Database, Feed, Ref } from '@dxos/echo';
@@ -16,8 +17,6 @@ import { TestHelpers } from '@dxos/effect/testing';
 import { invariant } from '@dxos/invariant';
 import { Text } from '@dxos/schema';
 import { HasSubject } from '@dxos/types';
-
-import { WithProperties } from '#testing';
 
 import { Markdown, MarkdownOperation } from '../types';
 import { MarkdownOperationHandlerSet } from './index';

--- a/packages/plugins/plugin-markdown/src/operations/suggest-edit.test.ts
+++ b/packages/plugins/plugin-markdown/src/operations/suggest-edit.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
 import { AssistantTestLayer } from '@dxos/agent-runtime/testing';
+import { WithProperties } from '@dxos/app-toolkit/testing';
 import { SpaceProperties } from '@dxos/client-protocol';
 import { AgentIdentity, Operation } from '@dxos/compute';
 import { Collection, Database, Feed, Ref } from '@dxos/echo';
@@ -13,8 +14,6 @@ import { TestHelpers } from '@dxos/effect/testing';
 import { invariant } from '@dxos/invariant';
 import { Text } from '@dxos/schema';
 import { HasSubject } from '@dxos/types';
-
-import { WithProperties } from '#testing';
 
 import { Markdown, MarkdownOperation } from '../types';
 import { MarkdownOperationHandlerSet } from './index';

--- a/packages/plugins/plugin-markdown/src/operations/update-markdown.test.ts
+++ b/packages/plugins/plugin-markdown/src/operations/update-markdown.test.ts
@@ -7,6 +7,7 @@ import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 
 import { AssistantTestLayer } from '@dxos/agent-runtime/testing';
+import { WithProperties } from '@dxos/app-toolkit/testing';
 import { SpaceProperties } from '@dxos/client-protocol';
 import { Operation, Skill } from '@dxos/compute';
 import { Collection, Database, DXN, Feed, Obj, Ref, Type } from '@dxos/echo';
@@ -17,7 +18,7 @@ import { Text } from '@dxos/schema';
 import { HasSubject } from '@dxos/types';
 
 import { MarkdownOperationHandlerSet } from '#operations';
-import { OperationTestLayer, WithProperties } from '#testing';
+import { OperationTestLayer } from '#testing';
 
 import { MarkdownOperation } from '../types';
 

--- a/packages/plugins/plugin-markdown/src/operations/versioning.test.ts
+++ b/packages/plugins/plugin-markdown/src/operations/versioning.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
 import { AssistantTestLayer } from '@dxos/agent-runtime/testing';
+import { WithProperties } from '@dxos/app-toolkit/testing';
 import { SpaceProperties } from '@dxos/client-protocol';
 import { Operation } from '@dxos/compute';
 import { Collection, Database, Feed, Ref, URI } from '@dxos/echo';
@@ -13,8 +14,6 @@ import { TestHelpers } from '@dxos/effect/testing';
 import { invariant } from '@dxos/invariant';
 import { Text } from '@dxos/schema';
 import { HasSubject } from '@dxos/types';
-
-import { WithProperties } from '#testing';
 
 import { Markdown, MarkdownOperation } from '../types';
 import { MarkdownOperationHandlerSet } from './index';

--- a/packages/plugins/plugin-markdown/src/testing.ts
+++ b/packages/plugins/plugin-markdown/src/testing.ts
@@ -3,13 +3,11 @@
 //
 
 import * as Toolkit from '@effect/ai/Toolkit';
-import * as Effect from 'effect/Effect';
 
 import { AssistantTestLayer } from '@dxos/agent-runtime/testing';
-import { AppAnnotation } from '@dxos/app-toolkit';
 import { SpaceProperties } from '@dxos/client-protocol';
 import { Skill } from '@dxos/compute';
-import { Annotation, Collection, Database, Feed, Obj, Ref } from '@dxos/echo';
+import { Collection, Feed } from '@dxos/echo';
 import { HasSubject } from '@dxos/types';
 
 import { MarkdownOperationHandlerSet } from '#operations';
@@ -21,27 +19,6 @@ import { Markdown } from '#types';
 // which references React-surface capabilities that are intentionally omitted
 // from `capabilities/node.ts`.
 export * from '#plugin';
-
-// TODO(wittjosiah): Factor out.
-export const WithProperties = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R | Database.Service> =>
-  Effect.zipRight(
-    Effect.gen(function* () {
-      const collection = Collection.make({ objects: [] });
-      const properties = Obj.make(SpaceProperties, {});
-      yield* Database.add(collection);
-      yield* Database.add(properties);
-      // Both entities are in the DB before setting the annotation so Database.load
-      // works in CollectionModel.add (which uses the Effect DB context, not Ref.load).
-      Obj.update(properties, (properties) => {
-        const meta = Obj.getMeta(properties);
-        if (!meta.annotations) {
-          meta.annotations = {};
-        }
-        Annotation.setDictionary(meta.annotations, AppAnnotation.RootCollectionAnnotation, Ref.make(collection));
-      });
-    }),
-    effect,
-  );
 
 export const testToolkit = Toolkit.empty as Toolkit.Toolkit<any>;
 

--- a/packages/plugins/plugin-review/src/containers/ObjectHistory/timeline.test.ts
+++ b/packages/plugins/plugin-review/src/containers/ObjectHistory/timeline.test.ts
@@ -6,12 +6,12 @@ import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
 import { AssistantTestLayer } from '@dxos/agent-runtime/testing';
+import { WithProperties } from '@dxos/app-toolkit/testing';
 import { SpaceProperties } from '@dxos/client-protocol';
 import { Collection, Database, Text as EchoText, Feed, Obj } from '@dxos/echo';
 import { TestHelpers } from '@dxos/effect/testing';
 import { invariant } from '@dxos/invariant';
 import { MarkdownOperationHandlerSet } from '@dxos/plugin-markdown';
-import { WithProperties } from '@dxos/plugin-markdown/testing';
 import { Markdown } from '@dxos/plugin-markdown/types';
 import { Text } from '@dxos/schema';
 import { HasSubject } from '@dxos/types';

--- a/packages/sdk/app-toolkit/package.json
+++ b/packages/sdk/app-toolkit/package.json
@@ -31,6 +31,11 @@
       "types": "./dist/types/src/echo/Query.d.ts",
       "import": "./dist/lib/echo/Query.mjs"
     },
+    "./testing": {
+      "source": "./src/testing/index.ts",
+      "types": "./dist/types/src/testing/index.d.ts",
+      "import": "./dist/lib/testing.mjs"
+    },
     "./ui": {
       "source": "./src/ui/index.ts",
       "types": "./dist/types/src/ui/index.d.ts",

--- a/packages/sdk/app-toolkit/src/testing/index.ts
+++ b/packages/sdk/app-toolkit/src/testing/index.ts
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { SpaceProperties } from '@dxos/client-protocol';
+import { Annotation, Collection, Database, Obj, Ref } from '@dxos/echo';
+
+import * as AppAnnotation from '../echo/AppAnnotation';
+
+/**
+ * Seeds a root collection and `SpaceProperties` with the `RootCollectionAnnotation` before running
+ * the effect, so operations that resolve the space root (e.g. `CollectionModel.add`) work in tests.
+ */
+export const WithProperties = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R | Database.Service> =>
+  Effect.zipRight(
+    Effect.gen(function* () {
+      const collection = Collection.make({ objects: [] });
+      const properties = Obj.make(SpaceProperties, {});
+      yield* Database.add(collection);
+      yield* Database.add(properties);
+      // Both entities are in the DB before setting the annotation so Database.load
+      // works in CollectionModel.add (which uses the Effect DB context, not Ref.load).
+      Obj.update(properties, (properties) => {
+        const meta = Obj.getMeta(properties);
+        if (!meta.annotations) {
+          meta.annotations = {};
+        }
+        Annotation.setDictionary(meta.annotations, AppAnnotation.RootCollectionAnnotation, Ref.make(collection));
+      });
+    }),
+    effect,
+  );

--- a/packages/sdk/app-toolkit/vite.config.ts
+++ b/packages/sdk/app-toolkit/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     'index': 'src/index.ts',
     'app-framework/AppActivationEvents': 'src/app-framework/AppActivationEvents.ts',
     'echo/Query': 'src/echo/Query.ts',
+    'testing': 'src/testing/index.ts',
     'ui': 'src/ui/index.ts',
   },
   jsx: 'react',


### PR DESCRIPTION
## What

Resolves the `// TODO(wittjosiah): Factor out.` on `WithProperties` in `plugin-markdown/src/testing.ts` — the Effect wrapper that seeds a space root collection + `SpaceProperties` with the `RootCollectionAnnotation` so `CollectionModel.add` resolves the space root in operation tests.

- New `@dxos/app-toolkit/testing` subpath export holding `WithProperties` (`CollectionModel` and `AppAnnotation` live in app-toolkit, so it's the natural owner).
- All importers updated in place — 7 plugin-markdown operation tests, `assistant-toolkit`'s browser skill test, and `plugin-review`'s timeline test. No compatibility re-export left behind.
- Removes the core→plugin import of `@dxos/plugin-markdown/testing` from `assistant-toolkit`.

## Notes for review

- All three consuming packages already depended on `@dxos/app-toolkit`, so no dependency edges changed.
- Changeset bumps both groups (new app-toolkit subpath; `WithProperties` removed from `@dxos/plugin-markdown/testing`).
- Verified: `moon run app-toolkit:build assistant-toolkit:build plugin-review:build plugin-markdown:test assistant-toolkit:test` green, plus the plugin-review timeline test file and lint on all touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public testing utility export for app toolkit integrations.
  * Made the utility available through a dedicated testing entry point.

* **Refactor**
  * Consolidated shared testing support in the app toolkit.
  * Removed the duplicate Markdown-specific testing helper.

* **Documentation**
  * Added release tracking for the updated app toolkit and Markdown packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->