### PR TITLE
echo: add Database.sync to close the trigger replication/index race (DX-1153)

### DIFF
--- a/.changeset/database-sync-indexed.md
+++ b/.changeset/database-sync-indexed.md
@@ -1,0 +1,5 @@
+---
+'@dxos/echo': minor
+---
+
+Add `Database.sync({ to: 'edge', entities, indexed })`, a barrier that waits until this peer's writes have replicated to EDGE and — with `indexed: true` — been indexed there. Connector sync now waits on it before force-running a remote sync trigger, so a trigger created moments earlier is no longer reported as "not found".

--- a/packages/core/echo/echo-client/src/client/echo-client.ts
+++ b/packages/core/echo/echo-client/src/client/echo-client.ts
@@ -14,7 +14,7 @@ import { type DataService, type FeedService, type QueryService } from '@dxos/pro
 
 import { type BranchStore } from '../core-db';
 import { HypergraphImpl } from '../hypergraph';
-import { DatabaseImpl } from '../proxy-db';
+import { DatabaseImpl, type RemoteIndexSync } from '../proxy-db';
 import { IndexQuerySourceProvider, type LoadObjectProps, type ObjectUpdate } from './index-query-source-provider';
 
 export type EchoClientProps = {};
@@ -23,6 +23,9 @@ export type ConnectToServiceProps = {
   dataService: DataService.Client;
   queryService: QueryService.Client;
   feedService?: FeedService.Client;
+
+  /** Barrier for `db.sync({ indexed: true })`. Absent when the client has no EDGE configured. */
+  remoteIndexSync?: RemoteIndexSync;
 
   /** Runtime used to run effect-rpc service calls at Promise/callback boundaries. */
   runtime?: EffectContext.Context<never>;
@@ -70,6 +73,7 @@ export class EchoClient extends Resource {
   private _dataService: DataService.Client | undefined = undefined;
   private _queryService: QueryService.Client | undefined = undefined;
   private _feedService: FeedService.Client | undefined = undefined;
+  private _remoteIndexSync: RemoteIndexSync | undefined = undefined;
   private _runtime: EffectContext.Context<never> = EffectContext.empty();
 
   private _indexQuerySourceProvider: IndexQuerySourceProvider | undefined = undefined;
@@ -94,11 +98,12 @@ export class EchoClient extends Resource {
    * Connects to the ECHO service.
    * Must be called before open.
    */
-  connectToService({ dataService, queryService, feedService, runtime }: ConnectToServiceProps): this {
+  connectToService({ dataService, queryService, feedService, remoteIndexSync, runtime }: ConnectToServiceProps): this {
     invariant(this._lifecycleState === LifecycleState.CLOSED);
     this._dataService = dataService;
     this._queryService = queryService;
     this._feedService = feedService;
+    this._remoteIndexSync = remoteIndexSync;
     this._runtime = runtime ?? EffectContext.empty();
     return this;
   }
@@ -155,6 +160,7 @@ export class EchoClient extends Resource {
       dataService: this._dataService!,
       queryService: this._queryService!,
       feedService: this._feedService,
+      remoteIndexSync: this._remoteIndexSync,
       runtime: this._runtime,
       graph: this._graph,
       spaceId,

--- a/packages/core/echo/echo-client/src/proxy-db/database.ts
+++ b/packages/core/echo/echo-client/src/proxy-db/database.ts
@@ -15,6 +15,7 @@ import {
   type Blob,
   Database,
   Entity,
+  Err,
   Feed,
   Filter,
   JsonSchema,
@@ -174,6 +175,19 @@ export interface EchoDatabase extends Database.Database {
  */
 export type BranchBinding<T extends Obj.Unknown = Obj.Unknown> = Database.BranchBinding<T>;
 
+/**
+ * Remote-index barrier used by {@link EchoDatabase.sync} with `indexed: true`.
+ *
+ * Injected rather than reached for, because the database layer has no EDGE transport of its own —
+ * `@dxos/client` supplies an adapter over `EdgeHttpClient` when an EDGE URL is configured.
+ */
+export interface RemoteIndexSync {
+  awaitIndexed(
+    spaceId: SpaceId,
+    request: { documents: Record<string, string[]>; timeoutMs: number },
+  ): Promise<{ indexed: boolean; pending: string[] }>;
+}
+
 export type EchoDatabaseProps = {
   graph: HypergraphImpl;
   dataService: DataService.Client;
@@ -184,6 +198,9 @@ export type EchoDatabaseProps = {
 
   /** Device-local persistence for the current-branch selection (non-synced). In-memory if omitted. */
   branchStore?: BranchStore;
+
+  /** Barrier for `sync({ indexed: true })`. Absent when the client has no EDGE configured. */
+  remoteIndexSync?: RemoteIndexSync;
 
   /**
    * Run a reactive query for dynamic schemas.
@@ -218,6 +235,9 @@ const FEED_SYNC_POLL_INTERVAL = 2_000;
  * same backlog, and resets to {@link FEED_SYNC_POLL_INTERVAL} the moment it changes.
  */
 const MAX_FEED_SYNC_POLL_INTERVAL = 15_000;
+
+/** Default budget for {@link DatabaseImpl.sync}. */
+const DEFAULT_SYNC_TIMEOUT = 30_000;
 
 const feedSyncStateChanged = (before: SpaceFeedSyncState, after: SpaceFeedSyncState): boolean =>
   before.blocksToPull !== after.blocksToPull ||
@@ -281,6 +301,9 @@ export class DatabaseImpl extends Resource implements EchoDatabase {
    */
   #feedService: FeedService.Client | undefined;
 
+  /** Barrier for `sync({ indexed: true })`; absent when no EDGE is configured. */
+  readonly #remoteIndexSync: RemoteIndexSync | undefined;
+
   /** Runtime used to run effect-rpc feed calls at Promise boundaries. */
   readonly #runtime: EffectContext.Context<never>;
 
@@ -297,6 +320,7 @@ export class DatabaseImpl extends Resource implements EchoDatabase {
     this._preloadSchemaOnOpen = params.preloadSchemaOnOpen ?? true;
     this._hypergraph = params.graph;
     this.#feedService = params.feedService;
+    this.#remoteIndexSync = params.remoteIndexSync;
     this.#runtime = params.runtime;
 
     this._entityManager = new EntityManager({
@@ -721,6 +745,57 @@ export class DatabaseImpl extends Resource implements EchoDatabase {
   async flush(opts?: Database.FlushOptions): Promise<void> {
     await this._entityManager.flush(opts);
     await Promise.all([...this.#feeds.values()].map((handle) => handle.waitForPendingWrites()));
+  }
+
+  async sync({ entities, indexed = false, timeout = DEFAULT_SYNC_TIMEOUT }: Database.SyncOptions = {}): Promise<void> {
+    const deadline = Date.now() + timeout;
+    // Local writes must be durable before their heads can mean anything to a remote.
+    await this.flush({ disk: true, indexes: false });
+
+    const { heads } = await this._entityManager.getDocumentHeads();
+    const scoped = entities ? this.#scopeHeadsToEntities(heads, entities) : heads;
+    await this._entityManager.waitUntilHeadsReplicated({ heads: scoped });
+
+    if (!indexed) {
+      return;
+    }
+    if (!this.#remoteIndexSync) {
+      // Nothing can observe remote indexing from here; a caller that asked for it must not be told
+      // it happened.
+      throw new Err.SyncTimeoutError({ timeout, pending: Object.keys(scoped) });
+    }
+
+    // Each EDGE call caps its own wait, so loop until this call's own budget is spent.
+    let pending = Object.keys(scoped);
+    while (Date.now() < deadline) {
+      const result = await this.#remoteIndexSync.awaitIndexed(this.spaceId, {
+        documents: scoped,
+        timeoutMs: deadline - Date.now(),
+      });
+      if (result.indexed) {
+        return;
+      }
+      pending = result.pending;
+    }
+    throw new Err.SyncTimeoutError({ timeout, pending });
+  }
+
+  /**
+   * Narrows a space-wide heads map to the documents that hold the given entities. Entities whose
+   * document cannot be resolved (not loaded locally) are skipped rather than widening the wait back
+   * to the whole space — the caller asked about specific entities.
+   */
+  #scopeHeadsToEntities(heads: Record<string, string[]>, entities: readonly URI.URI[]): Record<string, string[]> {
+    const scoped: Record<string, string[]> = {};
+    for (const uri of entities) {
+      const eid = EID.tryParse(uri);
+      const objectId = eid && EID.getEntityId(eid);
+      const documentId = objectId && this._entityManager.getObjectCoreById(objectId)?.docHandle?.documentId;
+      if (documentId && heads[documentId]) {
+        scoped[documentId] = heads[documentId];
+      }
+    }
+    return scoped;
   }
 
   async runMigrations(migrations: ObjectMigration[]): Promise<void> {

--- a/packages/core/echo/echo-client/src/proxy-db/sync.test.ts
+++ b/packages/core/echo/echo-client/src/proxy-db/sync.test.ts
@@ -1,0 +1,84 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { afterEach, beforeEach, describe, test } from 'vitest';
+
+import { Err, Obj } from '@dxos/echo';
+import { TestSchema } from '@dxos/echo/testing';
+import { PublicKey } from '@dxos/keys';
+
+import { EchoTestBuilder } from '../testing';
+import { type RemoteIndexSync } from './database';
+
+/** Records what the database asked EDGE to wait for, and answers with a scripted verdict. */
+const makeRemoteIndexSync = (
+  answers: { indexed: boolean; pending: string[] }[],
+): RemoteIndexSync & { calls: { documents: Record<string, string[]>; timeoutMs: number }[] } => {
+  const calls: { documents: Record<string, string[]>; timeoutMs: number }[] = [];
+  return {
+    calls,
+    awaitIndexed: async (_spaceId, request) => {
+      calls.push(request);
+      return answers[Math.min(calls.length - 1, answers.length - 1)];
+    },
+  };
+};
+
+describe('Database.sync', () => {
+  let builder: EchoTestBuilder;
+
+  beforeEach(async () => {
+    builder = await new EchoTestBuilder().open();
+  });
+
+  afterEach(async () => {
+    await builder.close();
+  });
+
+  test('resolves once the remote reports the documents indexed', async ({ expect }) => {
+    const remoteIndexSync = makeRemoteIndexSync([{ indexed: true, pending: [] }]);
+    await using peer = await builder.createPeer();
+    const client = await peer.createClient({ remoteIndexSync });
+    const db = await peer.createDatabase(PublicKey.random(), { client });
+
+    const object = db.add(Obj.make(TestSchema.Expando, { name: 'trigger' }));
+    await db.sync({ to: 'edge', entities: [Obj.getURI(object)], indexed: true });
+
+    expect(remoteIndexSync.calls).toHaveLength(1);
+    // Scoped to the object's own document, not the whole space.
+    expect(Object.keys(remoteIndexSync.calls[0].documents)).toHaveLength(1);
+  });
+
+  test('fails with SyncTimeoutError while the remote stays behind', async ({ expect }) => {
+    const remoteIndexSync = makeRemoteIndexSync([{ indexed: false, pending: ['doc-1'] }]);
+    await using peer = await builder.createPeer();
+    const client = await peer.createClient({ remoteIndexSync });
+    const db = await peer.createDatabase(PublicKey.random(), { client });
+
+    const object = db.add(Obj.make(TestSchema.Expando, { name: 'trigger' }));
+    await expect(db.sync({ to: 'edge', entities: [Obj.getURI(object)], indexed: true, timeout: 50 })).rejects.toThrow(
+      Err.SyncTimeoutError,
+    );
+  });
+
+  test('replication-only sync does not consult the remote index', async ({ expect }) => {
+    const remoteIndexSync = makeRemoteIndexSync([{ indexed: true, pending: [] }]);
+    await using peer = await builder.createPeer();
+    const client = await peer.createClient({ remoteIndexSync });
+    const db = await peer.createDatabase(PublicKey.random(), { client });
+
+    db.add(Obj.make(TestSchema.Expando, { name: 'trigger' }));
+    await db.sync();
+
+    expect(remoteIndexSync.calls).toHaveLength(0);
+  });
+
+  test('an indexed sync without an EDGE transport reports a timeout rather than success', async ({ expect }) => {
+    await using peer = await builder.createPeer();
+    const db = await peer.createDatabase(PublicKey.random());
+
+    const object = db.add(Obj.make(TestSchema.Expando, { name: 'trigger' }));
+    await expect(db.sync({ entities: [Obj.getURI(object)], indexed: true })).rejects.toThrow(Err.SyncTimeoutError);
+  });
+});

--- a/packages/core/echo/echo-client/src/testing/echo-test-builder.ts
+++ b/packages/core/echo/echo-client/src/testing/echo-test-builder.ts
@@ -30,7 +30,7 @@ import { range } from '@dxos/util';
 
 import { EchoClient } from '../client';
 import { type BranchStore } from '../core-db';
-import { type EchoDatabase } from '../proxy-db';
+import { type EchoDatabase, type RemoteIndexSync } from '../proxy-db';
 
 type OpenDatabaseOptions = {
   client?: EchoClient;
@@ -198,7 +198,7 @@ export class EchoTestPeer extends Resource {
    * Bridges the host's effect-rpc Handlers to the effect-rpc client surface in-process (no wire),
    * and connects the given client. The bridged clients live on {@link _serviceScope}.
    */
-  private async _connectServices(client: EchoClient): Promise<void> {
+  private async _connectServices(client: EchoClient, remoteIndexSync?: RemoteIndexSync): Promise<void> {
     invariant(this._serviceScope, 'Service scope not initialized');
     const [dataService, queryService, feedService] = await EffectEx.runPromise(
       Effect.all([
@@ -207,7 +207,7 @@ export class EchoTestPeer extends Resource {
         makeInProcessClient(FeedService.Rpcs, this._echoHost.feedService),
       ]).pipe(Effect.provideService(Scope.Scope, this._serviceScope)),
     );
-    client.connectToService({ dataService, queryService, feedService });
+    client.connectToService({ dataService, queryService, feedService, remoteIndexSync });
   }
 
   protected override async _close(ctx: Context): Promise<void> {
@@ -271,11 +271,11 @@ export class EchoTestPeer extends Resource {
     await this.open();
   }
 
-  async createClient(): Promise<EchoClient> {
+  async createClient({ remoteIndexSync }: { remoteIndexSync?: RemoteIndexSync } = {}): Promise<EchoClient> {
     const client = new EchoClient();
     await client.graph.registry.add(this._types);
     this._clients.add(client);
-    await this._connectServices(client);
+    await this._connectServices(client, remoteIndexSync);
     await client.open();
     return client;
   }

--- a/packages/core/echo/echo/src/Database.ts
+++ b/packages/core/echo/echo/src/Database.ts
@@ -103,6 +103,34 @@ export type FlushOptions = {
   updates?: boolean;
 };
 
+export type SyncOptions = {
+  /**
+   * Peer to sync with. Only EDGE is addressable today.
+   * @default 'edge'
+   */
+  to?: 'edge';
+
+  /**
+   * Entities whose documents must be synced. Omit for the whole space — cheap only for small
+   * spaces, since it waits on every document.
+   */
+  entities?: readonly URI.URI[];
+
+  /**
+   * Also wait until the remote has *indexed* the synced documents. Required before asking EDGE to
+   * act on a just-written object, because EDGE resolves objects through index queries — a trigger
+   * force-run right after its trigger was created is reported as "not found" otherwise (DX-1153).
+   * @default false
+   */
+  indexed?: boolean;
+
+  /**
+   * Budget for the whole wait, in milliseconds.
+   * @default 30000
+   */
+  timeout?: number;
+};
+
 /**
  * A caller-owned, writable **independent instance** of one object bound to one branch: a distinct
  * object instance (not a UI surface), separate from the device-global canonical object.
@@ -207,6 +235,12 @@ export interface Database extends Queryable {
    * Optionaly waits for changes to be propagated to indexes and event handlers.
    */
   flush(opts?: FlushOptions): Promise<void>;
+
+  /**
+   * Wait until this peer's writes are durable on the remote.
+   * @see {@link SyncOptions}
+   */
+  sync(options?: SyncOptions): Promise<void>;
 
   //
   // Branching. A branch is a writable alternate timeline of an object subtree (same object ids,
@@ -507,6 +541,27 @@ export const deleteFromFeed = (feed: Feed.Feed, entities: Entity.Unknown[]): Eff
 export const flush = (opts?: FlushOptions) =>
   Service.pipe(Effect.flatMap(({ db }) => Effect.promise(() => db.flush(opts)))).pipe(
     Effect.withSpan('Database.flush'),
+  );
+
+/**
+ * Waits until this peer's writes are durable — and optionally indexed — on the remote.
+ * @see {@link Database.sync}
+ */
+export const sync = (options?: SyncOptions): Effect.Effect<void, Err.SyncTimeoutError, Service> =>
+  Service.pipe(
+    Effect.flatMap(({ db }) =>
+      Effect.tryPromise({
+        try: () => db.sync(options),
+        // Only the timeout is actionable; anything else is a defect.
+        catch: (error) => {
+          if (error instanceof Err.SyncTimeoutError) {
+            return error;
+          }
+          throw error;
+        },
+      }),
+    ),
+    Effect.withSpan('Database.sync'),
   );
 
 /**

--- a/packages/core/echo/echo/src/Err.ts
+++ b/packages/core/echo/echo/src/Err.ts
@@ -96,3 +96,15 @@ export class GetReactiveError extends BaseError.extend(
     super({ context: { reason: options.reason, snapshotId: options.snapshotId }, ...options });
   }
 }
+
+/**
+ * Thrown when {@link Database.sync} exhausts its budget before the remote caught up.
+ *
+ * `pending` names what is still behind — document ids when the index wait timed out, empty when the
+ * replication wait did.
+ */
+export class SyncTimeoutError extends BaseError.extend('SyncTimeoutError', 'Timed out waiting for sync') {
+  constructor(context: { timeout: number; pending: readonly string[] }, options?: BaseErrorOptions) {
+    super({ context, ...options });
+  }
+}

--- a/packages/core/mesh/edge-client/src/edge-http-client.ts
+++ b/packages/core/mesh/edge-client/src/edge-http-client.ts
@@ -463,6 +463,23 @@ export class EdgeHttpClient extends BaseHttpClient {
     });
   }
 
+  /**
+   * Waits until EDGE has replicated and indexed the given documents, so a subsequent call that
+   * resolves objects through an index query sees them (DX-1153). `documents` maps documentId to the
+   * heads the caller requires; EDGE answers `{ indexed: false, pending }` on its own timeout rather
+   * than failing, so the caller decides between retrying and proceeding.
+   */
+  public async awaitIndexed(
+    ctx: Context,
+    spaceId: SpaceId,
+    request: { documents: Record<string, string[]>; timeoutMs?: number },
+  ): Promise<{ indexed: boolean; pending: string[] }> {
+    return this._call(ctx, new URL(`/spaces/${spaceId}/indexer/await`, this.baseUrl), {
+      method: 'POST',
+      body: request,
+    });
+  }
+
   //
   // Triggers
   //

--- a/packages/plugins/plugin-connector/src/util/sync-binding.test.ts
+++ b/packages/plugins/plugin-connector/src/util/sync-binding.test.ts
@@ -1,0 +1,134 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Context from 'effect/Context';
+import * as Effect from 'effect/Effect';
+import * as Schema from 'effect/Schema';
+import * as Atom from 'effect/unstable/reactivity/Atom';
+import * as Registry from 'effect/unstable/reactivity/AtomRegistry';
+import { afterEach, beforeEach, describe, test } from 'vitest';
+
+import * as Capabilities from '@dxos/app-framework/Capabilities';
+import * as Capability from '@dxos/app-framework/Capability';
+import * as CapabilityManager from '@dxos/app-framework/CapabilityManager';
+import * as Operation from '@dxos/compute/Operation';
+import * as ServiceResolver from '@dxos/compute/ServiceResolver';
+import { operationServiceLayerNoop } from '@dxos/compute/testing';
+import * as Trigger from '@dxos/compute/Trigger';
+import { DXN, Obj, Ref } from '@dxos/echo';
+import { type RemoteIndexSync } from '@dxos/echo-client';
+import { EchoTestBuilder } from '@dxos/echo-client/testing';
+import { EffectEx } from '@dxos/effect';
+import { invariant } from '@dxos/invariant';
+import { PublicKey } from '@dxos/keys';
+import { AccessToken, Connection, Cursor } from '@dxos/link';
+import { Expando } from '@dxos/schema';
+
+import { ConnectorSpec } from '#types';
+
+import { syncTarget } from './sync-target';
+
+/**
+ * Covers the DX-1153 barrier on the path that force-runs a remote sync trigger: EDGE resolves the
+ * trigger through an index query, so the client waits for EDGE to have indexed it first.
+ */
+describe('syncBinding (remote connector)', () => {
+  let builder: EchoTestBuilder;
+
+  beforeEach(async () => {
+    builder = await new EchoTestBuilder().open();
+  });
+
+  afterEach(async () => {
+    await builder.close();
+  });
+
+  /** Ordered log of what happened, so the barrier can be asserted to precede the force-run. */
+  let events: string[] = [];
+
+  const TestSync = Operation.make({
+    meta: { key: DXN.make('org.dxos.test.syncBinding.sync'), name: 'Test Sync' },
+    input: Schema.Struct({ binding: Ref.Ref(Cursor.Cursor) }),
+    output: Schema.Any,
+  });
+
+  const connector: ConnectorSpec.ConnectorEntry = {
+    id: 'example',
+    source: 'example.com',
+    sync: { operation: TestSync, trigger: Trigger.specTimer('*/10 * * * *'), remote: true },
+  };
+
+  const recordingMonitor: Trigger.Monitor = {
+    triggers: Atom.make<readonly Trigger.State[]>([]),
+    localDispatcherEnabled: false,
+    invokeTrigger: () => Effect.sync(() => void events.push('fired')),
+  };
+
+  test('waits for the remote index before force-running the trigger', async ({ expect }) => {
+    const indexed: RemoteIndexSync = {
+      awaitIndexed: async () => {
+        events.push('awaited');
+        return { indexed: true, pending: [] };
+      },
+    };
+    const { target } = await setup(indexed);
+
+    await run(target);
+
+    expect(events).toEqual(['awaited', 'fired']);
+  });
+
+  test('still force-runs the trigger when no EDGE transport is configured', async ({ expect }) => {
+    // The barrier is best-effort — failing the sync outright would be worse than the race it guards.
+    const { target } = await setup();
+
+    await run(target);
+
+    expect(events).toEqual(['fired']);
+  });
+
+  const capabilities = () => {
+    const manager = CapabilityManager.make({ registry: Registry.make() });
+    manager.contribute({ module: 'test', interface: ConnectorSpec.Connector, implementation: [connector] });
+    manager.contribute({
+      module: 'test',
+      interface: Capabilities.ServiceResolver,
+      implementation: ServiceResolver.fromContext(Context.make(Trigger.TriggerMonitorService, recordingMonitor)),
+    });
+    return manager;
+  };
+
+  const setup = async (remoteIndexSync?: RemoteIndexSync) => {
+    events = [];
+    // Not `await using` — the peer must outlive this helper; the builder closes it in `afterEach`.
+    const peer = await builder.createPeer();
+    const client = await peer.createClient({ remoteIndexSync });
+    const db = await peer.createDatabase(PublicKey.random(), { client });
+    client.graph.registry.add([
+      Connection.Connection,
+      Cursor.Cursor,
+      AccessToken.AccessToken,
+      Trigger.Trigger,
+      Expando.Expando,
+    ]);
+    const token = db.add(Obj.make(AccessToken.AccessToken, { source: 'example.com', token: 'tok' }));
+    db.add(Obj.make(Connection.Connection, { connectorId: 'example', accessToken: Ref.make(token) }));
+    const target = db.add(Obj.make(Expando.Expando, { name: 'Inbox' }));
+    const cursor = db.add(Cursor.makeExternal({ source: Ref.make(token), target: Ref.make(target) }));
+    invariant(Cursor.isExternal(cursor));
+    db.add(
+      Trigger.make({ enabled: true, spec: Trigger.specTimer('*/10 * * * *'), input: { binding: Ref.make(cursor) } }),
+    );
+    await db.flush({ indexes: true });
+    return { db, target };
+  };
+
+  const run = (target: Obj.Unknown) =>
+    syncTarget(target).pipe(
+      Effect.provideService(Capability.Service, capabilities()),
+      // Never reached: the connector declares a schedule, so the sync goes through the trigger.
+      Effect.provide(operationServiceLayerNoop),
+      EffectEx.runPromise,
+    );
+});

--- a/packages/plugins/plugin-connector/src/util/sync-binding.ts
+++ b/packages/plugins/plugin-connector/src/util/sync-binding.ts
@@ -49,8 +49,13 @@ export const syncBinding = ({
     if (sync.remote) {
       // EDGE dispatches a remote trigger by resolving it through an index query, so a trigger created
       // moments ago (the first sync of a new connection) is reported as "not found" unless EDGE has
-      // both replicated and indexed it first (DX-1153).
-      yield* Database.sync({ to: 'edge', entities: [Obj.getURI(trigger)], indexed: true });
+      // both replicated and indexed it first (DX-1153). The barrier is best-effort: an exhausted
+      // budget (or a peer with no EDGE transport at all) still leaves the force-run worth attempting,
+      // and failing the sync outright would be a worse outcome than the race it guards against.
+      yield* Database.sync({ to: 'edge', entities: [Obj.getURI(trigger)], indexed: true }).pipe(
+        Effect.tapError((error) => Effect.logWarning('sync barrier did not complete; running trigger anyway', error)),
+        Effect.ignore,
+      );
     }
 
     yield* fireSyncTrigger(trigger).pipe(Effect.provide(syncTriggerMonitorLayer(spaceId)));

--- a/packages/plugins/plugin-connector/src/util/sync-binding.ts
+++ b/packages/plugins/plugin-connector/src/util/sync-binding.ts
@@ -6,7 +6,7 @@ import * as Effect from 'effect/Effect';
 
 import * as Capability from '@dxos/app-framework/Capability';
 import * as Operation from '@dxos/compute/Operation';
-import { Database, type Key, Ref } from '@dxos/echo';
+import { Database, type Key, Obj, Ref } from '@dxos/echo';
 import { type Cursor } from '@dxos/link';
 
 import { ConnectorSpec } from '#types';
@@ -44,6 +44,13 @@ export const syncBinding = ({
       // TODO(wittjosiah): Invokes the sync once; nothing drives `Operation.runAgain()` continuation
       //   without a trigger, so a capped run's remaining batches are not synced here.
       return yield* Operation.invoke(sync.operation, { binding: Ref.make(cursor) }, { spaceId }).pipe(Effect.asVoid);
+    }
+
+    if (sync.remote) {
+      // EDGE dispatches a remote trigger by resolving it through an index query, so a trigger created
+      // moments ago (the first sync of a new connection) is reported as "not found" unless EDGE has
+      // both replicated and indexed it first (DX-1153).
+      yield* Database.sync({ to: 'edge', entities: [Obj.getURI(trigger)], indexed: true });
     }
 
     yield* fireSyncTrigger(trigger).pipe(Effect.provide(syncTriggerMonitorLayer(spaceId)));

--- a/packages/sdk/client/src/client/client.ts
+++ b/packages/sdk/client/src/client/client.ts
@@ -484,10 +484,15 @@ export class Client {
     log('client._open: connecting echo client to service...');
     // The effect-rpc client nests every service under its key, so the same `rpc` surface satisfies
     // each per-service Client (DataService.Client, etc.).
+    const edgeIndexClient = this._edgeHttpClient;
     this._echoClient.connectToService({
       dataService: this._services.rpc,
       queryService: this._services.rpc,
       feedService: this._services.rpc,
+      // `db.sync({ indexed: true })` has no transport of its own; give it one when EDGE is configured.
+      remoteIndexSync: edgeIndexClient && {
+        awaitIndexed: (spaceId, request) => edgeIndexClient.awaitIndexed(Context.default(), spaceId, request),
+      },
       runtime: this._effectRuntime,
     });
     log('client._open: opening echo client...');


### PR DESCRIPTION
## Summary

Adds `Database.sync({ to: 'edge', entities, indexed })` — a barrier that waits until this peer's writes are durable on EDGE and, with `indexed: true`, until EDGE's index has caught up to them.

- `@dxos/echo`: `Database.sync` on the interface, the `SyncOptions` type, the Effect wrapper, and `Err.SyncTimeoutError`.
- `@dxos/echo-client`: `DatabaseImpl.sync` — flush, resolve document heads, `waitUntilHeadsReplicated`, then (for `indexed`) loop the remote index barrier until the caller's own budget is spent. `entities` narrows the wait to the documents holding those objects rather than the whole space.
- `@dxos/edge-client`: `EdgeHttpClient.awaitIndexed`, hitting the new `POST /spaces/:spaceId/indexer/await` (dxos/edge#884).
- `@dxos/client`: supplies the `RemoteIndexSync` adapter when an EDGE URL is configured. The database layer has no EDGE transport of its own, so the barrier is injected rather than reached for; without it, an `indexed` sync reports a timeout rather than claiming success.
- `@dxos/plugin-connector`: `syncBinding` awaits the barrier before force-running a **remote** sync trigger.

## Why

EDGE resolves a trigger through an index query, so force-running a sync trigger created moments earlier (the first sync of a new inbox connection) is reported as "not found".

## Test plan

New `packages/core/echo/echo-client/src/proxy-db/sync.test.ts`, 4 passing:

- resolves once the remote reports the documents indexed (and scopes the request to the object's own document)
- fails with `SyncTimeoutError` while the remote stays behind
- replication-only sync does not consult the remote index
- an indexed sync without an EDGE transport reports a timeout rather than success

Builds: `echo-client`, `client`, `plugin-connector`. Lint clean on `echo`, `echo-client`, `edge-client`, `client`, `plugin-connector`; `pnpm format` applied. Changeset added (`@dxos/echo` minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fo4Hpst12bHR2XDTvK1Rtb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fo4Hpst12bHR2XDTvK1Rtb)_