### PR TITLE
review: scaffold agentic code-review harness project

### DIFF
--- a/.agents/projects/agentic-code-review/DESIGN.md
+++ b/.agents/projects/agentic-code-review/DESIGN.md
@@ -1,0 +1,205 @@
+# Agentic Code Review — Design
+
+## Problem
+
+The agent makes the same class of mistakes repeatedly (e.g. `sleep`/polling in
+tests, casts to silence the type-checker, compatibility shims left behind). These
+are encoded as prose in `CLAUDE.md` and skills, but nothing systematically
+_checks_ a diff against them. We want a **harness for agentic review**: durable,
+machine-collected rules applied by focused LLM subagents to exactly the files
+that changed, with diagnostics that can land as PR comments.
+
+Deterministic linters can't express these rules (they're semantic: "prefer
+subscribing to events over polling"). A grep can pre-filter candidates but can't
+judge. So the reviewer is an LLM subagent, scoped tightly to one rule over a few
+files to stay focused and cheap.
+
+**Claude owns the process** — it is packaged as a review _skill_ plus scripts, so
+the harness drives prepare → spawn subagents → finalize.
+
+## Rule format — `.mdl`
+
+Rules live in `.mdl` files anywhere in the repo, ideally colocated with the code
+they govern. `files:` globs resolve **relative to the `.mdl` file's directory**,
+so a package can drop a rule next to its own tests.
+
+Format: **YAML frontmatter + markdown body** (the body is the instructions,
+allowing rich markdown). One rule per file; the filename slug is the rule id.
+
+```markdown
+---
+name: no-sleep-in-test
+title: No sleep in tests
+files: "src/**/*.test.ts" # glob(s), relative to this file's dir; array allowed
+grep: sleep # optional pre-filter; only files matching are reviewed
+severity: warn # warn | error (default warn)
+---
+
+Using `sleep` or polling is disallowed in tests, prefer subscribing to events.
+
+Flag any use of `sleep`, `setTimeout`-based waits, or busy-poll loops. Prefer
+event subscription, `Trigger`, or Effect `TestClock`.
+```
+
+- `grep` is an **optimization + precision** filter: a file only enters a group
+  for this rule if it contains the pattern. Cheap way to skip files the rule
+  can't apply to. Optional.
+- `files` may be a string or a list. Globs are matched against repo-relative
+  paths after resolving relative to the rule dir.
+- Design decision: frontmatter+body over the inline-YAML sketch in the brief —
+  it keeps `.mdl` genuinely markdown-editable and lets instructions be long.
+
+## Store — `.agents/reviews/<slug>/`
+
+Each review run gets a slug directory:
+
+```
+.agents/reviews/<slug>/
+  REVIEW.md            # frontmatter + merged, finalized diagnostics
+  STAGING.md           # groups of (rule × files) for subagents; input only
+  groups/
+    01.md              # one fragment per group — a subagent writes here
+    02.md
+    ...
+```
+
+`<slug>` is derived from branch + short commit (e.g. `agentic-code-review-b217ecc`)
+so runs are addressable and don't collide.
+
+### REVIEW.md frontmatter
+
+Generated blank at prepare (step 1), finalized at step 3:
+
+```markdown
+---
+branch: claude/agentic-code-review-8621ce
+commit: b217ecc635 # HEAD at review time
+base: ea11703a42 # commit this review diffs against (see base resolution)
+createdAt: 2026-08-09T…
+isFinalized: false # set true by finalize; unfinalized reviews are ignored
+pr: 12520 # optional, if on a PR
+groups: 4
+---
+
+<!-- diagnostics merged here at finalize -->
+```
+
+`isFinalized: false` means the run is incomplete (subagents may still be
+writing / crashed) — the base-resolution scan **ignores** non-finalized reviews.
+
+## Diagnostic format
+
+Subagents emit diagnostics into their group fragment in a strict, parsable form:
+
+```markdown
+# WARN `path/to/file.ts:42:7`
+
+Body explaining the violation and the fix, referencing the rule.
+
+# ERROR `path/to/file.ts:88`
+
+Column is optional.
+```
+
+- Header line: `# WARN|ERROR` + space + backtick-wrapped `` `file:line[:col]` ``.
+- Body: everything until the next `# WARN|ERROR` header or EOF.
+- The severity comes from the subagent (seeded by the rule's `severity`, but the
+  subagent may downgrade/upgrade with justification — TBD, default: rule wins).
+
+## Workflow (three steps)
+
+### Step 1 — prepare (`prepare.mjs`)
+
+1. Discover all `.mdl` rule files (walk repo, honor `.gitignore`).
+2. **Resolve the diff base.** Scan `.agents/reviews/*/REVIEW.md` for **finalized**
+   reviews whose `commit` is an **ancestor of HEAD** (`git merge-base --is-ancestor`).
+   Pick the one with the **most recent** such commit → that's the base. This makes
+   review **incremental**: only re-review what changed since the last good review.
+   Fallback when none exists: `git merge-base HEAD origin/main` (review the whole
+   branch diff).
+3. Compute changed files: `git diff --name-only <base> HEAD` (+ untracked/working
+   set as configured). Keep only files that still exist.
+4. For each rule, intersect its resolved globs with the changed files, then apply
+   the `grep` pre-filter. Yields a set of `(rule, [files])` pairs.
+5. **Group** for subagents, preferring **few rules per group** over few files:
+   a group is one rule × a bounded chunk of its files (chunk size configurable,
+   e.g. ≤ 15 files). Big rules split into multiple groups; tiny rules are **not**
+   merged across rules (focus > packing).
+6. Write `STAGING.md` (human/agent-readable: per group, the rule frontmatter +
+   instructions + the file list) and a blank `REVIEW.md` (frontmatter above,
+   `isFinalized: false`), and empty `groups/NN.md` stubs.
+7. **Print to stdout**: paths to STAGING.md and REVIEW.md, and the **group
+   count** — the harness spawns exactly that many subagents. Also print a
+   per-group one-liner (rule + file count) for logging.
+
+### Step 2 — subagents (harness-driven, via the skill)
+
+The skill instructs the harness to spawn `groups` subagents on the **Sonnet**
+model. Each subagent is handed: its group number, the rule (title + instructions
++ severity), and its file list (read from STAGING.md). It reviews each file
+against that one rule and **appends diagnostics to `groups/NN.md`** in the
+diagnostic format. Per-group fragment files avoid concurrent-write races on a
+single REVIEW.md (design decision — the brief said "append to REVIEW.md"; we
+split to isolate writers, then merge in finalize).
+
+Subagents report **only** violations of their assigned rule — no general review,
+no style opinions outside the rule. If clean, the fragment stays empty.
+
+### Step 3 — finalize (`finalize.mjs`)
+
+1. Parse every `groups/NN.md`, validate diagnostic headers, collect them.
+2. Merge into `REVIEW.md` under the frontmatter, sorted by file then line;
+   dedupe identical diagnostics.
+3. Set `isFinalized: true`.
+4. **If on a PR** (`pr` set / detectable via `gh`): post diagnostics as review
+   comments anchored to `file:line` (via `gh pr review` / the comments API).
+   Idempotency: tag comments with the rule id + a hidden marker so re-runs
+   update rather than duplicate (TBD mechanism).
+5. Print a summary (counts by severity, PR link if posted).
+
+## Packaging — the skill
+
+`.agents/skills/agentic-review/` (name TBD — avoids the built-in `/review` and
+`/code-review`). Contains:
+
+- `SKILL.md` — the workflow the harness follows: run `prepare.mjs`, read the
+  group count, spawn that many **Sonnet** Task subagents with the per-group
+  brief, wait, then run `finalize.mjs`. Includes the subagent prompt template.
+- `scripts/prepare.mjs`, `scripts/finalize.mjs`, and a shared `lib/` (mdl parser,
+  git helpers, diagnostic parser).
+- Example rules seeded from existing `CLAUDE.md` non-negotiables (no-sleep-in-test,
+  no-casts, no-compat-shims, private-new-packages, workspace-deps).
+
+## Triggering
+
+Two intended modes (both supported; the scripts are trigger-agnostic):
+
+1. **On PRs** — run in CI (or on demand) against the PR branch; finalize posts
+   comments. Incremental base = last finalized review or merge-base with main.
+2. **Nightly on main** — run against main's recent diff; finalize can open an
+   issue / summary instead of PR comments.
+
+CI wiring is a later phase; the skill + scripts are usable manually first.
+
+## Open questions
+
+1. **Skill name.** `agentic-review` vs `review-rules` vs folding into an existing
+   name. Built-ins `/review` and `/code-review` already exist. Leaning
+   `agentic-review`.
+2. **Trigger priority.** Build for PR-comment flow first, or the manual/nightly
+   flow first? (Affects whether finalize's `gh` posting is Phase 1 or later.)
+3. **Severity authority.** Rule-fixed severity, or may a subagent adjust it with
+   justification? Leaning rule-fixed for determinism.
+4. **PR-comment idempotency** mechanism (hidden marker vs delete-and-repost).
+
+## Decisions log
+
+- `.mdl` = YAML frontmatter + markdown body (not inline YAML).
+- Globs resolve relative to the rule file's directory.
+- Per-group fragment files (`groups/NN.md`), merged at finalize — not concurrent
+  appends to one file.
+- Base resolution scans finalized reviews for the newest HEAD-ancestor commit;
+  fallback to merge-base with `origin/main`.
+- Grouping favors few rules per group over few files (focus over packing).
+- Scripts are Node ESM `.mjs` (no build step), matching `scripts/*.mjs`.
+- Subagents run on **Sonnet**.

--- a/.agents/projects/agentic-code-review/TASKS.md
+++ b/.agents/projects/agentic-code-review/TASKS.md
@@ -1,0 +1,49 @@
+# Agentic Code Review — Tasks
+
+_Resume: Design scaffolded (DESIGN.md). Next: implement Phase 1 — `.mdl` parser + `prepare.mjs`. Uncommitted: registry.yml, DESIGN.md, TASKS.md. Last: project created._
+
+## Phase 0: Design & scaffolding
+
+Capture the architecture and open questions before writing code.
+
+### Tasks
+
+- [x] **Register project + scaffold docs** — registry entry, DESIGN.md, TASKS.md.
+- [ ] **Resolve open questions** — skill name, trigger priority, severity authority, PR-comment idempotency (DESIGN.md §Open questions).
+
+## Phase 1: Core scripts + `.mdl` format
+
+The engine: rule discovery, diff-base resolution, staging, and finalize —
+usable manually before any CI wiring.
+
+### Tasks
+
+- [ ] **`.mdl` parser** — frontmatter (`name`,`title`,`files`,`grep`,`severity`) + markdown body; validate; glob resolution relative to the rule's dir.
+- [ ] **Rule discovery** — walk repo for `*.mdl`, honor `.gitignore`.
+- [ ] **Diff-base resolution** — scan `.agents/reviews/*/REVIEW.md` for finalized reviews whose `commit` is an ancestor of HEAD; pick newest; fallback `git merge-base HEAD origin/main`.
+- [ ] **`prepare.mjs`** — compute changed files vs base, intersect with rule globs, apply `grep` filter, group (few rules/group, chunk files ≤N), write STAGING.md + blank REVIEW.md + `groups/NN.md` stubs, print paths + group count.
+- [ ] **Diagnostic parser** — parse `# WARN|ERROR \`file:line[:col]\`` + body from group fragments.
+- [ ] **`finalize.mjs`** — merge fragments into REVIEW.md (sorted, deduped), set `isFinalized: true`, print summary.
+
+## Phase 2: Skill packaging
+
+Make Claude own the loop.
+
+### Tasks
+
+- [ ] **`SKILL.md`** — workflow: run prepare → read group count → spawn N Sonnet subagents with per-group brief → wait → run finalize. Include subagent prompt template.
+- [ ] **Seed example rules** from CLAUDE.md non-negotiables (no-sleep-in-test, no-casts, no-compat-shims, private-new-packages, workspace-deps).
+- [ ] **Dogfood** — run the harness on this branch's own diff; verify diagnostics land in REVIEW.md.
+
+## Phase 3: PR + CI integration
+
+### Tasks
+
+- [ ] **PR comment posting** in `finalize.mjs` — anchor to `file:line` via `gh`; idempotent (hidden marker per rule id).
+- [ ] **CI wiring** — run on PRs (post comments) and/or nightly on main (summary/issue).
+
+### References
+
+- Brief: `/project new` message (2026-08-09).
+- Existing script convention: `scripts/query-logs.mjs`.
+- Rule sources: `CLAUDE.md` Non-negotiables, `code-style` skill.

--- a/.agents/projects/registry.yml
+++ b/.agents/projects/registry.yml
@@ -285,6 +285,17 @@ projects:
     design: .agents/projects/startup-latency/DESIGN.md
     prs: [12415]
     resume: "PR #12415 targets main (retargeted once #12414 squash-landed as 34a84339) and is feature-complete, CI green, e2e green — landing. Shape: plugin start events are DEMAND-GATED — a plugin's own start fires when one of its modules contributes a ReactSurface (module-loader hook), so an unvisited feature never loads; contributions no surface can gate ride the feature they belong to (app-graph builders -> graph plugin's start, skills -> assistant's, cross-plugin contributions -> the consuming plugin's). All 71 surfaces are role-gated. Settings stay eager: app-shell components (transcription's ReactContext driver, DeckLayout) read them through the strict useAtomCapability at first render, so a post-ready gate trips the missing-capability invariant — verified by a fatal dialog in the e2e. Operation handler sets pair each definition with its handler module through Operation.lazyHandler, so a mispairing is a compile error and bodies still load per invocation. TWO CI BUDGETS LANDED: composer-app:check-boot-budget (static — entry + modulepreload closure, 30 entries / 6 MB, today 23 / 5.31 MB; count guards the chunk partition collapsing, NOT a bytes proxy) and composer-app:check-startup-budget (runtime — median modules-at-ready over 5 warm-cold repeats, budget 350, today 322). Timings are trend-only and CANNOT gate without a fixed runner: repeats of one unchanged commit span 1.9x in-container vs +/-1.7% on real hardware (TODO in TASKS.md). MERGE HAZARD, if this branch is ever re-derived: #12414 was SQUASHED into main, so a plain merge conflicts on ~499 files and silently reverts any line only our side changed — resolve conflicts to ours, then audit every merge-introduced hunk against main's non-#12414 commits. Open: react-aria still boot-reachable via Input->SegmentedInput->DatePicker (needs a component refactor); subpath migration remainder for plugin-space/client/graph (blocked on the export-namespace -> module-file refactor); PWA precaches 96.79MB for a 5MB shell (not implemented); map.json is 232KB of generated data whose pipeline was removed — decide whether to keep it."
+  - name: agentic-code-review
+    status: active
+    user: dmaretskyi
+    host: Dmytros-MacBook-Pro-M4
+    created: 2026-08-09
+    summary: "A Claude-owned agentic code-review harness — .mdl rule files (glob + grep + instructions), a prepare script that diffs git against the last finalized review and emits STAGING.md groups of rules×files, Sonnet subagents that emit parsable diagnostics into per-group review fragments, and a finalize script that merges + posts PR comments. Packaged as a review skill with scripts; store lives in .agents/reviews/<slug>/."
+    tasks: .agents/projects/agentic-code-review/TASKS.md
+    design: .agents/projects/agentic-code-review/DESIGN.md
+    prs: []
+    resume: "Design scaffolded; awaiting go-ahead to implement Phase 1 (.mdl parser + prepare.mjs). Next: build the rule discovery + diff-base resolution + STAGING/REVIEW generation."
+
 ended:
   - name: app-framework-capability-activation
     user: jdw


### PR DESCRIPTION
## What

Scaffolds a new project, **agentic-code-review**: a Claude-owned harness for applying semantic review rules to a git diff via focused LLM subagents. This PR is **design + planning only** — registry entry + `DESIGN.md` + `TASKS.md`, no scripts or skill yet.

- `.agents/projects/registry.yml` — new active entry.
- `.agents/projects/agentic-code-review/DESIGN.md` — full architecture.
- `.agents/projects/agentic-code-review/TASKS.md` — phased task ledger.

## Why

The agent repeats the same class of mistakes (e.g. `sleep`/polling in tests, casts to silence the type-checker, compat shims left behind). Those are encoded as prose in `CLAUDE.md`/skills but nothing systematically checks a diff against them. Deterministic linters can't express semantic rules like "prefer subscribing to events over polling", so the reviewer is an LLM subagent scoped tightly to one rule over a few files.

## Design shape

- **`.mdl` rules** — YAML frontmatter (`name`, `title`, `files`, `grep`, `severity`) + markdown body (instructions). Globs resolve relative to the rule file's dir, so packages colocate rules.
- **Store** — `.agents/reviews/<slug>/` with `STAGING.md`, `REVIEW.md` (frontmatter records branch/commit/base/`isFinalized`), and per-group `groups/NN.md` fragments.
- **Three steps** — `prepare.mjs` (resolve incremental diff base from the newest finalized review that is a HEAD-ancestor; intersect changed files with rule globs + `grep`; group few-rules-per-group; emit staging + group count) → harness spawns N **Sonnet** subagents → `finalize.mjs` (merge fragments, set `isFinalized`, post PR comments).
- Packaged as a review **skill** so Claude owns the loop.

## Reviewer notes

- No code paths touched; nothing in the build graph changes.
- Open questions (skill name, trigger priority, severity authority, PR-comment idempotency) are tracked in DESIGN.md §Open questions and Phase 0 of TASKS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an initial design for an agentic code-review workflow.
  * Defined configurable review rules, severity levels, diagnostics, and review-run summaries.
  * Documented a workflow for preparing reviews, running automated analysis, and finalizing results.
  * Added project planning materials covering future scripting, packaging, CI integration, and pull request reporting.
* **Documentation**
  * Registered the agentic code-review project and documented its current status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->