### PR TITLE
react-ui: default forms in cards to the sm gutter; factor the Message padding wrapper

### DIFF
--- a/.changeset/message-content-body.md
+++ b/.changeset/message-content-body.md
@@ -1,0 +1,6 @@
+---
+'@dxos/react-ui': minor
+'@dxos/plugin-space': patch
+---
+
+Rename `Message.Content` to `Message.Body` and add a new optional `Message.Content` wrapper that carries the message's default padding. `Card.Root` accepts a `gutter` prop so a card whose body is a form insets its fields like a standalone form.

--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatMcpErrors.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatMcpErrors.tsx
@@ -34,7 +34,7 @@ export const ChatMcpErrors = ({ classNames, processor }: ChatMcpErrorsProps) => 
   return (
     <Message.Root classNames={['m-1', classNames]} valence='warning'>
       <Message.Title onClose={handleDismiss}>{t('mcp-server-error.label')}</Message.Title>
-      <Message.Content asChild>
+      <Message.Body asChild>
         <ul className='flex flex-col gap-0.5 text-sm'>
           {errors.map((error) => (
             <li key={`${error.url}::${error.protocol}`} className='truncate'>
@@ -44,7 +44,7 @@ export const ChatMcpErrors = ({ classNames, processor }: ChatMcpErrorsProps) => 
             </li>
           ))}
         </ul>
-      </Message.Content>
+      </Message.Body>
     </Message.Root>
   );
 };

