### PR TITLE
tooling: pilot tstyche for type-level tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Check for import cycles
         run: pnpm run check-cycles
 
+      - name: Check type-level tests
+        run: pnpm run test-types
+
       - name: Check publish config
         run: pnpm run check-publish-config
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test": "moon run :test -- --no-file-parallelism",
     "test-browser": "MOON_CONCURRENCY=4 moon run :test-browser -- --no-file-parallelism",
     "test-storybook": "MOON_CONCURRENCY=4 moon run :test-storybook -- --no-file-parallelism",
+    "test-types": "tstyche",
     "toolbox": "vite-node tools/toolbox/src/main.ts"
   },
   "dependencies": {
@@ -170,6 +171,7 @@
     "tailwindcss": "catalog:",
     "ts-morph": "catalog:",
     "tsdown": "catalog:",
+    "tstyche": "catalog:",
     "tsx": "catalog:",
     "types-package-json": "catalog:",
     "typescript": "catalog:",

--- a/packages/common/eslint-plugin-rules/rules/operation-key-shape.js
+++ b/packages/common/eslint-plugin-rules/rules/operation-key-shape.js
@@ -211,7 +211,9 @@ const packageDomain = (filePath) => {
 /** A fixture is not part of the product surface and must not squat a real namespace. */
 const isFixture = (filePath) =>
   /\.test\.tsx?$/.test(filePath) ||
+  /\.tst\.tsx?$/.test(filePath) ||
   /\.stories\.tsx?$/.test(filePath) ||
+  filePath.includes('/typetest/') ||
   filePath.includes('/testing/') ||
   filePath.includes('/playground/') ||
   filePath.includes('/templates/') ||

--- a/packages/core/compute/operation/src/invoker.test.ts
+++ b/packages/core/compute/operation/src/invoker.test.ts
@@ -3,7 +3,6 @@
 //
 
 import { it } from '@effect/vitest';
-import * as Context from 'effect/Context';
 import * as Deferred from 'effect/Deferred';
 import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
@@ -20,10 +19,6 @@ import * as Operation from '@dxos/compute/Operation';
 import { DXN } from '@dxos/keys';
 
 import * as OperationInvoker from './OperationInvoker';
-
-// This file asserts that invalid usage is a type error, so the diagnostic reporting
-// it is the assertion succeeding.
-/** @effect-diagnostics missingEffectContext:skip-file */
 
 const testRuntime = ManagedRuntime.make(Layer.empty) as unknown as ManagedRuntime.ManagedRuntime<any, any>;
 
@@ -325,49 +320,5 @@ describe('OperationInvoker.invokePromise concurrency contract', () => {
     // Issued [stale, newest]; applied [newest, stale] — with last-write-wins state the stale value
     // wins, which is why such state must not be dispatched through invokePromise.
     expect(applied).toEqual(['newest', 'stale']);
-  });
-});
-
-//
-// Type-level tests for Operation.withHandler service constraints.
-//
-
-describe('Operation.withHandler type safety', () => {
-  test('handler using undeclared service is a type error', () => {
-    class DeclaredService extends Context.Service<DeclaredService, { declared: () => void }>()(
-      '@test/DeclaredService',
-    ) {}
-    class UndeclaredService extends Context.Service<UndeclaredService, { undeclared: () => void }>()(
-      '@test/UndeclaredService',
-    ) {}
-
-    const opWithDeclaredService = Operation.make({
-      input: Schema.Void,
-      output: Schema.Void,
-      meta: { key: DXN.make('com.example.operation.test.declaredService') },
-      services: [DeclaredService],
-    });
-
-    // Using the declared service is allowed.
-    Operation.withHandler(opWithDeclaredService, (_input) =>
-      Effect.gen(function* () {
-        yield* DeclaredService;
-      }),
-    );
-
-    // Using an undeclared service should be a type error.
-    Operation.withHandler(opWithDeclaredService, (_input) =>
-      // @ts-expect-error - UndeclaredService is not in the operation's services
-      Effect.gen(function* () {
-        yield* UndeclaredService;
-      }),
-    );
-
-    // Operation.Service is always available to handlers without declaring it.
-    Operation.withHandler(opWithDeclaredService, (_input) =>
-      Effect.gen(function* () {
-        yield* Operation.schedule(SideEffect);
-      }),
-    );
   });
 });

--- a/packages/core/compute/operation/src/operation.test.ts
+++ b/packages/core/compute/operation/src/operation.test.ts
@@ -13,10 +13,6 @@ import { TestSchema } from '@dxos/echo/testing';
 import { EffectEx } from '@dxos/effect';
 import { DXN } from '@dxos/keys';
 
