### PR TITLE
worker-framework: add manually-run Playwright worker stress suite

### DIFF
--- a/packages/sdk/worker-framework/moon.yml
+++ b/packages/sdk/worker-framework/moon.yml
@@ -7,3 +7,15 @@ tags:
   - ts-test-storybook
   - pack
   - storybook
+tasks:
+  # Manually-run stress suite (`src/playwright/worker-stress.spec.ts`) — real Chromium, real tabs,
+  # real dedicated + shared workers. Its own task rather than the `e2e` tag so it never gates a PR:
+  # it deliberately wedges workers and waits out stale-timeout-driven failover, so a run takes
+  # minutes. Not cacheable — the point is to re-provoke the races, not to replay a verdict.
+  e2e-stress:
+    command: pnpm exec playwright test --config=src/playwright/playwright-stress.config.ts
+    options:
+      cache: false
+      outputStyle: stream
+    deps:
+      - ^:build

--- a/packages/sdk/worker-framework/package.json
+++ b/packages/sdk/worker-framework/package.json
@@ -61,8 +61,11 @@
   },
   "devDependencies": {
     "@dxos/effect": "workspace:*",
+    "@dxos/node-std": "workspace:*",
     "@dxos/react-ui": "workspace:*",
+    "@dxos/test-utils": "workspace:*",
     "@dxos/ui-theme": "workspace:*",
+    "@playwright/test": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/packages/sdk/worker-framework/src/playwright/README.md
+++ b/packages/sdk/worker-framework/src/playwright/README.md
@@ -1,0 +1,67 @@
+# worker-framework stress suite
+
+Manually-run stress tests for the worker framework. Real Chromium, real tabs, a real dedicated
+worker, and a real SharedWorker coordinator — Playwright runs in Node and drives the browser from
+the outside, which is what the package's in-page browser tests (`src/stories/counter.browser.test.ts`)
+cannot do: those exercise a real worker, but every client lives in one tab.
+
+```bash
+moon run worker-framework:e2e-stress
+```
+
+Deliberately **not** part of `check`: the suite wedges workers on purpose and waits out
+stale-timeout-driven failover, so a run takes minutes.
+
+## What it does
+
+Both tests throw disruptive commands at the worker and then assert the system converged back:
+
+- `recovers after every individual command` — one command per iteration against a known-good fleet,
+  so a failure names the culprit.
+- `survives a randomised storm…` — a seeded random walk, which is where command _interactions_ show
+  up.
+
+Commands (`stress-commands.ts`):
+
+| Command | What it provokes |
+| --- | --- |
+| `open-tab` / `close-tab` | Ordinary follower churn. |
+| `reload-tab` | Tab loses its client identity; if it was the leader, failover. |
+| `close-all-tabs-and-open-new` | Whole system torn down (worker + coordinator) and rebuilt. |
+| `hang-worker` | Worker event loop starved for 8s — RPCs queue behind a busy spin. |
+| `block-leader-main-thread` | Leader's heartbeat starved; its worker keeps serving, so nothing should move. |
+| `block-leader-main-thread-and-open-tab` | The lock-steal path: the joining tab times out on `provide-port`, judges the leader stale, and steals. |
+| `hang-worker-forever-and-recycle-tabs` | Atomic: worker wedged in an unbreakable loop, then every tab that could observe it destroyed before it yields. |
+| `increment-counter` | Ordinary traffic; allowed to fail mid-storm. |
+
+## The recovery assertions
+
+`stress-recovery.ts`, run at the end (and after every command in the scripted test):
+
+1. At least one tab is open.
+2. Every tab reaches `connected`.
+3. Every tab reports the **same `workerId`** — the framework's per-worker liveness lock key, so this
+   rules out a split brain of two live workers rather than merely two workers agreeing on a count.
+4. Every tab agrees on the leader.
+5. The worker answers a `ping` from every tab — a wedged worker still holding the lock hangs here.
+6. A write through one tab reaches every other tab's subscription.
+
+## Knobs
+
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `DX_STRESS_SEED` | `1` | RNG seed. A failure prints its seed; re-run with it to replay exactly. |
+| `DX_STRESS_ITERATIONS` | `30` | Commands in the random walk. Raise for a soak. |
+| `DX_STRESS_TABS` | `2` | Tabs the random walk starts with. |
+
+## Layout
+
+- `harness/` — the page under test: `index.html`, `main.ts`, and `stress-harness.ts`, which installs
+  `window.__workerStress` (status / increment / ping / hang-worker / block-main-thread). Served by a
+  minimal Vite dev server (`harness/vite.config.ts`), not Storybook — the page needs no React or
+  design-system assets.
+- `stress-fleet.ts` — `StressTab` and `StressFleet`. All tabs share **one** `BrowserContext`: Web
+  Locks and the SharedWorker coordinator are scoped per context+origin, so tabs in separate contexts
+  would each get their own worker and the suite would assert nothing.
+- `stress-commands.ts` — the command catalogue and the seeded RNG.
+- `stress-recovery.ts` — the assertions above.

--- a/packages/sdk/worker-framework/src/playwright/harness/index.html
+++ b/packages/sdk/worker-framework/src/playwright/harness/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>worker-framework stress harness</title>
+  </head>
+  <body>
+    <pre id="status">connecting…</pre>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/sdk/worker-framework/src/playwright/harness/main.ts
+++ b/packages/sdk/worker-framework/src/playwright/harness/main.ts
@@ -1,0 +1,18 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { installStressHarness } from './stress-harness';
+
+const STATUS_POLL_MS = 250;
+
+installStressHarness();
+
+// Human aid for driving the harness by hand; the Playwright driver reads `window.__workerStress`,
+// never this element.
+const status = document.getElementById('status');
+setInterval(() => {
+  if (status) {
+    status.textContent = JSON.stringify(window.__workerStress?.status() ?? {}, null, 2);
+  }
+}, STATUS_POLL_MS);

--- a/packages/sdk/worker-framework/src/playwright/harness/stress-harness.ts
+++ b/packages/sdk/worker-framework/src/playwright/harness/stress-harness.ts
@@ -1,0 +1,132 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { CounterConnection, type CounterSessionInfo } from '../../stories/counter-connection';
+
+/**
+ * Snapshot of one tab's view of the shared worker. Every field is structured-clonable so the
+ * Playwright driver can read it straight out of `page.evaluate`.
+ */
+export type StressStatus = {
+  /** True once the connection has opened and an RPC client exists. */
+  connected: boolean;
+  clientId: string | undefined;
+  /** Worker INSTANCE identity — equal across tabs iff they share one worker. */
+  workerId: string | undefined;
+  leaderId: string | undefined;
+  isOwner: boolean;
+  /** Last counter value pushed by the worker's `subscribe` stream. */
+  count: number | undefined;
+  /** Times this tab failed over to a freshly elected leader. */
+  reconnectCount: number;
+  /** Errors this tab observed, for post-mortem reporting on a failed run. */
+  errors: string[];
+};
+
+/**
+ * Imperative surface the stress driver calls from Node over CDP. Kept free of Promises that outlive
+ * a command (`hangWorker`/`blockMainThread` are fire-and-forget) so a hung worker cannot also hang
+ * the driver.
+ */
+export type StressHarness = {
+  status: () => StressStatus;
+  increment: () => Promise<number>;
+  /** Round-trip time in ms; rejects if the worker is unreachable. */
+  ping: () => Promise<number>;
+  /** Spins the WORKER event loop for `durationMs`. Returns immediately. */
+  hangWorker: (durationMs: number) => void;
+  /** Spins this TAB's main thread for `durationMs`, starving the leader heartbeat. Returns immediately. */
+  blockMainThread: (durationMs: number) => void;
+};
+
+declare global {
+  interface Window {
+    __workerStress?: StressHarness;
+  }
+}
+
+const asMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+/**
+ * Installs {@link StressHarness} on `window` for the lifetime of one page load. Returns a disposer
+ * so the mounting story tears the connection down on unmount.
+ */
+export const installStressHarness = (): (() => Promise<void>) => {
+  const connection = new CounterConnection();
+  const state = {
+    connected: false,
+    session: undefined as CounterSessionInfo | undefined,
+    count: undefined as number | undefined,
+    reconnectCount: 0,
+    errors: [] as string[],
+  };
+
+  const recordError = (err: unknown) => {
+    state.errors.push(asMessage(err));
+  };
+
+  const unsubscribeSession = connection.sessionChanged.on((session) => {
+    state.session = session;
+  });
+
+  let unsubscribeCounter: (() => Promise<void>) | undefined;
+  const resubscribe = async () => {
+    await unsubscribeCounter?.();
+    unsubscribeCounter = connection.subscribe((value) => {
+      state.count = value;
+    });
+  };
+
+  const unsubscribeReconnect = connection.reconnected.on(async () => {
+    state.reconnectCount += 1;
+    // The old session's stream died with its worker, so the tab is only genuinely recovered once a
+    // subscription exists on the new one.
+    await resubscribe().catch(recordError);
+  });
+
+  const opened = connection
+    .open()
+    .then(async () => {
+      await resubscribe();
+      state.connected = true;
+    })
+    .catch(recordError);
+
+  window.__workerStress = {
+    status: () => ({
+      connected: state.connected,
+      clientId: state.session?.clientId,
+      workerId: state.session?.workerId,
+      leaderId: state.session?.leaderId,
+      isOwner: state.session?.isOwner ?? false,
+      count: state.count,
+      reconnectCount: state.reconnectCount,
+      errors: [...state.errors],
+    }),
+    increment: () => connection.increment(),
+    ping: async () => (await connection.ping()).rttMs,
+    hangWorker: (durationMs) => {
+      void connection.blockCpu(durationMs).catch(recordError);
+    },
+    blockMainThread: (durationMs) => {
+      // Deferred to a macrotask so the driver's `evaluate` round-trip completes before the thread
+      // stops answering — otherwise the command itself times out instead of the tab going dark.
+      setTimeout(() => {
+        const end = Date.now() + durationMs;
+        while (Date.now() < end) {
+          // Busy spin — starves this tab's leader heartbeat so peers judge it stale.
+        }
+      }, 0);
+    },
+  };
+
+  return async () => {
+    delete window.__workerStress;
+    unsubscribeSession();
+    unsubscribeReconnect();
+    await opened;
+    await unsubscribeCounter?.();
+    await connection.close();
+  };
+};

--- a/packages/sdk/worker-framework/src/playwright/harness/vite.config.ts
+++ b/packages/sdk/worker-framework/src/playwright/harness/vite.config.ts
@@ -1,0 +1,55 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Plugin, defineConfig } from 'vite';
+
+import PluginImportSource from '@dxos/vite-plugin-import-source';
+
+// Node built-ins that `@dxos/node-std` actually implements for the browser. Duplicated from the
+// workspace vite config rather than imported: that config is a vitest config factory, and loading it
+// here would pull the whole test harness into a plain dev server.
+const NODE_STD_MODULES = [
+  'fs/promises',
+  'assert',
+  'buffer',
+  'crypto',
+  'events',
+  'fs',
+  'path',
+  'process',
+  'stream',
+  'util',
+];
+
+/**
+ * Redirects node built-ins to their `@dxos/node-std` browser equivalents. Without it vite
+ * externalizes them to a stub and the harness dies on first use (`@dxos/util` imports `node:util`).
+ */
+const nodeStdResolvePlugin = (): Plugin => ({
+  name: 'node-std',
+  resolveId: {
+    order: 'pre',
+    async handler(source, importer, options) {
+      const moduleName = source.startsWith('node:') ? source.slice('node:'.length) : source;
+      if (NODE_STD_MODULES.includes(moduleName)) {
+        return this.resolve(`@dxos/node-std/${moduleName}`, importer, options);
+      }
+    },
+  },
+});
+
+/**
+ * Minimal dev server for the stress harness page. Deliberately NOT Storybook: the harness needs no
+ * React, theme, or design-system assets, and Storybook's static-asset preset requires unrelated
+ * packages' build output — a heavy prerequisite for a page that is one `<pre>` and a module script.
+ */
+export default defineConfig({
+  root: import.meta.dirname,
+  plugins: [
+    nodeStdResolvePlugin(),
+    // Resolve `@dxos/*` to their `source` export so the suite exercises src, not stale `dist/`.
+    PluginImportSource({ include: ['@dxos/**', '#*'] }),
+  ],
+  server: { strictPort: true },
+});

