### PR TITLE
app-toolkit: emit the NativeOAuth entry the export map already promises

### DIFF
--- a/packages/sdk/app-toolkit/vite.config.ts
+++ b/packages/sdk/app-toolkit/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     'app-graph/AppNodeMatcher': 'src/app-graph/AppNodeMatcher.ts',
     'app-graph/TypeSection': 'src/app-graph/TypeSection.ts',
     'app/GraphPath': 'src/app/GraphPath.ts',
+    'app/NativeOAuth': 'src/app/NativeOAuth.ts',
     'app/NativePasskey': 'src/app/NativePasskey.ts',
     'app/NavigationResolver': 'src/app/NavigationResolver.ts',
     'app/NotFound': 'src/app/NotFound.ts',


### PR DESCRIPTION
Unblocks publishing on `main`. One line.

## The break

`./NativeOAuth` was added to `app-toolkit`'s `exports` in #12690 without a matching `entry` in `packages/sdk/app-toolkit/vite.config.ts`, so `dist/lib/app/NativeOAuth.mjs` is never emitted. Anything resolving through the `import` condition then fails:

```
cli:bundle | error: Could not resolve: "@dxos/app-toolkit/NativeOAuth". Maybe you need to "bun install"?
```

It is the only one of the package's 34 exports missing from the 31 entries.

## Why CI was green on the PR that introduced it

In-repo consumers resolve via the `source` condition, so nothing in the normal graph reads `dist/lib`. The one task that does — `cli:bundle` — is deliberately kept out of the `^:build` fan-out (see its comment in `packages/devtools/cli/moon.yml`), so it never runs on a `pull_request`. It runs only in the `Publish` / `pkg.pr.new` workflows on `main`, which is where this first appeared.

## Blast radius

Every publish since `bb941246` has failed at the `Bundle CLI` step:

| main sha | PR | `pkg.pr.new` |
|---|---|---|
| `2531b942` | #12691 | success (last green) |
| `bb941246` | #12690 | **failure** — `Could not resolve` |
| `6ca75f7c` | #12694 | **failure** — same step, same message |

So no `pkg.pr.new` artifact exists for anything merged after `2531b942`. This is currently blocking [dxos/edge#924](https://github.com/dxos/edge/pull/924), which pins by merge sha.

## Verification

`app-toolkit:build` now emits `dist/lib/app/NativeOAuth.mjs` (+ sourcemap), and `cli:bundle` — the task that actually failed — completes locally, producing all six platform bundles:

```
cli:bundle | [Build] Generated packages in dist/:
cli:bundle |   - cli (main package)
cli:bundle |   - cli-darwin-arm64 / -x64, cli-linux-arm64 / -x64, cli-win32-x64
▮▮▮▮ cli:bundle (30s 557ms)
Tasks: 204 completed (97 cached)
```

## Not fixed here

The gap that let this land — an `exports` entry with no corresponding vite `entry` is invisible until publish — has no guard. Worth a check that diffs the two maps per package, but that is a separate change; I did not want to bundle a new CI rule into an unblock.

## Changeset

None: this repairs an unreleased build config and changes no consumer-visible API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tfqhrt2TJeKh6g7pZpShYj


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tfqhrt2TJeKh6g7pZpShYj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `app/NativeOAuth` entry point in the SDK toolkit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->