### PR TITLE
plugin-crm: bind the CRM automation template to ProcessMailbox

### DIFF
--- a/.changeset/crm-automation-template-operation.md
+++ b/.changeset/crm-automation-template-operation.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-crm': minor
+---
+
+The CRM automation template (`org.dxos.routine.crm`) now scaffolds a deterministic operation routine bound to `CrmOperation.ProcessMailbox` instead of an agentic instructions routine, so the mailbox's Automations companion offers the same cursored, idempotent CRM pipeline the `crmPipeline` project template does — no model between the feed trigger and the operation.

--- a/.changeset/crm-automation-template-operation.md
+++ b/.changeset/crm-automation-template-operation.md
@@ -1,5 +1,5 @@
 ---
-'@dxos/plugin-crm': minor
+'@dxos/plugin-crm': patch
 ---
 
 The CRM automation template (`org.dxos.routine.crm`) now scaffolds a deterministic operation routine bound to `CrmOperation.ProcessMailbox` instead of an agentic instructions routine, so the mailbox's Automations companion offers the same cursored, idempotent CRM pipeline the `crmPipeline` project template does — no model between the feed trigger and the operation.

--- a/packages/plugins/plugin-crm/DESIGN.md
+++ b/packages/plugins/plugin-crm/DESIGN.md
@@ -164,7 +164,7 @@ agentic-only, ❌ = missing (→ this change or backlog).
 | 4   | Research/enrich Person → profile dossier (`ProfileOf`) | 🟡→✅  | Was prose-only; **new `ResearchPerson`** (§5.2) scaffolds deterministically; LLM/web enrichment stays agentic behind the `ResearchSource` seam |
 | 5   | Research/enrich Organization → profile dossier         | 🟡→✅  | **new `ResearchOrganization`** (§5.2)                                                                                                          |
 | 6   | Process a Mailbox for CRM (cursored, idempotent)       | ❌→✅  | **new `ProcessMailbox`** (§5.3) — the CRM sibling of `AnalyzeMailbox`                                                                          |
-| 7   | Run CRM processing on sync (project + routine)         | 🟡→✅  | **new `crmPipeline` project template** (§5.4); agentic `crmResearch` template remains                                                          |
+| 7   | Run CRM processing on sync (project + routine)         | 🟡→✅  | **new `crmPipeline` project template** (§5.4) + the `crm` automation template (§5.5); agentic `crmResearch` template remains                   |
 | 8   | Attach avatar / logo                                   | ✅     | `AttachImage`                                                                                                                                  |
 | 9   | Track relationship stage (prospect → commit)           | 🟡     | `Organization.status` schema exists; no operation/board wiring (plugin-pipeline research board is a separate concept). Backlog                 |
 | 10  | Interaction ledger (last-touch, counts per sender)     | 🟡     | Agentic `inboxResearch` (sender ledger) template; facts via `AnalyzeMailbox`. Deterministic ledger op = backlog                                |
@@ -241,7 +241,17 @@ Ref.fromURI(ProcessMailbox key) }`, `trigger: { spec: Trigger.specFeed(mailbox.f
 The agentic `crmResearch` template is unchanged — the two are complementary (deterministic
 capture + skeleton vs. model-driven dossier writing).
 
-### 5.5 Removals
+### 5.5 `crm` automation template
+
+`org.dxos.routine.crm` ("CRM") is the routine-only counterpart of §5.4, contributed via
+`automation-templates` as a `RoutineCapabilities.Template` — so it, not the project templates, is
+what the mailbox's Automations companion offers. Converted from an instructions action to the same
+deterministic operation action: `spec: { kind: 'runnable', runnable: Ref.fromURI(ProcessMailbox
+key) }` with the §5.4 trigger (feed spec, `{ mailbox, research: true }` input, `concurrency: 1`,
+disabled). Its `DEFAULT_INSTRUCTIONS` and skill refs are dropped — an operation action owns no
+instructions, and the enrichment prose those carried now lives in the operations.
+
+### 5.6 Removals
 
 - `src/skills/crm/instructions.ts` (+ `makeInstructions` barrel exports). The skill keeps a
   **short** inline instructions template: subject resolution, upsert conventions
@@ -266,8 +276,10 @@ capture + skeleton vs. model-driven dossier writing).
      feed → cursor → contact → research → profile).
 3. `templates/crm-pipeline.test.ts` — scaffold shape, mirroring `mailbox-facts.test.ts`:
    `appliesTo`, runnable spec key, feed trigger, baked input refs, disabled, parenting.
