### PR TITLE
plugin-inbox: drop a deleted Gmail message instead of wedging sync

### DIFF
--- a/.changeset/gmail-sync-deleted-message.md
+++ b/.changeset/gmail-sync-deleted-message.md
@@ -1,0 +1,6 @@
+---
+'@dxos/plugin-inbox': patch
+---
+
+Fix Gmail sync wedging permanently when a message is deleted before it is fetched: the 404 now drops that
+message instead of failing the run and stranding the history token.

--- a/packages/plugins/plugin-inbox/src/operations/mail/google/sync/fetch.ts
+++ b/packages/plugins/plugin-inbox/src/operations/mail/google/sync/fetch.ts
@@ -91,11 +91,9 @@ export const fetchMessages = (
           config.onRetrieved?.();
           return Option.some(message);
         }).pipe(
-          // A message deleted between its id being enumerated (listed, or logged in `history.list`) and
-          // this fetch 404s permanently, so failing the run wedges the mailbox: the delta token only
-          // advances on a clean run, leaving every following run to re-read the same history page and die
-          // on the same id. Drop just that message; any other error still fails the run so the durable
-          // retry re-fetches it rather than stranding it once the cursor advances.
+          // A message deleted before this fetch 404s forever and the token only advances on a clean run,
+          // so failing here wedges the mailbox on that one id. Any other error must still fail, so the
+          // durable retry re-fetches it rather than stranding it once the cursor advances.
           Effect.catchIf(
             (error) => error instanceof GoogleApiError && error.code === 404,
             (error) => {

--- a/packages/plugins/plugin-inbox/src/operations/mail/google/sync/fetch.ts
+++ b/packages/plugins/plugin-inbox/src/operations/mail/google/sync/fetch.ts
@@ -14,6 +14,7 @@ import { log } from '@dxos/log';
 import { EmailStage } from '@dxos/pipeline-email';
 
 import { GoogleMail } from '../../../../apis';
+import { GoogleApiError } from '../../../../errors';
 import { GoogleMailApi, type GoogleMailApiError, type GoogleMailApiService } from '../../../../services';
 import { type SyncStreamConfig } from '../../../../types';
 import { type AttachmentMetadata } from '../mapper';
@@ -88,10 +89,24 @@ export const fetchMessages = (
             .getMessage(config.userId, messageId)
             .pipe(Effect.withSpan('google-sync.fetch.message'));
           config.onRetrieved?.();
-          return message;
-        }),
+          return Option.some(message);
+        }).pipe(
+          // A message deleted between its id being enumerated (listed, or logged in `history.list`) and
+          // this fetch 404s permanently, so failing the run wedges the mailbox: the delta token only
+          // advances on a clean run, leaving every following run to re-read the same history page and die
+          // on the same id. Drop just that message; any other error still fails the run so the durable
+          // retry re-fetches it rather than stranding it once the cursor advances.
+          Effect.catchIf(
+            (error) => error instanceof GoogleApiError && error.code === 404,
+            (error) => {
+              log.warn('gmail sync: message not found, skipping', { messageId, error });
+              return Effect.succeed(Option.none<GoogleMail.Message>());
+            },
+          ),
+        ),
       { concurrency: GOOGLE_SYNC_CONFIG.fetchConcurrency },
     ),
+    Stream.filterMap(Function.identity),
   );
 };
 

--- a/packages/plugins/plugin-inbox/src/operations/mail/google/sync/sync.test.ts
+++ b/packages/plugins/plugin-inbox/src/operations/mail/google/sync/sync.test.ts
@@ -19,6 +19,7 @@ import { TagIndex } from '@dxos/schema';
 import { Message, Person } from '@dxos/types';
 
 import { GMAIL_SOURCE } from '../../../../constants';
+import { GoogleApiError } from '../../../../errors';
 import { type GmailDataset, GoogleMailApi } from '../../../../services';
 import { generateGmailDataset } from '../../../../testing/gmail-fixtures';
 import {
@@ -79,6 +80,27 @@ const withFaultAfterMessages = (n: number, dataset: GmailDataset): Layer.Layer<G
           count += 1;
           return count > n ? Effect.die(new Error('injected fault')) : inner.getMessage(userId, messageId);
         },
+      });
+    }),
+  ).pipe(Layer.provide(GoogleMailApi.mock(dataset)));
+
+/**
+ * Wraps a mock {@link GoogleMailApi} so `getMessage` fails with Gmail's 404 for the given ids — the
+ * response for a message deleted between the id being listed (or logged in `history.list`) and the full
+ * fetch, which no retry can resolve.
+ */
+const withDeletedMessages = (ids: readonly string[], dataset: GmailDataset): Layer.Layer<GoogleMailApi> =>
+  Layer.effect(
+    GoogleMailApi,
+    Effect.gen(function* () {
+      const inner = yield* GoogleMailApi;
+      const deleted = new Set(ids);
+      return GoogleMailApi.of({
+        ...inner,
+        getMessage: (userId, messageId) =>
+          deleted.has(messageId)
+            ? Effect.fail(new GoogleApiError(404, 'Requested entity was not found.'))
+            : inner.getMessage(userId, messageId),
       });
     }),
   ).pipe(Layer.provide(GoogleMailApi.mock(dataset)));
