### PR TITLE
edge-client: migrate HTTP routes to per-service prefixes

### DIFF
--- a/.changeset/http-route-migration.md
+++ b/.changeset/http-route-migration.md
@@ -1,0 +1,11 @@
+---
+'@dxos/edge-client': patch
+'@dxos/plugin-wnfs': patch
+---
+
+EDGE HTTP requests now use the prefix-per-service paths (`/db`, `/identity`, `/compute`, `/blob`) instead of the legacy top-level ones, per `docs/design/system/http-route-migration.md` in `dxos/edge`.
+
+- `EdgeHttpClient`: `/spaces/*` → `/db/spaces/*`, `/identity/recover` → `/db/identity/recover`, `/agents/*` → `/identity/agents/*`, `/users/:did/agent/*` → `/identity/users/:did/agent/*`, `/functions/*` and `/workflows/*` → `/compute/*`, and `getBlobUrl` now returns `/blob/file/:key`.
+- `@dxos/plugin-wnfs` blockstore requests move from `/api/file` to `/blob/file`.
+
+Both forms answer on edge today, so this is not a breaking change for callers of these methods; `/oauth/*`, `/atproto/*`, `/registry/*`, `/status` and `/auth` are pinned and unchanged, and `/triggers/*` is left alone (it is not a migration target).

--- a/packages/core/compute/ai/src/testing/defs.ts
+++ b/packages/core/compute/ai/src/testing/defs.ts
@@ -20,11 +20,13 @@ export const SERVICES_CONFIG: Record<string, Runtime.Services> = {
     },
   },
   REMOTE: {
+    // ai-service is reached through the single edge entrypoint under the `/ai` prefix; its own
+    // hostname is an implementation detail of not having a domain.
     ai: {
-      server: 'https://ai-service.dxos.workers.dev',
+      server: 'https://main.dxos.network/ai',
     },
     edge: {
-      url: 'https://edge-main.dxos.workers.dev',
+      url: 'https://main.dxos.network',
     },
   },
 };

