### PR TITLE
plugin-client: label space sync progress with the sync phase

### DIFF
--- a/.changeset/space-sync-progress-label.md
+++ b/.changeset/space-sync-progress-label.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-client': patch
+---
+
+The space replication progress meter now labels itself `Syncing <space name>` instead of showing the space name alone, matching the mail sync meter's phase-first style.

--- a/packages/plugins/plugin-client/src/progress/space-sync-progress.test.ts
+++ b/packages/plugins/plugin-client/src/progress/space-sync-progress.test.ts
@@ -25,7 +25,7 @@ describe('toSpaceUpdate', () => {
       }),
     );
     expect(update).toEqual({
-      label: 'Notes',
+      label: 'Syncing Notes',
       current: 98,
       total: 110,
       note: '4 CRDTs · ↓6 ↑2',
@@ -34,7 +34,7 @@ describe('toSpaceUpdate', () => {
 
   test('unsynced documents alone keep the meter up', () => {
     expect(toSpaceUpdate(undefined, makeState({ unsyncedDocumentCount: 3 }))).toEqual({
-      label: 'Space',
+      label: 'Syncing space',
       current: 0,
       total: 3,
       note: '3 CRDTs',
@@ -43,7 +43,7 @@ describe('toSpaceUpdate', () => {
 
   test('feed blocks alone keep the meter up', () => {
     expect(toSpaceUpdate('Notes', makeState({ totalBlocks: '10', blocksToPush: '2' }))).toEqual({
-      label: 'Notes',
+      label: 'Syncing Notes',
       current: 8,
       total: 10,
       note: '↓0 ↑2',

--- a/packages/plugins/plugin-client/src/progress/space-sync-progress.ts
+++ b/packages/plugins/plugin-client/src/progress/space-sync-progress.ts
@@ -15,6 +15,9 @@ export type MonitorUpdate = {
 /**
  * Derives the combined (documents + feed blocks) monitor state for a space, or `undefined` when it
  * is fully caught up. Both backlogs share one meter so the UI shows one row per space.
+ *
+ * The label leads with the phase, matching the mail sync meter — a name-only label never said that
+ * the meter was tracking sync.
  */
 export const toSpaceUpdate = (name: string | undefined, state: Database.SyncState): MonitorUpdate | undefined => {
   const unsyncedDocuments = state.unsyncedDocumentCount;
@@ -39,7 +42,7 @@ export const toSpaceUpdate = (name: string | undefined, state: Database.SyncStat
   }
 
   return {
-    label: name ?? 'Space',
+    label: `Syncing ${name ?? 'space'}`,
     current: Math.max(0, total - pending),
     total,
     note: notes.join(' · '),


### PR DESCRIPTION
Fixes DX-1188.

The space replication progress meter labelled itself with the space name alone, so nothing in the row said it was tracking sync.

`toSpaceUpdate` now returns `Syncing <space name>` (`Syncing space` when the name is unavailable), matching the phase-first style already used by the mail sync meter (`Syncing <mailbox>` in `plugin-inbox/src/sync/mail-sync.ts`), where the phase leads so a truncated label still says what is happening.

- `packages/plugins/plugin-client/src/progress/space-sync-progress.ts` — label change + comment.
- `packages/plugins/plugin-client/src/progress/space-sync-progress.test.ts` — updated expectations.
- `.changeset/space-sync-progress-label.md` — patch changeset.

Testing: this sandbox has no `node_modules`/`moon`, so the unit test could not be run locally; the change is a single label string with the existing three-case test updated, and CI Check will exercise it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuKLdPJC6S4FpTcyHTTvg1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the space replication progress indicator to clearly show the active “Syncing” status.
  * Labels now include the space name when available, such as “Syncing Project,” with “Syncing space” used as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->