### PR TITLE
test: migrate check.yml to Depot CI

### DIFF
--- a/.depot/actions/branch/action.yml
+++ b/.depot/actions/branch/action.yml
@@ -1,0 +1,15 @@
+name: Extract Branch
+description: Get the current branch name
+
+outputs:
+  branch:
+    description: 'Branch name'
+    value: ${{ steps.extract-branch.outputs.branch }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Extract branch name
+      id: extract-branch
+      shell: bash
+      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT

--- a/.depot/actions/setup/action.yml
+++ b/.depot/actions/setup/action.yml
@@ -1,0 +1,199 @@
+name: Setup
+description: Setup the environment for the other workflows
+
+inputs:
+  cache-scope:
+    description: >
+      Prefix for the pnpm store cache key. Use a distinct value per trust boundary
+      (e.g. "publish") to prevent a PR-poisoned cache from being restored in release
+      workflows. Defaults to "ci" so all non-publish workflows share one pool.
+    default: 'ci'
+  verify-integrity:
+    description: >
+      Enable pnpm store integrity verification. Must be "true" for any workflow that
+      holds publish credentials (id-token: write) to guard against cache poisoning.
+    default: 'false'
+  remote-cache:
+    description: >
+      Set "false" to build without the remote cache. Deployment and publish workflows do this so a
+      released artifact is built from source rather than trusted from a cache any CI job can write
+      to. Certificates come from the MOON_CACHE_* environment variables, which every workflow that
+      wants the cache sets once at workflow level — a composite action cannot read `secrets`.
+    default: 'true'
+
+runs:
+  using: 'composite'
+  steps:
+    # TODO(wittjosiah): This shouldn't be necessary, but it is when running in BuildJet.
+    #   It's not clear why, the Docker image is setup for the user to own the workspace.
+    #   The checkout action also already runs this internally as a step as well.
+    - name: Mark workspace as safe
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      shell: bash
+
+    # `.moon/workspace.yml` points the remote cache at a self-hosted bazel-remote behind mTLS.
+    # moon degrades to local-cache-only when it cannot authenticate — silently, and green — so a
+    # missing secret would cost every job its cache with no red build to notice it. Fail here
+    # instead, except on fork PRs, which cannot be given secrets at all.
+    #
+    # MOON_CACHE_* are read straight from the environment: a composite action cannot access the
+    # `secrets` context, so each workflow binds them once in a workflow-level `env:` block rather
+    # than every call site repeating three `with:` lines.
+    - name: Install remote cache certificates
+      env:
+        IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        REMOTE_CACHE: ${{ inputs.remote-cache }}
+      run: |
+        if [ "$REMOTE_CACHE" != "true" ]; then
+          # Empty is moon's own "no remote": it makes no connection attempt and logs nothing.
+          # Set explicitly rather than relying on absent credentials, so this does not depend
+          # on a workflow having forgotten to bind the secrets.
+          echo "MOON_REMOTE_HOST=" >> "$GITHUB_ENV"
+          echo "Remote cache disabled for this job."
+          exit 0
+        fi
+        if [ -z "$MOON_CACHE_CA_PEM" ] || [ -z "$MOON_CACHE_CLIENT_PEM" ] || [ -z "$MOON_CACHE_CLIENT_KEY" ]; then
+          if [ "$IS_FORK" = "true" ]; then
+            echo "::warning::Fork PR — no remote cache credentials, moon will use the local cache only."
+            exit 0
+          fi
+          echo "::error::Remote cache certificates are missing. Bind MOON_CACHE_CA_PEM / MOON_CACHE_CLIENT_PEM / MOON_CACHE_CLIENT_KEY in the workflow's env block, or pass remote-cache: 'false'."
+          exit 1
+        fi
+        mkdir -p .moon/certs
+        printf '%s\n' "$MOON_CACHE_CA_PEM" > .moon/certs/ca.pem
+        printf '%s\n' "$MOON_CACHE_CLIENT_PEM" > .moon/certs/client.pem
+        printf '%s\n' "$MOON_CACHE_CLIENT_KEY" > .moon/certs/client.key
+        chmod 600 .moon/certs/client.key
+        openssl x509 -in .moon/certs/client.pem -noout -enddate
+
+        # Prove the cache is actually usable before any task runs. Checking connectivity rather
+        # than counting cache hits is deliberate: a legitimately cold branch has zero hits, so a
+        # hit count cannot separate "nothing to restore" from "cache is broken", whereas an
+        # unreachable host or a rejected certificate is unambiguous.
+        # `grpcs*` rather than `grpcs\?`: BSD sed treats \? literally, and a silently empty host
+        # would fail every job with a confusing error.
+        host=$(grep -v '^[[:space:]]*#' .moon/workspace.yml | sed -n "s|.*host: 'grpcs*://\([^':]*\).*|\1|p" | head -1)
+        if [ -z "$host" ]; then
+          echo "::error::Could not read remote.host from .moon/workspace.yml."
+          exit 1
+        fi
+
+        # curl exit codes already distinguish a timeout (28) from a cert/TLS failure (35/60) from
+        # an HTTP error (22), so surfacing the raw code beats guessing at a cause in prose.
+        curl_exit_meaning() {
+          case "$1" in
+            22) echo "HTTP error response" ;;
+            28) echo "timed out waiting for a response" ;;
+            35|60) echo "TLS/certificate handshake failed" ;;
+            *) echo "curl exit $1" ;;
+          esac
+        }
+        # The droplet has been observed going I/O-bound during a CI fan-out and answering the
+        # probe late rather than refusing it, which reddened jobs over a transient blip rather
+        # than a real cache fault. Retry before treating it as down, and degrade to a warning
+        # instead of failing the job: a cache miss costs a slower build, not a red one.
+        degrade() {
+          echo "::warning::$1"
+          echo "MOON_REMOTE_HOST=" >> "$GITHUB_ENV"
+          exit 0
+        }
+
+        # 9093 is the HTTP listener of the same process that serves gRPC on 9092.
+        # `|| preflight_exit=$?` rather than a bare call: the shell here runs with `set -e`, and an
+        # unguarded failing command would abort the script before the degrade logic below ever runs.
+        preflight_exit=0
+        curl -sf --max-time 20 --retry 3 --retry-all-errors --retry-delay 5 --retry-max-time 60 \
+             -o /dev/null -w 'time_connect=%{time_connect} time_appconnect=%{time_appconnect} time_total=%{time_total}\n' \
+             --cacert .moon/certs/ca.pem "https://$host:9093/status" || preflight_exit=$?
+        if [ "$preflight_exit" -ne 0 ]; then
+          degrade "Remote cache $host preflight failed after retries: $(curl_exit_meaning "$preflight_exit") (curl exit $preflight_exit). Falling back to the local cache for this job."
+        fi
+
+        # /status is unauthenticated; a CAS path is not. 404 means authorised and absent, which is
+        # what an all-zero digest should be. 401 means the client certificate was rejected.
+        cas_exit=0
+        code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 --retry 3 --retry-all-errors --retry-delay 5 --retry-max-time 60 \
+          --cacert .moon/certs/ca.pem --cert .moon/certs/client.pem --key .moon/certs/client.key \
+          "https://$host:9093/cas/0000000000000000000000000000000000000000000000000000000000000000") || cas_exit=$?
+        if [ "$cas_exit" -ne 0 ]; then
+          degrade "Remote cache $host CAS probe failed after retries: $(curl_exit_meaning "$cas_exit") (curl exit $cas_exit). Falling back to the local cache for this job."
+        fi
+        case "$code" in
+          404) ;;
+          401|403)
+            degrade "Remote cache $host rejected the client certificate (HTTP $code, expected 404). Falling back to the local cache for this job."
+            ;;
+          5??)
+            degrade "Remote cache $host CAS probe returned a server error (HTTP $code, expected 404). Falling back to the local cache for this job."
+            ;;
+          *)
+            degrade "Remote cache $host CAS probe returned an unexpected status (HTTP $code, expected 404). Falling back to the local cache for this job."
+            ;;
+        esac
+        echo "Remote cache $host reachable and authenticated."
+      shell: bash
+
+    # TODO(wittjosiah): Install moon in docker image?
+    - uses: moonrepo/setup-toolchain@v0
+      with:
+        # IMPORTANT: Keep in-sync with .prototools
+        moon-version: '2.5.2'
+        proto-version: '0.60.2'
+
+    # Installs the toolchains `.moon/toolchains.yml` declares, which the first moon task would do anyway.
+    # Deliberately not `auto-install` on setup-toolchain: that installs everything pinned, and rust is a
+    # 1.2 GB rustup toolchain that nothing in CI uses.
+    - name: Install moon toolchains
+      run: moon setup
+      shell: bash
+
+    # `.github/Dockerfile` installs node and pnpm to bootstrap CI while moon installs them from
+    # `.prototools`, so the two can drift and only a cold toolchain cache would reveal it — print what PATH
+    # resolves next to the pin and flag a divergence. Logged rather than failed: the image's copies are used
+    # only until moon's cache exists. bun is absent from the image on purpose, and `moon setup` populates
+    # moon's toolchain without creating a proto shim, so a bare `bun` exits 127 and only the pin can be read.
+    - name: Log out debug info
+      run: |
+        for tool in node pnpm; do
+          resolved=$( ("$tool" --version 2>/dev/null || true) | tail -1)
+          pinned=$( (proto run "$tool" -- --version 2>/dev/null || true) | tail -1)
+          if [ -z "$resolved" ] || [ -z "$pinned" ]; then
+            status=UNKNOWN
+          elif [ "$resolved" = "$pinned" ]; then
+            status=ok
+          else
+            status=MISMATCH
+          fi
+          printf '%-5s PATH=%-12s pinned=%-12s %s\n' "$tool" "${resolved:-<absent>}" "${pinned:-<none>}" "$status"
+        done
+        printf '%-5s pinned=%s\n' bun "$( (proto run bun -- --version 2>/dev/null || true) | tail -1)"
+      shell: bash
+
+    - name: PNPM Store Path
+      id: pnpm-store
+      run: echo "pnpm-store=$(pnpm store path)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Get Node version
+      id: node-version
+      run: echo "version=$(node --version)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Cache pnpm store
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pnpm-store.outputs.pnpm-store }}
+        key: ${{ inputs.cache-scope }}-${{ runner.os }}-node-${{ steps.node-version.outputs.version }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ inputs.cache-scope }}-${{ runner.os }}-node-${{ steps.node-version.outputs.version }}-pnpm-store-
+
+    - name: Install dependencies
+      run: |
+        if [ "${{ inputs.verify-integrity }}" = "true" ]; then
+          pnpm set verify-store-integrity true
+        else
+          pnpm set verify-store-integrity false
+        fi
+        pnpm install --prefer-offline
+      shell: bash

