### PR TITLE
compute-runtime: replace TriggerDispatcher polling with a reactive query

### DIFF
--- a/.agents/projects/memory-usage/TASKS.md
+++ b/.agents/projects/memory-usage/TASKS.md
@@ -76,17 +76,19 @@ fixed the same way.
       defaults to 1 s (~line 300), `_startNaturalTimeProcessing` repeats
       `invokeScheduledTriggers` on `Schedule.fixed` (~line 921), and each tick
       also runs an ECHO `Filter.type(Trigger)` query. Started by plugin-routine,
-      a core plugin, so every tab pays it. **Fixed (R1, reactive query):**
+      a core plugin, so every tab pays it. **Partially fixed, toward R1:**
       `start()` now subscribes once to a live `Filter.type(Trigger)` query
-      (`_subscribeToTriggers`); `refreshTriggers`/`_fetchTriggers` read the
+      (`#subscribeToTriggers`); `refreshTriggers`/`_fetchTriggers` read the
       subscription's cached `results` instead of re-querying the database, so
-      the 1 Hz tick no longer issues SQL when the trigger set hasn't changed.
-      The tick itself still runs every second (cron due-time checks and
-      feed/subscription trigger kinds are unchanged) — a full "sleep until
-      next due time, no timer while idle" scheduler (closing S1 completely per
-      R1's description) is a larger, riskier change to feed/subscription
-      trigger semantics and is left as a follow-up if further gains are
-      wanted.
+      the trigger-list lookup no longer issues SQL when the trigger set hasn't
+      changed. This is only the "subscription" half of R1 — the tick itself
+      still fires every second (`TriggerDispatcher.invokeScheduledTriggers`
+      still queries feed and subscription trigger data on each tick, and cron
+      due-time checks still run on the fixed schedule). The full R1 — no timer
+      while the working set is empty, sleep to the next due time otherwise —
+      would additionally need to skip firing altogether when idle, a larger,
+      riskier change to feed/subscription trigger semantics, left as a
+      follow-up if further gains are wanted.
 - [x] **S2. Every subscribed feed polls at 1 Hz.**
       `echo-client/src/feed/feed-handle.ts` (`POLLING_INTERVAL`,
       `beginPolling`): one timer and one refresh RPC per feed handle, so cost
@@ -135,15 +137,21 @@ fixed the same way.
 
 Independent of each other; some sites may want none, one, or several.
 
-- [ ] **R1. Event-driven scheduling.** Replace a fixed tick with "wake when
-      there is something to do": no timer while the working set is empty, and
-      sleep to the next due time otherwise. Fits S1 directly. Needs a
-      subscription so work arriving while idle still starts, and care around
-      clock changes.
-- [ ] **R2. No-change backoff.** Widen the interval while a poll keeps
+- [~] **R1. Event-driven scheduling.** Replace a fixed tick with "wake when
+  there is something to do": no timer while the working set is empty, and
+  sleep to the next due time otherwise. Fits S1 directly. Needs a
+  subscription so work arriving while idle still starts, and care around
+  clock changes. Partially done for S1: the trigger-list subscription
+  landed (no more per-tick DB query), but the tick itself still fires at a
+  fixed 1 Hz — "no timer while idle" is not yet implemented.
+- [x] **R2. No-change backoff.** Widen the interval while a poll keeps
       returning nothing (e.g. 1 s → 5 s → 30 s), reset on change or local
       write. Fits S2 and S3. Costs staleness after a quiet period, so pair it
-      with an explicit refresh on user action.
+      with an explicit refresh on user action. Done for both: `FeedHandle`
+      polling (capped 30 s) and space sync-state polling (capped 15 s), each
+      resetting to the fast interval the moment a poll observes a real
+      change — and also on a failed read, since a failure can't tell us the
+      feed/backlog is actually quiet and shouldn't compound the backoff.
 - [ ] **R3. Coordinated scheduling.** One scheduler batching all due work into
       a single round-trip instead of N independent timers. Fits S2 and S3
       together; the win is fewer wakeups and fewer payloads, not a longer

--- a/.agents/projects/memory-usage/TASKS.md
+++ b/.agents/projects/memory-usage/TASKS.md
@@ -1,6 +1,6 @@
 # Composer Memory Usage — Tasks
 
-_Resume: Phase 4 (idle churn) is the largest remaining pool; Phase 3 continues opportunistically. Uncommitted: none._
+_Resume: Phase 4 idle-churn sites S1-S4 fixed/investigated (see below), opened as a separate PR from #12505. Remedies section (R1-R6) and Sequencing still open — verify decommit with `scripts/memory/soak.mjs` once the PR lands. Phase 3 continues opportunistically. Uncommitted: none._
 
 **Target: 300–400 MB resting footprint for an idle tab, 500 MB ceiling.**
 Composition model and measurement rules: DESIGN.md. Industry comparison:
