### PR TITLE
plugin-computer: keep the shell mount out of a dev server's startup output

### DIFF
--- a/packages/plugins/plugin-computer/src/vite-plugin/shell-middleware.ts
+++ b/packages/plugins/plugin-computer/src/vite-plugin/shell-middleware.ts
@@ -69,7 +69,9 @@ export const make = ({
   // macOS — makes every file inside it look like an escape.
   const realRoot = resolveWithin(root);
   const scriptsDir = materializeScripts();
-  log.info('computer shell mounted', { path, root: realRoot, scriptsDir });
+  // Debug, not info: the route mounts in every dev server this plugin is added to, and most sessions
+  // never call it — but the mounted root is the first thing to check when a tool misbehaves.
+  log.debug('computer shell mounted', { path, root: realRoot, scriptsDir });
 
   return async (req: IncomingMessage, res: ServerResponse, next: () => void): Promise<void> => {
     if (req.method !== 'POST' || !req.url?.startsWith(path)) {


### PR DESCRIPTION
Follow-up to #12638: the harness announced itself at info level every time a dev server booted.

```
INFO computer shell mounted { path: '/api/computer/exec', root: '…', scriptsDir: '…' }
```

Since the mount became unconditional, that line prints for every developer running `composer-app:serve`, including the majority who never enable the plugin. It drops to `log.debug`, where the mounted root is still the first thing to check when a tool misbehaves.

Left at info: the per-request `exec` line. It fires only when the assistant actually runs something, which is a developer-visible action rather than boot noise — say the word if you want that one quieted too.

## Verification

```
moon run plugin-computer:{build,test,lint,check-module-structure}
  Test Files  4 passed (4)   Tests  41 passed (41)

pnpm run format-check
  All matched files use the correct format.
```

Confirmed in the built artifact that the emitted call is `.debug("computer shell mounted"…)`, not just the source.

No changeset: the package is `private: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMyipcAVg8qRAtrnCWBeJT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the visibility of shell middleware mount messages in standard logs.
  * No functional behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->