### PR TITLE
feat: point client configs at dxos.network edge domains

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -415,7 +415,7 @@ jobs:
     timeout-minutes: 90
     env:
       DX_ENVIRONMENT: ci
-      DX_EDGE_BASE_URL: 'wss://edge-main.dxos.workers.dev/'
+      DX_EDGE_BASE_URL: 'wss://main.dxos.network/'
       DX_TELEMETRY_TAG: e2e
       DX_PWA: false
     steps:

--- a/.github/workflows/env/labs
+++ b/.github/workflows/env/labs
@@ -16,5 +16,5 @@ DX_PWA=false
 DX_MINIFY=true
 DX_EDGE_ECHO_REPLICATOR=true
 DX_LABS=true
-DX_EDGE_BASE_URL="https://edge-production.dxos.workers.dev/"
-DX_EDGE_AI_SERVICE_URL="https://ai-service-labs.dxos.workers.dev" # MUST NOT END WITH /
+DX_EDGE_BASE_URL="https://dxos.network/"
+DX_EDGE_AI_SERVICE_URL="https://ai.labs.dxos.network" # MUST NOT END WITH /

--- a/.github/workflows/env/labs
+++ b/.github/workflows/env/labs
@@ -17,4 +17,4 @@ DX_MINIFY=true
 DX_EDGE_ECHO_REPLICATOR=true
 DX_LABS=true
 DX_EDGE_BASE_URL="https://dxos.network/"
-DX_EDGE_AI_SERVICE_URL="https://ai.labs.dxos.network" # MUST NOT END WITH /
+DX_EDGE_AI_SERVICE_URL="https://ai-service-labs.dxos.workers.dev" # MUST NOT END WITH /

--- a/.github/workflows/env/labs
+++ b/.github/workflows/env/labs
@@ -17,4 +17,3 @@ DX_MINIFY=true
 DX_EDGE_ECHO_REPLICATOR=true
 DX_LABS=true
 DX_EDGE_BASE_URL="https://dxos.network/"
-DX_EDGE_AI_SERVICE_URL="https://ai-service-labs.dxos.workers.dev" # MUST NOT END WITH /

--- a/.github/workflows/env/main
+++ b/.github/workflows/env/main
@@ -15,5 +15,3 @@ IPFS_API_SECRET=${IPFS_API_SECRET}
 DX_PWA=false
 DX_MINIFY=true
 DX_EDGE_BASE_URL="https://main.dxos.network/"
-# TODO(wittjosiah): Main env?
-DX_EDGE_AI_SERVICE_URL="https://ai-service.dxos.workers.dev/"

--- a/.github/workflows/env/main
+++ b/.github/workflows/env/main
@@ -14,6 +14,6 @@ IPFS_API_SECRET=${IPFS_API_SECRET}
 # End common vars
 DX_PWA=false
 DX_MINIFY=true
-DX_EDGE_BASE_URL="https://edge-main.dxos.workers.dev/"
+DX_EDGE_BASE_URL="https://main.dxos.network/"
 # TODO(wittjosiah): Main env?
 DX_EDGE_AI_SERVICE_URL="https://ai-service.dxos.workers.dev/"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           NODE_ENV: production
           LOG_FILTER: error
-          DX_EDGE_BASE_URL: https://edge-main.dxos.workers.dev
+          DX_EDGE_BASE_URL: https://main.dxos.network
 
       - name: Write deploy metadata
         run: |

--- a/packages/apps/composer-app/dx-env.yml
+++ b/packages/apps/composer-app/dx-env.yml
@@ -18,7 +18,6 @@ DX_EDGE_BASE_URL:
   path: runtime.services.edge.url
   type: string
 
-
 DX_SANDBOX_SERVICE_URL:
   path: runtime.services.sandbox.url
   type: string

--- a/packages/apps/composer-app/dx-env.yml
+++ b/packages/apps/composer-app/dx-env.yml
@@ -18,10 +18,6 @@ DX_EDGE_BASE_URL:
   path: runtime.services.edge.url
   type: string
 
