### PR TITLE
moon-cache: fix disk-exhaustion gap in repo unit + README

### DIFF
--- a/tools/moon-cache/README.md
+++ b/tools/moon-cache/README.md
@@ -97,11 +97,18 @@ Deploying a config change is `scp bazel-remote.service root@…:/etc/systemd/sys
 data — it's on disk and survives — but not instantaneous: see item 6 above for the ~70 s of
 downtime while the index rebuilds.
 
-`rsyslog-logrotate.conf` bounds `/var/log/syslog` — daily rotation, 500 MB max size, 3 generations
+`rsyslog-logrotate.conf` bounds the six paths rsyslog writes on this box (`syslog`, `mail.log`,
+`kern.log`, `auth.log`, `user.log`, `cron.log`) — daily rotation, 500 MB max size, 3 generations
 kept — so a future chatty service fills at most a few GB before rotation catches it, rather than
 the whole disk. Deploy with `scp rsyslog-logrotate.conf root@…:/etc/logrotate.d/rsyslog`; nothing
 to reload — `logrotate` reads the file fresh from its daily systemd timer, no service restart
-involved. `logrotate -d /etc/logrotate.d/rsyslog` dry-runs a change before deploying it.
+involved. Run `logrotate -d /etc/logrotate.d/rsyslog` after deploying — it names every file it
+plans to rotate, so a path missing from the config (and therefore left unbounded) shows up
+immediately.
+
+This file is a dpkg conffile owned by the `rsyslog` package, so `apt upgrade`'d rsyslog will
+prompt about the local modification; `apt.systemd.daily` runs unattended-upgrades here, which
+keeps the local version by default, so this is a footnote, not a risk.
 
 ## Certificates
 

--- a/tools/moon-cache/README.md
+++ b/tools/moon-cache/README.md
@@ -71,7 +71,7 @@ MOON_REMOTE_HOST= moon run :build
 | host | `cache.dxos.network` -> 64.225.13.237 (DigitalOcean NYC3) |
 | service | `bazel-remote` v2.5.0, systemd unit `bazel-remote` |
 | ports | 9092 gRPC, 9093 HTTPS (metrics + `/status`) |
-| storage | `/var/cache/moon`, zstd, 100 GB LRU |
+| storage | `/var/cache/moon`, zstd, 100 GiB LRU |
 | certificates | `/etc/bazel-remote/{server.pem,server.key,ca.pem}` |
 
 `--tls_ca_file` is what makes it mTLS. Without it the cache would be world-readable and

--- a/tools/moon-cache/README.md
+++ b/tools/moon-cache/README.md
@@ -54,9 +54,11 @@ MOON_REMOTE_HOST= moon run :build
    the OS — 100 GiB on the current 154 GiB disk.
 4. **Release workflows deliberately skip the cache** — `remote-cache: 'false'` on the setup action,
    or a workflow-level `MOON_REMOTE_HOST` where the workflow does not use that action.
-5. **`--access_log_level` defaults to `all`.** At CI volume that's one line per request and will
-   fill the disk within days — it took 8 days to produce 50 GB and exhaust a 154 GiB disk. The unit
-   sets `--access_log_level none`; do not drop it when copying this config elsewhere.
+5. **`--access_log_level` defaults to `all`.** At CI volume that's one line per request: 8 days
+   produced 50 GB of logs, which was enough to consume the headroom left by the 100 GiB cache
+   budget and exhaust the disk. The unit sets `--access_log_level none`; do not drop it when
+   copying this config elsewhere. `rsyslog-logrotate.conf` (below) is the backstop for the next
+   service that logs at this volume without a bound of its own.
 6. **A restart costs about 70 s of downtime.** `bazel-remote` walks every cache file to rebuild its
    in-memory index before it binds 9092/9093, so both ports refuse connections until that finishes
    — moon falls back to a local build for anyone hitting it during that window. Restarts are safe
@@ -94,6 +96,12 @@ Deploying a config change is `scp bazel-remote.service root@…:/etc/systemd/sys
 `systemctl daemon-reload && systemctl restart bazel-remote`. Restarts are safe for the cache
 data — it's on disk and survives — but not instantaneous: see item 6 above for the ~70 s of
 downtime while the index rebuilds.
+
+`rsyslog-logrotate.conf` bounds `/var/log/syslog` — daily rotation, 500 MB max size, 3 generations
+kept — so a future chatty service fills at most a few GB before rotation catches it, rather than
+the whole disk. Deploy with `scp rsyslog-logrotate.conf root@…:/etc/logrotate.d/rsyslog`; nothing
+to reload — `logrotate` reads the file fresh from its daily systemd timer, no service restart
+involved. `logrotate -d /etc/logrotate.d/rsyslog` dry-runs a change before deploying it.
 
 ## Certificates
 

--- a/tools/moon-cache/README.md
+++ b/tools/moon-cache/README.md
@@ -51,9 +51,16 @@ MOON_REMOTE_HOST= moon run :build
    change is a full cold build regardless of which cache is configured.
 3. **Disk is bounded by `--max_size 100`** (GiB), enforced as an LRU: `bazel-remote` evicts the
    least recently used blobs rather than filling the disk. Size it under the volume with room for
-   the OS — 100 GiB on the current 154 GB disk.
+   the OS — 100 GiB on the current 154 GiB disk.
 4. **Release workflows deliberately skip the cache** — `remote-cache: 'false'` on the setup action,
    or a workflow-level `MOON_REMOTE_HOST` where the workflow does not use that action.
