### PR TITLE
echo,assistant: rebuild recursive JSON schemas instead of overflowing the stack

### DIFF
--- a/.changeset/recursive-schema-tool-projection.md
+++ b/.changeset/recursive-schema-tool-projection.md
@@ -1,0 +1,5 @@
+---
+'@dxos/echo': patch
+---
+
+Fix `RangeError: Maximum call stack size exceeded` when a recursive JSON Schema is rebuilt or projected onto an AI tool. `JsonSchema.toEffectSchema` now resolves a cyclic `$ref` through `Schema.suspend` instead of recursing into it, the LLM-facing tool projection rewrites a suspended node lazily, and a projected tool carries the `$defs` its `$ref`s point at. A stored operation whose schema still cannot be rebuilt is now dropped from the toolkit rather than failing the whole request.

--- a/packages/core/compute/assistant/src/tool-runtime/services.test.ts
+++ b/packages/core/compute/assistant/src/tool-runtime/services.test.ts
@@ -156,4 +156,46 @@ describe('projectFunctionToTool', () => {
     });
     expect(decoded.properties).toEqual({ any: 1 });
   });
+
+  // A cyclic input schema serializes as `$defs` plus a `$ref` into them. Rebuilding it used to
+  // recurse until the stack blew, which reached the user as "Maximum call stack size exceeded" from
+  // the toolkit build and failed the whole chat request; and the advertised schema dropped the
+  // definitions, leaving the model a dangling `$ref`.
+  test('an operation with a recursive input schema survives the registry round trip', ({ expect }) => {
+    interface Node {
+      readonly name: string;
+      readonly children?: readonly Node[];
+    }
+
+    const Node: Schema.Codec<Node> = Schema.Struct({
+      name: Schema.String,
+      children: Schema.optional(Schema.Array(Schema.suspend((): Schema.Codec<Node> => Node))),
+    });
+
+    const Recursive = Operation.make({
+      meta: { key: DXN.make('org.dxos.test.function.recursive'), name: 'Recursive' },
+      input: Schema.Struct({ root: Node }),
+      output: Schema.Void,
+    });
+
+    const advertised = Tool.getJsonSchema(projectFunctionToTool(Operation.deserialize(Operation.serialize(Recursive))));
+    const refs = collectRefs(advertised);
+    expect(refs.length).toBeGreaterThan(0);
+    const defs = (advertised.$defs ?? {}) as Record<string, unknown>;
+    // Every `$ref` the model is shown must name a definition that is actually present.
+    expect(refs.filter((ref) => !(ref.replace('#/$defs/', '') in defs))).toEqual([]);
+  });
 });
+
+/** Every `$ref` value anywhere in a JSON Schema node. */
+const collectRefs = (node: unknown): string[] => {
+  if (Array.isArray(node)) {
+    return node.flatMap(collectRefs);
+  }
+  if (typeof node !== 'object' || node === null) {
+    return [];
+  }
+  return Object.entries(node as Record<string, unknown>).flatMap(([key, value]) =>
+    key === '$ref' && typeof value === 'string' ? [value] : collectRefs(value),
+  );
+};

--- a/packages/core/compute/assistant/src/tool-runtime/services.ts
+++ b/packages/core/compute/assistant/src/tool-runtime/services.ts
@@ -19,6 +19,7 @@ import { todo } from '@dxos/debug';
 import { DXN, Filter, Ref, Registry } from '@dxos/echo';
 import { SchemaAST, SchemaEx } from '@dxos/effect';
 import { invariant } from '@dxos/invariant';
+import { log } from '@dxos/log';
 
 import { RefFromLLM } from '../util';
 
@@ -50,7 +51,16 @@ export const makeToolResolverFromOperations = <R = never>({
               registry.query(Filter.and(Filter.type(Operation.PersistentOperation), Filter.key(key))).run(),
             );
             if (results.length > 0) {
-              return projectFunctionToTool(Operation.deserialize(results[0]));
+              // Rebuilding a stored schema can fail on a record this build cannot represent. Reported
+              // as "not found" so the caller drops that one tool, the way an unresolvable id is
+              // already handled — a throw here escapes as a defect and fails the whole request.
+              return yield* Effect.try({
+                try: () => projectFunctionToTool(Operation.deserialize(results[0])),
+                catch: (error) => {
+                  log.warn('Failed to project a stored operation to a tool', { id, error });
+                  return new AiToolNotFoundError(id);
+                },
+              });
             }
             return yield* Effect.fail(new AiToolNotFoundError(id));
           }),