-# NOTE: NORMALIZED THESE URLS.
-DX_EDGE_AI_SERVICE_URL:
-  path: runtime.services.ai.server
-  type: string
 
 DX_SANDBOX_SERVICE_URL:
   path: runtime.services.sandbox.url

--- a/packages/apps/composer-app/dx-local.yml
+++ b/packages/apps/composer-app/dx-local.yml
@@ -18,7 +18,7 @@ runtime:
       type: LOCAL_TESTING
     # NOTE: For local testing use the DX_EDGE_BASE_URL environment variable.
     edge:
-      url: https://edge-main.dxos.workers.dev
+      url: https://main.dxos.network
     ai:
       server: https://ai-service.dxos.workers.dev
     sandbox:

--- a/packages/apps/composer-app/dx-local.yml
+++ b/packages/apps/composer-app/dx-local.yml
@@ -19,7 +19,5 @@ runtime:
     # NOTE: For local testing use the DX_EDGE_BASE_URL environment variable.
     edge:
       url: https://main.dxos.network
-    ai:
-      server: https://ai-service.dxos.workers.dev
     sandbox:
       url: https://sandbox-service.dxos.workers.dev

--- a/packages/apps/composer-app/dx.yml
+++ b/packages/apps/composer-app/dx.yml
@@ -28,4 +28,4 @@ runtime:
       - name: image
         endpoint: https://image.main.dxos.network
       - name: discord
-        endpoint: https://discord-service.dxos.workers.dev
+        endpoint: https://discord.dxos.network

--- a/packages/apps/composer-app/dx.yml
+++ b/packages/apps/composer-app/dx.yml
@@ -12,9 +12,9 @@ runtime:
 
   services:
     edge:
-      url: wss://edge-production.dxos.workers.dev/
+      url: wss://dxos.network/
     iceProviders:
-      - urls: https://edge-production.dxos.workers.dev/ice
+      - urls: https://dxos.network/ice
     ai:
       server: https://ai-service.dxos.workers.dev
     sandbox:
@@ -24,10 +24,10 @@ runtime:
       gateway: https://gateway.ipfs.dxos.network/ipfs
     edgeServices:
       - name: calls
-        endpoint: https://calls-service.dxos.workers.dev
+        endpoint: https://calls.dxos.network
       - name: transcription
-        endpoint: https://calls-service.dxos.workers.dev
+        endpoint: https://calls.dxos.network
       - name: image
-        endpoint: https://image-service-main.dxos.workers.dev
+        endpoint: https://image.main.dxos.network
       - name: discord
         endpoint: https://discord-service.dxos.workers.dev

--- a/packages/apps/composer-app/dx.yml
+++ b/packages/apps/composer-app/dx.yml
@@ -15,8 +15,6 @@ runtime:
       url: wss://dxos.network/
     iceProviders:
       - urls: https://dxos.network/ice
-    ai:
-      server: https://ai-service.dxos.workers.dev
     sandbox:
       url: https://sandbox-service.dxos.workers.dev
     ipfs:

--- a/packages/apps/tasks/dx.yml
+++ b/packages/apps/tasks/dx.yml
@@ -9,6 +9,6 @@ runtime:
 
   services:
     edge:
-      url: wss://edge-production.dxos.workers.dev/
+      url: wss://dxos.network/
     iceProviders:
-      - urls: https://edge-production.dxos.workers.dev/ice
+      - urls: https://dxos.network/ice

--- a/packages/apps/testbench-app/dx.yml
+++ b/packages/apps/testbench-app/dx.yml
@@ -20,6 +20,6 @@ runtime:
         username: dxos
         credential: dxos
     edge:
-      url: https://edge-main.dxos.workers.dev/
+      url: https://main.dxos.network/
     iceProviders:
