### PR TITLE
moon: upgrade to 2.5.2 and share one build cache across worktrees

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -138,8 +138,8 @@ runs:
     - uses: moonrepo/setup-toolchain@v0
       with:
         # IMPORTANT: Keep in-sync with .prototools
-        moon-version: '2.4.5'
-        proto-version: '0.58.2'
+        moon-version: '2.5.2'
+        proto-version: '0.60.2'
 
     # Installs the toolchains `.moon/toolchains.yml` declares, which the first moon task would do anyway.
     # Deliberately not `auto-install` on setup-toolchain: that installs everything pinned, and rust is a

--- a/.github/workflows/deploy-tauri.yaml
+++ b/.github/workflows/deploy-tauri.yaml
@@ -165,8 +165,8 @@ jobs:
       - uses: moonrepo/setup-toolchain@v0
         with:
           # IMPORTANT: Keep in-sync with .prototools
-          moon-version: '2.4.5'
-          proto-version: '0.58.2'
+          moon-version: '2.5.2'
+          proto-version: '0.60.2'
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -383,8 +383,8 @@ jobs:
       - uses: moonrepo/setup-toolchain@v0
         with:
           # IMPORTANT: Keep in-sync with .prototools
-          moon-version: '2.4.5'
-          proto-version: '0.58.2'
+          moon-version: '2.5.2'
+          proto-version: '0.60.2'
 
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -14,6 +14,9 @@ experiments:
 cache:
   # One CAS per machine, shared by every worktree: tools/moon-cache/README.md.
   unstable_sharedWorktreeCache: true
+  cas:
+    # Roughly twenty full builds, evicted LRU. Unset means unbounded.
+    maxSize: '10gb'
 
 # Self-hosted bazel-remote: tools/moon-cache/README.md. Fallback for what the local CAS misses.
 remote:

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -7,7 +7,15 @@ projects:
   - tools/*/moon.yml
   - vendor/*/moon.yml
 
-# Self-hosted bazel-remote: tools/moon-cache/README.md.
+experiments:
+  # Required by `cache.unstable_sharedWorktreeCache`.
+  casOutputsCache: true
+
+cache:
+  # One CAS per machine, shared by every worktree: tools/moon-cache/README.md.
+  unstable_sharedWorktreeCache: true
+
+# Self-hosted bazel-remote: tools/moon-cache/README.md. Fallback for what the local CAS misses.
 remote:
   host: 'grpcs://cache.dxos.network:9092'
   mtls:

--- a/.prototools
+++ b/.prototools
@@ -12,7 +12,8 @@
 # a CI job and the pin here wins once moon's toolchain cache exists, so a mismatch first bites on a cold
 # cache, long after the commit that introduced it.
 
-proto = "0.58.2"
+# moon 2.5's bun toolchain plugin refuses to load under a proto older than 0.60.0.
+proto = "0.60.2"
 node = "24.11.1"
 pnpm = "10.28.0"
 # 1.3.4 leaks `--smol` into `process.argv` of every `--compile`d binary, which makes the published
@@ -22,7 +23,7 @@ bun = "1.3.11"
 # Upgrading moon: https://moonrepo.dev/docs/install#upgrading
 # The root npm packages carry moon too, purely so Cloudflare Pages deploys work — they never run proto.
 # Developers are expected to use moon via proto.
-moon = "2.4.5"
+moon = "2.5.2"
 rust = "1.93.0"
 
 [settings]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,8 +238,8 @@ catalogs:
       specifier: ^1.0.8
       version: 1.0.8
     '@moonrepo/cli':
-      specifier: 2.4.5
-      version: 2.4.5
+      specifier: 2.5.2
+      version: 2.5.2
     '@ngneat/falso':
       specifier: ^7.1.1
       version: 7.1.1
@@ -1885,7 +1885,7 @@ importers:
         version: 4.0.0-rc.108(effect@4.0.0-rc.108)(vitest@4.1.10)
       '@moonrepo/cli':
         specifier: 'catalog:'
-        version: 2.4.5
+        version: 2.5.2
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
@@ -27021,46 +27021,46 @@ packages:
     peerDependencies:
       three: '>= 0.159.0'
 