--- a/packages/core/compute/ai/src/testing/test-layers.ts
+++ b/packages/core/compute/ai/src/testing/test-layers.ts
@@ -59,7 +59,7 @@ export const LocalEdgeAiServiceLayer: AiServiceLayer = TestRouter.pipe(
 export const RemoteEdgeAiServiceLayer: AiServiceLayer = TestRouter.pipe(
   Layer.provide(
     AnthropicClient.layerConfig({
-      apiUrl: Config.succeed('https://ai-service.dxos.workers.dev/provider/anthropic'),
+      apiUrl: Config.succeed('https://main.dxos.network/ai/provider/anthropic'),
     }),
   ),
   Layer.provide(FetchHttpClient.layer),

--- a/packages/core/mesh/edge-client/src/edge-http-client.test.ts
+++ b/packages/core/mesh/edge-client/src/edge-http-client.test.ts
@@ -172,7 +172,7 @@ describe('EdgeHttpClient auth refresh', () => {
     await inFlight;
 
     // The stale presentation was discarded: the request went out without it.
-    const putCall = fetchMock.mock.calls.find((call) => String(call[0]).includes('/api/file/one'));
+    const putCall = fetchMock.mock.calls.find((call) => String(call[0]).includes('/blob/file/one'));
     expect((putCall![1]?.headers as Record<string, string> | undefined)?.Authorization).toBeUndefined();
   });
 
@@ -302,8 +302,8 @@ describe('EdgeHttpClient blobs', () => {
 
   test('getBlobUrl URL-encodes the key', ({ expect }) => {
     const client = new EdgeHttpClient('https://edge.example.com');
-    expect(client.getBlobUrl('abc123').toString()).toBe('https://edge.example.com/api/file/abc123');
-    expect(client.getBlobUrl('a/b/../c').toString()).toBe('https://edge.example.com/api/file/a%2Fb%2F..%2Fc');
+    expect(client.getBlobUrl('abc123').toString()).toBe('https://edge.example.com/blob/file/abc123');
+    expect(client.getBlobUrl('a/b/../c').toString()).toBe('https://edge.example.com/blob/file/a%2Fb%2F..%2Fc');
   });
 
   test('putBlob sends a raw POST body and pre-fetches /auth', async ({ expect }) => {
@@ -331,9 +331,9 @@ describe('EdgeHttpClient blobs', () => {
     const authCall = fetchMock.mock.calls.find((call) => String(call[0]).endsWith('/auth'));
     expect(authCall).toBeDefined();
 
-    const putCall = fetchMock.mock.calls.find((call) => String(call[0]).includes('/api/file/abc123'));
+    const putCall = fetchMock.mock.calls.find((call) => String(call[0]).includes('/blob/file/abc123'));
     expect(putCall).toBeDefined();
-    expect(String(putCall![0])).toBe('https://edge.example.com/api/file/abc123');
+    expect(String(putCall![0])).toBe('https://edge.example.com/blob/file/abc123');
     expect(putCall![1]?.method).toBe('POST');
     expect(putCall![1]?.body).toBe(bytes);
     expect((putCall![1]?.headers as Record<string, string>)['Content-Type']).toBe('application/octet-stream');
@@ -366,7 +366,7 @@ describe('EdgeHttpClient blobs', () => {
     client.setIdentity(identity);
     await client.putBlob(Context.default(), 'abc123', new Uint8Array([1, 2, 3]));
 
-    const fileCalls = fetchMock.mock.calls.filter((call) => String(call[0]).includes('/api/file/abc123'));
+    const fileCalls = fetchMock.mock.calls.filter((call) => String(call[0]).includes('/blob/file/abc123'));
     expect(fileCalls.length).toBe(2);
     expect((fileCalls[1][1]?.headers as Record<string, string>).Authorization).toMatch(/^VerifiablePresentation/);
   });
@@ -400,7 +400,7 @@ describe('EdgeHttpClient blobs', () => {
       await expect(client.getBlob(Context.default(), 'abc123')).rejects.toThrow(/HTTP code 401/);
 
       // Exactly one attempt at the resource: no auth retry.
-      const fileCalls = fetchMock.mock.calls.filter((call) => String(call[0]).includes('/api/file/abc123'));
+      const fileCalls = fetchMock.mock.calls.filter((call) => String(call[0]).includes('/blob/file/abc123'));
       expect(fileCalls.length).toBe(1);
     });
   }
@@ -408,7 +408,7 @@ describe('EdgeHttpClient blobs', () => {
   test('getBlob returns bytes on success', async ({ expect }) => {
     const fetchMock = vi.fn(async (input: any) => {
       const url = String(input instanceof URL ? input : (input.url ?? input));
-      expect(url).toBe('https://edge.example.com/api/file/abc123');
+      expect(url).toBe('https://edge.example.com/blob/file/abc123');
       return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
     });
     vi.stubGlobal('fetch', fetchMock);
@@ -441,7 +441,7 @@ describe('EdgeHttpClient blobs', () => {
   test('deleteBlob sends a DELETE request', async ({ expect }) => {
     const fetchMock = vi.fn(async (input: any, init?: RequestInit) => {
       expect(String(input instanceof URL ? input : (input.url ?? input))).toBe(
-        'https://edge.example.com/api/file/abc123',
+        'https://edge.example.com/blob/file/abc123',
       );
       expect(init?.method).toBe('DELETE');
       return new Response(null, { status: 200 });
@@ -505,7 +505,7 @@ describe('EdgeHttpClient api key', () => {
 
     const authCall = fetchMock.mock.calls.find((call) => String(call[0]).endsWith('/auth'));
     expect(authCall).toBeUndefined();
-    const putCall = fetchMock.mock.calls.find((call) => String(call[0]).includes('/api/file/abc123'));
+    const putCall = fetchMock.mock.calls.find((call) => String(call[0]).includes('/blob/file/abc123'));
     expect((putCall![1]?.headers as Record<string, string>).Authorization).toBe('Bearer secret-key');
   });
 });

--- a/packages/core/mesh/edge-client/src/edge-http-client.ts
+++ b/packages/core/mesh/edge-client/src/edge-http-client.ts
@@ -159,7 +159,12 @@ export class EdgeHttpClient extends BaseHttpClient {
     body: CreateAgentRequestBody,
     args?: EdgeHttpCallArgs,
   ): Promise<CreateAgentResponseBody> {
-    return this._call(ctx, new URL('/agents/create', this.baseUrl), { ...args, method: 'POST', body, auth: true });
+    return this._call(ctx, new URL('/identity/agents/create', this.baseUrl), {
+      ...args,
+      method: 'POST',
+      body,
+      auth: true,
+    });
   }
 
   public getAgentStatus(
@@ -167,7 +172,7 @@ export class EdgeHttpClient extends BaseHttpClient {
     request: { ownerIdentityDid: string },
     args?: EdgeHttpCallArgs,
   ): Promise<GetAgentStatusResponseBody> {
-    return this._call(ctx, new URL(`/users/${request.ownerIdentityDid}/agent/status`, this.baseUrl), {
+    return this._call(ctx, new URL(`/identity/users/${request.ownerIdentityDid}/agent/status`, this.baseUrl), {
       ...args,
       method: 'GET',
       auth: true,
@@ -183,7 +188,7 @@ export class EdgeHttpClient extends BaseHttpClient {
     spaceId: SpaceId,
     args?: EdgeHttpCallArgs,
   ): Promise<GetNotarizationResponseBody> {
-    return this._call(ctx, new URL(`/spaces/${spaceId}/notarization`, this.baseUrl), {
+    return this._call(ctx, new URL(`/db/spaces/${spaceId}/notarization`, this.baseUrl), {
       ...args,
       method: 'GET',
       auth: true,
@@ -196,7 +201,7 @@ export class EdgeHttpClient extends BaseHttpClient {
     body: PostNotarizationRequestBody,
     args?: EdgeHttpCallArgs,
   ): Promise<void> {
-    await this._call(ctx, new URL(`/spaces/${spaceId}/notarization`, this.baseUrl), {
+    await this._call(ctx, new URL(`/db/spaces/${spaceId}/notarization`, this.baseUrl), {
       ...args,
       body,
       method: 'POST',
@@ -213,7 +218,7 @@ export class EdgeHttpClient extends BaseHttpClient {
     body: RecoverIdentityRequest,
     args?: EdgeHttpCallArgs,
   ): Promise<RecoverIdentityResponseBody> {
-    return this._call(ctx, new URL('/identity/recover', this.baseUrl), { ...args, body, method: 'POST' });
+    return this._call(ctx, new URL('/db/identity/recover', this.baseUrl), { ...args, body, method: 'POST' });
   }
 
   //
@@ -226,7 +231,7 @@ export class EdgeHttpClient extends BaseHttpClient {
     body: JoinSpaceRequest,
     args?: EdgeHttpCallArgs,
   ): Promise<JoinSpaceResponseBody> {
-    return this._call(ctx, new URL(`/spaces/${spaceId}/join`, this.baseUrl), {
+    return this._call(ctx, new URL(`/db/spaces/${spaceId}/join`, this.baseUrl), {
       ...args,
       body,
       method: 'POST',
@@ -271,7 +276,7 @@ export class EdgeHttpClient extends BaseHttpClient {
   //
 
   async createSpace(ctx: Context, body: CreateSpaceRequest, args?: EdgeHttpCallArgs): Promise<CreateSpaceResponseBody> {
-    return this._call(ctx, new URL('/spaces/create', this.baseUrl), { ...args, body, method: 'POST', auth: true });
+    return this._call(ctx, new URL('/db/spaces/create', this.baseUrl), { ...args, body, method: 'POST', auth: true });
   }
 
   //
@@ -289,7 +294,7 @@ export class EdgeHttpClient extends BaseHttpClient {
     invariant(queueId, 'queueId required');
     return this._call(
       ctx,
-      createUrl(new URL(`/spaces/${subspaceTag}/${spaceId}/queue/${queueId}/query`, this.baseUrl), {
+      createUrl(new URL(`/db/spaces/${subspaceTag}/${spaceId}/queue/${queueId}/query`, this.baseUrl), {
         after: query.after,
         before: query.before,
         limit: query.limit,
@@ -308,7 +313,7 @@ export class EdgeHttpClient extends BaseHttpClient {
     objects: unknown[],
     args?: EdgeHttpCallArgs,
   ): Promise<void> {
-    return this._call(ctx, new URL(`/spaces/${subspaceTag}/${spaceId}/queue/${queueId}`, this.baseUrl), {
+    return this._call(ctx, new URL(`/db/spaces/${subspaceTag}/${spaceId}/queue/${queueId}`, this.baseUrl), {
       ...args,
       body: { objects },
       method: 'POST',
@@ -326,7 +331,7 @@ export class EdgeHttpClient extends BaseHttpClient {
   ): Promise<void> {
     return this._call(
       ctx,
-      createUrl(new URL(`/spaces/${subspaceTag}/${spaceId}/queue/${queueId}`, this.baseUrl), {
+      createUrl(new URL(`/db/spaces/${subspaceTag}/${spaceId}/queue/${queueId}`, this.baseUrl), {
         ids: objectIds.join(','),
       }),
       { ...args, method: 'DELETE', auth: true },
@@ -342,7 +347,7 @@ export class EdgeHttpClient extends BaseHttpClient {
    * callers pass a lowercase hex SHA-256 digest (extracted from an `ni:` URI by the edge backend).
    */
   public getBlobUrl(key: string): URL {
-    return new URL(`/api/file/${encodeURIComponent(key)}`, this.baseUrl);
+    return new URL(`/blob/file/${encodeURIComponent(key)}`, this.baseUrl);
   }
 
   /**
@@ -433,7 +438,7 @@ export class EdgeHttpClient extends BaseHttpClient {
         filename,
       );
     }
-    const path = ['functions', ...(pathParts.functionId ? [pathParts.functionId] : [])].join('/');
+    const path = ['/compute/functions', ...(pathParts.functionId ? [pathParts.functionId] : [])].join('/');
     return this._call(ctx, new URL(path, this.baseUrl), {
       ...args,
       body: formData,
@@ -444,7 +449,7 @@ export class EdgeHttpClient extends BaseHttpClient {
   }
 
   public async listFunctions(ctx: Context, args?: EdgeHttpCallArgs): Promise<any> {
-    return this._call(ctx, new URL('/functions', this.baseUrl), { ...args, method: 'GET', auth: true });
+    return this._call(ctx, new URL('/compute/functions', this.baseUrl), { ...args, method: 'GET', auth: true });
   }
 
   public async invokeFunction(
@@ -459,7 +464,7 @@ export class EdgeHttpClient extends BaseHttpClient {
     input: unknown,
     args?: EdgeHttpCallArgs,
   ): Promise<any> {
-    const url = new URL(`/functions/${params.functionId}`, this.baseUrl);
+    const url = new URL(`/compute/functions/${params.functionId}`, this.baseUrl);
     if (params.version) {
       url.searchParams.set('version', params.version);
     }
@@ -486,7 +491,7 @@ export class EdgeHttpClient extends BaseHttpClient {
     input: any,
     args?: EdgeHttpCallArgs,
   ): Promise<ExecuteWorkflowResponseBody> {
-    return this._call(ctx, new URL(`/workflows/${spaceId}/${graphId}`, this.baseUrl), {
+    return this._call(ctx, new URL(`/compute/workflows/${spaceId}/${graphId}`, this.baseUrl), {
       ...args,
       body: input,
       method: 'POST',
@@ -499,10 +504,14 @@ export class EdgeHttpClient extends BaseHttpClient {
   //
 
   public async getCronTriggers(ctx: Context, spaceId: SpaceId): Promise<GetCronTriggersResponse> {
-    return this._call<GetCronTriggersResponse>(ctx, new URL(`/functions/${spaceId}/triggers/crons`, this.baseUrl), {
-      method: 'GET',
-      auth: true,
-    });
+    return this._call<GetCronTriggersResponse>(
+      ctx,
+      new URL(`/compute/functions/${spaceId}/triggers/crons`, this.baseUrl),
+      {
+        method: 'GET',
+        auth: true,
+      },
+    );
   }
 
   public async getTriggersDispatcherStatus(
@@ -518,7 +527,7 @@ export class EdgeHttpClient extends BaseHttpClient {
   }
 
   public async forceRunCronTrigger(ctx: Context, spaceId: SpaceId, triggerId: ObjectId) {
-    return this._call(ctx, new URL(`/functions/${spaceId}/triggers/crons/${triggerId}/run`, this.baseUrl), {
+    return this._call(ctx, new URL(`/compute/functions/${spaceId}/triggers/crons/${triggerId}/run`, this.baseUrl), {
       method: 'POST',
       auth: true,
     });
@@ -529,7 +538,7 @@ export class EdgeHttpClient extends BaseHttpClient {
    * `runAgain` continuation chain. The trigger stays enabled, so its schedule keeps firing.
    */
   public async cancelTriggerRun(ctx: Context, spaceId: SpaceId, triggerId: ObjectId) {
-    return this._call(ctx, new URL(`/functions/${spaceId}/triggers/crons/${triggerId}/cancel`, this.baseUrl), {
+    return this._call(ctx, new URL(`/compute/functions/${spaceId}/triggers/crons/${triggerId}/cancel`, this.baseUrl), {
       method: 'POST',
       auth: true,
     });
@@ -563,7 +572,7 @@ export class EdgeHttpClient extends BaseHttpClient {
     body: QueryRequestProto,
     args?: EdgeHttpCallArgs,
   ): Promise<QueryResponseProto> {
-    return this._call(ctx, new URL(`/spaces/${spaceId}/exec-query`, this.baseUrl), {
+    return this._call(ctx, new URL(`/db/spaces/${spaceId}/exec-query`, this.baseUrl), {
       ...args,
       body,
       method: 'POST',
@@ -607,7 +616,7 @@ export class EdgeHttpClient extends BaseHttpClient {
     body: ImportBundleRequest,
     args?: EdgeHttpCallArgs,
   ): Promise<void> {
-    return this._call(ctx, new URL(`/spaces/${spaceId}/import`, this.baseUrl), {
+    return this._call(ctx, new URL(`/db/spaces/${spaceId}/import`, this.baseUrl), {
       ...args,
       body,
       method: 'PUT',
@@ -621,7 +630,7 @@ export class EdgeHttpClient extends BaseHttpClient {
     body: ExportBundleRequest,
     args?: EdgeHttpCallArgs,
   ): Promise<ExportBundleResponse> {
-    return this._call(ctx, new URL(`/spaces/${spaceId}/export`, this.baseUrl), {
+    return this._call(ctx, new URL(`/db/spaces/${spaceId}/export`, this.baseUrl), {
       ...args,
       body,
       method: 'POST',

--- a/packages/plugins/plugin-wnfs/src/blockstore.ts
+++ b/packages/plugins/plugin-wnfs/src/blockstore.ts
@@ -57,7 +57,7 @@ export class MixedBlockstore extends BaseBlockstore {
 
   url(apiHost: string, cid?: CID): string {
     const path = cid ? cid.toString() : '';
-    return `${apiHost}/api/file${path.length ? '/' + path : ''}`;
+    return `${apiHost}/blob/file${path.length ? '/' + path : ''}`;
   }
 
   // BLOCKSTORE IMPLEMENTATION

--- a/packages/sdk/client/src/edge/edge-blob-backend.test.ts
+++ b/packages/sdk/client/src/edge/edge-blob-backend.test.ts
@@ -65,14 +65,14 @@ describe('createEdgeBlobBackend', () => {
   });
 
   test('getUrl builds a direct edge URL from the digest encoded in the URI', async ({ expect }) => {
-    const getBlobUrl = vi.fn((key: string) => new URL(`/api/file/${key}`, 'https://edge.example.com'));
+    const getBlobUrl = vi.fn((key: string) => new URL(`/blob/file/${key}`, 'https://edge.example.com'));
     const edgeClient = { getBlobUrl } as unknown as EdgeHttpClient;
     const backend = createEdgeBlobBackend({ edgeClient });
 
     const spaceId = SpaceId.random();
     const result = await backend.getUrl?.({ spaceId, uri: niUri });
 
-    expect(result).toBe('https://edge.example.com/api/file/deadbeef');
+    expect(result).toBe('https://edge.example.com/blob/file/deadbeef');
     expect(getBlobUrl).toHaveBeenCalledWith('deadbeef');
   });
 });


### PR DESCRIPTION
Applies the client half of `docs/design/system/http-route-migration.md` (in `dxos/edge`): one path prefix per service on the single edge entrypoint. Both forms answer on edge today, so nothing breaks — the legacy paths stay mounted until they go cold, and moving off them is what stops the `Deprecation`/`deprecated route used` signals.

## Paths moved (`EdgeHttpClient`)

| Before | After |
| --- | --- |
| `/spaces/*` (notarization, join, create, queue, exec-query, import, export) | `/db/spaces/*` |
| `/identity/recover` | `/db/identity/recover` |
| `/agents/create` | `/identity/agents/create` |
| `/users/:did/agent/status` | `/identity/users/:did/agent/status` |
| `/functions*` (incl. `…/triggers/crons*`) | `/compute/functions*` |
| `/workflows/:spaceId/:graphId` | `/compute/workflows/:spaceId/:graphId` |
| `/api/file/:key` | `/blob/file/:key` |

`@dxos/plugin-wnfs`'s blockstore moves from `/api/file` to `/blob/file` for the same reason.

## Host

`@dxos/ai` test config addressed ai-service at `ai-service.dxos.workers.dev`; it now goes through the edge entrypoint as `https://main.dxos.network/ai`, matching the spec's "one base URL per environment, service selected by prefix". Local dev keeps `localhost:8788` (standalone `ai-service` dev server).

## Deliberately unchanged

- `/oauth/*`, `/atproto/*`, `/status`, `/auth`, `/registry/*` — pinned or already clean per the spec.
- `/triggers/:spaceId*` (`getTriggersDispatcherStatus`, `getSpaceTriggers`) — the spec states this mount forwards to a route compute-service does not register and is not a migration target.
- `packages/sdk/config/src/preset.ts` already matches the entrypoint table.
- `plugin-sandbox`'s `/spaces/:spaceId/sandboxes/*` — served by the standalone sandbox-service, not the edge `/db` mount.

## Verification

- `moon run edge-client:test -- src/edge-http-client.test.ts` — 19 passed, 1 skipped
- `moon run client:test -- src/edge/edge-blob-backend.test.ts` — 5 passed
- `moon run edge-client:build plugin-wnfs:build ai:build` — clean
- `moon run edge-client:lint plugin-wnfs:lint ai:lint` — clean; `pnpm format` run

Changeset added (`@dxos/edge-client`, `@dxos/plugin-wnfs`, patch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HV6ovk2WL13zGDUh4H7sUi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated service routes for database, identity, compute, and blob operations to use clearer service-specific paths.
  - Blob uploads, downloads, retrieval, and deletion now use the standardized blob service route.
  - AI service connections now use the shared edge entry point for improved consistency.
  - Existing authentication, request behavior, and unchanged services continue to work as before.
- **Bug Fixes**
  - Updated related integrations and request handling to align with the new route structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->