### PR TITLE
app-framework: resolve RemoteTraceMonitor through a live view, drop the Startup gate

### DIFF
--- a/.changeset/mailbox-sync-progress-and-swarm-panel.md
+++ b/.changeset/mailbox-sync-progress-and-swarm-panel.md
@@ -3,4 +3,4 @@
 '@dxos/devtools': minor
 ---
 
-Fix remote (EDGE) sync progress never reaching progress meters — the swarm trace monitor and the progress registry now activate at startup, so the process monitor's remote trace source and the registry exist before anything subscribes — and add a Swarm announcements panel to devtools stats for inspecting the raw swarm trace broadcasts that progress rides on.
+Fix remote (EDGE) sync progress never reaching progress meters — the progress registry now activates at startup, so it exists before anything subscribes — and add a Swarm announcements panel to devtools stats for inspecting the raw swarm trace broadcasts that progress rides on.

--- a/.changeset/remote-trace-monitor-live-view.md
+++ b/.changeset/remote-trace-monitor-live-view.md
@@ -1,0 +1,6 @@
+---
+'@dxos/app-framework': patch
+'@dxos/plugin-client': patch
+---
+
+Resolve the remote trace monitor through a live capability view instead of a startup snapshot, so the aggregate `ProcessMonitor` picks the swarm-backed monitor up whenever it is contributed — even after its consumers have already subscribed. The client's `RemoteTraceMonitor` module no longer activates at startup as a result.

