### PR TITLE
moon: route prebuild through a `prebuild` task tag

### DIFF
--- a/docs/moon.yml
+++ b/docs/moon.yml
@@ -5,7 +5,7 @@ tags:
 tasks:
   build:
     deps:
-      - prebuild
+      - ~:#prebuild
     options:
       mergeOutputs: replace
     outputs: []

--- a/docs/moon.yml
+++ b/docs/moon.yml
@@ -28,6 +28,8 @@ tasks:
       - '@group(sources)'
     outputs:
       - .astro
+    tags:
+      - prebuild
   serve:
     command: pnpm exec astro dev
     deps:

--- a/packages/apps/composer-app/moon.yml
+++ b/packages/apps/composer-app/moon.yml
@@ -18,7 +18,7 @@ tasks:
   bundle:
     script: pnpm exec vite build --configLoader native && pnpm run --silent build:functions
     deps:
-      - prebuild
+      - ~:#prebuild
   # The bundle Playwright serves, as its own target rather than an `env` override on `e2e`'s `bundle`
   # dep: a dependency-level `env` map is part of that dependency's hash, so the override yields a bundle
   # no other invocation can hydrate. `DX_PWA` stays on for `bundle`, which production deploys ship.
@@ -131,7 +131,7 @@ tasks:
       cache: false
       outputStyle: stream
     deps:
-      - prebuild
+      - ~:#prebuild
       - '#dist-runtime:build'
       - '#vite-plugin:build'
       - echo-query:prebuild-query-lite
@@ -147,7 +147,7 @@ tasks:
   prebuild:
     script: pnpm run --silent copy:assets
     deps:
-      - ^:prebuild
+      - ^:#prebuild
     inputs:
       - package.json
       - moon.yml
@@ -172,7 +172,7 @@ tasks:
       # command's.
       mergeArgs: replace
     deps:
-      - prebuild
+      - ~:#prebuild
       # dist consumed at runtime.
       - '#dist-runtime:build'
       # dist consumed at config-load time: `vite.config.ts` runs in Node, before importSource is
@@ -186,8 +186,8 @@ tasks:
       # A build artifact, not runtime dist: plugin-script imports `@dxos/echo-query/api.d.ts?raw`
       # for in-editor type hints, and vite's dependency scan aborts wholesale — pre-bundling
       # nothing at all — if a single import in the crawl fails to resolve. Named explicitly because
-      # `prebuild`'s `^:prebuild` stops at the first hop: echo-query is reached through
-      # plugin-script, which has no `prebuild` task of its own to continue the chain.
+      # `prebuild`'s `^:#prebuild` stops at the first hop: echo-query is reached through
+      # plugin-script, which has no `prebuild`-tagged task of its own to continue the chain.
       - echo-query:prebuild-query-lite
       # Dist consumed by the dev server itself: the `dx-agent-claude` plugin imports the middleware
       # in `configureServer`. Named explicitly rather than tagged — it exports no vite plugin, and
@@ -218,7 +218,7 @@ tasks:
     env:
       DX_PWA: 'false'
     deps:
-      - prebuild
+      - ~:#prebuild
       # `vite preview` serves `out/composer`, and PWA is a build-time decision — so the flag rides
       # the dep too, or the harness measures a service worker precaching ~30 MB mid-run.
       - target: bundle
@@ -230,14 +230,14 @@ tasks:
   e2e-dev:
     command: pnpm exec playwright test --config=src/playwright/playwright-dev.config.ts
     deps:
-      - prebuild
+      - ~:#prebuild
       - ^:build
   # Welcome-screen focus regression — drives Storybook on :9009 rather than the app, so it cannot
   # run under `e2e`'s `vite preview` web server.
   e2e-welcome-focus:
     command: pnpm exec playwright test --config=src/playwright/playwright-welcome-focus.config.ts
     deps:
-      - prebuild
+      - ~:#prebuild
       - ^:build
   # Vitest (inherited from `ts-test`); the extra inputs keep the cache honest about the Storybook
   # and Vite config this app's tests load.

--- a/packages/apps/composer-app/moon.yml
+++ b/packages/apps/composer-app/moon.yml
@@ -153,6 +153,8 @@ tasks:
       - moon.yml
     outputs:
       - public/assets/plugin-tldraw
+    tags:
+      - prebuild
   # Dev server (`vite dev`) — the everyday inner loop, with the full plugin registry. Vite dev
   # resolves @dxos/* from source (importSource), so pre-building the whole graph is wasted work:
   # only packages whose dist is actually consumed need it, and each kind declares itself by tag.