@@ -71,23 +71,65 @@ in heap-used, so measure with `scripts/memory/soak.mjs` rather than a snapshot.
 Four independent loops. Each needs its own decision; they do not have to be
 fixed the same way.
 
-- [ ] **S1. `TriggerDispatcher` fires at 1 Hz with no triggers defined.**
+- [x] **S1. `TriggerDispatcher` fires at 1 Hz with no triggers defined.**
       `compute-runtime/src/triggers/trigger-dispatcher.ts`: `livePollInterval`
       defaults to 1 s (~line 300), `_startNaturalTimeProcessing` repeats
       `invokeScheduledTriggers` on `Schedule.fixed` (~line 921), and each tick
       also runs an ECHO `Filter.type(Trigger)` query. Started by plugin-routine,
-      a core plugin, so every tab pays it.
-- [ ] **S2. Every subscribed feed polls at 1 Hz.**
+      a core plugin, so every tab pays it. **Fixed (R1, reactive query):**
+      `start()` now subscribes once to a live `Filter.type(Trigger)` query
+      (`_subscribeToTriggers`); `refreshTriggers`/`_fetchTriggers` read the
+      subscription's cached `results` instead of re-querying the database, so
+      the 1 Hz tick no longer issues SQL when the trigger set hasn't changed.
+      The tick itself still runs every second (cron due-time checks and
+      feed/subscription trigger kinds are unchanged) — a full "sleep until
+      next due time, no timer while idle" scheduler (closing S1 completely per
+      R1's description) is a larger, riskier change to feed/subscription
+      trigger semantics and is left as a follow-up if further gains are
+      wanted.
+- [x] **S2. Every subscribed feed polls at 1 Hz.**
       `echo-client/src/feed/feed-handle.ts` (`POLLING_INTERVAL`,
       `beginPolling`): one timer and one refresh RPC per feed handle, so cost
-      scales with feeds open (a mailbox is the common case).
-- [ ] **S3. Each open space polls sync state at 2 s.**
+      scales with feeds open (a mailbox is the common case). No server push
+      exists (`FeedService` has no subscribe/watch RPC — confirmed via
+      `packages/core/protocols/src/FeedService.ts`), so R1 doesn't apply; R6
+      (real push) stays deferred to `feed-live-objects`. **Fixed (R2, no-change
+      backoff):** `beginPolling` now doubles the poll delay (capped at 30 s)
+      each tick that finds no object-set change, and resets to
+      `POLLING_INTERVAL` the moment a poll observes one. R4 (visibility
+      gating) was considered but deferred — orthogonal, applies to all four
+      sites, better done as one pass.
+- [x] **S3. Each open space polls sync state at 2 s.**
       `echo-client/src/proxy-db/database.ts` (`FEED_SYNC_POLL_INTERVAL`):
-      aggregates block backlog across namespaces.
-- [ ] **S4. Query re-execution amplifies every tick.** `echo-host`'s
+      aggregates block backlog across namespaces via a real per-namespace
+      `FeedService.getSyncState` RPC (SQLite `COUNT(*)` server-side) — not a
+      local aggregation, so R1 doesn't apply here either; started
+      unconditionally per open space by `plugin-client`'s
+      `space-replication-progress.ts`. **Fixed (R2, no-change backoff):**
+      `subscribeToSyncState`'s `pollFeeds` now self-reschedules with a delay
+      that doubles (capped at 15 s) while `blocksToPull`/`blocksToPush`/
+      `totalBlocks` stay unchanged, and resets to `FEED_SYNC_POLL_INTERVAL` on
+      any observed delta. Noted but not fixed here: `space-replication-progress.ts`
+      re-subscribes per space on every `client.spaces` emission with no
+      de-dupe, which can spawn duplicate pollers per space over a session —
+      worth its own follow-up.
+- [x] **S4. Query re-execution amplifies every tick.** `echo-host`'s
       `QueryService._executeQueries` re-runs each dirty reactive query per
       invalidation hint; the loops above generate hints, which is what turns
-      three timers into the observed SQL fan-out.
+      three timers into the observed SQL fan-out. **Investigated, no code
+      change:** `matchesHint`/`extractScopes` (`query-executor.ts`) already do
+      real per-dimension filtering, not a broad type/space-only match, and are
+      covered by extensive regression tests (DX-966 canonicalization, id-rooted
+      relation traversal) — tightening further is a speculative change to the
+      invalidation core for unclear benefit. More importantly, S1's
+      `_fetchTriggers().run` was a one-shot query (`ActiveQuery.firstResult`),
+      unconditionally dirty regardless of any hint — `matchesHint` was never
+      in the amplification path for it, so R5 targets the wrong layer. With
+      S1-S3 no longer generating spurious ticks/RPCs on an idle tab, S4's
+      observed fan-out should fall away as a consequence rather than needing
+      its own fix. Separately noted (not actioned): `query-service.ts` has a
+      standing TODO that an idle Composer registers ~80 queries with only ~10
+      unique — a dedup opportunity independent of this phase.
 
 ### Remedies — options to evaluate per site
 

