### PR TITLE
client: fix stale sync progress; one replication monitor per space

### DIFF
--- a/.changeset/sync-progress-single-space-monitor.md
+++ b/.changeset/sync-progress-single-space-monitor.md
@@ -1,0 +1,11 @@
+---
+'@dxos/echo-client': patch
+'@dxos/plugin-client': patch
+'@dxos/app-toolkit': patch
+---
+
+Fixed the sync progress indicator getting stuck showing "sync in progress" after replication had caught up, and collapsed a space's CRDT and feed backlogs into a single progress item.
+
+- `subscribeToSyncState` now re-establishes the feed sync-state stream after a reconnect (leader change) and clears the feed backlog while it is down — previously the stream died silently and every later document update re-published the last (non-zero) feed counts forever.
+- The space replication progress capability no longer stacks a subscription fiber per space on every spaces-subscription delivery (duplicate writers raced over one monitor key), drops the monitor for a space that leaves the list, and reconciles against a fresh `getSyncState` read every 10s so a missed update cannot outlive the backlog.
+- Documents and feed blocks now share one monitor per space; the breakdown (`4 CRDTs · ↓6 ↑2`) is rendered as the meter's note, which `ProgressMeter` previously ignored.

--- a/packages/core/echo/echo-client/src/core-db/entity-manager.ts
+++ b/packages/core/echo/echo-client/src/core-db/entity-manager.ts
@@ -148,6 +148,11 @@ export class EntityManager implements IDatabaseBinding {
   /** Fires when service connection is re-established after a leader change. */
   private readonly _reconnected = new Event<void>();
 
+  /** Public view of {@link EntityManager._reconnected}, so sibling streams can re-establish too. */
+  get reconnected(): ReadOnlyEvent<void> {
+    return this._reconnected;
+  }
+
   // ── Automerge document state ────────────────────────────────────────────
   private _spaceRootDocHandle: DocHandleProxy<DatabaseDirectory> | null = null;
 

--- a/packages/core/echo/echo-client/src/proxy-db/database.ts
+++ b/packages/core/echo/echo-client/src/proxy-db/database.ts
@@ -789,25 +789,39 @@ export class DatabaseImpl extends Resource implements EchoDatabase {
       }),
     );
 
