### PR TITLE
deck: keep the companion open across a nav-tree navigation

### DIFF
--- a/.changeset/companion-survives-navigation.md
+++ b/.changeset/companion-survives-navigation.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-deck': patch
+---
+
+Keep the companion open when navigating from the nav tree: the companion now follows the plank the new one replaces instead of closing on every navigation.

--- a/packages/plugins/plugin-deck/DESIGN.md
+++ b/packages/plugins/plugin-deck/DESIGN.md
@@ -125,6 +125,9 @@ never moves it.
   to its mailbox.
 - **Per plank, not per deck** — `DeckState.companionPlanks` lists the planks showing their companion,
   so moving between planks restores what each was left in.
+- **Carried across a replacing open** — a navigate (or a level swap) closes the plank the companion was
+  open on, which would prune its entry and close a companion the user never touched. `carryCompanion`
+  hands the entry to the plank standing in for it, so the pane survives nav-tree navigation.
 - **Sizing** — the tile is the plank's own width _plus_ the companion beside it, and the companion's
   width is held deck-wide under `COMPANION_SIZE_KEY` (not a valid node id, so it cannot collide).
   Opening or closing the companion therefore never resizes the plank. Dragging the seam commits both

--- a/packages/plugins/plugin-deck/src/operations/open.ts
+++ b/packages/plugins/plugin-deck/src/operations/open.ts
@@ -21,7 +21,13 @@ import * as ObservabilityOperation from '@dxos/plugin-observability/Observabilit
 import { DeckCapabilities } from '#types';
 
 import { addSubjectsToActiveDeck, resolveLevelOpen, resolveSeededPlanks, updatePlankNames } from '../layout';
