### PR TITLE
echo: make graph-node type lookups reactive to schema registration

### DIFF
--- a/.changeset/type-icon-registry-reactivity.md
+++ b/.changeset/type-icon-registry-reactivity.md
@@ -1,0 +1,6 @@
+---
+'@dxos/echo': minor
+'@dxos/plugin-crm': patch
+---
+
+Add `Registry.typeAtom(registry, typename)`, a reactive lookup of a registered type entity, and use it when building app-graph nodes. Objects whose schema registered after their graph node was built no longer keep the placeholder icon until an unrelated change rebuilds the node.

--- a/packages/core/echo/echo-client-e2e/src/registry.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/registry.test.ts
@@ -4,9 +4,11 @@
 
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
+import * as Schema from 'effect/Schema';
+import * as AtomRegistry from 'effect/unstable/reactivity/AtomRegistry';
 import { describe, test } from 'vitest';
 
-import { Filter, Obj, Query, Registry, Type } from '@dxos/echo';
+import { DXN, Filter, Obj, Query, Registry, Type } from '@dxos/echo';
 import { makeRegistry, registryLayer, registryLayerWithUpstream } from '@dxos/echo-client';
 import { TestSchema } from '@dxos/echo/testing';
 import { EffectEx } from '@dxos/effect';
@@ -191,6 +193,32 @@ describe('Registry', () => {
 
     const results = registry.query(Query.select(Filter.type(TestSchema.Expando)).limit(2)).results;
     expect(results).toHaveLength(2);
+  });
+
+  test('typeAtom emits when the typename registers, and ignores unrelated churn', ({ expect }) => {
+    const registry = makeRegistry();
+    const atoms = AtomRegistry.make();
+    const atom = Registry.typeAtom(registry, 'org.example.type.late');
+    let emissions = 0;
+    const unsubscribe = atoms.subscribe(atom, () => emissions++);
+
+    expect(atoms.get(atom)).toBeUndefined();
+
+    const Late = Type.makeObject(DXN.make('org.example.type.late', '0.1.0'))(Schema.Struct({}));
+    registry.add([Late]);
+    expect(atoms.get(atom)).toBe(Late);
+    expect(emissions).toBeGreaterThan(0);
+
+    // The registry also holds operations, skills, and routines; their churn must not re-emit here.
+    const settled = emissions;
+    registry.add([makeObj({ key: 'org.example.fn.unrelated', value: 1 })]);
+    expect(emissions).toBe(settled);
+
+    registry.remove(Late.id);
+    expect(atoms.get(atom)).toBeUndefined();
+    expect(emissions).toBeGreaterThan(settled);
+
+    unsubscribe();
   });
 
   test('changed fires on add/remove/clear', ({ expect }) => {

--- a/packages/core/echo/echo-client-e2e/src/registry.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/registry.test.ts
@@ -199,6 +199,10 @@ describe('Registry', () => {
     const registry = makeRegistry();
     const atoms = AtomRegistry.make();
     const atom = Registry.typeAtom(registry, 'org.example.type.late');
+    // Memoized per (registry, typename), so consumers share one atom and one subscription.
+    expect(Registry.typeAtom(registry, 'org.example.type.late')).toBe(atom);
+    expect(Registry.typeAtom(registry, 'org.example.type.other')).not.toBe(atom);
+    expect(Registry.typeAtom(makeRegistry(), 'org.example.type.late')).not.toBe(atom);
     let emissions = 0;
     const unsubscribe = atoms.subscribe(atom, () => emissions++);
 

--- a/packages/core/echo/echo/src/Registry.ts
+++ b/packages/core/echo/echo/src/Registry.ts
@@ -4,15 +4,14 @@
 
 import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
-import * as Atom from 'effect/unstable/reactivity/Atom';
 
 import { type ReadOnlyEvent } from '@dxos/async';
 
 import type * as Database from './Database';
 import * as Entity from './Entity';
 import type * as Filter from './Filter';
+import * as registryAtoms from './internal/Registry/atoms';
 import type * as Query from './Query';
-import * as Type from './Type';
 
 /**
  * Identifier denoting an ECHO Registry.
@@ -157,40 +156,12 @@ export const runQuery: {
   });
 
 //
-// Reactive lookup.
+// Atoms
 //
 
 /**
- * Nested atom family: registry instance -> typename -> the registered type entity.
- * Memoized, so every consumer of a typename shares one atom and one `changed` subscription.
- */
-const typeEntityFamily = Atom.family((registry: Registry) =>
-  Atom.family((typename: string): Atom.Atom<Type.AnyEntity | undefined> => {
-    const resolve = (): Type.AnyEntity | undefined =>
-      registry
-        .list()
-        .filter(Type.isType)
-        .find((type) => Type.getTypename(type) === typename);
-
-    return Atom.make<Type.AnyEntity | undefined>((get) => {
-      let current = resolve();
-      const unsubscribe = registry.changed.on(() => {
-        const next = resolve();
-        // Identity guard: the registry also holds operations, skills, and routines, whose churn
-        // must not re-run consumers keyed to an unrelated typename.
-        if (next !== current) {
-          current = next;
-          get.setSelf(next);
-        }
-      });
-      get.addFinalizer(() => unsubscribe());
-      return current;
-    });
-  }),
-);
-
-/**
- * Reactive lookup of the type entity registered under `typename`.
+ * Reactive lookup of the type entity registered under `typename`. Memoized per (registry, typename),
+ * so every consumer of a typename shares one atom and one `changed` subscription.
  *
  * Registration is asynchronous — plugin schema modules activate lazily and `client.addTypes` is
  * awaited — so anything that derives display state from a schema (icon, annotations) must read it
@@ -198,5 +169,4 @@ const typeEntityFamily = Atom.family((registry: Registry) =>
  *
  * @example `const type = get(Registry.typeAtom(db.graph.registry, typename));`
  */
-export const typeAtom = (registry: Registry, typename: string): Atom.Atom<Type.AnyEntity | undefined> =>
-  typeEntityFamily(registry)(typename);
+export const typeAtom = registryAtoms.makeTypeAtom;

--- a/packages/core/echo/echo/src/Registry.ts
+++ b/packages/core/echo/echo/src/Registry.ts
@@ -160,12 +160,11 @@ export const runQuery: {
 //
 
 /**
- * Reactive lookup of the type entity registered under `typename`. Memoized per (registry, typename),
- * so every consumer of a typename shares one atom and one `changed` subscription.
+ * Reactive lookup of the type entity registered under `typename`, or `undefined` while unregistered.
+ * Memoized per (registry, typename), so consumers share one atom and one `changed` subscription.
  *
- * Registration is asynchronous — plugin schema modules activate lazily and `client.addTypes` is
- * awaited — so anything that derives display state from a schema (icon, annotations) must read it
- * through this atom or it freezes at whatever the registry happened to hold on first evaluation.
+ * Registration is asynchronous, so anything deriving display state from a schema must read it here
+ * rather than through a plain lookup, which freezes at whatever was registered on first evaluation.
  *
  * @example `const type = get(Registry.typeAtom(db.graph.registry, typename));`
  */

--- a/packages/core/echo/echo/src/Registry.ts
+++ b/packages/core/echo/echo/src/Registry.ts
@@ -4,6 +4,7 @@
 
 import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
+import * as Atom from 'effect/unstable/reactivity/Atom';
 
 import { type ReadOnlyEvent } from '@dxos/async';
 
@@ -11,6 +12,7 @@ import type * as Database from './Database';
 import * as Entity from './Entity';
 import type * as Filter from './Filter';
 import type * as Query from './Query';
+import * as Type from './Type';
 
 /**
  * Identifier denoting an ECHO Registry.
@@ -153,3 +155,48 @@ export const runQuery: {
     const registry = yield* Service;
     return (yield* Effect.promise(() => registry.query(queryOrFilter as any).run())) as any;
   });
+
+//
+// Reactive lookup.
+//
+
+/**
+ * Nested atom family: registry instance -> typename -> the registered type entity.
+ * Memoized, so every consumer of a typename shares one atom and one `changed` subscription.
+ */
+const typeEntityFamily = Atom.family((registry: Registry) =>
+  Atom.family((typename: string): Atom.Atom<Type.AnyEntity | undefined> => {
+    const resolve = (): Type.AnyEntity | undefined =>
+      registry
+        .list()
+        .filter(Type.isType)
+        .find((type) => Type.getTypename(type) === typename);
+
+    return Atom.make<Type.AnyEntity | undefined>((get) => {
+      let current = resolve();
+      const unsubscribe = registry.changed.on(() => {
+        const next = resolve();
+        // Identity guard: the registry also holds operations, skills, and routines, whose churn
+        // must not re-run consumers keyed to an unrelated typename.
+        if (next !== current) {
+          current = next;
+          get.setSelf(next);
+        }
+      });
+      get.addFinalizer(() => unsubscribe());
+      return current;
+    });
+  }),
+);
+
+/**
+ * Reactive lookup of the type entity registered under `typename`.
+ *
+ * Registration is asynchronous — plugin schema modules activate lazily and `client.addTypes` is
+ * awaited — so anything that derives display state from a schema (icon, annotations) must read it
+ * through this atom or it freezes at whatever the registry happened to hold on first evaluation.
+ *
+ * @example `const type = get(Registry.typeAtom(db.graph.registry, typename));`
+ */
+export const typeAtom = (registry: Registry, typename: string): Atom.Atom<Type.AnyEntity | undefined> =>
+  typeEntityFamily(registry)(typename);

--- a/packages/core/echo/echo/src/internal/Registry/atoms.ts
+++ b/packages/core/echo/echo/src/internal/Registry/atoms.ts
@@ -10,10 +10,6 @@ import * as Type from '../../Type';
 /**
  * Atom family for the type entity registered under a typename.
  * Keyed by a structurally-equal tuple key `[registry, typename]` so nested families are avoided.
- *
- * No `Atom.keepAlive`, unlike the entity families: the registry is the source of truth, so a remount
- * re-resolves from it, and pinning would hold both a `changed` listener and the registry itself (the
- * family key) for the lifetime of the process, outliving the space that opened it.
  */
 const typeEntityFamily = Atom.family(
   ([registry, typename]: readonly [Registry.Registry, string]): Atom.Atom<Type.AnyEntity | undefined> => {
@@ -28,8 +24,8 @@ const typeEntityFamily = Atom.family(
 
       const unsubscribe = registry.changed.on(() => {
         const next = read();
-        // Identity comparison: the registry also holds operations, skills, and routines, whose churn
-        // must not re-run consumers keyed to an unrelated typename.
+        // The registry also holds operations, skills, and routines, whose churn must not re-run
+        // consumers keyed to an unrelated typename.
         if (next !== previous) {
           previous = next;
           get.setSelf(next);

--- a/packages/core/echo/echo/src/internal/Registry/atoms.ts
+++ b/packages/core/echo/echo/src/internal/Registry/atoms.ts
@@ -1,0 +1,49 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Atom from 'effect/unstable/reactivity/Atom';
+
+import type * as Registry from '../../Registry';
+import * as Type from '../../Type';
+
+/**
+ * Atom family for the type entity registered under a typename.
+ * Keyed by a structurally-equal tuple key `[registry, typename]` so nested families are avoided.
+ *
+ * No `Atom.keepAlive`, unlike the entity families: the registry is the source of truth, so a remount
+ * re-resolves from it, and pinning would hold both a `changed` listener and the registry itself (the
+ * family key) for the lifetime of the process, outliving the space that opened it.
+ */
+const typeEntityFamily = Atom.family(
+  ([registry, typename]: readonly [Registry.Registry, string]): Atom.Atom<Type.AnyEntity | undefined> => {
+    const read = (): Type.AnyEntity | undefined =>
+      registry
+        .list()
+        .filter(Type.isType)
+        .find((type) => Type.getTypename(type) === typename);
+
+    return Atom.make<Type.AnyEntity | undefined>((get) => {
+      let previous = read();
+
+      const unsubscribe = registry.changed.on(() => {
+        const next = read();
+        // Identity comparison: the registry also holds operations, skills, and routines, whose churn
+        // must not re-run consumers keyed to an unrelated typename.
+        if (next !== previous) {
+          previous = next;
+          get.setSelf(next);
+        }
+      });
+      get.addFinalizer(() => unsubscribe());
+
+      return previous;
+    });
+  },
+);
+
+/**
+ * Reactive atom for the type entity registered under `typename`, or `undefined` while unregistered.
+ */
+export const makeTypeAtom = (registry: Registry.Registry, typename: string): Atom.Atom<Type.AnyEntity | undefined> =>
+  typeEntityFamily([registry, typename]);

--- a/packages/plugins/plugin-crm/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-crm/src/capabilities/app-graph-builder.ts
@@ -14,7 +14,7 @@ import * as AppNode from '@dxos/app-toolkit/AppNode';
 import * as AppNodeMatcher from '@dxos/app-toolkit/AppNodeMatcher';
 import * as GraphPath from '@dxos/app-toolkit/GraphPath';
 import * as Operation from '@dxos/compute/Operation';
-import { Annotation, Filter, Obj, Ref, Type } from '@dxos/echo';
+import { Annotation, Filter, Obj, Ref, Registry, Type } from '@dxos/echo';
 import * as RoutineOperation from '@dxos/plugin-routine/RoutineOperation';
 import { type Space } from '@dxos/react-client/echo';
 import { Organization, Person } from '@dxos/types';
@@ -62,20 +62,12 @@ export default Capability.makeModule(
         id: 'crmTypes',
         url: { key: 'crm', kind: 'item', path: [GraphPath.GroupSegments.crm] },
         match: AppNodeMatcher.whenNavTreeGroup(GraphPath.GroupTypes.crm),
-        connector: (space, get) => {
-          // Index the registry once per rebuild so each type resolves its registered schema in O(1).
-          const registered = new Map(
-            space.db.graph.registry
-              .list()
-              .filter(Type.isType)
-              .map((entry) => [Type.getTypename(entry), entry] as const),
-          );
-          return Effect.succeed(
-            CRM_TYPES.map((type) => createTypeNode({ type, space, get, registered })).filter(
+        connector: (space, get) =>
+          Effect.succeed(
+            CRM_TYPES.map((type) => createTypeNode({ type, space, get })).filter(
               (node): node is NonNullable<typeof node> => node !== null,
             ),
-          );
-        },
+          ),
       }),
 
       // Research on the object's own node, so any surface showing a Person/Organization (the record
@@ -165,12 +157,10 @@ const createTypeNode = ({
   type,
   space,
   get,
-  registered,
 }: {
   type: Type.AnyEntity;
   space: Space;
   get: Atom.AtomContext;
-  registered: ReadonlyMap<string, Type.AnyEntity>;
 }): Node.NodeArg<Type.AnyEntity> | null => {
   const typename = Type.getTypename(type);
   const objects = get(space.db.query(Filter.type(Type.getURI(type))).atom);
@@ -179,7 +169,8 @@ const createTypeNode = ({
   }
 
   // Prefer the registry copy of the schema: raw schema classes don't carry annotations reliably.
-  const entity = registered.get(typename) ?? type;
+  // Read reactively so a schema registered after this node was built still lands.
+  const entity = get(Registry.typeAtom(space.db.graph.registry, typename)) ?? type;
   const annotation = Option.getOrUndefined(Annotation.IconAnnotation.get(Type.getSchema(entity)));
 
   return Node.make({

--- a/packages/plugins/plugin-crm/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-crm/src/capabilities/app-graph-builder.ts
@@ -168,8 +168,8 @@ const createTypeNode = ({
     return null;
   }
 
-  // Prefer the registry copy of the schema: raw schema classes don't carry annotations reliably.
-  // Read reactively so a schema registered after this node was built still lands.
+  // Raw schema classes don't carry annotations reliably, and schemas register lazily, so read
+  // the registry copy through the atom.
   const entity = get(Registry.typeAtom(space.db.graph.registry, typename)) ?? type;
   const annotation = Option.getOrUndefined(Annotation.IconAnnotation.get(Type.getSchema(entity)));
 

--- a/packages/sdk/app-toolkit/src/app-graph/AppNode.test.ts
+++ b/packages/sdk/app-toolkit/src/app-graph/AppNode.test.ts
@@ -33,14 +33,11 @@ describe('makeObject', () => {
     await testBuilder.close();
   });
 
-  const iconAtom = (object: Obj.Unknown) =>
-    Atom.make((get) => AppNode.makeObject({ get, db, object })?.properties.icon);
-
   test('reads the icon annotation from the registered type', async ({ expect }) => {
     const object = db.add(Obj.make(Doc, { name: 'New document' }));
     await db.flush();
 
-    expect(AtomRegistry.make().get(iconAtom(object))).toBe('ph--text-aa--regular');
+    expect(AtomRegistry.make().get(iconAtom(db, object))).toBe('ph--text-aa--regular');
   });
 
   test('recomputes the icon when the type registers after the node is built', async ({ expect }) => {
@@ -55,7 +52,7 @@ describe('makeObject', () => {
     expect(db.graph.registry.remove(type!.id)).toBe(true);
 
     const registry = AtomRegistry.make();
-    const atom = iconAtom(object);
+    const atom = iconAtom(db, object);
     // Subscribe so the atom stays mounted and observes the registration.
     const unsubscribe = registry.subscribe(atom, () => {});
     expect(registry.get(atom)).toBe('ph--circle-dashed--regular');
@@ -66,3 +63,6 @@ describe('makeObject', () => {
     unsubscribe();
   });
 });
+
+const iconAtom = (db: Database.Database, object: Obj.Unknown) =>
+  Atom.make((get) => AppNode.makeObject({ get, db, object })?.properties.icon);

--- a/packages/sdk/app-toolkit/src/app-graph/AppNode.test.ts
+++ b/packages/sdk/app-toolkit/src/app-graph/AppNode.test.ts
@@ -1,0 +1,68 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+import * as Atom from 'effect/unstable/reactivity/Atom';
+import * as AtomRegistry from 'effect/unstable/reactivity/AtomRegistry';
+import { afterEach, beforeEach, describe, test } from 'vitest';
+
+import { Annotation, type Database, DXN, Obj, Type } from '@dxos/echo';
+import { EchoTestBuilder } from '@dxos/echo-client/testing';
+
+import * as AppNode from './AppNode';
+
+const TYPENAME = 'com.example.type.doc';
+
+const Doc = Type.makeObject(DXN.make(TYPENAME, '0.1.0'))(
+  Schema.Struct({ name: Schema.optional(Schema.String) }).pipe(
+    Annotation.IconAnnotation.set({ icon: 'ph--text-aa--regular', hue: 'indigo' }),
+  ),
+);
+
+describe('makeObject', () => {
+  let testBuilder: EchoTestBuilder;
+  let db: Database.Database;
+
+  beforeEach(async () => {
+    testBuilder = await new EchoTestBuilder().open();
+    ({ db } = (await testBuilder.createDatabase({ types: [Doc] })) as { db: Database.Database });
+  });
+
+  afterEach(async () => {
+    await testBuilder.close();
+  });
+
+  const iconAtom = (object: Obj.Unknown) =>
+    Atom.make((get) => AppNode.makeObject({ get, db, object })?.properties.icon);
+
+  test('reads the icon annotation from the registered type', async ({ expect }) => {
+    const object = db.add(Obj.make(Doc, { name: 'New document' }));
+    await db.flush();
+
+    expect(AtomRegistry.make().get(iconAtom(object))).toBe('ph--text-aa--regular');
+  });
+
+  test('recomputes the icon when the type registers after the node is built', async ({ expect }) => {
+    const object = db.add(Obj.make(Doc, { name: 'New document' }));
+    await db.flush();
+
+    // Plugin schema modules activate lazily, so a node can be built before its type is registered.
+    const type = db.graph.registry
+      .list()
+      .find((entity) => Type.isType(entity) && Type.getTypename(entity) === TYPENAME);
+    expect(type).toBeDefined();
+    expect(db.graph.registry.remove(type!.id)).toBe(true);
+
+    const registry = AtomRegistry.make();
+    const atom = iconAtom(object);
+    // Subscribe so the atom stays mounted and observes the registration.
+    const unsubscribe = registry.subscribe(atom, () => {});
+    expect(registry.get(atom)).toBe('ph--circle-dashed--regular');
+
+    db.graph.registry.add([type!]);
+    expect(registry.get(atom)).toBe('ph--text-aa--regular');
+
+    unsubscribe();
+  });
+});

--- a/packages/sdk/app-toolkit/src/app-graph/AppNode.ts
+++ b/packages/sdk/app-toolkit/src/app-graph/AppNode.ts
@@ -218,9 +218,8 @@ export const makeObject = ({
     return null;
   }
 
-  // Schemas register asynchronously (plugin schema modules activate lazily), so subscribe to the
-  // registry: `Obj.getType` is a live but non-reactive lookup, and without this dependency a node
-  // built before its schema landed keeps the fallback icon until an unrelated change rebuilds it.
+  // Read through the atom because `Obj.getType` is a live but non-reactive lookup, so a node built
+  // before its schema registered would keep the fallback icon.
   const registered = get(Registry.typeAtom(db.graph.registry, typename));
   // Obj.getType uses the stored type URI to look up the schema. For database-registered
   // (dynamic) schemas the stored TypeSchema jsonSchema.$id is the echo:/<objectId> EID, so an

--- a/packages/sdk/app-toolkit/src/app-graph/AppNode.ts
+++ b/packages/sdk/app-toolkit/src/app-graph/AppNode.ts
@@ -12,7 +12,7 @@ import type * as Atom from 'effect/unstable/reactivity/Atom';
 
 import * as Node from '@dxos/app-graph/Node';
 import { type Space } from '@dxos/client/echo';
-import { Annotation, Collection, type Database, Obj, Ref, Type } from '@dxos/echo';
+import { Annotation, Collection, type Database, Obj, Ref, Registry, Type } from '@dxos/echo';
 import { Attention } from '@dxos/react-ui-attention/types';
 import { type TreeData } from '@dxos/react-ui-list';
 import { CollectionItemAnnotation } from '@dxos/schema';
@@ -218,16 +218,15 @@ export const makeObject = ({
     return null;
   }
 
+  // Schemas register asynchronously (plugin schema modules activate lazily), so subscribe to the
+  // registry: `Obj.getType` is a live but non-reactive lookup, and without this dependency a node
+  // built before its schema landed keeps the fallback icon until an unrelated change rebuilds it.
+  const registered = get(Registry.typeAtom(db.graph.registry, typename));
   // Obj.getType uses the stored type URI to look up the schema. For database-registered
   // (dynamic) schemas the stored TypeSchema jsonSchema.$id is the echo:/<objectId> EID, so an
-  // id-based lookup can miss. Fall back to a typename query against the registry which matches
+  // id-based lookup can miss. Fall back to the typename-keyed registry entry, which matches
   // the TypeSchema.typename field.
-  const type =
-    Obj.getType(object) ??
-    db.graph.registry
-      .list()
-      .filter(Type.isType)
-      .find((t) => Type.getTypename(t) === typename);
+  const type = Obj.getType(object) ?? registered;
   const schema = type && Type.getSchema(type);
   const staticIcon = schema ? Option.getOrUndefined(Annotation.IconAnnotation.get(schema)) : undefined;
   const iconFromRefProp = schema ? Option.getOrUndefined(Annotation.IconFromRefAnnotation.get(schema)) : undefined;

--- a/packages/sdk/app-toolkit/src/app-graph/TypeSection.ts
+++ b/packages/sdk/app-toolkit/src/app-graph/TypeSection.ts
@@ -172,9 +172,8 @@ export const createTypeSectionExtension = (
         return Effect.succeed([]);
       }
 
-      // Mirror AppNode.makeObject: look up the registered Type.Type entity to read icon/hue.
-      // Raw schema classes don't carry annotations reliably; the registry copy does. Read it
-      // through the atom so a schema registered after this node was built still lands.
+      // Raw schema classes don't carry annotations reliably, and schemas register lazily, so read
+      // the registry copy through the atom.
       const typeEntity = get(Registry.typeAtom(space.db.graph.registry, typename));
       const registeredSchema = typeEntity ? Type.getSchema(typeEntity) : undefined;
       const annotation = (() => {

--- a/packages/sdk/app-toolkit/src/app-graph/TypeSection.ts
+++ b/packages/sdk/app-toolkit/src/app-graph/TypeSection.ts
@@ -11,7 +11,7 @@ import type * as Atom from 'effect/unstable/reactivity/Atom';
 import * as GraphBuilder from '@dxos/app-graph/GraphBuilder';
 import * as Node from '@dxos/app-graph/Node';
 import { type Space, isSpace } from '@dxos/client/echo';
-import { Annotation, Filter, Obj, Query, Ref, Type } from '@dxos/echo';
+import { Annotation, Filter, Obj, Query, Ref, Registry, Type } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
 import { EID } from '@dxos/keys';
 import { type TreeData } from '@dxos/react-ui-list';
@@ -173,11 +173,9 @@ export const createTypeSectionExtension = (
       }
 
       // Mirror AppNode.makeObject: look up the registered Type.Type entity to read icon/hue.
-      // Raw schema classes don't carry annotations reliably; the registry copy does.
-      const typeEntity = space.db.graph.registry
-        .list()
-        .filter(Type.isType)
-        .find((entry) => Type.getTypename(entry) === typename);
+      // Raw schema classes don't carry annotations reliably; the registry copy does. Read it
+      // through the atom so a schema registered after this node was built still lands.
+      const typeEntity = get(Registry.typeAtom(space.db.graph.registry, typename));
       const registeredSchema = typeEntity ? Type.getSchema(typeEntity) : undefined;
       const annotation = (() => {
         try {


### PR DESCRIPTION
## Problem

Objects sometimes render with the `ph--circle-dashed--regular` placeholder icon instead of their type's icon, inconsistently between reloads.

`AppNode.makeObject` resolved the schema like this:

```ts
const type =
  Obj.getType(object) ??
  db.graph.registry.list().filter(Type.isType).find((t) => Type.getTypename(t) === typename);
```

Both branches are *live* reads of `db.graph.registry` (`getTypeEntity` in `echo-prototypes.ts` re-resolves through the registry on every access), but neither is *reactive*. The connector body is an atom computation whose dependencies are `Obj.atom(space.properties)`, `Obj.atom(collectionRef)`, and `Obj.atom(ref)` per child — nothing tied to the registry. So a node built before its schema registered keeps the fallback icon until something unrelated invalidates the connector.

Registration is genuinely late and async:

- Plugin schemas are contributed by `AppCapability.schema(() => import('./schema'))`, a lazy module — one dynamic `import()` per plugin.
- `plugin-client`'s `schema-defs.ts` subscribes to the `Schema` capability atom and `await client.addTypes(...)` on every change.

Meanwhile the collections connector runs as soon as the space's root collection resolves. Whether a given object wins or loses that race depends on module-load and space-open timing, which matches the reported inconsistency.

The same non-reactive pattern is in `TypeSection.ts` and `plugin-crm`'s graph builder. `plugin-space`'s `database.ts` (the Types section) already reads reactively via `get(space.db.query(...).from(Scope.registry()).atom)`, so it heals — which is why the Types tree looks right while object nodes do not.

## Fix

Add `Registry.typeAtom(registry, typename)` to `@dxos/echo` — a memoized reactive lookup of a registered type entity, living in `internal/Registry/atoms.ts` alongside the package's other atom families and re-exported from the `Registry` namespace like `Obj.atom` / `Entity.atom`.

It is a single `Atom.family` keyed by a structurally-equal `[registry, typename]` tuple, mirroring `annotationPropertyFamily`'s "keyed by a tuple key so nested families are avoided". Nesting would be unsound here: `Atom.family` memoizes through a `WeakRef`, which is safe for an atom a mounted consumer keeps alive but not for the per-registry lookup an outer family would hold — collecting it would silently hand the next caller a second atom with its own subscription.

The atom re-emits only when *that* typename's resolved entity changes. The identity guard matters because `graph.registry` also holds operations, skills, and routines, and their churn must not re-run every nav-tree connector.

No `Atom.keepAlive`, matching the other registry-backed atoms (`RegistryQueryResult.atom`, `QueryResult.atom`) rather than the entity/ref families. Those pin an expensive or async resolution across mount cycles; this one resolves synchronously from an in-memory scan, so a remount just re-reads, and pinning would hold a `changed` listener plus the registry itself (the family key) for the process lifetime.

Read through it in the three affected builders. Beyond the icon this also heals `iconHue`, `GraphPropsAnnotation` (e.g. `managesAutofocus`), and `DeckAnnotation`, all derived from the same schema.

## Validation

A test written against the unfixed code reproduced the bug — building a node while the type was absent from the registry, then registering it:

```
before registration: ph--circle-dashed--regular
after  registration: ph--circle-dashed--regular
```

That scenario is now `packages/sdk/app-toolkit/src/app-graph/AppNode.test.ts`, asserting the icon becomes `ph--text-aa--regular` after registration; plus a `typeAtom` unit test in `registry.test.ts` covering memoization, emit-on-register, and ignore-unrelated-churn.

Verified on top of current `main`, including the TypeScript 7 upgrade (#12647):

```
echo:test          572 passed | 9 skipped (581)
echo-client-e2e    298 passed | 1 expected fail | 7 skipped (306)
app-toolkit:test   158 passed (158)
plugin-space:test   54 passed | 3 todo (57)
plugin-crm:test     15 passed | 4 skipped (19)
lint (echo, app-toolkit, plugin-crm, echo-client-e2e)  clean
pnpm format        clean
```

## Not addressed

- The same non-reactive registry read exists in React containers — `RecordArticle.tsx`, `SpaceHomeRecent.tsx`, `TypeArticle.tsx`, `CollectionArticle.tsx`. Those mount long after startup so they rarely lose the race, and they re-render on unrelated state. They can consume the same atom via `useAtomValue(Registry.typeAtom(...))` if it proves to matter.
- `RegistryImpl.list()` merges upstream entities but `changed` fires only on local mutations, so upstream registrations go unobserved. That gap predates this PR and affects every `registry.changed` consumer; it is not reachable today (the only production registry is `hypergraph.ts:75`, `makeRegistry()` with no upstream). Fixing it belongs in `RegistryImpl`, with lifecycle management for the forwarded listener.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAujCDrWF37iNbz86pLc8K)_