### PR TITLE
ci: order the check job into cost-ranked stages, move the boot budget into it

### DIFF
--- a/.agents/projects/ci/DESIGN.md
+++ b/.agents/projects/ci/DESIGN.md
@@ -12,6 +12,38 @@ on `depot-ubuntu-24.04-8`, all inside `ghcr.io/dxos/gh-actions`, with e2e sharde
 
 Everything routes through `moon`, and `.moon/workspace.yml` decides where the remote cache lives.
 
+### The `check` job runs in three stages, ordered by cost
+
+Its steps are cheap-first, because what the ordering buys is time-to-red-signal on a broken PR — not
+a shorter Check, which `storybook` (~20 min) sets, not `check` (~8 min). Stage boundaries are the
+dependency edges:
+
+1. **No-build gates, ~30 s combined** — `format-check` first (one unformatted file fails every job
+   in the workflow), then the packaging scripts, then the peer-dependency resolution.
+2. **The compile gate** — `moon run :lint :build`, ~15 s warm and the job's floor cold.
+   `check-module-structure` belongs here and not in stage 1 despite costing 5 s: it declares
+   `deps: [build]`, so ahead of the gate it would pull the builds along with it.
+3. **The two slow checks** — `knip` (~2m36s, 85% of the job's real work) and `check-boot-budget`
+   (~1 min). Only this stage is report-all (`continue-on-error` plus a gate step): fail-fast costs
+   nothing when steps cost seconds, but here it hides one failure behind the other for a whole
+   further run of the job.
+
+Two facts the ordering depends on, both verified rather than assumed:
+
+- **`pnpm-lock.yaml` is an input to every moon task** (`.moon/tasks/all.yml`). Editing it and
+  re-running a cached task changes the hash, so the peer-dependency step — which passes
+  `--no-frozen-lockfile` and may rewrite the lockfile — restores it under a `trap` instead of
+  invalidating stages 2 and 3. That is why the step could not simply be moved to the front.
+- **The production `bundle` is not otherwise built anywhere in Check.** `:build` does not include it
+  and `e2e-bundle` builds `bundle-e2e`, a separate cache entry by design (`DX_PWA=false` changes the
+  very boot graph the budget measures). So `check-boot-budget` pays for that bundle wherever it
+  lives; on the `check` job it at least follows stage 2, which has warmed the library builds under
+  it. Its former home — one `e2e` cell — could only ever check post-merge, since `e2e` is gated to
+  main/changeset-release/dispatch.
+
+Neither caching the small scripts as moon tasks nor caching `knip` was worth it: the scripts run in
+1–6 s, and knip is a whole-repo analysis that any real PR invalidates, so its hit rate is ~0.
+
 ## The failure mode that governs every decision here
 
 **moon treats every remote-cache failure as non-fatal.** A missing credential, a rejected

--- a/.agents/projects/ci/DESIGN.md
+++ b/.agents/projects/ci/DESIGN.md
@@ -23,10 +23,10 @@ dependency edges:
 2. **The compile gate** — `moon run :lint :build`, ~15 s warm and the job's floor cold.
    `check-module-structure` belongs here and not in stage 1 despite costing 5 s: it declares
    `deps: [build]`, so ahead of the gate it would pull the builds along with it.
-3. **The two slow checks** — `knip` (~2m36s, 85% of the job's real work) and `check-boot-budget`
-   (~1 min). Only this stage is report-all (`continue-on-error` plus a gate step): fail-fast costs
-   nothing when steps cost seconds, but here it hides one failure behind the other for a whole
-   further run of the job.
+3. **The two slow checks** — `knip` (2m36s–3m21s, and the bulk of the job's real work) and
+   `check-boot-budget` (53 s cold). Only this stage is report-all (`continue-on-error` plus a gate
+   step): fail-fast costs nothing when steps cost seconds, but here it hides one failure behind the
+   other for a whole further run of the job.
 
 Two facts the ordering depends on, both verified rather than assumed:
 
@@ -38,8 +38,9 @@ Two facts the ordering depends on, both verified rather than assumed:
   and `e2e-bundle` builds `bundle-e2e`, a separate cache entry by design (`DX_PWA=false` changes the
   very boot graph the budget measures). So `check-boot-budget` pays for that bundle wherever it
   lives; on the `check` job it at least follows stage 2, which has warmed the library builds under
-  it. Its former home — one `e2e` cell — could only ever check post-merge, since `e2e` is gated to
-  main/changeset-release/dispatch.
+  it. Measured there: 53 s for the step, 28 s of it the bundle building from source with its 281
+  dependency tasks hydrated. Its former home — one `e2e` cell — could only ever check post-merge,
+  since `e2e` is gated to main/changeset-release/dispatch.
 
 Neither caching the small scripts as moon tasks nor caching `knip` was worth it: the scripts run in
 1–6 s, and knip is a whole-repo analysis that any real PR invalidates, so its hit rate is ~0.

--- a/.agents/projects/ci/DESIGN.md
+++ b/.agents/projects/ci/DESIGN.md
@@ -39,8 +39,8 @@ Two facts the ordering depends on, both verified rather than assumed:
   very boot graph the budget measures). So `check-boot-budget` pays for that bundle wherever it
   lives; on the `check` job it at least follows stage 2, which has warmed the library builds under
   it. Measured there: 53 s for the step, 28 s of it the bundle building from source with its 281
-  dependency tasks hydrated. Its former home — one `e2e` cell — could only ever check post-merge,
-  since `e2e` is gated to main/changeset-release/dispatch.
+  dependency tasks hydrated. Its former home — one `e2e` cell — could never gate a PR automatically:
+  `e2e` runs on main/changeset-release, or on an explicit dispatch someone has to ask for.
 
 Neither caching the small scripts as moon tasks nor caching `knip` was worth it: the scripts run in
 1–6 s, and knip is a whole-repo analysis that any real PR invalidates, so its hit rate is ~0.

--- a/.agents/projects/ci/TASKS.md
+++ b/.agents/projects/ci/TASKS.md
@@ -231,12 +231,12 @@ Browser gates are listed only where this work changed them. Ordered by cost to f
       `check-boot-budget` as the only report-all pair. The peer-dependency step moved from last to
       stage 1 behind a `trap` that restores `pnpm-lock.yaml` — confirmed empirically that the
       lockfile is a hash input to every task (editing it re-hashed a cached `dx-build:build`).
-- [ ] **Measure the cold cost of `check-boot-budget` on the `check` job.** Its 50 s in the chromium
-      cell was a cache hit on `composer-app:bundle`; nothing else in Check builds the production
-      bundle, so a PR touching composer's dependency closure builds it from source on the job's
-      critical path. If that proves too expensive, the fallback is its own job with
-      `needs: e2e-bundle` — pointing it at `bundle-e2e` is refuted, `DX_PWA=false` changes the boot
-      graph being budgeted.
+- [x] **Measured the cold cost of `check-boot-budget` on the `check` job: 53 s**, of which
+      `composer-app:bundle` built from source in 28 s (run 31539993812 — `284 completed (281
+    cached)`, so the libraries hydrated and only the bundle ran; the script itself is 28 ms). The
+      dedicated-job fallback (`needs: e2e-bundle`) is therefore not needed. Note the e2e cell's
+      former 50 s was NOT a cache hit as assumed — building this bundle simply costs ~30 s once its
+      closure is warm.
 
 ## Phase 4: Storybook failures the cache was hiding
 

--- a/.agents/projects/ci/TASKS.md
+++ b/.agents/projects/ci/TASKS.md
@@ -232,9 +232,9 @@ Browser gates are listed only where this work changed them. Ordered by cost to f
       stage 1 behind a `trap` that restores `pnpm-lock.yaml` — confirmed empirically that the
       lockfile is a hash input to every task (editing it re-hashed a cached `dx-build:build`).
 - [x] **Measured the cold cost of `check-boot-budget` on the `check` job: 53 s**, of which
-      `composer-app:bundle` built from source in 28 s (run 31539993812 — `284 completed (281
-    cached)`, so the libraries hydrated and only the bundle ran; the script itself is 28 ms). The
-      dedicated-job fallback (`needs: e2e-bundle`) is therefore not needed. Note the e2e cell's
+      `composer-app:bundle` built from source in 28 s. Run 31539993812 reported 284 tasks completed
+      with 281 cached, so the libraries hydrated and only the bundle ran; the script itself is 28 ms.
+      The dedicated-job fallback (`needs: e2e-bundle`) is therefore not needed. Note the e2e cell's
       former 50 s was NOT a cache hit as assumed — building this bundle simply costs ~30 s once its
       closure is warm.
 

--- a/.agents/projects/ci/TASKS.md
+++ b/.agents/projects/ci/TASKS.md
@@ -224,8 +224,8 @@ Browser gates are listed only where this work changed them. Ordered by cost to f
       masked failure could not make a green cell unfalsifiable; all eight uploads now agree.
 - [x] **Sync with main** (Changesets v3 added a `check-changeset-bumps` step whose script the branch
       lacked, so the `check` job failed until the merge) **and drop draft status.**
-- [x] **Move `check-boot-budget` off the e2e cell** — it is now the last step of the `check` job,
-      which also makes it gate the PR rather than only run post-merge. Landed with the `check` job's
+- [x] **Move `check-boot-budget` off the e2e cell** — it is now the last check in the `check` job's
+      stage 3, which also makes it gate the PR. Landed with the `check` job's
       cost-ordered stages (DESIGN.md, "The `check` job runs in three stages"): stage 1 the ~30 s
       no-build gates with `format-check` leading, stage 2 the compile gate, stage 3 `knip` +
       `check-boot-budget` as the only report-all pair. The peer-dependency step moved from last to

--- a/.agents/projects/ci/TASKS.md
+++ b/.agents/projects/ci/TASKS.md
@@ -224,10 +224,19 @@ Browser gates are listed only where this work changed them. Ordered by cost to f
       masked failure could not make a green cell unfalsifiable; all eight uploads now agree.
 - [x] **Sync with main** (Changesets v3 added a `check-changeset-bumps` step whose script the branch
       lacked, so the `check` job failed until the merge) **and drop draft status.**
-- [ ] **Move `check-boot-budget` off the e2e cell.** It is static (a Node script reading
-      `out/composer/index.html`) but depends on the production `bundle`, which the composer cell does
-      not otherwise build — it cost 51 s in one chromium cell. `e2e-bundle` or `check` is the right
-      home; neither installs browsers for it.
+- [x] **Move `check-boot-budget` off the e2e cell** — it is now the last step of the `check` job,
+      which also makes it gate the PR rather than only run post-merge. Landed with the `check` job's
+      cost-ordered stages (DESIGN.md, "The `check` job runs in three stages"): stage 1 the ~30 s
+      no-build gates with `format-check` leading, stage 2 the compile gate, stage 3 `knip` +
+      `check-boot-budget` as the only report-all pair. The peer-dependency step moved from last to
+      stage 1 behind a `trap` that restores `pnpm-lock.yaml` — confirmed empirically that the
+      lockfile is a hash input to every task (editing it re-hashed a cached `dx-build:build`).
+- [ ] **Measure the cold cost of `check-boot-budget` on the `check` job.** Its 50 s in the chromium
+      cell was a cache hit on `composer-app:bundle`; nothing else in Check builds the production
+      bundle, so a PR touching composer's dependency closure builds it from source on the job's
+      critical path. If that proves too expensive, the fallback is its own job with
+      `needs: e2e-bundle` — pointing it at `bundle-e2e` is refuted, `DX_PWA=false` changes the boot
+      graph being budgeted.
 
 ## Phase 4: Storybook failures the cache was hiding
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -591,9 +591,6 @@ jobs:
       # No bundle step: the `e2e-ci` targets declare `bundle-e2e` as a dep, so moon hydrates it from the
       # cache `e2e-bundle` warmed.
 
-      # No boot-budget step: this job is gated, so it could only ever check post-merge — it moved to
-      # the `check` job, whose `bundle` build it was paying for here anyway.
-
       # Clear Storybook Vite cache in every package so Storybook dev server does a fresh optimizeDeps run.
       # Avoids 504 Outdated Optimize Dep when graph differs from bundle step.
       # Storybook puts cache under node_modules/.cache/storybook/<hash>/sb-vite per package.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -92,17 +92,18 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      # ─── Stage 1: gates that need no build ──────────────────────────────────────────────────────
+      # Ordered by measured cost, cheapest first, so the common failure lands in seconds instead of
+      # behind minutes of work it does not depend on; the whole stage is ~30 s. `format-check` leads
+      # because a single unformatted file fails every job in the workflow.
+      - name: Check formatting
+        run: pnpm run format-check
+
       - name: Check for import cycles
         run: pnpm run check-cycles
 
-      - name: Check public packages don't depend on private packages
-        run: pnpm run check-public-dependencies
-
       - name: Check publish config
         run: pnpm run check-publish-config
-
-      - name: Check public packages are published
-        run: pnpm run check-packages-published
 
       # Pre-1.0 a breaking change rides the minor; `major` is reserved for the deliberate 1.0.0 cut. The
       # groups are `fixed`, so one stray `major` versions every package to 1.0.0. Delete with the cut.
@@ -114,21 +115,30 @@ jobs:
         # sync-versions.mjs during release; fail the PR if a committed copy drifts out of sync.
         run: node scripts/sync-versions.mjs --check
 
-      - name: Check package.json paths
-        run: pnpm run pkg-lint
-
       - name: Check remote cache wiring
         run: node scripts/check-cache-wiring.mjs
 
-      # Unused/undeclared dependencies and unreferenced files. Analyses the source tree — the knip
-      # config resolves workspace packages through their `source` export condition — so it needs no
-      # build and runs before the expensive `moon run :lint :build` step below.
-      - name: Check dependencies
-        run: pnpm run knip
+      - name: Check package.json paths
+        run: pnpm run pkg-lint
 
-      - name: Check formatting
-        run: pnpm run format-check
+      - name: Check public packages don't depend on private packages
+        run: pnpm run check-public-dependencies
 
+      - name: Check public packages are published
+        run: pnpm run check-packages-published
+
+      # `.npmrc` sets `strict-peer-dependencies` with `auto-install-peers=false`, so re-resolving is
+      # what surfaces an unsatisfiable peer. The `trap` restores the lockfile on failure as well as on
+      # success: `--no-frozen-lockfile` can rewrite `pnpm-lock.yaml`, which `.moon/tasks/all.yml`
+      # declares as an input to every task, so a rewritten copy would miss the cache for both stages
+      # below — the reason this step used to sit at the very end.
+      - name: Check for peer dependency issues
+        run: |
+          trap 'git checkout -- pnpm-lock.yaml' EXIT
+          pnpm install --resolution-only --no-frozen-lockfile
+
+      # ─── Stage 2: the compile gate ──────────────────────────────────────────────────────────────
+      # ~15 s warm, minutes cold, and the floor under everything below it.
       - name: Check Affected
         if: ${{ steps.extract_branch.outputs.branch != 'main' }}
         run: moon run :lint :build --affected remote
@@ -137,6 +147,8 @@ jobs:
         if: ${{ steps.extract_branch.outputs.branch == 'main' }}
         run: moon run :lint :build
 
+      # `check-module-structure` traces the built artifacts (`deps: [build]`), so it cannot move ahead
+      # of the gate however cheap it looks — its 5 s is a post-build number.
       - name: Check module structure (affected)
         if: ${{ steps.extract_branch.outputs.branch != 'main' }}
         run: moon run :check-module-structure --affected remote
@@ -145,8 +157,42 @@ jobs:
         if: ${{ steps.extract_branch.outputs.branch == 'main' }}
         run: moon run :check-module-structure
 
-      - name: Check for peer dependency issues
-        run: pnpm install --resolution-only --no-frozen-lockfile
+      # ─── Stage 3: the two slow checks ───────────────────────────────────────────────────────────
+      # ~2m30s and ~1m against ~30 s for all of stage 1, so these run last. Both are
+      # `continue-on-error` with a gate step below: fail-fast is free when steps are cheap, but here
+      # it would hide one failure behind the other at the cost of a whole further run of the job.
+      #
+      # Unused/undeclared dependencies and unreferenced files. Analyses the source tree — the knip
+      # config resolves workspace packages through their `source` export condition — so it needs no
+      # build, but at 85% of the job's real work it earns no place ahead of anything.
+      - name: Check dependencies
+        id: knip
+        continue-on-error: true
+        run: pnpm run knip
+
+      # Static boot-graph budget over the production bundle. The class it catches is a property of an
+      # IMPORT EDGE — a boot-reachable module reaching a barrel instead of a subpath — so a refactor
+      # that relocates the edge silently drops the fix and neither the build nor the tests notice;
+      # three separate fixes were undone that way. Not `--affected`-scoped, because the offending edit
+      # lands in some other package. Here rather than on an `e2e` cell so that it gates the PR that
+      # introduces the regression: `e2e` is gated to main/changeset-release/dispatch, where the check
+      # could only ever run post-merge. `bundle` is not otherwise built in this workflow, so this step
+      # pays for it; stage 2 has at least warmed the library builds underneath it.
+      - name: Check boot budget
+        id: boot_budget
+        continue-on-error: true
+        run: moon run composer-app:check-boot-budget
+
+      - name: Report slow-check failures
+        if: ${{ steps.knip.outcome == 'failure' || steps.boot_budget.outcome == 'failure' }}
+        run: |
+          if [ "${{ steps.knip.outcome }}" = failure ]; then
+            echo '::error::knip failed — see the "Check dependencies" step.'
+          fi
+          if [ "${{ steps.boot_budget.outcome }}" = failure ]; then
+            echo '::error::boot budget failed — see the "Check boot budget" step.'
+          fi
+          exit 1
 
   test:
     strategy:
@@ -545,16 +591,8 @@ jobs:
       # No bundle step: the `e2e-ci` targets declare `bundle-e2e` as a dep, so moon hydrates it from the
       # cache `e2e-bundle` warmed.
 
-      # Static boot-graph budget over the bundle just built. The class it catches is a property of an
-      # IMPORT EDGE — a boot-reachable module reaching a barrel instead of a subpath — so a refactor
-      # that relocates the edge silently drops the fix and neither the build nor the tests notice;
-      # three separate fixes were undone that way. Not `--affected`-scoped, because the offending
-      # edit lands in some other package. NOTE: this job is gated to main/changeset-release/dispatch,
-      # so today the check runs post-merge and does not gate the PR that introduces the regression.
-      # One cell only: it is a property of the bundle, identical across every cell of the matrix.
-      - name: Check boot budget
-        if: ${{ matrix.browser == 'chromium' && matrix.shard == 'composer' }}
-        run: moon run composer-app:check-boot-budget
+      # No boot-budget step: this job is gated, so it could only ever check post-merge — it moved to
+      # the `check` job, whose `bundle` build it was paying for here anyway.
 
       # Clear Storybook Vite cache in every package so Storybook dev server does a fresh optimizeDeps run.
       # Avoids 504 Outdated Optimize Dep when graph differs from bundle step.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -175,9 +175,9 @@ jobs:
       # that relocates the edge silently drops the fix and neither the build nor the tests notice;
       # three separate fixes were undone that way. Not `--affected`-scoped, because the offending edit
       # lands in some other package. Here rather than on an `e2e` cell so that it gates the PR that
-      # introduces the regression: `e2e` is gated to main/changeset-release/dispatch, where the check
-      # could only ever run post-merge. `bundle` is not otherwise built in this workflow, so this step
-      # pays for it; stage 2 has at least warmed the library builds underneath it.
+      # introduces the regression: `e2e` runs on main/changeset-release or an explicit dispatch, so
+      # there it never gated one. `bundle` is not otherwise built in this workflow, so this step pays
+      # for it; stage 2 has at least warmed the library builds underneath it.
       - name: Check boot budget
         id: boot_budget
         continue-on-error: true

--- a/packages/apps/composer-app/moon.yml
+++ b/packages/apps/composer-app/moon.yml
@@ -30,9 +30,9 @@ tasks:
       DX_PWA: 'false'
   # Structural budget on the eager boot graph (entry + modulepreload closure). Its own task rather
   # than a step inside `bundle`: a perf budget must not fail the local build you are running in
-  # order to measure the very thing it is budgeting. `check-boot-budget` runs on the `e2e` job
-  # (post-merge, since that job is gated to main/changeset-release/dispatch);
-  # `check-startup-budget` is still manual — its timings cannot gate without a fixed runner.
+  # order to measure the very thing it is budgeting. `check-boot-budget` runs in the `check` job, so
+  # it gates every PR; `check-startup-budget` is still manual — its timings cannot gate without a
+  # fixed runner.
   check-boot-budget:
     command: node scripts/check-boot-budget.mjs
     deps:


### PR DESCRIPTION
The `check` job ran ~12 steps in no particular order, so a 5 s formatting failure surfaced only after `knip`'s 2m36s. Steps are now cheapest-first in three stages. What the ordering buys is **time-to-red-signal on a broken PR** — not a shorter Check, whose length is set by `storybook` (~20 min), not by this job.

### Stages, as measured on this PR's own runs

| stage | steps | cost |
| :-- | :-- | --: |
| 1 — no build needed | `format-check` → `check-cycles` → the seven packaging scripts → peer-dep resolution | **32 s** |
| 2 — compile gate | `:lint :build --affected` → `check-module-structure` | 3 s warm |
| 3 — slow checks | `knip`, then `check-boot-budget` | 2m29s–3m21s + 13–53 s |

`format-check` leads because a single unformatted file fails every job in the workflow, so finding it after a cold build is pure waste. That was demonstrated for real mid-PR: an unformatted markdown file failed the job in 65 s instead of behind `knip`.

### The three constraints that shaped it

- **`check-boot-budget` moves off the `e2e (chromium, composer)` cell.** `e2e` runs on main/changeset-release or an explicit dispatch, so it could never gate a PR automatically — the check now gates the PR that introduces the regression, which is the point of a budget on an import edge. No e2e cell builds the production `bundle` it needs (`e2e-bundle` warms `bundle-e2e`, deliberately a separate entry — `DX_PWA=false` changes the very boot graph being budgeted), so that cell was paying for the bundle anyway.
- **The peer-dependency step moved from last to stage 1 behind a `trap` that restores `pnpm-lock.yaml`.** `.moon/tasks/all.yml` declares the lockfile an input to every task, so a rewrite from `--no-frozen-lockfile` would miss the cache for stages 2 and 3. Verified rather than assumed: editing the lockfile and re-running a cached task re-hashed `dx-build:build` (`13202c06…` → `b4eade0e…`). The `trap` fires on failure as well as success — confirmed it still propagates exit 1 under GitHub's `bash -e`.
- **`check-module-structure` stays after the compile gate** despite costing 5 s — it declares `deps: [build]`, so ahead of the gate it would pull the builds along with it. Its 5 s is a post-build number.

### Report-all in stage 3 only

`knip` and `check-boot-budget` run `continue-on-error` with a gate step that fails the job and names which one broke. Fail-fast costs nothing when steps cost seconds, which is why stages 1–2 stay plain sequential; here it hid one failure behind the other at the cost of a whole further ~4-minute run.

### What `check-boot-budget` actually costs on this job

53 s cold — the bundle built from source rather than hydrating:

```
▮▮▮▮ composer-app:bundle (28s 161ms, 5b057a3c)
composer-app:check-boot-budget | boot graph: 25 preload entries, 5.46 MB (budget: 30 entries, 6.00 MB)
▮▮▮▮ composer-app:check-boot-budget (28ms, 14921938)
Tasks: 284 completed (281 cached)
```

281 of 284 tasks hydrated, so the marginal cost is composer's own `vite build`; warm it is 13 s. That settles the open question this PR was going to leave behind — the dedicated-job fallback (`needs: e2e-bundle`) is not needed — and corrects a prior assumption: the e2e cell's 50 s was not a cache hit, this bundle just costs ~30 s once its closure is warm.

### Verification

- `check`, `test`, `storybook`, `workerd` and `changeset-reminder` all green on `7adfb821`.
- Peer-dep step green in CI with the `trap` in place, and run verbatim locally beforehand: exit 0 in 29.6 s, lockfile hash unchanged.
- `oxfmt --check` clean repo-wide.
- Rationale and numbers recorded in `.agents/projects/ci/DESIGN.md` and `TASKS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bHLppPmSZakVmceQzCA8k
