### PR TITLE
compute-runtime: stop an unroutable scheduled followup from failing its caller

### DIFF
--- a/.changeset/edge-schedule-unroutable-followup.md
+++ b/.changeset/edge-schedule-unroutable-followup.md
@@ -1,0 +1,5 @@
+---
+'@dxos/compute-runtime': patch
+---
+
+Scheduling an unroutable followup operation in the EDGE runtime no longer fails the operation that scheduled it. `Operation.schedule` is typed as non-failing, but the EDGE-backed `Operation.Service` asserted on a missing `deployedId` — so a handler that scheduled a directly-imported definition (rather than one deserialized from the operation registry) took its caller down with it. Such followups are now logged and dropped. `Operation.invoke` is unchanged and still fails loudly.

--- a/packages/core/compute/compute-runtime/src/protocol.test.ts
+++ b/packages/core/compute/compute-runtime/src/protocol.test.ts
@@ -2,13 +2,18 @@
 // Copyright 2025 DXOS.org
 //
 
+import * as Effect from 'effect/Effect';
+import * as Schema from 'effect/Schema';
 import { describe, test } from 'vitest';
 
 import { InvalidOperationInputError } from '@dxos/compute';
+import * as Operation from '@dxos/compute/Operation';
 import { FibonacciHandler, ReplyHandler } from '@dxos/compute/testing';
+import { EffectEx } from '@dxos/effect';
 import { DXN } from '@dxos/keys';
+import { type EdgeFunctionEnv } from '@dxos/protocols';
 
-import { wrapFunctionHandler } from './protocol';
+import { makeOperationServiceLayer, wrapFunctionHandler } from './protocol';
 
 describe('wrapFunctionHandler', () => {
   test('wraps reply function and executes handler', async ({ expect }) => {
@@ -55,5 +60,61 @@ describe('wrapFunctionHandler', () => {
         },
       }),
     ).rejects.toThrow(InvalidOperationInputError);
+  });
+});
+
+describe('makeOperationServiceLayer', () => {
+  const Deployed = Operation.make({
+    meta: { key: DXN.make('org.example.operation.deployed'), name: 'Deployed', deployedId: 'fn-deployed' },
+    input: Schema.Struct({ value: Schema.String }),
+    output: Schema.Void,
+  });
+
+  // No `deployedId`: the shape of any definition a handler imported directly rather than
+  // deserializing from the registry — e.g. `space.addObject` scheduling `observability.sendEvent`.
+  const Local = Operation.make({
+    meta: { key: DXN.make('org.example.operation.local'), name: 'Local' },
+    input: Schema.Struct({ value: Schema.String }),
+    output: Schema.Void,
+  });
+
+  // Results cross a Cloudflare RPC boundary in production, so every one carries `Symbol.dispose`.
+  const disposable = { [Symbol.dispose]: () => {} };
+
+  const makeFunctionsService = (
+    calls: { deploymentId: string; input: unknown }[],
+  ): EdgeFunctionEnv.FunctionsService => ({
+    query: async () => Object.assign([], disposable),
+    invoke: async (deploymentId, input) => {
+      calls.push({ deploymentId, input });
+      return { _kind: 'success' as const, data: undefined, ...disposable };
+    },
+  });
+
+  const scheduleWith = async (
+    op: Operation.Definition<{ readonly value: string }, void>,
+    calls: { deploymentId: string; input: unknown }[],
+  ) =>
+    EffectEx.runPromise(
+      Effect.flatMap(Operation.Service, (service) => service.schedule(op, { value: 'x' })).pipe(
+        Effect.provide(makeOperationServiceLayer(makeFunctionsService(calls))),
+      ),
+    );
+
+  test('routes a scheduled operation by deployedId', async ({ expect }) => {
+    const calls: { deploymentId: string; input: unknown }[] = [];
+    await scheduleWith(Deployed, calls);
+
+    expect(calls).toEqual([{ deploymentId: 'fn-deployed', input: { value: 'x' } }]);
+  });
+
+  // Regression: this used to assert, and the resulting defect propagated out of the *calling*
+  // operation — `projects.create` 500'd at EDGE because the `space.addObject` inside it scheduled
+  // an observability event no worker registers a handler for.
+  test('drops an unroutable scheduled operation instead of failing its caller', async ({ expect }) => {
+    const calls: { deploymentId: string; input: unknown }[] = [];
+    await expect(scheduleWith(Local, calls)).resolves.toBeUndefined();
+
+    expect(calls).toEqual([]);
   });
 });

