### PR TITLE
plugin-search: swap search and command palette shortcuts

### DIFF
--- a/.changeset/search-commands-shortcut-swap.md
+++ b/.changeset/search-commands-shortcut-swap.md
@@ -1,5 +1,5 @@
 ---
-'@dxos/plugin-markdown': patch
+'@dxos/plugin-search': patch
 ---
 
 Open search with ⌘K / Ctrl+K and the command palette with ⇧⌘K / Ctrl+Shift+K, swapping the two shortcuts so the more frequently used search takes the primary binding.

--- a/.changeset/search-commands-shortcut-swap.md
+++ b/.changeset/search-commands-shortcut-swap.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-markdown': patch
+---
+
+Open search with ⌘K / Ctrl+K and the command palette with ⇧⌘K / Ctrl+Shift+K, swapping the two shortcuts so the more frequently used search takes the primary binding.

--- a/packages/plugins/plugin-navtree/PLUGIN.mdl
+++ b/packages/plugins/plugin-navtree/PLUGIN.mdl
@@ -139,7 +139,7 @@ component CommandsDialogContent
 
 ```mdl
 component CommandsTrigger
-  desc: Search-input surface slot component — opens the commands dialog on click or ⌘K / Ctrl+K.
+  desc: Search-input surface slot component — opens the commands dialog on click or ⇧⌘K / Ctrl+Shift+K.
   slots:
     (none)
   actions:
@@ -237,7 +237,7 @@ feat F-5: Keyboard Shortcuts
 
   req F-5.1: NavTree plugin registers keyboard shortcuts for all graph actions that declare a keyBinding property.
   req F-5.2: Graph is traversed on change (debounced 500 ms) to bind newly added shortcuts.
-  req F-5.3: The commands dialog is opened via ⌘K (macOS) / Ctrl+K (Windows/Linux).
+  req F-5.3: The commands dialog is opened via ⇧⌘K (macOS) / Ctrl+Shift+K (Windows/Linux).
   req F-5.4:
     when: plugin deactivates
     then: Keyboard.singleton is destroyed and all shortcuts are unregistered
@@ -296,7 +296,7 @@ test T-4: Select item
 ```mdl
 test T-5: Command palette opens on keyboard shortcut
   given: NavTree is active
-  when: user presses ⌘K (macOS) or Ctrl+K (Windows)
+  when: user presses ⇧⌘K (macOS) or Ctrl+Shift+K (Windows)
   then:
     - CommandsDialogContent is shown in the layout dialog slot
     - search input is focused

--- a/packages/plugins/plugin-navtree/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-navtree/src/capabilities/app-graph-builder.ts
@@ -32,8 +32,8 @@ export default Capability.makeModule(
               label: ['open-commands.label', { ns: meta.profile.key }],
               icon: 'ph--magnifying-glass--regular',
               keyBinding: {
-                macos: 'meta+k',
-                windows: 'ctrl+k',
+                macos: 'shift+meta+k',
+                windows: 'ctrl+shift+k',
               },
             },
           }),

--- a/packages/plugins/plugin-search/docs/AUDIT.md
+++ b/packages/plugins/plugin-search/docs/AUDIT.md
@@ -95,7 +95,7 @@ via `JSON.parse(JSON.stringify(object))`, keeps string fields, and scans them.
 
 - **Surfaces** (`react-surface.tsx`): the `SEARCH_DIALOG` command palette, an
   `AppSurface.SearchInput` slot, and a `Space` deck-companion (`SearchArticle`).
-- **Operation**: `OpenSearch` (opens the dialog; keybinding `shift+meta+f`).
+- **Operation**: `OpenSearch` (opens the dialog; keybinding `meta+k`).
 - **The global-filter side channel matters:** `GlobalFilterProvider` /
   `useGlobalFilteredObjects` (re-exported from `@dxos/react-ui-search`) let other
   views live-filter on the active query — `plugin-table` consumes it in

--- a/packages/plugins/plugin-search/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-search/src/capabilities/app-graph-builder.ts
@@ -65,8 +65,8 @@ export default Capability.makeModule(
                 label: ['search-action.label', { ns: meta.profile.key }],
                 icon: 'ph--magnifying-glass--regular',
                 keyBinding: {
-                  macos: 'shift+meta+f',
-                  windows: 'shift+alt+f',
+                  macos: 'meta+k',
+                  windows: 'ctrl+k',
                 },
               },
             },


### PR DESCRIPTION
Follow-up to #12701.

## Problem

Search was on `⇧⌘F` / `Shift+Alt+F` while the command palette held the primary `⌘K` / `Ctrl+K`. Search is the more frequently reached surface, so it should own `⌘K`.

## Changes

| Action | Before | After |
| --- | --- | --- |
| Search (`OpenSearch`) | `shift+meta+f` / `shift+alt+f` | `meta+k` / `ctrl+k` |
| Command palette (`COMMANDS_DIALOG`) | `meta+k` / `ctrl+k` | `shift+meta+k` / `ctrl+shift+k` |

- `plugin-search/src/capabilities/app-graph-builder.ts` — search action's `keyBinding`.
- `plugin-navtree/src/capabilities/app-graph-builder.ts` — commands action's `keyBinding`.
- `plugin-navtree/PLUGIN.mdl` — `CommandsTrigger` desc, req F-5.3, and test T-5 updated to `⇧⌘K` / `Ctrl+Shift+K`.
- `plugin-search/docs/AUDIT.md` — recorded keybinding for `OpenSearch`.

Modifier order in the source is cosmetic: `Keyboard.parseShortcut` normalizes to `ctrl, shift, alt, meta`, so `shift+meta+k` is the canonical stored form and matches what `handleKeyDown` builds from the event.

No conflicts with existing bindings — `meta+k` is freed by the same change, and nothing else binds `shift+meta+k` / `ctrl+shift+k` (nearest neighbours are `meta+shift+,` and `ctrl+shift+,` for the space dialog).

Note `plugin-search/PLUGIN.mdl` test T-1 already documented `⌘K` for `OpenSearch`; that was inaccurate before this change and is now correct, so it needed no edit.

## Tests

- `plugin-search` 11 passed, `plugin-navtree` 2 passed, `keyboard` 3 passed.
- Lint and `oxfmt --check` clean.

Bindings are declarative (`keyBinding` properties consumed by `plugin-navtree`'s keyboard capability), so there is no unit-testable seam beyond the existing suites; the shortcuts want a manual check in the preview.

## Follow-up worth a look

`Ctrl+Shift+K` is Firefox's Web Console shortcut on Windows/Linux, and browser devtools shortcuts generally are not suppressible by page `preventDefault`. The macOS `⇧⌘K` side is unaffected. Worth confirming in Firefox before this reaches users, and picking a different Windows/Linux mapping if it does collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXoDfoyMiasYoojabFtcte

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXoDfoyMiasYoojabFtcte)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated keyboard shortcuts for faster access:
    - Open Search with **⌘K** on macOS or **Ctrl+K** on Windows/Linux.
    - Open the Commands dialog with **⇧⌘K** on macOS or **Ctrl+Shift+K** on Windows/Linux.
  - Shortcut changes provide distinct, consistent access to Search and Commands.

- **Documentation**
  - Updated shortcut descriptions and guidance throughout the app to reflect the new keybindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->