### PR TITLE
agents: scaffold outbound-tag-sync project (registry entry + DESIGN/TASKS)

### DIFF
--- a/.agents/projects/outbound-tag-sync/docs/DESIGN.md
+++ b/.agents/projects/outbound-tag-sync/docs/DESIGN.md
@@ -1,0 +1,119 @@
+# Outbound Tag Sync — Design
+
+Bidirectional email tag/label sync: applying or removing a provider label on an email in
+Composer is pushed back to the provider (Gmail label / JMAP mailbox·keyword) on the next edge
+sync run. Both providers (plugin-google, plugin-jmap).
+
+Designed against main @ `1c995c468d`; all file citations below re-verified at that commit
+(2026-08-14) — no drift.
+
+## Goal & scope
+
+- **Core acceptance:** add a Gmail label to a message in Composer → next sync run → label
+  visible in Gmail.
+- Offline durability is NOT a design constraint — sync is edge-driven; retry across sync
+  ticks is sufficient.
+
+## Current state
+
+- **Inbound label→tag sync is landed.** Gmail labels map to DXOS Tag objects
+  (`packages/plugins/plugin-google/src/operations/mail/tags.ts` — `GMAIL_TAG_SOURCE` foreign
+  key; system labels map to canonical SystemTags via `GMAIL_SYSTEM_TAGS`). The delta path
+  (`history.list`) folds `labelsAdded`/`labelsRemoved` into `retag` reconcile items
+  (`packages/plugins/plugin-google/src/operations/mail/sync/sync-provider.ts`,
+  `collectLabelChanges`) applied by the shared harness
+  (`packages/plugins/plugin-inbox/src/sync/mail-sync.ts`, `reconcileToChanges`).
+- **JMAP mirrors this:** folders/keywords → tags
+  (`packages/plugins/plugin-jmap/src/operations/mail/tags.ts`, `JMAP_DOMAIN`); its reconcile
+  re-fetches `updated` emails and diffs.
+- **NO outbound path exists:** nothing calls Gmail `users.messages.modify` for labels. The
+  only Gmail write scopes in use: `gmail.send`, and `gmail.modify` solely for trash
+  (`packages/plugins/plugin-google/src/capabilities/connector.ts:136`) — so the OAuth scope
+  needed for label writes is ALREADY granted.
+- **JMAP already has a generic write primitive:** `emailSetUpdate`
+  (`packages/plugins/plugin-jmap/src/apis/JmapMail/api.ts:216`, used for trash).
+- **Provider tags are read-only by design:** `Tag.isProviderTag`
+  (`packages/core/echo/echo/src/Tag.ts:61`) and `partitionMetaTags`
+  (`packages/ui/react-ui-form/src/components/Form/meta-tags.ts:87`).
+- **No user-facing tag-apply UI on inbox messages yet** — only the classifier/extractor call
+  `Mailbox.applyTag` (`packages/plugins/plugin-inbox/src/types/Mailbox.ts:205`).
+- **The three-way-merge connector pattern this project reuses already exists:**
+  `Cursor.readSnapshot`/`writeSnapshot` on the external binding
+  (`packages/core/compute/link/src/Cursor.ts:178-195`) + shared merge primitives in
+  `packages/sdk/app-toolkit/src/types/ConnectorSync.ts` (`mergeField`, `mergeDeep`), used by
+  plugin-linear/sync.ts (also Trello/GitHub). Mail sync does not use snapshots yet.
+- **Testing:** `GoogleMailApi.mock`
+  (`packages/plugins/plugin-google/src/services/google-mail-api.ts`) serves an in-memory
+  `GmailDataset` incl. historyLog steps; sync.test.ts / sync-e2e.test.ts / sync-bench.test.ts
+  drive the real pipeline offline. JMAP has equivalent fixtures.
+
+## Architecture (DECIDED)
+
+> A pending-op journal / intent log was **explicitly rejected** — do not substitute one.
+> Everything is computed by diffing against a per-message last-sync snapshot.
+
+Per synced message the binding stores the tag set as of last sync, in **tag-uri space** (the
+canonical middle: local side = the Mailbox TagIndex; remote side = provider label ids mapped
+through the existing labelMap):
+
+- `Cursor.writeSnapshot(binding, foreignId, { tagUris })` written at three points: insert
+  commit, inbound retag apply, outbound push success.
+- Each sync run, per message, a **set-wise three-way merge**: base = snapshot; local =
+  current tag index; remote = base ⊕ delta (Gmail `labelsAdded`/`labelsRemoved`) or the
+  re-fetched current set (JMAP `updated` re-fetch).
+  - local△base only → push outbound (provider write)
+  - remote△base only → apply inbound (existing retag commit path)
+  - both moved same way → no-op
+  - true conflict (local add vs remote remove, or inverse) → **LOCAL WINS** (user intent is
+    the feature); policy isolated in one function
+  - no snapshot (pre-existing messages / first run after upgrade) → **first-sync**: take
+    remote, push nothing, write snapshot — upgrade-safe by construction
+- Merged result becomes the new snapshot. **Echo-proof:** when the provider's next delta
+  reports our own push back, remote == base → merge no-op. No suppression bookkeeping.
+- **Local-change discovery = scan:** diff `buildMessageTagsIndex(mailbox)` against snapshots
+  over the committed foreign index. Pure in-memory ECHO data, no API calls. Acceptable at
+  current scale; dirty-set optimization is a follow-up, not v1.
+- **Push failure:** log + leave that message's snapshot unadvanced → self-retries next tick.
+  Per-run push budget alongside `maxMessages`.
+
+### Open sub-decision (resolve in Phase 1 with a size measurement)
+
+`cursor.spec.snapshots` is one record on the binding object; thousands of messages × tag
+arrays is real growth.
+
+1. Keep on binding + prune to sync window **[default]**
+2. Child object beside TagIndex
+
+### Provider specifics
+
+- **Gmail:** new `modifyMessage` API (`users.messages.modify`,
+  `addLabelIds`/`removeLabelIds`). Reverse tag map: custom labels via `GMAIL_TAG_SOURCE`
+  foreign key; canonical via inverted `GMAIL_SYSTEM_TAGS`. Empirically verify which system
+  labels modify accepts (`CATEGORY_*` suspect); unpushable → skip + log + exclude from the
+  merge's push side so they don't retry forever. Remote set derived by folding
+  `labelsAdded`/`labelsRemoved` onto base per message (no extra fetch). Unmapped user tags
+  (no Gmail label): skip; label creation is a follow-up.
+- **JMAP:** push via existing `emailSetUpdate`: folder tags patch `mailboxIds/<id>`, flag
+  tags patch `keywords/<kw>` via inverted JMAP system-tag map; remote set from existing
+  re-fetch. **Folder floor:** an email must keep ≥1 mailbox; removing the last folder tag →
+  skip + log.
+
+### Tag applicability split
+
+Provider tags stay non-renamable/non-recolorable but become **membership-toggleable**:
+`isProviderTag` (`packages/core/echo/echo/src/Tag.ts`) splits into two predicates; audit all
+call sites (meta-tags.ts, SystemTags.ts).
+
+## Sequencing
+
+- **PR 1** = Phases 1+2 (Gmail round-trip demos the core goal)
+- **PR 2** = Phase 3 (JMAP)
+- **PR 3** = Phase 4 (Composer UI; parallelizable after Phase 1)
+- Tests ride each PR.
+
+## Follow-ups (out of scope for v1)
+
+- Dirty-set scan optimization (v1 scans the full committed foreign index).
+- Label creation for unmapped user tags.
+- Read-state (UNREAD / `$seen`) sync.
+- Local (non-edge) sync parity.

