### PR TITLE
compute: evict a failed lazy operation handler load so retries re-import

### DIFF
--- a/.changeset/lazy-handler-load-retry.md
+++ b/.changeset/lazy-handler-load-retry.md
@@ -1,0 +1,5 @@
+---
+'@dxos/compute': patch
+---
+
+A failed lazy operation handler load is no longer memoized, so retrying the operation re-imports the module. Previously `OperationHandlerSet.lazy` cached the rejected dynamic-import promise, so once a chunk fetch failed — e.g. a stale asset hash after a redeploy — every later invocation of that operation rejected instantly without re-fetching, and only a page reload recovered.

--- a/packages/core/compute/compute/src/OperationHandlerSet.test.ts
+++ b/packages/core/compute/compute/src/OperationHandlerSet.test.ts
@@ -148,6 +148,9 @@ describe('OperationHandlerSet.lazy', () => {
     const found = await set.getHandlerFor(KEY_A);
     expect(found?.meta.key).toEqual(KEY_A);
     expect(loads).toEqual(2);
+    // The successful load is still cached.
+    await set.getHandlerFor(KEY_A);
+    expect(loads).toEqual(2);
   });
 
   test('merge loads only the matched child', async ({ expect }) => {

--- a/packages/core/compute/compute/src/OperationHandlerSet.test.ts
+++ b/packages/core/compute/compute/src/OperationHandlerSet.test.ts
@@ -132,6 +132,24 @@ describe('OperationHandlerSet.lazy', () => {
     expect(loads.a).toEqual(1);
   });
 
+  test('a failed load is not memoized, so a retry re-imports', async ({ expect }) => {
+    let loads = 0;
+    const set = OperationHandlerSet.lazy([
+      Operation.make({ input: Schema.Void, output: Schema.String, meta: { key: KEY_A } }).pipe(
+        Operation.lazyHandler(() => {
+          loads++;
+          return loads === 1
+            ? Promise.reject(new TypeError('Failed to fetch dynamically imported module'))
+            : Promise.resolve({ default: makeHandler(KEY_A, 'A') });
+        }),
+      ),
+    ]);
+    await expect(set.getHandlerFor(KEY_A)).rejects.toThrow('Failed to fetch dynamically imported module');
+    const found = await set.getHandlerFor(KEY_A);
+    expect(found?.meta.key).toEqual(KEY_A);
+    expect(loads).toEqual(2);
+  });
+
   test('merge loads only the matched child', async ({ expect }) => {
     const loads = { a: 0, b: 0 };
     const setA = OperationHandlerSet.lazy([

--- a/packages/core/compute/compute/src/OperationHandlerSet.ts
+++ b/packages/core/compute/compute/src/OperationHandlerSet.ts
@@ -176,7 +176,15 @@ export const lazy = (entries: readonly Operation.LazyHandler[]): OperationHandle
     const key = normalizeKey(definition.meta.key);
     let promise = loaded.get(key);
     if (!promise) {
-      promise = load().then(({ default: handler }) => handler);
+      // Evict on failure: a transient import failure (a stale chunk hash after a redeploy) would
+      // otherwise be memoized, so every later invocation rejects instantly without re-fetching.
+      promise = load().then(
+        ({ default: handler }) => handler,
+        (err) => {
+          loaded.delete(key);
+          throw err;
+        },
+      );
       loaded.set(key, promise);
     }
     return promise;


### PR DESCRIPTION
Fixes the retry path for lazily-loaded operation handlers. Found while triaging DX-1183.

## Problem

`OperationHandlerSet.lazy` memoized the dynamic-import promise per operation key and never evicted it on rejection. Once a chunk fetch failed — e.g. a stale asset hash after a redeploy, while the page still holds the old entry chunk — every subsequent invocation of that operation rejected instantly from the cached rejected promise, with no re-fetch. The only recovery was a page reload.

Evidence from the DX-1183 debug log bundle (`preview`, 0.11.1-preview.1):

- `17:13:09` `captureFeedback` invoked → fails at `17:13:23` (~13.5s, a real network attempt) with `TypeError: Failed to fetch dynamically imported module: /assets/capture-feedback-DclDG6OH.js`
- `17:13:29` `layout.operation.addToast` fails the same way — so the toast meant to surface the error never rendered and the user saw nothing
- `17:15:44` user retries → both operations fail again in **0ms**, the memoized rejection
- `17:16:10` page reload → `17:16:20` submit succeeds

This is the same memoization pitfall documented for Durable Object lazy init: a memoized promise must be reset on failure so a retry can make progress.

## Change

- `OperationHandlerSet.lazy`: attach a rejection handler that deletes the map entry and rethrows, so a later call re-runs `load()`. Success caching is unchanged.
- Regression test: a loader that rejects once then succeeds — the first `getHandlerFor` rejects, the second resolves, and `load()` ran twice.
- Changeset: `@dxos/compute` patch.

## Notes

- Does not add import retry/backoff or a "new version, reload" prompt; those are a larger UX change and out of scope here. This only makes a user-initiated retry able to succeed.
- Not addressed, seen in the same logs: `log.error('failed to send message', { err })` fired 70× with an empty context (`echo-edge-subduction-replicator.ts:719`, same at `echo-edge-replicator.ts:440`) — no diagnostic information about why the sends failed. Worth a separate issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lazy-loaded operation handlers so failed loads can be retried successfully.
  * Prevented temporary loading failures from blocking future attempts.
  * Ensured successfully loaded handlers remain available for subsequent operations.

* **Tests**
  * Added coverage confirming retry behavior and successful handler caching.

* **Release**
  * Included a patch release for the compute package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->