### PR TITLE
composer-app: serve WebAuthn Related Origin Requests manifest

### DIFF
--- a/packages/apps/composer-app/src/functions/_worker.ts
+++ b/packages/apps/composer-app/src/functions/_worker.ts
@@ -217,7 +217,8 @@ const WEBAUTHN_RELATED_ORIGINS = ['https://auth.dxos.org'];
  */
 const handleWebAuthnWellKnown = (request: Request): Response => {
   if (request.method !== 'GET' && request.method !== 'HEAD') {
-    return new Response('Method not allowed', { status: 405 });
+    // RFC 9110 §15.5.6 requires a 405 to advertise the methods the resource does support.
+    return new Response('Method not allowed', { status: 405, headers: { Allow: 'GET, HEAD' } });
   }
 
   const body = JSON.stringify({ origins: WEBAUTHN_RELATED_ORIGINS });

--- a/packages/apps/composer-app/src/functions/_worker.ts
+++ b/packages/apps/composer-app/src/functions/_worker.ts
@@ -187,6 +187,49 @@ const handleRssProxy = async (request: Request): Promise<Response> => {
   }
 };
 
+/**
+ * Origins permitted to assert the `composer.space` relying party via WebAuthn Related Origin
+ * Requests.
+ *
+ * Composer registers passkeys with `rp: { id: location.hostname }` (plugin-client
+ * `create-passkey.ts`), so production credentials are permanently scoped to the `composer.space`
+ * relying party. WebAuthn otherwise only lets a page assert an RP ID that is a registrable-domain
+ * suffix of its own origin, which would confine every ceremony to `*.composer.space`. Listing an
+ * origin here is what lets the MCP passkey ceremony — served from the `hub-service` worker on
+ * `auth.dxos.org` — reach those existing credentials without re-registration.
+ *
+ * `composer.space` itself is deliberately absent: same-origin assertions are always permitted.
+ *
+ * Clients are only required to support 5 unique eTLD+1 labels, so entries are not free — but every
+ * `*.composer.space` origin shares one label, and `dxos` covers `auth.dxos.org`.
+ *
+ * https://w3c.github.io/webauthn/#sctn-related-origins
+ */
+const WEBAUTHN_RELATED_ORIGINS = ['https://auth.dxos.org'];
+
+/**
+ * Handle /.well-known/webauthn — the Related Origin Requests manifest.
+ *
+ * The response must be `application/json`; browsers reject the manifest on any other content type,
+ * which is why this is a Worker route rather than a static asset (an extensionless asset is served
+ * as `application/octet-stream`) and why it is listed in `run_worker_first` (the SPA fallback would
+ * otherwise answer with index.html).
+ */
+const handleWebAuthnWellKnown = (request: Request): Response => {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  const body = JSON.stringify({ origins: WEBAUTHN_RELATED_ORIGINS });
+  return new Response(request.method === 'HEAD' ? null : body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=300',
+    },
+  });
+};
+
 const OTEL_PREFIX = '/api/otel';
 const OTEL_SIGNALS = new Set(['/v1/traces', '/v1/logs', '/v1/metrics']);
 
