### PR TITLE
skills: resolve operation definitions through the introspect MCP server

### DIFF
--- a/.agents/skills/composer-debug/SKILL.md
+++ b/.agents/skills/composer-debug/SKILL.md
@@ -138,6 +138,26 @@ The namespace is open-ended — plugins `??=` their own members onto it as they 
 
 `recovery` — safe mode only; see `composer-forensics`.
 
+### Resolving an operation before you invoke it
+
+`composer.operations()` lists what the _running page_ has activated, with top-level `input`/`output`
+fields. That is the live truth, and it is what you should trust about a session. But it only sees
+active plugins, and it flattens nested structs — so when you need the authoritative definition
+(including `services`, which `operations()` does not report), read it from the `dxos-introspect` MCP
+server instead of grepping:
+
+1. `mcp__dxos-introspect__list_plugins({ id: 'space' })` → the exact plugin id.
+2. `mcp__dxos-introspect__find_symbol({ query: 'SpaceOperation' })` → `@dxos/plugin-space#SpaceOperation`.
+3. `mcp__dxos-introspect__get_symbol({ ref: '…#SpaceOperation', include: ['source'] })` → every
+   definition with `meta.key`, `input`, `output` and `services`.
+
+Search `<Plugin>Operation` regardless of how the plugin structures it — `plugin-space` uses a
+`namespace`, `plugin-markdown` a module of top-level exports, and `find_symbol` finds both.
+
+`services` is the payoff: a definition listing `Database.Service` needs a `spaceId` that
+`composer.invoke` does not pass (gotcha 2), and the key alone never tells you that. Note that
+`list_operations` does _not_ enumerate operations — it returns the handler-file location per plugin.
+
 ## 5. Recipes
 
 ```js
@@ -226,7 +246,8 @@ Each of these cost a retry in practice; they are why this file exists.
 2. **Database-backed operations need a `spaceId`, which `composer.invoke` does not pass.** An
    operation declaring `services: [Database.Service]` (`markdown.update`, most write paths) fails
    with `Service not available: @dxos/echo/Database/Service … spawn environment is missing space`.
-   Until `invoke` forwards options, reach the invoker directly:
+   Check `services` on the definition via `dxos-introspect` (§4) _before_ invoking — it is the only
+   place this is visible. Until `invoke` forwards options, reach the invoker directly:
 
    ```js
    const mgr = composer.manager;
@@ -250,14 +271,18 @@ Each of these cost a retry in practice; they are why this file exists.
    There is no programmatic rename operation: `space.operation.renameObject` takes only
    `{ object, caller? }` because it opens the rename dialog.
 
-4. **`operations()` reports top-level fields only.** Each entry carries `input`/`output` field
-   lists — name, type, optionality — which is enough to call most operations without opening the
-   source. Nested structs are not expanded, and a non-struct input (`Schema.Void`, a union) has no
-   field list at all; read the schema in source for those.
+4. **`operations()` reports top-level fields only, for active plugins only.** Each entry carries
+   `input`/`output` field lists — name, type, optionality — enough to call most operations. Nested
+   structs are not expanded, a non-struct input (`Schema.Void`, a union) has no field list at all,
+   and `services` is absent. For any of those, resolve the definition through `dxos-introspect`
+   (§4) rather than reading files.
 5. **Keys are DXN-form.** `operations()` prints `dxn:org.dxos.plugin.layout.operation.select`.
    `invoke` accepts that or the bare NSID.
 6. **An operation's key namespace is not its owning plugin.** That `layout` key is contributed
-   by `plugin-attention`. Trust `pluginId`, which is derived from the contributing module.
+   by `plugin-attention`, and `plugin-markdown` keys its LLM-facing operations
+   `org.dxos.function.markdown.*` while its UI ones are `org.dxos.plugin.markdown.operation.*` —
+   `update` and `create` live in different namespaces in the same file. Trust `pluginId`, which is
+   derived from the contributing module.
 7. **`space.db.query(…).run()` resolves to an array**, not `{ objects }`. Destructuring the
    wrong shape throws inside the snippet rather than returning an empty result.
 8. **`SpaceState.SPACE_READY === 3`.** Guessing `4` silently yields empty results rather than

--- a/.agents/skills/composer-debug/SKILL.md
+++ b/.agents/skills/composer-debug/SKILL.md
@@ -246,8 +246,10 @@ Each of these cost a retry in practice; they are why this file exists.
 2. **Database-backed operations need a `spaceId`, which `composer.invoke` does not pass.** An
    operation declaring `services: [Database.Service]` (`markdown.update`, most write paths) fails
    with `Service not available: @dxos/echo/Database/Service … spawn environment is missing space`.
