### PR TITLE
composer-app: fix WebKit dev-server boot and narrow tauri dev deps

### DIFF
--- a/.changeset/native-updates-dev-mode-message.md
+++ b/.changeset/native-updates-dev-mode-message.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-native': patch
+---
+
+Distinguish the two disabled updater states in settings: a platform with no OTA channel still reads "Updates are not available on this platform", while a dev-server build on a platform that does support OTA now reads "Updates are not enabled in dev mode".

--- a/packages/apps/composer-app/moon.yml
+++ b/packages/apps/composer-app/moon.yml
@@ -72,6 +72,21 @@ tasks:
   tauri-ios-build:
     deps:
       - bundle
+  # Both native dev loops run this app's `vite dev` through `beforeDevCommand` (`tauri.ios.conf.json`
+  # overrides only `bundle`), so they need exactly `serve`'s narrowed dependency set rather than the
+  # `tauri` tag's whole-graph `^:build` — extended so the three inner loops cannot drift.
+  tauri-dev:
+    extends: serve
+    command: pnpm exec tauri dev
+    options:
+      # Args merge by append, so both the extended `vite dev` and the tag's own `tauri dev` would
+      # otherwise be concatenated onto this command.
+      mergeArgs: replace
+  tauri-ios:
+    extends: serve
+    command: pnpm exec tauri ios dev
+    options:
+      mergeArgs: replace
   # Downloads the pinned macOS ollama runtime + triple-named sidecars embedded in the desktop app. Cacheable:
   # keyed on the fetch script (which pins the version + SHA-256), with the downloaded sidecar dir as the
   # output — so a cache hit restores it instead of re-downloading the (large) runtime.

--- a/packages/apps/composer-app/package.json
+++ b/packages/apps/composer-app/package.json
@@ -212,6 +212,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "jsdom": "catalog:",
+    "oxc-resolver": "catalog:",
     "pwa-asset-generator": "catalog:",
     "rollup-plugin-visualizer": "catalog:",
     "vite": "catalog:",