@@ -204,6 +226,27 @@ describe('runGoogleSync against a mock Gmail API', () => {
     );
     expect(rerun.newMessages).toBe(0);
     expect(fetched).toEqual([]);
+  });
+
+  test('a window-scan id deleted between the list and the fetch is dropped, not fatal', async ({ expect }) => {
+    const now = new Date('2026-07-16T12:00:00.000Z');
+    const dataset = generateGmailDataset({ count: 4, seed: 89, start: subDays(now, 6), end: subDays(now, 2) });
+    const { db, mailbox, binding } = await seedMailboxBinding(builder, { options: { syncBackDays: 14 } });
+    const deletedId = dataset.messages[1].id;
+
+    // `listMessages` enumerates the id, then the user deletes the message before `getMessage` runs. The
+    // 404 is per-message and permanent, so it must drop that id rather than fail the whole run.
+    const result = await EffectEx.runPromise(
+      runGoogleSync({ binding: Ref.make(binding), now }).pipe(
+        Effect.provide(ambientSyncServices(db)),
+        Effect.provide(withDeletedMessages([deletedId], dataset)),
+      ),
+    );
+
+    expect(result.newMessages).toBe(dataset.messages.length - 1);
+    const ids = await syncedIdsOf(db, mailbox);
+    expect(ids).not.toContain(deletedId);
+    expect(ids.length).toBe(dataset.messages.length - 1);
   });
 
   test('emits trace status updates with advancing progress during sync', async ({ expect }) => {
@@ -820,6 +863,47 @@ describe('runGoogleSync against a mock Gmail API', () => {
     const ids = await syncedIdsOf(db, mailbox);
     expect(new Set(ids).size).toBe(ids.length);
     expect(ids.length).toBe(base.messages.length + arrivals.length);
+  });
+
+  test('a delta naming a deleted message drops it, syncs the rest, and advances the token', async ({ expect }) => {
+    const now = new Date('2026-07-16T12:00:00.000Z');
+    const base = generateGmailDataset({ count: 3, seed: 87, start: subDays(now, 6), end: subDays(now, 2) });
+    const { db, mailbox, binding } = await seedMailboxBinding(builder, { options: { syncBackDays: 14 } });
+
+    // First tick: backfill + capture '1000'.
+    await EffectEx.runPromise(
+      runGoogleSync({ binding: Ref.make(binding), now }).pipe(
+        Effect.provide(inboxSyncTestServices(db, { ...base, historyId: '1000' })),
+      ),
+    );
+    expect(tokenOf(binding)).toBe('1000');
+
+    // The delta adds two messages, one already deleted by the time this run fetches it. Unlike the crash
+    // above, this 404 is permanent: failing the run would leave the token at '1000', so every following
+    // run re-reads the same history page, 404s again, and the mailbox never syncs another message.
+    const arrival = generateGmailDataset({ count: 1, seed: 88, start: subDays(now, 1), end: now, idPrefix: 'new' })
+      .messages[0];
+    const deletedId = 'deleted-1';
+    const dataset = {
+      ...base,
+      messages: [...base.messages, arrival],
+      historyId: '1001',
+      historyLog: [{ startHistoryId: '1000', historyId: '1001', messagesAdded: [deletedId, arrival.id] }],
+    };
+
+    const result = await EffectEx.runPromise(
+      runGoogleSync({ binding: Ref.make(binding), now }).pipe(
+        Effect.provide(ambientSyncServices(db)),
+        Effect.provide(withDeletedMessages([deletedId], dataset)),
+      ),
+    );
+
+    expect(result.newMessages).toBe(1);
+    expect(tokenOf(binding)).toBe('1001');
+    const ids = await syncedIdsOf(db, mailbox);
+    expect(ids).toContain(arrival.id);
+    expect(ids).not.toContain(deletedId);
+    expect(ids.length).toBe(base.messages.length + 1);
   });
 
   test('an incremental label add retags an existing message with no new feed append', async ({ expect }) => {

--- a/packages/plugins/plugin-inbox/src/operations/mail/google/sync/sync.test.ts
+++ b/packages/plugins/plugin-inbox/src/operations/mail/google/sync/sync.test.ts
@@ -234,8 +234,6 @@ describe('runGoogleSync against a mock Gmail API', () => {
     const { db, mailbox, binding } = await seedMailboxBinding(builder, { options: { syncBackDays: 14 } });
     const deletedId = dataset.messages[1].id;
 
-    // `listMessages` enumerates the id, then the user deletes the message before `getMessage` runs. The
-    // 404 is per-message and permanent, so it must drop that id rather than fail the whole run.
     const result = await EffectEx.runPromise(
       runGoogleSync({ binding: Ref.make(binding), now }).pipe(
         Effect.provide(ambientSyncServices(db)),
@@ -878,9 +876,8 @@ describe('runGoogleSync against a mock Gmail API', () => {
     );
     expect(tokenOf(binding)).toBe('1000');
 
-    // The delta adds two messages, one already deleted by the time this run fetches it. Unlike the crash
-    // above, this 404 is permanent: failing the run would leave the token at '1000', so every following
-    // run re-reads the same history page, 404s again, and the mailbox never syncs another message.
+    // Unlike the transient crash above, this 404 is permanent: failing the run would strand the token at
+    // '1000', leaving every following run to re-read the same history page and die on the same id.
     const arrival = generateGmailDataset({ count: 1, seed: 88, start: subDays(now, 1), end: now, idPrefix: 'new' })
       .messages[0];
     const deletedId = 'deleted-1';


### PR DESCRIPTION
## What

A `404` from Gmail's `messages.get` escaped `fetchMessages`' stream unhandled, failing the entire sync run. Since the delta token is written only after a clean run ([mail-sync.ts:560-569](https://github.com/dxos/dxos/blob/main/packages/plugins/plugin-inbox/src/operations/mail/mail-sync.ts#L560-L569)), a message deleted between its id being enumerated — listed, or logged in `history.list` — and the full fetch **wedged the mailbox permanently**: the cursor never advanced, so every following run re-read the same history page and died on the same id. `Cursor.skipCommitted` can't filter it either, because it was never committed.

This catches the 404 and drops that one message. Every other error still fails the run, so the durable retry re-fetches it rather than stranding it once the cursor advances.

## Why this shape

Not an invented policy — it's the rule the JMAP provider already documents at [`jmap/sync/sync-provider.ts:430`](https://github.com/dxos/dxos/blob/main/packages/plugins/plugin-inbox/src/operations/mail/jmap/sync/sync-provider.ts#L430):

> Drop an id deleted between query and `emailGet` (returns nothing) by filtering out the null. Do NOT recover the error channel: a real `JmapApiError` must propagate and fail the run…

JMAP got that behavior for free because `emailGet` returns an empty list for a missing id. Gmail signals the same condition with a `404`, and that path was never handled — so Gmail was the only provider where a deleted message was fatal. The same asymmetry exists locally: a 404 is already tolerated for `listHistory` (stale token → fresh capture) and for attachment fetches (logged and dropped); the message fetch was the one hop with no tolerance.

## Production evidence

From SigNoz (edge `main`, `operation-service`), one mailbox on `gmail`:

- **71 consecutive** `mail sync failed` runs from 12:20:16 UTC onward, **zero** successes — retrying every 5 min with no self-recovery.
- All 71 hit the **same** call: `GET .../users/me/messages/19fc8a34d65488b4` → `404 Requested entity was not found.`
- Preceded by a ~62h sync outage for that space, which built the history backlog that came to contain a since-deleted message.

Once this deploys the wedged mailbox recovers on its own — the next run drops that id, the backlog drains, and the token advances past it.

## Tests

Two tests, both written first and confirmed to fail with the exact production signature (`MailSyncError` ← `GoogleApiError 404` at `fetch.ts:88`):

1. `a delta naming a deleted message drops it, syncs the rest, and advances the token` — the incident path. Asserts the live arrival syncs, the deleted id doesn't, and **the token advances `1000` → `1001`**; that last assertion is what proves the wedge is gone.
2. `a window-scan id deleted between the list and the fetch is dropped, not fatal` — the non-incremental path into the same line, for the list→get race during backfill.

Plus a `withDeletedMessages` layer wrapper, alongside the existing `withFaultAfterMessages` / `countingGmailApi` helpers.

```
Test Files  28 passed | 7 skipped (35)
     Tests  234 passed | 14 skipped (248)
```

## Reviewer notes

- One wasted `getMessage` per dropped id per run — a never-committed id can't be filtered by `skipCommitted`. Bounded by `maxItemsPerRun`, same trade the attachment-drop path already makes.
- The dropped message is `log.warn`'d with its id, so a mailbox silently losing messages this way stays visible in SigNoz.
- A separate `401` cluster on the same mailbox (07-30 → 07-31, 366 errors) is **not** addressed here — different cause, self-resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Gmail synchronization now skips messages deleted before they can be fetched.
  - Sync runs continue successfully when Gmail returns a “not found” response.
  - Remaining messages are processed normally, and synchronization history continues to advance.
  - Prevents deleted messages from interrupting both initial scans and incremental updates.
- **Release**
  - Included as a patch update for the inbox plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->