--- a/.agents/projects/outbound-tag-sync/docs/TASKS.md
+++ b/.agents/projects/outbound-tag-sync/docs/TASKS.md
@@ -1,0 +1,84 @@
+# Outbound Tag Sync — Tasks
+
+_Resume: Start Phase 1 — `mergeSet` primitive in app-toolkit ConnectorSync. Uncommitted: none. Last: project scaffolded (docs + registry entry); no implementation yet._
+
+Design + decisions: [DESIGN.md](./DESIGN.md). PR sequencing: PR 1 = Phases 1+2, PR 2 =
+Phase 3, PR 3 = Phase 4 (parallelizable after Phase 1); tests ride each PR.
+
+## Phase 1: Merge machinery (app-toolkit, plugin-inbox)
+
+The snapshot three-way merge core, shared by both providers, plus the harness rewiring and
+the Tag applicability split.
+
+### Tasks
+
+- [ ] **Add `mergeSet` primitive to ConnectorSync** (`packages/sdk/app-toolkit/src/types/ConnectorSync.ts`)
+  - Element-wise three-way membership merge returning `{ merged, pushAdd, pushRemove, applyAdd, applyRemove }`.
+  - Local-wins conflict policy isolated in one place.
+  - Unit tests covering the full element truth table.
+- [ ] **Tag-snapshot helpers in plugin-inbox/sync** over `Cursor.readSnapshot`/`writeSnapshot` (`{ tagUris }`)
+  - Three write points: insert commit, inbound retag apply, outbound push success.
+  - Resolve storage-location decision (a: on binding + prune to sync window [default] vs b: child object beside TagIndex) with a size measurement.
+- [ ] **Rewire the harness** (`packages/plugins/plugin-inbox/src/sync/mail-sync.ts`)
+  - Replace apply-remote-blindly retag reconcile with the merge — provider reconcile branch supplies remote per-message tag sets.
+  - Route `apply*` to the existing retag commit path; `push*` to a new OPTIONAL `MailSyncProviderService.pushTagChanges(ops)`.
+  - Add the local-discovery scan (diff `buildMessageTagsIndex(mailbox)` against snapshots).
+  - Per-run push budget alongside `maxMessages`; push failure = log + leave snapshot unadvanced.
+- [ ] **Tag applicability split** (`packages/core/echo/echo/src/Tag.ts`)
+  - Provider tags stay non-renamable/non-recolorable but become membership-toggleable.
+  - Audit all `isProviderTag` call sites (meta-tags.ts, SystemTags.ts) and split into two predicates.
+
+## Phase 2: Gmail (plugin-google)
+
+Outbound push via `users.messages.modify`; with Phase 1 this demos the core acceptance
+(PR 1).
+
+### Tasks
+
+- [ ] **`modifyMessage` API** (`users.messages.modify`, `addLabelIds`/`removeLabelIds`) in `apis/GoogleMail/api.ts` + `GoogleMailApiService` + mock
+  - Mock mutates the dataset AND appends a historyLog step so tests exercise the echo round-trip.
+- [ ] **Reverse tag map**
+  - Custom labels via `GMAIL_TAG_SOURCE` foreign key; canonical via inverted `GMAIL_SYSTEM_TAGS`.
+  - Empirically verify which system labels modify accepts (`CATEGORY_*` suspect); unpushable → skip + log + exclude from the merge's push side so they don't retry forever.
+- [ ] **Remote-set derivation** — fold `labelsAdded`/`labelsRemoved` onto base per message (no extra fetch).
+- [ ] **Unmapped user tags** (no Gmail label): skip; label creation is a follow-up.
+
+## Phase 3: JMAP (plugin-jmap)
+
+Outbound push via the existing `emailSetUpdate` primitive (PR 2).
+
+### Tasks
+
+- [ ] **`pushTagChanges` via `emailSetUpdate`** — folder tags patch `mailboxIds/<id>`, flag tags patch `keywords/<kw>` via inverted JMAP system-tag map; remote set from the existing `updated` re-fetch.
+- [ ] **Folder floor** — email must keep ≥1 mailbox; removing the last folder tag → skip + log.
+- [ ] **Mock parity** — `emailSetUpdate` mutates the mock dataset + changes log.
+
+## Phase 4: Composer UI (plugin-inbox)
+
+Tag add/remove affordance on messages (none exists today); parallelizable after Phase 1
+(PR 3).
+
+### Tasks
+
+- [ ] **Tag add/remove affordance in ConversationStack** — picker + chip remove, writing via `Mailbox.applyTag`/`removeTag` (no special API — the scan finds it); provider tags selectable but label/hue-locked.
+  - Follow the composer-ui skill; storybook + play fn.
+
+## Phase 5: Tests + landing
+
+### Tasks
+
+- [ ] **Unit tests, both providers** — round-trip echo no-op; conflict truth table; first-sync/no-snapshot upgrade; unpushable skip; failure-retry-via-stale-snapshot; snapshot pruning.
+- [ ] **Live e2e** — label round-trip in sync-e2e.test.ts (creds-gated).
+- [ ] **Changesets** — plugin-inbox, plugin-google, plugin-jmap, app-toolkit, echo.
+
+## Follow-ups
+
+- [ ] Dirty-set scan optimization (v1 scans full committed foreign index).
+- [ ] Label creation for unmapped user tags.
+- [ ] Read-state (UNREAD / `$seen`) sync.
+- [ ] Local (non-edge) sync parity.
+
+### References
+
+- [DESIGN.md](./DESIGN.md) — architecture, decisions, verified file anchors.
+- Existing merge pattern: `packages/sdk/app-toolkit/src/types/ConnectorSync.ts`, `packages/core/compute/link/src/Cursor.ts`, plugin-linear/sync.ts.

