### PR TITLE
cli: restore the CLI publish, and import dx.config.ts directly

### DIFF
--- a/.changeset/cli-publish-dx-config.md
+++ b/.changeset/cli-publish-dx-config.md
@@ -1,0 +1,6 @@
+---
+'@dxos/echo': patch
+'@dxos/plugin-markdown': patch
+---
+
+Import `dx.config.ts` directly instead of transpiling it, so `dx registry publish` can read a plugin config from the compiled CLI.

--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -117,6 +117,23 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: 'true' # provenance via OIDC; trusted publisher means no NPM_TOKEN.
 
+      # `changeset publish` cannot ship the CLI: `@dxos/cli` is `private`, and what it actually ships is one
+      # prebuilt binary per platform generated into `dist/`, so neither is a workspace member Changesets can
+      # see. Runs before the tag step so a failed CLI publish is not tagged as a complete release.
+      - name: Publish the CLI (@latest)
+        if: github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Version packages')
+        run: moon run cli:publish
+        env:
+          NODE_ENV: production
+          NPM_CONFIG_PROVENANCE: 'true' # provenance via OIDC; trusted publisher means no NPM_TOKEN.
+
+      - name: Publish the CLI (@next snapshot)
+        if: github.event_name == 'workflow_dispatch'
+        run: moon run cli:publish -- --tag next
+        env:
+          NODE_ENV: production
+          NPM_CONFIG_PROVENANCE: 'true'
+
       # One tag + one GitHub Release per lockstep group (`v<version>` for core/SDK, `plugins-v<version>` for
       # plugins + CLI), both refs in a single push.
       #

--- a/packages/devtools/cli/scripts/publish.ts
+++ b/packages/devtools/cli/scripts/publish.ts
@@ -46,12 +46,21 @@ if (!mainPackage) {
 }
 
 const NPM_REGISTRY = 'https://registry.npmjs.org';
