### PR TITLE
plugin-client: pin WebAuthn relying party to composer.space

### DIFF
--- a/.changeset/lucky-pianos-shake.md
+++ b/.changeset/lucky-pianos-shake.md
@@ -1,0 +1,6 @@
+---
+'@dxos/plugin-client': patch
+'@dxos/app-toolkit': patch
+---
+
+Pin the WebAuthn relying party to `composer.space` for deployed builds so recovery passkeys created at labs/staging are accepted by the hub. Existing passkeys created at `labs.composer.space` are orphaned and must be re-created.

--- a/packages/plugins/plugin-client/src/operations/create-passkey.ts
+++ b/packages/plugins/plugin-client/src/operations/create-passkey.ts
@@ -47,7 +47,7 @@ const handler: Operation.WithHandler<typeof CreatePasskey> = CreatePasskey.pipe(
               navigator.credentials.create({
                 publicKey: {
                   challenge: new Uint8Array(),
-                  rp: { id: location.hostname, name: 'Composer' },
+                  rp: { id: NativePasskey.getRelyingPartyId(), name: 'Composer' },
                   user: {
                     id: lookupKey.asUint8Array() as Uint8Array<ArrayBuffer>,
                     name: identity.did,

--- a/packages/plugins/plugin-client/src/operations/redeem-passkey.ts
+++ b/packages/plugins/plugin-client/src/operations/redeem-passkey.ts
@@ -52,7 +52,7 @@ const webAssertion = (challenge: string): Effect.Effect<Assertion, PasskeyDismis
         navigator.credentials.get({
           publicKey: {
             challenge: Buffer.from(challenge, 'base64'),
-            rpId: location.hostname,
+            rpId: NativePasskey.getRelyingPartyId(),
             userVerification: 'required',
           },
         }),

--- a/packages/sdk/app-toolkit/src/app/NativePasskey.test.ts
+++ b/packages/sdk/app-toolkit/src/app/NativePasskey.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
-import { describe, test } from 'vitest';
+import { afterEach, describe, test, vi } from 'vitest';
 
 import * as NativePasskey from './NativePasskey';
 
@@ -119,6 +119,23 @@ const concat = (...arrays: Uint8Array[]): Uint8Array => {
   }
   return result;
 };
+
+describe('getRelyingPartyId', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test.for([
+    ['composer.space', 'composer.space'],
+    ['labs.composer.space', 'composer.space'],
+    ['staging.composer.space', 'composer.space'],
+    ['localhost', 'localhost'],
+    ['dxos-composer.netlify.app', 'dxos-composer.netlify.app'],
+  ])('%s -> %s', ([hostname, expected], { expect }) => {
+    vi.stubGlobal('location', { hostname });
+    expect(NativePasskey.getRelyingPartyId()).toBe(expected);
+  });
+});
 
 describe('extractPublicKeyFromAttestation', () => {
   test('extracts ES256 public key from attestation object', ({ expect }) => {

--- a/packages/sdk/app-toolkit/src/app/NativePasskey.test.ts
+++ b/packages/sdk/app-toolkit/src/app/NativePasskey.test.ts
@@ -135,6 +135,11 @@ describe('getRelyingPartyId', () => {
     vi.stubGlobal('location', { hostname });
     expect(NativePasskey.getRelyingPartyId()).toBe(expected);
   });
+
+  test('falls back to the app domain outside a browser', ({ expect }) => {
+    vi.stubGlobal('location', undefined);
+    expect(NativePasskey.getRelyingPartyId()).toBe(NativePasskey.APP_DOMAIN);
+  });
 });
 
 describe('extractPublicKeyFromAttestation', () => {

--- a/packages/sdk/app-toolkit/src/app/NativePasskey.ts
+++ b/packages/sdk/app-toolkit/src/app/NativePasskey.ts
@@ -41,6 +41,17 @@ export type NativePasskeyLoginResult = {
 /** Domain for the Composer app (used for passkey RP ID, app links, and share links). */
 export const APP_DOMAIN = 'composer.space';
 
+/**
+ * WebAuthn relying party id for the current page.
+ * Deployments under `composer.space` (labs, staging) must pin the apex domain: the hub verifies
+ * assertions against it, and the rpId is baked into the credential at creation. Local development
+ * falls back to the page host, since `composer.space` is not a valid rp id there.
+ */
+export const getRelyingPartyId = (): string => {
+  const hostname = globalThis.location?.hostname ?? APP_DOMAIN;
+  return hostname === APP_DOMAIN || hostname.endsWith(`.${APP_DOMAIN}`) ? APP_DOMAIN : hostname;
+};
+
 /** Normalize URL-safe base64 to standard base64 and decode to bytes. */
 export const decodeUrlSafeBase64 = (encoded: string): Uint8Array => {
   const b64 = encoded.replace(/-/g, '+').replace(/_/g, '/');


### PR DESCRIPTION
## Problem

Recovery-passkey creation passed `rp: { id: location.hostname }`, so a passkey created at `labs.composer.space` is bound to the rpId `labs.composer.space`. The hub (`packages/services/hub-service` in dxos/edge) verifies assertions with `DX_WEBAUTHN_RP_ID="composer.space"` in every deployed environment, and `https://composer.space/.well-known/webauthn` pins the allowed origins. A labs-created passkey therefore can never satisfy the hub: MCP authorization (`auth.dxos.network/auth/mcp`) and the account profile (`account.composer.space/profile`) both reject it, and credential providers such as 1Password never offer it on those origins.

Confirmed empirically: a passkey created at `labs.composer.space` is not offered at `composer.space`.

## Change

New `getRelyingPartyId()` in `@dxos/app-toolkit/NativePasskey`, next to the existing `APP_DOMAIN` constant the native (Tauri) path already pins:

- host is `composer.space` or any subdomain (`labs.`, `staging.`) → `composer.space`. It is a registrable-domain suffix of both, so one credential works across all three deployments and matches what the hub already expects.
- anything else (`localhost`, netlify previews) → the page host, since `composer.space` is not a valid rp id there and local dev must keep working.

Applied to both sides so they stay in sync:

- `create-passkey.ts` — `rp: { id: getRelyingPartyId(), name: 'Composer' }`
- `redeem-passkey.ts` — `rpId: getRelyingPartyId()` (without this, the assertion at labs would still scope to the labs hostname and never find the new credential)

Unchanged, deliberately: the WebAuthn `user.id` is still the identity's `lookupKey`, and `residentKey: 'required'` remains — the hub resolves the credential by `userHandle` via `AGENTS_SERVICE.getRecoveryInformation`, and discoverable login depends on it.

## ⚠️ Breaking for existing passkeys

Passkeys already created at `labs.composer.space` are **orphaned** by this change and must be re-created. There is no migration path — the rpId is baked into the credential at creation time.

## Testing

- Five table-driven cases for `getRelyingPartyId` in `NativePasskey.test.ts`; `moon run app-toolkit:test` → 9 passed.
- `plugin-client:build` and lint clean; `pnpm format` run.
- **Not yet run:** the end-to-end check needs a deployed build of this branch and a real authenticator — create a recovery passkey from `labs.composer.space`, then sign in at https://account.composer.space/profile. The passkey should be offered directly by the platform or password-manager authenticator, with no QR / cross-device fallback.

Reviewer note: `https://composer.space/.well-known/webauthn` must list the labs and staging origins, or the browser will reject `rp.id: composer.space` from those pages at *creation* time with a `SecurityError`. Worth confirming before the e2e test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAuthn passkey compatibility across deployed Composer environments by using a consistent relying-party domain.
  * Passkey requests now work correctly across supported Composer subdomains and custom hostnames.
  * Added fallback handling when the current hostname is unavailable.

* **Important Note**
  * Existing passkeys created on `labs.composer.space` must be recreated after upgrading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->