### PR TITLE
plugin-tasks: observe task renames directly in OutlineArticle label sync

### DIFF
--- a/.changeset/outline-link-label-rename.md
+++ b/.changeset/outline-link-label-rename.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-tasks': patch
+---
+
+Fixed outline link chips not updating when the linked task is renamed; the label sync now observes task changes directly instead of relying on query re-emission.

--- a/packages/plugins/plugin-tasks/src/containers/OutlineArticle/OutlineArticle.tsx
+++ b/packages/plugins/plugin-tasks/src/containers/OutlineArticle/OutlineArticle.tsx
@@ -2,7 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 
 import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { Filter, Obj, Type } from '@dxos/echo';
@@ -54,11 +54,18 @@ export const OutlineArticle = ({ role, attendableId, subject: outline }: Outline
   const handleConvertCurrent = useCallback(() => outlineRef.current?.convertToTask(), []);
 
   // Task titles are edited independently of the document, so the link text is reconciled from the
-  // live objects rather than trusted as written. A type query re-emits on task edits (a
-  // `children()` query does not re-emit on a child's property change); membership is then the
-  // parent edge, so unrelated tasks in the space are dropped before the map is built.
+  // live objects rather than trusted as written. Membership is the parent edge, so unrelated tasks
+  // in the space are dropped before the map is built.
   const taskSet = outline.taskSet?.target;
   const tasks = useQuery(space?.db, taskSet ? Filter.type(Task.Task) : Filter.nothing());
+  // `useQuery` re-emits only when result membership changes, never on a member's property change,
+  // so renames are observed by subscribing to each task; the bump rebuilds the resolver, whose new
+  // identity re-runs the editor's label sync.
+  const [tick, bump] = useReducer((count: number) => count + 1, 0);
+  useEffect(() => {
+    const unsubscribes = tasks.map((task) => Obj.subscribe(task, bump));
+    return () => unsubscribes.forEach((unsubscribe) => unsubscribe());
+  }, [tasks]);
   const resolveLinkLabel = useMemo(() => {
     const labels = new Map(
       tasks
@@ -66,7 +73,7 @@ export const OutlineArticle = ({ role, attendableId, subject: outline }: Outline
         .map((task) => [Obj.getURI(task).toString(), task.title]),
     );
     return (url: string) => labels.get(url);
-  }, [tasks, taskSet]);
+  }, [tasks, taskSet, tick]);
 
   const taskActions = useMenuBuilder(
     (): ActionGraphProps =>


### PR DESCRIPTION
## Summary

Fixes the flaky `OutlineArticle > Convert To Task` storybook play test (failed on Check run 30780600116) by fixing the underlying reactivity bug it exposed.

`useQuery` re-emits only when result membership or order changes — never on a member's property change (`QueryResult.subscribe` contract). `OutlineArticle` assumed the opposite: its link-label resolver was memoized on the query's array identity, so after a task rename the outline's chip label and document link text were only reconciled if an unrelated re-render happened to land *after* the query cache invalidation rebuilt the results array. Cold first runs (CI, first storybook attempt) lost that race deterministically; warm retries won it. The same race existed in the app.

## Fix

Subscribe to each task with `Obj.subscribe` and bump a reducer on change, rebuilding `resolveLinkLabel`; its new identity re-runs the editor's `syncLinkLabels` effect deterministically. Same pattern as plugin-inbox's `CalendarArticle` (which documents the same `useQuery` limitation). The stale comment claiming type queries re-emit on edits is corrected.

## Verification

- `Convert To Task` play test: 10/10 consecutive first-attempt passes with `--retry=0` (~1.6s each; previously a deterministic first-attempt 10s timeout, passing only on retry).
- plugin-tasks unit tests (22), full storybook suite, and lint green; repo-wide `:lint` and `:test` green (one unrelated load-flake in plugin-observability, passes in isolation).
- Changeset included (`@dxos/plugin-tasks` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed outline link labels not updating when linked task titles are renamed.
  * Link labels now refresh automatically while preserving existing parent-task filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->