### PR TITLE
plugin-claude-agents: authenticate managed agents with Anthropic OAuth

### DIFF
--- a/.changeset/anthropic-oauth-provider.md
+++ b/.changeset/anthropic-oauth-provider.md
@@ -1,0 +1,6 @@
+---
+'@dxos/protocols': minor
+---
+
+Add the `anthropic` OAuth provider, so a Claude account can be connected over OAuth and the
+managed-agent operations run against the resulting access token instead of a pasted Console API key.

--- a/packages/core/protocols/src/edge/edge.ts
+++ b/packages/core/protocols/src/edge/edge.ts
@@ -334,6 +334,7 @@ export type EdgeAuthChallenge = {
 };
 
 export enum OAuthProvider {
+  ANTHROPIC = 'anthropic',
   ATLASSIAN = 'atlassian',
   ATPROTO = 'atproto',
   /** @deprecated Use ATPROTO instead. */

--- a/packages/plugins/plugin-claude-agents/PLUGIN.mdl
+++ b/packages/plugins/plugin-claude-agents/PLUGIN.mdl
@@ -162,8 +162,18 @@ feat F-6: Credentials
 
   req F-6.1:
     when: any operation calls the Anthropic API
-    then: the API key is resolved from the credential stored under the
-          "anthropic.com" service and sent as the `x-api-key` header
+    then: |
+      the credential is resolved from the "anthropic.com" service and sent as
+      the header its kind requires — an OAuth access token (`sk-ant-oat…`, minted
+      by connecting a Claude account) on `Authorization: Bearer` alongside the
+      `oauth-2025-04-20` beta, a Console API key on `x-api-key`
+
+  req F-6.4:
+    when: the user connects the "anthropic" connector
+    then: |
+      EDGE runs the Anthropic authorization-code flow (PKCE) and the resulting
+      access token is stored as the space's "anthropic.com" credential, so no key
+      is ever pasted into the conversation
 
   req F-6.3:
     when: no "anthropic.com" credential exists in the space

--- a/packages/plugins/plugin-claude-agents/PLUGIN.mdl
+++ b/packages/plugins/plugin-claude-agents/PLUGIN.mdl
@@ -169,11 +169,17 @@ feat F-6: Credentials
       `oauth-2025-04-20` beta, a Console API key on `x-api-key`
 
   req F-6.4:
-    when: the user connects the "anthropic" connector
+    when: the user connects the "anthropic" connector and leaves the API key empty
     then: |
       EDGE runs the Anthropic authorization-code flow (PKCE) and the resulting
       access token is stored as the space's "anthropic.com" credential, so no key
       is ever pasted into the conversation
+
+  req F-6.5:
+    when: the user enters an API key in the "anthropic" connector form
+    then: |
+      the key is stored directly as the "anthropic.com" credential and no OAuth
+      flow runs — an org that will not grant the OAuth client keeps working
 
   req F-6.3:
     when: no "anthropic.com" credential exists in the space

--- a/packages/plugins/plugin-claude-agents/package.json
+++ b/packages/plugins/plugin-claude-agents/package.json
@@ -135,6 +135,8 @@
     "@dxos/echo": "workspace:*",
     "@dxos/edge-client": "workspace:*",
     "@dxos/errors": "workspace:*",
+    "@dxos/plugin-connector": "workspace:*",
+    "@dxos/protocols": "workspace:*",
     "@dxos/util": "workspace:*",
     "effect": "catalog:"
   },

--- a/packages/plugins/plugin-claude-agents/package.json
+++ b/packages/plugins/plugin-claude-agents/package.json
@@ -135,6 +135,7 @@
     "@dxos/echo": "workspace:*",
     "@dxos/edge-client": "workspace:*",
     "@dxos/errors": "workspace:*",
+    "@dxos/link": "workspace:*",
     "@dxos/plugin-connector": "workspace:*",
     "@dxos/protocols": "workspace:*",
     "@dxos/util": "workspace:*",

--- a/packages/plugins/plugin-claude-agents/src/api/client.ts
+++ b/packages/plugins/plugin-claude-agents/src/api/client.ts
@@ -7,20 +7,42 @@ import * as Schema from 'effect/Schema';
 
 import { proxyFetchLegacy } from '@dxos/edge-client';
 
