### PR TITLE
config, ci: point dev-tier clients at EDGE preview; retire the labs introspect defaults (DX-1150)

### DIFF
--- a/.changeset/edge-preview-defaults.md
+++ b/.changeset/edge-preview-defaults.md
@@ -2,9 +2,12 @@
 '@dxos/config': patch
 '@dxos/plugin-client': patch
 '@dxos/ai': patch
+'@dxos/edge-client': patch
 ---
 
 Default service URLs follow the EDGE environment rename (DX-1150): the config preset and CLI profile
 templates gain `preview` (with `main` preserved as a deprecated alias of the same worker), the default
 edge URL moves to `https://preview.dxos.network`, and the Image/Introspect service defaults become the
-production hostnames (`image.dxos.network`, `introspect.dxos.network/mcp`).
+production hostnames (`image.dxos.network`, `introspect.dxos.network/mcp`), including
+`@dxos/edge-client`'s `DEFAULT_IMAGE_SERVICE_URL` (the retired `image-service-main` workers.dev
+name no longer resolves).

--- a/.changeset/edge-preview-defaults.md
+++ b/.changeset/edge-preview-defaults.md
@@ -1,0 +1,10 @@
+---
+'@dxos/config': patch
+'@dxos/plugin-client': patch
+'@dxos/ai': patch
+---
+
+Default service URLs follow the EDGE environment rename (DX-1150): the config preset and CLI profile
+templates gain `preview` (with `main` preserved as a deprecated alias of the same worker), the default
+edge URL moves to `https://preview.dxos.network`, and the Image/Introspect service defaults become the
+production hostnames (`image.dxos.network`, `introspect.dxos.network/mcp`).

--- a/.github/workflows/env/dev
+++ b/.github/workflows/env/dev
@@ -20,6 +20,6 @@ IPFS_API_SECRET=${IPFS_API_SECRET}
 DX_PWA=false
 DX_MINIFY=true
 DX_EDGE_ECHO_REPLICATOR=true
-# EDGE preview. TODO(wittjosiah): `https://preview.dxos.network/` once DX-1150 renames EDGE's `main`
+# EDGE preview (renamed from `main` by DX-1150; `main.dxos.network` still aliases it).
 # environment — the instance is the same one, only the name changes.
-DX_EDGE_BASE_URL="https://main.dxos.network/"
+DX_EDGE_BASE_URL="https://preview.dxos.network/"

--- a/.github/workflows/env/dev
+++ b/.github/workflows/env/dev
@@ -20,6 +20,4 @@ IPFS_API_SECRET=${IPFS_API_SECRET}
 DX_PWA=false
 DX_MINIFY=true
 DX_EDGE_ECHO_REPLICATOR=true
-# EDGE preview (renamed from `main` by DX-1150; `main.dxos.network` still aliases it).
-# environment — the instance is the same one, only the name changes.
 DX_EDGE_BASE_URL="https://preview.dxos.network/"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -53,8 +53,8 @@ jobs:
           NODE_ENV: production
           LOG_FILTER: error
           # EDGE preview — the instance Composer `dev` targets, so a PR preview and a dev deploy see the
-          # same data. TODO(wittjosiah): `https://preview.dxos.network` after the EDGE rename (DX-1150).
-          DX_EDGE_BASE_URL: https://main.dxos.network/
+          # same data (EDGE preview — renamed from `main` by DX-1150).
+          DX_EDGE_BASE_URL: https://preview.dxos.network/
 
       - name: Write deploy metadata
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -52,8 +52,8 @@ jobs:
         env:
           NODE_ENV: production
           LOG_FILTER: error
-          # EDGE preview — the instance Composer `dev` targets, so a PR preview and a dev deploy see the
-          # same data (EDGE preview — renamed from `main` by DX-1150).
+          # EDGE preview — the instance Composer `dev` targets, so a PR preview and a dev deploy
+          # see the same data.
           DX_EDGE_BASE_URL: https://preview.dxos.network/
 
       - name: Write deploy metadata

--- a/.github/workflows/upload-introspect-cache.yml
+++ b/.github/workflows/upload-introspect-cache.yml
@@ -32,6 +32,9 @@ env:
 
 jobs:
   upload:
