### PR TITLE
plugin-inbox: auto-sync mail connectors and run their sync on EDGE

### DIFF
--- a/.changeset/email-sync-remote-auto.md
+++ b/.changeset/email-sync-remote-auto.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-inbox': patch
+---
+
+Sync Gmail and JMAP mailboxes automatically as soon as they are connected, and run their sync schedule on EDGE so mail keeps arriving while the app is closed.

--- a/packages/apps/composer-app/src/playwright/inbox.spec.ts
+++ b/packages/apps/composer-app/src/playwright/inbox.spec.ts
@@ -17,7 +17,7 @@ if (process.env.DX_PWA !== 'false') {
  * plugin-inbox's connector capability — a stale value here fails these tests rather than quietly
  * exercising the other path, since the two configurations differ in whether "Sync now" is pressed.
  */
-const AUTO_SYNC = false;
+const AUTO_SYNC = true;
 
 test.describe('Inbox', () => {
   let host: AppManager;

--- a/packages/plugins/plugin-connector/src/types/connector.ts
+++ b/packages/plugins/plugin-connector/src/types/connector.ts
@@ -113,6 +113,13 @@ export type ConnectorSync = {
    * should only sync on demand: {@link operation} is then invoked directly.
    */
   trigger?: Trigger.Spec;
+  /**
+   * Run the sync on EDGE rather than on the client. Defaults to false: a connector opts in only once
+   * its sync operation is registered in the workerd plugin build, since a remote trigger is dispatched
+   * where the client may be closed. Applies to newly created sync Routines; an existing Routine keeps
+   * whatever the user last chose in the trigger editor.
+   */
+  remote?: boolean;
 };
 
 /**

--- a/packages/plugins/plugin-connector/src/types/connector.ts
+++ b/packages/plugins/plugin-connector/src/types/connector.ts
@@ -117,7 +117,9 @@ export type ConnectorSync = {
    * Run the sync on EDGE rather than on the client. Defaults to false: a connector opts in only once
    * its sync operation is registered in the workerd plugin build, since a remote trigger is dispatched
    * where the client may be closed. Applies to newly created sync Routines; an existing Routine keeps
-   * whatever the user last chose in the trigger editor.
+   * whatever the user last chose in the trigger editor. Only meaningful alongside {@link trigger} —
+   * with no trigger spec there is no Routine to mark, and the on-demand path invokes {@link operation}
+   * locally.
    */
   remote?: boolean;
 };

--- a/packages/plugins/plugin-connector/src/util/sync-routine.test.ts
+++ b/packages/plugins/plugin-connector/src/util/sync-routine.test.ts
@@ -83,6 +83,8 @@ describe('createSyncRoutine', () => {
     const trigger = triggerRef.target;
     expect(trigger?.spec).toEqual({ kind: 'timer', cron: '*/10 * * * *' });
     expect(trigger?.enabled).toBe(true);
+    // A connector that does not declare `sync.remote` gets a local trigger, with nothing stored.
+    expect(trigger?.remote).toBeUndefined();
     // `input` carries only `binding` (matching the sync operation's input schema); the target is reached
     // through the binding cursor's `spec.target`, not smuggled in as an extra input key.
     expect(Object.keys(trigger?.input ?? {})).toEqual(['binding']);
@@ -96,6 +98,24 @@ describe('createSyncRoutine', () => {
     // The reverse-ref from the cursor is how a manual sync finds this trigger to force-run.
     const found = await findSyncTriggerForBinding(cursor).pipe(Effect.provide(Database.layer(db)), EffectEx.runPromise);
     expect(found?.id).toBe(trigger?.id);
+  });
+
+  test('marks the trigger remote for a connector that syncs on EDGE', async ({ expect }) => {
+    await using harness = await createComposerTestApp({ plugins: [ClientPlugin({ types })] });
+    const db = await initSpace(harness);
+
+    const target = db.add(Obj.make(Expando.Expando, { name: 'Inbox' }));
+    const cursor = makeCursor(db, target);
+    await createSyncRoutine({ target, cursor, operation: TestSync, spec: SYNC_SPEC, remote: true }).pipe(
+      Effect.provide(Database.layer(db)),
+      EffectEx.runPromise,
+    );
+    await db.flush();
+
+    await expect.poll(() => findSyncRoutine(db, target), { timeout: 5_000 }).toHaveLength(1);
+    const [routine] = await findSyncRoutine(db, target);
+    // The monitor routes a `remote` trigger to EDGE, so the schedule keeps running with the app closed.
+    expect(routine.triggers[0].target?.remote).toBe(true);
   });
 
   test('is idempotent: a second call is a no-op once a sync routine is connected', async ({ expect }) => {

--- a/packages/plugins/plugin-connector/src/util/sync-routine.ts
+++ b/packages/plugins/plugin-connector/src/util/sync-routine.ts
@@ -15,13 +15,13 @@ import { type ConnectorEntry, type SyncInput, type SyncOutput } from '../types';
 import { findSyncTriggerForBinding } from './sync-trigger';
 
 /**
- * Creates the sync Routine for `cursor`: a Routine wrapping a local (`remote` unset) trigger built
- * from the connector's declared `sync.trigger` spec, wired to the connector's sync operation with
- * `binding` bound to `cursor`. `input` carries only `binding`, matching the sync operation's input
- * schema — the routine is related to `target` by query ({@link connectedRoutinesQuery}, surfaced in the
- * routines companion), which reaches it through `binding` → the cursor → the cursor's `spec.target`,
- * so no target ref is smuggled into the operation input. Returns the existing trigger instead when a
- * sync routine is already connected to `target`.
+ * Creates the sync Routine for `cursor`: a Routine wrapping a trigger built from the connector's
+ * declared `sync.trigger` spec — running on EDGE when the connector declares `sync.remote`, otherwise
+ * locally — wired to the connector's sync operation with `binding` bound to `cursor`. `input` carries
+ * only `binding`, matching the sync operation's input schema — the routine is related to `target` by
+ * query ({@link connectedRoutinesQuery}, surfaced in the routines companion), which reaches it through
+ * `binding` → the cursor → the cursor's `spec.target`, so no target ref is smuggled into the operation
+ * input. Returns the existing trigger instead when a sync routine is already connected to `target`.
  */
 /**
  * Creation in flight, keyed by binding. The existence check below is an index query, so it cannot see
@@ -36,11 +36,13 @@ export const createSyncRoutine = ({
   cursor,
   operation,
   spec,
+  remote,
 }: {
   target: Obj.Unknown;
   cursor: Cursor.ExternalCursor;
   operation: Operation.Definition<SyncInput, SyncOutput>;
   spec: Trigger.Spec;
+  remote?: boolean;
 }): Effect.Effect<Trigger.Trigger, never, Database.Service> =>
   // Claimed synchronously, before the first yield point, so no caller can interleave between the
   // lookup and the claim.
@@ -52,7 +54,7 @@ export const createSyncRoutine = ({
 
     const deferred = Deferred.unsafeMake<Trigger.Trigger>(FiberId.none);
     creating.set(cursor.id, deferred);
-    return createRoutine({ target, cursor, operation, spec }).pipe(
+    return createRoutine({ target, cursor, operation, spec, remote }).pipe(
       // Waiters see the same outcome, including a defect, rather than hanging on the deferred.
       Effect.onExit((exit) => Deferred.done(deferred, exit)),
       Effect.ensuring(Effect.sync(() => creating.delete(cursor.id))),
@@ -64,11 +66,13 @@ const createRoutine = ({
   cursor,
   operation,
   spec,
+  remote,
 }: {
   target: Obj.Unknown;
   cursor: Cursor.ExternalCursor;
   operation: Operation.Definition<SyncInput, SyncOutput>;
   spec: Trigger.Spec;
+  remote?: boolean;
 }): Effect.Effect<Trigger.Trigger, never, Database.Service> =>
   Effect.gen(function* () {
     const connected = yield* Database.query(connectedRoutinesQuery(target)).run;
@@ -79,7 +83,14 @@ const createRoutine = ({
       }
     }
 
-    const trigger = Trigger.make({ enabled: true, spec, input: { binding: Ref.make(cursor) } });
+    // `remote` is left unset for a local connector rather than written as `false`, so the trigger
+    // editor shows the schema default instead of a stored choice the connector never made.
+    const trigger = Trigger.make({
+      enabled: true,
+      ...(remote ? { remote: true } : {}),
+      spec,
+      input: { binding: Ref.make(cursor) },
+    });
 
     const routine = makeRoutine({
       name: 'Sync',
@@ -117,5 +128,11 @@ export const ensureSyncTrigger = ({
     // A binding whose target ref no longer resolves is broken beyond what routine setup can fix, and
     // a scheduled connector has no direct-sync path to fall back to.
     const target = yield* Database.load(cursor.spec.target).pipe(Effect.orDie);
-    return yield* createSyncRoutine({ target, cursor, operation: sync.operation, spec: sync.trigger });
+    return yield* createSyncRoutine({
+      target,
+      cursor,
+      operation: sync.operation,
+      spec: sync.trigger,
+      remote: sync.remote,
+    });
   });

--- a/packages/plugins/plugin-inbox/src/capabilities/connector.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/connector.ts
@@ -31,8 +31,19 @@ import { jmapCredentialForm } from './jmap-credential-form';
 /** How often a mailbox's sync Routine polls for new mail. */
 const MAIL_SYNC_CRON = '*/10 * * * *';
 
-/** Whether a newly bound mailbox syncs itself instead of waiting for the user to ask. */
-const MAIL_AUTO_SYNC = false;
+/**
+ * Whether a newly bound mailbox syncs itself instead of waiting for the user to ask. Safe for mail
+ * because a first sync is bounded by the binding's sync horizon (`Cursor.resolveHorizon`, 30 days by
+ * default) and continues in capped batches through the dispatcher rather than in one unbounded run.
+ */
+const MAIL_AUTO_SYNC = true;
+
+/**
+ * Whether a mailbox's sync Routine runs on EDGE rather than on the client, so mail keeps arriving
+ * while Composer is closed. The mail sync operations are in the shared handler set the workerd plugin
+ * registers, so EDGE can run them.
+ */
+const MAIL_REMOTE_SYNC = true;
 
 const GoogleUserInfo = Schema.Struct({
   email: Schema.optional(Schema.String),
@@ -146,6 +157,7 @@ export default Capability.makeModule(
           optionsSchema: SyncOptions,
           auto: MAIL_AUTO_SYNC,
           trigger: Trigger.specTimer(MAIL_SYNC_CRON),
+          remote: MAIL_REMOTE_SYNC,
         },
         onTokenCreated,
         testConnection: testGoogleConnection,
@@ -165,6 +177,7 @@ export default Capability.makeModule(
           optionsSchema: SyncOptions,
           auto: MAIL_AUTO_SYNC,
           trigger: Trigger.specTimer(MAIL_SYNC_CRON),
+          remote: MAIL_REMOTE_SYNC,
         },
       },
       {


### PR DESCRIPTION
Switches the email connectors (Gmail, JMAP Mail) to auto-sync on connect and to run their sync schedule on EDGE.

## Changes

- `plugin-connector`: new `ConnectorSync.remote` flag. `createSyncRoutine` / `ensureSyncTrigger` thread it into the sync Routine's trigger, so a connector declares *where* its sync runs. Left unset for local connectors rather than written as `false`, so the trigger editor keeps showing the schema default.
- `plugin-inbox`: `MAIL_AUTO_SYNC` flipped to `true` and a new `MAIL_REMOTE_SYNC = true`, applied to both the Gmail and JMAP Mail connector entries.

## Why this is safe for mail

- Auto: a first mail sync is bounded by the binding's sync horizon (`Cursor.resolveHorizon`, 30 days by default) and continues in capped batches driven by the dispatcher, not one unbounded full-history run.
- Remote: both mail sync operations (`mail/google/sync`, `mail/jmap/sync`) are in `InboxOperationHandlerSet`, which the workerd plugin build registers, so EDGE can run them. `TriggerMonitor` routes a `remote` trigger to EDGE for scheduled fires and for manual "Sync now" alike.

## Scope note

`remote` is applied when the sync Routine is created. Mailboxes bound before this change keep their existing local trigger — reconciling them would overwrite a choice the user may have made in the trigger editor.

## Test plan

- `moon run plugin-connector:test` — 37 passed, incl. a new case asserting the trigger is marked remote when the connector declares it, and that it stays unset otherwise.
- `moon run plugin-inbox:test` — 235 passed / 14 skipped.
- `moon run plugin-connector:build plugin-inbox:build`, `moon run plugin-connector:lint plugin-inbox:lint`, `pnpm format` — clean.

Changeset: `@dxos/plugin-inbox` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G36L4taz8xDAUKK7oQBihr

---
_Generated by [Claude Code](https://claude.ai/code/session_01G36L4taz8xDAUKK7oQBihr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gmail and JMAP mailboxes now begin synchronizing automatically after connection.
  * Mail synchronization continues running remotely, including while the app is closed.
  * Synchronization can now be configured to run either locally or remotely.

* **Bug Fixes**
  * Improved sync trigger configuration for local and remote mailbox synchronization.

* **Tests**
  * Added coverage for automatic and remote synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->