--- a/.depot/actions/test-report/action.yml
+++ b/.depot/actions/test-report/action.yml
@@ -1,0 +1,16 @@
+name: Test Report
+description: Send a test report to the team
+
+inputs:
+  name:
+    description: 'The name of the test report'
+    required: true
+  result:
+    description: 'Result of the job'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - run: ./.depot/actions/test-report/send-test-report.sh "${{ inputs.name }}" "${{ inputs.result }}"
+      shell: bash

--- a/.depot/actions/test-report/send-test-report.sh
+++ b/.depot/actions/test-report/send-test-report.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Fail loudly: a report that cannot be delivered has to surface as a red step, otherwise the nightly
+# looks reported when nobody was told.
+set -euo pipefail
+
+NAME="${1:-unknown}"
+RESULT="${2:-unknown}"
+
+ROLE_ID=1166483404066402414
+GREEN=4783872
+ORANGE=16744192
+RED=16711680
+GH_BUILD_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+# Workflow commands are newline-delimited, so an unescaped webhook response could forge annotations.
+function escape() {
+  local value=${1//'%'/'%25'}
+  value=${value//$'\r'/'%0D'}
+  printf '%s' "${value//$'\n'/'%0A'}"
+}
+
+if [ -z "${DISCORD_TEST_REPORT_WEBHOOK:-}" ]; then
+  echo "::error title=Test report not sent::DISCORD_TEST_REPORT_WEBHOOK is unset ($(escape "$NAME"): $(escape "$RESULT"))"
+  exit 1
+fi
+
+# Discord answers 204 with an empty body. Anything else — including a 3xx from a stale or proxied webhook
+# URL, which curl reports as success since redirects are not followed — means nobody was told.
+function notify() {
+  local message response status body
+  message=$(
+    printf '{ "content": %s, "embeds": [{ "title": %s, "description": %s, "color": %s }] }' \
+      "\"$1\"" "\"$2: $NAME\"" "\"$GH_BUILD_URL\"" "$3"
+  )
+  echo "$message"
+  response=$(
+    curl --silent --show-error --connect-timeout 10 --max-time 30 --write-out '\n%{http_code}' \
+      -H "Content-Type: application/json" -d "$message" "$DISCORD_TEST_REPORT_WEBHOOK"
+  )
+  status=${response##*$'\n'}
+  body=${response%$'\n'*}
+  if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+    echo "::error title=Test report not delivered::Discord webhook returned $status ($(escape "$NAME"): $(escape "$RESULT")) $(escape "$body")"
+    return 1
+  fi
+}
+
+case "$RESULT" in
+  success)
+    notify "🌈✨✅" "Daily testing successful" "$GREEN"
+    ;;
+  # A cancelled job means the run never produced a verdict (job timeout, or the run was cancelled), so it
+  # must not read as a test failure — nothing was proven either way.
+  cancelled | skipped)
+    notify "⏹️ <@&$ROLE_ID>" "Daily testing did not complete ($RESULT)" "$ORANGE"
+    ;;
+  *)
+    notify "⚠️ <@&$ROLE_ID>" "Daily testing failed" "$RED"
+    ;;
+esac