+    # `dxos/main/` is the canonical trunk cache: only schedule runs (default branch) and manual
+    # dispatches of `main` itself may publish it — a dispatch from any other ref must not.
+    if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'
     runs-on: depot-ubuntu-24.04-8
     container:
       image: ghcr.io/dxos/gh-actions:24.11.1

--- a/.github/workflows/upload-introspect-cache.yml
+++ b/.github/workflows/upload-introspect-cache.yml
@@ -1,7 +1,8 @@
 # Builds the @dxos/introspect core.json (symbol cache) and plugins.json
 # (plugin metadata sidecar) and uploads both to R2 so the
-# @dxos/mcp-introspect-service edge worker can read them. Triggers on push to the
-# `labs` branch; manual dispatch is also supported for ad-hoc reruns.
+# @dxos/mcp-introspect-service edge worker can read them. Runs on a daily schedule
+# (the old `labs` branch trigger died with trunk-based development); manual dispatch
+# is also supported for ad-hoc reruns.
 #
 # Secrets required:
 #   CLOUDFLARE_API_TOKEN     — R2 write on the `dxos-introspect-cache` bucket.
@@ -10,9 +11,9 @@
 name: Upload Introspect Cache to R2
 
 on:
-  push:
-    branches:
-      - labs
+  schedule:
+    # Daily; content tracks the trunk. 05:17 UTC avoids the top-of-hour crunch.
+    - cron: '17 5 * * *'
   workflow_dispatch:
 
 permissions:
@@ -66,12 +67,12 @@ jobs:
             node_modules/.cache/dxos-introspect/core.json \
             node_modules/.cache/dxos-introspect/plugins.json
           pnpm exec wrangler r2 object put \
-            dxos-introspect-cache/dxos/labs/core.json \
+            dxos-introspect-cache/dxos/main/core.json \
             --file=node_modules/.cache/dxos-introspect/core.json \
             --content-type=application/json \
             --remote
           pnpm exec wrangler r2 object put \
-            dxos-introspect-cache/dxos/labs/plugins.json \
+            dxos-introspect-cache/dxos/main/plugins.json \
             --file=node_modules/.cache/dxos-introspect/plugins.json \
             --content-type=application/json \
             --remote

--- a/packages/apps/composer-app/dx-local.yml
+++ b/packages/apps/composer-app/dx-local.yml
@@ -20,8 +20,7 @@ runtime:
     agentHosting:
       type: LOCAL_TESTING
     # EDGE preview by default. Point at EDGE dev or a local EDGE with DX_EDGE_BASE_URL.
-    # TODO(wittjosiah): `https://preview.dxos.network` after the EDGE rename (DX-1150).
     edge:
-      url: https://main.dxos.network/
+      url: https://preview.dxos.network/
     sandbox:
       url: https://sandbox-service.dxos.workers.dev

--- a/packages/apps/composer-app/dx.yml
+++ b/packages/apps/composer-app/dx.yml
@@ -26,6 +26,6 @@ runtime:
       - name: transcription
         endpoint: https://calls.dxos.network
       - name: image
-        endpoint: https://image.main.dxos.network
+        endpoint: https://image.dxos.network
       - name: discord
         endpoint: https://discord.dxos.network

--- a/packages/apps/composer-crx/src/config.ts
+++ b/packages/apps/composer-crx/src/config.ts
@@ -10,10 +10,10 @@ import { debugLog } from './debug-log';
 export const HOME_URL = 'https://labs.composer.space';
 
 const DEV_CHAT_AGENT_URL = 'ws://localhost:8791';
-const MAIN_CHAT_AGENT_URL = 'wss://chat-agent-labs.dxos.workers.dev';
+const MAIN_CHAT_AGENT_URL = 'wss://chat-agent.dxos.workers.dev';
 
 const DEV_IMAGE_SERVICE_URL = 'http://localhost:8790';
