### PR TITLE
agents: install the dxos plugin in cloud containers, correct the hook claims

### DIFF
--- a/.agents/skills/cloud-sandbox/SKILL.md
+++ b/.agents/skills/cloud-sandbox/SKILL.md
@@ -21,47 +21,47 @@ several of their instructions do not hold here.
 (`CCR_AGENT_PROXY_ENABLED`, `CCR_EGRESS_GATEWAY_ENABLED`, …). Any of these means the sandbox.
 `/root/.ccr/README.md` documents the network proxy from the platform side.
 
-## Project hooks DO run — plugins do not install themselves
+## Project hooks run; plugins do not install themselves
 
-`.claude/settings.json` hooks fire here exactly as they do locally. `mode.sh` injects the
-`RESPONSE RULES` block on every prompt, so `/mode terse|normal` works, and `guard-branch.sh` /
-`guard-worktree.sh` deny as usual — still a backstop rather than a guarantee, so check
-`git branch --show-current` before the first edit regardless.
+`.claude/settings.json` hooks fire here as they do locally: `mode.sh` injects the `RESPONSE RULES`
+block on every prompt, so `/mode terse|normal` works, and `guard-branch.sh` / `guard-worktree.sh`
+deny edits whose target working tree is on `main`. They are a backstop, not a guarantee — check
+`git branch --show-current` before the first edit.
 
-What does not survive a fresh container is `~/.claude`. It starts with an empty
-`installed_plugins.json` and only the official marketplace known, and `enabledPlugins` /
-`extraKnownMarketplaces` in `.claude/settings.json` merely _declare_ — nothing fetches. So every
-plugin listed there is absent: `/dxos:project` answers `Unknown command`, and the skills those
-plugins ship (`task-planning`, `superpowers:*`) never appear in the session's skill list. Repo
-skills are unaffected — they arrive through the `.claude/skills -> ../.agents/skills` symlink,
-a different mechanism entirely.
+`~/.claude` does not survive a fresh container. It starts with an empty `installed_plugins.json`
+and only the official marketplace known, and `enabledPlugins` / `extraKnownMarketplaces` in
+`.claude/settings.json` only _declare_ a plugin — nothing fetches one. Every plugin listed there
+is therefore absent: `/dxos:project` answers `Unknown command`, and the skills those plugins ship
+(`task-planning`, `superpowers:*`) are missing from the session's skill list. Skills committed to
+the repo arrive by a different route — the `.claude/skills -> ../.agents/skills` symlink — and
+are always there.
 
-Fix it with the repo's idempotent bootstrap, which registers the marketplace from the local
-checkout (no network) and installs:
+The repo's bootstrap registers the marketplace from the local checkout (no network) and installs.
+It is idempotent:
 
 ```bash
 bash .claude/scripts/bootstrap-plugins.sh
 ```
 
-Installing does not retrofit the session you are in; a fresh session in the same container picks
-the plugin up. That is why the same script runs from `.config/claude-code-setup.sh` — where the
-environment's setup command is wired, the install is baked into the cached image and the first
-session already has it.
+Installing does not retrofit the running session; a fresh session in the same container is the
+first to see the plugin. `.config/claude-code-setup.sh` runs the same script, so where the
+environment's setup command is wired the install lands in the cached image and the first session
+already has it.
 
 `claude plugin uninstall` and `claude plugin marketplace remove` **rewrite tracked
 `.claude/settings.json`**, stripping the `dxos` entries out of `enabledPlugins` and
-`extraKnownMarketplaces`. `git diff` after either, and restore. Plain `add`/`install` leave the
-file alone.
+`extraKnownMarketplaces`. `git diff` after either, and restore. `add` and `install` leave the file
+alone.
 
-There is no repo `SessionStart` hook emitting a `SESSION CONTEXT` block: run
+No `SessionStart` hook emits a `SESSION CONTEXT` block: run
 `git rev-parse --show-toplevel && git branch --show-current` before any file op.
 
-## Tooling not on PATH — and possibly not installed at all
+## Tooling not on PATH
 
