### PR TITLE
skills: point the effect skill at the pinned Effect source

### DIFF
--- a/.agents/skills/effect/SKILL.md
+++ b/.agents/skills/effect/SKILL.md
@@ -1,15 +1,12 @@
 ---
 name: effect
-description: Effect 4 in DXOS: the pinned copy in node_modules, and the house rules that override it. Use when writing or changing Effect code, composing test layer stacks, working with Schema or SchemaAST, or reading pre-migration v3 code.
+description: Effect in DXOS: the pinned copy in node_modules, and the house rules that override it. Use when writing or changing Effect code, composing test layer stacks, working with Schema or SchemaAST, or reading pre-migration code.
 ---
 
-# Effect 4 in DXOS
+# Effect in DXOS
 
-This repo is on Effect 4, where services, errors, Schema and the AST all changed
-shape. v3 written against them is **compile-clean and test-silent**: it typechecks,
-the tests pass, and the behaviour is wrong.
-
-Read the **pinned** copy.
+Effect written from memory is **compile-clean and test-silent**: it typechecks, the
+tests pass, and the behaviour is wrong. Read the **pinned** copy.
 
 ## The pinned copy
 
@@ -18,13 +15,18 @@ own agent documentation to npm, matched to the exact version this repo compiles
 against. Its `files` field ships `src/**/*.ts`, `AGENTS.md`, and `ai-docs/**`, so
 this is real source on disk, not `dist`:
 
-| Path                                 | What it holds                                                                                                                                                                  |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `node_modules/effect/AGENTS.md`      | The Effect team's authoring guide, 380 lines                                                                                                                                   |
-| `node_modules/effect/ai-docs/src/**` | 48 compiling examples, one per topic, linked from `AGENTS.md`                                                                                                                  |
-| `node_modules/effect/src/**`         | 436 files of implementation, JSDoc and every export, including the whole `unstable/` tree where v4 keeps `sql`, `http`, `httpapi`, `cli`, `ai`, `cluster`, and `observability` |
+| Path                                 | What it holds                                                                                                                                                       |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `node_modules/effect/AGENTS.md`      | The Effect team's authoring guide, 380 lines                                                                                                                        |
+| `node_modules/effect/ai-docs/src/**` | 48 compiling examples, one per topic, linked from `AGENTS.md`                                                                                                       |
+| `node_modules/effect/src/**`         | 436 files of implementation, JSDoc and every export, including the `unstable/` tree that holds `sql`, `http`, `httpapi`, `cli`, `ai`, `cluster` and `observability` |
 
 effect.website tracks `main`; the pinned copy tracks what you compile against.
+
+Research that reaches past the pinned copy, to an upstream issue, a migration note or
+a blog post, has to match the installed version first. `pnpm-workspace.yaml` pins the
+`effect` catalog entry, currently a 4.x release candidate; material written for 3.x
+describes a different library.
 
 Tests are the one thing npm leaves out: the package has no `test/` or `dtslint/`.
 
@@ -83,10 +85,10 @@ function that returns `Effect.gen`.
 Composing a layer stack, and test environments above all: read
 [layer-composition.md](layer-composition.md). One parameterized factory per
 environment, a flat `Layer.empty.pipe(...)`, `provide` for private dependencies
-against `provideMerge` for shared ones, and v4's shared memo map, which hands you the
+against `provideMerge` for shared ones, and the shared memo map, which hands you the
 same instance across two provides in one run with no compile error to warn you.
 
-## Schema, SchemaAST, and reading v3 code
+## Schema, SchemaAST, and pre-migration code
 
 Touching `Schema`, annotations, `toJsonSchema`, or anything under `SchemaAST`: read
 [v4-schema.md](v4-schema.md). It carries the rule that `effect/SchemaAST` is imported
