### PR TITLE
protocols: resolve google.protobuf.Any in shape-compat; move the metadata stores to buf

### DIFF
--- a/.changeset/buf-any-support.md
+++ b/.changeset/buf-any-support.md
@@ -1,5 +1,4 @@
 ---
-'@dxos/client-services': minor
 '@dxos/protocols': minor
 ---
 

--- a/.changeset/buf-any-support.md
+++ b/.changeset/buf-any-support.md
@@ -1,0 +1,5 @@
+---
+'@dxos/protocols': minor
+---
+
+Resolve `google.protobuf.Any` in the buf shape-compat layer, so every `protoMessage()` type encodes through buf.

--- a/.changeset/buf-any-support.md
+++ b/.changeset/buf-any-support.md
@@ -1,5 +1,6 @@
 ---
+'@dxos/client-services': minor
 '@dxos/protocols': minor
 ---
 
-Resolve `google.protobuf.Any` in the buf shape-compat layer, so every `protoMessage()` type encodes through buf.
+Resolve `google.protobuf.Any` in the buf shape-compat layer, so every `protoMessage()` type encodes through buf, and move the ECHO metadata stores onto it.

--- a/.changeset/buf-metadata-store.md
+++ b/.changeset/buf-metadata-store.md
@@ -1,0 +1,6 @@
+---
+'@dxos/client-services': minor
+'@dxos/protocols': minor
+---
+
+Encode the ECHO metadata records through buf; credentials now survive the shape-compat layer.

--- a/.changeset/buf-metadata-store.md
+++ b/.changeset/buf-metadata-store.md
@@ -1,6 +1,0 @@
----
-'@dxos/client-services': minor
-'@dxos/protocols': minor
----
-
-Encode the ECHO metadata records through buf; credentials now survive the shape-compat layer.

--- a/docs/audits/protobufjs-to-buf.md
+++ b/docs/audits/protobufjs-to-buf.md
@@ -378,6 +378,12 @@ Measured while building the compat layer, so the ranking above understates #9c/#
 5. **`google.protobuf.Any`** needs a type registry to resolve, and the `preserve_any` field option
    to know when not to. Handled in `#3`; see above for the semantics reproduced.
 
+   A prefixed `type_url` (`type.googleapis.com/example.Message`, which buf's own `anyPack` emits)
+   deliberately stays packed rather than being resolved by its last path segment: the legacy codec
+   gates on `schema.hasType(type_url)` and leaves it packed too, and resolving it would change the
+   decoded shape of `Credential.subject.assertion` and so the canonical payload `signing.ts` signs.
+   Normalise on the producer when something buf-native starts packing, never on this consumer.
+
 ### Verified: devtools is already on effect-rpc
 
 `packages/devtools/devtools` imports its service types from `@dxos/protocols/rpc` and contains no

--- a/docs/audits/protobufjs-to-buf.md
+++ b/docs/audits/protobufjs-to-buf.md
@@ -10,20 +10,22 @@ at the bottom — read those before picking up a thread.
 | --- | --------------------------------------- | -------- | ------------------------------------------------------------------------ |
 | 1   | `@dxos/effect-proto` removal            | **done** | Package deleted; storybook rewritten on a hand-authored Effect Schema.   |
 | 2   | Test/example protos                     | todo     | Untouched — `#3`'s harness was built against real dxos messages instead. |
-| 3   | Shape-compat layer                      | **done** | `@dxos/protocols/buf-shape-compat` + conformance harness (5 tests).      |
+| 3   | Shape-compat layer                      | **done** | `@dxos/protocols/buf-shape-compat` + conformance harness (15 tests).     |
 | 4   | `dxos.config`                           | **done** | Converted natively; `@dxos/config` inputs are `ConfigInit`, values buf.  |
-| 5   | devtools                                | **part** | Enum imports moved; the rest needs `#7` first.                           |
+| 5   | devtools                                | **part** | Enums, `JsonView`, and two mis-annotated imports moved; 14 left.         |
 | 6   | `Stream` extraction                     | **done** | Moved to `@dxos/async`; generator emits it from there.                   |
-| 7   | `protoMessage()` / `serviceError` → buf | **part** | 31 of 45 types route through buf; 14 `Any` carriers wait on `#3`.        |
+| 7   | `protoMessage()` / `serviceError` → buf | **done** | All 45 types route through buf, once `#3` learned to resolve `Any`.      |
 | 8   | Remaining `ServiceDescriptor` RPC       | todo     | 21 production sites / 10 services, all cross-peer; 49 more are tests.    |
 | 9a  | keyring `KeyRecord`                     | **done** | No substituted fields; wire format unchanged, asserted byte-for-byte.    |
 | 9b  | `echo.query.Heads`                      | **done** | Same; also dropped the workerd lazy-codec workaround.                    |
-| 9c  | `echo/metadata` + `echo/feed`           | **part** | `EchoMetadata` fixture landed; the other two types are `Any`-blocked.    |
-| 9d  | credentials signing/verification        | todo     | Highest risk; additionally needs `Any` support in the compat layer.      |
+| 9c  | `echo/metadata` + `echo/feed`           | **part** | Both metadata stores swapped; `pipeline/codec` held back for `#9d`.      |
+| 9d  | credentials signing/verification        | **part** | Signature stability proven by test; the type sweep is what is left.      |
 
-**Next up, in order:** `Any` support in `#3` -- it gates `#7`'s last 14 types, two of `#9c`'s three,
-and all of `#9d` -- then `#9c`'s store swap, `#8`, `#9d`, with the import sweep (which is what `#5`'s
-remainder needs) alongside. `#2` is independent and can slot in anywhere.
+**Next up, in order:** `#8` (the last `ServiceDescriptor` RPC, ~1.5-2 weeks and the only remaining
+milestone-sized thread), then the import sweep that `#5`'s and `#9d`'s remainders both decompose
+into, then `pipeline/codec` as the tail of `#9c`/`#9d`. `#2` is independent and can slot in
+anywhere. `Any` support is done, so nothing is gated any more -- what is left is volume, not
+blockers.
 
 Deleting `protobuf-compiler`/`codec-protobuf` and dropping `protobufjs` from the catalog is the
 last step, and needs every thread above done.
@@ -36,24 +38,15 @@ reproduces the protobuf.js field shapes -- `PublicKey`, `Timeframe`, plain-objec
 Callers are untouched and cannot observe which codec carried a type, which is what makes this one
 file rather than a sweep.
 
-Routing is decided per type when `protoMessage()` is called, by walking the descriptor for a
-transitive `google.protobuf.Any` field: shape-compat cannot represent one, so those types stay on
-the protobuf.js codec. A construction-time decision rather than a runtime throw on the first
-payload. Measured on `22bea85f`: **31 of 45 types route through buf, 14 stay legacy.** The count is
-of types `protoMessage()` still resolves; `SignedMessage` is not among them, having moved to an
-explicit `bufMessage()` in this same change.
+Every type `protoMessage()` resolves now routes through buf. The construction-time gate that kept
+`google.protobuf.Any` carriers on the protobuf.js codec is gone, because `#3` resolves `Any`.
 
-The 14 are the `Any` carriers: `Space`, `QuerySpacesResponse`, `JoinSpaceResponse`,
-`CreateEpochResponse`, `Credential`, `Presentation`, `GossipMessage`, `QueryResponse`,
-`edge.signal.Message`, `SignalResponse`, `SubscribeToFeedBlocksResponse`,
-`Get`/`SaveSpaceSnapshotResponse`, and top-level `google.protobuf.Any` itself. Clearing them is
-`Any` support in `#3`, which `#9d` needs anyway -- do it once, there.
-
-An earlier revision of this section claimed `#7` _was_ the import sweep, on the reasoning that a
-type still on `protoMessage` is one consumed outside the RPC boundary
-(`plans/worker-package/service-rpc-schemas.md`), so flipping it rewrites its consumers. That is true
-of moving a type to `bufMessage`, and it is why the sweep is separately expensive -- but `#7` never
-required it. Re-pointing the implementation keeps the shapes.
+Routing the last 14 types fixed a live bug rather than merely moving them. `dxos.echo.query.QueryResponse`
+was one of them, and `@protobufjs/utf8.read` corrupts a >8KB payload containing an astral character on
+the JS Reader path -- a plain `Uint8Array`, which is what arrives over the browser worker MessagePort,
+rather than Node's native `BufferReader`. That is why the query wire was rewritten as an inline Effect
+schema in the first place. `QueryService.test.ts` used to assert the corruption; it now asserts the
+round-trip, so the guard points the other way.
 
 ### Struct was double-encoded
 
