### PR TITLE
react-ui-assistant: show tool call params instead of block metadata

### DIFF
--- a/.changeset/tool-widget-show-params.md
+++ b/.changeset/tool-widget-show-params.md
@@ -1,0 +1,5 @@
+---
+'@dxos/react-ui-assistant': patch
+---
+
+Tool call panels now show the call's parameters (and the result payload / error message) instead of the raw content block's transport metadata, and a streamed pending call is replaced by its completed form rather than shown as a duplicate tab.

--- a/packages/ui/react-ui-assistant/src/widgets/ToolWidget.tsx
+++ b/packages/ui/react-ui-assistant/src/widgets/ToolWidget.tsx
@@ -10,7 +10,7 @@ import { NumericTabs, TogglePanel, type TogglePanelRootProps } from '@dxos/react
 import { JsonHighlighter } from '@dxos/react-ui-syntax-highlighter';
 import { type ContentBlock } from '@dxos/types';
 import { type XmlWidgetProps, getXmlTextChild } from '@dxos/ui-editor';
-import { isNonNullable, safeParseJson } from '@dxos/util';
+import { safeParseJson } from '@dxos/util';
 
 import { translationKey } from '../translations';
 
@@ -31,66 +31,77 @@ export const ToolWidget = ({ view, children }: ToolWidgetProps) => {
   const items = useMemo<ToolPanelProps['items']>(() => {
     let lastToolCall: { tool: Tool.Any | undefined; block: ContentBlock.ToolCall } | undefined;
     const tools: Tool.Any[] = [];
-    return blocks
-      .filter((block) => block._tag === 'toolCall' || block._tag === 'toolResult' || block._tag === 'stats')
-      .map((block) => {
-        switch (block._tag) {
-          case 'toolCall': {
-            if (block.pending && lastToolCall?.block.toolCallId === block.toolCallId) {
-              return null;
-            }
+    const items: ToolPanelItem[] = [];
+    // Index of the panel for each call, so a streamed pending call is replaced by its completed
+    // form rather than shown twice.
+    const indexByToolCallId = new Map<string, number>();
 
-            const tool = tools.find((tool) => tool.name === block.name);
-            lastToolCall = { tool, block };
-            return {
-              title: tool?.description ?? [t('tool-call.label'), block.name].filter(Boolean).join(' '),
-              icon: block.operationIcon,
-              content: {
-                ...block,
-                input: safeParseJson(block.input),
-              },
-            };
-          }
-
-          case 'toolResult': {
-            // TODO(burdon): Parse error type.
-            if (block.error) {
-              return {
-                title: t('tool-error.label'),
-                icon: lastToolCall?.block.operationIcon,
-                content: block,
-              };
-            }
-
-            const title =
-              lastToolCall?.tool?.description ??
-              [t('tool-result.label'), lastToolCall?.block.name].filter(Boolean).join(' ');
-            const icon = lastToolCall?.block.operationIcon;
-            lastToolCall = undefined;
-            return {
-              title,
-              icon,
-              content: {
-                ...block,
-                result: typeof block.result === 'string' ? safeParseJson(block.result) : block.result,
-              },
-            };
-          }
-
-          case 'stats': {
-            if (!lastToolCall) {
-              return null;
-            }
-
-            return {
-              title: t('stats.label'),
-              icon: lastToolCall.block.operationIcon,
-              content: block,
-            };
-          }
+    const push = (id: string | undefined, item: ToolPanelItem) => {
+      const existing = id !== undefined ? indexByToolCallId.get(id) : undefined;
+      if (existing !== undefined) {
+        items[existing] = item;
+      } else {
+        if (id !== undefined) {
+          indexByToolCallId.set(id, items.length);
         }
-      })
-      .filter(isNonNullable);
+        items.push(item);
+      }
+    };
+
+    for (const block of blocks) {
+      switch (block._tag) {
+        case 'toolCall': {
+          const tool = tools.find((tool) => tool.name === block.name);
+          lastToolCall = { tool, block };
+          push(block.toolCallId, {
+            title: tool?.description ?? [t('tool-call.label'), block.name].filter(Boolean).join(' '),
+            icon: block.operationIcon,
+            // Show the call's params; the block's transport metadata is noise to the reader.
+            content: safeParseJson(block.input) ?? (block.input || {}),
+          });
+          break;
+        }
+
+        case 'toolResult': {
+          // TODO(burdon): Parse error type.
+          if (block.error) {
+            push(undefined, {
+              title: t('tool-error.label'),
+              icon: lastToolCall?.block.operationIcon,
+              content: block.error,
+            });
+            break;
+          }
+
+          const title =
+            lastToolCall?.tool?.description ??
+            [t('tool-result.label'), lastToolCall?.block.name].filter(Boolean).join(' ');
+          const icon = lastToolCall?.block.operationIcon;
+          lastToolCall = undefined;
+          push(undefined, {
+            title,
+            icon,
+            content: typeof block.result === 'string' ? (safeParseJson(block.result) ?? block.result) : block.result,
+          });
+          break;
+        }
+
+        case 'stats': {
+          if (!lastToolCall) {
+            break;
+          }
+
+          push(undefined, {
+            title: t('stats.label'),
+            icon: lastToolCall.block.operationIcon,
+            content: block,
+          });
+          break;
+        }
+      }
+    }
+
+    return items;
   }, [blocks, t]);
 
   const handleChangeOpen = useCallback(() => {

--- a/packages/ui/react-ui-assistant/src/widgets/ToolWidget.tsx
+++ b/packages/ui/react-ui-assistant/src/widgets/ToolWidget.tsx
@@ -56,7 +56,7 @@ export const ToolWidget = ({ view, children }: ToolWidgetProps) => {
           push(block.toolCallId, {
             title: tool?.description ?? [t('tool-call.label'), block.name].filter(Boolean).join(' '),
             icon: block.operationIcon,
-            // Show the call's params; the block's transport metadata is noise to the reader.
+            // Show the call's params rather than the block's transport metadata.
             content: safeParseJson(block.input) ?? (block.input || {}),
           });
           break;


### PR DESCRIPTION
Fixes DX-1191.

The tool-call panel rendered the whole `ContentBlock.ToolCall` — `toolCallId`, `pending`, `providerExecuted`, `operationKey/Name/Icon` — which is transport metadata the reader never wants. When the call was still pending (`input` empty), the panel showed nothing but that metadata.

Changes in `ToolWidget.tsx`:
- `toolCall` panels render the parsed `input` (the params), falling back to the raw string for partial/streamed JSON, or `{}` when empty.
- `toolResult` panels render the result payload directly; error panels render the error message.
- Pending and completed forms of the same `toolCallId` now occupy one tab (the completed block replaces the pending one), instead of appearing as two tabs when a pending block was not immediately followed by its own duplicate.

Verification: no `node_modules` in this cloud sandbox (`moon`/`oxfmt` unavailable), so the package build/lint was not run here — CI will cover it. A standalone `tsc --noResolve` pass on the file reports only the expected unresolved-import errors, no syntax or local type errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsMK7iQHVw1qSW2sQhCaBn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tool call panels now display parsed parameters alongside results or errors.
  - Result panels support structured responses and plain-text results.
  - Error panels show the relevant error details more clearly.

- **Bug Fixes**
  - Completed tool calls replace pending streamed entries, preventing duplicate panels.
  - Related titles, icons, statistics, and status information are preserved across tool panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->