### PR TITLE
compute-runtime: stop the TriggerDispatcher timer while no triggers exist

### DIFF
--- a/.changeset/trigger-dispatcher-idle-timer.md
+++ b/.changeset/trigger-dispatcher-idle-timer.md
@@ -1,0 +1,9 @@
+---
+'@dxos/compute-runtime': patch
+---
+
+`TriggerDispatcher` no longer runs its fixed-interval timer while no triggers are defined.
+
+The natural-time loop used to be forked unconditionally by `start()` and repeat forever, so a client with an empty trigger set still woke every `livePollInterval` to invoke nothing. The loop is now forked when the trigger working set becomes non-empty and interrupted when it empties again, driven by the live trigger query that already backs `refreshTriggers`. The interval itself is unchanged while the loop runs.
+
+`TriggerDispatcher` gains a `timerScheduled` getter reporting whether the loop is currently forked, which is how the behaviour is asserted.

--- a/packages/core/compute/compute-runtime/src/triggers/trigger-dispatcher.test.ts
+++ b/packages/core/compute/compute-runtime/src/triggers/trigger-dispatcher.test.ts
@@ -191,6 +191,23 @@ const registerOperation = (operation: Operation.Definition.Any) =>
     return record;
   });
 
+/**
+ * Poll a predicate against real time. The timer lifecycle is driven by the trigger-query
+ * subscription callback, which runs on its own fiber, so a transition is never observable on the
+ * turn that caused it. Returns the final value so a caller can assert either polarity — a `false`
+ * result after the full budget is the "never happened" assertion.
+ */
+const waitFor = (predicate: () => boolean, attempts = 100) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      if (predicate()) {
+        return true;
+      }
+      yield* Effect.sleep(Duration.millis(20));
+    }
+    return predicate();
+  });
+
 describe('TriggerDispatcher', () => {
   describe('Time Control', () => {
     it.effect(
@@ -640,6 +657,44 @@ describe('TriggerDispatcher', () => {
           }).pipe(Effect.ensuring(dispatcher.stop()));
         },
         Effect.provide(TestLayer({ timeControl: 'natural', livePollInterval: Duration.hours(1) })),
+      ),
+    );
+
+    // `it.live` (not `it.effect`): the timer is started and stopped from a real subscription
+    // callback, so the waits below must pass real time rather than a virtual clock nothing advances.
+    it.live(
+      'schedules no timer while no trigger exists, and starts/stops one across the empty boundary',
+      Effect.fnUntraced(
+        function* ({ expect }) {
+          const dispatcher = yield* TriggerDispatcher;
+          yield* dispatcher.start();
+
+          // Stopped in a finalizer: a failure below would otherwise leave a detached timer fiber
+          // and the reactive subscriptions running into the next test.
+          yield* Effect.gen(function* () {
+            // An idle dispatcher is up, but schedules no repeating wake at all.
+            expect(dispatcher.running).toBe(true);
+            expect(yield* waitFor(() => dispatcher.timerScheduled, 10)).toBe(false);
+
+            // The first trigger starts the loop.
+            const functionObj = yield* registerOperation(Reply);
+            const trigger = Trigger.make({
+              runnable: Ref.make(functionObj),
+              enabled: true,
+              spec: Trigger.specTimer('* * * * *'),
+            });
+            yield* Database.add(trigger);
+            yield* Database.flush();
+            expect(yield* waitFor(() => dispatcher.timerScheduled)).toBe(true);
+
+            // Removing the last trigger stops it again.
+            yield* Database.remove(trigger);
+            yield* Database.flush();
+            expect(yield* waitFor(() => !dispatcher.timerScheduled)).toBe(true);
+          }).pipe(Effect.ensuring(dispatcher.stop()));
+        },
+        // Also covers the devtools/cli path, which passes a 1s interval rather than the default.
+        Effect.provide(TestLayer({ timeControl: 'natural', livePollInterval: Duration.seconds(1) })),
       ),
     );
   });