-      - urls: https://edge-production.dxos.workers.dev/ice
+      - urls: https://dxos.network/ice

--- a/packages/apps/todomvc/dx.yml
+++ b/packages/apps/todomvc/dx.yml
@@ -9,6 +9,6 @@ runtime:
 
   services:
     edge:
-      url: wss://edge-production.dxos.workers.dev/
+      url: wss://dxos.network/
     iceProviders:
-      - urls: https://edge-production.dxos.workers.dev/ice
+      - urls: https://dxos.network/ice

--- a/packages/core/compute/assistant-toolkit/src/skills/discord/operations/fetch-messages.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/discord/operations/fetch-messages.ts
@@ -29,7 +29,8 @@ const DiscordConfigFromCredential = Layer.unwrapEffect(
     return DiscordConfig.layer({
       token: yield* Credential.CredentialsService.getApiKey({ service: 'discord.com' }),
       rest: {
-        baseUrl: 'https://api-proxy.dxos.workers.dev/discord.com/api/v10',
+        // Routed through the DXOS CORS proxy (cors-proxy worker), which forwards `Authorization` verbatim.
+        baseUrl: 'https://cors.dxos.network/discord.com/api/v10',
       },
     });
   }),

--- a/packages/core/mesh/edge-client/src/cors-proxy.ts
+++ b/packages/core/mesh/edge-client/src/cors-proxy.ts
@@ -6,7 +6,7 @@
 // dependencies so they can be bundled into workerd / browser environments
 // without pulling in protobufjs or similar node-only packages.
 
-const LEGACY_CORS_PROXY_URL = 'https://cors-proxy.dxos.workers.dev';
+const LEGACY_CORS_PROXY_URL = 'https://cors.dxos.network';
 
 // Matches EDGE_CLIENT_TAG_HEADER from @dxos/protocols.
 // Duplicated here to avoid importing the heavy protocols bundle in edge environments.
