### PR TITLE
plugin-client: rename storage reset to logout and gate identity-recovery resets

### DIFF
--- a/.changeset/client-logout-identity-recovery.md
+++ b/.changeset/client-logout-identity-recovery.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-client': minor
+---
+
+Rename the device storage reset to "Log out" and gate the join-existing-identity and recovery-code resets behind the new `identityRecovery` option on `ClientPlugin` (off by default).

--- a/.changeset/client-logout-identity-recovery.md
+++ b/.changeset/client-logout-identity-recovery.md
@@ -2,4 +2,4 @@
 '@dxos/plugin-client': minor
 ---
 
-Rename the device storage reset to "Log out" and gate the join-existing-identity and recovery-code resets behind the new `identityRecovery` option on `ClientPlugin` (off by default).
+Rename the device storage reset to "Log out" and move the join-existing-identity and recovery-code resets into their own section behind the new `identityTestActions` option on `ClientPlugin` (off by default). The account, invitations, and usage panels are hidden when no hub URL is configured.

--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -128,8 +128,8 @@ export class AppManager {
     return await this._authCode.wait();
   }
 
-  async resetDevice(confirmInput = 'RESET'): Promise<void> {
-    await this.page.getByTestId('devicesContainer.reset').click();
+  async logout(confirmInput = 'RESET'): Promise<void> {
+    await this.page.getByTestId('devicesContainer.logout').click();
     await this.page.getByTestId('reset-storage.reset-identity-input').fill(confirmInput);
     await this.page.getByTestId('reset-storage.reset-identity-confirm').click();
   }

--- a/packages/apps/composer-app/src/playwright/basic.spec.ts
+++ b/packages/apps/composer-app/src/playwright/basic.spec.ts
@@ -89,8 +89,8 @@ test.describe('Basic tests', () => {
     await expect(host.getPluginToggle(StackPlugin.meta.profile.key)).not.toBeChecked();
   });
 
-  test('reset device', async ({ browserName }) => {
-    // Reset triggers a full page reload; post-reset boot (HTML + bundle parse +
+  test('logout', async ({ browserName }) => {
+    // Logout wipes storage and triggers a full page reload; post-reset boot (HTML + bundle parse +
     // plugin manager + identity creation) consistently runs ~8-11s, which
     // doesn't fit the default 60s test timeout comfortably alongside setup.
     test.slow();
@@ -104,8 +104,8 @@ test.describe('Basic tests', () => {
     await expect(host.getSpaceItems()).toHaveCount(INITIAL_SPACE_COUNT + 1);
 
     await host.openUserDevices();
-    await host.resetDevice();
-    // Wait for reset to complete and attempt to reload.
+    await host.logout();
+    // Wait for the reset to complete and attempt to reload.
     await host.page.waitForRequest(INITIAL_URL, { timeout: 45_000 });
     // Post-reset boot (page reload + bundle parse + identity creation) is ~8-11s;
     // 30s gives ~3x headroom over the observed worst case.

--- a/packages/apps/composer-app/src/plugin-defs.core.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.core.tsx
@@ -80,10 +80,9 @@ export const getCorePlugins = ({
       // plugin-onboarding owns invitation URL params in Composer.
       invitationUrlHandler: false,
       // Inverse of the onboarding gate (`DX_HUB_URL` present => welcome screen): where the gate
-      // runs it already offers joining a device and recovering an identity before any local data
-      // exists, so the storage-wiping variants in settings would only be a worse path to the same
-      // place.
-      identityRecovery: !config.values.runtime?.app?.env?.DX_HUB_URL,
+      // runs it already offers joining a device and recovering an identity on a clean profile, so
+      // the storage-wiping variants are only wanted in local testing.
+      identityTestActions: !config.values.runtime?.app?.env?.DX_HUB_URL,
       // The forked init is outside the render tree, so a failure or a stalled handshake reaches
       // the user only if the entry point raises it — React never sees one.
       onClientInitializationError: ({ error }) => Effect.sync(() => onFatalError?.(error)),

--- a/packages/apps/composer-app/src/plugin-defs.core.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.core.tsx
@@ -79,6 +79,11 @@ export const getCorePlugins = ({
       shareableLinkOrigin: origin,
       // plugin-onboarding owns invitation URL params in Composer.
       invitationUrlHandler: false,
+      // Inverse of the onboarding gate (`DX_HUB_URL` present => welcome screen): where the gate
+      // runs it already offers joining a device and recovering an identity before any local data
+      // exists, so the storage-wiping variants in settings would only be a worse path to the same
+      // place.
+      identityRecovery: !config.values.runtime?.app?.env?.DX_HUB_URL,
       // The forked init is outside the render tree, so a failure or a stalled handshake reaches
       // the user only if the entry point raises it — React never sees one.
       onClientInitializationError: ({ error }) => Effect.sync(() => onFatalError?.(error)),

--- a/packages/plugins/plugin-client/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-client/src/capabilities/app-graph-builder.ts
@@ -51,6 +51,9 @@ export default Capability.makeModule(
           }
           const identity = get(CreateAtom.fromObservable(client.halo.identity));
           const status = get(CreateAtom.fromObservable(client.mesh.networkStatus));
+          // Account, invitations, and usage are all hub-service reads; without a hub URL there is
+          // no `HubHttpClient` capability and those panels render empty shells forever.
+          const hub = !!client.config.values?.runtime?.app?.env?.DX_HUB_URL;
 
           return [
             Node.make({
@@ -77,15 +80,19 @@ export default Capability.makeModule(
                     icon: 'ph--user--regular',
                   },
                 }),
-                Node.make({
-                  id: Account.Account,
-                  data: Account.Account,
-                  type: meta.profile.key,
-                  properties: {
-                    label: ['account-panel.label', { ns: meta.profile.key }],
-                    icon: 'ph--identification-card--regular',
-                  },
-                }),
+                ...(hub
+                  ? [
+                      Node.make({
+                        id: Account.Account,
+                        data: Account.Account,
+                        type: meta.profile.key,
+                        properties: {
+                          label: ['account-panel.label', { ns: meta.profile.key }],
+                          icon: 'ph--identification-card--regular',
+                        },
+                      }),
+                    ]
+                  : []),
                 Node.make({
                   id: Account.Devices,
                   data: Account.Devices,
@@ -105,24 +112,28 @@ export default Capability.makeModule(
                     icon: 'ph--key--regular',
                   },
                 }),
-                Node.make({
-                  id: Account.Invitations,
-                  data: Account.Invitations,
-                  type: meta.profile.key,
-                  properties: {
-                    label: ['invitations-panel.label', { ns: meta.profile.key }],
-                    icon: 'ph--ticket--regular',
-                  },
-                }),
-                Node.make({
-                  id: Account.Usage,
-                  data: Account.Usage,
-                  type: meta.profile.key,
-                  properties: {
-                    label: ['usage-panel.label', { ns: meta.profile.key }],
-                    icon: 'ph--chart-bar--regular',
-                  },
-                }),
+                ...(hub
+                  ? [
+                      Node.make({
+                        id: Account.Invitations,
+                        data: Account.Invitations,
+                        type: meta.profile.key,
+                        properties: {
+                          label: ['invitations-panel.label', { ns: meta.profile.key }],
+                          icon: 'ph--ticket--regular',
+                        },
+                      }),
+                      Node.make({
+                        id: Account.Usage,
+                        data: Account.Usage,
+                        type: meta.profile.key,
+                        properties: {
+                          label: ['usage-panel.label', { ns: meta.profile.key }],
+                          icon: 'ph--chart-bar--regular',
+                        },
+                      }),
+                    ]
+                  : []),
               ],
             }),
           ];

--- a/packages/plugins/plugin-client/src/capabilities/index.ts
+++ b/packages/plugins/plugin-client/src/capabilities/index.ts
@@ -77,13 +77,14 @@ export const ReactSurface = AppCapability.surface(() => import('./react-surface'
     invitationPath = '/',
     invitationProp = 'deviceInvitationCode',
     onReset,
+    identityRecovery,
   }: ClientOptions.ClientPluginOptions) => {
     const createInvitationUrl = (invitationCode: string) => {
       const baseUrl = new URL(invitationPath || '/', shareableLinkOrigin);
       baseUrl.searchParams.set(invitationProp, invitationCode);
       return baseUrl.toString();
     };
-    return { createInvitationUrl, onReset };
+    return { createInvitationUrl, onReset, identityRecovery };
   },
 });
 export const SchemaDefs = Capability.lazyModule(

--- a/packages/plugins/plugin-client/src/capabilities/index.ts
+++ b/packages/plugins/plugin-client/src/capabilities/index.ts
@@ -77,14 +77,14 @@ export const ReactSurface = AppCapability.surface(() => import('./react-surface'
     invitationPath = '/',
     invitationProp = 'deviceInvitationCode',
     onReset,
-    identityRecovery,
+    identityTestActions,
   }: ClientOptions.ClientPluginOptions) => {
     const createInvitationUrl = (invitationCode: string) => {
       const baseUrl = new URL(invitationPath || '/', shareableLinkOrigin);
       baseUrl.searchParams.set(invitationProp, invitationCode);
       return baseUrl.toString();
     };
-    return { createInvitationUrl, onReset, identityRecovery };
+    return { createInvitationUrl, onReset, identityTestActions };
   },
 });
 export const SchemaDefs = Capability.lazyModule(

--- a/packages/plugins/plugin-client/src/capabilities/react-surface.ts
+++ b/packages/plugins/plugin-client/src/capabilities/react-surface.ts
@@ -26,12 +26,12 @@ import { JOIN_DIALOG, RECOVERY_CODE_DIALOG, RESET_DIALOG } from '../constants';
 import * as Account from '../types/Account';
 import * as ClientOptions from '../types/ClientOptions';
 
-type ReactSurfaceOptions = Pick<ClientOptions.ClientPluginOptions, 'onReset'> & {
+type ReactSurfaceOptions = Pick<ClientOptions.ClientPluginOptions, 'onReset' | 'identityRecovery'> & {
   createInvitationUrl: (invitationCode: string) => string;
 };
 
 export default Capability.makeModule(
-  Effect.fnUntraced(function* ({ createInvitationUrl, onReset }: ReactSurfaceOptions) {
+  Effect.fnUntraced(function* ({ createInvitationUrl, onReset, identityRecovery }: ReactSurfaceOptions) {
     const capabilityManager = yield* Capability.Service;
 
     return Capability.contribute(Capabilities.ReactSurface, [
@@ -44,7 +44,7 @@ export default Capability.makeModule(
         id: Account.Devices,
         filter: AppSurface.literal(AppSurface.Article, Account.Devices),
         component: DevicesContainer,
-        props: () => ({ createInvitationUrl }),
+        props: () => ({ createInvitationUrl, identityRecovery }),
       }),
       Surface.create({
         id: Account.Security,

--- a/packages/plugins/plugin-client/src/capabilities/react-surface.ts
+++ b/packages/plugins/plugin-client/src/capabilities/react-surface.ts
@@ -26,12 +26,12 @@ import { JOIN_DIALOG, RECOVERY_CODE_DIALOG, RESET_DIALOG } from '../constants';
 import * as Account from '../types/Account';
 import * as ClientOptions from '../types/ClientOptions';
 
-type ReactSurfaceOptions = Pick<ClientOptions.ClientPluginOptions, 'onReset' | 'identityRecovery'> & {
+type ReactSurfaceOptions = Pick<ClientOptions.ClientPluginOptions, 'onReset' | 'identityTestActions'> & {
   createInvitationUrl: (invitationCode: string) => string;
 };
 
 export default Capability.makeModule(
-  Effect.fnUntraced(function* ({ createInvitationUrl, onReset, identityRecovery }: ReactSurfaceOptions) {
+  Effect.fnUntraced(function* ({ createInvitationUrl, onReset, identityTestActions }: ReactSurfaceOptions) {
     const capabilityManager = yield* Capability.Service;
 
     return Capability.contribute(Capabilities.ReactSurface, [
@@ -44,7 +44,7 @@ export default Capability.makeModule(
         id: Account.Devices,
         filter: AppSurface.literal(AppSurface.Article, Account.Devices),
         component: DevicesContainer,
-        props: () => ({ createInvitationUrl, identityRecovery }),
+        props: () => ({ createInvitationUrl, identityTestActions }),
       }),
       Surface.create({
         id: Account.Security,

--- a/packages/plugins/plugin-client/src/containers/DevicesContainer/DevicesContainer.tsx
+++ b/packages/plugins/plugin-client/src/containers/DevicesContainer/DevicesContainer.tsx
@@ -21,17 +21,19 @@ import { hexToEmoji } from '@dxos/util';
 import { meta } from '#meta';
 import { ClientOperation } from '#operations';
 
-export type DevicesContainerProps = {
+import * as ClientOptions from '../../types/ClientOptions';
+
+export type DevicesContainerProps = Pick<ClientOptions.ClientPluginOptions, 'identityRecovery'> & {
   createInvitationUrl?: (invitationCode: string) => string;
 };
 
-export const DevicesContainer = ({ createInvitationUrl }: DevicesContainerProps) => {
+export const DevicesContainer = ({ createInvitationUrl, identityRecovery }: DevicesContainerProps) => {
   const { t } = useTranslation(meta.profile.key);
   const { invokePromise } = useOperationInvoker();
   const devices = useDevices();
   const { swarm: connectionState } = useNetworkStatus();
 
-  const handleResetStorage = useCallback(() => invokePromise(ClientOperation.ResetStorage, {}), [invokePromise]);
+  const handleLogout = useCallback(() => invokePromise(ClientOperation.ResetStorage, {}), [invokePromise]);
 
   const handleRecover = useCallback(
     () => invokePromise(ClientOperation.ResetStorage, { mode: 'recover' }),
@@ -76,37 +78,38 @@ export const DevicesContainer = ({ createInvitationUrl }: DevicesContainerProps)
               </Form.Group>
             </Form.Section>
             <Form.Section
-              title={t('danger-zone.title', { ns: meta.profile.key })}
-              description={t('danger-zone.description', { ns: meta.profile.key })}
+              title={t('logout-section.title', { ns: meta.profile.key })}
+              description={t('logout-section.description', { ns: meta.profile.key })}
             >
-              <Form.Row
-                label={t('reset-device.label')}
-                description={t('reset-device.description', { ns: meta.profile.key })}
-              >
-                <Button variant='destructive' onClick={handleResetStorage} data-testid='devicesContainer.reset'>
-                  {t('reset-device.label')}
+              <Form.Row label={t('logout.label')} description={t('logout.description', { ns: meta.profile.key })}>
+                <Button variant='destructive' onClick={handleLogout} data-testid='devicesContainer.logout'>
+                  {t('logout.label')}
                 </Button>
               </Form.Row>
-              <Form.Row
-                label={t('recover-identity.label')}
-                description={t('recover-identity.description', { ns: meta.profile.key })}
-              >
-                <Button variant='destructive' onClick={handleRecover} data-testid='devicesContainer.recover'>
-                  {t('recover-identity.label')}
-                </Button>
-              </Form.Row>
-              <Form.Row
-                label={t('join-new-identity.label')}
-                description={t('join-new-identity.description', { ns: meta.profile.key })}
-              >
-                <Button
-                  variant='destructive'
-                  onClick={handleJoinNewIdentity}
-                  data-testid='devicesContainer.joinExisting'
-                >
-                  {t('join-new-identity.label')}
-                </Button>
-              </Form.Row>
+              {identityRecovery && (
+                <>
+                  <Form.Row
+                    label={t('recover-identity.label')}
+                    description={t('recover-identity.description', { ns: meta.profile.key })}
+                  >
+                    <Button variant='destructive' onClick={handleRecover} data-testid='devicesContainer.recover'>
+                      {t('recover-identity.label')}
+                    </Button>
+                  </Form.Row>
+                  <Form.Row
+                    label={t('join-new-identity.label')}
+                    description={t('join-new-identity.description', { ns: meta.profile.key })}
+                  >
+                    <Button
+                      variant='destructive'
+                      onClick={handleJoinNewIdentity}
+                      data-testid='devicesContainer.joinExisting'
+                    >
+                      {t('join-new-identity.label')}
+                    </Button>
+                  </Form.Row>
+                </>
+              )}
             </Form.Section>
           </Form.Content>
         </Form.Viewport>

--- a/packages/plugins/plugin-client/src/containers/DevicesContainer/DevicesContainer.tsx
+++ b/packages/plugins/plugin-client/src/containers/DevicesContainer/DevicesContainer.tsx
@@ -86,31 +86,34 @@ export const DevicesContainer = ({ createInvitationUrl, identityRecovery }: Devi
                   {t('logout.label')}
                 </Button>
               </Form.Row>
-              {identityRecovery && (
-                <>
-                  <Form.Row
-                    label={t('recover-identity.label')}
-                    description={t('recover-identity.description', { ns: meta.profile.key })}
-                  >
-                    <Button variant='destructive' onClick={handleRecover} data-testid='devicesContainer.recover'>
-                      {t('recover-identity.label')}
-                    </Button>
-                  </Form.Row>
-                  <Form.Row
-                    label={t('join-new-identity.label')}
-                    description={t('join-new-identity.description', { ns: meta.profile.key })}
-                  >
-                    <Button
-                      variant='destructive'
-                      onClick={handleJoinNewIdentity}
-                      data-testid='devicesContainer.joinExisting'
-                    >
-                      {t('join-new-identity.label')}
-                    </Button>
-                  </Form.Row>
-                </>
-              )}
             </Form.Section>
+            {identityRecovery && (
+              <Form.Section
+                title={t('identity-recovery-section.title', { ns: meta.profile.key })}
+                description={t('identity-recovery-section.description', { ns: meta.profile.key })}
+              >
+                <Form.Row
+                  label={t('recover-identity.label')}
+                  description={t('recover-identity.description', { ns: meta.profile.key })}
+                >
+                  <Button variant='destructive' onClick={handleRecover} data-testid='devicesContainer.recover'>
+                    {t('recover-identity.label')}
+                  </Button>
+                </Form.Row>
+                <Form.Row
+                  label={t('join-new-identity.label')}
+                  description={t('join-new-identity.description', { ns: meta.profile.key })}
+                >
+                  <Button
+                    variant='destructive'
+                    onClick={handleJoinNewIdentity}
+                    data-testid='devicesContainer.joinExisting'
+                  >
+                    {t('join-new-identity.label')}
+                  </Button>
+                </Form.Row>
+              </Form.Section>
+            )}
           </Form.Content>
         </Form.Viewport>
       </Form.Root>

--- a/packages/plugins/plugin-client/src/containers/DevicesContainer/DevicesContainer.tsx
+++ b/packages/plugins/plugin-client/src/containers/DevicesContainer/DevicesContainer.tsx
@@ -23,11 +23,11 @@ import { ClientOperation } from '#operations';
 
 import * as ClientOptions from '../../types/ClientOptions';
 
-export type DevicesContainerProps = Pick<ClientOptions.ClientPluginOptions, 'identityRecovery'> & {
+export type DevicesContainerProps = Pick<ClientOptions.ClientPluginOptions, 'identityTestActions'> & {
   createInvitationUrl?: (invitationCode: string) => string;
 };
 
-export const DevicesContainer = ({ createInvitationUrl, identityRecovery }: DevicesContainerProps) => {
+export const DevicesContainer = ({ createInvitationUrl, identityTestActions }: DevicesContainerProps) => {
   const { t } = useTranslation(meta.profile.key);
   const { invokePromise } = useOperationInvoker();
   const devices = useDevices();
@@ -77,33 +77,24 @@ export const DevicesContainer = ({ createInvitationUrl, identityRecovery }: Devi
                 )}
               </Form.Group>
             </Form.Section>
-            <Form.Section
-              title={t('logout-section.title', { ns: meta.profile.key })}
-              description={t('logout-section.description', { ns: meta.profile.key })}
-            >
-              <Form.Row label={t('logout.label')} description={t('logout.description', { ns: meta.profile.key })}>
+            <Form.Section title={t('logout-section.title')} description={t('logout-section.description')}>
+              <Form.Row label={t('logout.label')} description={t('logout.description')}>
                 <Button variant='destructive' onClick={handleLogout} data-testid='devicesContainer.logout'>
                   {t('logout.label')}
                 </Button>
               </Form.Row>
             </Form.Section>
-            {identityRecovery && (
+            {identityTestActions && (
               <Form.Section
-                title={t('identity-recovery-section.title', { ns: meta.profile.key })}
-                description={t('identity-recovery-section.description', { ns: meta.profile.key })}
+                title={t('identity-test-section.title')}
+                description={t('identity-test-section.description')}
               >
-                <Form.Row
-                  label={t('recover-identity.label')}
-                  description={t('recover-identity.description', { ns: meta.profile.key })}
-                >
+                <Form.Row label={t('recover-identity.label')} description={t('recover-identity.description')}>
                   <Button variant='destructive' onClick={handleRecover} data-testid='devicesContainer.recover'>
                     {t('recover-identity.label')}
                   </Button>
                 </Form.Row>
-                <Form.Row
-                  label={t('join-new-identity.label')}
-                  description={t('join-new-identity.description', { ns: meta.profile.key })}
-                >
+                <Form.Row label={t('join-new-identity.label')} description={t('join-new-identity.description')}>
                   <Button
                     variant='destructive'
                     onClick={handleJoinNewIdentity}

--- a/packages/plugins/plugin-client/src/containers/ResetDialog/ResetDialog.tsx
+++ b/packages/plugins/plugin-client/src/containers/ResetDialog/ResetDialog.tsx
@@ -30,7 +30,6 @@ export type ResetDialogProps = Pick<ConfirmResetProps, 'mode'> &
 
 export const ResetDialog = ({ mode, onReset, onBeforeReset, capabilityManager }: ResetDialogProps) => {
   const { t } = useTranslation(translationKey);
-  const { t: tClient } = useTranslation(meta.profile.key);
   const { invokePromise } = useOperationInvoker();
   const client = useClient();
   // The bare storage reset is presented as logging out; the other modes swap to a new identity.
@@ -57,16 +56,16 @@ export const ResetDialog = ({ mode, onReset, onBeforeReset, capabilityManager }:
   return (
     <Dialog.Content>
       <Dialog.Header>
-        <Dialog.Title>{isLogout ? tClient('logout.label') : t('reset-dialog.title')}</Dialog.Title>
+        <Dialog.Title>{isLogout ? t('logout.label', { ns: meta.profile.key }) : t('reset-dialog.title')}</Dialog.Title>
       </Dialog.Header>
       <Dialog.Body>
         <Dialog.Description classNames='sr-only'>
-          {isLogout ? tClient('logout.description') : t('reset-dialog.description')}
+          {isLogout ? t('logout.description', { ns: meta.profile.key }) : t('reset-dialog.description')}
         </Dialog.Description>
         <ConfirmReset
           active
           mode={mode}
-          confirmLabel={isLogout ? tClient('logout.label') : undefined}
+          confirmLabel={isLogout ? t('logout.label', { ns: meta.profile.key }) : undefined}
           onConfirm={handleReset}
           onCancel={handleCancel}
         />

--- a/packages/plugins/plugin-client/src/containers/ResetDialog/ResetDialog.tsx
+++ b/packages/plugins/plugin-client/src/containers/ResetDialog/ResetDialog.tsx
@@ -14,6 +14,8 @@ import { useClient } from '@dxos/react-client';
 import { Dialog, useTranslation } from '@dxos/react-ui';
 import { ConfirmReset, type ConfirmResetProps, translationKey } from '@dxos/shell/react';
 
+import { meta } from '#meta';
+
 import * as ClientOptions from '../../types/ClientOptions';
 
 export type ResetDialogProps = Pick<ConfirmResetProps, 'mode'> &
@@ -28,8 +30,11 @@ export type ResetDialogProps = Pick<ConfirmResetProps, 'mode'> &
 
 export const ResetDialog = ({ mode, onReset, onBeforeReset, capabilityManager }: ResetDialogProps) => {
   const { t } = useTranslation(translationKey);
+  const { t: tClient } = useTranslation(meta.profile.key);
   const { invokePromise } = useOperationInvoker();
   const client = useClient();
+  // The bare storage reset is presented as logging out; the other modes swap to a new identity.
+  const isLogout = (mode ?? 'reset-storage') === 'reset-storage';
 
   const handleReset = useCallback(async () => {
     if (onBeforeReset) {
@@ -52,11 +57,19 @@ export const ResetDialog = ({ mode, onReset, onBeforeReset, capabilityManager }:
   return (
     <Dialog.Content>
       <Dialog.Header>
-        <Dialog.Title>{t('reset-dialog.title')}</Dialog.Title>
+        <Dialog.Title>{isLogout ? tClient('logout.label') : t('reset-dialog.title')}</Dialog.Title>
       </Dialog.Header>
       <Dialog.Body>
-        <Dialog.Description classNames='sr-only'>{t('reset-dialog.description')}</Dialog.Description>
-        <ConfirmReset active mode={mode} onConfirm={handleReset} onCancel={handleCancel} />
+        <Dialog.Description classNames='sr-only'>
+          {isLogout ? tClient('logout.description') : t('reset-dialog.description')}
+        </Dialog.Description>
+        <ConfirmReset
+          active
+          mode={mode}
+          confirmLabel={isLogout ? tClient('logout.label') : undefined}
+          onConfirm={handleReset}
+          onCancel={handleCancel}
+        />
       </Dialog.Body>
     </Dialog.Content>
   );

--- a/packages/plugins/plugin-client/src/containers/ResetDialog/ResetDialog.tsx
+++ b/packages/plugins/plugin-client/src/containers/ResetDialog/ResetDialog.tsx
@@ -12,7 +12,7 @@ import * as LayoutOperation from '@dxos/app-toolkit/LayoutOperation';
 import { EffectEx } from '@dxos/effect';
 import { useClient } from '@dxos/react-client';
 import { Dialog, useTranslation } from '@dxos/react-ui';
-import { ConfirmReset, type ConfirmResetProps, translationKey } from '@dxos/shell/react';
+import { ConfirmReset, type ConfirmResetProps } from '@dxos/shell/react';
 
 import { meta } from '#meta';
 
@@ -29,11 +29,9 @@ export type ResetDialogProps = Pick<ConfirmResetProps, 'mode'> &
   };
 
 export const ResetDialog = ({ mode, onReset, onBeforeReset, capabilityManager }: ResetDialogProps) => {
-  const { t } = useTranslation(translationKey);
+  const { t } = useTranslation(meta.profile.key);
   const { invokePromise } = useOperationInvoker();
   const client = useClient();
-  // The bare storage reset is presented as logging out; the other modes swap to a new identity.
-  const isLogout = (mode ?? 'reset-storage') === 'reset-storage';
 
   const handleReset = useCallback(async () => {
     if (onBeforeReset) {
@@ -56,16 +54,14 @@ export const ResetDialog = ({ mode, onReset, onBeforeReset, capabilityManager }:
   return (
     <Dialog.Content>
       <Dialog.Header>
-        <Dialog.Title>{isLogout ? t('logout.label', { ns: meta.profile.key }) : t('reset-dialog.title')}</Dialog.Title>
+        <Dialog.Title>{t('logout.label')}</Dialog.Title>
       </Dialog.Header>
       <Dialog.Body>
-        <Dialog.Description classNames='sr-only'>
-          {isLogout ? t('logout.description', { ns: meta.profile.key }) : t('reset-dialog.description')}
-        </Dialog.Description>
+        <Dialog.Description classNames='sr-only'>{t('logout.description')}</Dialog.Description>
         <ConfirmReset
           active
           mode={mode}
-          confirmLabel={isLogout ? t('logout.label', { ns: meta.profile.key }) : undefined}
+          confirmLabel={t('logout.label')}
           onConfirm={handleReset}
           onCancel={handleCancel}
         />

--- a/packages/plugins/plugin-client/src/translations.ts
+++ b/packages/plugins/plugin-client/src/translations.ts
@@ -81,14 +81,14 @@ const pluginTranslations = [
         'generate-invitation.description_other': 'You have {{count}} invitations left to generate.',
         'available-invitations.title': 'Available invitations',
         'redeemed-invitations.title': 'Redeemed invitations',
-        'logout.description': 'Log out from this device, erasing all the data on this device.',
+        'logout.description': 'Log out and erase all data on this device.',
         'join-new-identity.description':
           'Log out from this device, erasing all the data currently on this device, and use a QR code or URL to log in.',
         'recover-identity.description':
           'Log out from this device, erasing all the data currently on this device, and use a passkey or recovery code to log in.',
         'logout-section.title': 'Log out',
         'logout-section.description':
-          'Because Composer is decentralized, logging out entails erasing all the data on this device. If you have any data on this device that you’d like to keep, you can log in on a separate device using a passkey or complete a peer-to-peer device invitation above.',
+          'Logging out erases all data on this device. Anything that has not synced to another device or to the cloud will be lost.',
         'display-name.label': 'Display name',
         'display-name.description': 'Your name as it appears in the app.',
         'display-name-input.placeholder': 'Enter a name',

--- a/packages/plugins/plugin-client/src/translations.ts
+++ b/packages/plugins/plugin-client/src/translations.ts
@@ -82,13 +82,14 @@ const pluginTranslations = [
         'available-invitations.title': 'Available invitations',
         'redeemed-invitations.title': 'Redeemed invitations',
         'logout.description': 'Log out and erase all data on this device.',
-        'join-new-identity.description':
-          'Log out from this device, erasing all the data currently on this device, and use a QR code or URL to log in.',
-        'recover-identity.description':
-          'Log out from this device, erasing all the data currently on this device, and use a passkey or recovery code to log in.',
+        'join-new-identity.description': 'Erase this device and join an existing identity with a QR code or URL.',
+        'recover-identity.description': 'Erase this device and log in with a passkey or recovery code.',
         'logout-section.title': 'Log out',
         'logout-section.description':
           'Logging out erases all data on this device. Anything that has not synced to another device or to the cloud will be lost.',
+        'identity-recovery-section.title': 'Testing',
+        'identity-recovery-section.description':
+          'Shown only when no hub is configured. These adopt a different identity on this device, erasing all data on it first.',
         'display-name.label': 'Display name',
         'display-name.description': 'Your name as it appears in the app.',
         'display-name-input.placeholder': 'Enter a name',

--- a/packages/plugins/plugin-client/src/translations.ts
+++ b/packages/plugins/plugin-client/src/translations.ts
@@ -87,8 +87,8 @@ const pluginTranslations = [
         'logout-section.title': 'Log out',
         'logout-section.description':
           'Logging out erases all data on this device. Anything that has not synced to another device or to the cloud will be lost.',
-        'identity-recovery-section.title': 'Testing',
-        'identity-recovery-section.description':
+        'identity-test-section.title': 'Testing',
+        'identity-test-section.description':
           'Shown only when no hub is configured. These adopt a different identity on this device, erasing all data on it first.',
         'display-name.label': 'Display name',
         'display-name.description': 'Your name as it appears in the app.',

--- a/packages/plugins/plugin-client/src/translations.ts
+++ b/packages/plugins/plugin-client/src/translations.ts
@@ -81,13 +81,13 @@ const pluginTranslations = [
         'generate-invitation.description_other': 'You have {{count}} invitations left to generate.',
         'available-invitations.title': 'Available invitations',
         'redeemed-invitations.title': 'Redeemed invitations',
-        'reset-device.description': 'Log out from this device, erasing all the data on this device.',
+        'logout.description': 'Log out from this device, erasing all the data on this device.',
         'join-new-identity.description':
           'Log out from this device, erasing all the data currently on this device, and use a QR code or URL to log in.',
         'recover-identity.description':
           'Log out from this device, erasing all the data currently on this device, and use a passkey or recovery code to log in.',
-        'danger-zone.title': 'Log out',
-        'danger-zone.description':
+        'logout-section.title': 'Log out',
+        'logout-section.description':
           'Because Composer is decentralized, logging out entails erasing all the data on this device. If you have any data on this device that you’d like to keep, you can log in on a separate device using a passkey or complete a peer-to-peer device invitation above.',
         'display-name.label': 'Display name',
         'display-name.description': 'Your name as it appears in the app.',
@@ -128,7 +128,7 @@ const pluginTranslations = [
         'join-new-identity.label': 'Join an existing identity',
         'qr.label': 'QR Code',
         'recover-identity.label': 'Use a recovery code',
-        'reset-device.label': 'Reset storage',
+        'logout.label': 'Log out',
         'reset-dialog.description': 'Reset storage',
         'reset-dialog.title': 'Reset storage',
         'navigation-failed-toast.title': 'Link could not be processed',

--- a/packages/plugins/plugin-client/src/translations.ts
+++ b/packages/plugins/plugin-client/src/translations.ts
@@ -89,7 +89,7 @@ const pluginTranslations = [
           'Logging out erases all data on this device. Anything that has not synced to another device or to the cloud will be lost.',
         'identity-test-section.title': 'Testing',
         'identity-test-section.description':
-          'Shown only when no hub is configured. These adopt a different identity on this device, erasing all data on it first.',
+          'Enabled for testing. These switch this device to a different identity, erasing all data on it first.',
         'display-name.label': 'Display name',
         'display-name.description': 'Your name as it appears in the app.',
         'display-name-input.placeholder': 'Enter a name',
@@ -130,8 +130,6 @@ const pluginTranslations = [
         'qr.label': 'QR Code',
         'recover-identity.label': 'Use a recovery code',
         'logout.label': 'Log out',
-        'reset-dialog.description': 'Reset storage',
-        'reset-dialog.title': 'Reset storage',
         'navigation-failed-toast.title': 'Link could not be processed',
         'navigation-failed-toast.description': 'Something went wrong while handling this link. Please try again.',
       },

--- a/packages/plugins/plugin-client/src/types/ClientOptions.ts
+++ b/packages/plugins/plugin-client/src/types/ClientOptions.ts
@@ -21,6 +21,15 @@ export type ClientPluginOptions = ClientOptions & {
   shareableLinkOrigin?: string;
 
   /**
+   * Surface the destructive flows for adopting an existing identity on this device (join via
+   * device invitation, restore from a recovery code). Both wipe local storage first, so they
+   * duplicate — and are strictly worse than — an onboarding gate that offers the same flows
+   * before any data exists. Apps that show such a gate pass the inverse of its condition.
+   * @default false
+   */
+  identityRecovery?: boolean;
+
+  /**
    * Path for the invitation link.
    */
   invitationPath?: string;

--- a/packages/plugins/plugin-client/src/types/ClientOptions.ts
+++ b/packages/plugins/plugin-client/src/types/ClientOptions.ts
@@ -21,13 +21,13 @@ export type ClientPluginOptions = ClientOptions & {
   shareableLinkOrigin?: string;
 
   /**
-   * Surface the destructive flows for adopting an existing identity on this device (join via
-   * device invitation, restore from a recovery code). Both wipe local storage first, so they
-   * duplicate — and are strictly worse than — an onboarding gate that offers the same flows
-   * before any data exists. Apps that show such a gate pass the inverse of its condition.
+   * Surface the identity-swapping actions kept for testing: join another identity by device
+   * invitation, or restore one from a recovery code. Both wipe local storage before they run, so
+   * an app whose onboarding gate offers the same flows on a clean profile should pass the inverse
+   * of that gate's condition rather than expose them to real users.
    * @default false
    */
-  identityRecovery?: boolean;
+  identityTestActions?: boolean;
 
   /**
    * Path for the invitation link.


### PR DESCRIPTION
Refactors the three reset entry points in Account ▸ Devices.

## Log out

The bare `reset-storage` flow is now presented as **Log out** rather than "Reset storage": the settings row, the confirm dialog title, the confirm button, and the `data-testid` (`devicesContainer.reset` → `devicesContainer.logout`). Position is unchanged — the section it lives in was already titled "Log out" and its description already explains that logging out entails erasing local data, so the section now collapses to that single row in deployed builds. The underlying `ClientOperation.ResetStorage` operation is untouched.

## Gating the other two

"Join an existing identity" and "Use a recovery code" both wipe local storage before adopting another identity, which duplicates — and is strictly worse than — an onboarding gate that offers the same flows before any data exists. They are now behind a new `identityRecovery` option on `ClientPlugin` (default `false`).

Composer passes the inverse of its onboarding-gate condition:

```ts
identityRecovery: !config.values.runtime?.app?.env?.DX_HUB_URL,
```

`DX_HUB_URL` is set only in deployed environments (`.github/workflows/env/*`), and it is exactly what `OnboardingManager` keys `skipAuth` off — so the rows appear on localhost and in e2e, where nothing else offers those flows, and disappear wherever the welcome screen does the job. The deployed device-invitation path is unaffected: `plugin-onboarding` still invokes the reset dialog with `mode: 'join-new-identity'` when a `?deviceInvitationCode` lands on an existing identity.

## Verification

- `moon run plugin-client:build composer-app:build` — pass
- `moon run plugin-client:lint composer-app:lint` — pass
- `moon run plugin-client:test` — 14 passed, 2 skipped, 2 todo
- `pnpm format`

Playwright: `AppManager.resetDevice()` → `logout()` and the `reset device` spec renamed to `logout`; both run on localhost, where `identityRecovery` is on, so the `joinNewIdentity()` helper keeps its target.

---
_Generated by [Claude Code](https://claude.ai/code/session_0115RkgVtvZ2PGUjYREhxhGP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renamed device storage reset to **Log out**, with updated confirmation messaging.
  * Added optional identity recovery and identity-switching actions for testing.
  * Organized device actions into separate logout and identity sections.
* **Bug Fixes**
  * Account, invitation, and usage panels now appear only when the required service is connected.
* **Documentation**
  * Documented the logout terminology update and identity testing option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->