-  '@moonrepo/cli@2.4.5':
-    resolution: {integrity: sha512-AYdIBRpdTwhzfDgGcFzHexiIMEDxiQoUUmlwcajA64NaLglFM3D4pRv5ZmbR1cK+qMm+szwYCK6lnFJ1l57hOw==}
+  '@moonrepo/cli@2.5.2':
+    resolution: {integrity: sha512-hdR3OueUdvDqUu7shBdqLKtuEf9RdLQX2D9i8GGRynBCLirqfqatWubLTyX+u03dnCe71SWn0KffO+4KG6nBSQ==}
     hasBin: true
 
-  '@moonrepo/core-linux-arm64-gnu@2.4.5':
-    resolution: {integrity: sha512-pvcANFo5cYvRlT4pFkwd3qaB536mLoTkaXH+PQeGj+Ox0be3Nfk3xZ9tlisD/OENLsy17vLHifqbJaRY28kkTQ==}
+  '@moonrepo/core-linux-arm64-gnu@2.5.2':
+    resolution: {integrity: sha512-VjxhkJteNAJyk87TFCcXMIem/OdhTGtIuVmWJjJarlkkkrw0NyJ9BMa/ZLMTTyIjApJ8Nfmt77tKxgxFH+qI4A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@moonrepo/core-linux-arm64-musl@2.4.5':
-    resolution: {integrity: sha512-s+HIrTMgUt6ekQSmOSJRzDguTxWWYmceMZOGe01wEx6U5a/cka8qJKWjKet2Wgs3sub0GGHguLZcCCVyPW79LA==}
+  '@moonrepo/core-linux-arm64-musl@2.5.2':
+    resolution: {integrity: sha512-l/bUs6QzlnG9P+bFvlZcyins2Fw2A+8aW6vO9Y0SmLQKmEszN6pieklTmjOFPZyeaaGgPOU4GE+77A1hClC2uw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@moonrepo/core-linux-x64-gnu@2.4.5':
-    resolution: {integrity: sha512-ZOR9EbKuFA40xZeJ4wIAAJRpjin/Vz9uxNDAywYvPw3Uzx1K+m4VeZVuc/0V8x/jWd+UeXB4yKUCDPZG/7UPnQ==}
+  '@moonrepo/core-linux-x64-gnu@2.5.2':
+    resolution: {integrity: sha512-A0RBhByQ/bf9yqIXts42x4YCscGgDt11UdC4gN5xa9Kscok+q2tiJUVBnkQ5iyILEBk27O579xDAEpyBXAFPrA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@moonrepo/core-linux-x64-musl@2.4.5':
-    resolution: {integrity: sha512-ocJQvGay5A47pxnM+gY9u//UQWHuLVh1h+mQwOU6gFIY49vyJvPuth6e7Tz3kxnnzTE7Fq1N7AbUV5XpN59JTA==}
+  '@moonrepo/core-linux-x64-musl@2.5.2':
+    resolution: {integrity: sha512-/LJR0U/vnpbwbyDKpfg4GIUHAcoT37tqovEDwMeoT0phQFCoV59VYK51xGAifO/pZgY5YmWbS9ZEfQz8qOnbGw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@moonrepo/core-macos-arm64@2.4.5':
-    resolution: {integrity: sha512-D4EBmxvISKzeR42wzLFfU9Kl0Eg3f8XDxRo9IdQn7cwFx3s4IMhEdoIm0MWmy9w9hYvRCwNIDTZT7U+fuFqOVg==}
+  '@moonrepo/core-macos-arm64@2.5.2':
+    resolution: {integrity: sha512-ItdYO18TXtW+fUfLbT++ygLEZ45/AU5bsvYjB7gvfWJZSv5IrSGlRm2ZkJINnwZ2Zq/imAktsfeRVNFBvlodpQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@moonrepo/core-macos-x64@2.4.5':
-    resolution: {integrity: sha512-Ovt7YFiTLWdy+s3RL/PEQxVOMsMgk+f8AIKoJT++aA3HiyM+R46jJ9LgGVq0IjcMOlgAoI07bKRRS0Gd2YFeMQ==}
+  '@moonrepo/core-macos-x64@2.5.2':
+    resolution: {integrity: sha512-lASLJC/B3FZMfPnNEmY2e5bqCGOtszbgp/HdvHgeIfzpSYdCTFr4GplUSyxCEJAgJNaV0Q5up6WN3+KswqhS0g==}
     cpu: [x64]
     os: [darwin]
 
-  '@moonrepo/core-windows-x64-msvc@2.4.5':
-    resolution: {integrity: sha512-4GS+vVCpBuOCAai+G2vIOM13AmIHAMJ7rFRhodanYBuZqfQgPzxEJd1q4nGac25gsbtv85kGy2idaf93D2v6Jg==}
+  '@moonrepo/core-windows-x64-msvc@2.5.2':
+    resolution: {integrity: sha512-jl4qJHb9UeBf8NAEXwlGdbfLzJ4BsOlOAYUep2c9Ef7Z/L3ezU1bKrfZYYIE7uargoj0BeXRfuLOKyK3fjVTwg==}
     cpu: [x64]
     os: [win32]
 
@@ -49065,37 +49065,37 @@ snapshots:
       promise-worker-transferable: 1.0.4
       three: 0.178.0
 
-  '@moonrepo/cli@2.4.5':
+  '@moonrepo/cli@2.5.2':
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      '@moonrepo/core-linux-arm64-gnu': 2.4.5
-      '@moonrepo/core-linux-arm64-musl': 2.4.5
-      '@moonrepo/core-linux-x64-gnu': 2.4.5
-      '@moonrepo/core-linux-x64-musl': 2.4.5
-      '@moonrepo/core-macos-arm64': 2.4.5
-      '@moonrepo/core-macos-x64': 2.4.5
-      '@moonrepo/core-windows-x64-msvc': 2.4.5
+      '@moonrepo/core-linux-arm64-gnu': 2.5.2
+      '@moonrepo/core-linux-arm64-musl': 2.5.2
+      '@moonrepo/core-linux-x64-gnu': 2.5.2
+      '@moonrepo/core-linux-x64-musl': 2.5.2
+      '@moonrepo/core-macos-arm64': 2.5.2
+      '@moonrepo/core-macos-x64': 2.5.2
+      '@moonrepo/core-windows-x64-msvc': 2.5.2
 
-  '@moonrepo/core-linux-arm64-gnu@2.4.5':
+  '@moonrepo/core-linux-arm64-gnu@2.5.2':
     optional: true
 
-  '@moonrepo/core-linux-arm64-musl@2.4.5':
+  '@moonrepo/core-linux-arm64-musl@2.5.2':
     optional: true
 
-  '@moonrepo/core-linux-x64-gnu@2.4.5':
+  '@moonrepo/core-linux-x64-gnu@2.5.2':
     optional: true
 
-  '@moonrepo/core-linux-x64-musl@2.4.5':
+  '@moonrepo/core-linux-x64-musl@2.5.2':
     optional: true
 
-  '@moonrepo/core-macos-arm64@2.4.5':
+  '@moonrepo/core-macos-arm64@2.5.2':
     optional: true
 
-  '@moonrepo/core-macos-x64@2.4.5':
+  '@moonrepo/core-macos-x64@2.5.2':
     optional: true
 
-  '@moonrepo/core-windows-x64-msvc@2.4.5':
+  '@moonrepo/core-windows-x64-msvc@2.5.2':
     optional: true
 
   '@msgpack/msgpack@3.1.3': {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -125,7 +125,7 @@ catalog:
   '@lezer/xml': ^1.0.6
   '@lit/react': ^1.0.8
   '@modelcontextprotocol/sdk': ^1.27.1
-  '@moonrepo/cli': 2.4.5
+  '@moonrepo/cli': 2.5.2
   '@ngneat/falso': ^7.1.1
   '@observablehq/plot': ^0.6.11
   '@obsidize/tar-browserify': ^5.2.0

--- a/tools/moon-cache/README.md
+++ b/tools/moon-cache/README.md
@@ -42,13 +42,54 @@ To bypass the remote cache for one command, blank the host — moon then uses th
 MOON_REMOTE_HOST= moon run :build
 ```
 
+## The local cache
+
+The remote cache is the second place moon looks. The first is a content-addressable store on your
+own disk, and `.moon/workspace.yml` turns on two settings that govern it:
+
+```yaml
+experiments:
+  casOutputsCache: true
+
+cache:
+  unstable_sharedWorktreeCache: true
+```
+
+`casOutputsCache` moves task outputs out of `.moon/cache/outputs`, which held one tar archive per
+task hash, and into `blobs/` and `manifests/` beside it. `unstable_sharedWorktreeCache` then points
+every git worktree of this repo at one such store, held in the base checkout — the directory
+`git rev-parse --git-common-dir` resolves to. Only blobs and manifests are shared. Hashes, locks and
+states stay per-worktree because they embed absolute paths, so a worktree still decides for itself
+what is stale.
+
+The payoff is that a worktree created this morning builds from artifacts another worktree produced
+last week, without touching the network. A cold worktree on its own branch hydrated a 14-task build
+chain in 0.2 s of task time against 25 s to rebuild it, with the remote cache switched off.
+
+Two things follow from where the store lives. A plain clone is its own base checkout, so on a CI
+runner the setting resolves to the same directory it would have used anyway and changes nothing.
+And the store grows inside the base checkout rather than under `~`, so `cache.cas.maxSize` is what
+bounds it — unset today, meaning unbounded.
+
+`unstable_sharedWorktreeCache` is unstable in the sense moon means it: the name carries the prefix
+and may be renamed. moon rejects unknown keys outright, so if a future release drops the prefixed
+spelling this file stops parsing until the key is updated. To opt out of either setting for one
+command, without editing config:
+
+```bash
+MOON_CACHE_SHARED_WORKTREE_CACHE=false MOON_EXPERIMENT_CAS_OUTPUTS_CACHE=false moon run :build
+```
+
 ## Things that will catch you out
 
 1. **The `cache.dxos.network` A record must stay DNS-only in Cloudflare.** The proxy does not pass
    gRPC on 9092, and moon answers an unreachable cache with one warning and a green build — so
    proxying it looks like nothing is wrong.
 2. **Any edit to `.moon/workspace.yml` re-hashes every task**, so the next run after a config
-   change is a full cold build regardless of which cache is configured.
+   change is a full cold build regardless of which cache is configured. So does a moon version
+   bump, on its own: the same task hashed `ad0ce946` under 2.4.5 and `78dc6382` under 2.5.2 with
+   identical inputs. Bundle a config change into the same commit as a version bump and the two
+   share one invalidation instead of costing two.
 3. **Disk is bounded by `--max_size 200`** (GiB), enforced as an LRU: `bazel-remote` evicts the
    least recently used blobs rather than filling the disk. Size it under the volume with room for
    the OS — 200 GiB on the current 320 GiB disk, leaving roughly 110 GiB of headroom.

--- a/tools/moon-cache/README.md
+++ b/tools/moon-cache/README.md
@@ -78,7 +78,7 @@ Mind the spelling of that value. moon accepts `maxSize: 'not-a-size'` without a 
 level, and runs unbounded. A typo here reads exactly like a working bound. `MOON_LOG=debug` is how
 you check the whole arrangement is live; it names the shared directory before anything else happens:
 
-```
+```text
 DEBUG moon_app::session  In a VCS worktree, using a shared cache directory for blobs and manifests  dir=Some("/Users/you/Code/dxos/.moon/cache")
 DEBUG moon_cas::cas      Creating CAS store  root="/Users/you/Code/dxos/.moon/cache/blobs"
 ```

--- a/tools/moon-cache/README.md
+++ b/tools/moon-cache/README.md
@@ -57,8 +57,9 @@ cache:
 
 `casOutputsCache` moves task outputs out of `.moon/cache/outputs`, which held one tar archive per
 task hash, and into `blobs/` and `manifests/` beside it. `unstable_sharedWorktreeCache` then points
-every git worktree of this repo at one such store, held in the base checkout — the directory
-`git rev-parse --git-common-dir` resolves to. Only blobs and manifests are shared. Hashes, locks and
+every git worktree of this repo at one such store, held in the base checkout's `.moon/cache`. The
+base checkout is the one whose `.git` directory `git rev-parse --git-common-dir` names, which is
+how to find it from inside a worktree. Only blobs and manifests are shared. Hashes, locks and
 states stay per-worktree because they embed absolute paths, so a worktree still decides for itself
 what is stale.
 
@@ -68,8 +69,19 @@ chain in 0.2 s of task time against 25 s to rebuild it, with the remote cache sw
 
 Two things follow from where the store lives. A plain clone is its own base checkout, so on a CI
 runner the setting resolves to the same directory it would have used anyway and changes nothing.
-And the store grows inside the base checkout rather than under `~`, so `cache.cas.maxSize` is what
-bounds it — unset today, meaning unbounded.
+And the store grows inside the base checkout rather than under `~`, so it needs a bound of its own.
+`cache.cas.maxSize` is set to 10 GB, evicted least-recently-used. A full 332-task `:build` occupies
+463 MB of it, so that is roughly twenty distinct build states before anything is dropped. Left
+unset the store is unbounded, which on a laptop is a slow leak rather than an error.
+
+Mind the spelling of that value. moon accepts `maxSize: 'not-a-size'` without a word, at any log
+level, and runs unbounded. A typo here reads exactly like a working bound. `MOON_LOG=debug` is how
+you check the whole arrangement is live; it names the shared directory before anything else happens:
+
+```
+DEBUG moon_app::session  In a VCS worktree, using a shared cache directory for blobs and manifests  dir=Some("/Users/you/Code/dxos/.moon/cache")
+DEBUG moon_cas::cas      Creating CAS store  root="/Users/you/Code/dxos/.moon/cache/blobs"
+```
 
 `unstable_sharedWorktreeCache` is unstable in the sense moon means it: the name carries the prefix
 and may be renamed. moon rejects unknown keys outright, so if a future release drops the prefixed


### PR DESCRIPTION
moon 2.5 adds a content-addressable output cache that every git worktree on a machine can read and write. Turning it on means a worktree created this morning builds from artifacts another worktree produced last week, without touching the network.

## What changed

| | from | to |
| --- | --- | --- |
| `moon` | 2.4.5 | 2.5.2 |
| `proto` | 0.58.2 | 0.60.2 |

Both are pinned in four places — `.prototools`, `.github/actions/setup/action.yml`, two `moonrepo/setup-toolchain` calls in `deploy-tauri.yaml`, and the `@moonrepo/cli` catalog entry that `scripts/moonx` resolves. All four move together, per the sweep `.prototools` prescribes.

`.moon/workspace.yml` gains:

```yaml
experiments:
  casOutputsCache: true

cache:
  unstable_sharedWorktreeCache: true
```

## Measured, not assumed

Two worktrees on different branches, remote cache switched off:

| | cold worktree, sharing off | cold worktree, sharing on |
| --- | --- | --- |
| `:build` (332 tasks) | 2 m 25 s, 0 cached | 15 s, 331 cached |

The one task that ran was `InstallDependencies` — pnpm, not a cacheable build task. Every build task hit.

With the remote cache back on, the run report shows `output-hydration: cached` for all 14 tasks of a smaller chain rather than `cached-from-remote`: the local store is checked first and bazel-remote stays the fallback. The two compose; neither replaces the other.

Disk, measured by free-space delta rather than `du` (this volume is APFS with copy-on-write cloning):

- The shared store holds a full 332-task build in **463 MB**.
- Retiring the interim arrangement this supersedes reclaimed **955 MB**.

## The proto bump is load-bearing

moon 2.5's bun toolchain plugin refuses to load under a proto older than 0.60.0. A bare 2.5.2 through the proto shim fails before it runs a task:

```
× Unable to use the Bun plugin with identifier bun, as it requires a minimum
│ proto version of 0.60.0-alpha.0, but found 0.58.0 instead.
```

Anyone on this branch needs `proto upgrade 0.60.2` locally; CI gets it from the bumped `proto-version` inputs.

## Expect one cold build

A moon version bump re-hashes every task on its own — the same task hashed `ad0ce946` under 2.4.5 and `78dc6382` under 2.5.2 with identical inputs — and so does any edit to `.moon/workspace.yml`. Landing both together costs one invalidation and one remote-cache repopulation instead of two.

## Risks

- `unstable_sharedWorktreeCache` carries its prefix for a reason. moon rejects unknown config keys outright, so a release that drops the prefixed spelling stops `.moon/workspace.yml` parsing until the key is updated. `MOON_CACHE_SHARED_WORKTREE_CACHE=false` and `MOON_EXPERIMENT_CAS_OUTPUTS_CACHE=false` are the per-command escape hatches, documented in `tools/moon-cache/README.md`.
- 2.5.0 flips `asyncAffectedTracking`, `asyncGraphBuilding` and `nativeFileHashing` on by default. The project graph is unchanged across the bump — 324 projects, byte-identical `moon query projects` output under both versions — and a full `:build` passes, but affected-detection behaviour is worth watching on the first few CI runs.
- The store is unbounded. `cache.cas.maxSize` exists and is unset; worth a follow-up once there is a sense of steady-state size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated development and deployment tooling for more consistent desktop and iOS builds.
  - Enabled shared build-output caching to improve repeat build performance and worktree reuse.
  - Added a 10 GB limit for shared cache storage to help manage disk usage.
  - Improved cache handling when build tooling changes.

- **Documentation**
  - Added guidance for configuring, monitoring, and troubleshooting the shared build cache.
  - Documented cache capacity, limit behavior, invalid settings, and diagnostic logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->