### PR TITLE
plugin-client: issue and redeem invitation codes from the CLI

### DIFF
--- a/.changeset/cli-account-login-code.md
+++ b/.changeset/cli-account-login-code.md
@@ -3,4 +3,9 @@
 '@dxos/plugin-client': minor
 ---
 
-`dx account login` accepts an invitation code: `--code <CODE>` (email method). The hub no longer exempts any address from its invitation gate, so a code is now the only way to create an account from the CLI; omit the option to recover an existing one. `LoginRequest` gains an optional `code` field, sent on both the identity probe and the retry that redeems it.
+The CLI can issue and redeem invitation codes. The hub no longer exempts any address from its invitation gate, so a code is now the only way to create an account from the CLI.
+
+- `dx account invitation create` issues a code against the logged-in account's own quota.
+- `dx account login --code <CODE>` (email method) redeems one; omit the option to recover an existing account.
+
+`LoginRequest` gains an optional `code` field, sent on both the identity probe and the retry that redeems it.

--- a/.changeset/cli-account-login-code.md
+++ b/.changeset/cli-account-login-code.md
@@ -1,0 +1,6 @@
+---
+'@dxos/protocols': minor
+'@dxos/plugin-client': minor
+---
+
+`dx account login` accepts an invitation code: `--code <CODE>` (email method). The hub no longer exempts any address from its invitation gate, so a code is now the only way to create an account from the CLI; omit the option to recover an existing one. `LoginRequest` gains an optional `code` field, sent on both the identity probe and the retry that redeems it.

