### PR TITLE
worker-framework: fix leader-lock election and worker session reclaim

### DIFF
--- a/.changeset/worker-leader-lock-wait.md
+++ b/.changeset/worker-leader-lock-wait.md
@@ -2,4 +2,4 @@
 '@dxos/echo': patch
 ---
 
-Fix tabs reporting a healthy worker connection as failing: waiting for the worker leader lock is no longer bounded by a timeout, so a follower tab stays queued for takeover instead of backing off and escalating to a persistent-failure reload.
+Fix tabs reporting a healthy worker connection as failing: waiting for the worker leader lock is no longer bounded by a timeout, so a follower tab stays queued for takeover instead of backing off and escalating to a persistent-failure reload. A tab whose connect fails after the worker handed out its ports can also reconnect now, rather than having every retry discarded as a duplicate session.

--- a/.changeset/worker-leader-lock-wait.md
+++ b/.changeset/worker-leader-lock-wait.md
@@ -1,0 +1,5 @@
+---
+'@dxos/echo': patch
+---
+
+Fix tabs reporting a healthy worker connection as failing: waiting for the worker leader lock is no longer bounded by a timeout, so a follower tab stays queued for takeover instead of backing off and escalating to a persistent-failure reload.

--- a/packages/sdk/worker-framework/src/Client.test.ts
+++ b/packages/sdk/worker-framework/src/Client.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, onTestFinished, test } from 'vitest';
 import { Event, Trigger, asyncTimeout, sleep } from '@dxos/async';
 
 import * as Client from './Client';
+import { LOCK_OR_RPC_WAIT_TIMEOUT } from './internal/locks';
 import * as Worker from './Worker';
 import * as WorkerProtocol from './WorkerProtocol';
 