-4. Existing `templates/crm.test.ts` / `crm-project.test.ts` stay green (instructions text there
-   is template-local, not from `instructions.ts`).
+4. `templates/crm.test.ts` asserts the same shape as (3) after the §5.5 conversion: runnable spec
+   key, feed trigger, baked input refs, disabled, and no owned instructions.
+   `templates/crm-project.test.ts` stays green (its instructions text is template-local, not from
+   `instructions.ts`).
 
 Out of scope (recorded, not built): live/eval coverage of the enrichment seam (the
 `crm-mailbox.eval.ts` graded eval already covers the agentic path); Organization creation from

--- a/packages/plugins/plugin-crm/src/templates/crm.test.ts
+++ b/packages/plugins/plugin-crm/src/templates/crm.test.ts
@@ -56,7 +56,7 @@ describe('crm routine template', () => {
       expect(triggerFeedUri).toBe(mailbox.feed.uri);
 
       // The operation reads the mailbox itself, so the input carries the subject ref plus the research flag.
-      expect(trigger?.input?.mailbox).toBeDefined();
+      expect(trigger?.input?.mailbox?.target?.id).toBe(mailbox.id);
       expect(trigger?.input?.research).toBe(true);
       expect(trigger?.concurrency).toBe(1);
     }).pipe(Effect.provide(TestLayer), EffectEx.runAndForwardErrors);

--- a/packages/plugins/plugin-crm/src/templates/crm.test.ts
+++ b/packages/plugins/plugin-crm/src/templates/crm.test.ts
@@ -6,19 +6,17 @@ import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import { describe, test } from 'vitest';
 
-import { Instructions, Routine, Trace, Trigger } from '@dxos/compute';
+import { Routine, Trace, Trigger } from '@dxos/compute';
 import { Database, Feed, Obj } from '@dxos/echo';
 import { TestDatabaseLayer } from '@dxos/echo-client/testing';
 import { EffectEx } from '@dxos/effect';
 import { Mailbox } from '@dxos/plugin-inbox';
 
+import { CrmOperation } from '../types';
 import { crm } from './crm';
 
-/** Number of skill keys wired into a CRM routine. */
-const SKILL_COUNT = 4;
-
 const dbLayer = TestDatabaseLayer({
-  types: [Routine.Routine, Instructions.Instructions, Trigger.Trigger, Mailbox.Mailbox, Feed.Feed],
+  types: [Routine.Routine, Trigger.Trigger, Mailbox.Mailbox, Feed.Feed],
 });
 
 const TestLayer = Layer.mergeAll(dbLayer, Trace.writerLayerNoop);
@@ -30,9 +28,7 @@ describe('crm routine template', () => {
     expect(crm.appliesTo?.(undefined)).toBe(false);
   });
 
