### PR TITLE
navtree: show loading state for spaces and account avatar

### DIFF
--- a/.changeset/pending-space-rail-items.md
+++ b/.changeset/pending-space-rail-items.md
@@ -1,0 +1,6 @@
+---
+'@dxos/lit-ui': patch
+'@dxos/plugin-navtree': minor
+---
+
+Render avatar fallbacks whose emoji rely on a variation selector (☀️, ⚙️, ♻️ …) instead of a coloured circle with no symbol. Spaces that are listed but not yet open now hold a place in the sidebar rail, and the rail keeps its shape — a placeholder workspace and account avatar — while the client initialises.

--- a/packages/plugins/plugin-navtree/src/components/NavTree/NavTree.stories.tsx
+++ b/packages/plugins/plugin-navtree/src/components/NavTree/NavTree.stories.tsx
@@ -27,7 +27,7 @@ import { mx } from '@dxos/ui-theme';
 
 import { NavTreeContainer } from '#containers';
 import { NavTreePlugin } from '#plugin';
-import { storybookGraphBuilders } from '#testing';
+import { type StorybookGraphOptions, storybookGraphBuilders } from '#testing';
 import { translations } from '#translations';
 
 random.seed(1234);
@@ -135,41 +135,43 @@ const UnavailableWorkspaceStory = () => {
   return <DefaultStory />;
 };
 
+const navTreeDecorators = (graphOptions?: StorybookGraphOptions) => [
+  withLayout({ layout: 'fullscreen' }),
+  withPluginManager({
+    plugins: [
+      ...corePlugins(),
+      StorybookPlugin.make({
+        initialState: { sidebarState: 'expanded' },
+      }),
+
+      NavTreePlugin(),
+    ],
+    capabilities: () => {
+      const storyStateAtom = Atom.make({ tab: 'root/space-0' }).pipe(Atom.keepAlive);
+      return [
+        Capability.contribute(StoryState, storyStateAtom),
+        Capability.contribute(AppCapabilities.AppGraphBuilder, storybookGraphBuilders(graphOptions)),
+        Capability.contribute(
+          Capabilities.OperationHandler,
+          OperationHandlerSet.make(
+            Operation.withHandler(LayoutOperation.SwitchWorkspace, ({ subject }) =>
+              Effect.gen(function* () {
+                const registry: Registry.AtomRegistry = yield* Capability.get(Capabilities.AtomRegistry);
+                registry.set(storyStateAtom, { tab: subject });
+              }),
+            ),
+          ),
+        ),
+      ];
+    },
+  }),
+];
+
 const meta = {
   title: 'plugins/plugin-navtree/components/NavTree',
   component: NavTreeContainer,
   render: DefaultStory,
-  decorators: [
-    withLayout({ layout: 'fullscreen' }),
-    withPluginManager({
-      plugins: [
-        ...corePlugins(),
-        StorybookPlugin.make({
-          initialState: { sidebarState: 'expanded' },
-        }),
-
-        NavTreePlugin(),
-      ],
-      capabilities: () => {
-        const storyStateAtom = Atom.make({ tab: 'root/space-0' }).pipe(Atom.keepAlive);
-        return [
-          Capability.contribute(StoryState, storyStateAtom),
-          Capability.contribute(AppCapabilities.AppGraphBuilder, storybookGraphBuilders()),
-          Capability.contribute(
-            Capabilities.OperationHandler,
-            OperationHandlerSet.make(
-              Operation.withHandler(LayoutOperation.SwitchWorkspace, ({ subject }) =>
-                Effect.gen(function* () {
-                  const registry: Registry.AtomRegistry = yield* Capability.get(Capabilities.AtomRegistry);
-                  registry.set(storyStateAtom, { tab: subject });
-                }),
-              ),
-            ),
-          ),
-        ];
-      },
-    }),
-  ],
+  decorators: navTreeDecorators(),
   parameters: {
     layout: 'fullscreen',
     translations,
@@ -234,5 +236,25 @@ export const UnavailableWorkspace: Story = {
     const canvas = within(canvasElement);
     // Plugin startup plus the message's own render delay; allow for a slow CI runner.
     await canvas.findByTestId('navtree.workspace.unavailable', {}, { timeout: 15000 });
+  },
+};
+
+/** Spaces the client has listed but not yet opened: named from cache, with nothing to navigate into. */
+export const PendingWorkspaces: Story = {
+  decorators: navTreeDecorators({ spaces: 'pending' }),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    // Every listed space holds a place in the rail, so the count is right before any of them opens.
+    const items = await canvas.findAllByTestId('spacePlugin.space.pending', {}, { timeout: 15000 });
+    await expect(items).toHaveLength(3);
+  },
+};
+
+/** Before the client has initialised, when the app knows it will have workspaces but not how many. */
+export const NoWorkspacesYet: Story = {
+  decorators: navTreeDecorators({ spaces: 'none' }),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByTestId('navtree.workspace.pending', {}, { timeout: 15000 });
   },
 };

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L0Menu.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L0Menu.tsx
@@ -49,6 +49,7 @@ import { meta } from '#meta';
 import { l0ItemType } from '../../util';
 import { useNavTreeContext } from '../NavTreeContext';
 import { UserAccountAvatar } from '../UserAccountAvatar';
+import { L0PendingAvatar, L0PendingItem } from './L0PendingItem';
 
 //
 // L0Item