@@ -80,23 +81,41 @@ const createWorkerFactory = (storageLockKey: string) => () => {
 
 type Connected = { clientToWorker: MessagePort; workerToClient: MessagePort; isOwner: boolean };
 
+/** Polls until `predicate` holds; the events under test are driven by locks and timers, not promises. */
+const waitFor = async (predicate: () => boolean, timeout: number): Promise<void> => {
+  const deadline = Date.now() + timeout;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error('timed out waiting for condition');
+    }
+    await sleep(50);
+  }
+};
+
 const makeConnection = (
   hub: ReturnType<typeof createHub>,
   keys: { leaderLockKey: string; storageLockKey: string },
   leaderTimeouts = { heartbeatInterval: 50, staleTimeout: 1_000, portTimeout: 3_000 },
+  options: { maxLeaderFailures?: number } = {},
 ) => {
   const connectedTrigger = new Trigger<Connected>();
+  // Every connect (initial and post-failover) is recorded; `connected` still resolves on the first.
+  const connects: Connected[] = [];
+  const failures: unknown[] = [];
   const connection = new Client.Connection({
     createWorker: createWorkerFactory(keys.storageLockKey),
     createCoordinator: () => hub.connect(),
     leaderLockKey: keys.leaderLockKey,
     leaderTimeouts,
+    maxLeaderFailures: options.maxLeaderFailures,
+    onPersistentFailure: (error) => failures.push(error),
     onConnect: async ({ clientToWorker, workerToClient, isOwner }) => {
+      connects.push({ clientToWorker, workerToClient, isOwner });
       connectedTrigger.wake({ clientToWorker, workerToClient, isOwner });
       return { close: async () => {} };
     },
   });
-  return { connection, connected: connectedTrigger.wait() };
+  return { connection, connected: connectedTrigger.wait(), connects, failures };
 };
 
 describe('Connection multi-client', () => {
@@ -195,6 +214,44 @@ describe('Connection multi-client', () => {
     await sleep(200);
     expect(calls).toBe(1);
   });
+
+  test(
+    'a follower waiting on the leader lock is never reported as a failure',
+    async () => {
+      const hub = createHub();
+      const keys = uniqueKeys();
+
+      const leader = makeConnection(hub, keys);
+      await asyncTimeout(leader.connection.open(), 5_000);
+      onTestFinished(async () => {
+        await leader.connection.close();
+      });
+      const leaderInfo = await asyncTimeout(leader.connected, 5_000);
+      expect(leaderInfo.isOwner).toBe(true);
+
+      // `maxLeaderFailures: 1` escalates on the very first failure, so any misreading of "another tab
+      // holds the lock" as a leader-session failure is caught immediately.
+      const follower = makeConnection(hub, keys, undefined, { maxLeaderFailures: 1 });
+      await asyncTimeout(follower.connection.open(), 5_000);
+      onTestFinished(async () => {
+        await follower.connection.close();
+      });
+      const followerInfo = await asyncTimeout(follower.connected, 5_000);
+      expect(followerInfo.isOwner).toBe(false);
+
+      // Outlive the lock/RPC budget. A bounded wait on the leader lock expires here, and the election
+      // loop reports the expiry as a failed leader session: the tab escalates to `onPersistentFailure`
+      // (a coordinated reload in dev) even though it is connected and healthy.
+      await sleep(LOCK_OR_RPC_WAIT_TIMEOUT + 1_000);
+      expect(follower.failures).toEqual([]);
+
+      // And the more damaging half: a timed-out request leaves the lock's wait queue, so while the
+      // follower backs off there is nobody positioned to take over when the leader goes away.
+      const { pending } = await navigator.locks.query();
+      expect((pending ?? []).map(({ name }) => name)).toContain(keys.leaderLockKey);
+    },
+    LOCK_OR_RPC_WAIT_TIMEOUT + 30_000,
+  );
 
   test('rejects a non-positive maxLeaderFailures', () => {
     const hub = createHub();

--- a/packages/sdk/worker-framework/src/Client.test.ts
+++ b/packages/sdk/worker-framework/src/Client.test.ts
@@ -253,6 +253,37 @@ describe('Connection multi-client', () => {
     LOCK_OR_RPC_WAIT_TIMEOUT + 30_000,
   );
 
+  test('reconnects after a connect attempt fails past the port exchange', async () => {
+    const hub = createHub();
+    const keys = uniqueKeys();
+
+    let attempts = 0;
+    const connected = new Trigger<void>();
+    const connection = new Client.Connection({
+      createWorker: createWorkerFactory(keys.storageLockKey),
+      createCoordinator: () => hub.connect(),
+      leaderLockKey: keys.leaderLockKey,
+      leaderTimeouts: { heartbeatInterval: 50, staleTimeout: 1_000, portTimeout: 3_000 },
+      onConnect: async () => {
+        // Fails only after the worker has handed out ports and claimed the clientId — the shape of a
+        // handle that rejects before `WorkerService.start` registers a tab-liveness lock, so nothing
+        // on the tab side will ever close the session the worker is holding.
+        if (++attempts === 1) {
+          throw new Error('TEST: transient connect failure');
+        }
+        connected.wake();
+        return { close: async () => {} };
+      },
+    });
+    onTestFinished(async () => {
+      await connection.close();
+    });
+
+    await asyncTimeout(connection.open(), 10_000);
+    await asyncTimeout(connected.wait(), 10_000);
+    expect(attempts).toBeGreaterThan(1);
+  });
+
   test('rejects a non-positive maxLeaderFailures', () => {
     const hub = createHub();
     const keys = uniqueKeys();

--- a/packages/sdk/worker-framework/src/Client.test.ts
+++ b/packages/sdk/worker-framework/src/Client.test.ts
@@ -81,17 +81,6 @@ const createWorkerFactory = (storageLockKey: string) => () => {
 
 type Connected = { clientToWorker: MessagePort; workerToClient: MessagePort; isOwner: boolean };
 
-/** Polls until `predicate` holds; the events under test are driven by locks and timers, not promises. */
-const waitFor = async (predicate: () => boolean, timeout: number): Promise<void> => {
-  const deadline = Date.now() + timeout;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error('timed out waiting for condition');
-    }
-    await sleep(50);
-  }
-};
-
 const makeConnection = (
   hub: ReturnType<typeof createHub>,
   keys: { leaderLockKey: string; storageLockKey: string },
@@ -99,8 +88,6 @@ const makeConnection = (
   options: { maxLeaderFailures?: number } = {},
 ) => {
   const connectedTrigger = new Trigger<Connected>();
-  // Every connect (initial and post-failover) is recorded; `connected` still resolves on the first.
-  const connects: Connected[] = [];
   const failures: unknown[] = [];
   const connection = new Client.Connection({
     createWorker: createWorkerFactory(keys.storageLockKey),
@@ -110,12 +97,11 @@ const makeConnection = (
     maxLeaderFailures: options.maxLeaderFailures,
     onPersistentFailure: (error) => failures.push(error),
     onConnect: async ({ clientToWorker, workerToClient, isOwner }) => {
-      connects.push({ clientToWorker, workerToClient, isOwner });
       connectedTrigger.wake({ clientToWorker, workerToClient, isOwner });
       return { close: async () => {} };
     },
   });
-  return { connection, connected: connectedTrigger.wait(), connects, failures };
+  return { connection, connected: connectedTrigger.wait(), failures };
 };
 
 describe('Connection multi-client', () => {

--- a/packages/sdk/worker-framework/src/Client.ts
+++ b/packages/sdk/worker-framework/src/Client.ts
@@ -2,13 +2,19 @@
 // Copyright 2026 DXOS.org
 //
 
-import { AsyncTask, Event, Trigger, sleepWithContext } from '@dxos/async';
+import { AsyncTask, Event, Trigger, asyncTimeout, sleepWithContext } from '@dxos/async';
 import { type Context, Resource } from '@dxos/context';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 import type { MaybePromise } from '@dxos/util';
 
-import { isAbortError, requestExclusiveLockWithTimeout, waitWithLockOrRpcTimeout } from './internal/locks';
+import {
+  LOCK_OR_RPC_WAIT_TIMEOUT,
+  isAbortError,
+  lockOrRpcTimeoutError,
+  requestExclusiveLock,
+  waitWithLockOrRpcTimeout,
+} from './internal/locks';
 import * as WorkerProtocol from './WorkerProtocol';
 
 // Sentinel resolved when a follower gives up waiting for a port from the leader.
@@ -109,7 +115,9 @@ export class Connection extends Resource {
   #leaderSession: LeaderSession | undefined;
   #coordinator: WorkerProtocol.WorkerCoordinator | undefined;
 
-  // Timestamp (ms) of the last heartbeat seen from any leader; 0 if none observed yet.
+  // Timestamp (ms) of the last heartbeat seen from any leader. Seeded at open so "not yet observed"
+  // is measured from when we started listening — otherwise a tab that opens between two heartbeats
+  // reads the epoch as an infinitely stale leader and steals the lock from a healthy one.
   #lastLeaderHeartbeat = 0;
   // Timestamp (ms) of the last steal attempt; gates against thrashing re-election.
   #lastStealAttempt = 0;
@@ -121,6 +129,8 @@ export class Connection extends Resource {
 
   readonly #initialConnection = new Trigger<void>();
   #isInitialConnection = true;
+  // Last error the connect task failed with, surfaced by `_open` in place of the bare timeout.
+  #lastConnectError: unknown;
   readonly #reconnectCallbacks: Array<() => Promise<void>> = [];
 
   readonly closed = new Event<Error | undefined>();
@@ -157,16 +167,31 @@ export class Connection extends Resource {
 
   override async _open(): Promise<void> {
     log('worker-connection: opening', { clientId: this.#clientId });
+    this.#lastLeaderHeartbeat = Date.now();
     this.#coordinator = await this.#createCoordinator();
     this.#coordinator.onMessage.on(this._ctx, (message) => {
-      if (message.type === 'leader-heartbeat') {
+      // `new-leader` is proof of life too, and it is the first thing a freshly elected leader sends —
+      // counting it avoids a steal in the window before its first heartbeat lands.
+      if (message.type === 'leader-heartbeat' || message.type === 'new-leader') {
         this.#lastLeaderHeartbeat = Date.now();
       }
     });
     this.#watchLeader();
     this.#connectTask.open();
-    await waitWithLockOrRpcTimeout(this.#connectTask.runBlocking(), 'running worker connection initial connect task');
-    await waitWithLockOrRpcTimeout(this.#initialConnection.wait(), 'establishing initial worker connection');
+    // The connect task retries on its own, so its first run completing is not the readiness signal —
+    // only `#initialConnection` is. Bounding that first run separately would reject `open()` for a
+    // follower whose leader is merely slow to hand out a port.
+    this.#connectTask.schedule();
+    // One full attempt: wait out the port exchange, then open the connection handle. Derived from
+    // `portTimeout` so a caller that widens the port wait widens the boot budget with it.
+    const openTimeout = this.#leaderPortTimeout + LOCK_OR_RPC_WAIT_TIMEOUT;
+    await asyncTimeout(
+      this.#initialConnection.wait(),
+      openTimeout,
+      lockOrRpcTimeoutError('establishing initial worker connection', openTimeout),
+    ).catch((error) => {
+      throw this.#lastConnectError ?? error;
+    });
     log('worker-connection: initial connection established');
   }
 
@@ -181,48 +206,41 @@ export class Connection extends Resource {
     queueMicrotask(async () => {
       try {
         log('worker-connection: requesting leader lock', { clientId: this.#clientId });
-        await requestExclusiveLockWithTimeout(
-          this.#leaderLockKey,
-          'acquiring worker leader lock',
-          this._ctx.signal,
-          async () => {
-            log('worker-connection: leader lock acquired (this tab is leader)', { clientId: this.#clientId });
-            invariant(this.#coordinator);
-            invariant(!this.#leaderSession);
+        await requestExclusiveLock(this.#leaderLockKey, this._ctx.signal, async () => {
+          log('worker-connection: leader lock acquired (this tab is leader)', { clientId: this.#clientId });
+          invariant(this.#coordinator);
+          invariant(!this.#leaderSession);
 
-            const sendHeartbeat = () =>
-              this.#coordinator?.sendMessage({ type: 'leader-heartbeat', leaderId: this.#clientId });
-            sendHeartbeat();
-            const heartbeat = setInterval(sendHeartbeat, this.#leaderHeartbeatInterval);
+          const sendHeartbeat = () =>
+            this.#coordinator?.sendMessage({ type: 'leader-heartbeat', leaderId: this.#clientId });
+          sendHeartbeat();
+          const heartbeat = setInterval(sendHeartbeat, this.#leaderHeartbeatInterval);
 
-            this.#leaderSession = new LeaderSession(
-              this.#createWorker,
-              this.#coordinator,
-              this.#config,
-              this.#clientId,
-            );
-            const done = new Trigger();
-            this.#leaderDone = done;
-            this._ctx.onDispose(() => done.wake());
-            this.#leaderSession.onClose.on((error) => {
-              log('worker-connection: leader session closed', { hasError: !!error });
-              this.#leaderSession = undefined;
-              if (error) {
-                done.throw(error);
-              } else {
-                done.wake();
-              }
-            });
-            try {
-              await waitWithLockOrRpcTimeout(this.#leaderSession.open(), 'opening worker leader session');
-              this.#leaderFailureCount = 0;
-              await done.wait();
-            } finally {
-              clearInterval(heartbeat);
-              this.#leaderDone = undefined;
+          this.#leaderSession = new LeaderSession(this.#createWorker, this.#coordinator, this.#config, this.#clientId);
+          const done = new Trigger();
+          this.#leaderDone = done;
+          // Removed in the `finally` below: election re-enters on every steal/failure, so a
+          // permanent registration would grow the connection's dispose list for the tab's lifetime.
+          const removeDoneDisposer = this._ctx.onDispose(() => done.wake());
+          this.#leaderSession.onClose.on((error) => {
+            log('worker-connection: leader session closed', { hasError: !!error });
+            this.#leaderSession = undefined;
+            if (error) {
+              done.throw(error);
+            } else {
+              done.wake();
             }
-          },
-        );
+          });
+          try {
+            await waitWithLockOrRpcTimeout(this.#leaderSession.open(), 'opening worker leader session');
+            this.#leaderFailureCount = 0;
+            await done.wait();
+          } finally {
+            removeDoneDisposer();
+            clearInterval(heartbeat);
+            this.#leaderDone = undefined;
+          }
+        });
         log('worker-connection: leader lock released');
       } catch (error: any) {
         if (isAbortError(error) && this._ctx.disposed) {
@@ -336,6 +354,7 @@ export class Connection extends Resource {
 
       const { clientToWorker, workerToClient, leaderId, livenessLockKey, isOwner } = result;
       log('worker-connection: connected to worker', { leaderId, isOwner });
+      this.#lastConnectError = undefined;
 
       queueMicrotask(async () => {
         try {
@@ -371,8 +390,11 @@ export class Connection extends Resource {
         this.reconnected.emit();
       }
     } catch (err: any) {
+      // Deliberately does not settle `#initialConnection`: a Trigger cannot be re-armed once it
+      // throws, so rejecting here would fail `open()` permanently for a failure the reschedule below
+      // recovers from — the tab then sits on a boot spinner while its worker connection is live.
+      this.#lastConnectError = err;
       log.warn('worker-connection: connect task failed, will reschedule', { err });
-      this.#initialConnection.throw(err);
       log.catch(err);
       void ctx.dispose();
       this.#connectTask?.schedule();

--- a/packages/sdk/worker-framework/src/Client.ts
+++ b/packages/sdk/worker-framework/src/Client.ts
@@ -131,6 +131,9 @@ export class Connection extends Resource {
   #isInitialConnection = true;
   // Last error the connect task failed with, surfaced by `_open` in place of the bare timeout.
   #lastConnectError: unknown;
+  // Monotonic connect-attempt counter sent with `request-port`, so the worker can tell a raced
+  // duplicate of the current attempt from a reconnect after a failed one.
+  #connectAttempt = 0;
   readonly #reconnectCallbacks: Array<() => Promise<void>> = [];
 
   readonly closed = new Event<Error | undefined>();
@@ -295,6 +298,9 @@ export class Connection extends Resource {
 
   #connectTask = new AsyncTask(async () => {
     const ctx = this._ctx.derive();
+    // One attempt per run: the heartbeat-driven re-requests below belong to this same attempt, so
+    // the worker keeps discarding them as duplicates rather than churning the session.
+    const attempt = ++this.#connectAttempt;
 
     const handleLeaderStopped = async () => {
       log('worker-connection: lost connection');
@@ -326,6 +332,7 @@ export class Connection extends Resource {
             this.#coordinator?.sendMessage({
               type: 'request-port',
               clientId: this.#clientId,
+              attempt,
             });
           }
         });
@@ -342,6 +349,7 @@ export class Connection extends Resource {
         this.#coordinator.sendMessage({
           type: 'request-port',
           clientId: this.#clientId,
+          attempt,
         });
       });
 
@@ -535,7 +543,7 @@ class LeaderSession extends Resource {
           }
           break;
         case 'request-port':
-          this.#sendMessage({ type: 'start-session', clientId: msg.clientId });
+          this.#sendMessage({ type: 'start-session', clientId: msg.clientId, attempt: msg.attempt });
           break;
         default:
           break;

--- a/packages/sdk/worker-framework/src/Worker.ts
+++ b/packages/sdk/worker-framework/src/Worker.ts
@@ -158,6 +158,10 @@ export const run = ({
           break;
         }
         case 'start-session': {
+          // TODO(wittjosiah): De-dupe by session attempt, not by clientId alone. A tab whose connect
+          //  failed after receiving its ports (e.g. the handle open rejected before `WorkerService.start`
+          //  registered a tab-liveness lock) is never released from this set, so its retries are all
+          //  discarded and it can never reconnect to this worker.
           if (tabsProcessed.has(message.clientId)) {
             log('ignoring duplicate client', { clientId: message.clientId });
             break;

--- a/packages/sdk/worker-framework/src/Worker.ts
+++ b/packages/sdk/worker-framework/src/Worker.ts
@@ -89,7 +89,9 @@ export const run = ({
 
     let runtime: RuntimeHandle | undefined;
     let owningClientId: string;
-    const tabsProcessed = new Set<string>();
+    // Live session per client, keyed by the connect attempt that claimed it. `supersede` tears the
+    // session down from this side — the only way to reclaim a slot whose tab abandoned it.
+    const sessionsByClient = new Map<string, { attempt: number; supersede: () => void }>();
 
     let releaseStorageLock: () => void;
     const storageLockHeld = new Promise<void>((resolve) => {
@@ -158,23 +160,32 @@ export const run = ({
           break;
         }
         case 'start-session': {
-          // TODO(wittjosiah): De-dupe by session attempt, not by clientId alone. A tab whose connect
-          //  failed after receiving its ports (e.g. the handle open rejected before `WorkerService.start`
-          //  registered a tab-liveness lock) is never released from this set, so its retries are all
-          //  discarded and it can never reconnect to this worker.
-          if (tabsProcessed.has(message.clientId)) {
-            log('ignoring duplicate client', { clientId: message.clientId });
+          // Absent on a client that predates the field; 0 then reproduces the old first-wins de-dupe.
+          const attempt = message.attempt ?? 0;
+          const current = sessionsByClient.get(message.clientId);
+          // Same (or older) attempt: a raced re-request for a session that already exists, e.g. the
+          // heartbeat-driven re-request a follower sends until its ports arrive.
+          if (current && attempt <= current.attempt) {
+            log('ignoring duplicate client', { clientId: message.clientId, attempt });
             break;
           }
           // Validate the runtime before mutating any session state: a `start-session` can race an
-          // in-flight `init` (whose handler awaits `createRuntime` before setting `runtime`). Marking
-          // the client processed or posting ports here would hand out a session nobody serves and
-          // permanently wedge the client (future retries hit "ignoring duplicate client").
+          // in-flight `init` (whose handler awaits `createRuntime` before setting `runtime`). Claiming
+          // the slot or posting ports here would hand out a session nobody serves and permanently
+          // wedge the client (future retries hit "ignoring duplicate client").
           if (!runtime) {
             log.error('start-session before init; runtime not initialized', { clientId: message.clientId });
             break;
           }
-          tabsProcessed.add(message.clientId);
+          // A newer attempt means the tab gave up on the session it already holds — its connect failed
+          // after we handed out ports, so nothing on that side will ever close it. Tear it down here
+          // or the clientId stays claimed for the worker's lifetime and every retry is discarded.
+          if (current) {
+            log.warn('superseding abandoned session', { clientId: message.clientId, attempt });
+            current.supersede();
+          }
+          const superseded = new Trigger();
+          sessionsByClient.set(message.clientId, { attempt, supersede: () => superseded.wake() });
 
           const clientToWorkerChannel = new MessageChannel();
           const workerToClientChannel = new MessageChannel();
@@ -199,10 +210,17 @@ export const run = ({
             })
             .pipe(
               Effect.provide(sessionProtocols(clientToWorkerChannel.port2, workerToClientChannel.port2)),
+              // `createSession` blocks for the session's lifetime, so this race is what ends it early
+              // when a newer attempt supersedes this one; `Effect.scoped` below then runs teardown.
+              Effect.raceFirst(Effect.promise(() => superseded.wait())),
               Effect.ensuring(
                 Effect.sync(() => {
-                  log('dedicated-worker: session closed', { clientId: message.clientId });
-                  tabsProcessed.delete(message.clientId);
+                  log('dedicated-worker: session closed', { clientId: message.clientId, attempt });
+                  // Guarded: a superseded session finishes after the newer attempt claimed the slot,
+                  // and must not evict it.
+                  if (sessionsByClient.get(message.clientId)?.attempt === attempt) {
+                    sessionsByClient.delete(message.clientId);
+                  }
                 }),
               ),
             );

--- a/packages/sdk/worker-framework/src/WorkerProtocol.ts
+++ b/packages/sdk/worker-framework/src/WorkerProtocol.ts
@@ -51,6 +51,13 @@ export interface DedicatedWorkerReadyMessage {
 export interface DedicatedWorkerStartSessionMessage {
   type: 'start-session';
   clientId: string;
+  /**
+   * Monotonic per-client connect attempt, forwarded from `request-port`. Distinguishes a raced
+   * duplicate of the current attempt (ignored) from a genuine reconnect after a failed one
+   * (supersedes it). Absent from a client that predates the field: the worker then treats every
+   * request as the first attempt, i.e. first-wins.
+   */
+  attempt?: number;
 }
 
 /**
@@ -87,6 +94,8 @@ export type CoordinatorMessage =
   | {
       type: 'request-port';
       clientId: string;
+      /** See {@link DedicatedWorkerStartSessionMessage.attempt}; the leader forwards it verbatim. */
+      attempt?: number;
     }
   | {
       type: 'provide-port';

--- a/packages/sdk/worker-framework/src/internal/locks.ts
+++ b/packages/sdk/worker-framework/src/internal/locks.ts
@@ -4,7 +4,7 @@
 
 import { asyncTimeout } from '@dxos/async';
 
-/** Max time to wait for a Web Lock or coordinator/worker RPC reply during worker connect. */
+/** Max time to wait for a coordinator/worker RPC reply during worker connect. */
 export const LOCK_OR_RPC_WAIT_TIMEOUT = 15_000;
 
 export const lockOrRpcTimeoutError = (operation: string, timeout = LOCK_OR_RPC_WAIT_TIMEOUT): Error =>
@@ -17,51 +17,17 @@ export const isAbortError = (error: Error) => {
   return error.name === 'AbortError';
 };
 
-export const mergeAbortSignals = (signals: AbortSignal[]): AbortSignal => {
-  if (typeof AbortSignal !== 'undefined' && 'any' in AbortSignal && typeof AbortSignal.any === 'function') {
-    return AbortSignal.any(signals);
-  }
-
-  const controller = new AbortController();
-  for (const signal of signals) {
-    if (signal.aborted) {
-      controller.abort(signal.reason);
-      return controller.signal;
-    }
-    signal.addEventListener('abort', () => controller.abort(signal.reason), { once: true });
-  }
-  return controller.signal;
-};
-
 /**
- * Times out only lock acquisition; once the callback runs, the caller may hold the lock indefinitely.
+ * Requests an exclusive Web Lock, waiting for as long as it takes to be granted.
+ *
+ * Acquisition is deliberately unbounded: for an election lock, "another holder has it" is the normal
+ * steady state of every follower, so a timeout would both report healthy followers as failures and —
+ * worse — drop them out of the lock's wait queue, leaving nobody positioned to take over when the
+ * holder goes away. Only `ctxSignal` cancels the wait; a wedged (rather than dead) holder is handled
+ * by the caller's steal path.
  */
-export const requestExclusiveLockWithTimeout = async (
+export const requestExclusiveLock = (
   name: string,
-  operation: string,
   ctxSignal: AbortSignal,
   callback: () => Promise<void>,
-): Promise<void> => {
-  const acquisitionTimedOut = new AbortController();
-  const timeoutId = setTimeout(() => acquisitionTimedOut.abort(), LOCK_OR_RPC_WAIT_TIMEOUT);
-  let acquired = false;
-
-  try {
-    await navigator.locks.request(
-      name,
-      { mode: 'exclusive', signal: mergeAbortSignals([ctxSignal, acquisitionTimedOut.signal]) },
-      async () => {
-        acquired = true;
-        clearTimeout(timeoutId);
-        await callback();
-      },
-    );
-  } catch (error: any) {
-    if (!acquired && acquisitionTimedOut.signal.aborted && !ctxSignal.aborted) {
-      throw lockOrRpcTimeoutError(operation);
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeoutId);
-  }
-};
+): Promise<void> => navigator.locks.request<void>(name, { mode: 'exclusive', signal: ctxSignal }, callback);


### PR DESCRIPTION
Two independent ways a tab can be left stranded from its worker — the reported one, and one found while testing the retry path it unblocks.

## 1. A follower's leader-lock wait was bounded by a timeout

A second tab logging in via OAuth/email spins these warnings and then dies:

```
WARN worker-connection: leader session failed, backing off and re-watching
  { error: Error: Worker connection timed out after 15000ms: acquiring worker leader lock.,
    failureCount: 2, backoff: 1543.86 }
...
ERROR worker connection failing persistently
  Error: Worker connection timed out after 15000ms: acquiring worker leader lock.
    at NS (locks.ts:11:7) at LS (locks.ts:61:13) at async Client.ts:184:9
```

The tab is healthy — `dxos.client.spaces.get()` returns its spaces — it is simply not the leader.

`#watchLeader` requested the leader lock through `requestExclusiveLockWithTimeout`, which aborted acquisition after `LOCK_OR_RPC_WAIT_TIMEOUT` (15s). But holding that lock is the normal steady state of a healthy leader, so **every follower tab expired its request on a timer**, and the election loop's catch-all classified the expiry as a failed *leader session*: it incremented `#leaderFailureCount`, backed off exponentially, and at `maxLeaderFailures` (4, ≈30s after load) fired `onPersistentFailure` — which in dev broadcasts a coordinated reload of every same-origin tab, tearing down whatever login was in flight.

The more damaging half is the backoff. A timed-out `navigator.locks.request` leaves the lock's **wait queue**, so a follower that should have been first in line to take over spends most of its life asleep (backoff capped at 30s) rather than queued. When the leader tab does go away, the lock sits free with nobody waiting on it while followers busy-loop on `provide-port` timeouts — `#maybeStealStaleLeader` correctly reports "no leader holds the lock, awaiting election" and returns, and nothing advances until the backoff expires. That is the "regularly locks" symptom.

Changes:

- **Election waits for the lock for as long as it takes** (`requestExclusiveLock`), cancelled only by context disposal. A wedged — rather than dead — leader is still handled by the existing heartbeat/steal path, which is the mechanism actually designed for it; the acquisition timeout was redundant with it and actively undermined it, since stealing only helps if someone is queued. `#leaderFailureCount` / `onPersistentFailure` now count only genuine session failures.
- **Seed the heartbeat clock at open, and count `new-leader` as proof of life.** `#lastLeaderHeartbeat` started at `0`, so a tab opening between two heartbeats read the epoch as an infinitely stale leader and was eligible to steal the lock from a healthy one on its first port timeout.
- **Drop the per-election `_ctx.onDispose` registration** once the hold ends; election re-enters on every steal/failure, so it accumulated for the tab's lifetime.
- **Stop settling `#initialConnection` from the connect task's retry loop.** A `Trigger` cannot be re-armed once it throws, so a transient failure failed `open()` permanently while the reschedule went on to connect fine. `_open` now bounds the wait itself (`portTimeout + LOCK_OR_RPC_WAIT_TIMEOUT` — one full attempt, same 30s default budget as before) and rethrows the last connect error in place of the bare timeout.

## 2. A failed connect claimed the clientId forever

Fixing (1) made the connect task's retry reachable, which exposed the next wedge. The worker added the clientId to `tabsProcessed` before the tab had confirmed anything, and only removed it when the session *closed*. A tab whose connect failed **after** the ports were handed out — e.g. the handle open rejects before `WorkerService.start` registers a tab-liveness lock — left behind a session nothing on the tab side would ever close, so its clientId stayed claimed for the worker's lifetime and every retry hit `ignoring duplicate client`. That tab could never reconnect to that worker.

`request-port` / `start-session` now carry a monotonic per-client `attempt`, and the worker keys live sessions by it:

- attempt **≤** current → raced duplicate, still ignored (this is the heartbeat-driven re-request a follower sends until its ports arrive, so the existing de-dupe is preserved exactly);
- attempt **>** current → the tab abandoned the session it holds, so supersede it (raced against the session effect, letting `Effect.scoped` run teardown) and take the slot.

The field is optional and defaults to `0`, so a client that predates it keeps today's first-wins behaviour against a newer worker — this matters because mixed-generation workers are a known state in this codebase.

## Tests

Both new tests were verified to fail on the unfixed code and pass with the fix.

`a follower waiting on the leader lock is never reported as a failure` — a follower connects behind a healthy leader, stays up past `LOCK_OR_RPC_WAIT_TIMEOUT`, and must (a) report no failure with `maxLeaderFailures: 1` and (b) still hold a *pending* entry on the leader lock, proving it stayed queued for takeover.

```
× a follower waiting on the leader lock is never reported as a failure 16017ms
  AssertionError: expected [ …(1) ] to deeply equal []
```

`reconnects after a connect attempt fails past the port exchange` — `onConnect` throws once, after the worker has handed out ports and claimed the clientId; `open()` must still resolve via the retry.

```
× reconnects after a connect attempt fails past the port exchange 10004ms
  Error: Timeout [10,000ms]
```

With both fixes:

```
worker-framework:test | ✓ |node| src/Client.test.ts (6 tests) 16348ms
worker-framework:test |  Test Files  4 passed (4)
worker-framework:test |       Tests  16 passed (16)
```

`moon run client:test -- src/services` also passes, including `identity subscription survives leader change`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker reconnection after connection failures during port assignment.
  * Prevented false persistent-failure reports while waiting for a leader lock.
  * Improved handling of duplicate, outdated, and superseded connection attempts.
  * Added retry behavior for recoverable leader-session failures.

* **Reliability**
  * Worker startup can now wait for leader-lock availability while applying bounded RPC timeouts.
  * Improved leader liveness tracking and connection recovery.

* **Documentation**
  * Added release documentation for worker leader-lock and reconnection improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->