-`pnpm` and `node` are always present (`/opt/node22/bin`); `gh` never is. Everything else hangs on
-whether the environment's setup command ran `.config/claude-code-setup.sh`. Where it did not,
-`proto`, `moon`, and `node_modules` are all absent, so `pnpm exec moon` fails too — check before
-concluding a command is broken:
+`pnpm` and `node` are present (`/opt/node22/bin`); `gh` is not. `proto`, `moon`, and
+`node_modules` exist only where the environment's setup command ran
+`.config/claude-code-setup.sh`; without it `pnpm exec moon` fails too. Establish which case you
+are in before concluding a command is broken:
 
 ```bash
 command -v proto moon; ls node_modules | wc -l   # 0 => setup never ran
@@ -78,14 +78,14 @@ GitHub's REST API is **also unreachable from the shell**: `curl https://api.gith
 `Monitor` around it — it fails identically whether CI is red, green, or still running, so silence
 means nothing. Read run status through the `mcp__github__*` tools, which go through the server side.
 
-## Dependencies are never built, and may not even be installed
+## Nothing is prebuilt, and `node_modules` may be missing
 
 The clone ships no build outputs, and `node_modules` only where the setup command ran. A first
 `moon run <app>:serve` runs a pnpm install and then builds the whole dependency graph — expect
-10+ minutes. Bundled sub-packages may
-still be missing afterward: `@dxos/shell` needs `moon run shell:bundle` explicitly, or the app's
-shell entry 500s with `Failed to resolve import "@dxos/shell/style.css"`. Build before running
-anything, and budget for it.
+10+ minutes. Bundled sub-packages may still be missing afterward: `@dxos/shell` needs
+`moon run shell:bundle` explicitly, or the app's shell entry 500s with
+`Failed to resolve import "@dxos/shell/style.css"`. Build before running anything, and budget
+for it.
 
 A task whose inputs have not changed replays its cached result, so after editing a library, e2e
 bundles pick the edit up only once the library actually rebuilds. When a fix "doesn't work", confirm

--- a/.agents/skills/cloud-sandbox/SKILL.md
+++ b/.agents/skills/cloud-sandbox/SKILL.md
@@ -4,9 +4,9 @@ description: >-
   Working inside the Claude Code cloud sandbox (Claude Code on the web, remote sessions,
   scheduled runs). Use when CLAUDE_CODE_REMOTE is set; when `moon`, `gh`, or `oxfmt` are
   "command not found"; when Chromium or Playwright fails with ERR_CONNECTION_RESET or a TLS
-  error against an HTTPS host that curl reaches fine; when /mode, /project, or the branch and
-  worktree guard hooks appear to do nothing; or when a build or dev server unexpectedly
-  triggers a full pnpm install.
+  error against an HTTPS host that curl reaches fine; when /dxos:project answers `Unknown
+  command` or a plugin's skills are missing from the session; or when a build or dev server
+  unexpectedly triggers a full pnpm install.
 ---
 
 # Working in the Claude Code cloud sandbox
@@ -21,41 +21,68 @@ several of their instructions do not hold here.
 (`CCR_AGENT_PROXY_ENABLED`, `CCR_EGRESS_GATEWAY_ENABLED`, …). Any of these means the sandbox.
 `/root/.ccr/README.md` documents the network proxy from the platform side.
 
-## Project hooks do NOT run
+## Project hooks DO run — plugins do not install themselves
 
-`.claude/settings.json` hooks are inert in cloud sessions. Consequences:
+`.claude/settings.json` hooks fire here exactly as they do locally. `mode.sh` injects the
+`RESPONSE RULES` block on every prompt, so `/mode terse|normal` works, and `guard-branch.sh` /
+`guard-worktree.sh` deny as usual — still a backstop rather than a guarantee, so check
+`git branch --show-current` before the first edit regardless.
 