-  test('scaffolds a routine draft graph with instructions, a feed trigger, and the event-item input binding', async ({
-    expect,
-  }) => {
+  test('scaffolds a routine draft bound to ProcessMailbox with a feed trigger', async ({ expect }) => {
     await Effect.gen(function* () {
       const mailbox = Mailbox.make({ name: 'Test Mailbox' });
       yield* Database.add(mailbox);
@@ -40,10 +36,16 @@ describe('crm routine template', () => {
 
       const draft = yield* crm.scaffold({ subject: mailbox });
 
-      // The draft is a routine graph with a recognisable name, wired for an instructions action.
+      // The draft is a routine graph with a recognisable name, wired for an operation action.
       expect(Obj.instanceOf(Routine.Routine, draft)).toBe(true);
       expect(draft.name).toContain('Test Mailbox');
-      expect(draft.spec?.kind).toBe('instructions');
+      expect(draft.spec?.kind).toBe('runnable');
+      expect(draft.spec?.kind === 'runnable' && draft.spec.runnable.uri.toString()).toBe(
+        CrmOperation.ProcessMailbox.meta.key.toString(),
+      );
+
+      // No model between trigger and operation: an operation action owns no instructions.
+      expect(Routine.instructionsRef(draft)).toBeUndefined();
 
       // Feed trigger pointing at the mailbox's feed, owned by the routine.
       const trigger = draft.triggers[0]?.target;
@@ -53,19 +55,10 @@ describe('crm routine template', () => {
       const triggerFeedUri = trigger?.spec?.kind === 'feed' ? trigger.spec.feed?.uri : undefined;
       expect(triggerFeedUri).toBe(mailbox.feed.uri);
 
-      // The event-item input binding is preserved (the instructions ref is wired into the trigger input at
-      // save time, not on the draft).
-      expect(trigger?.input?.input).toBe('{{event.item}}');
-
-      // The owned instructions is the routine's action (an instructions action).
-      const instructions = Routine.instructionsRef(draft)?.target;
-      expect(Obj.instanceOf(Instructions.Instructions, instructions)).toBe(true);
-      expect(Obj.instanceOf(Instructions.Instructions, instructions) ? instructions.name : undefined).toContain(
-        'Test Mailbox',
-      );
-      expect(Obj.instanceOf(Instructions.Instructions, instructions) ? instructions.skills : []).toHaveLength(
-        SKILL_COUNT,
-      );
+      // The operation reads the mailbox itself, so the input carries the subject ref plus the research flag.
+      expect(trigger?.input?.mailbox).toBeDefined();
+      expect(trigger?.input?.research).toBe(true);
+      expect(trigger?.concurrency).toBe(1);
     }).pipe(Effect.provide(TestLayer), EffectEx.runAndForwardErrors);
   });
 });

--- a/packages/plugins/plugin-crm/src/templates/crm.ts
+++ b/packages/plugins/plugin-crm/src/templates/crm.ts
@@ -4,36 +4,22 @@
 
 import * as Effect from 'effect/Effect';
 
-import { Instructions, Skill, Trigger } from '@dxos/compute';
+import { Trigger } from '@dxos/compute';
 import { Database, Obj, Ref } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
 import { Mailbox } from '@dxos/plugin-inbox';
 import { makeRoutine } from '@dxos/plugin-routine';
 import { type RoutineCapabilities } from '@dxos/plugin-routine/types';
-import { trim } from '@dxos/util';
+
+import { CrmOperation } from '../types';
 
 /**
- * Skill keys composed into the CRM instructions. The CRM skill provides CRM-specific tools; the others
- * supply the database, web-search, and document utilities the agent relies on.
+ * CRM automation template: the routine-only counterpart of the `crmPipeline` project template. The
+ * trigger binds `ProcessMailbox` directly (kind: runnable) so the loop is deterministic — no model
+ * between trigger and operation. The operation's durable feed cursor plus the identity index make
+ * per-item firing idempotent: each firing catches up on everything new and extra firings process
+ * nothing. Only applies to a Mailbox subject — the feed trigger needs `mailbox.feed`.
  */
-const SKILL_KEYS = [
-  'org.dxos.skill.crm',
-  'org.dxos.skill.webSearch',
-  'org.dxos.skill.database',
-  'org.dxos.skill.markdown',
-] as const;
-
-/** Default instructions seeded into the instructions; the user edits these by opening the instructions. */
-const DEFAULT_INSTRUCTIONS = trim`
-  A new email message is provided in the <input> block below.
-
-  - Research the sender and any contacts mentioned in the message.
-  - Create and link a summary document for the sender's Organization if one does not already exist.
-  - Create or update CRM Profiles (Person and/or Organization objects) for those contacts using the CRM tools.
-  - Attach a profile photo or company logo if you can find one.
-`;
-
-/** CRM automation template. Only applies to a Mailbox subject — the feed trigger needs `mailbox.feed`. */
 export const crm: RoutineCapabilities.Template = {
   id: 'org.dxos.routine.crm',
   label: 'CRM',
@@ -46,24 +32,18 @@ export const crm: RoutineCapabilities.Template = {
         'CRM template requires a Mailbox subject.',
       );
       const mailbox = subject;
-      const instructionsName = `CRM — ${mailbox.name ?? 'Mailbox'}`;
-
-      const skillRefs = SKILL_KEYS.map((key) => Ref.fromURI(Skill.registryURI(key)));
 
       // The feed spec requires the live feed object; Database.load is a read-only DB operation.
       const feed = yield* Database.load(mailbox.feed);
       return makeRoutine({
-        name: name ?? instructionsName,
-        instructions: Instructions.make({
-          name: instructionsName,
-          text: DEFAULT_INSTRUCTIONS,
-          skills: skillRefs,
-        }),
+        name: name ?? `CRM — ${mailbox.name ?? 'Mailbox'}`,
+        spec: { kind: 'runnable', runnable: Ref.fromURI(CrmOperation.ProcessMailbox.meta.key) },
         trigger: Trigger.make({
           enabled: false,
           spec: Trigger.specFeed(feed),
-          // The raw trigger event item is passed as the agent's input.
-          input: { input: '{{event.item}}' },
+          // The operation reads the mailbox itself, so the trigger passes the subject rather than the
+          // event item; `research` scaffolds a Profile per new contact.
+          input: { mailbox: Ref.make(mailbox), research: true },
           concurrency: 1,
         }),
       });


### PR DESCRIPTION
Converts the CRM automation template (`org.dxos.routine.crm`) from an instructions action to an operation action, so the deterministic CRM pipeline is reachable from a mailbox's Automations companion — not only through project creation.

#12441 landed `CrmOperation.ProcessMailbox` and the `crmPipeline` **project** template, but left `templates/crm.ts` — the only CRM entry in the **routine** picker (`RoutineCapabilities.Template`, consumed by `CreateRoutinePanel` / `RoutineCompanion`) — still agentic, carrying `DEFAULT_INSTRUCTIONS` and four skill refs.

## Changes

- **`src/templates/crm.ts`** — `spec: { kind: 'runnable', runnable: Ref.fromURI(CrmOperation.ProcessMailbox.meta.key) }`. The trigger keeps `Trigger.specFeed(feed)`, `enabled: false`, and `concurrency: 1`; its input becomes `{ mailbox: Ref.make(mailbox), research: true }`, matching `crm-pipeline.ts` and `mailbox-action.ts`, rather than the raw `{{event.item}}` — the operation reads the mailbox itself and cursors its feed. `DEFAULT_INSTRUCTIONS`, `SKILL_KEYS`, and the `Instructions`/`Skill`/`trim` imports are removed.
- **`src/templates/crm.test.ts`** — asserts the runnable spec resolves to the `ProcessMailbox` key, that `Routine.instructionsRef(draft)` is `undefined`, and the feed/input/concurrency wiring. `Instructions.Instructions` dropped from the test DB layer.
- **`DESIGN.md`** — new §5.5 for the conversion (Removals shifted to §5.6), §4 row 7 updated, and the test-plan item that claimed `crm.test.ts` keeps template-local instructions text corrected.
- **`.changeset/crm-automation-template-operation.md`** — `@dxos/plugin-crm: patch`. The template's `id`, `label`, and `appliesTo` are unchanged, so nothing a consumer imports changes shape; only what the scaffold produces does.

## Discoverability

Dropping the instructions' `objects` binding does not hide the routine from its mailbox. `connectedRoutinesQuery` (`plugin-routine/src/util/routines-for-object.ts`) matches it through two trigger paths now instead of one: `byFeed` (the trigger's `spec.feed` is the mailbox's feed, as before) and `byInput` (the new direct `input.mailbox` ref — the reverse-ref index is structural, so nested `input` refs match).

## Verification

`moon run plugin-crm:lint plugin-crm:test` — clean, 191 tasks, exit 0:

```
✓ src/templates/crm.test.ts (2 tests) 556ms
    ✓ scaffolds a routine draft bound to ProcessMailbox with a feed trigger
✓ src/templates/crm-pipeline.test.ts (2 tests)
✓ src/templates/crm-project.test.ts (2 tests)
✓ src/operations/research.test.ts (3 tests)
✓ src/operations/process-mailbox.test.ts (2 tests)
↓ src/skills/crm/skill.test.ts (4 skipped — memoized-LLM playground, .skip by default)

 Test Files  5 passed | 1 skipped (6)
      Tests  11 passed | 4 skipped (15)
```

`pnpm format` — clean, no files touched beyond this diff.

## Not done

The agentic `crmProject` template ("Sender Research (CRM)") keeps its instructions — `crm-pipeline.ts` documents itself as that template's deterministic counterpart, so the pair looks intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZqgXNMJxc2aJowRFznCZE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the CRM automation template to process mailboxes through a deterministic operation.
  * Added mailbox and research settings to the automation trigger.
  * Ensured serialized processing with a concurrency limit of one.

* **Documentation**
  * Updated CRM design documentation to reflect the operation-based automation workflow.

* **Tests**
  * Added coverage for operation-based scaffolding, trigger inputs, and removal of instruction-based configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->