### PR TITLE
composer-app: update passkey well-known auth origin to auth.dxos.network

### DIFF
--- a/.agents/projects/mcp/TASKS.md
+++ b/.agents/projects/mcp/TASKS.md
@@ -71,7 +71,7 @@ space session, open questions) and §9 (milestones M6–M9).
       `IdentityRecovery` (agents/prisma/schema.prisma:27) + `verifyWebauthnSignature`
       (sdk/edge-crypto/src/webauthn.ts:24) + hub `lookupAccount`; `@simplewebauthn/server` comes
       OUT of hub-service. (2) RP ID stays **composer.space** via Related Origin Requests —
-      `composer.space/.well-known/webauthn` (application/json) lists `https://auth.dxos.org`, so
+      `composer.space/.well-known/webauthn` (application/json) lists `https://auth.dxos.network`, so
       existing passkeys work with NO re-registration. (3) My audit was WRONG that no server-side
       passkey verification exists: `db-service/src/worker/api-handler/recovery.ts:199` does it
       today (in EDGE, not the hub). (4) Passkeys were never being deprecated; the two `TODO`s mean

--- a/packages/apps/composer-app/src/functions/_worker.ts
+++ b/packages/apps/composer-app/src/functions/_worker.ts
@@ -197,16 +197,16 @@ const handleRssProxy = async (request: Request): Promise<Response> => {
  * relying party. WebAuthn otherwise only lets a page assert an RP ID that is a registrable-domain
  * suffix of its own origin, which would confine every ceremony to `*.composer.space`. Listing an
  * origin here is what lets the MCP passkey ceremony — served from the `hub-service` worker on
- * `auth.dxos.org` — reach those existing credentials without re-registration.
+ * `auth.dxos.network` — reach those existing credentials without re-registration.
  *
  * `composer.space` itself is deliberately absent: same-origin assertions are always permitted.
  *
  * Clients are only required to support 5 unique eTLD+1 labels, so entries are not free — but every
- * `*.composer.space` origin shares one label, and `dxos` covers `auth.dxos.org`.
+ * `*.composer.space` origin shares one label, and `dxos` covers `auth.dxos.network`.
  *
  * https://w3c.github.io/webauthn/#sctn-related-origins
  */
-const WEBAUTHN_RELATED_ORIGINS = ['https://auth.dxos.org'];
+const WEBAUTHN_RELATED_ORIGINS = ['https://auth.dxos.network'];
 
 /**
  * The native app's bundle id. Qualified by `APPLE_TEAM_ID` (wrangler.jsonc) into the `<team id>.<bundle


### PR DESCRIPTION
## Summary

Update the WebAuthn related origins configuration from `auth.dxos.org` to `auth.dxos.network` in the Composer app's Cloudflare Worker. This reflects the new authentication endpoint for passkey operations.

## Changes

- Updated `WEBAUTHN_RELATED_ORIGINS` constant to use `https://auth.dxos.network`
- Updated related documentation comments to reference the new domain

## Impact

This allows MCP passkey ceremonies served from `auth.dxos.network` to reach existing credentials registered on `composer.space` without re-registration via WebAuthn Related Origin Requests.

---
_Generated by [Claude Code](https://claude.ai/code/session_012oKWcC4g9gyQpRUS7bpWH1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated passkey authentication to use the correct WebAuthn related-origin URL.
  * Updated accompanying documentation comments to reflect the new authentication domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->