### PR TITLE
ci: size the moon cache from RAM, and fix the bench harness that hid it

### DIFF
--- a/tools/moon-cache/README.md
+++ b/tools/moon-cache/README.md
@@ -106,9 +106,12 @@ MOON_CACHE_SHARED_WORKTREE_CACHE=false MOON_EXPERIMENT_CAS_OUTPUTS_CACHE=false m
    `bazel-remote` evicts the least recently used blobs rather than filling the volume. The
    temptation is to size it against the 320 GiB disk, and that is how it was first set, at 200.
    The real constraint is that `bazel-remote` holds one index entry per cache file, measured here
-   at ~1.1 KB. Budget half of RAM for the index, divide by the observed mean file size (~14.6 KB
-   compressed), and on this 16 GB droplet that lands near 50 GiB. See item 7 for what happens
-   when the cap is set from the disk instead.
+   at ~1.2 KB against a mean compressed blob of ~14.3 KB. Budget **a quarter of RAM** for the
+   index, not half: the heap has to leave room for the GC target above it and the page cache
+   beside it, and the 16 GB droplet was already thrashing at a 11.7 GB heap. A quarter of 16 GB
+   is 4 GB, which buys 4 GB / 1.2 KB = ~3.3M files, which at 14.3 KB each is ~44 GiB. 50 GiB is
+   that rounded up, and it measured out at 3.78M files and a 4.59 GB heap. See item 7 for what
+   happens when the cap is set from the disk instead.
 4. **Release workflows deliberately skip the cache** — `remote-cache: 'false'` on the setup action,
    or a workflow-level `MOON_REMOTE_HOST` where the workflow does not use that action.
 5. **`--access_log_level` defaults to `all`.** At CI volume that's one line per request: 8 days
@@ -144,8 +147,10 @@ MOON_CACHE_SHARED_WORKTREE_CACHE=false MOON_EXPERIMENT_CAS_OUTPUTS_CACHE=false m
    The related failure it was originally blamed for is real but separate: a saturated host also
    queues the CI setup action's `/status` preflight past its 20 s budget, which reddened three
    otherwise-unrelated jobs between 2026-08-09 and 2026-08-19 with a false "unreachable or
-   certificate does not verify" error while the host was up the whole time. The fix there is the
-   setup action retrying the preflight before failing the job (see `.github/actions/setup/action.yml`).
+   certificate does not verify" error while the host was up the whole time. That one is already
+   handled: `.github/actions/setup/action.yml` retries the probe (`--retry 3 --retry-all-errors`)
+   and its `degrade()` then warns, blanks `MOON_REMOTE_HOST` and exits 0 rather than failing the
+   job, so an unreachable cache costs a slower build instead of a red one.
 
 ## The server
 

--- a/tools/moon-cache/README.md
+++ b/tools/moon-cache/README.md
@@ -102,9 +102,13 @@ MOON_CACHE_SHARED_WORKTREE_CACHE=false MOON_EXPERIMENT_CAS_OUTPUTS_CACHE=false m
    bump, on its own: the same task hashed `ad0ce946` under 2.4.5 and `78dc6382` under 2.5.2 with
    identical inputs. Bundle a config change into the same commit as a version bump and the two
    share one invalidation instead of costing two.
-3. **Disk is bounded by `--max_size 200`** (GiB), enforced as an LRU: `bazel-remote` evicts the
-   least recently used blobs rather than filling the disk. Size it under the volume with room for
-   the OS — 200 GiB on the current 320 GiB disk, leaving roughly 110 GiB of headroom.
+3. **`--max_size` is bounded by RAM, not by disk.** It is 50 (GiB), enforced as an LRU:
+   `bazel-remote` evicts the least recently used blobs rather than filling the volume. The
+   temptation is to size it against the 320 GiB disk, and that is how it was first set, at 200.
+   The real constraint is that `bazel-remote` holds one index entry per cache file, measured here
+   at ~1.1 KB. Budget half of RAM for the index, divide by the observed mean file size (~14.6 KB
+   compressed), and on this 16 GB droplet that lands near 50 GiB. See item 7 for what happens
+   when the cap is set from the disk instead.
 4. **Release workflows deliberately skip the cache** — `remote-cache: 'false'` on the setup action,
    or a workflow-level `MOON_REMOTE_HOST` where the workflow does not use that action.
 5. **`--access_log_level` defaults to `all`.** At CI volume that's one line per request: 8 days