--- a/packages/plugins/plugin-atproto/src/containers/AtprotoCompanion/AtprotoCompanion.tsx
+++ b/packages/plugins/plugin-atproto/src/containers/AtprotoCompanion/AtprotoCompanion.tsx
@@ -223,25 +223,25 @@ export const AtprotoCompanion = ({ subject, role, attendableId }: AtprotoCompani
               {/* Reasons publishing is unavailable. */}
               {!connection && (
                 <Message.Root valence='info'>
-                  <Message.Content>{t('no-connection.label')}</Message.Content>
+                  <Message.Body>{t('no-connection.label')}</Message.Body>
                 </Message.Root>
               )}
               {ineligibleReason && (
                 <Message.Root valence={reasonValence}>
-                  <Message.Content>{ineligibleReason}</Message.Content>
+                  <Message.Body>{ineligibleReason}</Message.Body>
                 </Message.Root>
               )}
               {error && (
                 <Message.Root valence='error'>
-                  <Message.Content>{error}</Message.Content>
+                  <Message.Body>{error}</Message.Body>
                 </Message.Root>
               )}
 
               {/* First-publish confirmation. */}
               {confirming && (
                 <Message.Root valence='warning'>
-                  <Message.Content>{t('confirm-publish.message')}</Message.Content>
-                  <Message.Content asChild>
+                  <Message.Body>{t('confirm-publish.message')}</Message.Body>
+                  <Message.Body asChild>
                     <div role='none' className='flex gap-2 pbs-2'>
                       <Button variant='primary' disabled={busy} onClick={handlePublish}>
                         {t('confirm-publish.label')}
@@ -250,7 +250,7 @@ export const AtprotoCompanion = ({ subject, role, attendableId }: AtprotoCompani
                         {t('cancel.label')}
                       </Button>
                     </div>
-                  </Message.Content>
+                  </Message.Body>
                 </Message.Root>
               )}
 
@@ -261,7 +261,7 @@ export const AtprotoCompanion = ({ subject, role, attendableId }: AtprotoCompani
                 <h2 className='text-xs uppercase tracking-wide text-description'>{t('network-view.label')}</h2>
                 {mirroredUnresolved && (
                   <Message.Root valence='warning'>
-                    <Message.Content>{t('mirror-unresolved.label')}</Message.Content>
+                    <Message.Body>{t('mirror-unresolved.label')}</Message.Body>
                   </Message.Root>
                 )}
                 <Treegrid.Root gridTemplateColumns='minmax(0, 1fr) minmax(0, 1fr) min-content' classNames='gap-x-3'>

--- a/packages/plugins/plugin-client/src/containers/AccountContainer/AccountContainer.tsx
+++ b/packages/plugins/plugin-client/src/containers/AccountContainer/AccountContainer.tsx
@@ -121,7 +121,7 @@ export const AccountContainer = () => {
               <>
                 <Message.Root valence='warning'>
                   <Message.Title icon='ph--warning--duotone'>{t('no-edge-access.title')}</Message.Title>
-                  <Message.Content>{t('no-edge-access.description')}</Message.Content>
+                  <Message.Body>{t('no-edge-access.description')}</Message.Body>
                 </Message.Root>
                 <Form.Row label={t('request-access.label')} description={t('request-access.description')}>
                   {requestSubmitted ? (
@@ -148,7 +148,7 @@ export const AccountContainer = () => {
             ) : accountState === 'error' && !account ? (
               <Message.Root valence='error'>
                 <Message.Title icon='ph--cloud-x--duotone'>{t('account-offline.title')}</Message.Title>
-                <Message.Content>{t('account-offline.description')}</Message.Content>
+                <Message.Body>{t('account-offline.description')}</Message.Body>
               </Message.Root>
             ) : account ? (
               <>

--- a/packages/plugins/plugin-client/src/containers/RecoveryCredentialsContainer/RecoveryCredentialsContainer.tsx
+++ b/packages/plugins/plugin-client/src/containers/RecoveryCredentialsContainer/RecoveryCredentialsContainer.tsx
@@ -49,7 +49,7 @@ export const RecoveryCredentialsContainer = () => {
             {recoveryCredentials.length < 1 ? (
               <Message.Root valence='error'>
                 <Message.Title icon='ph--shield-warning--duotone'>{t('no-credentials.title')}</Message.Title>
-                <Message.Content>{t('no-credentials.message')}</Message.Content>
+                <Message.Body>{t('no-credentials.message')}</Message.Body>
               </Message.Root>
             ) : (
               <Listbox.Root>

--- a/packages/plugins/plugin-client/src/containers/UsageContainer/UsageView.tsx
+++ b/packages/plugins/plugin-client/src/containers/UsageContainer/UsageView.tsx
@@ -216,7 +216,7 @@ export const UsageView = ({ state, data, lastUpdated, onRefresh }: UsageViewProp
             {message ? (
               <Message.Root valence={message.valence}>
                 <Message.Title icon={message.icon}>{t(message.title)}</Message.Title>
-                <Message.Content>{t(message.description)}</Message.Content>
+                <Message.Body>{t(message.description)}</Message.Body>
               </Message.Root>
             ) : (
               <Form.FieldSet fieldProvider={meterFieldProvider} />

--- a/packages/plugins/plugin-doctor/src/containers/DiagnosticsPanel/DiagnosticsPanel.tsx
+++ b/packages/plugins/plugin-doctor/src/containers/DiagnosticsPanel/DiagnosticsPanel.tsx
@@ -195,7 +195,7 @@ const ProviderResult = ({ result, t }: { result: DiagnosticRunResult; t: TFuncti
       </header>
       {result.error && (
         <Message.Root valence='error' classNames='m-2'>
-          <Message.Content>{result.error}</Message.Content>
+          <Message.Body>{result.error}</Message.Body>
         </Message.Root>
       )}
       {result.issues.length > 0 && (

--- a/packages/plugins/plugin-ibkr/src/components/FundamentalsPanel/FundamentalsPanel.tsx
+++ b/packages/plugins/plugin-ibkr/src/components/FundamentalsPanel/FundamentalsPanel.tsx
@@ -120,12 +120,12 @@ export const FundamentalsPanel = ({ snapshot, loading, error, onRefresh }: Funda
           ) : error ? (
             <Message.Root valence='error'>
               <Message.Title icon='ph--warning-circle--duotone'>{t('fundamentals.heading')}</Message.Title>
-              <Message.Content>{error}</Message.Content>
+              <Message.Body>{error}</Message.Body>
             </Message.Root>
           ) : empty ? (
             <Message.Root valence='neutral'>
               <Message.Title icon='ph--chart-bar--duotone'>{t('fundamentals.heading')}</Message.Title>
-              <Message.Content>{t('fundamentals.empty.label')}</Message.Content>
+              <Message.Body>{t('fundamentals.empty.label')}</Message.Body>
             </Message.Root>
           ) : (
             <Form.FieldSet readonly fieldProvider={fieldProvider} />

--- a/packages/plugins/plugin-observability/src/containers/ObservabilitySettings/ObservabilitySettings.tsx
+++ b/packages/plugins/plugin-observability/src/containers/ObservabilitySettings/ObservabilitySettings.tsx
@@ -36,7 +36,7 @@ export const ObservabilitySettings = ({ subject }: ObservabilitySettingsProps) =
         <Form.Content>
           <Form.Section title={meta.profile.name ?? meta.profile.key}>
             <Message.Root valence='info'>
-              <Message.Content>{t('observability.description')}</Message.Content>
+              <Message.Body>{t('observability.description')}</Message.Body>
             </Message.Root>
             <Form.FieldSet />
           </Form.Section>

--- a/packages/plugins/plugin-payments/src/containers/PaymentsSettings/PaymentsSettings.tsx
+++ b/packages/plugins/plugin-payments/src/containers/PaymentsSettings/PaymentsSettings.tsx
@@ -89,7 +89,7 @@ export const PaymentsSettings = ({ subject }: PaymentsSettingsProps) => {
               {status.kind === 'error' && (
                 <Message.Root valence='error'>
                   <Message.Title>{t('error.label')}</Message.Title>
-                  <Message.Content>{status.text}</Message.Content>
+                  <Message.Body>{status.text}</Message.Body>
                 </Message.Root>
               )}
             </div>

--- a/packages/plugins/plugin-registry/src/components/RegistrySettings/RegistrySettings.tsx
+++ b/packages/plugins/plugin-registry/src/components/RegistrySettings/RegistrySettings.tsx
@@ -96,7 +96,7 @@ export const RegistrySettings = ({
         <Form.Content>
           <Form.Section title={t('dev-plugin.section.title')}>
             <Message.Root valence='neutral'>
-              <Message.Content>{t('dev-plugin.description')}</Message.Content>
+              <Message.Body>{t('dev-plugin.description')}</Message.Body>
             </Message.Root>
             <Form.Row label={t('dev-plugin.url.label')} description={t('dev-plugin.url.description')}>
               <Input.Root>
@@ -120,7 +120,7 @@ export const RegistrySettings = ({
             </Form.Row>
             {enabled && !loadedDevId && !busy && (
               <Message.Root valence='warning'>
-                <Message.Content>{t('dev-plugin.not-loaded.message')}</Message.Content>
+                <Message.Body>{t('dev-plugin.not-loaded.message')}</Message.Body>
               </Message.Root>
             )}
           </Form.Section>

--- a/packages/plugins/plugin-review/src/containers/CommentsArticle/CommentsArticle.tsx
+++ b/packages/plugins/plugin-review/src/containers/CommentsArticle/CommentsArticle.tsx
@@ -461,7 +461,7 @@ export const CommentsArticle = ({ attendableId, subject }: CommentsArticleProps)
     ) : hasSuggestions ? null : (
       <div className='p-form-padding'>
         <Message.Root>
-          <Message.Content>
+          <Message.Body>
             <span>
               <Trans
                 {...{
@@ -474,7 +474,7 @@ export const CommentsArticle = ({ attendableId, subject }: CommentsArticleProps)
                 }}
               />
             </span>
-          </Message.Content>
+          </Message.Body>
         </Message.Root>
       </div>
     );

--- a/packages/plugins/plugin-space/src/containers/ObjectCardStack/ObjectCardStack.tsx
+++ b/packages/plugins/plugin-space/src/containers/ObjectCardStack/ObjectCardStack.tsx
@@ -48,11 +48,11 @@ export const ObjectCardStack = forwardRef<HTMLDivElement, ObjectCardStackProps>(
         </Panel.Toolbar>
         <Panel.Content>
           {selectedObjects.length === 0 ? (
-            <div className='p-trim-md'>
-              <Message.Root>
+            <Message.Root>
+              <Message.Content>
                 <Message.Title>{t('row-details-no-selection.label')}</Message.Title>
-              </Message.Root>
-            </div>
+              </Message.Content>
+            </Message.Root>
           ) : (
             <Mosaic.Container asChild orientation='vertical' autoScroll={viewport} eventHandler={eventHandler}>
               <ScrollArea.Root orientation='vertical' centered padding>
@@ -64,7 +64,8 @@ export const ObjectCardStack = forwardRef<HTMLDivElement, ObjectCardStackProps>(
                     getId={(obj) => obj.id}
                     Tile={({ ...props }) => (
                       <Mosaic.Tile {...props}>
-                        <Card.Root fullWidth classNames='pb-form-gap'>
+                        {/* The card's only content is a form, so it takes the form gutter rather than the card's chrome inset. */}
+                        <Card.Root fullWidth gutter='sm' classNames='pb-form-gap'>
                           <ObjectForm object={props.data} type={type} />
                         </Card.Root>
                       </Mosaic.Tile>

--- a/packages/plugins/plugin-trip/src/containers/BookingSearch/BookingSearch.tsx
+++ b/packages/plugins/plugin-trip/src/containers/BookingSearch/BookingSearch.tsx
@@ -182,11 +182,11 @@ export const BookingSearch = ({ segment }: BookingSearchProps) => {
       <div className='p-form-padding'>
         <Message.Root valence='info'>
           <Message.Title>{t('booking.no-providers.message')}</Message.Title>
-          <Message.Content classNames='flex flex-col py-1 gap-2'>
-            {/* `span` (not `p`): Message.Content already renders a `<p>`, and `<p>` cannot nest `<p>`. */}
+          <Message.Body classNames='flex flex-col py-1 gap-2'>
+            {/* `span` (not `p`): Message.Body already renders a `<p>`, and `<p>` cannot nest `<p>`. */}
             <span>{t('booking.enable-providers.message')}</span>
             <PluginRegistryButton />
-          </Message.Content>
+          </Message.Body>
         </Message.Root>
       </div>
     );

--- a/packages/sdk/shell/src/steps/ConfirmReset.tsx
+++ b/packages/sdk/shell/src/steps/ConfirmReset.tsx
@@ -80,7 +80,7 @@ export const ConfirmReset = ({
     <>
       <Message.Root valence='error' classNames='mb-2'>
         <Message.Title>{resolvedTitle}</Message.Title>
-        <Message.Content>{resolvedMessage}</Message.Content>
+        <Message.Body>{resolvedMessage}</Message.Body>
       </Message.Root>
       <TextInput
         {...{ validationMessage }}

--- a/packages/ui/react-ui-introspect/src/components/ToolResults/ToolResults.tsx
+++ b/packages/ui/react-ui-introspect/src/components/ToolResults/ToolResults.tsx
@@ -49,7 +49,7 @@ export const ToolResults = composable<HTMLDivElement, ToolResultsProps>(
           <div className='p-form-chrome'>
             <Message.Root valence='error'>
               {error instanceof Error && <Message.Title>{error.name}</Message.Title>}
-              <Message.Content>{error instanceof Error ? error.message : String(error)}</Message.Content>
+              <Message.Body>{error instanceof Error ? error.message : String(error)}</Message.Body>
             </Message.Root>
           </div>
         )}

--- a/packages/ui/react-ui-introspect/src/components/ToolsExplorer/ToolsExplorer.tsx
+++ b/packages/ui/react-ui-introspect/src/components/ToolsExplorer/ToolsExplorer.tsx
@@ -126,7 +126,7 @@ export const ToolsExplorer = composable<HTMLDivElement, ToolsExplorerProps>(
         <div {...composableProps(props, { role: 'none' })} ref={forwardedRef}>
           <Message.Root classNames='m-4' valence='error'>
             <Message.Title>{t('connection-failed.title')}</Message.Title>
-            <Message.Content>{connectError.message}</Message.Content>
+            <Message.Body>{connectError.message}</Message.Body>
           </Message.Root>
         </div>
       );

--- a/packages/ui/react-ui/src/components/Card/Card.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.tsx
@@ -26,7 +26,7 @@ import { useThemeContext } from '../../hooks';
 import { composable, composableProps, slottable } from '../../util';
 import { type ThemedClassName } from '../../util';
 import { Button, IconButton } from '../Button';
-import { Column } from '../Column';
+import { Column, type ColumnRootProps } from '../Column';
 import { Icon } from '../Icon';
 import { Image, type ImageProps } from '../Image';
 import { DropdownMenu } from '../Menu';
@@ -47,6 +47,12 @@ type CardRootProps = {
    * used to align a nested card's rows to an outer 3-track grid. See `Column.Root`.
    */
   'subgrid'?: boolean;
+  /**
+   * Width of the card's leading/trailing gutter tracks. Defaults to `lg` (chrome-sized inset for
+   * headers and rows); a card whose whole body is a form should use `sm` so the fields inset like
+   * a standalone form rather than by the card's chrome.
+   */
+  'gutter'?: ColumnRootProps['gutter'];
   'density'?: Density;
   'style'?: CSSProperties;
   'tabIndex'?: number;
@@ -68,14 +74,14 @@ type CardRootProps = {
  * `<div>` exactly the way `slottable`'s `Slot`/`Primitive.div` branch did.
  */
 const CardRoot = composable<HTMLDivElement, CardRootProps>(
-  ({ children, id, role, border = true, fullWidth, subgrid, density, ...props }, forwardedRef) => {
+  ({ children, id, role, border = true, fullWidth, subgrid, gutter = 'lg', density, ...props }, forwardedRef) => {
     const { className, ...rest } = composableProps(props);
     const { tx } = useThemeContext();
 
     return (
       <Column.Root
         asChild
-        gutter='lg'
+        gutter={gutter}
         subgrid={subgrid}
         classNames={tx('card.root', { border, fullWidth }, className)}
         role={role ?? 'group'}

--- a/packages/ui/react-ui/src/components/Message/Message.stories.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.stories.tsx
@@ -19,23 +19,30 @@ type StoryArgs = {
   title: string;
   body: string;
   button?: boolean;
+  /** Wrap the title/body in `Message.Content` so the message carries its own inset. */
+  padded?: boolean;
 };
 
-const DefaultStory = ({ valence, title, body, button }: StoryArgs) => (
-  <div className='w-[30rem]'>
-    <Message.Root valence={valence}>
-      {title && <Message.Title onClose={() => console.log('close')}>{title}</Message.Title>}
-      {body && (
-        <Message.Content asChild classNames='gap-2'>
-          <div>
-            <p>{body}</p>
-            {button && <Button>Test</Button>}
-          </div>
-        </Message.Content>
-      )}
-    </Message.Root>
-  </div>
-);
+const DefaultStory = ({ valence, title, body, button, padded }: StoryArgs) => {
+  const Wrapper = padded ? Message.Content : React.Fragment;
+  return (
+    <div className='w-[30rem]'>
+      <Message.Root valence={valence}>
+        <Wrapper>
+          {title && <Message.Title onClose={() => console.log('close')}>{title}</Message.Title>}
+          {body && (
+            <Message.Body asChild classNames='gap-2'>
+              <div>
+                <p>{body}</p>
+                {button && <Button>Test</Button>}
+              </div>
+            </Message.Body>
+          )}
+        </Wrapper>
+      </Message.Root>
+    </div>
+  );
+};
 
 const meta = {
   title: 'ui/react-ui-core/components/Message',
@@ -99,5 +106,15 @@ export const Error: Story = {
     title: 'Error',
     body: random.lorem.paragraphs(1),
     button: true,
+  },
+};
+
+export const Padded: Story = {
+  args: {
+    valence: 'neutral',
+    title: 'Padded',
+    body: random.lorem.paragraphs(1),
+    button: true,
+    padded: true,
   },
 };

--- a/packages/ui/react-ui/src/components/Message/Message.theme.ts
+++ b/packages/ui/react-ui/src/components/Message/Message.theme.ts
@@ -14,6 +14,11 @@ const root: ComponentFunction<MessageStyleProps> = ({ valence }, etc) => {
   return mx('p-1 rounded-sm', messageValence(valence), etc);
 };
 
+// Subgrid rather than a plain block so a nested `Message.Title` row still reaches the root's gutters.
+const content: ComponentFunction<MessageStyleProps> = (_, etc) => {
+  return mx('col-span-full grid grid-cols-subgrid p-trim-md', etc);
+};
+
 const header: ComponentFunction<MessageStyleProps> = (_, etc) => {
   return mx('items-center', etc);
 };
@@ -22,13 +27,14 @@ const title: ComponentFunction<MessageStyleProps> = (_, etc) => {
   return mx('col-start-2 overflow-hidden truncate', etc);
 };
 
-const content: ComponentFunction<MessageStyleProps> = (_, etc) => {
+const body: ComponentFunction<MessageStyleProps> = (_, etc) => {
   return mx('col-start-2 flex flex-col first:font-medium pb-1.5', etc);
 };
 
 export const messageTheme: Theme<MessageStyleProps> = {
   root,
+  content,
   header,
   title,
-  content,
+  body,
 };

--- a/packages/ui/react-ui/src/components/Message/Message.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.tsx
@@ -118,6 +118,35 @@ const MessageRoot = forwardRef<HTMLDivElement, MessageRootProps>(
 MessageRoot.displayName = MESSAGE_NAME;
 
 //
+// Content
+//
+
+type MessageContentProps = ThemedClassName<ComponentPropsWithRef<typeof Primitive.div>> & {
+  asChild?: boolean;
+};
+
+const MESSAGE_CONTENT_NAME = 'Message.Content';
+
+/**
+ * Optional padded wrapper around a message's title and body — supplies the inset that hosts
+ * otherwise had to add with their own wrapper `div`. Spans the root's tracks via subgrid so
+ * `Message.Title` still places its icon in the gutter.
+ */
+const MessageContent = forwardRef<HTMLDivElement, MessageContentProps>(
+  ({ asChild, classNames, children, ...props }, forwardedRef) => {
+    const { tx } = useThemeContext();
+    const Comp = asChild ? Slot : Primitive.div;
+    return (
+      <Comp {...props} className={tx('message.content', {}, classNames)} ref={forwardedRef}>
+        {children}
+      </Comp>
+    );
+  },
+);
+
+MessageContent.displayName = MESSAGE_CONTENT_NAME;
+
+//
 // Title
 //
 
@@ -164,29 +193,29 @@ const MessageTitle = forwardRef<HTMLDivElement, MessageTitleProps>(
 MessageTitle.displayName = MESSAGE_TITLE_NAME;
 
 //
-// Content
+// Body
 //
 
-type MessageContentProps = Omit<ThemedClassName<ComponentPropsWithRef<typeof Primitive.h2>>, 'id'> & {
+type MessageBodyProps = Omit<ThemedClassName<ComponentPropsWithRef<typeof Primitive.h2>>, 'id'> & {
   asChild?: boolean;
 };
 
-const MESSAGE_CONTENT_NAME = 'Message.Content';
+const MESSAGE_BODY_NAME = 'Message.Body';
 
-const MessageContent = forwardRef<HTMLParagraphElement, MessageContentProps>(
+const MessageBody = forwardRef<HTMLParagraphElement, MessageBodyProps>(
   ({ asChild, classNames, children, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
-    const { descriptionId } = useMessageContext(MESSAGE_CONTENT_NAME);
+    const { descriptionId } = useMessageContext(MESSAGE_BODY_NAME);
     const Comp = asChild ? Slot : Primitive.p;
     return (
-      <Comp {...props} className={tx('message.content', {}, classNames)} id={descriptionId} ref={forwardedRef}>
+      <Comp {...props} className={tx('message.body', {}, classNames)} id={descriptionId} ref={forwardedRef}>
         {children}
       </Comp>
     );
   },
 );
 
-MessageContent.displayName = MESSAGE_CONTENT_NAME;
+MessageBody.displayName = MESSAGE_BODY_NAME;
 
 //
 // Message
@@ -194,10 +223,11 @@ MessageContent.displayName = MESSAGE_CONTENT_NAME;
 
 export const Message = {
   Root: MessageRoot,
-  Title: MessageTitle,
   Content: MessageContent,
+  Title: MessageTitle,
+  Body: MessageBody,
 };
 
 export const Callout = Message;
 
-export type { MessageContentProps, MessageRootProps, MessageTitleProps };
+export type { MessageBodyProps, MessageContentProps, MessageRootProps, MessageTitleProps };

--- a/packages/ui/react-ui/src/playground/Elevation.stories.tsx
+++ b/packages/ui/react-ui/src/playground/Elevation.stories.tsx
@@ -278,12 +278,12 @@ const AppFrame = () => {
           </Panel.Toolbar>
 
           <Panel.Content>
-            <div className='p-trim-md'>
-              <Message.Root valence='warning'>
+            <Message.Root valence='warning'>
+              <Message.Content>
                 <Message.Title>Message.Root</Message.Title>
-                <Message.Content>A valence surface nested inside a card.</Message.Content>
-              </Message.Root>
-            </div>
+                <Message.Body>A valence surface nested inside a card.</Message.Body>
+              </Message.Content>
+            </Message.Root>
             <ScrollArea.Root centered>
               <ScrollArea.Viewport classNames='flex flex-col gap-trim-md'>
                 <ContactCard />


### PR DESCRIPTION
## Summary

Two small UI-refactor follow-ups.

**1. Gutter spacing in `SelectedObjectsSurface`.** Forms rendered inside `ObjectCardStack` cards inherited the card's `lg` (32px) gutter — `Form.Viewport` detects a host Column and places its body in the host's content track, so the fields inset by the card's chrome instead of the form's own `sm` (8px). `Card.Root` now takes a `gutter` prop (default `lg`, unchanged), and `ObjectCardStack` passes `sm`, so the card stack matches the properties companion.

**2. `Message` padding wrapper.** Call sites wrapped `Message.Root` in a `<div className='p-trim-md'>` to give the message its inset. The current `Message.Content` (the description paragraph) is renamed to `Message.Body`, and a new optional `Message.Content` supplies that padding as a subgrid row — so `Message.Title` still reaches the gutters:

```tsx
<Message.Root>
  <Message.Content>
    <Message.Title>{t('row-details-no-selection.label')}</Message.Title>
  </Message.Content>
</Message.Root>
```

`Message.Content` → `Message.Body` is applied across all 17 call sites; the wrapper is factored out at the two `p-trim-md` sites (`ObjectCardStack`, `Elevation.stories`). Three other sites wrap with different tokens (`p-form-padding`, `p-form-chrome`) and are left alone.

## Verification

- `moon run :build` for every touched package — green.
- `moon run :lint` for the touched UI packages — green.
- Storybook, `plugins/plugin-space/containers/TypeArticle`: selected-object form cards now compute `grid-template-columns: 8px 632px 8px` (was 32px), and the empty-state message renders full-bleed with its own inset.
- Storybook, `ui/react-ui-core/components/Message`: `Default` unchanged; new `Padded` story exercises `Message.Content` — icon and close button still land in the gutters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated message body component for clearer, consistent message descriptions.
  * Added optional message content padding support.
  * Added a configurable card gutter, defaulting to the existing spacing.
* **UI Improvements**
  * Updated informational, warning, error, and empty-state messages across the app for consistent presentation.
  * Adjusted object form cards to use a smaller gutter.
* **Documentation**
  * Added release notes covering the message and card component updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->