### PR TITLE
composer-app: give each release channel its own localhost asset-server port

### DIFF
--- a/.changeset/composer-channel-localhost-port.md
+++ b/.changeset/composer-channel-localhost-port.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-native': patch
+---
+
+Give each Composer desktop release channel its own localhost asset-server port, so channel apps installed side by side no longer serve each other's bundles.

--- a/packages/apps/composer-app/src-tauri/capabilities/desktop.json
+++ b/packages/apps/composer-app/src-tauri/capabilities/desktop.json
@@ -1,9 +1,15 @@
 {
   "identifier": "desktop-capability",
+  "description": "Permissions for the bundled app, served over HTTP from the asset-server port this build's release channel owns (see src/channel.rs). Every channel's port is listed because the capability set is static while the port is chosen at runtime.",
   "platforms": ["macOS"],
   "windows": ["main", "popover"],
   "remote": {
-    "urls": ["http://localhost:26777/*"]
+    "urls": [
+      "http://localhost:26777/*",
+      "http://localhost:26778/*",
+      "http://localhost:26779/*",
+      "http://localhost:26780/*"
+    ]
   },
   "permissions": [
     "core:default",

--- a/packages/apps/composer-app/src-tauri/src/channel.rs
+++ b/packages/apps/composer-app/src-tauri/src/channel.rs
@@ -1,0 +1,124 @@
+//! Release channel of the running build, and the localhost asset-server port it owns.
+//!
+//! Desktop release builds serve their bundled frontend over HTTP from `localhost` (SharedWorker needs
+//! an HTTP origin), and every channel installs as its own app — so a single shared port meant whichever
+//! app bound it first served its code to every other channel's webview. Each channel therefore owns a
+//! distinct port.
+//!
+//! The web origin keys OPFS/IndexedDB/localStorage, so a channel's port is permanent once shipped:
+//! moving it orphans every profile stored under the old one. Production therefore keeps the 26777 it
+//! has always served from, and each other channel's port is fixed from this change onward.
+
+/// Bundle identifier of the released app. `.github/actions/cn-config` appends `.<environment>` to it
+/// for every other channel at build time, so the identifier baked into `tauri.conf.json` is what a
+/// running build knows about which channel it is.
+const BASE_IDENTIFIER: &str = "org.dxos.composer";
+
+/// Vite dev server, which `tauri dev` points the webview at instead of the bundled asset server.
+pub const DEV_SERVER_PORT: u16 = 5173;
+
+/// Release channel a desktop build was produced for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReleaseChannel {
+    Production,
+    Staging,
+    Preview,
+    Dev,
+}
+
+impl ReleaseChannel {
+    /// Channel a bundle identifier denotes. Anything unrecognised — including the stock identifier a
+    /// local `tauri build` produces, which cn-config never rewrote — is production, so an unsigned
+    /// local build behaves like the released app.
+    pub fn from_identifier(identifier: &str) -> Self {
+        match identifier
+            .strip_prefix(BASE_IDENTIFIER)
+            .and_then(|suffix| suffix.strip_prefix('.'))
+        {
+            Some("staging") => Self::Staging,
+            Some("preview") => Self::Preview,
+            Some("dev") => Self::Dev,
+            _ => Self::Production,
+        }
+    }
+
+    /// Port this channel's localhost asset server binds, and therefore the origin its storage lives
+    /// under. Permanent — see the module comment. Production's 26777 spells CMPSR on a keypad; the
+    /// rest follow it.
+    pub const fn localhost_port(self) -> u16 {
+        match self {
+            Self::Production => 26777,
+            Self::Staging => 26778,
+            Self::Preview => 26779,
+            Self::Dev => 26780,
+        }
+    }
+
+    /// Human-readable channel name, for the diagnostics a port conflict prints.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Production => "production",
+            Self::Staging => "staging",
+            Self::Preview => "preview",
+            Self::Dev => "dev",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_every_channel_identifier() {
+        assert_eq!(
+            ReleaseChannel::from_identifier("org.dxos.composer"),
+            ReleaseChannel::Production
+        );
+        assert_eq!(
+            ReleaseChannel::from_identifier("org.dxos.composer.staging"),
+            ReleaseChannel::Staging
+        );
+        assert_eq!(
+            ReleaseChannel::from_identifier("org.dxos.composer.preview"),
+            ReleaseChannel::Preview
+        );
+        assert_eq!(
+            ReleaseChannel::from_identifier("org.dxos.composer.dev"),
+            ReleaseChannel::Dev
+        );
+    }
+
+    #[test]
+    fn falls_back_to_production_for_unknown_identifiers() {
+        for identifier in ["", "org.dxos.composer.nightly", "org.dxos.composerdev", "com.example.app"] {
+            assert_eq!(
+                ReleaseChannel::from_identifier(identifier),
+                ReleaseChannel::Production,
+                "{identifier}"
+            );
+        }
+    }
+
+    /// Production's port is load-bearing: existing installs store their data under that origin.
+    #[test]
+    fn production_keeps_its_shipped_port() {
+        assert_eq!(ReleaseChannel::Production.localhost_port(), 26777);
+    }
+
+    #[test]
+    fn channels_do_not_share_a_port() {
+        let ports = [
+            ReleaseChannel::Production,
+            ReleaseChannel::Staging,
+            ReleaseChannel::Preview,
+            ReleaseChannel::Dev,
+        ]
+        .map(ReleaseChannel::localhost_port);
+
+        let mut unique = ports.to_vec();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), ports.len(), "duplicate port in {ports:?}");
+    }
+}