--- a/.agents/projects/registry.yml
+++ b/.agents/projects/registry.yml
@@ -354,6 +354,16 @@ projects:
     design: packages/core/halo/halo/CONSUMER_MIGRATION.md
     prs: [12229, 12583, 12588]
     resume: "The ledger IS packages/core/halo/halo/MIGRATION_PLAN.md (per-plugin table + numbered Missing APIs 1-10); CONSUMER_MIGRATION.md is the cookbook, API_AUDIT.md the pre-migration inventory. THE HALO TIER IS COMPLETE — Missing APIs 1-6 all landed: #12229 (React + imperative singleton tiers), #12583 (1: Identity.personalSpaceId; 2: createRecoveryCredential/requestRecoveryChallenge/revokeRecoveryCredential + passkey recover), #12588 (3: Identity.getEdgeIdentity), and this branch (4: useInvitationFlow in halo-react + DeviceInfo.presence/os/platform/kind + shell DeviceListItem takes the structural ShellDevice with toShellDevice for client callers; 5: ClientOperation.GrantServiceAccess, plugin-script off writeCredentials; 6: Identity.atom(service), an Atom<Option<Info>> keyed by service reference, used by app-graph-builder). No plugin touches @dxos/client for HALO anymore. NEXT is the non-HALO remainder, all bigger: 7 = ECHO React bindings (~340 imports, the dominant blocker), 8 = space-invitation UI on Space.share/join, 9 = config/mesh/services access without the client root (what still pins DevicesContainer via useNetworkStatus + the DX_ENVIRONMENT gate, app-graph-builder, plugin-debug, plugin-observability), 10 = a @dxos/react-client/testing replacement. DELIBERATE BOUNDARIES (not gaps): CLI src/commands/** construct the client; plugin-client provides it. CARVE-OUTS: requestRecoveryChallenge needs EDGE so halo-e2e cannot cover it; plugin-onboarding queryAllCredentials wants an exhaustive credential QUERY verb distinct from the credentials stream; oauth-recovery-redirect keeps a client for Account.createHubClient and a 30s recover timeout vs the proxy's 20s. E2E: playwright app-manager.ts parses the DevicesContainer console JSON for invitationCode — that log line is load-bearing, keep it."
