### PR TITLE
composer-app: fix tauri build — use include_image! for the menu bar icon

### DIFF
--- a/packages/apps/composer-app/src-tauri/src/menubar.rs
+++ b/packages/apps/composer-app/src-tauri/src/menubar.rs
@@ -37,8 +37,9 @@ pub fn init_menubar(app: &AppHandle, spotlight_config: SpotlightConfig) -> Resul
 
     // A monochrome template image, not the colored dock icon: macOS recolors template images to match
     // the menu bar's light/dark appearance, the same way the built-in status icons behave.
-    let icon = tauri::image::Image::from_bytes(include_bytes!("../icons/menubarTemplate.png"))
-        .map_err(|e| e.to_string())?;
+    // `include_image!` decodes the PNG at build time (path relative to the crate manifest), so the
+    // binary needs no runtime decoder — `Image::from_bytes` would require tauri's `image-png` feature.
+    let icon = tauri::include_image!("./icons/menubarTemplate.png");
 
     TrayIconBuilder::new()
         .icon(icon)


### PR DESCRIPTION
Fixes the `build_tauri` failure in [run 32405221621](https://github.com/dxos/dxos/actions/runs/32405221621/job/96545900043).

## Problem

The macOS menu bar (tray) icon added in f8ec427b builds the icon with `tauri::image::Image::from_bytes`. That constructor is feature-gated:

```rust
// tauri-2.11.2/src/image/mod.rs
#[cfg(any(feature = "image-ico", feature = "image-png"))]
pub fn from_bytes(bytes: &[u8]) -> crate::Result<Self> { … }
```

`src-tauri/Cargo.toml` enables `devtools`, `macos-private-api`, and `tray-icon` — neither `image-png` nor `image-ico` — so the release build failed to compile:

```
error[E0599]: no associated function or constant named `from_bytes` found for struct `tauri::image::Image<'a>`
  --> src/menubar.rs:40:37
```

The web deploy was unaffected; only the Tauri desktop job was red.

## Fix

Use `tauri::include_image!` instead. It is not feature-gated, resolves its path from `CARGO_MANIFEST_DIR`, decodes the PNG at build time in `tauri-codegen`, and expands to `Image::new(include_bytes!(<cached RGBA>), width, height)`.

```diff
-let icon = tauri::image::Image::from_bytes(include_bytes!("../icons/menubarTemplate.png"))
-    .map_err(|e| e.to_string())?;
+let icon = tauri::include_image!("./icons/menubarTemplate.png");
```

Preferred over adding tauri's `image-png` feature because the icon is known at compile time, so linking the `image` crate's runtime PNG decoder into the binary buys nothing. The call is also now infallible, dropping the `map_err`.

## Verification

The `Check` workflow does not build the Tauri app, and `menubar.rs` is `#[cfg(target_os = "macos")]`, so it cannot be compiled from a Linux sandbox. The macro's behaviour was verified instead against the exact pinned versions (`tauri-macros` 2.6.2 / `tauri-codegen` 2.6.2) with a stub crate reproducing the call site:

- `./icons/menubarTemplate.png` resolves from the crate manifest directory.
- The icon decodes to 48×48 RGBA (9216 bytes) — `tauri-codegen::CachedIcon::new_png` panics on non-RGBA PNGs, and this one is 8-bit RGBA.
- The expansion is an `Image<'static>`, which `TrayIconBuilder::icon(icon: Image<'_>)` accepts.

`rustfmt --edition 2021 --check src/menubar.rs` passes. No changeset — this is an app-internal build fix, not a consumer-facing package change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVugpNue14zpg5ywDpaj5s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the menubar tray icon loading for more reliable display.
  * Removed a potential runtime error when initializing the tray icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->