### PR TITLE
ci: re-measure Depot's hosted cache after their per-blob fix

### DIFF
--- a/.github/workflows/cache-bench.yml
+++ b/.github/workflows/cache-bench.yml
@@ -3,10 +3,18 @@ name: Cache benchmark
 # Measures the moon remote cache on a real runner. Manual only: it seeds each arm with a cold build
 # and is far too expensive to run on push.
 #
-# It exists because the question "is this cache fast enough" keeps coming back, and answering it
-# from a dev machine does not transfer — absolute times differ and the sandbox cannot even reach
-# port 9092. Method and the prior numbers: `.agents/projects/ci/REPORT.md`.
+# It exists because "is this cache fast enough" keeps coming back, and answering it from a dev
+# machine does not transfer — absolute times differ and the agent sandbox cannot even reach port
+# 9092. Method and the prior numbers: `.agents/projects/ci/REPORT.md`.
+#
+# The `cache-bench` label is how to run it from a branch: `workflow_dispatch` is only offered for
+# workflows that already exist on the default branch, so the PR introducing a benchmark cannot
+# dispatch it. `labeled` rather than `synchronize` keeps an hour-long job off every push to a
+# labelled PR — remove and re-add the label to re-run.
 on:
+  pull_request:
+    types: [labeled]
+
   workflow_dispatch:
     inputs:
       arms:
@@ -35,7 +43,7 @@ env:
   # Named by `remote.auth.token` in the Depot arm's config, which takes an environment variable name.
   DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
 
-# Keyed on the run id so repeated dispatches of one ref run in parallel: comparing caches needs
+# Keyed on the run id so repeated runs of one ref proceed in parallel: comparing caches needs
 # independent samples of the same commit.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.run_id }}
@@ -43,8 +51,9 @@ concurrency:
 
 jobs:
   bench:
-    # The same runner and image as `check`, so the numbers sit next to the ones in REPORT.md rather
-    # than needing their own baseline.
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'cache-bench'
+    # The same runner and image as `check`, so these numbers sit next to the ones already in
+    # REPORT.md rather than needing their own baseline.
     runs-on: depot-ubuntu-24.04-8
     container:
       image: ghcr.io/dxos/gh-actions:24.11.1
@@ -52,19 +61,24 @@ jobs:
         username: dxos-bot
         password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 120
