### PR TITLE
react-ui-form: fix FormLayout story tests timing out on an empty DOM

### DIFF
--- a/packages/ui/react-ui-form/src/components/Form/FormLayout/FormLayout.stories.test.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormLayout/FormLayout.stories.test.tsx
@@ -10,10 +10,11 @@ import * as stories from './FormLayout.stories';
 
 const { NestedLabel, NestedLabelStatic } = composeStories(stories);
 
-// `withClientProvider` renders nothing until the client has created its identity and first space,
-// which takes seconds — well past testing-library's 1s `findBy*` default, so every query below
-// must opt into a longer window (still inside each test's own timeout).
-const FIND_TIMEOUT = 20_000;
+// `withClientProvider` renders nothing until the client has created its identity and first space —
+// measured at ~1.8s here, past testing-library's 1s `findBy*` default. Waiting for the form once
+// covers it: `Form.Content` renders `role="form"` with the fields as its children, so the whole
+// form lands in a single commit and every assertion after the wait can be synchronous.
+const CLIENT_READY_TIMEOUT = 10_000;
 
 describe('FormLayout — nested fields', () => {
   afterEach(async () => {
@@ -25,24 +26,24 @@ describe('FormLayout — nested fields', () => {
 
   test('renders nested struct labels and dotted sub-fields', { timeout: 30_000 }, async () => {
     await NestedLabel.run();
+    const form = await screen.findByRole('form', undefined, { timeout: CLIENT_READY_TIMEOUT });
 
     // `<field name="origin"/>` / `<field name="destination"/>` auto-convert to the
     // place's `LabelAnnotation` label (the `name` field), rendered as read-only text.
-    // `findByText` retries while the async client provider initializes.
-    expect(await screen.findByText('John F. Kennedy Intl', undefined, { timeout: FIND_TIMEOUT })).toBeInTheDocument();
-    expect(await screen.findByText('Charles de Gaulle', undefined, { timeout: FIND_TIMEOUT })).toBeInTheDocument();
+    expect(within(form).getByText('John F. Kennedy Intl')).toBeInTheDocument();
+    expect(within(form).getByText('Charles de Gaulle')).toBeInTheDocument();
 
     // `<field name="origin.code"/>` / `<field name="destination.code"/>` drill into the
     // leaf sub-field, rendered as editable inputs holding the code.
-    expect(await screen.findByDisplayValue('JFK', undefined, { timeout: FIND_TIMEOUT })).toBeInTheDocument();
-    expect(await screen.findByDisplayValue('CDG', undefined, { timeout: FIND_TIMEOUT })).toBeInTheDocument();
+    expect(within(form).getByDisplayValue('JFK')).toBeInTheDocument();
+    expect(within(form).getByDisplayValue('CDG')).toBeInTheDocument();
   });
 
   test('static layout formats dates and renders labels as read-only text', { timeout: 30_000 }, async () => {
     await NestedLabelStatic.run();
 
     // Scope assertions to the form: the debug panel echoes the raw values JSON.
-    const form = await screen.findByRole('form', undefined, { timeout: FIND_TIMEOUT });
+    const form = await screen.findByRole('form', undefined, { timeout: CLIENT_READY_TIMEOUT });
 
     // The depart date renders human-readable (contains the year) rather than the raw ISO
     // string. Match `2026` and assert no ISO time fragment leaks through — timezone-robust.

--- a/packages/ui/react-ui-form/src/components/Form/FormLayout/FormLayout.stories.test.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormLayout/FormLayout.stories.test.tsx
@@ -10,6 +10,11 @@ import * as stories from './FormLayout.stories';
 
 const { NestedLabel, NestedLabelStatic } = composeStories(stories);
 
+// `withClientProvider` renders nothing until the client has created its identity and first space,
+// which takes seconds — well past testing-library's 1s `findBy*` default, so every query below
+// must opt into a longer window (still inside each test's own timeout).
+const FIND_TIMEOUT = 20_000;
+
 describe('FormLayout — nested fields', () => {
   afterEach(async () => {
     // Flush pending React scheduler work before teardown to prevent
@@ -24,20 +29,20 @@ describe('FormLayout — nested fields', () => {
     // `<field name="origin"/>` / `<field name="destination"/>` auto-convert to the
     // place's `LabelAnnotation` label (the `name` field), rendered as read-only text.
     // `findByText` retries while the async client provider initializes.
-    expect(await screen.findByText('John F. Kennedy Intl')).toBeInTheDocument();
-    expect(await screen.findByText('Charles de Gaulle')).toBeInTheDocument();
+    expect(await screen.findByText('John F. Kennedy Intl', undefined, { timeout: FIND_TIMEOUT })).toBeInTheDocument();
+    expect(await screen.findByText('Charles de Gaulle', undefined, { timeout: FIND_TIMEOUT })).toBeInTheDocument();
 
     // `<field name="origin.code"/>` / `<field name="destination.code"/>` drill into the
     // leaf sub-field, rendered as editable inputs holding the code.
-    expect(await screen.findByDisplayValue('JFK')).toBeInTheDocument();
-    expect(await screen.findByDisplayValue('CDG')).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('JFK', undefined, { timeout: FIND_TIMEOUT })).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('CDG', undefined, { timeout: FIND_TIMEOUT })).toBeInTheDocument();
   });
 
   test('static layout formats dates and renders labels as read-only text', { timeout: 30_000 }, async () => {
     await NestedLabelStatic.run();
 
     // Scope assertions to the form: the debug panel echoes the raw values JSON.
-    const form = await screen.findByRole('form');
+    const form = await screen.findByRole('form', undefined, { timeout: FIND_TIMEOUT });
 
     // The depart date renders human-readable (contains the year) rather than the raw ISO
     // string. Match `2026` and assert no ISO time fragment leaks through — timezone-robust.

--- a/packages/ui/react-ui-form/src/vitest-setup.ts
+++ b/packages/ui/react-ui-form/src/vitest-setup.ts
@@ -36,6 +36,27 @@ afterEach(() => {
   }
 });
 
+// `ThemeProvider`'s icon registry fetches the static sprite (`/icons.svg`) and any missing glyph
+// (`/phosphor/…`) from the document origin. happy-dom points that origin at `http://localhost:3000`,
+// where nothing listens, so every request opens a real socket and dies with `ECONNREFUSED` —
+// and since the registry treats a network error as transient, each re-render retries forever.
+// Answering 404 marks the symbol permanently missing, which is the truth in a test environment.
+const ICON_ROUTES = ['/icons.svg', '/phosphor/'];
+
+const FETCH_FLAG = '__dxos_icon_fetch_stub__';
+if (!(globalThis as Record<string, unknown>)[FETCH_FLAG] && typeof globalThis.fetch === 'function') {
+  (globalThis as Record<string, unknown>)[FETCH_FLAG] = true;
+  const originalFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    const { pathname } = new URL(url, globalThis.location?.href);
+    if (ICON_ROUTES.some((route) => pathname.startsWith(route))) {
+      return Promise.resolve(new Response(null, { status: 404, statusText: 'Not Found' }));
+    }
+    return originalFetch(input, init);
+  };
+}
+
 const FLAG = '__dxos_tabster_post_teardown_filter__';
 if (!(globalThis as Record<string, unknown>)[FLAG]) {
   (globalThis as Record<string, unknown>)[FLAG] = true;


### PR DESCRIPTION
## Problem

`packages/ui/react-ui-form/src/components/Form/FormLayout/FormLayout.stories.test.tsx` failed with an empty document:

```
TestingLibraryElementError: Unable to find an element with the text: John F. Kennedy Intl
<body>
  <div />
</body>
```

…alongside ~170 `Error: connect ECONNREFUSED 127.0.0.1:3000` lines per run.

## Root cause

The story's meta decorator is `withClientProvider({ createIdentity: true, createSpace: true })`, which renders its fallback (`null`) until the client has created an identity and its first space. Measured on the real test under real suite conditions:

```
cold render (test 1) = 1813ms
warm render (test 2) =  639ms
```

The assertions used bare `screen.findBy*`, i.e. testing-library's **1000ms** default `waitFor` timeout. The cold render is ~1.8× that, so the queries gave up while the provider was still initializing. The per-test `{ timeout: 30_000 }` never applied to the queries — it bounds the test, not the query.

This was never a regression: the `test` job was green on both commits that touched this file (`d1b3f4d4`, which added it, and `bcfe4c56`). CI runners are fast enough to land under 1s; slower or more contended environments are not.

## Changes

**1. Wait once for the client, not per query** (`FormLayout.stories.test.tsx`)

`Form.Content` renders `<div role="form">` with the fields as its children (`FormControls.tsx:171`), so the form and its contents land in a single React commit. Waiting for the form once covers the only genuine async boundary; everything after it is synchronous:

```ts
await NestedLabel.run();
const form = await screen.findByRole('form', undefined, { timeout: CLIENT_READY_TIMEOUT });

expect(within(form).getByText('John F. Kennedy Intl')).toBeInTheDocument();
expect(within(form).getByDisplayValue('JFK')).toBeInTheDocument();
```

Beyond being shorter, this is a stronger test:

- `getBy*` asserts the form rendered *complete*, where four independent `findBy*` calls could each be satisfied at different moments and still pass a half-rendered form.
- `within(form)` scopes the queries. Test 1 previously searched all of `document.body`, so it could match the debug panel that echoes the raw values JSON instead of the form.
- Test 2 already had this shape; test 1 was the outlier.

**2. Stub the icon-registry routes in the happy-dom setup** (`src/vitest-setup.ts`)

`ThemeProvider`'s icon registry fetches `/icons.svg` and `/phosphor/{variant}/{name}.svg` from the document origin. vitest's happy-dom environment points that origin at `http://localhost:3000`, where nothing listens, so each request opens a real socket and dies with `ECONNREFUSED`. `resolveDynamic` treats a network error as transient and leaves the symbol eligible for retry, so every re-render re-queued it — an unbounded loop, ~196 sockets per run.

Answering 404 is what the registry records as a permanent miss, so the loop stops; a network error would not. This is secondary — it is worth ~200ms of cold render and removes the log noise, but it does **not** by itself make the test pass (verified: with the stub active and the original bare `findBy*`, the suite still failed with zero `ECONNREFUSED`).

## Verification

`moon run react-ui-form:test` — 3 full-suite runs after the restructure:

```
 Test Files  12 passed (12)
      Tests  64 passed (64)
```

`grep -c ECONNREFUSED` = 0 on every run. `moon run react-ui-form:lint` clean; `pnpm format` applied.

No changeset — test-only change, no consumer-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQAKD6kM8z2J8BgjHNy3Bf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved form rendering tests to accommodate asynchronous initialization.
  * Streamlined nested-label assertions for more reliable results.
  * Applied consistent waiting behavior across layout tests.

* **Chores**
  * Added test-environment handling for icon-related requests while preserving normal network behavior for other requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->