-import { ANTHROPIC_API_URL, ANTHROPIC_VERSION, MANAGED_AGENTS_BETA, REQUEST_TIMEOUT_MS } from '../constants';
+import {
+  ANTHROPIC_API_URL,
+  ANTHROPIC_OAUTH_BETA,
+  ANTHROPIC_VERSION,
+  MANAGED_AGENTS_BETA,
+  REQUEST_TIMEOUT_MS,
+} from '../constants';
+import { type AnthropicCredential } from '../credentials';
 import { ClaudeAgentApiError } from '../errors';
 import { type AgentConfig, AgentResponse, EnvironmentResponse, EventPage, Ignored, SessionResponse } from './types';
 
 type Request<A> = {
-  apiKey: string;
+  credential: AnthropicCredential;
   method: 'GET' | 'POST';
   path: string;
   schema: Schema.Codec<A>;
   body?: unknown;
 };
 
+/**
+ * An OAuth access token authenticates as a bearer and must announce the OAuth beta, while a Console
+ * key goes on `x-api-key`; sending the wrong pair is rejected as an authentication error.
+ */
+const authHeaders = ({ token, scheme }: AnthropicCredential): Record<string, string> =>
+  scheme === 'oauth'
+    ? { 'authorization': `Bearer ${token}`, 'anthropic-beta': `${MANAGED_AGENTS_BETA},${ANTHROPIC_OAUTH_BETA}` }
+    : { 'x-api-key': token, 'anthropic-beta': MANAGED_AGENTS_BETA };
+
 /** Calls the Managed Agents control plane through the edge CORS proxy, which api.anthropic.com requires. */
