### PR TITLE
edge-client: authenticate registry uploads with DX_HUB_API_KEY

### DIFF
--- a/.changeset/registry-upload-api-key.md
+++ b/.changeset/registry-upload-api-key.md
@@ -1,0 +1,6 @@
+---
+'@dxos/echo': patch
+'@dxos/plugin-markdown': patch
+---
+
+`dx registry publish` authenticates the edge upload with `DX_HUB_API_KEY` when set, so headless callers without a HALO identity can publish.

--- a/packages/core/mesh/edge-client/src/base-http-client.ts
+++ b/packages/core/mesh/edge-client/src/base-http-client.ts
@@ -43,7 +43,7 @@ export type BaseHttpClientOptions = {
    */
   clientTag?: string;
   /**
-   * Admin API key, sent as `X-Admin-Key` on every request in place of the identity
+   * Admin API key, sent as `Authorization: Bearer` on every request in place of the identity
    * verifiable-presentation flow — for headless callers (CI) that hold no HALO identity.
    */
   apiKey?: string;
@@ -274,11 +274,10 @@ const createRequest = (
 
   if (authHeader) {
     headers['Authorization'] = authHeader;
-  }
-
-  // Same header the Edge Admin API authenticates with (see the CLI's adminRequest).
-  if (apiKey) {
-    headers['X-Admin-Key'] = apiKey;
+  } else if (apiKey) {
+    // Canonical edgeAuth admin-key form; never collides with the VP header, since the
+    // api-key path skips the auth flow that would populate it.
+    headers['Authorization'] = `Bearer ${apiKey}`;
   }
 
   if (traceHeaders) {

--- a/packages/core/mesh/edge-client/src/base-http-client.ts
+++ b/packages/core/mesh/edge-client/src/base-http-client.ts
@@ -42,6 +42,11 @@ export type BaseHttpClientOptions = {
    * Used on Edge to classify traffic for metering (e.g. `ci-e2e`).
    */
   clientTag?: string;
+  /**
+   * Admin API key, sent as `X-Admin-Key` on every request in place of the identity
+   * verifiable-presentation flow — for headless callers (CI) that hold no HALO identity.
+   */
+  apiKey?: string;
 };
 
 type HttpRequestArgs = {
@@ -64,6 +69,7 @@ export type RawHttpRequestArgs = {
 export abstract class BaseHttpClient {
   protected readonly _baseUrl: string;
   protected readonly _clientTag: string | undefined;
+  protected readonly _apiKey: string | undefined;
   protected _edgeIdentity: EdgeIdentity | undefined;
   /** Auth header cached until next 401. */
   protected _authHeader: string | undefined;
@@ -71,6 +77,7 @@ export abstract class BaseHttpClient {
   constructor(baseUrl: string, options?: BaseHttpClientOptions) {
     this._baseUrl = getEdgeUrlWithProtocol(baseUrl, 'http');
     this._clientTag = options?.clientTag;
+    this._apiKey = options?.apiKey;
     log('created', { url: this._baseUrl });
   }
 
@@ -101,14 +108,14 @@ export abstract class BaseHttpClient {
     while (true) {
       let processingError: EdgeCallFailedError | undefined = undefined;
       try {
-        if (!this._authHeader && args.auth) {
+        if (!this._authHeader && args.auth && !this._apiKey) {
           const response = await fetch(new URL('/auth', this._baseUrl));
           if (response.status === 401) {
             this._authHeader = await this._handleUnauthorized(response);
           }
         }
 
-        const request = createRequest(args, this._authHeader, traceHeaders, this._clientTag);
+        const request = createRequest(args, this._authHeader, traceHeaders, this._clientTag, this._apiKey);
         log('call', { url, tryCount, authHeader: !!this._authHeader });
         const response = await fetch(url, request);
 
@@ -231,6 +238,10 @@ export abstract class BaseHttpClient {
   }
 
   protected async _handleUnauthorized(response: Response): Promise<string> {
+    // A rejected API key is terminal — there is no challenge an identityless caller could answer.
+    if (this._apiKey) {
+      throw await EdgeCallFailedError.fromHttpFailure(response);
+    }
     if (!this._edgeIdentity) {
       log.warn('unauthorized response received before identity was set');
       throw await EdgeCallFailedError.fromHttpFailure(response);
@@ -245,6 +256,7 @@ const createRequest = (
   authHeader: string | undefined,
   traceHeaders?: Record<string, string>,
   clientTag?: string,
+  apiKey?: string,
 ): RequestInit => {
   let requestBody: BodyInit | undefined;
   const headers: HeadersInit = {};
@@ -262,6 +274,11 @@ const createRequest = (
 
   if (authHeader) {
     headers['Authorization'] = authHeader;
+  }
+
+  // Same header the Edge Admin API authenticates with (see the CLI's adminRequest).
+  if (apiKey) {
+    headers['X-Admin-Key'] = apiKey;
   }
 
   if (traceHeaders) {

--- a/packages/core/mesh/edge-client/src/base-http-client.ts
+++ b/packages/core/mesh/edge-client/src/base-http-client.ts
@@ -163,7 +163,10 @@ export abstract class BaseHttpClient {
           processingError = await EdgeCallFailedError.fromHttpFailure(response);
         }
       } catch (error: any) {
-        processingError = EdgeCallFailedError.fromProcessingFailureCause(error);
+        // A thrown EdgeCallFailedError already carries its retry semantics (e.g. the terminal
+        // rejected-api-key 401) — wrapping it as a processing failure would mark it retryable.
+        processingError =
+          error instanceof EdgeCallFailedError ? error : EdgeCallFailedError.fromProcessingFailureCause(error);
       }
 
       if (processingError?.isRetryable && (await shouldRetry(ctx, processingError.retryAfterMs))) {
@@ -194,7 +197,7 @@ export abstract class BaseHttpClient {
     while (true) {
       let processingError: EdgeCallFailedError | undefined;
       try {
-        if (!this._authHeader && args.auth) {
+        if (!this._authHeader && args.auth && !this._apiKey) {
           const response = await fetch(new URL('/auth', this._baseUrl));
           if (response.status === 401) {
             this._authHeader = await this._handleUnauthorized(response);
@@ -204,6 +207,10 @@ export abstract class BaseHttpClient {
         const headers: Record<string, string> = { ...args.headers };
         if (this._authHeader) {
           headers['Authorization'] = this._authHeader;
+        } else if (this._apiKey) {
+          // Canonical edgeAuth admin-key form; never collides with the VP header, since the
+          // api-key path skips the auth flow that would populate it.
+          headers['Authorization'] = `Bearer ${this._apiKey}`;
         }
         if (traceHeaders) {
           Object.assign(headers, traceHeaders);
@@ -226,7 +233,10 @@ export abstract class BaseHttpClient {
 
         processingError = await EdgeCallFailedError.fromHttpFailure(response);
       } catch (error: any) {
-        processingError = EdgeCallFailedError.fromProcessingFailureCause(error);
+        // A thrown EdgeCallFailedError already carries its retry semantics (e.g. the terminal
+        // rejected-api-key 401) — wrapping it as a processing failure would mark it retryable.
+        processingError =
+          error instanceof EdgeCallFailedError ? error : EdgeCallFailedError.fromProcessingFailureCause(error);
       }
 
       if (processingError?.isRetryable && (await shouldRetry(ctx, processingError.retryAfterMs))) {

--- a/packages/core/mesh/edge-client/src/edge-http-client.test.ts
+++ b/packages/core/mesh/edge-client/src/edge-http-client.test.ts
@@ -175,3 +175,58 @@ describe('EdgeHttpClient blobs', () => {
     expect(fetchMock).toHaveBeenCalled();
   });
 });
+
+describe('EdgeHttpClient api key', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('uploadPluginBundle sends the key as a Bearer header without the /auth prefetch', async ({ expect }) => {
+    const fetchMock = vi.fn(
+      async (_input: any, _init?: RequestInit) =>
+        new Response(JSON.stringify({ success: true, data: { moduleUrl: 'url' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new EdgeHttpClient('https://edge.example.com', { apiKey: 'secret-key' });
+    await client.uploadPluginBundle(Context.default(), { slug: 'x', version: '1', files: [] });
+
+    const authCall = fetchMock.mock.calls.find((call) => String(call[0]).endsWith('/auth'));
+    expect(authCall).toBeUndefined();
+    const uploadCall = fetchMock.mock.calls.find((call) => String(call[0]).includes('/registry/upload'));
+    expect((uploadCall![1]?.headers as Record<string, string>).Authorization).toBe('Bearer secret-key');
+  });
+
+  test('a rejected api key is terminal — no retry on the auth 401', async ({ expect }) => {
+    const fetchMock = vi.fn(
+      async (_input: any, _init?: RequestInit) =>
+        new Response(null, {
+          status: 401,
+          headers: { 'WWW-Authenticate': 'VerifiablePresentation challenge=Y2hhbGxlbmdl' },
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new EdgeHttpClient('https://edge.example.com', { apiKey: 'rejected-key' });
+    await expect(
+      client.uploadPluginBundle(Context.default(), { slug: 'x', version: '1', files: [] }),
+    ).rejects.toMatchObject({ isRetryable: false });
+    expect(fetchMock.mock.calls.length).toBe(1);
+  });
+
+  test('putBlob sends the key as a Bearer header without the /auth prefetch', async ({ expect }) => {
+    const fetchMock = vi.fn(async (_input: any, _init?: RequestInit) => new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new EdgeHttpClient('https://edge.example.com', { apiKey: 'secret-key' });
+    await client.putBlob(Context.default(), 'abc123', new Uint8Array([1, 2, 3]));
+
+    const authCall = fetchMock.mock.calls.find((call) => String(call[0]).endsWith('/auth'));
+    expect(authCall).toBeUndefined();
+    const putCall = fetchMock.mock.calls.find((call) => String(call[0]).includes('/api/file/abc123'));
+    expect((putCall![1]?.headers as Record<string, string>).Authorization).toBe('Bearer secret-key');
+  });
+});

--- a/packages/core/mesh/edge-client/src/edge-http-client.test.ts
+++ b/packages/core/mesh/edge-client/src/edge-http-client.test.ts
@@ -192,7 +192,8 @@ describe('EdgeHttpClient api key', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const client = new EdgeHttpClient('https://edge.example.com', { apiKey: 'secret-key' });
-    await client.uploadPluginBundle(Context.default(), { slug: 'x', version: '1', files: [] });
+    // Mirror uploadBundleDirect's call shape: VP auth off, so the api key is the only credential.
+    await client.uploadPluginBundle(Context.default(), { slug: 'x', version: '1', files: [] }, { auth: false });
 
     const authCall = fetchMock.mock.calls.find((call) => String(call[0]).endsWith('/auth'));
     expect(authCall).toBeUndefined();

--- a/packages/plugins/plugin-registry/src/commands/registry/publish.ts
+++ b/packages/plugins/plugin-registry/src/commands/registry/publish.ts
@@ -19,7 +19,7 @@ import { findDxConfigFile, loadDxConfig } from '@dxos/app-framework/vite-plugin'
 import { type Client, ClientService } from '@dxos/client';
 import { Context } from '@dxos/context';
 import { EdgeHttpClient } from '@dxos/edge-client';
-import { Config2 } from '@dxos/protocols';
+import { Config2, EdgeCallFailedError } from '@dxos/protocols';
 
 import { AUTH_OPTION_DESCRIPTIONS, NSID, putRecord, resolveSession } from './util';
 
@@ -125,6 +125,16 @@ export const publish = Command.make(
         const version = manifest.version;
         const manifestHash = `sha256-${yield* Effect.promise(() => sha256Base64(new TextEncoder().encode(manifestRaw)))}`;
 
+        // Authenticate for the record writes BEFORE uploading: hosted bundles are immutable once
+        // uploaded, so a publish whose PDS session cannot authenticate must fail before it burns
+        // the version with an orphaned upload.
+        const client = yield* ClientService;
+        const session = yield* resolveSession({
+          handle: Option.getOrUndefined(options.handle),
+          appPassword: Option.getOrUndefined(options.appPassword),
+          client,
+        });
+
         // Resolve hosting → moduleUrl.
         const assetBaseUrl = Option.getOrUndefined(options.assetBaseUrl) ?? config.publish?.assetBaseUrl;
         let moduleUrl: string;
@@ -143,24 +153,15 @@ export const publish = Command.make(
           } else if (apiKey) {
             // Headless callers (CI) hold no HALO identity, so the VP flow cannot run; the admin
             // API key authenticates the upload instead.
-            const client = yield* ClientService;
             const http = new EdgeHttpClient(client.edge.http.baseUrl, { apiKey });
             moduleUrl = yield* uploadBundleDirect({ http, key, version, outdir });
           } else {
-            const client = yield* ClientService;
             const hasIdentity = !!client.halo.identity.get();
             moduleUrl = yield* uploadBundle({ client, key, version, outdir, auth: hasIdentity });
           }
           yield* Console.log(`Uploaded:  ${moduleUrl}`);
         }
 
-        // Authenticate and write records.
-        const client = yield* ClientService;
-        const session = yield* resolveSession({
-          handle: Option.getOrUndefined(options.handle),
-          appPassword: Option.getOrUndefined(options.appPassword),
-          client,
-        });
         const createdAt = new Date().toISOString();
 
         const profile: Record<string, unknown> = { key, name: manifest.name, createdAt };
@@ -279,8 +280,19 @@ const uploadBundleDirect = ({
       files.push({ path: entry.split(path.sep).join('/'), content: Buffer.from(bytes).toString('base64') });
     }
 
-    const { moduleUrl } = yield* Effect.tryPromise(() =>
-      http.uploadPluginBundle(Context.default(), { slug: key, version, files }, { auth: false }),
+    const { moduleUrl } = yield* Effect.tryPromise({
+      try: () => http.uploadPluginBundle(Context.default(), { slug: key, version, files }, { auth: false }),
+      catch: (error) => error,
+    }).pipe(
+      // Hosted versions are immutable, so a re-run of an already-uploaded version answers 409 —
+      // the existing bundle is the publish's outcome, keeping registry publishes re-runnable.
+      Effect.catchIf(
+        (error) => error instanceof EdgeCallFailedError && error.data?.type === 'conflict',
+        () => {
+          const existingUrl = new URL(`/registry/modules/${key}/${version}/manifest.json`, http.baseUrl).toString();
+          return Console.log(`Version already in registry: ${existingUrl}`).pipe(Effect.as({ moduleUrl: existingUrl }));
+        },
+      ),
     );
     return moduleUrl;
   });

--- a/packages/plugins/plugin-registry/src/commands/registry/publish.ts
+++ b/packages/plugins/plugin-registry/src/commands/registry/publish.ts
@@ -8,6 +8,7 @@ import * as PlatformCommand from '@effect/platform/Command';
 import * as FetchHttpClient from '@effect/platform/FetchHttpClient';
 import * as FileSystem from '@effect/platform/FileSystem';
 import * as Path from '@effect/platform/Path';
+import * as Config from 'effect/Config';
 import * as Console from 'effect/Console';
 import * as Effect from 'effect/Effect';
 import * as Function from 'effect/Function';
@@ -135,8 +136,15 @@ export const publish = Command.make(
           // When --edge-url is provided we bypass the profile's edge config and post directly
           // with auth: false — relies on WORKER_ENV=dev skipAuth on the server (local dev only).
           const explicitEdgeUrl = Option.getOrUndefined(options.edgeUrl);
+          const apiKey = Option.getOrUndefined(yield* Config.option(Config.string('DX_HUB_API_KEY')));
           if (explicitEdgeUrl) {
             const http = new EdgeHttpClient(explicitEdgeUrl);
+            moduleUrl = yield* uploadBundleDirect({ http, key, version, outdir });
+          } else if (apiKey) {
+            // Headless callers (CI) hold no HALO identity, so the VP flow cannot run; the admin
+            // API key authenticates the upload instead.
+            const client = yield* ClientService;
+            const http = new EdgeHttpClient(client.edge.http.baseUrl, { apiKey });
             moduleUrl = yield* uploadBundleDirect({ http, key, version, outdir });
           } else {
             const client = yield* ClientService;

--- a/packages/plugins/plugin-registry/src/commands/registry/publish.ts
+++ b/packages/plugins/plugin-registry/src/commands/registry/publish.ts
@@ -282,7 +282,8 @@ const uploadBundleDirect = ({
 
     const { moduleUrl } = yield* Effect.tryPromise({
       try: () => http.uploadPluginBundle(Context.default(), { slug: key, version, files }, { auth: false }),
-      catch: (error) => error,
+      // Keep EdgeCallFailedError intact for the conflict recovery below; type everything else.
+      catch: (error) => (error instanceof EdgeCallFailedError ? error : new Error(`Bundle upload failed: ${error}`)),
     }).pipe(
       // Hosted versions are immutable, so a re-run of an already-uploaded version answers 409 —
       // the existing bundle is the publish's outcome, keeping registry publishes re-runnable.


### PR DESCRIPTION
## Summary

`dx registry publish` authenticates the edge upload with the caller's hub-identity verifiable presentation, which a headless caller (CI) cannot produce — it holds no HALO identity, and seeding one per run would accrete a device into the identity's HALO on every release.

The edge client now takes an `apiKey` option, sent as `Authorization: Bearer` — the canonical edgeAuth admin-key form (`X-Admin-Key` is legacy, kept for one release) — in place of the VP flow: the `/auth` challenge prefetch is skipped, and a 401 is terminal since a rejected key has no challenge an identityless caller could answer. The publish command uses it when `DX_HUB_API_KEY` is set, leaving the identity path unchanged otherwise.

Server side: dxos/edge#822 (merged, deployed to main + production) allows the `adminKey` method on `/registry/upload`, as a placeholder until dynamic API keys land.

## Verification

- Local header-capture server: with `apiKey` set, the `/auth` prefetch is skipped, `Authorization: Bearer <key>` is sent, and no legacy `X-Admin-Key` header is present.
- End-to-end: the dxos/plugins Release workflow (`registry_only`, CLI pinned to this branch's pkg.pr.new build `@1edc570`) published `org.dxos.plugin.tictactoe@0.10.1` to the production registry — edge upload authenticated with `DX_HUB_API_KEY`, ATProto Profile/Release records written: [run](https://github.com/dxos/plugins/actions/runs/31310780246).

## Changeset

`@dxos/echo` patch (Group A, edge-client) + `@dxos/plugin-markdown` patch (Group B, plugin-registry).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ4ZdaPo9erkh5yF4eXh3Z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added API-key authentication for registry publishing.
  - Headless publishing is supported by setting `DX_HUB_API_KEY`, without requiring a HALO identity.
  - Publishing can use a configured edge URL with the API key.
- **Bug Fixes**
  - Invalid API keys now fail immediately without prompting for identity authentication.
  - Re-publishing an existing bundle is handled as a successful operation.
- **Documentation**
  - Added release notes for API-key-based registry publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->