### PR TITLE
fix(react-ui-assistant): build the translations entry the manifest declares

### DIFF
--- a/.changeset/react-ui-assistant-translations-entry.md
+++ b/.changeset/react-ui-assistant-translations-entry.md
@@ -1,5 +1,0 @@
----
-'@dxos/react-ui-assistant': patch
----
-
-`@dxos/react-ui-assistant/translations` now resolves. The package has always exported that subpath, but `dist/lib/translations.mjs` was never built, so anything importing it failed to bundle — which is what `@dxos/plugin-assistant` started doing in #12610.

--- a/.changeset/react-ui-assistant-translations-entry.md
+++ b/.changeset/react-ui-assistant-translations-entry.md
@@ -1,0 +1,5 @@
+---
+'@dxos/react-ui-assistant': patch
+---
+
+`@dxos/react-ui-assistant/translations` now resolves. The package has always exported that subpath, but `dist/lib/translations.mjs` was never built, so anything importing it failed to bundle — which is what `@dxos/plugin-assistant` started doing in #12610.

--- a/packages/ui/react-ui-assistant/vite.config.ts
+++ b/packages/ui/react-ui-assistant/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     testing: 'src/testing/index.ts',
+    translations: 'src/translations.ts',
     types: 'src/types.ts',
   },
   jsx: 'react',


### PR DESCRIPTION
`@dxos/react-ui-assistant`'s package.json exports `./translations` → `dist/lib/translations.mjs`, but `vite.config.ts` never listed `src/translations.ts` in its entry map, so the build never emitted that file. The manifest has been pointing at a bundle that doesn't exist.

Nothing noticed until #12610, which switched `@dxos/plugin-assistant/src/translations.ts` from importing the package root to importing the subpath. Any bundler resolving `@dxos/plugin-assistant` now dies on:

```
✘ [ERROR] Could not resolve "@dxos/react-ui-assistant/translations"
   The module "./dist/lib/translations.mjs" was not found on the file system
```

That is what dxos/edge hit when bumping its pkg.pr.new pin past `1ab4bb8c`: the edge worker bundle fails to build, taking down every `test-edge` shard and `operation-service:test`. Sibling `@dxos/react-ui-task` lists `translations` in its entry map and ships the file, which is the shape this restores.

Verified with `pnpm exec vite build` in the package: `dist/lib/translations.mjs` (0.66 kB) now emits alongside index, testing, and types.

One thought for a follow-up, not done here: `conditionalSubpathEntries` in `vite.base.config.ts` already derives entries from the manifest for `#` subpaths, and its comment spells out this exact failure mode ("a hand-maintained entry list drifts silently and leaves the manifest pointing at a bundle the build never produced"). Public `exports` subpaths still rely on the hand-maintained list, so the same drift can happen again in any package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added translations as a build entry, enabling translation resources to be included in the published package.
  * Enabled the package’s translations subpath to resolve correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->