### PR TITLE
plugin-illustrator: register Canvas on the owning plugin

### DIFF
--- a/.changeset/illustrator-canvas-schema.md
+++ b/.changeset/illustrator-canvas-schema.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-illustrator': patch
+---
+
+Register the `Canvas` type on the plugin that owns it, so creating a drawing no longer fails with "Schema not registered" when the Excalidraw plugin is disabled.

--- a/packages/plugins/plugin-excalidraw/src/ExcalidrawPlugin.test.ts
+++ b/packages/plugins/plugin-excalidraw/src/ExcalidrawPlugin.test.ts
@@ -21,7 +21,7 @@ describe('ExcalidrawPlugin', () => {
     });
 
     expect(harness.manager.getActive()).toEqual(
-      expect.arrayContaining([moduleId('drawing-variant'), moduleId('schema'), moduleId('ReactSurface')]),
+      expect.arrayContaining([moduleId('drawing-variant'), moduleId('ReactSurface')]),
     );
   });
 });

--- a/packages/plugins/plugin-excalidraw/src/ExcalidrawPlugin.tsx
+++ b/packages/plugins/plugin-excalidraw/src/ExcalidrawPlugin.tsx
@@ -4,7 +4,6 @@
 
 import { Plugin } from '@dxos/app-framework';
 import { AppActivationEvents, AppPlugin } from '@dxos/app-toolkit';
-import { Drawing } from '@dxos/plugin-illustrator/types';
 
 import { DrawingVariant, ExcalidrawSettings, ReactSurface } from '#capabilities';
 import { meta } from '#meta';
@@ -16,7 +15,6 @@ export const ExcalidrawPlugin = Plugin.define(meta).pipe(
     activatesOn: AppActivationEvents.SetupSchema,
     activate: DrawingVariant,
   }),
-  AppPlugin.addSchemaModule({ schema: [Drawing.Canvas] }),
   AppPlugin.addSettingsModule({ activate: ExcalidrawSettings }),
   AppPlugin.addSurfaceModule({ activate: ReactSurface }),
   AppPlugin.addTranslationsModule({ translations }),

