### PR TITLE
Add authorizing device dialog for magic-link token redemption

### DIFF
--- a/packages/plugins/plugin-onboarding/src/capabilities/react-surface.ts
+++ b/packages/plugins/plugin-onboarding/src/capabilities/react-surface.ts
@@ -9,8 +9,8 @@ import * as Capability from '@dxos/app-framework/Capability';
 import { Surface } from '@dxos/app-framework/ui';
 import { AppSurface } from '@dxos/app-toolkit/ui';
 
-import { AboutDialog, NativeRedirectDialog } from '../components';
-import { ABOUT_DIALOG, NATIVE_REDIRECT_DIALOG, WELCOME_SCREEN } from '../constants';
+import { AboutDialog, AuthorizingDeviceDialog, NativeRedirectDialog } from '../components';
+import { ABOUT_DIALOG, AUTHORIZING_DEVICE_DIALOG, NATIVE_REDIRECT_DIALOG, WELCOME_SCREEN } from '../constants';
 import { ExemplarSettings, WelcomeContainer } from '../containers';
 import { meta } from '../meta';
 
@@ -26,6 +26,11 @@ export default Capability.makeModule(() =>
         id: 'welcome',
         filter: AppSurface.component(AppSurface.Dialog, WELCOME_SCREEN),
         component: WelcomeContainer,
+      }),
+      Surface.create({
+        id: 'authorizingDevice',
+        filter: AppSurface.component(AppSurface.Dialog, AUTHORIZING_DEVICE_DIALOG),
+        component: AuthorizingDeviceDialog,
       }),
       Surface.create({
         id: 'nativeRedirect',

--- a/packages/plugins/plugin-onboarding/src/components/AuthorizingDeviceDialog/AuthorizingDeviceDialog.stories.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/AuthorizingDeviceDialog/AuthorizingDeviceDialog.stories.tsx
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import '@fontsource/poiret-one';
+
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import React from 'react';
+
+import { AlertDialog } from '@dxos/react-ui';
+import { withTheme } from '@dxos/react-ui/testing';
+
+import hero from '../../../assets/hero.webp?url';
+import { translations } from '../../translations';
+import { AuthorizingDeviceDialog } from './AuthorizingDeviceDialog';
+
+const DefaultStory = () => (
+  <AlertDialog.Root defaultOpen>
+    <AlertDialog.Overlay
+      classNames='dark bg-neutral-950! bg-no-repeat bg-center'
+      style={{ backgroundImage: `url(${hero})` }}
+    >
+      <AuthorizingDeviceDialog />
+    </AlertDialog.Overlay>
+  </AlertDialog.Root>
+);
+
+const meta = {
+  title: 'apps/composer-app/AuthorizingDeviceDialog',
+  component: AuthorizingDeviceDialog,
+  render: DefaultStory,
+  decorators: [withTheme()],
+  parameters: {
+    translations,
+  },
+} satisfies Meta<typeof AuthorizingDeviceDialog>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/plugins/plugin-onboarding/src/components/AuthorizingDeviceDialog/AuthorizingDeviceDialog.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/AuthorizingDeviceDialog/AuthorizingDeviceDialog.tsx
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import '@fontsource/poiret-one';
+
+import React from 'react';
+
+import { DXOSHorizontalType } from '@dxos/brand';
+import { Flex, Icon, useTranslation } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+import { meta } from '../../meta';
+
+/**
+ * Shown while a magic-link token is being redeemed and this device admitted to the existing
+ * identity. Mirrors the Welcome card's chrome (border, gradient, logo, footer) so swapping between
+ * the two dialogs reads as a continuation of the login gate rather than a different screen.
+ */
+export const AuthorizingDeviceDialog = () => {
+  const { t } = useTranslation(meta.profile.key);
+
+  return (
+    <div
+      className={mx(
+        'relative grid grid-cols-1 md:w-[37rem] max-w-[37rem] h-full md:h-[675px] overflow-hidden',
+        'border-2 border-sky-950 rounded-xl lg:translate-x-[-40%]',
+      )}
+      style={{
+        backgroundImage: 'radial-gradient(circle farthest-corner at 50% 50%, #2d6fff80, var(--color-neutral-950))',
+      }}
+    >
+      <Flex column gap='2xl' classNames='z-10 p-8 md:px-16 h-full'>
+        <span className='font-["Poiret One"] text-[80px]' style={{ fontFamily: 'Poiret One' }}>
+          composer
+        </span>
+
+        <Flex column align='center' justify='center' gap='lg' classNames='flex-1'>
+          <Icon icon='ph--spinner-gap--regular' size={10} classNames='animate-spin text-description' />
+          <h1 className='text-2xl text-center'>{t('authorizing-device.title')}</h1>
+        </Flex>
+
+        <Flex column classNames='z-[11] mt-auto'>
+          <a href='https://dxos.org' target='_blank' rel='noreferrer'>
+            <Flex gap='xs' center classNames='text-sm pr-3 pb-1 opacity-70'>
+              <span className='text-description'>Powered by</span>
+              <DXOSHorizontalType className='fill-white w-[80px]' />
+            </Flex>
+          </a>
+        </Flex>
+      </Flex>
+    </div>
+  );
+};
+
+export default AuthorizingDeviceDialog;

--- a/packages/plugins/plugin-onboarding/src/components/AuthorizingDeviceDialog/index.ts
+++ b/packages/plugins/plugin-onboarding/src/components/AuthorizingDeviceDialog/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-export * from './AboutDialog';
 export * from './AuthorizingDeviceDialog';
-export * from './NativeRedirectDialog';

--- a/packages/plugins/plugin-onboarding/src/constants.ts
+++ b/packages/plugins/plugin-onboarding/src/constants.ts
@@ -11,6 +11,8 @@ import { meta } from './meta';
  */
 export const WELCOME_SCREEN = `${meta.profile.key}.component.welcome-screen`;
 
+export const AUTHORIZING_DEVICE_DIALOG = `${meta.profile.key}.component.authorizing-device-dialog`;
+
 export const ABOUT_DIALOG = `${meta.profile.key}.component.about-dialog`;
 
 export const NATIVE_REDIRECT_DIALOG = `${meta.profile.key}.component.native-redirect-dialog`;

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
@@ -22,7 +22,7 @@ import { type Credential, DeviceType, type Identity } from '@dxos/react-client/h
 import { osTranslations } from '@dxos/ui-theme';
 
 import hero from '../assets/hero.webp?url';
-import { WELCOME_SCREEN } from './constants';
+import { AUTHORIZING_DEVICE_DIALOG, WELCOME_SCREEN } from './constants';
 import { meta } from './meta';
 import { queryAllCredentials, removeQueryParamByValue } from './util';
 
@@ -160,7 +160,14 @@ export class OnboardingManager {
     } else if (!this._skipAuth && this._deviceInvitationCode === undefined) {
       // No identity yet: show welcome. Skipped when a device invitation is pending, since both dialog
       // updates then race through the operation layer and a welcome landing second hides the join.
-      await this._showWelcome();
+      // A `?token=...` param means a magic-link redemption is about to run: show the "authorizing"
+      // dialog instead of the login form, so the multi-second server + HALO-replication wait doesn't
+      // look like a stuck login gate.
+      if (this._token) {
+        await this._showAuthorizingDevice();
+      } else {
+        await this._showWelcome();
+      }
       if (aborted()) {
         return;
       }
@@ -201,8 +208,14 @@ export class OnboardingManager {
       // the existing identity. Awaiting `_login()` lets HALO finish replicating
       // any pre-existing IdentityRecovery credentials before `_setupRecovery`
       // checks them, so we don't prompt a user who already has a passkey.
-      await this._login();
-      await this._setupRecovery();
+      if (await this._login()) {
+        await this._setupRecovery();
+      } else {
+        // Token was invalid, expired, or already used: fall back to the ordinary login form so the
+        // user can request a fresh link, rather than leaving them on the "authorizing" dialog forever.
+        await this._showLoginExpiredToast();
+        await this._showWelcome();
+      }
     }
     if (aborted()) {
       return;
@@ -250,11 +263,18 @@ export class OnboardingManager {
     });
   }
 
-  private async _login(): Promise<void> {
+  /** Resolves false when the token was rejected -- `invokePromise` resolves with `{ error }` rather
+   * than rejecting, so the result must be inspected or a failed redemption is silently swallowed. */
+  private async _login(): Promise<boolean> {
     invariant(this._token);
-    await this._invokePromise(ClientOperation.RedeemToken, { token: this._token });
-    this._token && removeQueryParamByValue(this._token);
+    const { error } = await this._invokePromise(ClientOperation.RedeemToken, { token: this._token });
+    removeQueryParamByValue(this._token);
     removeQueryParamByValue('login');
+    if (error) {
+      log.warn('token redemption failed', { error });
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -357,6 +377,26 @@ export class OnboardingManager {
 
   private async _closeWelcome(): Promise<void> {
     await this._invokePromise(LayoutOperation.UpdateDialog, { state: false });
+  }
+
+  /** Shown in place of the login form while a `?token=...` magic-link redemption is in flight. */
+  private async _showAuthorizingDevice(): Promise<void> {
+    await this._invokePromise(LayoutOperation.UpdateDialog, {
+      subject: AUTHORIZING_DEVICE_DIALOG,
+      type: 'alert',
+      overlayClasses: 'dark bg-neutral-950! bg-no-repeat bg-center',
+      overlayStyle: { backgroundImage: `url(${hero})` },
+    });
+  }
+
+  private async _showLoginExpiredToast(): Promise<void> {
+    await this._invokePromise(LayoutOperation.AddToast, {
+      id: 'login-link-expired-toast',
+      title: ['login-link-expired-toast.title', { ns: meta.profile.key }],
+      description: ['login-link-expired-toast.description', { ns: meta.profile.key }],
+      icon: 'ph--warning--regular',
+      closeLabel: ['close.label', { ns: osTranslations }],
+    });
   }
 
   private async _createIdentity(): Promise<void> {

--- a/packages/plugins/plugin-onboarding/src/translations.ts
+++ b/packages/plugins/plugin-onboarding/src/translations.ts
@@ -88,6 +88,11 @@ export const translations = [
         'passkey-setup-toast-action.label': 'Setup',
         'passkey-setup-toast-action.alt': 'Navigate to the passkeys management page.',
 
+        'authorizing-device.title': 'Authorizing this device',
+        'login-link-expired-toast.title': 'Login link expired',
+        'login-link-expired-toast.description':
+          'This login link is no longer valid. Please request a new one to log in.',
+
         'native-redirect.message': 'Opening in the Composer app...',
         'open-in-browser-button.label': 'Open here instead',
 


### PR DESCRIPTION
## Summary
Adds a new "Authorizing Device" dialog that displays while a magic-link token is being redeemed, improving UX by providing visual feedback during the multi-second server and HALO replication wait instead of showing a stuck login form.

## Key Changes
- **New `AuthorizingDeviceDialog` component**: Displays a spinner and "Authorizing this device" message while token redemption is in flight. Mirrors the Welcome card's styling (border, gradient, logo, footer) to read as a continuation of the login flow.
- **Enhanced token redemption flow**: Modified `_login()` to return a boolean indicating success/failure, allowing graceful fallback to the login form if the token is invalid, expired, or already used.
- **Token-aware dialog selection**: When a `?token=...` query parameter is present, the onboarding manager now shows the authorizing dialog instead of the welcome/login form.
- **Error handling and recovery**: Added `_showLoginExpiredToast()` to notify users when token redemption fails, then falls back to the welcome screen so they can request a fresh link.
- **New translations**: Added strings for the authorizing dialog title and login-link-expired toast.
- **Surface registration**: Registered the new dialog component in the React surface capability system.

## Implementation Details
- The authorizing dialog uses the same hero background image and dark theme as the welcome screen for visual consistency.
- Token validation errors are logged and inspected (rather than silently swallowed) since `invokePromise` resolves with `{ error }` instead of rejecting.
- Query parameters are cleaned up after redemption attempt regardless of success/failure.
- Storybook story included for component testing.

https://claude.ai/code/session_01MEY7TQG678ES7HMXBoku4q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a localized authorization dialog with branding, loading indicator, and progress messaging.
  * Magic-link onboarding now shows authorization progress while access is verified.
  * Added clear handling for expired or invalid login links, including an explanatory notification and return to the welcome screen.
* **Documentation**
  * Added a Storybook example for the authorization dialog.
* **Translations**
  * Added English text for device authorization and expired login links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->