### PR TITLE
plugin-space: fix duplicate settings space created during onboarding

### DIFF
--- a/.changeset/fix-duplicate-settings-space.md
+++ b/.changeset/fix-duplicate-settings-space.md
@@ -1,0 +1,6 @@
+---
+'@dxos/app-toolkit': patch
+'@dxos/plugin-space': patch
+---
+
+Fix fresh onboarding creating a duplicate settings space: the settings-space bootstrap now waits for the genesis-created space instead of racing its creation, and profiles already carrying a duplicate resolve the space holding the default-space designation as canonical.

--- a/packages/plugins/plugin-space/src/capabilities/spaces-ready.ts
+++ b/packages/plugins/plugin-space/src/capabilities/spaces-ready.ts
@@ -33,7 +33,7 @@ import { SpaceOperation } from '#operations';
 
 import { migrateToSettingsSpace } from '../migrations/settings-space';
 import * as SpaceCapabilities from '../types/SpaceCapabilities';
-import { ensureSettingsSpace } from '../util/settings-space';
+import { resolveSettingsSpace } from '../util/settings-space';
 
 const ACTIVE_NODE_BROADCAST_INTERVAL = 30_000;
 const WAIT_FOR_OBJECT_TIMEOUT = 5_000;
@@ -105,7 +105,7 @@ export default Capability.makeModule(
     let initFiber: Fiber.RuntimeFiber<void, unknown> | undefined;
 
     const initSettingsSpace = Effect.gen(function* () {
-      const settingsSpace = yield* ensureSettingsSpace(client);
+      const settingsSpace = yield* resolveSettingsSpace(client);
       const defaultSpace = yield* resolveDefaultSpace(client, settingsSpace);
 
       // Only relevant on a cold boot with no workspace in the deck state.

--- a/packages/plugins/plugin-space/src/util/settings-space.test.ts
+++ b/packages/plugins/plugin-space/src/util/settings-space.test.ts
@@ -1,0 +1,87 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, it } from '@effect/vitest';
+import * as Effect from 'effect/Effect';
+import * as Fiber from 'effect/Fiber';
+
+import * as AppSpace from '@dxos/app-toolkit/AppSpace';
+import { TestLayer } from '@dxos/cli-util/testing';
+import { ClientService } from '@dxos/client';
+import { Filter } from '@dxos/echo';
+import { Expando } from '@dxos/schema';
+
+import { migrateToSettingsSpace } from '../migrations/settings-space';
+import * as SpaceSchema from '../types/SpaceSchema';
+import { resolveSettingsSpace } from './settings-space';
+
+describe('resolveSettingsSpace', () => {
+  it.effect('waits out identity genesis instead of racing it into a duplicate', () =>
+    Effect.gen(function* () {
+      const client = yield* ClientService;
+      yield* Effect.tryPromise(() => client.halo.createIdentity());
+      // The ordering object is an Expando; the app registers it via its schema module.
+      yield* Effect.tryPromise(() => client.addTypes([Expando.Expando]));
+
+      // The app forks the resolver the moment the first space lands, mid-genesis; forking before
+      // genesis reproduces that window (default space published, settings space still pending).
+      const resolver = yield* Effect.fork(resolveSettingsSpace(client));
+      const { settingsSpace, defaultSpace } = yield* AppSpace.setupIdentitySpaces(client);
+      const resolved = yield* Fiber.join(resolver);
+
+      expect(resolved.id).toBe(settingsSpace.id);
+      expect(client.spaces.get().filter((space) => AppSpace.isSettingsSpace(space))).toHaveLength(1);
+
+      // The single settings space ends up holding both the designation and the ordering.
+      yield* migrateToSettingsSpace({
+        settingsSpace: resolved,
+        legacySpace: AppSpace.resolveLegacyDefaultSpace(client),
+      });
+      expect(AppSpace.getDefaultSpaceId(resolved)).toBe(defaultSpace.id);
+      const [ordering] = yield* Effect.promise(() =>
+        resolved.db.query(Filter.type(Expando.Expando, { key: SpaceSchema.SHARED })).run(),
+      );
+      expect(ordering).toBeDefined();
+      expect(AppSpace.getDefaultSpace(client)?.id).toBe(defaultSpace.id);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect('creates the settings space for a legacy profile that predates it', () =>
+    Effect.gen(function* () {
+      const client = yield* ClientService;
+      yield* Effect.tryPromise(() => client.halo.createIdentity());
+
+      const legacySpace = yield* Effect.promise(() =>
+        client.spaces.create({}, { tags: [AppSpace.PERSONAL_SPACE_TAG] }),
+      );
+      yield* Effect.promise(() => legacySpace.waitUntilReady());
+
+      const settingsSpace = yield* resolveSettingsSpace(client);
+
+      expect(AppSpace.isSettingsSpace(settingsSpace)).toBe(true);
+      expect(client.spaces.get().filter((space) => AppSpace.isSettingsSpace(space))).toHaveLength(1);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect('resolves the annotated settings space on a profile carrying a duplicate', () =>
+    Effect.gen(function* () {
+      const client = yield* ClientService;
+      yield* Effect.tryPromise(() => client.halo.createIdentity());
+
+      // The duplicate the race used to create lands first in the space list; the genesis-created
+      // space carries the default-space designation.
+      const duplicate = yield* Effect.promise(() => client.spaces.create({}, { tags: [AppSpace.SETTINGS_SPACE_TAG] }));
+      yield* Effect.promise(() => duplicate.waitUntilReady());
+      const canonical = yield* Effect.promise(() => client.spaces.create({}, { tags: [AppSpace.SETTINGS_SPACE_TAG] }));
+      yield* Effect.promise(() => canonical.waitUntilReady());
+      const defaultSpace = yield* Effect.promise(() => client.spaces.create({ name: AppSpace.DEFAULT_SPACE_NAME }));
+      yield* Effect.promise(() => defaultSpace.waitUntilReady());
+      AppSpace.setDefaultSpaceId(canonical, defaultSpace.id);
+
+      expect(AppSpace.getSettingsSpace(client)?.id).toBe(canonical.id);
+      expect((yield* resolveSettingsSpace(client)).id).toBe(canonical.id);
+      expect(AppSpace.getDefaultSpace(client)?.id).toBe(defaultSpace.id);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});

--- a/packages/plugins/plugin-space/src/util/settings-space.ts
+++ b/packages/plugins/plugin-space/src/util/settings-space.ts
@@ -6,14 +6,47 @@ import * as Effect from 'effect/Effect';
 
 import * as AppSpace from '@dxos/app-toolkit/AppSpace';
 import { type Client } from '@dxos/client';
+import { type Space } from '@dxos/client/echo';
 import { EdgeReplicationSetting } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { MembershipPolicy } from '@dxos/protocols/proto/dxos/halo/credentials';
+
+/**
+ * Resolve the settings space, creating one only for legacy profiles that predate it.
+ *
+ * On every other path a tagged settings space is guaranteed to arrive — genesis creates it for
+ * fresh profiles, replication delivers it for existing profiles on a new device — so this waits
+ * for it rather than creating: an eager create here races {@link AppSpace.setupIdentitySpaces}
+ * (which publishes the default space before the settings space) and loses, leaving the profile
+ * with a duplicate settings space.
+ */
+export const resolveSettingsSpace = Effect.fnUntraced(function* (client: Client) {
+  // The space list replays on subscribe, so the current state is checked with no gap in which an
+  // arriving settings space could be missed.
+  const existing = yield* Effect.async<Space | undefined>((resume) => {
+    const sub = client.spaces.subscribe(() => {
+      const settingsSpace = AppSpace.getSettingsSpace(client);
+      if (settingsSpace) {
+        resume(Effect.succeed(settingsSpace));
+      } else if (AppSpace.resolveLegacyDefaultSpace(client)) {
+        resume(Effect.succeed(undefined));
+      }
+    });
+    return Effect.sync(() => sub.unsubscribe());
+  });
+  if (!existing) {
+    return yield* ensureSettingsSpace(client);
+  }
+
+  yield* Effect.promise(() => existing.waitUntilReady());
+  return existing;
+});
 
 /**
  * Find the settings space, creating it if the profile does not have one yet.
  *
  * Profiles created through {@link AppSpace.setupIdentitySpaces} already have one; this covers the
- * profiles that predate the settings space, whose first sight of it is the migration.
+ * profiles that predate the settings space, whose first sight of it is the migration. Callers that
+ * cannot prove the profile is legacy use {@link resolveSettingsSpace} instead.
  */
 export const ensureSettingsSpace = Effect.fnUntraced(function* (client: Client) {
   const existing = AppSpace.getSettingsSpace(client);

--- a/packages/sdk/app-toolkit/src/echo/AppSpace.ts
+++ b/packages/sdk/app-toolkit/src/echo/AppSpace.ts
@@ -47,9 +47,25 @@ export const isExemplarSpace = (space: Space): boolean => hasTag(space, EXEMPLAR
 /** Check if a space is the settings space. */
 export const isSettingsSpace = (space: Space): boolean => hasTag(space, SETTINGS_SPACE_TAG);
 
-/** Find the settings space. */
-export const getSettingsSpace = (client: { spaces: { get(): Space[] } }): Space | undefined =>
-  client.spaces.get().find((space) => isSettingsSpace(space));
+/**
+ * Find the settings space.
+ *
+ * Profiles that hit the duplicate-creation race carry two tagged spaces; the one holding the
+ * default-space designation is canonical, so it wins over list order.
+ */
+export const getSettingsSpace = (client: { spaces: { get(): Space[] } }): Space | undefined => {
+  const tagged = client.spaces.get().filter((space) => isSettingsSpace(space));
+  if (tagged.length <= 1) {
+    return tagged[0];
+  }
+
+  // Properties are unreadable until the space is ready, so an unopened duplicate cannot be judged
+  // and the first tagged space stands in until one proves canonical.
+  return (
+    tagged.find((space) => space.state.get() === SpaceState.SPACE_READY && getDefaultSpaceId(space) !== undefined) ??
+    tagged[0]
+  );
+};
 
 /**
  * Whether a space belongs in the user-facing space lists (navtree, settings, create-object target).


### PR DESCRIPTION
## Problem

Every fresh onboarding created **two** `org.dxos.space.settings`-tagged spaces instead of one (4 spaces total instead of 3). Two independent creators race, and the race is guaranteed to be lost:

1. `identity-created.ts` runs `AppSpace.setupIdentitySpaces`, which deliberately creates the default space first (so it is first in `client.spaces.get()`), awaits `waitUntilReady()` + edge-replication setup, and only then creates the settings space and stamps the `defaultSpace` annotation.
2. `spaces-ready.ts` forks its settings-space init the moment `client.spaces.get().length > 0` — squarely inside that awaited window — and `ensureSettingsSpace` finds no tagged space yet, so it creates the duplicate. The migration then puts the shared-spaces ordering Expando in it.

Secondary damage: the duplicate (annotation-less) space is created first, so `AppSpace.getSettingsSpace` (a `.find()` over list order) returned it and `getDefaultSpace()` missed the designation.

## Fix

- **`plugin-space/util/settings-space.ts`** — new `resolveSettingsSpace`: creation from the spaces-ready path now happens **only** for legacy profiles that predate the settings space (the reason this path could create at all). Otherwise it subscribes to `client.spaces` and waits for the tagged space, which is guaranteed to arrive — genesis creates it for fresh profiles, replication delivers it for existing profiles on a new device. The check runs inside the subscription callback (which replays current state), so there is no gap in which an arriving settings space could be missed. This removes the second creator outright rather than shrinking a check-then-create window.
- **`spaces-ready.ts`** — `initSettingsSpace` uses `resolveSettingsSpace` instead of `ensureSettingsSpace`.
- **`app-toolkit/AppSpace.ts`** — `getSettingsSpace` now prefers the tagged space that is ready and carries the default-space designation, falling back to list order. This repairs profiles that already carry a duplicate: `getDefaultSpace()` resolves the canonical space again, at the cost of the (near-empty) ordering Expando in the duplicate being ignored and recreated in the canonical space. The stray duplicate space itself is not deleted — it is hidden, locked, and inert; a full merge/delete was judged not worth the risk given the bug shipped recently and affected profiles are fresh onboardings.

## Tests

New `settings-space.test.ts` pins the genesis interleaving with a real client: a resolver fiber forked *before* `setupIdentitySpaces` (strictly wider than the real race window) must resolve the genesis-created space, the profile must end with exactly one settings space holding **both** the ordering Expando and the designation, and `getDefaultSpace()` must resolve the default space. Two more tests cover the legacy-profile create path and duplicate-profile canonical resolution.

```
plugin-space:  ✓ 16 files passed | 1 skipped — 50 tests passed | 3 todo
app-toolkit:   ✓ 13 files passed — 142 tests passed
lint: clean; formatted with oxfmt
```

Manual verification against a local edge stack (fresh onboarding → 3 spaces, `getDefaultSpace()` → "My Space", MCP consent page lists 3 space ids) still needs a human run — this environment has no local stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dfiDoDAGmswUzTbQQb885

---
_Generated by [Claude Code](https://claude.ai/code/session_014dfiDoDAGmswUzTbQQb885)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate settings spaces from being created during onboarding.
  * Improved settings-space selection when duplicates exist by favoring the designated default.
  * Added support for legacy profiles without an existing settings space.
  * Ensured settings spaces are ready before they’re used, improving reliability during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->