### PR TITLE
edge-compute: retry a trigger force-run while edge is catching up

### DIFF
--- a/.changeset/tidy-buttons-smash.md
+++ b/.changeset/tidy-buttons-smash.md
@@ -1,0 +1,5 @@
+---
+'@dxos/echo': patch
+---
+
+Retry an EDGE trigger force-run with exponential backoff while the trigger is not yet replicated to EDGE, so a manual sync started right after a connection is created no longer fails.

--- a/.changeset/tidy-buttons-smash.md
+++ b/.changeset/tidy-buttons-smash.md
@@ -2,4 +2,4 @@
 '@dxos/echo': patch
 ---
 
-Retry an EDGE trigger force-run with exponential backoff while the trigger is not yet replicated to EDGE, so a manual sync started right after a connection is created no longer fails.
+Retry an EDGE trigger force-run with exponential backoff, so a manual sync started right after a connection is created no longer fails while EDGE catches up with the client.

--- a/packages/core/compute/edge-compute/src/EdgeTriggerManager.test.ts
+++ b/packages/core/compute/edge-compute/src/EdgeTriggerManager.test.ts
@@ -23,6 +23,12 @@ const SPACE_ID = SpaceId.random();
 
 const notReplicatedError = () => new EdgeCallFailedError({ message: 'HTTP code 404: Not Found.' });
 
