### PR TITLE
ci: stop rust-cache clobbering the tauri build's cargo

### DIFF
--- a/.github/workflows/deploy-tauri.yaml
+++ b/.github/workflows/deploy-tauri.yaml
@@ -149,13 +149,28 @@ jobs:
       - uses: moonrepo/setup-toolchain@v0
         with:
           # IMPORTANT: Keep in-sync with .prototools
-          moon-version: '2.2.3'
+          moon-version: '2.4.5'
+          proto-version: '0.58.2'
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          cache: true
+          # The lone crate is composer-app's, so at the repo root rust-cache's `cargo metadata` finds no
+          # Cargo.toml; it keys on an empty lockfile hash and restores its own `~/.cargo/bin` snapshot over
+          # rustup's, leaving `cargo` a symlink to `rustup-init` ("unexpected argument 'metadata'"). Pointing
+          # it at the crate would fix the key but restore a `target/` any CI job can write to into a signed,
+          # notarized release — the same reason MOON_REMOTE_HOST is empty above.
+          cache: false
+
+      # `cargo metadata` is the first thing `tauri build`/`tauri ios init` run, ~10 min into the job.
+      # Assert it here so a toolchain that resolves to the wrong binary fails in a second, with the
+      # resolved path in the log, rather than as an opaque tauri error.
+      - name: Verify Rust toolchain
+        run: |
+          echo "cargo resolves to: $(command -v cargo)"
+          cargo metadata --no-deps --format-version 1 > /dev/null
+        working-directory: ./packages/apps/composer-app/src-tauri
 
       - name: Import Apple Developer Certificate
         if: matrix.os == 'depot-macos-latest'
@@ -343,16 +358,24 @@ jobs:
       - uses: moonrepo/setup-toolchain@v0
         with:
           # IMPORTANT: Keep in-sync with .prototools
-          moon-version: '2.2.3'
+          moon-version: '2.4.5'
+          proto-version: '0.58.2'
 
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          cache: true
+          # Disabled for the reasons spelled out in build_tauri's copy of this step.
+          cache: false
 
       - name: Install iOS target
         run: rustup target add aarch64-apple-ios
+
+      - name: Verify Rust toolchain
+        run: |
+          echo "cargo resolves to: $(command -v cargo)"
+          cargo metadata --no-deps --format-version 1 > /dev/null
+        working-directory: ./packages/apps/composer-app/src-tauri
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.prototools
+++ b/.prototools
@@ -1,18 +1,18 @@
 # https://moonrepo.dev/docs/proto/config
 
-# IMPORTANT: every pin below is duplicated outside this file — CI workflows and composite actions pin
-# moon/proto and the container image tag, `.github/Dockerfile` installs node and pnpm, and the root
-# `package.json` + catalog carry pnpm and moon for the non-proto entrypoints. None of those read
-# `.prototools`, and a divergence only surfaces on a cold cache, so bumping a version here is half the
-# change. Sweep for the old one and update every hit:
+# IMPORTANT — this file is the intended source of truth for every version below, but not all of them can
+# live only here: a container image is built before proto exists, a GitHub Action takes its version as an
+# input, an npm manifest needs a literal. Those copies are kept to a minimum and each survivor is one that
+# could not be removed, so a bump here is only the first half of the change — sweep the repo for the old
+# version and update every hit:
 #
 #   git grep -n '<old version>' -- ':!pnpm-lock.yaml'
 #
+# Divergence is silent, which is why the sweep matters: the copy outside this file typically wins early in
+# a CI job and the pin here wins once moon's toolchain cache exists, so a mismatch first bites on a cold
+# cache, long after the commit that introduced it.
+
 proto = "0.58.2"
-# NOTE: Keep node and pnpm in sync with `.github/Dockerfile`, which installs them too.
-#  CI's setup action runs `pnpm install` before any moon task, so the image supplies them until moon's
-#  toolchain cache exists. Everything after that uses the versions here, which is why a mismatch stays
-#  invisible until a cache miss.
 node = "24.11.1"
 pnpm = "10.28.0"
 # 1.3.4 leaks `--smol` into `process.argv` of every `--compile`d binary, which makes the published
@@ -20,10 +20,8 @@ pnpm = "10.28.0"
 bun = "1.3.11"
 
 # Upgrading moon: https://moonrepo.dev/docs/install#upgrading
-# NOTE: Moon is also included in the npm packages at the repo root.
-#  This is only for compability purposes (i.e., supporting Cloudflare Pages deploys).
-#  It is expected that developers will be using moon via proto, but they should be kept in sync.
-# NOTE: Make sure those versions match!
+# The root npm packages carry moon too, purely so Cloudflare Pages deploys work — they never run proto.
+# Developers are expected to use moon via proto.
 moon = "2.4.5"
 rust = "1.93.0"
 