+    # A label event carries no inputs, so each knob repeats its dispatch default here.
+    env:
+      # `ARMS` is the name ci-bench.sh reads.
+      ARMS: ${{ inputs.arms || 'selfhosted depot' }}
+      BENCH_REPS: ${{ inputs.reps || '3' }}
+      BENCH_TARGET: ${{ inputs.target || 'build' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
           filter: blob:none
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       # The Depot arm degrades to an uncached build on a missing token, green and silent — the same
       # failure mode the whole cache project is about. Fail before spending an hour measuring it.
       - name: Check the requested arms have credentials
-        env:
-          ARMS: ${{ inputs.arms }}
         run: |
           if [ "$ARMS" != "${ARMS#*depot}" ] && [ -z "$DEPOT_TOKEN" ]; then
             echo "::error::The depot arm needs the DEPOT_TOKEN repository secret. It is unset or empty."
@@ -75,19 +89,16 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Benchmark
-        env:
-          ARMS: ${{ inputs.arms }}
         run: |
           set -o pipefail
-          ./tools/moon-cache/bench/ci-bench.sh '${{ inputs.reps }}' '${{ inputs.target }}' 2>&1 \
-            | tee bench.out
+          ./tools/moon-cache/bench/ci-bench.sh "$BENCH_REPS" "$BENCH_TARGET" 2>&1 | tee bench.out
 
       # The table is the deliverable, so put it where the run page shows it rather than only in a log.
       - name: Summarise
         if: always()
         run: |
           {
-            echo '### `:${{ inputs.target }}` — ${{ inputs.arms }}, ${{ inputs.reps }} reps'
+            echo "### \`:$BENCH_TARGET\` — $ARMS, $BENCH_REPS reps"
             echo
             echo '```text'
             sed -n '/^== RTT/,$p' bench.out 2>/dev/null || echo 'no output'

--- a/.github/workflows/cache-bench.yml
+++ b/.github/workflows/cache-bench.yml
@@ -1,0 +1,105 @@
+name: Cache benchmark
+
+# Measures the moon remote cache on a real runner. Manual only: it seeds each arm with a cold build
+# and is far too expensive to run on push.
+#
+# It exists because the question "is this cache fast enough" keeps coming back, and answering it
+# from a dev machine does not transfer — absolute times differ and the sandbox cannot even reach
+# port 9092. Method and the prior numbers: `.agents/projects/ci/REPORT.md`.
+on:
+  workflow_dispatch:
+    inputs:
+      arms:
+        description: 'Caches to compare, space-separated: selfhosted, depot'
+        required: false
+        default: 'selfhosted depot'
+      reps:
+        description: 'Recorded reps per arm (each arm also gets one unrecorded seeding build)'
+        required: false
+        default: '3'
+      target:
+        description: 'moon target to run, without the leading colon'
+        required: false
+        default: 'build'
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  # Bound once here rather than at every setup call site: a composite action cannot read the
+  # `secrets` context, but it does inherit the process environment.
+  MOON_CACHE_CA_PEM: ${{ secrets.MOON_CACHE_CA_PEM }}
+  MOON_CACHE_CLIENT_PEM: ${{ secrets.MOON_CACHE_CLIENT_PEM }}
+  MOON_CACHE_CLIENT_KEY: ${{ secrets.MOON_CACHE_CLIENT_KEY }}
+  # Named by `remote.auth.token` in the Depot arm's config, which takes an environment variable name.
+  DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
+
+# Keyed on the run id so repeated dispatches of one ref run in parallel: comparing caches needs
+# independent samples of the same commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  bench:
+    # The same runner and image as `check`, so the numbers sit next to the ones in REPORT.md rather
+    # than needing their own baseline.
+    runs-on: depot-ubuntu-24.04-8
+    container:
+      image: ghcr.io/dxos/gh-actions:24.11.1
+      credentials:
+        username: dxos-bot
+        password: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+
+      # The Depot arm degrades to an uncached build on a missing token, green and silent — the same
+      # failure mode the whole cache project is about. Fail before spending an hour measuring it.
+      - name: Check the requested arms have credentials
+        env:
+          ARMS: ${{ inputs.arms }}
+        run: |
+          if [ "$ARMS" != "${ARMS#*depot}" ] && [ -z "$DEPOT_TOKEN" ]; then
+            echo "::error::The depot arm needs the DEPOT_TOKEN repository secret. It is unset or empty."
+            exit 1
+          fi
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Benchmark
+        env:
+          ARMS: ${{ inputs.arms }}
+        run: |
+          set -o pipefail
+          ./tools/moon-cache/bench/ci-bench.sh '${{ inputs.reps }}' '${{ inputs.target }}' 2>&1 \
+            | tee bench.out
+
+      # The table is the deliverable, so put it where the run page shows it rather than only in a log.
+      - name: Summarise
+        if: always()
+        run: |
+          {
+            echo '### `:${{ inputs.target }}` — ${{ inputs.arms }}, ${{ inputs.reps }} reps'
+            echo
+            echo '```text'
+            sed -n '/^== RTT/,$p' bench.out 2>/dev/null || echo 'no output'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cache-bench-${{ github.run_id }}
+          path: |
+            .moon-bench/
+            bench.out
+          if-no-files-found: warn

--- a/tools/moon-cache/bench/ci-bench.sh
+++ b/tools/moon-cache/bench/ci-bench.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Compare two remote caches on one runner, in one job.
+#
+#   ci-bench.sh [reps] [target]
+#
+# `bench.sh` switches caches with MOON_REMOTE_HOST, which carries neither an auth token nor a TLS
+# block — so it cannot reach a cache that needs either. This one rewrites the `remote` block in
+# `.moon/workspace.yml` per arm instead, which is the only way to put Depot's bearer token and the
+# self-hosted mTLS certificates in the same run.
+#
+# The cost of that is a re-hash: the config is a task input, so each arm has its own hashes and
+# needs its own seeding run. That is why every arm builds cold once before any rep is recorded.
+# Arms are interleaved after seeding (A,B,A,B) so a change in runner load reads as variance within
+# an arm rather than as a difference between caches.
+#
+# Reports land in $OUT/report-<arm><n>.json for analyze.mjs. `.moon/workspace.yml` is restored on
+# exit.
+set -uo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+OUT="${OUT:-$ROOT/.moon-bench}"
+REPS="${1:-${REPS:-3}}"
+TARGET="${2:-${TARGET:-build}}"
+ARMS="${ARMS:-selfhosted depot}"
+MOON="${MOON:-moon}"
+CONFIG="$ROOT/.moon/workspace.yml"
+
+cd "$ROOT" || exit 1
+mkdir -p "$OUT"
+trap 'git checkout -- "$CONFIG" 2>/dev/null || true' EXIT
+
+# The `remote` block each arm runs with. Kept here rather than in a fixture file so the rest of
+# `workspace.yml` is always whatever the commit under test says.
+remote_block() {
+  case "$1" in
+    selfhosted)
+      cat <<'YAML'
+remote:
+  host: 'grpcs://cache.dxos.network:9092'
+  mtls:
+    caCert: '.moon/certs/ca.pem'
+    clientCert: '.moon/certs/client.pem'
+    clientKey: '.moon/certs/client.key'
+    domain: 'cache.dxos.network'
+YAML
+      ;;
+    depot)
+      # As committed before PR #12494. `token` names the environment variable, not the secret.
+      cat <<'YAML'
+remote:
+  host: 'grpcs://cache.depot.dev'
+  auth:
+    token: 'DEPOT_TOKEN'
+    headers:
+      'X-Depot-Org': 't8fblrl00n'
+YAML
+      ;;
+    *)
+      echo "unknown arm: $1" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Replace the top-level `remote:` block, leaving every other key alone. A top-level key is a line
+# starting in column zero, which is what ends the block.
+write_config() {
+  local arm=$1 replacement
+  replacement=$(remote_block "$arm") || return 1
+  git checkout -- "$CONFIG" || return 1
+  awk -v replacement="$replacement" '
+    /^remote:/ { print replacement; print ""; skip = 1; next }
+    skip && /^[^[:space:]#]/ { skip = 0 }
+    !skip { print }
+  ' "$CONFIG" > "$CONFIG.arm" && mv "$CONFIG.arm" "$CONFIG"
+  grep -q "^remote:" "$CONFIG" || { echo "== $arm: remote block did not survive the rewrite" >&2; return 1; }
+}
+
+# One run with a cold local cache. The toolchain and pnpm store stay warm deliberately — they are
+# not under test. The report is removed as well as the caches: without that, a failed run would
+# leave the previous one's report to be copied as if it were this one's.
+run_once() {
+  local label=$1 log="$OUT/$1.log" code hits
+  rm -rf .moon/cache/outputs .moon/cache/states .moon/cache/hashes .moon/cache/runReport.json
+  "$MOON" run ":$TARGET" > "$log" 2>&1
+  code=$?
+  hits=$(grep -c 'cached from remote' "$log")
+  echo "== $label exit=$code remote_hits=$hits"
+  if [ "$code" -ne 0 ]; then
+    echo "== $label FAILED — tail of $log:"
+    tail -40 "$log"
+    return "$code"
+  fi
+  [ -f .moon/cache/runReport.json ] || { echo "== $label produced no run report"; return 1; }
+  # A green run proves nothing: an absent, rejected or unroutable cache all produce a passing build
+  # with no caching at all. Non-zero hits is the only evidence the arm measured a cache.
+  if [ "$label" != "${label#seed-}" ] || [ "$hits" -gt 0 ]; then
+    return 0
+  fi
+  echo "== $label had zero remote hits — the arm measured a rebuild, not a cache."
+  return 1
+}
+
+record() {
+  local label=$1
+  run_once "$label" || return 1
+  cp .moon/cache/runReport.json "$OUT/report-$label.json"
+}
+
+# TCP connect time to each cache, so per-task hydration can be read against the round trip it is
+# made of. `time_connect` is the TCP handshake and is reported even when the TLS layer then fails.
+echo "== RTT"
+for host_port in cache.dxos.network:9093 cache.depot.dev:443; do
+  samples=$(for _ in 1 2 3; do
+    curl -s -o /dev/null --max-time 10 -w '%{time_connect} ' "https://$host_port" 2>/dev/null || true
+  done)
+  echo "   $host_port  ${samples:-unreachable}"
+done
+
+echo "== $($MOON --version | tail -1) | $(git rev-parse --short HEAD) | :$TARGET | $REPS reps | arms: $ARMS"
+
+# Seed. Each arm's hashes are new, so this is a cold build per arm and is not a measurement.
+for arm in $ARMS; do
+  write_config "$arm" || exit 1
+  echo "== seeding $arm (cold build, uploads; not a measurement)"
+  run_once "seed-$arm" || exit 1
+done
+
+for rep in $(seq 1 "$REPS"); do
+  for arm in $ARMS; do
+    write_config "$arm" || exit 1
+    record "$arm$rep" || exit 1
+  done
+done
+
+echo
+node "$ROOT/tools/moon-cache/bench/analyze.mjs" "$OUT"


### PR DESCRIPTION
Follow-up to #12494. Depot reports finding the cause of the latency measured there — moon requests
hundreds of cache blobs at once and they were fetching them one at a time, so a small per-blob delay
compounded — and has shipped a fix. They asked us to re-run an affected job.

This PR adds the harness to do that on a real runner, and will carry the result once it has run.

## Why this needs a new harness

The existing `bench.sh` cannot do it. It switches caches with `MOON_REMOTE_HOST`, which carries
neither Depot's bearer token nor the self-hosted mTLS block, so it cannot reach either cache in a
run that also reaches the other. Nor can the comparison be done off a runner:

- **From the agent sandbox, not at all.** The egress gateway resets `cache.dxos.network:9092`
  outright, and moon's gRPC client does not read `HTTPS_PROXY`.
- **From a dev machine, not comparably.** Every "In CI" number in `REPORT.md` came from a Depot
  runner 7 ms from the cache; a laptop at 25 ms measures a different question, and absolute times
  from macOS do not transfer.

## What changed

- **`tools/moon-cache/bench/ci-bench.sh`** rewrites the top-level `remote` block in
  `.moon/workspace.yml` per arm, which is the only way to hold both credentials in one run. The
  config is a task input, so each arm has its own hashes and gets its own cold seeding build before
  any rep is recorded; arms interleave after that, so runner load reads as variance within an arm
  rather than as a difference between caches. A recorded rep with **zero remote hits fails** — a
  green run with no caching is the failure mode this whole area is about, and it must not be
  reported as a cache measurement. `.moon/workspace.yml` is restored on exit.
- **`.github/workflows/cache-bench.yml`** runs it on `depot-ubuntu-24.04-8` in the same container
  image as `check`, so the numbers sit next to the ones already in `REPORT.md`. It fails up front if
  the `depot` arm is requested without `DEPOT_TOKEN`, writes the `analyze.mjs` table to the run
  summary, and uploads the run reports.

The workflow is gated on a **`cache-bench` label** as well as `workflow_dispatch`: a dispatch is
only offered for workflows already on the default branch, so the PR that introduces a benchmark
cannot dispatch it. `labeled` rather than `synchronize` keeps an hour-long job off every push.

## The baseline being re-compared against

From `.agents/projects/ci/REPORT.md`, for the same 324-action `:build` graph:

| arm                             | hydration median | wall median | per-task p50 |
| ------------------------------- | ---------------: | ----------: | -----------: |
| Depot hosted cache (dev, 25 ms) |        1,100.1 s |     338.0 s |     2,027 ms |
| self-hosted nyc3 + mTLS (dev)   |          109.2 s |      29.9 s |       173 ms |
| self-hosted nyc3, Depot runner  |           13.6 s |        14 s |        31 ms |

The report's model is that hydration is latency-bound at ~2.3 sequential round-trips per cached
task, and that Depot's 2,027 ms at 25 ms RTT implied roughly **85** round-trips per task — which is
consistent with what Depot has now described. So the test of their fix is whether per-task
hydration falls to a small multiple of the round trip.

## Verification

- Both workflow files parse, and `check-cache-wiring.mjs`'s rule is satisfied (all three
  `MOON_CACHE_*` bound at workflow level).
- `ci-bench.sh` passes `bash -n`.
- The benchmark itself has not run yet — the label triggers it once this PR exists. **Results, and
  any change to the "cancel the Depot cache subscription" decision, land as a follow-up commit
  here.** No `packages/` changes, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBCmpZ244CbdBBEtbBCdo8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBCmpZ244CbdBBEtbBCdo8)_