### PR TITLE
plugin-client: order first-run schema registration ahead of its consumers

### DIFF
--- a/.changeset/schema-registered-ordering.md
+++ b/.changeset/schema-registered-ordering.md
@@ -1,0 +1,9 @@
+---
+'@dxos/echo': patch
+'@dxos/plugin-client': patch
+---
+
+Register contributed schema before first-run consumers create typed objects. `SchemaDefs` now
+contributes a `ClientCapabilities.SchemaRegistered` marker that modules writing typed objects on
+`IdentityCreated` can require, and `ManagerOptions`/`TestAppOptions` accept a `whenIdle` effect so a
+test can model a host that has not gone idle yet.

--- a/packages/plugins/plugin-client/src/capabilities/index.ts
+++ b/packages/plugins/plugin-client/src/capabilities/index.ts
@@ -87,7 +87,10 @@ export const ReactSurface = AppCapability.surface(() => import('./react-surface'
 });
 export const SchemaDefs = Capability.lazyModule(
   'SchemaDefs',
-  { requires: [Capabilities.AtomRegistry, ClientCapabilities.Client, AppCapabilities.Schema], provides: [] },
+  {
+    requires: [Capabilities.AtomRegistry, ClientCapabilities.Client, AppCapabilities.Schema],
+    provides: [ClientCapabilities.SchemaRegistered],
+  },
   () => import('./schema-defs'),
 );
 export const RemoteTraceMonitor = Capability.lazyModule(

--- a/packages/plugins/plugin-client/src/capabilities/node.ts
+++ b/packages/plugins/plugin-client/src/capabilities/node.ts
@@ -59,6 +59,9 @@ export const OperationHandler = Capability.lazyModule(
 );
 export const SchemaDefs = Capability.lazyModule(
   'SchemaDefs',
-  { requires: [Capabilities.AtomRegistry, ClientCapabilities.Client, AppCapabilities.Schema], provides: [] },
+  {
+    requires: [Capabilities.AtomRegistry, ClientCapabilities.Client, AppCapabilities.Schema],
+    provides: [ClientCapabilities.SchemaRegistered],
+  },
   () => import('./schema-defs'),
 );

--- a/packages/plugins/plugin-client/src/capabilities/schema-defs.test.ts
+++ b/packages/plugins/plugin-client/src/capabilities/schema-defs.test.ts
@@ -35,8 +35,7 @@ describe('SchemaDefs', () => {
     const result: { registered?: boolean } = {};
     await using harness = await createComposerTestApp({
       plugins: [ClientPlugin.make({}), NotePlugin(), makeSeedPlugin(result)()],
-      // A cold boot creates the identity long before the host goes idle, so the wave `SchemaDefs`
-      // rides in on has not run.
+      // A cold boot creates the identity before the host idles, where `SchemaDefs` would activate.
       autoStart: false,
       whenIdle: Effect.never,
     });

--- a/packages/plugins/plugin-client/src/capabilities/schema-defs.test.ts
+++ b/packages/plugins/plugin-client/src/capabilities/schema-defs.test.ts
@@ -11,7 +11,7 @@ import * as Capability from '@dxos/app-framework/Capability';
 import * as Plugin from '@dxos/app-framework/Plugin';
 import * as AppCapabilities from '@dxos/app-toolkit/AppCapabilities';
 import { DXN, Type } from '@dxos/echo';
-// ClientPlugin's `#plugin` loader resolves to `plugin.node.ts` under the source condition vitest uses.
+// Resolves to `plugin.node.ts` under the source condition vitest uses.
 import * as ClientPlugin from '@dxos/plugin-client/ClientPlugin';
 import { createComposerTestApp } from '@dxos/plugin-testing/harness';
 
@@ -30,12 +30,32 @@ const NotePlugin = Plugin.define(Plugin.makeMeta({ key: DXN.make('example.com.pl
   Plugin.make,
 );
 
-/**
- * Stands in for every first-run consumer that writes a typed object as soon as an identity exists
- * (Composer's seeded README is the one this was found through). `SchemaRegistered` is what pulls
- * the otherwise idle-gated registration into the `IdentityCreated` wave. It records what
- * `Database.add` would check, which is the assertion that fails without the ordering.
- */
+describe('SchemaDefs', () => {
+  test('registers contributed schema before an IdentityCreated consumer runs', async ({ expect }) => {
+    const result: { registered?: boolean } = {};
+    await using harness = await createComposerTestApp({
+      plugins: [ClientPlugin.make({}), NotePlugin(), makeSeedPlugin(result)()],
+      // A cold boot creates the identity long before the host goes idle, so the wave `SchemaDefs`
+      // rides in on has not run.
+      autoStart: false,
+      whenIdle: Effect.never,
+    });
+    await harness.fire(ActivationEvents.Startup);
+
+    const client = harness.get(ClientCapabilities.Client);
+    await client.waitUntilInitialized();
+    expect(harness.manager.getActive()).not.toContain('org.dxos.plugin.client.module.SchemaDefs');
+
+    // What `ClientOperation.CreateIdentity` does, minus its idle-gated handler registration.
+    await client.halo.createIdentity();
+    await harness.fire(ClientEvents.IdentityCreated);
+
+    expect(result.registered).toBe(true);
+    expect(harness.manager.getActive()).toContain('org.dxos.plugin.client.module.SchemaDefs');
+  });
+});
+
+/** Records what `Database.add` checks, at the point a first-run consumer would write. */
 const makeSeedPlugin = (result: { registered?: boolean }) =>
   Plugin.define(Plugin.makeMeta({ key: DXN.make('example.com.plugin.seed'), name: 'Seed' })).pipe(
     Plugin.addModule({
@@ -52,32 +72,3 @@ const makeSeedPlugin = (result: { registered?: boolean }) =>
     }),
     Plugin.make,
   );
-
-describe('SchemaDefs', () => {
-  test('registers contributed schema before an IdentityCreated consumer runs', async ({ expect }) => {
-    const result: { registered?: boolean } = {};
-    await using harness = await createComposerTestApp({
-      plugins: [ClientPlugin.make({}), NotePlugin(), makeSeedPlugin(result)()],
-      // A cold boot creates the identity seconds before the host goes idle, so the wave
-      // `SchemaDefs` normally rides in on has not run: `autoStart: false` skips the harness's
-      // explicit Idle dispatch and `Effect.never` holds the scheduler's own idle wait open.
-      autoStart: false,
-      whenIdle: Effect.never,
-    });
-    await harness.fire(ActivationEvents.Startup);
-
-    const client = harness.get(ClientCapabilities.Client);
-    // The harness forks client initialization off startup; `spaces` is unreadable until it lands.
-    await client.waitUntilInitialized();
-    expect(harness.manager.getActive()).not.toContain('org.dxos.plugin.client.module.SchemaDefs');
-
-    // `ClientOperation.CreateIdentity` in miniature: its handler creates the identity and then
-    // fires the event. Invoking it here would instead exercise the node barrel's idle-gated
-    // operation handlers, which this test deliberately holds back.
-    await client.halo.createIdentity();
-    await harness.fire(ClientEvents.IdentityCreated);
-
-    expect(result.registered).toBe(true);
-    expect(harness.manager.getActive()).toContain('org.dxos.plugin.client.module.SchemaDefs');
-  });
-});

--- a/packages/plugins/plugin-client/src/capabilities/schema-defs.ts
+++ b/packages/plugins/plugin-client/src/capabilities/schema-defs.ts
@@ -19,40 +19,45 @@ export default Capability.makeModule(
     const schemas = yield* AppCapabilities.Schema;
 
     // TODO(wittjosiah): Unregister schemas when they are disabled.
-    let previousDxns = new Set<string>();
-    const cancel = registry.subscribe(
-      schemas.atom,
-      async (schemas) => {
-        const seenSchemaDxns = new Set<string>();
-        const batch: { schema: Type.AnyEntity; dxnKey: string }[] = [];
-        for (const schema of schemas.flat()) {
-          const uri = Type.getURI(schema);
-          if (!uri) {
-            log.warn('skipping schema without uri');
-            continue;
-          }
-
-          const key = uri.toString();
-          if (seenSchemaDxns.has(key)) {
-            log('skipping duplicate schema for echo registration', { uri: key });
-            continue;
-          }
-
-          seenSchemaDxns.add(key);
-          batch.push({ schema, dxnKey: key });
+    const previousDxns = new Set<string>();
+    const register = async (contributions: readonly AppCapabilities.Schema[]) => {
+      const seenSchemaDxns = new Set<string>();
+      const batch: { schema: Type.AnyEntity; dxnKey: string }[] = [];
+      for (const schema of contributions.flat()) {
+        const uri = Type.getURI(schema);
+        if (!uri) {
+          log.warn('skipping schema without uri');
+          continue;
         }
 
-        const toRegister = batch.filter(({ dxnKey }) => !previousDxns.has(dxnKey));
-
-        await client.addTypes(toRegister.map(({ schema }) => schema));
-        for (const { dxnKey } of toRegister) {
-          previousDxns.add(dxnKey);
+        const key = uri.toString();
+        if (seenSchemaDxns.has(key)) {
+          log('skipping duplicate schema for echo registration', { uri: key });
+          continue;
         }
-      },
-      { immediate: true },
-    );
+
+        seenSchemaDxns.add(key);
+        batch.push({ schema, dxnKey: key });
+      }
+
+      const toRegister = batch.filter(({ dxnKey }) => !previousDxns.has(dxnKey));
+
+      await client.addTypes(toRegister.map(({ schema }) => schema));
+      for (const { dxnKey } of toRegister) {
+        previousDxns.add(dxnKey);
+      }
+    };
+
+    // Awaited in the body so the module does not complete until the first batch is registered:
+    // `SchemaRegistered` is the ordering guarantee consumers depend on, and a subscription
+    // callback nobody awaits would only promise that a subscriber exists.
+    yield* Effect.tryPromise(() => register(schemas.get()));
+
+    // `previousDxns` is already populated, so the immediate pass is a no-op and only subsequent
+    // contributions (a plugin enabled later) register here.
+    const cancel = registry.subscribe(schemas.atom, register, { immediate: true });
 
     yield* Effect.addFinalizer(() => Effect.sync(() => cancel()));
-    return [];
+    return Capability.contribute(ClientCapabilities.SchemaRegistered, true);
   }),
 );

--- a/packages/plugins/plugin-client/src/capabilities/schema-defs.ts
+++ b/packages/plugins/plugin-client/src/capabilities/schema-defs.ts
@@ -48,13 +48,10 @@ export default Capability.makeModule(
       }
     };
 
-    // Awaited in the body so the module does not complete until the first batch is registered:
-    // `SchemaRegistered` is the ordering guarantee consumers depend on, and a subscription
-    // callback nobody awaits would only promise that a subscriber exists.
+    // Awaited here so `SchemaRegistered` means the types are registered, not that a subscriber exists.
     yield* Effect.tryPromise(() => register(schemas.get()));
 
-    // `previousDxns` is already populated, so the immediate pass is a no-op and only subsequent
-    // contributions (a plugin enabled later) register here.
+    // `previousDxns` is populated, so the immediate pass is a no-op.
     const cancel = registry.subscribe(schemas.atom, register, { immediate: true });
 
     yield* Effect.addFinalizer(() => Effect.sync(() => cancel()));

--- a/packages/plugins/plugin-client/src/schema-defs.test.ts
+++ b/packages/plugins/plugin-client/src/schema-defs.test.ts
@@ -1,0 +1,83 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import * as Schema from 'effect/Schema';
+import { describe, test } from 'vitest';
+
+import * as ActivationEvents from '@dxos/app-framework/ActivationEvents';
+import * as Capability from '@dxos/app-framework/Capability';
+import * as Plugin from '@dxos/app-framework/Plugin';
+import * as AppCapabilities from '@dxos/app-toolkit/AppCapabilities';
+import { DXN, Type } from '@dxos/echo';
+// ClientPlugin's `#plugin` loader resolves to `plugin.node.ts` under the source condition vitest uses.
+import * as ClientPlugin from '@dxos/plugin-client/ClientPlugin';
+import { createComposerTestApp } from '@dxos/plugin-testing/harness';
+
+import { ClientCapabilities, ClientEvents } from '#types';
+
+const NOTE_URI = DXN.make('example.com.type.note', '0.1.0');
+
+class Note extends Type.makeObject<Note>(NOTE_URI)(Schema.Struct({ title: Schema.String })) {}
+
+const NotePlugin = Plugin.define(Plugin.makeMeta({ key: DXN.make('example.com.plugin.note'), name: 'Note' })).pipe(
+  Plugin.addModule({
+    id: 'schema',
+    provides: [AppCapabilities.Schema],
+    activate: () => Effect.succeed(Capability.contribute(AppCapabilities.Schema, [Note])),
+  }),
+  Plugin.make,
+);
+
+/**
+ * Stands in for every first-run consumer that writes a typed object as soon as an identity exists
+ * (Composer's seeded README is the one this was found through). `SchemaRegistered` is what pulls
+ * the otherwise idle-gated registration into the `IdentityCreated` wave. It records what
+ * `Database.add` would check, which is the assertion that fails without the ordering.
+ */
+const makeSeedPlugin = (result: { registered?: boolean }) =>
+  Plugin.define(Plugin.makeMeta({ key: DXN.make('example.com.plugin.seed'), name: 'Seed' })).pipe(
+    Plugin.addModule({
+      id: 'seed',
+      requires: [ClientCapabilities.Client, ClientCapabilities.SchemaRegistered],
+      provides: [],
+      activatesOn: ClientEvents.IdentityCreated,
+      activate: () =>
+        Effect.gen(function* () {
+          const client = yield* ClientCapabilities.Client;
+          result.registered = client.graph.registry.getByURI(NOTE_URI.toString()) !== undefined;
+          return [];
+        }),
+    }),
+    Plugin.make,
+  );
+
+describe('SchemaDefs', () => {
+  test('registers contributed schema before an IdentityCreated consumer runs', async ({ expect }) => {
+    const result: { registered?: boolean } = {};
+    await using harness = await createComposerTestApp({
+      plugins: [ClientPlugin.make({}), NotePlugin(), makeSeedPlugin(result)()],
+      // A cold boot creates the identity seconds before the host goes idle, so the wave
+      // `SchemaDefs` normally rides in on has not run: `autoStart: false` skips the harness's
+      // explicit Idle dispatch and `Effect.never` holds the scheduler's own idle wait open.
+      autoStart: false,
+      whenIdle: Effect.never,
+    });
+    await harness.fire(ActivationEvents.Startup);
+
+    const client = harness.get(ClientCapabilities.Client);
+    // The harness forks client initialization off startup; `spaces` is unreadable until it lands.
+    await client.waitUntilInitialized();
+    expect(harness.manager.getActive()).not.toContain('org.dxos.plugin.client.module.SchemaDefs');
+
+    // `ClientOperation.CreateIdentity` in miniature: its handler creates the identity and then
+    // fires the event. Invoking it here would instead exercise the node barrel's idle-gated
+    // operation handlers, which this test deliberately holds back.
+    await client.halo.createIdentity();
+    await harness.fire(ClientEvents.IdentityCreated);
+
+    expect(result.registered).toBe(true);
+    expect(harness.manager.getActive()).toContain('org.dxos.plugin.client.module.SchemaDefs');
+  });
+});

--- a/packages/plugins/plugin-client/src/types/ClientCapabilities.ts
+++ b/packages/plugins/plugin-client/src/types/ClientCapabilities.ts
@@ -20,12 +20,9 @@ import { type AccountCache as AccountCacheType } from './AccountCache';
 export const Client = Capability.makeSingleton<Client$>()(`${meta.profile.key}.capability.client`);
 export const Schema = Capability.make<Type.AnyEntity[]>()(`${meta.profile.key}.capability.schema`);
 /**
- * Ordering marker: contributed by `SchemaDefs` once the initial batch of contributed schema has
- * been registered with the client. Requiring `AppCapabilities.Schema` only orders a module after
- * the schema PROVIDERS — two consumers of one capability have no ordering relative to each other —
- * so anything creating typed objects during first-run (before the idle wave registers them) must
- * require this instead. The value is `true` rather than `void` because an `undefined`
- * implementation reads as "not contributed" when the loader resolves a module's requires.
+ * Ordering marker for modules that create typed objects: requiring `Schema` only orders after the
+ * schema PROVIDERS, which says nothing about `SchemaDefs`, the fellow consumer that registers them.
+ * `true` rather than `void` — the loader reads an `undefined` implementation as not contributed.
  */
 export const SchemaRegistered = Capability.makeSingleton<true>()(`${meta.profile.key}.capability.schemaRegistered`);
 export const Migration = Capability.make<ObjectMigration[]>()(`${meta.profile.key}.capability.migration`);

--- a/packages/plugins/plugin-client/src/types/ClientCapabilities.ts
+++ b/packages/plugins/plugin-client/src/types/ClientCapabilities.ts
@@ -19,6 +19,15 @@ import { type AccountCache as AccountCacheType } from './AccountCache';
 
 export const Client = Capability.makeSingleton<Client$>()(`${meta.profile.key}.capability.client`);
 export const Schema = Capability.make<Type.AnyEntity[]>()(`${meta.profile.key}.capability.schema`);
+/**
+ * Ordering marker: contributed by `SchemaDefs` once the initial batch of contributed schema has
+ * been registered with the client. Requiring `AppCapabilities.Schema` only orders a module after
+ * the schema PROVIDERS — two consumers of one capability have no ordering relative to each other —
+ * so anything creating typed objects during first-run (before the idle wave registers them) must
+ * require this instead. The value is `true` rather than `void` because an `undefined`
+ * implementation reads as "not contributed" when the loader resolves a module's requires.
+ */
+export const SchemaRegistered = Capability.makeSingleton<true>()(`${meta.profile.key}.capability.schemaRegistered`);
 export const Migration = Capability.make<ObjectMigration[]>()(`${meta.profile.key}.capability.migration`);
 export const AccountCache = Capability.makeSingleton<Atom.Writable<AccountCacheType>>()(
   `${meta.profile.key}.capability.accountCache`,

--- a/packages/plugins/plugin-onboarding/src/capabilities/index.ts
+++ b/packages/plugins/plugin-onboarding/src/capabilities/index.ts
@@ -20,13 +20,16 @@ export const DefaultContent = Capability.lazyModule(
       Capabilities.OperationInvoker,
       AppCapabilities.AppGraph,
       ClientCapabilities.Client,
+      ClientCapabilities.SchemaRegistered,
       SpaceCapabilities.OnCreateSpace,
       SpaceCapabilities.DefaultSpace,
     ],
     provides: [],
     // Runtime event: the default space exists once identity is created, not at startup.
     // `requires: [SpaceCapabilities.DefaultSpace]` orders this after plugin-space's
-    // `IdentityCreated` module within the same event wave.
+    // `IdentityCreated` module within the same event wave. `SchemaRegistered` pulls the
+    // otherwise idle-gated schema registration into that wave: the seeded README is a typed
+    // object, and first-run identity creation happens long before the idle wave.
     activatesOn: ClientEvents.IdentityCreated,
   },
   () => import('./default-content'),

--- a/packages/plugins/plugin-onboarding/src/capabilities/index.ts
+++ b/packages/plugins/plugin-onboarding/src/capabilities/index.ts
@@ -26,10 +26,8 @@ export const DefaultContent = Capability.lazyModule(
     ],
     provides: [],
     // Runtime event: the default space exists once identity is created, not at startup.
-    // `requires: [SpaceCapabilities.DefaultSpace]` orders this after plugin-space's
-    // `IdentityCreated` module within the same event wave. `SchemaRegistered` pulls the
-    // otherwise idle-gated schema registration into that wave: the seeded README is a typed
-    // object, and first-run identity creation happens long before the idle wave.
+    // `DefaultSpace` orders this after plugin-space's `IdentityCreated` in the same wave;
+    // `SchemaRegistered` pulls the idle-gated schema registration into it, for the seeded README.
     activatesOn: ClientEvents.IdentityCreated,
   },
   () => import('./default-content'),

--- a/packages/plugins/plugin-space/src/capabilities/index.ts
+++ b/packages/plugins/plugin-space/src/capabilities/index.ts
@@ -23,9 +23,8 @@ export const CreateObject = SpaceCapability.createObject(() => import('./create-
 export const IdentityCreated = Capability.lazyModule(
   'IdentityCreated',
   {
-    // `SchemaRegistered` pulls the otherwise idle-gated schema registration into this wave: the
-    // root collection is a typed object, and first-run identity creation happens long before the
-    // host goes idle.
+    // `SchemaRegistered` pulls the idle-gated schema registration into this wave; the root
+    // collection is a typed object.
     requires: [ClientCapabilities.Client, ClientCapabilities.SchemaRegistered],
     provides: [SpaceCapabilities.DefaultSpace],
     // Runtime event: the default space is created when a local identity is created, not at startup.

--- a/packages/plugins/plugin-space/src/capabilities/index.ts
+++ b/packages/plugins/plugin-space/src/capabilities/index.ts
@@ -23,7 +23,10 @@ export const CreateObject = SpaceCapability.createObject(() => import('./create-
 export const IdentityCreated = Capability.lazyModule(
   'IdentityCreated',
   {
-    requires: [ClientCapabilities.Client],
+    // `SchemaRegistered` pulls the otherwise idle-gated schema registration into this wave: the
+    // root collection is a typed object, and first-run identity creation happens long before the
+    // host goes idle.
+    requires: [ClientCapabilities.Client, ClientCapabilities.SchemaRegistered],
     provides: [SpaceCapabilities.DefaultSpace],
     // Runtime event: the default space is created when a local identity is created, not at startup.
     activatesOn: ClientEvents.IdentityCreated,

--- a/packages/plugins/plugin-space/src/capabilities/node.ts
+++ b/packages/plugins/plugin-space/src/capabilities/node.ts
@@ -19,9 +19,8 @@ export const CreateObject = SpaceCapability.createObject(() => import('./create-
 export const IdentityCreated = Capability.lazyModule(
   'IdentityCreated',
   {
-    // `SchemaRegistered` pulls the otherwise idle-gated schema registration into this wave: the
-    // root collection is a typed object, and first-run identity creation happens long before the
-    // host goes idle.
+    // `SchemaRegistered` pulls the idle-gated schema registration into this wave; the root
+    // collection is a typed object.
     requires: [ClientCapabilities.Client, ClientCapabilities.SchemaRegistered],
     provides: [SpaceCapabilities.DefaultSpace],
     // Runtime event: the default space is created when a local identity is created, not at startup.

--- a/packages/plugins/plugin-space/src/capabilities/node.ts
+++ b/packages/plugins/plugin-space/src/capabilities/node.ts
@@ -19,7 +19,10 @@ export const CreateObject = SpaceCapability.createObject(() => import('./create-
 export const IdentityCreated = Capability.lazyModule(
   'IdentityCreated',
   {
-    requires: [ClientCapabilities.Client],
+    // `SchemaRegistered` pulls the otherwise idle-gated schema registration into this wave: the
+    // root collection is a typed object, and first-run identity creation happens long before the
+    // host goes idle.
+    requires: [ClientCapabilities.Client, ClientCapabilities.SchemaRegistered],
     provides: [SpaceCapabilities.DefaultSpace],
     // Runtime event: the default space is created when a local identity is created, not at startup.
     activatesOn: ClientEvents.IdentityCreated,

--- a/packages/sdk/app-framework/src/core/plugin-manager/plugin-manager.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager/plugin-manager.ts
@@ -140,8 +140,7 @@ export type ManagerOptions = {
   activationTimeout?: Duration.Input;
   /**
    * Completes when the host is idle, gating the Idle wave. Defaults to the real paint/idle wait,
-   * which resolves immediately off-browser — a test modelling a browser cold boot (where the wave
-   * lands seconds after startup) passes `Effect.never` to hold it open.
+   * which resolves immediately off-browser; `Effect.never` models a browser that has not idled.
    */
   whenIdle?: Effect.Effect<void>;
 };

--- a/packages/sdk/app-framework/src/core/plugin-manager/plugin-manager.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager/plugin-manager.ts
@@ -138,6 +138,12 @@ export type ManagerOptions = {
    * pass `Duration.infinity` to disable.
    */
   activationTimeout?: Duration.Input;
+  /**
+   * Completes when the host is idle, gating the Idle wave. Defaults to the real paint/idle wait,
+   * which resolves immediately off-browser — a test modelling a browser cold boot (where the wave
+   * lands seconds after startup) passes `Effect.never` to hold it open.
+   */
+  whenIdle?: Effect.Effect<void>;
 };
 
 /**
@@ -313,6 +319,7 @@ class ManagerImpl implements PluginManager {
     onRemove,
     loadTimeout = DEFAULT_LOAD_TIMEOUT,
     activationTimeout = DEFAULT_ACTIVATION_TIMEOUT,
+    whenIdle,
   }: ManagerOptions) {
     // Core plugins default to `meta.tags.includes('system')`, overridden by the host's
     // explicit set. Either way the set is a snapshot of the initial `plugins` array
@@ -330,7 +337,7 @@ class ManagerImpl implements PluginManager {
 
     this._state = new ManagerState(this.registry, { plugins, core, enabled });
     this._loader = new ModuleLoader(this._state, this.capabilities, activationTimeout);
-    this._scheduler = new ActivationScheduler(this._state, this.capabilities, this._loader);
+    this._scheduler = new ActivationScheduler(this._state, this.capabilities, this._loader, whenIdle);
     this._catalog = new PluginCatalog(this._state, this._scheduler, this.pluginRegistry, {
       pluginLoader,
       loadTimeout,

--- a/packages/sdk/app-framework/src/testing/harness.ts
+++ b/packages/sdk/app-framework/src/testing/harness.ts
@@ -36,6 +36,12 @@ export type TestAppOptions = {
    * Defaults to true.
    */
   registerFrameworkCapabilities?: boolean;
+  /**
+   * Completes when the host is idle, gating the Idle wave. Off-browser the real wait resolves
+   * immediately, so the wave lands before the test body runs; pass `Effect.never` to model a
+   * browser cold boot, where idle-gated modules are still inactive while the app is starting up.
+   */
+  whenIdle?: Effect.Effect<void>;
 };
 
 /**
@@ -114,6 +120,7 @@ export const createTestApp = async (opts: TestAppOptions): Promise<TestHarness> 
     setupEvents = [],
     autoStart = true,
     registerFrameworkCapabilities = true,
+    whenIdle,
   } = opts;
 
   const pluginLoader = (id: string) =>
@@ -123,7 +130,7 @@ export const createTestApp = async (opts: TestAppOptions): Promise<TestHarness> 
       return { plugin };
     });
 
-  const manager = PluginManager.make({ pluginLoader, plugins, enabled });
+  const manager = PluginManager.make({ pluginLoader, plugins, enabled, whenIdle });
 
   if (registerFrameworkCapabilities) {
     manager.capabilities.contribute({

--- a/packages/sdk/app-framework/src/testing/harness.ts
+++ b/packages/sdk/app-framework/src/testing/harness.ts
@@ -38,8 +38,7 @@ export type TestAppOptions = {
   registerFrameworkCapabilities?: boolean;
   /**
    * Completes when the host is idle, gating the Idle wave. Off-browser the real wait resolves
-   * immediately, so the wave lands before the test body runs; pass `Effect.never` to model a
-   * browser cold boot, where idle-gated modules are still inactive while the app is starting up.
+   * immediately; pass `Effect.never` to keep idle-gated modules inactive, as on a browser cold boot.
    */
   whenIdle?: Effect.Effect<void>;
 };


### PR DESCRIPTION
## Problem

On a cold boot of a **new** profile, `plugin-onboarding`'s `DefaultContent` module fails to activate:

```
module failed to activate {module: org.dxos.plugin.onboarding.module.DefaultContent,
  parentEvent: dxn:org.dxos.app-framework.event.startup,
  error: Schema not registered Schema: org.dxos.type.document}
```

Not fatal — identity and the default space are still created — but the seeded README welcome document is never added. A warm boot never reproduces it, because `ClientEvents.IdentityCreated` does not fire.

## Root cause

`SchemaDefs` (`plugin-client`) declares no `activatesOn`, which normalizes to **Idle**. `packages/apps/composer-app/scripts/memory/boot-census.json` records it activating at **t≈3859 ms, in the idle wave** — never at boot. First-run identity creation happens seconds earlier, so `Markdown.Document` is not yet registered with the client when `DefaultContent` calls `defaultSpace.db.add(...)`.

Requiring `AppCapabilities.Schema` from the consumer is **not** sufficient: that orders it after the schema *providers*, and two consumers of the same capability have no ordering relative to each other.

### Second, silent instance of the same race

`plugin-space`'s `IdentityCreated` module writes `Ref.make(Collection.make())` into the default space's properties. `Collection` ships in the same idle-registered `DataTypes` batch, so it is persisted against an unregistered schema — it just does not throw, because [`createRef`](https://github.com/dxos/dxos/blob/main/packages/core/echo/echo-client/src/echo-handler/echo-handler.ts) converts the object with `createObject()` *before* calling `database.add()`, and `_addObject`'s schema-registration guard only runs on the `!isEchoObject(obj)` branch. Fixed here too.

## Correction to the original diagnosis

The issue was reported as having a second layer: that `SchemaDefs` installs the subscription and returns without awaiting the registration, so even a correctly-ordered consumer would only get "a subscriber exists". **That premise does not hold.** `registry.subscribe(..., { immediate: true })` invokes the callback synchronously (`effect/unstable/reactivity/AtomRegistry.ts:520`), and `client.addTypes` is `async` but has no `await` before `graph.registry.add(types)` — so the first batch was already registered by the time the module body returned.

The restructuring is kept anyway, so the guarantee is structural rather than incidental (and survives `addTypes` becoming genuinely async), but reviewers should know **ordering was the whole defect**.

## Changes

1. **`ClientCapabilities.SchemaRegistered`** — an ordering marker contributed once the initial batch is registered.
   Its value is `true`, not `void`: `module-loader.ts`'s `#resolveRequires` treats an `undefined` implementation as "not contributed" and stalls the consumer for the full 30 s activation timeout before failing with `CapabilityNotFoundError` — even though the capability *is* in the registered list. This cost a debugging cycle; the reason is recorded in a comment on the tag.
2. **`schema-defs.ts`** — the first registration pass runs in the Effect body (awaited); the subscription then handles later contributions. `previousDxns` already dedupes, so the `immediate: true` pass is a no-op.
3. **`plugin-onboarding` `DefaultContent`** and **`plugin-space` `IdentityCreated`** (browser + `node.ts` barrels) require the marker. `#pullDependencyProviders` then pulls `SchemaDefs` — and, transitively, every `AppCapabilities.Schema` provider — into the `IdentityCreated` wave, ahead of both modules.
4. **`whenIdle` seam** on `ManagerOptions` / `TestAppOptions`. `ActivationScheduler` already accepted one; this just exposes it. Off-browser `whenIdle` resolves immediately (no `requestIdleCallback`), so without it a node harness fires the idle wave right after startup and the race is unreproducible.
5. **`plugin-client/src/schema-defs.test.ts`** — regression test.

## Verification

| Check | Result |
| --- | --- |
| `schema-defs.test.ts` with the fix | passes |
| Same test with `SchemaRegistered` removed from the consumer's `requires` | fails — `expected false to be true` (type absent from the client registry when the `IdentityCreated` consumer runs) |
| `build` / `test` / `lint` — app-framework, plugin-client, plugin-space, plugin-onboarding | 65 test files, 0 failures |
| `pnpm format` | clean |
| Real cold boot | **not achieved — see below** |

### The cold boot could not be verified locally

I served `composer-app` from this worktree on two fresh origins (ports 5273 and 5181 — a distinct origin gives a distinct storage profile) and confirmed the dev server was serving worktree sources. On **both**, first-run never completes:

```
Error: Timeout [20,000ms]: Waiting for the edge replication preference to converge
```

`setupIdentitySpaces` dies there, so `plugin-space`'s `IdentityCreated` fails, `SpaceCapabilities.DefaultSpace` is never contributed, and `DefaultContent` never runs. This happens identically with and without this change, so it is environmental — but it also *masks* the bug: 20 s of edge waiting lets the idle wave register the schema first.

What I did confirm in the running app with the fix applied: 233 modules active, `failed: []`, no `module failed to activate`, `SchemaDefs` active, and no `MissingProviderError` for `schemaRegistered` — i.e. the new hard require neither deadlocks nor strands the activation graph.

**Ask for the reviewer:** please confirm on a machine where EDGE converges that a brand-new profile boots without the error and lands a "README" document in the default space's root collection.

## Notes

- Changeset added (`@dxos/echo` + `@dxos/plugin-client`, both `patch`).
- Found while running an agent-driven QA flow on `claude/deus-lang-extension-8f3621` (#12713); unrelated to that branch's subject and deliberately kept out of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured contributed schemas are registered before identity-related features activate.
  * Prevented duplicate schema registrations.
  * Improved startup ordering for default content and space initialization.
  * Made schema registration complete reliably before dependent features become available.

* **Testing**
  * Added coverage verifying schema availability before identity creation processing.

* **Documentation**
  * Clarified schema registration ordering and idle-processing behavior.
  * Documented how idle processing behaves during application startup and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->