### PR TITLE
ci: partial-clone every full-depth checkout and drop the no-op LFS fetch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -440,7 +440,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          lfs: true
+          filter: blob:none
           persist-credentials: false
 
       - name: Extract branch

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -252,7 +252,6 @@ jobs:
     env:
       DEPLOY_ENV: ${{ needs.plan.outputs.env }}
     steps:
-      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -252,11 +252,12 @@ jobs:
     env:
       DEPLOY_ENV: ${{ needs.plan.outputs.env }}
     steps:
+      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          lfs: true
+          filter: blob:none
           # On production, the bumped release commit; otherwise the triggering commit.
           ref: ${{ needs.release.outputs.sha || github.sha }}
 
@@ -330,7 +331,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          lfs: true
+          filter: blob:none
           ref: ${{ needs.release.outputs.sha || github.sha }}
 
       # Needed before "Check app targets this environment" — apps.mjs imports json5 from node_modules.

--- a/.github/workflows/deploy-tauri.yaml
+++ b/.github/workflows/deploy-tauri.yaml
@@ -131,7 +131,6 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
@@ -353,7 +352,6 @@ jobs:
     continue-on-error: true
 
     steps:
-      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0

--- a/.github/workflows/deploy-tauri.yaml
+++ b/.github/workflows/deploy-tauri.yaml
@@ -131,10 +131,11 @@ jobs:
     timeout-minutes: 60
 
     steps:
+      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          lfs: true
+          filter: blob:none
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Install Linux dependencies
@@ -352,10 +353,11 @@ jobs:
     continue-on-error: true
 
     steps:
+      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          lfs: true
+          filter: blob:none
           ref: ${{ inputs.ref || github.sha }}
 
       - uses: tecolicom/actions-use-homebrew-tools@v1

--- a/.github/workflows/edge-tests.yml
+++ b/.github/workflows/edge-tests.yml
@@ -33,17 +33,20 @@ jobs:
         with:
           detached: true
 
+      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - name: Checkout DXOS
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          lfs: true
+          filter: blob:none
           path: dxos
 
+      # `lfs: true` stays: dxos/edge may track LFS files, unlike this tree.
       - name: Checkout EDGE
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          filter: blob:none
           lfs: true
           token: ${{ secrets.CREATE_PR_TOKEN }}
           repository: dxos/edge

--- a/.github/workflows/edge-tests.yml
+++ b/.github/workflows/edge-tests.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           detached: true
 
-      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - name: Checkout DXOS
         uses: actions/checkout@v5
         with:
@@ -41,7 +40,6 @@ jobs:
           filter: blob:none
           path: dxos
 
-      # `lfs: true` stays: dxos/edge may track LFS files, unlike this tree.
       - name: Checkout EDGE
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/model-fixture.yml
+++ b/.github/workflows/model-fixture.yml
@@ -48,12 +48,13 @@ jobs:
       VITEST_XML_REPORT: 'true'
       MOON_CONCURRENCY: 4
     steps:
+      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - name: Checkout
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
-          lfs: true
+          filter: blob:none
           persist-credentials: false
 
       - name: Setup

--- a/.github/workflows/model-fixture.yml
+++ b/.github/workflows/model-fixture.yml
@@ -48,7 +48,6 @@ jobs:
       VITEST_XML_REPORT: 'true'
       MOON_CONCURRENCY: 4
     steps:
-      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -32,11 +32,12 @@ jobs:
     # workspace packages, which does not fit the previous 30.
     timeout-minutes: 60
     steps:
+      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          lfs: true
+          filter: blob:none
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -32,7 +32,6 @@ jobs:
     # workspace packages, which does not fit the previous 30.
     timeout-minutes: 60
     steps:
-      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -38,11 +38,12 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 45
     steps:
+      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          lfs: true
+          filter: blob:none
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -38,7 +38,6 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 45
     steps:
-      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/todo-tracker.yml
+++ b/.github/workflows/todo-tracker.yml
@@ -37,7 +37,6 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/todo-tracker.yml
+++ b/.github/workflows/todo-tracker.yml
@@ -37,11 +37,12 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      # Blobless: full history without every historical file version. Nothing in the tree is LFS-tracked.
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          lfs: true
+          filter: blob:none
 
       - name: Extract branch
         id: extract_branch


### PR DESCRIPTION
Adds `filter: blob:none` to the eleven `fetch-depth: 0` checkouts that still lacked it, and removes `lfs: true`, which fetches nothing in this tree.

## Why this regressed

#12485 (*"ci: partial-clone the checkouts in Check"*, Aug 6) converted every checkout in `check.yml` — but it was scoped to that one workflow. #12482 (*"e2e: bundle once, then shard by browser × moon --job"*) merged five days later and introduced the `e2e-bundle` job with a hand-written `fetch-depth: 0` + `lfs: true` block copied from the pre-#12485 template. So Check regressed one job, and the ten call sites outside Check never had the filter at all.