@@ -112,22 +116,36 @@ MOON_CACHE_SHARED_WORKTREE_CACHE=false MOON_EXPERIMENT_CAS_OUTPUTS_CACHE=false m
    budget and exhaust the disk. The unit sets `--access_log_level none`; do not drop it when
    copying this config elsewhere. `rsyslog-logrotate.conf` (below) is the backstop for the next
    service that logs at this volume without a bound of its own.
-6. **A restart costs about 70 s of downtime**, more at high file counts. `bazel-remote` walks every
-   cache file to rebuild its in-memory index before it binds 9092/9093, so both ports refuse
-   connections until that finishes — moon falls back to a local build for anyone hitting it during
-   that window. Restarts are safe for the data (below), just not instantaneous. At 7.2M files the
-   scan/sort/index sequence (visible in `journalctl -u bazel-remote`) has taken several minutes,
-   not 70 s.
-7. **Sustained disk I/O saturation degrades the cache before it looks broken.** A CI fan-out can
-   drive the droplet to 40-60% iowait for the better part of an hour, especially when the cache
-   sits pinned at its `--max_size` cap and every insert forces an LRU eviction. Everything queues
-   behind the disk at that point, including the CI setup action's `/status` preflight probe, which
-   answered after its 20 s budget and reddened three otherwise-unrelated CI jobs between 2026-08-09
-   and 2026-08-19 with a false "unreachable or certificate does not verify" error — the host was up
-   the whole time. `sar -u` showing iowait above ~20% during a fan-out is the tell; the fixes are
-   more RAM (page cache absorbs reads before they reach disk), more disk headroom (fewer forced
-   evictions), and the setup action retrying the preflight before failing the job (see
-   `.github/actions/setup/action.yml`).
+6. **A restart costs minutes of downtime, not seconds.** `bazel-remote` walks every cache file to
+   rebuild its in-memory index before it binds 9092/9093, so both ports refuse connections until
+   that finishes — moon falls back to a local build for anyone hitting it during that window.
+   Restarts are safe for the data (below), just not instantaneous. The scan/sort/index sequence is
+   visible in `journalctl -u bazel-remote` and scales with file count: 70 s at low counts, several
+   minutes at 7.2M. Lowering `--max_size` adds an eviction pass on top, which is far more expensive
+   than the scan. Cutting 200 GiB to 50 on 2026-08-25 took **15 min 46 s** end to end at 10.5M
+   files: 2 min to scan, 26 s to sort, then 13 min to delete 6.7M files and 81 GB.
+7. **An oversized `--max_size` degrades the cache slowly, and the symptom looks like disk.** With
+   the cap at 200 GiB the cache never reached it, so `bazel_remote_disk_cache_evicted_bytes_total`
+   sat at 0 from the day the server was built and the file count only ever grew. By 2026-08-25 it
+   was 10.5M files, an 11.7 GB heap and a `go_memstats_next_gc_bytes` target of 14.06 GB on a
+   16 GB box: every GC cycle dragged the index back through swap. `BatchReadBlobs` averaged
+   **18.3 s**, a CI shard spent 70 min of cumulative hydration inside a 28 min budget and was
+   cancelled without running a test, and the merge queue jammed. Lowering the cap to 50 GiB and
+   restarting took the heap to 4.59 GB, `BatchReadBlobs` to normal and the same CI shard's
+   per-task p50 from 6,016 ms to 29 ms.
+
+   What makes this one nasty is that it reads as a disk problem. `sar -u` shows 20-24% iowait and
+   `vmstat` shows the disk busy, but the I/O is swap traffic, not cache I/O, and adding disk would
+   not have touched it. Two counters separate the cases in one look: `evicted_bytes_total` at 0
+   means the cap is not the constraint, and `next_gc_bytes` above physical RAM means the index is.
+   Watch `pswpin/s` in `sar -W` for the early warning — it ran 247/s on 2026-08-17 and 6,260/s on
+   2026-08-24, a slide visible eight days before anything went red.
+
+   The related failure it was originally blamed for is real but separate: a saturated host also
+   queues the CI setup action's `/status` preflight past its 20 s budget, which reddened three
+   otherwise-unrelated jobs between 2026-08-09 and 2026-08-19 with a false "unreachable or
+   certificate does not verify" error while the host was up the whole time. The fix there is the
+   setup action retrying the preflight before failing the job (see `.github/actions/setup/action.yml`).
 
 ## The server
 
