### PR TITLE
app-framework: evaluate dx.config.ts in a node subprocess

### DIFF
--- a/.changeset/dx-config-subprocess.md
+++ b/.changeset/dx-config-subprocess.md
@@ -1,0 +1,6 @@
+---
+'@dxos/echo': patch
+'@dxos/plugin-markdown': patch
+---
+
+Evaluate `dx.config.ts` in a node subprocess, so the compiled CLI reads a plugin's config the same way every other runtime does.

--- a/packages/sdk/app-framework/src/vite-plugin/load.ts
+++ b/packages/sdk/app-framework/src/vite-plugin/load.ts
@@ -3,8 +3,11 @@
 //
 
 import * as Schema from 'effect/Schema';
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { Config2 } from '@dxos/protocols';
@@ -12,6 +15,14 @@ import { Config2 } from '@dxos/protocols';
 const CONFIG_BASENAMES = ['dx.config.ts', 'dx.config.mjs', 'dx.config.js'];
 
 const decodeConfig2 = Schema.decodeUnknownSync(Config2.Config);
+
+// Evaluated by the subprocess below; dependency-free so any plugin-toolchain node runs it. The
+// result travels through a file (argv[2]) rather than stdout, which belongs to the config — a
+// `console.log` during module evaluation would otherwise corrupt the JSON.
+const LOADER_SCRIPT =
+  'const module = await import(process.argv[1]); const { writeFileSync } = await import("node:fs"); writeFileSync(process.argv[2], JSON.stringify(module.default));';
+
+const LOADER_TIMEOUT = 30_000;
 
 /**
  * Resolves the first `dx.config.{ts,mjs,js}` found under `dir`, or `undefined` if none exist.
@@ -24,10 +35,25 @@ export const findDxConfigFile = (dir: string): string | undefined =>
  * Loads a `dx.config.ts` (or `.mjs`/`.js`) file at the given `filePath`, decoding its default export
  * against the `Config2` schema — a malformed config throws a `Schema` parse error.
  *
- * The runtime executes the TypeScript itself (bun natively, node by type stripping), so a config may
- * only use erasable syntax — no `enum`, no `namespace`.
+ * The config is evaluated by a `node` subprocess and handed back as JSON, so its imports resolve in
+ * the plugin's own module context — one behavior whether the caller is node (`composerPlugin`), bun,
+ * or the compiled CLI, whose embedded resolver cannot reach an external `node_modules`. `Config2` is
+ * pure data, so JSON carries it losslessly. node executes the TypeScript itself (type stripping), so
+ * a config may only use erasable syntax — no `enum`, no `namespace`.
  */
 export const loadDxConfig = async (filePath: string): Promise<Config2.Config> => {
-  const module = await import(pathToFileURL(filePath).href);
-  return decodeConfig2(module.default);
+  const resultPath = join(tmpdir(), `dx-config-${randomUUID()}.json`);
+  try {
+    execFileSync('node', ['--input-type=module', '-e', LOADER_SCRIPT, pathToFileURL(filePath).href, resultPath], {
+      cwd: dirname(filePath),
+      // The subprocess's stdout and stderr pass through, so the config's own logs and a throwing
+      // config's actual error both reach the terminal.
+      stdio: ['ignore', 'inherit', 'inherit'],
+      timeout: LOADER_TIMEOUT,
+    });
+
+    return decodeConfig2(JSON.parse(readFileSync(resultPath, 'utf8')));
+  } finally {
+    rmSync(resultPath, { force: true });
+  }
 };


### PR DESCRIPTION
Follow-up to #12513. That PR's direct import works under node but not in the compiled CLI, whose embedded resolver cannot reach a plugin's `node_modules`:

```
Cannot find module '@dxos/app-framework/config' from …/packages/tictactoe/dx.config.ts
```

(Reproduced with a synthetic package too — standalone bun loads the file, a compiled binary does not, regardless of scope, export style, or whether the binary bundles the package.)

## Approach

Evaluate the config in a **`node` subprocess** and hand back JSON:

```
caller (node · bun · compiled CLI)
  └─ node --input-type=module -e "import(config); print JSON.stringify(default)"
       └─ imports resolve in the plugin's own module context — where they always worked
  └─ caller decodes the JSON against its own Config2 schema
```

- **One code path, no per-runtime branch.** All three callers spawn the same subprocess.
- **A single Effect instance by construction.** Only JSON crosses the process boundary; nothing branded ever leaves the subprocess, and `decodeUnknownSync` decodes plain data on the caller's side. (An earlier revision of this PR bundled the config with `Bun.build` and injected the binary's Effect via runtime plugins — it worked, but carried a bun/node branch, a copy of the CLI build's `node-std` workaround, and specifier-scraping. All deleted; the file is 49 lines.)
- **Lossless.** `Config2.Config` is pure data — strings, optional strings, string arrays, nested structs; `make` is an identity — so JSON carries every valid config exactly.
- **No new requirement.** `dx registry publish` already runs the plugin's `buildCommand` (`vite build`) through the plugin's toolchain; node being on PATH is a precondition this command has always had.
- A throwing config surfaces its real error: the subprocess's stderr is inherited.
- Erasable-syntax-only for `.ts` configs (node type stripping) — unchanged from #12513, documented in the JSDoc.

## Verification

Source-level, through the real `loadDxConfig`, against the real external plugin (dxos/plugins `packages/tictactoe`):

```
parent = bun 1.3.11   : org.dxos.plugin.tictactoe / vite build
parent = node 24.11.1 : org.dxos.plugin.tictactoe / vite build
dx.config.mjs         : loads
throwing config       : "Error: intentional config failure" passes through verbatim
```

The real compiled binary (app-framework dist rebuilt → CLI recompiled → run against the plugin):

```
before: Failed to load dx.config.ts: Cannot find module '@dxos/app-framework/config'
after:  UnknownException in Effect.tryPromise
          [cause] Error processing request.
            [cause] The socket connection was closed unexpectedly.
```

Config loading is out of the failure path; it reaches the ATProto request and fails on the socket — this sandbox has no credentials or network. The credentialed publish is the remaining step, via the plugins repo's `registry_only` dispatch once a CLI carrying this ships.

CI on this head ([run 31275835373](https://github.com/dxos/dxos/actions/runs/31275835373), dispatched with `e2e: true` to unlock the CLI jobs a normal PR skips):

```
cli           ✓   compiles the binary with the subprocess loader, packs it, dx --version from the tarball
cli-foreign   ✓   the packed tarball runs on a machine that never built it
check · test · workerd · storybook · model-fixture   ✓
e2e           running at last update
```

The previous head's red `e2e` was a playwright identity-test flake plus a 1-hour job timeout in the analytics uploader — `Bundle All` (the step that exercises config loading) passed there, and passes on this head too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin configuration loading so compiled applications consistently interpret `dx.config.ts` settings across supported runtimes.
  - Configuration errors and diagnostic output are now surfaced more clearly.
  - Added protection against configuration loading processes that exceed the allowed time limit.
  - Improved support for TypeScript configuration files using supported syntax.

- **Chores**
  - Updated release metadata for the affected packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->