-// This file asserts that invalid usage is a type error, so the diagnostic reporting
-// it is the assertion succeeding.
-/** @effect-diagnostics missingEffectContext:skip-file */
-
 describe('Operation', () => {
   describe('make', () => {
     test('creates an operation definition with required fields', () => {
@@ -244,37 +240,6 @@ describe('Operation', () => {
       );
 
       expect(result.results).toEqual(['user1', 'user2']);
-    });
-
-    test('handler using undeclared service is a type error', () => {
-      class DeclaredService extends Context.Service<DeclaredService, { declared: () => void }>()(
-        '@test/DeclaredService',
-      ) {}
-      class UndeclaredService extends Context.Service<UndeclaredService, { undeclared: () => void }>()(
-        '@test/UndeclaredService',
-      ) {}
-
-      const op = Operation.make({
-        input: Schema.Void,
-        output: Schema.Void,
-        meta: { key: DXN.make('com.example.operation.test.typeError') },
-        services: [DeclaredService],
-      });
-
-      // Using the declared service is allowed.
-      Operation.withHandler(op, (_input) =>
-        Effect.gen(function* () {
-          yield* DeclaredService;
-        }),
-      );
-
-      // Using an undeclared service should be a type error.
-      Operation.withHandler(op, (_input) =>
-        // @ts-expect-error - UndeclaredService is not in the operation's services
-        Effect.gen(function* () {
-          yield* UndeclaredService;
-        }),
-      );
     });
   });
 });

--- a/packages/core/compute/operation/typetest/operation.tst.ts
+++ b/packages/core/compute/operation/typetest/operation.tst.ts
@@ -1,0 +1,65 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// Deliberately-invalid usage lives here, so the diagnostic that reports it is the
+// assertion succeeding.
+/** @effect-diagnostics missingEffectContext:skip-file unnecessaryEffectGen:skip-file */
+
+import * as Context from 'effect/Context';
+import * as Effect from 'effect/Effect';
+import * as Schema from 'effect/Schema';
+import { describe, expect, it } from 'tstyche';
+
+import * as Operation from '@dxos/compute/Operation';
+import { DXN } from '@dxos/keys';
+
+class DeclaredService extends Context.Service<DeclaredService, { declared: () => void }>()('@test/DeclaredService') {}
+class UndeclaredService extends Context.Service<UndeclaredService, { undeclared: () => void }>()(
+  '@test/UndeclaredService',
+) {}
+
+const op = Operation.make({
+  input: Schema.Void,
+  output: Schema.Void,
+  meta: { key: DXN.make('com.example.operation.test.typeError') },
+  services: [DeclaredService],
+});
+
+const sideEffect = Operation.make({
+  input: Schema.Void,
+  output: Schema.Void,
+  meta: { key: DXN.make('com.example.operation.test.sideEffect') },
+});
+
+describe('Operation.withHandler service requirements', () => {
+  it('accepts a service the operation declares', () => {
+    expect(
+      Operation.withHandler(op, (_input) =>
+        Effect.gen(function* () {
+          yield* DeclaredService;
+        }),
+      ),
+    ).type.not.toRaiseError();
+  });
+
+  it('rejects a service the operation does not declare', () => {
+    expect(
+      Operation.withHandler(op, (_input) =>
+        Effect.gen(function* () {
+          yield* UndeclaredService;
+        }),
+      ),
+    ).type.toRaiseError("Type 'UndeclaredService' is not assignable to type 'DeclaredService | Service'");
+  });
+
+  it('accepts Operation.Service without declaring it', () => {
+    expect(
+      Operation.withHandler(op, (_input) =>
+        Effect.gen(function* () {
+          yield* Operation.schedule(sideEffect);
+        }),
+      ),
+    ).type.not.toRaiseError();
+  });
+});

--- a/packages/sdk/app-framework/src/core/capability.test.ts
+++ b/packages/sdk/app-framework/src/core/capability.test.ts
@@ -10,10 +10,6 @@ import * as Registry from 'effect/unstable/reactivity/AtomRegistry';
 import * as Capability from './capability';
 import * as CapabilityManager from './capability-manager';
 
-// This file asserts that invalid usage is a type error, so the diagnostic reporting
-// it is the assertion succeeding.
-/** @effect-diagnostics missingEffectContext:skip-file */
-
 type Example = { example: string };
 
 describe('Capability tags', () => {
@@ -84,20 +80,6 @@ describe('Capability tags', () => {
       const contribution = Capability.contributeAll(multi, [{ example: 'one' }, { example: 'two' }]);
       expect(contribution.values).toHaveLength(2);
     });
-
-    it('rejects arity crossing at the type level', () => {
-      const single = Capability.makeSingleton<Example>()('org.dxos.test.single');
-      const multi = Capability.make<Example>()('org.dxos.test.multi');
-
-      // @ts-expect-error provideAll only accepts multi capabilities.
-      Capability.contributeAll(single, [{ example: 'value' }]);
-      // Singleton and multi tags are not interchangeable in typed positions (runtime still
-      // executes the push; only the type is rejected).
-      const singletonOnly: Capability.Tag<Example>[] = [single];
-      // @ts-expect-error a multi tag is not a singleton tag.
-      singletonOnly.push(multi);
-      expect(singletonOnly).toHaveLength(2);
-    });
   });
 
   describe('type-level enforcement', () => {
@@ -137,25 +119,6 @@ describe('Capability tags', () => {
       // @ts-expect-error the branded error type is unconstructible from a string.
       const uncovered: Capability.EnsureProvides<WrongReturn, Provides> = 'missing a';
       expect(uncovered).toBeDefined();
-    });
-
-    it('Requirements exposes the identifiers of the declared requires', () => {
-      const a = Capability.makeSingleton<Example>()('org.dxos.test.a');
-
-      // A program yielding the declared tag typechecks against Requirements.
-      const program: Effect.Effect<Example, never, Capability.Requirements<readonly [typeof a]>> = Effect.gen(
-        function* () {
-          return yield* a;
-        },
-      );
-
-      const undeclared = Capability.makeSingleton<Example>()('org.dxos.test.undeclared');
-      // @ts-expect-error yielding an undeclared capability is rejected by the R channel.
-      const invalid: Effect.Effect<Example, never, Capability.Requirements<readonly []>> = Effect.gen(function* () {
-        return yield* undeclared;
-      });
-      expect(program).toBeDefined();
-      expect(invalid).toBeDefined();
     });
   });
 });

