### PR TITLE
react-ui-assistant: default MessageChrome context so a missing provider degrades instead of crashing

### DIFF
--- a/.changeset/message-chrome-default-context.md
+++ b/.changeset/message-chrome-default-context.md
@@ -1,0 +1,5 @@
+---
+'@dxos/react-ui-assistant': patch
+---
+
+MessageChrome no longer throws when rendered without its provider; the context now defaults to empty so the chrome degrades to its default behavior instead of crashing the thread.

--- a/packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatArticle/ChatArticle.tsx
@@ -102,9 +102,7 @@ export const ChatArticle = forwardRef<HTMLDivElement, ChatArticleProps>(
             <ChatComponent.Content>
               <div className='dx-container relative'>
                 {/* Thread outline. */}
-                {viewType !== 'summary' && (
-                  <ChatComponent.Outline classNames='absolute left-0 top-1/2 -translate-y-1/2 z-10' />
-                )}
+                <ChatComponent.Outline classNames='absolute left-0 top-1/2 -translate-y-1/2 z-10' />
                 {/* Main thread. */}
                 <ChatComponent.Thread viewType={viewType} tailLines={4} onViewUsage={handleViewUsage} />
                 {/* Floating thread status. */}

--- a/packages/ui/react-ui-assistant/src/components/MessageChrome/MessageChrome.tsx
+++ b/packages/ui/react-ui-assistant/src/components/MessageChrome/MessageChrome.tsx
@@ -31,9 +31,7 @@ type MessageChromeContextValue = {
   debug?: boolean;
 };
 
-// The default keeps the chrome usable without a provider: every field is optional configuration,
-// and a missing provider (standalone use, or a dev hot-update re-pairing the context) must not
-// throw and take the whole thread down with it.
+// Every field is optional configuration, so a missing provider defaults instead of throwing.
 const [MessageChromeProvider, useMessageChromeContext] = createContext<MessageChromeContextValue>(
   MESSAGE_CHROME_NAME,
   {},

--- a/packages/ui/react-ui-assistant/src/components/MessageChrome/MessageChrome.tsx
+++ b/packages/ui/react-ui-assistant/src/components/MessageChrome/MessageChrome.tsx
@@ -31,7 +31,13 @@ type MessageChromeContextValue = {
   debug?: boolean;
 };
 
-const [MessageChromeProvider, useMessageChromeContext] = createContext<MessageChromeContextValue>(MESSAGE_CHROME_NAME);
+// The default keeps the chrome usable without a provider: every field is optional configuration,
+// and a missing provider (standalone use, or a dev hot-update re-pairing the context) must not
+// throw and take the whole thread down with it.
+const [MessageChromeProvider, useMessageChromeContext] = createContext<MessageChromeContextValue>(
+  MESSAGE_CHROME_NAME,
+  {},
+);
 
 export { MessageChromeProvider };
 

--- a/packages/ui/react-ui-components/src/components/Spinner/Spinner.tsx
+++ b/packages/ui/react-ui-components/src/components/Spinner/Spinner.tsx
@@ -12,7 +12,7 @@ export type SpinnerState = 'pulse' | 'spin' | 'flash' | 'error';
 
 const stateClassNames: Record<SpinnerState, string> = {
   pulse: 'bg-primary-500',
-  spin: 'bg-amber-500',
+  spin: 'bg-lime-500',
   flash: 'bg-primary-500',
   error: 'bg-rose-700 border-2 border-rose-bg',
 };


### PR DESCRIPTION
## Summary

Fixes the plank-killing crash reported in the assistant thread:

```
Error: `MessageChrome` must be used within `MessageChrome`
    at useContext2 (...)
    at MessageChrome (MessageChrome.tsx:193)
```

`MessageChrome`'s radix context had no default, so any render without a live `MessageChromeProvider` pairing threw and took the whole thread down via the plank's ErrorBoundary. Every field on the context is optional configuration (`onRewind`, `streaming`, `showContext`, `debug`), so the component has sensible standalone behavior — the context now defaults to `{}` and the chrome degrades (no rewind button, toolbars visible, context panels shown) instead of crashing.

### Investigation notes

- The only production render path (`ChatThread.Root` → `MessageList.Root` → `Chrome`) is provider-wrapped; a cold tree cannot reproduce the crash, and the package/plugin storybook stories render clean.
- The reported stack fires in `updateFunctionComponent` — an in-place update of an already-mounted fiber — consistent with a dev hot-update re-instantiating the module's context pair (the mounted radix Provider is not a Fast Refresh-registered component, so it keeps providing the old context object while refreshed consumers read the new one). Defaulting the context removes the crash class for that case and for future standalone use of the exported chrome/toolbars.

Also includes two edits from the shared worktree: `Chat.Outline` renders unconditionally in `ChatArticle` (drops the `summary` gate), and the Spinner's `spin` state color moves from amber to lime.

## Testing

- `moon run react-ui-assistant:build plugin-assistant:build react-ui-components:build` + `:lint` green; `moon run :lint -- --fix` full-repo green.
- `moon run react-ui-assistant:test plugin-assistant:test react-ui-components:test` pass.
- Verified live in storybook (`ChatThread` Default story): thread renders, no console errors, and provider-supplied behavior still flows (rewind buttons present on prompt toolbars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Message displays now work safely even when no surrounding context is available.
  - Chat outlines are now shown consistently, including in summary views.

- **Style**
  - Updated the spinner’s active-state color from amber to lime for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->