@@ -71,57 +64,102 @@ well-known type to before writing a substitution for it. And prefer a JSON-strin
 diverge between the generators, and it is what consumers reach through
 (`signalEvent.payload.payload.data?.type` in the WebRTC proxy only parses because of it).
 
-## `Any` support in `#3` is the one gate left
+## `Any` support in `#3`, and what it retired
 
-Measured while landing `#7` and `#9c`, and it reshapes the order of everything remaining:
-`google.protobuf.Any` blocks `#7`'s last 14 types, two of `#9c`'s three, and all of `#9d`. Every
-`Any` reached is the same field -- `Credential.subject.assertion`:
+`google.protobuf.Any` had blocked `#7`'s last 14 types, two of `#9c`'s three and all of `#9d`, always
+at the same field -- `Credential.subject.assertion`. It is now resolved in the compat layer, keyed off
+`buf/registry.ts`:
 
-| Thread | Blocked on `Any` at                                                                |
-| ------ | ---------------------------------------------------------------------------------- |
-| `#7`   | 14 of 45 types, via `Credential` / `Presentation`                                  |
-| `#9c`  | `LargeSpaceMetadata.controlPipelineSnapshot.messages.credential.subject.assertion` |
-| `#9c`  | `FeedMessage.payload.credential.credential.subject.assertion`                      |
-| `#9d`  | the credential itself                                                              |
+- A resolvable `type_url` is unpacked recursively through the compat layer, so the payload's own
+  substituted fields come back substituted, and tagged with `@type` as the legacy codec does.
+- An unresolvable `type_url` stays packed as `{ '@type': 'google.protobuf.Any', type_url, value }`,
+  again matching the legacy codec rather than failing.
+- A field carrying `[(preserve_any) = true]` keeps its payload packed. The option is read from the
+  generated `preserve_any` extension, so the field decides -- there is no caller-supplied encoding
+  option, because `protoMessage()` never passed one.
+- `google.protobuf.Struct` as an `Any` payload goes through buf's JSON form, since `protoc-gen-es`
+  aliases a Struct _field_ to `JsonObject` but a standalone Struct message is still a message.
 
-So `Any` support is not `#9d`'s tail-end problem, it is the prerequisite for three threads. Do it
-once in `#3` -- it needs a buf-side type registry (`buf/registry.ts` now provides one) and the
-`preserve_any` field option -- rather than per thread.
+### Credential signatures are safer than the plan assumed
 
-## `#9c`: byte identity is not achievable, and that is the finding
+The stated top risk was that any decoded-shape drift invalidates every credential, because
+`signing.ts` stringifies the substituted object. Reading `canonicalStringify` closes most of that:
+`json-stable-stringify` **sorts keys**, and the replacer normalises `PublicKey`, `Buffer` and
+`Uint8Array` all to the same hex string. So two divergences that do exist between the codecs are
+provably harmless to signatures:
 
-`EchoMetadata` is the one `#9c` type not `Any`-blocked, and its fixture is in
-`shape-compat.test.ts`. It does **not** encode byte-identically, for two reasons that apply to any
-message with an unset non-optional message field:
+- **Key order.** The compat layer emits buf's field order, not protobuf.js'.
+- **`bytes` views.** protobuf.js decodes a `bytes` field to a `Buffer`; buf to a `Uint8Array`.
 
-- protobuf.js materialises the unset `updated` field as an empty `Timestamp`; buf omits it.
-- protobuf.js writes `nanos: 0` explicitly; buf omits the proto3 default.
+`getCredentialProofPayload` also already strips an empty `parentCredentialIds` and the assertion's
+proto3 defaults, which covers the third divergence (buf materialises an unset repeated field as `[]`,
+protobuf.js omits the key). An earlier attempt here deleted empty collections in the compat layer to
+"fix" this; that was backwards -- protobuf.js materialises them too, and the change made the layer
+diverge. Do not repeat it.
 
-18 bytes against 10 on a minimal record. They stay wire-compatible, which is what a persisted
-profile actually needs, so the fixture asserts that each codec reads the other's output rather than
-that the bytes match. This qualifies the habit stated above: assert byte equality for anything
-_signed_, but for merely _persisted_ data assert cross-codec round-trips, because byte equality is
-unachievable wherever protobuf.js materialises an empty submessage.
+What is asserted, in `credentials/buf-compat.test.ts`: a credential signed on protobuf.js verifies
+after a buf round-trip and in the reverse direction, and both codecs produce byte-identical
+`getCredentialProofPayload` output. `#9d`'s remaining work is therefore the type sweep at the 94
+declaration sites, not the signature question.
 
-The metadata store's codec is deliberately **not** switched yet. Decoding is asymmetric: bytes buf
-wrote read back through the legacy codec as `updated: { seconds, nanos }` rather than a `Date`,
-because the legacy substitution does not fire on a field buf omitted. That is a downgrade hazard for
-existing profiles -- a client rolled back after writing buf-encoded metadata sees a raw object where
-it expects a `Date` -- and wants either an `updated` default on write or a legacy-side fix first.
+## `#9c`: the stores are on buf; the feed codec is not
 
-## `#5`: what is left needs sweep slices, not devtools edits
+All three `#9c` types now have byte-equality fixtures, including the two `Any` had blocked:
+`LargeSpaceMetadata`'s control-pipeline snapshot of credentials, and `FeedMessage`'s credential
+payload (which also exercises a `oneof` wrapping a packed `Any`).
 
-`JsonView` no longer resolves `google.protobuf.Any` through the protobuf.js schema; it uses the buf
-registry and the compat layer, so a substituted field still renders in the shape the viewer formats.
-That is the last piece of `#5` that stands alone.
+`metadata-store.ts` and `sqlite-metadata-store.ts` encode through `compatCodec(EchoMetadataSchema)` /
+`compatCodec(LargeSpaceMetadataSchema)`. The downgrade hazard an earlier revision recorded here does
+not arise: it assumed an unset `updated`, and both stores' `_save` sets `created` and `updated`
+unconditionally, so buf's omission of proto3 defaults never reaches a rolled-back reader as a missing
+field. `compatCodec` exists so a store can swap codecs without touching its own file/CRC plumbing --
+both stores took only their two codec constants and one type annotation.
 
-The remaining 17 legacy imports in `devtools/src` are consumers of types `protoMessage` still hands
-out in protobuf.js shape, so switching an import to buf makes the annotation disagree with the
-runtime value. Each needs its type moved to `bufMessage` first, and the two that would unblock
-`EdgePanel` are not small: `QueryEdgeStatusResponse` embeds `EdgeStatus`, which reaches **22 source
-files** across edge-client, echo-host, client-services and plugin-space's sync UI. `EdgePanel`'s
-nested-enum access (`WsStatus.ConnectionState.CONNECTED`, which buf emits as
+`EchoMetadata` still cannot be byte-identical, for the reason recorded before: protobuf.js
+materialises an unset non-optional message field as an empty submessage and writes `nanos: 0`
+explicitly, where buf omits both (18 bytes against 10 on a minimal record). Its fixture asserts
+cross-codec round-trips rather than byte equality. That qualification stands for merely _persisted_
+data; assert byte equality for anything _signed_.
+
+`pipeline/codec.ts` -- the `FeedMessage` codec -- is deliberately **not** swapped. Its fixture now
+passes byte-identically, so nothing technical blocks it, but it is the value encoding for
+hypercore-signed feed blocks replicated between peers, and `createCodecEncoding` is typed on
+`codec-protobuf`'s `Codec` (it passes an options argument the compat codec has no use for). Swapping
+the signed replication path wants cross-version fixtures of real feeds, which is `#9d`'s job, not a
+rider on a metadata change.
+
+## `#5`: most of the remainder was a stale annotation, not a sweep
+
+An earlier revision priced all 17 remaining devtools imports as needing their type moved to
+`bufMessage` first. That over-counted, and the correction is the useful finding: **only six of
+`DevtoolsHost`'s RPC responses are `protoMessage`-carried** (`SubscribeToSpaces`,
+`SubscribeToFeedBlocks`, `SubscribeToMetadata`, `GetSpaceSnapshot`, `SaveSpaceSnapshot`, `Signal`).
+Everything else on that service is a hand-authored Effect struct. So a devtools file annotating one
+of those values with a `@dxos/protocols/proto/*` type is not blocked on anything -- the annotation is
+simply pointing at the wrong type, and the fix is to point it at the Effect type the service actually
+declares.
+
+Two moved that way -- `KeyRecord` and `ConnectionInfo`, both to `DevtoolsHost.*` -- and
+`devtools:build` is the proof, per the attempt-and-let-`tsc`-rule habit below. `NetworkPanel`'s
+`PeerState` looked like a third and is not: `SpaceSyncState.PeerState` in `DataService` is a _sync_
+peer, unrelated to `dxos.mesh.presence.PeerState`, and `tsc` said so rather than the two silently
+unifying. Fourteen declarations remain, and those are the genuinely blocked ones: values whose wire
+type is `protoMessage`-carried (`SubscribeToSpacesResponse`, `SubscribeToFeedBlocksResponse`,
+`SubscribeToMetadataResponse`, `SignalResponse`, `Credential`, `Contact`, `LogEntry`,
+`QueryLogsRequest`, `QueryEdgeStatusResponse`, `Space`, `PeerState`). Each needs its type moved to `bufMessage`,
+which rewrites that type's consumers -- and `QueryEdgeStatusResponse` embeds `EdgeStatus`, which
+reaches **22 source files** across edge-client, echo-host, client-services and plugin-space's sync
+UI. `EdgePanel`'s nested-enum access (`WsStatus.ConnectionState.CONNECTED`, which buf emits as
 `EdgeStatus_ConnectionState`) is a one-line fix gated behind that slice.
