### PR TITLE
protocols, echo-host, echo-client: stream feed content instead of polling

### DIFF
--- a/.agents/projects/memory-usage/TASKS.md
+++ b/.agents/projects/memory-usage/TASKS.md
@@ -177,14 +177,14 @@ Independent of each other; some sites may want none, one, or several.
   landed (no more per-tick DB query), but the tick itself still fires at a
   fixed 1 Hz — "no timer while idle" is not yet implemented.
 - [x] **R2. No-change backoff.** Widen the interval while a poll keeps
-  returning nothing (e.g. 1 s → 5 s → 30 s), reset on change or local
-  write. Interim fix for S2 and S3 while a real streaming RPC was out of
-  scope; both have since been upgraded past it (see below), so this
-  remedy is fully superseded — kept `[x]` as a record of what shipped
-  first, not as an open remedy.
-  **Superseded for S2 and S3**: both were upgraded from backoff to a real
-  streaming RPC (`FeedService.subscribeFeed`, `FeedService.subscribeSyncState`)
-  — see their entries above; R2 no longer applies to either.
+      returning nothing (e.g. 1 s → 5 s → 30 s), reset on change or local
+      write. Interim fix for S2 and S3 while a real streaming RPC was out of
+      scope; both have since been upgraded past it (see below), so this
+      remedy is fully superseded — kept `[x]` as a record of what shipped
+      first, not as an open remedy.
+      **Superseded for S2 and S3**: both were upgraded from backoff to a real
+      streaming RPC (`FeedService.subscribeFeed`, `FeedService.subscribeSyncState`)
+      — see their entries above; R2 no longer applies to either.
 - [x] **R3. Coordinated scheduling.** One scheduler batching all due work into
       a single round-trip instead of N independent timers. Moot for S2 and
       S3 now that both push independently instead of polling on any
@@ -200,7 +200,7 @@ Independent of each other; some sites may want none, one, or several.
       change, so an idle tab does no work at all. Still open: what S2 and S3
       shipped is push from the local `echo-host` to the client
       (`FeedStore.onNewBlocks` → a streaming RPC), which eliminates client-side
-      polling entirely, but the *pull* leg — EDGE notifying `echo-host` of
+      polling entirely, but the _pull_ leg — EDGE notifying `echo-host` of
       remote changes, rather than `FeedSyncer`'s own poll cadence against it —
       is the larger, still-unimplemented half of this remedy. Lands with
       feed-live-objects stage 4 rather than here.

--- a/.agents/projects/memory-usage/TASKS.md
+++ b/.agents/projects/memory-usage/TASKS.md
@@ -1,6 +1,6 @@
 # Composer Memory Usage — Tasks
 
-_Resume: Phase 4 idle-churn sites S1-S4 fixed/investigated (see below), opened as a separate PR from #12505. Remedies section (R1-R6) and Sequencing still open — verify decommit with `scripts/memory/soak.mjs` once the PR lands. Phase 3 continues opportunistically. Uncommitted: none._
+_Resume: Phase 4 idle-churn sites S1-S4 fixed/investigated (see below). S1 landed in #12561 (trigger-list subscription); S3 upgraded from backoff to a real streaming RPC in #12580; S2 likewise upgraded from backoff to a real streaming RPC in this pass. Sequencing still open — verify decommit with `scripts/memory/soak.mjs` once this lands. Phase 3 continues opportunistically. Uncommitted: none._
 
 **Target: 300–400 MB resting footprint for an idle tab, 500 MB ceiling.**
 Composition model and measurement rules: DESIGN.md. Industry comparison:
@@ -90,17 +90,29 @@ fixed the same way.
       riskier change to feed/subscription trigger semantics, left as a
       follow-up if further gains are wanted.
 - [x] **S2. Every subscribed feed polls at 1 Hz.**
