### PR TITLE
Gate native email login behind feature flag

### DIFF
--- a/packages/plugins/plugin-onboarding/src/containers/WelcomeContainer/WelcomeScreen.tsx
+++ b/packages/plugins/plugin-onboarding/src/containers/WelcomeContainer/WelcomeScreen.tsx
@@ -34,6 +34,18 @@ const hostPlatform = isTauri() ? getHostPlatform() : undefined;
  */
 const passkeyOnly = hostPlatform === 'ios' || (hostPlatform === 'macos' && navigator.maxTouchPoints > 1);
 
+/**
+ * Whether the native app offers email sign-in. Off because the emailed link can only return to a web
+ * origin — the app's own origin is a bundled `localhost` asset server no mail client can usefully
+ * open — and the web app hands a link back to the native app only when `enableNativeRedirect` is
+ * set, which still defaults to false. Until then the link would strand the user in a browser tab
+ * instead of the app they started from, so the option is hidden rather than offered broken. Flip
+ * this to true once native redirects are the default.
+ */
+const NATIVE_EMAIL_LOGIN_ENABLED: boolean = false;
+
+const emailLoginEnabled = !passkeyOnly && (!isTauri() || NATIVE_EMAIL_LOGIN_ENABLED);
+
 export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
   const client = useClient();
   const identity = useIdentity();
@@ -280,7 +292,7 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
         state={state}
         error={error}
         identity={identity}
-        onEmailLogin={!passkeyOnly ? handleLogin : undefined}
+        onEmailLogin={emailLoginEnabled ? handleLogin : undefined}
         onPasskey={!identity ? handlePasskey : undefined}
         onJoinIdentity={!identity && !passkeyOnly ? handleJoinIdentity : undefined}
         onRecoverIdentity={!identity && !passkeyOnly ? handleRecoverIdentity : undefined}


### PR DESCRIPTION
## Summary

Adds a feature flag to control email sign-in availability in the native app, with email login currently disabled due to limitations in the native redirect flow.

## Changes

- Added `NATIVE_EMAIL_LOGIN_ENABLED` constant (defaulting to `false`) to gate email sign-in in native apps
- Introduced `emailLoginEnabled` computed flag that disables email login on native platforms unless the feature flag is explicitly enabled
- Updated the `onEmailLogin` handler condition to use the new `emailLoginEnabled` flag instead of the simpler `!passkeyOnly` check

## Implementation Details

The change addresses a UX issue where emailed sign-in links cannot properly return to the native app because:
- The app's origin is a bundled `localhost` asset server that mail clients cannot open
- Native redirects (`enableNativeRedirect`) still default to false, so links would strand users in a browser tab instead of returning them to the app

The flag can be flipped to `true` once native redirects become the default behavior, at which point email sign-in will automatically become available on native platforms.

https://claude.ai/code/session_01KSDpeQrvFfquohzW9SREbA