@@ -285,6 +328,11 @@ const handleOtelProxy = async (request: Request, env: Env, signal: string): Prom
 const handler: ExportedHandler<Env> = {
   fetch: async (request, env, _context) => {
     const url = new URL(request.url);
+
+    // WebAuthn Related Origin Requests manifest (must precede the SPA fallback).
+    if (url.pathname === '/.well-known/webauthn') {
+      return handleWebAuthnWellKnown(request);
+    }
 
     // API routes.
     if (url.pathname === '/api/feedback-logs') {

--- a/packages/apps/composer-app/wrangler.jsonc
+++ b/packages/apps/composer-app/wrangler.jsonc
@@ -20,7 +20,7 @@
     // Unmatched routes return index.html (client-side router owns them)...
     "not_found_handling": "single-page-application",
     // ...except /api/*, which must reach the Worker before the SPA fallback swallows it.
-    "run_worker_first": ["/api/*"],
+    "run_worker_first": ["/api/*", "/.well-known/webauthn"],
   },
   // Per-env Workers (name = the deployed Worker; production = the bare name that carries the custom domain,
   // others suffixed). Bindings are NOT inherited, so each env repeats them. Cloudflare-side: each Worker

--- a/packages/apps/composer-app/wrangler.jsonc
+++ b/packages/apps/composer-app/wrangler.jsonc
@@ -1,7 +1,8 @@
 {
   // Cloudflare Workers (Static Assets) config for Composer. Migrated from Pages advanced mode: `_worker.js`
-  // is the Worker entry (main), static assets are served via the ASSETS binding, and /api/* runs the Worker
-  // first (feedback-logs, RSS proxy, OTel -> SigNoz) while every other route is asset-first with SPA fallback.
+  // is the Worker entry (main), static assets are served via the ASSETS binding, and the `run_worker_first`
+  // paths run the Worker first (feedback-logs, RSS proxy, OTel -> SigNoz, the WebAuthn Related Origin
+  // Requests manifest) while every other route is asset-first with SPA fallback.
   // Deployed by .github/workflows/scripts/deploy-env.mjs via `wrangler deploy --config <this> --env <env>`.
   // `_worker.js` lives in the asset dir (the PR preview deploy — a `versions upload` against `env.main` —
   // also consumes it there), so it is kept out of the asset upload with a generated `.assetsignore`.
@@ -19,7 +20,7 @@
     "binding": "ASSETS",
     // Unmatched routes return index.html (client-side router owns them)...
     "not_found_handling": "single-page-application",
-    // ...except /api/*, which must reach the Worker before the SPA fallback swallows it.
+    // ...except these, which must reach the Worker before the SPA fallback swallows them.
     "run_worker_first": ["/api/*", "/.well-known/webauthn"],
   },
   // Per-env Workers (name = the deployed Worker; production = the bare name that carries the custom domain,


### PR DESCRIPTION
## Summary

Serves `https://composer.space/.well-known/webauthn` as `application/json` with body `{"origins":["https://auth.dxos.org"]}`.

Composer registers passkeys with `rp: { id: location.hostname }` ([create-passkey.ts](https://github.com/dxos/dxos/blob/main/packages/plugins/plugin-client/src/operations/create-passkey.ts)), so production credentials are permanently scoped to the `composer.space` relying party. The DXOS MCP passkey auth ceremony is served by `hub-service` from `https://auth.dxos.org`, and WebAuthn only lets a page assert an RP ID that is a registrable-domain suffix of its own origin — `composer.space` is not a suffix of `auth.dxos.org`, so without [Related Origin Requests](https://w3c.github.io/webauthn/#sctn-related-origins) the browser rejects the ceremony with a `SecurityError`.

Today the path returns HTTP 200 `text/html` (the SPA catch-all), which does not satisfy the spec.

## Mechanism

Two constraints force a Worker route rather than a static file:

1. `not_found_handling: "single-page-application"` means an unmatched path never reaches the Worker — so `/.well-known/webauthn` is added to `run_worker_first`.
2. An extensionless file in `public/` is served as `application/octet-stream`, not `application/json` — so it cannot be a static asset.

`run_worker_first` lives on the top-level `assets` block, which the per-env sections do not override, so the route lands on production, staging, labs, and main alike. All four are `*.composer.space`, sharing the one relying party — no per-env change needed.

## Counterpart

Depends on dxos/edge#789 (branch `mcp-task-tools`), which sets `DX_AUTH_ALLOWED_ORIGINS=https://auth.dxos.org` on hub-service production and declares `auth.dxos.org` as a second custom domain.

## Verification

⚠️ **The PR preview URL cannot exercise this change.** `preview-deploy.yml` sparse-checks out `wrangler.jsonc` from the base branch, so the preview runs the PR's `_worker.js` against **main's** asset config — without the new `run_worker_first` entry, the SPA fallback still answers `/.well-known/webauthn` with `text/html` there. That is expected, not a defect.

Verified locally instead, with `wrangler dev` (4.112.0) against this branch's `wrangler.jsonc`:

```
$ curl -sI http://localhost:8799/.well-known/webauthn
HTTP/1.1 200 OK
Content-Type: application/json
Cache-Control: public, max-age=300

$ curl -s http://localhost:8799/.well-known/webauthn
{"origins":["https://auth.dxos.org"]}

$ curl -sI http://localhost:8799/some/spa/route     # control: fallback still intact
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
```

Method handling, by invoking `handler.fetch` on the esbuild bundle directly:

| Method | Status | Content-Type |
|---|---|---|
| GET | 200 | `application/json` |
| HEAD | 200 | `application/json` (no body) |
| POST | 405 | `text/plain` |

Also: `moon run composer-app:build` green (284 tasks), `composer-app:lint` green, `pnpm format-check` clean.

Post-deploy acceptance check:

```bash
curl -sI https://composer.space/.well-known/webauthn
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)