### PR TITLE
onboarding: fix email login on composer dev and stop mislabelling failures as expired links

### DIFF
--- a/.changeset/tidy-links-report.md
+++ b/.changeset/tidy-links-report.md
@@ -1,0 +1,6 @@
+---
+'@dxos/protocols': patch
+'@dxos/plugin-onboarding': patch
+---
+
+Distinguish a rejected email login token from a recovery that failed for another reason, so a backend failure is no longer reported as an expired link.

--- a/.github/workflows/env/dev
+++ b/.github/workflows/env/dev
@@ -5,7 +5,10 @@ COMPOSER_APP_POSTHOG_API_KEY=${COMPOSER_APP_TEST_POSTHOG_API_KEY}
 COMPOSER_APP_POSTHOG_FEEDBACK_SURVEY_ID=0199be95-be15-0000-56ca-1f0dfde8731f
 COMPOSER_APP_POSTHOG_PROJECT_ID=93152
 POSTHOG_CLI_API_KEY=${POSTHOG_CLI_API_KEY}
-DX_HUB_URL="https://hub-staging.dxos.workers.dev/"
+# Must be the hub that EDGE's `HUB_SERVICE` binding resolves to (`hub` for EDGE `main` below):
+# magic-link tokens live in that hub's SESSION_KV and db-service redeems them through the binding,
+# so a hub from another environment mints links no redemption can resolve.
+DX_HUB_URL="https://hub.dxos.workers.dev/"
 DX_IPDATA_API_KEY=${IPDATA_API_KEY}
 DX_OTEL_ENDPOINT=/api/otel
 DX_POSTHOG_API_HOST=https://o.composer.space

--- a/packages/core/protocols/src/edge/edge.ts
+++ b/packages/core/protocols/src/edge/edge.ts
@@ -327,14 +327,6 @@ export type EdgeAuthChallenge = {
   challenge: string;
 };
 
