### PR TITLE
fix(echo-client): don't forward registry-only queries to the remote QueryService

### DIFF
--- a/.changeset/registry-only-query-routing.md
+++ b/.changeset/registry-only-query-routing.md
@@ -1,0 +1,9 @@
+---
+'@dxos/echo-client': patch
+---
+
+Registry-only queries are no longer forwarded to the remote query service. A query whose explicit `from` scopes contain no space or feed scope — e.g. `Query.select(...).from(Scope.registry())` — is answered entirely by the in-process registry source, so `IndexQuerySource` now resolves it locally instead of issuing a `QueryService.execQuery` round-trip.
+
+Previously such a query still went remote. Hosts that reject space-less queries (EDGE) failed it, and because query sources are merged fail-fast, that rejection discarded the registry source's correct results and failed the whole query — breaking every operation that resolves a type through the registry (`SpaceOperation.AddObject`, and so anything filing an object into the graph). Browser hosts masked it by returning empty for registry scopes.
+
+Mixed-scope queries (`Scope.space(), Scope.registry()`) are unchanged: they still query the index for the space part.

--- a/packages/core/echo/echo-client/src/client/index-query-source-provider.test.ts
+++ b/packages/core/echo/echo-client/src/client/index-query-source-provider.test.ts
@@ -34,7 +34,7 @@ const mockGraph = {} as Hypergraph.Hypergraph;
 /** No-op update signal for tests that don't exercise re-hydration. */
 const noopUpdateEvent = new Event<ObjectUpdate>();
 