@@ -94,6 +96,6 @@ only through `@dxos/effect`, the annotation reads that silently return `undefine
 refined types, `mutableKey` placement, lost brands, and the emitted-JSON-Schema wire
 contract.
 
-It also holds the **v3 to v4 name map**. Reach for that table when reading
-pre-migration code, an old PR, or an upstream issue, and when a v3 name you were about
-to write needs its v4 replacement.
+It also holds a **rename table**. Reach for it when reading an older file, an old PR
+or an upstream issue, and when a name you were about to write turns out to have been
+replaced.

--- a/.agents/skills/effect/SKILL.md
+++ b/.agents/skills/effect/SKILL.md
@@ -5,8 +5,9 @@ description: Effect in DXOS: the pinned copy in node_modules, and the house rule
 
 # Effect in DXOS
 
-Effect written from memory is **compile-clean and test-silent**: it typechecks, the
-tests pass, and the behaviour is wrong. Read the **pinned** copy.
+Answer Effect questions from `node_modules/effect` rather than from recall. What is
+on disk is **pinned** to the version this repo compiles against. What you remember is
+pinned to nothing, and Effect moves.
 
 ## The pinned copy
 

--- a/.agents/skills/effect/SKILL.md
+++ b/.agents/skills/effect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: effect
-description: DXOS conventions for Effect 4: the pinned-source lookup order, BaseError in the error channel, layer stack composition, and Schema/SchemaAST rules. Use when writing or changing Effect code, defining services or layers, composing test layer stacks, working with Schema or SchemaAST, or reading pre-migration v3 code.
+description: Effect 4 in DXOS: the pinned copy in node_modules, and the house rules that override it. Use when writing or changing Effect code, composing test layer stacks, working with Schema or SchemaAST, or reading pre-migration v3 code.
 ---
 
 # Effect 4 in DXOS
@@ -9,7 +9,7 @@ Your Effect knowledge is v3. This repo is on a v4 release candidate, where servi
 errors, Schema, and the AST all moved. v3 written here is **compile-clean and
 test-silent**: it typechecks, the tests pass, and the behaviour is wrong.
 
-So do not write Effect from memory. Read the **pinned** copy.
+Read the **pinned** copy.
 
 ## The pinned copy
 
@@ -24,8 +24,7 @@ this is real source on disk, not `dist`:
 | `node_modules/effect/ai-docs/src/**` | 48 compiling examples, one per topic, linked from `AGENTS.md`                                                                                                                  |
 | `node_modules/effect/src/**`         | 436 files of implementation, JSDoc and every export, including the whole `unstable/` tree where v4 keeps `sql`, `http`, `httpapi`, `cli`, `ai`, `cluster`, and `observability` |
 
-Prefer these over effect.website, over an `effect-smol` checkout, and over recall.
-The website tracks `main`; the pinned copy tracks what you compile against.
+effect.website tracks `main`; the pinned copy tracks what you compile against.
 
 Tests are the one thing npm leaves out: the package has no `test/` or `dtslint/`.
 
@@ -45,8 +44,7 @@ Before writing Effect, in this order, stopping as soon as the answer is settled:
 4. **Check the divergences below.** Three DXOS rules override the pinned guide.
 
 Done when every Effect API in the change either came from a neighbouring DXOS file or
-was confirmed by grep in `node_modules/effect/src/`. An API you recalled and did not
-confirm is the one that will be wrong.
+was confirmed by grep in `node_modules/effect/src/`.
 
 ## Where DXOS diverges from the pinned guide
 
@@ -55,7 +53,9 @@ code. Everything else in it applies as written.
 
 **Domain errors are `BaseError.extend`, not `Schema.TaggedError`.** `BaseError` from
 `@dxos/errors` supplies a `_tag` getter, so `Effect.catchTag` still discriminates,
-and it carries `context`, `wrap`, and `is` that the rest of the stack expects.
+and it carries `context`, `wrap`, and `is` that the rest of the stack expects. Keep
+the channel typed either way: bare `Error` or `unknown` in `Effect<A, E, R>` erases
+the recovery `catchTag` depends on.
 
 ```ts
 import { BaseError } from '@dxos/errors';
@@ -76,9 +76,6 @@ form here. `return yield*` works only for the few `Schema.TaggedError` classes.
 for the span it attaches. This repo leans the other way, running `fnUntraced` roughly
 two to one and reserving the traced form for boundaries worth a span. Either beats a
 function that returns `Effect.gen`.
-
-Keep the error channel typed. Bare `Error` or `unknown` in `Effect<A, E, R>` erases
-the recovery that `catchTag` depends on.
 
 ## Layer stacks
 

--- a/.agents/skills/effect/SKILL.md
+++ b/.agents/skills/effect/SKILL.md
@@ -1,141 +1,61 @@
 ---
 name: effect
-description: Guides working with Effect-TS in TypeScript codebases. Use when writing Effect programs, defining services/layers, handling errors, running effects, or when code uses effect, Context, Layer, Effect.gen, or related Effect patterns.
+description: DXOS conventions for Effect 4: the pinned-source lookup order, BaseError in the error channel, layer stack composition, and Schema/SchemaAST rules. Use when writing or changing Effect code, defining services or layers, composing test layer stacks, working with Schema or SchemaAST, or reading pre-migration v3 code.
 ---
 
-# Working with Effect
+# Effect 4 in DXOS
 
-Effect is a TypeScript library for building complex synchronous and asynchronous programs with typed errors, dependency injection, and resource management. Reference: <https://effect.website/llms.txt>.
+Your Effect knowledge is v3. This repo is on a v4 release candidate, where services,
+errors, Schema, and the AST all moved. v3 written here is **compile-clean and
+test-silent**: it typechecks, the tests pass, and the behaviour is wrong.
 
-## Core Principles (Inlined)
+So do not write Effect from memory. Read the **pinned** copy.
 
-### The Effect Type
+## The pinned copy
 
-`Effect<Success, Error, Requirements>` is a lazy, immutable description of a workflow:
+Unlike nearly every other package, `effect` publishes its TypeScript source and its
+own agent documentation to npm, matched to the exact version this repo compiles
+against. Its `files` field ships `src/**/*.ts`, `AGENTS.md`, and `ai-docs/**`, so
+this is real source on disk, not `dist`:
 
-- **Success**: Value on success.
-- **Error**: Expected (typed) errors; use `never` when effect cannot fail.
-- **Requirements**: Services/dependencies from `Context`; use `never` when none needed.
+| Path                                 | What it holds                                                                                                                                                                  |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `node_modules/effect/AGENTS.md`      | The Effect team's authoring guide, 380 lines                                                                                                                                   |
+| `node_modules/effect/ai-docs/src/**` | 48 compiling examples, one per topic, linked from `AGENTS.md`                                                                                                                  |
+| `node_modules/effect/src/**`         | 436 files of implementation, JSDoc and every export, including the whole `unstable/` tree where v4 keeps `sql`, `http`, `httpapi`, `cli`, `ai`, `cluster`, and `observability` |
 
-Effects are _descriptions_, not executions. They run via the Effect runtime at a single entry point.
+Prefer these over effect.website, over an `effect-smol` checkout, and over recall.
+The website tracks `main`; the pinned copy tracks what you compile against.
 
-```ts
-import { Effect, Context, Layer } from 'effect';
+Tests are the one thing npm leaves out: the package has no `test/` or `dtslint/`.
 
-// Effect<number, never, never> - succeeds with number, no errors, no deps
-const pure = Effect.succeed(42);
+`node_modules/effect` is a pnpm symlink into `.pnpm/effect@<version>/`, and it is
+gitignored, so nothing will surface it for you. Open it by path.
 
-// Effect<never, HttpError, never> - fails with a typed domain error
-const failure = Effect.fail(new HttpError({ status: 404 }));
-```
+## Lookup order
 
-Never use bare `Error` (or `unknown`) as the error type in `Effect<A, E, R>` — in DXOS, prefer `BaseError.extend` from `@dxos/errors` so failures are tagged and recoverable via `Effect.catchTag`.
+Before writing Effect, in this order, stopping as soon as the answer is settled:
 
-### Two Types of Errors
+1. **Read a neighbour.** Find the nearest DXOS file already doing this and copy its
+   shape. House conventions beat upstream defaults.
+2. **Read `node_modules/effect/AGENTS.md`**, then follow its link to the
+   `ai-docs/src/**` example for your topic.
+3. **Grep `node_modules/effect/src/`** for the exact export. This settles whether an
+   API exists and what its signature is.
+4. **Check the divergences below.** Three DXOS rules override the pinned guide.
 
-| Type           | Tracked in type         | Purpose                                                           |
-| -------------- | ----------------------- | ----------------------------------------------------------------- |
-| **Expected**   | Yes (`Error` in Effect) | Anticipated, domain errors, recoverable (like checked exceptions) |
-| **Unexpected** | No                      | Defects, bugs, unanticipated (like unchecked exceptions)          |
+Done when every Effect API in the change either came from a neighbouring DXOS file or
+was confirmed by grep in `node_modules/effect/src/`. An API you recalled and did not
+confirm is the one that will be wrong.
 
-Use `Effect.fail()` for expected errors. Thrown errors in sync/async code become defects. Avoid `throw`; prefer `Effect.fail` or `Effect.try`.
+## Where DXOS diverges from the pinned guide
 
-### Creating Effects
+Three rules where following `AGENTS.md` literally produces broken or off-convention
+code. Everything else in it applies as written.
 
-| Constructor                        | Use case                               |
-| ---------------------------------- | -------------------------------------- |
-| `Effect.succeed(v)`                | Pure success                           |
-| `Effect.fail(e)`                   | Expected failure                       |
-| `Effect.sync(() => x)`             | Sync side effect; must not throw       |
-| `Effect.try(() => x)`              | Sync that may throw → defect or caught |
-| `Effect.promise(() => Promise)`    | Wrap Promise (reject → defect)         |
-| `Effect.gen(function* () { ... })` | Generator style, like async/await      |
-
-```ts
-const program = Effect.gen(function* () {
-  const a = yield* Effect.succeed(1);
-  const b = yield* Effect.succeed(2);
-  return a + b;
-});
-```
-
-### Running Effects
-
-| Function                   | Returns               | When to use                          |
-| -------------------------- | --------------------- | ------------------------------------ |
-| `Effect.runSync(e)`        | `A`                   | Sync only, no fail; throws otherwise |
-| `Effect.runPromise(e)`     | `Promise<A>`          | Async; rejects on failure            |
-| `Effect.runPromiseExit(e)` | `Promise<Exit<A, E>>` | Get Exit for custom handling         |
-
-Provide requirements before running: `Effect.runPromise(Effect.provide(program, layer))`.
-
-### Services and Context
-
-1. **Define a service** with `Context.Tag`:
-
-```ts
-class MyService extends Context.Tag('MyService')<
-  MyService,
-  { readonly doSomething: () => Effect.Effect<string, never> }
->() {}
-```
-
-2. **Use in effects** – the service appears in `Requirements`:
-
-```ts
-const program = Effect.gen(function* () {
-  const service = yield* MyService;
-  return yield* service.doSomething();
-});
-// Effect<string, never, MyService>
-```
-
-3. **Provide** with `Effect.provideService` or `Effect.provide` + `Layer`.
-
-### Layers
-
-Layers construct services and hide implementation dependencies. Avoid leaking internal deps in service interfaces.
-
-- `Layer.succeed(Tag, implementation)` – static implementation
-- `Layer.effect(Tag, Effect)` – effectful construction
-- `Layer.merge(a, b)` – combine layers
-- Compose with `Layer.provide` / `Layer.provideMerge` for dependency graphs
-
-Provide at the edge: `Effect.provide(program, AppLive)`.
-
-For composing layer stacks (test environments in particular) — single parameterized factory, flat
-`Layer.empty.pipe(...)` stack, ternaries for alternative implementations, `provide` vs
-`provideMerge` — see [layer-composition.md](layer-composition.md).
-
-This repo is on Effect 4. Schema and AST carry gotchas that fail compile-clean and test-silent —
-annotation reads on refined types, `mutableKey` placement, lost brands, the `toJsonSchema` wire
-contract, and the rule that `effect/SchemaAST` is only ever imported through `@dxos/effect`. See
-[v4-schema.md](v4-schema.md), which also carries the v3 → v4 name map for reading older code.
-
-### Common Patterns
-
-- **Do notation**: Prefer `Effect.gen` over manual `flatMap` chains.
-- **Error recovery**: `Effect.catchAll`, `Effect.catchTag`, `Effect.orElse`, `Effect.retry`.
-- **Resource management**: `Effect.scoped`, `Scope`, `acquireRelease`.
-- **Concurrency**: `Effect.all` (parallel), `Effect.forEach` with concurrency.
-- **Tagged errors**: Use `Data.TaggedClass` or `Data.TaggedEnum` for typed domain errors.
-
-## Quick Reference
-
-**Import:**
-
-```ts
-import { Effect, Context, Layer, Data } from 'effect';
-```
-
-**Run program with layer:**
-
-```ts
-const runnable = Effect.provide(program, AppLive);
-Effect.runPromise(runnable);
-```
-
-**Typed error (DXOS — prefer `BaseError`):**
+**Domain errors are `BaseError.extend`, not `Schema.TaggedError`.** `BaseError` from
+`@dxos/errors` supplies a `_tag` getter, so `Effect.catchTag` still discriminates,
+and it carries `context`, `wrap`, and `is` that the rest of the stack expects.
 
 ```ts
 import { BaseError } from '@dxos/errors';
@@ -145,18 +65,37 @@ export class HttpError extends BaseError.extend('HttpError', 'HTTP request faile
     super({ context });
   }
 }
-
-// Pure Effect boundaries may use Data.TaggedClass instead:
-class ValidationError extends Data.TaggedClass('ValidationError')<{ readonly field: string }> {}
 ```
 
-## Documentation Index
+**Raise with `Effect.fail`, not `return yield*`.** `AGENTS.md` teaches
+`return yield* new SomeError()`, which needs the error to be yieldable. `BaseError`
+extends `Error` and is not, so `Effect.fail(new HttpError({ status: 404 }))` is the
+form here. `return yield*` works only for the few `Schema.TaggedError` classes.
 
-For deeper topics, see <https://effect.website/docs/>:
+**`Effect.fnUntraced` is the default wrapper.** `AGENTS.md` prefers `Effect.fn('name')`
+for the span it attaches. This repo leans the other way, running `fnUntraced` roughly
+two to one and reserving the traced form for boundaries worth a span. Either beats a
+function that returns `Effect.gen`.
 
-- **Getting started**: Creating Effects, Running Effects, The Effect Type, Using Generators
-- **Error management**: Two Error Types, Expected Errors, Fallback, Retrying
-- **Services**: Managing Services, Managing Layers, Default Services
-- **Concurrency**: Basic Concurrency, Fibers, Queue, Semaphore
-- **Schema**: effect/Schema for validation and encoding
-- **API**: <https://effect.website/docs/additional-resources/api-reference/>
+Keep the error channel typed. Bare `Error` or `unknown` in `Effect<A, E, R>` erases
+the recovery that `catchTag` depends on.
+
+## Layer stacks
+
+Composing a layer stack, and test environments above all: read
+[layer-composition.md](layer-composition.md). One parameterized factory per
+environment, a flat `Layer.empty.pipe(...)`, `provide` for private dependencies
+against `provideMerge` for shared ones, and v4's shared memo map, which hands you the
+same instance across two provides in one run with no compile error to warn you.
+
+## Schema, SchemaAST, and reading v3 code
+
+Touching `Schema`, annotations, `toJsonSchema`, or anything under `SchemaAST`: read
+[v4-schema.md](v4-schema.md). It carries the rule that `effect/SchemaAST` is imported
+only through `@dxos/effect`, the annotation reads that silently return `undefined` on
+refined types, `mutableKey` placement, lost brands, and the emitted-JSON-Schema wire
+contract.
+
+It also holds the **v3 to v4 name map**. Reach for that table when reading
+pre-migration code, an old PR, or an upstream issue, and when a v3 name you were about
+to write needs its v4 replacement.

--- a/.agents/skills/effect/SKILL.md
+++ b/.agents/skills/effect/SKILL.md
@@ -5,9 +5,9 @@ description: Effect 4 in DXOS: the pinned copy in node_modules, and the house ru
 
 # Effect 4 in DXOS
 
-Your Effect knowledge is v3. This repo is on a v4 release candidate, where services,
-errors, Schema, and the AST all moved. v3 written here is **compile-clean and
-test-silent**: it typechecks, the tests pass, and the behaviour is wrong.
+This repo is on Effect 4, where services, errors, Schema and the AST all changed
+shape. v3 written against them is **compile-clean and test-silent**: it typechecks,
+the tests pass, and the behaviour is wrong.
 
 Read the **pinned** copy.
 
@@ -48,8 +48,8 @@ was confirmed by grep in `node_modules/effect/src/`.
 
 ## Where DXOS diverges from the pinned guide
 
-Three rules where following `AGENTS.md` literally produces broken or off-convention
-code. Everything else in it applies as written.
+`AGENTS.md` applies as written except on three points, where following it literally
+produces broken or off-convention code here.
 
 **Domain errors are `BaseError.extend`, not `Schema.TaggedError`.** `BaseError` from
 `@dxos/errors` supplies a `_tag` getter, so `Effect.catchTag` still discriminates,
@@ -67,10 +67,11 @@ export class HttpError extends BaseError.extend('HttpError', 'HTTP request faile
 }
 ```
 
-**Raise with `Effect.fail`, not `return yield*`.** `AGENTS.md` teaches
-`return yield* new SomeError()`, which needs the error to be yieldable. `BaseError`
-extends `Error` and is not, so `Effect.fail(new HttpError({ status: 404 }))` is the
-form here. `return yield*` works only for the few `Schema.TaggedError` classes.
+**Raise `BaseError` with `Effect.fail`.** `AGENTS.md` teaches
+`return yield* new SomeError()`, which needs an error implementing
+`Cause.YieldableError`. `Data.Error`, `Data.TaggedError` and `Schema.TaggedError` all
+do; `BaseError` is a plain `Error` subclass and does not. DXOS domain errors go
+through `Effect.fail(new HttpError({ status: 404 }))`.
 
 **`Effect.fnUntraced` is the default wrapper.** `AGENTS.md` prefers `Effect.fn('name')`
 for the span it attaches. This repo leans the other way, running `fnUntraced` roughly

--- a/.agents/skills/effect/v4-schema.md
+++ b/.agents/skills/effect/v4-schema.md
@@ -58,12 +58,6 @@ The **type** side of a `Ref` field admits only a live `Ref` instance. Callers se
 `{'/': dxn}` form, so validating the raw input against `Schema.toType(...)` rejects every
 ref-bearing payload. Hydrate refs first, then validate.
 
-## `Schema.Date` is not `DateFromString`
-
-v4's `Schema.Date` is a `declare<globalThis.Date>` — the identity/instance schema, the direct
-replacement for v3's `DateFromSelf`. Decoding _from a string_ is `Schema.DateFromString`. Swapping
-one for the other changes the wire format of every field that uses it.
-
 ## The `toJsonSchema` output shape is a wire contract
 
 ECHO's emitted JSON Schema has consumers on both sides of the LLM boundary (the assistant's
@@ -105,7 +99,7 @@ Useful when reading pre-migration code, old PRs, or upstream issues.
 | `S.extend`                             | removed — `S.StructWithRest`                             |
 | `S.optionalWith(X, { default })`       | `X.pipe(S.withDecodingDefault(...))` on the bare field   |
 | `schema.pick(...)` / `.omit(...)`      | `schema.mapFields(Struct.pick([...]))`                   |
-| `S.DateFromSelf`                       | `S.Date`                                                 |
+| `S.DateFromSelf`                       | `S.Date` (decoding from a string is `S.DateFromString`)  |
 | `S.asserts(schema)(input)`             | `S.asserts(schema, input)`                               |
 | `effect/Either`                        | `effect/Result` (`isFailure`/`isSuccess`, `.failure`)    |
 | `decodeUnknownEither`                  | `decodeUnknownResult`                                    |
@@ -119,19 +113,21 @@ Useful when reading pre-migration code, old PRs, or upstream issues.
 
 ## Upstream docs
 
-Read these rather than recalling v4 from memory — the beta moves.
+Read these rather than recalling v4 from memory; the release candidate moves. The
+pinned copy in `node_modules/effect` is the first stop and [SKILL.md](SKILL.md)
+describes it. These are the migration notes it does not carry, now on
+`Effect-TS/effect` (`effect-smol` is archived, and its links are dead):
 
-- **`node_modules/effect/ai-docs/src/`** — the installed version's own guides, so they always match
-  the pinned beta. `01_effect/02_schema` is the Schema guide; `10_predicate`, `03_stream`,
-  `50_http-client`, `70_cli`, `71_ai` cover the other tiers. `node_modules/effect/AGENTS.md` is the
-  short-form authoring guide.
-- [effect-smol `MIGRATION.md`](https://github.com/Effect-TS/effect-smol/blob/main/MIGRATION.md) —
+- [`MIGRATION.md`](https://github.com/Effect-TS/effect/blob/main/MIGRATION.md) —
   package consolidation, the `effect/unstable/*` split, versioning.
-- [`migration/schema.md`](https://github.com/Effect-TS/effect-smol/blob/main/migration/schema.md) and
-  [`migration/v3-to-v4.md`](https://github.com/Effect-TS/effect-smol/blob/main/migration/v3-to-v4.md)
+- [`migration/schema.md`](https://github.com/Effect-TS/effect/blob/main/migration/schema.md)
+  and [`migration/v3-to-v4.md`](https://github.com/Effect-TS/effect/blob/main/migration/v3-to-v4.md)
   — the rename tables `tools/codemods/effect-4-verified-renames.mjs` was built from.
-- [`migration/layer-memoization.md`](https://github.com/Effect-TS/effect-smol/blob/main/migration/layer-memoization.md)
+- [`migration/layer-memoization.md`](https://github.com/Effect-TS/effect/blob/main/migration/layer-memoization.md)
   — background for §8 of [layer-composition.md](layer-composition.md).
+- [`migration/yieldable.md`](https://github.com/Effect-TS/effect/blob/main/migration/yieldable.md)
+  — why `return yield* new SomeError()` works for `Schema.TaggedError` and not for
+  `BaseError.extend`.
 
 ## Bundling: watch for dynamic imports in `export *` chains
 

--- a/.agents/skills/effect/v4-schema.md
+++ b/.agents/skills/effect/v4-schema.md
@@ -118,14 +118,14 @@ pinned copy in `node_modules/effect` is the first stop and [SKILL.md](SKILL.md)
 describes it. These are the migration notes it does not carry, now on
 `Effect-TS/effect` (`effect-smol` is archived, and its links are dead):
 
-- [`MIGRATION.md`](https://github.com/Effect-TS/effect/blob/main/MIGRATION.md) —
+- [`MIGRATION.md`](https://github.com/Effect-TS/effect/blob/effect%404.0.0-rc.108/MIGRATION.md) —
   package consolidation, the `effect/unstable/*` split, versioning.
-- [`migration/schema.md`](https://github.com/Effect-TS/effect/blob/main/migration/schema.md)
-  and [`migration/v3-to-v4.md`](https://github.com/Effect-TS/effect/blob/main/migration/v3-to-v4.md)
+- [`migration/schema.md`](https://github.com/Effect-TS/effect/blob/effect%404.0.0-rc.108/migration/schema.md)
+  and [`migration/v3-to-v4.md`](https://github.com/Effect-TS/effect/blob/effect%404.0.0-rc.108/migration/v3-to-v4.md)
   — the rename tables `tools/codemods/effect-4-verified-renames.mjs` was built from.
-- [`migration/layer-memoization.md`](https://github.com/Effect-TS/effect/blob/main/migration/layer-memoization.md)
+- [`migration/layer-memoization.md`](https://github.com/Effect-TS/effect/blob/effect%404.0.0-rc.108/migration/layer-memoization.md)
   — background for §8 of [layer-composition.md](layer-composition.md).
-- [`migration/yieldable.md`](https://github.com/Effect-TS/effect/blob/main/migration/yieldable.md)
+- [`migration/yieldable.md`](https://github.com/Effect-TS/effect/blob/effect%404.0.0-rc.108/migration/yieldable.md)
   — why `return yield* new SomeError()` works for `Schema.TaggedError` and not for
   `BaseError.extend`.
 


### PR DESCRIPTION
The `effect` skill routes Effect work to `node_modules/effect`, which carries the Effect team's own agent guide, 48 compiling examples, and 436 files of source, all matched to the version this repo compiles against.

That works because `effect` publishes `src/**/*.ts`, `AGENTS.md`, `CLAUDE.md` and `ai-docs/**` in its `files` field. From the registry tarball for the pinned `4.0.0-rc.108`:

```
1744  dist/
 436  src/       full source, incl. the whole unstable/ tree
  73  ai-docs/
   1  AGENTS.md
   0  test/  dtslint/
```

Most packages ship `dist` alone. The skill states this outright, because an agent carries a strong prior that `node_modules` holds compiled output and will skip it otherwise.

## The skill

A lookup order (nearest DXOS file, then `AGENTS.md`, then grep `src/`) under a completion criterion that binds every Effect API in a change to a neighbouring file or a grep hit.

Then the three rules where following `AGENTS.md` literally produces broken or off-convention code here:

- **`BaseError.extend` from `@dxos/errors` for domain errors.** It supplies a `_tag` getter, so `Effect.catchTag` discriminates.
- **`Effect.fail(new X())` to raise.** `return yield*` requires a yieldable error, and `BaseError` extends `Error`. All 66 files using `BaseError.extend` raise through `Effect.fail`.
- **`Effect.fnUntraced` as the default wrapper**, with traced `Effect.fn('name')` at boundaries worth a span.

The rest of `AGENTS.md` applies as written, so the skill does not restate it.

## v4-schema.md

Carries the rules with no upstream equivalent: the `@dxos/effect` SchemaAST facade, annotation reads on refined types, `mutableKey` placement, the emitted-JSON-Schema wire contract, and the v3 decoder that retires on space coverage rather than a date.

It also carries the curated v3 to v4 name map. Upstream's `migration/v3-to-v4.md` covers the same ground in 16,133 lines and is not published to npm, so 28 rows on disk is the cheaper lookup.

Docs only, so no changeset (rule 2, `agents/instructions/changesets.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reworked Effect guidance around DXOS-specific practices, pinned source verification, version-matched research, lookup order, error handling, untraced functions, layers, and schemas.
  - Updated Effect v4 date schema guidance to clarify string decoding and v3-to-v4 mappings.
  - Replaced outdated beta and archived-package migration references with current release-candidate guidance and links.
  - Removed obsolete generic Effect fundamentals, examples, quick references, and documentation indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->