-      `echo-client/src/feed/feed-handle.ts` (`POLLING_INTERVAL`,
-      `beginPolling`): one timer and one refresh RPC per feed handle, so cost
-      scales with feeds open (a mailbox is the common case). No server push
-      exists (`FeedService` has no subscribe/watch RPC — confirmed via
-      `packages/core/protocols/src/FeedService.ts`), so R1 doesn't apply; R6
-      (real push) stays deferred to `feed-live-objects`. **Fixed (R2, no-change
-      backoff):** `beginPolling` now doubles the poll delay (capped at 30 s)
-      each tick that finds no object-set change, and resets to
-      `POLLING_INTERVAL` the moment a poll observes one. R4 (visibility
-      gating) was considered but deferred — orthogonal, applies to all four
-      sites, better done as one pass.
+      `echo-client/src/feed/feed-handle.ts` (`beginPolling`): one timer and one
+      refresh RPC per feed handle, so cost scales with feeds open (a mailbox
+      is the common case). **Superseded by a real streaming RPC (R1, not
+      R2):** the initial no-change-backoff polling (landed in #12561) has been
+      replaced by `FeedService.subscribeFeed`, a genuine `stream: true` RPC —
+      `LocalFeedServiceImpl` (`echo-host`) pushes a fresh query snapshot on
+      subscribe and again whenever `FeedStore.onNewBlocks` fires and the
+      recomputed snapshot actually differs (string-compared against the last
+      one sent, since this payload is real object content rather than
+      `subscribeSyncState`'s small aggregate count — suppressing unchanged
+      snapshots server-side matters more here); `FeedHandle.beginPolling`
+      consumes it via `subscribeStream` instead of any client-side timer, and
+      shares the same decode/upsert/diff logic as the still-present one-shot
+      `refresh()` path. The two `subscribeX` RPCs' identical
+      recompute-on-`onNewBlocks`-and-coalesce logic is factored into
+      `LocalFeedServiceImpl#recomputeOnNewBlocks`, parameterized by a compute
+      function and a change comparator. Verified end-to-end in
+      `echo-host/src/db-host/feed-service.test.ts` (initial snapshot + a
+      second push after a local write). R4 (visibility gating) was considered
+      but deferred — orthogonal, applies to all four sites, better done as one
+      pass. Same `onNewBlocks`-is-unscoped caveat as S3 applies here too (see
+      the S3 entry's note) — this subscription also recomputes on any space's
+      write, not just its own.
 - [x] **S3. Each open space polls sync state at 2 s.**
       `echo-client/src/proxy-db/database.ts` (`FEED_SYNC_POLL_INTERVAL`):
       aggregates block backlog across namespaces via a real per-namespace
@@ -164,19 +176,19 @@ Independent of each other; some sites may want none, one, or several.
   clock changes. Partially done for S1: the trigger-list subscription
   landed (no more per-tick DB query), but the tick itself still fires at a
   fixed 1 Hz — "no timer while idle" is not yet implemented.
-- [~] **R2. No-change backoff.** Widen the interval while a poll keeps
+- [x] **R2. No-change backoff.** Widen the interval while a poll keeps
   returning nothing (e.g. 1 s → 5 s → 30 s), reset on change or local
-  write. Fits S2 and S3. Costs staleness after a quiet period, so pair it
-  with an explicit refresh on user action. Done for `FeedHandle` polling
-  (capped 30 s), resetting to the fast interval on a real change or a
-  failed read (a failure can't tell us the feed is actually quiet).
-  **Superseded for S3**: space sync-state polling was upgraded from
-  backoff to a real streaming RPC (`FeedService.subscribeSyncState`) —
-  see the S3 entry above; R2 no longer applies there.
-- [ ] **R3. Coordinated scheduling.** One scheduler batching all due work into
-      a single round-trip instead of N independent timers. Fits S2 and S3
-      together; the win is fewer wakeups and fewer payloads, not a longer
-      interval.
+  write. Interim fix for S2 and S3 while a real streaming RPC was out of
+  scope; both have since been upgraded past it (see below), so this
+  remedy is fully superseded — kept `[x]` as a record of what shipped
+  first, not as an open remedy.
+  **Superseded for S2 and S3**: both were upgraded from backoff to a real
+  streaming RPC (`FeedService.subscribeFeed`, `FeedService.subscribeSyncState`)
+  — see their entries above; R2 no longer applies to either.
+- [x] **R3. Coordinated scheduling.** One scheduler batching all due work into
+      a single round-trip instead of N independent timers. Moot for S2 and
+      S3 now that both push independently instead of polling on any
+      schedule — there's no timer left to coordinate.
 - [ ] **R4. Visibility gating.** Pause or stretch while `document.hidden`,
       resume on `visibilitychange`. Applies to every site, and is the cheapest
       change, but only helps background tabs. Note the client worker keeps
@@ -185,8 +197,13 @@ Independent of each other; some sites may want none, one, or several.
       shapes so a tick re-runs fewer queries. Addresses S4 without changing any
       timer.
 - [ ] **R6. Push over poll.** A persistent connection where EDGE notifies on
-      change, so an idle tab does no work at all. Supersedes R1–R3 for S2 and
-      S3. Lands with feed-live-objects stage 4 rather than here.
+      change, so an idle tab does no work at all. Still open: what S2 and S3
+      shipped is push from the local `echo-host` to the client
+      (`FeedStore.onNewBlocks` → a streaming RPC), which eliminates client-side
+      polling entirely, but the *pull* leg — EDGE notifying `echo-host` of
+      remote changes, rather than `FeedSyncer`'s own poll cadence against it —
+      is the larger, still-unimplemented half of this remedy. Lands with
+      feed-live-objects stage 4 rather than here.
 
 ### Sequencing
 

--- a/.changeset/feed-content-streaming.md
+++ b/.changeset/feed-content-streaming.md
@@ -1,0 +1,5 @@
+---
+'@dxos/echo': patch
+---
+
+Replace client-side polling of feed content with a real streaming RPC (`FeedService.subscribeFeed`): the host now pushes a fresh object-set snapshot when the feed actually changes, instead of the client asking on a timer.

--- a/packages/core/compute/functions-runtime-cloudflare/src/internal/feed-service-impl.ts
+++ b/packages/core/compute/functions-runtime-cloudflare/src/internal/feed-service-impl.ts
@@ -41,6 +41,16 @@ export class FeedServiceImpl implements FeedService.Handlers {
     });
   }
 
+  /**
+   * The queue-backed store has no change-notification mechanism in this runtime, so this pushes a
+   * single snapshot (the same one `queryFeed` would return) rather than live updates.
+   */
+  ['FeedService.subscribeFeed'](
+    request: FeedProtocol.QueryFeedRequest,
+  ): EffectStream.Stream<FeedProtocol.QueryResult, Error> {
+    return EffectStream.fromEffect(this['FeedService.queryFeed'](request));
+  }
+
   ['FeedService.insertIntoFeed'](request: FeedProtocol.InsertIntoFeedRequest): Effect.Effect<void, Error> {
     return Effect.tryPromise({
       try: async () => {

--- a/packages/core/echo/echo-client/src/feed/feed-handle.ts
+++ b/packages/core/echo/echo-client/src/feed/feed-handle.ts
@@ -35,6 +35,15 @@ const TRACE_FEED_LOAD = false;
 // https://linear.app/dxos/issue/DX-449/queueappend-fails-when-there-are-too-many-objects-due-to-there-being
 const FEED_APPEND_BATCH_SIZE = 15;
 
+const RECONNECT_INITIAL_DELAY = 1_000;
+
+/**
+ * Ceiling for {@link FeedHandle.beginPolling}'s reconnect backoff after a stream error: the delay
+ * doubles after each failed attempt, capped here, and resets to {@link RECONNECT_INITIAL_DELAY} the
+ * moment a reconnected stream observes data.
+ */
+const RECONNECT_MAX_DELAY = 30_000;
+
 /**
  * Client-side handle for a single feed, backed by an EDGE queue.
  * Internal to echo-client — feed operations are exposed through {@link DatabaseImpl}.
@@ -68,6 +77,7 @@ export class FeedHandle {
       }
       this._error = err as Error;
       this._isLoading = false;
+      this.updated.emit();
     }
   });
 
@@ -150,6 +160,15 @@ export class FeedHandle {
 
   /** Cleanup for the active `FeedService.subscribeFeed` stream, set only while polling handlers > 0. */
   #feedSubscriptionCleanup: (() => void) | null = null;
+  /** Pending reconnect after a stream error; cancelled on unsubscribe/dispose. */
+  #reconnectTimer: NodeJS.Timeout | null = null;
+  /** Current reconnect delay; grows on repeated failures, resets once a reconnected stream observes data. */
+  #reconnectDelay = RECONNECT_INITIAL_DELAY;
+  /**
+   * Bumped on every unsubscribe-to-zero and every fresh {@link beginPolling}, invalidating any
+   * reconnect scheduled by a superseded subscription so it can't fire alongside a newer one.
+   */
+  #subscriptionGeneration = 0;
 
   constructor(
     private readonly _service: FeedService.Client,
@@ -560,38 +579,70 @@ export class FeedHandle {
    */
   beginPolling(): () => void {
     if (this._pollingHandlers++ === 0) {
-      this.#feedSubscriptionCleanup = subscribeStream(
-        this._runtime,
-        this._service['FeedService.subscribeFeed']({
-          query: {
-            feedNamespace: this._namespace,
-            spaceId: this._spaceId,
-            feedIds: [this._feedId],
-          },
-        }),
-        {
-          onData: (result) => {
-            const refreshId = ++this._refreshId;
-            void this.#applyQueryResult(refreshId, result);
-          },
-          onError: (error) => {
-            if (!(error instanceof RpcClosedError)) {
-              log.catch(error);
-            }
-            this._error = error;
-            this._isLoading = false;
-            this.updated.emit();
-          },
-        },
-      );
+      this.#reconnectDelay = RECONNECT_INITIAL_DELAY;
+      this.#subscribeToFeed(++this.#subscriptionGeneration);
     }
 
     return () => {
       if (--this._pollingHandlers === 0) {
-        this.#feedSubscriptionCleanup?.();
-        this.#feedSubscriptionCleanup = null;
+        this.#teardownFeedSubscription();
       }
     };
+  }
+
+  /**
+   * Opens the shared `subscribeFeed` stream. On a stream error (the RPC connection dropping, say)
+   * this reopens after a backoff delay rather than leaving the handle without updates for the rest
+   * of its session — the poll loop it replaced self-healed on its next tick, so this subscription
+   * needs an equivalent recovery path. `generation` guards a reconnect scheduled by an earlier,
+   * now-superseded subscription (unsubscribed, or replaced by a fresh `beginPolling()`) from firing.
+   */
+  #subscribeToFeed(generation: number): void {
+    this.#feedSubscriptionCleanup = subscribeStream(
+      this._runtime,
+      this._service['FeedService.subscribeFeed']({
+        query: {
+          feedNamespace: this._namespace,
+          spaceId: this._spaceId,
+          feedIds: [this._feedId],
+        },
+      }),
+      {
+        onData: (result) => {
+          this.#reconnectDelay = RECONNECT_INITIAL_DELAY;
+          const refreshId = ++this._refreshId;
+          void this.#applyQueryResult(refreshId, result);
+        },
+        onError: (error) => {
+          if (!(error instanceof RpcClosedError)) {
+            log.catch(error);
+          }
+          this._error = error;
+          this._isLoading = false;
+          this.#feedSubscriptionCleanup = null;
+          this.updated.emit();
+          if (generation === this.#subscriptionGeneration && this._pollingHandlers > 0 && !this._ctx.disposed) {
+            const delay = this.#reconnectDelay;
+            this.#reconnectDelay = Math.min(this.#reconnectDelay * 2, RECONNECT_MAX_DELAY);
+            this.#reconnectTimer = setTimeout(() => {
+              this.#reconnectTimer = null;
+              this.#subscribeToFeed(generation);
+            }, delay);
+          }
+        },
+      },
+    );
+  }
+
+  /** Tears down the active subscription and cancels any pending reconnect. */
+  #teardownFeedSubscription(): void {
+    this.#subscriptionGeneration++;
+    if (this.#reconnectTimer) {
+      clearTimeout(this.#reconnectTimer);
+      this.#reconnectTimer = null;
+    }
+    this.#feedSubscriptionCleanup?.();
+    this.#feedSubscriptionCleanup = null;
   }
 
   async dispose() {
@@ -601,8 +652,7 @@ export class FeedHandle {
     await this.waitForPendingWrites();
 
     this._pollingHandlers = 0;
-    this.#feedSubscriptionCleanup?.();
-    this.#feedSubscriptionCleanup = null;
+    this.#teardownFeedSubscription();
     for (const core of this.#cores.values()) {
       core.dispose();
     }

--- a/packages/core/echo/echo-client/src/feed/feed-handle.ts
+++ b/packages/core/echo/echo-client/src/feed/feed-handle.ts
@@ -23,7 +23,7 @@ import { defineHiddenProperty } from '@dxos/echo/internal';
 import { failedInvariant, invariant } from '@dxos/invariant';
 import { EID, EntityId, type SpaceId } from '@dxos/keys';
 import { log } from '@dxos/log';
-import { runServiceCall } from '@dxos/protocols';
+import { RpcClosedError, runServiceCall, subscribeStream } from '@dxos/protocols';
 import { type FeedService } from '@dxos/protocols/rpc';
 
 import { type DatabaseImpl } from '../proxy-db';
@@ -34,15 +34,6 @@ const TRACE_FEED_LOAD = false;
 // Appending large amount of objects at once is not supported by the server.
 // https://linear.app/dxos/issue/DX-449/queueappend-fails-when-there-are-too-many-objects-due-to-there-being
 const FEED_APPEND_BATCH_SIZE = 15;
-
-const POLLING_INTERVAL = 1_000;
-
-/**
- * Ceiling for the no-change backoff in {@link FeedHandle.beginPolling}: the delay doubles after
- * each poll that finds nothing new, capped here, and resets to {@link POLLING_INTERVAL} the moment
- * a poll observes a change.
- */
-const MAX_POLLING_INTERVAL = 30_000;
 
 /**
  * Client-side handle for a single feed, backed by an EDGE queue.
@@ -55,12 +46,10 @@ export class FeedHandle {
 
   private readonly _refreshTask = new DeferredTask(this._ctx, async () => {
     const thisRefreshId = ++this._refreshId;
-    let changed = false;
-    let succeeded = false;
     try {
       TRACE_FEED_LOAD &&
         log.info('feed refresh begin', { currentObjects: this._objects.length, refreshId: thisRefreshId });
-      const { objects } = await runServiceCall(
+      const result = await runServiceCall(
         this._runtime,
         this._service['FeedService.queryFeed']({
           query: {
@@ -70,43 +59,7 @@ export class FeedHandle {
           },
         }),
       );
-      TRACE_FEED_LOAD && log.info('items fetched', { refreshId: thisRefreshId, count: objects?.length ?? 0 });
-      if (thisRefreshId !== this._refreshId) {
-        return;
-      }
-      if (this._ctx.disposed) {
-        return;
-      }
-
-      const parsedObjects = (objects ?? []).flatMap((encoded) => {
-        try {
-          const obj = JSON.parse(encoded) as ObjectJSON;
-          if (!EntityId.isValid(obj.id)) {
-            log.verbose('feed object missing valid id; ignored', { obj });
-            return [];
-          }
-          return [obj];
-        } catch (err) {
-          log.verbose('feed object JSON parse failed; object ignored', { encoded, error: err });
-          return [];
-        }
-      });
-
-      // Routes through the same core-tracking materialization as query hydration, so a polled
-      // re-read never clobbers a not-yet-echoed local `Obj.update` and preserves entity identity.
-      const decodedObjects = await Promise.all(parsedObjects.map((obj) => this.upsertFromJSON(obj))).then((objects) =>
-        objects.filter(Predicate.isNotUndefined),
-      );
-
-      if (thisRefreshId !== this._refreshId) {
-        return;
-      }
-
-      changed = objectSetChanged(this._objects, decodedObjects);
-
-      TRACE_FEED_LOAD && log.info('feed refresh', { changed, objects: objects?.length ?? 0, refreshId: thisRefreshId });
-      this._objects = decodedObjects;
-      succeeded = true;
+      await this.#applyQueryResult(thisRefreshId, result);
     } catch (err) {
       // TODO(dmaretskyi): This task occasionally fails with "The database connection is not open" error in tests -- some issue with teardown ordering.
       //                   We should find the root cause and fix it instead of muting the error.
@@ -114,17 +67,55 @@ export class FeedHandle {
         log.catch(err);
       }
       this._error = err as Error;
-    } finally {
       this._isLoading = false;
-      // Only a successful, quiet poll should widen the backoff — a failed (or superseded/disposed)
-      // attempt tells us nothing about whether the feed actually changed, so treat it like a change
-      // for backoff purposes and retry promptly rather than compounding an existing delay.
-      this.#lastPollWasQuiet = succeeded && !changed;
-      if (changed) {
-        this.updated.emit();
-      }
     }
   });
+
+  /**
+   * Applies a `queryFeed`/`subscribeFeed` snapshot to the working set, shared by the manual
+   * one-shot {@link _refreshTask} and {@link beginPolling}'s streaming subscription. `refreshId`
+   * guards against a superseded response (an overlapping manual {@link refresh} or a later stream
+   * push) clobbering fresher state that already landed.
+   */
+  async #applyQueryResult(refreshId: number, result: FeedService.FeedQueryResult): Promise<void> {
+    const { objects } = result;
+    TRACE_FEED_LOAD && log.info('items fetched', { refreshId, count: objects?.length ?? 0 });
+    if (refreshId !== this._refreshId || this._ctx.disposed) {
+      return;
+    }
+
+    const parsedObjects = (objects ?? []).flatMap((encoded) => {
+      try {
+        const obj = JSON.parse(encoded) as ObjectJSON;
+        if (!EntityId.isValid(obj.id)) {
+          log.verbose('feed object missing valid id; ignored', { obj });
+          return [];
+        }
+        return [obj];
+      } catch (err) {
+        log.verbose('feed object JSON parse failed; object ignored', { encoded, error: err });
+        return [];
+      }
+    });
+
+    // Routes through the same core-tracking materialization as query hydration, so a refreshed
+    // re-read never clobbers a not-yet-echoed local `Obj.update` and preserves entity identity.
+    const decodedObjects = await Promise.all(parsedObjects.map((obj) => this.upsertFromJSON(obj))).then((objects) =>
+      objects.filter(Predicate.isNotUndefined),
+    );
+
+    if (refreshId !== this._refreshId) {
+      return;
+    }
+
+    const changed = objectSetChanged(this._objects, decodedObjects);
+    TRACE_FEED_LOAD && log.info('feed refresh', { changed, objects: objects?.length ?? 0, refreshId });
+    this._objects = decodedObjects;
+    this._isLoading = false;
+    if (changed) {
+      this.updated.emit();
+    }
+  }
 
   /**
    * Debounces `Obj.update` mutations on live feed objects into a single background append per
@@ -157,21 +148,8 @@ export class FeedHandle {
   private _refreshId = 0;
   private _loadObjectsPromise: Promise<Entity.Unknown[]> | undefined;
 
-  /**
-   * Whether the most recent poll succeeded and found no object-set change — the only case that
-   * should widen the backoff in {@link beginPolling}. A failed, superseded, or disposed attempt
-   * resets it to `false` (fast retry) since it can't tell us the feed is actually quiet.
-   */
-  #lastPollWasQuiet = false;
-  /** Current delay between polls; grows on quiet ticks, resets to {@link POLLING_INTERVAL} otherwise. */
-  #currentPollingDelay = POLLING_INTERVAL;
-  /**
-   * Bumped each time the last polling handler unsubscribes, invalidating any `poll()` iteration
-   * still awaiting `_refreshTask.runBlocking()` from that generation — otherwise a fresh
-   * `beginPolling()` call racing that in-flight await can end up with two self-rescheduling poll
-   * loops running concurrently, each issuing its own `FeedService.queryFeed` RPC.
-   */
-  #pollingGeneration = 0;
+  /** Cleanup for the active `FeedService.subscribeFeed` stream, set only while polling handlers > 0. */
+  #feedSubscriptionCleanup: (() => void) | null = null;
 
   constructor(
     private readonly _service: FeedService.Client,
@@ -576,35 +554,42 @@ export class FeedHandle {
     return decodedObjects;
   }
 
-  private _pollingInterval: NodeJS.Timeout | null = null;
-
+  /**
+   * Subscribes to `FeedService.subscribeFeed`, replacing the previous poll-timer loop with a real
+   * server-push subscription — ref-counted so concurrent callers share one underlying stream.
+   */
   beginPolling(): () => void {
     if (this._pollingHandlers++ === 0) {
-      const generation = ++this.#pollingGeneration;
-      this.#currentPollingDelay = POLLING_INTERVAL;
-      const poll = async () => {
-        await this._refreshTask.runBlocking();
-        // The generation check rejects a stale iteration: if the last handler unsubscribed and a
-        // new `beginPolling()` call started its own generation while this `await` was pending, this
-        // iteration must not reschedule alongside it.
-        if (generation === this.#pollingGeneration && this._pollingHandlers > 0 && !this._ctx.disposed) {
-          // No-change backoff: an idle feed widens its own poll interval instead of holding at 1 Hz
-          // forever, and snaps back to POLLING_INTERVAL the moment a poll observes real change (or
-          // fails to observe anything conclusive at all).
-          this.#currentPollingDelay = this.#lastPollWasQuiet
-            ? Math.min(this.#currentPollingDelay * 2, MAX_POLLING_INTERVAL)
-            : POLLING_INTERVAL;
-          this._pollingInterval = setTimeout(poll, this.#currentPollingDelay);
-        }
-      };
-      queueMicrotask(poll);
+      this.#feedSubscriptionCleanup = subscribeStream(
+        this._runtime,
+        this._service['FeedService.subscribeFeed']({
+          query: {
+            feedNamespace: this._namespace,
+            spaceId: this._spaceId,
+            feedIds: [this._feedId],
+          },
+        }),
+        {
+          onData: (result) => {
+            const refreshId = ++this._refreshId;
+            void this.#applyQueryResult(refreshId, result);
+          },
+          onError: (error) => {
+            if (!(error instanceof RpcClosedError)) {
+              log.catch(error);
+            }
+            this._error = error;
+            this._isLoading = false;
+            this.updated.emit();
+          },
+        },
+      );
     }
 
     return () => {
       if (--this._pollingHandlers === 0) {
-        this.#pollingGeneration++;
-        clearTimeout(this._pollingInterval!);
-        this._pollingInterval = null;
+        this.#feedSubscriptionCleanup?.();
+        this.#feedSubscriptionCleanup = null;
       }
     };
   }
@@ -616,10 +601,8 @@ export class FeedHandle {
     await this.waitForPendingWrites();
 
     this._pollingHandlers = 0;
-    if (this._pollingInterval) {
-      clearTimeout(this._pollingInterval);
-      this._pollingInterval = null;
-    }
+    this.#feedSubscriptionCleanup?.();
+    this.#feedSubscriptionCleanup = null;
     for (const core of this.#cores.values()) {
       core.dispose();
     }

--- a/packages/core/echo/echo-host/src/db-host/feed-service.test.ts
+++ b/packages/core/echo/echo-host/src/db-host/feed-service.test.ts
@@ -222,4 +222,40 @@ describe('LocalFeedServiceImpl', () => {
       }).pipe(Effect.provide(TestLayer)),
     ),
   );
+
+  it.effect('subscribeFeed pushes an initial snapshot, then another on a local write', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const feedStore = new FeedStore({ localActorId: 'actor-id', assignPositions: true });
+        const runtime = yield* RuntimeProvider.currentRuntime<SqlClient.SqlClient | SqlTransaction.SqlTransaction>();
+        const service = new LocalFeedServiceImpl(runtime, feedStore);
+        yield* feedStore.migrate();
+
+        const spaceId = SpaceId.random();
+        const feedId = EntityId.random();
+        const object1 = { id: 'obj1', data: 'test1' };
+
+        // A scoped pull, rather than a timing-based delay before the write, guarantees the
+        // initial snapshot is consumed before the write fires -- so the second pull can only
+        // resolve from the write's `FeedStore.onNewBlocks` signal, never from a race.
+        const pull = yield* EffectStream.toPull(
+          service['FeedService.subscribeFeed']({ query: { spaceId, feedIds: [feedId] } }),
+        );
+
+        const [initial] = yield* pull;
+        expect(initial.objects).toHaveLength(0);
+
+        yield* service['FeedService.insertIntoFeed']({
+          subspaceTag: FeedProtocol.WellKnownNamespaces.data,
+          spaceId,
+          feedId,
+          objects: [JSON.stringify(object1)],
+        });
+
+        const [next] = yield* pull;
+        expect(next.objects).toHaveLength(1);
+        expect(JSON.parse(next.objects![0])).toMatchObject(object1);
+      }).pipe(Effect.provide(TestLayer)),
+    ),
+  );
 });

