### PR TITLE
plugin-client: label, distinguish, and revoke recovery credentials

### DIFF
--- a/.changeset/revoke-recovery-credentials.md
+++ b/.changeset/revoke-recovery-credentials.md
@@ -1,0 +1,15 @@
+---
+'@dxos/protocols': minor
+'@dxos/client-services': minor
+'@dxos/halo': minor
+'@dxos/halo-adapter-client': minor
+'@dxos/plugin-client': minor
+---
+
+Recovery credentials can be labelled, told apart by kind, and revoked from Composer.
+
+`dxos.halo.credentials.IdentityRecovery` gains `label` and `kind` (`PASSKEY`, `RECOVERY_CODE`, `OAUTH`), so a management surface can distinguish a passkey from a recovery code rather than showing a column of identical dates. Both are set at creation: the passkey flow derives a default label from the platform, the recovery-code flow labels itself.
+
+A new `dxos.halo.credentials.IdentityRecoveryRevoked` assertion cancels a recovery credential. It is written to the identity's own control feed, mirroring how `SpaceDeleted` tombstones a space — the feed is append-only, so the original credential stays and the revocation marks it spent, and it replicates to the user's other devices. `IdentityService.revokeRecoveryCredential` writes it and refuses the last un-revoked credential.
+
+`Identity.Credential` gains an optional `recovery` field (`lookupKey`, `label`, `kind`, `revoked`) so consumers of the public HALO view can render and revoke without reaching into protobuf assertions.

--- a/.changeset/revoke-recovery-credentials.md
+++ b/.changeset/revoke-recovery-credentials.md
@@ -1,8 +1,5 @@
 ---
 '@dxos/protocols': minor
-'@dxos/client-services': minor
-'@dxos/halo': minor
-'@dxos/halo-adapter-client': minor
 '@dxos/plugin-client': minor
 ---
 

--- a/packages/core/halo/halo-adapter-client/package.json
+++ b/packages/core/halo/halo-adapter-client/package.json
@@ -26,6 +26,7 @@
     "@dxos/halo": "workspace:*",
     "@dxos/keys": "workspace:*",
     "@dxos/protocols": "workspace:*",
+    "@dxos/util": "workspace:*",
     "effect": "catalog:"
   },
   "publishConfig": {

--- a/packages/core/halo/halo-adapter-client/src/identity.ts
+++ b/packages/core/halo/halo-adapter-client/src/identity.ts
@@ -11,13 +11,15 @@ import * as Stream from 'effect/Stream';
 import { type Client } from '@dxos/client';
 import { InvitationEncoder } from '@dxos/client/invitations';
 import { Identity as HaloIdentity, IdentityError } from '@dxos/halo';
-import { IdentityDid } from '@dxos/keys';
+import { IdentityDid, PublicKey } from '@dxos/keys';
+import { type TypedMessage } from '@dxos/protocols/proto';
 import {
   type Device as ClientDevice,
   type Identity as ClientIdentity,
   DeviceKind,
 } from '@dxos/protocols/proto/dxos/client/services';
-import { type Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
+import { type Credential, IdentityRecovery } from '@dxos/protocols/proto/dxos/halo/credentials';
+import { ComplexSet } from '@dxos/util';
 
 import { makeFlow, streamFromClientObservable, toShareOptions } from './util';
 
@@ -34,11 +36,46 @@ const toDeviceInfo = (device: ClientDevice): HaloIdentity.DeviceInfo => ({
   current: device.kind === DeviceKind.CURRENT,
 });
 
-const toCredential = (credential: Credential): HaloIdentity.Credential => ({
-  id: credential.id?.toHex(),
-  type: credential.subject.assertion['@type'],
-  issuanceDate: credential.issuanceDate,
-});
+const RECOVERY_KINDS: Record<IdentityRecovery.Kind, HaloIdentity.RecoveryKind> = {
+  [IdentityRecovery.Kind.UNKNOWN]: 'unknown',
+  [IdentityRecovery.Kind.PASSKEY]: 'passkey',
+  [IdentityRecovery.Kind.RECOVERY_CODE]: 'recovery-code',
+  [IdentityRecovery.Kind.OAUTH]: 'oauth',
+};
+
+const toCredential = (credential: Credential, revoked: ComplexSet<PublicKey>): HaloIdentity.Credential => {
+  // Annotated because the protobuf `Any` decodes untyped, which defeats narrowing on `@type`.
+  const assertion: TypedMessage = credential.subject.assertion;
+  return {
+    id: credential.id?.toHex(),
+    type: assertion['@type'],
+    issuanceDate: credential.issuanceDate,
+    recovery:
+      assertion['@type'] === 'dxos.halo.credentials.IdentityRecovery'
+        ? {
+            lookupKey: assertion.lookupKey?.toHex(),
+            label: assertion.label,
+            kind: RECOVERY_KINDS[assertion.kind ?? IdentityRecovery.Kind.UNKNOWN],
+            revoked: !!assertion.lookupKey && revoked.has(assertion.lookupKey),
+          }
+        : undefined,
+  };
+};
+
+/**
+ * Lookup keys cancelled by an `IdentityRecoveryRevoked` assertion. Collected over the whole feed
+ * before mapping, since a revocation is always written after the credential it cancels.
+ */
+const collectRevoked = (credentials: readonly Credential[]): ComplexSet<PublicKey> => {
+  const revoked = new ComplexSet<PublicKey>(PublicKey.hash);
+  for (const credential of credentials) {
+    const assertion: TypedMessage = credential.subject.assertion;
+    if (assertion['@type'] === 'dxos.halo.credentials.IdentityRecoveryRevoked') {
+      revoked.add(assertion.lookupKey);
+    }
+  }
+  return revoked;
+};
 
 /**
  * Builds the {@link HaloIdentity.Service} implementation over a client's `halo` proxy.
@@ -112,7 +149,10 @@ export const makeIdentityService = (client: Client): Context.Tag.Service<HaloIde
   getDevicesSnapshot: () => (client.initialized ? client.halo.devices.get().map(toDeviceInfo) : []),
 
   credentials: streamFromClientObservable(client, () => client.halo.credentials).pipe(
-    Stream.map((credentials) => credentials.map(toCredential)),
+    Stream.map((credentials) => {
+      const revoked = collectRevoked(credentials);
+      return credentials.map((credential) => toCredential(credential, revoked));
+    }),
   ),
 
   grantServiceAccess: (options) =>

--- a/packages/core/halo/halo-adapter-client/tsconfig.json
+++ b/packages/core/halo/halo-adapter-client/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../../../common/keys"
     },
     {
+      "path": "../../../common/util"
+    },
+    {
       "path": "../../../sdk/client"
     },
     {

--- a/packages/core/halo/halo/src/Identity.ts
+++ b/packages/core/halo/halo/src/Identity.ts
@@ -51,6 +51,26 @@ export const DeviceInfo = Schema.Struct({
 });
 export type DeviceInfo = typeof DeviceInfo.Type;
 
+/** How a recovery key is held. Mirrors `dxos.halo.credentials.IdentityRecovery.Kind`. */
+export const RecoveryKind = Schema.Literal('passkey', 'recovery-code', 'oauth', 'unknown');
+export type RecoveryKind = typeof RecoveryKind.Type;
+
+/**
+ * Recovery-specific detail, present only on credentials whose `type` is
+ * `dxos.halo.credentials.IdentityRecovery`. Surfaced because a management UI cannot otherwise tell
+ * two recovery credentials apart, nor know which of them is still usable.
+ */
+export const RecoveryInfo = Schema.Struct({
+  /** Hex-encoded lookup key — the public handle used to revoke this credential. */
+  lookupKey: Schema.optional(Schema.String),
+  /** User-visible name assigned at creation. */
+  label: Schema.optional(Schema.String),
+  kind: RecoveryKind,
+  /** Whether an `IdentityRecoveryRevoked` assertion cancels this credential. */
+  revoked: Schema.Boolean,
+});
+export type RecoveryInfo = typeof RecoveryInfo.Type;
+
 /**
  * Public view of a HALO credential. Replaces direct consumption of the protobuf `Credential`:
  * `type` is the subject assertion's `@type`, `id` its hex-encoded credential id.
@@ -61,6 +81,7 @@ export const Credential = Schema.Struct({
   /** The subject assertion's `@type` (e.g. `dxos.halo.credentials.IdentityRecovery`). */
   type: Schema.String,
   issuanceDate: Schema.optional(Schema.DateFromSelf),
+  recovery: Schema.optional(RecoveryInfo),
 });
 export type Credential = typeof Credential.Type;
 

