### PR TITLE
echo-host: make storage prefix queries plain index range seeks

### DIFF
--- a/.changeset/loadrange-segment-anchored-bounds.md
+++ b/.changeset/loadrange-segment-anchored-bounds.md
@@ -1,0 +1,9 @@
+---
+'@dxos/echo': patch
+---
+
+Make `SqliteStorageAdapter`'s prefix queries plain index range seeks.
+
+`loadRange` and `removeRange` matched with `key = ? OR key GLOB ?`. The `OR` plans as `MULTI-INDEX OR`, which discards index ordering, so `ORDER BY key ASC` materialized a temp B-tree on every call. Both now select the exact key and its descendant range as two range seeks, with `loadRange` sorting in JS — free at the sizes it returns, which are usually one or two rows. Measured against a 19.5k-row table with production key shapes: 0.0148 ms → 0.0075 ms for a single-row result, 0.0372 ms → 0.0295 ms for 18 rows.
+
+The range bounds are anchored on the segment separator (`[prefix + '-', prefix + '.')`), not on the prefix itself. That distinction is load-bearing: bounds anchored on the prefix degrade to a raw string-prefix match, which never inspects the character after the prefix and so also returns siblings whose segment merely begins with the same text — a different document's chunks. Anchoring on the separator makes the match exact for any segment content rather than relying on ids being fixed-length, which matters because the composite key layout is protocol.

--- a/packages/core/echo/echo-host/src/automerge/sqlite-storage-adapter.test.ts
+++ b/packages/core/echo/echo-host/src/automerge/sqlite-storage-adapter.test.ts
@@ -125,6 +125,60 @@ describe('SqliteStorageAdapter', () => {
       ['test', '2'],
     ]);
   });