--- a/packages/common/protobuf-compiler/moon.yml
+++ b/packages/common/protobuf-compiler/moon.yml
@@ -6,7 +6,7 @@ tags:
 tasks:
   build:
     deps:
-      - prebuild
+      - ~:#prebuild
     inputs:
       - bin/main.js
   prebuild:
@@ -22,7 +22,7 @@ tasks:
   test:
     command: pnpm run --silent test
     deps:
-      - prebuild
+      - ~:#prebuild
       - ^:build
     inputs:
       - '@group(sources)'

--- a/packages/common/protobuf-compiler/moon.yml
+++ b/packages/common/protobuf-compiler/moon.yml
@@ -17,6 +17,8 @@ tasks:
       - test/proto/example/
     outputs:
       - test/proto/gen/
+    tags:
+      - prebuild
   test:
     command: pnpm run --silent test
     deps:

--- a/packages/core/echo/echo-query/moon.yml
+++ b/packages/core/echo/echo-query/moon.yml
@@ -7,13 +7,7 @@ tags:
 tasks:
   build:
     deps:
-      - prebuild
-  prebuild:
-    deps:
-      - echo-query:prebuild-lezer
-      - echo-query:prebuild-query-lite
-    tags:
-      - prebuild
+      - ~:#prebuild
   prebuild-lezer:
     command: pnpm exec lezer-generator --typeScript ./src/parser/query.grammar -o ./src/parser/gen/query.ts
     inputs:
@@ -36,4 +30,4 @@ tasks:
       - prebuild
   test:
     deps:
-      - prebuild
+      - ~:#prebuild

--- a/packages/core/echo/echo-query/moon.yml
+++ b/packages/core/echo/echo-query/moon.yml
@@ -12,6 +12,8 @@ tasks:
     deps:
       - echo-query:prebuild-lezer
       - echo-query:prebuild-query-lite
+    tags:
+      - prebuild
   prebuild-lezer:
     command: pnpm exec lezer-generator --typeScript ./src/parser/query.grammar -o ./src/parser/gen/query.ts
     inputs:
@@ -19,6 +21,8 @@ tasks:
     outputs:
       - src/parser/gen/query.terms.ts
       - src/parser/gen/query.ts
+    tags:
+      - prebuild
   prebuild-query-lite:
     command: pnpm exec tsdown --logLevel error
     deps:
@@ -28,6 +32,8 @@ tasks:
       - tsdown.config.ts
     outputs:
       - dist/query-lite/*
+    tags:
+      - prebuild
   test:
     deps:
       - prebuild

--- a/packages/core/protocols/moon.yml
+++ b/packages/core/protocols/moon.yml
@@ -27,6 +27,8 @@ tasks:
       - gen-buf
     outputs:
       - src/proto/gen
+    tags:
+      - prebuild
   test:
     deps:
       - prebuild

--- a/packages/core/protocols/moon.yml
+++ b/packages/core/protocols/moon.yml
@@ -7,7 +7,7 @@ tags:
 tasks:
   build:
     deps:
-      - prebuild
+      - ~:#prebuild
   gen-buf:
     command: buf generate
     inputs:
@@ -31,4 +31,4 @@ tasks:
       - prebuild
   test:
     deps:
-      - prebuild
+      - ~:#prebuild

--- a/packages/plugins/plugin-kanban/moon.yml
+++ b/packages/plugins/plugin-kanban/moon.yml
@@ -36,7 +36,7 @@ tasks:
     # taking the web server down with it.
     deps:
       - '#vendor:build'
-      - '#storybook:prebuild'
+      - '#storybook:#prebuild'
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts

--- a/packages/plugins/plugin-sheet/moon.yml
+++ b/packages/plugins/plugin-sheet/moon.yml
@@ -32,7 +32,7 @@ tasks:
     # taking the web server down with it.
     deps:
       - '#vendor:build'
-      - '#storybook:prebuild'
+      - '#storybook:#prebuild'
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts

--- a/packages/plugins/plugin-tldraw/moon.yml
+++ b/packages/plugins/plugin-tldraw/moon.yml
@@ -19,3 +19,5 @@ tasks:
       - moon.yml
     outputs:
       - dist/assets
+    tags:
+      - prebuild

--- a/packages/plugins/plugin-tldraw/moon.yml
+++ b/packages/plugins/plugin-tldraw/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   build:
     deps:
-      - prebuild
+      - ~:#prebuild
   prebuild:
     command: bash ./scripts/copy_assets.sh
     toolchains: node # enforce that deps are installed

--- a/packages/reflect/deus/moon.yml
+++ b/packages/reflect/deus/moon.yml
@@ -7,7 +7,7 @@ tags:
 tasks:
   build:
     deps:
-      - deus:prebuild-lezer
+      - ~:#prebuild
   prebuild-lezer:
     command: pnpm exec lezer-generator --typeScript ./src/extension/mdl.grammar -o ./src/extension/gen/mdl.ts
     inputs:

--- a/packages/reflect/deus/moon.yml
+++ b/packages/reflect/deus/moon.yml
@@ -15,3 +15,5 @@ tasks:
     outputs:
       - src/extension/gen/mdl.terms.ts
       - src/extension/gen/mdl.ts
+    tags:
+      - prebuild

--- a/packages/sdk/observability/moon.yml
+++ b/packages/sdk/observability/moon.yml
@@ -19,3 +19,5 @@ tasks:
       - $NODE_ENV
     outputs:
       - src/cli-observability-secrets.json
+    tags:
+      - prebuild

--- a/packages/sdk/observability/moon.yml
+++ b/packages/sdk/observability/moon.yml
@@ -8,7 +8,7 @@ tags:
 tasks:
   build:
     deps:
-      - prebuild
+      - ~:#prebuild
   prebuild:
     command: node ./scripts/inject_api_keys.mjs
     inputs:

--- a/packages/ui/lit-grid/moon.yml
+++ b/packages/ui/lit-grid/moon.yml
@@ -11,7 +11,7 @@ tasks:
     # taking the web server down with it.
     deps:
       - '#vendor:build'
-      - '#storybook:prebuild'
+      - '#storybook:#prebuild'
     inputs:
       - .storybook/*
       - /tools/storybook-lit/.storybook/main.ts

--- a/packages/ui/react-ui-experimental/moon.yml
+++ b/packages/ui/react-ui-experimental/moon.yml
@@ -9,8 +9,8 @@ tags:
 tasks:
   build:
     deps:
-      - prebuild
-  # Named `prebuild` so storybook's `#storybook:prebuild` reaches it; the gen dir does not exist until it runs.
+      - ~:#prebuild
+  # Tagged `prebuild` so storybook's `#storybook:#prebuild` reaches it; the gen dir does not exist until it runs.
   prebuild:
     command: pnpm run --silent glsl
     inputs:

--- a/packages/ui/react-ui-experimental/moon.yml
+++ b/packages/ui/react-ui-experimental/moon.yml
@@ -17,3 +17,5 @@ tasks:
       - src/shaders/glsl/*.*
     outputs:
       - src/shaders/glsl/gen
+    tags:
+      - prebuild

--- a/packages/ui/react-ui-gameboard/moon.yml
+++ b/packages/ui/react-ui-gameboard/moon.yml
@@ -9,8 +9,8 @@ tags:
 tasks:
   build:
     deps:
-      - prebuild
-  # Named `prebuild` so storybook's `#storybook:prebuild` reaches it; `src/gen` does not exist until it runs.
+      - ~:#prebuild
+  # Tagged `prebuild` so storybook's `#storybook:#prebuild` reaches it; `src/gen` does not exist until it runs.
   prebuild:
     command: pnpm run --silent gen:pieces
     inputs:

--- a/packages/ui/react-ui-gameboard/moon.yml
+++ b/packages/ui/react-ui-gameboard/moon.yml
@@ -17,3 +17,5 @@ tasks:
       - assets/*.*
     outputs:
       - src/gen
+    tags:
+      - prebuild

--- a/packages/ui/react-ui-mosaic/moon.yml
+++ b/packages/ui/react-ui-mosaic/moon.yml
@@ -13,7 +13,7 @@ tasks:
     # taking the web server down with it.
     deps:
       - '#vendor:build'
-      - '#storybook:prebuild'
+      - '#storybook:#prebuild'
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts

--- a/packages/ui/react-ui-table/moon.yml
+++ b/packages/ui/react-ui-table/moon.yml
@@ -13,7 +13,7 @@ tasks:
     # taking the web server down with it.
     deps:
       - '#vendor:build'
-      - '#storybook:prebuild'
+      - '#storybook:#prebuild'
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts

--- a/tools/storybook-react/moon.yml
+++ b/tools/storybook-react/moon.yml
@@ -16,9 +16,9 @@ tasks:
       # `ts-compile`, so they are not covered above; without their dist Vite's dep-scan aborts.
       - '#vendor:build'
       # Storybook resolves packages straight from source, so anything *generated* — assets, sprites,
-      # compiled shaders — is missing until its producer runs. Each such package exposes it as `prebuild`;
+      # compiled shaders — is missing until its producer runs. Each such producer tags its task `prebuild`;
       # depending on their `build` instead would drag in ts-vite-build's recursive `^:build`.
-      - '#storybook:prebuild'
+      - '#storybook:#prebuild'
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts
@@ -43,7 +43,7 @@ tasks:
       - '#vendor:build'
       # See `bundle` — generated sources and static assets, which hang off each package's `build` and so
       # are absent in a fresh worktree.
-      - '#storybook:prebuild'
+      - '#storybook:#prebuild'
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts
@@ -65,7 +65,7 @@ tasks:
       - '#ts-compile:build'
       - '#vendor:build'
       # See `bundle` — generated sources and static assets the tag deps above never produce.
-      - '#storybook:prebuild'
+      - '#storybook:#prebuild'
     inputs:
       - .storybook/*
       - /tools/storybook-react/.storybook/main.ts


### PR DESCRIPTION
moon 2.3 added **task-level** tags (`tasks.<name>.tags`) and a matching target scope, distinct from the project-level tags this repo already uses for inheritance (`.moon/tasks/tag-*.yml`). This PR tags every codegen / asset-staging task `prebuild`, then routes the dependency graph through that tag instead of through task names.

## 1. Tagged tasks (12)

| Target | What it produces |
| --- | --- |
| `composer-app:prebuild` | `public/assets/plugin-tldraw` |
| `docs:prebuild` | `.astro` (astro sync) |
| `deus:prebuild-lezer` | `src/extension/gen/mdl.ts` |
| `echo-query:prebuild-lezer` | `src/parser/gen/query.ts` |
| `echo-query:prebuild-query-lite` | `dist/query-lite/*` |
| `protobuf-compiler:prebuild` | `test/proto/gen/` |
| `protocols:prebuild` | `src/proto/gen` |
| `observability:prebuild` | `src/cli-observability-secrets.json` |
| `plugin-tldraw:prebuild` | `dist/assets` |
| `react-ui-experimental:prebuild` | compiled GLSL shaders |
| `react-ui-gameboard:prebuild` | `src/gen` piece assets |

## 2. Dependency targets rewritten to use the tag

| Before | After | Where |
| --- | --- | --- |
| `prebuild` | `~:#prebuild` | 15 deps across 9 projects |
| `deus:prebuild-lezer` | `~:#prebuild` | `deus:build` |
| `^:prebuild` | `^:#prebuild` | `composer-app:prebuild` |
| `'#storybook:prebuild'` | `'#storybook:#prebuild'` | 7 deps across 6 projects |

The tag, not the task name, is now what makes a codegen step reachable. Previously `deus:prebuild-lezer` needed a hardcoded fully-qualified target precisely because it is not *called* `prebuild`; a producer can now name its task for what it generates and stay in the graph.

This also retires `echo-query:prebuild`, an aggregator task whose entire body was `deps: [prebuild-lezer, prebuild-query-lite]` — `~:#prebuild` reaches both directly, so the indirection node is dead weight.

## Verification

`moon query tasks --tags prebuild` against moon 2.4.5 (the version pinned in `.prototools`) resolves all 12 tagged tasks.

The fully-expanded dependency graph was dumped via `moon query tasks` before and after and diffed across all 2174 targets:

```
removed tasks: ['echo-query:prebuild']
added tasks:   []

composer-app:prebuild / echo-query:build / echo-query:test
  + echo-query:prebuild-lezer, echo-query:prebuild-query-lite
  - echo-query:prebuild
```

Every other edge resolves to a byte-identical set; the only delta is the retired aggregator collapsing into its two members. The mechanism was also confirmed to be live rather than silently ignored — substituting a non-existent tag fails hard with `task_builder::unknown_target`.

## Notes

- No task command, input, or output changed; this is build-graph wiring only.
- Four comments that named the old name-based lookup were updated to describe the tag.
- `echo-query:prebuild-query-lite` is left named explicitly in `composer-app:serve` and `gen-optimize-deps`. Its comment claims `^:prebuild` "stops at the first hop", but the graph dump shows echo-query is a direct dependency of composer-app, so that dep is already transitively satisfied either way. Flagging rather than removing it, since the premise looks stale but the reasoning is deliberate.