--- a/packages/core/protocols/src/IdentityService.ts
+++ b/packages/core/protocols/src/IdentityService.ts
@@ -8,6 +8,7 @@ import * as RpcGroup from '@effect/rpc/RpcGroup';
 import * as Context from 'effect/Context';
 import * as Schema from 'effect/Schema';
 
+import { IdentityRecovery } from './proto/gen/dxos/halo/credentials.ts';
 import { protoMessage, serviceError } from './service-rpc.ts';
 import { publicKey } from './service-schemas.ts';
 
@@ -41,8 +42,24 @@ export const RecoveryCredentialData = Schema.Struct({
    * Algorithm used to generate the recovery key.
    */
   algorithm: Schema.String,
+  /**
+   * User-visible name, so one credential can be told from another when revoking.
+   */
+  label: Schema.optional(Schema.String),
+  /**
+   * How the recovery key is held.
+   */
+  kind: Schema.optional(Schema.Enums(IdentityRecovery.Kind)),
 });
 export interface RecoveryCredentialData extends Schema.Schema.Type<typeof RecoveryCredentialData> {}
+
+export const RevokeRecoveryCredentialRequest = Schema.Struct({
+  /**
+   * Lookup key of the credential to revoke.
+   */
+  lookupKey: publicKey,
+});
+export interface RevokeRecoveryCredentialRequest extends Schema.Schema.Type<typeof RevokeRecoveryCredentialRequest> {}
 
 export const CreateRecoveryCredentialRequest = Schema.Struct({
   /**
@@ -91,6 +108,11 @@ export class Rpcs extends RpcGroup.make(
   Rpc.make('createRecoveryCredential', {
     payload: CreateRecoveryCredentialRequest,
     success: CreateRecoveryCredentialResponse,
+    error: serviceError,
+  }),
+  Rpc.make('revokeRecoveryCredential', {
+    payload: RevokeRecoveryCredentialRequest,
+    success: Schema.Void,
     error: serviceError,
   }),
   Rpc.make('queryIdentity', {

--- a/packages/core/protocols/src/proto/dxos/client/services.proto
+++ b/packages/core/protocols/src/proto/dxos/client/services.proto
@@ -161,6 +161,12 @@ message RecoveryCredentialData {
 
   /// Algorithm used to generate the recovery key.
   string algorithm = 3;
+
+  /// User-visible name, without which credentials are told apart only by issuance date.
+  optional string label = 4;
+
+  /// How the recovery key is held.
+  optional dxos.halo.credentials.IdentityRecovery.Kind kind = 5;
 }
 
 message CreateRecoveryCredentialRequest {
@@ -170,6 +176,11 @@ message CreateRecoveryCredentialRequest {
 
 message CreateRecoveryCredentialResponse {
   optional string recovery_code = 1;
+}
+
+message RevokeRecoveryCredentialRequest {
+  /// Lookup key of the credential to revoke.
+  dxos.keys.PublicKey lookup_key = 1;
 }
 
 message QueryIdentityResponse {
@@ -194,6 +205,7 @@ service IdentityService {
   rpc RequestRecoveryChallenge(google.protobuf.Empty) returns (RequestRecoveryChallengeResponse);
   rpc RecoverIdentity(RecoverIdentityRequest) returns (Identity);
   rpc CreateRecoveryCredential(CreateRecoveryCredentialRequest) returns (CreateRecoveryCredentialResponse);
+  rpc RevokeRecoveryCredential(RevokeRecoveryCredentialRequest) returns (google.protobuf.Empty);
   rpc QueryIdentity(google.protobuf.Empty) returns (stream QueryIdentityResponse);
   rpc UpdateProfile(halo.credentials.ProfileDocument) returns (Identity);
   rpc SignPresentation(SignPresentationRequest) returns (dxos.halo.credentials.Presentation);

--- a/packages/core/protocols/src/proto/dxos/halo/credentials.proto
+++ b/packages/core/protocols/src/proto/dxos/halo/credentials.proto
@@ -157,6 +157,18 @@ message HaloSpace {
 
 /// [ASSERTION]: Grants recovery permissions to a recovery key.
 message IdentityRecovery {
+  /// How the recovery key is held. Determines how it is presented and how it is redeemed.
+  enum Kind {
+    /// Written before this field existed; infer from `algorithm` and treat as unlabelled.
+    UNKNOWN = 0;
+    /// WebAuthn passkey held by an authenticator (password manager, platform keychain, security key).
+    PASSKEY = 1;
+    /// Seed-phrase recovery code held by the user.
+    RECOVERY_CODE = 2;
+    /// Recovery delegated to an OAuth provider.
+    OAUTH = 3;
+  }
+
   dxos.keys.PublicKey identity_key = 1;
   /// Public key derived from the recovery seedphrase.
   dxos.keys.PublicKey recovery_key = 2;
@@ -164,6 +176,22 @@ message IdentityRecovery {
   optional string algorithm = 3;
   /// Public key used to identify the recovery key (e.g., passkey user handle).
   optional dxos.keys.PublicKey lookup_key = 4;
+  /// User-visible name, without which credentials are told apart only by issuance date.
+  optional string label = 5;
+  /// How the recovery key is held.
+  optional Kind kind = 6;
+}
+
+// [ASSERTION]: A recovery credential has been revoked by its holder.
+// Written to the identity's HALO so the revocation replicates across the user's devices, mirroring
+// SpaceDeleted. The control feed is append-only, so the IdentityRecovery credential itself stays;
+// this assertion is what marks it spent. The authoritative refusal is still the agents service
+// moving the row to REVOKED — this credential is what tells it to.
+message IdentityRecoveryRevoked {
+  dxos.keys.PublicKey identity_key = 1;
+  /// Lookup key of the revoked recovery credential.
+  dxos.keys.PublicKey lookup_key = 2;
+  google.protobuf.Timestamp revoked_at = 3;
 }
 
 message ProfileDocument {

--- a/packages/plugins/plugin-client/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-client/src/capabilities/app-graph-builder.ts
@@ -87,6 +87,15 @@ export default Capability.makeModule(
                   },
                 }),
                 Node.make({
+                  id: Account.Security,
+                  data: Account.Security,
+                  type: meta.profile.key,
+                  properties: {
+                    label: ['security.label', { ns: meta.profile.key }],
+                    icon: 'ph--key--regular',
+                  },
+                }),
+                Node.make({
                   id: Account.Devices,
                   data: Account.Devices,
                   type: meta.profile.key,
@@ -94,15 +103,6 @@ export default Capability.makeModule(
                     label: ['devices.label', { ns: meta.profile.key }],
                     icon: 'ph--devices--regular',
                     testId: 'clientPlugin.devices',
-                  },
-                }),
-                Node.make({
-                  id: Account.Security,
-                  data: Account.Security,
-                  type: meta.profile.key,
-                  properties: {
-                    label: ['security.label', { ns: meta.profile.key }],
-                    icon: 'ph--key--regular',
                   },
                 }),
                 Node.make({

--- a/packages/plugins/plugin-client/src/constants.ts
+++ b/packages/plugins/plugin-client/src/constants.ts
@@ -9,3 +9,12 @@ import { meta } from '#meta';
 export const JOIN_DIALOG = DXN.make(`${meta.profile.key}.joinDialog`);
 export const RECOVERY_CODE_DIALOG = DXN.make(`${meta.profile.key}.recoveryCodeDialog`);
 export const RESET_DIALOG = DXN.make(`${meta.profile.key}.resetDialog`);
+
+/**
+ * Account profile page, where passkeys are revoked and the account is managed.
+ *
+ * Hub-service serves it from a `composer.space` subdomain rather than `hub.dxos.network` so that
+ * passkeys created here — bound to the `composer.space` relying party — can be asserted there.
+ * Overridable per deployment via the `DX_ACCOUNT_URL` build environment variable.
+ */
+export const ACCOUNT_PROFILE_URL = 'https://account.composer.space/profile';

--- a/packages/plugins/plugin-client/src/containers/AccountContainer/AccountContainer.stories.tsx
+++ b/packages/plugins/plugin-client/src/containers/AccountContainer/AccountContainer.stories.tsx
@@ -4,35 +4,58 @@
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import * as Effect from 'effect/Effect';
+import { expect, waitFor, within } from 'storybook/test';
 
 import { ProcessManagerPlugin } from '@dxos/app-framework';
+import * as Capability from '@dxos/app-framework/Capability';
 import { withPluginManager } from '@dxos/app-framework/testing';
+import { HubHttpClient } from '@dxos/edge-client';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 
 import { initializeIdentity } from '#testing';
 import { translations } from '#translations';
 
 import { ClientPlugin } from '../../ClientPlugin';
+import * as ClientCapabilities from '../../types/ClientCapabilities';
 import { AccountContainer } from './AccountContainer';
+
+/**
+ * A `HubHttpClient` whose account lookup is answered locally. Constructed for real and overridden
+ * per method — a partial stand-in would need a cast, and `setIdentity` (called by the hook on every
+ * identity change) has to keep working.
+ */
+const stubHubHttpClient = (account: { email: string; emailVerified: boolean }) => {
+  const client = new HubHttpClient('https://hub.test');
+  client.getAccount = async () => ({
+    identityDid: 'did:key:test',
+    email: account.email,
+    emailVerified: account.emailVerified,
+    createdAt: new Date(0).toISOString(),
+    invitationsRemaining: 2,
+  });
+  return client;
+};
+
+const decorators = (hub?: HubHttpClient) => [
+  withTheme(),
+  withLayout({ layout: 'fullscreen' }),
+  withPluginManager({
+    plugins: [
+      ClientPlugin({
+        onClientInitialized: ({ client }) =>
+          Effect.gen(function* () {
+            yield* initializeIdentity(client);
+          }),
+      }),
+      ProcessManagerPlugin(),
+    ],
+    capabilities: hub ? [Capability.contribute(ClientCapabilities.HubHttpClient, hub)] : [],
+  }),
+];
 
 const meta = {
   title: 'plugins/plugin-client/containers/AccountContainer',
   component: AccountContainer,
-  decorators: [
-    withTheme(),
-    withLayout({ layout: 'fullscreen' }),
-    withPluginManager({
-      plugins: [
-        ClientPlugin({
-          onClientInitialized: ({ client }) =>
-            Effect.gen(function* () {
-              yield* initializeIdentity(client);
-            }),
-        }),
-        ProcessManagerPlugin(),
-      ],
-    }),
-  ],
   parameters: {
     layout: 'fullscreen',
     translations,
@@ -43,4 +66,32 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+/** No hub client configured, so the container reports that the identity has no edge access. */
+export const Default: Story = {
+  decorators: decorators(),
+};
+
+/** The signed-in branch, which is the only one that reaches the account-page section. */
+export const WithAccount: Story = {
+  decorators: decorators(stubHubHttpClient({ email: 'someone@example.com', emailVerified: true })),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(async () => expect(canvas.getByText('someone@example.com')).toBeInTheDocument(), { timeout: 20_000 });
+    await expect(canvas.getByRole('button', { name: 'Open account page' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Delete account' })).toBeInTheDocument();
+  },
+};
+
+/** An unverified email offers the resend action instead of the verified check. */
+export const UnverifiedEmail: Story = {
+  decorators: decorators(stubHubHttpClient({ email: 'unverified@example.com', emailVerified: false })),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(
+      async () => expect(canvas.getByRole('button', { name: 'Resend verification email' })).toBeInTheDocument(),
+      {
+        timeout: 20_000,
+      },
+    );
+  },
+};

--- a/packages/plugins/plugin-client/src/containers/AccountContainer/AccountContainer.tsx
+++ b/packages/plugins/plugin-client/src/containers/AccountContainer/AccountContainer.tsx
@@ -15,7 +15,7 @@ import { Form } from '@dxos/react-ui-form';
 import { meta } from '#meta';
 
 import { RESET_DIALOG } from '../../constants';
-import { useHubHttpClient } from '../../hooks';
+import { useAccountUrl, useHubHttpClient } from '../../hooks';
 import * as ClientCapabilities from '../../types/ClientCapabilities';
 
 type AccountState = 'loading' | 'present' | 'missing' | 'error';
@@ -35,6 +35,7 @@ export const AccountContainer = () => {
   // Single shared instance keeps the VP-auth handshake (request → 401 → signed
   // retry) at one round-trip per session instead of one per panel.
   const hubHttp = useHubHttpClient();
+  const { openAccountPage } = useAccountUrl();
 
   useAsyncEffect(async () => {
     if (!hubHttp) {
@@ -179,6 +180,18 @@ export const AccountContainer = () => {
               </>
             ) : null}
           </Form.Section>
+          {account ? (
+            <Form.Section title={t('account-page-section.title')} description={t('account-page-section.description')}>
+              <Form.Row label={t('open-account-page.label')} description={t('open-account-page.description')}>
+                <IconButton
+                  icon='ph--arrow-square-out--regular'
+                  label={t('open-account-page.label')}
+                  variant='default'
+                  onClick={openAccountPage}
+                />
+              </Form.Row>
+            </Form.Section>
+          ) : null}
         </Form.Content>
       </Form.Viewport>
     </Form.Root>

--- a/packages/plugins/plugin-client/src/containers/RecoveryCredentialsContainer/RecoveryCredentialsContainer.stories.tsx
+++ b/packages/plugins/plugin-client/src/containers/RecoveryCredentialsContainer/RecoveryCredentialsContainer.stories.tsx
@@ -4,9 +4,13 @@
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import * as Effect from 'effect/Effect';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { ProcessManagerPlugin } from '@dxos/app-framework';
 import { withPluginManager } from '@dxos/app-framework/testing';
+import { type Client, PublicKey } from '@dxos/client';
+import { invariant } from '@dxos/invariant';
+import { IdentityRecovery } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 
 import { initializeIdentity } from '#testing';
@@ -15,24 +19,52 @@ import { translations } from '#translations';
 import { ClientPlugin } from '../../ClientPlugin';
 import { RecoveryCredentialsContainer } from './RecoveryCredentialsContainer';
 
+type SeedCredential = { label: string; kind: IdentityRecovery.Kind; algorithm: string };
+
+/**
+ * Writes recovery credentials straight through `IdentityService` rather than clicking the create
+ * buttons: the create operations finish by opening a dialog, and no layout plugin is mounted here.
+ */
+const seedCredentials = (client: Client, credentials: SeedCredential[]) =>
+  Effect.gen(function* () {
+    const identityService = client.services.services.IdentityService;
+    invariant(identityService, 'IdentityService not available');
+    for (const { label, kind, algorithm } of credentials) {
+      yield* Effect.promise(() =>
+        identityService.createRecoveryCredential({
+          data: { recoveryKey: PublicKey.random(), lookupKey: PublicKey.random(), algorithm, label, kind },
+        }),
+      );
+    }
+  });
+
+const decorators = (credentials: SeedCredential[] = []) => [
+  withTheme(),
+  withLayout({ layout: 'fullscreen' }),
+  withPluginManager({
+    plugins: [
+      ClientPlugin({
+        onClientInitialized: ({ client }) =>
+          Effect.gen(function* () {
+            yield* initializeIdentity(client);
+            yield* seedCredentials(client, credentials);
+          }),
+      }),
+      ProcessManagerPlugin(),
+    ],
+  }),
+];
+
+const PASSKEY: SeedCredential = { label: 'Laptop passkey', kind: IdentityRecovery.Kind.PASSKEY, algorithm: 'ES256' };
+const RECOVERY_CODE: SeedCredential = {
+  label: 'Backup code',
+  kind: IdentityRecovery.Kind.RECOVERY_CODE,
+  algorithm: 'ED25519',
+};
+
 const meta = {
   title: 'plugins/plugin-client/containers/RecoveryCredentialsContainer',
   component: RecoveryCredentialsContainer,
-  decorators: [
-    withTheme(),
-    withLayout({ layout: 'fullscreen' }),
-    withPluginManager({
-      plugins: [
-        ClientPlugin({
-          onClientInitialized: ({ client }) =>
-            Effect.gen(function* () {
-              yield* initializeIdentity(client);
-            }),
-        }),
-        ProcessManagerPlugin(),
-      ],
-    }),
-  ],
   parameters: {
     layout: 'fullscreen',
     translations,
@@ -43,4 +75,43 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+/** No credentials, so the container warns that the account cannot be recovered. */
+export const Default: Story = {
+  decorators: decorators(),
+};
+
+/** A single credential cannot be revoked, so no revoke action is offered. */
+export const OneCredential: Story = {
+  decorators: decorators([PASSKEY]),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(async () => expect(canvas.getByText('Laptop passkey')).toBeInTheDocument(), { timeout: 20_000 });
+    await expect(canvas.queryByRole('button', { name: 'Revoke' })).toBeNull();
+    await expect(canvas.getByText(/only way back into your account/)).toBeInTheDocument();
+  },
+};
+
+/** Revoking marks the credential spent and protects whichever one remains. */
+export const Revoke: Story = {
+  decorators: decorators([PASSKEY, RECOVERY_CODE]),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(async () => expect(canvas.getByText('Laptop passkey')).toBeInTheDocument(), { timeout: 20_000 });
+    await expect(canvas.getByText('Backup code')).toBeInTheDocument();
+    await expect(canvas.getAllByRole('button', { name: 'Revoke' })).toHaveLength(2);
+
+    // The confirmation is a native dialog, which cannot be driven from the test environment.
+    const confirm = window.confirm;
+    window.confirm = () => true;
+    try {
+      await userEvent.click(canvas.getAllByRole('button', { name: 'Revoke' })[0]);
+      // The list re-renders off the HALO credential stream, with no explicit refresh.
+      await waitFor(async () => expect(canvas.getByText('Revoked')).toBeInTheDocument(), { timeout: 10_000 });
+      // The survivor is now the only active credential, so its revoke action is withdrawn.
+      await expect(canvas.queryByRole('button', { name: 'Revoke' })).toBeNull();
+      await expect(canvas.getByText(/only way back into your account/)).toBeInTheDocument();
+    } finally {
+      window.confirm = confirm;
+    }
+  },
+};

--- a/packages/plugins/plugin-client/src/containers/RecoveryCredentialsContainer/RecoveryCredentialsContainer.tsx
+++ b/packages/plugins/plugin-client/src/containers/RecoveryCredentialsContainer/RecoveryCredentialsContainer.tsx
@@ -2,11 +2,12 @@
 // Copyright 2024 DXOS.org
 //
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { type Identity } from '@dxos/halo';
 import { useCredentials } from '@dxos/halo-react';
+import { log } from '@dxos/log';
 import { Icon, IconButton, Message, useTranslation } from '@dxos/react-ui';
 import { Form } from '@dxos/react-ui-form';
 import { Listbox } from '@dxos/react-ui-list';
@@ -34,18 +35,25 @@ export const RecoveryCredentialsContainer = () => {
     (credential) => credential.type === 'dxos.halo.credentials.IdentityRecovery',
   );
   const activeCount = recoveryCredentials.filter((credential) => !credential.recovery?.revoked).length;
+  const [revokeError, setRevokeError] = useState<string | null>(null);
 
   // The account page is where a revocation can also be confirmed with a fresh passkey assertion.
   const { openAccountPage } = useAccountUrl();
 
   const handleRevoke = useCallback(
-    async (lookupKey: string) => {
+    (lookupKey: string) => {
       // Revoking is not undoable and the passkey survives in the authenticator, so say both before
       // writing anything.
       if (!window.confirm(t('revoke-credential-confirm.message'))) {
         return;
       }
-      await invokePromise(ClientOperation.RevokeRecoveryCredential, { lookupKey });
+      setRevokeError(null);
+      // Surfaced rather than rethrown: `onClick` does not await, so an escaping rejection would only
+      // reach the console and the row would silently stay.
+      void invokePromise(ClientOperation.RevokeRecoveryCredential, { lookupKey }).catch((error) => {
+        log.warn('failed to revoke recovery credential', { error });
+        setRevokeError(t('revoke-failed.message'));
+      });
     },
     [invokePromise, t],
   );
@@ -113,6 +121,13 @@ export const RecoveryCredentialsContainer = () => {
                   })}
                 </Listbox.Content>
               </Listbox.Root>
+            )}
+            {revokeError && (
+              <Message.Root valence='error'>
+                <Message.Content>
+                  <Message.Body>{revokeError}</Message.Body>
+                </Message.Content>
+              </Message.Root>
             )}
             {activeCount === 1 && (
               <Message.Root valence='warning'>

--- a/packages/plugins/plugin-client/src/containers/RecoveryCredentialsContainer/RecoveryCredentialsContainer.tsx
+++ b/packages/plugins/plugin-client/src/containers/RecoveryCredentialsContainer/RecoveryCredentialsContainer.tsx
@@ -2,9 +2,10 @@
 // Copyright 2024 DXOS.org
 //
 
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
+import { type Identity } from '@dxos/halo';
 import { useCredentials } from '@dxos/halo-react';
 import { Icon, IconButton, Message, useTranslation } from '@dxos/react-ui';
 import { Form } from '@dxos/react-ui-form';
@@ -13,7 +14,17 @@ import { Listbox } from '@dxos/react-ui-list';
 import { meta } from '#meta';
 import { ClientOperation } from '#operations';
 
+import { useAccountUrl } from '../../hooks';
+
 export const MANAGE_CREDENTIALS_DIALOG = `${meta.profile.key}.ManageCredentialsDialog`;
+
+/** Icon per recovery kind, so a passkey is distinguishable from a recovery code at a glance. */
+const KIND_ICONS: Record<Identity.RecoveryKind, string> = {
+  'passkey': 'ph--key--regular',
+  'recovery-code': 'ph--receipt--regular',
+  'oauth': 'ph--user-circle--regular',
+  'unknown': 'ph--question--regular',
+};
 
 export const RecoveryCredentialsContainer = () => {
   const { t } = useTranslation(meta.profile.key);
@@ -21,6 +32,22 @@ export const RecoveryCredentialsContainer = () => {
   const credentials = useCredentials();
   const recoveryCredentials = credentials.filter(
     (credential) => credential.type === 'dxos.halo.credentials.IdentityRecovery',
+  );
+  const activeCount = recoveryCredentials.filter((credential) => !credential.recovery?.revoked).length;
+
+  // The account page is where a revocation can also be confirmed with a fresh passkey assertion.
+  const { openAccountPage } = useAccountUrl();
+
+  const handleRevoke = useCallback(
+    async (lookupKey: string) => {
+      // Revoking is not undoable and the passkey survives in the authenticator, so say both before
+      // writing anything.
+      if (!window.confirm(t('revoke-credential-confirm.message'))) {
+        return;
+      }
+      await invokePromise(ClientOperation.RevokeRecoveryCredential, { lookupKey });
+    },
+    [invokePromise, t],
   );
 
   return (
@@ -56,14 +83,53 @@ export const RecoveryCredentialsContainer = () => {
             ) : (
               <Listbox.Root>
                 <Listbox.Content classNames='gap-1'>
-                  {recoveryCredentials.map((credential, index) => (
-                    <Listbox.Item key={credential.id ?? index} id={credential.id ?? `${index}`} classNames='gap-2'>
-                      <Icon icon='ph--key--regular' />
-                      <Listbox.ItemLabel>{credential.issuanceDate?.toLocaleString()}</Listbox.ItemLabel>
-                    </Listbox.Item>
-                  ))}
+                  {recoveryCredentials.map((credential, index) => {
+                    const { lookupKey, label, kind = 'unknown', revoked } = credential.recovery ?? { revoked: false };
+                    return (
+                      <Listbox.Item key={credential.id ?? index} id={credential.id ?? `${index}`} classNames='gap-2'>
+                        <Icon icon={KIND_ICONS[kind]} />
+                        <Listbox.ItemLabel classNames={revoked ? 'text-subdued line-through' : undefined}>
+                          {label ?? t(`recovery-kind-${kind}.label`)}
+                        </Listbox.ItemLabel>
+                        <span className='text-description text-sm'>{credential.issuanceDate?.toLocaleString()}</span>
+                        {revoked ? (
+                          <span className='text-subdued text-sm'>{t('credential-revoked.label')}</span>
+                        ) : (
+                          // Withheld on the last one: revoking it would leave no way to recover the
+                          // identity, and there is no self-service way back.
+                          lookupKey &&
+                          activeCount > 1 && (
+                            <IconButton
+                              iconOnly
+                              label={t('revoke-credential.label')}
+                              icon='ph--trash--regular'
+                              variant='ghost'
+                              onClick={() => handleRevoke(lookupKey)}
+                            />
+                          )
+                        )}
+                      </Listbox.Item>
+                    );
+                  })}
                 </Listbox.Content>
               </Listbox.Root>
+            )}
+            {activeCount === 1 && (
+              <Message.Root valence='warning'>
+                <Message.Content>
+                  <Message.Body>{t('last-credential.message')}</Message.Body>
+                </Message.Content>
+              </Message.Root>
+            )}
+            {recoveryCredentials.length > 0 && (
+              <Form.Row label={t('manage-passkeys.label')} description={t('manage-passkeys.description')}>
+                <IconButton
+                  label={t('manage-passkeys.label')}
+                  icon='ph--arrow-square-out--regular'
+                  variant='default'
+                  onClick={openAccountPage}
+                />
+              </Form.Row>
             )}
           </Form.Section>
         </Form.Content>

--- a/packages/plugins/plugin-client/src/hooks/index.ts
+++ b/packages/plugins/plugin-client/src/hooks/index.ts
@@ -2,4 +2,5 @@
 // Copyright 2026 DXOS.org
 //
 
+export * from './useAccountUrl';
 export * from './useHubClient';

--- a/packages/plugins/plugin-client/src/hooks/useAccountUrl.ts
+++ b/packages/plugins/plugin-client/src/hooks/useAccountUrl.ts
@@ -1,0 +1,23 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { useCallback } from 'react';
+
+import { useClient } from '@dxos/react-client';
+
+import { ACCOUNT_PROFILE_URL } from '../constants';
+
+/**
+ * The account profile page and an opener for it. Served from a different origin to the app, so the
+ * window is opened with `noopener`.
+ */
+export const useAccountUrl = (): { accountUrl: string; openAccountPage: () => void } => {
+  const client = useClient();
+  const accountUrl = client.config.values?.runtime?.app?.env?.DX_ACCOUNT_URL ?? ACCOUNT_PROFILE_URL;
+  const openAccountPage = useCallback(() => {
+    window.open(accountUrl, '_blank', 'noopener');
+  }, [accountUrl]);
+
+  return { accountUrl, openAccountPage };
+};

--- a/packages/plugins/plugin-client/src/operations/create-passkey.ts
+++ b/packages/plugins/plugin-client/src/operations/create-passkey.ts
@@ -11,6 +11,7 @@ import { PublicKey } from '@dxos/client';
 import * as Operation from '@dxos/compute/Operation';
 import { invariant } from '@dxos/invariant';
 import { IdentityRecovery } from '@dxos/protocols/proto/dxos/halo/credentials';
+import { getHostPlatform } from '@dxos/util';
 
 import * as ClientCapabilities from '../types/ClientCapabilities';
 import { CreatePasskey } from './definitions';
@@ -20,8 +21,15 @@ import { CreatePasskey } from './definitions';
  * The authenticator never tells us which it is, so the platform is the only distinguishing thing
  * available at creation time; the user can rename it on the account page.
  */
+const PLATFORM_NAMES: Partial<Record<ReturnType<typeof getHostPlatform>, string>> = {
+  macos: 'macOS',
+  windows: 'Windows',
+  ios: 'iOS',
+  linux: 'Linux',
+};
+
 const defaultPasskeyLabel = (): string => {
-  const platform = NativePasskey.getPlatform();
+  const platform = PLATFORM_NAMES[getHostPlatform()];
   return platform ? `Passkey on ${platform}` : 'Passkey';
 };
 

--- a/packages/plugins/plugin-client/src/operations/create-passkey.ts
+++ b/packages/plugins/plugin-client/src/operations/create-passkey.ts
@@ -21,7 +21,7 @@ import { CreatePasskey } from './definitions';
  * available at creation time; the user can rename it on the account page.
  */
 const defaultPasskeyLabel = (): string => {
-  const platform = (navigator as any).userAgentData?.platform ?? navigator.platform;
+  const platform = NativePasskey.getPlatform();
   return platform ? `Passkey on ${platform}` : 'Passkey';
 };
 

--- a/packages/plugins/plugin-client/src/operations/create-passkey.ts
+++ b/packages/plugins/plugin-client/src/operations/create-passkey.ts
@@ -10,9 +10,20 @@ import * as NativePasskey from '@dxos/app-toolkit/NativePasskey';
 import { PublicKey } from '@dxos/client';
 import * as Operation from '@dxos/compute/Operation';
 import { invariant } from '@dxos/invariant';
+import { IdentityRecovery } from '@dxos/protocols/proto/dxos/halo/credentials';
 
 import * as ClientCapabilities from '../types/ClientCapabilities';
 import { CreatePasskey } from './definitions';
+
+/**
+ * Best-effort name for a newly created passkey, so the list is not a column of identical dates.
+ * The authenticator never tells us which it is, so the platform is the only distinguishing thing
+ * available at creation time; the user can rename it on the account page.
+ */
+const defaultPasskeyLabel = (): string => {
+  const platform = (navigator as any).userAgentData?.platform ?? navigator.platform;
+  return platform ? `Passkey on ${platform}` : 'Passkey';
+};
 
 const handler: Operation.WithHandler<typeof CreatePasskey> = CreatePasskey.pipe(
   Operation.withHandler(
@@ -80,6 +91,8 @@ const handler: Operation.WithHandler<typeof CreatePasskey> = CreatePasskey.pipe(
             recoveryKey,
             algorithm,
             lookupKey,
+            label: defaultPasskeyLabel(),
+            kind: IdentityRecovery.Kind.PASSKEY,
           },
         }),
       );

--- a/packages/plugins/plugin-client/src/operations/definitions.ts
+++ b/packages/plugins/plugin-client/src/operations/definitions.ts
@@ -117,6 +117,20 @@ export const CreatePasskey = Operation.make({
   output: Schema.Void,
 });
 
+export const RevokeRecoveryCredential = Operation.make({
+  meta: {
+    key: makeKey('revokeRecoveryCredential'),
+    name: 'Revoke Recovery Credential',
+    icon: 'ph--key--regular',
+  },
+  services: [Capability.Service],
+  input: Schema.Struct({
+    /** Lookup key of the credential to revoke, as hex. */
+    lookupKey: Schema.String,
+  }),
+  output: Schema.Void,
+});
+
 export const RedeemPasskey = Operation.make({
   meta: { key: makeKey('redeemPasskey'), name: 'Redeem Passkey', icon: 'ph--key--regular' },
   services: [Capability.Service],

--- a/packages/plugins/plugin-client/src/operations/definitions.ts
+++ b/packages/plugins/plugin-client/src/operations/definitions.ts
@@ -125,8 +125,12 @@ export const RevokeRecoveryCredential = Operation.make({
   },
   services: [Capability.Service],
   input: Schema.Struct({
-    /** Lookup key of the credential to revoke, as hex. */
-    lookupKey: Schema.String,
+    /**
+     * Lookup key of the credential to revoke, as hex. Constrained to a full key because
+     * `PublicKey.from` silently drops non-hex characters rather than rejecting them, so an
+     * unvalidated string would decode to some other key instead of failing.
+     */
+    lookupKey: Schema.String.pipe(Schema.pattern(/^[0-9a-fA-F]{64}$/)),
   }),
   output: Schema.Void,
 });

--- a/packages/plugins/plugin-client/src/operations/index.ts
+++ b/packages/plugins/plugin-client/src/operations/index.ts
@@ -8,6 +8,7 @@ import * as OperationHandlerSet from '@dxos/compute/OperationHandlerSet';
 
 import { UpdateProfile } from './definitions';
 import { ShareIdentity } from './definitions';
+import { RevokeRecoveryCredential } from './definitions';
 import { ResetStorage } from './definitions';
 import { RedeemToken } from './definitions';
 import { RedeemPasskey } from './definitions';
@@ -33,6 +34,7 @@ export const ClientOperationHandlerSet = OperationHandlerSet.lazy([
   RedeemPasskey.pipe(Operation.lazyHandler(() => import('./redeem-passkey'))),
   RedeemToken.pipe(Operation.lazyHandler(() => import('./redeem-token'))),
   ResetStorage.pipe(Operation.lazyHandler(() => import('./reset-storage'))),
+  RevokeRecoveryCredential.pipe(Operation.lazyHandler(() => import('./revoke-recovery-credential'))),
   ShareIdentity.pipe(Operation.lazyHandler(() => import('./share-identity'))),
   NavigationOperation.ResolveNavigationTargets.pipe(
     Operation.lazyHandler(() => import('./resolve-navigation-targets')),

--- a/packages/plugins/plugin-client/src/operations/revoke-recovery-credential.ts
+++ b/packages/plugins/plugin-client/src/operations/revoke-recovery-credential.ts
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Capability from '@dxos/app-framework/Capability';
+import { PublicKey } from '@dxos/client';
+import * as Operation from '@dxos/compute/Operation';
+import { invariant } from '@dxos/invariant';
+
+import * as ClientCapabilities from '../types/ClientCapabilities';
+import { RevokeRecoveryCredential } from './definitions';
+
+/**
+ * Revoke one recovery credential.
+ *
+ * The write is an `IdentityRecoveryRevoked` assertion on the identity's own control feed, so the
+ * identity key is the authorization and no identity can be passed in from the UI. Client services
+ * refuse the last un-revoked credential.
+ */
+const handler: Operation.WithHandler<typeof RevokeRecoveryCredential> = RevokeRecoveryCredential.pipe(
+  Operation.withHandler(
+    Effect.fnUntraced(function* ({ lookupKey }) {
+      const client = yield* Capability.get(ClientCapabilities.Client);
+      const identityService = client.services.services.IdentityService;
+      invariant(identityService, 'IdentityService not available');
+
+      yield* Effect.promise(() => identityService.revokeRecoveryCredential({ lookupKey: PublicKey.from(lookupKey) }));
+    }),
+  ),
+);
+
+export default handler;

--- a/packages/plugins/plugin-client/src/translations.ts
+++ b/packages/plugins/plugin-client/src/translations.ts
@@ -113,6 +113,7 @@ const pluginTranslations = [
         'recovery-kind-unknown.label': 'Recovery credential',
         'credential-revoked.label': 'Revoked',
         'revoke-credential.label': 'Revoke',
+        'revoke-failed.message': 'Could not revoke that credential. Reconnect and try again.',
         'revoke-credential-confirm.message':
           'Revoke this credential?\n\nIt will no longer be accepted for recovering your account, and this cannot be undone.\n\nThe passkey itself is not deleted — it stays in your password manager or on your device until you remove it there too.',
         'last-credential.message':

--- a/packages/plugins/plugin-client/src/translations.ts
+++ b/packages/plugins/plugin-client/src/translations.ts
@@ -72,6 +72,11 @@ const pluginTranslations = [
         'verification-sent.message': 'Verification email sent.',
         'verification-cooldown.message': 'Please wait {{seconds}}s before resending.',
         'verification-failed.message': 'Could not send verification email.',
+        'account-page-section.title': 'Account page',
+        'account-page-section.description':
+          'Operations that need proof you are present, rather than just a signed-in device: revoking a passkey, changing the registered email, and deleting the account. You will be asked for a passkey to sign in.',
+        'open-account-page.label': 'Open account page',
+        'open-account-page.description': 'Opens in a new tab.',
         'delete-account.label': 'Delete account',
         'delete-account.description':
           'Permanently delete your account and all associated data. This will sign you out of this device.',
@@ -102,6 +107,19 @@ const pluginTranslations = [
         'open-user-account.label': 'Open user account',
         'manage-credentials-dialog.title': 'Manage Account Recovery',
         'credentials-list.label': 'Recovery credentials',
+        'recovery-kind-passkey.label': 'Passkey',
+        'recovery-kind-recovery-code.label': 'Recovery code',
+        'recovery-kind-oauth.label': 'Linked account',
+        'recovery-kind-unknown.label': 'Recovery credential',
+        'credential-revoked.label': 'Revoked',
+        'revoke-credential.label': 'Revoke',
+        'revoke-credential-confirm.message':
+          'Revoke this credential?\n\nIt will no longer be accepted for recovering your account, and this cannot be undone.\n\nThe passkey itself is not deleted — it stays in your password manager or on your device until you remove it there too.',
+        'last-credential.message':
+          'This is your only way back into your account, so it cannot be revoked. Add another passkey first, then revoke this one.',
+        'manage-passkeys.label': 'Manage passkeys',
+        'manage-passkeys.description':
+          'Opens your account page, which shows when each passkey was last used and asks for a passkey to confirm before revoking. Revoking here or there only stops the server accepting the passkey — it stays in your password manager or on your device until you delete it there too.',
         'no-credentials.title': 'WARNING: There is currently no way to recover your account.',
         'no-credentials.message': 'Create a recovery credential above to secure your account.',
         'recovery-setup-dialog.title': 'Account Security',

--- a/packages/sdk/app-toolkit/src/app/NativePasskey.ts
+++ b/packages/sdk/app-toolkit/src/app/NativePasskey.ts
@@ -16,7 +16,7 @@
 //   The iOS entitlements file also needs webcredentials:composer.space and a deployment target bump to 16.0+.
 
 import { log } from '@dxos/log';
-import { isTauri } from '@dxos/util';
+import { getHostPlatform, isTauri } from '@dxos/util';
 
 /** Result from the native passkey registration command. */
 export type NativePasskeyRegistrationResult = {
@@ -67,8 +67,7 @@ export const supportsNativePasskeys = (): boolean => {
   if (!isTauri()) {
     return false;
   }
-  const platform = ((navigator as any).userAgentData?.platform || navigator.platform)?.toLowerCase();
-  return platform?.startsWith('mac') === true;
+  return getHostPlatform() === 'macos';
 };
 
 /**

--- a/packages/sdk/client-services/src/packlets/identity/identity-recovery-manager.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-recovery-manager.ts
@@ -7,6 +7,7 @@ import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as Option from 'effect/Option';
 
+import { synchronized } from '@dxos/async';
 import { type Context } from '@dxos/context';
 import { generateSeedPhrase, getCredentialAssertion, keyPairFromSeedPhrase } from '@dxos/credentials';
 import { sign } from '@dxos/crypto';
@@ -114,7 +115,13 @@ export class EdgeIdentityRecoveryManager {
    *
    * Refuses the last un-revoked credential. Doing so would leave the holder unable to recover their
    * identity with no self-service way back — the replacement has to be added first.
+   *
+   * `@synchronized` so two revocations on this device cannot both observe two active credentials and
+   * each cancel a different one. It cannot serialize across devices: the control feed is append-only
+   * with no consensus, so two devices revoking at once can still drive the count to zero. The agents
+   * service is the authority there — it re-checks the active count before flipping a row to REVOKED.
    */
+  @synchronized
   public async revokeRecoveryCredential({ lookupKey }: { lookupKey: PublicKey }): Promise<void> {
     const identity = this._identityProvider();
     invariant(identity);

--- a/packages/sdk/client-services/src/packlets/identity/identity-recovery-manager.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-recovery-manager.ts
@@ -8,7 +8,7 @@ import * as Layer from 'effect/Layer';
 import * as Option from 'effect/Option';
 
 import { type Context } from '@dxos/context';
-import { generateSeedPhrase, keyPairFromSeedPhrase } from '@dxos/credentials';
+import { generateSeedPhrase, getCredentialAssertion, keyPairFromSeedPhrase } from '@dxos/credentials';
 import { sign } from '@dxos/crypto';
 import { type EdgeHttpClient, EdgeHttpClientService } from '@dxos/edge-client';
 import { invariant } from '@dxos/invariant';
@@ -25,7 +25,9 @@ import {
   type CreateRecoveryCredentialRequest,
   type RecoverIdentityRequest,
 } from '@dxos/protocols/proto/dxos/client/services';
+import { type Credential, IdentityRecovery } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { Timeframe } from '@dxos/timeframe';
+import { ComplexSet } from '@dxos/util';
 
 import { type Identity } from './identity';
 import { IdentityManagerService, type JoinIdentityProps } from './identity-manager';
@@ -65,16 +67,23 @@ export class EdgeIdentityRecoveryManager {
     let lookupKey: PublicKey;
     let algorithm: string;
     let recoveryCode: string | undefined;
+    let kind: IdentityRecovery.Kind;
+    let label: string | undefined;
     if (data) {
       recoveryKey = data.recoveryKey;
       lookupKey = data.lookupKey;
       algorithm = data.algorithm;
+      kind = data.kind ?? IdentityRecovery.Kind.UNKNOWN;
+      label = data.label;
     } else {
+      // The seed phrase is generated here rather than by the caller, so the label is too.
       recoveryCode = await generateSeedPhrase();
       const keypair = await keyPairFromSeedPhrase(recoveryCode);
       recoveryKey = PublicKey.from(keypair.publicKey);
       lookupKey = PublicKey.from(keypair.publicKey);
       algorithm = 'ED25519';
+      kind = IdentityRecovery.Kind.RECOVERY_CODE;
+      label = 'Recovery code';
     }
 
     const identityKey = identity.identityKey;
@@ -86,6 +95,8 @@ export class EdgeIdentityRecoveryManager {
         identityKey,
         algorithm,
         lookupKey,
+        label,
+        kind,
       },
     });
 
@@ -93,6 +104,69 @@ export class EdgeIdentityRecoveryManager {
     await identity.controlPipeline.state.waitUntilTimeframe(new Timeframe([[receipt.feedKey, receipt.seq]]));
 
     return { recoveryCode };
+  }
+
+  /**
+   * Revoke a recovery credential by writing an `IdentityRecoveryRevoked` assertion to the identity's
+   * control feed, mirroring how `SpaceDeleted` tombstones a space: the feed is append-only, so the
+   * original credential stays and this marks it spent. The assertion replicates to the user's other
+   * devices and to their agent, which is what drives the server-side refusal.
+   *
+   * Refuses the last un-revoked credential. Doing so would leave the holder unable to recover their
+   * identity with no self-service way back — the replacement has to be added first.
+   */
+  public async revokeRecoveryCredential({ lookupKey }: { lookupKey: PublicKey }): Promise<void> {
+    const identity = this._identityProvider();
+    invariant(identity);
+
+    const active = this.listActiveRecoveryCredentials();
+    if (!active.some(({ assertion }) => assertion.lookupKey?.equals(lookupKey))) {
+      throw new Error('Recovery credential is not registered, or is already revoked.');
+    }
+    if (active.length <= 1) {
+      throw new Error('Cannot revoke the only remaining recovery credential; add another one first.');
+    }
+
+    const identityKey = identity.identityKey;
+    const credential = await identity.getIdentityCredentialSigner().createCredential({
+      subject: identityKey,
+      assertion: {
+        '@type': 'dxos.halo.credentials.IdentityRecoveryRevoked',
+        identityKey,
+        lookupKey,
+        'revokedAt': new Date(),
+      },
+    });
+
+    const receipt = await identity.controlPipeline.writer.write({ credential: { credential } });
+    await identity.controlPipeline.state.waitUntilTimeframe(new Timeframe([[receipt.feedKey, receipt.seq]]));
+  }
+
+  /**
+   * Recovery credentials in the identity's HALO that no `IdentityRecoveryRevoked` assertion cancels.
+   *
+   * Credentials written before `lookupKey` existed cannot be matched by a revocation, so they are
+   * always active — and still count towards the last-credential check, since they remain usable.
+   */
+  public listActiveRecoveryCredentials(): { credential: Credential; assertion: IdentityRecovery }[] {
+    const identity = this._identityProvider();
+    invariant(identity);
+
+    const revoked = new ComplexSet<PublicKey>(PublicKey.hash);
+    const registered: { credential: Credential; assertion: IdentityRecovery }[] = [];
+    for (const credential of identity.space.spaceState.credentials) {
+      const assertion = getCredentialAssertion(credential);
+      switch (assertion['@type']) {
+        case 'dxos.halo.credentials.IdentityRecovery':
+          registered.push({ credential, assertion });
+          break;
+        case 'dxos.halo.credentials.IdentityRecoveryRevoked':
+          revoked.add(assertion.lookupKey);
+          break;
+      }
+    }
+
+    return registered.filter(({ assertion }) => !(assertion.lookupKey && revoked.has(assertion.lookupKey)));
   }
 
   public async requestRecoveryChallenge(ctx: Context) {

--- a/packages/sdk/client-services/src/packlets/identity/identity-service.test.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-service.test.ts
@@ -66,25 +66,9 @@ describe('IdentityService', () => {
   describe.skip('recoverIdentity', () => {});
 
   describe('revokeRecoveryCredential', () => {
-    const createCredential = async () => {
-      const lookupKey = PublicKey.random();
-      await EffectEx.runPromise(
-        identityService['IdentityService.createRecoveryCredential']({
-          data: {
-            recoveryKey: PublicKey.random(),
-            lookupKey,
-            algorithm: 'ED25519',
-            label: 'Test passkey',
-            kind: IdentityRecovery.Kind.PASSKEY,
-          },
-        }),
-      );
-      return lookupKey;
-    };
-
     test('records the label and kind on the credential', async () => {
       await EffectEx.runPromise(identityService['IdentityService.createIdentity']({}));
-      await createCredential();
+      await createCredential(identityService);
 
       const [{ assertion }] = serviceContext.recoveryManager.listActiveRecoveryCredentials();
       expect(assertion.label).to.equal('Test passkey');
@@ -93,8 +77,8 @@ describe('IdentityService', () => {
 
     test('revoking removes the credential from the active list', async () => {
       await EffectEx.runPromise(identityService['IdentityService.createIdentity']({}));
-      const first = await createCredential();
-      const second = await createCredential();
+      const first = await createCredential(identityService);
+      const second = await createCredential(identityService);
 
       await EffectEx.runPromise(identityService['IdentityService.revokeRecoveryCredential']({ lookupKey: first }));
 
@@ -105,7 +89,7 @@ describe('IdentityService', () => {
 
     test('refuses to revoke the only remaining credential', async () => {
       await EffectEx.runPromise(identityService['IdentityService.createIdentity']({}));
-      const only = await createCredential();
+      const only = await createCredential(identityService);
 
       await expect(
         EffectEx.runPromise(identityService['IdentityService.revokeRecoveryCredential']({ lookupKey: only })),
@@ -114,8 +98,8 @@ describe('IdentityService', () => {
 
     test('refuses to revoke a credential twice', async () => {
       await EffectEx.runPromise(identityService['IdentityService.createIdentity']({}));
-      const first = await createCredential();
-      await createCredential();
+      const first = await createCredential(identityService);
+      await createCredential(identityService);
 
       await EffectEx.runPromise(identityService['IdentityService.revokeRecoveryCredential']({ lookupKey: first }));
       await expect(
@@ -162,6 +146,23 @@ describe('IdentityService', () => {
     });
   });
 });
+
+/** Registers a passkey-kind recovery credential and returns its lookup key. */
+const createCredential = async (identityService: IdentityServiceImpl) => {
+  const lookupKey = PublicKey.random();
+  await EffectEx.runPromise(
+    identityService['IdentityService.createRecoveryCredential']({
+      data: {
+        recoveryKey: PublicKey.random(),
+        lookupKey,
+        algorithm: 'ED25519',
+        label: 'Test passkey',
+        kind: IdentityRecovery.Kind.PASSKEY,
+      },
+    }),
+  );
+  return lookupKey;
+};
 
 const createIdentityService = (serviceContext: ServiceContext) => {
   return new IdentityServiceImpl(

--- a/packages/sdk/client-services/src/packlets/identity/identity-service.test.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-service.test.ts
@@ -11,6 +11,7 @@ import { EffectEx } from '@dxos/effect';
 import { PublicKey } from '@dxos/keys';
 import { subscribeStream } from '@dxos/protocols';
 import { type Identity } from '@dxos/protocols/proto/dxos/client/services';
+import { IdentityRecovery } from '@dxos/protocols/proto/dxos/halo/credentials';
 
 import { type ServiceContext } from '../services';
 import { createServiceContext } from '../testing';
@@ -63,6 +64,65 @@ describe('IdentityService', () => {
   });
 
   describe.skip('recoverIdentity', () => {});
+
+  describe('revokeRecoveryCredential', () => {
+    const createCredential = async () => {
+      const lookupKey = PublicKey.random();
+      await EffectEx.runPromise(
+        identityService['IdentityService.createRecoveryCredential']({
+          data: {
+            recoveryKey: PublicKey.random(),
+            lookupKey,
+            algorithm: 'ED25519',
+            label: 'Test passkey',
+            kind: IdentityRecovery.Kind.PASSKEY,
+          },
+        }),
+      );
+      return lookupKey;
+    };
+
+    test('records the label and kind on the credential', async () => {
+      await EffectEx.runPromise(identityService['IdentityService.createIdentity']({}));
+      await createCredential();
+
+      const [{ assertion }] = serviceContext.recoveryManager.listActiveRecoveryCredentials();
+      expect(assertion.label).to.equal('Test passkey');
+      expect(assertion.kind).to.equal(IdentityRecovery.Kind.PASSKEY);
+    });
+
+    test('revoking removes the credential from the active list', async () => {
+      await EffectEx.runPromise(identityService['IdentityService.createIdentity']({}));
+      const first = await createCredential();
+      const second = await createCredential();
+
+      await EffectEx.runPromise(identityService['IdentityService.revokeRecoveryCredential']({ lookupKey: first }));
+
+      const active = serviceContext.recoveryManager.listActiveRecoveryCredentials();
+      expect(active).to.have.length(1);
+      expect(active[0].assertion.lookupKey?.equals(second)).to.be.true;
+    });
+
+    test('refuses to revoke the only remaining credential', async () => {
+      await EffectEx.runPromise(identityService['IdentityService.createIdentity']({}));
+      const only = await createCredential();
+
+      await expect(
+        EffectEx.runPromise(identityService['IdentityService.revokeRecoveryCredential']({ lookupKey: only })),
+      ).rejects.toThrowError('add another one first');
+    });
+
+    test('refuses to revoke a credential twice', async () => {
+      await EffectEx.runPromise(identityService['IdentityService.createIdentity']({}));
+      const first = await createCredential();
+      await createCredential();
+
+      await EffectEx.runPromise(identityService['IdentityService.revokeRecoveryCredential']({ lookupKey: first }));
+      await expect(
+        EffectEx.runPromise(identityService['IdentityService.revokeRecoveryCredential']({ lookupKey: first })),
+      ).rejects.toThrowError('already revoked');
+    });
+  });
 
   describe('updateProfile', () => {
     test('updates profile', async () => {

--- a/packages/sdk/client-services/src/packlets/identity/identity-service.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-service.ts
@@ -17,6 +17,7 @@ import {
   type QueryIdentityResponse,
   type RecoverIdentityRequest,
   type RequestRecoveryChallengeResponse,
+  type RevokeRecoveryCredentialRequest,
   type SignPresentationRequest,
 } from '@dxos/protocols/proto/dxos/client/services';
 import { type Credential, type Presentation, type ProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
@@ -80,6 +81,13 @@ export class IdentityServiceImpl extends Resource implements IdentityService.Han
   ): Effect.Effect<CreateRecoveryCredentialResponse, Error> {
     return Effect.tryPromise({
       try: async () => this._recoveryManager.createRecoveryCredential(request),
+      catch: (error) => error as Error,
+    });
+  }
+
+  ['IdentityService.revokeRecoveryCredential'](request: RevokeRecoveryCredentialRequest): Effect.Effect<void, Error> {
+    return Effect.tryPromise({
+      try: async () => this._recoveryManager.revokeRecoveryCredential(request),
       catch: (error) => error as Error,
     });
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6205,6 +6205,9 @@ importers:
       '@dxos/protocols':
         specifier: workspace:*
         version: link:../../protocols
+      '@dxos/util':
+        specifier: workspace:*
+        version: link:../../../common/util
       effect:
         specifier: 3.21.4
         version: 3.21.4


### PR DESCRIPTION
Composer's Security panel listed recovery credentials as a column of identical issuance dates and offered no way to remove one. This adds labels, kind, and revocation.

## Changes

**Protocol** — `dxos.halo.credentials.IdentityRecovery` gains `label` and `kind` (`PASSKEY` / `RECOVERY_CODE` / `OAUTH`). New `IdentityRecoveryRevoked` assertion (`identityKey`, `lookupKey`, `revokedAt`) cancels a credential. `RecoveryCredentialData` and a new `RevokeRecoveryCredential` RPC carry them through `IdentityService`.

**Client services** — `revokeRecoveryCredential` writes the revocation to the identity's own control feed and refuses the last un-revoked credential. `listActiveRecoveryCredentials` reads the HALO state, treating pre-`lookupKey` credentials as always active since a revocation cannot match them.

**Public HALO view** — `Identity.Credential` gains an optional `recovery` field (`lookupKey`, `label`, `kind`, `revoked`) so UI can render and revoke without reaching into protobuf assertions.

**Composer** — per-credential revoke with confirmation; kind-specific icons; revoked entries struck through and labelled; an "add another first" warning when one remains; a new **Account page** section and a **Manage passkeys** link; Security tab moved above Devices.

## Why an appended HALO assertion, not a delete

The control feed is append-only, so the `IdentityRecovery` credential cannot be removed — this mirrors the existing `SpaceDeleted` tombstone: the credential stays, the revocation marks it spent. It replicates to the user's other devices and to their agent for free, so the same write can drive the server-side refusal.

## Presence proof — deliberate, and deliberately split

The hub's account page demands a fresh WebAuthn assertion before revoking, precisely so an unattended session cannot strip the account's means of authenticating. Composer authenticates with the identity key, which is ambient: it signs with no user interaction, so an unattended session or anything with XSS-level reach could revoke silently. That is a weaker bar and the difference is real.

Rather than silently take the weaker option, both paths ship:

1. **In Composer** — the revoke button writes the HALO assertion, authorized by the identity key. Cheap, works offline, replicates across devices, and cannot revoke the last credential. Chosen for the everyday case because the alternative is no self-service revocation at all.
2. **On the account page** — the **Manage passkeys** / **Account page** links lead to the assertion-gated flow, which additionally shows `lastSignCount` (last-used), the signal you actually want when deciding which credential to drop.

Composer's copy says which is which. The identity key is not a *weaker* authorization than a passkey for a HALO write in general — it is the identity's own signing key — but it does not prove presence, so the stronger path stays available and is what the panel points at.

## Not in this PR — the edge half

`db-service`'s `recovery-processor` reads `IdentityRecovery` credentials out of HALO and calls `AgentsService.registerIdentityRecovery`. It needs the symmetric branch before revocation takes effect server-side:

- On `IdentityRecoveryRevoked`, call `AgentsService.revokeRecoveryCredential({ lookupKey, identity })`.
- Forward the new `label` / `kind` on `registerIdentityRecovery` so the hub list shows them too.

Until that lands, revocation is device-local: Composer stops showing the credential as usable, but `getRecoveryInformation` still resolves it. The `AGENTS_SERVICE` RPCs (`listRecoveryCredentials`, `revokeRecoveryCredential`) already exist. Note also that the hub's `/profile` page — the target of the new links — is currently on an unmerged branch (`claude/hub-ui-schema-error-161c96`); the links resolve via `DX_ACCOUNT_URL`, defaulting to `https://account.composer.space/profile`.

## Verification

- 4 new tests in `identity-service.test.ts`: label/kind recorded, revoking removes from the active list, last-credential refused, double-revoke refused. `client-services` 164 passed, `protocols` 18, `plugin-client` 14.
- Driven live in storybook: created a passkey and a recovery code (distinct labels, icons, dates), revoked the passkey — it struck through and labelled "Revoked", its button disappeared, the remaining credential lost its revoke button, and the amber "only way back" warning appeared, all without a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery credentials can now be labelled and identified by type, including passkeys, recovery codes, and OAuth.
  * Added the ability to revoke recovery credentials from Composer.
  * Revoked credentials are clearly marked and removed from active credentials.
  * The final active recovery credential cannot be revoked.
  * Added navigation to the account page for passkey management.
  * New passkeys receive a suggested label automatically.

* **UI Improvements**
  * Recovery credentials now display labels, types, issue dates, icons, and status indicators.
  * Added warnings when only one active recovery credential remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->