### PR TITLE
feat(edge-client): proactively refresh the auth header before the advertised challenge TTL

### DIFF
--- a/.changeset/edge-client-proactive-auth-refresh.md
+++ b/.changeset/edge-client-proactive-auth-refresh.md
@@ -1,0 +1,5 @@
+---
+'@dxos/edge-client': patch
+---
+
+Proactively refresh the cached HTTP auth header shortly before the server-advertised challenge TTL elapses, instead of provoking a 401 once per window. `/auth` responses may now carry `expiresInMs` beside the challenge; against servers that do not advertise it, behavior is unchanged (refresh on 401 only). `authenticateViaChallengeEndpoint` now returns `{ presentation, expiresInMs }`.

--- a/.changeset/edge-client-proactive-auth-refresh.md
+++ b/.changeset/edge-client-proactive-auth-refresh.md
@@ -2,4 +2,6 @@
 '@dxos/edge-client': patch
 ---
 
-Proactively refresh the cached HTTP auth header shortly before the server-advertised challenge TTL elapses, instead of provoking a 401 once per window. `/auth` responses may now carry `expiresInMs` beside the challenge; against servers that do not advertise it, behavior is unchanged (refresh on 401 only). `authenticateViaChallengeEndpoint` now returns `{ presentation, expiresInMs }`.
+Proactively refresh the cached HTTP auth header shortly before the server-advertised challenge TTL elapses, instead of provoking a 401 once per window. `/auth` responses may now carry `expiresInMs` beside the challenge; against servers that do not advertise it, behavior is unchanged (refresh on 401 only).
+
+Signature change: `authenticateViaChallengeEndpoint` (public since the previous release train, introduced in #12541) now returns `{ presentation, expiresInMs }` instead of the bare presentation bytes — destructure `presentation` at call sites.

--- a/packages/core/mesh/edge-client/src/auth-challenge.test.ts
+++ b/packages/core/mesh/edge-client/src/auth-challenge.test.ts
@@ -191,9 +191,15 @@ describe('fetchAuthChallengeInfo', () => {
     );
     expect((await fetchAuthChallengeInfo('https://edge.example.com'))?.expiresInMs).toBeUndefined();
 
-    // `1e400` parses to Infinity; accepting it would schedule the proactive refresh at never.
-    vi.stubGlobal('fetch', async () =>
-      jsonResponse({ success: true, data: { challenge: CHALLENGE, expiresInMs: 1e400 } }),
+    // `1e400` in the JSON text parses to Infinity; accepting it would schedule the refresh at never.
+    // Raw body rather than a JS literal: the number exists only on the wire.
+    vi.stubGlobal(
+      'fetch',
+      async () =>
+        new Response(`{ "success": true, "data": { "challenge": "${CHALLENGE}", "expiresInMs": 1e400 } }`, {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
     );
     expect((await fetchAuthChallengeInfo('https://edge.example.com'))?.expiresInMs).toBeUndefined();
   });

--- a/packages/core/mesh/edge-client/src/auth-challenge.test.ts
+++ b/packages/core/mesh/edge-client/src/auth-challenge.test.ts
@@ -9,6 +9,7 @@ import { type Presentation } from '@dxos/protocols/proto/dxos/halo/credentials';
 import {
   authenticateViaChallengeEndpoint,
   fetchAuthChallenge,
+  fetchAuthChallengeInfo,
   parseChallengeHeader,
   readAuthChallenge,
 } from './auth-challenge';
@@ -166,6 +167,44 @@ describe('fetchAuthChallenge', () => {
   });
 });
 
+describe('fetchAuthChallengeInfo', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('surfaces the advertised TTL beside the challenge', async ({ expect }) => {
+    vi.stubGlobal('fetch', async () =>
+      jsonResponse({ success: true, data: { challenge: CHALLENGE, expiresInMs: 300_000 } }),
+    );
+    expect(await fetchAuthChallengeInfo('https://edge.example.com')).toEqual({
+      challenge: CHALLENGE,
+      expiresInMs: 300_000,
+    });
+  });
+
+  test('tolerates servers that advertise no TTL, or a nonsensical one', async ({ expect }) => {
+    vi.stubGlobal('fetch', async () => jsonResponse({ success: true, data: { challenge: CHALLENGE } }));
+    expect((await fetchAuthChallengeInfo('https://edge.example.com'))?.expiresInMs).toBeUndefined();
+
+    vi.stubGlobal('fetch', async () =>
+      jsonResponse({ success: true, data: { challenge: CHALLENGE, expiresInMs: -5 } }),
+    );
+    expect((await fetchAuthChallengeInfo('https://edge.example.com'))?.expiresInMs).toBeUndefined();
+  });
+
+  test('a 401-shaped challenge carries no TTL', async ({ expect }) => {
+    vi.stubGlobal(
+      'fetch',
+      async () =>
+        new Response('Unauthorized', {
+          status: 401,
+          headers: { 'WWW-Authenticate': `VerifiablePresentation challenge="${CHALLENGE}"` },
+        }),
+    );
+    expect(await fetchAuthChallengeInfo('https://edge.example.com')).toEqual({ challenge: CHALLENGE });
+  });
+});
+
 describe('authenticateViaChallengeEndpoint', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -175,14 +214,14 @@ describe('authenticateViaChallengeEndpoint', () => {
     vi.stubGlobal('fetch', async () => jsonResponse({ success: true, data: { challenge: CHALLENGE } }));
 
     let signed: Uint8Array | undefined;
-    const presentation = await authenticateViaChallengeEndpoint(
+    const authentication = await authenticateViaChallengeEndpoint(
       'https://edge.example.com',
       identity((challenge) => {
         signed = challenge;
       }),
     );
 
-    expect(presentation).toBeDefined();
+    expect(authentication?.presentation).toBeDefined();
     // Normalised to a plain Uint8Array on both sides: the decoder hands back a Buffer, which
     // `toEqual` treats as a distinct type despite identical bytes.
     expect(new Uint8Array(signed!)).toEqual(new Uint8Array(Buffer.from(CHALLENGE, 'base64')));

--- a/packages/core/mesh/edge-client/src/auth-challenge.test.ts
+++ b/packages/core/mesh/edge-client/src/auth-challenge.test.ts
@@ -190,6 +190,12 @@ describe('fetchAuthChallengeInfo', () => {
       jsonResponse({ success: true, data: { challenge: CHALLENGE, expiresInMs: -5 } }),
     );
     expect((await fetchAuthChallengeInfo('https://edge.example.com'))?.expiresInMs).toBeUndefined();
+
+    // `1e400` parses to Infinity; accepting it would schedule the proactive refresh at never.
+    vi.stubGlobal('fetch', async () =>
+      jsonResponse({ success: true, data: { challenge: CHALLENGE, expiresInMs: 1e400 } }),
+    );
+    expect((await fetchAuthChallengeInfo('https://edge.example.com'))?.expiresInMs).toBeUndefined();
   });
 
   test('a 401-shaped challenge carries no TTL', async ({ expect }) => {

--- a/packages/core/mesh/edge-client/src/auth-challenge.ts
+++ b/packages/core/mesh/edge-client/src/auth-challenge.ts
@@ -176,7 +176,8 @@ export const fetchAuthChallengeInfo = async (baseHttpUrl: string | URL): Promise
     try {
       const body = await response.clone().json();
       const advertised = body?.data?.expiresInMs;
-      expiresInMs = typeof advertised === 'number' && advertised > 0 ? advertised : undefined;
+      // Finite-positive only: `1e400` parses to `Infinity`, which would schedule a refresh at never.
+      expiresInMs = Number.isFinite(advertised) && advertised > 0 ? advertised : undefined;
     } catch {
       // Header-shaped challenge (the 401 fallback) — no JSON body to read a TTL from.
     }

--- a/packages/core/mesh/edge-client/src/auth-challenge.ts
+++ b/packages/core/mesh/edge-client/src/auth-challenge.ts
@@ -144,6 +144,16 @@ export const readAuthChallenge = async (response: Response): Promise<string | un
   }
 };
 
+export type AuthChallengeInfo = {
+  /** Base64 challenge nonce. */
+  challenge: string;
+  /**
+   * Server-advertised challenge validity. Absent on servers predating the TTL contract — there the
+   * only refresh signal is the eventual 401.
+   */
+  expiresInMs?: number;
+};
+
 /**
  * Fetch a challenge nonce from the edge `/auth` endpoint.
  *
@@ -154,19 +164,32 @@ export const readAuthChallenge = async (response: Response): Promise<string | un
  * Returns undefined if the endpoint is unreachable or answers in neither known shape; callers fall
  * back to the 401 path, which still works against every server.
  */
-export const fetchAuthChallenge = async (baseHttpUrl: string | URL): Promise<string | undefined> => {
+export const fetchAuthChallengeInfo = async (baseHttpUrl: string | URL): Promise<AuthChallengeInfo | undefined> => {
   try {
     const response = await fetch(new URL('/auth', baseHttpUrl));
     const challenge = await readAuthChallenge(response);
     if (!challenge) {
       log.verbose('no challenge in /auth response', { status: response.status });
+      return undefined;
     }
-    return challenge;
+    let expiresInMs: number | undefined;
+    try {
+      const body = await response.clone().json();
+      const advertised = body?.data?.expiresInMs;
+      expiresInMs = typeof advertised === 'number' && advertised > 0 ? advertised : undefined;
+    } catch {
+      // Header-shaped challenge (the 401 fallback) — no JSON body to read a TTL from.
+    }
+    return { challenge, expiresInMs };
   } catch (error) {
     log.verbose('failed to fetch auth challenge', { error });
     return undefined;
   }
 };
+
+/** The challenge alone; see {@link fetchAuthChallengeInfo}. */
+export const fetchAuthChallenge = async (baseHttpUrl: string | URL): Promise<string | undefined> =>
+  (await fetchAuthChallengeInfo(baseHttpUrl))?.challenge;
 
 /**
  * Sign a base64 challenge, returning the encoded presentation.
@@ -182,6 +205,13 @@ export const presentCredentialsForChallenge = async (
   return schema.getCodecForType('dxos.halo.credentials.Presentation').encode(presentation);
 };
 
+export type ChallengeAuthentication = {
+  /** Encoded presentation bound to the fetched challenge. */
+  presentation: Uint8Array;
+  /** TTL advertised beside the challenge, when the server provides one. */
+  expiresInMs?: number;
+};
+
 /**
  * Obtain a challenge from `/auth` and sign it.
  * Returns undefined when no challenge could be obtained, leaving the caller on the 401 fallback.
@@ -189,9 +219,15 @@ export const presentCredentialsForChallenge = async (
 export const authenticateViaChallengeEndpoint = async (
   baseHttpUrl: string | URL,
   identity: EdgeIdentity,
-): Promise<Uint8Array | undefined> => {
-  const challenge = await fetchAuthChallenge(baseHttpUrl);
-  return challenge === undefined ? undefined : presentCredentialsForChallenge(identity, challenge);
+): Promise<ChallengeAuthentication | undefined> => {
+  const info = await fetchAuthChallengeInfo(baseHttpUrl);
+  if (info === undefined) {
+    return undefined;
+  }
+  return {
+    presentation: await presentCredentialsForChallenge(identity, info.challenge),
+    expiresInMs: info.expiresInMs,
+  };
 };
 
 /**

--- a/packages/core/mesh/edge-client/src/base-http-client.ts
+++ b/packages/core/mesh/edge-client/src/base-http-client.ts
@@ -74,9 +74,9 @@ export abstract class BaseHttpClient {
   protected _edgeIdentity: EdgeIdentity | undefined;
   /** Auth header cached until it goes stale (see `_authRefreshAt`) or a 401 replaces it. */
   protected _authHeader: string | undefined;
-  /** When to proactively refresh `_authHeader`; undefined = refresh only on 401. */
-  private _authRefreshAt: number | undefined;
-  /** Last TTL `/auth` advertised — reapplied to 401-minted headers, since the TTL is a server constant. */
+  /** When the current `_authHeader` was signed; with the TTL below it decides proactive refresh. */
+  private _authAcquiredAt: number | undefined;
+  /** Last TTL `/auth` advertised — a server constant, so 401-minted headers reuse it. */
   private _authTtlMs: number | undefined;
   /** Single-flight guard so concurrent requests with a stale header share one `/auth` round trip. */
   private _authPrefetch: Promise<void> | undefined;
@@ -96,7 +96,7 @@ export abstract class BaseHttpClient {
     if (this._edgeIdentity?.identityDid !== identity.identityDid || this._edgeIdentity?.peerKey !== identity.peerKey) {
       this._edgeIdentity = identity;
       this._authHeader = undefined;
-      this._authRefreshAt = undefined;
+      this._authAcquiredAt = undefined;
       // Drop any in-flight prefetch: it authenticates the previous identity, and awaiting it
       // would commit that identity's header for requests now belonging to the new one.
       this._authPrefetch = undefined;
@@ -277,25 +277,29 @@ export abstract class BaseHttpClient {
     // committing then would send the new identity's requests signed as the old one.
     if (authentication && this._edgeIdentity === identity) {
       this._authHeader = encodeAuthHeader(authentication.presentation);
-      this._recordAuthExpiry(authentication.expiresInMs);
+      this._recordAuthAcquired(authentication.expiresInMs);
     }
   }
 
   /** Stale means past the proactive-refresh point, not necessarily rejected yet. */
   private _authHeaderIsStale(): boolean {
-    return this._authRefreshAt !== undefined && Date.now() >= this._authRefreshAt;
+    if (this._authAcquiredAt === undefined || this._authTtlMs === undefined) {
+      return false;
+    }
+    // Refresh a margin ahead of expiry, floored at half the TTL so tiny windows still refresh.
+    const refreshAfterMs = Math.max(this._authTtlMs - AUTH_REFRESH_MARGIN_MS, Math.floor(this._authTtlMs / 2));
+    return Date.now() - this._authAcquiredAt >= refreshAfterMs;
   }
 
   /**
-   * Schedule the next proactive refresh from an advertised TTL. Without one (older servers, the
-   * 401-minted path on a server that never advertised), the last known TTL is reused; if none was
-   * ever advertised the header lives until a 401, exactly as before proactive refresh existed.
+   * Record when the current header was signed and the TTL advertised beside its challenge — only
+   * originals; the refresh point is derived at read time. Without an advertised TTL (older
+   * servers, the 401-minted path) the last known one is reused; if none was ever advertised the
+   * header lives until a 401, exactly as before proactive refresh existed.
    */
-  private _recordAuthExpiry(expiresInMs: number | undefined): void {
+  private _recordAuthAcquired(expiresInMs: number | undefined): void {
+    this._authAcquiredAt = Date.now();
     this._authTtlMs = expiresInMs ?? this._authTtlMs;
-    const ttl = this._authTtlMs;
-    this._authRefreshAt =
-      ttl === undefined ? undefined : Date.now() + Math.max(ttl - AUTH_REFRESH_MARGIN_MS, Math.floor(ttl / 2));
   }
 
   protected async _handleUnauthorized(response: Response): Promise<string> {
@@ -309,7 +313,7 @@ export abstract class BaseHttpClient {
     }
     const challenge = await handleAuthChallenge(response, this._edgeIdentity);
     // The fresh header starts a new window; the 401 body carries no TTL, so the last one applies.
-    this._recordAuthExpiry(undefined);
+    this._recordAuthAcquired(undefined);
     return encodeAuthHeader(challenge);
   }
 }

--- a/packages/core/mesh/edge-client/src/base-http-client.ts
+++ b/packages/core/mesh/edge-client/src/base-http-client.ts
@@ -72,7 +72,7 @@ export abstract class BaseHttpClient {
   protected readonly _clientTag: string | undefined;
   protected readonly _apiKey: string | undefined;
   protected _edgeIdentity: EdgeIdentity | undefined;
-  /** Auth header cached until it goes stale (see `_authRefreshAt`) or a 401 replaces it. */
+  /** Auth header cached until it goes stale (see `_authHeaderIsStale`) or a 401 replaces it. */
   protected _authHeader: string | undefined;
   /** When the current `_authHeader` was signed; with the TTL below it decides proactive refresh. */
   private _authAcquiredAt: number | undefined;

--- a/packages/core/mesh/edge-client/src/base-http-client.ts
+++ b/packages/core/mesh/edge-client/src/base-http-client.ts
@@ -72,8 +72,14 @@ export abstract class BaseHttpClient {
   protected readonly _clientTag: string | undefined;
   protected readonly _apiKey: string | undefined;
   protected _edgeIdentity: EdgeIdentity | undefined;
-  /** Auth header cached until next 401. */
+  /** Auth header cached until it goes stale (see `_authRefreshAt`) or a 401 replaces it. */
   protected _authHeader: string | undefined;
+  /** When to proactively refresh `_authHeader`; undefined = refresh only on 401. */
+  private _authRefreshAt: number | undefined;
+  /** Last TTL `/auth` advertised — reapplied to 401-minted headers, since the TTL is a server constant. */
+  private _authTtlMs: number | undefined;
+  /** Single-flight guard so concurrent requests with a stale header share one `/auth` round trip. */
+  private _authPrefetch: Promise<void> | undefined;
 
   constructor(baseUrl: string, options?: BaseHttpClientOptions) {
     this._baseUrl = getEdgeUrlWithProtocol(baseUrl, 'http');
@@ -90,6 +96,7 @@ export abstract class BaseHttpClient {
     if (this._edgeIdentity?.identityDid !== identity.identityDid || this._edgeIdentity?.peerKey !== identity.peerKey) {
       this._edgeIdentity = identity;
       this._authHeader = undefined;
+      this._authRefreshAt = undefined;
     }
   }
 
@@ -109,7 +116,7 @@ export abstract class BaseHttpClient {
     while (true) {
       let processingError: EdgeCallFailedError | undefined = undefined;
       try {
-        if (!this._authHeader && args.auth && !this._apiKey) {
+        if (args.auth && !this._apiKey && (!this._authHeader || this._authHeaderIsStale())) {
           await this._prefetchAuthHeader();
         }
 
@@ -196,7 +203,7 @@ export abstract class BaseHttpClient {
     while (true) {
       let processingError: EdgeCallFailedError | undefined;
       try {
-        if (!this._authHeader && args.auth && !this._apiKey) {
+        if (args.auth && !this._apiKey && (!this._authHeader || this._authHeaderIsStale())) {
           await this._prefetchAuthHeader();
         }
 
@@ -250,15 +257,39 @@ export abstract class BaseHttpClient {
    * unauthenticated, falling back to the 401-and-retry path below. That fallback is what keeps
    * this working against servers whose `/auth` only issues a challenge by rejecting.
    */
-  private async _prefetchAuthHeader(): Promise<void> {
+  private _prefetchAuthHeader(): Promise<void> {
+    return (this._authPrefetch ??= this._prefetchAuthHeaderOnce().finally(() => {
+      this._authPrefetch = undefined;
+    }));
+  }
+
+  private async _prefetchAuthHeaderOnce(): Promise<void> {
     if (!this._edgeIdentity) {
       log.verbose('auth prefetch skipped: no identity set');
       return;
     }
-    const presentation = await authenticateViaChallengeEndpoint(this._baseUrl, this._edgeIdentity);
-    if (presentation) {
-      this._authHeader = encodeAuthHeader(presentation);
+    const authentication = await authenticateViaChallengeEndpoint(this._baseUrl, this._edgeIdentity);
+    if (authentication) {
+      this._authHeader = encodeAuthHeader(authentication.presentation);
+      this._recordAuthExpiry(authentication.expiresInMs);
     }
+  }
+
+  /** Stale means past the proactive-refresh point, not necessarily rejected yet. */
+  private _authHeaderIsStale(): boolean {
+    return this._authRefreshAt !== undefined && Date.now() >= this._authRefreshAt;
+  }
+
+  /**
+   * Schedule the next proactive refresh from an advertised TTL. Without one (older servers, the
+   * 401-minted path on a server that never advertised), the last known TTL is reused; if none was
+   * ever advertised the header lives until a 401, exactly as before proactive refresh existed.
+   */
+  private _recordAuthExpiry(expiresInMs: number | undefined): void {
+    this._authTtlMs = expiresInMs ?? this._authTtlMs;
+    const ttl = this._authTtlMs;
+    this._authRefreshAt =
+      ttl === undefined ? undefined : Date.now() + Math.max(ttl - AUTH_REFRESH_MARGIN_MS, Math.floor(ttl / 2));
   }
 
   protected async _handleUnauthorized(response: Response): Promise<string> {
@@ -271,9 +302,14 @@ export abstract class BaseHttpClient {
       throw await EdgeCallFailedError.fromHttpFailure(response);
     }
     const challenge = await handleAuthChallenge(response, this._edgeIdentity);
+    // The fresh header starts a new window; the 401 body carries no TTL, so the last one applies.
+    this._recordAuthExpiry(undefined);
     return encodeAuthHeader(challenge);
   }
 }
+
+/** Refresh the cached auth header this long before its advertised expiry, absorbing request latency and clock skew. */
+const AUTH_REFRESH_MARGIN_MS = 30_000;
 
 /**
  * Whether a response carries a VerifiablePresentation challenge we can actually answer.

--- a/packages/core/mesh/edge-client/src/base-http-client.ts
+++ b/packages/core/mesh/edge-client/src/base-http-client.ts
@@ -97,6 +97,9 @@ export abstract class BaseHttpClient {
       this._edgeIdentity = identity;
       this._authHeader = undefined;
       this._authRefreshAt = undefined;
+      // Drop any in-flight prefetch: it authenticates the previous identity, and awaiting it
+      // would commit that identity's header for requests now belonging to the new one.
+      this._authPrefetch = undefined;
     }
   }
 
@@ -264,12 +267,15 @@ export abstract class BaseHttpClient {
   }
 
   private async _prefetchAuthHeaderOnce(): Promise<void> {
-    if (!this._edgeIdentity) {
+    const identity = this._edgeIdentity;
+    if (!identity) {
       log.verbose('auth prefetch skipped: no identity set');
       return;
     }
-    const authentication = await authenticateViaChallengeEndpoint(this._baseUrl, this._edgeIdentity);
-    if (authentication) {
+    const authentication = await authenticateViaChallengeEndpoint(this._baseUrl, identity);
+    // `setIdentity` may have swapped identities while the challenge round trip was in flight;
+    // committing then would send the new identity's requests signed as the old one.
+    if (authentication && this._edgeIdentity === identity) {
       this._authHeader = encodeAuthHeader(authentication.presentation);
       this._recordAuthExpiry(authentication.expiresInMs);
     }

--- a/packages/core/mesh/edge-client/src/edge-client.ts
+++ b/packages/core/mesh/edge-client/src/edge-client.ts
@@ -356,9 +356,9 @@ export class EdgeClient extends Resource implements EdgeConnection {
    * that predate the challenge endpoint.
    */
   private async _createAuthHeader(path: string): Promise<string | undefined> {
-    const presentation = await authenticateViaChallengeEndpoint(this._baseHttpUrl, this._identity);
-    if (presentation) {
-      return encodePresentationWsAuthHeader(presentation);
+    const authentication = await authenticateViaChallengeEndpoint(this._baseHttpUrl, this._identity);
+    if (authentication) {
+      return encodePresentationWsAuthHeader(authentication.presentation);
     }
 
     const response = await fetch(new URL(path, this._baseHttpUrl), { method: 'GET' });

--- a/packages/core/mesh/edge-client/src/edge-http-client.test.ts
+++ b/packages/core/mesh/edge-client/src/edge-http-client.test.ts
@@ -108,6 +108,40 @@ describe('EdgeHttpClient auth refresh', () => {
     expect(authCalls(fetchMock)).toBe(2);
   });
 
+  test('an identity swap mid-prefetch discards the stale header', async ({ expect }) => {
+    let releaseAuth = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseAuth = resolve;
+    });
+    const fetchMock = vi.fn(async (input: any, _init?: RequestInit) => {
+      const url = String(input instanceof URL ? input : (input.url ?? input));
+      if (url.endsWith('/auth')) {
+        await gate;
+        return new Response(JSON.stringify({ success: true, data: { challenge: 'Y2hhbGxlbmdl' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(null, { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new EdgeHttpClient('https://edge.example.com');
+    client.setIdentity(identity);
+    const inFlight = client.putBlob(Context.default(), 'one', new Uint8Array([1]), {
+      contentType: 'application/octet-stream',
+    });
+    // Let the prefetch reach the gated /auth round trip, then swap identities under it.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    client.setIdentity({ ...identity, identityDid: 'did:halo:other' });
+    releaseAuth();
+    await inFlight;
+
+    // The stale presentation was discarded: the request went out without it.
+    const putCall = fetchMock.mock.calls.find((call) => String(call[0]).includes('/api/file/one'));
+    expect((putCall![1]?.headers as Record<string, string> | undefined)?.Authorization).toBeUndefined();
+  });
+
   test('no advertised TTL means no proactive refresh', async ({ expect }) => {
     vi.useFakeTimers();
     const fetchMock = makeFetchMock({ challenge: 'Y2hhbGxlbmdl' });

--- a/packages/core/mesh/edge-client/src/edge-http-client.test.ts
+++ b/packages/core/mesh/edge-client/src/edge-http-client.test.ts
@@ -113,9 +113,14 @@ describe('EdgeHttpClient auth refresh', () => {
     const gate = new Promise<void>((resolve) => {
       releaseAuth = resolve;
     });
+    let signalAuthStarted = () => {};
+    const authStarted = new Promise<void>((resolve) => {
+      signalAuthStarted = resolve;
+    });
     const fetchMock = vi.fn(async (input: any, _init?: RequestInit) => {
       const url = String(input instanceof URL ? input : (input.url ?? input));
       if (url.endsWith('/auth')) {
+        signalAuthStarted();
         await gate;
         return new Response(JSON.stringify({ success: true, data: { challenge: 'Y2hhbGxlbmdl' } }), {
           status: 200,
@@ -131,8 +136,8 @@ describe('EdgeHttpClient auth refresh', () => {
     const inFlight = client.putBlob(Context.default(), 'one', new Uint8Array([1]), {
       contentType: 'application/octet-stream',
     });
-    // Let the prefetch reach the gated /auth round trip, then swap identities under it.
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Swap identities only once the prefetch is provably parked inside the gated /auth round trip.
+    await authStarted;
     client.setIdentity({ ...identity, identityDid: 'did:halo:other' });
     releaseAuth();
     await inFlight;

--- a/packages/core/mesh/edge-client/src/edge-http-client.test.ts
+++ b/packages/core/mesh/edge-client/src/edge-http-client.test.ts
@@ -59,6 +59,70 @@ describe('EdgeHttpClient.anthropicAiRequest', () => {
   });
 });
 
+describe('EdgeHttpClient auth refresh', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  const identity = {
+    peerKey: 'peer-key',
+    identityDid: 'did:halo:test',
+    presentCredentials: async (): Promise<Presentation> => ({}),
+  };
+
+  const makeFetchMock = (authData: Record<string, unknown>) =>
+    vi.fn(async (input: any, _init?: RequestInit) => {
+      const url = String(input instanceof URL ? input : (input.url ?? input));
+      if (url.endsWith('/auth')) {
+        return new Response(JSON.stringify({ success: true, data: authData }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(null, { status: 200 });
+    });
+
+  const authCalls = (fetchMock: { mock: { calls: unknown[][] } }) =>
+    fetchMock.mock.calls.filter((call) => String(call[0]).endsWith('/auth')).length;
+
+  test('re-authenticates via /auth before the advertised TTL elapses', async ({ expect }) => {
+    vi.useFakeTimers();
+    const fetchMock = makeFetchMock({ challenge: 'Y2hhbGxlbmdl', expiresInMs: 300_000 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new EdgeHttpClient('https://edge.example.com');
+    client.setIdentity(identity);
+
+    await client.putBlob(Context.default(), 'one', new Uint8Array([1]), { contentType: 'application/octet-stream' });
+    expect(authCalls(fetchMock)).toBe(1);
+
+    // Inside the window the cached header is reused.
+    vi.advanceTimersByTime(60_000);
+    await client.putBlob(Context.default(), 'two', new Uint8Array([2]), { contentType: 'application/octet-stream' });
+    expect(authCalls(fetchMock)).toBe(1);
+
+    // Past the refresh point (TTL minus margin) a fresh challenge is fetched — no 401 involved.
+    vi.advanceTimersByTime(300_000);
+    await client.putBlob(Context.default(), 'three', new Uint8Array([3]), { contentType: 'application/octet-stream' });
+    expect(authCalls(fetchMock)).toBe(2);
+  });
+
+  test('no advertised TTL means no proactive refresh', async ({ expect }) => {
+    vi.useFakeTimers();
+    const fetchMock = makeFetchMock({ challenge: 'Y2hhbGxlbmdl' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new EdgeHttpClient('https://edge.example.com');
+    client.setIdentity(identity);
+
+    await client.putBlob(Context.default(), 'one', new Uint8Array([1]), { contentType: 'application/octet-stream' });
+    vi.advanceTimersByTime(3_600_000);
+    await client.putBlob(Context.default(), 'two', new Uint8Array([2]), { contentType: 'application/octet-stream' });
+    expect(authCalls(fetchMock)).toBe(1);
+  });
+});
+
 describe('EdgeHttpClient blobs', () => {
   afterEach(() => {
     vi.unstubAllGlobals();


### PR DESCRIPTION
Client half of proactive nonce refresh — pairs with dxos/edge#881 (edge advertises its nonce TTL as `expiresInMs` on the anonymous `/auth` 200) and follows up dxos/edge#880 (nonce enforcement on by default).

## Problem

The HTTP client caches its auth header until a 401 replaces it. With nonce enforcement on, every session older than the server's 5-minute nonce TTL provokes exactly one 401-plus-retry per window — functionally fine, but it re-introduces the periodic console-401 noise that the `/auth` 200 path was built to eliminate, and doubles one request per window.

## Change

- `fetchAuthChallengeInfo` reads `{ challenge, expiresInMs }` from `/auth`; `authenticateViaChallengeEndpoint` now returns `{ presentation, expiresInMs }`.
- `BaseHttpClient` records a refresh point (`expiry − 30s` margin, floored at half the TTL) and re-authenticates via `/auth` before sending once it's past — single-flight, so concurrent stale requests share one round trip. Applies to both `_call` and `_callRaw`.
- 401-minted headers reuse the last advertised TTL (it's a server constant), so steady-state stays proactive even after a race.
- Servers that advertise nothing (pre-dxos/edge#881 edge): behavior unchanged — refresh on 401 only. Either side can deploy first.
- WebSocket path unchanged: it already signs a fresh challenge on every connect.

Tests: TTL parsing (present / absent / nonsensical / 401-shaped), proactive re-auth under fake timers (refresh after the window, not inside it), and the no-TTL control. `edge-client` suite: 67 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication credentials now refresh proactively using server-provided expiration times.
  * Concurrent requests share a single authentication refresh.
  * Credential refresh state is safely reset when switching identities.
* **Bug Fixes**
  * Preserved 401-triggered authentication refresh when expiration details are unavailable.
  * Improved handling of authentication responses and expiration metadata.
* **Tests**
  * Added coverage for proactive refresh, expiration handling, fallback behavior, concurrent requests, and identity changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->