-    if (this.#feedService) {
-      ctx.onDispose(
-        subscribeStream(
-          this.#runtime,
-          this.#feedService['FeedService.subscribeSyncState']({ spaceId: this.spaceId, namespaces: [] }),
-          {
-            onData: (response) => {
-              feeds = aggregateFeedSyncState(response);
-              emit();
-            },
-            onError: (error) => {
-              if (!(error instanceof RpcClosedError)) {
-                log.warn('feed sync state stream failed', { error });
-              }
-            },
+    // Feed blocks arrive on a separate stream, which dies on reconnect (leader change) — re-established
+    // from the refreshed service, and cleared meanwhile so a consumer never keeps reporting a backlog
+    // measured against a connection that no longer exists.
+    let cleanupFeedStream: (() => void) | undefined;
+    const subscribeFeedSyncState = () => {
+      cleanupFeedStream?.();
+      cleanupFeedStream = undefined;
+      if (!this.#feedService) {
+        return;
+      }
+      cleanupFeedStream = subscribeStream(
+        this.#runtime,
+        this.#feedService['FeedService.subscribeSyncState']({ spaceId: this.spaceId, namespaces: [] }),
+        {
+          onData: (response) => {
+            feeds = aggregateFeedSyncState(response);
+            emit();
           },
-        ),
+          onError: (error) => {
+            feeds = EMPTY_FEED_SYNC_STATE;
+            emit();
+            if (error instanceof RpcClosedError) {
+              ctx.onDispose(this._entityManager.reconnected.once(() => subscribeFeedSyncState()));
+            } else if (error) {
+              log.warn('feed sync state stream failed', { error });
+            }
+          },
+        },
       );
-    }
+    };
+
+    subscribeFeedSyncState();
+    ctx.onDispose(() => cleanupFeedStream?.());
 
     return () => {
       void ctx.dispose();

--- a/packages/plugins/plugin-client/src/capabilities/space-replication-progress.ts
+++ b/packages/plugins/plugin-client/src/capabilities/space-replication-progress.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
+import * as Cause from 'effect/Cause';
 import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
@@ -16,6 +17,7 @@ import { type Space, SpaceState } from '@dxos/client/echo';
 import * as ServiceResolver from '@dxos/compute/ServiceResolver';
 import { Database } from '@dxos/echo';
 import { type SpaceId } from '@dxos/keys';
+import { log } from '@dxos/log';
 
 import { ClientCapabilities } from '#types';
 
@@ -87,12 +89,15 @@ export default Capability.makeModule(
         processManagerRuntime.runFork(
           Database.subscribeToSyncState().pipe(
             Stream.runForEach((state) => Effect.sync(() => apply(state))),
+            Effect.catchCause((cause) => reportSyncFailure('sync state stream failed', space.id, cause)),
             Effect.provide(provide),
           ),
         ),
         processManagerRuntime.runFork(
+          // Caught inside the loop so a transient read failure cannot kill reconciliation.
           Database.getSyncState().pipe(
             Effect.map(apply),
+            Effect.catchCause((cause) => reportSyncFailure('sync state read failed', space.id, cause)),
             Effect.repeat(Schedule.spaced(RECONCILE_INTERVAL)),
             Effect.provide(provide),
           ),
@@ -118,8 +123,7 @@ export default Capability.makeModule(
       }),
     );
 
-    // A space that leaves the list (closed, left) never emits another sync state, so its monitor
-    // would linger forever — and its still-running fibers would re-register it.
+    // A departed space stops emitting sync state, so its monitor and fibers must be torn down here.
     const pruneSpaces = (spaces: readonly Space[]): void => {
       const live = new Set(spaces.map((space) => space.id));
       for (const spaceId of [...subscriptions.keys()]) {
@@ -143,3 +147,14 @@ export default Capability.makeModule(
     return [];
   }),
 );
+
+/**
+ * Swallows a sync-state failure so the reconciliation loop survives it (a rejected read arrives as a
+ * defect via `Effect.promise`); interruption is teardown, not a fault, so it is not reported.
+ */
+const reportSyncFailure = (message: string, space: SpaceId, cause: Cause.Cause<unknown>): Effect.Effect<void> =>
+  Effect.sync(() => {
+    if (!Cause.hasInterrupts(cause)) {
+      log.warn(message, { space, cause });
+    }
+  });

--- a/packages/plugins/plugin-client/src/capabilities/space-replication-progress.ts
+++ b/packages/plugins/plugin-client/src/capabilities/space-replication-progress.ts
@@ -7,7 +7,6 @@ import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
 import * as Option from 'effect/Option';
 import * as Schedule from 'effect/Schedule';
-import * as Scope from 'effect/Scope';
 import * as Stream from 'effect/Stream';
 
 import * as Capabilities from '@dxos/app-framework/Capabilities';
@@ -49,15 +48,6 @@ export default Capability.makeModule(
 
     const monitors = new Map<string, AppCapabilities.ProgressMonitor>();
 
-    yield* Effect.addFinalizer(() =>
-      Effect.sync(() => {
-        for (const monitor of monitors.values()) {
-          monitor.remove();
-        }
-        monitors.clear();
-      }),
-    );
-
     const applyMonitor = (key: string, update: MonitorUpdate | undefined): void => {
       if (update === undefined) {
         monitors.get(key)?.remove();
@@ -83,46 +73,58 @@ export default Capability.makeModule(
 
     // The spaces subscription re-delivers the whole list on every change, so subscribing blindly
     // would stack a fiber per space per delivery — duplicate writers then race over one monitor key.
-    const subscribed = new Set<SpaceId>();
-    const runtime = yield* Effect.context<Scope.Scope>();
+    const subscriptions = new Map<SpaceId, Fiber.Fiber<unknown, unknown>[]>();
     const subscribeSpace = (space: Space): void => {
-      if (subscribed.has(space.id)) {
+      if (subscriptions.has(space.id)) {
         return;
       }
-      subscribed.add(space.id);
 
-      void Effect.gen(function* () {
-        const key = createSpaceReplicationProgressKey(space.id);
-        const apply = (state: Database.SyncState) => applyMonitor(key, toSpaceUpdate(getSpaceName(space), state));
-        const provide = ServiceResolver.provide({ space: space.id }, Database.Service);
+      const key = createSpaceReplicationProgressKey(space.id);
+      const apply = (state: Database.SyncState) => applyMonitor(key, toSpaceUpdate(getSpaceName(space), state));
+      const provide = ServiceResolver.provide({ space: space.id }, Database.Service);
 
-        const streamFiber = processManagerRuntime.runFork(
+      subscriptions.set(space.id, [
+        processManagerRuntime.runFork(
           Database.subscribeToSyncState().pipe(
             Stream.runForEach((state) => Effect.sync(() => apply(state))),
             Effect.provide(provide),
           ),
-        );
-        const reconcileFiber = processManagerRuntime.runFork(
+        ),
+        processManagerRuntime.runFork(
           Database.getSyncState().pipe(
             Effect.map(apply),
             Effect.repeat(Schedule.spaced(RECONCILE_INTERVAL)),
             Effect.provide(provide),
           ),
-        );
-
-        yield* Effect.addFinalizer(() =>
-          Effect.all([Fiber.interrupt(streamFiber), Fiber.interrupt(reconcileFiber)], { discard: true }),
-        );
-      }).pipe(Effect.provide(runtime), Effect.runFork);
+        ),
+      ]);
     };
 
+    const unsubscribeSpace = (spaceId: SpaceId): void => {
+      const fibers = subscriptions.get(spaceId);
+      if (!fibers) {
+        return;
+      }
+      subscriptions.delete(spaceId);
+      applyMonitor(createSpaceReplicationProgressKey(spaceId), undefined);
+      Effect.runFork(Effect.all(fibers.map(Fiber.interrupt), { discard: true }));
+    };
+
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        for (const spaceId of [...subscriptions.keys()]) {
+          unsubscribeSpace(spaceId);
+        }
+      }),
+    );
+
     // A space that leaves the list (closed, left) never emits another sync state, so its monitor
-    // would linger forever — drop it here instead.
-    const pruneMonitors = (spaces: readonly Space[]): void => {
-      const live = new Set(spaces.map((space) => createSpaceReplicationProgressKey(space.id)));
-      for (const key of [...monitors.keys()]) {
-        if (!live.has(key)) {
-          applyMonitor(key, undefined);
+    // would linger forever — and its still-running fibers would re-register it.
+    const pruneSpaces = (spaces: readonly Space[]): void => {
+      const live = new Set(spaces.map((space) => space.id));
+      for (const spaceId of [...subscriptions.keys()]) {
+        if (!live.has(spaceId)) {
+          unsubscribeSpace(spaceId);
         }
       }
     };
@@ -131,7 +133,7 @@ export default Capability.makeModule(
       for (const space of spaces) {
         subscribeSpace(space);
       }
-      pruneMonitors(spaces);
+      pruneSpaces(spaces);
     });
     yield* Effect.addFinalizer(() => Effect.sync(() => spacesSubscription.unsubscribe()));
     for (const space of client.spaces.get()) {

--- a/packages/plugins/plugin-client/src/capabilities/space-replication-progress.ts
+++ b/packages/plugins/plugin-client/src/capabilities/space-replication-progress.ts
@@ -2,9 +2,11 @@
 // Copyright 2026 DXOS.org
 //
 
+import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
 import * as Option from 'effect/Option';
+import * as Schedule from 'effect/Schedule';
 import * as Scope from 'effect/Scope';
 import * as Stream from 'effect/Stream';
 
@@ -14,22 +16,23 @@ import * as AppCapabilities from '@dxos/app-toolkit/AppCapabilities';
 import { type Space, SpaceState } from '@dxos/client/echo';
 import * as ServiceResolver from '@dxos/compute/ServiceResolver';
 import { Database } from '@dxos/echo';
+import { type SpaceId } from '@dxos/keys';
 
 import { ClientCapabilities } from '#types';
 
-import { createSpaceFeedReplicationProgressKey, createSpaceReplicationProgressKey } from '../progress';
-
-type MonitorUpdate = {
-  readonly label: string;
-  readonly current: number;
-  readonly total: number;
-  readonly note?: string;
-};
+import { type MonitorUpdate, createSpaceReplicationProgressKey, toSpaceUpdate } from '../progress';
 
 /**
- * Publishes per-space replication backlog — automerge documents and ECHO feed blocks — into the
- * {@link AppCapabilities.ProgressRegistry}. Subscribes to the combined sync-state stream and drops
- * monitors once a space catches up.
+ * Reconciliation interval. The sync-state streams are the primary signal; a periodic re-read
+ * guarantees a monitor cannot outlive its backlog if an update is ever missed (a dropped stream,
+ * a leader change), which would otherwise leave the indicator spinning forever.
+ */
+const RECONCILE_INTERVAL = Duration.seconds(10);
+
+/**
+ * Publishes per-space replication backlog — automerge documents and ECHO feed blocks combined into a
+ * single monitor per space — into the {@link AppCapabilities.ProgressRegistry}. Subscribes to the
+ * combined sync-state stream and drops a space's monitor once it catches up.
  */
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
@@ -69,9 +72,7 @@ export default Capability.makeModule(
       }
       monitor.set(update.current);
       monitor.total(update.total);
-      if (update.note !== undefined) {
-        monitor.note(update.note);
-      }
+      monitor.note(update.note ?? '');
     };
 
     // A space that has not finished initializing throws from its `properties` getter, and the
@@ -80,29 +81,57 @@ export default Capability.makeModule(
     const getSpaceName = (space: Space): string | undefined =>
       space.state.get() === SpaceState.SPACE_READY ? space.properties.name : undefined;
 
+    // The spaces subscription re-delivers the whole list on every change, so subscribing blindly
+    // would stack a fiber per space per delivery — duplicate writers then race over one monitor key.
+    const subscribed = new Set<SpaceId>();
     const runtime = yield* Effect.context<Scope.Scope>();
-    const subscribeSpace = (space: Space): void =>
+    const subscribeSpace = (space: Space): void => {
+      if (subscribed.has(space.id)) {
+        return;
+      }
+      subscribed.add(space.id);
+
       void Effect.gen(function* () {
-        const fiber = processManagerRuntime.runFork(
+        const key = createSpaceReplicationProgressKey(space.id);
+        const apply = (state: Database.SyncState) => applyMonitor(key, toSpaceUpdate(getSpaceName(space), state));
+        const provide = ServiceResolver.provide({ space: space.id }, Database.Service);
+
+        const streamFiber = processManagerRuntime.runFork(
           Database.subscribeToSyncState().pipe(
-            Stream.runForEach(
-              Effect.fnUntraced(function* (state) {
-                const name = getSpaceName(space);
-                applyMonitor(createSpaceReplicationProgressKey(space.id), toDocumentUpdate(name, state));
-                applyMonitor(createSpaceFeedReplicationProgressKey(space.id), toFeedUpdate(name, state));
-              }),
-            ),
-            Effect.provide(ServiceResolver.provide({ space: space.id }, Database.Service)),
+            Stream.runForEach((state) => Effect.sync(() => apply(state))),
+            Effect.provide(provide),
+          ),
+        );
+        const reconcileFiber = processManagerRuntime.runFork(
+          Database.getSyncState().pipe(
+            Effect.map(apply),
+            Effect.repeat(Schedule.spaced(RECONCILE_INTERVAL)),
+            Effect.provide(provide),
           ),
         );
 
-        yield* Effect.addFinalizer(() => Fiber.interrupt(fiber));
+        yield* Effect.addFinalizer(() =>
+          Effect.all([Fiber.interrupt(streamFiber), Fiber.interrupt(reconcileFiber)], { discard: true }),
+        );
       }).pipe(Effect.provide(runtime), Effect.runFork);
+    };
+
+    // A space that leaves the list (closed, left) never emits another sync state, so its monitor
+    // would linger forever — drop it here instead.
+    const pruneMonitors = (spaces: readonly Space[]): void => {
+      const live = new Set(spaces.map((space) => createSpaceReplicationProgressKey(space.id)));
+      for (const key of [...monitors.keys()]) {
+        if (!live.has(key)) {
+          applyMonitor(key, undefined);
+        }
+      }
+    };
 
     const spacesSubscription = client.spaces.subscribe((spaces) => {
       for (const space of spaces) {
         subscribeSpace(space);
       }
+      pruneMonitors(spaces);
     });
     yield* Effect.addFinalizer(() => Effect.sync(() => spacesSubscription.unsubscribe()));
     for (const space of client.spaces.get()) {
@@ -112,43 +141,3 @@ export default Capability.makeModule(
     return [];
   }),
 );
-
-/** Derives the automerge document monitor state, or `undefined` when caught up. */
-const toDocumentUpdate = (name: string | undefined, state: Database.SyncState): MonitorUpdate | undefined => {
-  const unsynced = state.unsyncedDocumentCount;
-  if (unsynced === 0) {
-    return undefined;
-  }
-
-  const total = state.totalDocumentCount > 0 ? state.totalDocumentCount : unsynced;
-  return {
-    label: getSpaceProgressLabel(name ?? 'Space', 'CRDTs'),
-    current: Math.max(0, total - unsynced),
-    total,
-  };
-};
-
-/** Derives the ECHO feed block monitor state, or `undefined` when caught up. */
-const toFeedUpdate = (name: string | undefined, state: Database.SyncState): MonitorUpdate | undefined => {
-  const blocksToPull = Number(state.blocksToPull);
-  const blocksToPush = Number(state.blocksToPush);
-  const pending = blocksToPull + blocksToPush;
-  if (pending === 0) {
-    return undefined;
-  }
-
-  const totalBlocks = Number(state.totalBlocks);
-  const total = totalBlocks > 0 ? totalBlocks : pending;
-  return {
-    label: getSpaceProgressLabel(name ?? 'Space', 'Feeds'),
-    current: Math.max(0, total - pending),
-    total,
-    note: `↓${blocksToPull} ↑${blocksToPush}`,
-  };
-};
-
-/** Human label for a space progress monitor. */
-const getSpaceProgressLabel = (name: string | undefined, suffix?: string): string => {
-  const name_ = name ?? 'Space';
-  return suffix ? `${name_} · ${suffix}` : name_;
-};

--- a/packages/plugins/plugin-client/src/progress/index.ts
+++ b/packages/plugins/plugin-client/src/progress/index.ts
@@ -3,3 +3,4 @@
 //
 
 export * from './progress-keys';
+export * from './space-sync-progress';

--- a/packages/plugins/plugin-client/src/progress/progress-keys.ts
+++ b/packages/plugins/plugin-client/src/progress/progress-keys.ts
@@ -6,10 +6,6 @@ import { type SpaceId } from '@dxos/keys';
 
 import { meta } from '#meta';
 
-/** Stable progress-monitor key for automerge document replication in a space. */
+/** Stable progress-monitor key for a space's combined (documents + feed blocks) replication backlog. */
 export const createSpaceReplicationProgressKey = (spaceId: SpaceId): string =>
   `${meta.profile.key}:space:${spaceId}#replication`;
-
-/** Stable progress-monitor key for ECHO feed block replication in a space. */
-export const createSpaceFeedReplicationProgressKey = (spaceId: SpaceId): string =>
-  `${meta.profile.key}:space:${spaceId}#feeds`;

--- a/packages/plugins/plugin-client/src/progress/space-sync-progress.test.ts
+++ b/packages/plugins/plugin-client/src/progress/space-sync-progress.test.ts
@@ -1,0 +1,63 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, test } from 'vitest';
+
+import { type Database } from '@dxos/echo';
+
+import { toSpaceUpdate } from './space-sync-progress';
+
+const makeState = (state: Partial<Database.SyncState>): Database.SyncState => ({
+  localDocumentCount: 0,
+  remoteDocumentCount: 0,
+  totalDocumentCount: 0,
+  unsyncedDocumentCount: 0,
+  blocksToPull: '0',
+  blocksToPush: '0',
+  totalBlocks: '0',
+  ...state,
+});
+
+describe('toSpaceUpdate', () => {
+  test('caught up on both backlogs yields no monitor', () => {
+    expect(toSpaceUpdate('Space', makeState({ totalDocumentCount: 10, totalBlocks: '100' }))).toBeUndefined();
+  });
+
+  test('combines documents and feed blocks into one meter', () => {
+    const update = toSpaceUpdate(
+      'Notes',
+      makeState({
+        totalDocumentCount: 10,
+        unsyncedDocumentCount: 4,
+        totalBlocks: '100',
+        blocksToPull: '6',
+        blocksToPush: '2',
+      }),
+    );
+    expect(update).toEqual({
+      label: 'Notes',
+      current: 98, // (10 + 100) − (4 + 8)
+      total: 110,
+      note: '4 CRDTs · ↓6 ↑2',
+    });
+  });
+
+  test('unsynced documents alone keep the meter up', () => {
+    expect(toSpaceUpdate(undefined, makeState({ unsyncedDocumentCount: 3 }))).toEqual({
+      label: 'Space',
+      current: 0,
+      total: 3,
+      note: '3 CRDTs',
+    });
+  });
+
+  test('feed blocks alone keep the meter up', () => {
+    expect(toSpaceUpdate('Notes', makeState({ totalBlocks: '10', blocksToPush: '2' }))).toEqual({
+      label: 'Notes',
+      current: 8,
+      total: 10,
+      note: '↓0 ↑2',
+    });
+  });
+});

--- a/packages/plugins/plugin-client/src/progress/space-sync-progress.test.ts
+++ b/packages/plugins/plugin-client/src/progress/space-sync-progress.test.ts
@@ -8,17 +8,6 @@ import { type Database } from '@dxos/echo';
 
 import { toSpaceUpdate } from './space-sync-progress';
 
-const makeState = (state: Partial<Database.SyncState>): Database.SyncState => ({
-  localDocumentCount: 0,
-  remoteDocumentCount: 0,
-  totalDocumentCount: 0,
-  unsyncedDocumentCount: 0,
-  blocksToPull: '0',
-  blocksToPush: '0',
-  totalBlocks: '0',
-  ...state,
-});
-
 describe('toSpaceUpdate', () => {
   test('caught up on both backlogs yields no monitor', () => {
     expect(toSpaceUpdate('Space', makeState({ totalDocumentCount: 10, totalBlocks: '100' }))).toBeUndefined();
@@ -37,7 +26,7 @@ describe('toSpaceUpdate', () => {
     );
     expect(update).toEqual({
       label: 'Notes',
-      current: 98, // (10 + 100) − (4 + 8)
+      current: 98,
       total: 110,
       note: '4 CRDTs · ↓6 ↑2',
     });
@@ -60,4 +49,16 @@ describe('toSpaceUpdate', () => {
       note: '↓0 ↑2',
     });
   });
+});
+
+/** A fully caught-up sync state, overridden per case. */
+const makeState = (state: Partial<Database.SyncState>): Database.SyncState => ({
+  localDocumentCount: 0,
+  remoteDocumentCount: 0,
+  totalDocumentCount: 0,
+  unsyncedDocumentCount: 0,
+  blocksToPull: '0',
+  blocksToPush: '0',
+  totalBlocks: '0',
+  ...state,
 });

--- a/packages/plugins/plugin-client/src/progress/space-sync-progress.ts
+++ b/packages/plugins/plugin-client/src/progress/space-sync-progress.ts
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Database } from '@dxos/echo';
+
+/** Registry update for a space's replication monitor. */
+export type MonitorUpdate = {
+  readonly label: string;
+  readonly current: number;
+  readonly total: number;
+  readonly note?: string;
+};
+
+/**
+ * Derives the combined (documents + feed blocks) monitor state for a space, or `undefined` when it
+ * is fully caught up. Both backlogs share one meter so the UI shows one row per space.
+ */
+export const toSpaceUpdate = (name: string | undefined, state: Database.SyncState): MonitorUpdate | undefined => {
+  const unsyncedDocuments = state.unsyncedDocumentCount;
+  const blocksToPull = Number(state.blocksToPull);
+  const blocksToPush = Number(state.blocksToPush);
+  const unsyncedBlocks = blocksToPull + blocksToPush;
+  const pending = unsyncedDocuments + unsyncedBlocks;
+  if (pending === 0) {
+    return undefined;
+  }
+
+  const totalDocuments = state.totalDocumentCount > 0 ? state.totalDocumentCount : unsyncedDocuments;
+  const totalBlocks = Number(state.totalBlocks) > 0 ? Number(state.totalBlocks) : unsyncedBlocks;
+  const total = totalDocuments + totalBlocks;
+
+  const notes: string[] = [];
+  if (unsyncedDocuments > 0) {
+    notes.push(`${unsyncedDocuments} CRDTs`);
+  }
+  if (unsyncedBlocks > 0) {
+    notes.push(`↓${blocksToPull} ↑${blocksToPush}`);
+  }
+
+  return {
+    label: name ?? 'Space',
+    current: Math.max(0, total - pending),
+    total,
+    note: notes.join(' · '),
+  };
+};

--- a/packages/sdk/app-toolkit/src/ui/components/ProgressMeter.tsx
+++ b/packages/sdk/app-toolkit/src/ui/components/ProgressMeter.tsx
@@ -76,13 +76,17 @@ export const ProgressMeter = composable<HTMLDivElement, ProgressMeterProps>(
           </div>
         )}
 
-        <div className='flex items-center'>
+        <div className='flex items-center justify-between gap-2'>
           {status === 'error' && state.error ? (
             <div className='text-xs text-error-text truncate'>{state.error}</div>
           ) : (
-            !indeterminate &&
-            eta !== undefined &&
-            status === 'running' && <div className='text-xs text-subdued'>{formatDuration(eta)} remaining</div>
+            <>
+              {/* The producer's breakdown of what is outstanding (e.g. per-kind counts). */}
+              <div className='text-xs text-subdued truncate'>{state.note}</div>
+              {!indeterminate && eta !== undefined && status === 'running' && (
+                <div className='text-xs text-subdued shrink-0'>{formatDuration(eta)} remaining</div>
+              )}
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
## How the sync indicator is wired up

`plugin-progress` contributes the always-on `AppCapabilities.ProgressRegistry` (a `@dxos/progress` core mirrored into a kept-alive atom). `plugin-client`'s `space-replication-progress` module is the producer: it subscribes to `Database.subscribeToSyncState()` per space and registers/updates/removes monitors. `ProgressStatusIndicator` (R0 rail) spins while any task is `running`/`pending` and lists each as a `ProgressMeter`.

## 1. Stale "sync in progress"

Two independent causes, both fixed:

- **Feed sync-state stream never recovered.** `DatabaseImpl.subscribeToSyncState` combines two sources: the automerge stream (which *does* resubscribe on `RpcClosedError` via the entity manager's reconnect event) and the feed stream (which only logged and gave up). After a leader change the feed accumulator froze at its last non-zero value, and every subsequent automerge update re-published that stale backlog — so the meter never cleared. The feed stream now clears its counts on error and resubscribes on reconnect; `EntityManager.reconnected` is exposed read-only for that.
- **Duplicate producer fibers.** `client.spaces.subscribe` re-delivers the whole list on every change, and the capability subscribed *every* space on *every* delivery — stacking fibers that raced over one monitor key (a late nonzero write after another fiber's removal re-registers a monitor nothing will ever clear again). Spaces are now subscribed once.

Two safety nets on top: monitors for spaces that leave the list are pruned (a closed space emits nothing further), and each space reconciles against a fresh `getSyncState()` read every 10s, so a missed update cannot outlive the backlog.

## 2. One item per space

`createSpaceFeedReplicationProgressKey` is gone; documents and feed blocks are summed into the single `#replication` monitor per space, with the breakdown carried as the note (`4 CRDTs · ↓6 ↑2`). `ProgressMeter` did not render `note` at all — it now shows it on the bottom row alongside the ETA.

## Test plan

- New `space-sync-progress.test.ts` covers the combined derivation (caught up → no monitor, docs only, blocks only, both).
- `echo-client:test` 525 passed, `plugin-client:test` 19 passed, `app-toolkit:test` 158 passed; `echo-client`, `plugin-client`, `plugin-progress`, `app-toolkit` build clean; `pnpm format` run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fpqcr6uV4BWoqLvHLeV72H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed replication progress indicators remaining active after synchronization completes or after reconnecting.
  - Improved recovery of sync progress tracking following connection interruptions.
  - Removed stale progress entries when spaces are no longer available.
  - Prevented duplicate progress monitors and improved handling of temporary sync errors.

- **New Features**
  - Combined document and feed replication into a single per-space progress indicator.
  - Added backlog details to progress displays, including pending document and feed activity.
  - Progress meters now show supplementary status details and estimated completion time when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->