--- a/.agents/projects/registry.yml
+++ b/.agents/projects/registry.yml
@@ -25,8 +25,8 @@ projects:
     summary: "Profile Composer's runtime memory usage — find what dominates the heap (main thread + workers), attribute it to subsystems, and queue fixes."
     tasks: .agents/projects/memory-usage/TASKS.md
     design: .agents/projects/memory-usage/DESIGN.md
-    prs: [12505]
-    resume: 'Investigation complete (DESIGN.md composition model; RESEARCH.md industry comparison). Phase 3 code-residency fixes landed: ~2.9MB of resident code removed (~32MB memory) across onboarding assets, emoji-mart, mermaid, bip39, AI/MCP runtime, ML runtime, EVM client, welcome screen. Target 300-400MB resting. PR #12505 OPEN (draft). Next: Phase 4 idle churn (largest pool, ~51 SQL/s from four loops); Phase 2 payload retention is Linear DX-1148 (reverted from this PR, to land separately).'
+    prs: [12505, 12561]
+    resume: 'Investigation complete (DESIGN.md composition model; RESEARCH.md industry comparison). Phase 3 code-residency fixes landed: ~2.9MB of resident code removed (~32MB memory) across onboarding assets, emoji-mart, mermaid, bip39, AI/MCP runtime, ML runtime, EVM client, welcome screen. Target 300-400MB resting. PR #12505 OPEN (draft) — Phase 3 + Phase 2 payload retention (Linear DX-1148, reverted from this PR to land separately). PR #12561 OPEN (separate from #12505) — Phase 4 idle-churn sites S1-S4: S1 TriggerDispatcher now watches Trigger objects via one reactive query instead of re-querying every 1Hz tick; S2 (FeedHandle) and S3 (space sync-state) polling now back off on repeated no-change ticks (capped 30s/15s) and reset to fast interval on real change; S4 investigated, no code change (matchesHint already precise; amplification traced to S1s one-shot per-tick query, expected to fall away once S1-S3 stop generating spurious ticks). Next: verify with scripts/memory/soak.mjs once #12561 lands; Remedies/Sequencing sections in TASKS.md still open.'
 
   - name: leveldb-removal
     status: active

--- a/.changeset/idle-poll-backoff.md
+++ b/.changeset/idle-poll-backoff.md
@@ -1,0 +1,5 @@
+---
+'@dxos/echo': patch
+---
+
+Reduce idle-tab churn: `TriggerDispatcher` watches its trigger list reactively instead of re-querying the database on every 1 Hz tick, and feed/sync-state polling now backs off (up to 30 s / 15 s) while nothing changes, resetting to the fast interval as soon as it does.

--- a/packages/core/compute/compute-runtime/src/triggers/trigger-dispatcher.ts
+++ b/packages/core/compute/compute-runtime/src/triggers/trigger-dispatcher.ts
@@ -27,7 +27,7 @@ import * as Operation from '@dxos/compute/Operation';
 import * as Process from '@dxos/compute/Process';
 import * as Trigger from '@dxos/compute/Trigger';
 import * as TriggerEvent from '@dxos/compute/TriggerEvent';
-import { Database, Entity, Feed, Filter, Obj, Query, Ref } from '@dxos/echo';
+import { Database, Entity, Feed, Filter, Obj, Query, QueryResult, Ref } from '@dxos/echo';
 import { EffectEx } from '@dxos/effect';
 import { failedInvariant, invariant } from '@dxos/invariant';
 import { EntityId, type URI } from '@dxos/keys';
@@ -263,6 +263,15 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
   private _triggers: Trigger.Trigger[] = [];
 
   /**
+   * Live query over `Trigger` objects, subscribed once in {@link start} so the trigger list stays
+   * current reactively. While set, {@link _fetchTriggers} reads {@link QueryResult.results}
+   * directly instead of re-querying the database, so the natural-time poll loop no longer issues a
+   * fresh `Filter.type(Trigger)` query on every tick.
+   */
+  private _triggerQuery: QueryResult.QueryResult<Trigger.Trigger> | undefined;
+  private _triggerQueryUnsubscribe: (() => void) | undefined;
+
+  /**
    * Unified runtime state for every trigger kind: cron schedule, failure cooldown, and pending
    * {@link RunAgainError} retries. Keyed by trigger id.
    */
