### PR TITLE
app-graph: key observable atoms by reference

### DIFF
--- a/.changeset/lucky-donuts-shave.md
+++ b/.changeset/lucky-donuts-shave.md
@@ -1,0 +1,5 @@
+---
+'@dxos/app-graph': patch
+---
+
+Key observable atoms by reference so graph extensions no longer fail on clients without a shell.

--- a/packages/sdk/app-graph/src/atoms.test.ts
+++ b/packages/sdk/app-graph/src/atoms.test.ts
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { MulticastObservable } from '@dxos/async';
+
+import { fromObservable } from './atoms';
+
+describe('fromObservable', () => {
+  test('same observable yields the same atom', ({ expect }) => {
+    const observable = MulticastObservable.of(1);
+    expect(fromObservable(observable)).to.equal(fromObservable(observable));
+  });
+
+  test('distinct observables yield distinct atoms', ({ expect }) => {
+    expect(fromObservable(MulticastObservable.of(1))).not.to.equal(fromObservable(MulticastObservable.of(1)));
+  });
+
+  test('does not read accessors on the observable', ({ expect }) => {
+    const observable = MulticastObservable.of(1);
+    // A structural key reads every accessor it collects, which throws for subsystems that are
+    // absent at runtime, such as `Client.shell` on a runtime with no iframe.
+    Object.defineProperty(observable, 'unavailable', {
+      enumerable: true,
+      get: () => {
+        throw new Error('accessor should not be read');
+      },
+    });
+
+    expect(() => fromObservable(observable)).not.to.throw();
+  });
+});

--- a/packages/sdk/app-graph/src/atoms.ts
+++ b/packages/sdk/app-graph/src/atoms.ts
@@ -2,6 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
+import * as Equal from 'effect/Equal';
 import * as Atom from 'effect/unstable/reactivity/Atom';
 
 import { type MulticastObservable } from '@dxos/async';
@@ -21,5 +22,8 @@ const observableFamily = Atom.family((observable: MulticastObservable<any>) => {
  * Will return the same atom instance for the same observable.
  */
 export const fromObservable = <T>(observable: MulticastObservable<T>): Atom.Atom<T> => {
-  return observableFamily(observable) as Atom.Atom<T>;
+  // Keyed by reference because the family's default structural key collects every accessor on the
+  // observable's prototype chain and reads each one, throwing on those whose subsystem is absent
+  // (e.g. `Client.shell` on a runtime with no iframe).
+  return observableFamily(Equal.byReferenceUnsafe(observable)) as Atom.Atom<T>;
 };


### PR DESCRIPTION
## Problem

No spaces rendered in the navtree, on a profile whose data was entirely intact — all four spaces were `SPACE_READY`, and three of them passed every visibility filter.

The `spaces` connector in `plugin-space` was throwing before it emitted anything:

```
invariant violation: Shell not available. [this._runtime.shell]
  at get shell (packages/sdk/client/src/client/client.ts:274)
  at structureKeys → structure → hash   (effect/Hash)
```

Nothing was asking for the shell. `CreateAtom.fromObservable(client.spaces)` memoized through `Atom.family`, which keys its `MutableHashMap` by Effect's structural hash. The two halves of that hash explain the rest:

```js
// getAllObjectKeys — collects the keys to hash
const keys = new Set(Reflect.ownKeys(obj))
if (obj.constructor === Object) return keys      // plain object → own keys, stop
while (current !== null && current !== Object.prototype) {
  keys.add(...Reflect.ownKeys(current))          // class instance → whole prototype chain
  current = Object.getPrototypeOf(current)
}

// structureKeys — hashes each collected key
h ^= combine(hash(key), hash((o)[key]))          // ← raw read; invokes getters
```

`SpaceList` is a class instance rather than a plain object, so Effect collected every accessor on its prototype chain and *read* each one, recursing until it reached the `Client`, where `shell` is a prototype getter. `_shellManager` is only constructed when there is an iframe manager, so on a runtime without one the getter's invariant throws.

`graph-builder.ts` catches extension defects and logs `WARN Extension failed`, so this surfaced only as an empty navtree.

`plugin-client` was unaffected because it passes `client.halo.identity` and `client.mesh.networkStatus` — observables that do not reach the `Client`. Only the `client.spaces` consumers walked into it.

## Fix

Mark the observable with `Equal.byReferenceUnsafe` before handing it to the family, so `Hash.hash` short-circuits to an identity-cached value (`Hash.random`) before reaching `structure`.

This restores the contract the docstring already claimed — *"same atom instance for the same observable"* — which the structural key only approximated, and avoids deep-hashing the client object graph on every call.

Verified first that the observables involved are stable stored instances (`this._runtime.spaces`, `this._state`, `this._networkStatus`), so reference keying preserves memoization rather than allocating an atom per call.

## Reviewer notes

- **`Equal.byReference` is not a substitute.** It is `byReferenceUnsafe(new Proxy(obj, {}))` — a fresh proxy per call, so every `fromObservable` would return a *different* atom. The naming invites the wrong choice here.
- **Tradeoff:** `byReferenceUnsafe` marks the observable for reference equality process-wide and irreversibly. For an identity-valued observable that is the intended semantics, but it is a global mark.
- **Considered and rejected:** implementing `[Hash.symbol]`/`[Equal.symbol]` on `Observable` in `@dxos/async`, mirroring the existing `Ref` precedent. It is cleaner conceptually and would fix every Effect consumer of any DXOS observable, but no package in `packages/common/` currently depends on `effect` — `async`, `util`, `context`, `invariant`, `log`, and `debug` are all effect-free. That is an architecture decision rather than a bug fix, so it is left as a follow-up.

## Related

`Obj/atoms.ts` in `@dxos/echo` has the same mismatch — it documents *"Uses object reference as key"* but uses `Atom.family`, and only `Ref` implements the Hash/Equal traits. Not addressed here: the right fix there is traits keyed by id (the `Ref` pattern), not reference marking, and it needs a proxy-stability check first.

## Test plan

Added `atoms.test.ts`. The key case reproduces the production failure at unit level — reverting to `Atom.family` fails it with `expected [Function] to not throw an error but 'Error: accessor should not be read' was thrown`.

```
app-graph        154 passed (6 files)
plugin-space      54 passed | 3 todo
plugin-client     15 passed | 2 skipped | 2 todo
plugin-meeting     1 passed
lint             app-graph, plugin-space, plugin-client, plugin-support — clean
oxfmt            clean
```

Root cause was diagnosed against a live session over the debug port; live confirmation that the navtree repopulates is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when extending application graphs in environments without a shell.
  * Prevented observable state from being incorrectly shared or duplicated, ensuring consistent updates and behavior.
  * Added safer handling for observables with properties that cannot be read successfully.

* **Tests**
  * Added coverage for observable identity reuse, separation of distinct observables, and safe accessor handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->