@@ -136,7 +154,7 @@ MOON_CACHE_SHARED_WORKTREE_CACHE=false MOON_EXPERIMENT_CAS_OUTPUTS_CACHE=false m
 | host | `cache.dxos.network` -> 64.225.13.237 (DigitalOcean NYC3) |
 | service | `bazel-remote` v2.5.0, systemd unit `bazel-remote` |
 | ports | 9092 gRPC, 9093 HTTPS (metrics + `/status`) |
-| storage | `/var/cache/moon`, zstd, 200 GiB LRU |
+| storage | `/var/cache/moon`, zstd, 50 GiB LRU (~3.8M files, see item 3) |
 | certificates | `/etc/bazel-remote/{server.pem,server.key,ca.pem}` |
 
 `--tls_ca_file` is what makes it mTLS. Without it the cache would be world-readable and

--- a/tools/moon-cache/bazel-remote.service
+++ b/tools/moon-cache/bazel-remote.service
@@ -8,9 +8,12 @@ Wants=network-online.target
 # accept any client, and the cache is reachable from the public internet.
 # --access_log_level defaults to all (one line per CAS/AC request) and filled the disk in
 # 8 days at CI volume; `none` disables it, the request rate isn't otherwise interesting.
+# --max_size is bounded by RAM, not disk: bazel-remote holds one index entry per cache file,
+# measured at ~1.1 KB. At 200 GiB the cache reached 10.5M files and an 11.7 GB heap on a 16 GB
+# droplet, which swapped and took BatchReadBlobs to 18 s. 50 GiB is ~3.7M files, ~4 GB of index.
 ExecStart=/usr/local/bin/bazel-remote \
   --dir /var/cache/moon \
-  --max_size 200 \
+  --max_size 50 \
   --storage_mode zstd \
   --grpc_address 0.0.0.0:9092 \
   --http_address 0.0.0.0:9093 \

--- a/tools/moon-cache/bench/bench.sh
+++ b/tools/moon-cache/bench/bench.sh
@@ -22,7 +22,14 @@ OUT="${OUT:-$ROOT/.moon-bench}"
 # MOON_REMOTE_MTLS_*, exported by a profile line that a non-interactive shell never sources. Absent
 # them moon logs "Failed to connect to storage backend, disabling it" and every rep silently
 # measures the local cache — a green run reporting hits=0.
-[ -f "$HOME/.config/dxos/moon-cache/env.sh" ] && . "$HOME/.config/dxos/moon-cache/env.sh"
+# An `&&` list that fails does not abort a script running without errexit, so source explicitly:
+# a half-read env file would otherwise leave the run credential-less and looking deliberate.
+if [ -f "$HOME/.config/dxos/moon-cache/env.sh" ]; then
+  if ! . "$HOME/.config/dxos/moon-cache/env.sh"; then
+    echo "== could not source $HOME/.config/dxos/moon-cache/env.sh — fix it or move it aside." >&2
+    exit 1
+  fi
+fi
 
 # Give this checkout its own blob store so the per-rep wipe below can empty it. Under
 # `unstable_sharedWorktreeCache` the store lives in the *base* checkout, where a wipe would take
@@ -67,17 +74,20 @@ for i in $(seq 1 "$REPS"); do
     exit 1
   fi
   cp .moon/cache/runReport.json "$OUT/report-$ARM$i.json"
-  # `|| true` because grep exits 1 on no match, and this script runs without errexit, so the
-  # count would otherwise be read from a command whose failure went unnoticed.
-  hits=$(grep -c 'cached from remote' "$OUT/$ARM$i.log" || true)
+  # Counted from the run report rather than by grepping the console: MOON_LOG and MOON_QUIET are
+  # inherited from whatever shell runs this, and either can suppress the "cached from remote" line
+  # while the hydration still happens. The report is the same source `analyze.mjs` reads, and the
+  # same query the README gives for checking a cache by hand.
+  hits=$(node -e 'const r=require(process.argv[1]);console.log(r.actions.flatMap(a=>a.operations??[]).filter(o=>o.meta?.type==="output-hydration"&&o.status==="cached-from-remote").length)' "$OUT/report-$ARM$i.json")
   echo "== $ARM$i exit=$code hits=$hits"
   if [ "$hits" -eq 0 ]; then
     # Zero does not separate "the remote was never asked" from "the remote had nothing", and
