### PR TITLE
codemirror: bump @codemirror/lang-html, lang-markdown, view (patch)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ catalogs:
       specifier: ^6.0.2
       version: 6.0.2
     '@codemirror/lang-markdown':
-      specifier: 6.5.1
-      version: 6.5.1
+      specifier: 6.5.2
+      version: 6.5.2
     '@codemirror/lang-xml':
       specifier: ^6.1.0
       version: 6.1.0
@@ -133,8 +133,8 @@ catalogs:
       specifier: ^6.1.3
       version: 6.1.3
     '@codemirror/view':
-      specifier: ^6.43.6
-      version: 6.43.6
+      specifier: ^6.43.8
+      version: 6.43.8
     '@comunica/query-sparql-rdfjs':
       specifier: 5.2.3
       version: 5.2.3
@@ -2286,7 +2286,7 @@ importers:
         version: 6.0.2
       '@codemirror/lang-markdown':
         specifier: 'catalog:'
-        version: 6.5.1
+        version: 6.5.2
       '@codemirror/language':
         specifier: 'catalog:'
         version: 6.12.4
@@ -2298,7 +2298,7 @@ importers:
         version: 6.1.3
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -7412,7 +7412,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/agent-runtime':
         specifier: workspace:*
         version: link:../../core/compute/agent-runtime
@@ -8720,7 +8720,7 @@ importers:
         version: 6.2.5
       '@codemirror/lang-markdown':
         specifier: 'catalog:'
-        version: 6.5.1
+        version: 6.5.2
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -10153,7 +10153,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -10879,7 +10879,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -11743,7 +11743,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -12024,7 +12024,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -13283,7 +13283,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -13455,7 +13455,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/agent-runtime':
         specifier: workspace:*
         version: link:../../core/compute/agent-runtime
@@ -13770,7 +13770,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -13929,10 +13929,10 @@ importers:
         version: 1.6.2(typescript@6.0.3)
       '@valtown/codemirror-continue':
         specifier: 'catalog:'
-        version: 2.3.1(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)(@lezer/common@1.5.2)
+        version: 2.3.1(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)(@lezer/common@1.5.2)
       '@valtown/codemirror-ts':
         specifier: 'catalog:'
-        version: 2.3.1(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.7)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)
+        version: 2.3.1(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.7)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)
       chess.js:
         specifier: 'catalog:'
         version: 1.4.0
@@ -14224,7 +14224,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -15442,7 +15442,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -16468,7 +16468,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -16841,7 +16841,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@lezer/lr':
         specifier: ^1.4.10
         version: 1.4.10
@@ -19887,7 +19887,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/conductor':
         specifier: workspace:*
         version: link:../../core/compute/conductor
@@ -20063,7 +20063,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -20130,7 +20130,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/assistant':
         specifier: workspace:*
         version: link:../../core/compute/assistant
@@ -20429,7 +20429,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/app-graph':
         specifier: workspace:*
         version: link:../../sdk/app-graph
@@ -20469,7 +20469,7 @@ importers:
         version: 6.2.5
       '@codemirror/lang-markdown':
         specifier: 'catalog:'
-        version: 6.5.1
+        version: 6.5.2
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -20662,7 +20662,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -21027,7 +21027,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/lit-grid':
         specifier: workspace:*
         version: link:../lit-grid
@@ -21234,7 +21234,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -21469,7 +21469,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../core/echo/echo
@@ -21765,7 +21765,7 @@ importers:
         version: 6.20.3
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -22027,7 +22027,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../core/echo/echo
@@ -22094,7 +22094,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -22259,7 +22259,7 @@ importers:
         version: 6.0.2
       '@codemirror/lang-markdown':
         specifier: 'catalog:'
-        version: 6.5.1
+        version: 6.5.2
       '@codemirror/lang-xml':
         specifier: 'catalog:'
         version: 6.1.0
@@ -22283,7 +22283,7 @@ importers:
         version: 6.7.1
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.43.6
+        version: 6.43.8
       '@dxos/app-graph':
         specifier: workspace:*
         version: link:../../sdk/app-graph
@@ -22349,13 +22349,13 @@ importers:
         version: 1.6.3
       '@replit/codemirror-vim':
         specifier: 'catalog:'
-        version: 6.3.0(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)
+        version: 6.3.0(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)
       '@replit/codemirror-vscode-keymap':
         specifier: 'catalog:'