--- a/packages/apps/composer-app/src-tauri/src/lib.rs
+++ b/packages/apps/composer-app/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 #[cfg(target_os = "ios")]
 mod audio_input;
 mod asset_cache;
+pub mod channel;
 #[cfg(desktop)]
 mod oauth;
 #[cfg(desktop)]
@@ -19,11 +20,38 @@ use oauth::OAuthServerState;
 #[cfg(desktop)]
 use window_state::WindowState;
 
-/// Fixed port for the localhost asset server in production builds (CMPSR = 26777).
-pub const LOCALHOST_PORT: u16 = 26777;
+/// Port the desktop webview loads the app from: the Vite dev server in development, and in release the
+/// asset-server port this build's release channel owns.
+#[cfg(desktop)]
+pub fn webview_port(identifier: &str) -> u16 {
+    if cfg!(debug_assertions) {
+        channel::DEV_SERVER_PORT
+    } else {
+        channel::ReleaseChannel::from_identifier(identifier).localhost_port()
+    }
+}
+
+/// Whether the asset server can still claim this channel's port. `tauri-plugin-localhost` only panics
+/// on a background thread when its bind fails, leaving the webview to load whatever else answers there
+/// — so the port is probed before the plugin is registered rather than after it has failed.
+#[cfg(all(not(debug_assertions), desktop))]
+fn port_available(port: u16) -> bool {
+    std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // `tauri.conf.json` is compiled in, so the identifier here is the one `.github/actions/cn-config`
+    // rewrote for this channel — the only thing a running build knows about which channel it is.
+    let context = tauri::generate_context!();
+
+    #[cfg(all(not(debug_assertions), desktop))]
+    let release_channel = channel::ReleaseChannel::from_identifier(&context.config().identifier);
+    #[cfg(all(not(debug_assertions), desktop))]
+    let localhost_port = release_channel.localhost_port();
+    #[cfg(all(not(debug_assertions), desktop))]
+    let port_taken = !port_available(localhost_port);
+
     let builder = tauri::Builder::default()
         .manage(asset_cache::AssetCacheState::default())
         // Custom URI scheme: serves cached third-party plugin assets so plugins keep
@@ -39,7 +67,11 @@ pub fn run() {
     // Serve bundled assets via localhost plugin on desktop only (needed for SharedWorker support).
     // Mobile uses Tauri's default asset protocol instead.
     #[cfg(all(not(debug_assertions), desktop))]
-    let builder = builder.plugin(tauri_plugin_localhost::Builder::new(LOCALHOST_PORT).build());
+    let builder = if port_taken {
+        builder
+    } else {
+        builder.plugin(tauri_plugin_localhost::Builder::new(localhost_port).build())
+    };
 
     // Only include updater plugin for non-mobile targets.
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -159,8 +191,36 @@ pub fn run() {
             {
                 use tauri::WebviewWindowBuilder;
 
-                // In production, use the localhost plugin port; in dev, use the Vite dev server.
-                let app_port: u16 = if cfg!(debug_assertions) { 5173 } else { LOCALHOST_PORT };
+                // Something else already answers on this channel's port, so the window would render that
+                // process's build as if it were ours. Report it and quit rather than create the window.
+                #[cfg(not(debug_assertions))]
+                if port_taken {
+                    let message = format!(
+                        "Another application is already using port {}, which Composer's {} channel serves its app from.\n\nQuit that application and open Composer again.",
+                        localhost_port,
+                        release_channel.label(),
+                    );
+                    log::error!("{}", message);
+                    eprintln!("[composer] {}", message);
+
+                    // `blocking_show` deadlocks on the main thread, and the dialog is the only UI this
+                    // failure has — no window is created.
+                    let handle = app.handle().clone();
+                    std::thread::spawn(move || {
+                        use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
+                        handle
+                            .dialog()
+                            .message(message)
+                            .title("Composer cannot start")
+                            .kind(MessageDialogKind::Error)
+                            .blocking_show();
+                        handle.exit(1);
+                    });
+
+                    return Ok(());
+                }
+
+                let app_port = webview_port(&app.config().identifier);
                 let url: tauri::Url = format!("http://localhost:{}", app_port).parse().unwrap();
                 let main_window = WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::External(url))
                     .title("Composer")
@@ -205,6 +265,6 @@ pub fn run() {
 
             Ok(())
         })
-        .run(tauri::generate_context!())
+        .run(context)
         .expect("error while running tauri application");
 }

--- a/packages/apps/composer-app/src-tauri/src/lib.rs
+++ b/packages/apps/composer-app/src-tauri/src/lib.rs
@@ -34,9 +34,19 @@ pub fn webview_port(identifier: &str) -> u16 {
 /// Whether the asset server can still claim this channel's port. `tauri-plugin-localhost` only panics
 /// on a background thread when its bind fails, leaving the webview to load whatever else answers there
 /// — so the port is probed before the plugin is registered rather than after it has failed.
+///
+/// Every address `localhost` resolves to has to be free, not merely the first: the plugin binds whichever
+/// one it reaches first while the webview resolves the name itself, so a port held on the other address
+/// family would still hand the window foreign content.
 #[cfg(all(not(debug_assertions), desktop))]
 fn port_available(port: u16) -> bool {
-    std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
+    use std::net::{TcpListener, ToSocketAddrs};
+
+    match ("localhost", port).to_socket_addrs() {
+        Ok(addresses) => addresses.into_iter().all(|address| TcpListener::bind(address).is_ok()),
+        // A resolver failure is no evidence the port is taken; leave the verdict to the plugin's own bind.
+        Err(_) => true,
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -196,9 +206,9 @@ pub fn run() {
                 #[cfg(not(debug_assertions))]
                 if port_taken {
                     let message = format!(
-                        "Another application is already using port {}, which Composer's {} channel serves its app from.\n\nQuit that application and open Composer again.",
-                        localhost_port,
+                        "Composer's {} channel serves its app from port {}, which another program is already using — most often a second copy of Composer that is still running.\n\nQuit it and open Composer again.",
                         release_channel.label(),
+                        localhost_port,
                     );
                     log::error!("{}", message);
                     eprintln!("[composer] {}", message);

--- a/packages/apps/composer-app/src-tauri/src/spotlight/mod.rs
+++ b/packages/apps/composer-app/src-tauri/src/spotlight/mod.rs
@@ -13,8 +13,6 @@ use tauri_nspanel::{
     tauri_panel, CollectionBehavior, ManagerExt, PanelBuilder, PanelHandle, PanelLevel, StyleMask,
 };
 
-use crate::LOCALHOST_PORT;
-
 // Define panel class - no event handlers needed (frontend-driven dismiss).
 tauri_panel! {
     panel!(SpotlightPanel {
@@ -30,7 +28,7 @@ tauri_panel! {
 pub fn init_spotlight(app: &AppHandle, config: &SpotlightConfig) -> Result<(), String> {
     log::debug!("Creating spotlight panel as NSPanel");
 
-    let port = if cfg!(debug_assertions) { 5173 } else { LOCALHOST_PORT };
+    let port = crate::webview_port(&app.config().identifier);
     let url: tauri::Url = format!("http://localhost:{}", port).parse().unwrap();
 
     let panel = PanelBuilder::<_, SpotlightPanel>::new(app, SpotlightConfig::LABEL)

--- a/packages/plugins/plugin-native/PLUGIN.mdl
+++ b/packages/plugins/plugin-native/PLUGIN.mdl
@@ -142,7 +142,7 @@ feat F-2: Over-the-Air Updates
     then: the status atom transitions to failed with a human-readable error string
 
   req F-2.4:
-    when: the app is running in a dev-server build (port ≠ TAURI_LOCALHOST_PORT)
+    when: the app is running in a dev-server build (port not in TAURI_LOCALHOST_PORTS)
     then: the updater is disabled and status remains unsupported
 
   req F-2.5:
@@ -207,7 +207,7 @@ test T-4: Failed update check transitions to failed status
 
 ```mdl
 test T-5: Dev-server build disables updater
-  given: the app is served on a port other than TAURI_LOCALHOST_PORT
+  given: the app is served on a port outside TAURI_LOCALHOST_PORTS
   when: the Updater module activates
   then:
     - status is set to unsupported immediately

--- a/packages/plugins/plugin-native/src/capabilities/updater.ts
+++ b/packages/plugins/plugin-native/src/capabilities/updater.ts
@@ -20,7 +20,7 @@ import { log } from '@dxos/log';
 import { meta } from '#meta';
 import { NativeCapabilities, Update } from '#types';
 
-import { TAURI_LOCALHOST_PORT } from '../constants';
+import { TAURI_LOCALHOST_PORTS } from '../constants';
 
 const SUPPORTS_OTA = ['linux', 'macos', 'windows'];
 
@@ -62,7 +62,7 @@ const formatError = (error: unknown): string => {
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
     const platform = type();
-    const isDevServer = window.location.port !== TAURI_LOCALHOST_PORT;
+    const isDevServer = !TAURI_LOCALHOST_PORTS.includes(window.location.port);
     const enabled = SUPPORTS_OTA.includes(platform) && !isDevServer;
 
     const registry = yield* Capabilities.AtomRegistry;

--- a/packages/plugins/plugin-native/src/constants.ts
+++ b/packages/plugins/plugin-native/src/constants.ts
@@ -2,6 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-/// Stable port for the Tauri localhost asset server in production builds.
-/// Must match LOCALHOST_PORT in src-tauri/src/lib.rs.
-export const TAURI_LOCALHOST_PORT = '26777';
+/**
+ * Ports the Tauri localhost asset server binds, one per release channel — each channel installs as its
+ * own app and needs its own origin, since a shared port let whichever app bound it first serve its code
+ * to the others.
+ * Must match `ReleaseChannel::localhost_port` in `src-tauri/src/channel.rs`.
+ */
+export const TAURI_LOCALHOST_PORTS = ['26777', '26778', '26779', '26780'];


### PR DESCRIPTION
## Problem

Desktop release builds serve their embedded frontend from a localhost asset server on a port that was hardcoded for every release channel:

```rust
pub const LOCALHOST_PORT: u16 = 26777;
let builder = builder.plugin(tauri_plugin_localhost::Builder::new(LOCALHOST_PORT).build());
```

Since per-channel app identity landed (#12501), a user can have several channel apps installed side by side ("Composer", "Composer Dev", …). They all bound 26777, so whichever app bound it first served *its* code to every other channel app's webview. Reproduced: "Composer Dev" (0.11.1-dev.0) rendered the preview channel's bundle (0.10.6-preview.1) because the preview app was still running and owned the port.

Nothing failed loudly, because `tauri-plugin-localhost` only `expect()`s its bind on a spawned thread — the panic is invisible and the webview then loads whatever else answers on the port.

## Fix

New `src-tauri/src/channel.rs` maps the bundle identifier to a channel and a port. The identifier is the right source: `.github/actions/cn-config` rewrites `tauri.conf.json`'s `identifier` per channel at build time, and `tauri.conf.json` is compiled into the binary, so `context.config().identifier` (and `app.config().identifier` at runtime) is exactly what that build was stamped with — no guessing, no new build-time plumbing.

| Channel    | Identifier                  | Port    |
| ---------- | --------------------------- | ------- |
| production | `org.dxos.composer`         | `26777` |
| staging    | `org.dxos.composer.staging` | `26778` |
| preview    | `org.dxos.composer.preview` | `26779` |
| dev        | `org.dxos.composer.dev`     | `26780` |

The mapping is total: anything unrecognised falls back to production. That covers a local unsigned `tauri build`, which never runs cn-config and keeps the stock identifier — it behaves exactly as it does today.

Also updated:

- `capabilities/desktop.json` — `remote.urls` now lists all four origins (the capability set is static; the port is picked at runtime). The CSP already allowed `http://localhost:*`, so it needed no change.
- `spotlight/mod.rs` — the macOS panel used the same constant; it now goes through the shared `webview_port()` helper.
- `@dxos/plugin-native` — `TAURI_LOCALHOST_PORT` becomes `TAURI_LOCALHOST_PORTS`, and the updater's "am I on a dev server?" check tests membership rather than equality (otherwise every non-production channel would think it was a dev server and disable OTA updates).

## ⚠️ Storage impact (confirmed — landing)

Browser storage (OPFS / IndexedDB / localStorage) is keyed by web origin, so changing a channel's port orphans the data stored under the old one.

- **Production is untouched.** It keeps 26777, which is why the mapping is a fixed table rather than anything computed.
- **Staging / preview / dev lose local profiles once.** Any profile those channels created under `http://localhost:26777` is orphaned (not deleted — just unreachable from the new origin) the first time a user runs a build from this change.

My read is that this is acceptable, and it is smaller than it sounds: per-channel identity only landed in #12501, and macOS keys the WKWebView data store on the bundle identifier, so those channels' storage was already reset at that point — the loss here is limited to data created since. Non-production channels are also *currently* serving each other's bundles, so their storage state is already unreliable. Preview is the channel people are asked to run alongside production, so this was raised for confirmation before merging; @wittjosiah confirmed and asked for it to land.

Once merged, every port above is permanent for the same reason 26777 is.

## Hardening

Because a bind failure is otherwise silent, the port is probed with `TcpListener::bind` *before* the localhost plugin is registered. The probe requires **every** address `localhost` resolves to be free, not just the first: the plugin binds the *name* (`Server::http("localhost:{port}")`), tiny_http collects all resolved addresses and takes the first that binds, and the webview resolves the name independently — so a port held on the other address family would read as free, let the plugin bind the family the probe checked, and still leave the window free to reach the foreign server. A resolver failure is treated as inconclusive rather than as a conflict.

On a conflict the app skips the plugin, skips creating the window, logs the port and channel, and shows an error dialog before exiting — rather than rendering another process's build.

Behaviour note: on Windows/Linux this means launching a second instance of the *same* channel now fails with that dialog instead of quietly attaching to the first instance's server. There is no `tauri-plugin-single-instance` in the crate, so that is the likely trigger there and the dialog names it. macOS already prevents double-launching a bundled app, and two instances sharing one storage origin isn't something we want anyway, but flagging it as a real behaviour change.

## Verification

- `cargo check --release` and `cargo check` (debug) on `x86_64-unknown-linux-gnu` — clean, no warnings. The only error is pre-existing and unrelated: `hidden_title` / `title_bar_style` are macOS-only `WebviewWindowBuilder` methods, so the crate has never compiled on Linux. I confirmed the rest by temporarily dropping those two lines, getting a clean build, then restoring them; a darwin cross-check isn't possible here (no Apple SDK for the `objc2` build script).
- `cargo test --lib` — 4 unit tests in `channel.rs` pass: every channel identifier maps to its channel, unknown identifiers fall back to production, production still resolves to 26777, and no two channels share a port.
- `moon run plugin-native:build` (180 tasks, type emit included), `:lint`, `:test` — all pass.
- `pnpm format` run; grepped the repo for `26777` — the only remaining hits are the port table and unrelated geo fixture data.
- Confirmed the identifier→channel mapping covers every desktop build: cn-config's `suffix-identifier: 'false'` escape hatch, which would leave a non-production build on the bare identifier and therefore on production's port, is passed in exactly one place (`deploy-tauri.yaml:374`, the `build_tauri_ios` job), and iOS never registers the localhost plugin.

## Follow-up not done here

The main window title is still hardcoded `"Composer"` for every channel, so a dev build's window doesn't identify itself the way its dock icon and product name do. Out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeDsgBrEsVYZv8W8hZegra


---
_Generated by [Claude Code](https://claude.ai/code/session_01LeDsgBrEsVYZv8W8hZegra)_