### PR TITLE
cli: hide OAuth callback server HTTP logs unless --verbose

### DIFF
--- a/.changeset/oauth-http-logs-verbose.md
+++ b/.changeset/oauth-http-logs-verbose.md
@@ -2,4 +2,4 @@
 '@dxos/echo': patch
 ---
 
-Suppress the local OAuth callback server's HTTP request logs during CLI login unless `--verbose` is set.
+Suppress the local OAuth callback server's per-request HTTP logs and listen banner during CLI OAuth flows (`dx account login`, `dx connector add`) unless `--verbose` is set.

--- a/.changeset/oauth-http-logs-verbose.md
+++ b/.changeset/oauth-http-logs-verbose.md
@@ -1,0 +1,5 @@
+---
+'@dxos/echo': patch
+---
+
+Suppress the local OAuth callback server's HTTP request logs during CLI login unless `--verbose` is set.

--- a/packages/devtools/cli-util/src/oauth/server.ts
+++ b/packages/devtools/cli-util/src/oauth/server.ts
@@ -16,6 +16,8 @@ import { getPort } from 'get-port-please';
 
 import { openBrowser } from '#platform';
 
+import { CommandConfig } from '../services';
+
 /** Default timeout for a full OAuth browser round-trip. */
 export const OAUTH_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -124,7 +126,15 @@ export const startOAuthCallbackServer = (callbackPath: `/${string}`): Effect.Eff
       ),
     ]);
 
-    const serverLayer = HttpRouter.serve(routes).pipe(Layer.provide(BunHttpServer.layer({ port })));
+    // The flow is interactive, so the router's per-request log lines (and the listen banner) are
+    // noise between the user's command and its result; keep them behind `--verbose`.
+    const verbose = yield* Effect.serviceOption(CommandConfig).pipe(
+      Effect.map(Option.match({ onNone: () => false, onSome: (config) => config.verbose })),
+    );
+    const serverLayer = HttpRouter.serve(routes, {
+      disableLogger: !verbose,
+      disableListenLog: !verbose,
+    }).pipe(Layer.provide(BunHttpServer.layer({ port })));
     const scope = yield* Scope.make();
     yield* Layer.build(serverLayer).pipe(Scope.provide(scope));
 


### PR DESCRIPTION
`dx account login … --method atmosphere` printed the local OAuth callback server's internals between the command and its result — the listen banner, a `Sent HTTP response` line per request, and an `HttpServerError: RouteNotFound (GET /favicon.ico)` stack from the browser's favicon probe.

`HttpRouter.serve` installs `HttpMiddleware.logger` and `HttpServer.withLogAddress` by default. `startOAuthCallbackServer` now disables both unless the CLI's `--verbose` flag is set, read via `Effect.serviceOption(CommandConfig)` so the server keeps its requirement-free signature and defaults to quiet where the service isn't provided.

This also covers the `connector add` OAuth path, which shares the same server.

Before:

```
[15:51:23.591] INFO (#196): Listening on http://localhost:55444
[15:51:26.013] INFO (#652) http.span=1ms: Sent HTTP response
http.method: GET
http.url: /oauth-relay
http.status: 200
…
Logged in successfully
```

After: only `Logged in successfully` and the identity block (the full output returns with `-v`).

Verified with `moon run cli-util:build`, `tsc --noEmit`, `moon run cli-util:lint`, and `pnpm format`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KmF3E1vsDT3v3NFpftVESx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced OAuth callback HTTP log noise during CLI login.
  * Detailed request and server startup logs remain available when verbose mode is enabled.
* **Release**
  * Included in a patch release of the CLI package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->