@@ -213,9 +223,16 @@ export const projectFunctionToTool = (fn: Operation.Definition.Any): Tool.Any =>
  * optional property is therefore dropped, stating the property as the bare type and leaving it out of
  * `required` — the same contract ECHO's own emitter keeps (`stripUndefinedMember`) and the one the
  * pre-migration corpus was recorded against.
+ *
+ * The document's definitions are carried over as `$defs`: v4 emits them for a cyclic schema and
+ * refers to them by `$ref`, so dropping them would state a dangling reference the provider rejects.
  */
-const toModelJsonSchema = (schema: Schema.Codec<any, any>): JsonSchema.JsonSchema =>
-  statePropertyOpenness(dropNullBranches(Schema.toJsonSchemaDocument(schema).schema, new Set(asStringArray(schema))));
+const toModelJsonSchema = (schema: Schema.Codec<any, any>): JsonSchema.JsonSchema => {
+  const { schema: root, definitions } = Schema.toJsonSchemaDocument(schema);
+  const withDefs =
+    Object.keys(definitions).length > 0 ? { ...root, $defs: definitions as Record<string, unknown> } : root;
+  return statePropertyOpenness(dropNullBranches(withDefs, new Set(asStringArray(schema))));
+};
 
 /**
  * States openness on every object node that leaves it implied.
@@ -295,10 +312,16 @@ const makeToolName = (name: string) => {
 export const createStructFieldsFromSchema = (
   schema: Schema.Codec<any, any>,
 ): Record<string, Schema.Codec<any, any>> => {
+  // One expansions map for the whole struct: a recursive property is rewritten once and every
+  // reference to it shares that node, which is what terminates the walk (see `mapSchemaTypeForLLM`).
+  const expansions = new Map<SchemaAST.AST, SchemaAST.AST>();
   switch (schema.ast._tag) {
     case 'Objects':
       return Object.fromEntries(
-        schema.ast.propertySignatures.map((prop) => [prop.name, Schema.make(mapSchemaTypeForLLM(prop.type))]),
+        schema.ast.propertySignatures.map((prop) => [
+          prop.name,
+          Schema.make(mapSchemaTypeForLLM(prop.type, expansions)),
+        ]),
       );
     case 'Void':
       return {};
@@ -311,7 +334,7 @@ export const createStructFieldsFromSchema = (
  * Picks an LLM-friendly schema type for the given schema AST.
  * The picked schema type decodes to the original schema type.
  */