--- a/.depot/workflows/check.yml
+++ b/.depot/workflows/check.yml
@@ -1,0 +1,669 @@
+# Depot CI Migration
+# Source: .github/workflows/check.yml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Check
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
+      - ci/*
+  schedule:
+    - cron: '0 4 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+      e2e:
+        type: boolean
+        description: 'Run the e2e tests'
+        required: false
+        default: false
+permissions:
+  contents: read
+  packages: read
+env:
+  # Bound once here rather than at every setup call site: a composite action cannot read the
+  # `secrets` context, but it does inherit the process environment.
+  MOON_CACHE_CA_PEM: ${{ secrets.MOON_CACHE_CA_PEM }}
+  MOON_CACHE_CLIENT_PEM: ${{ secrets.MOON_CACHE_CLIENT_PEM }}
+  MOON_CACHE_CLIENT_KEY: ${{ secrets.MOON_CACHE_CLIENT_KEY }}
+  DISCORD_TEST_REPORT_WEBHOOK: ${{ secrets.DISCORD_TEST_REPORT_WEBHOOK }}
+  TRUNK_TOKEN: ${{ secrets.TRUNK_TOKEN }}
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
+# The event is part of the key because on a schedule `github.ref` is `refs/heads/main`: without it the
+# nightly shares a group with pushes to main and the next push cancels it mid-e2e.
+#
+# A manual dispatch also keys on its run id, so repeated dispatches of one ref run in parallel:
+# measuring flakiness needs N independent samples of the same commit. Every other event keeps
+# one-run-per-ref, where superseding an in-flight run is what you want.
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || '' }}
+  cancel-in-progress: true
+# https://moonrepo.dev/docs/guides/ci
+jobs:
+  check:
+    permissions:
+      contents: read
+      packages: read
+    runs-on: depot-ubuntu-24.04-8
+    container:
+      image: ghcr.io/dxos/gh-actions:24.11.1
+      credentials:
+        username: dxos-bot
+        password: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 30
+    steps:
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && !inputs.e2e }}
+        with:
+          detached: true
+      # Full depth keeps the commit graph that `--affected remote` / `merge-base` resolve against,
+      # while `filter: blob:none` stops the transfer of every historical file version — the previous
+      # full fetch ranged 32s–15m on the same commit. No `lfs: true`: nothing in the tree is
+      # LFS-tracked. `fetch-tags: false` is not used because checkout ignores it at depth 0; at
+      # ~150 tags the residual refspec cost is noise.
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Extract branch
+        id: extract_branch
+        uses: ./.depot/actions/branch
+      - name: Setup
+        uses: ./.depot/actions/setup
+      # ─── Stage 1: gates that need no build ──────────────────────────────────────────────────────
+      # Ordered by measured cost, cheapest first, so the common failure lands in seconds instead of
+      # behind minutes of work it does not depend on; the whole stage is ~30 s. `format-check` leads
+      # because a single unformatted file fails every job in the workflow.
+      - name: Check formatting
+        run: pnpm run format-check
+      - name: Check for import cycles
+        run: pnpm run check-cycles
+      - name: Check publish config
+        run: pnpm run check-publish-config
+      # Every gating rule on `.changeset/*.md` — parseability, bump levels, versionable packages, one
+      # entry per PR — in one pass, so a run reports all of them instead of stopping at the first. Each fails on something
+      # otherwise invisible until `changeset version` runs on `main`. The count rule is diff-based and
+      # self-skips outside a `pull_request`: on `main` `.changeset/` holds every unreleased entry, and a
+      # `merge_group` batches PRs that each legitimately carry their own. The missing-changeset reminder
+      # is advisory and stays its own job (`changeset-reminder`).
+      - name: Check changesets
+        env:
+          CHANGESET_BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: pnpm run check-changesets
+      - name: Check version files in sync
+        # version.ts (DXOS_VERSION) + tauri.conf.json are derived from their package versions by
+        # sync-versions.mjs during release; fail the PR if a committed copy drifts out of sync.
+        run: node scripts/sync-versions.mjs --check
+      - name: Check remote cache wiring
+        run: node scripts/check-cache-wiring.mjs
+      - name: Check package.json paths
+        run: pnpm run pkg-lint
+      - name: Check public packages don't depend on private packages
+        run: pnpm run check-public-dependencies
+      - name: Check public packages are published
+        run: pnpm run check-packages-published
+      # `.npmrc` sets `strict-peer-dependencies` with `auto-install-peers=false`, so re-resolving is
+      # what surfaces an unsatisfiable peer. The `trap` restores the lockfile on failure as well as on
+      # success: `--no-frozen-lockfile` can rewrite `pnpm-lock.yaml`, which `.moon/tasks/all.yml`
+      # declares as an input to every task, so a rewritten copy would miss the cache for both stages
+      # below — the reason this step used to sit at the very end.
+      - name: Check for peer dependency issues
+        run: |
+          trap 'git checkout -- pnpm-lock.yaml' EXIT
+          pnpm install --resolution-only --no-frozen-lockfile
+      # ─── Stage 2: the compile gate ──────────────────────────────────────────────────────────────
+      # ~15 s warm, minutes cold, and the floor under everything below it.
+      - name: Check Affected
+        if: ${{ steps.extract_branch.outputs.branch != 'main' }}
+        run: moon run :lint :build :test-types --affected remote
+      - name: Check All
+        if: ${{ steps.extract_branch.outputs.branch == 'main' }}
+        run: moon run :lint :build :test-types
+      # `check-module-structure` traces the built artifacts (`deps: [build]`), so it cannot move ahead
+      # of the gate however cheap it looks — its 5 s is a post-build number.
+      - name: Check module structure (affected)
+        if: ${{ steps.extract_branch.outputs.branch != 'main' }}
+        run: moon run :check-module-structure --affected remote
+      - name: Check module structure (all)
+        if: ${{ steps.extract_branch.outputs.branch == 'main' }}
+        run: moon run :check-module-structure
+      # ─── Stage 3: the three slow checks ─────────────────────────────────────────────────────────
+      # ~2m30s, ~1m and ~1m against ~30 s for all of stage 1, so these run last. All three are
+      # `continue-on-error` with a gate step below: fail-fast is free when steps are cheap, but here
+      # it would hide one failure behind the others at the cost of a whole further run of the job.
+      #
+      # Unused/undeclared dependencies and unreferenced files. Analyses the source tree — the knip
+      # config resolves workspace packages through their `source` export condition — so it needs no
+      # build, but at 85% of the job's real work it earns no place ahead of anything.
+      - name: Check dependencies
+        id: knip
+        continue-on-error: true
+        run: pnpm run knip
+      # What composer.space actually ships: fails when a plugin the production set does not name
+      # reached the bundle anyway. Same reasoning as the boot budget — it is a property of an import
+      # edge, invisible to the build, the tests, and the app's own UI (a plugin absent from the
+      # registry can still be in the bundle) — and it needs its own `DX_PLUGIN_SET=production` bundle,
+      # which no other step builds. Gated here so the PR that introduces the leak is the one that fails.
+      #
+      # `DX_PLUGIN_SET=production` bundle built here rather than on a runner of its own: the `^:build`
+      # graph is already warm from stage 2, which put its cost at 22s against the boot budget's 41s
+      # when the two shared this job — cheap enough that a second machine's ~160s of setup would
+      # dominate it.
+      - name: Check production plugin set
+        id: plugin_set
+        continue-on-error: true
+        run: moon run composer-app:check-plugin-set
+      # `starlight-links-validator` runs as the last phase of `astro build`, so bundling the site IS
+      # the link check.
+      - name: Check docs links
+        id: docs
+        continue-on-error: true
+        run: moon run docs:bundle
+      - name: Report slow-check failures
+        if: ${{ steps.knip.outcome == 'failure' || steps.plugin_set.outcome == 'failure' || steps.docs.outcome == 'failure' }}
+        run: |
+          if [ "${{ steps.knip.outcome }}" = failure ]; then
+            echo '::error::knip failed — see the "Check dependencies" step.'
+          fi
+          if [ "${{ steps.plugin_set.outcome }}" = failure ]; then
+            echo '::error::production plugin set check failed — see the "Check production plugin set" step.'
+          fi
+          if [ "${{ steps.docs.outcome }}" = failure ]; then
+            echo '::error::docs link validation failed — see the "Check docs links" step.'
+          fi
+          exit 1
+  # Static boot-graph budget over the production bundle, on its own runner. The class it catches is a
+  # property of an IMPORT EDGE — a boot-reachable module reaching a barrel instead of a subpath — so a
+  # refactor that relocates the edge silently drops the fix and neither the build nor the tests notice;
+  # three separate fixes were undone that way. Not `--affected`-scoped, because the offending edit lands
+  # in some other package. Here rather than on an `e2e` cell so that it gates the PR that introduces the
+  # regression: `e2e` runs on main/changeset-release or an explicit dispatch, so there it never gated
+  # one. Split out of `check`, where its ~41s of bundling (nothing else in the workflow builds
+  # `bundle`) sat behind that job's whole stage 1+2 sequence; the library builds it needs come from the
+  # remote cache instead.
+  boot-budget:
+    permissions:
+      contents: read
+      packages: read
+    runs-on: depot-ubuntu-24.04-8
+    container:
+      image: ghcr.io/dxos/gh-actions:24.11.1
+      credentials:
+        username: dxos-bot
+        password: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Setup
+        uses: ./.depot/actions/setup
+      - name: Check boot budget
+        run: moon run composer-app:check-boot-budget
+  # Retention suites (the `memory` tag), which the normal `test` job skips: they need `--expose-gc`
+  # and force a single non-isolated fork, neither of which the sharded matrix can provide. Gated on
+  # DX_DEBUG_LEAKS, the one variable that both un-skips the tag and supplies the flag.
+  #
+  # Both suites gate: the feed one guards the fix that made feed objects collectable, the automerge
+  # one the fix that made ECHO objects and their documents collectable. Do NOT silence a failure here
+  # with `test.fails`, which would also swallow an unrelated crash (the WASM allocator abort these
+  # suites can provoke looks identical to an assertion failure from the outside).
+  memory:
+    permissions:
+      contents: read
+      packages: read
+    runs-on: depot-ubuntu-24.04-8
+    container:
+      image: ghcr.io/dxos/gh-actions:24.11.1
+      credentials:
+        username: dxos-bot
+        password: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 30
+    env:
+      DX_DEBUG_LEAKS: '1'
+      VITEST_ENV: 'node'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Setup
+        uses: ./.depot/actions/setup
+      # `DX_DEBUG_LEAKS_DIR` keeps the heap snapshots the probe writes out of the workspace. It is
+      # set per step, not on the job: `runner` is not among the contexts available to job-level `env`
+      # (only github/needs/strategy/matrix/vars/inputs), and referencing it there fails the whole
+      # workflow to parse — no jobs run at all.
+      - name: Feed retention
+        env:
+          DX_DEBUG_LEAKS_DIR: ${{ runner.temp }}/profiles
+        run: moon run echo-client-e2e:test -- src/feed-retention.test.ts
+      # One invocation per test, because vitest isolation is per FILE and both tests live in one:
+      # a single run leaves the second test measuring the first test's WASM, which is never returned
+      # to the OS. A fresh process per test is the only clean floor.
+      - name: Automerge retention (collection)
+        env:
+          DX_DEBUG_LEAKS_DIR: ${{ runner.temp }}/profiles
+        run: moon run echo-client-e2e:test -- src/automerge-retention.test.ts -t 'collecting removed objects releases them'
+      - name: Automerge retention (caller reference)
+        env:
+          DX_DEBUG_LEAKS_DIR: ${{ runner.temp }}/profiles
+        run: moon run echo-client-e2e:test -- src/automerge-retention.test.ts -t 'dropping the caller reference releases objects'
+  # Every vitest flavour in one sharded job: unit (`:test`), browser (`:test-browser`), storybook
+  # (`:test-storybook`) and the Cloudflare Workers runtime (`:test-workerd`). They used to be three
+  # jobs split by flavour, which fixed each shard's size to its flavour's total — storybook alone ran
+  # far longer than workerd, and no amount of runners helped. `moon exec --job N --job-total` partitions
+  # the whole target set instead, so the four cells are sized by work rather than by kind and a new
+  # suite lands wherever there is room. File parallelism stays disabled — overloaded runners flake — so
+  # the win is concurrency across machines, not within one. `--on-failure continue` because moon's
+  # default bail drops a failing cell's remaining targets, hiding what they cost.
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['24.11.1']
+        # 0-based: `--job` is an index. Four cells against the ~13m the three flavour jobs' critical
+        # path took, over ~160s of fixed per-cell setup.
+        shard: [0, 1, 2, 3]
+    runs-on: depot-ubuntu-24.04-8
+    container:
+      image: ghcr.io/dxos/gh-actions:${{ matrix.node-version }}
+      credentials:
+        username: dxos-bot
+        password: ${{ github.token }}
+    timeout-minutes: 30
+    env:
+      NODE_VERSION: ${{ matrix.node-version }}
+      # Opt the test job in to flaky-tagged suites (Trunk pass-on-rerun keeps signal),
+      # while still excluding the heavier opt-in tag families.
+      VITEST_TAGS_FILTER: '!sync && !sync-e2e && !functions-e2e && !manual'
+      VITEST_ENV: 'node'
+      # Coverage is unsupported for the workers pool (v8 coverage imports `node:inspector/promises`,
+      # absent in workerd), so `vite.base.config.ts` drops it for the `workerd` project type — which is
+      # what lets a cell mix workerd targets with the rest under one flag.
+      VITEST_COVERAGE: ${{ secrets.CODECOV_TOKEN != '' && 'true' || 'false' }}
+      VITEST_XML_REPORT: 'true'
+      # NOTE: Browser and storybook tests also require a process for chromium. Limiting to 4 provides
+      # headroom for those processes.
+      MOON_CONCURRENCY: 4
+      # Exposed so step conditions can branch on token presence without referencing
+      # secrets directly (secrets are not allowed in if: expressions).
+      TRUNK_TOKEN: ${{ secrets.TRUNK_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+      - name: Extract branch
+        id: extract_branch
+        uses: ./.depot/actions/branch
+      - name: Setup
+        uses: ./.depot/actions/setup
+      # Unconditional: moon owns cell assignment, so which flavours a shard draws is not known here.
+      - name: Install Playwright
+        run: pnpm run install-playwright
+      - name: Clean stale test results
+        run: rm -rf test-results
+      - name: Test Affected
+        if: ${{ steps.extract_branch.outputs.branch != 'main' && env.TRUNK_TOKEN != '' }}
+        uses: trunk-io/analytics-uploader@v1
+        with:
+          junit-paths: 'test-results/**/results.xml'
+          org-slug: dxos
+          token: ${{ secrets.TRUNK_TOKEN }}
+          quarantine: true
+          run: >-
+            moon exec --on-failure continue :test :test-browser :test-storybook :test-workerd --affected remote --job ${{ matrix.shard }} --job-total 4 -- --no-file-parallelism
+      # Fallback for fork PRs and local runs where TRUNK_TOKEN is unavailable.
+      - name: Test Affected (no analytics)
+        if: ${{ steps.extract_branch.outputs.branch != 'main' && env.TRUNK_TOKEN == '' }}
+        run: >-
+          moon exec --on-failure continue :test :test-browser :test-storybook :test-workerd --affected remote --job ${{ matrix.shard }} --job-total 4 -- --no-file-parallelism
+      - name: Test All
+        if: ${{ steps.extract_branch.outputs.branch == 'main' && env.TRUNK_TOKEN != '' }}
+        uses: trunk-io/analytics-uploader@v1
+        with:
+          junit-paths: 'test-results/**/results.xml'
+          org-slug: dxos
+          token: ${{ secrets.TRUNK_TOKEN }}
+          quarantine: true
+          run: >-
+            moon exec --on-failure continue :test :test-browser :test-storybook :test-workerd --job ${{ matrix.shard }} --job-total 4 -- --no-file-parallelism
+      # Fallback for forks running against their own main where TRUNK_TOKEN is unavailable.
+      - name: Test All (no analytics)
+        if: ${{ steps.extract_branch.outputs.branch == 'main' && env.TRUNK_TOKEN == '' }}
+        run: >-
+          moon exec --on-failure continue :test :test-browser :test-storybook :test-workerd --job ${{ matrix.shard }} --job-total 4 -- --no-file-parallelism
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: vitest-report-${{ matrix.node-version }}-${{ matrix.shard }}
+          path: test-results
+          retention-days: 7
+      - uses: codecov/codecov-action@v5
+        if: ${{ matrix.node-version == '24.11.1' && env.VITEST_COVERAGE == 'true' }}
+        with:
+          directory: ./coverage
+          fail_ci_if_error: false
+          handle_no_reports_found: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+  # Bundles once and publishes to the moon remote cache, so the cells hydrate the artifacts instead of
+  # each rebuilding the graph. Concurrent cells cannot hit each other's cache writes, which is why this
+  # has to be a job they all depend on.
+  e2e-bundle:
+    if: >-
+      startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/changeset-release/') || startsWith(github.head_ref, 'changeset-release/') || inputs.e2e
+    runs-on: depot-ubuntu-24.04-8
+    container:
+      image: ghcr.io/dxos/gh-actions:24.11.1
+      credentials:
+        username: dxos-bot
+        password: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 30
+    env:
+      # Must stay IDENTICAL to the `e2e` job's: moon hashes the AMBIENT value of any env var a task
+      # lists in `inputs`, so jobs that disagree hash `bundle-e2e` differently and never share the
+      # warmed entry. The edge/telemetry/PWA vars live in the task `env`s instead (`tag-e2e.yml`,
+      # `bundle-e2e`), where consistent absence from the ambient environment keeps hashes agreeing
+      # with nothing to keep in sync. Scoped per job because at workflow level it would also move
+      # the hashes of `test`, `storybook`, `workerd` and `cli`.
+      DX_ENVIRONMENT: ci
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+      - name: Extract branch
+        id: extract_branch
+        uses: ./.depot/actions/branch
+      - name: Setup
+        uses: ./.depot/actions/setup
+      # `:bundle-e2e`, not a project list and not `:bundle`. Only a project that serves a production
+      # bundle to Playwright (`vite preview`) defines `bundle-e2e`, so the glob is already exactly the
+      # set that needs warming and stays correct as suites are added — the other e2e suites serve from
+      # source (`vite dev` / `storybook dev`) and need library builds, not bundles. `:bundle` by contrast
+      # built all eleven apps, so every e2e runner also hydrated the docs, cli, storybook-react,
+      # testbench-app, composer-crx, devtools-extension, examples and tasks closures — including docs'
+      # typedoc tasks, which cost more to download than composer's bundle costs to build. Warming
+      # `bundle` instead would warm a hash the e2e closure never waits on.
+      - name: Bundle Affected
+        if: ${{ steps.extract_branch.outputs.branch != 'main' && !inputs.e2e }}
+        run: moon run :bundle-e2e --affected remote
+      - name: Bundle All
+        if: ${{ steps.extract_branch.outputs.branch == 'main' || inputs.e2e }}
+        run: moon run :bundle-e2e
+  # Sharded browser × cell, three cells per browser: a cell costs ~160s of fixed setup against
+  # ~450-590s of test work, so more cells buy less than they cost. Cells are `moon exec --job`, so moon
+  # packs whichever targets it assigns and no target list is hand-maintained. `--on-failure continue`
+  # because moon's default bail drops a failing cell's remaining targets, hiding what they cost. The
+  # shape, and the alternatives measured against it, are in `.agents/projects/ci/DESIGN.md`.
+  e2e:
+    # e2e runs on pushes/schedules to main AND on the Changesets "Version Packages" PR (so we never
+    # publish untested). For push events github.ref is refs/heads/<branch>; for pull_request events
+    # github.ref is refs/pull/N/merge so we also check github.head_ref (the source branch name, set only
+    # on pull_request events) to catch the changesets/action PR branch (changeset-release/<base>).
+    needs: e2e-bundle
+    if: >-
+      startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/changeset-release/') || startsWith(github.head_ref, 'changeset-release/') || inputs.e2e
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+        # `composer` gets a dedicated cell (it dwarfs every other suite); `rest` runs the pool.
+        # Explicit here rather than via `moon --job`, whose partitioner co-located composer's former
+        # halves and (at --concurrency=1) ran them serially — measured in .agents/projects/ci/DESIGN.md.
+        shard: [composer, rest]
+    runs-on: depot-ubuntu-24.04-8
+    container:
+      image: ghcr.io/dxos/gh-actions:24.11.1
+      credentials:
+        username: dxos-bot
+        password: ${{ secrets.GITHUB_TOKEN }}
+    # Headroom over the step's own cap, which fails cleanly with traces attached; hitting this one
+    # cancels the job and proves nothing.
+    timeout-minutes: 50
+    env:
+      # Must stay IDENTICAL to `e2e-bundle`'s block above, which explains why.
+      DX_ENVIRONMENT: ci
+      # Selects this cell's Playwright project; also a moon task hash input, so each browser gets its
+      # own remote-cache entry.
+      PLAYWRIGHT_BROWSER: ${{ matrix.browser }}
+    steps:
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        with:
+          detached: true
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+      - name: Extract branch
+        id: extract_branch
+        uses: ./.depot/actions/branch
+      - name: Setup
+        uses: ./.depot/actions/setup
+      # Only this cell's browser — the other two engines' downloads are dead weight here.
+      - name: Install Playwright
+        run: pnpm run install-playwright ${{ matrix.browser }}
+      # No bundle step: the `e2e-ci` targets declare `bundle-e2e` as a dep, so moon hydrates it from the
+      # cache `e2e-bundle` warmed.
+
+      # Clear Storybook Vite cache in every package so Storybook dev server does a fresh optimizeDeps run.
+      # Avoids 504 Outdated Optimize Dep when graph differs from bundle step.
+      # Storybook puts cache under node_modules/.cache/storybook/<hash>/sb-vite per package.
+      - name: Clear Storybook Vite cache
+        run: find . -type d -path '*/node_modules/.cache/storybook' -prune -print0 | xargs -0 rm -rf
+      - name: Clean stale test results
+        run: rm -rf test-results
+      # The pool list is computed, not globbed: `:e2e` would match composer-app too, and only
+      # `moon query` honours MQL negation (`moon exec --query` ignores it). Empty is fatal — a bad
+      # query would otherwise run nothing and report green.
+      - name: Select shard targets
+        id: shard
+        run: |
+          if [ "${{ matrix.shard }}" = "composer" ]; then
+            targets=composer-app:e2e
+          else
+            targets=$(moon query tasks "task=e2e && project!=composer-app" |
+              node -e "let s='';process.stdin.on('data',(d)=>(s+=d)).on('end',()=>console.log(Object.keys(JSON.parse(s).tasks).sort().map((project)=>project+':e2e').join(' ')))")
+          fi
+          [ -n "$targets" ] || { echo 'no e2e targets resolved'; exit 1; }
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+      - name: Test Affected
+        if: ${{ steps.extract_branch.outputs.branch != 'main' && !inputs.e2e }}
+        timeout-minutes: 35
+        uses: trunk-io/analytics-uploader@v1
+        with:
+          junit-paths: 'test-results/playwright/report/*.xml'
+          org-slug: dxos
+          token: ${{ secrets.TRUNK_TOKEN }}
+          quarantine: true
+          run: >-
+            moon exec --on-failure continue ${{ steps.shard.outputs.targets }} --affected remote --concurrency=1
+      - name: Test All
+        if: ${{ steps.extract_branch.outputs.branch == 'main' || inputs.e2e }}
+        timeout-minutes: 35
+        uses: trunk-io/analytics-uploader@v1
+        env:
+          # Forces the e2e tasks to actually run: re-running one commit otherwise replays a cache hit and
+          # reports green without executing a test. Unlike MOON_CACHE=off, this leaves the cached
+          # bundle/build dependencies alone.
+          DX_E2E_RUN_ID: ${{ (inputs.e2e || github.event_name == 'schedule') && format('{0}-{1}', github.run_id, github.run_attempt) || '' }}
+        with:
+          junit-paths: 'test-results/playwright/report/*.xml'
+          org-slug: dxos
+          token: ${{ secrets.TRUNK_TOKEN }}
+          quarantine: true
+          run: >-
+            moon exec --on-failure continue ${{ steps.shard.outputs.targets }} --concurrency=1
+      - name: Upload Traces
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report-${{ matrix.browser }}-${{ matrix.shard }}
+          path: test-results/playwright
+          retention-days: 7
+  # Builds, packs and smoke-tests the CLI on its own runner, in parallel with `e2e`. It used to ride along
+  # in that job, which meant the foreign-machine check waited on the Playwright suite for an artifact that
+  # was ready in minutes — and a browser test consuming the 45 minute step budget withheld it entirely.
+  cli:
+    if: >-
+      startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/changeset-release/') || startsWith(github.head_ref, 'changeset-release/') || inputs.e2e
+    runs-on: depot-ubuntu-24.04-8
+    container:
+      image: ghcr.io/dxos/gh-actions:24.11.1
+      credentials:
+        username: dxos-bot
+        password: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Setup
+        uses: ./.depot/actions/setup
+      # `@dxos/cli` ships as prebuilt platform binaries, so its failure modes live in the packed tarball
+      # rather than the source tree. Depends on `bundle`, so this compiles the binaries too.
+      - name: Smoke test packed CLI
+        run: moon run cli:smoke
+      - name: Pack the CLI for the foreign-machine job
+        run: |
+          mkdir -p cli-verify
+          npm pack --silent --pack-destination cli-verify ./packages/devtools/cli/dist/cli
+          npm pack --silent --pack-destination cli-verify ./packages/devtools/cli/dist/cli-linux-x64
+          cp packages/devtools/cli/scripts/verify-installed.mjs cli-verify/
+      # The verifier travels with the tarballs because the job that runs them has no checkout.
+      - name: Upload packed CLI
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-verify
+          path: cli-verify/
+          retention-days: 1
+  # Runs the packed CLI where the tree that built it does not exist. Deliberately no checkout, no container
+  # and a different runner: a `--compile`d binary is meant to carry everything, and when a dependency
+  # resolves a path at bundle time instead — `@automerge/automerge`'s WASM, `better-sqlite3`'s native addon —
+  # it works in the job that built it and nowhere else, which is how @dxos/cli@0.10.0 shipped unrunnable.
+  # `cli:smoke` cannot cover this in CI because the build container forbids mount namespaces.
+  cli-foreign:
+    needs: cli
+    if: ${{ !cancelled() && needs.cli.result == 'success' }}
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    timeout-minutes: 10
+    steps:
+      - name: Download packed CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-verify
+          path: cli-verify
+      # `--omit=optional` so the launcher's optionalDependencies are not fetched from npm — those versions
+      # are published, so without it the released (and possibly broken) platform package could satisfy the
+      # dependency instead of the tarball built here.
+      # The `./` is load-bearing: npm reads a bare `dir/file.tgz` as the GitHub shorthand `owner/repo` and
+      # tries to clone it.
+      - name: Install from the tarballs
+        run: |
+          npm init -y > /dev/null
+          npm install --no-audit --no-fund --omit=optional ./cli-verify/*.tgz
+      # The same verifier `cli:smoke` runs, so the two cannot check different things.
+      - name: Verify the install
+        run: node cli-verify/verify-installed.mjs .
+  # Reports every nightly job from one place. e2e is in `needs` so a cancelled e2e is still reported (its
+  # former in-job step used `success() || failure()`, which skips on cancellation) and so the test report
+  # can no longer go out green while e2e is still running. `needs.test.result` aggregates the four
+  # shards: one red cell makes the whole matrix red.
+  report:
+    needs: [test, e2e]
+    if: always() && github.event_name == 'schedule'
+    runs-on: depot-ubuntu-24.04-8
+    container:
+      image: ghcr.io/dxos/gh-actions:24.11.1
+      credentials:
+        username: dxos-bot
+        password: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 10
+    steps:
+      # This job only runs a repository-local action, so it never needs git auth; leaving the token in
+      # `.git/config` would expose it to anything in the checked-out tree.
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      # Each report is `always()` so an undelivered one cannot suppress the rest — without it a failing
+      # first report skips the e2e report, silencing the very signal this job exists to send. A failed
+      # step still fails the job.
+      - name: Send test report
+        if: always()
+        uses: ./.depot/actions/test-report
+        with:
+          name: test-24.11.1
+          result: ${{ needs.test.result }}
+      - name: Send e2e report
+        if: always()
+        uses: ./.depot/actions/test-report
+        with:
+          name: e2e
+          result: ${{ needs.e2e.result }}
+  # Advisory changeset reminder (NOT a gate): when a PR changes publishable source but has no
+  # `.changeset/*.md`, post/update a single sticky comment; remove it once a changeset is added.
+  # A change that needs no release just omits the changeset — no empty changeset required.
+  # Same-repo PRs only — fork PRs get a read-only token and cannot be commented on.
+  changeset-reminder:
+    if: >-
+      github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+      - name: Detect missing changeset
+        id: detect
+        env:
+          CHANGESET_BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/check-changeset.mjs
+      - name: Post or remove reminder comment
+        uses: actions/github-script@v7
+        env:
+          MISSING: ${{ steps.detect.outputs.missing }}
+          PACKAGES: ${{ steps.detect.outputs.packages }}
+        with:
+          script: "const marker = '<!-- changeset-reminder -->';\nconst missing = process.env.MISSING === 'true';\nconst packages = process.env.PACKAGES || '';\nconst { owner, repo } = context.repo;\nconst issue_number = context.payload.pull_request.number;\nconst comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });\nconst existing = comments.find((comment) => comment.body && comment.body.includes(marker));\nif (missing) {\n  const body = [\n    marker,\n    '### \U0001F98B No changeset found',\n    '',\n    'This PR changes publishable source but has no `.changeset/*.md`.',\n    packages ? `Affected: ${packages}` : '',\n    '',\n    '- If the change is consumer-relevant (worth a changelog entry), run `pnpm changeset` and commit the file.',\n    \"- If it isn't changelog-relevant (chore / refactor / internal), you can ignore this — the code still ships with the next release.\",\n  ].filter(Boolean).join('\\n');\n  if (existing) {\n    await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });\n  } else {\n    await github.rest.issues.createComment({ owner, repo, issue_number, body });\n  }\n} else if (existing) {\n  await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });\n}\n"

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -460,6 +460,10 @@ jobs:
   # preview channel get the same daily build the web deploy does. iOS ships on `dev` alone for now (see the
   # `ios` input). CrabNebula channel is derived from the environment inside the reusable workflow. On
   # production it builds the bumped release commit.
+  #
+  # TODO: this job (and deploy-tauri.yaml, which it calls) keeps this workflow on GitHub Actions rather
+  # than Depot CI — deploy-tauri.yaml's build_tauri/build_tauri_ios jobs need depot-macos-latest, and
+  # Depot CI's own orchestrator has no macOS sandboxes yet. Revisit once Depot CI supports macOS runners.
   tauri:
     needs: [plan, release, version, build-bundle]
     if: ${{ !cancelled() && needs.release.result != 'failure' && needs.build-bundle.result == 'success' && needs.plan.outputs.tauri == 'true' }}

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,10 @@ build/Release
 node_modules/
 jspm_packages/
 
+# pnpm store, when it resolves inside the checkout instead of a global cache dir (observed on Depot
+# CI's sandbox — see .oxfmtrc.json's ignorePatterns for why this also needs to be there).
+.pnpm-store/
+
 # Optional npm cache directory
 .npm
 

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -29,6 +29,7 @@
     "**/tsconfig.json",
     "**/vendor/**",
     ".moon/cache",