-const makeQuery = (spaceId: SpaceId = SpaceId$.random()): QueryAST.Query => ({
+const makeScopedQuery = (scopes: QueryAST.Scope[]): QueryAST.Query => ({
   type: 'from',
   query: {
     type: 'select',
@@ -46,9 +46,12 @@ const makeQuery = (spaceId: SpaceId = SpaceId$.random()): QueryAST.Query => ({
   },
   from: {
     _tag: 'scope',
-    scopes: [Scope.space({ id: spaceId })],
+    scopes,
   },
 });
+
+const makeQuery = (spaceId: SpaceId = SpaceId$.random()): QueryAST.Query =>
+  makeScopedQuery([Scope.space({ id: spaceId })]);
 
 describe('IndexQuerySource', () => {
   test('does not start a REACTIVE remote query until open() is called', async () => {
@@ -126,6 +129,59 @@ describe('IndexQuerySource', () => {
     expect(results).toEqual([]);
     expect(calls).toHaveLength(1);
     expect(calls[0].reactivity).toBe(QueryReactivity.ONE_SHOT);
+  });
+
+  // Regression: a registry-only query forwarded to the remote QueryService fails the whole
+  // query on edge — the query host rejects space-less queries ("Query must specify at least one
+  // spaceId in options") and `GraphQueryContext.run`'s fail-fast merge discards the
+  // `RegistryQuerySource`'s results. Surfaced by `projectCreate` over MCP (`SpaceOperation.
+  // AddObject`'s type lookup is registry-scoped); dxos/edge mcp-operations project, DESIGN §6.
+  test('registry-only queries never reach the remote service', async () => {
+    const calls: QueryRequest[] = [];
+
+    const service = await makeQueryClient({
+      'QueryService.setConfig': () => Effect.void,
+      'QueryService.execQuery': (request) => {
+        calls.push(request);
+        return Stream.async<QueryResponse>((emit) => {
+          queueMicrotask(() => void emit.single({ queryId: request.queryId, results: [] }));
+        });
+      },
+      'QueryService.reindex': () => Effect.void,
+    });
+
+    const source = new IndexQuerySource({
+      service,
+      runtime: Runtime.defaultRuntime,
+      objectLoader: {
+        loadObject: async () => undefined,
+        updateEvent: noopUpdateEvent,
+      },
+      graph: mockGraph,
+    });
+
+    // `open()` subscribes to the shared `noopUpdateEvent` and `update()` opens a reactive
+    // stream; close on teardown so neither outlives the test, including when an assertion throws.
+    onTestFinished(() => source.close());
+
+    const registryOnlyQuery = makeScopedQuery([Scope.registry()]);
+
+    // One-shot: resolves empty locally without a remote round-trip.
+    const results = await source.run(Context.default(), registryOnlyQuery);
+    expect(results).toEqual([]);
+    expect(calls).toHaveLength(0);
+
+    // Reactive: no remote stream is opened either.
+    source.open();
+    source.update(registryOnlyQuery);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(calls).toHaveLength(0);
+
+    // A mixed-scope query (space + registry) still queries the index for the space part.
+    const mixedQuery = makeScopedQuery([Scope.space({ id: SpaceId$.random() }), Scope.registry()]);
+    source.update(mixedQuery);
+    await expect.poll(() => calls).toHaveLength(1);
+    expect(calls[0].reactivity).toBe(QueryReactivity.REACTIVE);
   });
 
   test('re-hydrates reactive results when a previously-unavailable object loads', async () => {

--- a/packages/core/echo/echo-client/src/client/index-query-source-provider.ts
+++ b/packages/core/echo/echo-client/src/client/index-query-source-provider.ts
@@ -25,7 +25,7 @@ import { isNonNullable } from '@dxos/util';
 import { type FeedHandle } from '../feed/feed-handle';
 import { type QuerySourceProvider, recordObjectDiagnostic } from '../hypergraph';
 import { DatabaseImpl } from '../proxy-db';
-import { type QuerySource, type SourceEntry, getTargetSpacesForQuery } from '../query';
+import { type QuerySource, type SourceEntry, getTargetSpacesForQuery, queryTargetsSpacesOrFeeds } from '../query';
 
 export type LoadObjectProps = {
   spaceId: SpaceId;
@@ -149,6 +149,13 @@ export class IndexQuerySource implements QuerySource {
 
   async run(_ctx: Context, query: QueryAST.Query): Promise<SourceEntry[]> {
     this._query = query;
+    // The index serves spaces and feeds; a query whose explicit scopes target neither
+    // (e.g. registry-only) is answered entirely by other sources. Forwarding it anyway
+    // made the whole query fail on edge — the query host rejects space-less queries, and
+    // the fail-fast merge in `GraphQueryContext.run` discarded the registry source's results.
+    if (!queryTargetsSpacesOrFeeds(query)) {
+      return [];
+    }
     return new Promise((resolve, reject) => {
       this._runOneShot(query, resolve, reject);
     });
@@ -169,6 +176,11 @@ export class IndexQuerySource implements QuerySource {
     // Don't start a reactive remote query until the query context is started (calls `open()`).
     // This prevents `.query(...).run()` from accidentally triggering a REACTIVE query in addition to the ONE_SHOT query.
     if (!this._open) {
+      return;
+    }
+
+    // Same gate as `run`: no space/feed scope means nothing here to watch.
+    if (!queryTargetsSpacesOrFeeds(query)) {
       return;
     }
 

--- a/packages/core/echo/echo-client/src/query/graph-query-context.ts
+++ b/packages/core/echo/echo-client/src/query/graph-query-context.ts
@@ -14,7 +14,7 @@ import { log } from '@dxos/log';
 import { type ItemsUpdatedEvent, type ObjectCore } from '../core-db';
 import { type DatabaseImpl } from '../proxy-db';
 import { type QueryContext, type SourceEntry } from './query-context';
-import { getTargetSpacesForQuery, isSimpleSelectionQuery, queryHasWindowing } from './util';
+import { getTargetSpacesForQuery, isSimpleSelectionQuery, queryHasWindowing, queryTargetsSpacesOrFeeds } from './util';
 import { type WorkingSetDataProvider, type WorkingSetItem, WorkingSetQueryExecutor } from './working-set-executor';
 
 export type GraphQueryContextProps = {
@@ -379,17 +379,7 @@ export class SpaceQuerySource implements QuerySource {
     }
 
     // Disabled if the from clause has explicit scopes but none target spaces or feeds (e.g. registry-only).
-    let hasExplicitNonEmptyScope = false;
-    let hasSpaceOrFeedScope = false;
-    QueryAST.visit(query, (node) => {
-      if (node.type === 'from' && node.from._tag === 'scope' && node.from.scopes.length > 0) {
-        hasExplicitNonEmptyScope = true;
-        if (node.from.scopes.some((s) => s._tag === 'space' || s._tag === 'feed')) {
-          hasSpaceOrFeedScope = true;
-        }
-      }
-    });
-    if (hasExplicitNonEmptyScope && !hasSpaceOrFeedScope) {
+    if (!queryTargetsSpacesOrFeeds(query)) {
       return false;
     }
 

--- a/packages/core/echo/echo-client/src/query/util.ts
+++ b/packages/core/echo/echo-client/src/query/util.ts
@@ -148,6 +148,31 @@ export const isSimpleSelectionQuery = (
   }
 };
 
+/**
+ * Whether the query selects from spaces or feeds — the data that space-backed sources
+ * (`SpaceQuerySource`, `IndexQuerySource`) can serve.
+ *
+ * A query with no explicit `from` scope defaults to the owning space and returns true.
+ * A query whose explicit scopes contain no space/feed entry (e.g. registry-only) returns
+ * false: it is answered entirely by other sources (`RegistryQuerySource`), and forwarding
+ * it to a space-backed source is at best wasted work — the edge query host rejects such
+ * queries outright ("Query must specify at least one spaceId in options"), failing the
+ * whole query even though the registry source produced results.
+ */
+export const queryTargetsSpacesOrFeeds = (query: QueryAST.Query): boolean => {
+  let hasExplicitNonEmptyScope = false;
+  let hasSpaceOrFeedScope = false;
+  QueryAST.visit(query, (node) => {
+    if (node.type === 'from' && node.from._tag === 'scope' && node.from.scopes.length > 0) {
+      hasExplicitNonEmptyScope = true;
+      if (node.from.scopes.some((scope) => scope._tag === 'space' || scope._tag === 'feed')) {
+        hasSpaceOrFeedScope = true;
+      }
+    }
+  });
+  return !hasExplicitNonEmptyScope || hasSpaceOrFeedScope;
+};
+
 export type RegistryQueryScope = { included: boolean; locations: ReadonlySet<'local' | 'remote'> };
 
 /**


### PR DESCRIPTION
## Problem

`IndexQuerySource` forwards **every** query to the remote `QueryService`, regardless of scope. A registry-only query — e.g. `SpaceOperation.AddObject`'s type lookup, `Query.select(Filter.type(Type.Type)).from(Scope.registry())` — therefore reaches the query host even though it is answered entirely by the in-process `RegistryQuerySource`.

On edge this fails hard: the edge query host rejects space-less queries (`invariant violation: Query must specify at least one spaceId in options`, after its planner discards the registry scope), and `GraphQueryContext.run`'s fail-fast `Promise.all` merge then throws away the registry source's already-computed correct results — failing the whole query, and with it every `projectCreate` on edge (any operation routed through `AddObject`).

The browser host masks the bug: its executor silently ignores registry scopes and returns empty, so the bogus forward was invisible there.

## Fix

- Add `queryTargetsSpacesOrFeeds` to `query/util.ts`: a query with explicit scopes but no space/feed scope is not served by space-backed sources.
- Gate `IndexQuerySource.run` (resolve `[]` locally) and `.update` (skip the reactive stream) on it.
- Dedupe `SpaceQuerySource._isValidSourceForQuery`'s inline copy of the same check onto the helper.

Registry-only queries now never leave the process on any platform; mixed-scope queries (`Scope.space(), Scope.registry()`) still hit the index for the space part.

## Testing

- New regression test in `index-query-source-provider.test.ts`: registry-only queries produce zero remote calls on both the one-shot and reactive paths; a mixed-scope query still queries the index.
- Full `echo-client` suite: 520 passed, no new failures.
- Reproduced end-to-end in dxos/edge (`mcp-space-service.node.test.ts`, currently `test.fails`): real space → MCP `tools/call projectCreate` → operation-service → the field error verbatim. That test flips to `test` when edge's pins pick this up.

## Context

Found via the dxos/edge **mcp-operations** project (dxos/edge#858): `projectCreate` over MCP failed on every edge space with `RuntimeServiceError: Query execution failed (queryCount=1)`. Diagnosis notes live in that repo's `.agents/projects/mcp-operations/DESIGN.md` §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query handling for registry-only and unsupported scopes.
  * Prevented unnecessary remote requests when queries do not target spaces or feeds.
  * Preserved remote execution for queries combining supported and registry scopes.
  * Ensured consistent behavior for both one-time and reactive query execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->