--- a/.prototools
+++ b/.prototools
@@ -1,5 +1,13 @@
 # https://moonrepo.dev/docs/proto/config
 
+# IMPORTANT: every pin below is duplicated outside this file — CI workflows and composite actions pin
+# moon/proto and the container image tag, `.github/Dockerfile` installs node and pnpm, and the root
+# `package.json` + catalog carry pnpm and moon for the non-proto entrypoints. None of those read
+# `.prototools`, and a divergence only surfaces on a cold cache, so bumping a version here is half the
+# change. Sweep for the old one and update every hit:
+#
+#   git grep -n '<old version>' -- ':!pnpm-lock.yaml'
+#
 proto = "0.58.2"
 # NOTE: Keep node and pnpm in sync with `.github/Dockerfile`, which installs them too.
 #  CI's setup action runs `pnpm install` before any moon task, so the image supplies them until moon's


### PR DESCRIPTION
Fixes both macOS jobs in `Composer Tauri Release`, which have been failing with:

```
failed to run 'cargo metadata' command to get workspace directory:
  failed to run command cargo metadata: error: error: unexpected argument 'metadata' found
Usage: rustup-init[EXE] [OPTIONS]
```

([`build_tauri`](https://github.com/dxos/dxos/actions/runs/31429645064/job/93591900966) died in `tauri build`, `build_tauri_ios` in `tauri ios init` — same error.)

## Root cause

`actions-rust-lang/setup-rust-toolchain` ran with `cache: true`, which invokes `Swatinem/rust-cache` against the repo root. There is no `Cargo.toml` there — the only crate is `packages/apps/composer-app/src-tauri` — so rust-cache's own `cargo metadata` failed:

```
commandFailed: { command: 'cargo metadata --all-features --format-version 1 --no-deps',
  stderr: 'error: could not find `Cargo.toml` in `/Users/runner/work/dxos/dxos` or any parent directory' }
```

It carried on with an empty lockfile hash, giving a cache key constant across every commit (`…-Darwin-arm64-2e933a5e-da39a3ee`, where `da39a3ee` is the SHA-1 of the empty string). The 1.5 KB entry stored under that key contains a `~/.cargo/bin`, and restoring it laid a `cargo` symlink to `rustup-init` over the rustup shims the step had installed seconds earlier. The job log shows exactly that ordering:

| Time | Event |
| --- | --- |
| 20:45:59 | `cargo --version` → `cargo 1.97.1` |
| 20:45:59–20:46:52 | rust-cache restores `/Users/runner/.cargo/bin` from the stale key |
| 20:47:06 | `cargo metadata` → `rustup-init` usage text, build fails |

`rustup` itself kept working (`rustup target add aarch64-apple-ios` succeeds after the restore), which is why only the cargo-driven steps broke. rust-cache's own `cleanBin` skips symlinks (`dirent.isFile()`), so once such an entry is cached it is never cleaned and every later run inherits it.

## Changes

- **`cache: false`** on both jobs' Rust setup. Repointing rust-cache at the crate would fix the key, but it would also restore a `target/` that any CI job can write to into a signed, notarized release — the same objection that makes this workflow blank `MOON_REMOTE_HOST`. The cache was restoring nothing useful (1.5 KB, and it never saved: *"Toolchain does not exist, not saving cache"*), so no build time is lost.
- **A `Verify Rust toolchain` step** after the toolchain install: `cargo metadata --no-deps --format-version 1` in `src-tauri`, with `command -v cargo` echoed. That is the first thing `tauri build` / `tauri ios init` do ~10 minutes into the job; asserting it up front turns this class of failure into a one-second error with the resolved path in the log.
- **Realigned the pinned toolchain versions** with `.prototools`: `moon-version` `2.2.3` → `2.4.5` and `proto-version: '0.58.2'` added, matching `.github/actions/setup` and the adjacent *"Keep in-sync with .prototools"* comment. The run installed proto 0.60.2 and moon 2.2.3 against configs written for 0.58.2/2.4.5.

## Testing

Workflow-only change, so it can only be exercised by a deploy run. Verified locally that the new assertion is correct — `cargo metadata --no-deps --format-version 1` succeeds in `packages/apps/composer-app/src-tauri` and needs no network — and that the YAML parses with both new steps landing in the intended position in each job. The real check is a `Deploy Apps` run with `app=composer` once this is merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1MqRg3KjvLdHqqhxWMGZF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop and iOS build reliability by preventing invalid build artifacts from being reused.
  * Added early validation to detect project metadata issues sooner during builds.

* **Documentation**
  * Added guidance for keeping development tool versions synchronized across project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->