### PR TITLE
composer-app: fix vite dependency resolution failure for @effect/platform

### DIFF
--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -270,7 +270,6 @@ export default defineConfig((env) => ({
       'effect/Context',
       'effect/Stream',
       'effect/Console',
-      '@effect/platform',
       '@effect/platform-browser',
       // Effect Atom (reactive state; always loaded, triggered a mid-session reload before being listed).
       '@effect/atom-react',


### PR DESCRIPTION
## Summary

- `composer-app`'s dev server was failing to start with `Failed to resolve dependency: @effect/platform, present in client 'optimizeDeps.include'`.
- Root cause: the Effect 3→4 migration (#12521) correctly dropped `@effect/ai` and renamed `@effect-atom/atom` → `@effect/atom-react` (both absorbed/renamed in Effect 4), but missed doing the same for `@effect/platform`, which was also absorbed into the `effect` core package. Only `@effect/platform-browser`/`-node`/`-bun` remain as standalone packages in this Effect version — bare `@effect/platform` no longer exists and isn't a dependency anywhere in the repo.
- Vite's dependency scanner aborts the *entire* pre-bundle pass when any `optimizeDeps.include` entry is unresolvable, which is exactly what surfaced as this error.
- Fix: remove the stale `'@effect/platform'` entry from `optimizeDeps.include` in `packages/apps/composer-app/vite.config.ts`, keeping `'@effect/platform-browser'`.

## Test plan

- [x] Confirmed no source file or `package.json` in the repo references bare `@effect/platform`.
- [x] Confirmed the lockfile only contains `@effect/platform-browser`/`-node`/`-bun`, not `@effect/platform`.
- [x] Ran `moon run composer-app:serve` locally — the dev server now starts cleanly (`VITE v8.1.4 ready in 2335 ms`), the `@effect/platform` resolution error is gone, dependency optimization completes, and the server responds `200` on `http://localhost:5173/`.

Note: the local run surfaced an unrelated, non-fatal scan warning (`@dxos/vendor-hyperformula`, `@dxos/echo-query/api.d.ts?raw` not resolvable) that only skips esbuild's auto-discovery scan and doesn't stop the server — it's caused by those two packages' dist not being built under this partial local build and is out of scope for this fix.