### PR TITLE
release: point the outliner changeset at @dxos/plugin-tasks

### DIFF
--- a/.changeset/outliner-task-management.md
+++ b/.changeset/outliner-task-management.md
@@ -1,5 +1,5 @@
 ---
-'@dxos/plugin-outliner': minor
+'@dxos/plugin-tasks': minor
 '@dxos/ui-editor': minor
 ---
 


### PR DESCRIPTION
## Problem

The `Version PR or publish (@latest)` job fails at `pnpm changeset:version`:

```
error Error: Found changeset outliner-task-management for package @dxos/plugin-outliner
      which is not in the workspace
    at mapGetOrThrow (@changesets/assemble-release-plan)
```

`@dxos/plugin-outliner` was renamed to `@dxos/plugin-tasks` in #12431 (`plugin-projects: milestone 5`). That commit updated the `fixed` group in `.changeset/config.json` for the rename, but the changeset still pending from #12423 (`.changeset/outliner-task-management.md`) kept naming the old package. `assembleReleasePlan` throws on any changeset that names a package outside the workspace, so the Version PR / publish job aborts.

## Change

One line — the changeset's frontmatter now names `@dxos/plugin-tasks`. The prose is unchanged and still accurate (the release note describes outline items, which live in `plugin-tasks` now), and `@dxos/ui-editor` was already correct.

```diff
-'@dxos/plugin-outliner': minor
+'@dxos/plugin-tasks': minor
```

## Verification

`changeset status` exercises the same `assembleReleasePlan` path that failed in CI. Before the fix it reproduces the exact error:

```
$ npx changeset status
🦋  error Error: Found changeset outliner-task-management for package @dxos/plugin-outliner which is not in the workspace
🦋  error     at mapGetOrThrow (…/@changesets/assemble-release-plan/…)
🦋  error     at getRelevantChangesets (…)
🦋  error     at Object.assembleReleasePlan [as default] (…)
```

After the fix it assembles the plan cleanly and exits 0 (`info NO packages to be bumped at major`).

I also swept every pending changeset's frontmatter against the 317 workspace package names — `@dxos/plugin-outliner` was the only stale reference.

## Note

Nothing validates changeset package names at PR time, so this class of failure stays invisible until the release job runs on `main`. A `changeset status` step in the `Check` workflow would catch it on the PR that does the rename. Happy to add that here or separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGqynfh3QgRvbnoQtz7Koy)_