+  - name: outbound-tag-sync
+    status: active
+    user: root
+    host: vm
+    created: 2026-08-14
+    summary: 'Outbound email tag sync — push Composer tag edits back to Gmail/JMAP via snapshot three-way merge'
+    tasks: .agents/projects/outbound-tag-sync/docs/TASKS.md
+    design: .agents/projects/outbound-tag-sync/docs/DESIGN.md
+    prs: []
+    resume: 'Start Phase 1: mergeSet primitive in app-toolkit ConnectorSync. Project scaffolded 2026-08-14 (docs + registry only, no implementation); plan designed in a prior session against main @ 1c995c468d, all cited file anchors re-verified at that commit — no drift. Architecture DECIDED (per-message tag-set snapshot + set-wise three-way merge, local wins; pending-op journal explicitly rejected). Sequencing: PR 1 = Phases 1+2 (merge machinery + Gmail round-trip), PR 2 = Phase 3 (JMAP), PR 3 = Phase 4 (Composer tag UI, parallelizable after Phase 1).'
 ended:
   - name: app-framework-capability-activation
     user: jdw


### PR DESCRIPTION
Docs-only scaffold for the **outbound-tag-sync** project — bidirectional email tag/label sync (outbound push): applying/removing a provider label on an email in Composer gets pushed back to the provider (Gmail label / JMAP mailbox·keyword) on the next edge sync run.

## Changes

- `.agents/projects/registry.yml` — new active entry for `outbound-tag-sync`.
- `.agents/projects/outbound-tag-sync/docs/DESIGN.md` — architecture + decisions: per-message tag-set snapshot (`Cursor.readSnapshot`/`writeSnapshot`) + set-wise three-way merge in tag-uri space, local-wins conflict policy, echo-proof by construction; pending-op journal explicitly rejected. All cited file anchors re-verified against main @ `1c995c468d` (this branch's base) — no drift.
- `.agents/projects/outbound-tag-sync/docs/TASKS.md` — phased ledger: Phase 1 merge machinery (app-toolkit `mergeSet`, snapshot helpers, mail-sync harness rewiring, Tag applicability split), Phase 2 Gmail (`users.messages.modify`), Phase 3 JMAP (`emailSetUpdate`), Phase 4 Composer tag UI, Phase 5 tests + changesets, plus a follow-ups ledger.

No implementation in this PR — project scaffolding only. Implementation PR sequencing (in TASKS.md): PR 1 = Phases 1+2, PR 2 = Phase 3, PR 3 = Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEF8ArC6hZ5pQB4NNazGpz

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEF8ArC6hZ5pQB4NNazGpz)_