@@ -374,6 +383,7 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
 
       // Start natural time processing if enabled
       if (this.timeControl === 'natural') {
+        yield* this._subscribeToTriggers();
         this._timerFiber = yield* this._startNaturalTimeProcessing().pipe(
           Effect.tapCause((cause) => {
             const error = EffectEx.causeToError(cause);
@@ -417,6 +427,11 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
         yield* Fiber.interrupt(this._timerFiber);
         this._timerFiber = undefined;
       }
+
+      // Stop the reactive trigger query subscription.
+      this._triggerQueryUnsubscribe?.();
+      this._triggerQueryUnsubscribe = undefined;
+      this._triggerQuery = undefined;
 
       // Clear runtime state for all triggers.
       this._runtimeState.clear();
@@ -909,12 +924,43 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
 
   private _fetchTriggers = () =>
     Effect.gen({ self: this }, function* () {
+      // The local dispatcher only runs triggers that are not explicitly routed to edge.
+      if (this._triggerQuery) {
+        // `_subscribeToTriggers` keeps this query current reactively — reuse its cached results
+        // instead of issuing a fresh database query on every poll tick.
+        return this._triggerQuery.results.filter((t) => !t.remote);
+      }
       const objects = yield* Database.query(
         Query.select(Filter.type(Trigger.Trigger)).debugLabel('TriggerDispatcher.fetchTriggers'),
       ).run;
-      // The local dispatcher only runs triggers that are not explicitly routed to edge.
       return objects.filter((t) => !t.remote);
     }).pipe(Effect.withSpan('TriggerDispatcher.fetchTriggers'));
+
+  /**
+   * Subscribe once to a live `Trigger` query so trigger objects update reactively as they change,
+   * replacing the previous behavior of re-querying the database for the full trigger list on every
+   * natural-time poll tick (~1/s), the dominant contributor to `TriggerDispatcher`'s idle-time SQL
+   * churn. Torn down in {@link stop}.
+   */
+  private _subscribeToTriggers = (): Effect.Effect<void> =>
+    Effect.gen({ self: this }, function* () {
+      const queryResult = yield* Database.query(
+        Query.select(Filter.type(Trigger.Trigger)).debugLabel('TriggerDispatcher.watchTriggers'),
+      );
+      this._triggerQuery = queryResult;
+      this._triggerQueryUnsubscribe = queryResult.subscribe(
+        () => {
+          Effect.runFork(
+            this.refreshTriggers().pipe(
+              Effect.tapCause((cause) =>
+                Effect.sync(() => log.error('failed to refresh triggers', { error: EffectEx.causeToError(cause) })),
+              ),
+            ),
+          );
+        },
+        { fire: true },
+      );
+    }).pipe(Effect.provide(this._services));
 
   private _startNaturalTimeProcessing = (): Effect.Effect<void> =>
     Effect.gen({ self: this }, function* () {

--- a/packages/core/compute/compute-runtime/src/triggers/trigger-dispatcher.ts
+++ b/packages/core/compute/compute-runtime/src/triggers/trigger-dispatcher.ts
@@ -268,8 +268,15 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
    * directly instead of re-querying the database, so the natural-time poll loop no longer issues a
    * fresh `Filter.type(Trigger)` query on every tick.
    */
-  private _triggerQuery: QueryResult.QueryResult<Trigger.Trigger> | undefined;
-  private _triggerQueryUnsubscribe: (() => void) | undefined;
+  #triggerQuery: QueryResult.QueryResult<Trigger.Trigger> | undefined;
+  #triggerQueryUnsubscribe: (() => void) | undefined;
+
+  /**
+   * Fiber forked by the trigger-query subscription callback to run {@link refreshTriggers}
+   * reactively. Tracked so {@link stop} (and the natural-time-processing failure path) can
+   * interrupt an in-flight refresh instead of letting it repopulate state after shutdown.
+   */
+  #pendingRefreshFiber: Fiber.Fiber<void, never> | undefined;
 
   /**
    * Unified runtime state for every trigger kind: cron schedule, failure cooldown, and pending
@@ -383,21 +390,26 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
 
       // Start natural time processing if enabled
       if (this.timeControl === 'natural') {
-        yield* this._subscribeToTriggers();
+        yield* this.#subscribeToTriggers();
         this._timerFiber = yield* this._startNaturalTimeProcessing().pipe(
-          Effect.tapCause((cause) => {
-            const error = EffectEx.causeToError(cause);
-            log.error('trigger dispatcher error', { error });
-            this._running = false;
-            registry.update(
-              this._state,
-              Struct.evolve({
-                enabled: () => false,
-                errors: (errors) => [...errors, error].slice(-MAX_TRACKED_ERRORS),
-              }),
-            );
-            return Effect.void;
-          }),
+          Effect.tapCause((cause) =>
+            Effect.gen({ self: this }, function* () {
+              const error = EffectEx.causeToError(cause);
+              log.error('trigger dispatcher error', { error });
+              this._running = false;
+              this._timerFiber = undefined;
+              registry.update(
+                this._state,
+                Struct.evolve({
+                  enabled: () => false,
+                  errors: (errors) => [...errors, error].slice(-MAX_TRACKED_ERRORS),
+                }),
+              );
+              // A crash bypasses `stop()` (`_running` is already false, so a later `stop()` call
+              // would no-op) — tear the subscription down here so it doesn't outlive the dispatcher.
+              yield* this.#teardownTriggerSubscription();
+            }),
+          ),
           Effect.forkDetach,
         );
       } else {
@@ -429,9 +441,7 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
       }
 
       // Stop the reactive trigger query subscription.
-      this._triggerQueryUnsubscribe?.();
-      this._triggerQueryUnsubscribe = undefined;
-      this._triggerQuery = undefined;
+      yield* this.#teardownTriggerSubscription();
 
       // Clear runtime state for all triggers.
       this._runtimeState.clear();
@@ -925,10 +935,10 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
   private _fetchTriggers = () =>
     Effect.gen({ self: this }, function* () {
       // The local dispatcher only runs triggers that are not explicitly routed to edge.
-      if (this._triggerQuery) {
-        // `_subscribeToTriggers` keeps this query current reactively — reuse its cached results
+      if (this.#triggerQuery) {
+        // `#subscribeToTriggers` keeps this query current reactively — reuse its cached results
         // instead of issuing a fresh database query on every poll tick.
-        return this._triggerQuery.results.filter((t) => !t.remote);
+        return this.#triggerQuery.results.filter((t) => !t.remote);
       }
       const objects = yield* Database.query(
         Query.select(Filter.type(Trigger.Trigger)).debugLabel('TriggerDispatcher.fetchTriggers'),
@@ -940,17 +950,21 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
    * Subscribe once to a live `Trigger` query so trigger objects update reactively as they change,
    * replacing the previous behavior of re-querying the database for the full trigger list on every
    * natural-time poll tick (~1/s), the dominant contributor to `TriggerDispatcher`'s idle-time SQL
-   * churn. Torn down in {@link stop}.
+   * churn. Torn down in {@link #teardownTriggerSubscription}.
    */
-  private _subscribeToTriggers = (): Effect.Effect<void> =>
+  #subscribeToTriggers = (): Effect.Effect<void> =>
     Effect.gen({ self: this }, function* () {
       const queryResult = yield* Database.query(
         Query.select(Filter.type(Trigger.Trigger)).debugLabel('TriggerDispatcher.watchTriggers'),
       );
-      this._triggerQuery = queryResult;
-      this._triggerQueryUnsubscribe = queryResult.subscribe(
+      this.#triggerQuery = queryResult;
+      this.#triggerQueryUnsubscribe = queryResult.subscribe(
         () => {
-          Effect.runFork(
+          // Tracked so a subsequent `#teardownTriggerSubscription` can interrupt this fiber —
+          // otherwise a refresh forked just before shutdown could still complete afterward, see
+          // `this.#triggerQuery` as already cleared, fall back to a fresh one-shot query, and
+          // repopulate trigger state after the dispatcher has stopped.
+          this.#pendingRefreshFiber = Effect.runFork(
             this.refreshTriggers().pipe(
               Effect.tapCause((cause) =>
                 Effect.sync(() => log.error('failed to refresh triggers', { error: EffectEx.causeToError(cause) })),
@@ -961,6 +975,23 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
         { fire: true },
       );
     }).pipe(Effect.provide(this._services));
+
+  /**
+   * Unsubscribe from the live trigger query and interrupt any refresh it forked, so neither can
+   * repopulate trigger state after the dispatcher has stopped — called from both {@link stop} and
+   * the natural-time-processing failure path in {@link start} (a crash bypasses `stop()` since it
+   * sets `_running` to `false` directly).
+   */
+  #teardownTriggerSubscription = (): Effect.Effect<void> =>
+    Effect.gen({ self: this }, function* () {
+      this.#triggerQueryUnsubscribe?.();
+      this.#triggerQueryUnsubscribe = undefined;
+      this.#triggerQuery = undefined;
+      if (this.#pendingRefreshFiber) {
+        yield* Fiber.interrupt(this.#pendingRefreshFiber);
+        this.#pendingRefreshFiber = undefined;
+      }
+    });
 
   private _startNaturalTimeProcessing = (): Effect.Effect<void> =>
     Effect.gen({ self: this }, function* () {

--- a/packages/core/echo/echo-client/src/feed/feed-handle.ts
+++ b/packages/core/echo/echo-client/src/feed/feed-handle.ts
@@ -38,6 +38,13 @@ const FEED_APPEND_BATCH_SIZE = 15;
 const POLLING_INTERVAL = 1_000;
 
 /**
+ * Ceiling for the no-change backoff in {@link FeedHandle.beginPolling}: the delay doubles after
+ * each poll that finds nothing new, capped here, and resets to {@link POLLING_INTERVAL} the moment
+ * a poll observes a change.
+ */
+const MAX_POLLING_INTERVAL = 30_000;
+
+/**
  * Client-side handle for a single feed, backed by an EDGE queue.
  * Internal to echo-client — feed operations are exposed through {@link DatabaseImpl}.
  */
@@ -107,6 +114,7 @@ export class FeedHandle {
       this._error = err as Error;
     } finally {
       this._isLoading = false;
+      this._lastRefreshChanged = changed;
       if (changed) {
         this.updated.emit();
       }
@@ -143,6 +151,11 @@ export class FeedHandle {
   private _error: Error | null = null;
   private _refreshId = 0;
   private _loadObjectsPromise: Promise<Entity.Unknown[]> | undefined;
+
+  /** Whether the most recent poll found a different object set — drives the backoff in {@link beginPolling}. */
+  private _lastRefreshChanged = true;
+  /** Current delay between polls; grows on no-change ticks, resets to {@link POLLING_INTERVAL} on change. */
+  private _currentPollingDelay = POLLING_INTERVAL;
 
   constructor(
     private readonly _service: FeedService.Client,
@@ -551,10 +564,16 @@ export class FeedHandle {
 
   beginPolling(): () => void {
     if (this._pollingHandlers++ === 0) {
+      this._currentPollingDelay = POLLING_INTERVAL;
       const poll = async () => {
         await this._refreshTask.runBlocking();
         if (this._pollingHandlers > 0 && !this._ctx.disposed) {
-          this._pollingInterval = setTimeout(poll, POLLING_INTERVAL);
+          // No-change backoff: an idle feed widens its own poll interval instead of holding at 1 Hz
+          // forever, and snaps back to POLLING_INTERVAL the moment a poll observes real change.
+          this._currentPollingDelay = this._lastRefreshChanged
+            ? POLLING_INTERVAL
+            : Math.min(this._currentPollingDelay * 2, MAX_POLLING_INTERVAL);
+          this._pollingInterval = setTimeout(poll, this._currentPollingDelay);
         }
       };
       queueMicrotask(poll);

--- a/packages/core/echo/echo-client/src/feed/feed-handle.ts
+++ b/packages/core/echo/echo-client/src/feed/feed-handle.ts
@@ -56,6 +56,7 @@ export class FeedHandle {
   private readonly _refreshTask = new DeferredTask(this._ctx, async () => {
     const thisRefreshId = ++this._refreshId;
     let changed = false;
+    let succeeded = false;
     try {
       TRACE_FEED_LOAD &&
         log.info('feed refresh begin', { currentObjects: this._objects.length, refreshId: thisRefreshId });
@@ -105,6 +106,7 @@ export class FeedHandle {
 
       TRACE_FEED_LOAD && log.info('feed refresh', { changed, objects: objects?.length ?? 0, refreshId: thisRefreshId });
       this._objects = decodedObjects;
+      succeeded = true;
     } catch (err) {
       // TODO(dmaretskyi): This task occasionally fails with "The database connection is not open" error in tests -- some issue with teardown ordering.
       //                   We should find the root cause and fix it instead of muting the error.
@@ -114,7 +116,10 @@ export class FeedHandle {
       this._error = err as Error;
     } finally {
       this._isLoading = false;
-      this._lastRefreshChanged = changed;
+      // Only a successful, quiet poll should widen the backoff — a failed (or superseded/disposed)
+      // attempt tells us nothing about whether the feed actually changed, so treat it like a change
+      // for backoff purposes and retry promptly rather than compounding an existing delay.
+      this.#lastPollWasQuiet = succeeded && !changed;
       if (changed) {
         this.updated.emit();
       }
@@ -152,10 +157,21 @@ export class FeedHandle {
   private _refreshId = 0;
   private _loadObjectsPromise: Promise<Entity.Unknown[]> | undefined;
 
-  /** Whether the most recent poll found a different object set — drives the backoff in {@link beginPolling}. */
-  private _lastRefreshChanged = true;
-  /** Current delay between polls; grows on no-change ticks, resets to {@link POLLING_INTERVAL} on change. */
-  private _currentPollingDelay = POLLING_INTERVAL;
+  /**
+   * Whether the most recent poll succeeded and found no object-set change — the only case that
+   * should widen the backoff in {@link beginPolling}. A failed, superseded, or disposed attempt
+   * resets it to `false` (fast retry) since it can't tell us the feed is actually quiet.
+   */
+  #lastPollWasQuiet = false;
+  /** Current delay between polls; grows on quiet ticks, resets to {@link POLLING_INTERVAL} otherwise. */
+  #currentPollingDelay = POLLING_INTERVAL;
+  /**
+   * Bumped each time the last polling handler unsubscribes, invalidating any `poll()` iteration
+   * still awaiting `_refreshTask.runBlocking()` from that generation — otherwise a fresh
+   * `beginPolling()` call racing that in-flight await can end up with two self-rescheduling poll
+   * loops running concurrently, each issuing its own `FeedService.queryFeed` RPC.
+   */
+  #pollingGeneration = 0;
 
   constructor(
     private readonly _service: FeedService.Client,
@@ -564,16 +580,21 @@ export class FeedHandle {
 
   beginPolling(): () => void {
     if (this._pollingHandlers++ === 0) {
-      this._currentPollingDelay = POLLING_INTERVAL;
+      const generation = ++this.#pollingGeneration;
+      this.#currentPollingDelay = POLLING_INTERVAL;
       const poll = async () => {
         await this._refreshTask.runBlocking();
-        if (this._pollingHandlers > 0 && !this._ctx.disposed) {
+        // The generation check rejects a stale iteration: if the last handler unsubscribed and a
+        // new `beginPolling()` call started its own generation while this `await` was pending, this
+        // iteration must not reschedule alongside it.
+        if (generation === this.#pollingGeneration && this._pollingHandlers > 0 && !this._ctx.disposed) {
           // No-change backoff: an idle feed widens its own poll interval instead of holding at 1 Hz
-          // forever, and snaps back to POLLING_INTERVAL the moment a poll observes real change.
-          this._currentPollingDelay = this._lastRefreshChanged
-            ? POLLING_INTERVAL
-            : Math.min(this._currentPollingDelay * 2, MAX_POLLING_INTERVAL);
-          this._pollingInterval = setTimeout(poll, this._currentPollingDelay);
+          // forever, and snaps back to POLLING_INTERVAL the moment a poll observes real change (or
+          // fails to observe anything conclusive at all).
+          this.#currentPollingDelay = this.#lastPollWasQuiet
+            ? Math.min(this.#currentPollingDelay * 2, MAX_POLLING_INTERVAL)
+            : POLLING_INTERVAL;
+          this._pollingInterval = setTimeout(poll, this.#currentPollingDelay);
         }
       };
       queueMicrotask(poll);
@@ -581,6 +602,7 @@ export class FeedHandle {
 
     return () => {
       if (--this._pollingHandlers === 0) {
+        this.#pollingGeneration++;
         clearTimeout(this._pollingInterval!);
         this._pollingInterval = null;
       }

--- a/packages/core/echo/echo-client/src/proxy-db/database.ts
+++ b/packages/core/echo/echo-client/src/proxy-db/database.ts
@@ -809,6 +809,9 @@ export class DatabaseImpl extends Resource implements EchoDatabase {
         }
       } catch (error) {
         // Keep the previous feeds state on failure rather than leaving an unhandled rejection.
+        // Reset the delay too: a failed read can't tell us the backlog is quiet, so retry promptly
+        // rather than waiting out whatever delay a prior run of no-change ticks had grown to.
+        pollDelay = FEED_SYNC_POLL_INTERVAL;
         if (!cancelled) {
           log.warn('failed to poll feed sync state', { error });
         }

--- a/packages/core/echo/echo-client/src/proxy-db/database.ts
+++ b/packages/core/echo/echo-client/src/proxy-db/database.ts
@@ -214,6 +214,17 @@ const EMPTY_FEED_SYNC_STATE: SpaceFeedSyncState = { blocksToPull: '0', blocksToP
 const FEED_SYNC_POLL_INTERVAL = 2_000;
 
 /**
+ * Ceiling for the no-change backoff below: the poll delay doubles after each tick that reports the
+ * same backlog, and resets to {@link FEED_SYNC_POLL_INTERVAL} the moment it changes.
+ */
+const MAX_FEED_SYNC_POLL_INTERVAL = 15_000;
+
+const feedSyncStateChanged = (before: SpaceFeedSyncState, after: SpaceFeedSyncState): boolean =>
+  before.blocksToPull !== after.blocksToPull ||
+  before.blocksToPush !== after.blocksToPush ||
+  before.totalBlocks !== after.totalBlocks;
+
+/**
  * Selects the peer to report the automerge backlog against: the explicit `peerId` when given,
  * otherwise the EDGE peer.
  */
@@ -775,8 +786,12 @@ export class DatabaseImpl extends Resource implements EchoDatabase {
       }),
     );
 
-    // Feed blocks have no change stream, so poll the backend.
+    // Feed blocks have no change stream, so poll the backend. No-change backoff widens the delay
+    // while the backlog stays put (an idle space otherwise polls forever at a fixed 2 s cadence)
+    // and snaps back to FEED_SYNC_POLL_INTERVAL the moment the backlog actually moves.
     let pollInFlight = false;
+    let pollDelay = FEED_SYNC_POLL_INTERVAL;
+    let pollTimer: ReturnType<typeof setTimeout> | undefined;
     const pollFeeds = async () => {
       // Skip overlapping ticks so a slow RPC can't emit stale state after a newer poll.
       if (pollInFlight) {
@@ -786,6 +801,9 @@ export class DatabaseImpl extends Resource implements EchoDatabase {
       try {
         const next = await this.#getSpaceFeedSyncState();
         if (!cancelled) {
+          pollDelay = feedSyncStateChanged(feeds, next)
+            ? FEED_SYNC_POLL_INTERVAL
+            : Math.min(pollDelay * 2, MAX_FEED_SYNC_POLL_INTERVAL);
           feeds = next;
           emit();
         }
@@ -796,13 +814,17 @@ export class DatabaseImpl extends Resource implements EchoDatabase {
         }
       } finally {
         pollInFlight = false;
+        if (!cancelled) {
+          pollTimer = setTimeout(() => void pollFeeds(), pollDelay);
+        }
       }
     };
     void pollFeeds();
-    const timer = setInterval(() => void pollFeeds(), FEED_SYNC_POLL_INTERVAL);
     ctx.onDispose(() => {
       cancelled = true;
-      clearInterval(timer);
+      if (pollTimer) {
+        clearTimeout(pollTimer);
+      }
     });
 
     return () => {


### PR DESCRIPTION
## Summary

Part of the `memory-usage` project (`.agents/projects/memory-usage/`), Phase 4 "idle churn" — separate PR from the in-flight #12505 (Phase 3 code residency), covering sites **S1-S4**.

- **S1 (fixed).** `TriggerDispatcher` re-queried the database for the full `Trigger` list on every 1 Hz natural-time tick, even with no triggers defined — the dominant contributor to an idle tab's SQL churn from this loop. `start()` now subscribes once to a live `Filter.type(Trigger)` query; `refreshTriggers`/`_fetchTriggers` read the subscription's cached results instead of re-querying. The tick itself still runs every second for cron due-time checks and feed/subscription trigger kinds — a full "no timer while idle" scheduler is a larger, riskier change left as a follow-up.
- **S2 (fixed).** `FeedHandle.beginPolling` polled at a fixed 1 Hz per open feed. No server-push alternative exists (`FeedService` has no subscribe/watch RPC — real fix deferred to `feed-live-objects`), so this adds no-change backoff instead: the poll delay doubles (capped at 30s) on ticks that find nothing new, and resets to 1s the instant something changes.
- **S3 (fixed).** Space sync-state polling (`DatabaseImpl.subscribeToSyncState`) issued a real per-namespace `FeedService.getSyncState` RPC (SQLite `COUNT(*)` server-side) every 2s per open space, unconditionally. Same no-change backoff treatment, capped at 15s.
- **S4 (investigated, no change).** `QueryService`'s `matchesHint` already filters invalidation hints precisely and is covered by extensive regression tests; tightening it further looked speculative. The actual amplification traced back to S1: a one-shot per-tick query bypasses hint-matching entirely (always dirty on first run). With S1-S3 no longer generating spurious ticks/RPCs at idle, S4's observed SQL fan-out should fall away as a consequence.

Decisions and rationale recorded in `.agents/projects/memory-usage/TASKS.md` (Phase 4 sites section).

## Test plan

- [x] `moon run compute-runtime:build` — full dependency graph builds clean
- [x] `moon run compute-runtime:test -- src/triggers/trigger-dispatcher.test.ts` — 33/33 passing (incl. natural-time-control start/stop)
- [x] `moon run compute-runtime:test -- src/TriggerMonitor.test.ts` — 7/7 passing
- [x] `moon run echo-client:build`
- [x] `moon run echo-client:test` — full suite, 522 passing / 7 expected-fail / 12 skipped / 2 todo
- [x] `moon run compute-runtime:lint echo-client:lint`
- [x] `pnpm format`
- [ ] Manual idle-churn verification with `scripts/memory/soak.mjs` (tracked in TASKS.md as a follow-up once this lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwgNG6Ehcs8rC75PoVZSiW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary background activity by reusing trigger results and monitoring updates reactively.
  * Added adaptive polling for feeds and synchronization, slowing checks when no changes are detected and responding faster when updates occur.
  * Improved resource usage during idle periods while preserving timely updates when data changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->