+const REGISTRY_TIMEOUT = 30_000;
 
 /** Whether npm already serves this exact version. */
 async function isPublished(name: string, version: string): Promise<boolean> {
-  const response = await fetch(`${NPM_REGISTRY}/${encodeURIComponent(name)}`, {
-    headers: { Accept: 'application/vnd.npm.install-v1+json' },
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${NPM_REGISTRY}/${encodeURIComponent(name)}`, {
+      headers: { Accept: 'application/vnd.npm.install-v1+json' },
+      // Bounded so an unresponsive registry cannot stall the publish indefinitely.
+      signal: AbortSignal.timeout(REGISTRY_TIMEOUT),
+    });
+  } catch (error) {
+    throw new Error(`failed to query ${name}: ${error instanceof Error ? error.message : error}`);
+  }
+
   if (response.status === 404) {
     return false;
   }
@@ -59,8 +68,9 @@ async function isPublished(name: string, version: string): Promise<boolean> {
     throw new Error(`unexpected status ${response.status} querying ${name}`);
   }
 
-  const body = (await response.json()) as { versions?: Record<string, unknown> };
-  return Object.hasOwn(body.versions ?? {}, version);
+  const body: unknown = await response.json();
+  const versions = typeof body === 'object' && body !== null && 'versions' in body ? body.versions : undefined;
+  return typeof versions === 'object' && versions !== null && Object.hasOwn(versions, version);
 }
 
 // Helper function to publish a package.

--- a/packages/devtools/cli/scripts/publish.ts
+++ b/packages/devtools/cli/scripts/publish.ts
@@ -45,6 +45,24 @@ if (!mainPackage) {
   process.exit(1);
 }
 
+const NPM_REGISTRY = 'https://registry.npmjs.org';
+
+/** Whether npm already serves this exact version. */
+async function isPublished(name: string, version: string): Promise<boolean> {
+  const response = await fetch(`${NPM_REGISTRY}/${encodeURIComponent(name)}`, {
+    headers: { Accept: 'application/vnd.npm.install-v1+json' },
+  });
+  if (response.status === 404) {
+    return false;
+  }
+  if (!response.ok) {
+    throw new Error(`unexpected status ${response.status} querying ${name}`);
+  }
+
+  const body = (await response.json()) as { versions?: Record<string, unknown> };
+  return Object.hasOwn(body.versions ?? {}, version);
+}
+
 // Helper function to publish a package.
 function publishPackage(packageDir: string): boolean {
   const packagePath = join(distDir, packageDir);
@@ -56,6 +74,11 @@ function publishPackage(packageDir: string): boolean {
   }
 
   const packageJson = require(`../${packageJsonPath}`);
+  if (published.has(`${packageJson.name}@${packageJson.version}`)) {
+    console.log(`[Publish] ✓ ${packageJson.name}@${packageJson.version} already published`);
+    return true;
+  }
+
   console.log(`[Publish] Publishing ${packageJson.name}@${packageJson.version}...`);
 
   // npm, not pnpm: `pnpm publish` normalizes every file in the tarball to 0644, which strips the
@@ -78,6 +101,16 @@ function publishPackage(packageDir: string): boolean {
 
   console.log(`[Publish] ✓ ${packageJson.name}@${packageJson.version}`);
   return true;
+}
+
+// A release makes six publish calls, so one failing partway must not strand the launcher: skipping what
+// already landed lets the run be retried.
+const published = new Set<string>();
+for (const packageDir of packageDirs) {
+  const { name, version } = require(`../${join(distDir, packageDir, 'package.json')}`);
+  if (await isPublished(name, version)) {
+    published.add(`${name}@${version}`);
+  }
 }
 
 // Publish platform packages first (main package depends on them).

--- a/packages/sdk/app-framework/src/vite-plugin/load.ts
+++ b/packages/sdk/app-framework/src/vite-plugin/load.ts
@@ -3,10 +3,7 @@
 //
 
 import * as Schema from 'effect/Schema';
-import { build } from 'esbuild';
-import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -24,34 +21,13 @@ export const findDxConfigFile = (dir: string): string | undefined =>
   CONFIG_BASENAMES.map((basename) => join(dir, basename)).find((candidate) => existsSync(candidate));
 
 /**
- * Loads and validates a `dx.config.ts` (or `.mjs`/`.js`) file at the given `filePath`.
+ * Loads a `dx.config.ts` (or `.mjs`/`.js`) file at the given `filePath`, decoding its default export
+ * against the `Config2` schema — a malformed config throws a `Schema` parse error.
  *
- * Transpiles the file with esbuild — leaving its bare imports (`@dxos/protocols`, `@dxos/app-framework`, …)
- * external so they resolve from the project's `node_modules` — imports the result, then decodes the
- * default export against the `Config2` schema (a malformed config throws a `Schema` parse error).
- * Node-only (esbuild + filesystem); used by `composerPlugin` and `dx registry publish`.
+ * The runtime executes the TypeScript itself (bun natively, node by type stripping), so a config may
+ * only use erasable syntax — no `enum`, no `namespace`.
  */
 export const loadDxConfig = async (filePath: string): Promise<Config2.Config> => {
-  const result = await build({
-    entryPoints: [filePath],
-    bundle: true,
-    format: 'esm',
-    platform: 'node',
-    write: false,
-    // Leave node_modules (incl. @dxos/*) as runtime imports so the temp module below resolves them
-    // from the project's node_modules rather than inlining heavy deps (effect, etc.) on every load.
-    packages: 'external',
-    logLevel: 'silent',
-  });
-
-  // Import via a temp file so its externalized bare specifiers resolve against the project's
-  // node_modules (a data-URL import cannot resolve bare specifiers).
-  const tempPath = join(filePath, '..', `.dx.config.${randomUUID()}.mjs`);
-  try {
-    await writeFile(tempPath, result.outputFiles[0].text, 'utf-8');
-    const module = await import(pathToFileURL(tempPath).href);
-    return decodeConfig2(module.default);
-  } finally {
-    await rm(tempPath, { force: true });
-  }
+  const module = await import(pathToFileURL(filePath).href);
+  return decodeConfig2(module.default);
 };


### PR DESCRIPTION
Two bugs blocking the external-plugin release flow, both found driving `dx registry publish` from dxos/plugins.

## 1. `dx registry publish` cannot read any plugin config

```
Failed to load dx.config.ts in …/packages/tictactoe:
  ResolveMessage: Cannot find package 'esbuild' from '/$bunfs/root/bin.js'
```

`loadDxConfig` transpiled the config with esbuild into a temp `.mjs` beside it, imported that, then deleted it. esbuild is a native binary `Bun.build` cannot embed, so the compiled CLI has nothing to resolve and the command dies before reading a single field. Same failure on a CLI built from current `main` (`0a182f7`), so it is not a stale pin.

That whole shape existed because node could not execute TypeScript. Both runtimes that load a config now can — bun natively, node by type stripping, which this repo already requires (`engines.node: ^24.0.0`, both repos pinned to 24.11.1). So the config is imported directly:

```ts
export const loadDxConfig = async (filePath: string): Promise<Config2.Config> => {
  const module = await import(pathToFileURL(filePath).href);
  return decodeConfig2(module.default);
};
```

That removes the dependency the bundler could not embed, the temp file written next to the user's config, and its cleanup — 39 lines out, 6 in. The esbuild dependency stays in the package; `boot-loader/loader.ts` still uses it.

**Behavioural narrowing:** type stripping handles erasable syntax only, so a config using `enum` or `namespace` now fails where esbuild would have transpiled it. Documented in the JSDoc. For a file exporting a plain object this seems a fair trade — say so if you'd rather keep a transpiler for that case.

## 2. The CLI publish lost its caller in the Changesets cutover

npm's `@dxos/cli` is on **0.10.0** while Group B is on **0.11.1**.

`cli:publish` still exists and still does the right thing — `bundle` → `smoke` → `publish`, with `scripts/publish.ts` already publishing platform packages before the launcher. What disappeared is the call. The pre-Changesets `.github/workflows/scripts/publish.sh` ended with:

```bash
pnpm --filter-prod=… publish --provenance --tag=latest
moon run :publish -- --provenance --tag latest    # ← the CLI
```

`d412fcac64` (#12106) deleted that script, and `publish-all.yml` replaced it with `changeset publish` alone. `changeset publish` cannot stand in: `@dxos/cli` is `private`, and the per-platform packages it ships are generated into `dist/`, so they are not workspace members Changesets can see. The task has been orphaned since — Group B versioning the CLI every release into something nothing invoked.

So this is one line per channel, restored before the tag step (a failed CLI publish should not be tagged as a complete release):

```yaml
- name: Publish the CLI (@latest)
  run: moon run cli:publish
- name: Publish the CLI (@next snapshot)
  run: moon run cli:publish -- --tag next
```

The one addition is idempotency in `publish.ts`: a release makes six separate publish calls, and without it a re-run dies on the first package that already landed, leaving the launcher unpublished and the CLI uninstallable at that version.

## Verification

Config loading, against the real external plugin on the exact pinned binaries:

```
bun 1.3.11   : org.dxos.plugin.tictactoe / vite build
node 24.11.1 : org.dxos.plugin.tictactoe / vite build
```

A `dx.config.mjs` still resolves and loads, so the non-TS config forms are unaffected.

`publish.ts --dry-run` against the real registry (0.10.0 published, 0.11.1 not — one run covers both paths):

```
[Publish] Publishing @dxos/cli-darwin-arm64@0.11.1...
[Publish] ✓ @dxos/cli-linux-x64@0.10.0 already published
[Publish] Publishing main package...
[Publish] ✓ @dxos/cli@0.11.1                       ← launcher last
```

`moon run app-framework:build` → `Tasks: 96 completed`.

**The compiled binary.** A `Check` run dispatched with `e2e: true` unlocks the CLI jobs a normal PR skips. On an earlier revision (`ba3ada9c`) both were green — [run 31270103652](https://github.com/dxos/dxos/actions/runs/31270103652): `cli` (compiles, packs, runs `dx --version` from the tarball) and `cli-foreign` (runs it on a machine that never built it, the check that exists because `@dxos/cli@0.10.0` shipped unrunnable). `loadDxConfig` has been rewritten since, so that result does not carry forward and I re-dispatched against the current head.

## Still unverified

**npm trusted publishers** must exist for `@dxos/cli` and all five `@dxos/cli-<platform>` packages, naming `publish-all.yml`. Four of the five platform packages have never been published, and a first publish cannot have a trusted publisher — those likely need one manual publish first, the same bootstrap problem as the plugin rule. Without it this step fails the release.

Nothing here proves `dx registry publish` end to end; that needs a CLI built from this branch pointed at a real plugin, which is the next step in dxos/plugins.

The changeset names both groups: Group A for the `app-framework` fix, Group B so the CLI publishes a version that contains it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for publishing stable CLI releases under the `latest` tag and snapshot releases under the `next` tag.
  * CLI publishing now includes npm provenance for improved release verification.
  * Added documentation for importing `dx.config.ts` directly when publishing to the registry.

* **Bug Fixes**
  * Prevented already-published package versions from being republished.
  * Improved handling of incomplete or partially successful releases.
  * Configuration loading continues to report clear errors for malformed files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->