### PR TITLE
scripts: point the verify hint at the undeployed version

### DIFF
--- a/scripts/secrets.mjs
+++ b/scripts/secrets.mjs
@@ -271,7 +271,8 @@ for (const target of targets) {
       `\n  ${versioned.length} secret(s) landed in a NEW UNDEPLOYED version of "${workerName}": ` +
         `${versioned.join(', ')}\n` +
         '  They take effect on the next deploy or `versions upload` — the currently deployed version does\n' +
-        '  not have them. Verify with `wrangler versions secret list`.',
+        '  not have them. Verify with `wrangler versions secret list --latest-version` — without that flag\n' +
+        '  the command reports the DEPLOYED version, which is exactly the one that lacks them.',
     );
   }
 


### PR DESCRIPTION
Follow-up to #12680, which merged before this could be pushed onto it. CodeRabbit caught it there and was right.

When `pnpm secrets` falls back to `wrangler versions secret put`, it tells you to confirm with:

```
wrangler versions secret list
```

That command reports the **deployed** version — its own summary is literally "List the secrets currently deployed", and `--latest-version` is `[default: false]`. The secret we just wrote is in a *new, undeployed* version, so the check as written would show it missing and read as a failure. The hint pointed at exactly the wrong thing.

Now names `--latest-version` and says why:

```
1 secret(s) landed in a NEW UNDEPLOYED version of "composer-preview": SIGNOZ_INGESTION_KEY
They take effect on the next deploy or `versions upload` — the currently deployed version does
not have them. Verify with `wrangler versions secret list --latest-version` — without that flag
the command reports the DEPLOYED version, which is exactly the one that lacks them.
```

## Test plan

- Confirmed the flag against the pinned wrangler rather than taking the review's web search on trust: `pnpm exec wrangler versions secret list --help` shows `--latest-version  Only show the latest version  [boolean] [default: false]`.
- Re-ran the stubbed-`wrangler` fallback case from #12680 and read the emitted text; output above is verbatim.
- `node --check scripts/secrets.mjs`, `pnpm format` clean.
- `REPOSITORY_GUIDE.md` checked — it describes the fallback but never names the list command, so nothing to correct there.

Message-only; no change to which command writes the secret.

---
_Generated by [Claude Code](https://claude.ai/code/session_014u3eKMLzJwLw8ZGBG3cYiZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the post-secret-write verification message with the correct command for checking secrets on the latest undeployed Worker version.
  * Clarified that omitting the latest-version option displays secrets for the deployed version instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->