-    # neither is a measurement — the rep timed a cold build. Rep 1 is exempt because populating an
-    # empty server is the documented way to start an arm; from rep 2 on, zero is a hard failure.
+    # neither is a measurement — the rep timed a cold build. Populating an empty server is the
+    # documented way to start an arm, so rep 1 is exempt when more reps follow; a single-rep run
+    # has nothing to follow it and fails, rather than reporting a local-only build as a success.
     echo "== $ARM$i observed no remote hits."
     grep -m1 'disabling it' "$OUT/$ARM$i.log" || true
-    if [ "$i" -gt 1 ]; then
+    if [ "$i" -gt 1 ] || [ "$REPS" -eq 1 ]; then
       echo "== $ARM$i measures nothing — see $OUT/$ARM$i.log. Not continuing."
       exit 1
     fi

--- a/tools/moon-cache/bench/bench.sh
+++ b/tools/moon-cache/bench/bench.sh
@@ -78,7 +78,19 @@ for i in $(seq 1 "$REPS"); do
   # inherited from whatever shell runs this, and either can suppress the "cached from remote" line
   # while the hydration still happens. The report is the same source `analyze.mjs` reads, and the
   # same query the README gives for checking a cache by hand.
-  hits=$(node -e 'const r=require(process.argv[1]);console.log(r.actions.flatMap(a=>a.operations??[]).filter(o=>o.meta?.type==="output-hydration"&&o.status==="cached-from-remote").length)' "$OUT/report-$ARM$i.json")
+  # `if ! hits=$(...)` rather than a bare assignment: without errexit a failed command
+  # substitution leaves `hits` empty, and `[ "" -eq 0 ]` errors and is skipped, so an unreadable
+  # report would sail past the zero-hit gate below.
+  if ! hits=$(node -e 'const r=require(process.argv[1]);console.log(r.actions.flatMap(a=>a.operations??[]).filter(o=>o.meta?.type==="output-hydration"&&o.status==="cached-from-remote").length)' "$OUT/report-$ARM$i.json"); then
+    echo "== $ARM$i could not read $OUT/report-$ARM$i.json — no hit count, so no measurement."
+    exit 1
+  fi
+  case "$hits" in
+    ''|*[!0-9]*)
+      echo "== $ARM$i hit count is not a number: '$hits'"
+      exit 1
+      ;;
+  esac
   echo "== $ARM$i exit=$code hits=$hits"
   if [ "$hits" -eq 0 ]; then
     # Zero does not separate "the remote was never asked" from "the remote had nothing", and

--- a/tools/moon-cache/bench/bench.sh
+++ b/tools/moon-cache/bench/bench.sh
@@ -67,11 +67,21 @@ for i in $(seq 1 "$REPS"); do
     exit 1
   fi
   cp .moon/cache/runReport.json "$OUT/report-$ARM$i.json"
-  hits=$(grep -c 'cached from remote' "$OUT/$ARM$i.log")
+  # `|| true` because grep exits 1 on no match, and this script runs without errexit, so the
+  # count would otherwise be read from a command whose failure went unnoticed.
+  hits=$(grep -c 'cached from remote' "$OUT/$ARM$i.log" || true)
   echo "== $ARM$i exit=$code hits=$hits"
   if [ "$hits" -eq 0 ]; then
-    echo "== $ARM$i hydrated nothing — the remote was not consulted, this rep measures nothing."
+    # Zero does not separate "the remote was never asked" from "the remote had nothing", and
+    # neither is a measurement — the rep timed a cold build. Rep 1 is exempt because populating an
+    # empty server is the documented way to start an arm; from rep 2 on, zero is a hard failure.
+    echo "== $ARM$i observed no remote hits."
     grep -m1 'disabling it' "$OUT/$ARM$i.log" || true
+    if [ "$i" -gt 1 ]; then
+      echo "== $ARM$i measures nothing — see $OUT/$ARM$i.log. Not continuing."
+      exit 1
+    fi
+    echo "== treating rep 1 as a populate pass; rep 2 must hydrate or this arm aborts."
   fi
 done
 

--- a/tools/moon-cache/bench/bench.sh
+++ b/tools/moon-cache/bench/bench.sh
@@ -16,6 +16,18 @@ set -uo pipefail
 
 ROOT=$(git rev-parse --show-toplevel)
 OUT="${OUT:-$ROOT/.moon-bench}"