@@ -169,9 +170,12 @@ const L0Item = memo(({ item, parent, path, pinned, onRearrange, onItemHover }: L
   const [closestEdge, setEdge] = useState<Edge | null>(null);
   const localizedString = toLocalizedString(item.properties.label, t);
   const hue = item.properties.hue ?? null;
+  const pending = item.properties.pending === true;
 
   useLayoutEffect(() => {
-    if (!itemElement.current || !onRearrange) {
+    // A pending workspace has no space to reorder into yet, and its ordering is written to the
+    // settings space, so it stays undraggable until it opens.
+    if (!itemElement.current || !onRearrange || pending) {
       return;
     }
 
@@ -223,7 +227,7 @@ const L0Item = memo(({ item, parent, path, pinned, onRearrange, onItemHover }: L
         },
       }),
     );
-  }, [item, onRearrange]);
+  }, [item, onRearrange, pending]);
 
   const handleMouseEnter = useCallback(() => onItemHover?.({ item }), [item, onItemHover]);
 
@@ -231,6 +235,7 @@ const L0Item = memo(({ item, parent, path, pinned, onRearrange, onItemHover }: L
     <L0ItemRoot ref={itemElement} item={item} parent={parent} path={path} onMouseEnter={handleMouseEnter}>
       <div
         data-frame={true}
+        {...(pending && { 'data-pending': true, 'aria-busy': true })}
         {...(hue && { style: { background: `var(--color-${hue}-surface)` } })}
         className={mx(
           'flex justify-center items-center dx-focus-ring-group-indicator transition-colors rounded-sm',
@@ -252,6 +257,12 @@ const L0Item = memo(({ item, parent, path, pinned, onRearrange, onItemHover }: L
 
 const ItemAvatar = ({ item }: Pick<L0ItemProps, 'item'>) => {
   const { t } = useTranslation(meta.profile.key);
+
+  // A space that has not opened yet has no hue or icon of its own to show, so it holds the frame
+  // rather than rendering an avatar that would change under the user once it lands.
+  if (item.properties.pending === true) {
+    return <L0PendingAvatar />;
+  }
 
   // Actions.
   if (item.properties.icon) {
@@ -317,7 +328,10 @@ export const L0Menu = ({
           : targetIndex +
             (sourceIndex < targetIndex ? (closestEdge === 'top' ? -1 : 0) : closestEdge === 'bottom' ? 1 : 0);
       const nextOrder = arrayMove([...topLevelItems], sourceIndex, insertIndex);
-      return sourceItem.properties.onRearrange(nextOrder.map((item) => item.data));
+      // A pending workspace carries no space to order, and takes its place once it opens.
+      return sourceItem.properties.onRearrange(
+        nextOrder.filter((item) => item.properties.pending !== true).map((item) => item.data),
+      );
     },
     [topLevelItems],
   );
@@ -357,16 +371,22 @@ export const L0Menu = ({
       {/* Space list. */}
       <ScrollArea.Root centered thin orientation='vertical'>
         <ScrollArea.Viewport classNames='flex flex-col gap-2 py-1'>
-          {topLevelItems.map((item) => (
-            <L0Item
-              key={item.id}
-              item={item}
-              parent={parent}
-              path={path}
-              onItemHover={onItemHover}
-              {...(hasRearrangeableItems && { onRearrange: handleRearrange })}
-            />
-          ))}
+          {topLevelItems.length > 0 ? (
+            topLevelItems.map((item) => (
+              <L0Item
+                key={item.id}
+                item={item}
+                parent={parent}
+                path={path}
+                onItemHover={onItemHover}
+                {...(hasRearrangeableItems && { onRearrange: handleRearrange })}
+              />
+            ))
+          ) : (
+            // Spaces reach the graph only once the client has initialised, and every identity ends
+            // up with at least one, so an empty rail means the list is still on its way.
+            <L0PendingItem />
+          )}
         </ScrollArea.Viewport>
       </ScrollArea.Root>
 
@@ -377,8 +397,8 @@ export const L0Menu = ({
         ))}
       </div>
 
-      {userAccountItem && (
-        <div className='grid dx-app-no-drag'>
+      <div className='grid dx-app-no-drag'>
+        {userAccountItem ? (
           <L0ItemRoot key={userAccountItem.id} item={userAccountItem} parent={parent} path={path}>
             <UserAccountAvatar
               userId={userAccountItem.properties.userId}
@@ -388,8 +408,14 @@ export const L0Menu = ({
               size={10}
             />
           </L0ItemRoot>
-        </div>
-      )}
+        ) : (
+          // The account node arrives with the client; hold its place so the corner of the rail is
+          // never empty, rather than collapsing the row until then.
+          <div className='flex w-full justify-center items-center'>
+            <UserAccountAvatar size={10} />
+          </div>
+        )}
+      </div>
     </Tabs.Tablist>
   );
 };

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L0PendingItem.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L0PendingItem.tsx
@@ -14,11 +14,18 @@ import { meta } from '#meta';
  */
 const PENDING_ANIMATION_DELAY = '2s';
 
+/**
+ * Slower than the skeleton default, so a rail of them reads as quietly waiting rather than blinking
+ * for attention. The palette stays the achromatic `neutral` ramp: a placeholder should not imply a
+ * hue the space has not published yet.
+ */
+const PENDING_ANIMATION_DURATION = '4s';
+
 /** Fills a rail item's frame while the workspace it stands for is still opening. */
 export const L0PendingAvatar = () => (
   <Skeleton
     classNames='w-(--dx-l0-avatar-size) h-(--dx-l0-avatar-size) rounded-sm'
-    style={{ animationDelay: PENDING_ANIMATION_DELAY }}
+    style={{ animationDelay: PENDING_ANIMATION_DELAY, animationDuration: PENDING_ANIMATION_DURATION }}
   />
 );
 

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L0PendingItem.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L0PendingItem.tsx
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React from 'react';
+
+import { Skeleton, useTranslation } from '@dxos/react-ui';
+
+import { meta } from '#meta';
+
+/**
+ * Delay before a pending placeholder starts animating. The square itself is present from the first
+ * frame so the rail never reads as empty; only a load slow enough to notice advertises itself.
+ */
+const PENDING_ANIMATION_DELAY = '2s';
+
+/** Fills a rail item's frame while the workspace it stands for is still opening. */
+export const L0PendingAvatar = () => (
+  <Skeleton
+    classNames='w-(--dx-l0-avatar-size) h-(--dx-l0-avatar-size) rounded-sm'
+    style={{ animationDelay: PENDING_ANIMATION_DELAY }}
+  />
+);
+
+/**
+ * Stands in for the whole space list before the client has initialised, when the app knows it will
+ * have workspaces but not yet how many.
+ */
+export const L0PendingItem = () => {
+  const { t } = useTranslation(meta.profile.key);
+
+  return (
+    <div
+      role='status'
+      aria-label={t('pending-workspace.label')}
+      data-testid='navtree.workspace.pending'
+      className='flex w-full justify-center items-center'
+    >
+      <L0PendingAvatar />
+    </div>
+  );
+};

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
@@ -61,6 +61,7 @@ export type L1PanelProps = {
  */
 const L1PanelInner = ({ open, path, id, item, spaces, isCurrent, onBack }: L1PanelProps) => {
   const { t } = useTranslation(meta.profile.key);
+  const pending = item?.properties.pending === true;
   const title = item ? toLocalizedString(item.properties.label, t) : t('workspace-unavailable.heading');
   const isActivated = useIsActivatedWorkspace(id);
   const shouldRenderContent = isCurrent || isActivated;
@@ -84,12 +85,24 @@ const L1PanelInner = ({ open, path, id, item, spaces, isCurrent, onBack }: L1Pan
       // reference a missing element.
       {...(!item && { 'aria-labelledby': undefined })}
       {...(isCurrent && {
-        'data-testid': item ? 'navtree.workspace.visible' : 'navtree.workspace.unavailable',
+        'data-testid': pending
+          ? 'navtree.workspace.pending'
+          : item
+            ? 'navtree.workspace.visible'
+            : 'navtree.workspace.unavailable',
       })}
       {...(!open && { inert: true })}
     >
       {shouldRenderContent &&
-        (item ? (
+        (pending ? (
+          // Its children live in a database that has not opened, so there is no tree to build yet.
+          <Empty
+            label={t('loading-workspace.label')}
+            icon='ph--circle-notch--regular'
+            classNames='row-start-2 self-start animate-fade-in [&_svg]:animate-spin'
+            style={{ animationDelay: RENDER_DELAY, animationFillMode: 'backwards' }}
+          />
+        ) : item ? (
           <L1PanelContent open={open} path={path} item={item} onBack={onBack} />
         ) : (
           reportUnavailable && (

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/index.ts
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/index.ts
@@ -3,5 +3,6 @@
 //
 
 export * from './L0Menu';
+export * from './L0PendingItem';
 export * from './L1Panel';
 export * from './L1Tabs';

--- a/packages/plugins/plugin-navtree/src/components/UserAccountAvatar/UserAccountAvatar.stories.tsx
+++ b/packages/plugins/plugin-navtree/src/components/UserAccountAvatar/UserAccountAvatar.stories.tsx
@@ -18,4 +18,14 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+/** What the rail's corner shows while the client is still initialising. */
+export const Placeholder: Story = {};
+
+export const Identity: Story = {
+  args: { userId: '9f8e7d6c5b4a39281706f5e4d3c2b1a0' },
+};
+
+/** A profile whose emoji is one that defaults to text presentation, so it needs U+FE0F to render. */
+export const ChosenIdentity: Story = {
+  args: { userId: '9f8e7d6c5b4a39281706f5e4d3c2b1a0', emoji: '☀️', hue: 'cyan' },
+};

--- a/packages/plugins/plugin-navtree/src/components/UserAccountAvatar/UserAccountAvatar.tsx
+++ b/packages/plugins/plugin-navtree/src/components/UserAccountAvatar/UserAccountAvatar.tsx
@@ -18,7 +18,10 @@ export type UserAccountAvatarProps = {
 };
 
 export const UserAccountAvatar = ({ size, userId, hue, emoji, status }: UserAccountAvatarProps) => {
-  const fallbackValue = hexToFallback(userId ?? '0');
+  // The identity resolves only once the client has initialised. Seeding the deterministic fallback
+  // with a placeholder id would render a stranger's colour and emoji until it lands, so an
+  // identity-less avatar is a plain circle: present, but making no claim about who is signed in.
+  const fallbackValue = userId ? hexToFallback(userId) : undefined;
 
   return (
     <>
@@ -31,10 +34,13 @@ export const UserAccountAvatar = ({ size, userId, hue, emoji, status }: UserAcco
           <Avatar.Content
             variant='circle'
             size={size ?? 12}
-            status={status ?? 'active'}
-            hue={hue || fallbackValue.hue}
-            fallback={emoji || fallbackValue.emoji}
-            data-testid='treeView.userAccount'
+            // The status ring reads as presence, which an unresolved identity cannot claim.
+            {...(fallbackValue && { status: status ?? 'active' })}
+            hue={hue || fallbackValue?.hue}
+            fallback={emoji || fallbackValue?.emoji || ''}
+            // Distinct from the resolved avatar: `treeView.userAccount` is what the e2e harness
+            // waits on to call the app booted.
+            data-testid={fallbackValue ? 'treeView.userAccount' : 'treeView.userAccount.placeholder'}
           />
         </Avatar.Root>
       </div>

--- a/packages/plugins/plugin-navtree/src/testing/app-graph-builder.ts
+++ b/packages/plugins/plugin-navtree/src/testing/app-graph-builder.ts
@@ -12,7 +12,16 @@ import * as NodeMatcher from '@dxos/app-graph/NodeMatcher';
 import { log } from '@dxos/log';
 import { random } from '@dxos/random';
 
-export const storybookGraphBuilders = (): BuilderExtensions => {
+export type StorybookGraphOptions = {
+  /**
+   * How the rail's workspaces are published. `growing` (the default) starts at three and adds one
+   * every few seconds; `none` withholds them, as before the client has initialised; `pending` emits
+   * them as spaces that are listed but have not opened.
+   */
+  spaces?: 'growing' | 'none' | 'pending';
+};
+
+export const storybookGraphBuilders = ({ spaces = 'growing' }: StorybookGraphOptions = {}): BuilderExtensions => {
   const propertiesCache = new Map<string, Record<string, unknown>>();
   const getProperties = (id: string, defaults: Record<string, unknown>) => {
     const cached = propertiesCache.get(id);
@@ -98,6 +107,10 @@ export const storybookGraphBuilders = (): BuilderExtensions => {
         match: NodeMatcher.whenRoot,
         connector: (_, get) =>
           Effect.sync(() => {
+            if (spaces === 'none') {
+              return [];
+            }
+
             const count = Atom.make((get) => {
               let value = 3;
               const interval = setInterval(() => {
@@ -113,16 +126,27 @@ export const storybookGraphBuilders = (): BuilderExtensions => {
               return value;
             });
 
-            return Array.from({ length: get(count) }, (_, i) =>
+            return Array.from({ length: spaces === 'pending' ? 3 : get(count) }, (_, i) =>
               Node.make({
                 id: `space-${i}`,
                 type: 'space',
-                properties: getProperties(`space-${i}`, {
-                  label: `Space ${i}`,
-                  icon: random.properties.icon(),
-                  hue: random.properties.hue(),
-                  disposition: 'workspace',
-                }),
+                // A pending space publishes its cached name but no hue or icon, since those live in
+                // the database it has not opened.
+                properties:
+                  spaces === 'pending'
+                    ? getProperties(`space-pending-${i}`, {
+                        label: `Space ${i}`,
+                        disabled: true,
+                        pending: true,
+                        disposition: 'workspace',
+                        testId: 'spacePlugin.space.pending',
+                      })
+                    : getProperties(`space-${i}`, {
+                        label: `Space ${i}`,
+                        icon: random.properties.icon(),
+                        hue: random.properties.hue(),
+                        disposition: 'workspace',
+                      }),
               }),
             );
           }),

--- a/packages/plugins/plugin-navtree/src/translations.ts
+++ b/packages/plugins/plugin-navtree/src/translations.ts
@@ -17,6 +17,8 @@ export const translations = [
         'node-actions-menu-invoker.label': 'More options',
         'tree-item-actions.label': 'More actions',
         'button-back.button': 'Back to Space',
+        'pending-workspace.label': 'Loading workspaces',
+        'loading-workspace.label': 'Loading workspace…',
         'workspace-unavailable.heading': 'Workspace unavailable',
         'workspace-unavailable.description':
           'You don’t have this workspace, or it no longer exists. Select one of your workspaces to continue.',

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/shared.ts
@@ -63,6 +63,7 @@ export const COPY_LINK_LABEL: Label = ['copy-link.label', META_NS];
 export const CREATE_OBJECT_IN_COLLECTION_LABEL: Label = ['create-object-in-collection.label', META_NS];
 export const CREATE_OBJECT_IN_SPACE_LABEL: Label = ['create-object-in-space.label', META_NS];
 export const EXPOSE_OBJECT_LABEL: Label = ['expose-object.label', META_NS];
+export const LOADING_SPACE_LABEL: Label = ['loading-space.label', META_NS];
 export const MIGRATE_SPACE_LABEL: Label = ['migrate-space.label', META_NS];
 export const NEW_TYPE_LABEL: Label = ['new-type.label', META_NS];
 export const RENAME_SPACE_LABEL: Label = ['rename-space.label', META_NS];

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.test.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.test.ts
@@ -1,0 +1,81 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Option from 'effect/Option';
+import { describe, test } from 'vitest';
+
+import type * as Node from '@dxos/app-graph/Node';
+import * as AppNodeMatcher from '@dxos/app-toolkit/AppNodeMatcher';
+import { type Space, SpaceState } from '@dxos/client/echo';
+
+import { constructPendingSpaceNode, isPendingSpace } from './spaces';
+
+describe('isPendingSpace', () => {
+  test('a space on its way to ready is pending', ({ expect }) => {
+    expect(isPendingSpace(SpaceState.SPACE_INITIALIZING)).toBe(true);
+    expect(isPendingSpace(SpaceState.SPACE_ACTIVE)).toBe(true);
+    // The proxy's initial state, which opens on its own.
+    expect(isPendingSpace(SpaceState.SPACE_CLOSED)).toBe(true);
+  });
+
+  test('a ready space is not pending, since it has a node of its own', ({ expect }) => {
+    expect(isPendingSpace(SpaceState.SPACE_READY)).toBe(false);
+  });
+
+  test('states a space rests in are not pending', ({ expect }) => {
+    expect(isPendingSpace(SpaceState.SPACE_INACTIVE)).toBe(false);
+    expect(isPendingSpace(SpaceState.SPACE_ERROR)).toBe(false);
+    expect(isPendingSpace(SpaceState.SPACE_REQUIRES_MIGRATION)).toBe(false);
+    expect(isPendingSpace(SpaceState.SPACE_CONTROL_ONLY)).toBe(false);
+    expect(isPendingSpace(SpaceState.SPACE_DELETED)).toBe(false);
+    expect(isPendingSpace(SpaceState.INVALID)).toBe(false);
+    expect(isPendingSpace(undefined)).toBe(false);
+  });
+
+  test('a closed space is not pending under lazySpaceOpen, where nothing would open it', ({ expect }) => {
+    expect(isPendingSpace(SpaceState.SPACE_CLOSED, true)).toBe(false);
+    // Spaces already opening are unaffected by the setting.
+    expect(isPendingSpace(SpaceState.SPACE_INITIALIZING, true)).toBe(true);
+  });
+});
+
+describe('constructPendingSpaceNode', () => {
+  const SPACE_ID = 'BFEDCBA9876543210FEDCBA9876543210';
+
+  /**
+   * Carries only the id the pending node reads — deliberately nothing else, since anything a
+   * pending node touched on an unopened space would throw in the app.
+   */
+  const makeFakeSpace = (): Space => ({ id: SPACE_ID }) as unknown as Space;
+
+  /** The graph fills in a connector's omitted fields; do the same so assertions see a whole node. */
+  const makePendingNode = (namesCache?: Record<string, string>): Node.Node => {
+    const { id, type, data, properties } = constructPendingSpaceNode({ space: makeFakeSpace(), namesCache });
+    return { id, type, data, properties: properties ?? {} };
+  };
+
+  test('is a disabled, pending workspace keyed by the space it stands for', ({ expect }) => {
+    const node = makePendingNode();
+
+    expect(node.id).toBe(SPACE_ID);
+    expect(node.properties.pending).toBe(true);
+    expect(node.properties.disabled).toBe(true);
+    expect(node.properties.disposition).toBe('workspace');
+  });
+
+  test('child connectors cannot match it', ({ expect }) => {
+    // Every space-scoped extension — in this plugin and in others — funnels through `whenSpace`,
+    // which needs `node.data` to be a space. A match here would query a database that has not
+    // opened. The positive case needs a real space, so it is left to the integration path.
+    expect(Option.isNone(AppNodeMatcher.whenSpace(makePendingNode()))).toBe(true);
+  });
+
+  test('takes its label from the cache, so a returning user sees real names while spaces open', ({ expect }) => {
+    expect(makePendingNode({ [SPACE_ID]: 'Reading list' }).properties.label).toBe('Reading list');
+  });
+
+  test('says it is loading when the space has never been seen before', ({ expect }) => {
+    expect(makePendingNode().properties.label).toEqual(['loading-space.label', { ns: 'org.dxos.plugin.space' }]);
+  });
+});

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.test.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.test.ts
@@ -8,8 +8,9 @@ import { describe, test } from 'vitest';
 import type * as Node from '@dxos/app-graph/Node';
 import * as AppNodeMatcher from '@dxos/app-toolkit/AppNodeMatcher';
 import { type Space, SpaceState } from '@dxos/client/echo';
+import { Entity, Obj } from '@dxos/echo';
 
-import { constructPendingSpaceNode, isPendingSpace } from './spaces';
+import { constructPendingSpaceNode, constructSpaceNode, isPendingSpace } from './spaces';
 
 describe('isPendingSpace', () => {
   test('a space on its way to ready is pending', ({ expect }) => {
@@ -77,5 +78,53 @@ describe('constructPendingSpaceNode', () => {
 
   test('says it is loading when the space has never been seen before', ({ expect }) => {
     expect(makePendingNode().properties.label).toEqual(['loading-space.label', { ns: 'org.dxos.plugin.space' }]);
+  });
+});
+
+describe('pending and ready space nodes', () => {
+  const SPACE_ID = 'BFEDCBA9876543210FEDCBA9876543210';
+
+  /**
+   * Passes `isEntity` and carries `Obj.Meta`, which the migration check reads through
+   * `Annotation.get`; the space's own display properties are left unset.
+   */
+  const makeFakeProperties = (): Record<string | symbol, unknown> => ({
+    [Entity.KindId]: Entity.Kind.Object,
+    [Obj.Meta]: { keys: [], annotations: {} },
+  });
+
+  const makeReadySpace = (): Space =>
+    ({
+      id: SPACE_ID,
+      state: { get: () => SpaceState.SPACE_READY },
+      properties: makeFakeProperties(),
+    }) as unknown as Space;
+
+  test('the same keys are emitted either way, so a stale one cannot survive the transition', ({ expect }) => {
+    // The graph merges node properties rather than replacing them, so a key one generation sets and
+    // the next omits can never be cleared: a space that opened would stay `pending` forever.
+    const pending = Object.keys(constructPendingSpaceNode({ space: makeReadySpace() }).properties ?? {});
+    const ready = Object.keys(constructSpaceNode({ space: makeReadySpace(), navigable: true }).properties ?? {});
+
+    expect(pending.filter((key) => key !== 'testId').toSorted()).toEqual(
+      ready.filter((key) => key !== 'testId').toSorted(),
+    );
+  });
+
+  test('an opened space is no longer pending', ({ expect }) => {
+    const node = constructSpaceNode({ space: makeReadySpace(), navigable: true });
+
+    expect(node.properties?.pending).toBe(false);
+  });
+
+  test('a pending space publishes no appearance of its own', ({ expect }) => {
+    const properties: Record<string, unknown> = constructPendingSpaceNode({ space: makeReadySpace() }).properties ?? {};
+
+    expect(properties.hue).toBeUndefined();
+    expect(properties.icon).toBeUndefined();
+    expect(properties.iconHue).toBeUndefined();
+    // Reordering writes through the space's own database, and dropping onto it would need one.
+    expect(properties.onRearrange).toBeUndefined();
+    expect(properties.canDrop).toBeUndefined();
   });
 });

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
@@ -376,6 +376,14 @@ export const constructPendingSpaceNode = ({
       // Names are cached from previous sessions, so a returning user sees real labels while the
       // spaces behind them open; a space never yet seen has none to show.
       label: namesCache?.[space.id] ?? LOADING_SPACE_LABEL,
+      // Cleared rather than omitted, so a space that closes after being ready drops the appearance
+      // and affordances it had then — the merge above would otherwise keep them.
+      description: undefined,
+      hue: undefined,
+      icon: undefined,
+      iconHue: undefined,
+      onRearrange: undefined,
+      canDrop: undefined,
       disabled: true,
       pending: true,
       disposition: 'workspace',
@@ -384,7 +392,7 @@ export const constructPendingSpaceNode = ({
   });
 
 /** Builds an app-graph node for a space, including settings children and optional rearrange handler. */
-const constructSpaceNode = ({
+export const constructSpaceNode = ({
   space,
   navigable = false,
   namesCache,
@@ -434,6 +442,9 @@ const constructSpaceNode = ({
           : undefined,
       iconHue: space.state.get() === SpaceState.SPACE_READY && space.properties.iconHue,
       disabled: !navigable || space.state.get() !== SpaceState.SPACE_READY || hasPendingMigration,
+      // Emitted on every generation, not just when true: the graph merges properties, so a key the
+      // pending generation set and this one omitted could never be cleared.
+      pending: false,
       disposition: 'workspace',
       testId: 'spacePlugin.space',
       onRearrange,

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
@@ -31,6 +31,7 @@ import { getSpaceDisplayName } from '../../../util';
 import {
   CAN_DROP_SPACE,
   CREATE_OBJECT_IN_SPACE_LABEL,
+  LOADING_SPACE_LABEL,
   MIGRATE_SPACE_LABEL,
   RENAME_SPACE_LABEL,
   checkPendingMigration,
@@ -257,6 +258,8 @@ export const createSpaceExtensions = Effect.fnUntraced(function* () {
             }
           });
 
+          const lazySpaceOpen = !!client.config.values.runtime?.client?.lazySpaceOpen;
+
           return Effect.succeed(
             [
               ...spaces
@@ -264,16 +267,23 @@ export const createSpaceExtensions = Effect.fnUntraced(function* () {
                 .sort((sortA, sortB) => orderMap.get(sortA.id)! - orderMap.get(sortB.id)!),
               ...spaces.filter((space) => !orderMap.has(space.id)),
             ]
-              .filter((space) => spaceStates.get(space.id) === SpaceState.SPACE_READY)
+              // A space that is listed but still opening gets a node too, so the rail shows how
+              // many workspaces are arriving instead of filling in from nothing.
+              .filter((space) => {
+                const spaceState = spaceStates.get(space.id);
+                return spaceState === SpaceState.SPACE_READY || isPendingSpace(spaceState, lazySpaceOpen);
+              })
               .filter((space) => AppSpace.isVisibleSpace(space))
               .map((space) =>
-                constructSpaceNode({
-                  space,
-                  navigable: ephemeralState.navigableCollections,
-                  namesCache: state.spaceNames,
-                  graph,
-                  spacesOrder,
-                }),
+                spaceStates.get(space.id) === SpaceState.SPACE_READY
+                  ? constructSpaceNode({
+                      space,
+                      navigable: ephemeralState.navigableCollections,
+                      namesCache: state.spaceNames,
+                      graph,
+                      spacesOrder,
+                    })
+                  : constructPendingSpaceNode({ space, namesCache: state.spaceNames }),
               ),
           );
         } catch {
@@ -333,6 +343,45 @@ export const createSpaceExtensions = Effect.fnUntraced(function* () {
 //
 // Helpers
 //
+
+/**
+ * Whether a listed space is on its way to `SPACE_READY` and should hold a place in the rail.
+ * `SPACE_CLOSED` is the proxy's initial state and opens on its own, except under `lazySpaceOpen`,
+ * where nothing would ever open it and the placeholder would never resolve. Deliberately excludes
+ * the states a space can rest in (inactive, error, awaiting migration), which are not loading.
+ */
+export const isPendingSpace = (state: SpaceState | undefined, lazySpaceOpen = false): boolean =>
+  state === SpaceState.SPACE_INITIALIZING ||
+  state === SpaceState.SPACE_ACTIVE ||
+  (state === SpaceState.SPACE_CLOSED && !lazySpaceOpen);
+
+/**
+ * Builds an app-graph node for a space that has not opened yet. `data` is null so
+ * `AppNodeMatcher.whenSpace` cannot match it: every child connector — in this plugin and in every
+ * other — funnels through that matcher, and each would otherwise query a database or read the
+ * `properties` getter that throws until the space is ready.
+ */
+export const constructPendingSpaceNode = ({
+  space,
+  namesCache,
+}: {
+  space: Space;
+  namesCache?: Record<string, string>;
+}) =>
+  Node.make({
+    id: space.id,
+    type: SpaceSchema.SPACE_TYPE,
+    data: null,
+    properties: {
+      // Names are cached from previous sessions, so a returning user sees real labels while the
+      // spaces behind them open; a space never yet seen has none to show.
+      label: namesCache?.[space.id] ?? LOADING_SPACE_LABEL,
+      disabled: true,
+      pending: true,
+      disposition: 'workspace',
+      testId: 'spacePlugin.space.pending',
+    },
+  });
 
 /** Builds an app-graph node for a space, including settings children and optional rearrange handler. */
 const constructSpaceNode = ({

--- a/packages/ui/lit-ui/moon.yml
+++ b/packages/ui/lit-ui/moon.yml
@@ -3,4 +3,5 @@ language: typescript
 tags:
   - dist-runtime
   - ts-compile
+  - ts-test
   - pack

--- a/packages/ui/lit-ui/src/dx-avatar/dx-avatar.ts
+++ b/packages/ui/lit-ui/src/dx-avatar/dx-avatar.ts
@@ -9,6 +9,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { makeId } from '@dxos/react-hooks';
 
 import { type Size } from '../defs';
+import { getFallbackGlyph } from './fallback';
 
 export type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
@@ -196,7 +197,7 @@ export class DxAvatar extends LitElement {
                 font-size=${this.size === 'px' ? '200%' : this.size * fontScale}
                 mask=${`url(#${this.maskId})`}
               >
-                ${/\p{Emoji_Presentation}/u.test(this.fallback) ? this.fallback : getInitials(this.fallback)}
+                ${getFallbackGlyph(this.fallback)}
               </text>`
         }
         ${
@@ -222,17 +223,3 @@ export class DxAvatar extends LitElement {
     return this;
   }
 }
-
-/**
- * Returns the first two renderable characters from a string that are separated by non-word characters.
- * Handles Unicode characters correctly.
- */
-const getInitials = (label = ''): string[] => {
-  return label
-    .trim()
-    .split(/\s+/)
-    .map((str) => str.replace(/[^\p{L}\p{N}\s]/gu, ''))
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((word) => word[0].toUpperCase());
-};

--- a/packages/ui/lit-ui/src/dx-avatar/fallback.test.ts
+++ b/packages/ui/lit-ui/src/dx-avatar/fallback.test.ts
@@ -1,0 +1,43 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { getFallbackGlyph } from './fallback';
+
+describe('avatar fallback glyph', () => {
+  test('a label initialises to at most two letters', ({ expect }) => {
+    expect(getFallbackGlyph('Alice Smith')).toBe('AS');
+    expect(getFallbackGlyph('alice')).toBe('A');
+    expect(getFallbackGlyph('Ada Byron Lovelace')).toBe('AB');
+  });
+
+  test('an emoji renders as itself', ({ expect }) => {
+    expect(getFallbackGlyph('👻')).toBe('👻');
+    expect(getFallbackGlyph('🫥')).toBe('🫥');
+  });
+
+  test('text-presentation emoji render rather than initialising to nothing', ({ expect }) => {
+    // The `idEmoji` palette entries that `\p{Emoji_Presentation}` rejects, which previously left
+    // the avatar a coloured circle with no symbol.
+    for (const emoji of ['👁️', '🐿️', '☀️', '☄️', '☁️', '⛱️', '🌶️', '🏔️', '🏝️', '🛰️', '🎙️', '⚙️', '🌡️', '🛎️', '♻️']) {
+      expect(getFallbackGlyph(emoji)).toBe(emoji);
+    }
+  });
+
+  test('a label wins over an emoji it contains', ({ expect }) => {
+    expect(getFallbackGlyph('Alice ☀️')).toBe('A');
+    expect(getFallbackGlyph('Alice 😀')).toBe('A');
+  });
+
+  test('non-latin labels initialise', ({ expect }) => {
+    expect(getFallbackGlyph('北京')).toBe('北');
+    expect(getFallbackGlyph('Ольга Иванова')).toBe('ОИ');
+  });
+
+  test('an empty fallback renders nothing', ({ expect }) => {
+    expect(getFallbackGlyph('')).toBe('');
+    expect(getFallbackGlyph()).toBe('');
+  });
+});

--- a/packages/ui/lit-ui/src/dx-avatar/fallback.ts
+++ b/packages/ui/lit-ui/src/dx-avatar/fallback.ts
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+/**
+ * Returns the first two renderable characters from a string that are separated by non-word characters.
+ * Handles Unicode characters correctly.
+ */
+const getInitials = (label = ''): string[] =>
+  label
+    .trim()
+    .split(/\s+/)
+    .map((str) => str.replace(/[^\p{L}\p{N}\s]/gu, ''))
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0].toUpperCase());
+
+/**
+ * Glyph rendered inside an avatar for a `fallback` string: initials for a label, or the string
+ * itself when it holds nothing to initialise. Emoji are recognised by that absence rather than by
+ * `\p{Emoji_Presentation}`, which rejects the text-presentation emoji that rely on U+FE0F (☀️, ⚙️,
+ * ♻️ …) and left them initialising to an empty glyph — a coloured avatar with no symbol.
+ */
+export const getFallbackGlyph = (fallback = ''): string => {
+  const initials = getInitials(fallback);
+  return initials.length > 0 ? initials.join('') : fallback;
+};

--- a/packages/ui/lit-ui/vitest.config.ts
+++ b/packages/ui/lit-ui/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});


### PR DESCRIPTION
Shows loading state in the sidebar rail while the client and spaces are still opening, and fixes an avatar bug found along the way.

**Preview:** https://pr-12705-composer-dev.dxos.workers.dev

## The problem

During boot the rail was empty in three different ways:

1. **While the client initialised**, the graph had no account node, so the account row collapsed.
2. **Per space**, the `spaces` connector dropped every space that wasn't `SPACE_READY`. Downstream, "spaces still opening" and "you have no spaces" were the same empty array.
3. **Cross-space ordering** lives in an object in the settings space. Until it resolved, spaces rendered in arrival order and then re-sorted, so the rail visibly reshuffled.

## Changes

### Placeholder space nodes (`plugin-space`)

A listed space that hasn't opened gets a node with `pending: true` and its cached name. `data` is `null`, so `AppNodeMatcher.whenSpace` can't match it. Every space-scoped child connector (this plugin, `plugin-assistant`, `plugin-code`, `plugin-crm`, `TypeSection`, and others) goes through that matcher, so none of them can query an unopened database or read the `properties` getter that throws until the space is ready. No app-graph API change was needed.

A space counts as pending in the states `SpaceList` opens it through: `SPACE_CLOSED`, `SPACE_CONTROL_ONLY` and `SPACE_INITIALIZING`. Under `runtime.client.lazySpaceOpen` a space can rest in CLOSED or CONTROL_ONLY, so those don't count there. Resting states (inactive, error, awaiting migration) never count.

The app graph merges node properties instead of replacing them, so a key one generation sets and the next omits is never cleared. `constructPendingSpaceNode` and `constructSpaceNode` both return a `SpaceNodeProperties` record whose keys are all required, so leaving one out is a compile error and `pending`, `hue` and friends clear on every transition. The pending builder takes only an id, so it has no space to put in `data` or to read properties from.

### Waiting for the ordering

Spaces stay placeholders until the ordering object resolves, then take their final positions together. `isOrderResolved` stops the wait early in three cases:

- The settings space isn't listed. A profile that never gets one would otherwise hold open spaces back on every boot.
- The settings space rests short of ready: error, awaiting migration, or closed under `lazySpaceOpen`.
- The settings space passes its own 60s open deadline.

Once the rail has rendered real nodes, a keep-alive atom latches the resolution. If the ordering is lost later, for example while the settings space reopens under `lazySpaceOpen` or duplicates heal, spaces can re-sort but never go back to placeholders.

### Dropping a space that never opens

A pending space that hasn't opened after `SPACE_OPEN_TIMEOUT` (60s) is dropped from the rail, which is how it behaved before placeholders. A placeholder has no settings child and so no route to delete, and a user can't dismiss something they can see but can't act on. A `TODO(wittjosiah)` tracks surfacing it as a deletable node once space nodes carry actions. `space.delete()` already works on an unopened space, so that follow-up only needs the affordance.

A stuck space emits no state change, so a per-space deadline atom (`Atom.family`) re-runs the connector when the deadline passes. The connector reads that atom only for a pending space. A ready space holds no timer, and a space that starts opening again gets a fresh 60s. The rule keys off the space's own state, so holding every space for the ordering can't empty the rail.

### Rail and panel rendering (`plugin-navtree`, `plugin-mobile`)

- Pending workspaces render a placeholder instead of an avatar, and can't be dragged or selected.
- Reordering passes node ids to `onRearrange`, so a pending workspace keeps its slot in the saved order. The `plugin-file-system` workspace callback takes ids to match.
- A pending current tab, which only happens through a restored or direct link, shows a spinner after the 1s render delay instead of a tree.
- The rail renders only the graph nodes it has: pending workspaces as placeholders, opened ones as avatars, and nothing when there are none. Until the account node arrives, the account corner holds a plain circle.
- Placeholders are present from the first frame but only start pulsing after 2s, at a 4s cycle, so a fast boot never flashes. They use the achromatic `neutral` ramp, since a hue would claim something the space hasn't published.
- Mobile Home renders a pending workspace tile as busy and not selectable.

### Avatar glyph fix (`lit-ui`)

`dx-avatar` chose between the raw fallback and its initials with `/\p{Emoji_Presentation}/u`, which is false for emoji that default to text presentation and rely on U+FE0F. For those, `getInitials` stripped everything and the avatar rendered a coloured circle with no symbol. 15 of the 132 `idEmoji` palette entries are affected (☀️ ⚙️ ♻️ 👁️ 🐿️ ☄️ ☁️ ⛱️ 🌶️ 🏔️ 🏝️ 🛰️ 🎙️ 🌡️ 🛎️), so about one identity in eight had a blank avatar. It looked like a boot race but is deterministic per identity. The logic moved to a lit-free `fallback.ts` and now checks whether there's anything to initialise. This also fixes space presence, thread avatars and the device list.

It also removes the `hexToFallback('0')` seed for an unresolved identity, which briefly showed a stranger's colour and emoji (👻 on red).

## Testing

- `lit-ui:test`: a new suite (added the `ts-test` tag and `vitest.config.ts`, following `core/protocols`). 2 tests: a label initialises, and emoji render as themselves, including all 15 variation-selector palette entries.
- `plugin-space:test`: `spaces.test.ts` has 8 tests: which states are pending (including CONTROL_ONLY and the `lazySpaceOpen` gate), the open timeout and that a ready space starts no deadline, when the ordering wait ends, when a node is pending, and that `whenSpace` can't match a pending node. Package suite: 40 files, 121 passing.
- `plugin-navtree:test-storybook`: `PendingWorkspaces` checks that all three listed spaces hold a place before any opens, and `NoWorkspacesYet` checks the account placeholder and an empty rail before initialisation. 10 pass in Chromium. `plugin-mobile:test-storybook`: 23 pass.
- Builds and lint are clean for `plugin-space`, `plugin-navtree`, `plugin-mobile` and `plugin-file-system`.

I haven't verified this in the running app; storybook covers the loading states in real Chromium.

## Notes for review

- The branch carries a merge of `main` from when it was about 400 commits behind. That merge adapts this work to the `Node` → `AppGraphNode`, `NodeMatcher` → `GraphNodeMatcher` and `GraphBuilder` → `AppGraphBuilder` renames and the explicit import-extension rule. The one non-mechanical resolution was `NavTree.stories.tsx`: `main` added a `LayoutOperation.Open` handler to the inline decorators while this branch had moved them into `navTreeDecorators(graphOptions)`, so the handler went into the factory. `main`'s `Row Menu` story passes.
- `Model Fixture / model-fixture` is red on `main` too. The 4 failures are in `assistant-toolkit`'s planning skill (`No memoized conversation found for the given prompt`), this branch matches `main` byte for byte under that package, and it reproduces offline. #13108 changed planning prompts without re-recording fixtures.

## Out of scope

- A list-level readiness observable on `SpaceList`. The internal `gotInitialUpdate` trigger exists but isn't exposed. It would give `L1Panel` and the rail a real signal instead of inferring readiness from graph nodes.
- Letting the settings space open first. `SpaceList.onData` opens every space at once with no priority, so the ordering, and the placeholder wait, sits behind whatever else is opening. That belongs in the SDK.
- Registry-level tests for the deadline atoms and graph-level tests for the property merge. plugin-space has no connector-level harness yet; it needs the plugin harness to supply five capabilities, which is its own piece of work.
- A shared, typed workspace rearrange callback in `app-toolkit`. The space and file-system callbacks are now identical and each keeps its own never-invalidated cache.
- `UserAccountAvatar` switches its test id so the e2e harness can tell when the app has booted. A real ready signal for the harness would remove that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12705-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
