### PR TITLE
search, assistant, tasks: fix the three storybook suites red on main

### DIFF
--- a/packages/plugins/plugin-inbox/src/containers/SubscriptionsArticle/SubscriptionsArticle.stories.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/SubscriptionsArticle/SubscriptionsArticle.stories.tsx
@@ -29,8 +29,7 @@ const SENDERS: { email: string; name: string; count: number }[] = [
 ];
 
 const DefaultStory = () => {
-  const spaces = useSpaces();
-  const space = spaces[spaces.length - 1];
+  const [space] = useSpaces();
   const [mailbox] = useQuery(space?.db, Filter.type(Mailbox.Mailbox));
   if (!mailbox) {
     return <Loading />;

--- a/packages/plugins/plugin-search/src/components/SearchResultList/SearchResultList.stories.tsx
+++ b/packages/plugins/plugin-search/src/components/SearchResultList/SearchResultList.stories.tsx
@@ -49,8 +49,7 @@ const enrichResult = (result: SearchResult, query: string): SearchResult => {
 };
 
 const DefaultStory = () => {
-  const spaces = useSpaces();
-  const space = spaces[spaces.length - 1];
+  const [space] = useSpaces();
   const [query, setQuery] = useState('');
 
   const objects = useQuery(space?.db, buildSearchQuery(query));

--- a/packages/plugins/plugin-search/src/containers/SearchArticle/SearchArticle.stories.tsx
+++ b/packages/plugins/plugin-search/src/containers/SearchArticle/SearchArticle.stories.tsx
@@ -26,8 +26,7 @@ import { SearchArticle } from './SearchArticle';
 random.seed(0);
 
 const DefaultStory = () => {
-  const spaces = useSpaces();
-  const space = spaces[spaces.length - 1];
+  const [space] = useSpaces();
   if (!space) {
     return <Loading />;
   }

--- a/packages/plugins/plugin-search/src/containers/SearchDialog/SearchDialog.stories.tsx
+++ b/packages/plugins/plugin-search/src/containers/SearchDialog/SearchDialog.stories.tsx
@@ -28,8 +28,7 @@ import { SearchDialog } from './SearchDialog';
 random.seed(0);
 
 const DefaultStory = () => {
-  const spaces = useSpaces();
-  const space = spaces[spaces.length - 1];
+  const [space] = useSpaces();
   if (!space) {
     return <Loading />;
   }

--- a/packages/plugins/plugin-tasks/src/containers/OutlineArticle/OutlineArticle.stories.tsx
+++ b/packages/plugins/plugin-tasks/src/containers/OutlineArticle/OutlineArticle.stories.tsx
@@ -207,8 +207,15 @@ export const ConvertToTask: Story = {
     // neighbours (the chip's vertical padding is cancelled by a negative margin).
     await waitFor(() => {
       const lines = [...canvasElement.querySelectorAll('.cm-content')][0].querySelectorAll('.cm-line');
-      const heights = [...lines].map((line) => line.getBoundingClientRect().height).filter((height) => height > 0);
-      return expect(Math.max(...heights) - Math.min(...heights)).toBeLessThan(1);
+      const chipLine = [...lines].find((line) => line.querySelector('dx-anchor'));
+      invariant(chipLine, 'No line carries the anchor chip.');
+      // Against the shortest plain line, not the tallest: the longest item soft-wraps to two line
+      // boxes at this column width, which says nothing about the chip.
+      const plain = [...lines]
+        .filter((line) => line !== chipLine)
+        .map((line) => line.getBoundingClientRect().height)
+        .filter((height) => height > 0);
+      return expect(Math.abs(chipLine.getBoundingClientRect().height - Math.min(...plain))).toBeLessThan(1);
     });
 
     // The promoted task appears in the durable task list (third column), proving the outliner

--- a/packages/stories/stories-assistant/src/stories/Chat.stories.tsx
+++ b/packages/stories/stories-assistant/src/stories/Chat.stories.tsx
@@ -312,6 +312,14 @@ export const WithSubAgentsTest2: Story = {
         turns: [{ parts: [text('Delegation Demo')] }],
       },
       {
+        // The delegated item is open when the supervisor finishes — the sub-agent owns closing it —
+        // so the planning skill's end-request reminder consults the model. Without its own route it
+        // falls through to the supervisor fallback and exhausts that script.
+        name: 'plan-reminder',
+        match: promptIncludes('whether an agent should stop or continue'),
+        turns: [{ parts: [text('stop')] }],
+      },
+      {
         name: 'supervisor',
         match: () => true,
         turns: [

--- a/packages/stories/stories-assistant/src/stories/Chat.stories.tsx
+++ b/packages/stories/stories-assistant/src/stories/Chat.stories.tsx
@@ -312,14 +312,6 @@ export const WithSubAgentsTest2: Story = {
         turns: [{ parts: [text('Delegation Demo')] }],
       },
       {
-        // The delegated item is open when the supervisor finishes — the sub-agent owns closing it —
-        // so the planning skill's end-request reminder consults the model. Without its own route it
-        // falls through to the supervisor fallback and exhausts that script.
-        name: 'plan-reminder',
-        match: promptIncludes('whether an agent should stop or continue'),
-        turns: [{ parts: [text('stop')] }],
-      },
-      {
         name: 'supervisor',
         match: () => true,
         turns: [

--- a/packages/stories/stories-assistant/src/testing/decorators.tsx
+++ b/packages/stories/stories-assistant/src/testing/decorators.tsx
@@ -28,6 +28,7 @@ import {
   DelegationSkill,
   PlanningHandlers,
   PlanningSkill,
+  makeDelegationStrategy,
 } from '@dxos/assistant-toolkit';
 import { type Space } from '@dxos/client/echo';
 import { persistentClientServices } from '@dxos/client/testing';
@@ -59,6 +60,7 @@ import * as Markdown from '@dxos/plugin-markdown/Markdown';
 import { MarkdownOperationHandlerSet } from '@dxos/plugin-markdown/operations';
 import { PreviewPlugin } from '@dxos/plugin-preview/testing';
 import { RoutinePlugin } from '@dxos/plugin-routine/plugin';
+import * as RoutineCapabilities from '@dxos/plugin-routine/RoutineCapabilities';
 import { StorybookPlugin, corePlugins } from '@dxos/plugin-testing';
 import { TranscriptionPlugin } from '@dxos/plugin-transcription/plugin';
 import { type Client, Config } from '@dxos/react-client';
@@ -463,11 +465,19 @@ const StoryPlugin = Plugin.define<StoryPluginOptions>(
   })),
   Plugin.addModule({
     id: 'com.example.plugin.testing.module.testing',
-    provides: [AppCapabilities.SkillDefinition, Capabilities.OperationHandler],
+    provides: [
+      AppCapabilities.SkillDefinition,
+      Capabilities.OperationHandler,
+      RoutineCapabilities.AgentDelegationStrategy,
+    ],
     activate: () =>
       Effect.succeed([
         // TODO(burdon): Clean up.
         Capability.contributeAll(AppCapabilities.SkillDefinition, [MarkdownSkill, PlanningSkill, DelegationSkill]),
+        // Supervisor behaviour, so a delegating story spawns its sub-agent. The app's copy rides
+        // plugin-assistant's `AssistantStart`-gated skill-definition module, which loses the race
+        // against `AgentService`'s layer — that layer reads this capability once, at build time.
+        Capability.contribute(RoutineCapabilities.AgentDelegationStrategy, makeDelegationStrategy()),
         Capability.contributeAll(Capabilities.OperationHandler, [
           MarkdownOperationHandlerSet,
           PlanningHandlers,

--- a/packages/stories/stories-assistant/src/testing/decorators.tsx
+++ b/packages/stories/stories-assistant/src/testing/decorators.tsx
@@ -9,6 +9,7 @@ import React, { type FC, ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { ScriptedLanguageModel, SERVICES_CONFIG } from '@dxos/ai/testing';
 import { CapabilityManager } from '@dxos/app-framework';
+import * as ActivationEvents from '@dxos/app-framework/ActivationEvents';
 import * as Capabilities from '@dxos/app-framework/Capabilities';
 import * as Capability from '@dxos/app-framework/Capability';
 import * as Plugin from '@dxos/app-framework/Plugin';
@@ -465,6 +466,10 @@ const StoryPlugin = Plugin.define<StoryPluginOptions>(
   })),
   Plugin.addModule({
     id: 'com.example.plugin.testing.module.testing',
+    // Startup, not the implicit Idle: `AgentServiceSpec` reads `AgentDelegationStrategy` through
+    // `Capability.getAll` once, when its layer materializes, so the contribution has to be in place
+    // before anything can build that layer rather than merely before the story asserts.
+    activatesOn: ActivationEvents.Startup,
     provides: [
       AppCapabilities.SkillDefinition,
       Capabilities.OperationHandler,


### PR DESCRIPTION
Follow-up to #12510. Three storybook failures were left on `main` @ `da37a13e` ([run 31261684165](https://github.com/dxos/dxos/actions/runs/31261684165/job/93113380490)); all three are fixed here, each verified locally.

| Suite | Cause | Result |
| --- | --- | --- |
| `plugin-search` ×2 (+2 latent) | #12510's ordering flip made `spaces[length-1]` the settings space | 5/5 |
| `stories-assistant > With Sub Agents Test 2` | harness never contributed `AgentDelegationStrategy`, so no sub-agent spawned | 30/30 |
| `plugin-tasks > OutlineArticle > Convert To Task` | assertion measured a soft-wrapped line, not the chip | 9/9 |

## 1. `plugin-search` — a regression from #12510

Four story harnesses seed `initializeIdentity`'s `defaultSpace`, then resolve it back with `spaces[spaces.length - 1]`. That held while `setupIdentitySpaces` created the settings space first and the content space last. #12510 flipped the order, so the *last* entry became the internal settings space — the harnesses queried app configuration, rendered `<Loading />`, and the plays timed out at the 15s default. `SearchResultList > Test` and `SearchDialog > Test` failed; `SearchArticle` and `SubscriptionsArticle` (plugin-inbox) carry the same lookup with no play, so they were broken only in the storybook UI.

All four now use `const [space] = useSpaces()`. Index 0 is the content space at every point in the ramp-up, where the last index flips as the second space becomes ready — so this is the race-free lookup, not merely the currently-correct one. No timeout change was needed; both stories land at ~9.5s.

## 2. `stories-assistant > With Sub Agents Test 2` — pre-existing

Failing before #12510 as well ([run 31220856584](https://github.com/dxos/dxos/actions/runs/31220856584)). Not an EDGE-connectivity failure — the story is fully scripted and offline. #12510's description was wrong on this point.

`agent-process.ts:151` makes supervisor behaviour optional:

```ts
const strategy = Option.fromNullable(options.delegationStrategy);
```

Absent a strategy the agent is a plain conversational agent: `delegate-task` still created the durable task and mirrored the checklist item — the play's first three assertions passed — while nothing reconciled it into a child process, so the `The sub-agent completed …` fold-back never arrived.

`AgentDelegationStrategy` is contributed in exactly one place, plugin-assistant's `skill-definition` module, which activates on `AssistantStart`. `AgentServiceSpec` reads it through `Capability.getAll` **once, at layer-build time**, so a contribution landing later is missed. The story harness supplies its own `SkillDefinition`s from its own module and never contributed the strategy, so it always got `undefined`. It now contributes it there, as the passing node analog `assistant-toolkit/src/supervisor/delegation-strategy.test.ts` does explicitly via `agent: { delegationStrategy: makeDelegationStrategy() }`.

That module also now declares `activatesOn: ActivationEvents.Startup`. `activatesOn` defaults to **Idle** (`plugin.ts:454`), so without the declaration the contribution rode a demand-gated wave and worked only because the harness force-fires Idle via `activateDemandGatedModules` and the `AgentService` layer does not materialize until an agent process starts. Declaring the wave replaces that timing assumption; the module's `activate` returns static contributions with no `requires`, so startup is safe for it.

Corroborating detail: the job log also showed the planning skill's `end-request` reminder dying on `Scripted model exhausted: route supervisor requested turn 2 but the script has only 2`. That is downstream of the same absence — `runEndRequestHooks` only runs from `maybeComplete`, behind `isAgentWorkPending({ inputQueue, alarmManager, delegations, toolCallManager })`, so a pending delegation would have early-returned. The reminder firing at all *proved* `delegations` was empty. An intermediate commit on this branch scripted a route for that reminder; it is reverted here, since it silenced the symptom and the story still failed.

The whole suite passes (30/30), so contributing the strategy does not disturb the other stories — `WithPlanningScripted` included.

## 3. `plugin-tasks > OutlineArticle > Convert To Task` — pre-existing

`expected 24 to be less than 1`, deterministic: 24 on every CI attempt and locally. Not flaky, which is why Trunk stopped quarantining it — a consistently failing test is broken, not flaky — so it had begun gating every PR rather than aging out.

The assertion claimed a converted item's line must match its plain neighbours, but tested it as `max − min` across every line. Measured before and after the conversion:

```
before: "Draft the launch announc…"  h 56  pad 4px/4px  mar 0px/0px  lh 24px
        "Review pricing page"        h 32  pad 4px/4px  mar 0px/0px  lh 24px
after:  "Draft the launch announc…"  h 56   ← unchanged
        "∙Review pricing page"       h 32   ← now carries DX-ANCHOR.dx-tag--anchor
```

Line 1 is 56px *before* the conversion, with an identical class list, padding, margin, line-height and children to its 32px siblings. 56 = 24×2 + 8: `Draft the launch announcement` is the longest item and soft-wraps to two line boxes in the story's ~286px column. The chip is nowhere near it.

So the property the comment describes holds exactly — the chip's line is 32px, matching an unwrapped neighbour, and `tag.css`'s `padding-block: 2px` / `margin-block: -2px` cancellation is correct. The fix is to the measurement: compare the chip's line against the *shortest* plain line, which is width-independent.

## Verification

| Suite | Result |
| --- | --- |
| `plugin-search:test-storybook` | 5 passed (3 files) |
| `stories-assistant:test-storybook` | 30 passed (8 files) |
| `plugin-tasks:test-storybook` | 9 passed (5 files) |

`tsc --noEmit` clean on `stories-assistant`.

## One thing reviewers should know

**This PR's storybook job does not run any of the three suites it fixes.** `moon run :test-storybook --affected remote` selects the complement of the affected set — the same defect called out in #12510. On these commits it ran 76–78 tests, none from `plugin-search` or `stories-assistant`. A green tick means the pre-existing `plugin-tasks` failure is gone; it cannot speak to items 1 or 2, whose evidence is the local runs above.

Related but untouched: `AgentServiceSpec` reading `AgentDelegationStrategy` via `getAll` at layer-build time, against a sole contributor gated on `AssistantStart`, looks like a genuine race in the app and not only in the harness — delegation could silently no-op there for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gQ4Kk7A4fHqtqTc4dBAAo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved inbox and search story scenarios by consistently using the first available space.
  * Updated task outline layout assertions to better handle wrapped text and converted-task chips.
  * Added delegation strategy capabilities to assistant routine testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->