### PR TITLE
plugin-onboarding: check email before creating identity on signup

### DIFF
--- a/.changeset/signup-duplicate-email.md
+++ b/.changeset/signup-duplicate-email.md
@@ -1,0 +1,20 @@
+---
+'@dxos/plugin-onboarding': patch
+---
+
+Reject a signup email that already has an account before creating a local identity.
+
+Both signup paths — the welcome dialog's invitation-code flow and the URL-driven
+`?accountInvitationCode=…&email=…` flow — created the local identity first and only
+then called `/account/invitation-code/redeem`. Hub correctly rejects a duplicate
+email with `email_already_registered`, but the client discarded the typed error and
+reported it as `'email'` ("Failed to send verification email."), leaving behind an
+identity that can never be bound to an account. Because the welcome dialog dismisses
+on identity-presence and its signup handlers are gated on `!identity`, the user was
+left with no account, no error, and no way to retry short of a storage reset.
+
+Signup now probes `/account/email/exists` first and stops before any identity is
+created, reporting a new `account-exists` error with a link through to email login.
+Redemption failures are still mapped by `data.type`, so a collision that slips past
+the probe (rate-limited, so it reports `false`) surfaces the same message rather than
+the misleading delivery error.

--- a/.changeset/signup-duplicate-email.md
+++ b/.changeset/signup-duplicate-email.md
@@ -15,6 +15,10 @@ left with no account, no error, and no way to retry short of a storage reset.
 
 Signup now probes `/account/email/exists` first and stops before any identity is
 created, reporting a new `account-exists` error with a link through to email login.
-Redemption failures are still mapped by `data.type`, so a collision that slips past
-the probe (rate-limited, so it reports `false`) surfaces the same message rather than
-the misleading delivery error.
+
+The probe is tri-state: a rate-limited or failed check reports `unavailable` rather
+than "free", and that also stops before identity creation with a retriable error —
+so no signup path can strand an unbindable identity. The URL-driven flow leaves its
+`accountInvitationCode`/`email` params intact in that case so a reload retries.
+Redemption failures are additionally mapped by `data.type`, so a collision reaching
+the server surfaces the same message rather than the misleading delivery error.

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.tsx
@@ -35,6 +35,7 @@ const ATMOSPHERE_PROVIDER = 'atproto';
 const errorMessageKeys: Record<WelcomeError, string> = {
   'email': 'email-error.message',
   'account-exists': 'account-exists-error.message',
+  'email-check-unavailable': 'email-check-unavailable-error.message',
   'oauth': 'oauth-error.message',
   'passkey-dismissed': 'passkey-dismissed-error.message',
   'passkey-rejected': 'passkey-rejected-error.message',
@@ -198,9 +199,12 @@ export const Welcome = ({
     }
   }, [code, email, onCreateAccount]);
 
