### PR TITLE
plugin-settings: render settings node icons in the neutral color

### DIFF
--- a/.changeset/neutral-settings-icons.md
+++ b/.changeset/neutral-settings-icons.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-settings': patch
+---
+
+Render plugin settings list icons in the neutral color instead of each plugin's hue.

--- a/packages/plugins/plugin-settings/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-settings/src/capabilities/app-graph-builder.ts
@@ -96,8 +96,8 @@ export default Capability.makeModule(
                   data: settings,
                   properties: {
                     label: meta.profile.name ?? meta.profile.key,
+                    // The plugin's own hue is dropped so the settings list reads as one uniform group.
                     icon: meta.profile.icon?.key ?? 'ph--circle--regular',
-                    iconHue: meta.profile.icon?.hue,
                   },
                 }),
               ),


### PR DESCRIPTION
Settings nodes inherited each plugin's own icon hue, so the Plugin Settings list mixed colored icons (Assistant sky, Markdown indigo, Support rose, Theme pink, Transcription sky) with the neutral ones from plugins that declare no hue (Layout, Spaces, Onboarding, Telemetry).

Dropping `iconHue` from the settings graph nodes lets every icon inherit the list's text color, matching how the un-hued entries already render.

- `packages/plugins/plugin-settings/src/capabilities/app-graph-builder.ts` — no longer forwards `meta.profile.icon?.hue`.
- Added a patch changeset for `@dxos/plugin-settings`.

Verified: `plugin-settings:build`, `plugin-settings:lint`, `plugin-settings:test` (1 passed), `pnpm format` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Evw6TGq4GGuboDpfDbLTVZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated plugin settings icons to use a neutral color scheme.
  * Improved consistency by relying on each plugin’s icon or a default icon without applying additional color tinting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->