+    ".pnpm-store/**",
     "coverage",
     "dist",
     "docs/design/refs/example.yml",


### PR DESCRIPTION
## Summary

Adds a Depot CI copy of `check.yml` alongside the existing GitHub Actions workflow, as a test migration — same pattern as [dxos/edge#974](https://github.com/dxos/edge/pull/974).

GitHub Actions has had repeated outages that block CI entirely, even though jobs here already run on Depot-hosted runners (`depot-ubuntu-24.04-8` etc.) — the orchestrator triggering them is still Actions. [Depot CI](https://depot.dev/products/ci) replaces the orchestrator itself: it reuses the same workflow YAML but triggers off Depot's own Code Access GitHub app instead.

- `.depot/workflows/check.yml` plus the actions it calls (`setup`, `branch`, `test-report`) are the Depot CI equivalents, produced by `depot ci migrate`.
- `.github/workflows/check.yml` is untouched — this is additive.

**Deliberately excluded:** `deploy-apps.yml`, `deploy-tauri.yaml`, and the `cn-channel`/`cn-config`/`cn-release` actions that only they use. `deploy-tauri.yaml`'s `build_tauri` and `build_tauri_ios` jobs run on `depot-macos-latest` for code signing, notarization, and the TestFlight upload — [Depot CI's own orchestrator has no macOS sandboxes](https://depot.dev/docs/ci/overview), only x86_64/Arm64 Ubuntu 24.04. Added a TODO on `deploy-apps.yml`'s `tauri` job noting this blocks its migration until Depot CI supports macOS runners.

The other workflows `depot ci migrate` generated `.depot/` copies for (`pkg-pr-new`, `publish-all`, `docker-image`, etc.) are left untracked for now, out of scope for this test.

## Test plan

- [ ] `depot ci run --workflow .depot/workflows/check.yml` — verify parity with the GitHub Actions run
- [ ] Confirm the Depot Code Access GitHub app is installed for `dxos/dxos` (it showed as already configured via `depot ci migrate preflight`, likely from the org-wide install done for `dxos/edge`)
- [ ] Decide whether/when to remove `.github/workflows/check.yml` once parity is confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added standardized automation for identifying branches and preparing build environments.
  - Expanded automated validation across builds, documentation, packaging, browser tests, end-to-end tests, and performance checks.
  - Added notifications for successful, incomplete, and failed test runs.
  - Improved caching and fallback behavior to keep validation running when remote services are unavailable.
  - Documented why certain desktop and mobile builds continue using macOS-based automation.
  - Excluded local package-manager cache files from version control and formatting checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->