-export const request = <A>({ apiKey, method, path, schema, body }: Request<A>): Effect.Effect<A, ClaudeAgentApiError> =>
+export const request = <A>({
+  credential,
+  method,
+  path,
+  schema,
+  body,
+}: Request<A>): Effect.Effect<A, ClaudeAgentApiError> =>
   Effect.tryPromise({
     try: async (): Promise<unknown> => {
       const controller = new AbortController();
@@ -30,10 +52,9 @@ export const request = <A>({ apiKey, method, path, schema, body }: Request<A>): 
         const response = await proxyFetchLegacy(new URL(`${ANTHROPIC_API_URL}${path}`), {
           method,
           headers: {
-            'x-api-key': apiKey,
             'anthropic-version': ANTHROPIC_VERSION,
-            'anthropic-beta': MANAGED_AGENTS_BETA,
             'content-type': 'application/json',
+            ...authHeaders(credential),
           },
           ...(body === undefined ? {} : { body: JSON.stringify(body) }),
           signal: controller.signal,
@@ -59,21 +80,24 @@ export const request = <A>({ apiKey, method, path, schema, body }: Request<A>): 
   );
 
 /** Creates a saved agent configuration. */
-export const createAgent = (apiKey: string, config: AgentConfig): Effect.Effect<AgentResponse, ClaudeAgentApiError> =>
-  request({ apiKey, method: 'POST', path: '/v1/agents', schema: AgentResponse, body: config });
+export const createAgent = (
+  credential: AnthropicCredential,
+  config: AgentConfig,
+): Effect.Effect<AgentResponse, ClaudeAgentApiError> =>
+  request({ credential, method: 'POST', path: '/v1/agents', schema: AgentResponse, body: config });
 
 /**
  * Updates an existing agent, bumping its version. `version` is sent for optimistic concurrency: a
  * mismatch is rejected with 409 rather than silently overwriting a config changed elsewhere.
  */
 export const updateAgent = (
-  apiKey: string,
+  credential: AnthropicCredential,
   agentId: string,
   config: AgentConfig,
   version?: number,
 ): Effect.Effect<AgentResponse, ClaudeAgentApiError> =>
   request({
-    apiKey,
+    credential,
     method: 'POST',
     path: `/v1/agents/${agentId}`,
     schema: AgentResponse,
@@ -82,11 +106,11 @@ export const updateAgent = (
 
 /** Creates the cloud environment sessions run in, with unrestricted egress for the agent's tools. */
 export const createEnvironment = (
-  apiKey: string,
+  credential: AnthropicCredential,
   name: string,
 ): Effect.Effect<EnvironmentResponse, ClaudeAgentApiError> =>
   request({
-    apiKey,
+    credential,
     method: 'POST',
     path: '/v1/environments',
     schema: EnvironmentResponse,
@@ -95,11 +119,11 @@ export const createEnvironment = (
 
 /** Starts a session against a deployed agent, optionally seeding it with the first user message. */
 export const createSession = (
-  apiKey: string,
+  credential: AnthropicCredential,
   params: { agentId: string; environmentId: string; title?: string; message?: string },
 ): Effect.Effect<SessionResponse, ClaudeAgentApiError> =>
   request({
-    apiKey,
+    credential,
     method: 'POST',
     path: '/v1/sessions',
     schema: SessionResponse,
@@ -114,17 +138,20 @@ export const createSession = (
   });
 
 /** Reads a session's current state, including its status and stop reason. */
-export const getSession = (apiKey: string, sessionId: string): Effect.Effect<SessionResponse, ClaudeAgentApiError> =>
-  request({ apiKey, method: 'GET', path: `/v1/sessions/${sessionId}`, schema: SessionResponse });
+export const getSession = (
+  credential: AnthropicCredential,
+  sessionId: string,
+): Effect.Effect<SessionResponse, ClaudeAgentApiError> =>
+  request({ credential, method: 'GET', path: `/v1/sessions/${sessionId}`, schema: SessionResponse });
 
 /** Sends a user message into a running session. */
 export const sendUserMessage = (
-  apiKey: string,
+  credential: AnthropicCredential,
   sessionId: string,
   message: string,
 ): Effect.Effect<unknown, ClaudeAgentApiError> =>
   request({
-    apiKey,
+    credential,
     method: 'POST',
     path: `/v1/sessions/${sessionId}/events`,
     schema: Ignored,
@@ -133,8 +160,12 @@ export const sendUserMessage = (
 
 /** Reads one page of session events, newest last. */
 export const listEvents = (
-  apiKey: string,
+  credential: AnthropicCredential,
   sessionId: string,
   limit: number,
 ): Effect.Effect<EventPage, ClaudeAgentApiError> =>
-  request({ apiKey, method: 'GET', path: `/v1/sessions/${sessionId}/events?limit=${limit}`, schema: EventPage });
+  request({ credential, method: 'GET', path: `/v1/sessions/${sessionId}/events?limit=${limit}`, schema: EventPage });
+
+/** Cheapest authenticated call, used to probe whether a stored credential still works. */
+export const verifyCredential = (credential: AnthropicCredential): Effect.Effect<unknown, ClaudeAgentApiError> =>
+  request({ credential, method: 'GET', path: '/v1/models?limit=1', schema: Ignored });

--- a/packages/plugins/plugin-claude-agents/src/capabilities/connector.ts
+++ b/packages/plugins/plugin-claude-agents/src/capabilities/connector.ts
@@ -1,0 +1,58 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Capability from '@dxos/app-framework/Capability';
+import * as Credential from '@dxos/compute/Credential';
+import { ConnectionTestError } from '@dxos/plugin-connector';
+import * as ConnectorSpec from '@dxos/plugin-connector/ConnectorSpec';
+import { OAuthProvider } from '@dxos/protocols';
+
+import { verifyCredential } from '#api';
+
+import { ANTHROPIC_OAUTH_TOKEN_PREFIX, ANTHROPIC_PROVIDER_ID, ANTHROPIC_SCOPES, ANTHROPIC_SOURCE } from '../constants';
+
+/**
+ * Anthropic `testConnection`: one authenticated read with the stored credential. A rejected token
+ * (expired, or a revoked grant) surfaces as a user-facing error so the connection UI can offer to
+ * reauthenticate before an agent run fails mid-session.
+ */
+const testConnection: ConnectorSpec.TestConnection = ({ accessToken }) =>
+  Effect.flatMap(Credential.getApiKeyValue({ accessTokenId: accessToken.id }), (token) =>
+    verifyCredential({
+      token,
+      scheme: token.startsWith(ANTHROPIC_OAUTH_TOKEN_PREFIX) ? 'oauth' : 'api-key',
+    }),
+  ).pipe(
+    Effect.asVoid,
+    Effect.mapError(
+      () =>
+        new ConnectionTestError({
+          message: 'Anthropic rejected the credential. Reauthenticate to continue running agents.',
+        }),
+    ),
+  );
+
+/**
+ * Contributes the Anthropic connector, which is authentication-only: it has no sync targets, it
+ * exists so a user can connect their Claude account and have the managed-agent operations run
+ * against the resulting OAuth token instead of a hand-pasted Console API key.
+ */
+export default Capability.makeModule(
+  Effect.fnUntraced(function* () {
+    return Capability.contribute(ConnectorSpec.Connector, [
+      {
+        id: ANTHROPIC_PROVIDER_ID,
+        source: ANTHROPIC_SOURCE,
+        label: 'Anthropic',
+        oauth: {
+          provider: OAuthProvider.ANTHROPIC,
+          scopes: ANTHROPIC_SCOPES,
+        },
+        testConnection,
+      },
+    ]);
+  }),
+);

--- a/packages/plugins/plugin-claude-agents/src/capabilities/connector.ts
+++ b/packages/plugins/plugin-claude-agents/src/capabilities/connector.ts
@@ -3,9 +3,12 @@
 //
 
 import * as Effect from 'effect/Effect';
+import * as Schema from 'effect/Schema';
 
 import * as Capability from '@dxos/app-framework/Capability';
 import * as Credential from '@dxos/compute/Credential';
+import { Obj, Ref } from '@dxos/echo';
+import { AccessToken, Connection } from '@dxos/link';
 import { ConnectionTestError } from '@dxos/plugin-connector';
 import * as ConnectorSpec from '@dxos/plugin-connector/ConnectorSpec';
 import { OAuthProvider } from '@dxos/protocols';
@@ -36,9 +39,47 @@ const testConnection: ConnectorSpec.TestConnection = ({ accessToken }) =>
   );
 
 /**
+ * Pre-flight form offering both credential kinds. A Console API key stays reachable — the OAuth
+ * client is workspace-scoped and an org may not want to grant it at all — so an entered key
+ * completes the connection directly and an empty field falls through to the OAuth flow.
+ */
+const credentialForm: ConnectorSpec.CredentialForm<{ token?: string; account?: string }> = {
+  schema: Schema.Struct({
+    token: Schema.String.annotate({
+      title: 'API key',
+      description: 'Anthropic Console API key (sk-ant-api…). Leave empty to connect a Claude account instead.',
+    }).pipe(Schema.optional),
+    account: Schema.String.annotate({
+      title: 'Account',
+      description: 'Optional label for the connection.',
+    }).pipe(Schema.optional),
+  }),
+  defaultValues: { token: '' },
+  onSubmit: ({ values, connector }) =>
+    Effect.sync(() => {
+      const token = values.token?.trim();
+      if (!token) {
+        return { kind: 'oauth' } as const;
+      }
+
+      const accessToken = Obj.make(AccessToken.AccessToken, {
+        source: ANTHROPIC_SOURCE,
+        account: values.account,
+        token,
+      });
+      const connection = Obj.make(Connection.Connection, {
+        name: values.account ?? connector.label ?? ANTHROPIC_SOURCE,
+        connectorId: connector.id,
+        accessToken: Ref.make(accessToken),
+      });
+      return { kind: 'complete', accessToken, connection } as const;
+    }),
+};
+
+/**
  * Contributes the Anthropic connector, which is authentication-only: it has no sync targets, it
- * exists so a user can connect their Claude account and have the managed-agent operations run
- * against the resulting OAuth token instead of a hand-pasted Console API key.
+ * exists so the managed-agent operations can run against a connected Claude account or a Console
+ * API key, whichever the user supplies in the form.
  */
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
@@ -51,6 +92,7 @@ export default Capability.makeModule(
           provider: OAuthProvider.ANTHROPIC,
           scopes: ANTHROPIC_SCOPES,
         },
+        credentialForm,
         testConnection,
       },
     ]);

--- a/packages/plugins/plugin-claude-agents/src/capabilities/index.ts
+++ b/packages/plugins/plugin-claude-agents/src/capabilities/index.ts
@@ -3,7 +3,10 @@
 //
 
 import * as ActivationEvents from '@dxos/app-framework/ActivationEvents';
+import * as Capability from '@dxos/app-framework/Capability';
 import * as AppCapability from '@dxos/app-toolkit/AppCapability';
+import * as ConnectorEvents from '@dxos/plugin-connector/ConnectorEvents';
+import * as ConnectorSpec from '@dxos/plugin-connector/ConnectorSpec';
 
 import { meta } from '#meta';
 import { translations } from '#translations';
@@ -11,6 +14,11 @@ import { translations } from '#translations';
 // eslint-disable-next-line import/no-relative-packages
 import pluginSpec from '../../PLUGIN.mdl?raw';
 
+export const Connector = Capability.lazyModule(
+  'ClaudeAgentsConnector',
+  { provides: [ConnectorSpec.Connector], activatesOn: ConnectorEvents.Start },
+  () => import('./connector'),
+);
 export const OperationHandler = AppCapability.operationHandler(() => import('./operation-handler'), {
   activatesOn: ActivationEvents.Idle,
 });

--- a/packages/plugins/plugin-claude-agents/src/constants.ts
+++ b/packages/plugins/plugin-claude-agents/src/constants.ts
@@ -2,8 +2,23 @@
 // Copyright 2026 DXOS.org
 //
 
-/** Credential service key under which the Anthropic API key is stored. */
+/** Credential service key under which the Anthropic credential is stored. */
 export const ANTHROPIC_SOURCE = 'anthropic.com';
+
+/** Connector id for the Anthropic OAuth connection; stored as `Connection.connectorId`. */
+export const ANTHROPIC_PROVIDER_ID = 'anthropic';
+
+/**
+ * OAuth scopes requested when connecting a Claude account: inference to run the agent, and the
+ * profile scope so the connection can be labelled with the authorizing account.
+ */
+export const ANTHROPIC_SCOPES = ['user:inference', 'user:profile'] as const;
+
+/** Prefix of an Anthropic OAuth access token, as opposed to an `sk-ant-api…` Console key. */
+export const ANTHROPIC_OAUTH_TOKEN_PREFIX = 'sk-ant-oat';
+
+/** OAuth-authenticated requests must carry this flag; `/v1/messages` rejects a bearer token without it. */
+export const ANTHROPIC_OAUTH_BETA = 'oauth-2025-04-20';
 
 export const ANTHROPIC_API_URL = 'https://api.anthropic.com';
 

--- a/packages/plugins/plugin-claude-agents/src/credentials.ts
+++ b/packages/plugins/plugin-claude-agents/src/credentials.ts
@@ -6,25 +6,45 @@ import * as Effect from 'effect/Effect';
 
 import * as Credential from '@dxos/compute/Credential';
 
-import { ANTHROPIC_SOURCE } from './constants';
+import { ANTHROPIC_OAUTH_TOKEN_PREFIX, ANTHROPIC_SOURCE } from './constants';
 import { MissingCredentialError } from './errors';
 
 /**
- * Resolves the Anthropic API key from the space's connected credentials, as a typed failure when
- * there is none so the model can prompt the user to connect rather than crashing.
+ * How the resolved credential authenticates: an OAuth access token goes on `Authorization: Bearer`,
+ * a Console API key on `x-api-key`. The two are not interchangeable — the API rejects either header
+ * carrying the other kind of credential.
  */
-export const getApiKey: Effect.Effect<string, MissingCredentialError, Credential.CredentialsService> = Effect.gen(
-  function* () {
+export type AnthropicAuthScheme = 'oauth' | 'api-key';
+
+export type AnthropicCredential = {
+  token: string;
+  scheme: AnthropicAuthScheme;
+};
+
+/**
+ * Anthropic OAuth access tokens are `sk-ant-oat…`-prefixed, which is what separates a connection
+ * authorized through the OAuth flow from a pasted Console API key (`sk-ant-api…`). The credential
+ * store keeps both under the same service, so the prefix is the only discriminator available.
+ */
+const classify = (token: string): AnthropicAuthScheme =>
+  token.startsWith(ANTHROPIC_OAUTH_TOKEN_PREFIX) ? 'oauth' : 'api-key';
+
+/**
+ * Resolves the Anthropic credential from the space's connected credentials — an OAuth access token
+ * where the user connected their Claude account, otherwise an API key. A missing credential is a
+ * typed failure so the model can prompt the user to connect rather than crashing.
+ */
+export const getCredential: Effect.Effect<AnthropicCredential, MissingCredentialError, Credential.CredentialsService> =
+  Effect.gen(function* () {
     const credentials = yield* Credential.CredentialsService;
     const matches = yield* Effect.tryPromise({
       try: () => credentials.queryCredentials({ service: ANTHROPIC_SOURCE }),
       catch: (cause) => new MissingCredentialError({ cause }),
     });
-    const apiKey = matches.find((credential) => credential.apiKey)?.apiKey;
-    if (!apiKey) {
+    const token = matches.find((credential) => credential.apiKey)?.apiKey;
+    if (!token) {
       return yield* Effect.fail(new MissingCredentialError());
     }
 
-    return apiKey;
-  },
-);
+    return { token, scheme: classify(token) };
+  });

--- a/packages/plugins/plugin-claude-agents/src/operations/deploy-agent.ts
+++ b/packages/plugins/plugin-claude-agents/src/operations/deploy-agent.ts
@@ -10,19 +10,19 @@ import { Database, Obj } from '@dxos/echo';
 import { createAgent, toAgentConfig, updateAgent } from '#api';
 import { ClaudeAgentOperation, ClaudeManagedAgent } from '#types';
 
-import { getApiKey } from '../credentials';
+import { getCredential } from '../credentials';
 
 const handler: Operation.WithHandler<typeof ClaudeAgentOperation.DeployAgent> = ClaudeAgentOperation.DeployAgent.pipe(
   Operation.withHandler(
     Effect.fn(function* ({ agent }) {
       const agentObj = yield* Database.load(agent);
-      const apiKey = yield* getApiKey;
+      const credential = yield* getCredential;
       const config = toAgentConfig(agentObj);
 
       const agentId = ClaudeManagedAgent.getAgentId(agentObj);
       const response = agentId
-        ? yield* updateAgent(apiKey, agentId, config, agentObj.agentVersion)
-        : yield* createAgent(apiKey, config);
+        ? yield* updateAgent(credential, agentId, config, agentObj.agentVersion)
+        : yield* createAgent(credential, config);
 
       Obj.update(agentObj, (agentObj) => {
         ClaudeManagedAgent.setAgentId(agentObj, response.id);

--- a/packages/plugins/plugin-claude-agents/src/operations/get-transcript.ts
+++ b/packages/plugins/plugin-claude-agents/src/operations/get-transcript.ts
@@ -11,7 +11,7 @@ import { getSession, listEvents, toTranscript } from '#api';
 import { ClaudeAgentOperation, ClaudeAgentSession } from '#types';
 
 import { DEFAULT_TRANSCRIPT_LIMIT } from '../constants';
-import { getApiKey } from '../credentials';
+import { getCredential } from '../credentials';
 import { SessionNotLinkedError } from '../errors';
 
 const handler: Operation.WithHandler<typeof ClaudeAgentOperation.GetTranscript> =
@@ -24,10 +24,10 @@ const handler: Operation.WithHandler<typeof ClaudeAgentOperation.GetTranscript> 
           return yield* Effect.fail(new SessionNotLinkedError());
         }
 
-        const apiKey = yield* getApiKey;
+        const credential = yield* getCredential;
 
         const [state, events] = yield* Effect.all(
-          [getSession(apiKey, sessionId), listEvents(apiKey, sessionId, limit ?? DEFAULT_TRANSCRIPT_LIMIT)],
+          [getSession(credential, sessionId), listEvents(credential, sessionId, limit ?? DEFAULT_TRANSCRIPT_LIMIT)],
           { concurrency: 2 },
         );
 

--- a/packages/plugins/plugin-claude-agents/src/operations/send-message.ts
+++ b/packages/plugins/plugin-claude-agents/src/operations/send-message.ts
@@ -10,7 +10,7 @@ import { Database } from '@dxos/echo';
 import { sendUserMessage } from '#api';
 import { ClaudeAgentOperation, ClaudeAgentSession } from '#types';
 
-import { getApiKey } from '../credentials';
+import { getCredential } from '../credentials';
 import { SessionNotLinkedError } from '../errors';
 
 const handler: Operation.WithHandler<typeof ClaudeAgentOperation.SendMessage> = ClaudeAgentOperation.SendMessage.pipe(
@@ -22,8 +22,8 @@ const handler: Operation.WithHandler<typeof ClaudeAgentOperation.SendMessage> = 
         return yield* Effect.fail(new SessionNotLinkedError());
       }
 
-      const apiKey = yield* getApiKey;
-      yield* sendUserMessage(apiKey, sessionId, message);
+      const credential = yield* getCredential;
+      yield* sendUserMessage(credential, sessionId, message);
 
       return { sessionId };
     }),

--- a/packages/plugins/plugin-claude-agents/src/operations/start-session.ts
+++ b/packages/plugins/plugin-claude-agents/src/operations/start-session.ts
@@ -11,7 +11,7 @@ import { createEnvironment, createSession } from '#api';
 import { ClaudeAgentOperation, ClaudeAgentSession, ClaudeManagedAgent } from '#types';
 
 import { DEFAULT_ENVIRONMENT_NAME } from '../constants';
-import { getApiKey } from '../credentials';
+import { getCredential } from '../credentials';
 import { AgentNotDeployedError } from '../errors';
 
 const handler: Operation.WithHandler<typeof ClaudeAgentOperation.StartSession> = ClaudeAgentOperation.StartSession.pipe(
@@ -23,11 +23,11 @@ const handler: Operation.WithHandler<typeof ClaudeAgentOperation.StartSession> =
         return yield* Effect.fail(new AgentNotDeployedError());
       }
 
-      const apiKey = yield* getApiKey;
+      const credential = yield* getCredential;
 
       // Provisioned on demand so the first run does not require a Console visit.
       const configured = environmentId ?? agentObj.environmentId;
-      const environment = configured ?? (yield* createEnvironment(apiKey, DEFAULT_ENVIRONMENT_NAME)).id;
+      const environment = configured ?? (yield* createEnvironment(credential, DEFAULT_ENVIRONMENT_NAME)).id;
       const provisioned = configured === undefined;
       if (provisioned) {
         Obj.update(agentObj, (agentObj) => {
@@ -36,7 +36,7 @@ const handler: Operation.WithHandler<typeof ClaudeAgentOperation.StartSession> =
       }
 
       const sessionTitle = title ?? `${agentObj.name} session`;
-      const response = yield* createSession(apiKey, {
+      const response = yield* createSession(credential, {
         agentId,
         environmentId: environment,
         title: sessionTitle,

--- a/packages/plugins/plugin-claude-agents/src/plugin.tsx
+++ b/packages/plugins/plugin-claude-agents/src/plugin.tsx
@@ -4,10 +4,11 @@
 
 import * as Plugin from '@dxos/app-framework/Plugin';
 
-import { OperationHandler, PluginAsset, Schema, SkillDefinition, Translations } from '#capabilities';
+import { Connector, OperationHandler, PluginAsset, Schema, SkillDefinition, Translations } from '#capabilities';
 import { meta } from '#meta';
 
 export const ClaudeAgentsPlugin = Plugin.define(meta).pipe(
+  Plugin.addModule(Connector),
   Plugin.addModule(PluginAsset),
   Plugin.addModule(Schema),
   Plugin.addModule(OperationHandler),

--- a/packages/plugins/plugin-claude-agents/src/skills/ClaudeAgentsSkill.ts
+++ b/packages/plugins/plugin-claude-agents/src/skills/ClaudeAgentsSkill.ts
@@ -46,7 +46,7 @@ export const make = (): Skill.Skill =>
 
         ## Credentials
         Every step past Create Claude Agent calls Anthropic and needs the space's "anthropic.com"
-        credential. When an operation fails with MissingCredentialError the credential is not connected
+        credential — either a Claude account connected over OAuth or a Console API key. When an operation fails with MissingCredentialError the credential is not connected
         yet — that is a setup gap, not an error to report and stop on:
         1. Enable the \`org.dxos.skill.connectors\` skill with Enable skills.
         2. Emit its connector prompt so the user can connect inline:

--- a/packages/plugins/plugin-claude-agents/tsconfig.json
+++ b/packages/plugins/plugin-claude-agents/tsconfig.json
@@ -34,6 +34,9 @@
       "path": "../../core/mesh/edge-client"
     },
     {
+      "path": "../../core/protocols"
+    },
+    {
       "path": "../../sdk/app-framework"
     },
     {
@@ -41,6 +44,9 @@
     },
     {
       "path": "../../ui/react-ui"
+    },
+    {
+      "path": "../plugin-connector"
     }
   ]
 }

--- a/packages/plugins/plugin-claude-agents/tsconfig.json
+++ b/packages/plugins/plugin-claude-agents/tsconfig.json
@@ -28,6 +28,9 @@
       "path": "../../core/compute/compute"
     },
     {
+      "path": "../../core/compute/link"
+    },
+    {
       "path": "../../core/echo/echo"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8738,6 +8738,9 @@ importers:
       '@dxos/errors':
         specifier: workspace:*
         version: link:../../common/errors
+      '@dxos/link':
+        specifier: workspace:*
+        version: link:../../core/compute/link
       '@dxos/plugin-connector':
         specifier: workspace:*
         version: link:../plugin-connector

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8738,6 +8738,12 @@ importers:
       '@dxos/errors':
         specifier: workspace:*
         version: link:../../common/errors
+      '@dxos/plugin-connector':
+        specifier: workspace:*
+        version: link:../plugin-connector
+      '@dxos/protocols':
+        specifier: workspace:*
+        version: link:../../core/protocols
       '@dxos/util':
         specifier: workspace:*
         version: link:../../common/util


### PR DESCRIPTION
Lets the Claude managed-agents plugin run agents on a token minted by connecting the user's Claude account, instead of requiring a Console API key pasted into the space.

## Changes

- `@dxos/protocols`: new `OAuthProvider.ANTHROPIC` (`'anthropic'`).
- `plugin-claude-agents`:
  - New authentication-only connector (`src/capabilities/connector.ts`) contributing `ConnectorSpec.Connector` with the Anthropic OAuth spec (`user:inference`, `user:profile`) and a `testConnection` probe (`GET /v1/models?limit=1`), so an expired or revoked grant surfaces as a reauthenticate prompt rather than a mid-session failure. No sync targets.
  - `credentials.ts`: `getApiKey` → `getCredential`, returning `{ token, scheme }`. The scheme is derived from the `sk-ant-oat…` prefix, which is the only discriminator the credential store exposes between an OAuth access token and an `sk-ant-api…` key.
  - `api/client.ts`: an OAuth token goes on `Authorization: Bearer` with `anthropic-beta: managed-agents-2026-04-01,oauth-2025-04-20`; an API key keeps `x-api-key`. All control-plane calls take the credential rather than a bare key.
  - `PLUGIN.mdl` / skill instructions updated for the two credential kinds.

The EDGE half of the flow (provider spec, PKCE, token custody) is dxos/edge#972 — it needs this change published before its `@dxos/protocols` pin can carry `OAuthProvider.ANTHROPIC`, so this lands first.

## Configuration still required

No DXOS OAuth client is registered with Anthropic yet. Until `ANTHROPIC_CLIENT_ID` is configured on EDGE, connecting the Anthropic connector fails at the provider; an API-key connection keeps working exactly as before.

## Testing

- `moon run plugin-claude-agents:build` (plus the 171 upstream builds) — clean.
- `moon run plugin-claude-agents:test` — 14 tests pass.
- `moon run plugin-claude-agents:lint protocols:lint`, `pnpm format` — clean.
- The OAuth flow itself is not exercised end to end here: it needs a registered client (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYQjzhJnhXfFaHSx38ynAf