### PR TITLE
cli: restore the @opentui platform packages the bundle cross-compiles against

### DIFF
--- a/.config/knip.ts
+++ b/.config/knip.ts
@@ -330,6 +330,17 @@ const BUNDLER_RESOLVED: Record<string, string[]> = {
   // from there, so the package has to resolve from `docs/node_modules` — astro's own optional
   // dependency is not reachable from the emitted chunk.
   'docs': ['sharp'],
+  // `@opentui/core` reaches its native library through a dynamic import interpolating
+  // `process.platform`/`process.arch`, which bun folds into a constant per `--compile` target, so
+  // cross-compiling the CLI resolves all five at bundle time. pnpm installs them for the host
+  // platform only, hence the explicit declarations.
+  'packages/devtools/cli': [
+    '@opentui/core-darwin-arm64',
+    '@opentui/core-darwin-x64',
+    '@opentui/core-linux-arm64',
+    '@opentui/core-linux-x64',
+    '@opentui/core-win32-x64',
+  ],
 };
 
 const workspaces: KnipConfig['workspaces'] = {

--- a/packages/devtools/cli/package.json
+++ b/packages/devtools/cli/package.json
@@ -86,6 +86,11 @@
     "yaml": "catalog:"
   },
   "devDependencies": {
+    "@opentui/core-darwin-arm64": "catalog:",
+    "@opentui/core-darwin-x64": "catalog:",
+    "@opentui/core-linux-arm64": "catalog:",
+    "@opentui/core-linux-x64": "catalog:",
+    "@opentui/core-win32-x64": "catalog:",
     "@types/node": "catalog:",
     "@types/wtfnode": "catalog:",
     "typescript": "catalog:"

--- a/packages/devtools/cli/scripts/build.ts
+++ b/packages/devtools/cli/scripts/build.ts
@@ -131,7 +131,11 @@ const automergeWasmPlugin: BunPlugin = {
   },
 };
 
-// Platform configurations.
+// Platform configurations. Every target needs its `@opentui/core-<platform>-<arch>` installed here —
+// `@opentui/core` reaches its native library through a dynamic import interpolating
+// `process.platform`/`process.arch`, which bun folds into a constant per target and resolves at
+// bundle time — hence the devDependencies on all five, which pnpm otherwise installs for the host
+// platform alone.
 const platforms = [
   { target: 'bun-darwin-arm64', platform: 'darwin', arch: 'arm64', ext: '' },
   { target: 'bun-darwin-x64', platform: 'darwin', arch: 'x64', ext: '' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,21 @@ catalogs:
     '@opentui/core':
       specifier: 0.1.61
       version: 0.1.61
+    '@opentui/core-darwin-arm64':
+      specifier: 0.1.61
+      version: 0.1.61
+    '@opentui/core-darwin-x64':
+      specifier: 0.1.61
+      version: 0.1.61
+    '@opentui/core-linux-arm64':
+      specifier: 0.1.61
+      version: 0.1.61
+    '@opentui/core-linux-x64':
+      specifier: 0.1.61
+      version: 0.1.61
+    '@opentui/core-win32-x64':
+      specifier: 0.1.61
+      version: 0.1.61
     '@opentui/solid':
       specifier: 0.1.61
       version: 0.1.61
@@ -6913,7 +6928,7 @@ importers:
         version: 0.96.2(effect@3.21.4)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/printer':
         specifier: 'catalog:'
         version: 0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4)
@@ -6963,6 +6978,21 @@ importers:
         specifier: 'catalog:'
         version: 2.8.2
     devDependencies:
+      '@opentui/core-darwin-arm64':
+        specifier: 'catalog:'
+        version: 0.1.61
+      '@opentui/core-darwin-x64':
+        specifier: 'catalog:'
+        version: 0.1.61
+      '@opentui/core-linux-arm64':
+        specifier: 'catalog:'
+        version: 0.1.61
+      '@opentui/core-linux-x64':
+        specifier: 'catalog:'
+        version: 0.1.61
+      '@opentui/core-win32-x64':
+        specifier: 'catalog:'
+        version: 0.1.61
       '@types/node':
         specifier: 22.10.2
         version: 22.10.2
@@ -7016,7 +7046,7 @@ importers:
         version: 0.96.2(effect@3.21.4)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+        version: 0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/printer':
         specifier: 'catalog:'
         version: 0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4)
@@ -47645,7 +47675,7 @@ snapshots:
       effect: 3.21.4
       multipasta: 0.2.7
 