--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -47,9 +47,8 @@ const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(file
 // Boot-path chunk grouping; `entry` is the page whose static closure defines the boot set.
 const boot = bootChunking({ entry: path.resolve(dirname, 'src/main.tsx') });
 
-// wasm-bindgen packages that publish both a bundler entry (`browser` condition, `.wasm` imported as
-// a module) and a base64 entry (default condition, `initSync`). Only the latter is free of
-// top-level await.
+// Only these packages' default-condition entry is free of top-level await; the `browser` one imports
+// `.wasm` as a module.
 const SYNC_WASM_PACKAGES = ['@automerge/automerge', '@automerge/automerge-subduction'];
 
 /**
@@ -67,8 +66,7 @@ const syncWasmInit = (): PluginOption => {
   return {
     name: 'dxos-sync-wasm-init',
     enforce: 'pre',
-    // Dev only: the base64 entry inlines the wasm bytes, which costs ~33% over the binary in a
-    // production bundle, and the failure needs vite's module-per-file dev graph to bite.
+    // The base64 entry costs ~33% over the binary, which a production bundle must not pay.
     apply: 'serve',
     resolveId: {
       order: 'pre',
@@ -134,11 +132,8 @@ const sharedPlugins = (env: ConfigEnv): PluginOption[] => [
   importSource({
     include: isFastBundle ? ['#*'] : ['@dxos/**', '#*'],
   }),
-  // WebKit — Safari and the Tauri WKWebView — evaluates a module before its own dependencies when
-  // the graph is reached by concurrent dynamic imports and contains top-level await, so a binding
-  // first reached that way reads as an uninitialized `const` ("Cannot access 'x' before
-  // initialization"). The plugin manager activates modules concurrently, so the only lever is the
-  // top-level await.
+  // WebKit evaluates a module before its dependencies when a graph reached by concurrent dynamic
+  // imports contains top-level await, leaving bindings in TDZ.
   syncWasmInit(),
   // Dev log file sink (serve only) + Rolldown log-meta injection (serve + build).
   DxosLogPlugin(),

--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -6,6 +6,7 @@ import react from '@vitejs/plugin-react';
 import { createReadStream, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { ResolverFactory } from 'oxc-resolver';
 // import sourcemaps from 'rollup-plugin-sourcemaps';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { type ConfigEnv, type PluginOption, defineConfig, searchForWorkspaceRoot } from 'vite';
@@ -45,6 +46,47 @@ const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(file
 
 // Boot-path chunk grouping; `entry` is the page whose static closure defines the boot set.
 const boot = bootChunking({ entry: path.resolve(dirname, 'src/main.tsx') });
+
+// wasm-bindgen packages that publish both a bundler entry (`browser` condition, `.wasm` imported as
+// a module) and a base64 entry (default condition, `initSync`). Only the latter is free of
+// top-level await.
+const SYNC_WASM_PACKAGES = ['@automerge/automerge', '@automerge/automerge-subduction'];
+
+/**
+ * Resolves {@link SYNC_WASM_PACKAGES} without the `browser` condition, selecting their
+ * synchronous-init entrypoints so no top-level await enters the module graph.
+ */
+// TODO(wittjosiah): Remove the need for this rather than waiting on a WebKit fix — either the
+//  automerge wasm packages stop requiring top-level await, or our bundling and dependencies change
+//  so the TDZ is unreachable. Only `serve` needs it, but the Tauri app renders in a WebKit web
+//  view, so that covers dev there too.
+const syncWasmInit = (): PluginOption => {
+  // `browser` is deliberately absent; the rest mirrors what vite would apply for the client.
+  const resolver = new ResolverFactory({ conditionNames: ['source', 'import', 'module', 'default'] });
+
+  return {
+    name: 'dxos-sync-wasm-init',
+    enforce: 'pre',
+    // Dev only: the base64 entry inlines the wasm bytes, which costs ~33% over the binary in a
+    // production bundle, and the failure needs vite's module-per-file dev graph to bite.
+    apply: 'serve',
+    resolveId: {
+      order: 'pre',
+      handler: (source, importer) => {
+        // Subpaths too: `./slim` re-exports the same wasm glue as the package root, so redirecting
+        // only the root would split the two across separate wasm instances and leave the signer
+        // that `/slim` hands out uninitialized.
+        const matched = SYNC_WASM_PACKAGES.some((pkg) => source === pkg || source.startsWith(`${pkg}/`));
+        if (!importer || !matched) {
+          return null;
+        }
+
+        const resolved = resolver.sync(path.dirname(importer), source);
+        return resolved.error || !resolved.path ? null : resolved.path;
+      },
+    },
+  };
+};
 
 /**
  * Transpile targets for oxc (dev) and Rolldown (build).
@@ -92,6 +134,12 @@ const sharedPlugins = (env: ConfigEnv): PluginOption[] => [
   importSource({
     include: isFastBundle ? ['#*'] : ['@dxos/**', '#*'],
   }),
+  // WebKit — Safari and the Tauri WKWebView — evaluates a module before its own dependencies when
+  // the graph is reached by concurrent dynamic imports and contains top-level await, so a binding
+  // first reached that way reads as an uninitialized `const` ("Cannot access 'x' before
+  // initialization"). The plugin manager activates modules concurrently, so the only lever is the
+  // top-level await.
+  syncWasmInit(),
   // Dev log file sink (serve only) + Rolldown log-meta injection (serve + build).
   DxosLogPlugin(),
   wasm(),
@@ -229,7 +277,10 @@ export default defineConfig((env) => ({
     },
   },
   optimizeDeps: {
-    exclude: ['@dxos/wa-sqlite'],
+    // The wasm packages `syncWasmInit` redirects must not be pre-bundled: the optimizer resolves
+    // with its own pipeline (the `browser` condition, so the bundler entry) and importers would
+    // land on that chunk's top-level await regardless of what the plugin resolves.
+    exclude: ['@dxos/wa-sqlite', ...SYNC_WASM_PACKAGES],
     // The full set of dep entrypoints the app reaches, so vite's optimize-deps phase pre-bundles
     // them up front rather than discovering them mid-load (when a dynamic import unwraps a new
     // subpath), which forces a full page reload with the "Discovered new dependencies" banner —

--- a/packages/plugins/plugin-native/src/capabilities/updater.ts
+++ b/packages/plugins/plugin-native/src/capabilities/updater.ts
@@ -68,9 +68,11 @@ export default Capability.makeModule(
     const registry = yield* Capabilities.AtomRegistry;
     const { invoke } = yield* Capabilities.OperationInvoker;
 
-    const statusAtom = Atom.make<Update.Status>(enabled ? { kind: 'idle' } : { kind: 'unsupported' }).pipe(
-      Atom.keepAlive,
-    );
+    // The two disabled states are distinct to the reader: a dev server on macOS would update fine
+    // once packaged, so reporting it as an unsupported platform is wrong.
+    const disabledStatus: Update.Status = SUPPORTS_OTA.includes(platform) ? { kind: 'dev' } : { kind: 'unsupported' };
+
+    const statusAtom = Atom.make<Update.Status>(enabled ? { kind: 'idle' } : disabledStatus).pipe(Atom.keepAlive);
 
     // Updater.Update is a class with instance methods (downloadAndInstall) and can't live in an
     // atom value; cache it here between check and install.

--- a/packages/plugins/plugin-native/src/containers/NativeSettings/NativeSettings.tsx
+++ b/packages/plugins/plugin-native/src/containers/NativeSettings/NativeSettings.tsx
@@ -93,6 +93,10 @@ const renderUpdateRow = (
       description: t('settings.updates.unsupported.message'),
       button: checkButton(true),
     })),
+    Match.when({ kind: 'dev' }, () => ({
+      description: t('settings.updates.dev.message'),
+      button: checkButton(true),
+    })),
     Match.when({ kind: 'idle' }, () => ({
       description: isChecking ? t('settings.updates.checking.message') : t('settings.updates.idle.message'),
       button: checkButton(),

--- a/packages/plugins/plugin-native/src/translations.ts
+++ b/packages/plugins/plugin-native/src/translations.ts
@@ -28,6 +28,7 @@ export const translations = [
         'settings.updates.ready.message': 'Update ready. Restart Composer to apply.',
         'settings.updates.failed.message': 'Update failed: {{error}}',
         'settings.updates.unsupported.message': 'Updates are not available on this platform.',
+        'settings.updates.dev.message': 'Updates are not enabled in dev mode.',
       },
     },
   },

--- a/packages/plugins/plugin-native/src/types/Update.ts
+++ b/packages/plugins/plugin-native/src/types/Update.ts
@@ -7,7 +7,10 @@ import type * as Atom from 'effect/unstable/reactivity/Atom';
 // @import-as-namespace
 
 export type Status =
+  // The platform has no OTA channel at all.
   | { kind: 'unsupported' }
+  // The platform supports OTA, but this build is served by the dev server.
+  | { kind: 'dev' }
   | { kind: 'idle' }
   | { kind: 'checking' }
   | { kind: 'up-to-date'; checkedAt: number }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2825,6 +2825,9 @@ importers:
       jsdom:
         specifier: 'catalog:'
         version: 29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0)
+      oxc-resolver:
+        specifier: 'catalog:'
+        version: 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       pwa-asset-generator:
         specifier: 'catalog:'
         version: 6.4.0


### PR DESCRIPTION
## What

Two fixes to composer-app's dev loop, plus a copy fix in the updater surfaced while verifying them.

**1. WebKit dev-server boot failure.** Booting the dev server in Safari or the Tauri WKWebView failed with `Cannot access 'makeIdentityService' before initialization`, leaving the app on the System Error screen. Chromium was unaffected on the same commit.

**2. `tauri-dev` / `tauri-ios` dependency scope.** Both inherited `deps: ^:build` from the `tauri` tag and built the whole workspace graph (100+ targets) before starting.

**3. Updater settings copy.** The updater disabled itself for two unrelated reasons — no OTA channel on the platform, and running against the dev server — but reported both as "Updates are not available on this platform". On macOS in dev that is simply wrong: the same build updates fine once packaged. Split into `unsupported` and `dev` with separate copy; both still disable the check button.

## Why

### The WebKit bug

WebKit evaluates a module **before its own dependencies** when the graph is reached by concurrent dynamic imports and contains top-level await, so a binding first reached that way reads as an uninitialized `const`. Marker order in the app confirmed it — `client-module, util, identity, space, barrel`, exactly backwards.

Isolated to a minimal case on the same dev server:

```
WebKit:   shared-dep, shared-barrel, c-root1, slow-tla, c-root2   ← c-root1 runs BEFORE the TLA module it imports
Chromium: shared-dep, shared-barrel, slow-tla, c-root2, c-root1   ← correct
```

Top-level await alone orders correctly in both engines; TLA **plus** concurrent overlapping dynamic imports is what breaks. The plugin manager activates modules concurrently, so the only lever is the top-level await — which is not in automerge's source, but injected by rolldown's optimizeDeps pre-bundle when it inlines `.wasm` as `var {...} = await initWasm({...})`.

`syncWasmInit` resolves `@automerge/automerge` and `@automerge/automerge-subduction` **without the `browser` condition**, selecting the base64 entrypoints that inline the same bytes and call a synchronous `initSync`.

### Rejected alternatives (both measured, not reasoned)

| Approach | Result |
|---|---|
| `optimizeDeps.exclude` alone | 3/3 still failed — excluding just moves the `.wasm` import to `vite-plugin-wasm`, which re-adds TLA |
| Barrel `export…from` → `import`+`export` | 3/3 still failed — the barrel itself evaluates last, so the binding is uninitialized either way |

### Tauri task deps

Both native dev loops run this app's `vite dev` through `beforeDevCommand` (`tauri.ios.conf.json` overrides only `bundle`), so they need exactly `serve`'s narrowed set — extended from it so the three inner loops cannot drift. Goes from 100+ build targets to 20.

## Reviewer notes

- **`mergeArgs: replace` is load-bearing.** Args merge by append; without it the resolved command was `pnpm exec tauri dev exec vite dev exec tauri dev`.
- **Subpath matching is load-bearing.** `/slim` re-exports the same wasm glue as the package root, so redirecting only the root would split them across separate wasm instances and leave the signer `Repo` gets uninitialized.
- **Scoped to `serve`** via `apply: 'serve'`. The base64 entry costs ~33% over the binary, and the app gates on `check-boot-budget`; the failure also needs vite's module-per-file dev graph to bite. Production Tauri ships today. Extending to production would need a bundle-size measurement first — there's a TODO on the plugin.
- `oxc-resolver` is now a declared devDependency rather than a phantom one; the lockfile diff is 3 lines.
- One changeset, for `@dxos/plugin-native` (the updater copy). The composer-app changes need none — it is private and out of Changesets.

## Verification

| Check | Result |
|---|---|
| Playwright WebKit × 5 | 0/5 (was 5/5) |
| Playwright Chromium × 2 | clean, real UI renders |
| Real Safari | 0 occurrences in `app.log` |
| Module eval order | `util, identity, space, barrel, client-module` — deps first |
| `moon run :lint -- --fix` | pass, 310 tasks |
| `composer-app:build` (tsgo --noEmit) | pass, 281 tasks |
| `composer-app:test` | 16 passed, 1 skipped |
| `plugin-native:build` / `:lint` / `:test` | pass (`Match.exhaustive` enforces the new status case) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed local development loading for Automerge WebAssembly modules, improving startup reliability.
  * Improved Composer development and iOS workflows with dedicated Tauri commands.

* **Development Experience**
  * Improved local module resolution for more consistent development builds.
  * Clarified update availability messaging in development mode and disabled unavailable update checks.
  * Improved update status reporting for platforms that do not support over-the-air updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