-import { computeActiveUpdates, openableChildren, resolveDeckSpec } from '../util';
+import {
+  carryCompanion,
+  computeActiveUpdates,
+  openableChildren,
+  resolveCompanionAnchor,
+  resolveDeckSpec,
+} from '../util';
 import { updateActiveDeck } from './helpers';
 
 const handler: Operation.WithHandler<typeof LayoutOperation.Open> = LayoutOperation.Open.pipe(
@@ -130,9 +136,6 @@ const handler: Operation.WithHandler<typeof LayoutOperation.Open> = LayoutOperat
       // Holding shift forces any disposition into an add (callers forward the raw modifier rather than
       // encoding the policy). Only 'auto' falls back to the attended plank; a shift-forced add from the
       // nav-tree (a 'solo' gesture with no pivot) appends at the end.
-      const navigateSolo = (active: readonly string[]): string[] =>
-        input.subject.every((id) => active.includes(id)) ? [...active] : [...input.subject];
-
       let previouslyOpenIds: Set<string>;
       {
         const deck = yield* DeckCapabilities.getDeck();
@@ -170,8 +173,11 @@ const handler: Operation.WithHandler<typeof LayoutOperation.Open> = LayoutOperat
             : undefined;
 
         let next: string[];
+        // The plank the open stands in for, when it replaces one — see `carryCompanion`.
+        let replacedId: string | undefined;
         if (levelOpen) {
           next = levelOpen.next;
+          replacedId = levelOpen.replacedId;
         } else if (seeded) {
           next = seeded;
         } else if (addBesideOrigin) {
@@ -181,7 +187,12 @@ const handler: Operation.WithHandler<typeof LayoutOperation.Open> = LayoutOperat
           const replaceId = input.name ? deck.plankNames[input.name] : undefined;
           next = addSubjectsToActiveDeck(deck.active, input.subject, { pivotId, replaceId });
         } else {
-          next = navigateSolo(deck.active);
+          // Subjects that are all already open are only scrolled into view; anything else replaces the
+          // deck, so the plank the companion sat beside stands replaced by the subject — anchored the same
+          // way the companion is rendered and serialized.
+          const alreadyOpen = input.subject.every((id) => deck.active.includes(id));
+          next = alreadyOpen ? [...deck.active] : [...input.subject];
+          replacedId = alreadyOpen ? undefined : resolveCompanionAnchor(deck.active, attention.getCurrent());
         }
 
         const { deckUpdates } = computeActiveUpdates({ next, deck, attention });
@@ -194,13 +205,12 @@ const handler: Operation.WithHandler<typeof LayoutOperation.Open> = LayoutOperat
           next,
           boundName && input.subject[0] ? { name: boundName, plankId: input.subject[0] } : undefined,
         );
-        // The companion follows a level swap: the new plank stands in for the replaced one, and closing
-        // it mid-read would also narrow the deck, which the browser answers by clamping the scroll — a
-        // one-frame snap measured at exactly the lost width.
-        const companionPlanks =
-          levelOpen?.replacedId && input.subject[0] && deck.companionPlanks.includes(levelOpen.replacedId)
-            ? [...deckUpdates.companionPlanks, input.subject[0]]
-            : deckUpdates.companionPlanks;
+        const companionPlanks = carryCompanion({
+          pruned: deckUpdates.companionPlanks,
+          previous: deck.companionPlanks,
+          replacedId,
+          replacementId: input.subject[0],
+        });
         yield* Capabilities.updateAtomValue(DeckCapabilities.State, (state) =>
           updateActiveDeck(state, { ...deckUpdates, companionPlanks, plankNames }),
         );

--- a/packages/plugins/plugin-deck/src/util/companion-anchor.test.ts
+++ b/packages/plugins/plugin-deck/src/util/companion-anchor.test.ts
@@ -5,6 +5,7 @@
 import { describe, test } from 'vitest';
 
 import {
+  carryCompanion,
   findAttendedPlank,
   getRenderedPlanks,
   resolveCompanionAnchor,
@@ -71,6 +72,38 @@ describe('resolveCompanionAnchor', () => {
 
   test('an empty deck has no anchor', ({ expect }) => {
     expect(resolveCompanionAnchor([], ['a'])).toBeUndefined();
+  });
+});
+
+describe('carryCompanion', () => {
+  test('an open companion follows the plank the new one replaces', ({ expect }) => {
+    // A nav-tree click replaces the deck: `a` closes, so pruning has already dropped its entry.
+    expect(carryCompanion({ pruned: [], previous: ['a'], replacedId: 'a', replacementId: 'b' })).toEqual(['b']);
+  });
+
+  test('a companion closed on the replaced plank stays closed', ({ expect }) => {
+    expect(carryCompanion({ pruned: [], previous: [], replacedId: 'a', replacementId: 'b' })).toEqual([]);
+    expect(carryCompanion({ pruned: [], previous: ['other'], replacedId: 'a', replacementId: 'b' })).toEqual([]);
+  });
+
+  test('an open that replaces nothing leaves the pruned state alone', ({ expect }) => {
+    expect(carryCompanion({ pruned: ['a'], previous: ['a'], replacedId: undefined, replacementId: 'b' })).toEqual([
+      'a',
+    ]);
+    expect(carryCompanion({ pruned: ['a'], previous: ['a'], replacedId: 'a', replacementId: undefined })).toEqual([
+      'a',
+    ]);
+  });
+
+  test('the surviving planks keep their own companion state', ({ expect }) => {
+    expect(carryCompanion({ pruned: ['c'], previous: ['a', 'c'], replacedId: 'a', replacementId: 'b' })).toEqual([
+      'c',
+      'b',
+    ]);
+  });
+
+  test('does not duplicate a replacement whose companion is already open', ({ expect }) => {
+    expect(carryCompanion({ pruned: ['b'], previous: ['a', 'b'], replacedId: 'a', replacementId: 'b' })).toEqual(['b']);
   });
 });
 

--- a/packages/plugins/plugin-deck/src/util/companion-anchor.ts
+++ b/packages/plugins/plugin-deck/src/util/companion-anchor.ts
@@ -45,6 +45,29 @@ export const findAttendedPlank = (planks: readonly string[], attended: readonly 
 export const resolveCompanionAnchor = (planks: readonly string[], attended: readonly string[]): string | undefined =>
   findAttendedPlank(planks, attended) ?? planks[planks.length - 1];
 
+export type CarryCompanionOptions = {
+  /** Companion state after the open, already pruned to the planks that stayed open. */
+  pruned: readonly string[];
+  /** Companion state before the open. */
+  previous: readonly string[];
+  /** The plank the open replaced, when it replaced one. */
+  replacedId: string | undefined;
+  /** The plank standing in for it. */
+  replacementId: string | undefined;
+};
+
+/**
+ * Companion state after an open that replaces a plank: the companion follows the plank the new one stands
+ * in for. Per-plank state is keyed by a plank id and pruned as that plank closes, so without this a
+ * replacing open — a nav-tree click, a level swap — always closes a companion the user never touched; and
+ * closing it also narrows the deck, which the browser answers by clamping the scroll in a one-frame snap
+ * measured at exactly the lost width.
+ */
+export const carryCompanion = ({ pruned, previous, replacedId, replacementId }: CarryCompanionOptions): string[] =>
+  replacedId && replacementId && previous.includes(replacedId) && !pruned.includes(replacementId)
+    ? [...pruned, replacementId]
+    : [...pruned];
+
 export type ResolveCompanionPlankOptions = {
   /** Qualified companion id (`<plank>/~<variant>`) or a bare `~<variant>`. */
   subject: string;


### PR DESCRIPTION
## Problem

Clicking an item in the nav tree closed the companion pane.

Companion state is per plank (`DeckState.companionPlanks`) and `computeActiveUpdates` prunes it to the planks that stay open. A nav-tree click is a `solo` `LayoutOperation.Open`: the deck becomes just the subject, so the plank the companion was open on leaves `active` and its entry is pruned. In solo mode that means *every* navigation closes a companion the user never touched — and the lost width makes the browser clamp the deck's scroll into a one-frame snap.

`open.ts` already carried the companion across a **level** swap (`resolveLevelOpen().replacedId`, e.g. mailbox → message). The plain navigate path had no equivalent.

## Change

- New pure helper `carryCompanion` in `util/companion-anchor.ts`: given the pruned companion list, the pre-open list, the replaced plank and its replacement, hand the entry to the replacement. It also de-dupes, which the old inline level-swap expression did not.
- `operations/open.ts` now tracks a single `replacedId` for both replacing paths — `levelOpen.replacedId`, and for a navigate the companion anchor of the outgoing deck (`resolveCompanionAnchor(deck.active, attended)`, the same anchor the companion is rendered and serialized against). A navigate whose subjects are all already open still only scrolls into view and replaces nothing.
- `DESIGN.md` §4 records the carry-over.

Unchanged: `add`/`auto` opens that grow the deck never open a companion, and a companion explicitly closed on the outgoing plank stays closed.

## Test

`carryCompanion` unit tests in `util/companion-anchor.test.ts` cover carry, closed-stays-closed, replaces-nothing, surviving planks keeping their own state, and the de-dupe.

```
✓ |node| src/util/companion-anchor.test.ts (21 tests) 31ms
 Test Files  10 passed (10)
      Tests  97 passed (97)
```

(full `plugin-deck` node suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vEa1TnvYQww38X4hkn78P


---
_Generated by [Claude Code](https://claude.ai/code/session_016vEa1TnvYQww38X4hkn78P)_