-   Check `services` on the definition via `dxos-introspect` (§4) _before_ invoking — it is the only
-   place this is visible. Until `invoke` forwards options, reach the invoker directly:
+   Check `services` on the definition via `dxos-introspect` (§4) _before_ invoking —
+   `composer.operations()` does not report it, though the runtime definition the snippet below
+   reaches through `set.definitions()` does. Until `invoke` forwards options, reach the invoker
+   directly:
 
    ```js
    const mgr = composer.manager;

--- a/.agents/skills/composer-plugins/SKILL.md
+++ b/.agents/skills/composer-plugins/SKILL.md
@@ -40,6 +40,21 @@ A "plugin" is a package whose `src/meta.ts` exports a `Plugin.Meta`, so `ls pack
 
 Reach for these first when answering questions like "how many plugins", "which plugin contributes X surface", or "where is symbol Y defined".
 
+### Reading an operation's key and input shape
+
+`list_operations` does **not** enumerate operations — it returns one row per
+`Capabilities.OperationHandler` contribution, i.e. where each plugin's handler file lives. The
+definitions live under a `<Plugin>Operation` symbol — a `namespace` in `plugin-space`, a module of
+top-level exports in `plugin-markdown` — so go through the symbol tools:
+
+1. `list_plugins({ id: 'space' })` → the exact plugin id, when you only have a loose name.
+2. `find_symbol({ query: 'SpaceOperation' })` → `@dxos/plugin-space#SpaceOperation`.
+3. `get_symbol({ ref: '@dxos/plugin-space#SpaceOperation', include: ['source'] })` → every
+   definition with its `meta.key`, `input`, `output` and `services`.
+
+Read `services` while you are there: a definition listing `Database.Service` needs a `spaceId` at
+invoke time, which is invisible from the key alone.
+
 ### Search idioms before implementing
 
 **Required.** Before writing or refactoring any container, capability, operation, skill, or schema, call `mcp__dxos-introspect__list_idioms` and scan for a slug that matches what you're about to build. An idiom is a JSDoc-tagged pinning of the canonical way to do one thing — when one exists, it is the answer, and you should `get_symbol` on the host artifact and follow the pattern rather than reinventing it.

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "dxos-introspect": {
       "type": "http",
-      "url": "https://mcp-introspect-service-labs.dxos.workers.dev/mcp"
+      "url": "https://introspect.dxos.network/mcp"
     },
     "trunk": {
       "type": "http",


### PR DESCRIPTION
## What

Points the `composer-debug` and `composer-plugins` skills at the chain that actually resolves an operation's key and input shape, and repoints `dxos-introspect` at its canonical origin.

Follow-up to #12519.

## Why

Both skills listed `mcp__dxos-introspect__list_operations` under "drill into a plugin's contributions". It does not do that. Tested against the live server, it returns **one row per `Capabilities.OperationHandler` contribution** — the handler file's location, one per plugin:

```json
{"pluginId":"org.dxos.plugin.space","type":"Capabilities.OperationHandler",
 "location":{"file":"packages/plugins/plugin-space/src/capabilities/operation-handler.ts","line":12}}
```

No keys, no input shapes. An agent asking "what does this operation take" was being sent to a dead end, and fell back to grepping source.

## The chain that works

```
list_plugins({id: 'space'})
  → find_symbol({query: 'SpaceOperation'})
    → get_symbol({ref, include: ['source']})
```

That yields every definition with `meta.key`, `input`, `output` — and **`services`**, which is the real payoff. `services: [Database.Service]` is the only place it is visible that an operation needs a `spaceId` that `composer.invoke` does not pass. That failure is documented as gotcha 2 in `composer-debug`; until now it was only discoverable by invoking and reading the error.

## Two corrections the testing forced

1. I first wrote that definitions live in a `<Name>Operation` **namespace**. True for `plugin-space`; `plugin-markdown` uses top-level module exports. `find_symbol` locates both, and the skills now say so rather than implying one structure.
2. `plugin-markdown` keys its LLM-facing operations `org.dxos.function.markdown.*` and its UI ones `org.dxos.plugin.markdown.operation.*` — `update` and `create` sit in **different namespaces in the same file**. Added as a concrete example to the existing "an operation's key namespace is not its owning plugin" gotcha.

## Reviewer notes

- `.mcp.json` moves `dxos-introspect` from `mcp-introspect-service-labs.dxos.workers.dev` to `introspect.dxos.network`. Both resolve today (probed the new one — 200 on `initialize`); the change takes effect on session restart, so nothing breaks either way.
- Docs and config only — no package code, hence no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for discovering and invoking operations, including nested schemas, services, required context, and plugin scope.
  - Added troubleshooting notes for database-backed operations and common operation-discovery issues.
  - Clarified how to inspect operation keys, inputs, outputs, metadata, and invocation requirements.

- **Chores**
  - Updated the introspection service connection to improve tooling reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->