--- a/packages/plugins/plugin-client/src/capabilities/index.ts
+++ b/packages/plugins/plugin-client/src/capabilities/index.ts
@@ -92,10 +92,10 @@ export const SchemaDefs = Capability.lazyModule(
 );
 export const RemoteTraceMonitor = Capability.lazyModule(
   'RemoteTraceMonitor',
-  // Startup: the process-manager runtime snapshots this capability once, in the Startup pass, and
-  // bakes a no-op remote source if it has not been contributed yet — demand activation always loses
-  // that race, silencing remote traces for every ProcessMonitor consumer.
-  { provides: [Capabilities.RemoteTraceMonitor], activatesOn: ActivationEvents.Startup },
+  // No Startup gate: the process-manager runtime reads this capability as a live view rather than a
+  // one-shot snapshot, so the aggregate ProcessMonitor picks the monitor up whenever it lands and
+  // nothing here has to run in the boot pass.
+  { provides: [Capabilities.RemoteTraceMonitor] },
   () => import('./remote-trace-monitor'),
 );
 export const SpaceReplicationProgress = Capability.lazyModule(

--- a/packages/sdk/app-framework/src/plugin-process-manager/process-manager-capability.test.ts
+++ b/packages/sdk/app-framework/src/plugin-process-manager/process-manager-capability.test.ts
@@ -5,8 +5,11 @@
 import { describe, expect, it, test } from '@effect/vitest';
 import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
+import * as Fiber from 'effect/Fiber';
 import * as Layer from 'effect/Layer';
+import * as Stream from 'effect/Stream';
 
+import type { RemoteTraceMonitor } from '@dxos/compute-runtime';
 import * as LayerSpec from '@dxos/compute/LayerSpec';
 import * as ServiceResolver from '@dxos/compute/ServiceResolver';
 import * as Trace from '@dxos/compute/Trace';
@@ -16,7 +19,7 @@ import { type LogConfig, type LogEntry, LogLevel, log } from '@dxos/log';
 
 import { ActivationEvents, Capabilities } from '../common';
 import { ActivationEvent, Capability, Plugin, PluginManager } from '../core';
-import { makeDynamicTraceSink } from './process-manager-capability';
+import { makeDynamicRemoteTraceMonitor, makeDynamicTraceSink } from './process-manager-capability';
 import { ProcessManagerPlugin } from './ProcessManagerPlugin';
 
 const LateEvent = ActivationEvent.make('org.dxos.test.lateLayerSpec');
@@ -27,6 +30,12 @@ const lateMeta = Plugin.makeMeta({ key: DXN.make('org.dxos.test.lateLayerSpec'),
 
 const LateSinkEvent = ActivationEvent.make('org.dxos.test.lateTraceSink');
 const lateSinkMeta = Plugin.makeMeta({ key: DXN.make('org.dxos.test.lateTraceSink'), name: 'Late TraceSink' });
+
+const LateMonitorEvent = ActivationEvent.make('org.dxos.test.lateRemoteTraceMonitor');
+const lateMonitorMeta = Plugin.makeMeta({
+  key: DXN.make('org.dxos.test.lateRemoteTraceMonitor'),
+  name: 'Late RemoteTraceMonitor',
+});
 
 describe('process manager LayerSpec snapshot', () => {
   it.effect('reports a LayerSpec contributed after the runtime was built', () =>
@@ -141,4 +150,171 @@ describe('dynamic trace sink', () => {
     makeDynamicTraceSink(() => factories, ServiceResolver.empty).write(message);
     expect(reached).toEqual(['second']);
   });
+});
+
+describe('dynamic remote trace monitor', () => {
+  const message = Obj.make(Trace.Message, {
+    meta: { runtimeName: Trace.CommonRuntimeName.edgeIntrinsic },
+    isEphemeral: true,
+    events: [{ type: Trace.StatusUpdate.key, timestamp: 0, data: { progress: { key: 'test#remote' } } }],
+  });
+
+  /** Stand-in for the capability manager's live contributions view, plus a hook to signal registration. */
+  const makeContributions = () => {
+    const monitors: RemoteTraceMonitor.Monitor[] = [];
+    const listeners = new Set<(values: readonly RemoteTraceMonitor.Monitor[]) => void>();
+    let onSubscribed = () => {};
+    const subscribed = new Promise<void>((resolve) => {
+      onSubscribed = resolve;
+    });
+    return {
+      subscribed,
+      view: {
+        get: () => monitors,
+        subscribe: (cb: (values: readonly RemoteTraceMonitor.Monitor[]) => void) => {
+          listeners.add(cb);
+          onSubscribed();
+          return () => listeners.delete(cb);
+        },
+      },
+      contribute: (monitor: RemoteTraceMonitor.Monitor) => {
+        monitors.push(monitor);
+        for (const listener of listeners) {
+          listener(monitors);
+        }
+      },
+    };
+  };
+
+  it.effect('delivers from a monitor contributed after the subscription started', () =>
+    Effect.gen(function* () {
+      const { view, subscribed, contribute } = makeContributions();
+      const fiber = yield* Effect.forkChild(
+        Stream.runCollect(
+          makeDynamicRemoteTraceMonitor(view)
+            .subscribeToTraceMessages({ type: Trace.StatusUpdate.key })
+            .pipe(Stream.take(1)),
+        ),
+      );
+
+      // The ordering the snapshot lost: the aggregate monitor is subscribed before plugin-client's
+      // swarm-backed monitor activates, so a baked-in no-op would leave this stream empty forever.
+      yield* Effect.promise(() => subscribed);
+      contribute({ subscribeToTraceMessages: () => Stream.make(message) });
+
+      expect(yield* Fiber.join(fiber)).toEqual([message]);
+    }),
+  );
+
+  it.effect('passes the filter through to the contributed monitor', () =>
+    Effect.gen(function* () {
+      const { view, subscribed, contribute } = makeContributions();
+      const filters: Trace.Filter[] = [];
+      const fiber = yield* Effect.forkChild(
+        Stream.runCollect(
+          makeDynamicRemoteTraceMonitor(view)
+            .subscribeToTraceMessages({ type: Trace.StatusUpdate.key })
+            .pipe(Stream.take(1)),
+        ),
+      );
+
+      yield* Effect.promise(() => subscribed);
+      contribute({
+        subscribeToTraceMessages: (filter) => {
+          filters.push(filter);
+          return Stream.make(message);
+        },
+      });
+
+      yield* Fiber.join(fiber);
+      expect(filters).toEqual([{ type: Trace.StatusUpdate.key }]);
+    }),
+  );
+
+  it.effect('keeps the live subscription when a second monitor is contributed behind the first', () =>
+    Effect.gen(function* () {
+      const { view, subscribed, contribute } = makeContributions();
+      let subscriptions = 0;
+      const first: RemoteTraceMonitor.Monitor = {
+        subscribeToTraceMessages: () => {
+          subscriptions += 1;
+          return Stream.make(message).pipe(Stream.concat(Stream.never));
+        },
+      };
+      const fiber = yield* Effect.forkChild(
+        Stream.runCollect(
+          makeDynamicRemoteTraceMonitor(view)
+            .subscribeToTraceMessages({ type: Trace.StatusUpdate.key })
+            .pipe(Stream.take(1)),
+        ),
+      );
+
+      yield* Effect.promise(() => subscribed);
+      contribute(first);
+      // A second contribution leaves `[0]` in place: resubscribing would tear the live swarm stream
+      // down underneath a running consumer.
+      contribute({ subscribeToTraceMessages: () => Stream.empty });
+
+      yield* Fiber.join(fiber);
+      expect(subscriptions).toBe(1);
+    }),
+  );
+});
+
+describe('remote trace monitor contributed after startup', () => {
+  const message = Obj.make(Trace.Message, {
+    meta: { runtimeName: Trace.CommonRuntimeName.edgeIntrinsic },
+    isEphemeral: true,
+    events: [{ type: Trace.StatusUpdate.key, timestamp: 0, data: { progress: { key: 'test#late-monitor' } } }],
+  });
+
+  it.effect('reaches a ProcessMonitor consumer that subscribed before it landed', () =>
+    Effect.gen(function* () {
+      // Gated on a runtime event, the way plugin-client's swarm-backed monitor activates on demand:
+      // the runtime is already built and its consumers already subscribed when this contributes.
+      const Late = Plugin.make(
+        Plugin.define(lateMonitorMeta).pipe(
+          Plugin.addModule({
+            id: 'late-remote-trace-monitor',
+            activatesOn: LateMonitorEvent,
+            provides: [Capabilities.RemoteTraceMonitor],
+            activate: () =>
+              Effect.succeed([
+                Capability.contribute(Capabilities.RemoteTraceMonitor, {
+                  subscribeToTraceMessages: () => Stream.make(message),
+                }),
+              ]),
+          }),
+        ),
+      );
+
+      const manager = PluginManager.make({
+        pluginLoader: () => Effect.die(new Error('not implemented')),
+        plugins: [ProcessManagerPlugin(), Late()],
+        enabled: [lateMonitorMeta.profile.key],
+      });
+      manager.capabilities.contribute({
+        interface: Capabilities.PluginManager,
+        implementation: manager,
+        module: 'org.dxos.app-framework.plugin-manager',
+      });
+      manager.capabilities.contribute({
+        interface: Capabilities.AtomRegistry,
+        implementation: manager.registry,
+        module: 'org.dxos.app-framework.atom-registry',
+      });
+
+      yield* manager.activate(ActivationEvents.Startup);
+
+      // The TraceProgress shape: subscribe to the aggregate, then wait for remote messages.
+      const monitor = manager.capabilities.get(Capabilities.ProcessMonitor);
+      const fiber = yield* Effect.forkChild(
+        Stream.runCollect(monitor.subscribeToTraceMessages({ type: Trace.StatusUpdate.key }).pipe(Stream.take(1))),
+      );
+
+      yield* manager.activate(LateMonitorEvent);
+
+      expect(yield* Fiber.join(fiber)).toEqual([message]);
+    }),
+  );
 });

--- a/packages/sdk/app-framework/src/plugin-process-manager/process-manager-capability.ts
+++ b/packages/sdk/app-framework/src/plugin-process-manager/process-manager-capability.ts
@@ -5,6 +5,7 @@
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as ManagedRuntime from 'effect/ManagedRuntime';
+import * as Stream from 'effect/Stream';
 import * as Registry from 'effect/unstable/reactivity/AtomRegistry';
 
 import {
@@ -19,6 +20,7 @@ import * as OperationHandlerSet from '@dxos/compute/OperationHandlerSet';
 import * as Process from '@dxos/compute/Process';
 import * as ServiceResolver from '@dxos/compute/ServiceResolver';
 import * as Trace from '@dxos/compute/Trace';
+import { EffectEx } from '@dxos/effect';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 // Explicit import so the emitted `.d.ts` references the package via its public
@@ -84,6 +86,30 @@ export const makeDynamicTraceSink = (
   return { write: (message) => Trace.mergeSinks(resolve()).write(message) };
 };
 
+/**
+ * Remote ephemeral-trace source over the LIVE contribution list (DX-1125), so a monitor contributed
+ * after this runtime was built still reaches every {@link Capabilities.ProcessMonitor} consumer. The
+ * swarm-backed monitor is client-aware and activates on demand, well after the Startup pass that
+ * builds the runtime — a one-shot snapshot would bake the no-op remote half into the aggregate for
+ * the rest of the session. Each subscription instead follows the contribution: empty until one
+ * arrives, then switched onto it.
+ */
+export const makeDynamicRemoteTraceMonitor = (
+  contributions: Pick<Capability.Contributions<RemoteTraceMonitor.Monitor>, 'get' | 'subscribe'>,
+): RemoteTraceMonitor.Monitor => ({
+  subscribeToTraceMessages: (filter) =>
+    EffectEx.streamFromEmitter<RemoteTraceMonitor.Monitor | undefined>((emit) => {
+      emit.single(contributions.get()[0]);
+      const unsubscribe = contributions.subscribe((values) => emit.single(values[0]));
+      return Effect.sync(unsubscribe);
+    }).pipe(
+      // First contribution wins, and a later change that leaves it in place must not tear the live
+      // swarm subscription down underneath a running consumer.
+      Stream.changes,
+      Stream.switchMap((monitor) => monitor?.subscribeToTraceMessages(filter) ?? Stream.empty),
+    ),
+});
+
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
     const capabilityManager = yield* Capability.Service;
@@ -120,8 +146,6 @@ export default Capability.makeModule(
       },
     );
     yield* Effect.addFinalizer(() => Effect.sync(cancelLayerSpecWatch));
-    // Optional swarm-backed remote trace source (DX-1125); first contribution wins, else empty.
-    const remoteTraceMonitors = remoteTraceMonitorContributions.get();
 
     log.info('setup process manager', { traceSinks: traceSinkContributions.get().length });
 
@@ -196,11 +220,11 @@ export default Capability.makeModule(
     // App-framework has no EDGE runtime, so the remote process view is empty;
     // the aggregate monitor therefore equals the local process tree.
     const remoteProcessManagerLayer = RemoteProcessManager.layerNoop.pipe(Layer.provide(baseLayer));
-    // Remote ephemeral trace (DX-1125): use the first contributed swarm-backed monitor, else no-op.
-    const remoteTraceMonitorLayer =
-      remoteTraceMonitors.length > 0
-        ? Layer.succeed(RemoteTraceMonitor.Service, remoteTraceMonitors[0])
-        : RemoteTraceMonitor.layerNoop;
+    // Remote ephemeral trace (DX-1125): live view, not a snapshot — see `makeDynamicRemoteTraceMonitor`.
+    const remoteTraceMonitorLayer = Layer.succeed(
+      RemoteTraceMonitor.Service,
+      makeDynamicRemoteTraceMonitor(remoteTraceMonitorContributions),
+    );
     const processMonitorLayer = ProcessMonitor.layer.pipe(
       Layer.provide(Layer.mergeAll(processManagerLayer, remoteProcessManagerLayer, remoteTraceMonitorLayer, baseLayer)),
     );


### PR DESCRIPTION
Follow-up to #12643, which fixed remote sync-progress delivery by forcing plugin-client's swarm-backed `RemoteTraceMonitor` module onto the Startup wave so its contribution would precede the process-manager runtime's one-shot capability snapshot. That worked, but made correctness depend on activation ordering and re-added a module to the boot path.

## What changed

- **`@dxos/app-framework`**: the process-manager capability no longer snapshots `Capabilities.RemoteTraceMonitor` at setup. A new `makeDynamicRemoteTraceMonitor` (the remote-trace twin of the existing `makeDynamicTraceSink`) wires the aggregate `ProcessMonitor`'s remote half to the **live contributions view**: each `subscribeToTraceMessages` stream starts empty and `Stream.switchMap`s onto the swarm-backed monitor whenever it is contributed — before, during, or after the subscription. `Stream.changes` keeps a second contribution from tearing down a running swarm subscription (first contribution wins, as before).
- **`@dxos/plugin-client`**: the `RemoteTraceMonitor` module drops `activatesOn: ActivationEvents.Startup` and returns to the idle default — nothing needs it at boot any more.

## Why

The Startup gate was the wrong mechanism: it inserted a chunk import serially ahead of the `ProcessManagerRuntime` hub (soft-ordering lands providers before consumers) and re-opened the add-one-module-to-Startup pattern the startup budgets police — `check-startup-budget.mjs`'s header names exactly this failure mode. With the live view, delivery no longer depends on who activates first, which also covers hosts where plugin-client enables late.

## Verification

- New tests in `process-manager-capability.test.ts`: three unit tests on the dynamic monitor (late contribution delivery, filter pass-through, no resubscribe on a second contribution) and an integration test that boots a real `PluginManager` + `ProcessManagerPlugin`, subscribes to the aggregate `Capabilities.ProcessMonitor`, then contributes the monitor on a later event and asserts delivery. The integration test times out against the old snapshot code (verified by temporarily restoring it) and passes in ~10 ms with the live view.
- A scheduler A/B probe (scratch, not committed) confirmed: with the Startup gate the monitor activates inside the startup wave before the process-manager snapshot; with the idle default it is absent at startup-done and lands on the idle wave — and the surviving `requires` edge on `ProcessManagerCapability` does **not** pull it into the wave.
- `app-framework` 240 tests / `plugin-client` 15 tests green; both packages `build` + `lint` green; `oxfmt` clean.

## Reviewer notes

1. `ProcessManagerCapability` keeps `requires: [Capabilities.RemoteTraceMonitor]` — the body still yields the capability for the live view, and `Requirements<Requires>` gates the Effect environment.
2. The unreleased changeset from #12643 (`.changeset/mailbox-sync-progress-and-swarm-panel.md`) claimed the monitor "now activates at startup"; trimmed to keep only what remains true. New changeset covers both packages (patch).
3. Cost of the Startup gate this removes was small (~1 KB gzip chunk + a few ms serial ahead of the hub, +1 module-at-ready) — the motivation is the ordering-dependence and the boot-floor precedent, not a measured regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Remote EDGE synchronization now displays progress meters after startup.
  - Devtools statistics include a Swarm announcements panel for viewing raw swarm trace broadcasts.
  - Remote trace monitors can become available dynamically after subscription, enabling live process monitoring.

- **Bug Fixes**
  - Improved detection and delivery of remote monitoring updates, including support for monitor filters and existing subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->