### PR TITLE
test-utils: launch Chromium correctly in the cloud sandbox

### DIFF
--- a/packages/common/test-utils/src/playwright.ts
+++ b/packages/common/test-utils/src/playwright.ts
@@ -38,6 +38,25 @@ const findWorkspaceRoot = (startDir: string): string => {
   throw new Error('Could not find pnpm workspace root');
 };
 
+/**
+ * Launch overrides for the Claude Code cloud sandbox, where the image ships a single Chromium build
+ * that rarely matches the revision Playwright pins, and outbound HTTPS is only reachable through a
+ * local proxy that resets Chromium's TLS 1.3 ClientHello.
+ */
+const sandboxUse = (): PlaywrightTestConfig['use'] => {
+  if (!process.env.CLAUDE_CODE_REMOTE) {
+    return {};
+  }
+
+  return {
+    launchOptions: {
+      executablePath: '/opt/pw-browsers/chromium',
+      args: ['--no-sandbox', '--ssl-version-max=tls1.2', '--proxy-bypass-list=127.0.0.1;localhost'],
+      proxy: { server: 'http://127.0.0.1:34301', bypass: '127.0.0.1,localhost' },
+    },
+  };
+};
+
 export const e2ePreset = (testDir: string): PlaywrightTestConfig => {
   const packageJson = pkgUp.sync({ cwd: testDir });
   const packageDir = packageJson!.split('/').slice(0, -1).join('/');
@@ -103,6 +122,7 @@ export const e2ePreset = (testDir: string): PlaywrightTestConfig => {
       // Playwright's default is no limit, so a stuck locator would absorb the whole per-test budget and
       // report a bare `Test timeout` naming nothing.
       actionTimeout: 30_000,
+      ...sandboxUse(),
     },
     projects,
   };

--- a/packages/common/test-utils/src/playwright.ts
+++ b/packages/common/test-utils/src/playwright.ts
@@ -44,15 +44,24 @@ const findWorkspaceRoot = (startDir: string): string => {
  * local proxy that resets Chromium's TLS 1.3 ClientHello.
  */
 const sandboxUse = (): PlaywrightTestConfig['use'] => {
-  if (!process.env.CLAUDE_CODE_REMOTE) {
+  const proxyServer = process.env.HTTPS_PROXY;
+  if (!process.env.CLAUDE_CODE_REMOTE || !proxyServer) {
     return {};
   }
 
   return {
     launchOptions: {
       executablePath: '/opt/pw-browsers/chromium',
-      args: ['--no-sandbox', '--ssl-version-max=tls1.2', '--proxy-bypass-list=127.0.0.1;localhost'],
-      proxy: { server: 'http://127.0.0.1:34301', bypass: '127.0.0.1,localhost' },
+      args: [
+        '--no-sandbox',
+        // Playwright's `proxy` launch option drops its `bypass` list for pages opened in a
+        // non-default context, which sends the app's own localhost URL through the proxy and
+        // yields a 405 — passing the switches directly keeps the bypass in effect everywhere.
+        `--proxy-server=${proxyServer}`,
+        '--proxy-bypass-list=127.0.0.1;localhost',
+        // The proxy resets Chromium's TLS 1.3 ClientHello; curl negotiates 1.3 through it fine.
+        '--ssl-version-max=tls1.2',
+      ],
     },
   };
 };


### PR DESCRIPTION
## Summary

Playwright e2e suites cannot launch a browser at all in the Claude Code cloud sandbox. This adds sandbox-gated launch overrides to `e2ePreset` so `moon run <app>:e2e` can run there. Local and CI runs are untouched — the whole block is skipped unless `CLAUDE_CODE_REMOTE` and `HTTPS_PROXY` are both set.

Three distinct failures, each found by running `moon run todomvc:e2e` and fixing what it hit:

1. **Browser revision mismatch.** The repo pins `@playwright/test` 1.57, which wants Chromium build 1200; the sandbox image ships 1194, and only in the pre-1200 `chrome-linux/headless_shell` layout. Every suite failed with `browserType.launch: Executable doesn't exist at …/chromium_headless_shell-1200/…`. Fixed with `executablePath: '/opt/pw-browsers/chromium'`.
2. **Proxy port is not stable.** Outbound HTTPS is only reachable through a local proxy whose port is assigned per container start — it changed mid-session during this work, so a pinned port fails as soon as the container restarts. Read from `HTTPS_PROXY` instead.
3. **Playwright's `proxy` option drops its `bypass` list in non-default contexts.** `setupPage` always calls `browser.newContext()`, so the app's own `http://localhost:9006/` navigation was sent through the proxy and came back as a 405 (`this proxy only accepts HTTPS CONNECT tunnels`), leaving the page showing proxy error text and no app. Passing `--proxy-server` / `--proxy-bypass-list` as Chromium args keeps the bypass in effect everywhere.

`--ssl-version-max=tls1.2` is also required: the proxy resets Chromium's TLS 1.3 ClientHello mid-handshake, while curl negotiates 1.3 through the same proxy without trouble. That looks like a proxy-side defect rather than anything about the browser, so it is worth re-testing periodically and dropping when fixed.

## Status

This is a draft because it does not yet get `todomvc:e2e` to green. With these changes the app boots and renders in sandbox Chromium, but the client's edge WebSocket repeatedly closes (`EdgeConnectionClosedError: Edge connection closed` from the dedicated worker), which blocks the space invitation in `beforeEach`. Also relevant for anyone picking this up: external UDP is blocked in the sandbox (STUN requests to Google and Cloudflare both time out), so any test needing real WebRTC to an external peer cannot pass there regardless of this change.

## Test plan

- [x] `moon run todomvc:e2e` — browser now launches; failures moved from launch to app/edge connectivity
- [ ] `moon run todomvc:e2e` green in the sandbox (blocked on the edge WebSocket issue above)
- [ ] Confirm a local (non-sandbox) e2e run is unaffected — the override is gated, but worth verifying on a normal machine


---
_Generated by [Claude Code](https://claude.ai/code/session_01PKAYgzEKWGZBLoygoefNtK)_