### PR TITLE
composer-app: read the chat e2e thread across per-message editors

### DIFF
--- a/packages/apps/composer-app/src/playwright/chat.spec.ts
+++ b/packages/apps/composer-app/src/playwright/chat.spec.ts
@@ -66,7 +66,7 @@ test.describe('Chat', () => {
           if (failure) {
             return `request failed: ${failure}`;
           }
-          const thread = await assistant.thread.innerText();
+          const thread = await assistant.text();
           if (REPLY.test(thread)) {
             return 'replied';
           }

--- a/packages/apps/composer-app/src/playwright/plugins/assistant.ts
+++ b/packages/apps/composer-app/src/playwright/plugins/assistant.ts
@@ -33,11 +33,11 @@ export class Assistant {
   }
 
   /**
-   * The message thread. It is a read-only CodeMirror document (`MarkdownStream`) rather than a list
-   * of message elements, so assertions read its text rather than count nodes.
+   * The message thread's root. The thread is a virtualized list of read-only CodeMirror documents,
+   * one per message, so this matches the container and {@link text} reads across the messages.
    */
   get thread(): Locator {
-    return this.#locator.getByTestId('assistant.thread').locator('.cm-content');
+    return this.#locator.getByTestId('assistant.thread');
   }
 
   /**
@@ -46,6 +46,14 @@ export class Assistant {
    */
   get error(): Locator {
     return this.#locator.page().getByTestId('assistant.error');
+  }
+
+  /**
+   * The thread's text, one message per line. Joined across the message editors because a
+   * single-element read would violate strict mode as soon as a reply joins the prompt.
+   */
+  async text(): Promise<string> {
+    return (await this.thread.locator('.cm-content').allInnerTexts()).join('\n');
   }
 
   /**


### PR DESCRIPTION
Fixes the deterministic failure that has held the composer e2e shard red on `main` — [run 32214917284](https://github.com/dxos/dxos/actions/runs/32214917284), where `e2e (chromium, composer)`, `e2e (webkit, composer)` and `e2e (firefox, composer)` all failed and the `rest` shards passed.

Preview: https://pr-12667-composer-dev.dxos.workers.dev

## The failure

`src/playwright/chat.spec.ts:42 › Chat › sends a message and receives a response`, identical on all three browsers:

```
Error: locator.innerText: Error: strict mode violation:
  getByTestId('deck.plank').filter({ has: getByTestId('assistant.thread') })
    .getByTestId('assistant.thread').locator('.cm-content') resolved to 2 elements:
    1) <div class="cm-content …"> aka getByRole('textbox').filter({ hasText: 'What color is the sky on a' })
    2) <div class="cm-content …"> aka getByRole('textbox').filter({ hasText: 'Blue' })
  at src/playwright/chat.spec.ts:69
```

The app is not broken: the model answered `Blue`. The page object is stale.

`Assistant.thread` was written (`8363f124`, 2026-08-14) against a thread that was a single read-only CodeMirror document (`MarkdownStream`), so locating `.cm-content` yielded one element. `cc9b81fc` (#12627) and `4cb12a92` (#12648) replaced it with the feed-driven virtualized `MessageList`, which renders **one editor per message row**. The locator therefore matches one element while only the prompt exists and two the instant a reply renders, so `innerText()` raises a strict-mode violation inside the poll callback — a thrown error, not a failed assertion, so it aborts the test rather than retrying. It fails on every browser and every retry, and Trunk reports it as "failed and was **not** quarantined", which is what sets exit code 1 in all three jobs.

## The change

- `Assistant.thread` matches the `assistant.thread` container rather than a single editor inside it.
- New `Assistant.text()` joins `allInnerTexts()` across the message editors; `chat.spec.ts` reads that instead of `thread.innerText()`.

Test-only, so no changeset.

## Validation

CI, via a manual `workflow_dispatch` with `e2e: true` on this branch — [run 32242611767](https://github.com/dxos/dxos/actions/runs/32242611767). All three composer cells green, each running `Test All` rather than `Affected`:

| job | result |
| --- | --- |
| `e2e (chromium, composer)` | ✅ |
| `e2e (firefox, composer)` | ✅ |
| `e2e (webkit, composer)` | ✅ |

Also reproduced locally on chromium (real AI round trip), before and after, same command and machine:

| code | result |
| --- | --- |
| `HEAD~1` (pre-fix) | ✘ failed — `strict mode violation … resolved to 2 elements` |
| this branch | ✓ `1 passed (39.1s)`, test itself 28.9s |

`pnpm format` clean.

## Why CI did not catch the regression

`e2e-bundle` and `e2e` are conditioned on `refs/heads/main`, `changeset-release/*`, or an explicit dispatch, so an ordinary PR never runs them — this PR's own Check run reports `e2e` as `skipped`. #12627 and #12648 rewrote the assistant thread and could not have been caught before merging. Worth considering separately whether the composer shard should run when `packages/apps/composer-app` or the UI packages its specs assert against are affected; not changed here.

## Not addressed

The other composer-shard failures in the nightly are pre-existing two-peer invitation/replication flake and did not gate the job — `collaboration.spec.ts:59` (quarantined by Trunk on chromium, flaky on webkit), `collaboration.spec.ts:139` (flaky on all three) and `halo.spec.ts:77` (flaky on chromium) each passed on retry or were quarantined. Left for separate work rather than widening this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat response reading when conversations contain multiple virtualized message editors.
  * Ensured assistant text is collected consistently across all messages, with proper newline separation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->