--- a/packages/sdk/worker-framework/src/playwright/playwright-stress.config.ts
+++ b/packages/sdk/worker-framework/src/playwright/playwright-stress.config.ts
@@ -3,6 +3,7 @@
 //
 
 import { defineConfig } from '@playwright/test';
+import { resolve } from 'node:path';
 
 import { e2ePreset } from '@dxos/test-utils/playwright';
 
@@ -19,6 +20,12 @@ export default defineConfig({
   ...preset,
   webServer: {
     command: `pnpm exec vite dev --config src/playwright/harness/vite.config.ts --port ${HARNESS_PORT}`,
+    // Playwright defaults `cwd` to the config's own directory, which is two levels below the package
+    // root the command's paths are written against.
+    cwd: resolve(import.meta.dirname, '../..'),
+    // Above Playwright's 60s default: the first launch of a run pays vite's cold dependency
+    // optimization, which a loaded machine can drag out past a minute.
+    timeout: 180_000,
     // Probed by url, not port: vite binds the socket before it can serve, and a bare TCP probe
     // satisfied in that gap hands the first test an ERR_CONNECTION_REFUSED.
     url: `http://localhost:${HARNESS_PORT}`,

--- a/packages/sdk/worker-framework/src/playwright/playwright-stress.config.ts
+++ b/packages/sdk/worker-framework/src/playwright/playwright-stress.config.ts
@@ -1,0 +1,36 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { defineConfig } from '@playwright/test';
+
+import { e2ePreset } from '@dxos/test-utils/playwright';
+
+import { HARNESS_PORT } from './stress-harness-server';
+
+const preset = e2ePreset(import.meta.dirname);
+
+/**
+ * Manually-run stress suite. Its own config (and its own moon task, `e2e-stress`) rather than the
+ * shared `e2e` tag: the suite deliberately wedges workers and recycles tabs, so a run takes minutes
+ * and is not something a PR should gate on.
+ */
+export default defineConfig({
+  ...preset,
+  webServer: {
+    command: `pnpm exec vite dev --config src/playwright/harness/vite.config.ts --port ${HARNESS_PORT}`,
+    // Probed by url, not port: vite binds the socket before it can serve, and a bare TCP probe
+    // satisfied in that gap hands the first test an ERR_CONNECTION_REFUSED.
+    url: `http://localhost:${HARNESS_PORT}`,
+    reuseExistingServer: false,
+  },
+  // Chromium only: the suite turns on Web Locks steal semantics, SharedWorker, and timing-sensitive
+  // failover — the other engines would each need their own budgets to mean anything.
+  projects: preset.projects?.filter((project) => project.name === 'chromium'),
+  // Every test drives one shared browser context full of tabs; two in parallel would elect leaders
+  // against each other.
+  workers: 1,
+  fullyParallel: false,
+  // Per-test budgets are set in the spec (`test.setTimeout`), sized from the iteration count.
+  timeout: 600_000,
+});

--- a/packages/sdk/worker-framework/src/playwright/stress-commands.ts
+++ b/packages/sdk/worker-framework/src/playwright/stress-commands.ts
@@ -2,6 +2,8 @@
 // Copyright 2026 DXOS.org
 //
 
+import { invariant } from '@dxos/invariant';
+
 import { HANG_FOREVER_MS, type StressFleet, type StressTab } from './stress-fleet';
 
 /** Bounded worker hang, long enough to outlast the leader stale timeout (5s) it is meant to provoke. */
@@ -25,8 +27,12 @@ export type StressCommand = {
   readonly run: (ctx: StressCommandContext) => Promise<void>;
 };
 
-const pick = <T>({ random }: StressCommandContext, items: readonly T[]): T =>
-  items[Math.floor(random() * items.length)];
+const pick = <T>({ random }: StressCommandContext, items: readonly T[]): T => {
+  // Asserted rather than encoded in the `T` return type alone: a future command that forgets its
+  // `enabled` guard would otherwise get `undefined` typed as `T` and fail somewhere unrelated.
+  invariant(items.length > 0, 'cannot pick from an empty list');
+  return items[Math.floor(random() * items.length)];
+};
 
 const pickTab = (ctx: StressCommandContext): StressTab => pick(ctx, ctx.fleet.tabs);
 
@@ -95,7 +101,9 @@ export const STRESS_COMMANDS: readonly StressCommand[] = [
     // steals. Blocking the leader alone provokes nothing while its worker keeps serving existing
     // tabs, which is why the two halves are one command.
     name: 'block-leader-main-thread-and-open-tab',
-    enabled: ({ fleet }) => fleet.tabs.length > 0,
+    // Bounded by MAX_TABS like `open-tab`: this command grows the fleet too, so without the ceiling
+    // a long soak walks past it.
+    enabled: ({ fleet }) => fleet.tabs.length > 0 && fleet.tabs.length < MAX_TABS,
     run: async (ctx) => {
       const leader = (await ctx.fleet.findLeader()) ?? pickTab(ctx);
       await leader.blockMainThread(BLOCK_MAIN_THREAD_MS);

--- a/packages/sdk/worker-framework/src/playwright/stress-commands.ts
+++ b/packages/sdk/worker-framework/src/playwright/stress-commands.ts
@@ -1,0 +1,154 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { HANG_FOREVER_MS, type StressFleet, type StressTab } from './stress-fleet';
+
+/** Bounded worker hang, long enough to outlast the leader stale timeout (5s) it is meant to provoke. */
+const HANG_WORKER_MS = 8_000;
+/** Bounded main-thread block, long enough for a peer to judge this leader stale and steal the lock. */
+const BLOCK_MAIN_THREAD_MS = 8_000;
+/** Ceiling on concurrently open tabs, so a random walk cannot exhaust the container's memory. */
+const MAX_TABS = 5;
+
+export type StressCommandContext = {
+  readonly fleet: StressFleet;
+  /** Deterministic RNG, seeded per run so a failure is replayable from its seed. */
+  readonly random: () => number;
+  readonly log: (message: string) => void;
+};
+
+export type StressCommand = {
+  readonly name: string;
+  /** Skipped when it cannot apply (e.g. closing a tab with none open). */
+  readonly enabled?: (ctx: StressCommandContext) => boolean;
+  readonly run: (ctx: StressCommandContext) => Promise<void>;
+};
+
+const pick = <T>({ random }: StressCommandContext, items: readonly T[]): T =>
+  items[Math.floor(random() * items.length)];
+
+const pickTab = (ctx: StressCommandContext): StressTab => pick(ctx, ctx.fleet.tabs);
+
+/**
+ * Everything the suite throws at the worker. Each command leaves the system in a state the recovery
+ * assertions must be able to reach from — no command is allowed to be unrecoverable by design.
+ */
+export const STRESS_COMMANDS: readonly StressCommand[] = [
+  {
+    name: 'open-tab',
+    enabled: ({ fleet }) => fleet.tabs.length < MAX_TABS,
+    run: async ({ fleet, log }) => {
+      const tab = await fleet.openTab();
+      log(`opened ${tab.label}`);
+    },
+  },
+  {
+    name: 'close-tab',
+    // Never the last tab: closing every tab is its own command, and doing it here would leave the
+    // walk with nothing to act on for the rest of the run.
+    enabled: ({ fleet }) => fleet.tabs.length > 1,
+    run: async (ctx) => {
+      const tab = pickTab(ctx);
+      await ctx.fleet.closeTab(tab);
+      ctx.log(`closed ${tab.label}`);
+    },
+  },
+  {
+    name: 'reload-tab',
+    enabled: ({ fleet }) => fleet.tabs.length > 0,
+    run: async (ctx) => {
+      const tab = pickTab(ctx);
+      await tab.reload();
+      ctx.log(`reloaded ${tab.label}`);
+    },
+  },
+  {
+    name: 'close-all-tabs-and-open-new',
+    run: async ({ fleet, log }) => {
+      await fleet.closeAllTabs();
+      const tab = await fleet.openTabWithoutWaiting();
+      log(`recycled all tabs into ${tab.label}`);
+    },
+  },
+  {
+    name: 'hang-worker',
+    enabled: ({ fleet }) => fleet.tabs.length > 0,
+    run: async (ctx) => {
+      const tab = pickTab(ctx);
+      await tab.hangWorker(HANG_WORKER_MS);
+      ctx.log(`hung worker for ${HANG_WORKER_MS}ms via ${tab.label}`);
+    },
+  },
+  {
+    name: 'block-leader-main-thread',
+    enabled: ({ fleet }) => fleet.tabs.length > 1,
+    run: async (ctx) => {
+      const leader = (await ctx.fleet.findLeader()) ?? pickTab(ctx);
+      await leader.blockMainThread(BLOCK_MAIN_THREAD_MS);
+      ctx.log(`blocked main thread of ${leader.label} for ${BLOCK_MAIN_THREAD_MS}ms`);
+    },
+  },
+  {
+    // The steal path proper: a wedged leader still holds the lock, and the joining tab is the only
+    // party that notices — it times out waiting for `provide-port`, judges the leader stale, and
+    // steals. Blocking the leader alone provokes nothing while its worker keeps serving existing
+    // tabs, which is why the two halves are one command.
+    name: 'block-leader-main-thread-and-open-tab',
+    enabled: ({ fleet }) => fleet.tabs.length > 0,
+    run: async (ctx) => {
+      const leader = (await ctx.fleet.findLeader()) ?? pickTab(ctx);
+      await leader.blockMainThread(BLOCK_MAIN_THREAD_MS);
+      const joiner = await ctx.fleet.openTabWithoutWaiting();
+      ctx.log(`blocked leader ${leader.label} for ${BLOCK_MAIN_THREAD_MS}ms, then opened ${joiner.label}`);
+    },
+  },
+  {
+    // The nastiest one, and the reason the two halves are a single command: a worker wedged in an
+    // unbreakable busy loop, then every tab that could observe it destroyed before it yields. The
+    // replacement tab must elect itself, spawn a new worker, and displace the old one's storage lock.
+    name: 'hang-worker-forever-and-recycle-tabs',
+    enabled: ({ fleet }) => fleet.tabs.length > 0,
+    run: async (ctx) => {
+      const tab = pickTab(ctx);
+      await tab.hangWorker(HANG_FOREVER_MS);
+      await ctx.fleet.closeAllTabs();
+      const replacement = await ctx.fleet.openTabWithoutWaiting();
+      ctx.log(`hung worker forever via ${tab.label}, recycled tabs into ${replacement.label}`);
+    },
+  },
+  {
+    name: 'increment-counter',
+    enabled: ({ fleet }) => fleet.tabs.length > 0,
+    run: async (ctx) => {
+      const tab = pickTab(ctx);
+      // A wedged worker never answers, and that is a legal state mid-storm — the recovery phase, not
+      // this command, decides whether the system came back.
+      const value = await tab.increment().catch((err) => `failed (${err.message})`);
+      ctx.log(`increment via ${tab.label} -> ${value}`);
+    },
+  },
+];
+
+/** Small, deterministic PRNG (mulberry32) so a run is replayable from its seed alone. */
+export const seededRandom = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+/** Runs one random applicable command. Returns its name, or undefined if none applied. */
+export const runRandomCommand = async (ctx: StressCommandContext): Promise<string | undefined> => {
+  const applicable = STRESS_COMMANDS.filter((command) => command.enabled?.(ctx) ?? true);
+  if (applicable.length === 0) {
+    return undefined;
+  }
+  const command = pick(ctx, applicable);
+  await command.run(ctx);
+  return command.name;
+};

--- a/packages/sdk/worker-framework/src/playwright/stress-fleet.ts
+++ b/packages/sdk/worker-framework/src/playwright/stress-fleet.ts
@@ -1,0 +1,136 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type BrowserContext, type Page } from '@playwright/test';
+
+import type { StressStatus } from './harness/stress-harness';
+
+/**
+ * How long a tab may take to reach `connected`. Generous: leader election, worker spawn, and (on the
+ * first load of a run) vite's on-demand dependency optimization all happen inside this budget.
+ */
+const CONNECT_TIMEOUT_MS = 60_000;
+
+const HARNESS_POLL_MS = 100;
+
+/**
+ * Duration passed to `hangWorker` for a hang the worker never returns from. Declared here rather
+ * than beside the harness: this module is loaded in Node by the spec, and the harness module pulls
+ * in the browser-only connection.
+ */
+export const HANG_FOREVER_MS = 1e12;
+
+/**
+ * One real browser tab running the stress harness story. Every accessor goes through
+ * `window.__workerStress` rather than the DOM, so the assertions read framework state instead of
+ * rendered text.
+ */
+export class StressTab {
+  constructor(
+    readonly label: string,
+    readonly page: Page,
+  ) {}
+
+  get closed(): boolean {
+    return this.page.isClosed();
+  }
+
+  status = (): Promise<StressStatus | undefined> =>
+    this.page.evaluate(() => globalThis.window.__workerStress?.status());
+
+  /** Waits for the harness to install and its connection to open. */
+  waitConnected = async (timeout = CONNECT_TIMEOUT_MS): Promise<void> => {
+    await this.page.waitForFunction(() => globalThis.window.__workerStress?.status().connected === true, undefined, {
+      timeout,
+      polling: HARNESS_POLL_MS,
+    });
+  };
+
+  increment = (): Promise<number> => this.page.evaluate(() => globalThis.window.__workerStress!.increment());
+
+  ping = (): Promise<number> => this.page.evaluate(() => globalThis.window.__workerStress!.ping());
+
+  /** Fire-and-forget: the RPC may never resolve, which is the point. */
+  hangWorker = (durationMs: number): Promise<void> =>
+    this.page.evaluate((ms) => globalThis.window.__workerStress!.hangWorker(ms), durationMs);
+
+  /** Fire-and-forget: starves this tab's leader heartbeat so peers judge it stale and steal the lock. */
+  blockMainThread = (durationMs: number): Promise<void> =>
+    this.page.evaluate((ms) => globalThis.window.__workerStress!.blockMainThread(ms), durationMs);
+
+  reload = async (): Promise<void> => {
+    await this.page.reload({ waitUntil: 'domcontentloaded' });
+  };
+
+  close = async (): Promise<void> => {
+    if (!this.page.isClosed()) {
+      await this.page.close({ runBeforeUnload: false });
+    }
+  };
+}
+
+/**
+ * The set of live tabs under test. All tabs share ONE {@link BrowserContext}, which is what makes
+ * them peers: Web Locks (leader election, worker liveness) and the SharedWorker coordinator are
+ * scoped per context+origin, so tabs in separate contexts would each get their own worker and the
+ * suite would assert nothing.
+ */
+export class StressFleet {
+  readonly #context: BrowserContext;
+  readonly #url: string;
+  readonly #tabs: StressTab[] = [];
+  #nextLabel = 0;
+
+  constructor(context: BrowserContext, url: string) {
+    this.#context = context;
+    this.#url = url;
+  }
+
+  get tabs(): readonly StressTab[] {
+    return this.#tabs;
+  }
+
+  /** Opens a tab and waits for it to connect. */
+  openTab = async (): Promise<StressTab> => {
+    const tab = await this.openTabWithoutWaiting();
+    await tab.waitConnected();
+    return tab;
+  };
+
+  /**
+   * Opens a tab without waiting for its connection — used by the atomic commands, where waiting
+   * between the two halves would defeat the race being provoked.
+   */
+  openTabWithoutWaiting = async (): Promise<StressTab> => {
+    const page = await this.#context.newPage();
+    const tab = new StressTab(`tab-${this.#nextLabel++}`, page);
+    this.#tabs.push(tab);
+    await page.goto(this.#url, { waitUntil: 'domcontentloaded' });
+    return tab;
+  };
+
+  closeTab = async (tab: StressTab): Promise<void> => {
+    const index = this.#tabs.indexOf(tab);
+    if (index >= 0) {
+      this.#tabs.splice(index, 1);
+    }
+    await tab.close();
+  };
+
+  closeAllTabs = async (): Promise<void> => {
+    const tabs = this.#tabs.splice(0, this.#tabs.length);
+    await Promise.all(tabs.map((tab) => tab.close()));
+  };
+
+  /** The tab holding the leader lock, if any tab currently reports itself the owner. */
+  findLeader = async (): Promise<StressTab | undefined> => {
+    for (const tab of this.#tabs) {
+      const status = await tab.status().catch(() => undefined);
+      if (status?.isOwner) {
+        return tab;
+      }
+    }
+    return undefined;
+  };
+}

--- a/packages/sdk/worker-framework/src/playwright/stress-harness-server.ts
+++ b/packages/sdk/worker-framework/src/playwright/stress-harness-server.ts
@@ -1,0 +1,12 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+/**
+ * Port for the suite's own harness dev server (`harness/vite.config.ts`). Fixed and `strictPort`, so
+ * a stale server from a previous run fails the launch loudly instead of the suite silently driving
+ * yesterday's code.
+ */
+export const HARNESS_PORT = 9010;
+
+export const HARNESS_URL = `http://localhost:${HARNESS_PORT}/`;

--- a/packages/sdk/worker-framework/src/playwright/stress-recovery.ts
+++ b/packages/sdk/worker-framework/src/playwright/stress-recovery.ts
@@ -39,6 +39,9 @@ export const assertRecovered = async (fleet: StressFleet, log: (message: string)
   // Exactly one leader, and every tab agrees on which one it is.
   const leaderIds = new Set(statuses.map(({ status }) => status?.leaderId));
   expect(leaderIds.size, `all tabs must agree on the leader, saw ${[...leaderIds].join(', ')}`).toBe(1);
+  // Size 1 alone is satisfied by every tab reporting `undefined` — "nobody was elected" is a
+  // recovery failure, not agreement.
+  expect([...leaderIds][0], 'a leader must be elected').toBeTruthy();
 
   // The worker answers every tab — a wedged worker holding the lock would hang here, not pass.
   for (const tab of fleet.tabs) {

--- a/packages/sdk/worker-framework/src/playwright/stress-recovery.ts
+++ b/packages/sdk/worker-framework/src/playwright/stress-recovery.ts
@@ -1,0 +1,60 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { expect } from '@playwright/test';
+
+import { type StressFleet } from './stress-fleet';
+
+/**
+ * Recovery budget. Failover is not instant by design: a peer only steals the leader lock after the
+ * 5s stale timeout, and a failed leader session backs off (1s, doubling) before re-electing — so a
+ * storm that lands mid-backoff needs several seconds of slack on top.
+ */
+const RECOVERY_TIMEOUT_MS = 90_000;
+
+/** How long a counter update may take to reach every tab once the worker is back. */
+const PROPAGATION_TIMEOUT_MS = 20_000;
+
+/**
+ * Asserts the system came back from the storm: at least one live tab, every tab connected to ONE
+ * worker instance, that worker responsive, and its state observable by every tab.
+ */
+export const assertRecovered = async (fleet: StressFleet, log: (message: string) => void): Promise<void> => {
+  expect(fleet.tabs.length, 'at least one tab must be open to observe recovery').toBeGreaterThan(0);
+
+  for (const tab of fleet.tabs) {
+    await tab.waitConnected(RECOVERY_TIMEOUT_MS);
+  }
+
+  const statuses = await Promise.all(fleet.tabs.map(async (tab) => ({ label: tab.label, status: await tab.status() })));
+  log(`recovered fleet: ${JSON.stringify(statuses)}`);
+
+  // One worker instance, not merely one agreed-on counter value: `workerId` is the framework's
+  // per-worker liveness lock key, so equality here rules out a split brain of two live workers.
+  const workerIds = new Set(statuses.map(({ status }) => status?.workerId));
+  expect(workerIds.size, `all tabs must share one worker, saw ${[...workerIds].join(', ')}`).toBe(1);
+  expect([...workerIds][0], 'worker id must be reported').toBeTruthy();
+
+  // Exactly one leader, and every tab agrees on which one it is.
+  const leaderIds = new Set(statuses.map(({ status }) => status?.leaderId));
+  expect(leaderIds.size, `all tabs must agree on the leader, saw ${[...leaderIds].join(', ')}`).toBe(1);
+
+  // The worker answers every tab — a wedged worker holding the lock would hang here, not pass.
+  for (const tab of fleet.tabs) {
+    const rttMs = await tab.ping();
+    expect(rttMs, `${tab.label} ping must complete`).toBeGreaterThanOrEqual(0);
+  }
+
+  // And it is genuinely shared: a write through one tab reaches every other tab's subscription.
+  const [writer] = fleet.tabs;
+  const expected = await writer.increment();
+  for (const tab of fleet.tabs) {
+    await tab.page.waitForFunction(
+      (value) => (globalThis.window.__workerStress?.status().count ?? -1) >= value,
+      expected,
+      { timeout: PROPAGATION_TIMEOUT_MS },
+    );
+  }
+  log(`counter propagated to all ${fleet.tabs.length} tab(s) at ${expected}`);
+};

--- a/packages/sdk/worker-framework/src/playwright/worker-stress.spec.ts
+++ b/packages/sdk/worker-framework/src/playwright/worker-stress.spec.ts
@@ -1,0 +1,100 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { test } from '@playwright/test';
+
+import { STRESS_COMMANDS, runRandomCommand, seededRandom } from './stress-commands';
+import { StressFleet } from './stress-fleet';
+import { HARNESS_URL } from './stress-harness-server';
+import { assertRecovered } from './stress-recovery';
+
+// Overridable so a failing CI/local run can be replayed exactly, and so a soak can be dialled up
+// without editing the suite.
+const SEED = Number(process.env.DX_STRESS_SEED) || 1;
+const ITERATIONS = Number(process.env.DX_STRESS_ITERATIONS) || 30;
+const INITIAL_TABS = Number(process.env.DX_STRESS_TABS) || 2;
+
+// Two tabs is the smallest fleet where leadership is observable — with one tab there is no peer to
+// steal a stale leader's lock, so the failover commands would be no-ops.
+const MIN_TABS = 2;
+
+// A single command can burn ~10s (bounded hangs, stale-timeout-driven re-election), and the recovery
+// phase adds its own budget on top, so the walk is sized in minutes rather than seconds.
+const RANDOM_WALK_TIMEOUT_MS = ITERATIONS * 20_000 + 180_000;
+const SCRIPTED_TIMEOUT_MS = 300_000;
+
+/**
+ * Manually-run stress suite: real Chromium, real tabs, a real dedicated worker, and a real
+ * SharedWorker coordinator. Not part of `check` — see `src/playwright/README.md`.
+ *
+ * Both tests are structured the same way: throw disruptive commands at the worker, then assert the
+ * system converged back to one live worker shared by every surviving tab.
+ */
+test.describe('worker-framework stress', () => {
+  test('survives a randomised storm of tab and worker disruptions', async ({ browser }) => {
+    test.setTimeout(RANDOM_WALK_TIMEOUT_MS);
+
+    // One context: Web Locks and the SharedWorker coordinator are scoped per context+origin, so
+    // separate contexts would not be peers at all.
+    const context = await browser.newContext();
+    const fleet = new StressFleet(context, HARNESS_URL);
+    const history: string[] = [];
+    const log = (message: string) => {
+      // eslint-disable-next-line no-console
+      console.log(`[stress] ${message}`);
+    };
+
+    try {
+      for (let index = 0; index < INITIAL_TABS; index++) {
+        await fleet.openTab();
+      }
+      log(`seed=${SEED} iterations=${ITERATIONS} initialTabs=${INITIAL_TABS}`);
+
+      const random = seededRandom(SEED);
+      for (let index = 0; index < ITERATIONS; index++) {
+        const name = await runRandomCommand({ fleet, random, log: (message) => log(`#${index} ${message}`) });
+        if (name) {
+          history.push(name);
+        }
+      }
+      log(`command history: ${history.join(', ')}`);
+
+      await assertRecovered(fleet, log);
+    } catch (err) {
+      log(`FAILED after: ${history.join(', ')} (replay with DX_STRESS_SEED=${SEED})`);
+      throw err;
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('recovers after every individual command', async ({ browser }) => {
+    test.setTimeout(SCRIPTED_TIMEOUT_MS);
+
+    const context = await browser.newContext();
+    const fleet = new StressFleet(context, HARNESS_URL);
+    const log = (message: string) => {
+      // eslint-disable-next-line no-console
+      console.log(`[stress] ${message}`);
+    };
+
+    try {
+      const random = seededRandom(SEED);
+      // One command per iteration against a known-good fleet, so a failure names the command that
+      // caused it — the random walk finds interactions, this finds culprits.
+      for (const command of STRESS_COMMANDS) {
+        // Topped up to two tabs first: several commands are gated on having a peer (there is no
+        // leader to starve with one tab), and a previous command may have left fewer.
+        while (fleet.tabs.length < MIN_TABS) {
+          await fleet.openTab();
+        }
+        log(`--- ${command.name}`);
+        await command.run({ fleet, random, log });
+        await assertRecovered(fleet, log);
+      }
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/packages/sdk/worker-framework/src/playwright/worker-stress.spec.ts
+++ b/packages/sdk/worker-framework/src/playwright/worker-stress.spec.ts
@@ -9,11 +9,27 @@ import { StressFleet } from './stress-fleet';
 import { HARNESS_URL } from './stress-harness-server';
 import { assertRecovered } from './stress-recovery';
 
-// Overridable so a failing CI/local run can be replayed exactly, and so a soak can be dialled up
-// without editing the suite.
-const SEED = Number(process.env.DX_STRESS_SEED) || 1;
-const ITERATIONS = Number(process.env.DX_STRESS_ITERATIONS) || 30;
-const INITIAL_TABS = Number(process.env.DX_STRESS_TABS) || 2;
+/**
+ * Reads a positive-integer knob. Throws rather than coercing: `Number('tow') || 2` would silently
+ * run a soak at the default workload and report success.
+ */
+const positiveIntEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer, got ${JSON.stringify(raw)}`);
+  }
+  return value;
+};
+
+// Overridable so a failing run can be replayed exactly, and so a soak can be dialled up without
+// editing the suite.
+const SEED = positiveIntEnv('DX_STRESS_SEED', 1);
+const ITERATIONS = positiveIntEnv('DX_STRESS_ITERATIONS', 30);
+const INITIAL_TABS = positiveIntEnv('DX_STRESS_TABS', 2);
 
 // Two tabs is the smallest fleet where leadership is observable — with one tab there is no peer to
 // steal a stale leader's lock, so the failover commands would be no-ops.
@@ -22,7 +38,15 @@ const MIN_TABS = 2;
 // A single command can burn ~10s (bounded hangs, stale-timeout-driven re-election), and the recovery
 // phase adds its own budget on top, so the walk is sized in minutes rather than seconds.
 const RANDOM_WALK_TIMEOUT_MS = ITERATIONS * 20_000 + 180_000;
-const SCRIPTED_TIMEOUT_MS = 300_000;
+// The scripted test runs a full recovery phase after EVERY command, so its budget scales with the
+// command count — a fixed total would abort on the timeout and blame the test rather than the
+// command, which is the whole point of running them one at a time.
+const SCRIPTED_TIMEOUT_MS = STRESS_COMMANDS.length * 60_000 + 180_000;
+
+const log = (message: string) => {
+  // eslint-disable-next-line no-console
+  console.log(`[stress] ${message}`);
+};
 
 /**
  * Manually-run stress suite: real Chromium, real tabs, a real dedicated worker, and a real
@@ -40,10 +64,6 @@ test.describe('worker-framework stress', () => {
     const context = await browser.newContext();
     const fleet = new StressFleet(context, HARNESS_URL);
     const history: string[] = [];
-    const log = (message: string) => {
-      // eslint-disable-next-line no-console
-      console.log(`[stress] ${message}`);
-    };
 
     try {
       for (let index = 0; index < INITIAL_TABS; index++) {
@@ -74,10 +94,6 @@ test.describe('worker-framework stress', () => {
 
     const context = await browser.newContext();
     const fleet = new StressFleet(context, HARNESS_URL);
-    const log = (message: string) => {
-      // eslint-disable-next-line no-console
-      console.log(`[stress] ${message}`);
-    };
 
     try {
       const random = seededRandom(SEED);

--- a/packages/sdk/worker-framework/src/stories/counter-connection.ts
+++ b/packages/sdk/worker-framework/src/stories/counter-connection.ts
@@ -31,6 +31,12 @@ export type CounterSessionInfo = {
   clientId: string;
   leaderId: string;
   isOwner: boolean;
+  /**
+   * Identity of the worker INSTANCE serving this session. The framework derives the liveness lock
+   * key from a per-worker UUID, so two clients reporting the same value are provably talking to the
+   * same worker rather than to two workers that merely agree on their state.
+   */
+  workerId: string;
 };
 
 export type PingMeasurement = {
@@ -66,9 +72,9 @@ export class CounterConnection extends Resource {
             }),
         }),
       leaderLockKey: COUNTER_LEADER_LOCK_KEY,
-      onConnect: async ({ clientToWorker, workerToClient, leaderId, isOwner }) => {
+      onConnect: async ({ clientToWorker, workerToClient, leaderId, livenessLockKey, isOwner }) => {
         invariant(this.#scope, 'counter rpc scope not initialized');
-        this.#sessionInfo = { clientId: this.#connection.clientId, leaderId, isOwner };
+        this.#sessionInfo = { clientId: this.#connection.clientId, leaderId, isOwner, workerId: livenessLockKey };
         this.sessionChanged.emit(this.#sessionInfo);
 
         // The framework provisions both directions per session. Serve the (empty) worker→client

--- a/packages/sdk/worker-framework/tsconfig.json
+++ b/packages/sdk/worker-framework/tsconfig.json
@@ -26,6 +26,12 @@
       "path": "../../common/log"
     },
     {
+      "path": "../../common/node-std"
+    },
+    {
+      "path": "../../common/test-utils"
+    },
+    {
       "path": "../../common/util"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2170,7 +2170,7 @@ importers:
         version: 2.3.0(rollup@3.30.0)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vite-plugin-inspect:
         specifier: 'catalog:'
-        version: 12.0.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 12.0.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vite-plugin-top-level-await:
         specifier: 'catalog:'
         version: 1.6.0(@swc/helpers@0.5.17)(rollup@3.30.0)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -2182,7 +2182,7 @@ importers:
         version: 6.1.1(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wait-on:
         specifier: 'catalog:'
         version: 8.0.3
@@ -3436,7 +3436,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/common/effect-zod:
     dependencies:
@@ -3455,7 +3455,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/common/errors: {}
 
@@ -4111,7 +4111,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/common/web-context-solid:
     dependencies:
@@ -4136,7 +4136,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: 'catalog:'
-        version: 0.3.233(@anthropic-ai/sdk@0.117.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(zod@4.3.6)
+        version: 0.3.233(@anthropic-ai/sdk@0.117.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(zod@4.3.6)
       '@anthropic-ai/sdk':
         specifier: 'catalog:'
         version: 0.117.1(zod@4.3.6)
@@ -4164,7 +4164,7 @@ importers:
         version: 4.0.0-rc.108
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/agent-runtime:
     dependencies:
@@ -4216,7 +4216,7 @@ importers:
         version: 4.0.0-rc.108(effect@4.0.0-rc.108)(vitest@4.1.10)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/ai:
     dependencies:
@@ -4429,7 +4429,7 @@ importers:
         version: 4.0.0-rc.108
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/assistant-evals:
     dependencies:
@@ -4514,7 +4514,7 @@ importers:
         version: 0.19.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/assistant-toolkit:
     dependencies:
@@ -4645,7 +4645,7 @@ importers:
         version: 4.0.0-rc.108
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/compute-hyperformula:
     dependencies:
@@ -4761,7 +4761,7 @@ importers:
         version: 4.0.0-rc.108(effect@4.0.0-rc.108)(vitest@4.1.10)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/conductor:
     dependencies:
@@ -4856,7 +4856,7 @@ importers:
         version: 4.0.0-rc.108
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/edge-compute:
     dependencies:
@@ -4929,7 +4929,7 @@ importers:
         version: link:../../echo/echo-client
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/extractor:
     dependencies:
@@ -4985,7 +4985,7 @@ importers:
         version: 4.0.0-rc.108
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/functions-runtime-cloudflare:
     dependencies:
@@ -5120,7 +5120,7 @@ importers:
         version: 4.0.0-rc.108
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/mcp-client:
     dependencies:
@@ -5138,7 +5138,7 @@ importers:
         version: link:../../../common/log
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 4.0.0-rc.108
         version: 4.0.0-rc.108
@@ -5201,7 +5201,7 @@ importers:
         version: 4.0.0-rc.108
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline:
     dependencies:
@@ -5223,7 +5223,7 @@ importers:
         version: 4.0.0-rc.108
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline-discord:
     dependencies:
@@ -5275,7 +5275,7 @@ importers:
         version: 4.0.0-rc.108
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline-email:
     dependencies:
@@ -5339,7 +5339,7 @@ importers:
         version: 0.16.1
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline-rdf:
     dependencies:
@@ -5400,7 +5400,7 @@ importers:
         version: 4.0.0-rc.108
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/compute/pipeline-transcription:
     dependencies:
@@ -5452,7 +5452,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/echo/echo:
     dependencies:
@@ -5943,7 +5943,7 @@ importers:
         version: 2.11.14(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core/echo/feed:
     dependencies:
@@ -8250,7 +8250,7 @@ importers:
         version: 8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-brain:
     dependencies:
@@ -9047,7 +9047,7 @@ importers:
         version: 8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-conductor:
     dependencies:
@@ -9356,7 +9356,7 @@ importers:
         version: 8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-crx:
     dependencies:
@@ -9429,7 +9429,7 @@ importers:
         version: 8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-debug:
     dependencies:
@@ -13864,7 +13864,7 @@ importers:
         version: 4.0.0-rc.108(effect@4.0.0-rc.108)(vitest@4.1.10)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/plugin-script:
     dependencies:
@@ -16975,7 +16975,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/reflect/introspect:
     dependencies:
@@ -17015,7 +17015,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/reflect/introspect-mcp:
     dependencies:
@@ -17027,7 +17027,7 @@ importers:
         version: link:../introspect-tools
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 4.0.0-rc.108
         version: 4.0.0-rc.108
@@ -17046,7 +17046,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/reflect/introspect-tools:
     dependencies:
@@ -17071,7 +17071,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -18393,7 +18393,7 @@ importers:
         version: link:../../common/typings
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/sdk/worker-framework:
     dependencies:
@@ -18422,12 +18422,21 @@ importers:
         specifier: 4.0.0-rc.108
         version: 4.0.0-rc.108
     devDependencies:
+      '@dxos/node-std':
+        specifier: workspace:*
+        version: link:../../common/node-std
       '@dxos/react-ui':
         specifier: workspace:*
         version: link:../../ui/react-ui
+      '@dxos/test-utils':
+        specifier: workspace:*
+        version: link:../../common/test-utils
       '@dxos/ui-theme':
         specifier: workspace:*
         version: link:../../ui/ui-theme
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.57.0
       '@storybook/react-vite':
         specifier: 'catalog:'
         version: 10.5.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@3.30.0)(storybook@10.5.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.6.2)(react@19.2.7))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -21361,7 +21370,7 @@ importers:
         version: link:../ui-theme
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.27.1(@cfworker/json-schema@4.1.1)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       effect:
         specifier: 4.0.0-rc.108
         version: 4.0.0-rc.108
@@ -23077,7 +23086,7 @@ importers:
         version: 8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   tools/vite-plugin-log/example:
     dependencies:
@@ -26867,6 +26876,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -41918,6 +41928,7 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
+      vite: '>=8.2.1'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -42627,10 +42638,10 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.233':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.233(@anthropic-ai/sdk@0.117.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.3.233(@anthropic-ai/sdk@0.117.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.117.1(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
       '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.233
@@ -44367,7 +44378,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 4.20260714.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wrangler: 4.112.0(@cloudflare/workers-types@5.20260719.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -47508,11 +47519,11 @@ snapshots:
       gonzales-pe: 4.3.0
       node-source-walk: 7.0.1
 
-  '@devframes/hub@0.6.0(devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22))':
+  '@devframes/hub@0.6.0(devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22))':
     dependencies:
       birpc: 4.0.0
       destr: 2.0.5
-      devframe: 0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)
+      devframe: 0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)
       nostics: 1.1.4
       pathe: 2.0.3
       perfect-debounce: 2.1.0
@@ -47665,7 +47676,7 @@ snapshots:
   '@effect/vitest@4.0.0-rc.108(effect@4.0.0-rc.108)(vitest@4.1.10)':
     dependencies:
       effect: 4.0.0-rc.108
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@effect/wa-sqlite@0.1.2': {}
 
@@ -48891,7 +48902,7 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.2)
       ajv: 8.18.0
@@ -52099,10 +52110,10 @@ snapshots:
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook: 10.5.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.6.2)(react@19.2.7)
     optionalDependencies:
-      '@vitest/browser': 4.1.10(patch_hash=a986f87598d00b4753574afb9fcad1a84d9b0145eaf80189a0b49d32b7af569a)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/browser-playwright': 4.1.10(playwright@1.57.0)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(patch_hash=a986f87598d00b4753574afb9fcad1a84d9b0145eaf80189a0b49d32b7af569a)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.57.0)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.10)
       '@vitest/runner': 4.1.10
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -53787,10 +53798,10 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitejs/devtools-kit@0.4.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/devtools-kit@0.4.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@devframes/hub': 0.6.0(devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22))
-      devframe: 0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)
+      '@devframes/hub': 0.6.0(devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22))
+      devframe: 0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)
       mlly: 1.8.2
       nostics: 1.1.4
       vite: 8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -53822,7 +53833,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -53835,7 +53846,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -53852,7 +53863,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -53869,7 +53880,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -53890,9 +53901,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(patch_hash=a986f87598d00b4753574afb9fcad1a84d9b0145eaf80189a0b49d32b7af569a)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(patch_hash=a986f87598d00b4753574afb9fcad1a84d9b0145eaf80189a0b49d32b7af569a)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.10)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -53971,7 +53982,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -54435,7 +54446,7 @@ snapshots:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@cloudflare/ai-chat': 0.0.6(agents@0.3.10)(ai@6.0.97(zod@4.3.6))(react@19.2.7)(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 6.0.97(zod@4.3.6)
       cron-schedule: 6.0.0
       escape-html: 1.0.3
@@ -56624,7 +56635,7 @@ snapshots:
 
   devalue@5.6.3: {}
 
-  devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22):
+  devframe@0.6.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22):
     dependencies:
       '@valibot/to-json-schema': 1.7.1(valibot@1.4.2)
       birpc: 4.0.0
@@ -56638,7 +56649,7 @@ snapshots:
       ufo: 1.6.4
       valibot: 1.4.2
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
     transitivePeerDependencies:
       - srvx
 
@@ -66062,9 +66073,9 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-inspect@12.0.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-plugin-inspect@12.0.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      '@vitejs/devtools-kit': 0.4.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1))(srvx@0.11.22)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitejs/devtools-kit': 0.4.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(srvx@0.11.22)(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ansis: 4.3.1
       error-stack-parser-es: 2.0.1
       obug: 2.1.3
@@ -66233,7 +66244,7 @@ snapshots:
     optionalDependencies:
       vite: 8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -66264,20 +66275,9 @@ snapshots:
       happy-dom: 20.7.0
       jsdom: 29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
-  vitest@4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
+  vitest@4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -66308,18 +66308,7 @@ snapshots:
       happy-dom: 20.7.0
       jsdom: 29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   void-elements@3.1.0: {}
 


### PR DESCRIPTION
## Context

`src/stories/counter.browser.test.ts` already exercises a **real** dedicated worker and a **real** SharedWorker coordinator in real Chromium (verified: `moon run worker-framework:test-browser` passes, and the failover test proves worker re-creation by observing the counter reset). But every "client" in it lives in **one tab**, so tab lifecycle — close, reload, recycle-all — is untestable there.

This adds a Node-side Playwright suite that drives real tabs from the outside.

## What's here

`packages/sdk/worker-framework/src/playwright/`

- **`harness/`** — the page under test: `index.html` + `main.ts` + `stress-harness.ts`, which installs `window.__workerStress` (status / increment / ping / hang-worker / block-main-thread). Served by a minimal Vite dev server rather than Storybook: the page needs no React or design-system assets, and Storybook's static-asset preset requires unrelated packages' build output.
- **`stress-fleet.ts`** — `StressTab` / `StressFleet`. All tabs share **one** `BrowserContext`, which is what makes them peers: Web Locks and the SharedWorker coordinator are scoped per context+origin.
- **`stress-commands.ts`** — the command catalogue:

  | Command | Provokes |
  | --- | --- |
  | `open-tab` / `close-tab` | follower churn |
  | `reload-tab` | tab loses its client identity; failover if it was leader |
  | `close-all-tabs-and-open-new` | whole system (worker + coordinator) torn down and rebuilt |
  | `hang-worker` | worker event loop starved 8s |
  | `block-leader-main-thread` | leader heartbeat starved; its worker keeps serving, so nothing should move |
  | `block-leader-main-thread-and-open-tab` | the lock-steal path — the joining tab times out on `provide-port` and steals |
  | `hang-worker-forever-and-recycle-tabs` | **atomic**: worker wedged in an unbreakable loop, then every tab that could observe it destroyed before it yields |
  | `increment-counter` | ordinary traffic, allowed to fail mid-storm |

- **`stress-recovery.ts`** — the recovery assertions: at least one live tab; every tab reaches `connected`; every tab reports the **same `workerId`** (the framework's per-worker liveness lock key, so a split brain of two live workers cannot pass — unlike comparing counter values); every tab agrees on the leader; the worker answers a `ping` from every tab (a wedged worker still holding the lock hangs here); and a write through one tab reaches every other tab's subscription.

Two tests: one command per iteration against a topped-up fleet (a failure names the culprit), and a seeded random walk (finds interactions).

`CounterSessionInfo` gains `workerId`, plumbed from the connection's existing `livenessLockKey`, to make worker instance identity observable.

## Running it

```bash
moon run worker-framework:e2e-stress
```

Its own moon task rather than the `e2e` tag, so it never gates a PR — it deliberately wedges workers and waits out stale-timeout-driven failover, so a run takes minutes. Knobs: `DX_STRESS_SEED` (a failure prints its seed for exact replay), `DX_STRESS_ITERATIONS`, `DX_STRESS_TABS`. Details in `src/playwright/README.md`.

## Verification

- `worker-framework:e2e-stress` — both tests pass; the random walk also passes on seeds 7 and 42 at 25 iterations / 3 initial tabs.
- `moon run worker-framework:test worker-framework:test-browser` — 16 + 20 tests pass (unchanged).
- `worker-framework:lint`, `worker-framework:build`, and `tsc --build` (which typechecks `src/playwright`) clean; `pnpm format` applied.

No changeset: test-only, plus a field on a stories-local type that the package does not export.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxXPaixqQVYTuzrboibfMA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Playwright-based stress-testing suite for worker connections, failover, tab lifecycle, and recovery scenarios.
  * Added configurable stress-test seeds, iterations, tab counts, and diagnostic logging.
  * Added worker identity information to connection session details.

* **Documentation**
  * Added instructions for running and understanding the stress tests, including configuration and recovery behavior.

* **Tests**
  * Added automated recovery checks for reconnection, leader consistency, responsiveness, and state propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->