-- `.claude/hooks/mode.sh` never injects the `RESPONSE RULES` block, and `/mode terse|normal` does
-  nothing. **Read the response rules from `AGENTS.md` → "Responding to the user" directly** —
-  nothing re-injects them mid-session.
-- `.claude/hooks/track.sh` never fires, so `/project …` does not work. Maintain `TASKS.md` /
-  `DESIGN.md` by hand when the work needs tracking.
-- `guard-branch.sh` and `guard-worktree.sh` deny nothing. The Non-negotiables they back (never
-  create/switch branches or worktrees, never edit while on `main`) still apply in full — **you are
-  the only thing enforcing them.** Check `git branch --show-current` before the first edit.
+What does not survive a fresh container is `~/.claude`. It starts with an empty
+`installed_plugins.json` and only the official marketplace known, and `enabledPlugins` /
+`extraKnownMarketplaces` in `.claude/settings.json` merely _declare_ — nothing fetches. So every
+plugin listed there is absent: `/dxos:project` answers `Unknown command`, and the skills those
+plugins ship (`task-planning`, `superpowers:*`) never appear in the session's skill list. Repo
+skills are unaffected — they arrive through the `.claude/skills -> ../.agents/skills` symlink,
+a different mechanism entirely.
 
-There is no `SessionStart` hook either, so no `SESSION CONTEXT` block: run
+Fix it with the repo's idempotent bootstrap, which registers the marketplace from the local
+checkout (no network) and installs:
+
+```bash
+bash .claude/scripts/bootstrap-plugins.sh
+```
+
+Installing does not retrofit the session you are in; a fresh session in the same container picks
+the plugin up. That is why the same script runs from `.config/claude-code-setup.sh` — where the
+environment's setup command is wired, the install is baked into the cached image and the first
+session already has it.
+
+`claude plugin uninstall` and `claude plugin marketplace remove` **rewrite tracked
+`.claude/settings.json`**, stripping the `dxos` entries out of `enabledPlugins` and
+`extraKnownMarketplaces`. `git diff` after either, and restore. Plain `add`/`install` leave the
+file alone.
+
+There is no repo `SessionStart` hook emitting a `SESSION CONTEXT` block: run
 `git rev-parse --show-toplevel && git branch --show-current` before any file op.
 
-## Tooling not on PATH
+## Tooling not on PATH — and possibly not installed at all
 
-`moon`, `gh`, and `oxfmt` are all missing. `pnpm` and `node` are present (`/opt/node22/bin`).
+`pnpm` and `node` are always present (`/opt/node22/bin`); `gh` never is. Everything else hangs on
+whether the environment's setup command ran `.config/claude-code-setup.sh`. Where it did not,
+`proto`, `moon`, and `node_modules` are all absent, so `pnpm exec moon` fails too — check before
+concluding a command is broken:
 
-| `AGENTS.md` says                            | In the sandbox                                                        |
-| ------------------------------------------- | --------------------------------------------------------------------- |
-| `moon run <package>:<task>`                 | `pnpm exec moon run <package>:<task>` (or `./node_modules/.bin/moon`) |
-| `gh run list --branch … --workflow "Check"` | `mcp__github__*` tools only — there is no `gh`                        |
-| `pnpm format`                               | works (goes through pnpm); a bare `oxfmt` does not                    |
+```bash
+command -v proto moon; ls node_modules | wc -l   # 0 => setup never ran
+```
+
+| `AGENTS.md` says     | Setup ran                      | Setup did not run                             |
+| -------------------- | ------------------------------ | --------------------------------------------- |
+| `moon run <pkg>:<t>` | `pnpm exec moon run <pkg>:<t>` | `bash .config/claude-code-setup.sh` (10+ min) |
+| `pnpm format`        | works                          | `pnpm dlx oxfmt@0.63` — matches the root pin  |
+| `gh run list …`      | `mcp__github__*` tools only    | same — there is no `gh` either way            |
 
 GitHub's REST API is **also unreachable from the shell**: `curl https://api.github.com/…` returns
 `GitHub access is not enabled for this session`, with or without a token. Never build a poll loop or
 `Monitor` around it — it fails identically whether CI is red, green, or still running, so silence
 means nothing. Read run status through the `mcp__github__*` tools, which go through the server side.
 
-## Dependencies are installed but not built
+## Dependencies are never built, and may not even be installed
 