-        version: 6.0.2(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)
+        version: 6.0.2(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)
       '@uiw/codemirror-theme-vscode':
         specifier: 'catalog:'
-        version: 4.25.2(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)
+        version: 4.25.2(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)
       ajv:
         specifier: 'catalog:'
         version: 8.18.0
@@ -24218,8 +24218,8 @@ packages:
   '@codemirror/lang-liquid@6.2.1':
     resolution: {integrity: sha512-J1Mratcm6JLNEiX+U2OlCDTysGuwbHD76XwuL5o5bo9soJtSbz2g6RU3vGHFyS5DC8rgVmFSzi7i6oBftm7tnA==}
 
-  '@codemirror/lang-markdown@6.5.1':
-    resolution: {integrity: sha512-6re5avCNfyRMIoi3XNjbEfQM1vTeVD3JS3g/Fyegyso/eoANFM71Cyvbb66LDyYtQLMEcRFlzioywCqDo9SlLA==}
+  '@codemirror/lang-markdown@6.5.2':
+    resolution: {integrity: sha512-AwBOdkWYuA//WcM0xO5PfHPUcmz/O2i5o0Nsg1U69SII/loCJlFI1Romd9xp2HYb1kYJRGZotyqRghuHH5n8Kw==}
 
   '@codemirror/lang-php@6.0.1':
     resolution: {integrity: sha512-ublojMdw/PNWa7qdN5TMsjmqkNuTBD3k6ndZ4Z0S25SBAiweFGyY68AS3xNcIOlb6DDFDvKlinLQ40vSLqf8xA==}
@@ -24278,8 +24278,8 @@ packages:
   '@codemirror/theme-one-dark@6.1.3':
     resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
 
-  '@codemirror/view@6.43.6':
-    resolution: {integrity: sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==}
+  '@codemirror/view@6.43.8':
+    resolution: {integrity: sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -44078,14 +44078,14 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
 
   '@codemirror/commands@6.10.4':
     dependencies:
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
 
   '@codemirror/lang-angular@0.1.2':
@@ -44125,7 +44125,7 @@ snapshots:
       '@codemirror/lang-javascript': 6.2.5
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/css': 1.1.1
       '@lezer/html': 1.3.12
@@ -44141,7 +44141,7 @@ snapshots:
       '@codemirror/language': 6.12.4
       '@codemirror/lint': 6.9.7
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.4.1
 
@@ -44151,7 +44151,7 @@ snapshots:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -44174,18 +44174,18 @@ snapshots:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
 
-  '@codemirror/lang-markdown@6.5.1':
+  '@codemirror/lang-markdown@6.5.2':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/markdown': 1.6.3
 
@@ -44244,7 +44244,7 @@ snapshots:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/xml': 1.0.6
 
@@ -44271,7 +44271,7 @@ snapshots:
       '@codemirror/lang-json': 6.0.2
       '@codemirror/lang-less': 6.0.1
       '@codemirror/lang-liquid': 6.2.1
-      '@codemirror/lang-markdown': 6.5.1
+      '@codemirror/lang-markdown': 6.5.2
       '@codemirror/lang-php': 6.0.1
       '@codemirror/lang-python': 6.1.2
       '@codemirror/lang-rust': 6.0.1
@@ -44287,7 +44287,7 @@ snapshots:
   '@codemirror/language@6.12.4':
     dependencies:
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -44300,33 +44300,33 @@ snapshots:
   '@codemirror/lint@6.8.5':
     dependencies:
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       crelt: 1.0.6
 
   '@codemirror/lint@6.9.7':
     dependencies:
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       crelt: 1.0.6
 
   '@codemirror/merge@6.12.2':
     dependencies:
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/highlight': 1.2.3
       style-mod: 4.1.0
 
   '@codemirror/search@6.5.11':
     dependencies:
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       crelt: 1.0.6
 
   '@codemirror/search@6.7.1':
     dependencies:
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       crelt: 1.0.6
 
   '@codemirror/state@6.7.1':
@@ -44337,10 +44337,10 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/highlight': 1.2.3
 
-  '@codemirror/view@6.43.6':
+  '@codemirror/view@6.43.8':
     dependencies:
       '@codemirror/state': 6.7.1
       crelt: 1.0.6
@@ -51122,15 +51122,15 @@ snapshots:
 
   '@remix-run/router@1.23.2': {}
 
-  '@replit/codemirror-vim@6.3.0(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)':
+  '@replit/codemirror-vim@6.3.0(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)':
     dependencies:
       '@codemirror/commands': 6.10.4
       '@codemirror/language': 6.12.4
       '@codemirror/search': 6.7.1
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
 
-  '@replit/codemirror-vscode-keymap@6.0.2(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)':
+  '@replit/codemirror-vscode-keymap@6.0.2(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.10.4
@@ -51138,7 +51138,7 @@ snapshots:
       '@codemirror/lint': 6.9.7
       '@codemirror/search': 6.7.1
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     optional: true
@@ -53431,19 +53431,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@uiw/codemirror-theme-vscode@4.25.2(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)':
+  '@uiw/codemirror-theme-vscode@4.25.2(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)':
     dependencies:
-      '@uiw/codemirror-themes': 4.25.2(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)
+      '@uiw/codemirror-themes': 4.25.2(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
 
-  '@uiw/codemirror-themes@4.25.2(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)':
+  '@uiw/codemirror-themes@4.25.2(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)':
     dependencies:
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
 
   '@ungap/structured-clone@1.2.0': {}
 
@@ -53517,19 +53517,19 @@ snapshots:
     dependencies:
       valibot: 1.4.2(typescript@6.0.3)
 
-  '@valtown/codemirror-continue@2.3.1(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)(@lezer/common@1.5.2)':
+  '@valtown/codemirror-continue@2.3.1(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)(@lezer/common@1.5.2)':
     dependencies:
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
 
-  '@valtown/codemirror-ts@2.3.1(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.7)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)':
+  '@valtown/codemirror-ts@2.3.1(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.7)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/lint': 6.9.7
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
 
   '@vercel/oidc@3.1.0': {}
 
@@ -55370,7 +55370,7 @@ snapshots:
       '@codemirror/lint': 6.8.5
       '@codemirror/search': 6.5.11
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
 
   collapse-white-space@2.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,10 +58,10 @@ catalog:
   '@cloudflare/workers-types': ^5.20260717.1
   '@codemirror/autocomplete': ^6.20.3
   '@codemirror/commands': ^6.10.4
-  '@codemirror/lang-html': ^6.4.11
+  '@codemirror/lang-html': ^6.4.12
   '@codemirror/lang-javascript': ^6.2.5
   '@codemirror/lang-json': ^6.0.2
-  '@codemirror/lang-markdown': 6.5.1
+  '@codemirror/lang-markdown': 6.5.2
   '@codemirror/lang-xml': ^6.1.0
   '@codemirror/lang-yaml': ^6.1.3
   '@codemirror/language': ^6.12.4
@@ -71,7 +71,7 @@ catalog:
   '@codemirror/search': ^6.7.1
   '@codemirror/state': ^6.7.1
   '@codemirror/theme-one-dark': ^6.1.3
-  '@codemirror/view': ^6.43.6
+  '@codemirror/view': ^6.43.8
   '@comunica/query-sparql-rdfjs': 5.2.3
   '@crxjs/vite-plugin': ^2.4.0
   '@dnd-kit/core': ^6.0.5


### PR DESCRIPTION
## Summary

Periodic dependency sweep — `codemirror` group (spec: `"@codemirror/*" "codemirror-lang-*"`).

## Versions

| Package | Old | New |
|---|---|---|
| `@codemirror/lang-html` | ^6.4.11 | ^6.4.12 |
| `@codemirror/lang-markdown` | 6.5.1 | 6.5.2 |
| `@codemirror/view` | ^6.43.6 | ^6.43.8 |

Everything else in the group (`@codemirror/autocomplete`, `commands`, `lang-javascript`, `lang-json`, `lang-xml`, `lang-yaml`, `language`, `language-data`, `lint`, `merge`, `search`, `state`, `theme-one-dark`, `codemirror-lang-mermaid`, `codemirror-lang-spreadsheet`) was already at npm latest.

## Validation

- **Install**: clean.
- **Lint**: green, 311/311 tasks.
- **Tests/build**: the two direct consumers, `@dxos/ui-editor` and `@dxos/react-ui-editor` — 94 tasks, all green (`ui-editor` 366/369 tests passed, 1 expected-fail/1 skip/1 todo, matching baseline).

## Classification: trivial

Small patch bumps only, all green. Enabling auto-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_016J5dQfeNANnnmcki2LHJbD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeMirror editor components to newer versions.
  * Improved compatibility and reliability for HTML, Markdown, and editor viewing experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->