### PR TITLE
ci: queue pkg.pr.new publishes instead of cancelling them

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -8,7 +8,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Queue rather than cancel: a cancelled run uploads nothing, so the commit it was building stays
+  # permanently un-installable for anything pinning pkg.pr.new — which is how the composer plugins
+  # repo tracks the SDK, and its nightly 404s when it lands on such a commit.
+  cancel-in-progress: false
 
 env:
   # Bound once here rather than at every setup call site: a composite action cannot read the


### PR DESCRIPTION
## Problem

`pkg-pr-new.yml` publishes on every push to `main` under `cancel-in-progress: true`. A cancelled run uploads nothing, so any commit superseded while its build was still going is **permanently** un-installable — not delayed, gone. That build is workspace-wide plus five CLI binaries (60-minute timeout), so it's a wide window to be superseded in.

Consumers pinning these builds hit it as a hard 404:

```
ERR_PNPM_FETCH_404  GET https://pkg.pr.new/dxos/dxos/@dxos/app-toolkit@5a0fc35: Not Found - 404
```

`5a0fc35` was `main`'s tip and still 404s days later, while `9e1aa71` resolves fine — confirming this is discarded work rather than publish lag.

The [composer plugins repo](https://github.com/dxos/plugins) tracks the SDK by pinning these builds nightly, and its upgrade PR has been failing on exactly this whenever the tip happens to be a cancelled commit.

## Change

`cancel-in-progress: false` — runs still serialize per ref, but a build that has started always finishes and uploads.

## Tradeoff

Publishes queue instead of being dropped, so a burst of pushes takes longer to drain and consumes more runner time than discarding intermediate work does. That seems clearly worth it: the current behaviour trades runner minutes for artifacts that quietly don't exist, and the failure only shows up later, in another repo, as a 404 with no obvious cause.

Note GitHub still keeps at most one in-progress plus one pending run per group — a third push displaces the pending one — so intermediate commits in a rapid burst can still go unpublished. What this guarantees is that **`main`'s tip always eventually publishes**, which is the property consumers actually depend on.

## Alternative considered

I had a workaround in the plugins repo ([dxos/plugins#21](https://github.com/dxos/plugins/pull/21)) that walked back to the newest commit with artifacts. Closing it in favour of this — the same gap would otherwise need working around by every consumer, and each would discover it the same confusing way.

## Test plan

- [x] YAML parses; `pnpm format` clean
- [ ] After merge: confirm consecutive `main` commits each get artifacts, and that the plugins nightly stops 404ing

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ4ZdaPo9erkh5yF4eXh3Z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated package preview workflows to queue new runs instead of canceling runs already in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->