-The clone ships `node_modules` but no build outputs. A first `moon run <app>:serve` runs a pnpm
-install and then builds the whole dependency graph — expect 10+ minutes. Bundled sub-packages may
+The clone ships no build outputs, and `node_modules` only where the setup command ran. A first
+`moon run <app>:serve` runs a pnpm install and then builds the whole dependency graph — expect
+10+ minutes. Bundled sub-packages may
 still be missing afterward: `@dxos/shell` needs `moon run shell:bundle` explicitly, or the app's
 shell entry 500s with `Failed to resolve import "@dxos/shell/style.css"`. Build before running
 anything, and budget for it.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,11 +36,12 @@
   also matches). It is shipped by the **`dxos` plugin**
   (`tools/claude/plugins/dxos`), enabled for this repo via `extraKnownMarketplaces`
   - `enabledPlugins` in `.claude/settings.json` — it is NOT a `.claude/` hook any
-    more. **Enabling is not installing:** on a fresh machine run
-    `claude plugin install dxos@dxos` once, or every invocation answers
-    `Unknown command`. The plugin's `UserPromptSubmit` hook reads the raw text before the
-    command expands and injects the matching directive, ending with a `BACKEND:`
-    line naming the store — follow the directive and obey that line.
+    more. **Enabling is not installing:** run `bash .claude/scripts/bootstrap-plugins.sh`
+    once per machine — and per cloud container, where `.config/claude-code-setup.sh`
+    runs it — or every invocation answers `Unknown command`. The plugin's
+    `UserPromptSubmit` hook reads the raw text before the command expands and
+    injects the matching directive, ending with a `BACKEND:` line naming the
+    store — follow the directive and obey that line.
   * `/dxos:project` (bare) — status of the CURRENT project: worktree + branch, the
     registry entry's status/docs/PRs, uncommitted files (as clickable links),
     and the next action.

--- a/.claude/scripts/bootstrap-plugins.sh
+++ b/.claude/scripts/bootstrap-plugins.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Install the repo's own Claude Code plugin (`dxos@dxos`, source tools/claude/plugins/dxos).
+#
+# `.claude/settings.json` only *declares* the marketplace and enables the plugin; nothing
+# fetches or installs it, so a fresh machine — and every cloud sandbox container, whose
+# ~/.claude starts empty — answers `Unknown command` to /dxos:project until this runs.
+#
+# Idempotent and safe to run repeatedly. Wired from two places, because either alone leaves a
+# gap: `.config/claude-code-setup.sh` (baked into the cached container image, so the FIRST
+# session has the plugin) and a SessionStart hook (covers environments whose setup command is
+# not wired — there the plugin lands from the next session on, since plugins resolve before
+# hooks fire).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLUGINS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins"
+
+# Already installed — the common path, kept to a single grep so the hook costs nothing.
+if grep -q '"dxos@dxos"' "${PLUGINS_DIR}/installed_plugins.json" 2>/dev/null; then
+  exit 0
+fi
+
+command -v claude >/dev/null 2>&1 || exit 0
+
+# Register from the local checkout rather than the GitHub source: it needs no network and
+# pins the plugin to the tree the session is actually working in.
+if ! grep -q '"dxos"' "${PLUGINS_DIR}/known_marketplaces.json" 2>/dev/null; then
+  claude plugin marketplace add "$REPO_ROOT" >/dev/null 2>&1
+fi
+
+claude plugin install dxos@dxos >/dev/null 2>&1 ||
+  echo "[bootstrap-plugins] could not install dxos@dxos; /dxos:project will be unavailable" >&2
+
+exit 0

--- a/.config/claude-code-setup.sh
+++ b/.config/claude-code-setup.sh
@@ -32,4 +32,9 @@ moon setup
 log "pnpm install"
 CI=true HUSKY=0 pnpm install --prefer-offline
 
+# 4. Claude Code plugin (/dxos:project). Enabling in .claude/settings.json does not install it,
+#    and a cloud container's ~/.claude starts empty — bake it into the cached image here.
+log "claude plugin bootstrap"
+bash .claude/scripts/bootstrap-plugins.sh
+
 log "Environment ready."

--- a/.config/claude-code-setup.sh
+++ b/.config/claude-code-setup.sh
@@ -16,7 +16,13 @@ export PATH="$PROTO_HOME/shims:$PROTO_HOME/bin:$PATH"
 
 log() { printf '\033[1;34m[setup]\033[0m %s\n' "$*"; }
 