-const mapSchemaTypeForLLM = (ast: SchemaAST.AST): SchemaAST.AST => {
+const mapSchemaTypeForLLM = (ast: SchemaAST.AST, expansions: Map<SchemaAST.AST, SchemaAST.AST>): SchemaAST.AST => {
   if (Ref.isRefType(ast)) {
     // v4's element and property nodes carry their own modifiers, so the wrapper types are gone and
     // the annotations record is optional.
@@ -322,9 +345,27 @@ const mapSchemaTypeForLLM = (ast: SchemaAST.AST): SchemaAST.AST => {
     return SchemaEx.retainContext(ast, RefFromLLM.annotate({ description }).ast);
   }
 
+  // Handled here rather than by `mapAst`, which forces the thunk: a self-referential schema (an
+  // operation whose input embeds JSON Schema, say) would rewrite its own body forever. Rebuilding
+  // lazily and memoizing on the body's identity terminates on the second visit instead, the same way
+  // ECHO's own serializer does.
+  if (SchemaAST.isSuspend(ast)) {
+    const body = ast.thunk();
+    const expand = () => {
+      const cached = expansions.get(body);
+      if (cached) {
+        return cached;
+      }
+      const mapped = mapSchemaTypeForLLM(body, expansions);
+      expansions.set(body, mapped);
+      return mapped;
+    };
+    return new SchemaAST.Suspend(expand, ast.annotations, undefined, ast.encoding, ast.context);
+  }
+
   // `mapAst` carries annotations, checks, encoding and `context` across every rebuilt node; in v4
   // optionality rides on `context`, so rebuilding by hand silently makes an optional key required.
-  return SchemaEx.mapAst(ast, (child) => mapSchemaTypeForLLM(child));
+  return SchemaEx.mapAst(ast, (child) => mapSchemaTypeForLLM(child, expansions));
 };
 
 const isHandlerLike = (value: unknown): value is Toolkit.WithHandler<Record<string, Tool.Any>> => {

--- a/packages/core/echo/echo/src/internal/JsonSchema/json-schema.test.ts
+++ b/packages/core/echo/echo/src/internal/JsonSchema/json-schema.test.ts
@@ -255,10 +255,59 @@ describe('effect-to-json', () => {
   test('serialize circular schema (TypeSchema)', () => {
     const jsonSchema = toJsonSchema(TypeSchema);
     expect(Object.keys(jsonSchema.properties!).length).toBeGreaterThan(0);
-
-    // TODO(dmaretskyi): Currently unable to deserialize.
-    // const effectSchema = toEffectSchema(jsonSchema);
     log('schema', { jsonSchema });
+
+    // A cyclic `$ref` used to recurse until the stack blew, which reached users as a bare
+    // "Maximum call stack size exceeded" from whatever read the persisted schema back.
+    const effectSchema = toEffectSchema(jsonSchema);
+    expect(SchemaAST.isObjects(SchemaAST.toType(effectSchema.ast))).toBe(true);
+  });
+
+  test('deserialize a self-referential schema', () => {
+    interface Node {
+      readonly name: string;
+      readonly children?: readonly Node[];
+    }
+
+    const Node: Schema.Codec<Node> = Schema.Struct({
+      name: Schema.String,
+      children: Schema.optional(Schema.Array(Schema.suspend((): Schema.Codec<Node> => Node))),
+    });
+
+    const jsonSchema = toJsonSchema(Node);
+    const roundTripped = toEffectSchema(jsonSchema);
+
+    // Decoding is what proves the cycle was rebuilt rather than truncated to `Unknown`: a nested
+    // child is validated against the same node schema, so a wrong shape at any depth fails.
+    expect(Schema.decodeUnknownSync(roundTripped)({ name: 'a', children: [{ name: 'b', children: [] }] })).toEqual({
+      name: 'a',
+      children: [{ name: 'b', children: [] }],
+    });
+  });
+
+  test('deserialize a pair of mutually-recursive schemas', () => {
+    interface A {
+      readonly kind: 'a';
+      readonly b?: B;
+    }
+    interface B {
+      readonly kind: 'b';
+      readonly a?: A;
+    }
+    const A: Schema.Codec<A> = Schema.Struct({
+      kind: Schema.Literal('a'),
+      b: Schema.optional(Schema.suspend((): Schema.Codec<B> => B)),
+    });
+    const B: Schema.Codec<B> = Schema.Struct({
+      kind: Schema.Literal('b'),
+      a: Schema.optional(Schema.suspend((): Schema.Codec<A> => A)),
+    });
+
+    const roundTripped = toEffectSchema(toJsonSchema(A));
+    expect(Schema.decodeUnknownSync(roundTripped)({ kind: 'a', b: { kind: 'b', a: { kind: 'a' } } })).toEqual({
+      kind: 'a',
+      b: { kind: 'b', a: { kind: 'a' } },
+    });
   });
 
   test('serialize a pair of mutually-recursive schemas (A embeds B, B embeds A)', () => {

--- a/packages/core/echo/echo/src/internal/JsonSchema/json-schema.ts
+++ b/packages/core/echo/echo/src/internal/JsonSchema/json-schema.ts
@@ -264,7 +264,26 @@ const isEchoReferenceNode = (node: JsonSchemaType): boolean =>
   ('$ref' in node && node.$ref === JSON_SCHEMA_ECHO_REF_ID) ||
   ('$id' in node && decodeURIComponent(node.$id as string) === JSON_SCHEMA_ECHO_REF_ID);
 
-export const toEffectSchema = (root: JsonSchemaType, _defs?: JsonSchemaType['$defs']): Schema.Codec<any, any> => {
+/**
+ * A definition being rebuilt, or already rebuilt, within one {@link toEffectSchema} call.
+ *
+ * The cell is published to the cache *before* its body is built so that a `$ref` re-entering the
+ * definition it is nested in finds it in flight; `schema` is filled in once the body completes.
+ */
+type DefinitionCell = { schema?: Schema.Codec<any, any> };
+
+export const toEffectSchema = (root: JsonSchemaType, _defs?: JsonSchemaType['$defs']): Schema.Codec<any, any> =>
+  toEffectSchemaRec(root, _defs, new Map());
+
+/**
+ * @param definitions Definitions rebuilt so far, keyed by `$defs` name, shared across the whole
+ * conversion so that a cyclic `$ref` resolves to a lazy reference rather than recursing forever.
+ */
+const toEffectSchemaRec = (
+  root: JsonSchemaType,
+  _defs: JsonSchemaType['$defs'] | undefined,
+  definitions: Map<string, DefinitionCell>,
+): Schema.Codec<any, any> => {
   const defs = root.$defs ? { ..._defs, ...root.$defs } : (_defs ?? {});
 
   // Tested before the generic object branch: a reference structurally *is* an object, so one that
@@ -273,7 +292,7 @@ export const toEffectSchema = (root: JsonSchemaType, _defs?: JsonSchemaType['$de
   // reference semantics.
   const isReference = isEchoReferenceNode(root);
   if (!isReference && 'type' in root && root.type === 'object') {
-    return objectToEffectSchema(root, defs);
+    return objectToEffectSchema(root, defs, definitions);
   }
 
   let result: Schema.Codec<any, any> = Schema.Unknown;
@@ -300,12 +319,12 @@ export const toEffectSchema = (root: JsonSchemaType, _defs?: JsonSchemaType['$de
   } else if ('enum' in root) {
     result = Schema.Union(root.enum!.map((e) => Schema.Literal(e)));
   } else if ('oneOf' in root) {
-    result = Schema.Union(root.oneOf!.map((v) => toEffectSchema(v, defs)));
+    result = Schema.Union(root.oneOf!.map((v) => toEffectSchemaRec(v, defs, definitions)));
   } else if ('anyOf' in root) {
-    result = Schema.Union(root.anyOf!.map((v) => toEffectSchema(v, defs)));
+    result = Schema.Union(root.anyOf!.map((v) => toEffectSchemaRec(v, defs, definitions)));
   } else if ('allOf' in root) {
     if (root.allOf!.length === 1) {
-      result = toEffectSchema(root.allOf![0], defs);
+      result = toEffectSchemaRec(root.allOf![0], defs, definitions);
     } else {
       log.warn('allOf with multiple schemas is not supported');
       result = Schema.Unknown;
@@ -334,7 +353,7 @@ export const toEffectSchema = (root: JsonSchemaType, _defs?: JsonSchemaType['$de
         if (Array.isArray(root.items)) {
           const [required, optional] = Function.pipe(
             root.items,
-            Array.map((v) => toEffectSchema(v as JsonSchemaType, defs)),
+            Array.map((v) => toEffectSchemaRec(v as JsonSchemaType, defs, definitions)),
             Array.splitAt(root.minItems ?? root.items.length),
           );
           result = Schema.Tuple([...required, ...optional.map(Schema.optionalKey)]);
@@ -344,8 +363,8 @@ export const toEffectSchema = (root: JsonSchemaType, _defs?: JsonSchemaType['$de
         } else {
           const items = root.items;
           result = Array.isArray(items)
-            ? Schema.Tuple(items.map((v) => toEffectSchema(v as JsonSchemaType, defs)))
-            : Schema.Array(toEffectSchema(items as JsonSchemaType, defs));
+            ? Schema.Tuple(items.map((v) => toEffectSchemaRec(v as JsonSchemaType, defs, definitions)))
+            : Schema.Array(toEffectSchemaRec(items as JsonSchemaType, defs, definitions));
         }
         break;
       }
@@ -356,11 +375,23 @@ export const toEffectSchema = (root: JsonSchemaType, _defs?: JsonSchemaType['$de
     }
   } else if ('$ref' in root) {
     const refSegments = root.$ref!.split('/');
-    const jsonSchema = defs[refSegments[refSegments.length - 1]];
-    invariant(jsonSchema, `missing definition for ${root.$ref}`);
-    result = toEffectSchema(jsonSchema, defs).pipe(
-      Schema.annotate({ identifier: refSegments[refSegments.length - 1] }),
-    );
+    const name = refSegments[refSegments.length - 1];
+    const cell = definitions.get(name);
+    if (cell) {
+      // A definition already seen: `Schema.suspend` defers the lookup, which both terminates a cycle
+      // (the cell is still in flight, so its body cannot be read yet) and shares one node between
+      // every reference to it.
+      result = Schema.suspend(() => cell.schema ?? raise(new Error(`unresolved definition: ${name}`))).pipe(
+        Schema.annotate({ identifier: name }),
+      );
+    } else {
+      const jsonSchema = defs[name];
+      invariant(jsonSchema, `missing definition for ${root.$ref}`);
+      const pending: DefinitionCell = {};
+      definitions.set(name, pending);
+      pending.schema = toEffectSchemaRec(jsonSchema, defs, definitions).pipe(Schema.annotate({ identifier: name }));
+      result = pending.schema;
+    }
   }
 
   const annotations = jsonSchemaFieldsToAnnotations(root);
@@ -374,7 +405,11 @@ export const toEffectSchema = (root: JsonSchemaType, _defs?: JsonSchemaType['$de
   return result;
 };
 
-const objectToEffectSchema = (root: JsonSchemaType, defs: JsonSchemaType['$defs']): Schema.Codec<any, any> => {
+const objectToEffectSchema = (
+  root: JsonSchemaType,
+  defs: JsonSchemaType['$defs'],
+  definitions: Map<string, DefinitionCell>,
+): Schema.Codec<any, any> => {
   invariant('type' in root && root.type === 'object', `not an object: ${root}`);
 
   const echoRefinement: JsonSchemaEchoAnnotations = (root as any)[ECHO_ANNOTATIONS_NS_DEPRECATED_KEY];
@@ -386,14 +421,14 @@ const objectToEffectSchema = (root: JsonSchemaType, defs: JsonSchemaType['$defs'
   let immutableIdField: Schema.Codec<any, any> | undefined;
   for (const [key, value] of propertyList) {
     if (isEchoObject && key === 'id') {
-      immutableIdField = toEffectSchema(value, defs);
+      immutableIdField = toEffectSchemaRec(value, defs, definitions);
     } else {
       // TODO(burdon): Mutable cast.
       // `optionalKey`, not `optional`: the latter unions the value with `undefined`, which would put
       // every annotation one level below `PropertySignature.type` where the readers look for it.
       (fields as any)[key] = root.required?.includes(key)
-        ? toEffectSchema(value, defs)
-        : Schema.optionalKey(toEffectSchema(value, defs));
+        ? toEffectSchemaRec(value, defs, definitions)
+        : Schema.optionalKey(toEffectSchemaRec(value, defs, definitions));
     }
   }
 
@@ -416,7 +451,7 @@ const objectToEffectSchema = (root: JsonSchemaType, defs: JsonSchemaType['$defs'
       'only one pattern property is supported',
     );
 
-    schema = Schema.Record(Schema.String, toEffectSchema(root.patternProperties[''], defs));
+    schema = Schema.Record(Schema.String, toEffectSchemaRec(root.patternProperties[''], defs, definitions));
   } else if (
     root.additionalProperties !== true &&
     (typeof root.additionalProperties !== 'object' || root.additionalProperties === null)
@@ -428,7 +463,7 @@ const objectToEffectSchema = (root: JsonSchemaType, defs: JsonSchemaType['$defs'
     const indexValue =
       root.additionalProperties === true
         ? Schema.Any
-        : toEffectSchema(root.additionalProperties as JsonSchemaType, defs);
+        : toEffectSchemaRec(root.additionalProperties as JsonSchemaType, defs, definitions);
     if (propertyList.length > 0) {
       // v4 spells "struct plus an index signature" as `StructWithRest`.
       schema = Schema.StructWithRest(Schema.Struct(structFields), [Schema.Record(Schema.String, indexValue)]);


### PR DESCRIPTION
Fixes the composer e2e failure in [run 32446159816](https://github.com/dxos/dxos/actions/runs/32446159816): `chat.spec.ts › sends a message and receives a response` failed on chromium, firefox **and** webkit with `request failed: AI service error / An unexpected error occurred.`

## Diagnosis

The toast text is generic, so the cause came from the Playwright trace attached to the chromium job:

```
request failed RangeError: Maximum call stack size exceeded
    at ProxyHandlerSlot.get
    at Proxy.map
    at toEffectSchema$1
    at objectToEffectSchema
    at toEffectSchema$1
    …
    at AiSession.createRequest
```

Not an outage: the chat's own name-generation round trip succeeded in the same session (`chat name updated { newName: 'Clear Sky Blue' }`), so the AI service was reachable. The request died while building the toolkit.

`makeToolResolverFromOperations` falls back to the operation registry for any tool id the in-process toolkit does not carry, and `plugin-routine`'s registry sync persists **every** plugin operation handler there via `Operation.serialize`. A cyclic schema serializes as `$defs` plus a `$ref` into them — which is exactly what `JsonSchemaType` itself emits (its `$defs` include `jsonSchema` and `dependency`, the two names the `strict` path in `toJsonSchema` already strips as a workaround). Three stages of the read-back path could not represent that shape:

1. **`JsonSchema.toEffectSchema`** resolved a `$ref` by recursing into its definition with no cycle guard, so a cyclic definition recursed until the stack blew. This is the `TODO(dmaretskyi): Currently unable to deserialize` on the existing `serialize circular schema (TypeSchema)` test.
2. **`mapSchemaTypeForLLM`** (the LLM-facing tool projection) delegated `Suspend` to `SchemaEx.mapAst`, which forces the thunk — so once (1) was fixed, the same walk recursed forever one layer up.
3. **`toModelJsonSchema`** kept only `Schema.toJsonSchemaDocument(...).schema` and dropped `definitions`, so the model would have been shown a dangling `$ref`.

## Changes

- `toEffectSchema` publishes each `$defs` entry to a per-conversion cache *before* building its body, and closes a re-entrant `$ref` with `Schema.suspend`. The cache also shares one node between every reference to a definition.
- `mapSchemaTypeForLLM` handles `Suspend` itself: it rebuilds the body lazily and memoizes on node identity, the same technique `withEchoRefinements` already uses on the serialize side.
- `toModelJsonSchema` carries the document's definitions over as `$defs`.
- `makeToolResolverFromOperations` reports a record it cannot rebuild as `AiToolNotFoundError` (with a warning) instead of throwing, so one bad operation drops one tool rather than failing the whole request — matching how an unresolvable tool id is already handled.

## Tests

New, and each one fails on `main`:

- `echo`: `serialize circular schema (TypeSchema)` now deserializes (TODO removed); `deserialize a self-referential schema` and `deserialize a pair of mutually-recursive schemas` decode a nested value, which proves the cycle was rebuilt rather than truncated to `Unknown`.
- `assistant`: `an operation with a recursive input schema survives the registry round trip` drives `serialize → deserialize → projectFunctionToTool` and asserts every `$ref` the model is shown names a present definition.

```
echo:test        Tests  575 passed | 9 skipped (584)
assistant:test   Tests   54 passed | 5 skipped (59)
compute:test      56 passed · schema:test 51 passed · mcp-server:test 52 passed
conductor:test    31 passed · react-ui-table:test 21 passed
echo:lint / assistant:lint clean · pnpm format applied
```

## Not addressed

The same run also failed `collaboration.spec.ts › guest joins host's space` on **webkit only**, through all three retries (`space invitation never reached the auth-code step`). That is the tracked production-edge two-peer stall (DX-1152) the suite already documents, retries for, and deliberately keeps enabled as a sensor; the sibling test that performs the same invitation passed on webkit in the same run. No change made there.

I also did not identify the specific registry operation whose schema is cyclic — the trace does not name it, and enumerating the app's operation set needs the whole plugin graph activated. The fix is at the boundary and covers the class, and the last bullet above bounds the blast radius if another unrepresentable record shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvDB8qpHsRe76Xgh7YF4QD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvDB8qpHsRe76Xgh7YF4QD)_