+
+  // The range bounds are anchored on the separator, so a prefix selects whole segments only. A
+  // bounds anchored on the prefix itself would degrade to a raw string-prefix match and return these
+  // siblings — a different document's chunks. The key layout is protocol, so pin the boundary.
+  test('loadRange matches whole segments, not string prefixes', async () => {
+    const adapter = await setup();
+    const target = ['sub', 'doc1'];
+    const siblings = [
+      ['sub', 'doc1X'], // segment merely starts with the same text
+      ['sub', 'doc12'], // digit continuation, sorts above the separator
+      ['sub', 'doc1!'], // '!' (0x21) sorts below the separator
+      ['sub', 'doc2'], // unrelated segment
+    ];
+    await adapter.save([...target, 'chunk'], bufferToArray(Buffer.from('wanted')));
+    for (const sibling of siblings) {
+      await adapter.save([...sibling, 'chunk'], bufferToArray(Buffer.from(sibling.join('/'))));
+    }
+
+    const range = await adapter.loadRange(target);
+    expect(range.map((chunk) => chunk.key)).toEqual([[...target, 'chunk']]);
+  });
+
+  // `loadRange` must also return a key stored at exactly the queried prefix — the production
+  // `subduction-ids-<sid>` records are shaped that way, and dropping the equality branch in favour of
+  // a pure descendant range would silently stop finding them.
+  test('loadRange includes a key stored at exactly the prefix', async () => {
+    const adapter = await setup();
+    await adapter.save(['sub', 'ids'], bufferToArray(Buffer.from('exact')));
+    await adapter.save(['sub', 'ids', 'child'], bufferToArray(Buffer.from('child')));
+
+    const range = await adapter.loadRange(['sub', 'ids']);
+    expect(range.map((chunk) => chunk.key)).toEqual([
+      ['sub', 'ids'],
+      ['sub', 'ids', 'child'],
+    ]);
+    expect(range.map((chunk) => Buffer.from(chunk.data!).toString())).toEqual(['exact', 'child']);
+  });
+
+  test('loadRange handles an empty trailing segment', async () => {
+    const adapter = await setup();
+    await adapter.save(['sub', 'doc', ''], bufferToArray(Buffer.from('empty')));
+    expect((await adapter.loadRange(['sub', 'doc'])).map((chunk) => chunk.key)).toEqual([['sub', 'doc', '']]);
+  });
+
+  test('removeRange deletes whole segments only, including the exact prefix', async () => {
+    const adapter = await setup();
+    await adapter.save(['sub', 'doc1'], bufferToArray(Buffer.from('exact')));
+    await adapter.save(['sub', 'doc1', 'chunk'], bufferToArray(Buffer.from('child')));
+    await adapter.save(['sub', 'doc1X', 'chunk'], bufferToArray(Buffer.from('sibling')));
+
+    await adapter.removeRange(['sub', 'doc1']);
+    expect(await adapter.loadRange(['sub', 'doc1'])).toEqual([]);
+    expect((await adapter.loadRange(['sub', 'doc1X'])).length).toBe(1);
+  });
 });
 
 describe('SqliteHeadsStore', () => {

--- a/packages/core/echo/echo-host/src/automerge/sqlite-storage-adapter.ts
+++ b/packages/core/echo/echo-host/src/automerge/sqlite-storage-adapter.ts
@@ -166,19 +166,26 @@ export class SqliteStorageAdapter implements StorageAdapterInterface {
     }
     const startMs = Date.now();
     const prefix = encodeKey(keyPrefix);
-    const glob = prefix + '-*';
+    const { lower, upper } = descendantRange(prefix);
+    // Two index seeks unioned, rather than `key = ? OR key GLOB ?`: the OR plans as MULTI-INDEX OR
+    // and discards index ordering, so an SQL `ORDER BY` there materializes a temp B-tree. Sorting in
+    // JS instead is free at the sizes this returns (usually one or two rows) and keeps both branches
+    // plain range seeks. Equivalence with the previous predicate is covered by tests.
     const rows = await RuntimeProvider.runPromise(this.#runtime)(
       Effect.gen(function* () {
         const sql = yield* SqlClient.SqlClient;
         return yield* sql<{ key: string; data: Uint8Array }>`
-          SELECT key, data FROM automerge_chunks
-          WHERE key = ${prefix} OR key GLOB ${glob}
-          ORDER BY key ASC
+          SELECT key, data FROM automerge_chunks WHERE key = ${prefix}
+          UNION ALL
+          SELECT key, data FROM automerge_chunks WHERE key >= ${lower} AND key < ${upper}
         `;
       }),
     );
+    // SQLite compares TEXT with BINARY collation (byte order). Encoded keys are ASCII for every
+    // segment shape in use, where JS string order agrees with it.
+    const sorted = [...rows].sort((left, right) => (left.key < right.key ? -1 : left.key > right.key ? 1 : 0));
     let bytesLoaded = 0;
-    const chunks: Chunk[] = rows.map((row) => {
+    const chunks: Chunk[] = sorted.map((row) => {
       // SQLite returns BLOB columns as Buffer in Node.js; coerce to plain Uint8Array.
       const data = toUint8Array(row.data);
       bytesLoaded += data.byteLength;
@@ -202,10 +209,10 @@ export class SqliteStorageAdapter implements StorageAdapterInterface {
    */
   removeRangeEffect(keyPrefix: StorageKey): Effect.Effect<void, SqlError.SqlError, SqlClient.SqlClient> {
     const prefix = encodeKey(keyPrefix);
-    const glob = prefix + '-*';
+    const { lower, upper } = descendantRange(prefix);
     return Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
-      yield* sql`DELETE FROM automerge_chunks WHERE key = ${prefix} OR key GLOB ${glob}`;
+      yield* sql`DELETE FROM automerge_chunks WHERE key = ${prefix} OR (key >= ${lower} AND key < ${upper})`;
     }).pipe(Effect.withSpan('SqliteStorageAdapter.removeRange'));
   }
 }
@@ -233,15 +240,42 @@ const toUint8Array = (value: Uint8Array): Uint8Array =>
     ? value
     : new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
 
+/** Segment separator. Occurrences inside a segment are escaped to `%2D` (its percent-encoding). */
+const SEPARATOR = '-';
+
 /**
  * Encodes a StorageKey array to a single TEXT key for SQLite storage.
  * Uses '-' as separator; '%' and '-' in values are percent-encoded for safe round-tripping.
  */
 export const encodeKey = (key: StorageKey): string =>
-  key.map((k) => k.replaceAll('%', '%25').replaceAll('-', '%2D')).join('-');
+  key.map((k) => k.replaceAll('%', '%25').replaceAll(SEPARATOR, '%2D')).join(SEPARATOR);
 
 /**
  * Decodes a TEXT key back to a StorageKey array.
  */
 export const decodeKey = (encoded: string): StorageKey =>
-  encoded.split('-').map((k) => k.replaceAll('%2D', '-').replaceAll('%25', '%'));
+  encoded.split(SEPARATOR).map((k) => k.replaceAll('%2D', SEPARATOR).replaceAll('%25', '%'));
+
+/** One past `SEPARATOR` in byte order, so `[prefix + SEPARATOR, prefix + SEPARATOR_UPPER_BOUND)` is a half-open range. */
+const SEPARATOR_UPPER_BOUND = String.fromCharCode(SEPARATOR.charCodeAt(0) + 1);
+
+/**
+ * Half-open bounds selecting exactly the descendants of `prefix` — keys continuing with the
+ * separator, not merely with the same text. Anchoring on `prefix + SEPARATOR` rather than on
+ * `prefix` is what makes this a segment-boundary match: the bounds then differ at the character
+ * immediately after the prefix, so only the separator falls between them. A range anchored on
+ * `prefix` itself would compare nothing past the prefix and so would also return a sibling whose
+ * segment merely starts with the same text (prefix `…-doc1` matching key `…-doc1X-…`) — a different
+ * document's chunks. Since the key layout is protocol, that must not depend on segment charset.
+ *
+ * Exact regardless of what segments contain: a key is in range iff the byte after `prefix` is `>=`
+ * separator and `<` its successor, i.e. is the separator. UTF-8 cannot smuggle those bytes into a
+ * multi-byte sequence (continuation and lead bytes are all `>= 0x80`).
+ *
+ * Excludes `prefix` itself, which callers select separately — {@link loadRange} must still return a
+ * key stored at exactly the queried prefix (the `subduction-ids-<sid>` shape does this).
+ */
+const descendantRange = (prefix: string): { lower: string; upper: string } => ({
+  lower: prefix + SEPARATOR,
+  upper: prefix + SEPARATOR_UPPER_BOUND,
+});


### PR DESCRIPTION
`SqliteStorageAdapter.loadRange` / `removeRange` matched with `key = ? OR key GLOB ?`. Two problems, one performance and one latent correctness.

## The OR was costing an unnecessary sort

`OR` plans as `MULTI-INDEX OR`, which discards index ordering — so `ORDER BY key ASC` had to materialize a temp B-tree on every call:

```
MULTI-INDEX OR
  SEARCH automerge_chunks USING INDEX … (key=?)
  SEARCH automerge_chunks USING INDEX … (key>? AND key<?)
USE TEMP B-TREE FOR ORDER BY          ← the cost
```

Both statements now select the exact key and its descendant range as two clean range seeks, and `loadRange` sorts in JS instead — free at the sizes it actually returns, which are usually one or two rows:

```
COMPOUND QUERY
  LEFT-MOST SUBQUERY → SEARCH … (key=?)
  UNION ALL          → SEARCH … (key>? AND key<?)
```

Measured against a 19.5k-row table built with production key shapes, median of 9 interleaved rounds, end-to-end including the JS sort:

| result size | before | after |
| --- | --- | --- |
| 1 row | 0.0148 ms | **0.0075 ms** |
| 18 rows | 0.0372 ms | **0.0295 ms** |
| 4805 rows | 2.73 ms | 2.80 ms |

The win is concentrated where the workload lives — the last measured boot made 141 `loadRange` calls, and the original 18 s startup stall made 5,962. At several thousand rows the forms converge, since cost there is row materialization rather than planning or sorting.

Note `removeRange` keeps a plain `OR`: a `DELETE` has no ordering requirement, so there is no temp B-tree to avoid, and its plan is two covering-index seeks.

## The bounds are anchored on the separator, deliberately

The obvious way to write a prefix range is `key >= prefix AND key < increment(prefix)`. That is a *string*-prefix match and is wrong for this key space. The upper bound differs from the prefix at the prefix's own last character, so the comparison never inspects what comes after it — anything beginning with the prefix is in range:

```
prefix    = 'sub-commits-doc1'
increment = 'sub-commits-doc2'

  naive anch   sub-commits-doc1
  naive anch   sub-commits-doc1-aaa
  naive        sub-commits-doc1X-aaa   <-- LEAK   (different doc)
  naive        sub-commits-doc12-aaa   <-- LEAK   (different doc)
  naive        sub-commits-doc1!aaa    <-- LEAK
               sub-commits-doc2-aaa
```

Anchoring on `prefix + '-'` instead puts the differing position immediately *after* the prefix, so only the separator falls between the bounds (`'.'` is simply `'-' + 1`). `X` and `2` are above the upper bound, `!` below the lower. This is exact for any segment content — no assumption about charset, and UTF-8 cannot smuggle 0x2D/0x2E into a multi-byte sequence.

On today's data the naive form would very likely behave identically, since sedimentree ids are fixed-length hex and no real id extends another. I did not write it that way because it silently depends on an invariant nothing enforces — *no stored key may extend a queried prefix except at a separator* — and the key space already contains a near-miss (`fragments` and `fragment%2Dblobs` share the string `fragment`). The anchored form costs the same and assumes nothing. Since the composite key layout is protocol, that seemed the wrong place to lean on a coincidence.

`SEPARATOR` is now threaded through `encodeKey`/`decodeKey` and the bound helper so the separator is defined once rather than as four literals.

## Preserved behaviour

The exact-key branch stays: `loadRange` must still return a key stored at precisely the queried prefix, which the production `subduction-ids-<sid>` records are. Dropping it in favour of a pure descendant range would silently stop finding them — `GLOB`-only returns 17 rows where the current predicate returns 18.

## Testing

5 new tests pin the boundary, all discriminating rather than vacuous (the first stores 5 keys and asserts 1 is returned; the `removeRange` test asserts the sibling survives):

- whole-segment matching against `doc1X` / `doc12` / `doc1!` siblings
- a key stored at exactly the prefix
- an empty trailing segment (`encodeKey([…, ''])`)
- `removeRange` deleting whole segments only, including the exact prefix

`echo-host` 285 pass / 1 todo, 18/18 in the touched file, build and lint clean, `oxfmt --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prefix-based loading and removal of records.
  * Correctly includes exact matches and descendants while excluding similarly prefixed sibling records.
  * Handles empty trailing segments and segment boundaries more reliably.

* **Performance**
  * Optimized prefix queries using indexed range lookups for faster storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->