-const MAIN_IMAGE_SERVICE_URL = 'https://image-service-main.dxos.workers.dev';
+const MAIN_IMAGE_SERVICE_URL = 'https://image.dxos.network';
 
 export type Config = {
   devmode: boolean;

--- a/packages/apps/testbench-app/dx.yml
+++ b/packages/apps/testbench-app/dx.yml
@@ -20,6 +20,6 @@ runtime:
         username: dxos
         credential: dxos
     edge:
-      url: https://main.dxos.network/
+      url: https://preview.dxos.network/
     iceProviders:
       - urls: https://dxos.network/ice

--- a/packages/core/compute/ai/src/testing/defs.ts
+++ b/packages/core/compute/ai/src/testing/defs.ts
@@ -23,10 +23,10 @@ export const SERVICES_CONFIG: Record<string, Runtime.Services> = {
     // ai-service is reached through the single edge entrypoint under the `/ai` prefix; its own
     // hostname is an implementation detail of not having a domain.
     ai: {
-      server: 'https://main.dxos.network/ai',
+      server: 'https://preview.dxos.network/ai',
     },
     edge: {
-      url: 'https://main.dxos.network',
+      url: 'https://preview.dxos.network',
     },
   },
 };

--- a/packages/core/compute/ai/src/testing/test-layers.ts
+++ b/packages/core/compute/ai/src/testing/test-layers.ts
@@ -59,7 +59,7 @@ export const LocalEdgeAiServiceLayer: AiServiceLayer = TestRouter.pipe(
 export const RemoteEdgeAiServiceLayer: AiServiceLayer = TestRouter.pipe(
   Layer.provide(
     AnthropicClient.layerConfig({
-      apiUrl: Config.succeed('https://main.dxos.network/ai/provider/anthropic'),
+      apiUrl: Config.succeed('https://preview.dxos.network/ai/provider/anthropic'),
     }),
   ),
   Layer.provide(FetchHttpClient.layer),

--- a/packages/core/mesh/edge-client/src/service/Image.ts
+++ b/packages/core/mesh/edge-client/src/service/Image.ts
@@ -19,7 +19,7 @@ import { type EdgeServiceClient, type EdgeServiceError } from './edge-service';
  * production. Override per-environment via the client's `baseUrl`.
  */
 // TODO(burdon): Get from config.
-export const DEFAULT_IMAGE_SERVICE_URL = 'https://image-service-main.dxos.workers.dev';
+export const DEFAULT_IMAGE_SERVICE_URL = 'https://image.dxos.network';
 
 /** Hosted image returned by the service: a CDN `url` and its storage `id`. */
 export const Result = Schema.Struct({

--- a/packages/plugins/plugin-client/src/commands/profile/create.ts
+++ b/packages/plugins/plugin-client/src/commands/profile/create.ts
@@ -39,7 +39,7 @@ const makeTemplate = (edgeUrl: string) => trim`
 const TEMPLATES = {
   default: makeTemplate('https://dxos.network'),
   preview: makeTemplate('https://preview.dxos.network'),
-  // Deprecated alias of `preview` (the env was renamed by DX-1150).
+  // Preserve `main` as a deprecated alias for existing profiles.
   main: makeTemplate('https://preview.dxos.network'),
   dev: makeTemplate('https://edge.dxos.workers.dev'),
   local: makeTemplate('http://localhost:8787'),

--- a/packages/plugins/plugin-client/src/commands/profile/create.ts
+++ b/packages/plugins/plugin-client/src/commands/profile/create.ts
@@ -38,7 +38,9 @@ const makeTemplate = (edgeUrl: string) => trim`
 
 const TEMPLATES = {
   default: makeTemplate('https://dxos.network'),
-  main: makeTemplate('https://main.dxos.network'),
+  preview: makeTemplate('https://preview.dxos.network'),
+  // Deprecated alias of `preview` (the env was renamed by DX-1150).
+  main: makeTemplate('https://preview.dxos.network'),
   dev: makeTemplate('https://edge.dxos.workers.dev'),
   local: makeTemplate('http://localhost:8787'),
 } as const;

--- a/packages/plugins/plugin-onboarding/src/components/AboutDialog/AboutDialog.tsx
+++ b/packages/plugins/plugin-onboarding/src/components/AboutDialog/AboutDialog.tsx
@@ -14,12 +14,15 @@ import { meta } from '../../meta';
 // legacy `edge[-<env>].dxos.workers.dev` names still present in stored configs.
 const ENV_LABELS: Record<string, string> = {
   'edge.dxos.workers.dev': 'Dev',
-  'edge-main.dxos.workers.dev': 'Main',
-  'edge-labs.dxos.workers.dev': 'Labs',
+  'dev.dxos.network': 'Dev',
+  'edge-preview.dxos.workers.dev': 'Preview',
+  'preview.dxos.network': 'Preview',
+  'edge-main.dxos.workers.dev': 'Main (retired)',
+  'edge-labs.dxos.workers.dev': 'Labs (retired)',
   'edge-staging.dxos.workers.dev': 'Staging',
   'edge-production.dxos.workers.dev': 'Production',
-  'main.dxos.network': 'Main',
-  'labs.dxos.network': 'Labs',
+  'main.dxos.network': 'Preview',
+  'labs.dxos.network': 'Labs (retired)',
   'staging.dxos.network': 'Staging',
   'dxos.network': 'Production',
 };

--- a/packages/sdk/config/src/config-service.test.ts
+++ b/packages/sdk/config/src/config-service.test.ts
@@ -73,7 +73,7 @@ describe('ConfigService.load', () => {
   }) => {
     restoreEnv = withEnv({ DX_LOCAL_DEV: '1' });
     const { config } = await createMissing('local-dev');
-    expect(config.get(EDGE_URL)).toEqual('https://main.dxos.network');
+    expect(config.get(EDGE_URL)).toEqual('https://preview.dxos.network');
   });
 
   test('DX_LOCAL_DEV=0 opts back out to production', async ({ expect }) => {

--- a/packages/sdk/config/src/config-service.ts
+++ b/packages/sdk/config/src/config-service.ts
@@ -60,7 +60,7 @@ export const defaultConfig = new Config({
 
 /** Aligns a fresh monorepo CLI profile with the backend Composer's local dev server talks to. */
 export const localDevConfig = new Config(
-  { runtime: { services: { edge: { url: 'https://main.dxos.network' } } } },
+  { runtime: { services: { edge: { url: 'https://preview.dxos.network' } } } },
   defaultConfig.values,
 );
 

--- a/packages/sdk/config/src/edge-services.ts
+++ b/packages/sdk/config/src/edge-services.ts
@@ -26,11 +26,11 @@ export type EdgeServiceName = (typeof EdgeServiceName)[keyof typeof EdgeServiceN
  */
 export const EDGE_SERVICE_DEFAULTS: Readonly<Record<EdgeServiceName, string>> = Object.freeze({
   [EdgeServiceName.Calls]: 'https://calls.dxos.network',
-  [EdgeServiceName.Image]: 'https://image.main.dxos.network',
+  [EdgeServiceName.Image]: 'https://image.dxos.network',
   [EdgeServiceName.Transcription]: 'https://calls.dxos.network',
   [EdgeServiceName.Discord]: 'https://discord.dxos.network',
   [EdgeServiceName.CorsProxy]: 'https://cors.dxos.network',
-  [EdgeServiceName.Introspect]: 'https://introspect.labs.dxos.network/mcp',
+  [EdgeServiceName.Introspect]: 'https://introspect.dxos.network/mcp',
 });
 
 /**

--- a/packages/sdk/config/src/preset.ts
+++ b/packages/sdk/config/src/preset.ts
@@ -11,7 +11,7 @@ export type ConfigPresetOptions = {
    * Edge service.
    * @default main
    */
-  edge?: 'local' | 'dev' | 'main' | 'production';
+  edge?: 'local' | 'dev' | 'preview' | 'main' | 'production';
 
   /**
    * Sandbox service (standalone worker; API at /api/sandbox).
@@ -23,7 +23,9 @@ const edgeUrl = (edge: NonNullable<ConfigPresetOptions['edge']>) =>
   Match.value(edge).pipe(
     Match.when('local', () => 'http://localhost:8787'),
     Match.when('dev', () => 'https://edge.dxos.workers.dev'),
-    Match.when('main', () => 'https://main.dxos.network'),
+    // `preview` replaced `main` (DX-1150); `main` is kept as a deprecated alias of the same worker.
+    Match.when('preview', () => 'https://preview.dxos.network'),
+    Match.when('main', () => 'https://preview.dxos.network'),
     Match.when('production', () => 'https://dxos.network'),
     Match.exhaustive,
   );

--- a/packages/sdk/config/src/preset.ts
+++ b/packages/sdk/config/src/preset.ts
@@ -23,7 +23,7 @@ const edgeUrl = (edge: NonNullable<ConfigPresetOptions['edge']>) =>
   Match.value(edge).pipe(
     Match.when('local', () => 'http://localhost:8787'),
     Match.when('dev', () => 'https://edge.dxos.workers.dev'),
-    // `preview` replaced `main` (DX-1150); `main` is kept as a deprecated alias of the same worker.
+    // Preserve `main` as a deprecated alias for existing profiles.
     Match.when('preview', () => 'https://preview.dxos.network'),
     Match.when('main', () => 'https://preview.dxos.network'),
     Match.when('production', () => 'https://dxos.network'),

--- a/packages/sdk/observability/test/e2e/tracing-invitation.test.ts
+++ b/packages/sdk/observability/test/e2e/tracing-invitation.test.ts
@@ -32,7 +32,7 @@ import { identityProvider } from '../../src/providers/client-observability';
 // ...and flip `describe.skip` to `describe` below.
 
 const LOCAL = false;
-const EDGE_URL = LOCAL ? 'http://localhost:8787' : 'https://edge-main.dxos.workers.dev';
+const EDGE_URL = LOCAL ? 'http://localhost:8787' : 'https://edge-preview.dxos.workers.dev';
 
 const createEdgeConfig = () =>
   new Config({

--- a/packages/sdk/react-client/src/halo/Passkey.stories.tsx
+++ b/packages/sdk/react-client/src/halo/Passkey.stories.tsx
@@ -134,7 +134,7 @@ const config = new Config({
     },
     services: {
       edge: {
-        url: 'https://edge-main.dxos.workers.dev/',
+        url: 'https://edge-preview.dxos.workers.dev/',
         // url: 'ws://localhost:8787',
       },
       iceProviders: [{ urls: 'https://edge-production.dxos.workers.dev/ice' }],


### PR DESCRIPTION
The dxos-side flips for [DX-1150](https://linear.app/dxos/issue/DX-1150/environments-edge-previewdev-replace-mainlabs) (every `TODO(wittjosiah)` site naming it): EDGE `main`→`preview` happened (Cutover A, dxos/edge#958) and `labs` was superseded by the dev sandbox (Cutover B, dxos/edge#959). `main.dxos.network` still aliases the preview worker, so **nothing is broken today** — this PR moves clients to the canonical names and is **not urgent to merge**.

- `env/dev` / `dx-local.yml` / `pr-build.yml` / testbench / ai testing defs → `https://preview.dxos.network`
- config preset + CLI profile templates gain `preview` (`main` kept as deprecated alias); config-service default follows
- `edge-services` defaults are production URLs consistently: Image → `image.dxos.network`; Introspect → `https://introspect.dxos.network/mcp` (dev has `introspect.dev.dxos.network` for overrides)
- composer `dx.yml` image endpoint → `image.dxos.network` (production stops riding the preview image worker)
- `upload-introspect-cache.yml`: dead `labs`-branch trigger → daily schedule + dispatch, writing `dxos/main/` (edge reads that prefix as of dxos/edge#959; objects already copied server-side)

⚠️ Created on request, deliberately **not** queued for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `preview` environment in configuration and profile setup.
  * Updated default Edge, Image, Introspect, and AI service connections to use the appropriate preview or production endpoints.
  * Retained `main` as a deprecated alias for the preview environment.

* **Bug Fixes**
  * Updated automated cache uploads to run daily or manually and store results in the main environment path.
  * Corrected service endpoint settings across local development, testing, and application environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->