--- a/packages/core/echo/echo-host/src/db-host/local-feed-service.ts
+++ b/packages/core/echo/echo-host/src/db-host/local-feed-service.ts
@@ -46,35 +46,51 @@ export class LocalFeedServiceImpl implements FeedService.Handlers {
 
   ['FeedService.queryFeed'](request: FeedService.QueryFeedRequest): Effect.Effect<FeedService.FeedQueryResult, Error> {
     return Effect.tryPromise({
-      try: async () => {
-        const { query } = request;
-        invariant(query, 'query is required');
-        const { spaceId, feedIds } = query;
-        return RuntimeProvider.runPromise(this.#runtime)(
-          Effect.gen({ self: this }, function* () {
-            const result = yield* this.#feedStore.query({
-              requestId: crypto.randomUUID(),
-              feedNamespace: request.query.feedNamespace || FeedProtocol.WellKnownNamespaces.data,
-              spaceId: spaceId! as SpaceId,
-              query: { feedIds: feedIds ?? [] },
-              cursor: query.after ? FeedProtocol.FeedCursor.make(query.after) : undefined,
-              limit: query.limit,
-            });
-
-            const objects = result.blocks.map((block: FeedProtocol.Block) =>
-              JSON.stringify(EchoFeedCodec.decode(block.data, block.position ?? undefined) as ObjectJSON),
-            );
-
-            return Function.identity<FeedService.FeedQueryResult>({
-              objects,
-              nextCursor: result.nextCursor,
-              prevCursor: '',
-            });
-          }),
-        );
-      },
+      try: () => this.#queryFeedImpl(request),
       catch: (error) => error as Error,
     });