-# 1. proto — installs everything pinned in .prototools (auto-install is enabled).
+# 1. Claude Code plugin (/dxos:project). Enabling it in .claude/settings.json does not install
+#    it, and a container's ~/.claude starts empty. First, not last: it needs nothing below, and
+#    under `set -e` a toolchain failure would otherwise take the plugin down with it.
+log "claude plugin bootstrap"
+bash .claude/scripts/bootstrap-plugins.sh
+
+# 2. proto — installs everything pinned in .prototools (auto-install is enabled).
 if ! command -v proto >/dev/null 2>&1; then
   log "Installing proto"
   curl -fsSL https://moonrepo.dev/install/proto.sh | bash -s -- --yes >/dev/null
@@ -24,17 +30,12 @@ fi
 log "proto install"
 proto install
 
-# 2. moon workspace setup.
+# 3. moon workspace setup.
 log "moon setup"
 moon setup
 
-# 3. Workspace deps (non-interactive; skip husky hooks).
+# 4. Workspace deps (non-interactive; skip husky hooks).
 log "pnpm install"
 CI=true HUSKY=0 pnpm install --prefer-offline
-
-# 4. Claude Code plugin (/dxos:project). Enabling in .claude/settings.json does not install it,
-#    and a cloud container's ~/.claude starts empty — bake it into the cached image here.
-log "claude plugin bootstrap"
-bash .claude/scripts/bootstrap-plugins.sh
 
 log "Environment ready."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,14 +22,14 @@ This file is the shared, harness-agnostic entrypoint for coding agents.
   - `main` → STOP, write nothing, tell the user. Never create a worktree or
     branch to escape — the harness owns those.
 - **Cloud sandbox sessions differ.** If `CLAUDE_CODE_REMOTE` is set you are in the Claude Code
-  cloud sandbox. `.claude/settings.json` hooks DO run there — `/mode` and the branch/worktree
-  guards behave as they do locally. What is missing is everything outside the clone: `~/.claude`
-  starts empty, so `/dxos:project` answers `Unknown command` until
-  `.claude/scripts/bootstrap-plugins.sh` installs the plugin, and `gh` is absent for good (use
-  the `mcp__github__*` tools). Whether `moon`, `oxfmt`, and `node_modules` exist depends on the
-  environment running `.config/claude-code-setup.sh` — check before trusting a build command
-  rather than assuming either way. The container is ephemeral, so push before you stop. Full
-  details, including how to reach HTTPS from Chromium → `cloud-sandbox` skill.
+  cloud sandbox. `.claude/settings.json` hooks fire there as they do locally, so `/mode` and the
+  branch/worktree guards behave normally. What is missing is everything outside the clone:
+  `~/.claude` starts empty, so `/dxos:project` answers `Unknown command` until
+  `.claude/scripts/bootstrap-plugins.sh` installs the plugin, and `gh` is absent (use the
+  `mcp__github__*` tools). `moon`, `oxfmt`, and `node_modules` exist only where the environment
+  ran `.config/claude-code-setup.sh` — establish which case you are in before running a build.
+  The container is ephemeral, so push before you stop. Full details, including how to reach HTTPS
+  from Chromium → `cloud-sandbox` skill.
 - First reply: confirm these instructions and follow the reporting rule below.
 - If unsure how to implement something, ask rather than guess.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,14 @@ This file is the shared, harness-agnostic entrypoint for coding agents.
   - `main` → STOP, write nothing, tell the user. Never create a worktree or
     branch to escape — the harness owns those.
 - **Cloud sandbox sessions differ.** If `CLAUDE_CODE_REMOTE` is set you are in the Claude Code