-  // A duplicate email is a signup failure with a login remedy, so it reports under the
-  // signup email field rather than as a generic delivery error.
-  const signupEmailError = error === 'email' || error === 'account-exists' ? t(errorMessageKeys[error]) : null;
+  // Signup-specific failures report under the signup email field rather than as a
+  // generic delivery error.
+  const signupEmailError =
+    error === 'email' || error === 'account-exists' || error === 'email-check-unavailable'
+      ? t(errorMessageKeys[error])
+      : null;
 
   const handleSwitchToEmailLogin = useCallback(() => {
     setTab('login');

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/Welcome.tsx
@@ -34,6 +34,7 @@ const ATMOSPHERE_PROVIDER = 'atproto';
 
 const errorMessageKeys: Record<WelcomeError, string> = {
   'email': 'email-error.message',
+  'account-exists': 'account-exists-error.message',
   'oauth': 'oauth-error.message',
   'passkey-dismissed': 'passkey-dismissed-error.message',
   'passkey-rejected': 'passkey-rejected-error.message',
@@ -196,6 +197,15 @@ export const Welcome = ({
       setPending(false);
     }
   }, [code, email, onCreateAccount]);
+
+  // A duplicate email is a signup failure with a login remedy, so it reports under the
+  // signup email field rather than as a generic delivery error.
+  const signupEmailError = error === 'email' || error === 'account-exists' ? t(errorMessageKeys[error]) : null;
+
+  const handleSwitchToEmailLogin = useCallback(() => {
+    setTab('login');
+    setLoginPrimary('email');
+  }, []);
 
   const handleJoinWaitlist = useCallback(async () => {
     if (!validEmail(waitlistEmail)) {
@@ -397,8 +407,11 @@ export const Welcome = ({
                       submitLabel={t('continue-button.label')}
                       submitDisabled={!validEmail(email) || pending}
                       onSubmit={handleCreateAccount}
-                      validation={error === 'email' ? t(errorMessageKeys.email) : null}
+                      validation={signupEmailError}
                     />
+                    {error === 'account-exists' && (
+                      <SwapLink onClick={handleSwitchToEmailLogin}>{t('log-in-instead-link.label')}</SwapLink>
+                    )}
                     {onCreateAccountWithOAuth && (
                       <>
                         <OrDivider>{t('or-divider.label')}</OrDivider>

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/types.ts
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/types.ts
@@ -10,7 +10,7 @@ import { type MaybePromise } from '@dxos/util';
  * Which failure the screen is currently reporting. Only one login method is on screen at a time, so
  * one field is enough; the reason selects both the message and the control it renders under.
  */
-export type WelcomeError = 'email' | 'oauth' | `passkey-${PasskeyFailure}`;
+export type WelcomeError = 'email' | 'account-exists' | 'oauth' | `passkey-${PasskeyFailure}`;
 
 export const passkeyError = (failure: PasskeyFailure): WelcomeError => `passkey-${failure}`;
 

--- a/packages/plugins/plugin-onboarding/src/components/Welcome/types.ts
+++ b/packages/plugins/plugin-onboarding/src/components/Welcome/types.ts
@@ -10,7 +10,12 @@ import { type MaybePromise } from '@dxos/util';
  * Which failure the screen is currently reporting. Only one login method is on screen at a time, so
  * one field is enough; the reason selects both the message and the control it renders under.
  */
-export type WelcomeError = 'email' | 'account-exists' | 'oauth' | `passkey-${PasskeyFailure}`;
+export type WelcomeError =
+  | 'email'
+  | 'account-exists'
+  | 'email-check-unavailable'
+  | 'oauth'
+  | `passkey-${PasskeyFailure}`;
 
 export const passkeyError = (failure: PasskeyFailure): WelcomeError => `passkey-${failure}`;
 

--- a/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
@@ -14,7 +14,14 @@ import { useClient } from '@dxos/react-client';
 import { useIdentity } from '@dxos/react-client/halo';
 import { ThemeProvider, defaultTx } from '@dxos/react-ui';
 
-import { joinWaitlist, login, redeemAccountInvitation, validateInvitationCode } from '../credentials';
+import {
+  checkEmailExists,
+  isAccountErrorType,
+  joinWaitlist,
+  login,
+  redeemAccountInvitation,
+  validateInvitationCode,
+} from '../credentials';
 import { useForceDarkTheme } from '../hooks';
 import { meta } from '../meta';
 import { OnboardingOperation } from '../operations';
@@ -165,6 +172,13 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
       }
       pendingRef.current = true;
       try {
+        // Probe before creating anything: redemption rejects a duplicate email, and an
+        // identity created first would be stranded with no account and no way to retry.
+        if (await checkEmailExists({ hubUrl, email })) {
+          setError('account-exists');
+          return;
+        }
+
         const ensureIdentity = async () => {
           if (identity) {
             return identity;
@@ -192,7 +206,9 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
         await invokePromise(LayoutOperation.UpdateDialog, { state: false });
       } catch (err) {
         log.catch(err);
-        setError('email');
+        // The probe above reports `false` when rate-limited, so redemption is still the
+        // last line of defence against a collision.
+        setError(isAccountErrorType(err, 'email_already_registered') ? 'account-exists' : 'email');
       } finally {
         pendingRef.current = false;
       }

--- a/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
@@ -15,10 +15,10 @@ import { useIdentity } from '@dxos/react-client/halo';
 import { ThemeProvider, defaultTx } from '@dxos/react-ui';
 
 import {
-  checkEmailExists,
   isAccountErrorType,
   joinWaitlist,
   login,
+  probeEmailExists,
   redeemAccountInvitation,
   validateInvitationCode,
 } from '../credentials';
@@ -174,8 +174,10 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
       try {
         // Probe before creating anything: redemption rejects a duplicate email, and an
         // identity created first would be stranded with no account and no way to retry.
-        if (await checkEmailExists({ hubUrl, email })) {
-          setError('account-exists');
+        // An inconclusive probe is not permission to proceed, so it stops here too.
+        const probe = await probeEmailExists({ hubUrl, email });
+        if (probe !== 'available') {
+          setError(probe === 'exists' ? 'account-exists' : 'email-check-unavailable');
           return;
         }
 

--- a/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/WelcomeScreen.tsx
@@ -208,8 +208,8 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
         await invokePromise(LayoutOperation.UpdateDialog, { state: false });
       } catch (err) {
         log.catch(err);
-        // The probe above reports `false` when rate-limited, so redemption is still the
-        // last line of defence against a collision.
+        // Another signup can register the email between the probe and redemption, so the
+        // server remains the final duplicate-email check.
         setError(isAccountErrorType(err, 'email_already_registered') ? 'account-exists' : 'email');
       } finally {
         pendingRef.current = false;

--- a/packages/plugins/plugin-onboarding/src/credentials/util.ts
+++ b/packages/plugins/plugin-onboarding/src/credentials/util.ts
@@ -21,13 +21,30 @@ export type RedeemResult = { accountId: string; emailVerificationSent: boolean }
  */
 export type EmailProbeResult = 'exists' | 'available' | 'unavailable';
 
+/** Bounds the probe so an unresponsive hub cannot leave the signup flow pending. */
+const EMAIL_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Reads `data.exists` out of a hub success envelope, or `undefined` when the body isn't
+ * one. Narrowed field by field so a malformed response can't be mistaken for an answer.
+ */
+const readEmailExists = (body: unknown): boolean | undefined => {
+  if (typeof body !== 'object' || body === null || !('success' in body) || body.success !== true) {
+    return undefined;
+  }
+  if (!('data' in body) || typeof body.data !== 'object' || body.data === null || !('exists' in body.data)) {
+    return undefined;
+  }
+  return typeof body.data.exists === 'boolean' ? body.data.exists : undefined;
+};
+
 /**
  * POST `/account/email/exists` on hub-service. Lets the signup flow reject a
  * duplicate email before creating a local identity, since redemption rejects it
  * afterwards and the orphaned identity cannot be bound to any account.
  *
- * Rate limits (10/min) and transport errors both yield `unavailable`, so callers
- * must stop rather than assume the address is free.
+ * Rate limits (10/min), timeouts, transport errors, and unrecognised bodies all yield
+ * `unavailable`, so callers must stop rather than assume the address is free.
  */
 export const probeEmailExists = async ({
   hubUrl,
@@ -41,15 +58,16 @@ export const probeEmailExists = async ({
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email }),
+      signal: AbortSignal.timeout(EMAIL_PROBE_TIMEOUT_MS),
     });
     if (!response.ok) {
       return 'unavailable';
     }
-    const envelope = (await response.json()) as { success: boolean; data?: { exists: boolean } };
-    if (!envelope.success || typeof envelope.data?.exists !== 'boolean') {
+    const exists = readEmailExists(await response.json());
+    if (exists === undefined) {
       return 'unavailable';
     }
-    return envelope.data.exists ? 'exists' : 'available';
+    return exists ? 'exists' : 'available';
   } catch {
     return 'unavailable';
   }

--- a/packages/plugins/plugin-onboarding/src/credentials/util.ts
+++ b/packages/plugins/plugin-onboarding/src/credentials/util.ts
@@ -2,6 +2,8 @@
 // Copyright 2024 DXOS.org
 //
 
+import { type AccountErrorType } from '@dxos/protocols';
+
 /**
  * POST `/account/invitation-code/redeem` on hub-service. Unauthenticated.
  * Two-step signup: the redeemer supplies the invitation code + their identity
@@ -11,6 +13,28 @@
  * always pass all three.
  */
 export type RedeemResult = { accountId: string; emailVerificationSent: boolean } | { needsIdentity: true };
+
+/**
+ * POST `/account/email/exists` on hub-service. Lets the signup flow reject a
+ * duplicate email before creating a local identity, since redemption rejects it
+ * afterwards and the orphaned identity cannot be bound to any account.
+ *
+ * Reports `false` when the probe itself fails (network error, or the 10/min rate
+ * limit): redemption re-checks the collision server-side and stays the authority.
+ */
+export const checkEmailExists = async ({ hubUrl, email }: { hubUrl: string; email: string }): Promise<boolean> => {
+  try {
+    const response = await fetch(new URL('/account/email/exists', hubUrl), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    const envelope = (await response.json()) as { success: boolean; data?: { exists: boolean } };
+    return !!envelope.success && !!envelope.data?.exists;
+  } catch {
+    return false;
+  }
+};
 
 /**
  * POST `/account/invitation-code/validate` on hub-service. Returns true if the code
@@ -83,6 +107,21 @@ export const redeemAccountInvitation = async ({
     throw error;
   }
   return envelope.data as RedeemResult;
+};
+
+/**
+ * True when a rejected hub call carried this `data.type` discriminator, so callers can
+ * distinguish a known failure (e.g. `email_already_registered`) from a transport error.
+ */
+export const isAccountErrorType = (err: unknown, type: AccountErrorType): boolean => {
+  if (typeof err !== 'object' || err === null || !('data' in err)) {
+    return false;
+  }
+  const { data } = err;
+  if (typeof data !== 'object' || data === null || !('type' in data)) {
+    return false;
+  }
+  return typeof data.type === 'string' && data.type === type;
 };
 
 /**

--- a/packages/plugins/plugin-onboarding/src/credentials/util.ts
+++ b/packages/plugins/plugin-onboarding/src/credentials/util.ts
@@ -15,24 +15,43 @@ import { type AccountErrorType } from '@dxos/protocols';
 export type RedeemResult = { accountId: string; emailVerificationSent: boolean } | { needsIdentity: true };
 
 /**
+ * Outcome of the pre-signup email probe. `unavailable` is deliberately distinct from
+ * `available`: a failed probe says nothing about the address, and treating it as free
+ * would create a local identity that redemption then refuses to bind.
+ */
+export type EmailProbeResult = 'exists' | 'available' | 'unavailable';
+
+/**
  * POST `/account/email/exists` on hub-service. Lets the signup flow reject a
  * duplicate email before creating a local identity, since redemption rejects it
  * afterwards and the orphaned identity cannot be bound to any account.
  *
- * Reports `false` when the probe itself fails (network error, or the 10/min rate
- * limit): redemption re-checks the collision server-side and stays the authority.
+ * Rate limits (10/min) and transport errors both yield `unavailable`, so callers
+ * must stop rather than assume the address is free.
  */
-export const checkEmailExists = async ({ hubUrl, email }: { hubUrl: string; email: string }): Promise<boolean> => {
+export const probeEmailExists = async ({
+  hubUrl,
+  email,
+}: {
+  hubUrl: string;
+  email: string;
+}): Promise<EmailProbeResult> => {
   try {
     const response = await fetch(new URL('/account/email/exists', hubUrl), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email }),
     });
+    if (!response.ok) {
+      return 'unavailable';
+    }
     const envelope = (await response.json()) as { success: boolean; data?: { exists: boolean } };
-    return !!envelope.success && !!envelope.data?.exists;
+    if (!envelope.success || typeof envelope.data?.exists !== 'boolean') {
+      return 'unavailable';
+    }
+    return envelope.data.exists ? 'exists' : 'available';
   } catch {
-    return false;
+    return 'unavailable';
   }
 };
 

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-import { describe, onTestFinished, test } from 'vitest';
+import { describe, onTestFinished, test, vi } from 'vitest';
 
 import type * as Capabilities from '@dxos/app-framework/Capabilities';
 import { Client } from '@dxos/client';
@@ -45,6 +45,20 @@ describe('OnboardingManager', () => {
       }),
     ]);
   });
+
+  test('url-driven signup with an already-registered email creates no identity', async ({ expect }) => {
+    const { manager, getCalls } = await createManager({
+      hubUrl: 'https://hub.example.com',
+      email: 'existing@example.com',
+      accountInvitationCode: 'XK4F9P2A',
+      emailExists: true,
+    });
+    await manager.initialize();
+
+    // Redemption would reject the duplicate email, stranding this identity unbindable.
+    expect(getCalls(ClientOperation.CreateIdentity)).toHaveLength(0);
+    expect(getCalls(ClientOperation.CreateAgent)).toHaveLength(0);
+  });
 });
 
 const createClient = async () => {
@@ -69,13 +83,46 @@ const createInvoker = () => {
   return { invokePromise, getCalls, calls };
 };
 
-const createManager = async (options: { identity?: boolean; deviceInvitationCode?: string }) => {
+/**
+ * Stubs the `/account/email/exists` probe. Any other hub request throws so a test can't
+ * pass off the back of a silently-failing fetch.
+ */
+const stubEmailExists = (exists: boolean) => {
+  vi.stubGlobal('fetch', async (input: unknown) => {
+    if (!(input instanceof URL) || input.pathname !== '/account/email/exists') {
+      throw new Error(`Unexpected hub request: ${String(input)}`);
+    }
+    return new Response(JSON.stringify({ success: true, data: { exists } }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+  onTestFinished(() => vi.unstubAllGlobals());
+};
+
+const createManager = async (options: {
+  identity?: boolean;
+  deviceInvitationCode?: string;
+  hubUrl?: string;
+  email?: string;
+  accountInvitationCode?: string;
+  emailExists?: boolean;
+}) => {
   const client = await createClient();
   if (options.identity) {
     await client.halo.createIdentity();
   }
+  if (options.emailExists !== undefined) {
+    stubEmailExists(options.emailExists);
+  }
   const { invokePromise, getCalls, calls } = createInvoker();
-  const manager = new OnboardingManager({ invokePromise, client, deviceInvitationCode: options.deviceInvitationCode });
+  const manager = new OnboardingManager({
+    invokePromise,
+    client,
+    deviceInvitationCode: options.deviceInvitationCode,
+    hubUrl: options.hubUrl,
+    email: options.email,
+    accountInvitationCode: options.accountInvitationCode,
+  });
   onTestFinished(() => manager.destroy());
   return { manager, getCalls, calls };
 };

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
@@ -51,11 +51,26 @@ describe('OnboardingManager', () => {
       hubUrl: 'https://hub.example.com',
       email: 'existing@example.com',
       accountInvitationCode: 'XK4F9P2A',
-      emailExists: true,
+      emailProbe: 'exists',
     });
     await manager.initialize();
 
     // Redemption would reject the duplicate email, stranding this identity unbindable.
+    expect(getCalls(ClientOperation.CreateIdentity)).toHaveLength(0);
+    expect(getCalls(ClientOperation.CreateAgent)).toHaveLength(0);
+  });
+
+  test('url-driven signup creates no identity when the email probe is rate-limited', async ({ expect }) => {
+    const { manager, getCalls } = await createManager({
+      hubUrl: 'https://hub.example.com',
+      email: 'unknown@example.com',
+      accountInvitationCode: 'XK4F9P2A',
+      emailProbe: 'unavailable',
+    });
+    await manager.initialize();
+
+    // An inconclusive probe says nothing about the address, so proceeding could still
+    // strand an identity that redemption refuses to bind.
     expect(getCalls(ClientOperation.CreateIdentity)).toHaveLength(0);
     expect(getCalls(ClientOperation.CreateAgent)).toHaveLength(0);
   });
@@ -85,14 +100,21 @@ const createInvoker = () => {
 
 /**
  * Stubs the `/account/email/exists` probe. Any other hub request throws so a test can't
- * pass off the back of a silently-failing fetch.
+ * pass off the back of a silently-failing fetch. `'unavailable'` simulates the rate-limit
+ * response, which must not be read as "this email is free".
  */
-const stubEmailExists = (exists: boolean) => {
+const stubEmailProbe = (outcome: 'exists' | 'available' | 'unavailable') => {
   vi.stubGlobal('fetch', async (input: unknown) => {
     if (!(input instanceof URL) || input.pathname !== '/account/email/exists') {
       throw new Error(`Unexpected hub request: ${String(input)}`);
     }
-    return new Response(JSON.stringify({ success: true, data: { exists } }), {
+    if (outcome === 'unavailable') {
+      return new Response(JSON.stringify({ success: false, message: 'Too many requests' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify({ success: true, data: { exists: outcome === 'exists' } }), {
       headers: { 'Content-Type': 'application/json' },
     });
   });
@@ -107,14 +129,14 @@ const createManager = async (options: {
   hubUrl?: string;
   email?: string;
   accountInvitationCode?: string;
-  emailExists?: boolean;
+  emailProbe?: 'exists' | 'available' | 'unavailable';
 }) => {
   const client = await createClient();
   if (options.identity) {
     await client.halo.createIdentity();
   }
-  if (options.emailExists !== undefined) {
-    stubEmailExists(options.emailExists);
+  if (options.emailProbe !== undefined) {
+    stubEmailProbe(options.emailProbe);
   }
   const { invokePromise, getCalls, calls } = createInvoker();
   const manager = new OnboardingManager({

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
@@ -96,7 +96,9 @@ const stubEmailExists = (exists: boolean) => {
       headers: { 'Content-Type': 'application/json' },
     });
   });
-  onTestFinished(() => vi.unstubAllGlobals());
+  onTestFinished(() => {
+    vi.unstubAllGlobals();
+  });
 };
 
 const createManager = async (options: {

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
@@ -20,6 +20,7 @@ import { osTranslations } from '@dxos/ui-theme';
 
 import { WELCOME_SCREEN } from './components';
 import { OVERLAY_CLASSES, OVERLAY_STYLE } from './components/Welcome/Welcome';
+import { checkEmailExists } from './credentials';
 import { meta } from './meta';
 import { queryAllCredentials, removeQueryParamByValue } from './util';
 
@@ -172,10 +173,11 @@ export class OnboardingManager {
       // URL-driven signup: `?accountInvitationCode=...&email=...`. The user
       // landed here from the invitation email; redeem the code with the
       // emailed address.
-      await this._redeemAccountInvitation();
-      await this._setupRecovery();
-      await this._startHelp();
-      await this._createAgent();
+      if (await this._redeemAccountInvitation()) {
+        await this._setupRecovery();
+        await this._startHelp();
+        await this._createAgent();
+      }
     } else if (!this._identity && this._skipAuth) {
       // Auth disabled (e.g. integration tests): just bring up a fresh identity.
       await this._createIdentity();
@@ -257,10 +259,22 @@ export class OnboardingManager {
    * fresh local identity and bind it. Account restoration is intentionally not
    * supported on this path -- magic-link login (`/account/login`) handles
    * recovery for real emails, and test emails are always fresh (no restore).
+   *
+   * Resolves false when the email already has an account, in which case no identity
+   * is created and the welcome dialog stays open so the user can log in instead.
    */
-  private async _redeemAccountInvitation(): Promise<void> {
+  private async _redeemAccountInvitation(): Promise<boolean> {
     invariant(this._email);
     invariant(this._hubUrl, 'hubUrl required for redemption');
+
+    // Probe before creating anything: redemption rejects a duplicate email, and an
+    // identity created first would be stranded with no account and no way to retry.
+    if (await checkEmailExists({ hubUrl: this._hubUrl, email: this._email })) {
+      log.info('signup email already registered; awaiting login', { email: this._email });
+      this._accountInvitationCode && removeQueryParamByValue(this._accountInvitationCode);
+      removeQueryParamByValue(this._email);
+      return false;
+    }
 
     await this._createIdentity();
     invariant(this._identity, 'identity should exist after create');
@@ -277,6 +291,7 @@ export class OnboardingManager {
 
     this._accountInvitationCode && removeQueryParamByValue(this._accountInvitationCode);
     removeQueryParamByValue(this._email);
+    return true;
   }
 
   /**

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
@@ -20,7 +20,7 @@ import { osTranslations } from '@dxos/ui-theme';
 
 import { WELCOME_SCREEN } from './components';
 import { OVERLAY_CLASSES, OVERLAY_STYLE } from './components/Welcome/Welcome';
-import { checkEmailExists } from './credentials';
+import { probeEmailExists } from './credentials';
 import { meta } from './meta';
 import { queryAllCredentials, removeQueryParamByValue } from './util';
 
@@ -260,8 +260,10 @@ export class OnboardingManager {
    * supported on this path -- magic-link login (`/account/login`) handles
    * recovery for real emails, and test emails are always fresh (no restore).
    *
-   * Resolves false when the email already has an account, in which case no identity
-   * is created and the welcome dialog stays open so the user can log in instead.
+   * Resolves false when no identity was created — either the email already has an
+   * account (the welcome dialog stays open so the user can log in instead) or the
+   * probe was inconclusive, in which case the URL params are left intact so a reload
+   * retries the signup.
    */
   private async _redeemAccountInvitation(): Promise<boolean> {
     invariant(this._email);
@@ -269,8 +271,13 @@ export class OnboardingManager {
 
     // Probe before creating anything: redemption rejects a duplicate email, and an
     // identity created first would be stranded with no account and no way to retry.
-    if (await checkEmailExists({ hubUrl: this._hubUrl, email: this._email })) {
-      log.info('signup email already registered; awaiting login', { email: this._email });
+    const probe = await probeEmailExists({ hubUrl: this._hubUrl, email: this._email });
+    if (probe === 'unavailable') {
+      log.warn('could not check whether signup email is registered; leaving signup params for retry');
+      return false;
+    }
+    if (probe === 'exists') {
+      log.info('signup email already registered; awaiting login');
       this._accountInvitationCode && removeQueryParamByValue(this._accountInvitationCode);
       removeQueryParamByValue(this._email);
       return false;

--- a/packages/plugins/plugin-onboarding/src/translations.ts
+++ b/packages/plugins/plugin-onboarding/src/translations.ts
@@ -21,6 +21,7 @@ export const translations = [
           "A confirmation link has been sent to your inbox. If it doesn't arrive in the next three minutes please check your spam folder.",
         'email-error.message': 'Failed to send verification email.',
         'account-exists-error.message': 'That email already has an account. Log in instead.',
+        'email-check-unavailable-error.message': "Couldn't check that email just now. Please try again in a moment.",
         'log-in-instead-link.label': 'Log in with this email',
         'oauth-error.message': 'Could not connect to that account. Please try again.',
 

--- a/packages/plugins/plugin-onboarding/src/translations.ts
+++ b/packages/plugins/plugin-onboarding/src/translations.ts
@@ -20,6 +20,8 @@ export const translations = [
         'request-access-email.description':
           "A confirmation link has been sent to your inbox. If it doesn't arrive in the next three minutes please check your spam folder.",
         'email-error.message': 'Failed to send verification email.',
+        'account-exists-error.message': 'That email already has an account. Log in instead.',
+        'log-in-instead-link.label': 'Log in with this email',
         'oauth-error.message': 'Could not connect to that account. Please try again.',
 
         'email-input.label': 'Email',


### PR DESCRIPTION
## Problem

A user signed up with an email that already had a Hub Account, ended up with a brand-new unbindable DID, and had no edge access.

Hub **did** block it. From the production logs (`service.name = hub`):

| Time (UTC, Aug 6) | Request | Status |
|---|---|---|
| 04:34:03 | `POST /account/invitation-code/validate` | 200 |
| 04:34:15 | `POST /account/invitation-code/redeem` | **400** |
| 08:02:59 | `validate` (from `labs.composer.space`) | 200 |
| 08:03:12 | `redeem` | **400** |
| 13:33–13:34 | `/account/me` → 404, `/account/invitation` → 403 | stranded |

The 400 is `email_already_registered`, thrown in `AccountManager.redeemCode` and returned as a typed failure with `data.type`. On edge, the old DID gets 200 on `/users/<did>/agent/status` (which is gated on a Hub Account) while the new one gets 403 — confirming the collision.

The client is what went wrong:

1. `ensureIdentity()` ran `CreateIdentity` **before** the redeem call, so the identity was already persisted when the server said no.
2. The `catch` discarded `err.data.type` and set the generic `'email'` error.
3. `'email'` maps to `"Failed to send verification email."` — a delivery error for what was actually a duplicate account.
4. `OnboardingManager` dismisses the welcome dialog the moment a local identity appears, which happens in step 1 — so the error painted a closed dialog.
5. The signup handlers are gated on `!identity`, so once the orphan identity existed the whole signup tab went inert. No retry without a storage reset.

`/account/email/exists` and `HubHttpClient.checkEmailExists` already existed, rate-limited and purpose-built, with zero callers.

## Changes

Pre-check instead of rollback — nothing is created until the email is known to be free.

- **`credentials/util.ts`** — `probeEmailExists` returning `EmailProbeResult = 'exists' | 'available' | 'unavailable'`. `unavailable` is deliberately distinct from `available`: rate limits (429), non-2xx, timeouts, transport errors and unrecognised bodies all land there, so a failed probe is never mistaken for a free address. Bounded by a 10s `AbortSignal.timeout` so an unresponsive hub can't leave signup pending. The response body stays `unknown` and is narrowed field by field. Plus `isAccountErrorType`, a cast-free guard over the failure envelope's `data.type`.
- **`WelcomeScreen.tsx`** — probes before `ensureIdentity()` and stops unless the result is `available`. Redemption failures are still mapped by `data.type`, since another signup can register the address between probe and redeem.
- **`onboarding-manager.ts`** — same pre-check on the URL-driven `?accountInvitationCode=…&email=…` path, which had the identical defect. `_redeemAccountInvitation` resolves `boolean` so `initialize()` skips recovery/help/agent provisioning when it bails. On `unavailable` the URL params are left intact so a reload retries; on `exists` they're cleared and the welcome dialog stays open for login.
- **`Welcome.tsx` / `types.ts` / `translations.ts`** — `account-exists` ("That email already has an account. Log in instead.") with a link that switches to the Login tab, and a retriable `email-check-unavailable`. The email field is shared state, so it carries across tabs.

Net effect: **no signup path can strand an unbindable identity**, and a duplicate email produces an accurate message with a route to login.

## Testing

`plugin-onboarding`: build, lint, tests, and `pnpm format` all clean locally; CI green on `a1aeb93d` (Check, Preview Build, Model Fixture).

```
Test Files  2 passed (2)
     Tests  6 passed (6)
```

Two new cases — an already-registered email, and a rate-limited (429) probe — both asserting no identity and no agent are created. Verified non-vacuous: inverting the guard makes the first fail.

```
× url-driven signup with an already-registered email creates no identity
 Tests  1 failed | 4 passed (5)
```

The stubbed `fetch` throws on any request other than `/account/email/exists`, so a test can't pass off a silently-failing fetch.

## Notes / out of scope

- **This does not fix the originally affected user.** Their invitation code was never consumed (the collision check runs before the code is claimed), so it's still redeemable — but they need the **Login** tab, not Signup.
- **Separate bug, not fixed here:** `AccountManager.createApprovedAccount` (admin waitlist approval, `console/admin.tsx`) never persists `identityKey`, unlike `redeemCode` and `createTestAccount`. `/account/login` mints the token with `identityKey: account.identityKey ?? undefined`, `lookupRecoveryToken` returns `{}` without it, and `db-service` recovery then fails with `"Identity key not found."` — so magic-link login is broken for every admin-approved account. Needs its own PR in `dxos/edge` plus a backfill.
- The OAuth signup path (`RegisterOAuthRecovery`) can't take this pre-check — the email is only known after the provider round-trip, out-of-band in the redirect module.
- **Email enumeration:** `/account/email/exists` reveals account existence by design, whereas `/account/login` was deliberately built enumeration-safe. This PR surfaces an existing, rate-limited endpoint and adds no new exposure — `/account/invitation-code/redeem` is a stronger unrate-limited oracle that predates it. Tracked with the durable fix in **DX-1146**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLYaBtHNUEEDuxd9CsdZy9