@@ -22,7 +22,7 @@ const remapAuthorizationForProxy = (headers: Headers): Headers => {
 };
 
 /**
- * Fetch through the legacy standalone open proxy at `cors-proxy.dxos.workers.dev`.
+ * Fetch through the legacy standalone open proxy at `cors.dxos.network`.
  * TEMPORARY — delete when the authenticated `/proxy/*` route on edge ships.
  */
 export const proxyFetchLegacy = (target: URL, init: RequestInit = {}, clientTag?: string): Promise<Response> => {

--- a/packages/devtools/cli/config/config-dev.yml
+++ b/packages/devtools/cli/config/config-dev.yml
@@ -15,7 +15,7 @@ runtime:
     edge:
       url: wss://edge.dxos.workers.dev/
     iceProviders:
-      - urls: https://edge-production.dxos.workers.dev/ice
+      - urls: https://dxos.network/ice
     ai:
       server: https://ai-service.dxos.workers.dev
     ipfs:

--- a/packages/devtools/cli/config/config-dev.yml
+++ b/packages/devtools/cli/config/config-dev.yml
@@ -16,8 +16,6 @@ runtime:
       url: wss://edge.dxos.workers.dev/
     iceProviders:
       - urls: https://dxos.network/ice
-    ai:
-      server: https://ai-service.dxos.workers.dev
     ipfs:
       server: https://api.ipfs.dxos.network/api/v0
       gateway: https://gateway.ipfs.dxos.network/ipfs

--- a/packages/devtools/cli/config/config-local.yml
+++ b/packages/devtools/cli/config/config-local.yml
@@ -15,7 +15,7 @@ runtime:
     edge:
       url: ws://localhost:8787/
     iceProviders:
-      - urls: https://edge-production.dxos.workers.dev/ice
+      - urls: https://dxos.network/ice
     ai:
       server: http://localhost:8788
     sandbox:

--- a/packages/devtools/cli/config/config-local.yml
+++ b/packages/devtools/cli/config/config-local.yml
@@ -16,8 +16,6 @@ runtime:
       url: ws://localhost:8787/
     iceProviders:
       - urls: https://dxos.network/ice
-    ai:
-      server: http://localhost:8788
     sandbox:
       url: http://localhost:8792
     ipfs:

--- a/packages/devtools/devtools/src/containers/EdgeSelector.tsx
+++ b/packages/devtools/devtools/src/containers/EdgeSelector.tsx
@@ -13,9 +13,9 @@ import { getTarget } from './VaultSelector';
 
 const edgeServers = [
   { value: 'https://edge.dxos.workers.dev', label: 'Dev' },
-  { value: 'https://edge-main.dxos.workers.dev', label: 'Main' },
-  { value: 'https://edge-labs.dxos.workers.dev', label: 'Labs' },
-  { value: 'https://edge-production.dxos.workers.dev', label: 'Production' },
+  { value: 'https://main.dxos.network', label: 'Main' },
+  { value: 'https://labs.dxos.network', label: 'Labs' },
+  { value: 'https://dxos.network', label: 'Production' },
 ];
 
 export const EdgeSelector = () => {

--- a/packages/plugins/plugin-assistant/src/operations/prompt.node.test.ts
+++ b/packages/plugins/plugin-assistant/src/operations/prompt.node.test.ts
@@ -24,7 +24,7 @@ EntityId.dangerouslyDisableRandomness();
 
 describe('Agent prompt (composer plugin harness)', () => {
   // Hits RoutinePlugin compute runtime (plugin handlers, AiServiceLayer, skills).
-  // Requires reachable edge AI (see repo DX_EDGE_AI_SERVICE_URL); not memoized like AssistantTestLayer tests.
+  // Requires reachable edge AI (served through the edge /ai proxy); not memoized like AssistantTestLayer tests.
   test(
     'chat mode appends assistant messages to the chat queue',
     { tags: ['manual'], timeout: 60_000 },

--- a/packages/plugins/plugin-client/src/commands/profile/create.ts
+++ b/packages/plugins/plugin-client/src/commands/profile/create.ts
@@ -37,8 +37,8 @@ const makeTemplate = (edgeUrl: string) => trim`
 `;
 
 const TEMPLATES = {
-  default: makeTemplate('https://edge-production.dxos.workers.dev'),
-  main: makeTemplate('https://edge-main.dxos.workers.dev'),
+  default: makeTemplate('https://dxos.network'),
+  main: makeTemplate('https://main.dxos.network'),
   dev: makeTemplate('https://edge.dxos.workers.dev'),
   local: makeTemplate('http://localhost:8787'),
 } as const;

--- a/packages/plugins/plugin-onboarding/src/components/AboutDialog/AboutDialog.stories.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/AboutDialog/AboutDialog.stories.tsx
@@ -98,7 +98,7 @@ export const WithEdgeEnvironment: Story = {
           commitHash: 'b78990fdd5',
         },
         env: { DX_ENVIRONMENT: 'development' },
-        edgeUrl: 'https://edge-dev.dxos.workers.dev',
+        edgeUrl: 'https://edge.dxos.workers.dev',
       }),
     }),
   ],

--- a/packages/plugins/plugin-onboarding/src/components/AboutDialog/AboutDialog.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/AboutDialog/AboutDialog.tsx
@@ -15,6 +15,11 @@ const ENV_LABELS: Record<string, string> = {
   'edge-main': 'Main',
   'edge-labs': 'Labs',
   'edge-production': 'Production',
+  // dxos.network scheme: <env>.dxos.network per environment; the production apex yields 'dxos'.
+  'main': 'Main',
+  'labs': 'Labs',
+  'staging': 'Staging',
+  'dxos': 'Production',
 };
 
 const REPO = 'https://github.com/dxos/dxos';

--- a/packages/plugins/plugin-onboarding/src/components/AboutDialog/AboutDialog.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/AboutDialog/AboutDialog.tsx
@@ -10,16 +10,18 @@ import { Button, Dialog, Link, Trans, useTranslation } from '@dxos/react-ui';
 
 import { meta } from '../../meta';
 