+
+# `.moon/workspace.yml` names the client certificate by a repo-relative path, which only exists on
+# a CI runner. On a dev machine the certificate lives in ~/.config and is found through absolute
+# MOON_REMOTE_MTLS_*, exported by a profile line that a non-interactive shell never sources. Absent
+# them moon logs "Failed to connect to storage backend, disabling it" and every rep silently
+# measures the local cache — a green run reporting hits=0.
+[ -f "$HOME/.config/dxos/moon-cache/env.sh" ] && . "$HOME/.config/dxos/moon-cache/env.sh"
+
+# Give this checkout its own blob store so the per-rep wipe below can empty it. Under
+# `unstable_sharedWorktreeCache` the store lives in the *base* checkout, where a wipe would take
+# every other worktree's outputs with it.
+export MOON_CACHE_SHARED_WORKTREE_CACHE=false
 # Not a bare `moon`: `proto activate` can put an older version ahead of the shims on PATH, and the
 # client version is part of what is being measured.
 MOON="${MOON:-$HOME/.proto/shims/moon}"
@@ -35,7 +47,11 @@ for i in $(seq 1 "$REPS"); do
   # stay warm deliberately — they are not under test.
   # The report is removed as well as the caches: without this, a failed rep would leave the
   # previous rep's report in place and get copied as if it were this one's.
-  rm -rf .moon/cache/outputs .moon/cache/states .moon/cache/hashes .moon/cache/runReport.json
+  # `blobs` and `manifests` are where `casOutputsCache` puts task outputs; `outputs` is the
+  # pre-CAS location and is empty under the current config. Miss them and the local store answers
+  # every task and the remote is never asked.
+  rm -rf .moon/cache/outputs .moon/cache/blobs .moon/cache/manifests \
+         .moon/cache/states .moon/cache/hashes .moon/cache/runReport.json
   if [ -n "$HOST" ]; then
     MOON_REMOTE_HOST="$HOST" "$MOON" run ":$TARGET" > "$OUT/$ARM$i.log" 2>&1
   else
@@ -51,7 +67,12 @@ for i in $(seq 1 "$REPS"); do
     exit 1
   fi
   cp .moon/cache/runReport.json "$OUT/report-$ARM$i.json"
-  echo "== $ARM$i exit=$code hits=$(grep -c 'cached from remote' "$OUT/$ARM$i.log")"
+  hits=$(grep -c 'cached from remote' "$OUT/$ARM$i.log")
+  echo "== $ARM$i exit=$code hits=$hits"
+  if [ "$hits" -eq 0 ]; then
+    echo "== $ARM$i hydrated nothing — the remote was not consulted, this rep measures nothing."
+    grep -m1 'disabling it' "$OUT/$ARM$i.log" || true
+  fi
 done
 
 echo "== node tools/moon-cache/bench/analyze.mjs $OUT"


### PR DESCRIPTION
Follow-up to #12657, which measured the self-hosted cache at 60 ms per-task on a CI runner. It is
not that any more, and this is why.

## What broke

`--max_size 200` was sized against the droplet's 320 GiB disk. The binding constraint is RAM:
`bazel-remote` holds one index entry per cache file, measured here at ~1.1 KB. The cache never
reached 200 GiB, so `bazel_remote_disk_cache_evicted_bytes_total` sat at **0 from the day the
server was built** and the file count only ever grew.

By 2026-08-25 that was 10.5M files, an 11.7 GB heap and a `go_memstats_next_gc_bytes` target of
14.06 GB on a 16 GB box. Every GC cycle dragged the index back through swap.

The slide was visible for eight days before anything went red (`sar`, daily averages):

| | Aug 17 | Aug 19 | Aug 21 | Aug 23 | Aug 24 |
| --- | ---: | ---: | ---: | ---: | ---: |
| `pswpin/s` | 247 | 1,690 | 1,676 | 2,455 | **6,260** |
| iowait | 3.2% | 8.5% | 6.8% | 9.7% | **23.9%** |

At the bottom, `BatchReadBlobs` averaged **18.3 s** over a sampled 180 s window, and a CAS lookup
that missed, which is a pure in-memory index hit, took 570-1,155 ms of server time.

## What it did to CI

Test shards were burning their whole budget hydrating and getting cancelled before running a test.
The merge queue jammed. From the shard that prompted this, `test (24.11.1, 0)`, before and after
the fix:

| | before ([`97802664856`](https://github.com/dxos/dxos/actions/runs/32848174662/job/97802664856)) | after ([`97826764879`](https://github.com/dxos/dxos/actions/runs/32855590613/job/97826764879)) |
| --- | ---: | ---: |
| `Test Affected` step | 28 min, **cancelled** | 21 s, **success** |
| tasks hydrated | 242 | 388 |
| total hydration | 4,201 s | 14 s |
| per-task p50 | 6,016 ms | **29 ms** |
| per-task p90 | 37,350 ms | 64 ms |
| per-task p99 | 172,267 ms | 113 ms |
| slowest single hit | 194.3 s (`plugin-client:build`) | 0.2 s |

Cache hits were reporting `cached from remote, 3m 4s`. Those are hits, not misses.

## The fix

`--max_size` 200 to 50 GiB, restarted 13:29:57Z to 13:45:43Z on 2026-08-25. **Already deployed**;
this PR brings the unit file in the repo back in step with the server.

| | before | after |
| --- | ---: | ---: |
| files | 10,491,023 | 3,780,265 |
| heap in use | 11.7 GB | 4.59 GB |
| `next_gc` target | 14.06 GB (above RAM) | 4.16 GB |
| max GC pause | 1.42 s | none recorded |
| swap in/out | 13-33k pages/s | 0 |
| iowait | 21-24% | 2-4% |
| load average | 9-12 | 0.99 |

## Docs

`README.md` item 7 blamed the iowait on LRU eviction at the cap, which the zero eviction counter
rules out. It is rewritten around the index, and now names the two counters that separate the
cases in one look: `evicted_bytes_total` at 0 means the cap is not the constraint,
`next_gc_bytes` above physical RAM means the index is. Item 3 carries the sizing arithmetic so the
cap can be re-derived on different hardware; item 6 carries the real restart cost, 15 min 46 s at
10.5M files, against the 70 s it used to claim.

## The bench harness measured nothing

Retesting needed `tools/moon-cache/bench/`, and my first 5-rep run came back `hits=0` on every
rep, exit 0. Two defects, both of which make a broken measurement look like a clean one:

1. `.moon/workspace.yml` names the client certificate by a repo-relative path that only exists on
   a CI runner. On a dev machine it comes from absolute `MOON_REMOTE_MTLS_*`, exported by a
   profile line no non-interactive shell sources. moon logged `Failed to connect to storage
   backend, disabling it` and measured the local cache five times over.
2. `casOutputsCache` moved task outputs to `blobs/` and `manifests/`, so the per-rep
   `rm -rf .moon/cache/outputs` cleared a directory that is empty under the current config and
   left the local store fully populated to answer every task. This is exactly what the harness's
   own README rule 2 warns about. Under `unstable_sharedWorktreeCache` that store also lives in
   the *base* checkout, where a naive wipe would take every other worktree's outputs with it, so
   the harness now pins it to the current checkout before clearing.

It also shouts on `hits=0` rather than reporting it as a successful rep. Fixed, the same run gives
330 hits on all 5 reps: wall median 37.8 s, hydration 168.6 s, per-task p50 236 ms.

## Reviewer notes

- Config-only, no package changes, so no changeset. `--affected` finds nothing to build or test.
- The cache now runs pinned at its cap, so eviction is steady-state: one unlink per insert, cheap
  next to what it was doing before.
- The old unit is at `/root/bazel-remote.service.bak-maxsize200` on the droplet if 200 GiB is ever
  wanted back, though it would reproduce this.
- 50 GiB is the cap that fits 16 GB of RAM. Resizing the droplet to `s-8vcpu-32gb-amd` (32 GB,
  same 8 vCPU, 400 GB disk, \$96 to \$168/mo) would support roughly double the cap and a longer
  cache history. Not proposed here, just recorded.
- The dev-machine bench is 26% off the 29.9 s #12657 recorded on 2026-08-18, but on a different
  commit with 330 hits against 324 and against a cache that just lost 81 GB. Worth re-running in a
  few days once it refills before reading anything into that gap.
- #12657's own tables still carry pre-incident numbers, and `.agents/projects/ci/` has no record
  of this incident. Both left alone deliberately; say the word and I'll write them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified Moon cache sizing guidance, including the 50 GiB limit, RAM-based recommendations, and performance symptoms caused by oversized caches.
  - Documented how setup handles cache service preflight failures without failing jobs.

- **Chores**
  - Improved benchmark isolation and environment handling.
  - Added validation for cache-hit reports, including safeguards for unreadable or invalid results.
  - Added clearer reporting and safeguards when cache hydration does not occur.
  - Reduced the cache size limit to improve reliability on systems with limited memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->