+const identityNotAssociatedError = () =>
+  new EdgeCallFailedError({
+    message: 'Identity is not associated with an account.',
+    data: { type: 'identity_not_associated_with_account' },
+  });
+
 /**
  * Force-runs a trigger through a manager backed by `edgeClient`, on a forked fiber so the caller
  * can advance the `TestClock` across the retry backoff.
@@ -59,7 +65,24 @@ describe('EdgeTriggerManager', () => {
     }),
   );
 
-  it.effect('does not retry a failure unrelated to replication', () =>
+  it.effect('retries a force-run rejected while the identity is not yet known to edge', () =>
+    Effect.gen(function* () {
+      const edgeClient = new EdgeHttpClient('https://edge.example.com');
+      vi.spyOn(edgeClient, 'getSpaceTriggers').mockResolvedValue({ isActive: true, triggers: [] });
+      const forceRun = vi
+        .spyOn(edgeClient, 'forceRunCronTrigger')
+        .mockRejectedValueOnce(identityNotAssociatedError())
+        .mockResolvedValue(undefined);
+
+      const fiber = yield* forkInvoke(edgeClient);
+      yield* TestClock.adjust('5 seconds');
+
+      expect(Exit.isSuccess(yield* Effect.exit(Fiber.join(fiber)))).toBe(true);
+      expect(forceRun).toHaveBeenCalledTimes(2);
+    }),
+  );
+
+  it.effect('gives up once the backoff is exhausted', () =>
     Effect.gen(function* () {
       const edgeClient = new EdgeHttpClient('https://edge.example.com');
       vi.spyOn(edgeClient, 'getSpaceTriggers').mockResolvedValue({ isActive: true, triggers: [] });
@@ -68,10 +91,11 @@ describe('EdgeTriggerManager', () => {
         .mockRejectedValue(new EdgeCallFailedError({ message: 'HTTP code 500: Internal Server Error.' }));
 
       const fiber = yield* forkInvoke(edgeClient);
-      yield* TestClock.adjust('60 seconds');
+      yield* TestClock.adjust('120 seconds');
 
       expect(Exit.isFailure(yield* Effect.exit(Fiber.join(fiber)))).toBe(true);
-      expect(forceRun).toHaveBeenCalledTimes(1);
+      // The initial attempt plus the five scheduled retries.
+      expect(forceRun).toHaveBeenCalledTimes(6);
     }),
   );
 });

--- a/packages/core/compute/edge-compute/src/EdgeTriggerManager.test.ts
+++ b/packages/core/compute/edge-compute/src/EdgeTriggerManager.test.ts
@@ -21,29 +21,6 @@ import * as EdgeTriggerManager from './EdgeTriggerManager';
 
 const SPACE_ID = SpaceId.random();
 
-const notReplicatedError = () => new EdgeCallFailedError({ message: 'HTTP code 404: Not Found.' });
-
-const identityNotAssociatedError = () =>
-  new EdgeCallFailedError({
-    message: 'Identity is not associated with an account.',
-    data: { type: 'identity_not_associated_with_account' },
-  });
-
-/**
- * Force-runs a trigger through a manager backed by `edgeClient`, on a forked fiber so the caller
- * can advance the `TestClock` across the retry backoff.
- */
-const forkInvoke = (edgeClient: EdgeHttpClient) =>
-  Effect.gen(function* () {
-    const manager = yield* RemoteTriggerManager.Service;
-    const trigger = Trigger.make({ enabled: true, remote: true, spec: Trigger.specTimer('*/5 * * * *') });
-    yield* manager.invokeTrigger({ trigger, event: { tick: 0 } });
-  }).pipe(
-    Effect.provide(EdgeTriggerManager.fromEdgeClient(edgeClient, SPACE_ID)),
-    Effect.provide(Layer.succeed(Registry.AtomRegistry, Registry.make())),
-    Effect.forkChild,
-  );
-
 describe('EdgeTriggerManager', () => {
   it.effect('retries a force-run that races the trigger replicating to edge', () =>
     Effect.gen(function* () {
@@ -99,3 +76,26 @@ describe('EdgeTriggerManager', () => {
     }),
   );
 });
+
+const notReplicatedError = () => new EdgeCallFailedError({ message: 'HTTP code 404: Not Found.' });
+
+const identityNotAssociatedError = () =>
+  new EdgeCallFailedError({
+    message: 'Identity is not associated with an account.',
+    data: { type: 'identity_not_associated_with_account' },
+  });
+
+/**
+ * Force-runs a trigger through a manager backed by `edgeClient`, on a forked fiber so the caller
+ * can advance the `TestClock` across the retry backoff.
+ */
+const forkInvoke = (edgeClient: EdgeHttpClient) =>
+  Effect.gen(function* () {
+    const manager = yield* RemoteTriggerManager.Service;
+    const trigger = Trigger.make({ enabled: true, remote: true, spec: Trigger.specTimer('*/5 * * * *') });
+    yield* manager.invokeTrigger({ trigger, event: { tick: 0 } });
+  }).pipe(
+    Effect.provide(EdgeTriggerManager.fromEdgeClient(edgeClient, SPACE_ID)),
+    Effect.provide(Layer.succeed(Registry.AtomRegistry, Registry.make())),
+    Effect.forkChild,
+  );

--- a/packages/core/compute/edge-compute/src/EdgeTriggerManager.test.ts
+++ b/packages/core/compute/edge-compute/src/EdgeTriggerManager.test.ts
@@ -1,0 +1,77 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, it } from '@effect/vitest';
+import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
+import * as Fiber from 'effect/Fiber';
+import * as Layer from 'effect/Layer';
+import * as TestClock from 'effect/testing/TestClock';
+import * as Registry from 'effect/unstable/reactivity/AtomRegistry';
+import { vi } from 'vitest';
+
+import { RemoteTriggerManager } from '@dxos/compute-runtime';
+import * as Trigger from '@dxos/compute/Trigger';
+import { EdgeHttpClient } from '@dxos/edge-client';
+import { SpaceId } from '@dxos/keys';
+import { EdgeCallFailedError } from '@dxos/protocols';
+
+import * as EdgeTriggerManager from './EdgeTriggerManager';
+
+const SPACE_ID = SpaceId.random();
+
+const notReplicatedError = () => new EdgeCallFailedError({ message: 'HTTP code 404: Not Found.' });
+
+/**
+ * Force-runs a trigger through a manager backed by `edgeClient`, on a forked fiber so the caller
+ * can advance the `TestClock` across the retry backoff.
+ */
+const forkInvoke = (edgeClient: EdgeHttpClient) =>
+  Effect.gen(function* () {
+    const manager = yield* RemoteTriggerManager.Service;
+    const trigger = Trigger.make({ enabled: true, remote: true, spec: Trigger.specTimer('*/5 * * * *') });
+    yield* manager.invokeTrigger({ trigger, event: { tick: 0 } });
+  }).pipe(
+    Effect.provide(EdgeTriggerManager.fromEdgeClient(edgeClient, SPACE_ID)),
+    Effect.provide(Layer.succeed(Registry.AtomRegistry, Registry.make())),
+    Effect.forkChild,
+  );
+
+describe('EdgeTriggerManager', () => {
+  it.effect('retries a force-run that races the trigger replicating to edge', () =>
+    Effect.gen(function* () {
+      const edgeClient = new EdgeHttpClient('https://edge.example.com');
+      vi.spyOn(edgeClient, 'getSpaceTriggers').mockResolvedValue({ isActive: true, triggers: [] });
+      // The trigger becomes known to edge after two rejections.
+      const forceRun = vi
+        .spyOn(edgeClient, 'forceRunCronTrigger')
+        .mockRejectedValueOnce(notReplicatedError())
+        .mockRejectedValueOnce(notReplicatedError())
+        .mockResolvedValue(undefined);
+
+      const fiber = yield* forkInvoke(edgeClient);
+      // Backoff is 1s then 2s; advance past both so the third attempt lands.
+      yield* TestClock.adjust('5 seconds');
+
+      expect(Exit.isSuccess(yield* Effect.exit(Fiber.join(fiber)))).toBe(true);
+      expect(forceRun).toHaveBeenCalledTimes(3);
+    }),
+  );
+
+  it.effect('does not retry a failure unrelated to replication', () =>
+    Effect.gen(function* () {
+      const edgeClient = new EdgeHttpClient('https://edge.example.com');
+      vi.spyOn(edgeClient, 'getSpaceTriggers').mockResolvedValue({ isActive: true, triggers: [] });
+      const forceRun = vi
+        .spyOn(edgeClient, 'forceRunCronTrigger')
+        .mockRejectedValue(new EdgeCallFailedError({ message: 'HTTP code 500: Internal Server Error.' }));
+
+      const fiber = yield* forkInvoke(edgeClient);
+      yield* TestClock.adjust('60 seconds');
+
+      expect(Exit.isFailure(yield* Effect.exit(Fiber.join(fiber)))).toBe(true);
+      expect(forceRun).toHaveBeenCalledTimes(1);
+    }),
+  );
+});

--- a/packages/core/compute/edge-compute/src/EdgeTriggerManager.ts
+++ b/packages/core/compute/edge-compute/src/EdgeTriggerManager.ts
@@ -20,6 +20,8 @@ import { Context as DxosContext } from '@dxos/context';
 import { Ref } from '@dxos/echo';
 import { type EdgeTriggerStatus } from '@dxos/edge-client';
 import { EID, type SpaceId } from '@dxos/keys';
+import { log } from '@dxos/log';
+import { EdgeCallFailedError } from '@dxos/protocols';
 
 import { createEdgeClient } from './edge-client';
 
@@ -27,6 +29,22 @@ type EdgeClient = ReturnType<typeof createEdgeClient>;
 
 /** How often the remote trigger view is refreshed from the EDGE dispatcher. */
 const POLL_INTERVAL = Duration.seconds(15);
+
+/**
+ * Backoff for a force-run that reaches EDGE before the trigger object has replicated there
+ * (~31s total across 5 retries): a trigger created client-side is force-run immediately by the UI,
+ * so the first attempt can lose the race with replication.
+ *
+ * TODO(dmaretskyi): Remove once the client can await replication of the trigger to EDGE.
+ */
+const REPLICATION_BACKOFF = Schedule.exponential(Duration.seconds(1), 2).pipe(Schedule.upTo({ times: 5 }));
+
+/**
+ * Whether EDGE rejected the force-run because it does not know the trigger yet — a 404 from the
+ * dispatcher route, however it is spelled (bare HTTP failure or a JSON error envelope).
+ */
+const isTriggerNotReplicated = (error: unknown): boolean =>
+  error instanceof EdgeCallFailedError && /(HTTP code 404|not found)/i.test(error.message);
 
 /**
  * EDGE implementation of {@link RemoteTriggerManager.Service}.
@@ -86,9 +104,18 @@ const make = (
       invokeTrigger: (options: Trigger.InvokeOptions) =>
         // Manual invocation of a remote trigger maps onto force-running its cron on the EDGE
         // dispatcher; refresh the view promptly afterwards.
-        Effect.promise(() =>
-          getEdgeClient().forceRunCronTrigger(DxosContext.default(), spaceId, options.trigger.id),
-        ).pipe(
+        Effect.tryPromise({
+          try: () => getEdgeClient().forceRunCronTrigger(DxosContext.default(), spaceId, options.trigger.id),
+          catch: (error) => error,
+        }).pipe(
+          Effect.tapError((error) =>
+            isTriggerNotReplicated(error)
+              ? Effect.sync(() =>
+                  log('trigger not yet replicated to edge; retrying', { triggerId: options.trigger.id }),
+                )
+              : Effect.void,
+          ),
+          Effect.retry({ schedule: REPLICATION_BACKOFF, while: isTriggerNotReplicated }),
           Effect.asVoid,
           Effect.orDie,
           Effect.tap(() => refresh),

--- a/packages/core/compute/edge-compute/src/EdgeTriggerManager.ts
+++ b/packages/core/compute/edge-compute/src/EdgeTriggerManager.ts
@@ -21,7 +21,6 @@ import { Ref } from '@dxos/echo';
 import { type EdgeTriggerStatus } from '@dxos/edge-client';
 import { EID, type SpaceId } from '@dxos/keys';
 import { log } from '@dxos/log';
-import { EdgeCallFailedError } from '@dxos/protocols';
 
 import { createEdgeClient } from './edge-client';
 
@@ -31,20 +30,15 @@ type EdgeClient = ReturnType<typeof createEdgeClient>;
 const POLL_INTERVAL = Duration.seconds(15);
 
 /**
- * Backoff for a force-run that reaches EDGE before the trigger object has replicated there
+ * Backoff for a force-run that reaches EDGE before the client's state has caught up there
  * (~31s total across 5 retries): a trigger created client-side is force-run immediately by the UI,
- * so the first attempt can lose the race with replication.
+ * so the first attempt can lose the race — against replication of the trigger itself (rejected as
+ * not found) or against the identity being associated with an account. Every failure is retried
+ * rather than a specific code, since EDGE spells these races several ways.
  *
  * TODO(dmaretskyi): Remove once the client can await replication of the trigger to EDGE.
  */
 const REPLICATION_BACKOFF = Schedule.exponential(Duration.seconds(1), 2).pipe(Schedule.upTo({ times: 5 }));
-
-/**
- * Whether EDGE rejected the force-run because it does not know the trigger yet — a 404 from the
- * dispatcher route, however it is spelled (bare HTTP failure or a JSON error envelope).
- */
-const isTriggerNotReplicated = (error: unknown): boolean =>
-  error instanceof EdgeCallFailedError && /(HTTP code 404|not found)/i.test(error.message);
 
 /**
  * EDGE implementation of {@link RemoteTriggerManager.Service}.
@@ -109,13 +103,9 @@ const make = (
           catch: (error) => error,
         }).pipe(
           Effect.tapError((error) =>
-            isTriggerNotReplicated(error)
-              ? Effect.sync(() =>
-                  log('trigger not yet replicated to edge; retrying', { triggerId: options.trigger.id }),
-                )
-              : Effect.void,
+            Effect.sync(() => log.warn('edge force-run failed; retrying', { triggerId: options.trigger.id, error })),
           ),
-          Effect.retry({ schedule: REPLICATION_BACKOFF, while: isTriggerNotReplicated }),
+          Effect.retry({ schedule: REPLICATION_BACKOFF }),
           Effect.asVoid,
           Effect.orDie,
           Effect.tap(() => refresh),


### PR DESCRIPTION
Fixes DX-1153 (stopgap).

## Problem

New inbox sync does: init connection → create the sync trigger → force-run it on the UI button press. The force-run POSTs to the EDGE dispatcher, which can still be behind the client — it may not have the freshly created trigger replicated yet (rejected as not found), and it may not yet associate the identity with an account (`identity_not_associated_with_account`). Either way the run fails.

## Change

`EdgeTriggerManager.invokeTrigger` now retries a failed force-run with exponential backoff starting at 1s, up to 5 retries (~31s total), logging a warning per attempt. It matches no specific error code — EDGE spells these races several ways — so any failure is retried and only an exhausted backoff fails the invocation.

This is a stopgap until the client can await replication of the trigger to EDGE before running it (noted as a TODO in the code).

## Tests

New `EdgeTriggerManager.test.ts`:
- a force-run rejected twice as not-found succeeds on the third attempt after the backoff elapses;
- a force-run rejected once with `identity_not_associated_with_account` succeeds on retry;
- a permanently failing force-run gives up after the initial attempt plus five retries.

```
✓ |node| src/EdgeTriggerManager.test.ts (3 tests) 47ms
Test Files  1 passed (1)
```

`moon run edge-compute:build` and `edge-compute:lint` pass; `pnpm format` run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manual EDGE trigger runs immediately after connecting by retrying while synchronization completes.
  * Added exponential backoff across up to five retry attempts, reducing transient force-run failures.
  * Preserved completion and refresh behavior after successful runs.
  * Added clearer logging when force-run requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->