--- a/packages/core/compute/compute-runtime/src/triggers/trigger-dispatcher.test.ts
+++ b/packages/core/compute/compute-runtime/src/triggers/trigger-dispatcher.test.ts
@@ -697,6 +697,54 @@ describe('TriggerDispatcher', () => {
         Effect.provide(TestLayer({ timeControl: 'natural', livePollInterval: Duration.seconds(1) })),
       ),
     );
+
+    // The stop path leaves `_timerFiber` empty via a finalizer on the loop itself, so a second
+    // start has to fork a fresh loop rather than find a stale handle in the slot. Going one cycle
+    // further than the test above is what distinguishes a re-forkable timer from a one-shot.
+    it.live(
+      're-instates the timer when a trigger comes back into scope after the set emptied',
+      Effect.fnUntraced(
+        function* ({ expect }) {
+          const dispatcher = yield* TriggerDispatcher;
+          const functionObj = yield* registerOperation(Reply);
+          const makeTrigger = () =>
+            Trigger.make({
+              runnable: Ref.make(functionObj),
+              enabled: true,
+              spec: Trigger.specTimer('* * * * *'),
+            });
+
+          yield* dispatcher.start();
+
+          // Stopped in a finalizer: a failure below would otherwise leave a detached timer fiber
+          // and the reactive subscriptions running into the next test.
+          yield* Effect.gen(function* () {
+            expect(yield* waitFor(() => dispatcher.timerScheduled, 10)).toBe(false);
+
+            const first = makeTrigger();
+            yield* Database.add(first);
+            yield* Database.flush();
+            expect(yield* waitFor(() => dispatcher.timerScheduled)).toBe(true);
+
+            yield* Database.remove(first);
+            yield* Database.flush();
+            expect(yield* waitFor(() => !dispatcher.timerScheduled)).toBe(true);
+
+            // The assertion this test exists for: a loop forks again after a prior one was stopped.
+            const second = makeTrigger();
+            yield* Database.add(second);
+            yield* Database.flush();
+            expect(yield* waitFor(() => dispatcher.timerScheduled)).toBe(true);
+
+            // And the restarted loop is still gated, rather than running on past its working set.
+            yield* Database.remove(second);
+            yield* Database.flush();
+            expect(yield* waitFor(() => !dispatcher.timerScheduled)).toBe(true);
+          }).pipe(Effect.ensuring(dispatcher.stop()));
+        },
+        Effect.provide(TestLayer({ timeControl: 'natural', livePollInterval: Duration.seconds(1) })),
+      ),
+    );
   });
 
   describe('Feed Triggers', () => {

--- a/packages/core/compute/compute-runtime/src/triggers/trigger-dispatcher.ts
+++ b/packages/core/compute/compute-runtime/src/triggers/trigger-dispatcher.ts
@@ -202,6 +202,12 @@ export class TriggerDispatcher extends Context.Service<
     get running(): boolean;
 
     /**
+     * Whether the fixed-interval timer loop is currently scheduled. False while the dispatcher is
+     * running but its trigger working set is empty, since an idle dispatcher schedules no wake.
+     */
+    get timerScheduled(): boolean;
+
+    /**
      * Start the trigger dispatcher.
      * Will automatically invoke triggers.
      */
@@ -297,6 +303,13 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
   private _running = false;
   private _internalTime: Date;
   private _timerFiber: Fiber.Fiber<void, void> | undefined;
+
+  /**
+   * Incremented per forked timer loop so a loop that ends (by exhausting its working set, or by
+   * crashing) only clears {@link _timerFiber} when it still owns the slot — a restart in between
+   * must not have its handle cleared by its predecessor's finalizer.
+   */
+  #timerGeneration = 0;
   private _triggers: Trigger.Trigger[] = [];
 
   /**
@@ -427,6 +440,10 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
     return this._running;
   }
 
+  get timerScheduled(): boolean {
+    return this._timerFiber !== undefined;
+  }
+
   get state(): Atom.Atom<TriggerDispatcherState> {
     return this._state;
   }
@@ -449,28 +466,10 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
 
       // Start natural time processing if enabled
       if (this.timeControl === 'natural') {
+        // The timer is not started here: `#subscribeToTriggers` fires immediately and every time the
+        // trigger set changes, and `#syncTimerToWorkingSet` starts the loop only once that set is
+        // non-empty, so a dispatcher with no triggers schedules no repeating wake at all.
         yield* this.#subscribeToTriggers();
-        this._timerFiber = yield* this._startNaturalTimeProcessing().pipe(
-          Effect.tapCause((cause) =>
-            Effect.gen({ self: this }, function* () {
-              const error = EffectEx.causeToError(cause);
-              log.error('trigger dispatcher error', { error });
-              this._running = false;
-              this._timerFiber = undefined;
-              registry.update(
-                this._state,
-                Struct.evolve({
-                  enabled: () => false,
-                  errors: (errors) => [...errors, error].slice(-MAX_TRACKED_ERRORS),
-                }),
-              );
-              // A crash bypasses `stop()` (`_running` is already false, so a later `stop()` call
-              // would no-op) — tear the subscription down here so it doesn't outlive the dispatcher.
-              yield* this.#teardownTriggerSubscription();
-            }),
-          ),
-          Effect.forkDetach,
-        );
       } else {
         return yield* Effect.die(new Error('TriggerDispatcher started in manual time control mode'));
       }
@@ -1056,6 +1055,8 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
           // repopulate trigger state after the dispatcher has stopped.
           this.#pendingRefreshFiber = Effect.runFork(
             this.refreshTriggers().pipe(
+              // Runs on this fiber, never the timer's, so `#stopTimer` can interrupt the loop safely.
+              Effect.flatMap(() => this.#syncTimerToWorkingSet()),
               Effect.tapCause((cause) =>
                 Effect.sync(() => log.error('failed to refresh triggers', { error: EffectEx.causeToError(cause) })),
               ),
@@ -1212,12 +1213,103 @@ class TriggerDispatcherImpl implements Context.Service.Shape<typeof TriggerDispa
       }
     });
 
+  /**
+   * Whether anything in the working set justifies a repeating wake. An idle Composer tab defines no
+   * triggers at all, and a fixed-interval tick against an empty set is a pure no-op that keeps
+   * allocator pages committed — see `.agents/projects/memory-usage/TASKS.md` Phase 4, R1.
+   *
+   * Deliberately the whole working set rather than the timer-kind subset the tick actually invokes:
+   * cooldown and retry state is tracked for every kind, so narrowing this further would change
+   * dispatch semantics rather than just scheduling.
+   */
+  #hasSchedulableWork = (): boolean => this._triggers.length > 0;
+
+  /**
+   * Fork the fixed-interval timer loop unless one is already running. Idempotent: the trigger
+   * subscription fires on every change, and only an empty -> non-empty transition should start one.
+   */
+  #startTimer = (): Effect.Effect<void> =>
+    Effect.gen({ self: this }, function* () {
+      if (this._timerFiber) {
+        return;
+      }
+
+      const registry = yield* Registry.AtomRegistry;
+      const generation = ++this.#timerGeneration;
+      this._timerFiber = yield* this._startNaturalTimeProcessing().pipe(
+        Effect.tapCause((cause) =>
+          Effect.gen({ self: this }, function* () {
+            const error = EffectEx.causeToError(cause);
+            log.error('trigger dispatcher error', { error });
+            this._running = false;
+            registry.update(
+              this._state,
+              Struct.evolve({
+                enabled: () => false,
+                errors: (errors) => [...errors, error].slice(-MAX_TRACKED_ERRORS),
+              }),
+            );
+            // A crash bypasses `stop()` (`_running` is already false, so a later `stop()` call
+            // would no-op) — tear the subscription down here so it doesn't outlive the dispatcher.
+            yield* this.#teardownTriggerSubscription();
+          }),
+        ),
+        // Covers the loop ending on its own (empty working set) as well as crashing, so a later
+        // trigger can start a fresh one rather than finding a stale handle in the slot.
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (this.#timerGeneration === generation) {
+              this._timerFiber = undefined;
+            }
+          }),
+        ),
+        Effect.forkDetach,
+      );
+    }).pipe(Effect.provide(this._services));
+
+  /**
+   * Interrupt the timer loop if one is running. Only ever called from the trigger-subscription
+   * fiber: `refreshTriggers` also runs on the timer fiber itself (via `invokeScheduledTriggers`),
+   * and interrupting the current fiber there would kill the tick mid-flight. The loop's own
+   * `while` guard covers that case instead.
+   */
+  #stopTimer = (): Effect.Effect<void> =>
+    Effect.gen({ self: this }, function* () {
+      const fiber = this._timerFiber;
+      if (!fiber) {
+        return;
+      }
+      this._timerFiber = undefined;
+      yield* Fiber.interrupt(fiber);
+    });
+
+  /** Match the timer to the working set, starting or stopping it across an empty/non-empty edge. */
+  #syncTimerToWorkingSet = (): Effect.Effect<void> =>
+    Effect.gen({ self: this }, function* () {
+      if (!this._running || this.timeControl !== 'natural') {
+        return;
+      }
+      if (this.#hasSchedulableWork()) {
+        yield* this.#startTimer();
+      } else {
+        yield* this.#stopTimer();
+      }
+    });
+
   private _startNaturalTimeProcessing = (): Effect.Effect<void> =>
     Effect.gen({ self: this }, function* () {
       // Timer triggers only: feed and subscription triggers are woken by `#reactiveSources` when
       // their data changes, so the wall clock no longer re-reads every feed on every tick.
       yield* this.invokeScheduledTriggers({ kinds: ['timer'] });
-    }).pipe(Effect.repeat(Schedule.fixed(this.livePollInterval)), Effect.asVoid);
+    }).pipe(
+      Effect.repeat({
+        schedule: Schedule.fixed(this.livePollInterval),
+        // Stops the loop when the last trigger goes away while the tick is executing on this very
+        // fiber, which `#stopTimer` cannot interrupt from the outside without self-interrupting.
+        while: () => this.#hasSchedulableWork(),
+      }),
+      Effect.asVoid,
+    );
 
   private _prepareInputData = (trigger: Trigger.Trigger, event: TriggerEvent.TriggerEvent): any => {
     return createInvocationPayload(trigger, event);


### PR DESCRIPTION
# compute-runtime: stop the TriggerDispatcher timer while no triggers exist

## Motivation

Part of the **Composer memory-usage** effort — `.agents/projects/memory-usage/TASKS.md`,
Phase 4 (idle churn), remedy **R1 "Event-driven scheduling"**, which is currently `[~]`
(partially done).

Phase 4's premise: an idle tab's resting footprint tracks the *idle rhythm*, not live data.
Allocators keep pages committed while something keeps allocating, so a periodic no-op wake
costs resident memory even when it does nothing. DESIGN.md finding 4 records a barebones tab
holding ~140 MB live across all heaps while reporting 861 MB of private footprint.

`TriggerDispatcher` is started by `plugin-routine`, a core plugin, so **every tab pays it**.
#12561 landed the first half of R1: `start()` subscribes once to a live `Filter.type(Trigger)`
query and `refreshTriggers` reads its cached results, so the trigger-list lookup no longer
issues SQL per tick. The tick itself was left firing unconditionally — that is what this
change removes.

## What changed

`_startNaturalTimeProcessing` was forked unconditionally by `start()` and repeated on
`Schedule.fixed(this.livePollInterval)` forever. With no triggers defined it woke every
interval, ran `invokeScheduledTriggers({ kinds: ['timer'] })` over an empty runtime-state map,
and invoked nothing.

The loop is now forked when the trigger working set becomes **non-empty** and interrupted when
it **empties**, driven by the live trigger query that already backs `refreshTriggers`:

- `#hasSchedulableWork()` — the gate (`_triggers.length > 0`).
- `#startTimer()` — forks the loop, idempotent; carries the pre-existing crash handler.
- `#stopTimer()` — interrupts a running loop.
- `#syncTimerToWorkingSet()` — start/stop across the empty boundary, called from the
  trigger-subscription callback.
- `TriggerDispatcher.timerScheduled` — new getter, reports whether the loop is forked.

**The interval is unchanged while the loop runs.** The devtools/cli path
(`devtools/cli/src/util/trigger-runtime.ts`, which passes `livePollInterval: 1s`) is
unaffected and is covered by the new test.

### Two subtleties worth reviewing

1. **Self-interruption.** `refreshTriggers` also runs *on the timer fiber* (via
   `invokeScheduledTriggers` → `refreshTriggers`), so a stop driven from inside it would
   interrupt the current fiber mid-tick. The stop path is therefore driven only from the
   subscription fiber, and the loop additionally carries a `while: () => this.#hasSchedulableWork()`
   guard for the case where its working set empties mid-tick — the one case the outside
   cannot interrupt safely.

2. **Slot ownership.** `#timerGeneration` ensures a loop that ends (naturally or by crashing)
   only clears `_timerFiber` when it still owns the slot, so a restart in between does not get
   its handle cleared by its predecessor's finalizer.

### Deliberately not done

The gate is the **whole** working set, not the timer-kind subset the tick actually invokes.
Cooldown and retry state is tracked for every kind, so gating on `kind === 'timer'` would change
dispatch semantics rather than just scheduling. That narrowing is a plausible follow-up and
would remove the wake for tabs that hold only feed/subscription triggers.

The rest of R1 — "sleep to the next due time" rather than a fixed interval while triggers *do*
exist — is also still open.

## Testing

New test in `Natural Time Control`, covering the three acceptance transitions in one lifecycle:

- **(a)** zero triggers → no repeating timer scheduled (`timerScheduled === false`, while the
  dispatcher itself is running)
- **(b)** creating the first trigger starts the loop (`timerScheduled` becomes `true`)
- **(c)** deleting the last trigger stops it (`timerScheduled` returns to `false`)

It is `it.live` rather than `it.effect`: the timer is started and stopped from a real
subscription callback, so the waits must pass real time rather than a virtual clock nothing
advances. The dispatcher is stopped in a finalizer so a failure cannot leak the detached fiber
into the next test.

## Verification performed

- `oxlint` on both changed files — 0 warnings, 0 errors.
- `oxfmt --check` on all changed files — clean.
- The Effect scheduling semantics the change depends on were validated against the repo's
  pinned `effect@4.0.0-rc.108` with a standalone harness (8/8 checks): `repeat({schedule, while})`
  stops when the predicate goes false and does not sleep another interval first;
  `Fiber.interrupt` stops a loop parked in the schedule delay; `Effect.ensuring` runs on both
  natural end and interrupt; a fresh loop can be forked after either kind of stop.

> [!IMPORTANT]
> **The `compute-runtime` vitest suite was NOT run in the authoring environment** — the toolchain
> is blocked there, so acceptance (a)–(c) exist as a written test that has never executed, and (d)
> "existing trigger-dispatcher tests pass" is unverified. **This PR relies on CI to confirm all
> four.** Please do not merge on a green review alone.
>
> For the record, the two blockers were environmental and unrelated to this change: `moon` fails
> every task there with `plugin::wasm::failed_function_call` reading `pnpm-lock.yaml`, and a manual
> build of the dependency closure terminates at `@dxos/sql-sqlite`, whose `@effect/wa-sqlite` and
> `@effect/sql-sqlite-wasm` are devDependencies that `dx-compile`'s `bundle-deps` plugin refuses to
> bundle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Timer-based trigger processing now starts automatically when triggers become available and pauses when no triggers remain.
  - Added status visibility for whether trigger polling is currently active.

- **Bug Fixes**
  - Improved trigger timer lifecycle handling, including reliable stopping and restarting as trigger availability changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->