### PR TITLE
react-ui-components: atomic query editor tags, tag spacing, and selectionEnd fix

### DIFF
--- a/.changeset/query-editor-atomic-tags.md
+++ b/.changeset/query-editor-atomic-tags.md
@@ -1,0 +1,6 @@
+---
+'@dxos/react-ui-components': patch
+'@dxos/plugin-chess': patch
+---
+
+Treat query editor tags as atomic chips, keep typed text off them, fix `selectionEnd` never moving the caret, and expand the chess board to fill its card.

--- a/packages/plugins/plugin-chess/src/containers/ChessCard/ChessCard.tsx
+++ b/packages/plugins/plugin-chess/src/containers/ChessCard/ChessCard.tsx
@@ -21,7 +21,9 @@ export const ChessCard = ({ variant }: ChessCardProps) => {
   return (
     <Card.Body>
       <Card.Section classNames='aspect-square'>
-        <Card.Row fullWidth>
+        {/* `self-stretch`: the section centers its rows, so the row would sit at its content height —
+            zero here, since the board sizes itself from the container rather than from its content. */}
+        <Card.Row fullWidth classNames='self-stretch'>
           <Chessboard.Root state={variant}>
             <Chessboard.Content>
               <Chessboard.Board />

--- a/packages/ui/react-ui-components/src/components/QueryEditor/QueryEditor.stories.tsx
+++ b/packages/ui/react-ui-components/src/components/QueryEditor/QueryEditor.stories.tsx
@@ -93,15 +93,15 @@ export const Tags: Story = {
 };
 
 /**
- * A tag behaves as a single object: text typed against either edge is separated from it by a space,
- * the document keeps a trailing space to type into, and one forward-delete removes the whole chip.
- * Driven through real keystrokes, since atomicity is enforced by CodeMirror's own cursor and delete
- * commands rather than by the decorations the unit tests inspect.
+ * A tag behaves as a single object: one Backspace or Delete removes the whole chip, and text typed
+ * against either edge is separated from it by a space, with a trailing space always left to type
+ * into. Driven through real keystrokes, since atomicity is enforced by CodeMirror's own cursor and
+ * delete commands rather than by the decorations the unit tests inspect.
  */
 export const Atomic: Story = {
   args: {
     autoFocus: true,
-    value: '#important',
+    value: '#test',
   },
   play: async ({ canvasElement }) => {
     const content = await waitFor(() => {
@@ -112,18 +112,32 @@ export const Atomic: Story = {
       return element;
     });
 
+    // The placeholder renders inside the content element, so an empty document is not empty text.
+    const doc = () => (content.querySelector('.cm-placeholder') ? '' : content.textContent);
+
     await userEvent.click(content);
-    await waitFor(() => expect(content.textContent).toEqual('#important'));
+    await waitFor(() => expect(doc()).toEqual('#test'));
 
     // `keyboard`, not `type`: the latter clicks the element first, which would move the caret.
+    // The caret at the tag's own edge is still in the tag, so one Backspace takes the whole chip.
+    await userEvent.keyboard('{End}{Backspace}');
+    await waitFor(() => expect(doc()).toEqual(''));
+
+    // Atomic does not mean uneditable: each character lands outside the replaced range and grows it,
+    // so the tag is still typed a character at a time. The chip renders the label the whole way.
+    await userEvent.keyboard('#te');
+    await waitFor(() => expect(doc()).toEqual('#te '));
+    await userEvent.keyboard('st');
+    await waitFor(() => expect(doc()).toEqual('#test '));
+
+    // Typed text is never glued to a chip, in either direction.
     await userEvent.keyboard('{Home}X');
-    await waitFor(() => expect(content.textContent).toEqual('X #important '));
-
+    await waitFor(() => expect(doc()).toEqual('X #test '));
     await userEvent.keyboard('{End}Y');
-    await waitFor(() => expect(content.textContent).toEqual('X #important Y '));
+    await waitFor(() => expect(doc()).toEqual('X #test Y '));
 
-    // Two deletes for `X ` and then a single one for the whole ten-character tag.
+    // Two deletes for `X `, then a single one for the whole five-character tag.
     await userEvent.keyboard('{Home}{Delete}{Delete}{Delete}');
-    await waitFor(() => expect(content.textContent).toEqual(' Y '));
+    await waitFor(() => expect(doc()).toEqual(' Y '));
   },
 };

--- a/packages/ui/react-ui-components/src/components/QueryEditor/QueryEditor.stories.tsx
+++ b/packages/ui/react-ui-components/src/components/QueryEditor/QueryEditor.stories.tsx
@@ -4,6 +4,7 @@
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React, { useCallback, useMemo, useState } from 'react';
+import { expect, userEvent, waitFor } from 'storybook/test';
 
 import { type Filter, Tag } from '@dxos/echo';
 import { useClientStory, withClientProvider } from '@dxos/react-client/testing';
@@ -70,12 +71,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const Simple: Story = {
-  args: {
-    value: '#important',
-  },
-};
-
 export const Complex: Story = {
   args: {
     autoFocus: true,
@@ -94,5 +89,41 @@ export const Tags: Story = {
   args: {
     autoFocus: true,
     value: 'type:org.dxos.type.person #investor #new',
+  },
+};
+
+/**
+ * A tag behaves as a single object: text typed against either edge is separated from it by a space,
+ * the document keeps a trailing space to type into, and one forward-delete removes the whole chip.
+ * Driven through real keystrokes, since atomicity is enforced by CodeMirror's own cursor and delete
+ * commands rather than by the decorations the unit tests inspect.
+ */
+export const Atomic: Story = {
+  args: {
+    autoFocus: true,
+    value: '#important',
+  },
+  play: async ({ canvasElement }) => {
+    const content = await waitFor(() => {
+      const element = canvasElement.querySelector<HTMLElement>('.cm-content');
+      if (!element) {
+        throw new Error('Query editor content not found.');
+      }
+      return element;
+    });
+
+    await userEvent.click(content);
+    await waitFor(() => expect(content.textContent).toEqual('#important'));
+
+    // `keyboard`, not `type`: the latter clicks the element first, which would move the caret.
+    await userEvent.keyboard('{Home}X');
+    await waitFor(() => expect(content.textContent).toEqual('X #important '));
+
+    await userEvent.keyboard('{End}Y');
+    await waitFor(() => expect(content.textContent).toEqual('X #important Y '));
+
+    // Two deletes for `X ` and then a single one for the whole ten-character tag.
+    await userEvent.keyboard('{Home}{Delete}{Delete}{Delete}');
+    await waitFor(() => expect(content.textContent).toEqual(' Y '));
   },
 };

--- a/packages/ui/react-ui-components/src/components/QueryEditor/QueryEditor.stories.tsx
+++ b/packages/ui/react-ui-components/src/components/QueryEditor/QueryEditor.stories.tsx
@@ -2,6 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
+import { EditorView } from '@codemirror/view';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React, { useCallback, useMemo, useState } from 'react';
 import { expect, userEvent, waitFor } from 'storybook/test';
@@ -90,6 +91,26 @@ export const Tags: Story = {
     autoFocus: true,
     value: 'type:org.dxos.type.person #investor #new',
   },
+  play: async ({ canvasElement }) => {
+    const content = await waitFor(() => {
+      const element = canvasElement.querySelector<HTMLElement>('.cm-content');
+      if (!element) {
+        throw new Error('Query editor content not found.');
+      }
+      return element;
+    });
+
+    // The document, not `textContent`: a type filter is drawn as a widget, so the rendered text is
+    // the chip's label rather than what the document holds.
+    const view = EditorView.findFromDOM(content)!;
+
+    // `selectionEnd` puts the caret at the end of the document on the first render.
+    await waitFor(() => expect(view.state.selection.main.head).toEqual(view.state.doc.length));
+
+    // Which is what makes the first keystroke append rather than land in front of the query.
+    await userEvent.keyboard('X');
+    await waitFor(() => expect(view.state.doc.toString()).toEqual('type:org.dxos.type.person #investor #newX '));
+  },
 };
 
 /**
@@ -115,12 +136,13 @@ export const Atomic: Story = {
     // The placeholder renders inside the content element, so an empty document is not empty text.
     const doc = () => (content.querySelector('.cm-placeholder') ? '' : content.textContent);
 
-    await userEvent.click(content);
     await waitFor(() => expect(doc()).toEqual('#test'));
 
+    // No click and no `{End}`: `selectionEnd` is what puts the caret at the end of the document on
+    // the first render, and the caret at the tag's own edge is still in the tag — so this single
+    // Backspace both proves that and takes the whole chip.
     // `keyboard`, not `type`: the latter clicks the element first, which would move the caret.
-    // The caret at the tag's own edge is still in the tag, so one Backspace takes the whole chip.
-    await userEvent.keyboard('{End}{Backspace}');
+    await userEvent.keyboard('{Backspace}');
     await waitFor(() => expect(doc()).toEqual(''));
 
     // Atomic does not mean uneditable: each character lands outside the replaced range and grows it,

--- a/packages/ui/react-ui-components/src/components/QueryEditor/query-extension.test.ts
+++ b/packages/ui/react-ui-components/src/components/QueryEditor/query-extension.test.ts
@@ -18,7 +18,7 @@ const hue = tag.hue ?? getHashHue(tag.id);
 /**
  * A tag has two renderings: a widget that REPLACES the text, and marks drawn OVER it. The second
  * exists only because an atomic widget cannot be edited character by character — so the tag switches
- * to marks exactly while the caret is in it, and back once the caret leaves.
+ * to marks exactly while it is being composed (the caret at its trailing edge), and back otherwise.
  */
 describe('tag rendering', () => {
   test('is an atomic chip when the caret is elsewhere', async () => {
@@ -31,7 +31,13 @@ describe('tag rendering', () => {
     view.destroy();
   });
 
-  test('is marks while the caret is in it, so the text stays editable', async () => {
+  test('stays an atomic chip with the caret inside it', async () => {
+    const view = await viewOf('#important', 5);
+    expect(decorationsOf(view)).toMatchObject([{ from: 0, to: 10, atomic: true }]);
+    view.destroy();
+  });
+
+  test('is marks while it is being composed, so the text stays editable', async () => {
     const view = await viewOf('#important', 10);
     const ranges = decorationsOf(view);
     expect(ranges.every((range) => !range.atomic)).toBe(true);
@@ -113,6 +119,43 @@ describe('buildQueryDecorations', () => {
   test('the chip is drawn in the tag hue', async () => {
     const view = await viewOf('#important', 10);
     expect(decorationsOf(view).some((range) => range.class?.includes(hue))).toBe(true);
+    view.destroy();
+  });
+});
+
+/**
+ * Tags are atomic, so text must never end up glued to one — and there has to be a position at the end
+ * of the document that is not adjacent to a chip.
+ */
+describe('spacing', () => {
+  test('typing immediately before a tag is separated from it', async () => {
+    const view = await viewOf('#important', 0);
+    view.dispatch({ changes: { from: 0, insert: 'a' }, selection: EditorSelection.cursor(1) });
+    expect(view.state.doc.toString()).toBe('a #important ');
+    expect(view.state.selection.main.head).toBe(1);
+    view.destroy();
+  });
+
+  test('an insertion leaves a trailing space', async () => {
+    const view = await viewOf('#a', 2);
+    view.dispatch({ changes: { from: 2, insert: 'b' }, selection: EditorSelection.cursor(3) });
+    expect(view.state.doc.toString()).toBe('#ab ');
+    // The caret stays before the trailing space, so typing continues to extend the tag.
+    expect(view.state.selection.main.head).toBe(3);
+    view.destroy();
+  });
+
+  test('the trailing space is not re-added after a deletion', async () => {
+    const view = await viewOf('#a ', 3);
+    view.dispatch({ changes: { from: 2, to: 3 } });
+    expect(view.state.doc.toString()).toBe('#a');
+    view.destroy();
+  });
+
+  test('an empty document is left empty, so the placeholder shows', async () => {
+    const view = await viewOf('x', 1);
+    view.dispatch({ changes: { from: 0, to: 1 } });
+    expect(view.state.doc.toString()).toBe('');
     view.destroy();
   });
 });

--- a/packages/ui/react-ui-components/src/components/QueryEditor/query-extension.test.ts
+++ b/packages/ui/react-ui-components/src/components/QueryEditor/query-extension.test.ts
@@ -16,9 +16,10 @@ const tags: Tag.Map = { [tag.id]: tag };
 const hue = tag.hue ?? getHashHue(tag.id);
 
 /**
- * A tag has two renderings: a widget that REPLACES the text, and marks drawn OVER it. The second
- * exists only because an atomic widget cannot be edited character by character — so the tag switches
- * to marks exactly while it is being composed (the caret at its trailing edge), and back otherwise.
+ * A tag is one object: a widget REPLACES its text, atomically, wherever the caret is — including at
+ * the tag's own edges, so Backspace against it removes the whole chip rather than a character of the
+ * label. It is still typed a character at a time, since an insertion at the range's boundary lands
+ * outside it and grows the node.
  */
 describe('tag rendering', () => {
   test('is an atomic chip when the caret is elsewhere', async () => {
@@ -37,12 +38,11 @@ describe('tag rendering', () => {
     view.destroy();
   });
 
-  test('is marks while it is being composed, so the text stays editable', async () => {
+  test('stays an atomic chip with the caret at its trailing edge', async () => {
+    // Regression: the caret lands here both while the tag is being typed and after `End`, and an
+    // exception for it left Backspace deleting a character of the label instead of the whole tag.
     const view = await viewOf('#important', 10);
-    const ranges = decorationsOf(view);
-    expect(ranges.every((range) => !range.atomic)).toBe(true);
-    // The chip's four boxes: outer, bordered inner, the `#` badge, the label.
-    expect(ranges.map(({ from, to }) => `${from}-${to}`).sort()).toEqual(['0-1', '0-10', '0-10', '1-10']);
+    expect(decorationsOf(view)).toMatchObject([{ from: 0, to: 10, atomic: true }]);
     view.destroy();
   });
 
@@ -54,36 +54,17 @@ describe('tag rendering', () => {
     view.destroy();
   });
 
-  test('only the tag under the caret is marks; the rest stay chips', async () => {
+  test('every tag is a chip, wherever the caret is', async () => {
     const view = await viewOf('#alpha #beta', 12);
     const ranges = decorationsOf(view);
-    expect(ranges.filter((range) => range.atomic).map(({ from, to }) => [from, to])).toEqual([[0, 6]]);
+    expect(ranges.filter((range) => range.atomic).map(({ from, to }) => [from, to])).toEqual([
+      [0, 6],
+      [7, 12],
+    ]);
     view.destroy();
   });
-});
 
-/**
- * The two renderings have to be the same shape, or the tag visibly changes as the caret enters and
- * leaves it. Both are built from `chipClasses`, and this renders them to prove it holds end to end.
- */
-describe('the two renderings are the same chip', () => {
-  test('same class chain, part for part', async () => {
-    const view = await viewOf('#important', 10);
-    const marked = chipShape(view.contentDOM.querySelector('.cm-line')!);
-
-    const blurred = await viewOf('#important', 0);
-    blurred.contentDOM.dispatchEvent(new FocusEvent('blur'));
-    await new Promise((resolve) => requestAnimationFrame(resolve));
-    const replaced = chipShape(blurred.contentDOM.querySelector('.cm-line')!);
-
-    // Guard the comparison itself: two empty chains would otherwise "match".
-    expect(marked).toHaveLength(4);
-    expect(marked).toEqual(replaced);
-    view.destroy();
-    blurred.destroy();
-  });
-
-  test('the label is rendered once, either way', async () => {
+  test('the label is rendered once', async () => {
     const view = await viewOf('#important', 10);
     expect(view.contentDOM.textContent).toBe('#important');
     view.destroy();
@@ -118,7 +99,9 @@ describe('buildQueryDecorations', () => {
 
   test('the chip is drawn in the tag hue', async () => {
     const view = await viewOf('#important', 10);
-    expect(decorationsOf(view).some((range) => range.class?.includes(hue))).toBe(true);
+    // The hue lives in the widget's own DOM, so it is read off the rendered chip rather than a spec.
+    const classes = [...view.contentDOM.querySelectorAll('span')].map((el) => el.className);
+    expect(classes.some((className) => className.includes(hue))).toBe(true);
     view.destroy();
   });
 });
@@ -191,7 +174,3 @@ const decorationsOf = (view: EditorView) => {
 
   return ranges;
 };
-
-/** The class of every element from the tag's outermost box down to its innermost, in order. */
-const chipShape = (root: Element): string[] =>
-  [...root.querySelectorAll('span')].map((el) => el.className).filter(Boolean);

--- a/packages/ui/react-ui-components/src/components/QueryEditor/query-extension.ts
+++ b/packages/ui/react-ui-components/src/components/QueryEditor/query-extension.ts
@@ -3,7 +3,7 @@
 //
 
 import { HighlightStyle, LanguageSupport, LRLanguage, syntaxHighlighting, syntaxTree } from '@codemirror/language';
-import { type EditorState, type Extension, RangeSetBuilder, StateField } from '@codemirror/state';
+import { EditorState, type Extension, RangeSetBuilder, StateField, type TransactionSpec } from '@codemirror/state';
 import { Decoration, type DecorationSet, EditorView, WidgetType } from '@codemirror/view';
 import { type SyntaxNodeRef } from '@lezer/common';
 import { styleTags, tags as t } from '@lezer/highlight';
@@ -27,6 +27,7 @@ export const query = ({ tags }: QueryOptions = {}): Extension => {
     new LanguageSupport(queryLanguage),
     syntaxHighlighting(queryHighlightStyle),
     decorations({ tags }),
+    spacing,
     typeahead({
       onComplete: ({ line }: CompletionContext) => {
         const words = line.split(/\s+/).filter(Boolean);
@@ -54,6 +55,11 @@ export const buildQueryDecorations = (state: EditorState, { tags }: QueryOptions
       const range = intersectRanges(state.selection.main, node);
       return hasFocus && range && (state.selection.main.from > 0 || range.to - range.from > 0);
     };
+
+    // A tag is atomic everywhere except at its trailing edge, which is the only position from which it
+    // can still be composed — `#` then label characters. Atomic ranges keep the caret from landing
+    // anywhere else inside it, so this position is reachable only while typing the tag.
+    const isComposing = ({ to }: Range) => hasFocus && state.selection.main.empty && state.selection.main.head === to;
 
     // Collected rather than fed straight to a `RangeSetBuilder`, which demands ascending `from`:
     // the bare-`#` ranges below come from a document scan and interleave with the tree's own.
@@ -117,8 +123,8 @@ export const buildQueryDecorations = (state: EditorState, { tags }: QueryOptions
               const label = state.sliceDoc(tagNode.from + 1, tagNode.to);
               const tag = Tag.findTagByLabel(tags, label);
               const hue = tag?.hue ?? getHashHue(tag?.id ?? label);
-              if (isInside(node)) {
-                // Under the caret the text has to stay live and editable, so the chip is painted with
+              if (isComposing(tagNode)) {
+                // While the tag is being typed the text has to stay live and editable, so the chip is painted with
                 // marks over it rather than replacing it. `tagMarks` mirrors `TagWidget` class for
                 // class, so the tag does not change shape as the caret enters or leaves it.
                 for (const mark of tagMarks(node.from, node.to, hue)) {
@@ -245,6 +251,55 @@ const decorations = ({ tags }: QueryOptions): Extension => {
     }),
   ];
 };
+
+/**
+ * Keeps typed text from being glued onto a tag chip.
+ *
+ * Two rules, both applied as follow-up changes so the user's own transaction is left intact:
+ * 1. Text typed immediately before a tag is separated from it by a space.
+ * 2. An insertion leaves a trailing space at the end of the document, so there is always somewhere to
+ *    type that is not adjacent to a chip. Deletions are exempt, or backspace at the end of the
+ *    document would only ever delete a space this rule puts straight back.
+ */
+export const spacing: Extension = EditorState.transactionFilter.of((tr) => {
+  if (!tr.docChanged) {
+    return tr;
+  }
+
+  const tagStarts = new Set<number>();
+  syntaxTree(tr.startState).iterate({
+    enter: (node) => {
+      if (node.type.id === QueryDSL.Node.Tag) {
+        tagStarts.add(node.from);
+      }
+    },
+  });
+
+  let inserting = false;
+  let separator: number | undefined;
+  tr.changes.iterChanges((fromA, toA, _fromB, toB, inserted) => {
+    if (!inserted.length) {
+      return;
+    }
+
+    inserting = true;
+    if (fromA === toA && tagStarts.has(fromA) && !/\s$/.test(inserted.toString())) {
+      separator = toB;
+    }
+  });
+
+  const specs: TransactionSpec[] = [tr];
+  let text = tr.newDoc.toString();
+  if (separator !== undefined) {
+    specs.push({ changes: { from: separator, insert: ' ' }, sequential: true });
+    text = text.slice(0, separator) + ' ' + text.slice(separator);
+  }
+  if (inserting && text.length > 0 && !/\s$/.test(text)) {
+    specs.push({ changes: { from: text.length, insert: ' ' }, sequential: true });
+  }
+
+  return specs;
+});
 
 const lineHeight = '30px';
 

--- a/packages/ui/react-ui-components/src/components/QueryEditor/query-extension.ts
+++ b/packages/ui/react-ui-components/src/components/QueryEditor/query-extension.ts
@@ -118,10 +118,9 @@ export const buildQueryDecorations = (state: EditorState, { tags }: QueryOptions
               const label = state.sliceDoc(tagNode.from + 1, tagNode.to);
               const tag = Tag.findTagByLabel(tags, label);
               const hue = tag?.hue ?? getHashHue(tag?.id ?? label);
-              // Atomic in every caret position, including its own edges: a tag is one object, so
-              // Backspace against it removes the whole chip rather than a character of the label. The
-              // tag is still typed a character at a time — an insertion at the range's boundary lands
-              // outside it, growing the node, and the chip re-renders with the longer label.
+              // Atomic at its own edges too, so Backspace against a tag takes the chip rather than a
+              // character of the label; typing still grows it, since an insertion at the range's
+              // boundary lands outside it.
               //
               // `replace`, not `widget`: a widget is a POINT decoration, so one covering a range that
               // starts at offset 0 paints before that offset's coordinate and the caret draws to its
@@ -274,7 +273,9 @@ export const spacing: Extension = EditorState.transactionFilter.of((tr) => {
     }
 
     inserting = true;
-    if (fromA === toA && tagStarts.has(fromA) && !/\s$/.test(inserted.toString())) {
+    // Keyed on `toA`, the offset the inserted text ends against: that covers a replacement whose
+    // range ends at the tag as well as a plain insertion, where `fromA` and `toA` are the same.
+    if (tagStarts.has(toA) && !/\s$/.test(inserted.toString())) {
       separator = toB;
     }
   });

--- a/packages/ui/react-ui-components/src/components/QueryEditor/query-extension.ts
+++ b/packages/ui/react-ui-components/src/components/QueryEditor/query-extension.ts
@@ -56,11 +56,6 @@ export const buildQueryDecorations = (state: EditorState, { tags }: QueryOptions
       return hasFocus && range && (state.selection.main.from > 0 || range.to - range.from > 0);
     };
 
-    // A tag is atomic everywhere except at its trailing edge, which is the only position from which it
-    // can still be composed — `#` then label characters. Atomic ranges keep the caret from landing
-    // anywhere else inside it, so this position is reachable only while typing the tag.
-    const isComposing = ({ to }: Range) => hasFocus && state.selection.main.empty && state.selection.main.head === to;
-
     // Collected rather than fed straight to a `RangeSetBuilder`, which demands ascending `from`:
     // the bare-`#` ranges below come from a document scan and interleave with the tree's own.
     const collected: { from: number; to: number; deco: Decoration }[] = [];
@@ -123,19 +118,15 @@ export const buildQueryDecorations = (state: EditorState, { tags }: QueryOptions
               const label = state.sliceDoc(tagNode.from + 1, tagNode.to);
               const tag = Tag.findTagByLabel(tags, label);
               const hue = tag?.hue ?? getHashHue(tag?.id ?? label);
-              if (isComposing(tagNode)) {
-                // While the tag is being typed the text has to stay live and editable, so the chip is painted with
-                // marks over it rather than replacing it. `tagMarks` mirrors `TagWidget` class for
-                // class, so the tag does not change shape as the caret enters or leaves it.
-                for (const mark of tagMarks(node.from, node.to, hue)) {
-                  deco.add(mark.from, mark.to, mark.deco);
-                }
-              } else {
-                // `replace`, not `widget`: a widget is a POINT decoration, so one covering a range that
-                // starts at offset 0 paints before that offset's coordinate and the caret draws to its
-                // right — pressing Home appeared to leave the caret after the tag.
-                deco.add(node.from, node.to, Decoration.replace({ widget: new TagWidget(label, hue), atomic: true }));
-              }
+              // Atomic in every caret position, including its own edges: a tag is one object, so
+              // Backspace against it removes the whole chip rather than a character of the label. The
+              // tag is still typed a character at a time — an insertion at the range's boundary lands
+              // outside it, growing the node, and the chip re-renders with the longer label.
+              //
+              // `replace`, not `widget`: a widget is a POINT decoration, so one covering a range that
+              // starts at offset 0 paints before that offset's coordinate and the caret draws to its
+              // right — pressing Home appeared to leave the caret after the tag.
+              deco.add(node.from, node.to, Decoration.replace({ widget: new TagWidget(label, hue), atomic: true }));
             }
             break;
           }
@@ -314,42 +305,13 @@ const container = (classNames: string, ...children: Domino<HTMLElement>[]) => {
   return Domino.of('span').classNames(CHIP_OUTER).append(inner).root;
 };
 
-/**
- * A tag chip's parts, keyed by the nesting {@link container} produces.
- *
- * Single source for both of the tag's renderings — {@link TagWidget} when the caret is elsewhere,
- * {@link tagMarks} over live text when it is not. Anything that drifts between them shows up as the
- * tag changing shape as the caret enters or leaves it, so neither builds its own classes.
- */
+/** A tag chip's parts, keyed by the nesting {@link container} produces. */
 const chipClasses = (hue: string) => {
-  const { bg, fg, border, surface } = getStyles(hue);
+  const { bg, fg, surface } = getStyles(hue);
   return {
-    outer: CHIP_OUTER,
-    inner: mx(CHIP_INNER, border),
     hash: mx('flex items-center px-1 text-black text-xs', bg),
     label: mx('flex items-center px-1 text-sm', surface, fg),
   };
-};
-
-/**
- * The chip drawn as marks, so the text underneath stays editable.
- *
- * Ranges are returned outermost first; `buildQueryDecorations` sorts equal starts widest-first and
- * `Array.prototype.sort` is stable, so this order is the nesting order.
- */
-const tagMarks = (from: number, to: number, hue: string): { from: number; to: number; deco: Decoration }[] => {
-  const classes = chipClasses(hue);
-  const marks = [
-    { from, to, deco: Decoration.mark({ class: classes.outer }) },
-    { from, to, deco: Decoration.mark({ class: classes.inner }) },
-    { from, to: from + 1, deco: Decoration.mark({ class: classes.hash }) },
-  ];
-  // A bare `#` has no label yet, and an empty range is not a decoration.
-  if (to > from + 1) {
-    marks.push({ from: from + 1, to, deco: Decoration.mark({ class: classes.label }) });
-  }
-
-  return marks;
 };
 
 /**

--- a/packages/ui/react-ui-editor/src/hooks/useTextEditor.ts
+++ b/packages/ui/react-ui-editor/src/hooks/useTextEditor.ts
@@ -74,11 +74,12 @@ export const useTextEditor = (
     if (parentRef.current) {
       log('create', { id, instanceId, doc: initialValue?.length ?? 0 });
 
-      // Only records whether an explicit selection governs, so that `selectionEnd` defers to it. The
-      // selection itself is applied by the effect below, which also handles later changes to it.
+      // Only records whether an explicit selection governs, so that `selectionEnd` defers to it; the
+      // effect below applies it. `!== undefined`, since an explicit `{ anchor: 0 }` is a selection.
+      const length = (doc ?? initialValue)?.length ?? 0;
       let initialSelection;
-      if (selection?.anchor && initialValue?.length) {
-        if (selection.anchor <= initialValue.length && (selection?.head ?? 0) <= initialValue.length) {
+      if (selection?.anchor !== undefined && length) {
+        if (selection.anchor <= length && (selection?.head ?? 0) <= length) {
           initialSelection = selection;
         }
       }

--- a/packages/ui/react-ui-editor/src/hooks/useTextEditor.ts
+++ b/packages/ui/react-ui-editor/src/hooks/useTextEditor.ts
@@ -74,15 +74,13 @@ export const useTextEditor = (
     if (parentRef.current) {
       log('create', { id, instanceId, doc: initialValue?.length ?? 0 });
 
+      // Only records whether an explicit selection governs, so that `selectionEnd` defers to it. The
+      // selection itself is applied by the effect below, which also handles later changes to it.
       let initialSelection;
       if (selection?.anchor && initialValue?.length) {
         if (selection.anchor <= initialValue.length && (selection?.head ?? 0) <= initialValue.length) {
           initialSelection = selection;
         }
-      } else if (selectionEnd && selection === undefined) {
-        const index = initialValue?.indexOf('\n');
-        const anchor = !index || index === -1 ? 0 : index;
-        initialSelection = { anchor };
       }
 
       // https://codemirror.net/docs/ref/#state.EditorStateConfig
@@ -110,9 +108,7 @@ export const useTextEditor = (
       // Move to end of line after document loaded (unless selection is specified).
       if (selectionEnd && !initialSelection) {
         const { to } = view.state.doc.lineAt(0);
-        if (to) {
-          view.dispatch({ selection: { anchor: to } });
-        }
+        view.dispatch({ selection: { anchor: to } });
       }
 
       setView(view);


### PR DESCRIPTION
## Summary

Three fixes, found while making `QueryEditor` tags behave as single objects.

### 1. Tags are atomic (`react-ui-components`)

A tag is now an atomic `Decoration.replace` chip in **every** caret position, including its own edges — one Backspace or Delete removes the whole chip rather than a character of the label.

The first attempt kept a "composing exception" that left the tag editable while the caret sat at its trailing edge, on the assumption that an atomic widget could not be typed into. That assumption was wrong: an insertion at the replaced range's *boundary* lands outside it, growing the node, so the chip re-renders with the longer label and free-form typing still works. The exception was also exactly where `{End}` puts the caret, so Backspace there silently edited the label — the bug this PR's play test now pins.

Dropping it removed the second rendering entirely (`tagMarks`, `isComposing`, and half of `chipClasses`): there is one way a tag is drawn now, not two that had to be kept in visual sync.

### 2. Typed text is never glued to a chip (`react-ui-components`)

New `spacing` transaction filter:

- text typed immediately before a tag is separated from it by a space;
- an insertion leaves a trailing space at the end of the document, so there is always somewhere to type that is not adjacent to a chip.

Deletions are exempt from the second rule — otherwise Backspace at the end of the document would only ever remove a space the rule puts straight back. An emptied document stays empty so the placeholder still shows.

### 3. `selectionEnd` never moved the caret (`react-ui-editor`)

`useTextEditor` had a branch that, when `selectionEnd` was set, assigned `initialSelection = { anchor: <index of the first newline, else 0> }`. That value was never used — the `selection:` line in `EditorState.create` is commented out — but it *was* truthy, so the guard below it (`if (selectionEnd && !initialSelection)`) never fired and the "move to end of line" dispatch was dead code. Single-line or multi-line, the caret stayed at 0 for every editor in the repo.

`initialSelection` now only records whether an explicit `selection` prop governs (which a later effect applies anyway), so `selectionEnd` defers to it and otherwise moves the caret to the end of line 1.

### 4. Chess board expands to fill its card (`plugin-chess`)

`Card.Section` is a grid with `items-center`, so `Card.Row` sat at its content height. The board sizes itself from its container (`h-[min(100cqw,100cqh)]`) rather than from content, so with the row at height 0 the container query resolved to 0 and every square fell back to its 4px minimum — the board rendered as a dot in the middle of the popover. `self-stretch` on the row fixes it, kept local to the chess card rather than touching `.dx-card__section`, which every card depends on.

| | row | board |
|---|---|---|
| before | 352 × 0 | 0 × 0 |
| after | 352 × 352 | 352 × 352 |

## Testing

- `query-extension.test.ts` — decoration/atomicity rules and the spacing filter, as a pure function of `(state, options)`.
- `QueryEditor.stories.tsx` — two play tests driving real keystrokes in chromium, since atomicity is enforced by CodeMirror's own cursor and delete commands rather than by the decorations the unit tests inspect:
  - **Atomic** — one Backspace takes the whole chip; typing still builds a tag character by character; spacing holds on both sides; a single Delete removes all five characters at once.
  - **Tags** — the caret is at the end of the document on first render, so the first keystroke appends.
- Both play tests were confirmed to fail without their respective fixes (`expected '#test' to deeply equal ''`, `expected +0 to deeply equal 40`).
- Chess board verified by measuring the live storybook before and after; `ChessArticle` checked for regression at 678 × 678, unchanged.

```
react-ui-components:test              27 passed
react-ui-components:test-storybook    49 passed
react-ui-editor:test-storybook        63 passed
plugin-chess:test                      9 passed
plugin-chess:test-storybook            8 passed
```

## Reviewer notes

- The `useTextEditor` change affects every consumer of `selectionEnd` — `RefEditor`, the editor stories, and `QueryEditor`. Since the flag previously did nothing at all, the change is "it starts working", not "it works differently". `react-ui-editor` and `react-ui-form` storybook suites pass.
- The storybook suite resolves `@dxos/react-ui-editor` through its build output, so a run started against a stale `dist` can miss a source fix there; re-run before believing a red result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query editor tags now remain atomic chips while focused, with improved deletion, editing, spacing, and caret behavior.
  * Added automatic spacing around inserted query tags.
* **Bug Fixes**
  * Improved initial cursor placement in text editors, including line-start positions.
  * Chess boards now size correctly within their containing card sections.
* **Tests**
  * Expanded coverage for tag interactions, multiple chips, spacing, and empty queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->