--- a/packages/core/mesh/edge-client/src/hub-http-client.ts
+++ b/packages/core/mesh/edge-client/src/hub-http-client.ts
@@ -75,9 +75,11 @@ export class HubHttpClient extends BaseHttpClient {
   }
 
   /**
-   * Existing-account email login. Server inlines `token` for test emails; regular
-   * emails are delivered out-of-band. Response is identical for unknown emails
-   * (enumeration-safe).
+   * Email login. Without `code` this recovers an existing account: the link is delivered out of
+   * band, so the response carries no token. With `code` it redeems an invitation and creates the
+   * account, answering `needsIdentity` until an `identityDid` is supplied.
+   *
+   * Enumeration-safe: the response is identical for unknown emails and for invalid codes.
    */
   public async login(ctx: Context, body: LoginRequest, args?: EdgeHttpCallArgs): Promise<LoginResponse> {
     return this._call(ctx, new URL('/account/login', this.baseUrl), { ...args, body, method: 'POST' });

--- a/packages/core/protocols/src/edge/edge.ts
+++ b/packages/core/protocols/src/edge/edge.ts
@@ -708,13 +708,21 @@ export type ValidateInvitationCodeRequest = Schema.Schema.Type<typeof ValidateIn
 export type ValidateInvitationCodeResponse = { valid: boolean };
 
 /**
- * Body of `POST /account/login`. Existing-account email recovery only --
- * unlike `/account/signup`, this never creates new identities or waitlist rows.
+ * Body of `POST /account/login`.
+ *
+ * Two shapes:
+ * - **Recovery** (no `code`): an existing account gets a magic link by email. Never creates
+ *   identities or waitlist rows.
+ * - **Redemption** (`code` + `identityDid`): redeems an invitation code and creates the account.
+ *   The hub replies `{ needsIdentity: true }` when a code arrives without an identity, so the
+ *   caller can create one locally and retry -- the same handshake the recovery path uses.
  */
 export const LoginRequestSchema = Schema.Struct({
   email: Schema.String,
   identityDid: Schema.optional(Schema.String),
   identityKey: Schema.optional(Schema.String),
+  /** Invitation code. When present, this is a redemption rather than a recovery. */
+  code: Schema.optional(Schema.String),
 });
 export type LoginRequest = Schema.Schema.Type<typeof LoginRequestSchema>;
 

--- a/packages/plugins/plugin-client/src/commands/account/index.ts
+++ b/packages/plugins/plugin-client/src/commands/account/index.ts
@@ -4,10 +4,11 @@
 
 import * as Command from '@effect/cli/Command';
 
+import { invitation } from './invitation';
 import { login } from './login';
 import { logout } from './logout';
 
 export const account: Command.Command<any, any, any, any> = Command.make('account').pipe(
-  Command.withDescription('Log in and out of a DXOS identity.'),
-  Command.withSubcommands([login, logout]),
+  Command.withDescription('Log in and out of a DXOS identity, and issue invitation codes.'),
+  Command.withSubcommands([login, logout, invitation]),
 );

--- a/packages/plugins/plugin-client/src/commands/account/invitation/create/create.ts
+++ b/packages/plugins/plugin-client/src/commands/account/invitation/create/create.ts
@@ -1,0 +1,48 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Command from '@effect/cli/Command';
+import * as Console from 'effect/Console';
+import * as Effect from 'effect/Effect';
+
+import { CommandConfig } from '@dxos/cli-util';
+import { ClientService } from '@dxos/client';
+import { createEdgeIdentity } from '@dxos/client/edge';
+import { Context as DxContext } from '@dxos/context';
+import { HubHttpClient } from '@dxos/edge-client';
+import { invariant } from '@dxos/invariant';
+
+export const handler = Effect.fn(function* () {
+  const { json } = yield* CommandConfig;
+  const client = yield* ClientService;
+  const hubUrl = client.config.values?.runtime?.app?.env?.DX_HUB_URL;
+  invariant(hubUrl, 'Hub URL not configured (runtime.app.env.DX_HUB_URL).');
+  // `client.initialize()` is forked off startup, and `client.halo` throws until it lands.
+  yield* Effect.tryPromise(() => client.waitUntilInitialized());
+  invariant(client.halo.identity.get(), 'Not logged in. Run `dx account login` first.');
+
+  // Codes are issued against the caller's own account quota, so the request has to be
+  // authenticated -- the hub answers an unidentified client with a challenge it cannot sign.
+  const hub = new HubHttpClient(hubUrl);
+  hub.setIdentity(createEdgeIdentity(client));
+
+  const { code } = yield* Effect.tryPromise({
+    try: () => hub.issueAccountInvitation(DxContext.default()),
+    catch: (cause) =>
+      new Error(
+        `Could not issue an invitation code (${cause instanceof Error ? cause.message : String(cause)}). ` +
+          'Each account may issue a limited number of invitations, so an exhausted quota fails here too.',
+      ),
+  });
+
+  if (json) {
+    yield* Console.log(JSON.stringify({ code }, null, 2));
+  } else {
+    yield* Console.log(code);
+  }
+});
+
+export const create = Command.make('create', {}, handler).pipe(
+  Command.withDescription('Issue an invitation code, redeemable once with `dx account login --code <CODE>`.'),
+);

--- a/packages/plugins/plugin-client/src/commands/account/invitation/create/index.ts
+++ b/packages/plugins/plugin-client/src/commands/account/invitation/create/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './create';

--- a/packages/plugins/plugin-client/src/commands/account/invitation/index.ts
+++ b/packages/plugins/plugin-client/src/commands/account/invitation/index.ts
@@ -6,7 +6,7 @@ import * as Command from '@effect/cli/Command';
 
 import { create } from './create';
 
-export const invitation: Command.Command<any, any, any, any> = Command.make('invitation').pipe(
+export const invitation = Command.make('invitation').pipe(
   Command.withDescription('Manage account invitation codes.'),
   Command.withSubcommands([create]),
 );

--- a/packages/plugins/plugin-client/src/commands/account/invitation/index.ts
+++ b/packages/plugins/plugin-client/src/commands/account/invitation/index.ts
@@ -1,0 +1,12 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Command from '@effect/cli/Command';
+
+import { create } from './create';
+
+export const invitation: Command.Command<any, any, any, any> = Command.make('invitation').pipe(
+  Command.withDescription('Manage account invitation codes.'),
+  Command.withSubcommands([create]),
+);

--- a/packages/plugins/plugin-client/src/commands/account/login/login.ts
+++ b/packages/plugins/plugin-client/src/commands/account/login/login.ts
@@ -57,8 +57,14 @@ export const login = Command.make(
       Args.withDescription('Method input: email address / atproto handle / invitation code / recovery code.'),
       Args.optional,
     ),
+    code: Options.text('code').pipe(
+      Options.withDescription(
+        'Invitation code (email method). Required to create a new account on a gated hub; omit to recover an existing one.',
+      ),
+      Options.optional,
+    ),
   },
-  Effect.fn(function* ({ method, input }) {
+  Effect.fn(function* ({ method, input, code }) {
     const { json } = yield* CommandConfig;
     const client = yield* ClientService;
     const manager = yield* Plugin.Service;
@@ -76,7 +82,7 @@ export const login = Command.make(
 
     const identity = yield* Match.value(resolvedMethod).pipe(
       Match.when('atproto', () => loginWithAtproto(client, resolvedInput)),
-      Match.when('email', () => loginWithEmail(client, resolvedInput, invoke)),
+      Match.when('email', () => loginWithEmail(client, resolvedInput, invoke, Option.getOrUndefined(code))),
       Match.when('recovery-code', () => loginWithRecoveryCode(client, resolvedInput)),
       Match.when('device-invitation', () => loginWithDeviceInvitation(client, resolvedInput)),
       Match.exhaustive,
@@ -124,12 +130,19 @@ const loginWithRecoveryCode = (client: Client, recoveryCode: string) =>
  * - `token`: an Account exists and the hub returned a one-time recovery token inline.
  * - neither: the link went out by email, so prompt for the token from the message.
  */
-const loginWithEmail = (client: Client, email: string, invoke: Capabilities.OperationInvoker['invoke']) =>
+const loginWithEmail = (
+  client: Client,
+  email: string,
+  invoke: Capabilities.OperationInvoker['invoke'],
+  code?: string,
+) =>
   Effect.gen(function* () {
     const hubUrl = client.config.values?.runtime?.app?.env?.DX_HUB_URL;
     invariant(hubUrl, 'Hub URL not configured (runtime.app.env.DX_HUB_URL).');
     const hub = new HubHttpClient(hubUrl);
-    const result = yield* Effect.tryPromise(() => hub.login(DxContext.default(), { email }));
+    // The code rides along on both calls: the hub answers `needsIdentity` to the first and
+    // redeems on the second, so omitting it from the retry would lose the account creation.
+    const result = yield* Effect.tryPromise(() => hub.login(DxContext.default(), { email, code }));
 
     if (result.needsIdentity) {
       // `CreateIdentity` fires `IdentityCreated`, which is what provisions the identity's spaces.
@@ -141,14 +154,19 @@ const loginWithEmail = (client: Client, email: string, invoke: Capabilities.Oper
       // the same recovery guidance.
       const notAdmitted = (detail: string) =>
         new Error(
-          `Hub did not admit ${email} (${detail}). A local identity was created and remains bound to ` +
-            'this profile; run `dx account logout` to clear it before retrying.',
+          `Hub did not admit ${email} (${detail}). ` +
+            (code
+              ? 'The invitation code may be invalid, already redeemed, or revoked. '
+              : 'A gated hub requires an invitation code — pass `--code <CODE>` to create an account. ') +
+            'A local identity was created and remains bound to this profile; run `dx account logout` ' +
+            'to clear it before retrying.',
         );
 
       const retry = yield* Effect.tryPromise({
         try: () =>
           hub.login(DxContext.default(), {
             email,
+            code,
             identityDid: identity.did,
             identityKey: identity.identityKey.toHex(),
           }),

--- a/packages/plugins/plugin-client/src/commands/account/login/login.ts
+++ b/packages/plugins/plugin-client/src/commands/account/login/login.ts
@@ -76,6 +76,12 @@ export const login = Command.make(
       ? method.value
       : yield* Prompt.select({ message: 'Choose a login method:', choices: METHOD_CHOICES }).pipe(Prompt.run);
 
+    // Only the email method redeems an invitation code; the other branches would drop it, and a
+    // login that silently ignores the code the user asked for is worse than one that refuses.
+    if (Option.isSome(code) && resolvedMethod !== 'email') {
+      return yield* Effect.fail(new Error(`\`--code\` applies to \`--method email\`, not \`${resolvedMethod}\`.`));
+    }
+
     const resolvedInput = Option.isSome(input)
       ? input.value
       : yield* Prompt.text({ message: `${INPUT_PROMPT[resolvedMethod]}:` }).pipe(Prompt.run);
@@ -150,17 +156,10 @@ const loginWithEmail = (
       const identity = client.halo.identity.get();
       invariant(identity, 'identity should exist after create');
       // The local identity outlives any failure from here on, and the `Already logged in` guard
-      // above rejects a plain retry, so a rejected request and a non-admitting response both need
-      // the same recovery guidance.
-      const notAdmitted = (detail: string) =>
-        new Error(
-          `Hub did not admit ${email} (${detail}). ` +
-            (code
-              ? 'The invitation code may be invalid, already redeemed, or revoked. '
-              : 'A gated hub requires an invitation code — pass `--code <CODE>` to create an account. ') +
-            'A local identity was created and remains bound to this profile; run `dx account logout` ' +
-            'to clear it before retrying.',
-        );
+      // above rejects a plain retry, so every failure below carries the same recovery step.
+      const recovery =
+        'A local identity was created and remains bound to this profile; run `dx account logout` ' +
+        'to clear it before retrying.';
 
       const retry = yield* Effect.tryPromise({
         try: () =>
@@ -170,10 +169,24 @@ const loginWithEmail = (
             identityDid: identity.did,
             identityKey: identity.identityKey.toHex(),
           }),
-        catch: (cause) => notAdmitted(cause instanceof Error ? cause.message : String(cause)),
+        // A rejected request says nothing about the code: blaming it during an outage would send
+        // the user hunting for a fresh code when the one they hold is fine.
+        catch: (cause) =>
+          new Error(
+            `Login request for ${email} failed (${cause instanceof Error ? cause.message : String(cause)}). ${recovery}`,
+          ),
       });
+      // A well-formed response that does not admit is the case the code explains.
       if (!retry.admitted) {
-        return yield* Effect.fail(notAdmitted('no admission granted'));
+        return yield* Effect.fail(
+          new Error(
+            `Hub did not admit ${email}. ` +
+              (code
+                ? 'The invitation code may be invalid, already redeemed, or revoked. '
+                : 'A gated hub requires an invitation code — pass `--code <CODE>` to create an account. ') +
+              recovery,
+          ),
+        );
       }
       yield* invoke(ClientOperation.CreateAgent);
       return identity;


### PR DESCRIPTION
## Why

dxos/edge removed the `test+*@dxos.org` email carve-out (dxos/edge#824), which was the CLI's **only** path to creating an account. `dx account login` never sent an invitation code, and `LoginRequestSchema` had no field to carry one — so against the current hub the `needsIdentity`/admitted handshake fails. Worse, it fails *after* creating a local identity, which the "Already logged in" guard then refuses to reuse: the user has to run `dx account logout` before they can retry.

Codes are now the only way in, so the CLI needs both halves of the flow: issuing a code and redeeming one.

## What

**Redeem — `dx account login --code <CODE>`**

- **`packages/core/protocols/src/edge/edge.ts`** — add optional `code` to `LoginRequestSchema`, and document the two shapes of `POST /account/login` (recovery vs. redemption).
- **`packages/plugins/plugin-client/src/commands/account/login/login.ts`** — add a `--code` option (email method), threaded into **both** `hub.login` calls. The code has to ride on both: the hub answers `needsIdentity` to the probe and only redeems on the retry, so omitting it from the retry silently loses the account creation.
- Failure messages now distinguish three cases: a transport failure reports its cause, a non-admitting response with a code blames the code, and one without a code names the missing `--code`. All three keep the logout guidance, since the local identity outlives any of them.
- `--code` is rejected for the non-email methods, which would otherwise drop it silently.
- **`packages/core/mesh/edge-client/src/hub-http-client.ts`** — refresh the stale doc comment on `HubHttpClient.login`, which still described the inline-token-for-test-emails behaviour.

**Issue — `dx account invitation create`**

New command under a new `account invitation` group. Issues a code against the caller's own account quota via the authenticated `POST /account/invitation/issue`, so an ordinary team member needs no admin key. Prints the code (or `{"code": …}` under `--json`).

It waits on `client.waitUntilInitialized()` before touching `client.halo` — initialization is forked off startup and the getter throws until it lands.

## Usage

```bash
dx account invitation create
dx -p <profile> account login --method email you@example.com --code <CODE>
```

Omit `--code` to recover an existing account (unchanged behaviour).

## Landing

**Counterpart: dxos/edge#824**, which accepts `code` on `POST /account/login` — already merged, deployed-pending. `code` is optional on the wire and the CLI option defaults to absent, so this is additive and can land independently in either order.

## Test plan

Static:

- `moon run protocols:build` then `npx tsc --noEmit -p packages/plugins/plugin-client/tsconfig.json` — clean. (The schema change is invisible to plugin-client until protocols is rebuilt; it consumes it as a built artifact.)
- `moon run protocols:lint edge-client:lint plugin-client:lint` and `oxfmt --check` — clean.

Behavioural, running the real CLI against a mock hub:

- **Code on both calls.** Probe `{"email":…,"code":"…"}` → `needsIdentity`; retry `{"email":…,"code":"…","identityDid":"did:halo:…","identityKey":"04e2…"}` → `admitted`.
- **Non-admitting response, no code** → "A gated hub requires an invitation code — pass `--code <CODE>`…".
- **Non-admitting response, with code** → "The invitation code may be invalid, already redeemed, or revoked."
- **Hub 500 on the retry** → "Login request for … failed (Hub temporarily unavailable.)" — no longer blames the code.
- **`--code` with `--method recovery-code`** → refused before dispatch.
- **`account invitation create`** → `POST /account/invitation/issue` with no auth → 401 `VerifiablePresentation challenge` → retried with a signed 2293-char presentation → code returned and printed. `--json` and the not-logged-in guard also exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `account invitation create` to issue invitation codes from the CLI.
  * Added optional invitation-code support to email login through the `--code` option.
  * Login now supports both account recovery and invitation redemption flows.
  * Improved handling of gated hubs when codes are missing, invalid, or revoked.

* **Documentation**
  * Updated login guidance to explain invitation codes, recovery behavior, and retry flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->