-  cloud sandbox, where `.claude/settings.json` hooks do NOT run: `/mode` and `/project` are
-  inert, and the branch/worktree guards enforce nothing — you are the only thing upholding the
-  Non-negotiables. `moon`, `gh`, and `oxfmt` are not on `PATH` (use `pnpm exec moon`
-  and the `mcp__github__*` tools), dependencies are installed but not built, and the container
-  is ephemeral, so push before you stop. Full details, including how to reach HTTPS from
-  Chromium → `cloud-sandbox` skill.
+  cloud sandbox. `.claude/settings.json` hooks DO run there — `/mode` and the branch/worktree
+  guards behave as they do locally. What is missing is everything outside the clone: `~/.claude`
+  starts empty, so `/dxos:project` answers `Unknown command` until
+  `.claude/scripts/bootstrap-plugins.sh` installs the plugin, and `gh` is absent for good (use
+  the `mcp__github__*` tools). Whether `moon`, `oxfmt`, and `node_modules` exist depends on the
+  environment running `.config/claude-code-setup.sh` — check before trusting a build command
+  rather than assuming either way. The container is ephemeral, so push before you stop. Full
+  details, including how to reach HTTPS from Chromium → `cloud-sandbox` skill.
 - First reply: confirm these instructions and follow the reporting rule below.
 - If unsure how to implement something, ask rather than guess.
 


### PR DESCRIPTION
## Why

`/dxos:project` answers `Unknown command` in Claude Code cloud sessions. The cause is not the sandbox disabling plugins — it is that a fresh container's `~/.claude` starts with an empty `installed_plugins.json` and only the official marketplace known. `enabledPlugins` and `extraKnownMarketplaces` in `.claude/settings.json` merely *declare*; nothing fetches. Every plugin listed there is absent, along with the skills they ship (`task-planning`, `superpowers:*`).

While diagnosing that, two claims in our own docs turned out to be false.

## What

**`.claude/scripts/bootstrap-plugins.sh`** (new) — idempotent installer. Exits on a single `grep` when the plugin is already present, otherwise registers the marketplace from the local checkout (no network, and it pins to the tree the session is working in) and installs.

**Wired as step 1 of `.config/claude-code-setup.sh`**, ahead of the toolchain. That script is `set -euo pipefail`, so a failure in `proto`, `moon setup`, or the 10-minute `pnpm install` aborts everything after it — putting the bootstrap last would lose the plugin in exactly the containers whose toolchain install died. It depends on nothing below it.

**Doc corrections** in `AGENTS.md`, `.agents/skills/cloud-sandbox/SKILL.md`, and `.claude/CLAUDE.md`:

- `.claude/settings.json` hooks run in the sandbox. `mode.sh` injects the `RESPONSE RULES` block on every prompt (so `/mode` works), and the branch/worktree guards deny. All three files said they were inert.
- `moon`, `proto`, and `node_modules` exist only where `.config/claude-code-setup.sh` ran. The skill stated "dependencies are installed but not built" and recommended `pnpm exec moon` as an absolute; in a container where setup never ran, `node_modules` is empty and that command fails. Both sections are now conditional, with a one-line check and `pnpm dlx oxfmt@0.63` as the formatter fallback.
- Added a note that `claude plugin uninstall` / `marketplace remove` rewrite tracked `.claude/settings.json`, stripping the `dxos` entries (found while testing; plain `add`/`install` leave it alone).

## Verification

- Wiped `~/.claude/plugins` to the empty state a fresh container starts in, ran the bootstrap, and confirmed a new session in the same container resolves `/dxos:project help` to the full verb table.
- Ran `.config/claude-code-setup.sh` end to end twice, once per ordering. Both exit 0; after the reorder the log reads `claude plugin bootstrap` → `proto install` → `moon setup` → `pnpm install` → `Environment ready.`, with the plugin installed and `.claude/settings.json` unmodified.
- Re-ran the bootstrap with the plugin present: no-op, exit 0.
- Reproduced the hook claim: `bash .claude/hooks/mode.sh` emits text byte-identical to the `RESPONSE RULES` block delivered on the prompt.
- `bash -n` on both shell scripts; `oxfmt --check` clean on all three markdown files.

## A `SessionStart` hook would not help

Worth recording, since it is the obvious next idea. Measured with a fixture whose `.claude/settings.json` ran the bootstrap from `SessionStart`, starting from an empty plugin state:

```
before:  {"version":2,"plugins":{}}
session: Unknown command: /dxos:project
after:   {"version":2,"plugins":{"dxos@dxos":[...]}}
```

The hook ran and installed successfully during that session, and the session still did not have the command — plugins resolve before `SessionStart` hooks land, so that route is always one session late. The environment's setup command is the only placement that gets the plugin in before the first prompt.