--- a/packages/sdk/app-framework/typetest/capability.tst.ts
+++ b/packages/sdk/app-framework/typetest/capability.tst.ts
@@ -1,0 +1,53 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// Deliberately-invalid usage lives here, so the diagnostic that reports it is the
+// assertion succeeding.
+/** @effect-diagnostics missingEffectContext:skip-file unnecessaryEffectGen:skip-file */
+
+import * as Effect from 'effect/Effect';
+import { describe, expect, it } from 'tstyche';
+
+import * as Capability from '../src/core/capability';
+
+type Example = { example: string };
+
+const single = Capability.makeSingleton<Example>()('org.dxos.test.single');
+const multi = Capability.make<Example>()('org.dxos.test.multi');
+
+describe('Capability arity', () => {
+  it('contributeAll accepts a multi tag', () => {
+    expect(Capability.contributeAll(multi, [{ example: 'one' }])).type.not.toRaiseError();
+  });
+
+  it('contributeAll rejects a singleton tag', () => {
+    expect(Capability.contributeAll(single, [{ example: 'value' }])).type.toRaiseError(
+      "is not assignable to parameter of type 'MultiTag",
+    );
+  });
+
+  it('a multi tag is not a singleton tag', () => {
+    const singletonOnly: Capability.Tag<Example>[] = [single];
+    expect(singletonOnly.push(multi)).type.toRaiseError("is not assignable to parameter of type 'Tag");
+  });
+});
+
+describe('Capability requirements channel', () => {
+  it('carries a declared capability', () => {
+    expect(
+      Effect.gen(function* () {
+        return yield* single;
+      }),
+    ).type.toBeAssignableTo<Effect.Effect<Example, never, Capability.Requirements<readonly [typeof single]>>>();
+  });
+
+  it('rejects an undeclared capability against an empty requirements channel', () => {
+    const undeclared = Capability.makeSingleton<Example>()('org.dxos.test.undeclared');
+    expect(
+      Effect.gen(function* () {
+        return yield* undeclared;
+      }),
+    ).type.not.toBeAssignableTo<Effect.Effect<Example, never, Capability.Requirements<readonly []>>>();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1566,6 +1566,9 @@ catalogs:
     tslib:
       specifier: ^2.8.1
       version: 2.8.1
+    tstyche:
+      specifier: ^7.2.3
+      version: 7.2.3
     tsx:
       specifier: ^4.21.0
       version: 4.21.0
@@ -2147,6 +2150,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.22.14(@volar/typescript@2.4.28)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(tsx@4.21.0)
+      tstyche:
+        specifier: 'catalog:'
+        version: 7.2.3
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -41015,6 +41021,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tstyche@7.2.3:
+    resolution: {integrity: sha512-UqlBOleg3VR9U/BFUzamjD8GK/SeR5qnupJeiX8js9LUpzOAMaDd9tU8nfTLpDdf6AccTm6iqhA6NPd1RdO/yg==}
+    engines: {node: '>=22'}
+    hasBin: true
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -64864,6 +64875,10 @@ snapshots:
   tslib@2.6.2: {}
 
   tslib@2.8.1: {}
+
+  tstyche@7.2.3:
+    dependencies:
+      typescript: 6.0.3
 
   tsx@4.21.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -663,6 +663,7 @@ catalog:
   type-fest: 4.10.1
   typedoc: 0.28.1
   types-package-json: ^2.0.39
+  tstyche: ^7.2.3
   typescript: ^7.0.2
   ua-parser-js: ^1.0.39
   uint8arrays: ^5.1.0

--- a/tsconfig.typetest.json
+++ b/tsconfig.typetest.json
@@ -1,0 +1,11 @@
+// tsconfig for type-level tests. tstyche needs the JavaScript TypeScript API, which the
+// TypeScript 7 Go compiler does not expose, so these run against @typescript/typescript6.
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["packages/**/typetest/**/*.tst.ts"]
+}

--- a/tstyche.json
+++ b/tstyche.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "./node_modules/tstyche/schemas/config.json",
+  // Type-level tests: assertions about what the compiler accepts and rejects, which a
+  // runtime runner cannot make. `@ts-expect-error` asserts only that *some* error
+  // occurs on a line; `toRaiseError` pins which one.
+  //
+  // tstyche drives the JavaScript TypeScript API, so it runs on `@typescript/typescript6`
+  // rather than the TypeScript 7 Go compiler the repo builds with. The Effect project
+  // splits the same way (`tstyche` beside `check:tsgo`).
+  "testFileMatch": ["packages/*/*/typetest/**/*.tst.*", "packages/*/*/*/typetest/**/*.tst.*"],
+  "tsconfig": "./tsconfig.typetest.json"
+}


### PR DESCRIPTION
Stacked on #12732. Targets that branch, since the assertions this moves are the ones whose suppressions it adds.

`@ts-expect-error` asserts that *some* error occurs on a line, not which one. Rename an import, change an unrelated part of a signature, and the directive stays satisfied while the test has quietly stopped checking what it was written for. That is a weaker version of the failure I found in #12732, where two tests reported green while asserting nothing.

tstyche pins the message:

```ts
expect(
  Operation.withHandler(op, (_input) =>
    Effect.gen(function* () {
      yield* UndeclaredService;
    }),
  ),
).type.toRaiseError("Type 'UndeclaredService' is not assignable to type 'DeclaredService | Service'");
```

Verified load-bearing: swapping `UndeclaredService` for the declared one fails with `Expression did not raise a type error`.

## Following the Effect project's setup

Theirs is tstyche, a `typetest/` directory per package, `.tst.ts` files, and a `test-types` script. Two details taken from reading their config rather than guessing:

Their `tstyche.json` uses `testFileMatch` against `packages/*/typetest/**`. Ours needs one more level of nesting for `packages/core/compute/...`.

Their typetest files open with `/** @effect-diagnostics floatingEffect:skip-file missingEffectError:skip-file */`. A file whose purpose is to hold invalid code trips the analyzer no matter which runner reads it, so ours carry the same thing. This is worth stating plainly: **tstyche does not remove the need for diagnostic suppression.** What it buys is assertion quality.

## What moved

Five assertions leave two vitest files that were type tests wearing runtime clothing. `expect(invalid).toBeDefined()` and `expect(singletonOnly).toHaveLength(2)` existed so the blocks had something to run; `invoker.test.ts` even labelled its block `// Type-level tests for Operation.withHandler service constraints.`

Eight land in `typetest/`. The extra three are positive cases the vitest versions could only express by writing the call and leaving it unasserted:

| | |
|---|---|
| `operation.tst.ts` | declared service accepted, undeclared rejected, `Operation.Service` available undeclared |
| `capability.tst.ts` | `contributeAll` arity both ways, multi-vs-singleton tags, requirements channel both ways |

Two `@ts-expect-error` remain in `capability.test.ts`. They concern branded `EnsureProvides` types, never carried Effect suppressions, and are out of scope for a pilot.

## Caveat worth a reviewer's attention

tstyche drives the JavaScript TypeScript API, which the TypeScript 7 Go compiler does not expose, so it runs against `@typescript/typescript6`:

```
uses TypeScript 6.0.3 with ./tsconfig.typetest.json
```

Type assertions are therefore made against a compiler we do not ship. The Effect project splits the same way (`tstyche` beside `check:tsgo`), so it is inherent to the approach rather than a misconfiguration, but it is a real property of it.

## Incidental fix

`operation-key-shape` did not recognise type tests as fixtures, so `com.example.*` keys in `.tst.ts` files tripped the product-namespace rule. Added `.tst.ts` and `/typetest/` beside the `.test.ts` and `/testing/` entries already in `isFixture`.

`pnpm run test-types` is wired into the Check workflow. Full build is 331 tasks clean, lint and tests pass on all touched packages, 8/8 type assertions pass.

No changeset: internal tooling and tests, nothing published (`agents/instructions/changesets.md` rule 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