-/**
- * `EdgeFailure.data.type` marking a recovery token (email magic link) that no longer resolves to an
- * identity — invalid, expired, or already redeemed. Distinguishes "ask for a fresh link" from an
- * EDGE-side failure, which is otherwise indistinguishable to the client. Mirrored as a literal by
- * db-service's recovery handler in the edge repo.
- */
-export const RECOVERY_TOKEN_INVALID = 'recovery_token_invalid';
-
 export enum OAuthProvider {
   ATLASSIAN = 'atlassian',
   ATPROTO = 'atproto',

--- a/packages/core/protocols/src/edge/edge.ts
+++ b/packages/core/protocols/src/edge/edge.ts
@@ -327,6 +327,14 @@ export type EdgeAuthChallenge = {
   challenge: string;
 };
 
+/**
+ * `EdgeFailure.data.type` marking a recovery token (email magic link) that no longer resolves to an
+ * identity — invalid, expired, or already redeemed. Distinguishes "ask for a fresh link" from an
+ * EDGE-side failure, which is otherwise indistinguishable to the client. Mirrored as a literal by
+ * db-service's recovery handler in the edge repo.
+ */
+export const RECOVERY_TOKEN_INVALID = 'recovery_token_invalid';
+
 export enum OAuthProvider {
   ATLASSIAN = 'atlassian',
   ATPROTO = 'atproto',

--- a/packages/core/protocols/src/errors/errors.ts
+++ b/packages/core/protocols/src/errors/errors.ts
@@ -64,10 +64,8 @@ export class InvalidInvitationError extends BaseError.extend('InvalidInvitationE
 registerErrorMessageContext('InvalidInvitationError', InvalidInvitationError);
 
 /**
- * A recovery token (email magic link) no longer resolves to an identity — invalid, expired, or
- * already redeemed. EDGE returns it through `EdgeFailure.error`, whose codec preserves only the
- * error *name*; registered here so the same name also survives the services RPC boundary, letting a
- * surface tell "request a fresh link" from "recovery failed" by type.
+ * A recovery token (email magic link) no longer resolves to an identity — registered because error
+ * identity crosses the EDGE and services RPC boundaries by name.
  */
 export class InvalidRecoveryTokenError extends BaseError.extend(
   'InvalidRecoveryTokenError',

--- a/packages/core/protocols/src/errors/errors.ts
+++ b/packages/core/protocols/src/errors/errors.ts
@@ -63,6 +63,19 @@ export class InvalidInvitationError extends BaseError.extend('InvalidInvitationE
 
 registerErrorMessageContext('InvalidInvitationError', InvalidInvitationError);
 
+/**
+ * A recovery token (email magic link) no longer resolves to an identity — invalid, expired, or
+ * already redeemed. Registered so the name survives the services RPC boundary: `EdgeCallFailedError`
+ * carries the discriminator in `data`, which the error codec drops, so a surface that needs to tell
+ * "request a fresh link" from "recovery failed" must see a distinct error type instead.
+ */
+export class InvalidRecoveryTokenError extends BaseError.extend(
+  'InvalidRecoveryTokenError',
+  'Recovery token is invalid, expired, or already used.',
+) {}
+
+registerErrorMessageContext('InvalidRecoveryTokenError', InvalidRecoveryTokenError);
+
 export class AlreadyJoinedError extends BaseError.extend('AlreadyJoinedError') {}
 
 registerErrorMessageContext('AlreadyJoinedError', AlreadyJoinedError);

--- a/packages/core/protocols/src/errors/errors.ts
+++ b/packages/core/protocols/src/errors/errors.ts
@@ -65,9 +65,9 @@ registerErrorMessageContext('InvalidInvitationError', InvalidInvitationError);
 
 /**
  * A recovery token (email magic link) no longer resolves to an identity — invalid, expired, or
- * already redeemed. Registered so the name survives the services RPC boundary: `EdgeCallFailedError`
- * carries the discriminator in `data`, which the error codec drops, so a surface that needs to tell
- * "request a fresh link" from "recovery failed" must see a distinct error type instead.
+ * already redeemed. EDGE returns it through `EdgeFailure.error`, whose codec preserves only the
+ * error *name*; registered here so the same name also survives the services RPC boundary, letting a
+ * surface tell "request a fresh link" from "recovery failed" by type.
  */
 export class InvalidRecoveryTokenError extends BaseError.extend(
   'InvalidRecoveryTokenError',

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
@@ -10,9 +10,22 @@ import { Client } from '@dxos/client';
 import { TestBuilder } from '@dxos/client/testing';
 import type * as Operation from '@dxos/compute/Operation';
 import { ClientOperation } from '@dxos/plugin-client';
+import { InvalidRecoveryTokenError } from '@dxos/protocols';
 
 import { WELCOME_SCREEN } from './constants';
 import { OnboardingManager } from './onboarding-manager';
+
+/**
+ * How a recovery failure reaches the manager: the HALO adapter wraps it in an `IdentityError` whose
+ * cause travels under `context.error` rather than `cause`. Reproduced locally rather than imported,
+ * so the test does not pull `@dxos/halo` in for one error shape.
+ */
+class WrappedIdentityError extends Error {
+  constructor(public readonly context: { error: unknown }) {
+    super('Identity operation failed');
+    this.name = 'IdentityError';
+  }
+}
 
 // No hubUrl is passed, so auth is skipped — the local/dev Composer configuration.
 describe('OnboardingManager', () => {
@@ -91,6 +104,35 @@ describe('OnboardingManager', () => {
     expect(getCalls(ClientOperation.CreateIdentity)).toHaveLength(0);
     expect(getCalls(ClientOperation.CreateAgent)).toHaveLength(0);
   });
+
+  //
+  // A magic-link redemption can fail because the link is spent, or because EDGE could not finish
+  // the recovery it authorized. Reporting both as "expired" sends the user to request link after
+  // link against a backend that is not going to answer differently.
+  //
+  test('a refused token reports the link as expired', async ({ expect }) => {
+    const { manager, toastIds } = await createManager({
+      hubUrl: 'https://hub.example.com',
+      token: 'test-token',
+      // Shaped as it arrives: raised in client-services, wrapped by the HALO adapter, and
+      // reconstructed by name across the services RPC boundary.
+      redeemTokenError: new WrappedIdentityError({ error: new InvalidRecoveryTokenError() }),
+    });
+    await manager.initialize();
+
+    expect(toastIds()).toEqual(['login-link-expired-toast']);
+  });
+
+  test('any other redemption failure reports a failed login, not an expired link', async ({ expect }) => {
+    const { manager, toastIds } = await createManager({
+      hubUrl: 'https://hub.example.com',
+      token: 'test-token',
+      redeemTokenError: new WrappedIdentityError({ error: new Error('Halo space not initialized.') }),
+    });
+    await manager.initialize();
+
+    expect(toastIds()).toEqual(['login-failed-toast']);
+  });
 });
 
 const createClient = async () => {
@@ -104,15 +146,21 @@ const createClient = async () => {
   return client;
 };
 
-const createInvoker = () => {
+const createInvoker = (failures: Map<string, Error> = new Map()) => {
   const calls: { key: string; input: unknown }[] = [];
   const invokePromise: Capabilities.OperationInvoker['invokePromise'] = async (operation, ...args) => {
-    calls.push({ key: String(operation.meta.key), input: args[0] });
-    return {};
+    const key = String(operation.meta.key);
+    calls.push({ key, input: args[0] });
+    // `invokePromise` reports a failed operation as `{ error }` rather than by rejecting.
+    return failures.has(key) ? { error: failures.get(key) } : {};
   };
   const getCalls = (operation: Operation.Definition.Any) =>
     calls.filter((call) => call.key === String(operation.meta.key));
-  return { invokePromise, getCalls, calls };
+  const toastIds = () =>
+    calls
+      .filter((call) => call.key === String(LayoutOperation.AddToast.meta.key))
+      .map((call) => (call.input as { id: string }).id);
+  return { invokePromise, getCalls, calls, toastIds };
 };
 
 /**
@@ -144,9 +192,11 @@ const createManager = async (options: {
   identity?: boolean;
   deviceInvitationCode?: string;
   hubUrl?: string;
+  token?: string;
   email?: string;
   accountInvitationCode?: string;
   emailProbe?: 'exists' | 'available' | 'unavailable';
+  redeemTokenError?: Error;
 }) => {
   const client = await createClient();
   if (options.identity) {
@@ -155,15 +205,20 @@ const createManager = async (options: {
   if (options.emailProbe !== undefined) {
     stubEmailProbe(options.emailProbe);
   }
-  const { invokePromise, getCalls, calls } = createInvoker();
+  const failures = new Map<string, Error>();
+  if (options.redeemTokenError !== undefined) {
+    failures.set(String(ClientOperation.RedeemToken.meta.key), options.redeemTokenError);
+  }
+  const { invokePromise, getCalls, calls, toastIds } = createInvoker(failures);
   const manager = new OnboardingManager({
     invokePromise,
     client,
     deviceInvitationCode: options.deviceInvitationCode,
     hubUrl: options.hubUrl,
+    token: options.token,
     email: options.email,
     accountInvitationCode: options.accountInvitationCode,
   });
   onTestFinished(() => manager.destroy());
-  return { manager, getCalls, calls };
+  return { manager, getCalls, calls, toastIds };
 };

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.test.ts
@@ -15,11 +15,7 @@ import { InvalidRecoveryTokenError } from '@dxos/protocols';
 import { WELCOME_SCREEN } from './constants';
 import { OnboardingManager } from './onboarding-manager';
 
-/**
- * How a recovery failure reaches the manager: the HALO adapter wraps it in an `IdentityError` whose
- * cause travels under `context.error` rather than `cause`. Reproduced locally rather than imported,
- * so the test does not pull `@dxos/halo` in for one error shape.
- */
+/** The HALO adapter's wrapper shape: the cause travels under `context.error` rather than `cause`. */
 class WrappedIdentityError extends Error {
   constructor(public readonly context: { error: unknown }) {
     super('Identity operation failed');
@@ -105,17 +101,10 @@ describe('OnboardingManager', () => {
     expect(getCalls(ClientOperation.CreateAgent)).toHaveLength(0);
   });
 
-  //
-  // A magic-link redemption can fail because the link is spent, or because EDGE could not finish
-  // the recovery it authorized. Reporting both as "expired" sends the user to request link after
-  // link against a backend that is not going to answer differently.
-  //
   test('a refused token reports the link as expired', async ({ expect }) => {
     const { manager, toastIds } = await createManager({
       hubUrl: 'https://hub.example.com',
       token: 'test-token',
-      // Shaped as it arrives: raised in client-services, wrapped by the HALO adapter, and
-      // reconstructed by name across the services RPC boundary.
       redeemTokenError: new WrappedIdentityError({ error: new InvalidRecoveryTokenError() }),
     });
     await manager.initialize();

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
@@ -212,9 +212,7 @@ export class OnboardingManager {
       if (result === 'ok') {
         await this._setupRecovery();
       } else {
-        // Either way fall back to the ordinary login form, rather than leaving the user on the
-        // "authorizing" dialog forever: a refused token needs a fresh link, and any other failure
-        // is worth retrying from there.
+        // Fall back to the login form rather than leaving the user on the "authorizing" dialog forever.
         await this._showLoginFailedToast(result);
         await this._showWelcome();
       }
@@ -266,9 +264,7 @@ export class OnboardingManager {
   }
 
   /** `invokePromise` resolves with `{ error }` rather than rejecting, so the result must be
-   * inspected or a failed redemption is silently swallowed. Distinguishes a token EDGE refused
-   * (nothing a retry of this link can fix) from a recovery that failed for another reason, since
-   * the two need different things from the user. */
+   * inspected or a failed redemption is silently swallowed. */
   private async _login(): Promise<'ok' | 'invalid-token' | 'failed'> {
     invariant(this._token);
     const { error } = await this._invokePromise(ClientOperation.RedeemToken, { token: this._token });

--- a/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
+++ b/packages/plugins/plugin-onboarding/src/onboarding-manager.ts
@@ -24,7 +24,7 @@ import { osTranslations } from '@dxos/ui-theme';
 import hero from '../assets/hero.webp?url';
 import { AUTHORIZING_DEVICE_DIALOG, WELCOME_SCREEN } from './constants';
 import { meta } from './meta';
-import { queryAllCredentials, removeQueryParamByValue } from './util';
+import { isInvalidRecoveryToken, queryAllCredentials, removeQueryParamByValue } from './util';
 
 export type OnboardingManagerProps = {
   invokePromise: Capabilities.OperationInvoker['invokePromise'];
@@ -208,12 +208,14 @@ export class OnboardingManager {
       // the existing identity. Awaiting `_login()` lets HALO finish replicating
       // any pre-existing IdentityRecovery credentials before `_setupRecovery`
       // checks them, so we don't prompt a user who already has a passkey.
-      if (await this._login()) {
+      const result = await this._login();
+      if (result === 'ok') {
         await this._setupRecovery();
       } else {
-        // Token was invalid, expired, or already used: fall back to the ordinary login form so the
-        // user can request a fresh link, rather than leaving them on the "authorizing" dialog forever.
-        await this._showLoginExpiredToast();
+        // Either way fall back to the ordinary login form, rather than leaving the user on the
+        // "authorizing" dialog forever: a refused token needs a fresh link, and any other failure
+        // is worth retrying from there.
+        await this._showLoginFailedToast(result);
         await this._showWelcome();
       }
     }
@@ -263,18 +265,20 @@ export class OnboardingManager {
     });
   }
 
-  /** Resolves false when the token was rejected -- `invokePromise` resolves with `{ error }` rather
-   * than rejecting, so the result must be inspected or a failed redemption is silently swallowed. */
-  private async _login(): Promise<boolean> {
+  /** `invokePromise` resolves with `{ error }` rather than rejecting, so the result must be
+   * inspected or a failed redemption is silently swallowed. Distinguishes a token EDGE refused
+   * (nothing a retry of this link can fix) from a recovery that failed for another reason, since
+   * the two need different things from the user. */
+  private async _login(): Promise<'ok' | 'invalid-token' | 'failed'> {
     invariant(this._token);
     const { error } = await this._invokePromise(ClientOperation.RedeemToken, { token: this._token });
     removeQueryParamByValue(this._token);
     removeQueryParamByValue('login');
     if (error) {
       log.warn('token redemption failed', { error });
-      return false;
+      return isInvalidRecoveryToken(error) ? 'invalid-token' : 'failed';
     }
-    return true;
+    return 'ok';
   }
 
   /**
@@ -389,11 +393,12 @@ export class OnboardingManager {
     });
   }
 
-  private async _showLoginExpiredToast(): Promise<void> {
+  private async _showLoginFailedToast(reason: 'invalid-token' | 'failed'): Promise<void> {
+    const id = reason === 'invalid-token' ? 'login-link-expired-toast' : 'login-failed-toast';
     await this._invokePromise(LayoutOperation.AddToast, {
-      id: 'login-link-expired-toast',
-      title: ['login-link-expired-toast.title', { ns: meta.profile.key }],
-      description: ['login-link-expired-toast.description', { ns: meta.profile.key }],
+      id,
+      title: [`${id}.title`, { ns: meta.profile.key }],
+      description: [`${id}.description`, { ns: meta.profile.key }],
       icon: 'ph--warning--regular',
       closeLabel: ['close.label', { ns: osTranslations }],
     });

--- a/packages/plugins/plugin-onboarding/src/translations.ts
+++ b/packages/plugins/plugin-onboarding/src/translations.ts
@@ -92,6 +92,9 @@ export const translations = [
         'login-link-expired-toast.title': 'Login link expired',
         'login-link-expired-toast.description':
           'This login link is no longer valid. Please request a new one to log in.',
+        'login-failed-toast.title': 'Could not complete login',
+        'login-failed-toast.description':
+          'Something went wrong while authorizing this device. Please try logging in again.',
 
         'native-redirect.message': 'Opening in the Composer app...',
         'open-in-browser-button.label': 'Open here instead',

--- a/packages/plugins/plugin-onboarding/src/util.ts
+++ b/packages/plugins/plugin-onboarding/src/util.ts
@@ -8,10 +8,8 @@ import { type Client } from '@dxos/react-client';
 import { type Credential } from '@dxos/react-client/halo';
 
 /**
- * Whether a failed recovery was EDGE refusing the token itself (invalid, expired, already used)
- * rather than a failure of the recovery that followed. Walks the chain because the reason is raised
- * in client-services and reaches here wrapped: `IdentityError` carries its cause under `context`,
- * and the services RPC boundary reconstructs the error by name, not by class identity.
+ * Whether a failed recovery was EDGE refusing the token itself — walks the wrapper chain because
+ * the error arrives wrapped, with the cause under `context` rather than `cause`.
  */
 export const isInvalidRecoveryToken = (error: unknown): boolean => {
   // Wrapped errors can produce cyclic chains, so track what has been seen.

--- a/packages/plugins/plugin-onboarding/src/util.ts
+++ b/packages/plugins/plugin-onboarding/src/util.ts
@@ -3,8 +3,30 @@
 //
 
 import { invariant } from '@dxos/invariant';
+import { InvalidRecoveryTokenError } from '@dxos/protocols';
 import { type Client } from '@dxos/react-client';
 import { type Credential } from '@dxos/react-client/halo';
+
+/**
+ * Whether a failed recovery was EDGE refusing the token itself (invalid, expired, already used)
+ * rather than a failure of the recovery that followed. Walks the chain because the reason is raised
+ * in client-services and reaches here wrapped: `IdentityError` carries its cause under `context`,
+ * and the services RPC boundary reconstructs the error by name, not by class identity.
+ */
+export const isInvalidRecoveryToken = (error: unknown): boolean => {
+  // Wrapped errors can produce cyclic chains, so track what has been seen.
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (typeof current === 'object' && current !== null && !seen.has(current)) {
+    seen.add(current);
+    if (InvalidRecoveryTokenError.is(current)) {
+      return true;
+    }
+    const { cause, context } = current as { cause?: unknown; context?: { error?: unknown } };
+    current = cause ?? context?.error;
+  }
+  return false;
+};
 
 export const removeQueryParamByValue = (valueToRemove: string) => {
   if (typeof window === 'undefined') {

--- a/packages/sdk/client-services/src/packlets/identity/identity-recovery-manager.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-recovery-manager.ts
@@ -262,10 +262,7 @@ export class EdgeIdentityRecoveryManager {
     };
 
     const response = await this._edgeClient.recoverIdentity(ctx, request).catch((error) => {
-      // EDGE returns a token it cannot resolve as an `InvalidRecoveryTokenError` in the failure
-      // envelope, which `ErrorCodec` rebuilds by name as this error's `cause` — rethrow the local
-      // registered class so the name also survives the services RPC boundary and callers can offer
-      // a fresh link rather than reporting every failed recovery the same way.
+      // Rethrow the registered class so the token-rejection identity survives the services RPC boundary.
       if (error instanceof EdgeCallFailedError && InvalidRecoveryTokenError.is(error.cause)) {
         throw new InvalidRecoveryTokenError({ cause: error });
       }

--- a/packages/sdk/client-services/src/packlets/identity/identity-recovery-manager.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-recovery-manager.ts
@@ -18,8 +18,11 @@ import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import {
   EdgeAuthChallengeError,
+  EdgeCallFailedError,
   type RecoverIdentityRequest as EdgeRecoverIdentityRequest,
+  InvalidRecoveryTokenError,
   type RecoverIdentityResponseBody,
+  RECOVERY_TOKEN_INVALID,
 } from '@dxos/protocols';
 import { schema } from '@dxos/protocols/proto';
 import { type RecoverIdentityRequest } from '@dxos/protocols/proto/dxos/client/services';
@@ -259,7 +262,15 @@ export class EdgeIdentityRecoveryManager {
       ...fields,
     };
 
-    const response = await this._edgeClient.recoverIdentity(ctx, request);
+    const response = await this._edgeClient.recoverIdentity(ctx, request).catch((error) => {
+      // EDGE marks a token it cannot resolve with a discriminator in `data`, which the error codec
+      // drops at the services RPC boundary — rethrow as a typed error so callers can offer a fresh
+      // link rather than reporting every failed recovery the same way.
+      if (error instanceof EdgeCallFailedError && error.data?.type === RECOVERY_TOKEN_INVALID) {
+        throw new InvalidRecoveryTokenError({ cause: error });
+      }
+      throw error;
+    });
 
     await this.#acceptRecoveredIdentity({
       authorizedDeviceCredential: decodeCredential(response.deviceAuthCredential),

--- a/packages/sdk/client-services/src/packlets/identity/identity-recovery-manager.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-recovery-manager.ts
@@ -22,7 +22,6 @@ import {
   type RecoverIdentityRequest as EdgeRecoverIdentityRequest,
   InvalidRecoveryTokenError,
   type RecoverIdentityResponseBody,
-  RECOVERY_TOKEN_INVALID,
 } from '@dxos/protocols';
 import { schema } from '@dxos/protocols/proto';
 import { type RecoverIdentityRequest } from '@dxos/protocols/proto/dxos/client/services';
@@ -263,10 +262,11 @@ export class EdgeIdentityRecoveryManager {
     };
 
     const response = await this._edgeClient.recoverIdentity(ctx, request).catch((error) => {
-      // EDGE marks a token it cannot resolve with a discriminator in `data`, which the error codec
-      // drops at the services RPC boundary — rethrow as a typed error so callers can offer a fresh
-      // link rather than reporting every failed recovery the same way.
-      if (error instanceof EdgeCallFailedError && error.data?.type === RECOVERY_TOKEN_INVALID) {
+      // EDGE returns a token it cannot resolve as an `InvalidRecoveryTokenError` in the failure
+      // envelope, which `ErrorCodec` rebuilds by name as this error's `cause` — rethrow the local
+      // registered class so the name also survives the services RPC boundary and callers can offer
+      // a fresh link rather than reporting every failed recovery the same way.
+      if (error instanceof EdgeCallFailedError && InvalidRecoveryTokenError.is(error.cause)) {
         throw new InvalidRecoveryTokenError({ cause: error });
       }
       throw error;


### PR DESCRIPTION
Email login on the composer `dev` channel (and every PR preview, which deploys to the same worker) fails immediately with "Login link expired", even when the link is used seconds after it arrives.

## Root cause

`DX_HUB_URL` and `DX_EDGE_BASE_URL` were paired across the environment split. The app never talks to the hub to redeem a token: `RedeemToken` → `Identity.recover` → `POST <DX_EDGE_BASE_URL>/identity/recover`, and db-service resolves the token through EDGE's own `HUB_SERVICE` **service binding**. EDGE `main` binds the `hub` (dev) worker, whose `SESSION_KV` is a different namespace from `hub-staging`'s — so a token minted by hub-staging was looked up in the dev hub's namespace and never found.

Confirmed in telemetry: `GET /account/activate/<token>` returns 302 on `hub-staging` (token valid), then `POST https://main.dxos.network/identity/recover` 500s with a single child span, `HubServiceEntrypoint.lookupRecoveryToken` in `deployment.environment: dev`, and no spans after it.

The coherent pairings are (`hub`, EDGE dev/main/labs), (`hub-staging`, EDGE staging) and (`hub-production`, EDGE production); `dev` was the only environment file crossing them. Pointing it at the dev hub keeps the channel on EDGE nightly as `ENV.md` intends, and costs nothing account-wise — both hubs share the `dev-hub` D1, so existing accounts and identity keys are unchanged.

Follow-up worth doing separately: the dev hub's vars are still localhost-shaped (`DX_WEBAUTHN_RP_ID=localhost`, `APP_URL=http://localhost:5173`), so passkey ceremonies from `dev.composer.space` fail closed. Magic-link login is unaffected — the client-supplied `redirectUrl` overrides `APP_URL`.

## Also fixed: the toast lied

`OnboardingManager` mapped *every* redemption failure to `login-link-expired-toast`, so a misconfiguration or a backend fault was indistinguishable from a spent link and the only honest signal was a `log.warn` in the console. Now:

- `@dxos/protocols` gains `InvalidRecoveryTokenError`. EDGE returns it for a token it cannot resolve through the failure envelope's serialized-error channel (`EdgeFailure.error` / `ErrorCodec`, which preserves error identity by name — the same way other typed failures cross the edge API boundary); it is registered so the name also survives the services RPC boundary.
- `EdgeIdentityRecoveryManager.recoverIdentityWithToken` matches the decoded cause with the class's `.is()` and rethrows the registered class.
- Onboarding shows the expired-link toast only for a refused token, and a new "Could not complete login" toast otherwise.

The EDGE side of the contract (404 + typed error, retiring the token on success rather than on lookup, and a 15-minute login TTL to bound the replay window that change opens) is dxos/edge#903.

## Testing

- `moon run plugin-onboarding:test` — 9 passed, including two new cases asserting which toast each failure shape produces.
- `moon run client-services:build protocols:build plugin-onboarding:build` and the matching `:lint` tasks — clean.
- `pnpm format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE9kHpy6JjrKrnsCDhrtTR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery-link redemption now distinguishes invalid, expired, or already-used tokens from other login failures.
  * Backend errors are no longer incorrectly displayed as expired or invalid recovery links.
  * Login failures now show clearer, context-specific notifications and continue guiding you back to the welcome screen.
  * Improved handling of wrapped recovery errors provides more accurate feedback when a login attempt cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->