### PR TITLE
edge-client: floor connection uptime to whole seconds

### DIFF
--- a/.changeset/edge-status-uptime-int.md
+++ b/.changeset/edge-status-uptime-int.md
@@ -1,0 +1,5 @@
+---
+'@dxos/edge-client': patch
+---
+
+Report edge connection uptime as whole seconds, fixing the `invalid int32` error thrown when encoding `EdgeStatus`.

--- a/packages/core/mesh/edge-client/src/edge-ws-connection.ts
+++ b/packages/core/mesh/edge-client/src/edge-ws-connection.ts
@@ -87,7 +87,7 @@ export class EdgeWsConnection extends Resource {
     return this._rtt;
   }
 
-  /** Whole seconds; the wire type (EdgeStatus.uptime) is int32 and rejects fractions. */
+  /** Floor uptime to satisfy the int32 EdgeStatus.uptime wire type. */
   public get uptime(): number {
     return this._openTimestamp ? Math.floor((Date.now() - this._openTimestamp) / 1000) : 0;
   }

--- a/packages/core/mesh/edge-client/src/edge-ws-connection.ts
+++ b/packages/core/mesh/edge-client/src/edge-ws-connection.ts
@@ -87,8 +87,9 @@ export class EdgeWsConnection extends Resource {
     return this._rtt;
   }
 
+  /** Whole seconds; the wire type (EdgeStatus.uptime) is int32 and rejects fractions. */
   public get uptime(): number {
-    return this._openTimestamp ? (Date.now() - this._openTimestamp) / 1000 : 0;
+    return this._openTimestamp ? Math.floor((Date.now() - this._openTimestamp) / 1000) : 0;
   }
 
   public get uploadRate(): number {


### PR DESCRIPTION
## Problem

Every `EdgeStatus` encode logged:

```
Error: cannot encode field dxos.client.services.EdgeStatus.uptime to binary: invalid int32: 683.241
```

`EdgeStatus.uptime` is declared `int32` in `dxos/client/services.proto`, but `EdgeWsConnection.uptime` returned `(Date.now() - openTimestamp) / 1000` — a fractional value — so the codec rejected it on each status query.

## Change

Floor the getter to whole seconds (`packages/core/mesh/edge-client/src/edge-ws-connection.ts`). The sibling fields (`rtt`, rates, message counts) are already integers.

## Testing

Toolchain (`moon`, `oxfmt`, `node_modules`) is not installed in this cloud sandbox, so no local build/test was run — relying on CI's Check workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_012awqy1Pm5b7Jt7Wmr8mJmg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed edge connection uptime reporting to use whole seconds, preventing connection status encoding errors.
  * Improved reliability when reporting edge connection status.

* **Release**
  * Included this fix in a patch release of the edge client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->