--- a/packages/core/compute/compute-runtime/src/protocol.test.ts
+++ b/packages/core/compute/compute-runtime/src/protocol.test.ts
@@ -63,7 +63,7 @@ describe('wrapFunctionHandler', () => {
   });
 });
 
-describe('makeOperationServiceLayer', () => {
+describe('EDGE Operation.Service', () => {
   const Deployed = Operation.make({
     meta: { key: DXN.make('org.example.operation.deployed'), name: 'Deployed', deployedId: 'fn-deployed' },
     input: Schema.Struct({ value: Schema.String }),
@@ -78,28 +78,13 @@ describe('makeOperationServiceLayer', () => {
     output: Schema.Void,
   });
 
-  // Results cross a Cloudflare RPC boundary in production, so every one carries `Symbol.dispose`.
-  const disposable = { [Symbol.dispose]: () => {} };
-
-  const makeFunctionsService = (
-    calls: { deploymentId: string; input: unknown }[],
-  ): EdgeFunctionEnv.FunctionsService => ({
-    query: async () => Object.assign([], disposable),
-    invoke: async (deploymentId, input) => {
-      calls.push({ deploymentId, input });
-      return { _kind: 'success' as const, data: undefined, ...disposable };
-    },
-  });
-
-  const scheduleWith = async (
-    op: Operation.Definition<{ readonly value: string }, void>,
-    calls: { deploymentId: string; input: unknown }[],
-  ) =>
-    EffectEx.runPromise(
-      Effect.flatMap(Operation.Service, (service) => service.schedule(op, { value: 'x' })).pipe(
-        Effect.provide(makeOperationServiceLayer(makeFunctionsService(calls))),
-      ),
-    );
+  // Scheduling from inside a wrapped handler exercises the service the EDGE runtime actually
+  // installs, including the branch taken when no `functionsService` is configured.
+  const Scheduler = Operation.make({
+    meta: { key: DXN.make('org.example.operation.scheduler'), name: 'Scheduler' },
+    input: Schema.Void,
+    output: Schema.Void,
+  }).pipe(Operation.withHandler(() => Operation.schedule(Local, { value: 'x' })));
 
   test('routes a scheduled operation by deployedId', async ({ expect }) => {
     const calls: { deploymentId: string; input: unknown }[] = [];
@@ -117,4 +102,37 @@ describe('makeOperationServiceLayer', () => {
 
     expect(calls).toEqual([]);
   });
+
+  // The same contract on the other variant: a context with no `functionsService` cannot route
+  // anything, and must still not fail the handler that scheduled the followup.
+  test('drops a scheduled followup when no functionsService is configured', async ({ expect }) => {
+    const wrapped = wrapFunctionHandler(Scheduler);
+
+    await expect(wrapped.handler({ data: undefined, context: { services: {} } })).resolves.toBeUndefined();
+  });
 });
+
+//
+// Helpers.
+//
+
+// Results cross a Cloudflare RPC boundary in production, so every one carries `Symbol.dispose`.
+const disposable = { [Symbol.dispose]: () => {} };
+
+const makeFunctionsService = (calls: { deploymentId: string; input: unknown }[]): EdgeFunctionEnv.FunctionsService => ({
+  query: async () => Object.assign([], disposable),
+  invoke: async (deploymentId, input) => {
+    calls.push({ deploymentId, input });
+    return { _kind: 'success' as const, data: undefined, ...disposable };
+  },
+});
+
+const scheduleWith = async (
+  op: Operation.Definition<{ readonly value: string }, void>,
+  calls: { deploymentId: string; input: unknown }[],
+) =>
+  EffectEx.runPromise(
+    Effect.flatMap(Operation.Service, (service) => service.schedule(op, { value: 'x' })).pipe(
+      Effect.provide(makeOperationServiceLayer(makeFunctionsService(calls))),
+    ),
+  );

--- a/packages/core/compute/compute-runtime/src/protocol.ts
+++ b/packages/core/compute/compute-runtime/src/protocol.ts
@@ -285,8 +285,10 @@ const InternalAiServiceLayer = (functionsAiService: EdgeFunctionEnv.FunctionsAiS
  * Backs `Operation.Service` with the EDGE-provided `FunctionsService` so that operation
  * handlers can invoke other deployed operations remotely. The `deployedId` on the operation
  * definition is used as the routing key.
+ *
+ * @internal Exported for testing.
  */
-const makeOperationServiceLayer = (
+export const makeOperationServiceLayer = (
   functionsService: EdgeFunctionEnv.FunctionsService,
 ): Layer.Layer<Operation.Service> => {
   const invokeRemote = async (
@@ -317,7 +319,16 @@ const makeOperationServiceLayer = (
       )) as Operation.OperationService['invoke'],
     schedule: ((op: Operation.Definition.Any, input: unknown, _options?: Operation.InvokeOptions) =>
       Effect.sync(() => {
-        invariant(op.meta.deployedId, `Operation '${op.meta.key}' has no deployedId; cannot schedule remotely.`);
+        // Dropped rather than asserted: `schedule` is typed `Effect<void, never>`, so failing an
+        // unroutable followup would take its caller down with it — a handler that imported a
+        // definition directly (no `deployedId`, e.g. `observability.sendEvent` scheduled by
+        // `space.addObject`) must not fail the operation that emitted it.
+        if (!op.meta.deployedId) {
+          log.warn('scheduled operation dropped: no deployedId, cannot schedule remotely', {
+            key: String(op.meta.key),
+          });
+          return;
+        }
         // Fire and forget — schedule is intentionally non-awaiting.
         void functionsService.invoke(op.meta.deployedId, input).catch(() => {
           // Swallow errors — schedule is observability-only.
@@ -332,7 +343,13 @@ const makeOperationServiceLayer = (
 
 const unavailableOperationServiceLayer = Layer.succeed(Operation.Service, {
   invoke: () => Effect.die('Operation.Service is not available: missing functionsService in EDGE context.'),
-  schedule: () => Effect.die('Operation.Service is not available: missing functionsService in EDGE context.'),
+  // Warn rather than die, for the same reason the routable variant drops unroutable followups.
+  schedule: (op: Operation.Definition.Any) =>
+    Effect.sync(() => {
+      log.warn('scheduled operation dropped: missing functionsService in EDGE context', {
+        key: String(op.meta.key),
+      });
+    }),
   invokePromise: async () => ({
     error: new Error('Operation.Service is not available: missing functionsService in EDGE context.'),
   }),

--- a/packages/plugins/plugin-observability/src/ObservabilityPlugin.node.ts
+++ b/packages/plugins/plugin-observability/src/ObservabilityPlugin.node.ts
@@ -14,7 +14,10 @@ import { meta } from '#meta';
 
 import * as ObservabilityOperation from './types/ObservabilityOperation';
 
-// TODO(wittjosiah): Hook up.
+// TODO(wittjosiah): Hook up — `SendEvent` drops its event for the same two reasons as the workerd
+//   variant (no non-browser transport, no way to read the user's telemetry preference); see the
+//   note in `ObservabilityPlugin.workerd.ts`. Node has fewer platform constraints than workerd, so
+//   it can likely share whatever sink that gap is closed with.
 export const ObservabilityPlugin = Plugin.define(meta).pipe(
   Plugin.addModule(
     Capability.inlineModule('OperationHandler', { provides: [Capabilities.OperationHandler] }, () =>

--- a/packages/plugins/plugin-observability/src/ObservabilityPlugin.workerd.ts
+++ b/packages/plugins/plugin-observability/src/ObservabilityPlugin.workerd.ts
@@ -14,6 +14,19 @@ import { meta } from '#meta';
 
 import * as ObservabilityOperation from './types/ObservabilityOperation';
 
+// TODO(wittjosiah): Make observability actually work in a worker. `SendEvent` drops its event here
+//   because neither half of the browser implementation ports to workerd:
+//   1. Transport — `@dxos/observability` is browser-only (posthog-js, @dxos/client, localforage,
+//      zone.js, the OTel *-web SDKs), and its PostHog extension already stubs itself off-window. A
+//      worker needs a thin `fetch`-based sink (PostHog capture, the invocation's trace sink, or
+//      OTLP) rather than a port of that package.
+//   2. Consent — the browser handler reaches the `Observability` capability, which gates on the
+//      user's telemetry setting and the privacy notice. A worker has no such state, and
+//      `invokeOperation` carries no caller identity to look it up by, so there is currently no way
+//      to honour an opt-out. Sending events before that is resolved would leak past the user's
+//      choice; dropping them is the conservative default.
+//   NOTE: The real handler cannot simply be registered here — it resolves the capability with
+//   `Capability.waitFor`, which never settles when nothing contributes it, hanging the invocation.
 export const ObservabilityPlugin = Plugin.define(meta).pipe(
   Plugin.addModule(
     Capability.inlineModule('OperationHandler', { provides: [Capabilities.OperationHandler] }, () =>


### PR DESCRIPTION
## Problem

`projects.create` 500s at EDGE. The chain:

```
projects.create
  → Operation.invoke(SpaceOperation.AddObject)
  → Operation.schedule(ObservabilityOperation.SendEvent)     plugin-space/src/operations/add-object.ts:31
  → withLocalOperations.localFirst.schedule                  (edge) entrypoint.ts:466
  → findLocal(SendEvent) → undefined                         (no worker registers an observability handler)
  → fallback.schedule(op, …)                                 (remote dispatcher)
  ✗ invariant(op.meta.deployedId, …)                         compute-runtime/src/protocol.ts
```

`SendEvent` is imported directly rather than deserialized from the operation registry, so it carries no `deployedId`. The assert threw inside `Effect.sync`, and that defect propagated out of the **calling** operation — `space.addObject` failed, taking `projects.create` with it.

`Operation.schedule` is typed `Effect<void, never>`: fire-and-forget, cannot fail. Dying inside it violates that contract. The line directly below the assert already said *"Swallow errors — schedule is observability-only"*; the assert simply threw before it could.

## Change

`schedule` now logs and drops when an operation cannot be routed, in both the routable and the missing-`functionsService` variants of the EDGE `Operation.Service`. This fixes the whole class, not just observability: any handler scheduling a directly-imported definition now degrades instead of taking its caller down.

`Operation.invoke` is untouched — it has a return value its caller depends on, so it must still fail loudly.

Also adds TODOs recording what it would take for observability to work off-browser, since the drop is now silent:

1. **Transport** — `@dxos/observability` is browser-only (posthog-js, `@dxos/client`, localforage, zone.js, the OTel `*-web` SDKs), and its PostHog extension already stubs itself off-window. A worker needs a thin `fetch`-based sink, not a port of that package.
2. **Consent** — the browser handler reaches the `Observability` capability, which gates on the user's telemetry setting and the privacy notice. A worker has no such state and `invokeOperation` carries no caller identity to look one up by, so an opt-out cannot currently be honoured. Dropping is the conservative default.

The TODO also records that the real handler cannot simply be registered in a worker: it resolves the capability with `Capability.waitFor`, which never settles when nothing contributes it, hanging the invocation rather than failing it.

## Testing

```
compute-runtime: build ✓  lint ✓  Test Files 19 passed  Tests 160 passed | 1 skipped
plugin-observability: build ✓  lint ✓  1 passed
```

Two new regression tests in `protocol.test.ts`: a routable operation still dispatches by `deployedId`, and an unroutable one resolves instead of failing its caller.

## Notes

- `ProcessOperationInvoker.ts:135` has the same assert on the explicit `on: 'edge'` schedule path. Left alone deliberately: it is an explicit opt-in rather than a silent fallback, and the defect lands in a forked daemon fiber rather than the caller.
- EDGE still never registers an observability handler, so events are dropped by the fallback rather than by an intentional no-op. Merging `ObservabilityOperationHandlerSet` (workerd variant) into `operation-service`'s registry would make that explicit — a separate change in `dxos/edge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKTd9c6jSsgkzdRCjBuw9T

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKTd9c6jSsgkzdRCjBuw9T)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * EDGE runtime scheduling now safely drops unroutable follow-up operations and logs a warning instead of failing the caller.
  * Unavailable operation services no longer terminate callers when scheduled operations cannot be routed.
  * Operation invocation behavior remains unchanged.

* **Documentation**
  * Clarified observability limitations in server and worker environments, including telemetry consent and transport constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->