### PR TITLE
project: correct the sync count in the capability-activation closure

### DIFF
--- a/.agents/projects/app-framework-capability-activation/TASKS.md
+++ b/.agents/projects/app-framework-capability-activation/TASKS.md
@@ -548,8 +548,8 @@ byte-identical to the locally verified merge of `de1ad824` with `main` `0604e5b8
 
 Work after the sixth addendum:
 
-- **Eighth through thirteenth main syncs** (`e2a9ccfc`, `67a8e4ab`, `e203681a`, `d83fdf5e`,
-  `6375e745`, `ef14a7bc`, `12fd52b6`, `de1ad824`). Standing method, and it earned its keep: after
+- **Eight further main syncs** (`e2a9ccfc`, `67a8e4ab`, `e203681a`, `d83fdf5e`, `6375e745`,
+  `ef14a7bc`, `12fd52b6`, `de1ad824`). Standing method, and it earned its keep: after
   each merge, scan **every** incoming `.ts`/`.tsx` for removed-API usage, not just the conflicted
   files. Four migrations were caught that way and by nothing else — `SurfaceComponent.test.tsx`
   (`Capability.contributes` + `MappedPropsPlugin` on `SetupReactSurface`), `plugin-crm`'s


### PR DESCRIPTION
One-line docs correction to the closure section that landed in [#12486](https://github.com/dxos/dxos/pull/12486).

## Problem

The closure section reads "Eighth through thirteenth main syncs" over a list of **eight** SHAs — two errors in one phrase:

1. The range covers six, not eight.
2. It invents a global ordinal that conflicts with the seventh addendum's own numbering, which labels its three syncs locally as "Merge 1/2/3" rather than as part of a running count.

## Fix

Drops the ordinal: "Eight further main syncs". All eight are two-parent merges of `origin/main`, verified:

```
e2a9ccfc 67a8e4ab e203681a d83fdf5e 6375e745 ef14a7bc 12fd52b6 de1ad824
→ parents=2 for all eight
```

Caught by CodeRabbit on #12486. The correction was written before that PR merged but could not be pushed — the merge-queue entry pins the head branch, so it lands here instead.

## Verification

- `pnpm format` (oxfmt) clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWxqtZhYxXpoumkJzVAuiu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented main-sync count while preserving the associated commit details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->