### PR TITLE
react-ui: overlay the ScrollArea scrollbar thumb on content

### DIFF
--- a/.changeset/scrollarea-overlay-scrollbars.md
+++ b/.changeset/scrollarea-overlay-scrollbars.md
@@ -1,0 +1,7 @@
+---
+'@dxos/react-ui': minor
+---
+
+ScrollArea now overlays the scrollbar thumb on the content instead of reserving layout width for a
+native scrollbar. Native scrolling is retained, so scroll chaining and nested scrollers are
+unchanged. Pass `overlay={false}` to restore the classic native scrollbar.

--- a/.changeset/scrollarea-overlay-scrollbars.md
+++ b/.changeset/scrollarea-overlay-scrollbars.md
@@ -4,4 +4,6 @@
 
 ScrollArea now overlays the scrollbar thumb on the content instead of reserving layout width for a
 native scrollbar. Native scrolling is retained, so scroll chaining and nested scrollers are
-unchanged. Pass `overlay={false}` to restore the classic native scrollbar.
+unchanged. Pass `native` to restore the classic native scrollbar, which consumes layout width.
+
+The `padding` option reserves the strip the overlay thumb occupies, so content clears it.

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L0Menu.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L0Menu.tsx
@@ -355,7 +355,7 @@ export const L0Menu = ({
       </Menu.Root>
 
       {/* Space list. */}
-      <ScrollArea.Root centered thin orientation='vertical'>
+      <ScrollArea.Root centered padding thin orientation='vertical'>
         <ScrollArea.Viewport classNames='flex flex-col gap-2 py-1'>
           {topLevelItems.map((item) => (
             <L0Item

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
@@ -117,7 +117,7 @@ const L1PanelContent = ({
   return (
     <DensityProvider density='md'>
       <L1PanelHeader path={path} item={item} onBack={onBack} />
-      <ScrollArea.Root centered thin orientation='vertical'>
+      <ScrollArea.Root centered padding thin orientation='vertical'>
         <ScrollArea.Viewport>
           <Tree
             classNames='pt-[2px]'

--- a/packages/plugins/plugin-navtree/src/experimental/Tree.stories.tsx
+++ b/packages/plugins/plugin-navtree/src/experimental/Tree.stories.tsx
@@ -148,7 +148,7 @@ const Sidebar = ({ mutate }: { mutate?: boolean }) => {
   return (
     <Panel.Root>
       <Panel.Content asChild>
-        <ScrollArea.Root orientation='vertical' thin>
+        <ScrollArea.Root orientation='vertical' centered padding thin>
           <ScrollArea.Viewport>
             <Tree
               className='p-0.5 gap-1'

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -216,6 +216,124 @@ export const NestedScrollAreas = {
   },
 };
 
+export const Overlay = {
+  render: () => (
+    <Container classNames='h-72 w-48'>
+      <ScrollArea.Root orientation='vertical' overlay>
+        <ScrollArea.Viewport>
+          <List />
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>
+    </Container>
+  ),
+};
+
+export const OverlayVisible = {
+  render: () => (
+    <Container classNames='h-72 w-48'>
+      <ScrollArea.Root orientation='vertical' overlay autoHide={false}>
+        <ScrollArea.Viewport>
+          <List />
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>
+    </Container>
+  ),
+};
+
+export const OverlayPadded = {
+  render: () => (
+    <Container classNames='h-72 w-48'>
+      <ScrollArea.Root orientation='vertical' overlay centered padding thin>
+        <ScrollArea.Viewport>
+          <List />
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>
+    </Container>
+  ),
+};
+
+export const OverlayColumn = {
+  render: () => (
+    <Container classNames='h-72 w-48'>
+      <Column.Root gutter='sm' classNames='h-full overflow-hidden'>
+        <ScrollArea.Root orientation='vertical' overlay padding thin>
+          <ScrollArea.Viewport classNames='py-2'>
+            <Input.Root>
+              <Input.TextInput classNames='p-1' />
+            </Input.Root>
+            <List />
+          </ScrollArea.Viewport>
+        </ScrollArea.Root>
+      </Column.Root>
+    </Container>
+  ),
+};
+
+export const OverlayBoth = {
+  render: () => (
+    <Container classNames='w-96 h-96'>
+      <ScrollArea.Root orientation='all' overlay>
+        <ScrollArea.Viewport>
+          <div className='flex flex-col gap-2'>
+            {Array.from({ length: 50 }).map((_, rowIndex) => (
+              <div key={rowIndex} className='flex gap-2'>
+                {Array.from({ length: 50 }).map((_, colIndex) => (
+                  <div
+                    key={colIndex}
+                    className='shrink-0 h-20 w-20 flex items-center justify-center text-sm border border-separator font-mono'
+                  >
+                    [{colIndex}:{rowIndex}]
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>
+    </Container>
+  ),
+};
+
+/** The case Radix handled badly: a vertical overlay scroller inside a horizontal overlay scroller. */
+export const OverlayNested = {
+  decorators: [withTheme(), withLayout({ layout: 'fullscreen' })],
+  render: () => {
+    const columns = useMemo(
+      () =>
+        Array.from({ length: 8 }).map((_, index) => ({
+          id: String(index),
+          count: random.number.int({ min: 5, max: 20 }),
+        })),
+      [],
+    );
+
+    return (
+      <ScrollArea.Root orientation='horizontal' overlay thin padding>
+        <ScrollArea.Viewport classNames='gap-4'>
+          {columns.map((column) => (
+            <section
+              key={column.id}
+              className='shrink-0 h-full w-[16rem] grid grid-rows-[min-content_1fr_min-content] border border-separator'
+            >
+              <header className='flex shrink-0 p-2 border-b border-separator'>Column {column.id}</header>
+              <ScrollArea.Root orientation='vertical' overlay thin>
+                <ScrollArea.Viewport classNames='py-2 px-2 gap-2'>
+                  {Array.from({ length: column.count }, (_, i) => (
+                    <div key={i} role='listitem' className='shrink-0 p-2 text-sm border border-separator rounded-xs'>
+                      Item {i + 1}
+                    </div>
+                  ))}
+                </ScrollArea.Viewport>
+              </ScrollArea.Root>
+              <footer className='p-2 text-subdued border-t border-separator'>{column.count}</footer>
+            </section>
+          ))}
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>
+    );
+  },
+};
+
 export const NativeScroll = {
   render: () => (
     <div className='group h-48 w-48 border border-separator'>

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -216,10 +216,11 @@ export const NestedScrollAreas = {
   },
 };
 
-export const Overlay = {
+/** The classic native scrollbar, which consumes layout width. */
+export const NativeScrollbars = {
   render: () => (
     <Container classNames='h-72 w-48'>
-      <ScrollArea.Root orientation='vertical' overlay>
+      <ScrollArea.Root orientation='vertical' overlay={false}>
         <ScrollArea.Viewport>
           <List />
         </ScrollArea.Viewport>
@@ -274,100 +275,6 @@ export const OverlayDynamic = {
           Add 20 items ({items})
         </button>
       </div>
-    );
-  },
-};
-
-export const OverlayPadded = {
-  render: () => (
-    <Container classNames='h-72 w-48'>
-      <ScrollArea.Root orientation='vertical' overlay centered padding thin>
-        <ScrollArea.Viewport>
-          <List />
-        </ScrollArea.Viewport>
-      </ScrollArea.Root>
-    </Container>
-  ),
-};
-
-export const OverlayColumn = {
-  render: () => (
-    <Container classNames='h-72 w-48'>
-      <Column.Root gutter='sm' classNames='h-full overflow-hidden'>
-        <ScrollArea.Root orientation='vertical' overlay padding thin>
-          <ScrollArea.Viewport classNames='py-2'>
-            <Input.Root>
-              <Input.TextInput classNames='p-1' />
-            </Input.Root>
-            <List />
-          </ScrollArea.Viewport>
-        </ScrollArea.Root>
-      </Column.Root>
-    </Container>
-  ),
-};
-
-export const OverlayBoth = {
-  render: () => (
-    <Container classNames='w-96 h-96'>
-      <ScrollArea.Root orientation='all' overlay>
-        <ScrollArea.Viewport>
-          <div className='flex flex-col gap-2'>
-            {Array.from({ length: 50 }).map((_, rowIndex) => (
-              <div key={rowIndex} className='flex gap-2'>
-                {Array.from({ length: 50 }).map((_, colIndex) => (
-                  <div
-                    key={colIndex}
-                    className='shrink-0 h-20 w-20 flex items-center justify-center text-sm border border-separator font-mono'
-                  >
-                    [{colIndex}:{rowIndex}]
-                  </div>
-                ))}
-              </div>
-            ))}
-          </div>
-        </ScrollArea.Viewport>
-      </ScrollArea.Root>
-    </Container>
-  ),
-};
-
-/** The case Radix handled badly: a vertical overlay scroller inside a horizontal overlay scroller. */
-export const OverlayNested = {
-  decorators: [withTheme(), withLayout({ layout: 'fullscreen' })],
-  render: () => {
-    const columns = useMemo(
-      () =>
-        Array.from({ length: 8 }).map((_, index) => ({
-          id: String(index),
-          count: random.number.int({ min: 5, max: 20 }),
-        })),
-      [],
-    );
-
-    return (
-      <ScrollArea.Root orientation='horizontal' overlay thin padding>
-        <ScrollArea.Viewport classNames='gap-4'>
-          {columns.map((column) => (
-            <section
-              key={column.id}
-              className='shrink-0 h-full w-[16rem] grid grid-rows-[min-content_1fr_min-content] border border-separator'
-            >
-              <header className='flex shrink-0 p-2 border-b border-separator'>Column {column.id}</header>
-              <ScrollArea.Root orientation='vertical' overlay thin>
-                <ScrollArea.Viewport classNames='py-2 px-2 gap-2'>
-                  {Array.from({ length: column.count }, (_, i) => (
-                    <div key={i} role='listitem' className='shrink-0 p-2 text-sm border border-separator rounded-xs'>
-                      Item {i + 1}
-                    </div>
-                  ))}
-                </ScrollArea.Viewport>
-              </ScrollArea.Root>
-              <footer className='p-2 text-subdued border-t border-separator'>{column.count}</footer>
-            </section>
-          ))}
-        </ScrollArea.Viewport>
-      </ScrollArea.Root>
     );
   },
 };

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-import React, { PropsWithChildren, useMemo } from 'react';
+import React, { PropsWithChildren, useMemo, useState } from 'react';
 
 import { random } from '@dxos/random';
 import { mx } from '@dxos/ui-theme';
@@ -238,6 +238,44 @@ export const OverlayVisible = {
       </ScrollArea.Root>
     </Container>
   ),
+};
+
+export const OverlayAsChild = {
+  render: () => (
+    <ScrollArea.Root orientation='vertical' overlay autoHide={false} asChild>
+      <div className='border border-separator rounded-md overflow-hidden h-72 w-48'>
+        <ScrollArea.Viewport>
+          <List />
+        </ScrollArea.Viewport>
+      </div>
+    </ScrollArea.Root>
+  ),
+};
+
+/** Content appended after mount must re-measure the thumb without an intervening scroll. */
+export const OverlayDynamic = {
+  render: () => {
+    const [items, setItems] = useState(12);
+    return (
+      <div className='flex flex-col gap-2'>
+        <Container classNames='h-72 w-48'>
+          <ScrollArea.Root orientation='vertical' overlay autoHide={false}>
+            {/* Items are direct children so that appending them is a childList mutation. */}
+            <ScrollArea.Viewport>
+              {Array.from({ length: items }).map((_, index) => (
+                <div key={index} className='px-1'>
+                  Item {index + 1}
+                </div>
+              ))}
+            </ScrollArea.Viewport>
+          </ScrollArea.Root>
+        </Container>
+        <button className='p-1 border border-separator rounded-md' onClick={() => setItems((count) => count + 20)}>
+          Add 20 items ({items})
+        </button>
+      </div>
+    );
+  },
 };
 
 export const OverlayPadded = {

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -2,184 +2,134 @@
 // Copyright 2026 DXOS.org
 //
 
-import React, { PropsWithChildren, useMemo, useState } from 'react';
+import React, { PropsWithChildren, useMemo } from 'react';
 
 import { random } from '@dxos/random';
 import { mx } from '@dxos/ui-theme';
 import { ThemedClassName } from '@dxos/ui-types';
 
 import { withLayout, withTheme } from '../../testing';
-import { Column } from '../Column';
-import { Input } from '../Input';
-import { ScrollArea } from './ScrollArea';
+import { ScrollArea, type ScrollAreaRootProps } from './ScrollArea';
 
 random.seed(123);
-
-export default {
-  title: 'ui/react-ui-core/components/ScrollArea',
-  component: ScrollArea,
-  decorators: [withTheme()],
-  parameters: {
-    layout: 'centered',
-  },
-};
-
-const List = ({ items = 50 }: { items?: number }) => (
-  <div>
-    {Array.from({ length: items }).map((_, index) => (
-      <div key={index} className='px-1 cursor-pointer hover:bg-hover-surface'>
-        Item {index + 1}
-      </div>
-    ))}
-  </div>
-);
-
-const Row = ({ items = 50 }: { items?: number }) => (
-  <div className='flex gap-2 w-max'>
-    {Array.from({ length: items }).map((_, index) => (
-      <div
-        key={index}
-        className='shrink-0 h-20 w-20 cursor-pointer border border-separator rounded-md flex items-center justify-center hover:bg-hover-surface'
-      >
-        {index + 1}
-      </div>
-    ))}
-  </div>
-);
 
 const Container = ({ classNames, children }: ThemedClassName<PropsWithChildren>) => {
   return <div className={mx('border border-separator rounded-md overflow-hidden', classNames)}>{children}</div>;
 };
 
+// Items are direct children of the viewport, carrying their own `snap-start`: `snap` sets the
+// snap type on the scroller, but the browser needs an alignment on the items to snap to.
+// The filled background makes the `padding` inset visible against the scroller edge.
+
+const List = ({ items = 50 }: { items?: number }) => (
+  <>
+    {Array.from({ length: items }).map((_, index) => (
+      <div key={index} className='snap-start px-1 mbe-1 bg-hover-surface cursor-pointer'>
+        {index + 1} tempor incididunt ut labore et dolore magna aliqua
+      </div>
+    ))}
+  </>
+);
+
+const Row = ({ items = 50 }: { items?: number }) => (
+  <>
+    {Array.from({ length: items }).map((_, index) => (
+      <div
+        key={index}
+        className='snap-start shrink-0 h-20 w-20 mie-2 cursor-pointer border border-separator rounded-md flex items-center justify-center bg-hover-surface'
+      >
+        {index + 1}
+      </div>
+    ))}
+  </>
+);
+
+const Grid = ({ items = 50 }: { items?: number }) => (
+  <>
+    {Array.from({ length: items }).map((_, rowIndex) => (
+      <div key={rowIndex} className='snap-start flex gap-2 mbe-2'>
+        {Array.from({ length: items }).map((_, colIndex) => (
+          <div
+            key={colIndex}
+            className='shrink-0 h-20 w-20 flex items-center justify-center text-sm border border-separator font-mono bg-hover-surface'
+          >
+            [{colIndex}:{rowIndex}]
+          </div>
+        ))}
+      </div>
+    ))}
+  </>
+);
+
+const sizes: Record<string, string> = {
+  vertical: 'h-72 w-64',
+  horizontal: 'w-96',
+  all: 'w-96 h-96',
+};
+
+const Story = ({ orientation = 'vertical', ...props }: ScrollAreaRootProps) => (
+  <Container classNames={sizes[orientation]}>
+    <ScrollArea.Root orientation={orientation} {...props}>
+      <ScrollArea.Viewport>
+        {orientation === 'vertical' && <List />}
+        {orientation === 'horizontal' && <Row />}
+        {orientation === 'all' && <Grid />}
+      </ScrollArea.Viewport>
+    </ScrollArea.Root>
+  </Container>
+);
+
+export default {
+  title: 'ui/react-ui-core/components/ScrollArea',
+  component: ScrollArea.Root,
+  render: (args: ScrollAreaRootProps) => <Story {...args} />,
+  decorators: [withTheme()],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    orientation: { control: 'inline-radio', options: ['vertical', 'horizontal', 'all'] },
+    native: { control: 'boolean' },
+    autoHide: { control: 'boolean' },
+    scrollbars: { control: 'boolean' },
+    padding: { control: 'boolean' },
+    centered: { control: 'boolean' },
+    thin: { control: 'boolean' },
+    snap: { control: 'boolean' },
+  },
+  // Mirrors the component defaults so the controls panel reflects real behaviour.
+  args: {
+    native: false,
+    autoHide: true,
+    scrollbars: true,
+    padding: false,
+    centered: false,
+    thin: false,
+    snap: false,
+  } satisfies ScrollAreaRootProps,
+};
+
 export const Vertical = {
-  render: () => (
-    <Container classNames='h-72 w-48'>
-      <ScrollArea.Root orientation='vertical' padding={false}>
-        <ScrollArea.Viewport>
-          <List />
-        </ScrollArea.Viewport>
-      </ScrollArea.Root>
-    </Container>
-  ),
-};
-
-export const VerticalThin = {
-  render: () => (
-    <Container classNames='h-72 w-48'>
-      <ScrollArea.Root orientation='vertical' thin>
-        <ScrollArea.Viewport>
-          <List />
-        </ScrollArea.Viewport>
-      </ScrollArea.Root>
-    </Container>
-  ),
-};
-
-export const VerticalPadded = {
-  render: () => (
-    <Container classNames='h-72 w-48'>
-      <ScrollArea.Root orientation='vertical' centered padding thin>
-        <ScrollArea.Viewport>
-          <List />
-        </ScrollArea.Viewport>
-      </ScrollArea.Root>
-    </Container>
-  ),
-};
-
-export const VerticalColumn = {
-  render: () => (
-    <Container classNames='h-72 w-48'>
-      <Column.Root gutter='sm' classNames='h-full overflow-hidden'>
-        <ScrollArea.Root orientation='vertical' padding thin>
-          <ScrollArea.Viewport classNames='py-2'>
-            <Input.Root>
-              <Input.TextInput classNames='p-1' />
-            </Input.Root>
-            <List />
-          </ScrollArea.Viewport>
-        </ScrollArea.Root>
-      </Column.Root>
-    </Container>
-  ),
+  args: { orientation: 'vertical' },
 };
 
 export const Horizontal = {
-  render: () => (
-    <Container classNames='w-96'>
-      <ScrollArea.Root orientation='horizontal'>
-        <ScrollArea.Viewport>
-          <Row />
-        </ScrollArea.Viewport>
-      </ScrollArea.Root>
-    </Container>
-  ),
-};
-
-export const HorizontalThin = {
-  render: () => (
-    <Container classNames='w-96'>
-      <ScrollArea.Root orientation='horizontal' thin>
-        <ScrollArea.Viewport>
-          <Row />
-        </ScrollArea.Viewport>
-      </ScrollArea.Root>
-    </Container>
-  ),
+  args: { orientation: 'horizontal' },
 };
 
 export const Both = {
-  render: () => (
-    <Container classNames='w-96 h-96'>
-      <ScrollArea.Root orientation='all'>
-        <ScrollArea.Viewport>
-          <div className='flex flex-col gap-2'>
-            {Array.from({ length: 50 }).map((_, rowIndex) => (
-              <div key={rowIndex} className='flex gap-2'>
-                {Array.from({ length: 50 }).map((_, colIndex) => (
-                  <div
-                    key={colIndex}
-                    className='shrink-0 h-20 w-20 flex items-center justify-center text-sm border border-separator font-mono'
-                  >
-                    [{colIndex}:{rowIndex}]
-                  </div>
-                ))}
-              </div>
-            ))}
-          </div>
-        </ScrollArea.Viewport>
-      </ScrollArea.Root>
-    </Container>
-  ),
+  args: { orientation: 'all' },
 };
 
-export const Fullscreen = {
-  decorators: [withTheme(), withLayout({ layout: 'fullscreen' })],
-  render: () => (
-    <ScrollArea.Root orientation='all'>
-      <ScrollArea.Viewport>
-        <div className='flex flex-col gap-2'>
-          {Array.from({ length: 50 }).map((_, rowIndex) => (
-            <div key={rowIndex} className='flex gap-2'>
-              {Array.from({ length: 50 }).map((_, colIndex) => (
-                <div
-                  key={colIndex}
-                  className='shrink-0 h-20 w-20 flex items-center justify-center text-sm border border-separator font-mono'
-                >
-                  [{colIndex}:{rowIndex}]
-                </div>
-              ))}
-            </div>
-          ))}
-        </div>
-      </ScrollArea.Viewport>
-    </ScrollArea.Root>
-  ),
+/** The classic native scrollbar, which consumes layout width. */
+export const Native = {
+  args: { orientation: 'vertical', native: true },
 };
 
-export const NestedScrollAreas = {
+/** Nesting is not expressible through the controls panel: a vertical scroller inside a horizontal one. */
+export const Nested = {
   decorators: [withTheme(), withLayout({ layout: 'fullscreen' })],
-  render: () => {
+  render: ({ orientation: _orientation, ...props }: ScrollAreaRootProps) => {
     const columns = useMemo(
       () =>
         Array.from({ length: 8 }).map((_, index) => ({
@@ -190,7 +140,7 @@ export const NestedScrollAreas = {
     );
 
     return (
-      <ScrollArea.Root orientation='horizontal' thin padding>
+      <ScrollArea.Root orientation='horizontal' padding {...props}>
         <ScrollArea.Viewport classNames='gap-4'>
           {columns.map((column) => (
             <section
@@ -198,102 +148,24 @@ export const NestedScrollAreas = {
               className='shrink-0 h-full w-[16rem] grid grid-rows-[min-content_1fr_min-content] border border-separator'
             >
               <header className='flex shrink-0 p-2 border-b border-separator'>Column {column.id}</header>
-              <ScrollArea.Root thin orientation='vertical'>
+              <ScrollArea.Root orientation='vertical' padding {...props}>
                 <ScrollArea.Viewport classNames='py-2 px-2 gap-2'>
-                  {Array.from({ length: column.count }, (_, i) => (
-                    <div key={i} role='listitem' className={`shrink-0 p-2 text-sm border border-separator rounded-xs`}>
-                      Item {i + 1}
+                  {Array.from({ length: column.count }, (_, index) => (
+                    <div
+                      key={index}
+                      role='listitem'
+                      className='shrink-0 p-2 text-sm border border-separator rounded-xs'
+                    >
+                      Item {index + 1}
                     </div>
                   ))}
                 </ScrollArea.Viewport>
               </ScrollArea.Root>
-              <footer className={`p-2 text-subdued border-t border-separator`}>{column.count}</footer>
+              <footer className='p-2 text-subdued border-t border-separator'>{column.count}</footer>
             </section>
           ))}
         </ScrollArea.Viewport>
       </ScrollArea.Root>
     );
   },
-};
-
-/** The classic native scrollbar, which consumes layout width. */
-export const NativeScrollbars = {
-  render: () => (
-    <Container classNames='h-72 w-48'>
-      <ScrollArea.Root orientation='vertical' overlay={false}>
-        <ScrollArea.Viewport>
-          <List />
-        </ScrollArea.Viewport>
-      </ScrollArea.Root>
-    </Container>
-  ),
-};
-
-export const OverlayVisible = {
-  render: () => (
-    <Container classNames='h-72 w-48'>
-      <ScrollArea.Root orientation='vertical' overlay autoHide={false}>
-        <ScrollArea.Viewport>
-          <List />
-        </ScrollArea.Viewport>
-      </ScrollArea.Root>
-    </Container>
-  ),
-};
-
-export const OverlayAsChild = {
-  render: () => (
-    <ScrollArea.Root orientation='vertical' overlay autoHide={false} asChild>
-      <div className='border border-separator rounded-md overflow-hidden h-72 w-48'>
-        <ScrollArea.Viewport>
-          <List />
-        </ScrollArea.Viewport>
-      </div>
-    </ScrollArea.Root>
-  ),
-};
-
-/** Content appended after mount must re-measure the thumb without an intervening scroll. */
-export const OverlayDynamic = {
-  render: () => {
-    const [items, setItems] = useState(12);
-    return (
-      <div className='flex flex-col gap-2'>
-        <Container classNames='h-72 w-48'>
-          <ScrollArea.Root orientation='vertical' overlay autoHide={false}>
-            {/* Items are direct children so that appending them is a childList mutation. */}
-            <ScrollArea.Viewport>
-              {Array.from({ length: items }).map((_, index) => (
-                <div key={index} className='px-1'>
-                  Item {index + 1}
-                </div>
-              ))}
-            </ScrollArea.Viewport>
-          </ScrollArea.Root>
-        </Container>
-        <button className='p-1 border border-separator rounded-md' onClick={() => setItems((count) => count + 20)}>
-          Add 20 items ({items})
-        </button>
-      </div>
-    );
-  },
-};
-
-export const NativeScroll = {
-  render: () => (
-    <div className='group h-48 w-48 border border-separator'>
-      <div
-        className={mx(
-          'group h-full w-full overflow-y-scroll',
-          '[&::-webkit-scrollbar]:w-3',
-          '[&::-webkit-scrollbar-thumb]:rounded-none',
-          '[&::-webkit-scrollbar-track]:bg-scrollbar-track',
-          '[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumbSubdued',
-          'group-hover:[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb',
-        )}
-      >
-        <List />
-      </div>
-    </div>
-  ),
 };

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -54,7 +54,7 @@ const Container = ({ classNames, children }: ThemedClassName<PropsWithChildren>)
 export const Vertical = {
   render: () => (
     <Container classNames='h-72 w-48'>
-      <ScrollArea.Root orientation='vertical'>
+      <ScrollArea.Root orientation='vertical' padding={false}>
         <ScrollArea.Viewport>
           <List />
         </ScrollArea.Viewport>
@@ -156,7 +156,7 @@ export const Both = {
 export const Fullscreen = {
   decorators: [withTheme(), withLayout({ layout: 'fullscreen' })],
   render: () => (
-    <ScrollArea.Root orientation='all' thin>
+    <ScrollArea.Root orientation='all'>
       <ScrollArea.Viewport>
         <div className='flex flex-col gap-2'>
           {Array.from({ length: 50 }).map((_, rowIndex) => (

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.theme.ts
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.theme.ts
@@ -20,12 +20,17 @@ export type ScrollAreaStyleProps = {
   thin?: boolean;
   /** Enable snap scrolling. */
   snap?: boolean;
+  /** Paint the thumb over the content instead of reserving layout space. */
+  overlay?: boolean;
 };
 
-const root: ComponentFunction<ScrollAreaStyleProps> = ({ orientation }, ...etc) =>
+const root: ComponentFunction<ScrollAreaStyleProps> = ({ orientation, overlay }, ...etc) =>
   mx(
     // Expand
     'dx-container',
+
+    // Positioning context for the absolutely positioned overlay thumbs.
+    overlay && 'relative',
 
     orientation === 'vertical' && 'group/scroll-v flex flex-col',
     orientation === 'horizontal' && 'group/scroll-h flex',
@@ -44,7 +49,7 @@ const root: ComponentFunction<ScrollAreaStyleProps> = ({ orientation }, ...etc) 
  * NOTE: The browser reserves space for scrollbars.
  */
 const viewport: ComponentFunction<ScrollAreaStyleProps> = (
-  { orientation, centered, padding, snap, autoHide },
+  { orientation, centered, padding, snap, autoHide, overlay },
   ...etc
 ) => {
   return mx(
@@ -58,11 +63,16 @@ const viewport: ComponentFunction<ScrollAreaStyleProps> = (
     orientation === 'horizontal' && 'flex overflow-x-scroll overscroll-x-contain',
     orientation === 'all' && 'overflow-scroll',
 
-    '[&::-webkit-scrollbar-corner]:bg-transparent',
-    '[&::-webkit-scrollbar-track]:bg-transparent',
-    '[&::-webkit-scrollbar-thumb]:rounded-none',
-
-    '[&::-webkit-scrollbar]:w-[var(--scroll-width)] [&::-webkit-scrollbar]:h-[var(--scroll-width)]',
+    // A styled `::-webkit-scrollbar` is always a classic scrollbar and so consumes layout width;
+    // overlay mode removes it entirely and paints the thumb over the content instead.
+    overlay
+      ? ['[scrollbar-width:none]', '[&::-webkit-scrollbar]:hidden']
+      : [
+          '[&::-webkit-scrollbar-corner]:bg-transparent',
+          '[&::-webkit-scrollbar-track]:bg-transparent',
+          '[&::-webkit-scrollbar-thumb]:rounded-none',
+          '[&::-webkit-scrollbar]:w-[var(--scroll-width)] [&::-webkit-scrollbar]:h-[var(--scroll-width)]',
+        ],
 
     // If contained within Column.Root grid the gutter is set by that component (--gutter CSS variable).
     // If centered, left padding compensates for scrollbar width so content is visually centered.
@@ -85,17 +95,14 @@ const viewport: ComponentFunction<ScrollAreaStyleProps> = (
       orientation === 'all' && 'snap-both snap-mandatory',
     ],
 
-    autoHide
-      ? [
-          orientation === 'vertical' && 'group-hover/scroll-v:[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb',
-          orientation === 'horizontal' && 'group-hover/scroll-h:[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb',
-          orientation === 'all' && 'group-hover/scroll-all:[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb',
-        ]
-      : [
-          orientation === 'vertical' && '[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb',
-          orientation === 'horizontal' && '[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb',
-          orientation === 'all' && '[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb',
-        ],
+    !overlay &&
+      (autoHide
+        ? [
+            orientation === 'vertical' && 'group-hover/scroll-v:[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb',
+            orientation === 'horizontal' && 'group-hover/scroll-h:[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb',
+            orientation === 'all' && 'group-hover/scroll-all:[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb',
+          ]
+        : ['[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb']),
 
     ...etc,
   );

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.theme.ts
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.theme.ts
@@ -22,6 +22,8 @@ export type ScrollAreaStyleProps = {
   snap?: boolean;
   /** Use the native scrollbar, which reserves layout width, instead of an overlay thumb. */
   native?: boolean;
+  /** Show a scrollbar at all. */
+  scrollbars?: boolean;
 };
 
 const root: ComponentFunction<ScrollAreaStyleProps> = ({ orientation, native }, ...etc) =>
@@ -49,7 +51,7 @@ const root: ComponentFunction<ScrollAreaStyleProps> = ({ orientation, native }, 
  * NOTE: The browser reserves space for scrollbars.
  */
 const viewport: ComponentFunction<ScrollAreaStyleProps> = (
-  { orientation, centered, padding, snap, autoHide, native },
+  { orientation, centered, padding, snap, autoHide, native, scrollbars = true },
   ...etc
 ) => {
   return mx(
@@ -64,8 +66,9 @@ const viewport: ComponentFunction<ScrollAreaStyleProps> = (
     orientation === 'all' && 'overflow-scroll',
 
     // A styled `::-webkit-scrollbar` is always a classic scrollbar and so consumes layout width;
-    // overlay mode removes it entirely and paints the thumb over the content instead.
-    !native
+    // overlay mode removes it entirely and paints the thumb over the content instead. Zeroing
+    // `--scroll-width` is not enough to suppress it: Firefox needs `scrollbar-width` explicitly.
+    !native || !scrollbars
       ? ['[scrollbar-width:none]', '[&::-webkit-scrollbar]:hidden']
       : [
           '[&::-webkit-scrollbar-corner]:bg-transparent',

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.theme.ts
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.theme.ts
@@ -20,17 +20,17 @@ export type ScrollAreaStyleProps = {
   thin?: boolean;
   /** Enable snap scrolling. */
   snap?: boolean;
-  /** Paint the thumb over the content instead of reserving layout space. */
-  overlay?: boolean;
+  /** Use the native scrollbar, which reserves layout width, instead of an overlay thumb. */
+  native?: boolean;
 };
 
-const root: ComponentFunction<ScrollAreaStyleProps> = ({ orientation, overlay }, ...etc) =>
+const root: ComponentFunction<ScrollAreaStyleProps> = ({ orientation, native }, ...etc) =>
   mx(
     // Expand
     'dx-container',
 
     // Positioning context for the absolutely positioned overlay thumbs.
-    overlay && 'relative',
+    !native && 'relative',
 
     orientation === 'vertical' && 'group/scroll-v flex flex-col',
     orientation === 'horizontal' && 'group/scroll-h flex',
@@ -49,7 +49,7 @@ const root: ComponentFunction<ScrollAreaStyleProps> = ({ orientation, overlay },
  * NOTE: The browser reserves space for scrollbars.
  */
 const viewport: ComponentFunction<ScrollAreaStyleProps> = (
-  { orientation, centered, padding, snap, autoHide, overlay },
+  { orientation, centered, padding, snap, autoHide, native },
   ...etc
 ) => {
   return mx(
@@ -65,7 +65,7 @@ const viewport: ComponentFunction<ScrollAreaStyleProps> = (
 
     // A styled `::-webkit-scrollbar` is always a classic scrollbar and so consumes layout width;
     // overlay mode removes it entirely and paints the thumb over the content instead.
-    overlay
+    !native
       ? ['[scrollbar-width:none]', '[&::-webkit-scrollbar]:hidden']
       : [
           '[&::-webkit-scrollbar-corner]:bg-transparent',
@@ -75,19 +75,29 @@ const viewport: ComponentFunction<ScrollAreaStyleProps> = (
         ],
 
     // If contained within Column.Root grid the gutter is set by that component (--gutter CSS variable).
-    // If centered, left padding compensates for scrollbar width so content is visually centered.
+    // If centered, the opposite side is padded to match so content is visually centered.
+    // The overlay thumb sits outside the flow, so `padding` must reserve the whole strip it occupies
+    // (its thickness plus its inset at both ends); the native bar already consumes its own width, so
+    // that branch subtracts it back out.
     (orientation === 'vertical' || orientation === 'all') &&
       (padding
-        ? [
-            centered ? 'pl-[var(--gutter,calc(var(--scroll-width)+var(--scroll-padding)))]' : 'pl-[var(--gutter,0)]',
-            'pr-[calc(var(--gutter,calc(var(--scroll-width)+var(--scroll-padding)))-var(--scroll-width))]',
-          ]
-        : centered && 'pl-[var(--scroll-width)]'),
+        ? !native
+          ? [
+              centered ? 'pl-[var(--gutter,var(--scroll-strip))]' : 'pl-[var(--gutter,0)]',
+              'pr-[var(--gutter,var(--scroll-strip))]',
+            ]
+          : [
+              centered ? 'pl-[var(--gutter,calc(var(--scroll-width)+var(--scroll-padding)))]' : 'pl-[var(--gutter,0)]',
+              'pr-[calc(var(--gutter,calc(var(--scroll-width)+var(--scroll-padding)))-var(--scroll-width))]',
+            ]
+        : native && centered && 'pl-[var(--scroll-width)]'),
 
     (orientation === 'horizontal' || orientation === 'all') &&
       (padding
-        ? [centered && 'pt-[calc(var(--scroll-width)+var(--scroll-padding))]', 'pb-[var(--scroll-padding)]']
-        : centered && 'pt-[var(--scroll-width)]'),
+        ? !native
+          ? [centered && 'pt-[var(--gutter,var(--scroll-strip))]', 'pb-[var(--gutter,var(--scroll-strip))]']
+          : [centered && 'pt-[calc(var(--scroll-width)+var(--scroll-padding))]', 'pb-[var(--scroll-padding)]']
+        : native && centered && 'pt-[var(--scroll-width)]'),
 
     snap && [
       orientation === 'vertical' && 'snap-y snap-mandatory',
@@ -95,7 +105,7 @@ const viewport: ComponentFunction<ScrollAreaStyleProps> = (
       orientation === 'all' && 'snap-both snap-mandatory',
     ],
 
-    !overlay &&
+    native &&
       (autoHide
         ? [
             orientation === 'vertical' && 'group-hover/scroll-v:[&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb',

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
@@ -132,12 +132,7 @@ const ScrollAreaViewport = slottable<HTMLDivElement>(({ children, asChild, ...pr
   };
 
   return (
-    <Comp
-      {...rest}
-      style={vars}
-      className={tx('scrollArea.viewport', options, className)}
-      ref={ref}
-    >
+    <Comp {...rest} style={vars} className={tx('scrollArea.viewport', options, className)} ref={ref}>
       {children}
     </Comp>
   );

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
@@ -70,7 +70,7 @@ const ScrollAreaRoot = slottable<HTMLDivElement, ScrollAreaRootProps>(
       padding = false,
       thin = false,
       snap = false,
-      overlay = false,
+      overlay = true,
       ...props
     },
     forwardedRef,

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
@@ -5,7 +5,7 @@
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';
-import { Slot } from '@radix-ui/react-slot';
+import { Slot, Slottable } from '@radix-ui/react-slot';
 import React, { CSSProperties, useMemo, useState } from 'react';
 
 import { type AllowedAxis, type SlottableProps } from '@dxos/ui-types';
@@ -13,7 +13,7 @@ import { type AllowedAxis, type SlottableProps } from '@dxos/ui-types';
 import { useThemeContext } from '../../hooks';
 import { composableProps, slottable } from '../../util';
 import { ScrollAreaThumbs } from './ScrollAreaThumbs';
-import { scrollbar, type ScrollbarDensity } from './scrollbar';
+import { type ScrollbarDensity, scrollbar } from './scrollbar';
 
 //
 // Context
@@ -88,9 +88,9 @@ const ScrollAreaRoot = slottable<HTMLDivElement, ScrollAreaRootProps>(
     return (
       <ScrollAreaProvider {...options} density={density} setViewport={setViewport}>
         <Comp {...rest} className={tx('scrollArea.root', options, className)} ref={forwardedRef}>
-          {children}
-          {/* Slot forwards to a single child, so overlay thumbs are only available on a real element. */}
-          {overlay && scrollbars && !asChild && viewport && (
+          {/* Slottable marks the merge target so the thumbs render alongside `children` under `asChild`. */}
+          <Slottable>{children}</Slottable>
+          {overlay && scrollbars && viewport && (
             <ScrollAreaThumbs viewport={viewport} orientation={orientation} density={density} autoHide={autoHide} />
           )}
         </Comp>

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
@@ -109,27 +109,32 @@ const SCROLLAREA_VIEWPORT_NAME = 'ScrollArea.Viewport';
 
 type ScrollAreaViewportProps = SlottableProps;
 
+/** The custom properties the viewport publishes for the theme to size padding against. */
+type ScrollAreaVars = CSSProperties & {
+  '--scroll-width': string;
+  '--scroll-padding': string;
+  '--scroll-strip': string;
+};
+
 const ScrollAreaViewport = slottable<HTMLDivElement>(({ children, asChild, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
   const options = useScrollAreaContext(SCROLLAREA_VIEWPORT_NAME);
   const { density, setViewport } = options;
-  const { className, ...rest } = composableProps(props);
-  const { style, ...restWithoutStyle } = rest as { style?: CSSProperties; [key: string]: any };
+  const { className, style, ...rest } = composableProps(props);
   const Comp = asChild ? Slot : Primitive.div;
   const ref = useComposedRefs(forwardedRef, setViewport);
+  const vars: ScrollAreaVars = {
+    '--scroll-width': options.scrollbars ? `${density.size}px` : '0px',
+    '--scroll-padding': options.scrollbars ? `${density.padding}px` : '0px',
+    // Width of the strip the overlay thumb occupies: its thickness inset at both ends.
+    '--scroll-strip': options.scrollbars ? `${density.size + density.padding * 2}px` : '0px',
+    ...style,
+  };
 
   return (
     <Comp
-      {...restWithoutStyle}
-      style={
-        {
-          '--scroll-width': options.scrollbars ? `${density.size}px` : '0px',
-          '--scroll-padding': options.scrollbars ? `${density.padding}px` : '0px',
-          // Width of the strip the overlay thumb occupies: its thickness inset at both ends.
-          '--scroll-strip': options.scrollbars ? `${density.size + density.padding * 2}px` : '0px',
-          ...style,
-        } as CSSProperties
-      }
+      {...rest}
+      style={vars}
       className={tx('scrollArea.viewport', options, className)}
       ref={ref}
     >

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
@@ -34,10 +34,10 @@ type ScrollAreaOptions = {
   padding: boolean;
   /** Use thin scrollbars. */
   thin: boolean;
-  /** Enable snap scrolling. */
+  /** Enable snap scrolling; the content must carry its own snap alignment (e.g. `snap-start`). */
   snap: boolean;
-  /** Paint the thumb over the content instead of reserving layout space for a native scrollbar. */
-  overlay: boolean;
+  /** Use the native scrollbar, which reserves layout width, instead of an overlay thumb. */
+  native: boolean;
 };
 
 type ScrollAreaContextType = ScrollAreaOptions & {
@@ -70,7 +70,7 @@ const ScrollAreaRoot = slottable<HTMLDivElement, ScrollAreaRootProps>(
       padding = false,
       thin = false,
       snap = false,
-      overlay = true,
+      native = false,
       ...props
     },
     forwardedRef,
@@ -81,8 +81,8 @@ const ScrollAreaRoot = slottable<HTMLDivElement, ScrollAreaRootProps>(
     const [viewport, setViewport] = useState<HTMLDivElement | null>(null);
     const density = thin ? scrollbar.md : scrollbar.lg;
     const options = useMemo(
-      () => ({ orientation, autoHide, scrollbars, centered, padding, thin, snap, overlay }),
-      [orientation, autoHide, scrollbars, centered, padding, thin, snap, overlay],
+      () => ({ orientation, autoHide, scrollbars, centered, padding, thin, snap, native }),
+      [orientation, autoHide, scrollbars, centered, padding, thin, snap, native],
     );
 
     return (
@@ -90,7 +90,7 @@ const ScrollAreaRoot = slottable<HTMLDivElement, ScrollAreaRootProps>(
         <Comp {...rest} className={tx('scrollArea.root', options, className)} ref={forwardedRef}>
           {/* Slottable marks the merge target so the thumbs render alongside `children` under `asChild`. */}
           <Slottable>{children}</Slottable>
-          {overlay && scrollbars && viewport && (
+          {!native && scrollbars && viewport && (
             <ScrollAreaThumbs viewport={viewport} orientation={orientation} density={density} autoHide={autoHide} />
           )}
         </Comp>
@@ -123,9 +123,10 @@ const ScrollAreaViewport = slottable<HTMLDivElement>(({ children, asChild, ...pr
       {...restWithoutStyle}
       style={
         {
-          // In overlay mode the native scrollbar is hidden, so it reserves no width.
-          '--scroll-width': options.scrollbars && !options.overlay ? `${density.size}px` : '0px',
+          '--scroll-width': options.scrollbars ? `${density.size}px` : '0px',
           '--scroll-padding': options.scrollbars ? `${density.padding}px` : '0px',
+          // Width of the strip the overlay thumb occupies: its thickness inset at both ends.
+          '--scroll-strip': options.scrollbars ? `${density.size + density.padding * 2}px` : '0px',
           ...style,
         } as CSSProperties
       }

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.tsx
@@ -2,16 +2,18 @@
 // Copyright 2026 DXOS.org
 //
 
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
-import React, { CSSProperties, useMemo } from 'react';
+import React, { CSSProperties, useMemo, useState } from 'react';
 
 import { type AllowedAxis, type SlottableProps } from '@dxos/ui-types';
 
 import { useThemeContext } from '../../hooks';
 import { composableProps, slottable } from '../../util';
-import { scrollbar } from './scrollbar';
+import { ScrollAreaThumbs } from './ScrollAreaThumbs';
+import { scrollbar, type ScrollbarDensity } from './scrollbar';
 
 //
 // Context
@@ -19,7 +21,7 @@ import { scrollbar } from './scrollbar';
 
 const SCROLLAREA_NAME = 'ScrollArea';
 
-type ScrollAreaContextType = {
+type ScrollAreaOptions = {
   /** Orientation of scrollbars. */
   orientation: AllowedAxis;
   /** Hide scrollbars when not scrolling. */
@@ -34,6 +36,13 @@ type ScrollAreaContextType = {
   thin: boolean;
   /** Enable snap scrolling. */
   snap: boolean;
+  /** Paint the thumb over the content instead of reserving layout space for a native scrollbar. */
+  overlay: boolean;
+};
+
+type ScrollAreaContextType = ScrollAreaOptions & {
+  density: ScrollbarDensity;
+  setViewport: (viewport: HTMLDivElement | null) => void;
 };
 
 const [ScrollAreaProvider, useScrollAreaContext] = createContext<ScrollAreaContextType>(SCROLLAREA_NAME);
@@ -44,7 +53,7 @@ const [ScrollAreaProvider, useScrollAreaContext] = createContext<ScrollAreaConte
 
 const SCROLLAREA_ROOT_NAME = 'ScrollArea.Root';
 
-type ScrollAreaRootProps = Partial<ScrollAreaContextType>;
+type ScrollAreaRootProps = Partial<ScrollAreaOptions>;
 
 /**
  * ScrollArea provides native scrollbars with custom styling.
@@ -61,6 +70,7 @@ const ScrollAreaRoot = slottable<HTMLDivElement, ScrollAreaRootProps>(
       padding = false,
       thin = false,
       snap = false,
+      overlay = false,
       ...props
     },
     forwardedRef,
@@ -68,15 +78,21 @@ const ScrollAreaRoot = slottable<HTMLDivElement, ScrollAreaRootProps>(
     const { tx } = useThemeContext();
     const { className, ...rest } = composableProps(props);
     const Comp = asChild ? Slot : Primitive.div;
+    const [viewport, setViewport] = useState<HTMLDivElement | null>(null);
+    const density = thin ? scrollbar.md : scrollbar.lg;
     const options = useMemo(
-      () => ({ orientation, autoHide, scrollbars, centered, padding, thin, snap }),
-      [orientation, autoHide, scrollbars, centered, padding, thin, snap],
+      () => ({ orientation, autoHide, scrollbars, centered, padding, thin, snap, overlay }),
+      [orientation, autoHide, scrollbars, centered, padding, thin, snap, overlay],
     );
 
     return (
-      <ScrollAreaProvider {...options}>
+      <ScrollAreaProvider {...options} density={density} setViewport={setViewport}>
         <Comp {...rest} className={tx('scrollArea.root', options, className)} ref={forwardedRef}>
           {children}
+          {/* Slot forwards to a single child, so overlay thumbs are only available on a real element. */}
+          {overlay && scrollbars && !asChild && viewport && (
+            <ScrollAreaThumbs viewport={viewport} orientation={orientation} density={density} autoHide={autoHide} />
+          )}
         </Comp>
       </ScrollAreaProvider>
     );
@@ -96,23 +112,25 @@ type ScrollAreaViewportProps = SlottableProps;
 const ScrollAreaViewport = slottable<HTMLDivElement>(({ children, asChild, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
   const options = useScrollAreaContext(SCROLLAREA_VIEWPORT_NAME);
-  const density = options.thin ? scrollbar.md : scrollbar.lg;
+  const { density, setViewport } = options;
   const { className, ...rest } = composableProps(props);
   const { style, ...restWithoutStyle } = rest as { style?: CSSProperties; [key: string]: any };
   const Comp = asChild ? Slot : Primitive.div;
+  const ref = useComposedRefs(forwardedRef, setViewport);
 
   return (
     <Comp
       {...restWithoutStyle}
       style={
         {
-          '--scroll-width': options.scrollbars ? `${density.size}px` : '0px',
+          // In overlay mode the native scrollbar is hidden, so it reserves no width.
+          '--scroll-width': options.scrollbars && !options.overlay ? `${density.size}px` : '0px',
           '--scroll-padding': options.scrollbars ? `${density.padding}px` : '0px',
           ...style,
         } as CSSProperties
       }
       className={tx('scrollArea.viewport', options, className)}
-      ref={forwardedRef}
+      ref={ref}
     >
       {children}
     </Comp>

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.test.ts
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.test.ts
@@ -1,0 +1,39 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { measure } from './ScrollAreaThumbs';
+
+// Viewport of 200 over content of 800, inset 10 at both ends: track 180, thumb 45, travel 135.
+// Sized so the proportional length clears MIN_THUMB, which the clamping case covers separately.
+const VIEWPORT = 200;
+const CONTENT = 800;
+const PADDING = 10;
+
+const at = (scrollOffset: number) => measure(scrollOffset, CONTENT, VIEWPORT, PADDING);
+
+describe('ScrollArea thumb geometry', () => {
+  test('hides the thumb when the content fits', ({ expect }) => {
+    expect(measure(0, VIEWPORT, VIEWPORT, PADDING).visible).toBe(false);
+    // Sub-pixel overflow is not worth a scrollbar.
+    expect(measure(0, VIEWPORT + 1, VIEWPORT, PADDING).visible).toBe(false);
+  });
+
+  test('scales the thumb to the visible fraction of the content', ({ expect }) => {
+    expect(at(0)).toEqual({ visible: true, offset: PADDING, length: 45 });
+  });
+
+  test('maps scroll offset onto the track, inset at both ends', ({ expect }) => {
+    // Fully scrolled: the thumb ends flush with the far inset rather than the viewport edge.
+    const end = at(CONTENT - VIEWPORT);
+    expect(end.offset + end.length).toBe(VIEWPORT - PADDING);
+    expect(at((CONTENT - VIEWPORT) / 2).offset).toBe(PADDING + 67.5);
+  });
+
+  test('never shrinks below the minimum grabbable length', ({ expect }) => {
+    const { length } = measure(0, 100_000, VIEWPORT, PADDING);
+    expect(length).toBe(24);
+  });
+});

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.test.ts
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.test.ts
@@ -32,6 +32,11 @@ describe('ScrollArea thumb geometry', () => {
     expect(at((CONTENT - VIEWPORT) / 2).offset).toBe(PADDING + 67.5);
   });
 
+  test('hides the thumb when the track cannot seat the minimum length', ({ expect }) => {
+    // Track of 10 (30 - 2 x 10) is shorter than MIN_THUMB, which would overhang the far edge.
+    expect(measure(0, CONTENT, 30, PADDING).visible).toBe(false);
+  });
+
   test('never shrinks below the minimum grabbable length', ({ expect }) => {
     const { length } = measure(0, 100_000, VIEWPORT, PADDING);
     expect(length).toBe(24);

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.tsx
@@ -23,7 +23,7 @@ const HIDDEN: ThumbGeometry = { visible: false, offset: 0, length: 0 };
 /**
  * Project scroll state onto a track of `viewportLength`, inset by `padding` at both ends.
  */
-const measure = (
+export const measure = (
   scrollOffset: number,
   scrollLength: number,
   viewportLength: number,

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.tsx
@@ -74,15 +74,24 @@ export const ScrollAreaThumbs = ({ viewport, orientation, density, autoHide }: S
   }, [viewport, showVertical, showHorizontal, density.padding]);
 
   useEffect(() => {
-    update();
+    // Observe the scrolled content too, since content growth does not resize the viewport; the
+    // set of children is re-synced on mutation so appended content is measured as it arrives.
+    const resize = new ResizeObserver(update);
+    const observeContent = () => {
+      resize.disconnect();
+      resize.observe(viewport);
+      Array.from(viewport.children).forEach((child) => resize.observe(child));
+      update();
+    };
+
+    observeContent();
+    const mutation = new MutationObserver(observeContent);
+    mutation.observe(viewport, { childList: true });
     viewport.addEventListener('scroll', update, { passive: true });
-    // Observe the scrolled content too, since content growth does not resize the viewport.
-    const observer = new ResizeObserver(update);
-    observer.observe(viewport);
-    Array.from(viewport.children).forEach((child) => observer.observe(child));
     return () => {
       viewport.removeEventListener('scroll', update);
-      observer.disconnect();
+      mutation.disconnect();
+      resize.disconnect();
     };
   }, [viewport, update]);
 

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.tsx
@@ -158,11 +158,19 @@ export const ScrollAreaThumbs = ({ viewport, orientation, density, autoHide }: S
         )
       : 'opacity-100';
 
+  // A captured pointer keeps `:active` on the thumb only while the cursor stays over it, so the
+  // dragged state is driven by `dragging` instead.
+  const appearance = (axis: AllowedAxis) =>
+    mx(
+      'absolute z-10 rounded-full touch-none cursor-default transition-colors',
+      dragging === axis ? 'bg-scrollbar-thumb-active' : 'bg-scrollbar-thumb hover:bg-scrollbar-thumb-hover',
+    );
+
   return (
     <>
       {vertical.visible && (
         <div
-          className={mx('absolute z-10 rounded-full bg-scrollbar-thumb touch-none cursor-default', visibility)}
+          className={mx(appearance('vertical'), visibility)}
           style={{
             width: density.size,
             height: vertical.length,
@@ -176,7 +184,7 @@ export const ScrollAreaThumbs = ({ viewport, orientation, density, autoHide }: S
       )}
       {horizontal.visible && (
         <div
-          className={mx('absolute z-10 rounded-full bg-scrollbar-thumb touch-none cursor-default', visibility)}
+          className={mx(appearance('horizontal'), visibility)}
           style={{
             height: density.size,
             width: horizontal.length,

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.tsx
@@ -35,7 +35,12 @@ export const measure = (
   }
 
   const track = viewportLength - padding * 2;
-  const length = Math.max(MIN_THUMB, (viewportLength / scrollLength) * track);
+  // A viewport too short to seat the minimum thumb would otherwise place it past the far edge.
+  if (track <= MIN_THUMB) {
+    return HIDDEN;
+  }
+
+  const length = Math.min(track, Math.max(MIN_THUMB, (viewportLength / scrollLength) * track));
   const offset = padding + (scrollOffset / overflow) * (track - length);
   return { visible: true, offset, length };
 };
@@ -142,8 +147,13 @@ export const ScrollAreaThumbs = ({ viewport, orientation, density, autoHide }: S
     [viewport, density.padding],
   );
 
+  // Also bound to pointercancel and lostpointercapture: without them an interrupted drag leaves
+  // `drag` set, and the next hover-move over the thumb would scroll with no button held.
   const handlePointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    event.currentTarget.releasePointerCapture(event.pointerId);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+
     drag.current = undefined;
     setDragging(undefined);
   }, []);
@@ -180,6 +190,8 @@ export const ScrollAreaThumbs = ({ viewport, orientation, density, autoHide }: S
           onPointerDown={handlePointerDown('vertical')}
           onPointerMove={handlePointerMove('vertical')}
           onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+          onLostPointerCapture={handlePointerUp}
         />
       )}
       {horizontal.visible && (
@@ -194,6 +206,8 @@ export const ScrollAreaThumbs = ({ viewport, orientation, density, autoHide }: S
           onPointerDown={handlePointerDown('horizontal')}
           onPointerMove={handlePointerMove('horizontal')}
           onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+          onLostPointerCapture={handlePointerUp}
         />
       )}
     </>

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollAreaThumbs.tsx
@@ -1,0 +1,184 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { mx } from '@dxos/ui-theme';
+import { type AllowedAxis } from '@dxos/ui-types';
+
+import { type ScrollbarDensity } from './scrollbar';
+
+/** Smallest rendered thumb so it stays grabbable on very long content. */
+const MIN_THUMB = 24;
+
+type ThumbGeometry = {
+  visible: boolean;
+  offset: number;
+  length: number;
+};
+
+const HIDDEN: ThumbGeometry = { visible: false, offset: 0, length: 0 };
+
+/**
+ * Project scroll state onto a track of `viewportLength`, inset by `padding` at both ends.
+ */
+const measure = (
+  scrollOffset: number,
+  scrollLength: number,
+  viewportLength: number,
+  padding: number,
+): ThumbGeometry => {
+  const overflow = scrollLength - viewportLength;
+  if (overflow <= 1) {
+    return HIDDEN;
+  }
+
+  const track = viewportLength - padding * 2;
+  const length = Math.max(MIN_THUMB, (viewportLength / scrollLength) * track);
+  const offset = padding + (scrollOffset / overflow) * (track - length);
+  return { visible: true, offset, length };
+};
+
+type ScrollAreaThumbsProps = {
+  viewport: HTMLElement;
+  orientation: AllowedAxis;
+  density: ScrollbarDensity;
+  autoHide: boolean;
+};
+
+/**
+ * Absolutely positioned thumbs painted over the viewport; the viewport keeps native scrolling
+ * (its own scrollbars are hidden via CSS), so scroll chaining and nesting behave as the browser
+ * intends. Must be rendered as a sibling of the viewport inside a positioned root.
+ */
+export const ScrollAreaThumbs = ({ viewport, orientation, density, autoHide }: ScrollAreaThumbsProps) => {
+  const [vertical, setVertical] = useState<ThumbGeometry>(HIDDEN);
+  const [horizontal, setHorizontal] = useState<ThumbGeometry>(HIDDEN);
+  const [dragging, setDragging] = useState<AllowedAxis | undefined>();
+
+  const showVertical = orientation === 'vertical' || orientation === 'all';
+  const showHorizontal = orientation === 'horizontal' || orientation === 'all';
+
+  const update = useCallback(() => {
+    setVertical(
+      showVertical
+        ? measure(viewport.scrollTop, viewport.scrollHeight, viewport.clientHeight, density.padding)
+        : HIDDEN,
+    );
+    setHorizontal(
+      showHorizontal
+        ? measure(viewport.scrollLeft, viewport.scrollWidth, viewport.clientWidth, density.padding)
+        : HIDDEN,
+    );
+  }, [viewport, showVertical, showHorizontal, density.padding]);
+
+  useEffect(() => {
+    update();
+    viewport.addEventListener('scroll', update, { passive: true });
+    // Observe the scrolled content too, since content growth does not resize the viewport.
+    const observer = new ResizeObserver(update);
+    observer.observe(viewport);
+    Array.from(viewport.children).forEach((child) => observer.observe(child));
+    return () => {
+      viewport.removeEventListener('scroll', update);
+      observer.disconnect();
+    };
+  }, [viewport, update]);
+
+  // Read current geometry during a drag without re-binding the move handler on every frame.
+  const verticalRef = useRef(vertical);
+  const horizontalRef = useRef(horizontal);
+  verticalRef.current = vertical;
+  horizontalRef.current = horizontal;
+
+  const drag = useRef<{ origin: number; scroll: number } | undefined>(undefined);
+
+  const handlePointerDown = useCallback(
+    (axis: AllowedAxis) => (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      drag.current = {
+        origin: axis === 'vertical' ? event.clientY : event.clientX,
+        scroll: axis === 'vertical' ? viewport.scrollTop : viewport.scrollLeft,
+      };
+      setDragging(axis);
+    },
+    [viewport],
+  );
+
+  const handlePointerMove = useCallback(
+    (axis: AllowedAxis) => (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!drag.current) {
+        return;
+      }
+
+      const isVertical = axis === 'vertical';
+      const viewportLength = isVertical ? viewport.clientHeight : viewport.clientWidth;
+      const scrollLength = isVertical ? viewport.scrollHeight : viewport.scrollWidth;
+      const thumb = isVertical ? verticalRef.current : horizontalRef.current;
+      const track = viewportLength - density.padding * 2 - thumb.length;
+      if (track <= 0) {
+        return;
+      }
+
+      const delta = (isVertical ? event.clientY : event.clientX) - drag.current.origin;
+      const scroll = drag.current.scroll + (delta / track) * (scrollLength - viewportLength);
+      if (isVertical) {
+        viewport.scrollTop = scroll;
+      } else {
+        viewport.scrollLeft = scroll;
+      }
+    },
+    [viewport, density.padding],
+  );
+
+  const handlePointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    event.currentTarget.releasePointerCapture(event.pointerId);
+    drag.current = undefined;
+    setDragging(undefined);
+  }, []);
+
+  const visibility =
+    autoHide && !dragging
+      ? mx(
+          'opacity-0 transition-opacity',
+          orientation === 'vertical' && 'group-hover/scroll-v:opacity-100',
+          orientation === 'horizontal' && 'group-hover/scroll-h:opacity-100',
+          orientation === 'all' && 'group-hover/scroll-all:opacity-100',
+        )
+      : 'opacity-100';
+
+  return (
+    <>
+      {vertical.visible && (
+        <div
+          className={mx('absolute z-10 rounded-full bg-scrollbar-thumb touch-none cursor-default', visibility)}
+          style={{
+            width: density.size,
+            height: vertical.length,
+            top: vertical.offset,
+            insetInlineEnd: density.padding,
+          }}
+          onPointerDown={handlePointerDown('vertical')}
+          onPointerMove={handlePointerMove('vertical')}
+          onPointerUp={handlePointerUp}
+        />
+      )}
+      {horizontal.visible && (
+        <div
+          className={mx('absolute z-10 rounded-full bg-scrollbar-thumb touch-none cursor-default', visibility)}
+          style={{
+            height: density.size,
+            width: horizontal.length,
+            insetInlineStart: horizontal.offset,
+            bottom: density.padding,
+          }}
+          onPointerDown={handlePointerDown('horizontal')}
+          onPointerMove={handlePointerMove('horizontal')}
+          onPointerUp={handlePointerUp}
+        />
+      )}
+    </>
+  );
+};

--- a/packages/ui/react-ui/src/components/ScrollArea/scrollbar.ts
+++ b/packages/ui/react-ui/src/components/ScrollArea/scrollbar.ts
@@ -2,10 +2,17 @@
 // Copyright 2026 DXOS.org
 //
 
+export type ScrollbarDensity = {
+  /** Thickness of the bar/thumb. */
+  size: number;
+  /** Inset from the viewport edges. */
+  padding: number;
+};
+
 /**
  * Scrollbar sizing presets keyed by density tier.
  */
-export const scrollbar = {
+export const scrollbar: Record<'sm' | 'md' | 'lg', ScrollbarDensity> = {
   sm: {
     size: 2,
     padding: 2,

--- a/packages/ui/react-ui/src/components/ScrollArea/scrollbar.ts
+++ b/packages/ui/react-ui/src/components/ScrollArea/scrollbar.ts
@@ -19,10 +19,10 @@ export const scrollbar: Record<'sm' | 'md' | 'lg', ScrollbarDensity> = {
   },
   md: {
     size: 4,
-    padding: 4,
+    padding: 2,
   },
   lg: {
     size: 8,
-    padding: 8,
+    padding: 2,
   },
 };

--- a/packages/ui/ui-editor/src/styles/theme.ts
+++ b/packages/ui/ui-editor/src/styles/theme.ts
@@ -113,9 +113,11 @@ export const baseTheme = EditorView.baseTheme({
     // open/close) don't jump the user's view.
     overflowAnchor: 'auto',
   },
+  // The strip is the thumb plus its inset at both ends, matching the ScrollArea overlay thumb
+  // (8px thumb, 2px inset) so the two read identically side by side.
   '.cm-scroller::-webkit-scrollbar': {
-    width: 'var(--scrollbar-size,8px)',
-    height: 'var(--scrollbar-size,8px)',
+    width: 'var(--scrollbar-size,12px)',
+    height: 'var(--scrollbar-size,12px)',
   },
   '.cm-scroller::-webkit-scrollbar-corner': {
     background: 'transparent',
@@ -123,8 +125,13 @@ export const baseTheme = EditorView.baseTheme({
   '.cm-scroller::-webkit-scrollbar-track': {
     background: 'transparent',
   },
+  // Matches the ScrollArea overlay thumb: a pill inset from the edge. The inset is a transparent
+  // border with `background-clip: content-box`, since a scrollbar pseudo-element cannot be offset.
   '.cm-scroller::-webkit-scrollbar-thumb': {
     background: 'transparent',
+    borderRadius: 'var(--scrollbar-radius, 9999px)',
+    border: 'var(--scrollbar-inset, 2px) solid transparent',
+    backgroundClip: 'content-box',
     transition: 'background 0.15s',
   },
   '&:hover .cm-scroller::-webkit-scrollbar-thumb': {


### PR DESCRIPTION
## Summary

`ScrollArea` reserved layout width for a native scrollbar, so content stopped short of the gutter even when nothing was scrolling. This makes the thumb overlay the content instead, reclaiming that width.

The native scrollbar cannot do this. Styling `::-webkit-scrollbar` always produces a *classic* scrollbar, which shrinks the scroller's content box — nothing can render in that strip. `scrollbar-gutter` only reserves more, and macOS overlay bars are unstyleable and platform-dependent. So the thumb is now drawn by us.

## Approach

Native scrolling is **kept**. The viewport still uses `overflow: scroll`; only its scrollbar is hidden (`scrollbar-width: none` + `::-webkit-scrollbar { display: none }`), and `ScrollAreaThumbs` paints an absolutely-positioned, draggable thumb over it, driven by a passive `scroll` listener plus `ResizeObserver`/`MutationObserver`.

This is deliberately **not** Radix `ScrollArea`, which replaces native overflow with a JS-driven viewport — the source of this repo's previous problems with nested scrollers. Because scrolling stays the browser's here, chaining, overscroll containment, anchoring and `scrollIntoView` are unchanged, and nesting works by construction.

`overlay` defaults to `true`. Pass `overlay={false}` for the classic scrollbar; the `NativeScrollbars` story covers that path.

## Verification

Measured in storybook, not just eyeballed:

- Overlay viewport reports `clientWidth === offsetWidth` (was 8px less) — no reserved width.
- Thumb position tracks scroll exactly: inner nested column at `scrollTop 106` (its max) gives `thumb.top 93.626px`, matching `4 + (106/106) x (632 - 8 - 534.374)`.
- Nesting: scrolling an inner vertical column left the outer horizontal scroller at `scrollLeft: 0` — no chaining leak.
- Dynamic content: 12 -> 32 appended items shrank the thumb 268.1px -> 100.5px with no intervening scroll, matching `(286/768) x (286 - 16)`.
- `asChild`: root classes merge onto the user's element and the thumb renders as its sibling (via `Slottable`).
- `Column.Root` gutter interaction: padding is now symmetric 8px/8px instead of compensating asymmetrically for the bar.

`react-ui` build, lint and test are green (2 files, 9 tests).

## Reviewer note

The default flip changes every ScrollArea at once. I probed plugin storybooks for interactive elements landing within the thumb strip and found none in `PluginList`, but the sweep is **partial** — stories whose layout depends on the window size could not be measured reliably in my headless pane. Worth a look at any container with right-edge affordances (row actions, toggles, chevrons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scrollbars now overlay content without reserving layout space.
  * Added native scrollbar mode for a traditional scrolling appearance.
  * Added configurable padding to keep content clear of overlay scrollbars.
  * Added vertical, horizontal, bidirectional, nested, snapping, and auto-hiding scroll areas.
  * Improved scrollbar sizing, dragging, visibility, and responsive behavior.
  * Updated navigation panels with centered and padded scrolling layouts.
  * Refined editor scrollbars with larger, pill-shaped styling.
* **Documentation**
  * Expanded interactive examples and controls for configuring scroll areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->