--- a/packages/plugins/plugin-illustrator/src/IllustratorPlugin.node.tsx
+++ b/packages/plugins/plugin-illustrator/src/IllustratorPlugin.node.tsx
@@ -18,7 +18,7 @@ import { Drawing } from '#types';
  */
 export const IllustratorPlugin = Plugin.define(meta).pipe(
   AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
-  AppPlugin.addSchemaModule({ schema: [Drawing.Drawing] }),
+  AppPlugin.addSchemaModule({ schema: [Drawing.Drawing, Drawing.Canvas] }),
   AppPlugin.addSkillDefinitionModule({ activate: SkillDefinition }),
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,

--- a/packages/plugins/plugin-illustrator/src/IllustratorPlugin.test.ts
+++ b/packages/plugins/plugin-illustrator/src/IllustratorPlugin.test.ts
@@ -1,0 +1,32 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { AppCapabilities } from '@dxos/app-toolkit';
+import { Type } from '@dxos/echo';
+import { ClientPlugin } from '@dxos/plugin-client/plugin';
+import { createComposerTestApp } from '@dxos/plugin-testing/harness';
+
+import { IllustratorPlugin } from '#plugin';
+
+import { Drawing } from './types';
+
+describe('IllustratorPlugin', () => {
+  // Canvas is written to the database by every variant's create flow, so the plugin that owns the
+  // type must register it — registering it from a renderer plugin breaks the others when disabled.
+  test('registers both the Drawing and Canvas schemas', async ({ expect }) => {
+    await using harness = await createComposerTestApp({
+      plugins: [ClientPlugin({}), IllustratorPlugin()],
+    });
+
+    const typenames = harness
+      .getAll(AppCapabilities.Schema)
+      .flat()
+      .map((schema) => Type.getTypename(schema));
+    expect(typenames).toEqual(
+      expect.arrayContaining([Type.getTypename(Drawing.Drawing), Type.getTypename(Drawing.Canvas)]),
+    );
+  });
+});

--- a/packages/plugins/plugin-illustrator/src/IllustratorPlugin.tsx
+++ b/packages/plugins/plugin-illustrator/src/IllustratorPlugin.tsx
@@ -29,7 +29,7 @@ export const IllustratorPlugin = Plugin.define(meta).pipe(
   AppPlugin.addCommentConfigModule({ activate: CommentConfig }),
   AppPlugin.addCreateObjectModule({ activate: CreateObject }),
   AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
-  AppPlugin.addSchemaModule({ schema: [Drawing.Drawing] }),
+  AppPlugin.addSchemaModule({ schema: [Drawing.Drawing, Drawing.Canvas] }),
   AppPlugin.addSkillDefinitionModule({ activate: SkillDefinition }),
   AppPlugin.addSurfaceModule({ activate: ReactSurface }),
   AppPlugin.addTranslationsModule({ translations }),

--- a/packages/plugins/plugin-illustrator/src/IllustratorPlugin.workerd.tsx
+++ b/packages/plugins/plugin-illustrator/src/IllustratorPlugin.workerd.tsx
@@ -9,7 +9,7 @@ import { meta } from '#meta';
 import { Drawing } from '#types';
 
 export const IllustratorPlugin = Plugin.define(meta).pipe(
-  AppPlugin.addSchemaModule({ schema: [Drawing.Drawing] }),
+  AppPlugin.addSchemaModule({ schema: [Drawing.Drawing, Drawing.Canvas] }),
   Plugin.make,
 );
 

--- a/packages/plugins/plugin-registry/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-registry/src/capabilities/app-graph-builder.ts
@@ -203,7 +203,9 @@ export default Capability.makeModule(
 
           const registryEntries = get(manager.pluginRegistry.plugins).entries;
           const registryNodes = registryEntries
-            .filter((entry) => !installedIds.has(DXN.make(entry.profile.key)))
+            // `profile.key` is the bare NSID on both sides; comparing against a `dxn:`-prefixed
+            // URI here would never match and would duplicate every installed plugin's node.
+            .filter((entry) => !installedIds.has(entry.profile.key))
             .map((entry) => {
               const plugin = toDisplayPlugin(entry);
               return Node.make({


### PR DESCRIPTION
## What

Two independent fixes surfaced by a report of console errors when creating a tldraw drawing.

### 1. `Schema not registered: org.dxos.type.canvas` (the actual failure)

`Drawing.Canvas` is owned by `plugin-illustrator` but was registered by **`plugin-excalidraw`**. tldraw's variant deliberately supplies no `createCanvas` — it stores its records in the base `Canvas`, discriminated by `schema` — so with Excalidraw disabled, `create-object.ts` writes an unregistered type and the create flow throws.

Moved the registration to all three illustrator entrypoints (`IllustratorPlugin.tsx`, `.node`, `.workerd`) and removed it from excalidraw. Added `IllustratorPlugin.test.ts`, which boots illustrator *without* excalidraw and asserts both schemas are contributed.

### 2. Registry graph builder never filtered installed plugins

`app-graph-builder.ts` built `installedIds` from bare NSIDs (`makeMeta` stores `DXN.getName(key)`) but tested `installedIds.has(DXN.make(entry.profile.key))` — a `dxn:`-prefixed string that can never match. The installed-plugin dedup in the registry listing was a no-op for every plugin.

## Verification

The schema fix was verified in a running Composer against the exact repro (Excalidraw disabled, tldraw variant, Create Object → Drawing), A/B against the fix:

- **reverted:** `operation invocation failed`, no object created, error badge in the rail; a previously created drawing renders blank.
- **applied:** drawing created, tldraw canvas renders.

Builds green; 40 tests pass across `plugin-illustrator`, `plugin-excalidraw`, `plugin-registry`, `plugin-tldraw`.

## For reviewers

The original report also included two React warnings that this PR does **not** fix, and reviewers should not assume it does:

- `Encountered two children with the same key, root/!dxos:plugin-registry/org.dxos.plugin.excalidraw`
- `Cannot update a component (ForwardRef) while rendering a different component (NavTreeContainer)`

The duplicate key initially looked like fix #2, but that is ruled out: `addEdgeImpl` dedupes edge targets, so a connector emitting an id twice cannot produce a duplicate React key. Confirmed at runtime that it is also not duplicate graph edges (94 child edges, zero dupes), not duplicate entries in `getPlugins()` (89, zero dupes), and not `sortEdges` reintroducing dupes. It reproduces reliably **only when Excalidraw is disabled**, and the key is `getPluginPath(pluginId)` — a node id / plank path — so the duplicate lives in a render-layer list rather than the graph. The setState-in-render warning did not reproduce in any configuration tried. Both are worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)