+
+## `#8` is the last milestone-sized thread, and it is not a rider
+
+Everything above landed behind an interface that hides which codec carried a value, which is why it
+could go in one change. `#8` cannot: `schema.getService()` and `createProtoRpcPeer` are the RPC
+_transport_ for mesh/teleport, the iframe bridge and agentmanager, so migrating them changes what
+goes on the wire between peers -- a mismatch breaks replication between released versions rather than
+failing a local call. It needs its own change with cross-version fixtures, and the 49 test sites on
+`example.testing.*` protos should go first to prove the pattern without wire risk.
 
 Before starting any thread, read **Findings** at the bottom: the five generator divergences are
 what make the mechanical-looking parts non-mechanical, and two of them (`Any`, nested enums) are
@@ -153,14 +191,16 @@ generators run side by side and both outputs are consumed today.
 
 | Surface                                                                  | Count                        |
 | ------------------------------------------------------------------------ | ---------------------------- |
-| `.ts`/`.tsx` files importing `@dxos/protocols/proto/*` (protobuf.js gen) | 275 files / 409 declarations |
+| `.ts`/`.tsx` files importing `@dxos/protocols/proto/*` (protobuf.js gen) | 248 files / 367 declarations |
 | Files importing `@dxos/protocols/buf/*` (already migrated)               | 25 (dxos) + 85 (edge)        |
 | Files importing `@dxos/codec-protobuf`                                   | 39                           |
-| `schema.getCodecForType(...)` call sites                                 | 47                           |
+| `schema.getCodecForType(...)` call sites                                 | 51 (2 production sites left) |
 | `Stream` imports from `@dxos/codec-protobuf`                             | 26                           |
 
 Counted over git-tracked `*.ts`/`*.tsx` only, matching `import`/`export … from '@dxos/protocols/proto/…'`
-declarations (not raw mentions of the path, which come to 464 lines). How many of those declarations
+declarations (not raw mentions of the path). The `getCodecForType` figure rose while the import figure
+fell, because the sites that remain are overwhelmingly fixtures asserting the legacy codec against the
+compat layer -- the count is now a measure of test coverage rather than of exposure. How many of those declarations
 touch a _substituted_ field is not measured here — it needs per-field analysis, and it is the number
 that actually sizes the sweep.
 
@@ -220,22 +260,23 @@ Per open thread, assuming no behaviour change and no proto edits.
 
 | Thread | Work                                                                                                 | Estimate    |
 | ------ | ---------------------------------------------------------------------------------------------------- | ----------- |
-| 7      | Done for the 31 non-`Any` types; the remaining 14 ride `Any` support in `#3`                         | done        |
-| 5      | `JsonView` done; the 17 remaining imports need their types swept (see `#5` above)                    | in sweep    |
-| 9c     | `EchoMetadata` fixture done; store swap needs the downgrade fix, other two types need `Any`          | 3–5 days    |
+| 7      | All 45 types route through buf                                                                       | done        |
+| 5      | `JsonView` and two mis-annotated imports done; the 14 remaining need their types swept               | in sweep    |
+| 9c     | Both metadata stores swapped; `pipeline/codec` rides `#9d`                                           | 1–2 days    |
 | 8      | `ServiceDescriptor`/`createProtoRpcPeer` for mesh/teleport, iframe, bridge, agentmanager             | 1.5–2 weeks |
-| 9d     | Credentials signing/verification, incl. `Any` support in the compat layer                            | 1–1.5 weeks |
+| 9d     | Credentials type sweep; the signature question is settled by test                                    | 1 week      |
 | 2      | Test/example protos                                                                                  | 2–3 days    |
-| —      | Import sweep: moving the 46 types' 505 consumer references to buf shapes (independent of `#7`)       | 3–4 weeks   |
+| —      | Import sweep: moving the 45 types' consumer references to buf shapes (independent of `#7`)           | 3–4 weeks   |
 | —      | Delete `protobuf-compiler`, `codec-protobuf`, `substitutions.ts`; drop `protobufjs` from the catalog | 3–5 days    |
 
-**Remaining: roughly 8–12 engineer-weeks**, of which the import sweep is the long tail and the only
-item that touches most of the repo. That is the sum of the rows above at five days to the week. It
-has grown rather than shrunk as threads landed, for one reason each time: the first draft priced the
-mechanical-looking parts as mechanical, and the generator divergences keep turning a type flip into
-a rewrite at that type's consumers. `#7` folding into the sweep is the latest instance.
+**Remaining: roughly 7–10 engineer-weeks**, of which the import sweep is the long tail and the only
+item that touches most of the repo. That is the sum of the rows above at five days to the week. This
+is the first revision where the estimate fell, and for a reason worth keeping: two of the three items
+that shrank did so because a stated blocker turned out to be an assumption -- the credential signature
+risk (`canonicalStringify` sorts keys and normalises byte views) and `#9c`'s downgrade hazard (both
+stores always write both timestamps). Check the assumption before pricing the thread.
 
-Main risks, in order: credential signature stability (`#9d`), decoded-shape drift silently changing
+Main risks now, in order: `#8`'s cross-peer wire compatibility, decoded-shape drift silently changing
 behaviour across the sweep, and the five generator divergences below.
 
 ## Thread detail (ranked by risk × complexity)
@@ -334,7 +375,8 @@ Measured while building the compat layer, so the ranking above understates #9c/#
    (`EdgeStatus.ConnectionState`); buf flattens to `EdgeStatus_ConnectionState`. TypeScript rejects
    the mixed case outright (`no overlap`), so these are safe to attempt but cannot land before
    `#7` — the enum belongs to a value whose type still comes from the protobuf.js barrel.
-5. **`google.protobuf.Any`** is unsupported and throws.
+5. **`google.protobuf.Any`** needs a type registry to resolve, and the `preserve_any` field option
+   to know when not to. Handled in `#3`; see above for the semantics reproduced.
 
 ### Verified: devtools is already on effect-rpc
 

--- a/packages/core/halo/credentials/src/credentials/buf-compat.test.ts
+++ b/packages/core/halo/credentials/src/credentials/buf-compat.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-import { describe, expect, test } from 'vitest';
+import { describe, test } from 'vitest';
 
 import { Keyring } from '@dxos/keyring';
 import { PublicKey } from '@dxos/keys';
@@ -15,11 +15,36 @@ import { createCredential } from './credential-factory';
 import { canonicalStringify, getCredentialProofPayload } from './signing';
 import { verifyCredential } from './verifier';
 
-// A credential's signature covers the canonical stringification of the decoded object, not the wire
-// bytes, so a shape drift in the buf compat layer invalidates every credential ever issued. This is
-// the gate on migrating credentials off protobuf.js.
+// A credential's signature covers the canonical stringification of the decoded object, so a shape
+// drift in the compat layer invalidates every credential ever issued.
 
 const legacyCodec = schema.getCodecForType('dxos.halo.credentials.Credential');