## What it saves, measured on CI

Same workflow (`PR Build` → `build`), two runs 40 seconds apart on the same runner class:

| | run | Checkout |
| --- | --- | --- |
| unfiltered | [708](https://github.com/dxos/dxos/actions/runs/32965548500/job/98167117135), a branch without this change | **25 s** |
| filtered | [709](https://github.com/dxos/dxos/actions/runs/32965608699/job/98167300815), this branch | **12 s** |

`model-fixture`, also converted here, checks out in 13 s on this branch. Both figures now sit with Check's already-filtered jobs, which run 10–14 s — against 43 s for `e2e-bundle` on the unfiltered path.

So roughly **13 s per checkout**: ~26 s off every PR (`pr-build` + `model-fixture`), ~30 s off `e2e-bundle` on main and release runs, and the dispatch/schedule workflows when they run.

## Why the filter is what matters

Against this remote, one checkout of `main` measured locally (a sandbox with far less bandwidth than a Depot runner, so treat the absolute numbers as an upper bound — the *ratio* is what carried over to CI above):

| strategy | wall | `.git` |
| --- | --- | --- |
| `fetch-depth: 0`, no filter | 62 s | **1.10 GiB** |
| `fetch-depth: 0` + `filter: blob:none` | 13 s | **198 MiB** |
| `--depth=1` (the floor) | 9 s | 144 MiB |

The 13 s splits into 5 s for the commit graph (28,483 commits, 394,950 commit+tree objects, 58 MiB) and 8 s backfilling the 16,375 working-tree blobs the filter deferred. Since depth-1 is only 4 s cheaper, nearly all the remaining cost is materialising the working tree, which every job needs regardless.

Full depth is load-bearing: `--affected remote` and `merge-base` resolve against the commit graph. What the filter drops is every *historical* version of every file, which nothing in CI reads. The working tree is byte-identical either way.

## Why `lfs: true` goes

`.gitattributes` declares LFS filters for `*.dxprofile`, `*.spline` and `*.splinecode`, but `git ls-files` matches **zero** tracked files against them — the fetch is a round trip for nothing. This is the same finding the comment at `check.yml:77` already records.

It stays on the **EDGE** checkout in `edge-tests.yml`, whose tree is `dxos/edge` and cannot be audited from here.

## Sites changed

`check.yml` (`e2e-bundle`), `pr-build.yml`, `pkg-pr-new.yml`, `todo-tracker.yml`, `model-fixture.yml`, `edge-tests.yml` (×2), `deploy-apps.yml` (×2), `deploy-tauri.yaml` (×2).

Deliberately left unfiltered, having never carried `lfs: true`: the `release` job in `deploy-apps.yml`, `publish-all.yml`, `introspect-cache.yml`, `upload-introspect-cache.yml`, `claude-composer-implement.yml`. Worth a follow-up, but the release-path ones deserve their own change.

## Verification

- All 23 `fetch-depth: 0` sites audited; every one either carries the filter or is on the list above.
- Every workflow file parses (`yaml.safe_load`), with each checkout's `filter`/`lfs` values confirmed intact.
- `pnpm format` / `oxfmt --check` clean.
- No changeset: CI-only, per `agents/instructions/changesets.md` rule 2. The `changeset-reminder` comment naming `@dxos/react-ui-assistant` on this PR is a false positive unrelated to this diff — that job checks out `refs/pull/N/merge`, which tracks main's moving tip, while `CHANGESET_BASE_REF` stays frozen at the event's `base.sha`, so #12756 landing mid-run got attributed here. The gating `check-changesets` pins `ref:` to the head sha and is unaffected.
- **Only 3 of the 8 files are exercised before merge.** `check.yml`, `pr-build.yml` and `model-fixture.yml` run on `pull_request`; `pkg-pr-new` is push-only, and `todo-tracker` / `edge-tests` / `deploy-apps` / `deploy-tauri` are dispatch, schedule or `workflow_call`. `check.yml`'s own change is the `e2e-bundle` job, which is gated off PRs — it first runs on the merge to main.
- **Not verified:** `filter: blob:none` alongside `lfs: true` on the EDGE checkout. The two inputs are independent in `actions/checkout` (one goes to `git fetch`, the other runs `git lfs fetch`), but `git-lfs` isn't installed in this sandbox, so the combination is untested and `edge-tests.yml` won't exercise it without a dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111otfs5FgyWGGCtZkch6jS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated build, test, deployment, and packaging workflows to use Git’s blobless partial clones.
  - Reduced unnecessary repository content fetched during workflow checkouts.
  - Preserved required large-file support where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->