### PR TITLE
composer-app: update functions README for Workers migration

### DIFF
--- a/packages/apps/composer-app/src/functions/README.md
+++ b/packages/apps/composer-app/src/functions/README.md
@@ -1,4 +1,6 @@
-# Cloudflare Pages Functions
+# Cloudflare Worker
+
+`_worker.ts` is the Worker entry (see `wrangler.jsonc`); static assets are served via the `ASSETS` binding.
 
 NOTE: Separate `tsconfig.json` for server-side code.
 
@@ -10,8 +12,16 @@ Build the bundle from root:
 moon run composer-app:bundle
 ```
 
-Run pages from the app directory:
+Run the Worker from the app directory:
 
 ```bash
-wrangler pages dev
+wrangler dev
+```
+
+## Logs
+
+Tail production logs:
+
+```bash
+wrangler tail composer
 ```


### PR DESCRIPTION
## Summary

`packages/apps/composer-app/src/functions/README.md` still documented Cloudflare **Pages advanced mode** — it was titled "Cloudflare Pages Functions" and told you to run `wrangler pages dev`. composer-app has since migrated to **Cloudflare Workers with static assets**, so those instructions no longer work.

Realigned the README with the authoritative header comment in `wrangler.jsonc`:

- Retitled to "Cloudflare Worker", with a pointer to `_worker.ts` / `wrangler.jsonc` and the `ASSETS` binding.
- `wrangler pages dev` → `wrangler dev`, run from the app directory (required: `main` in `wrangler.jsonc` is the relative path `./out/composer/_worker.js`).
- Added a Logs section for `wrangler tail composer` (`composer` is the production Worker name).
- Kept the existing note about the separate server-side `tsconfig.json`.

## Verification

Every command was checked against source rather than carried over from the old text:

| Command | Verified against |
| --- | --- |
| `moon run composer-app:bundle` | `moon.yml` — `bundle` runs `vite build && build:functions` (esbuild → `out/composer/_worker.js`) |
| `wrangler dev` | `wrangler.jsonc` header comment; `main: ./out/composer/_worker.js` |
| `wrangler tail composer` | `wrangler.jsonc` header comment; `env.production.name = composer` |

Docs-only change — no changeset (nothing consumer-facing), and no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment documentation to reflect the Cloudflare Worker setup.
  * Added instructions for the `_worker.ts` entry point and `ASSETS` binding.
  * Updated local development and production log commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->