+
+describe('buf shape-compat carries credentials', () => {
+  test('a credential signed on protobuf.js still verifies after a buf round-trip', async ({ expect }) => {
+    const credential = await createTestCredential();
+
+    const decoded = decodeCompat(CredentialSchema, legacyCodec.encode(credential));
+    expect(await verifyCredential(decoded)).toEqual({ kind: 'pass' });
+
+    // And the other direction: bytes buf wrote, read back by the legacy codec.
+    expect(await verifyCredential(legacyCodec.decode(encodeCompat(CredentialSchema, credential)))).toEqual({
+      kind: 'pass',
+    });
+  });
+
+  test('both codecs produce the same signing payload', async ({ expect }) => {
+    const credential = await createTestCredential();
+    const legacyBytes = legacyCodec.encode(credential);
+
+    expect(canonicalStringify(decodeCompat(CredentialSchema, legacyBytes))).toEqual(
+      canonicalStringify(legacyCodec.decode(legacyBytes)),
+    );
+    expect(getCredentialProofPayload(decodeCompat(CredentialSchema, legacyBytes))).toEqual(
+      getCredentialProofPayload(legacyCodec.decode(legacyBytes)),
+    );
+  });
+});
 
 const createTestCredential = async () => {
   const keyring = new Keyring();
@@ -36,29 +61,3 @@ const createTestCredential = async () => {
     subject: PublicKey.random(),
   });
 };
-
-describe('buf shape-compat carries credentials', () => {
-  test('a credential signed on protobuf.js still verifies after a buf round-trip', async () => {
-    const credential = await createTestCredential();
-
-    const decoded = decodeCompat(CredentialSchema, legacyCodec.encode(credential));
-    expect(await verifyCredential(decoded)).toEqual({ kind: 'pass' });
-
-    // And the other direction: bytes buf wrote, read back by the legacy codec.
-    expect(await verifyCredential(legacyCodec.decode(encodeCompat(CredentialSchema, credential)))).toEqual({
-      kind: 'pass',
-    });
-  });
-
-  test('both codecs produce the same signing payload', async () => {
-    const credential = await createTestCredential();
-    const legacyBytes = legacyCodec.encode(credential);
-
-    expect(canonicalStringify(decodeCompat(CredentialSchema, legacyBytes))).toEqual(
-      canonicalStringify(legacyCodec.decode(legacyBytes)),
-    );
-    expect(getCredentialProofPayload(decodeCompat(CredentialSchema, legacyBytes))).toEqual(
-      getCredentialProofPayload(legacyCodec.decode(legacyBytes)),
-    );
-  });
-});

--- a/packages/core/halo/credentials/src/credentials/buf-compat.test.ts
+++ b/packages/core/halo/credentials/src/credentials/buf-compat.test.ts
@@ -1,0 +1,64 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, test } from 'vitest';
+
+import { Keyring } from '@dxos/keyring';
+import { PublicKey } from '@dxos/keys';
+import { decodeCompat, encodeCompat } from '@dxos/protocols/buf-shape-compat';
+import { CredentialSchema } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
+import { schema } from '@dxos/protocols/proto';
+import { SpaceMember } from '@dxos/protocols/proto/dxos/halo/credentials';
+
+import { createCredential } from './credential-factory';
+import { canonicalStringify, getCredentialProofPayload } from './signing';
+import { verifyCredential } from './verifier';
+
+// A credential's signature covers the canonical stringification of the decoded object, not the wire
+// bytes, so a shape drift in the buf compat layer invalidates every credential ever issued. This is
+// the gate on migrating credentials off protobuf.js.
+
+const legacyCodec = schema.getCodecForType('dxos.halo.credentials.Credential');
+
+const createTestCredential = async () => {
+  const keyring = new Keyring();
+  const issuer = await keyring.createKey();
+  return createCredential({
+    assertion: {
+      '@type': 'dxos.halo.credentials.SpaceMember',
+      'spaceKey': PublicKey.random(),
+      'role': SpaceMember.Role.ADMIN,
+      'genesisFeedKey': PublicKey.random(),
+    },
+    issuer,
+    signer: keyring,
+    subject: PublicKey.random(),
+  });
+};
+
+describe('buf shape-compat carries credentials', () => {
+  test('a credential signed on protobuf.js still verifies after a buf round-trip', async () => {
+    const credential = await createTestCredential();
+
+    const decoded = decodeCompat(CredentialSchema, legacyCodec.encode(credential));
+    expect(await verifyCredential(decoded)).toEqual({ kind: 'pass' });
+
+    // And the other direction: bytes buf wrote, read back by the legacy codec.
+    expect(await verifyCredential(legacyCodec.decode(encodeCompat(CredentialSchema, credential)))).toEqual({
+      kind: 'pass',
+    });
+  });
+
+  test('both codecs produce the same signing payload', async () => {
+    const credential = await createTestCredential();
+    const legacyBytes = legacyCodec.encode(credential);
+
+    expect(canonicalStringify(decodeCompat(CredentialSchema, legacyBytes))).toEqual(
+      canonicalStringify(legacyCodec.decode(legacyBytes)),
+    );
+    expect(getCredentialProofPayload(decodeCompat(CredentialSchema, legacyBytes))).toEqual(
+      getCredentialProofPayload(legacyCodec.decode(legacyBytes)),
+    );
+  });
+});

--- a/packages/core/protocols/src/QueryService.test.ts
+++ b/packages/core/protocols/src/QueryService.test.ts
@@ -40,22 +40,20 @@ describe('QueryService wire schema', () => {
     expect(() => JSON.parse(decoded.results?.[0]?.documentJson ?? '')).not.toThrow();
   });
 
-  // Documents the root cause the inline Effect schema replaces: the protobuf codec that previously backed
-  // the query wire corrupts the same payload via `@protobufjs/utf8.read`. The bug surfaces only on the JS
-  // Reader path (a plain Uint8Array, as arrives over the browser worker MessagePort), not Node's native
-  // BufferReader — which is why it broke the browser mailbox story but not Node tests. Guards against
-  // regressing the wire encoding back to protobuf.
-  test('protobuf codec corrupts the same payload on the browser Reader path (root cause)', () => {
+  // The root cause the inline Effect schema above replaces: the protobuf.js codec corrupted this
+  // payload via `@protobufjs/utf8.read`, on the JS Reader path (a plain Uint8Array, as arrives over
+  // the browser worker MessagePort) but not Node's native BufferReader -- which is why it broke the
+  // browser mailbox story and not Node tests. `protoMessage` now encodes through buf, which reads
+  // UTF-8 correctly, so this guards against routing the type back to protobuf.js.
+  test('the protoMessage codec no longer corrupts the same payload on the browser Reader path', () => {
     const documentJson = buildLargeString();
     const message = protoMessage('dxos.echo.query.QueryResponse');
     const encoded = Schema.encodeSync(message)({
       results: [{ id: 'obj1', spaceId: 'space1', rank: 0, documentJson }],
     });
 
-    // A plain (non-Buffer) Uint8Array forces protobufjs's JS Reader (utf8.read) instead of Node's
-    // native BufferReader, matching the structured-clone bytes delivered over the worker MessagePort.
     const decoded = Schema.decodeSync(message)(new Uint8Array(encoded));
-    expect(decoded.results?.[0]?.documentJson).not.toEqual(documentJson);
+    expect(decoded.results?.[0]?.documentJson).toEqual(documentJson);
   });
 });
 

--- a/packages/core/protocols/src/QueryService.test.ts
+++ b/packages/core/protocols/src/QueryService.test.ts
@@ -40,11 +40,8 @@ describe('QueryService wire schema', () => {
     expect(() => JSON.parse(decoded.results?.[0]?.documentJson ?? '')).not.toThrow();
   });
 