-  '@effect/platform-bun@0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.3.2))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)':
+  '@effect/platform-bun@0.90.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)':
     dependencies:
       '@effect/cluster': 0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/platform': 0.96.2(effect@3.21.4)
@@ -49575,23 +49605,18 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
-  '@opentui/core-darwin-arm64@0.1.61':
-    optional: true
+  '@opentui/core-darwin-arm64@0.1.61': {}
 
-  '@opentui/core-darwin-x64@0.1.61':
-    optional: true
+  '@opentui/core-darwin-x64@0.1.61': {}
 
-  '@opentui/core-linux-arm64@0.1.61':
-    optional: true
+  '@opentui/core-linux-arm64@0.1.61': {}
 
-  '@opentui/core-linux-x64@0.1.61':
-    optional: true
+  '@opentui/core-linux-x64@0.1.61': {}
 
   '@opentui/core-win32-arm64@0.1.61':
     optional: true
 
-  '@opentui/core-win32-x64@0.1.61':
-    optional: true
+  '@opentui/core-win32-x64@0.1.61': {}
 
   '@opentui/core@0.1.61(typescript@6.0.3)(web-tree-sitter@0.25.10)':
     dependencies:


### PR DESCRIPTION
Fixes the three checks that have been red on every push to `main` since #12398 landed: **Check / cli**, **Check / e2e**, and **pkg.pr.new / publish**. All three fail on the same task, `cli:bundle`:

```
cli:bundle | error: Could not resolve: "@opentui/core-darwin-arm64/index.ts". Maybe you need to "bun install"?
    at node_modules/.pnpm/@opentui+core@0.1.61.../node_modules/@opentui/core/index-rysm4rsr.js:10120:27
  × Task cli:bundle failed to run.
```

## Cause

`@opentui/core` reaches its native library through

```js
var module = await import(`@opentui/core-${process.platform}-${process.arch}/index.ts`);
```

Bun folds `process.platform`/`process.arch` into constants per `--compile` target, so building the five CLI binaries resolves all five `@opentui/core-<platform>-<arch>` packages at bundle time — not just the host's. They are `@opentui/core`'s own **optional** dependencies, carrying `os`/`cpu` fields, so pnpm installs only the one matching the build machine. The CLI therefore declared all five explicitly as devDependencies.

#12398 (the knip cleanup) removed them: nothing imports them by name, so knip reported them unused. The catalog entries were left behind, but a catalog entry alone installs nothing.

Reproduced locally on linux-x64 — after a clean `pnpm install` on `main`, `@opentui/core`'s `node_modules` contains only `core-linux-x64`; with this change all five are linked.

## Changes

- `packages/devtools/cli/package.json` — restore the five `@opentui/core-<platform>-<arch>` devDependencies.
- `.config/knip.ts` — record them in `BUNDLER_RESOLVED`, the map already used for dependencies a bundler resolves on a workspace's behalf, so knip stays green without hiding a real regression.
- `packages/devtools/cli/scripts/build.ts` — note next to the `platforms` list that each target needs its platform package installed.
- `pnpm-lock.yaml` — regenerated. Also carries an incidental `@effect/platform-bun` peer-key normalization that a plain `pnpm install` produces against `main` today (`@effect/experimental` dropped from the nested `@effect/sql`/`@effect/workflow` keys); `main`'s lockfile is slightly stale there and CI's resolution check does not write it back.

No changeset: devDependencies and build config only, no change to shipped CLI code.

## Verification

```
$ moon run cli:bundle
cli:bundle | [Build] ✓ @dxos/cli-darwin-arm64
cli:bundle | [Build] ✓ @dxos/cli-darwin-x64
cli:bundle | [Build] ✓ @dxos/cli-win32-x64
cli:bundle | [Build] ✓ @dxos/cli-linux-x64
cli:bundle | [Build] ✓ @dxos/cli-linux-arm64
cli:bundle | [Build] Build completed successfully!
Tasks: 195 completed
 Time: 8m 39s 892ms

$ moon run cli:smoke
cli:smoke | [Verify] ✓ 0.11.1 — 10 invocations
Tasks: 196 completed (195 cached)

$ pnpm knip     # exit 0
$ pnpm format   # oxfmt clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVUwq8eMHZnir94xUKEbFT


---
_Generated by [Claude Code](https://claude.ai/code/session_01VVUwq8eMHZnir94xUKEbFT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved platform-specific packaging support for the DevTools CLI across macOS, Linux, and Windows on supported CPU architectures.
  * Updated build configuration to ensure native components are available for each target platform.
  * Added documentation clarifying platform-specific build requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->