+// Keyed by the full edge host: `<env>.dxos.network` (apex = production) plus the
+// legacy `edge[-<env>].dxos.workers.dev` names still present in stored configs.
 const ENV_LABELS: Record<string, string> = {
-  'edge-dev': 'Dev',
-  'edge-main': 'Main',
-  'edge-labs': 'Labs',
-  'edge-production': 'Production',
-  // dxos.network scheme: <env>.dxos.network per environment; the production apex yields 'dxos'.
-  'main': 'Main',
-  'labs': 'Labs',
-  'staging': 'Staging',
-  'dxos': 'Production',
+  'edge.dxos.workers.dev': 'Dev',
+  'edge-main.dxos.workers.dev': 'Main',
+  'edge-labs.dxos.workers.dev': 'Labs',
+  'edge-staging.dxos.workers.dev': 'Staging',
+  'edge-production.dxos.workers.dev': 'Production',
+  'main.dxos.network': 'Main',
+  'labs.dxos.network': 'Labs',
+  'staging.dxos.network': 'Staging',
+  'dxos.network': 'Production',
 };
 
 const REPO = 'https://github.com/dxos/dxos';
@@ -42,7 +44,7 @@ export const AboutDialog = () => {
 
   // Show edge environment when not in production, so internal builds advertise which cluster they're on.
   const edgeUrl = config.values.runtime?.services?.edge?.url;
-  const envKey = edgeUrl ? parseUrl(edgeUrl)?.host.split('.')[0] : undefined;
+  const envKey = edgeUrl ? parseUrl(edgeUrl)?.host : undefined;
   const edgeEnv = envKey ? ENV_LABELS[envKey] : undefined;
   const showEnv = !!edgeEnv && edgeEnv !== 'Production';
 

--- a/packages/plugins/plugin-typefully/src/services/typefully-api.test.ts
+++ b/packages/plugins/plugin-typefully/src/services/typefully-api.test.ts
@@ -12,7 +12,7 @@ import { Connection } from '@dxos/plugin-connector/types';
 import { TYPEFULLY_CONNECTOR_ID, TYPEFULLY_SOURCE } from '../constants';
 import { makeTypefullyPublisherService } from './typefully-api';
 
-const PROXY = 'https://cors-proxy.dxos.workers.dev/api.typefully.com/v2';
+const PROXY = 'https://cors.dxos.network/api.typefully.com/v2';
 
 // Records what the stubbed `fetch` was called with so tests can assert the real request (method, URL,
 // auth header, body). Requests are routed through the DXOS CORS proxy, which relays the caller's

--- a/packages/sdk/config/src/config-service.ts
+++ b/packages/sdk/config/src/config-service.ts
@@ -50,9 +50,6 @@ export const defaultConfig = new Config({
           urls: 'https://dxos.network/ice',
         },
       ],
-      ai: {
-        server: 'https://ai-service.dxos.workers.dev',
-      },
       ipfs: {
         server: 'https://api.ipfs.dxos.network/api/v0',
         gateway: 'https://gateway.ipfs.dxos.network/ipfs',

--- a/packages/sdk/config/src/config-service.ts
+++ b/packages/sdk/config/src/config-service.ts
@@ -43,11 +43,11 @@ export const defaultConfig = new Config({
     },
     services: {
       edge: {
-        url: 'wss://edge-production.dxos.workers.dev/',
+        url: 'wss://dxos.network/',
       },
       iceProviders: [
         {
-          urls: 'https://edge-production.dxos.workers.dev/ice',
+          urls: 'https://dxos.network/ice',
         },
       ],
       ai: {

--- a/packages/sdk/config/src/edge-services.ts
+++ b/packages/sdk/config/src/edge-services.ts
@@ -27,11 +27,11 @@ export type EdgeServiceName = (typeof EdgeServiceName)[keyof typeof EdgeServiceN
  * Production values are supplied per-app via `dx.yml` (`runtime.services.edgeServices`).
  */
 export const EDGE_SERVICE_DEFAULTS: Readonly<Record<EdgeServiceName, string>> = Object.freeze({
-  [EdgeServiceName.Calls]: 'https://calls-service.dxos.workers.dev',
-  [EdgeServiceName.Image]: 'https://image-service-main.dxos.workers.dev',
-  [EdgeServiceName.Transcription]: 'https://calls-service.dxos.workers.dev',
+  [EdgeServiceName.Calls]: 'https://calls.dxos.network',
+  [EdgeServiceName.Image]: 'https://image.main.dxos.network',
+  [EdgeServiceName.Transcription]: 'https://calls.dxos.network',
   [EdgeServiceName.Discord]: 'https://discord-service.dxos.workers.dev',
-  [EdgeServiceName.CorsProxy]: 'https://cors-proxy.dxos.workers.dev',
+  [EdgeServiceName.CorsProxy]: 'https://cors.dxos.network',
   [EdgeServiceName.ApiProxy]: 'https://api-proxy.dxos.workers.dev',
   [EdgeServiceName.Introspect]: 'https://mcp-introspect-service-labs.dxos.workers.dev/mcp',
   [EdgeServiceName.ChatAgent]: 'wss://chat-agent-labs.dxos.workers.dev',

--- a/packages/sdk/config/src/edge-services.ts
+++ b/packages/sdk/config/src/edge-services.ts
@@ -14,7 +14,6 @@ export const EdgeServiceName = Object.freeze({
   Transcription: 'transcription',
   Discord: 'discord',
   CorsProxy: 'cors-proxy',
-  ApiProxy: 'api-proxy',
   Introspect: 'introspect',
 } as const);
 
@@ -31,7 +30,6 @@ export const EDGE_SERVICE_DEFAULTS: Readonly<Record<EdgeServiceName, string>> = 
   [EdgeServiceName.Transcription]: 'https://calls.dxos.network',
   [EdgeServiceName.Discord]: 'https://discord.dxos.network',
   [EdgeServiceName.CorsProxy]: 'https://cors.dxos.network',
-  [EdgeServiceName.ApiProxy]: 'https://api-proxy.dxos.workers.dev',
   [EdgeServiceName.Introspect]: 'https://introspect.labs.dxos.network/mcp',
 });
 

--- a/packages/sdk/config/src/edge-services.ts
+++ b/packages/sdk/config/src/edge-services.ts
@@ -16,7 +16,6 @@ export const EdgeServiceName = Object.freeze({
   CorsProxy: 'cors-proxy',
   ApiProxy: 'api-proxy',
   Introspect: 'introspect',
-  ChatAgent: 'chat-agent',
 } as const);
 
 export type EdgeServiceName = (typeof EdgeServiceName)[keyof typeof EdgeServiceName];
@@ -30,11 +29,10 @@ export const EDGE_SERVICE_DEFAULTS: Readonly<Record<EdgeServiceName, string>> = 
   [EdgeServiceName.Calls]: 'https://calls.dxos.network',
   [EdgeServiceName.Image]: 'https://image.main.dxos.network',
   [EdgeServiceName.Transcription]: 'https://calls.dxos.network',
-  [EdgeServiceName.Discord]: 'https://discord-service.dxos.workers.dev',
+  [EdgeServiceName.Discord]: 'https://discord.dxos.network',
   [EdgeServiceName.CorsProxy]: 'https://cors.dxos.network',
   [EdgeServiceName.ApiProxy]: 'https://api-proxy.dxos.workers.dev',
-  [EdgeServiceName.Introspect]: 'https://mcp-introspect-service-labs.dxos.workers.dev/mcp',
-  [EdgeServiceName.ChatAgent]: 'wss://chat-agent-labs.dxos.workers.dev',
+  [EdgeServiceName.Introspect]: 'https://introspect.labs.dxos.network/mcp',
 });
 
 /**

--- a/packages/sdk/config/src/preset.ts
+++ b/packages/sdk/config/src/preset.ts
@@ -23,8 +23,8 @@ const edgeUrl = (edge: NonNullable<ConfigPresetOptions['edge']>) =>
   Match.value(edge).pipe(
     Match.when('local', () => 'http://localhost:8787'),
     Match.when('dev', () => 'https://edge.dxos.workers.dev'),
-    Match.when('main', () => 'https://edge-main.dxos.workers.dev'),
-    Match.when('production', () => 'https://edge-production.dxos.workers.dev'),
+    Match.when('main', () => 'https://main.dxos.network'),
+    Match.when('production', () => 'https://dxos.network'),
     Match.exhaustive,
   );
 

--- a/packages/ui/react-ui-canvas-compute/src/shapes/GptRealtime.tsx
+++ b/packages/ui/react-ui-canvas-compute/src/shapes/GptRealtime.tsx
@@ -46,10 +46,7 @@ export const GptRealtimeComponent = ({ shape }: ShapeComponentProps<GptRealtimeS
 
       // Send offer to backend and get answer. AI is served through edge's /ai/* proxy;
       // the configured edge URL uses a ws(s) scheme, so swap it for http(s).
-      const aiServiceUrl = new URL(
-        '/ai/rtc-connect',
-        config.values.runtime?.services?.edge?.url ?? DEFAULT_EDGE_URL,
-      );
+      const aiServiceUrl = new URL('/ai/rtc-connect', config.values.runtime?.services?.edge?.url ?? DEFAULT_EDGE_URL);
       aiServiceUrl.protocol = aiServiceUrl.protocol.replace('ws', 'http');
       const response = await fetch(aiServiceUrl, {
         method: 'POST',

--- a/packages/ui/react-ui-canvas-compute/src/shapes/GptRealtime.tsx
+++ b/packages/ui/react-ui-canvas-compute/src/shapes/GptRealtime.tsx
@@ -44,12 +44,14 @@ export const GptRealtimeComponent = ({ shape }: ShapeComponentProps<GptRealtimeS
       const offer = await peerConnection.createOffer();
       await peerConnection.setLocalDescription(offer);
 
-      // Send offer to backend and get answer
-      const AiServiceUrl = new URL(
-        '/rtc-connect',
-        config.values.runtime?.services?.ai?.server ?? DEFAULT_AI_SERVICE_URL,
+      // Send offer to backend and get answer. AI is served through edge's /ai/* proxy;
+      // the configured edge URL uses a ws(s) scheme, so swap it for http(s).
+      const aiServiceUrl = new URL(
+        '/ai/rtc-connect',
+        config.values.runtime?.services?.edge?.url ?? DEFAULT_EDGE_URL,
       );
-      const response = await fetch(AiServiceUrl, {
+      aiServiceUrl.protocol = aiServiceUrl.protocol.replace('ws', 'http');
+      const response = await fetch(aiServiceUrl, {
         method: 'POST',
         body: offer.sdp,
         headers: {
@@ -138,4 +140,4 @@ export const GptRealtimeComponent = ({ shape }: ShapeComponentProps<GptRealtimeS
   );
 };
 
-const DEFAULT_AI_SERVICE_URL = 'http://localhost:8788';
+const DEFAULT_EDGE_URL = 'http://localhost:8787';


### PR DESCRIPTION
Companion to dxos/edge#799 (merged) and dxos/edge#800: migrates client-facing config defaults from `*.dxos.workers.dev` to the new `dxos.network` domain scheme. The old workers.dev URLs keep serving, so already-deployed clients and stored configs are unaffected; this flips what new builds/profiles point at.

> [!IMPORTANT]
> `main.dxos.network` is live (edge `/health` verified). **Still pending before merge:** (1) the apex — the production custom-domain attach failed on the pre-existing `dxos.network` DNS record and needs a one-time dashboard override (edge-production worker → Domains & Routes → add `dxos.network`); (2) dxos/edge#800 merged + deployed for `discord.dxos.network` and `introspect.labs.dxos.network`. Verify each responds before merging this.

## URL mapping

| Old | New |
|---|---|
| `edge-main.dxos.workers.dev` | `main.dxos.network` |
| `edge-labs.dxos.workers.dev` | `labs.dxos.network` |
| `edge-production.dxos.workers.dev` | `dxos.network` (apex) |
| `calls-service.dxos.workers.dev` | `calls.dxos.network` |
| `image-service-main.dxos.workers.dev` | `image.main.dxos.network` |
| `cors-proxy.dxos.workers.dev` | `cors.dxos.network` |
| `discord-service.dxos.workers.dev` | `discord.dxos.network` |
| `mcp-introspect-service-labs.dxos.workers.dev/mcp` | `introspect.labs.dxos.network/mcp` |

## Changed surfaces

- **CI env baked into deployed apps**: `.github/workflows/env/{main,labs}` (`DX_EDGE_BASE_URL`), `check.yml` e2e env, `preview.yml` PR-preview bundle. labs keeps pointing at the production edge cluster (now the apex), same semantics as before. `DX_EDGE_AI_SERVICE_URL` is deleted outright — see the drift fix below.
- **Drift fix — last direct ai-service consumer**: the GptRealtime voice shape now derives its SDP endpoint from `runtime.services.edge.url` + `/ai/rtc-connect`. The direct path predated the edge AI gateway (edge#605) and bypassed its usage metering. With its only reader gone, all `ai.server` plumbing is removed: the dx-env.yml mapping, `DX_EDGE_AI_SERVICE_URL` in env/main + env/labs (env/main had pointed main Composer at the **dev** ai worker since 2025-03), and the `ai.server` entries in composer/CLI configs and the Node `defaultConfig`. ai-service is now reachable from clients only through edge.
- **composer-app** `dx.yml` (edge, ice, edgeServices calls/transcription/image) and `dx-local.yml`.
- **@dxos/config**: `preset.ts` `edgeUrl()` (main/production), `config-service.ts` `defaultConfig` (Node/CLI fallback), `edge-services.ts` `EDGE_SERVICE_DEFAULTS` (calls, transcription — rides the calls worker —, image, cors-proxy, discord, introspect); the `chat-agent` entry is removed outright — the worker is a deprecated experiment (per its README) with zero consumers — and so is the `api-proxy` entry, a stale pointer from the #11839 consolidation that nothing ever read.
- **Media assets** are migrated separately in #12483 (+ dxos/edge#804 for hub email templates) — the apex currently serves the `media` R2 bucket, which stays in place for now.
- **Second drift fix**: assistant-toolkit's Discord skill (`fetch-messages.ts`) hard-coded the out-of-repo `api-proxy.dxos.workers.dev` relay; it now routes Discord REST through `cors.dxos.network` — identical `/host/path` contract, `Authorization` forwarded verbatim (the skill supplies the user's token via CredentialsService).
- **devtools** `EdgeSelector` options; **plugin-client** profile templates; **CLI** config presets (ice provider URLs).
- **plugin-onboarding AboutDialog**: `ENV_LABELS` is keyed on the first hostname segment, so new keys were added (`main`, `labs`, `staging`, `dxos`→Production); old `edge-*` keys retained for stored configs.

## Deliberately untouched

- Dev endpoints (`edge.dxos.workers.dev`) — the dev workers have no custom domains. Remaining `ai-service.dxos.workers.dev` references live only in test/story fixtures.
- Tests, stories, fixtures, and docs (`sdk/config/AUDIT.md` inventory) — old URLs still work; can migrate later.
- Hub URLs (already on `hub.dxos.network` where applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