+5. **`--access_log_level` defaults to `all`.** At CI volume that's one line per request and will
+   fill the disk within days — it took 8 days to produce 50 GB and exhaust a 154 GiB disk. The unit
+   sets `--access_log_level none`; do not drop it when copying this config elsewhere.
+6. **A restart costs about 70 s of downtime.** `bazel-remote` walks every cache file to rebuild its
+   in-memory index before it binds 9092/9093, so both ports refuse connections until that finishes
+   — moon falls back to a local build for anyone hitting it during that window. Restarts are safe
+   for the data (below), just not instantaneous.
 
 ## The server
 
@@ -84,8 +91,9 @@ ssh root@cache.dxos.network 'systemctl status bazel-remote; journalctl -u bazel-
 ```
 
 Deploying a config change is `scp bazel-remote.service root@…:/etc/systemd/system/` then
-`systemctl daemon-reload && systemctl restart bazel-remote`. Restarts are safe — the cache is on
-disk and survives.
+`systemctl daemon-reload && systemctl restart bazel-remote`. Restarts are safe for the cache
+data — it's on disk and survives — but not instantaneous: see item 6 above for the ~70 s of
+downtime while the index rebuilds.
 
 ## Certificates
 

--- a/tools/moon-cache/bazel-remote.service
+++ b/tools/moon-cache/bazel-remote.service
@@ -16,6 +16,7 @@ ExecStart=/usr/local/bin/bazel-remote \
   --tls_key_file /etc/bazel-remote/server.key \
   --tls_ca_file /etc/bazel-remote/ca.pem \
   --min_tls_version 1.2 \
+  --access_log_level none \
   --enable_endpoint_metrics
 Restart=always
 RestartSec=2

--- a/tools/moon-cache/bazel-remote.service
+++ b/tools/moon-cache/bazel-remote.service
@@ -6,6 +6,8 @@ Wants=network-online.target
 [Service]
 # --tls_ca_file is what makes this mTLS rather than plain TLS: without it the server would
 # accept any client, and the cache is reachable from the public internet.
+# --access_log_level defaults to all (one line per CAS/AC request) and filled the disk in
+# 8 days at CI volume; `none` disables it, the request rate isn't otherwise interesting.
 ExecStart=/usr/local/bin/bazel-remote \
   --dir /var/cache/moon \
   --max_size 100 \

--- a/tools/moon-cache/rsyslog-logrotate.conf
+++ b/tools/moon-cache/rsyslog-logrotate.conf
@@ -2,6 +2,11 @@
 # bazel-remote's own --access_log_level none is the primary fix; this caps what still lands in
 # syslog so a chatty service can no longer fill the disk the way access logging once did.
 /var/log/syslog
+/var/log/mail.log
+/var/log/kern.log
+/var/log/auth.log
+/var/log/user.log
+/var/log/cron.log
 {
 	rotate 3
 	daily

--- a/tools/moon-cache/rsyslog-logrotate.conf
+++ b/tools/moon-cache/rsyslog-logrotate.conf
@@ -1,0 +1,17 @@
+# Backstop for any service on this box that logs at CI volume without a bound of its own —
+# bazel-remote's own --access_log_level none is the primary fix; this caps what still lands in
+# syslog so a chatty service can no longer fill the disk the way access logging once did.
+/var/log/syslog
+{
+	rotate 3
+	daily
+	maxsize 500M
+	missingok
+	notifempty
+	compress
+	delaycompress
+	sharedscripts
+	postrotate
+		/usr/lib/rsyslog/rsyslog-rotate
+	endscript
+}


### PR DESCRIPTION
## Summary

Follow-up to the moon remote cache disk-exhaustion incident (`bazel-remote` filled a 154 GiB disk in 8 days via unbounded per-request access logging, compounded by a `weekly`/`delaycompress` logrotate policy). The server was already patched and verified live; this PR brings the repo's copy of the unit file into sync so the documented deploy procedure doesn't silently reintroduce the bug, and fills the README gaps the incident exposed.

- `tools/moon-cache/bazel-remote.service`: add `--access_log_level none`, matching the flag added to the running server (`--access_log_level` defaults to `all`, which is one line per CAS/AC request — ~107M lines / 50 GB over 8 days at CI volume).
- `tools/moon-cache/README.md`:
  - New "catch you out" items: the access-log default, and that a restart costs ~70s of downtime (bazel-remote reindexes all cache files before binding its ports) — the existing "restarts are safe" line only covers data durability, not availability.
  - Fixed a GB/GiB unit mix in the disk-sizing note (154 GiB, not 154 GB).

No changeset — `tools/moon-cache` is not a published package.

## Test plan

- [x] `pnpm format` — clean, no diff beyond the intended edits
- [x] Diff reviewed against the live, verified server unit (`/root/bazel-remote.service.bak` vs current `ExecStart`) — flag position and value match exactly
- [ ] Next deploy of `bazel-remote.service` picks up `--access_log_level none` automatically via the existing `scp` + restart procedure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disabled bazel-remote access logging to reduce unnecessary disk growth.
  * Added automatic rotation for common system logs, with size limits, compressed retention, and post-rotation handling.

* **Documentation**
  * Documented cache data persistence and approximately 70 seconds of downtime while the cache index rebuilds during restarts.
  * Added operational guidance about access-log disk usage, restart behavior, log rotation, retention, and package-upgrade handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->