+  }
+
+  /**
+   * Pushes a fresh query snapshot on subscribe, then again whenever {@link FeedStore.onNewBlocks}
+   * fires and the recomputed snapshot actually differs from the last one sent -- replacing the
+   * client's previous poll loop with a real subscription. Unlike `subscribeSyncState`'s small
+   * aggregate payload, this recomputation re-fetches the feed's full object set on every signal, so
+   * suppressing unchanged snapshots server-side (rather than leaving dedup to the client) matters
+   * more here.
+   */
+  ['FeedService.subscribeFeed'](
+    request: FeedService.QueryFeedRequest,
+  ): EffectStream.Stream<FeedService.FeedQueryResult, Error> {
+    return this.#recomputeOnNewBlocks(() => this.#queryFeedImpl(request), feedQueryResultChanged);
+  }
+
+  async #queryFeedImpl(request: FeedService.QueryFeedRequest): Promise<FeedService.FeedQueryResult> {
+    const { query } = request;
+    invariant(query, 'query is required');
+    const { spaceId, feedIds } = query;
+    return RuntimeProvider.runPromise(this.#runtime)(
+      Effect.gen({ self: this }, function* () {
+        const result = yield* this.#feedStore.query({
+          requestId: crypto.randomUUID(),
+          feedNamespace: request.query.feedNamespace || FeedProtocol.WellKnownNamespaces.data,
+          spaceId: spaceId! as SpaceId,
+          query: { feedIds: feedIds ?? [] },
+          cursor: query.after ? FeedProtocol.FeedCursor.make(query.after) : undefined,
+          limit: query.limit,
+        });
+
+        const objects = result.blocks.map((block: FeedProtocol.Block) =>
+          JSON.stringify(EchoFeedCodec.decode(block.data, block.position ?? undefined) as ObjectJSON),
+        );
+
+        return Function.identity<FeedService.FeedQueryResult>({
+          objects,
+          nextCursor: result.nextCursor,
+          prevCursor: '',
+        });
+      }),
+    );
   }
 
   ['FeedService.insertIntoFeed'](request: FeedService.InsertIntoFeedRequest): Effect.Effect<void, Error> {
@@ -156,12 +172,23 @@ export class LocalFeedServiceImpl implements FeedService.Handlers {
   ['FeedService.subscribeSyncState'](
     request: FeedService.GetSyncStateRequest,
   ): EffectStream.Stream<FeedService.GetSyncStateResponse, Error> {
-    return EffectEx.streamFromEmitter<FeedService.GetSyncStateResponse, Error>((emit) => {
+    return this.#recomputeOnNewBlocks(() => this.#getSyncStateImpl(request), syncStateResponseChanged);
+  }
+
+  /**
+   * Shared by every `subscribeX` RPC: pushes `compute()`'s result on subscribe, then again whenever
+   * {@link FeedStore.onNewBlocks} fires and `changed` says the recomputed value actually differs from
+   * the last one sent. Coalesced, not concurrent -- an `onNewBlocks` signal that arrives
+   * mid-recomputation only marks `dirty` rather than starting a second overlapping read, so a slow
+   * recomputation can never finish after (and thus emit over) a faster, later one.
+   */
+  #recomputeOnNewBlocks<T>(
+    compute: () => Promise<T>,
+    changed: (before: T, after: T) => boolean,
+  ): EffectStream.Stream<T, Error> {
+    return EffectEx.streamFromEmitter<T, Error>((emit) => {
       const ctx = Context.default();
-      let last: FeedService.GetSyncStateResponse | undefined;
-      // Coalesced, not concurrent: an `onNewBlocks` signal that arrives mid-recomputation only
-      // marks `dirty` rather than starting a second overlapping read, so a slow recomputation can
-      // never finish after (and thus emit over) a faster, later one.
+      let last: T | undefined;
       let running = false;
       let dirty = false;
       const recompute = async () => {
@@ -173,8 +200,8 @@ export class LocalFeedServiceImpl implements FeedService.Handlers {
         try {
           do {
             dirty = false;
-            const next = await this.#getSyncStateImpl(request);
-            if (!last || syncStateResponseChanged(last, next)) {
+            const next = await compute();
+            if (!last || changed(last, next)) {
               last = next;
               emit.single(next);
             }
@@ -254,4 +281,21 @@ const syncStateResponseChanged = (
       namespaceState.totalBlocks !== other.totalBlocks
     );
   });
+};
+
+/**
+ * String equality on the encoded objects (not a decoded/semantic diff) plus cursors -- cheap, and
+ * exact enough: a feed only grows via new blocks, so any real content change shows up as an
+ * appended or altered entry in `objects`, or a moved cursor.
+ */
+const feedQueryResultChanged = (before: FeedService.FeedQueryResult, after: FeedService.FeedQueryResult): boolean => {
+  if (before.nextCursor !== after.nextCursor || before.prevCursor !== after.prevCursor) {
+    return true;
+  }
+  const beforeObjects = before.objects ?? [];
+  const afterObjects = after.objects ?? [];
+  if (beforeObjects.length !== afterObjects.length) {
+    return true;
+  }
+  return beforeObjects.some((object, index) => object !== afterObjects[index]);
 };

--- a/packages/core/protocols/src/FeedService.ts
+++ b/packages/core/protocols/src/FeedService.ts
@@ -148,6 +148,16 @@ export class Rpcs extends RpcGroup.make(
     success: FeedQueryResult,
     error: serviceError,
   }),
+  /**
+   * Pushes a new query snapshot whenever the feed's contents change, so a client can subscribe
+   * instead of polling {@link queryFeed} on a timer.
+   */
+  Rpc.make('subscribeFeed', {
+    payload: QueryFeedRequest,
+    success: FeedQueryResult,
+    error: serviceError,
+    stream: true,
+  }),
   Rpc.make('insertIntoFeed', {
     payload: InsertIntoFeedRequest,
     error: serviceError,


### PR DESCRIPTION
## Summary

Follow-up to #12580 (memory-usage project, Phase 4 idle churn). That PR upgraded site S3 (space sync-state polling) from a client-side no-change backoff to a real streaming RPC. This PR does the same for site S2, `FeedHandle`'s 1Hz(+backoff) content polling, turning it into a real subscription end to end:

- **New RPC**: `FeedService.subscribeFeed` (`stream: true`), added by hand in `packages/core/protocols/src/FeedService.ts` alongside `subscribeSyncState` — same hand-authored-schema file, same reasoning (see that file's header / #12580's description).
- **Server** (`LocalFeedServiceImpl`, `echo-host`): pushes a fresh `queryFeed` snapshot on subscribe, then again whenever `FeedStore.onNewBlocks` fires and the recomputed snapshot actually differs from the last one sent — string-compared against the last snapshot, since this payload is real object content rather than `subscribeSyncState`'s small aggregate count, so suppressing unchanged pushes server-side matters more here. The two `subscribeX` RPCs share identical recompute-on-`onNewBlocks`-and-coalesce logic, now factored into `LocalFeedServiceImpl#recomputeOnNewBlocks`, parameterized by a compute function and a change comparator.
- **Client** (`FeedHandle.beginPolling`, `echo-client`): now subscribes via `subscribeStream` instead of running its own poll timer with no-change backoff. The still-present one-shot `refresh()` path shares the same decode/upsert/diff logic via a new `#applyQueryResult` helper.
- **functions-runtime-cloudflare**: `FeedServiceImpl` (an unrelated Cloudflare-queue-backed runtime with no change-notification mechanism) implements the new RPC as a single-snapshot stream, matching its existing one-shot `queryFeed` behavior.

Decision recorded in `.agents/projects/memory-usage/TASKS.md` (S2 entry); the R2/R3/R6 remedy notes are updated to reflect S2 and S3 both being past the backoff-polling stage now.

## Test plan

- [x] New test: `echo-host/src/db-host/feed-service.test.ts` — `subscribeFeed` pushes an initial (empty) snapshot, then a second one after a local write
- [x] `moon run echo-host:test` — 280/280 passing (7 in `feed-service.test.ts`, incl. the new test)
- [x] `moon run echo-client:test` — 523 passing / 7 expected-fail / 12 skipped / 2 todo (unchanged from baseline, incl. multi-peer feed-hydration tests exercising `beginPolling`)
- [x] `moon run echo-client-e2e:test` — 294 passing / 1 expected-fail / 7 skipped
- [x] `moon run client-services:test` — 165 passing / 3 skipped
- [x] `moon run protocols:build echo-host:build echo-client:build functions-runtime-cloudflare:build client-services:build client:build` — all clean
- [x] `moon run protocols:lint echo-host:lint echo-client:lint functions-runtime-cloudflare:lint`
- [x] `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwgNG6Ehcs8rC75PoVZSiW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Feed content now updates through a real-time streaming connection instead of periodic polling.
  - Displays an initial feed snapshot and automatically delivers subsequent changes as new content becomes available.
  - Improved handling of feed loading states, stale updates, and connection interruptions.

- **Bug Fixes**
  - Prevents redundant updates by coalescing unchanged feed results.

- **Documentation**
  - Updated release tracking to reflect completed streaming feed work and remaining synchronization items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->