### PR TITLE
app-framework: defer activation events dispatched during startup

### DIFF
--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -1,0 +1,6 @@
+---
+'@dxos/app-framework': minor
+'@dxos/plugin-client': minor
+---
+
+Defer activation events dispatched while startup is running until the startup wave completes, so a module activating on one can rely on every startup capability being present. Keep the composed React context stable across renders so a capability change no longer remounts the application. Add a `client` option to the client plugin, letting a host construct and begin initializing the client before the activation pass reaches the plugin.

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -413,14 +413,13 @@ const main = async () => {
   profiler?.mark('services:end');
   profiler?.measure('services', 'services:start', 'services:end');
 
-  // Started here rather than by plugin-client, whose module is lazily imported behind the entire
-  // plugin-loading pass: the worker handshake and storage open are seconds of work that depend on
-  // nothing but the services above, so they run alongside that pass instead of after it.
-  // `initialize()` is `@synchronized`, so the plugin's own call joins this one; that call is what
-  // reports a failure (via `onClientInitializationError`), hence the bare catch here.
+  // Started here so the handshake and storage open run alongside plugin loading rather than behind
+  // it: plugin-client's module is lazily imported, and this needs nothing but the services above.
+  // The plugin's own call is what surfaces a failure (via `onClientInitializationError`); this one
+  // only has to not reject unhandled.
   performance.mark('milestone:client-initialize:start');
   const client = new Client({ config, services });
-  void client.initialize().catch(() => {});
+  void client.initialize().catch((err) => log.catch(err));
 
   profiler?.mark('plugins:start');
 

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -184,7 +184,7 @@ const main = async () => {
 
   // Load these in parallel; HTTP/2 multiplexes the four chunks and even on
   // local-disk the parser can interleave parses.
-  const [{ Config, defs, SaveConfig }, { createClientServices }, { Migrations }, { __COMPOSER_MIGRATIONS__ }] =
+  const [{ Config, defs, SaveConfig }, { Client, createClientServices }, { Migrations }, { __COMPOSER_MIGRATIONS__ }] =
     await Promise.all([
       import('@dxos/config'),
       import('@dxos/react-client'),
@@ -413,6 +413,15 @@ const main = async () => {
   profiler?.mark('services:end');
   profiler?.measure('services', 'services:start', 'services:end');
 
+  // Started here rather than by plugin-client, whose module is lazily imported behind the entire
+  // plugin-loading pass: the worker handshake and storage open are seconds of work that depend on
+  // nothing but the services above, so they run alongside that pass instead of after it.
+  // `initialize()` is `@synchronized`, so the plugin's own call joins this one; that call is what
+  // reports a failure (via `onClientInitializationError`), hence the bare catch here.
+  performance.mark('milestone:client-initialize:start');
+  const client = new Client({ config, services });
+  void client.initialize().catch(() => {});
+
   profiler?.mark('plugins:start');
 
   const isPwa = !isFalse(config.values.runtime?.app?.env?.DX_PWA);
@@ -426,6 +435,7 @@ const main = async () => {
     appKey: APP_KEY,
     config,
     services,
+    client,
     observability,
     logStore,
     onFatalError: (error) => raiseFatalError(error),

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -413,10 +413,9 @@ const main = async () => {
   profiler?.mark('services:end');
   profiler?.measure('services', 'services:start', 'services:end');
 
-  // Started here so the handshake and storage open run alongside plugin loading rather than behind
-  // it: plugin-client's module is lazily imported, and this needs nothing but the services above.
-  // The plugin's own call is what surfaces a failure (via `onClientInitializationError`); this one
-  // only has to not reject unhandled.
+  // Started here so the handshake and storage open overlap plugin loading, which plugin-client's
+  // lazily-imported module would otherwise sit behind. Its call surfaces failures; this one only
+  // has to not reject unhandled.
   performance.mark('milestone:client-initialize:start');
   const client = new Client({ config, services });
   void client.initialize().catch((err) => log.catch(err));

--- a/packages/apps/composer-app/src/plugin-defs.core.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.core.tsx
@@ -7,7 +7,7 @@ import * as Effect from 'effect/Effect';
 import { ProcessManagerPlugin } from '@dxos/app-framework';
 import type * as Plugin from '@dxos/app-framework/Plugin';
 import * as NativePasskey from '@dxos/app-toolkit/NativePasskey';
-import { type ClientServicesProvider, type Config } from '@dxos/client';
+import { type Client, type ClientServicesProvider, type Config } from '@dxos/client';
 import { type IdbLogStore } from '@dxos/log-store-idb';
 import { type Observability } from '@dxos/observability';
 import * as AttentionPlugin from '@dxos/plugin-attention/AttentionPlugin';
@@ -36,6 +36,8 @@ export type State = {
   appKey: string;
   config: Config;
   services: ClientServicesProvider;
+  /** Constructed and initializing at the entry point, so the handshake overlaps plugin loading. */
+  client: Client;
   observability: Promise<Observability.Observability>;
   logStore: IdbLogStore;
 };
@@ -61,6 +63,7 @@ export const getCorePlugins = ({
   appKey,
   config,
   services,
+  client,
   observability,
   logStore,
   onFatalError,
@@ -74,6 +77,7 @@ export const getCorePlugins = ({
   return [
     AttentionPlugin.make(),
     ClientPlugin.make({
+      client,
       config,
       services,
       shareableLinkOrigin: origin,

--- a/packages/plugins/plugin-client/src/capabilities/client.ts
+++ b/packages/plugins/plugin-client/src/capabilities/client.ts
@@ -39,8 +39,7 @@ export default Capability.makeModule(
     log(hostClient ? 'adopting host client' : 'creating client');
     const client = hostClient ?? new Client(options);
     if (!hostClient) {
-      // Only when the client is ours: a host that supplied one marked this where it began
-      // initializing, which is what the span is measuring.
+      // A host-supplied client marked this where it began initializing, which is the span.
       performance.mark('milestone:client-initialize:start');
     }
     log('initializing client (forked)...');

--- a/packages/plugins/plugin-client/src/capabilities/client.ts
+++ b/packages/plugins/plugin-client/src/capabilities/client.ts
@@ -39,9 +39,8 @@ export default Capability.makeModule(
     log(hostClient ? 'adopting host client' : 'creating client');
     const client = hostClient ?? new Client(options);
     if (!hostClient) {
-      // Boot-waterfall milestone opening the client-init span, which `:end` closes around SDK
-      // initialize plus the app-supplied callback. A host-supplied client has already marked it,
-      // at the point it began initializing.
+      // Only when the client is ours: a host that supplied one marked this where it began
+      // initializing, which is what the span is measuring.
       performance.mark('milestone:client-initialize:start');
     }
     log('initializing client (forked)...');

--- a/packages/plugins/plugin-client/src/capabilities/client.ts
+++ b/packages/plugins/plugin-client/src/capabilities/client.ts
@@ -25,6 +25,7 @@ type ClientCapabilityOptions = Omit<
 
 export default Capability.makeModule(
   Effect.fnUntraced(function* ({
+    client: hostClient,
     onClientInitialized,
     onClientInitializationError,
     onSpacesReady,
@@ -35,12 +36,15 @@ export default Capability.makeModule(
     const capabilityManager = yield* Capability.Service;
     const pluginManager = yield* Plugin.Service;
 
-    log('creating client');
-    const client = new Client(options);
+    log(hostClient ? 'adopting host client' : 'creating client');
+    const client = hostClient ?? new Client(options);
+    if (!hostClient) {
+      // Boot-waterfall milestone opening the client-init span, which `:end` closes around SDK
+      // initialize plus the app-supplied callback. A host-supplied client has already marked it,
+      // at the point it began initializing.
+      performance.mark('milestone:client-initialize:start');
+    }
     log('initializing client (forked)...');
-    // Boot-waterfall milestones: split the client init (formerly the boot critical path's
-    // longest block) into SDK initialize vs the app-supplied callback.
-    performance.mark('milestone:client-initialize:start');
 
     let subscription: { unsubscribe: () => void } | undefined;
 

--- a/packages/plugins/plugin-client/src/types/ClientOptions.ts
+++ b/packages/plugins/plugin-client/src/types/ClientOptions.ts
@@ -9,6 +9,18 @@ import { type Client, type ClientOptions } from '@dxos/client';
 
 export type ClientPluginOptions = ClientOptions & {
   /**
+   * A client for this plugin to adopt instead of constructing one from the options above.
+   *
+   * The plugin's own module is lazily imported, so a client built here does not exist until the
+   * activation pass reaches it — seconds into boot, with the worker handshake and storage open
+   * still ahead of it. A host that already holds the config and services can construct the client
+   * at entry and call `initialize()` immediately, overlapping that cost with plugin loading;
+   * `initialize()` is `@synchronized`, so the plugin's own call joins the in-flight one rather
+   * than racing it. Lifecycle still belongs to the plugin, which destroys the client on teardown.
+   */
+  client?: Client;
+
+  /**
    * Whether the navigation handler consumes invitation codes from URL query params.
    * Disable when another plugin (e.g. plugin-onboarding) owns the invitation URL flow.
    * @default true

--- a/packages/plugins/plugin-client/src/types/ClientOptions.ts
+++ b/packages/plugins/plugin-client/src/types/ClientOptions.ts
@@ -9,14 +9,9 @@ import { type Client, type ClientOptions } from '@dxos/client';
 
 export type ClientPluginOptions = ClientOptions & {
   /**
-   * A client for this plugin to adopt instead of constructing one from the options above.
-   *
-   * The plugin's own module is lazily imported, so a client built here does not exist until the
-   * activation pass reaches it — seconds into boot, with the worker handshake and storage open
-   * still ahead of it. A host that already holds the config and services can construct the client
-   * at entry and call `initialize()` immediately, overlapping that cost with plugin loading;
-   * `initialize()` is `@synchronized`, so the plugin's own call joins the in-flight one rather
-   * than racing it. Lifecycle still belongs to the plugin, which destroys the client on teardown.
+   * A client to adopt instead of constructing one, so a host can start `initialize()` at entry
+   * rather than when activation reaches this lazily-imported module. `@synchronized`, so the
+   * plugin's own call joins it; lifecycle stays with the plugin, which destroys it on teardown.
    */
   client?: Client;
 

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
@@ -24,10 +24,17 @@ import { useNavTreeContext } from '../NavTreeContext';
 import { NavTreeItemColumns } from '../NavTreeItem/NavTreeItemColumns';
 
 /**
- * Delay before the unavailable-workspace message appears: a workspace whose space is still loading has
- * no graph node yet and materializes into a real panel on its own, so it must not flash during that window.
+ * Delay before the unavailable-workspace message appears, timed from the last change to the set of
+ * space workspaces rather than from mount, so it lands only once that set has held still.
  */
 const RENDER_DELAY = '1s';
+
+/**
+ * Width held for the item-end slot (`org.dxos.role.navtreeItemEnd`), whose surface resolves after the
+ * tree has painted: a bare `min-content` track starts collapsed and re-truncates every label in the
+ * panel when it lands. Sized to what fills it, an `AttentionGlyph` (`w-3`) inset by `mx-1`.
+ */
+const ITEM_END_SIZE = '1.25rem';
 
 export type L1PanelProps = {
   open?: boolean;
@@ -36,6 +43,14 @@ export type L1PanelProps = {
   id: string;
   /** Absent when the workspace is not in the graph; the panel then renders the unavailable message. */
   item?: Node.Node;
+  /**
+   * Identity of the set of space workspaces in the graph; empty until the client has published its
+   * space list. Gates the unavailable message, which is a claim about that list: it stays hidden
+   * while the set is empty, and each change to it restarts {@link RENDER_DELAY} so the claim is
+   * made only once spaces have stopped arriving. Every identity ends up with at least a settings
+   * space, so an empty set means not-loaded-yet rather than nothing-to-show.
+   */
+  spaces?: string;
   isCurrent: boolean;
   onBack?: () => void;
 };
@@ -45,7 +60,7 @@ export type L1PanelProps = {
  * longer exists, or persisted deck state pointing at one after a profile switch — the panel body is the
  * unavailable-workspace message, so the sidebar is never blank.
  */
-const L1PanelInner = ({ open, path, id, item, isCurrent, onBack }: L1PanelProps) => {
+const L1PanelInner = ({ open, path, id, item, spaces, isCurrent, onBack }: L1PanelProps) => {
   const { t } = useTranslation(meta.profile.key);
   const title = item ? toLocalizedString(item.properties.label, t) : t('workspace-unavailable.heading');
   const isActivated = useIsActivatedWorkspace(id);
@@ -75,13 +90,18 @@ const L1PanelInner = ({ open, path, id, item, isCurrent, onBack }: L1PanelProps)
         (item ? (
           <L1PanelContent open={open} path={path} item={item} onBack={onBack} />
         ) : (
-          <Empty
-            label={t('workspace-unavailable.description')}
-            // Second grid row, so the message clears the rail exactly as the tree does, and hugging its
-            // top rather than stretching to the row's full height.
-            classNames='row-start-2 self-start animate-fade-in'
-            style={{ animationDelay: RENDER_DELAY, animationFillMode: 'backwards' }}
-          />
+          !!spaces && (
+            <Empty
+              // Remounting restarts the delay animation, which is how a set that is still filling
+              // in keeps deferring the message.
+              key={spaces}
+              label={t('workspace-unavailable.description')}
+              // Second grid row, so the message clears the rail exactly as the tree does, and
+              // hugging its top rather than stretching to the row's full height.
+              classNames='row-start-2 self-start animate-fade-in'
+              style={{ animationDelay: RENDER_DELAY, animationFillMode: 'backwards' }}
+            />
+          )
         ))}
     </Tabs.Panel>
   );
@@ -127,7 +147,7 @@ const L1PanelContent = ({
             path={path}
             levelOffset={5}
             draggable
-            gridTemplateColumns='[tree-row-start] minmax(0, 1fr) min-content min-content [tree-row-end]'
+            gridTemplateColumns={`[tree-row-start] minmax(0, 1fr) min-content minmax(${ITEM_END_SIZE}, min-content) [tree-row-end]`}
             renderColumns={NavTreeItemColumns}
             blockInstruction={navTreeContext.blockInstruction}
             canDrop={navTreeContext.canDrop}
@@ -157,7 +177,9 @@ const L1PanelHeader = ({ item, path, onBack }: Pick<L1PanelProps, 'path' | 'onBa
   return (
     <div
       data-tauri-drag-region
-      className='grid grid-cols-[28px_1fr_min-content_min-content] w-full items-center dx-app-drag dx-density-lg'
+      className='grid w-full items-center dx-app-drag dx-density-lg'
+      // Same late item-end surface as the tree rows below, so the header holds the slot too.
+      style={{ gridTemplateColumns: `28px 1fr min-content minmax(${ITEM_END_SIZE}, min-content)` }}
     >
       {backCapableWorkspace ? (
         <IconButton

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
@@ -9,6 +9,7 @@ import * as Graph from '@dxos/app-graph/Graph';
 import * as Node from '@dxos/app-graph/Node';
 import * as GraphPath from '@dxos/app-toolkit/GraphPath';
 import { useAppGraph } from '@dxos/app-toolkit/ui';
+import * as DeckSchema from '@dxos/plugin-deck/DeckSchema';
 import { useActionRunner, useEdges } from '@dxos/plugin-graph/hooks';
 import { DensityProvider, IconButton, ScrollArea, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { Empty, Tree } from '@dxos/react-ui-list';
@@ -44,11 +45,10 @@ export type L1PanelProps = {
   /** Absent when the workspace is not in the graph; the panel then renders the unavailable message. */
   item?: Node.Node;
   /**
-   * Identity of the set of space workspaces in the graph; empty until the client has published its
-   * space list. Gates the unavailable message, which is a claim about that list: it stays hidden
-   * while the set is empty, and each change to it restarts {@link RENDER_DELAY} so the claim is
-   * made only once spaces have stopped arriving. Every identity ends up with at least a settings
-   * space, so an empty set means not-loaded-yet rather than nothing-to-show.
+   * Identity of the set of space workspaces in the graph, which the unavailable message is a claim
+   * about: it stays hidden while the set is empty, and every change restarts {@link RENDER_DELAY}
+   * so the claim waits for spaces to stop arriving. Empty means not-loaded-yet rather than
+   * nothing-to-show, since every identity ends up with at least a settings space.
    */
   spaces?: string;
   isCurrent: boolean;
@@ -65,6 +65,10 @@ const L1PanelInner = ({ open, path, id, item, spaces, isCurrent, onBack }: L1Pan
   const title = item ? toLocalizedString(item.properties.label, t) : t('workspace-unavailable.heading');
   const isActivated = useIsActivatedWorkspace(id);
   const shouldRenderContent = isCurrent || isActivated;
+  // The unavailable message is a claim about the space list, so it needs one to have been
+  // published; the sentinel deck means no workspace has been resolved yet, so none is being asked
+  // for and there is nothing to report as missing.
+  const reportUnavailable = !!spaces && id !== DeckSchema.DEFAULT_DECK_ID;
 
   return (
     <Tabs.Panel
@@ -90,10 +94,10 @@ const L1PanelInner = ({ open, path, id, item, spaces, isCurrent, onBack }: L1Pan
         (item ? (
           <L1PanelContent open={open} path={path} item={item} onBack={onBack} />
         ) : (
-          !!spaces && (
+          reportUnavailable && (
             <Empty
-              // Remounting restarts the delay animation, which is how a set that is still filling
-              // in keeps deferring the message.
+              // Spaces publish one at a time as each opens; remounting restarts the delay, so a set
+              // that is still filling in keeps pushing the message back.
               key={spaces}
               label={t('workspace-unavailable.description')}
               // Second grid row, so the message clears the rail exactly as the tree does, and

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
@@ -31,9 +31,9 @@ import { NavTreeItemColumns } from '../NavTreeItem/NavTreeItemColumns';
 const RENDER_DELAY = '1s';
 
 /**
- * Width held for the item-end slot (`org.dxos.role.navtreeItemEnd`), whose surface resolves after the
- * tree has painted: a bare `min-content` track starts collapsed and re-truncates every label in the
- * panel when it lands. Sized to what fills it, an `AttentionGlyph` (`w-3`) inset by `mx-1`.
+ * Width held for the item-end slot, whose surface resolves after the tree has painted: a
+ * `min-content` track would start collapsed and re-truncate every label when it lands. Sized to
+ * what fills it, an `AttentionGlyph` (`w-3`) inset by `mx-1`.
  */
 const ITEM_END_SIZE = '1.25rem';
 
@@ -45,10 +45,9 @@ export type L1PanelProps = {
   /** Absent when the workspace is not in the graph; the panel then renders the unavailable message. */
   item?: Node.Node;
   /**
-   * Identity of the set of space workspaces in the graph, which the unavailable message is a claim
-   * about: it stays hidden while the set is empty, and every change restarts {@link RENDER_DELAY}
-   * so the claim waits for spaces to stop arriving. Empty means not-loaded-yet rather than
-   * nothing-to-show, since every identity ends up with at least a settings space.
+   * Identity of the set of space workspaces, which the unavailable message is a claim about. Empty
+   * means not-loaded-yet rather than nothing-to-show, since every identity ends up with at least a
+   * settings space.
    */
   spaces?: string;
   isCurrent: boolean;
@@ -65,9 +64,8 @@ const L1PanelInner = ({ open, path, id, item, spaces, isCurrent, onBack }: L1Pan
   const title = item ? toLocalizedString(item.properties.label, t) : t('workspace-unavailable.heading');
   const isActivated = useIsActivatedWorkspace(id);
   const shouldRenderContent = isCurrent || isActivated;
-  // The unavailable message is a claim about the space list, so it needs one to have been
-  // published; the sentinel deck means no workspace has been resolved yet, so none is being asked
-  // for and there is nothing to report as missing.
+  // Needs a published space list to make the claim against, and a workspace actually being asked
+  // for — the sentinel deck means none has resolved yet.
   const reportUnavailable = !!spaces && id !== DeckSchema.DEFAULT_DECK_ID;
 
   return (
@@ -96,8 +94,7 @@ const L1PanelInner = ({ open, path, id, item, spaces, isCurrent, onBack }: L1Pan
         ) : (
           reportUnavailable && (
             <Empty
-              // Spaces publish one at a time as each opens; remounting restarts the delay, so a set
-              // that is still filling in keeps pushing the message back.
+              // Spaces publish one at a time, so remounting restarts the delay until they stop.
               key={spaces}
               label={t('workspace-unavailable.description')}
               // Second grid row, so the message clears the rail exactly as the tree does, and

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Tabs.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Tabs.tsx
@@ -2,9 +2,11 @@
 // Copyright 2025 DXOS.org
 //
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import type * as Node from '@dxos/app-graph/Node';
+import * as GraphPath from '@dxos/app-toolkit/GraphPath';
+import * as DeckSchema from '@dxos/plugin-deck/DeckSchema';
 
 import { l0ItemType } from '../../util';
 import { L1Panel, type L1PanelProps } from './L1Panel';
@@ -22,6 +24,18 @@ export const L1Tabs = ({ topLevelItems, currentItemId, onBack, open, path }: L1T
   // The current tab can name a workspace that is not in the graph, in which case it gets an item-less
   // panel carrying the unavailable message rather than no panel at all (a blank sidebar).
   const hasCurrentPanel = topLevelItems.some((item) => item.id === currentItemId && l0ItemType(item) === 'tab');
+  // Which spaces have reached the graph. Pinned workspaces (settings, plugins, account) are static
+  // and present from the first render, so they say nothing about loading; a space workspace is the
+  // first evidence that the client has opened storage and published its space list. While the set
+  // is empty it is empty for a reason that has nothing to do with the workspace being asked for.
+  const spaces = useMemo(
+    () =>
+      topLevelItems
+        .filter((item) => l0ItemType(item) === 'tab' && !GraphPath.isPinnedWorkspace(item.id))
+        .map(({ id }) => id)
+        .join(),
+    [topLevelItems],
+  );
 
   return (
     <>
@@ -42,7 +56,19 @@ export const L1Tabs = ({ topLevelItems, currentItemId, onBack, open, path }: L1T
         }
         return null;
       })}
-      {!hasCurrentPanel && <L1Panel key={currentItemId} id={currentItemId} path={path} open={open} isCurrent />}
+      {!hasCurrentPanel && (
+        <L1Panel
+          key={currentItemId}
+          id={currentItemId}
+          path={path}
+          open={open}
+          // The sentinel deck is "no workspace resolved yet" — held until the space plugin switches
+          // to the default space — so there is no workspace being asked for, and nothing to report
+          // as missing.
+          spaces={currentItemId === DeckSchema.DEFAULT_DECK_ID ? undefined : spaces}
+          isCurrent
+        />
+      )}
     </>
   );
 };

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Tabs.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Tabs.tsx
@@ -6,7 +6,6 @@ import React, { useMemo } from 'react';
 
 import type * as Node from '@dxos/app-graph/Node';
 import * as GraphPath from '@dxos/app-toolkit/GraphPath';
-import * as DeckSchema from '@dxos/plugin-deck/DeckSchema';
 
 import { l0ItemType } from '../../util';
 import { L1Panel, type L1PanelProps } from './L1Panel';
@@ -24,10 +23,8 @@ export const L1Tabs = ({ topLevelItems, currentItemId, onBack, open, path }: L1T
   // The current tab can name a workspace that is not in the graph, in which case it gets an item-less
   // panel carrying the unavailable message rather than no panel at all (a blank sidebar).
   const hasCurrentPanel = topLevelItems.some((item) => item.id === currentItemId && l0ItemType(item) === 'tab');
-  // Which spaces have reached the graph. Pinned workspaces (settings, plugins, account) are static
-  // and present from the first render, so they say nothing about loading; a space workspace is the
-  // first evidence that the client has opened storage and published its space list. While the set
-  // is empty it is empty for a reason that has nothing to do with the workspace being asked for.
+  // Pinned workspaces (settings, plugins, account) are static and present from the first render, so
+  // only a space workspace is evidence that the space list has been published.
   const spaces = useMemo(
     () =>
       topLevelItems
@@ -57,17 +54,7 @@ export const L1Tabs = ({ topLevelItems, currentItemId, onBack, open, path }: L1T
         return null;
       })}
       {!hasCurrentPanel && (
-        <L1Panel
-          key={currentItemId}
-          id={currentItemId}
-          path={path}
-          open={open}
-          // The sentinel deck is "no workspace resolved yet" — held until the space plugin switches
-          // to the default space — so there is no workspace being asked for, and nothing to report
-          // as missing.
-          spaces={currentItemId === DeckSchema.DEFAULT_DECK_ID ? undefined : spaces}
-          isCurrent
-        />
+        <L1Panel key={currentItemId} id={currentItemId} path={path} open={open} spaces={spaces} isCurrent />
       )}
     </>
   );

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Tabs.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Tabs.tsx
@@ -4,8 +4,7 @@
 
 import React, { useMemo } from 'react';
 
-import type * as Node from '@dxos/app-graph/Node';
-import * as GraphPath from '@dxos/app-toolkit/GraphPath';
+import * as Node from '@dxos/app-graph/Node';
 
 import { l0ItemType } from '../../util';
 import { L1Panel, type L1PanelProps } from './L1Panel';
@@ -23,12 +22,12 @@ export const L1Tabs = ({ topLevelItems, currentItemId, onBack, open, path }: L1T
   // The current tab can name a workspace that is not in the graph, in which case it gets an item-less
   // panel carrying the unavailable message rather than no panel at all (a blank sidebar).
   const hasCurrentPanel = topLevelItems.some((item) => item.id === currentItemId && l0ItemType(item) === 'tab');
-  // Pinned workspaces are present from the first render, so only a space workspace is evidence
-  // that the space list has been published.
+  // Pinned workspaces and the account are present from the first render, so only a workspace-
+  // disposition item is evidence that the space list has been published.
   const spaces = useMemo(
     () =>
       topLevelItems
-        .filter((item) => l0ItemType(item) === 'tab' && !GraphPath.isPinnedWorkspace(item.id))
+        .filter((item) => Node.hasDisposition(item, 'workspace'))
         .map(({ id }) => id)
         .join(),
     [topLevelItems],

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Tabs.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Tabs.tsx
@@ -23,8 +23,8 @@ export const L1Tabs = ({ topLevelItems, currentItemId, onBack, open, path }: L1T
   // The current tab can name a workspace that is not in the graph, in which case it gets an item-less
   // panel carrying the unavailable message rather than no panel at all (a blank sidebar).
   const hasCurrentPanel = topLevelItems.some((item) => item.id === currentItemId && l0ItemType(item) === 'tab');
-  // Pinned workspaces (settings, plugins, account) are static and present from the first render, so
-  // only a space workspace is evidence that the space list has been published.
+  // Pinned workspaces are present from the first render, so only a space workspace is evidence
+  // that the space list has been published.
   const spaces = useMemo(
     () =>
       topLevelItems

--- a/packages/sdk/app-framework/src/core/plugin-manager/activation-scheduler.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager/activation-scheduler.ts
@@ -155,6 +155,8 @@ export class ActivationScheduler {
       // signal (see useApp); it must not publish before the startup wave finishes.
       this.#state.markEventFired(key);
       yield* PubSub.publish(this.#state.activation, { event: key, state: 'activated' });
+      // Releases the events that were dispatched while this wave ran (see `activate`).
+      yield* Deferred.succeed(this.#state.startupComplete, undefined);
 
       // The idle wave belongs to the manager rather than to each host: it is an app-framework
       // event, and a host that owned the wait would re-implement it (and could forget to).
@@ -192,16 +194,27 @@ export class ActivationScheduler {
     params?: { before?: string; after?: string },
   ): Effect.Effect<boolean, Error, Plugin.Service> {
     const key = typeof event === 'string' ? event : ActivationEvent.eventKey(event);
+    const startupKey = ActivationEvent.eventKey(ActivationEvent.Startup);
     return Effect.gen({ self: this }, function* () {
       // Startup is not a plain event: it triggers the dependency pass alongside the event
       // dispatch. Delegating keeps useApp/harness/cli call sites unchanged.
-      if (key === ActivationEvent.eventKey(ActivationEvent.Startup)) {
+      if (key === startupKey) {
         return yield* this.start();
       }
 
       if (yield* this.#state.isShuttingDown()) {
         log('skipping activation during shutdown', { key, ...params });
         return false;
+      }
+
+      // Held until the Startup wave completes. Startup is what makes the baseline capabilities
+      // available, so a module activating on an event dispatched mid-startup could otherwise find
+      // a require unsatisfied purely because of when its event happened to land. Waiting also
+      // keeps the wave out of startup's own settle check, which counts every in-flight load and
+      // would otherwise hold `ready` behind work that has nothing to do with first paint.
+      if ((yield* Ref.get(this.#state.started)) && !this.#state.eventFired(startupKey)) {
+        log('deferring activation until startup completes', { key, ...params });
+        yield* Deferred.await(this.#state.startupComplete);
       }
 
       // Re-dispatching a fired event is already a no-op — an active module is never re-selected —

--- a/packages/sdk/app-framework/src/core/plugin-manager/activation-scheduler.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager/activation-scheduler.ts
@@ -207,11 +207,9 @@ export class ActivationScheduler {
         return false;
       }
 
-      // Held until the Startup wave completes. Startup is what makes the baseline capabilities
-      // available, so a module activating on an event dispatched mid-startup could otherwise find
-      // a require unsatisfied purely because of when its event happened to land. Waiting also
-      // keeps the wave out of startup's own settle check, which counts every in-flight load and
-      // would otherwise hold `ready` behind work that has nothing to do with first paint.
+      // Startup provides the baseline capabilities, so a module activating on an event dispatched
+      // mid-startup could otherwise find a require unsatisfied purely by timing. Waiting also keeps
+      // the wave out of startup's settle check, which would hold `ready` behind unrelated work.
       if ((yield* Ref.get(this.#state.started)) && !this.#state.eventFired(startupKey)) {
         log('deferring activation until startup completes', { key, ...params });
         yield* Deferred.await(this.#state.startupComplete);

--- a/packages/sdk/app-framework/src/core/plugin-manager/manager-state.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager/manager-state.ts
@@ -64,6 +64,12 @@ export class ManagerState {
   readonly initialized = Effect.runSync(Deferred.make<void, PluginInitializationError>());
   /** Whether `start()` has run — gates incremental activation on later enables. */
   readonly started = Effect.runSync(Ref.make(false));
+  /**
+   * Completed when the Startup wave has finished. Events dispatched while startup is in flight
+   * await it, so a module activating on one of them can rely on every startup capability being
+   * present. Reset by {@link clearEventsFired} so a restarted manager gates again.
+   */
+  startupComplete = Effect.runSync(Deferred.make<void>());
   /** Set for the duration of `shutdown()` — new starts/activations are skipped meanwhile. */
   readonly shuttingDown = Effect.runSync(Ref.make(false));
   /**
@@ -238,6 +244,7 @@ export class ManagerState {
 
   clearEventsFired(): void {
     this.#update(this.eventsFired, () => []);
+    this.startupComplete = Effect.runSync(Deferred.make<void>());
   }
 
   isStarted(): Effect.Effect<boolean> {

--- a/packages/sdk/app-framework/src/core/plugin-manager/manager-state.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager/manager-state.ts
@@ -65,9 +65,8 @@ export class ManagerState {
   /** Whether `start()` has run — gates incremental activation on later enables. */
   readonly started = Effect.runSync(Ref.make(false));
   /**
-   * Completed when the Startup wave has finished. Events dispatched while startup is in flight
-   * await it, so a module activating on one of them can rely on every startup capability being
-   * present. Reset by {@link clearEventsFired} so a restarted manager gates again.
+   * Completed when the Startup wave has finished; events dispatched mid-startup await it so their
+   * modules can rely on every startup capability. Reset by {@link clearEventsFired}.
    */
   startupComplete = Effect.runSync(Deferred.make<void>());
   /** Set for the duration of `shutdown()` — new starts/activations are skipped meanwhile. */

--- a/packages/sdk/app-framework/src/core/plugin-manager/plugin-manager.test.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager/plugin-manager.test.ts
@@ -3283,10 +3283,9 @@ describe('PluginManager', () => {
   describe('startup independence', () => {
     it.effect('ready does not wait for a wave a startup module fired from a forked fiber', () =>
       Effect.gen(function* () {
-        // The client's shape: its `activate` returns immediately and forks the initialization, then
-        // dispatches a follow-on event when that lands — mid-startup, because the rest of the
-        // startup wave is still loading. Nothing the follow-on pulls in gates first paint, so it
-        // must not hold `ready` open.
+        // The client's shape: `activate` returns immediately and forks the initialization, which
+        // dispatches a follow-on event when it lands — mid-startup, while the rest of the wave is
+        // still loading. Nothing that event pulls in gates first paint, so it must not hold `ready`.
         const slowGate = yield* Latch.make(false);
         const triggerGate = yield* Latch.make(false);
         const followerGate = yield* Latch.make(false);

--- a/packages/sdk/app-framework/src/core/plugin-manager/plugin-manager.test.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager/plugin-manager.test.ts
@@ -3283,9 +3283,8 @@ describe('PluginManager', () => {
   describe('startup independence', () => {
     it.effect('ready does not wait for a wave a startup module fired from a forked fiber', () =>
       Effect.gen(function* () {
-        // The client's shape: `activate` returns immediately and forks the initialization, which
-        // dispatches a follow-on event when it lands — mid-startup, while the rest of the wave is
-        // still loading. Nothing that event pulls in gates first paint, so it must not hold `ready`.
+        // The client's shape: `activate` returns immediately and forks work that dispatches a
+        // follow-on event mid-startup, while the rest of the wave is still loading.
         const slowGate = yield* Latch.make(false);
         const triggerGate = yield* Latch.make(false);
         const followerGate = yield* Latch.make(false);

--- a/packages/sdk/app-framework/src/core/plugin-manager/plugin-manager.test.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager/plugin-manager.test.ts
@@ -3280,4 +3280,90 @@ describe('PluginManager', () => {
       }),
     );
   });
+  describe('startup independence', () => {
+    it.effect('ready does not wait for a wave a startup module fired from a forked fiber', () =>
+      Effect.gen(function* () {
+        // The client's shape: its `activate` returns immediately and forks the initialization, then
+        // dispatches a follow-on event when that lands — mid-startup, because the rest of the
+        // startup wave is still loading. Nothing the follow-on pulls in gates first paint, so it
+        // must not hold `ready` open.
+        const slowGate = yield* Latch.make(false);
+        const triggerGate = yield* Latch.make(false);
+        const followerGate = yield* Latch.make(false);
+
+        const Follower = Plugin.define(
+          Plugin.makeMeta({ key: DXN.make('org.dxos.test.follower'), name: 'Follower' }),
+        ).pipe(
+          Plugin.addModule({
+            activatesOn: CountEvent,
+            id: 'Follower',
+            provides: [MultiNumber],
+            activate: () =>
+              Effect.gen(function* () {
+                yield* followerGate.await;
+                return [Capability.contribute(MultiNumber, { number: 1 })];
+              }),
+          }),
+          Plugin.make,
+        );
+
+        const Test = Plugin.define(testMeta).pipe(
+          // Keeps the startup wave in flight while the forked fiber below fires its event.
+          Plugin.addModule({
+            activatesOn: ActivationEvents.Startup,
+            id: 'Slow',
+            provides: [Number],
+            activate: () =>
+              Effect.gen(function* () {
+                yield* slowGate.await;
+                return [Capability.contribute(Number, { number: 0 })];
+              }),
+          }),
+          Plugin.addModule({
+            activatesOn: ActivationEvents.Startup,
+            id: 'Trigger',
+            provides: [String],
+            activate: () =>
+              Effect.gen(function* () {
+                yield* Effect.forkDetach(
+                  Effect.gen(function* () {
+                    yield* triggerGate.await;
+                    yield* Plugin.activate(CountEvent);
+                  }),
+                );
+                return [Capability.contribute(String, { string: 'ready' })];
+              }),
+          }),
+          Plugin.make,
+        );
+
+        plugins = [Test(), Follower()];
+        const manager = PluginManager.make({
+          pluginLoader,
+          plugins,
+          enabled: [testMeta.profile.key, 'org.dxos.test.follower'],
+        });
+
+        const startFiber = yield* Effect.forkChild(manager.activate(ActivationEvents.Startup));
+        yield* advance(Duration.millis(100));
+
+        // Fire the follow-on wave while startup is still waiting on its own slow module.
+        yield* triggerGate.open;
+        yield* advance(Duration.millis(100));
+
+        // Startup's own modules are now all done; only the follow-on wave is outstanding.
+        yield* slowGate.open;
+        yield* advance(Duration.millis(100));
+
+        assert.strictEqual(manager.capabilities.getAll(MultiNumber).length, 0);
+        assert.isTrue(manager.getEventsFired().includes(ActivationEvent.eventKey(ActivationEvents.Startup)));
+        assert.deepStrictEqual(manager.capabilities.get(String), { string: 'ready' });
+
+        yield* followerGate.open;
+        yield* Fiber.join(startFiber);
+        yield* advance(Duration.millis(100));
+        assert.strictEqual(manager.capabilities.getAll(MultiNumber).length, 1);
+      }),
+    );
+  });
 });

--- a/packages/sdk/app-framework/src/ui/components/App/App.tsx
+++ b/packages/sdk/app-framework/src/ui/components/App/App.tsx
@@ -115,11 +115,9 @@ export const App = ({ ready, error, debounce, progress }: AppProps) => {
 };
 
 /**
- * Nests each context provider around the next, walking the list at render time so the element type
- * is a constant: composing the nesting into a component instead makes it a new type on every
- * render, which remounts the whole app — every icon, scroll offset and editor state — on any
- * capability change. Sorting can only append a newly contributed context, so the chain extends
- * inward and the providers above it keep their positions.
+ * Nests each provider around the next at render time so the element type is a constant: composing
+ * the nesting into a component makes it a new type per render, remounting the whole app on any
+ * capability change. Sorting only appends, so the chain extends inward and providers keep place.
  */
 const ContextChain = ({ contexts, children }: PropsWithChildren<{ contexts: Capabilities.ReactContext[] }>) => {
   if (contexts.length === 0) {

--- a/packages/sdk/app-framework/src/ui/components/App/App.tsx
+++ b/packages/sdk/app-framework/src/ui/components/App/App.tsx
@@ -115,11 +115,11 @@ export const App = ({ ready, error, debounce, progress }: AppProps) => {
 };
 
 /**
- * Nests each context provider around the next, walking the list at render time so that the element
- * type stays constant: a folded-at-render composition mints a new type per render, and React
- * remounts the whole app — every icon, scroll offset and editor state — on any capability change.
- * Sorting can only append a newly contributed context, so the chain extends inward and the
- * providers above it keep their positions.
+ * Nests each context provider around the next, walking the list at render time so the element type
+ * is a constant: composing the nesting into a component instead makes it a new type on every
+ * render, which remounts the whole app — every icon, scroll offset and editor state — on any
+ * capability change. Sorting can only append a newly contributed context, so the chain extends
+ * inward and the providers above it keep their positions.
  */
 const ContextChain = ({ contexts, children }: PropsWithChildren<{ contexts: Capabilities.ReactContext[] }>) => {
   if (contexts.length === 0) {

--- a/packages/sdk/app-framework/src/ui/components/App/App.tsx
+++ b/packages/sdk/app-framework/src/ui/components/App/App.tsx
@@ -117,7 +117,8 @@ export const App = ({ ready, error, debounce, progress }: AppProps) => {
 /**
  * Nests each provider around the next at render time so the element type is a constant: composing
  * the nesting into a component makes it a new type per render, remounting the whole app on any
- * capability change. Sorting only appends, so the chain extends inward and providers keep place.
+ * capability change. A contributed context appends, so the chain extends inward and the providers
+ * above keep their positions; a removed one still shifts everything below it.
  */
 const ContextChain = ({ contexts, children }: PropsWithChildren<{ contexts: Capabilities.ReactContext[] }>) => {
   if (contexts.length === 0) {

--- a/packages/sdk/app-framework/src/ui/components/App/App.tsx
+++ b/packages/sdk/app-framework/src/ui/components/App/App.tsx
@@ -2,7 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
-import React, { type PropsWithChildren, Suspense, useEffect, useLayoutEffect } from 'react';
+import React, { type PropsWithChildren, Suspense, useEffect, useLayoutEffect, useMemo } from 'react';
 
 import { Capabilities } from '../../../common';
 import { topologicalSort } from '../../../helpers';
@@ -20,6 +20,7 @@ export type AppProps = Pick<UseAppOptions, 'debounce'> & {
 export const App = ({ ready, error, debounce, progress }: AppProps) => {
   const reactContexts = useCapabilities(Capabilities.ReactContext);
   const reactRoots = useCapabilities(Capabilities.ReactRoot);
+  const sortedContexts = useMemo(() => topologicalSort(reactContexts), [reactContexts]);
   const stage = useLoading(ready, debounce);
   const placeholderDismissed = stage >= LoadingState.Done;
   // The shell mounts a tick EARLIER than the dismissal, at the same stage that starts the loader's
@@ -95,12 +96,11 @@ export const App = ({ ready, error, debounce, progress }: AppProps) => {
     return null;
   }
 
-  const ComposedContext = composeContexts(reactContexts);
   return (
     // Contexts nest, so one suspending provider necessarily withholds everything below it; the
     // boundary here at least keeps that from unwinding past the app's providers.
     <Suspense fallback={null}>
-      <ComposedContext>
+      <ContextChain contexts={sortedContexts}>
         {reactRoots.map(({ id, root: Component }) => (
           // One boundary per root: roots read capabilities whose providers activate in a later
           // wave, and `useCapability` suspends on that. A shared boundary would let one late root
@@ -109,21 +109,27 @@ export const App = ({ ready, error, debounce, progress }: AppProps) => {
             <Component />
           </Suspense>
         ))}
-      </ComposedContext>
+      </ContextChain>
     </Suspense>
   );
 };
 
-const composeContexts = (contexts: Capabilities.ReactContext[]) => {
+/**
+ * Nests each context provider around the next, walking the list at render time so that the element
+ * type stays constant: a folded-at-render composition mints a new type per render, and React
+ * remounts the whole app — every icon, scroll offset and editor state — on any capability change.
+ * Sorting can only append a newly contributed context, so the chain extends inward and the
+ * providers above it keep their positions.
+ */
+const ContextChain = ({ contexts, children }: PropsWithChildren<{ contexts: Capabilities.ReactContext[] }>) => {
   if (contexts.length === 0) {
-    return ({ children }: PropsWithChildren) => <>{children}</>;
+    return <>{children}</>;
   }
 
-  return topologicalSort(contexts)
-    .map(({ context }) => context)
-    .reduce((Acc, Next) => ({ children }) => (
-      <Acc>
-        <Next>{children}</Next>
-      </Acc>
-    ));
+  const [{ context: Context }, ...rest] = contexts;
+  return (
+    <Context>
+      <ContextChain contexts={rest}>{children}</ContextChain>
+    </Context>
+  );
 };


### PR DESCRIPTION
Boot-path work, from a screen recording of a Composer reload where the spaces took ~9s to appear. Four independent findings, each verified against a running app.

## The startup wave absorbed unrelated work

`start()` publishes the event-level `activated` message — the app-ready signal `useApp` reads — only once **nothing anywhere** is still loading:

```ts
for (;;) {
  const settledAny = yield* this.#loader.awaitAllSettled();
  const ranAny = yield* this.runDependencyPass();
  if (!settledAny && !ranAny) break;
}
```

An event dispatched into that window pulls in its own modules, and everything it in turn pulls in, all of which the loop counts. The mop-up pass also *claims* those modules, because pooled candidate selection reads live fired state. A client that fires `initialized` mid-pass therefore drags the app-graph builders, migrations, `spacesReady` and the space opening into startup's settle check — enough to miss the 30s watchdog and boot into the fatal dialog.

Events dispatched while startup is in flight now wait for it. Beyond fixing the hang, that gives a module activating on such an event the guarantee that every startup capability is present, rather than finding a require unsatisfied purely because of when its event landed.

Reproduced first as a unit test — `startup independence > ready does not wait for a wave a startup module fired from a forked fiber`. Three latches recreate the shape: a Startup module that returns immediately and forks a fiber firing a follow-on event, a second Startup module keeping the wave in flight while that happens, and a follower on the follow-on event that blocks. Two earlier drafts of the test passed; the event has to land *while* startup is still waiting on its own modules, which is what the second latch forces.

## Every capability change remounted the app

`composeContexts` folded the context list into a new component per render, so React saw a new element type and remounted the entire application on any capability change — every icon, scroll offset and editor state. The tell in the recording was all icons in the navtree blanking for 67ms (10.685s–10.735s, 4 frames at 60fps) while labels and layout stayed put: the icon registry provider remounting and resetting to its initial noop registry.

Now walked at render time, so the element type is constant. Sorting can only append a newly contributed context, so the chain extends inward and providers above keep their positions.

## Client initialization sat behind plugin loading

`client.initialize()` did not start until the client plugin's own lazily-imported module was reached, despite depending on nothing but the config and services the entry point already holds.

| | before | after |
|---|---|---|
| `client.initialize:called` | 4974ms | 1939ms |
| `client.initialize:completed` | 7224ms | 5634ms |
| `milestone:spaces-ready` | 7618ms | 7799ms |

Composer constructs the client once services exist and starts initialization there; the plugin adopts it and joins the in-flight call (`initialize()` is `@synchronized`). The handshake and storage open now overlap plugin loading instead of following it. Numbers are dev-mode on one machine — read the ordering, not the absolutes.

## The sidebar claimed a loading workspace was missing

For several seconds the navtree said *"You don't have this workspace, or it no longer exists"* about a workspace that was loading normally. The message was on a fixed 1s delay from mount, which any slower boot outruns.

The cause turned out not to be "spaces haven't loaded" — reading the live DOM while the message was up showed the space present and the active panel on `DEFAULT_DECK_ID`, the deck's documented *"no workspace resolved yet"* sentinel, held until the space plugin switches to the default space. Gated on that plus a non-empty space-workspace set, with the delay restarting while that set changes.

Verified both directions: sentinel → panel renders empty, no message; `/w/<bogus-id>` → message renders, and only after the space list had loaded.

Also reserves the navtree item-end grid track. Its surface resolves after the tree paints, so a bare `min-content` track started collapsed and re-truncated every label in the panel when it landed (measured: labels lost 8 CSS px at ~11.2s).

## Reviewer notes

1. **The deferral applies to every event dispatched mid-startup**, not just ones from forked fibers. A module firing an event inline inside its own `activate` would now block on a wave waiting for it. Nothing in the suite does that, and `#notActivatingHere` suggests the pattern is contemplated — worth a deliberate decision rather than my assumption.
2. **A sentinel deck that never resolves now leaves the sidebar blank** rather than showing a wrong message. Correct by the trigger's logic, but blank is the failure mode if `SwitchWorkspace` can fail permanently.
3. `GraphPath.isPinnedWorkspace` takes a qualified path, and [L1Panel.tsx:172](https://github.com/dxos/dxos/blob/main/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx#L172) passes it one — that call is correct and untouched. I briefly thought otherwise and was wrong.

Tests: app-framework 232, app-toolkit 148, plugin-client 15, plugin-navtree 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for initializing and reusing the application client before plugins load.
  * Startup now prioritizes core readiness and defers follow-up activity until startup completes.
* **Bug Fixes**
  * Improved workspace navigation messaging and prevented sidebar labels from collapsing or truncating.
  * Improved UI stability when application capabilities change.
* **Performance**
  * Added startup performance tracking and improved initialization monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->