-  // The root cause the inline Effect schema above replaces: the protobuf.js codec corrupted this
-  // payload via `@protobufjs/utf8.read`, on the JS Reader path (a plain Uint8Array, as arrives over
-  // the browser worker MessagePort) but not Node's native BufferReader -- which is why it broke the
-  // browser mailbox story and not Node tests. `protoMessage` now encodes through buf, which reads
-  // UTF-8 correctly, so this guards against routing the type back to protobuf.js.
+  // A plain `Uint8Array`, as arrives over the browser worker MessagePort, takes protobufjs's JS
+  // Reader rather than Node's native BufferReader, which is the path that corrupted this payload.
   test('the protoMessage codec no longer corrupts the same payload on the browser Reader path', () => {
     const documentJson = buildLargeString();
     const message = protoMessage('dxos.echo.query.QueryResponse');

--- a/packages/core/protocols/src/buf/shape-compat.test.ts
+++ b/packages/core/protocols/src/buf/shape-compat.test.ts
@@ -9,7 +9,12 @@ import { Timeframe } from '@dxos/timeframe';
 
 import { schema } from '../proto/index.ts';
 import { InvitationSchema } from './proto/gen/dxos/client/invitation_pb.ts';
-import { EchoMetadataSchema, SpaceMetadataSchema } from './proto/gen/dxos/echo/metadata_pb.ts';
+import { FeedMessageSchema } from './proto/gen/dxos/echo/feed_pb.ts';
+import {
+  EchoMetadataSchema,
+  LargeSpaceMetadataSchema,
+  SpaceMetadataSchema,
+} from './proto/gen/dxos/echo/metadata_pb.ts';
 import { EchoObject_SnapshotSchema } from './proto/gen/dxos/echo/object_pb.ts';
 import { HeadsSchema } from './proto/gen/dxos/echo/query_pb.ts';
 import { ErrorSchema } from './proto/gen/dxos/error_pb.ts';
@@ -254,6 +259,73 @@ describe('buf shape-compat', () => {
     expect(decoded.model['@type']).toBe('google.protobuf.Any');
     expect(decoded.model.type_url).toBe('com.example.Model');
     expect(new Uint8Array(decoded.model.value)).toEqual(new Uint8Array([4, 5]));
+  });
+
+  test('LargeSpaceMetadata carries a credential snapshot across codecs', ({ expect }) => {
+    // The metadata store's on-disk record; its credentials made it the `Any`-blocked half of #9c.
+    const codec = schema.getCodecForType('dxos.echo.metadata.LargeSpaceMetadata');
+    const value = {
+      controlPipelineSnapshot: {
+        timeframe: new Timeframe([[PublicKey.random(), 4]]),
+        messages: [
+          {
+            feedKey: PublicKey.random(),
+            credential: {
+              issuer: PublicKey.random(),
+              issuanceDate: new Date(1700000000123),
+              subject: {
+                id: PublicKey.random(),
+                assertion: {
+                  '@type': 'dxos.halo.credentials.AdmittedFeed',
+                  'spaceKey': PublicKey.random(),
+                  'identityKey': PublicKey.random(),
+                  'deviceKey': PublicKey.random(),
+                  'designation': 1,
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const legacyBytes = codec.encode(value);
+    expect(new Uint8Array(encodeCompat(LargeSpaceMetadataSchema, value))).toEqual(new Uint8Array(legacyBytes));
+
+    const decoded = decodeCompat(LargeSpaceMetadataSchema, legacyBytes);
+    expect(decoded.controlPipelineSnapshot.timeframe).toBeInstanceOf(Timeframe);
+    const message = decoded.controlPipelineSnapshot.messages[0];
+    expect(message.feedKey).toBeInstanceOf(PublicKey);
+    expect(message.credential.issuanceDate).toBeInstanceOf(Date);
+    expect(message.credential.subject.assertion['@type']).toBe('dxos.halo.credentials.AdmittedFeed');
+    expect(message.credential.subject.assertion.deviceKey).toBeInstanceOf(PublicKey);
+  });
+
+  test('FeedMessage carries a credential across codecs', ({ expect }) => {
+    const codec = schema.getCodecForType('dxos.echo.feed.FeedMessage');
+    const value = {
+      timeframe: new Timeframe([[PublicKey.random(), 1]]),
+      payload: {
+        credential: {
+          credential: {
+            issuer: PublicKey.random(),
+            issuanceDate: new Date(1700000000123),
+            subject: {
+              id: PublicKey.random(),
+              assertion: { '@type': 'dxos.halo.credentials.SpaceGenesis', 'spaceKey': PublicKey.random() },
+            },
+          },
+        },
+      },
+    };
+
+    const legacyBytes = codec.encode(value);
+    expect(new Uint8Array(encodeCompat(FeedMessageSchema, value))).toEqual(new Uint8Array(legacyBytes));
+
+    // The `payload` oneof must stay flat and its packed credential resolved.
+    const decoded = decodeCompat(FeedMessageSchema, legacyBytes);
+    expect(decoded.timeframe).toBeInstanceOf(Timeframe);
+    expect(decoded.payload.credential.credential.subject.assertion['@type']).toBe('dxos.halo.credentials.SpaceGenesis');
   });
 
   test('packing an Any without an @type fails rather than writing an empty payload', ({ expect }) => {

--- a/packages/core/protocols/src/buf/shape-compat.test.ts
+++ b/packages/core/protocols/src/buf/shape-compat.test.ts
@@ -10,12 +10,13 @@ import { Timeframe } from '@dxos/timeframe';
 import { schema } from '../proto/index.ts';
 import { InvitationSchema } from './proto/gen/dxos/client/invitation_pb.ts';
 import { EchoMetadataSchema, SpaceMetadataSchema } from './proto/gen/dxos/echo/metadata_pb.ts';
+import { EchoObject_SnapshotSchema } from './proto/gen/dxos/echo/object_pb.ts';
 import { HeadsSchema } from './proto/gen/dxos/echo/query_pb.ts';
 import { ErrorSchema } from './proto/gen/dxos/error_pb.ts';
-import { ClaimSchema } from './proto/gen/dxos/halo/credentials_pb.ts';
+import { ClaimSchema, CredentialSchema } from './proto/gen/dxos/halo/credentials_pb.ts';
 import { KeyRecordSchema } from './proto/gen/dxos/halo/keyring_pb.ts';
 import { CommandSchema } from './proto/gen/dxos/mesh/muxer_pb.ts';
-import { UnsupportedSubstitutionError, decodeCompat, encodeCompat } from './shape-compat.ts';
+import { AnyEncodingError, decodeCompat, encodeCompat } from './shape-compat.ts';
 
 // Byte equality alone would miss a substitution decoding to the wrong JS type, and shape equality
 // alone would miss a field-numbering divergence between the two generators, so both are asserted.
@@ -163,10 +164,99 @@ describe('buf shape-compat', () => {
     expect(decoded.data).toBeUndefined();
   });
 
-  test('a message carrying google.protobuf.Any is rejected rather than mis-encoded', ({ expect }) => {
-    // Resolving `Any` needs a buf-side type registry and the `preserve_any` field option.
-    expect(() => encodeCompat(ClaimSchema, { id: PublicKey.random(), assertion: {} })).toThrow(
-      UnsupportedSubstitutionError,
-    );
+  test('an Any payload packs and unpacks in the legacy shape', ({ expect }) => {
+    const codec = schema.getCodecForType('dxos.halo.credentials.Claim');
+    const spaceKey = PublicKey.random();
+    const value = {
+      id: PublicKey.random(),
+      assertion: {
+        '@type': 'dxos.halo.credentials.SpaceMember',
+        'spaceKey': spaceKey,
+        'role': 2,
+        'genesisFeedKey': PublicKey.random(),
+      },
+    };
+
+    const legacyBytes = codec.encode(value);
+    expect(new Uint8Array(encodeCompat(ClaimSchema, value))).toEqual(new Uint8Array(legacyBytes));
+
+    // The packed payload's own substituted fields must come back substituted too.
+    const decoded = decodeCompat(ClaimSchema, legacyBytes);
+    expect(decoded.assertion['@type']).toBe('dxos.halo.credentials.SpaceMember');
+    expect(PublicKey.from(decoded.assertion.spaceKey).equals(spaceKey)).toBe(true);
+    expect(decoded.assertion.spaceKey).toBeInstanceOf(PublicKey);
+    // `toMatchObject`, because protobuf.js materialises the unset repeated `tags` as an empty array.
+    expect(codec.decode(encodeCompat(ClaimSchema, value)).assertion).toMatchObject(decoded.assertion);
+  });
+
+  test('a Credential round-trips byte-identically', ({ expect }) => {
+    // Credentials are the highest-stakes carrier of a packed `Any`; the signature payload itself is
+    // asserted against the real signing code in `credentials/signing.test.ts`.
+    const codec = schema.getCodecForType('dxos.halo.credentials.Credential');
+    const value = {
+      id: PublicKey.random(),
+      issuer: PublicKey.random(),
+      issuanceDate: new Date(1700000000123),
+      subject: {
+        id: PublicKey.random(),
+        assertion: {
+          '@type': 'dxos.halo.credentials.AuthorizedDevice',
+          'identityKey': PublicKey.random(),
+          'deviceKey': PublicKey.random(),
+        },
+      },
+      proof: {
+        type: 'Ed25519Signature2020',
+        creationDate: new Date(1700000000123),
+        signer: PublicKey.random(),
+        value: new Uint8Array([9, 8, 7]),
+      },
+    };
+
+    // Sub-second timestamps keep the bytes comparable: protobuf.js writes `nanos: 0` explicitly
+    // where buf omits the proto3 default, so a whole-second date diverges by two bytes.
+    const legacyBytes = codec.encode(value);
+    const bufBytes = encodeCompat(CredentialSchema, value);
+    expect(new Uint8Array(bufBytes)).toEqual(new Uint8Array(legacyBytes));
+
+    const decoded = decodeCompat(CredentialSchema, legacyBytes);
+    expect(decoded.issuanceDate).toBeInstanceOf(Date);
+    expect(decoded.issuer).toBeInstanceOf(PublicKey);
+    expect(decoded.subject.assertion['@type']).toBe('dxos.halo.credentials.AuthorizedDevice');
+    expect(decoded.subject.assertion.deviceKey).toBeInstanceOf(PublicKey);
+    expect(codec.decode(bufBytes)).toMatchObject({ proof: { type: 'Ed25519Signature2020' } });
+  });
+
+  test('an Any whose type is not in the registry stays packed', ({ expect }) => {
+    const value = {
+      id: PublicKey.random(),
+      assertion: { '@type': 'google.protobuf.Any', 'type_url': 'com.example.Unknown', 'value': new Uint8Array([1]) },
+    };
+
+    const decoded = decodeCompat(ClaimSchema, encodeCompat(ClaimSchema, value));
+    expect(decoded.assertion['@type']).toBe('google.protobuf.Any');
+    expect(decoded.assertion.type_url).toBe('com.example.Unknown');
+    expect(new Uint8Array(decoded.assertion.value)).toEqual(new Uint8Array([1]));
+  });
+
+  test('a preserve_any field leaves its payload packed', ({ expect }) => {
+    const codec = schema.getCodecForType('dxos.echo.object.EchoObject.Snapshot');
+    const value = {
+      model: { '@type': 'google.protobuf.Any', 'type_url': 'com.example.Model', 'value': new Uint8Array([4, 5]) },
+    };
+
+    const legacyBytes = codec.encode(value);
+    expect(new Uint8Array(encodeCompat(EchoObject_SnapshotSchema, value))).toEqual(new Uint8Array(legacyBytes));
+
+    // The compat layer normalises the packed bytes to a `Uint8Array`, where protobuf.js hands back
+    // a `Buffer` view.
+    const decoded = decodeCompat(EchoObject_SnapshotSchema, legacyBytes);
+    expect(decoded.model['@type']).toBe('google.protobuf.Any');
+    expect(decoded.model.type_url).toBe('com.example.Model');
+    expect(new Uint8Array(decoded.model.value)).toEqual(new Uint8Array([4, 5]));
+  });
+
+  test('packing an Any without an @type fails rather than writing an empty payload', ({ expect }) => {
+    expect(() => encodeCompat(ClaimSchema, { id: PublicKey.random(), assertion: {} })).toThrow(AnyEncodingError);
   });
 });

--- a/packages/core/protocols/src/buf/shape-compat.test.ts
+++ b/packages/core/protocols/src/buf/shape-compat.test.ts
@@ -195,8 +195,8 @@ describe('buf shape-compat', () => {
   });
 
   test('a Credential round-trips byte-identically', ({ expect }) => {
-    // Credentials are the highest-stakes carrier of a packed `Any`; the signature payload itself is
-    // asserted against the real signing code in `credentials/signing.test.ts`.
+    // The signature payload itself is asserted against the real signing code in
+    // `credentials/buf-compat.test.ts`.
     const codec = schema.getCodecForType('dxos.halo.credentials.Credential');
     const value = {
       id: PublicKey.random(),
@@ -262,7 +262,7 @@ describe('buf shape-compat', () => {
   });
 
   test('LargeSpaceMetadata carries a credential snapshot across codecs', ({ expect }) => {
-    // The metadata store's on-disk record; its credentials made it the `Any`-blocked half of #9c.
+    // The metadata store's on-disk record, whose credentials carry a packed `Any`.
     const codec = schema.getCodecForType('dxos.echo.metadata.LargeSpaceMetadata');
     const value = {
       controlPipelineSnapshot: {

--- a/packages/core/protocols/src/buf/shape-compat.ts
+++ b/packages/core/protocols/src/buf/shape-compat.ts
@@ -11,11 +11,19 @@ import {
   ScalarType,
   create,
   fromBinary,
+  fromJson,
+  getExtension,
+  hasExtension,
   toBinary,
+  toJson,
 } from '@bufbuild/protobuf';
+import { StructSchema } from '@bufbuild/protobuf/wkt';
 
 import { PublicKey } from '@dxos/keys';
 import { Timeframe } from '@dxos/timeframe';
+
+import { preserve_any } from './proto/gen/dxos/field_options_pb.ts';
+import { bufRegistry } from './registry.ts';
 
 /**
  * Thrown when a message reaches the compat layer carrying a field whose protobuf.js shape cannot
@@ -27,6 +35,9 @@ export class UnsupportedSubstitutionError extends Error {
     super(`No buf shape-compat substitution for ${typeName}.`);
   }
 }
+
+/** Thrown when a `google.protobuf.Any` value cannot be packed or unpacked in the legacy shape. */
+export class AnyEncodingError extends Error {}
 
 type Substitution = {
   /** Substituted JS value -> plain object accepted by the buf message constructor. */
@@ -84,9 +95,75 @@ const substitutions: Record<string, Substitution> = {
   },
 };
 
-// Field traversal.
+// `google.protobuf.Any`.
 
 const ANY_TYPE_NAME = 'google.protobuf.Any';
+const STRUCT_TYPE_NAME = 'google.protobuf.Struct';
+
+/** The legacy shape for an `Any` whose payload stays packed. */
+const packedAny = (typeUrl: string, value: Uint8Array) => ({
+  '@type': ANY_TYPE_NAME,
+  'type_url': typeUrl,
+  'value': value,
+});
+
+// The legacy codec resolves `Any` payloads unless the field opts out, so the option decides the
+// shape rather than any caller-supplied encoding option.
+const isPreservedAny = (field: DescField): boolean =>
+  field.proto.options !== undefined &&
+  hasExtension(field.proto.options, preserve_any) &&
+  getExtension(field.proto.options, preserve_any) === true;
+
+const anyToProto = (field: DescField, value: any): unknown => {
+  const packed = { typeUrl: value.type_url ?? '', value: value.value ?? new Uint8Array() };
+  if (isPreservedAny(field)) {
+    if (value['@type'] !== undefined && value['@type'] !== ANY_TYPE_NAME) {
+      throw new AnyEncodingError(`Field ${field.name} preserves Any, so its payload cannot be packed here.`);
+    }
+    return packed;
+  }
+  const typeName = value['@type'];
+  if (typeof typeName !== 'string') {
+    throw new AnyEncodingError(`Cannot pack ${field.name} without an '@type' string.`);
+  }
+  if (typeName === ANY_TYPE_NAME) {
+    return packed;
+  }
+  const { '@type': _type, ...payload } = value;
+  if (typeName === STRUCT_TYPE_NAME) {
+    return { typeUrl: typeName, value: toBinary(StructSchema, fromJson(StructSchema, payload)) };
+  }
+  const desc = bufRegistry.getMessage(typeName);
+  if (desc === undefined) {
+    throw new UnsupportedSubstitutionError(typeName);
+  }
+  return { typeUrl: typeName, value: encodeCompat(desc, payload) };
+};
+
+const anyFromProto = (field: DescField, value: any): unknown => {
+  // The legacy shape keys the packed payload `type_url`, where buf's message uses `typeUrl`.
+  const typeUrl: string = value.typeUrl ?? '';
+  const bytes = normalizeBytes(value.value ?? new Uint8Array());
+  if (isPreservedAny(field)) {
+    return packedAny(typeUrl, bytes);
+  }
+  if (typeUrl === STRUCT_TYPE_NAME) {
+    return { ...(toJson(StructSchema, fromBinary(StructSchema, bytes)) as object), '@type': typeUrl };
+  }
+  const desc = bufRegistry.getMessage(typeUrl);
+  if (desc === undefined) {
+    // An unresolvable type stays packed rather than failing, matching the legacy codec.
+    return packedAny(typeUrl, bytes);
+  }
+  return { ...decodeCompat(desc, bytes), '@type': typeUrl };
+};
+
+const anySubstitution = (field: DescField): Substitution => ({
+  toProto: (value) => anyToProto(field, value),
+  fromProto: (value) => anyFromProto(field, value),
+});
+
+// Field traversal.
 
 const substitutionFor = (field: DescField): Substitution | undefined => {
   const typeName = messageTypeName(field);
@@ -94,7 +171,7 @@ const substitutionFor = (field: DescField): Substitution | undefined => {
     return undefined;
   }
   if (typeName === ANY_TYPE_NAME) {
-    throw new UnsupportedSubstitutionError(typeName);
+    return anySubstitution(field);
   }
   return substitutions[typeName];
 };
@@ -202,7 +279,7 @@ const convert = (schema: DescMessage, value: any, direction: keyof Substitution)
   if (value == null) {
     return value;
   }
-  const { $typeName: _typeName, ...rest } = value;
+  const { $typeName: _typeName, $unknown: _unknown, '@type': _type, ...rest } = value;
   const result: Record<string, any> = rest;
   for (const field of schema.fields) {
     if (field.oneof !== undefined) {

--- a/packages/core/protocols/src/buf/shape-compat.ts
+++ b/packages/core/protocols/src/buf/shape-compat.ts
@@ -306,3 +306,17 @@ export const encodeCompat = <T extends Message>(schema: DescMessage, value: any)
  */
 export const decodeCompat = (schema: DescMessage, bytes: Uint8Array): any =>
   convert(schema, fromBinary(schema, bytes), 'fromProto');
+
+/** A codec over protobuf.js-shaped values, matching the surface a persisted store needs. */
+export type CompatCodec<T> = {
+  encode: (value: T) => Uint8Array;
+  decode: (bytes: Uint8Array) => T;
+};
+
+/**
+ * Codec adapter so a store can move its on-disk records to buf without changing its own plumbing.
+ */
+export const compatCodec = <T>(messageSchema: DescMessage): CompatCodec<T> => ({
+  encode: (value) => encodeCompat(messageSchema, value),
+  decode: (bytes) => decodeCompat(messageSchema, bytes),
+});

--- a/packages/core/protocols/src/buf/shape-compat.ts
+++ b/packages/core/protocols/src/buf/shape-compat.ts
@@ -107,8 +107,7 @@ const packedAny = (typeUrl: string, value: Uint8Array) => ({
   'value': value,
 });
 
-// The legacy codec resolves `Any` payloads unless the field opts out, so the option decides the
-// shape rather than any caller-supplied encoding option.
+// The legacy codec resolves `Any` payloads unless the field opts out, so the option decides.
 const isPreservedAny = (field: DescField): boolean =>
   field.proto.options !== undefined &&
   hasExtension(field.proto.options, preserve_any) &&

--- a/packages/core/protocols/src/service-rpc.ts
+++ b/packages/core/protocols/src/service-rpc.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-import { type DescMessage, type Message, fromBinary, toBinary } from '@bufbuild/protobuf';
+import { type Message, fromBinary, toBinary } from '@bufbuild/protobuf';
 import { type GenMessage } from '@bufbuild/protobuf/codegenv2';
 import * as Schema from 'effect/Schema';
 import * as SchemaTransformation from 'effect/SchemaTransformation';
@@ -12,41 +12,12 @@ import { decodeCompat, encodeCompat } from './buf/shape-compat.ts';
 import { decodeError, encodeError } from './errors/encoding.ts';
 import { type TYPES, schema } from './proto/gen/index.ts';
 
-const ANY_TYPE_NAME = 'google.protobuf.Any';
-
-/**
- * Whether any field reachable from `desc` is a `google.protobuf.Any`, which shape-compat cannot
- * represent. Guarded against the mutual recursion protobuf messages permit.
- */
-const containsAny = (desc: DescMessage, seen = new Set<string>()): boolean => {
-  if (seen.has(desc.typeName)) {
-    return false;
-  }
-  seen.add(desc.typeName);
-  return desc.fields.some((field) => {
-    const nested =
-      field.fieldKind === 'message' || field.fieldKind === 'list' || field.fieldKind === 'map'
-        ? field.message
-        : undefined;
-    return nested !== undefined && (nested.typeName === ANY_TYPE_NAME || containsAny(nested, seen));
-  });
-};
-
-/**
- * The buf descriptor to encode `typeName` through, or `undefined` to stay on the protobuf.js codec.
- * Resolved per `protoMessage()` call so an uncarryable type fails routing rather than a payload.
- */
-const bufDescriptorFor = (typeName: string): DescMessage | undefined => {
-  const desc = bufRegistry.getMessage(typeName);
-  return desc !== undefined && !containsAny(desc) ? desc : undefined;
-};
-
 /**
  * Effect schema for a protobuf message type, encoded as protobuf bytes on the wire.
  * Values keep the protobuf.js field shapes whichever codec carries them.
  */
 export const protoMessage = <K extends keyof TYPES & string>(typeName: K): Schema.Codec<TYPES[K], Uint8Array> => {
-  const desc = bufDescriptorFor(typeName);
+  const desc = bufRegistry.getMessage(typeName);
   return Schema.Uint8Array.pipe(
     Schema.decodeTo(
       Schema.declare<TYPES[K]>((_): _ is TYPES[K] => true),
@@ -78,7 +49,7 @@ export const bufMessage = <T extends Message>(messageSchema: GenMessage<T>): Sch
  * classes on decode so typed errors cross the RPC boundary.
  */
 export const serviceError: Schema.Codec<Error, Uint8Array> = (() => {
-  const desc = bufDescriptorFor('dxos.error.Error');
+  const desc = bufRegistry.getMessage('dxos.error.Error');
   return Schema.Uint8Array.pipe(
     Schema.decodeTo(
       Schema.declare<Error>((value): value is Error => value instanceof Error),

--- a/packages/devtools/devtools/src/panels/halo/KeyringPanel/KeyringPanel.tsx
+++ b/packages/devtools/devtools/src/panels/halo/KeyringPanel/KeyringPanel.tsx
@@ -6,7 +6,7 @@ import React, { useMemo } from 'react';
 
 import { Format } from '@dxos/echo/Format';
 import { PublicKey } from '@dxos/keys';
-import { type KeyRecord } from '@dxos/protocols/proto/dxos/halo/keyring';
+import { type DevtoolsHost } from '@dxos/protocols/rpc';
 import { useDevtools, useStream } from '@dxos/react-client/devtools';
 import { type TablePropertyDefinition } from '@dxos/react-ui-table';
 
@@ -23,7 +23,7 @@ export const KeyringPanel = () => {
 
   const data = useMemo(
     () =>
-      keys?.map((record: KeyRecord) => ({
+      keys?.map((record: DevtoolsHost.KeyRecord) => ({
         id: PublicKey.from(record.publicKey).toHex(),
         publicKey: PublicKey.from(record.publicKey).toHex(),
         _original: record,

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
@@ -7,7 +7,7 @@ import React, { useMemo } from 'react';
 
 import { Format } from '@dxos/echo/Format';
 import { PublicKey } from '@dxos/keys';
-import { type ConnectionInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
+import { type DevtoolsHost } from '@dxos/protocols/rpc';
 import { useDevtools, useStream } from '@dxos/react-client/devtools';
 import { type SpaceMember, useMembers, useSpaces } from '@dxos/react-client/echo';
 import { Panel } from '@dxos/react-ui';
@@ -29,7 +29,7 @@ type TableSwarmConnection = {
   transportDetails?: string;
   statsDisplay?: string;
   closeReason?: string;
-  connection?: ConnectionInfo;
+  connection?: DevtoolsHost.ConnectionInfo;
 };
 
 const stateOptions = [
@@ -92,7 +92,7 @@ export const SwarmPanel = () => {
     }
   }
 
-  const connectionMap = useMemo(() => new ComplexMap<PublicKey, ConnectionInfo>(PublicKey.hash), []);
+  const connectionMap = useMemo(() => new ComplexMap<PublicKey, DevtoolsHost.ConnectionInfo>(PublicKey.hash), []);
 
   // The state options order determines the sorting priority.
   const rows = useMemo(() => {
@@ -155,7 +155,7 @@ export const SwarmPanel = () => {
   );
 };
 
-const getStats = (connection: ConnectionInfo) => {
+const getStats = (connection: DevtoolsHost.ConnectionInfo) => {
   const stats = {
     bytesSent: 0,
     bytesReceived: 0,

--- a/packages/sdk/client-services/src/packlets/metadata/metadata-store.ts
+++ b/packages/sdk/client-services/src/packlets/metadata/metadata-store.ts
@@ -6,13 +6,13 @@ import CRC32 from 'crc-32';
 import * as EffectContext from 'effect/Context';
 
 import { Event, scheduleTaskInterval, synchronized } from '@dxos/async';
-import { type Codec } from '@dxos/codec-protobuf';
 import { Context } from '@dxos/context';
 import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { DataCorruptionError, STORAGE_VERSION } from '@dxos/protocols';
-import { schema } from '@dxos/protocols/proto';
+import { type CompatCodec, compatCodec } from '@dxos/protocols/buf-shape-compat';
+import { EchoMetadataSchema, LargeSpaceMetadataSchema } from '@dxos/protocols/buf/dxos/echo/metadata_pb';
 import { Invitation, SpaceState } from '@dxos/protocols/proto/dxos/client/services';
 import {
   type ControlPipelineSnapshot,
@@ -87,8 +87,10 @@ const emptyEchoMetadata = (): EchoMetadata => ({
 
 const emptyLargeSpaceMetadata = (): LargeSpaceMetadata => ({});
 
-const EchoMetadata = schema.getCodecForType('dxos.echo.metadata.EchoMetadata');
-const LargeSpaceMetadata = schema.getCodecForType('dxos.echo.metadata.LargeSpaceMetadata');
+// Both records are written with `created` and `updated` always set, so buf's omission of proto3
+// defaults leaves the bytes readable by a client rolled back to the protobuf.js codec.
+const EchoMetadata = compatCodec<EchoMetadata>(EchoMetadataSchema);
+const LargeSpaceMetadata = compatCodec<LargeSpaceMetadata>(LargeSpaceMetadataSchema);
 
 export class MetadataStore implements IMetadataStore {
   private _metadata: EchoMetadata = emptyEchoMetadata();
@@ -131,7 +133,7 @@ export class MetadataStore implements IMetadataStore {
     return this._metadata.deletedSpaces ?? [];
   }
 
-  private async _readFile<T>(file: File, codec: Codec<T>): Promise<T | undefined> {
+  private async _readFile<T>(file: File, codec: CompatCodec<T>): Promise<T | undefined> {
     try {
       const { size: fileLength } = await file.stat();
       if (fileLength < 8) {
@@ -165,7 +167,7 @@ export class MetadataStore implements IMetadataStore {
   /**
    * @internal
    */
-  async _writeFile<T>(file: File, codec: Codec<T>, data: T): Promise<void> {
+  async _writeFile<T>(file: File, codec: CompatCodec<T>, data: T): Promise<void> {
     const encoded = arrayToBuffer(codec.encode(data));
     const checksum = CRC32.buf(encoded);
 

--- a/packages/sdk/client-services/src/packlets/metadata/sqlite-metadata-store.ts
+++ b/packages/sdk/client-services/src/packlets/metadata/sqlite-metadata-store.ts
@@ -16,7 +16,8 @@ import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { DataCorruptionError, STORAGE_VERSION } from '@dxos/protocols';
-import { schema } from '@dxos/protocols/proto';
+import { compatCodec } from '@dxos/protocols/buf-shape-compat';
+import { EchoMetadataSchema, LargeSpaceMetadataSchema } from '@dxos/protocols/buf/dxos/echo/metadata_pb';
 import { Invitation, SpaceState } from '@dxos/protocols/proto/dxos/client/services';
 import {
   type ControlPipelineSnapshot,
@@ -47,8 +48,8 @@ const emptyEchoMetadata = (): EchoMetadata => ({
 
 const emptyLargeSpaceMetadata = (): LargeSpaceMetadata => ({});
 
-const EchoMetadataCodec = schema.getCodecForType('dxos.echo.metadata.EchoMetadata');
-const LargeSpaceMetadataCodec = schema.getCodecForType('dxos.echo.metadata.LargeSpaceMetadata');
+const EchoMetadataCodec = compatCodec<EchoMetadata>(EchoMetadataSchema);
+const LargeSpaceMetadataCodec = compatCodec<LargeSpaceMetadata>(LargeSpaceMetadataSchema);
 
 const MAIN_KEY = 'main';
 const largeKey = (spaceKey: PublicKey) => `large:${spaceKey.toHex()}`;


### PR DESCRIPTION
Clears the one gate left in the protobuf.js → buf migration and lands the work it unblocked.

## `Any` support in the shape-compat layer

`google.protobuf.Any` blocked `#7`'s last 14 types, two of `#9c`'s three and all of `#9d`, always at the same field — `Credential.subject.assertion`. It is now resolved against `buf/registry.ts`, reproducing the legacy codec's semantics:

- a resolvable `type_url` is unpacked recursively through the compat layer (so the payload's own substituted fields come back substituted) and tagged `@type`;
- an unresolvable `type_url` stays packed as `{ '@type': 'google.protobuf.Any', type_url, value }`;
- a field carrying `[(preserve_any) = true]` keeps its payload packed, read from the generated extension;
- a `Struct` payload goes through buf's JSON form, since `protoc-gen-es` aliases a Struct *field* to `JsonObject` but a standalone Struct message is still a message.

## `#7` is done, and it fixed a bug

The construction-time routing gate is gone: all 45 `protoMessage()` types encode through buf, up from 31. One of the newly routed types is `dxos.echo.query.QueryResponse`, and `@protobufjs/utf8.read` corrupts a >8KB payload containing an astral character on the JS Reader path — a plain `Uint8Array`, which is what arrives over the browser worker MessagePort. That bug is why the query wire was rewritten as an inline Effect schema. `QueryService.test.ts` used to assert the corruption; it now asserts the round-trip.

## Credentials

`credentials/buf-compat.test.ts` asserts what `#9d` actually turns on: a credential signed on protobuf.js verifies after a buf round-trip and in the reverse direction, and both codecs produce byte-identical `getCredentialProofPayload` output.

Two divergences between the codecs do exist and are provably harmless to signatures, because `canonicalStringify` sorts keys and normalises `PublicKey`/`Buffer`/`Uint8Array` to the same hex string: decoded key order, and `bytes` fields decoding to `Buffer` on protobuf.js versus `Uint8Array` on buf.

## `#9c`: both metadata stores are on buf

`metadata-store.ts` and `sqlite-metadata-store.ts` encode through a new `compatCodec(desc)` adapter, so they swapped codecs without touching their own file/CRC plumbing. The downgrade hazard recorded in the audit does not arise — it assumed an unset `updated`, and both stores' `_save` sets `created` and `updated` unconditionally.

New byte-equality fixtures cover the two types `Any` had blocked: `LargeSpaceMetadata`'s credential snapshot, and `FeedMessage`'s credential payload (which also exercises a `oneof` wrapping a packed `Any`).

`pipeline/codec.ts` is deliberately **not** swapped. Its fixture passes byte-identically, so nothing technical blocks it, but it is the value encoding for hypercore-signed feed blocks replicated between peers, and swapping the signed replication path wants cross-version fixtures of real feeds — that belongs with `#9d`, not as a rider on a metadata change.

## `#5`: two annotations were simply wrong

Only six `DevtoolsHost` responses are `protoMessage`-carried; everything else on that service is a hand-authored Effect struct. So `KeyringPanel`'s `KeyRecord` and `SwarmPanel`'s `ConnectionInfo` were never blocked on the type sweep — they were annotating Effect-schema values with protobuf.js types. `NetworkPanel`'s `PeerState` looked like a third and is not (`SpaceSyncState.PeerState` is a *sync* peer, unrelated to `dxos.mesh.presence.PeerState`); `tsc` caught it rather than the two silently unifying. Fourteen declarations remain and are genuinely blocked.

## Not in this change

`#8` — the remaining `schema.getService()`/`createProtoRpcPeer` transport for mesh/teleport, the iframe bridge and agentmanager — is the last milestone-sized thread (~1.5–2 weeks). Everything above could go in one change because it sits behind an interface that hides which codec carried a value; `#8` changes what goes on the wire between peers, where a mismatch breaks replication between released versions rather than failing a local call. It needs its own change with cross-version fixtures, and its 49 test sites on `example.testing.*` protos should go first to prove the pattern without wire risk. `docs/audits/protobufjs-to-buf.md` is updated accordingly — the remaining estimate falls to 7–10 engineer-weeks, the first revision where it has.

## Test plan

- `protocols:test` — 47 passed (15 in `shape-compat.test.ts`)
- `credentials:test` — 56 passed, 2 skipped
- `client-services:test` — 165 passed, 3 skipped
- `devtools:build`, `protocols:build`, `client-services:build`, lint and `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7

---
_Generated by [Claude Code](https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compatibility support for `google.protobuf.Any`, including registered, preserved, unknown, and nested payloads.
  * Improved protobuf message encoding and decoding across supported schemas.
  * Metadata storage now uses the updated compatibility encoding path.

* **Bug Fixes**
  * Improved handling of `Any` payloads with missing or prefixed type metadata.
  * Preserved credential verification and canonical signing behavior across encoding formats.

* **Documentation**
  * Updated the protobuf migration plan with compatibility findings and remaining work.

* **Tests**
  * Expanded coverage for credentials, metadata, feed messages, claims, and `Any` payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->