### PR TITLE
plugin-support: attach screenshot on every feedback submit path

### DIFF
--- a/.changeset/feedback-screenshot-toggle.md
+++ b/.changeset/feedback-screenshot-toggle.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-support': patch
+---
+
+Feedback panel: the "Attach screenshot" toggle is now always available (alongside "Include debug logs") and applies to every submit path — PostHog feedback and Discord help threads embed the uploaded screenshot in the report, not just GitHub issues.

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/DiscordAction.tsx
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/DiscordAction.tsx
@@ -16,6 +16,7 @@ import { meta } from '#meta';
 import { SupportOperation } from '#types';
 
 import { formatRequestMessage } from './request';
+import { useScreenshotAttachment } from './useScreenshotAttachment';
 
 /** Build a direct PostHog event permalink (±15s search window via timestamp). */
 const makePostHogEventUrl = (projectId: string, eventUuid: string): string =>
@@ -40,6 +41,7 @@ export const DiscordAction = ({ disabled }: DiscordActionProps) => {
     getEdgeServiceEndpoint(config, EdgeServiceName.Discord);
 
   const discordPresence = useDiscordPresence(discordServiceUrl);
+  const attachScreenshot = useScreenshotAttachment();
 
   const handleDiscord = useCallback<FeedbackSubmitHandler>(
     async (values) => {
@@ -47,7 +49,9 @@ export const DiscordAction = ({ disabled }: DiscordActionProps) => {
         return;
       }
 
-      const message = formatRequestMessage(values);
+      // Capture before submitting, while the reported screen is still on-screen.
+      const screenshot = await attachScreenshot(values);
+      const message = formatRequestMessage(values, screenshot.url);
 
       // PostHog submission is the primary path — if it fails the error propagates
       // and no misleading toast is shown.
@@ -106,7 +110,7 @@ export const DiscordAction = ({ disabled }: DiscordActionProps) => {
         });
       }
     },
-    [invokePromise, discordServiceUrl, posthogProjectId],
+    [invokePromise, discordServiceUrl, posthogProjectId, attachScreenshot],
   );
 
   return (

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/FeedbackPanel.tsx
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/FeedbackPanel.tsx
@@ -42,7 +42,6 @@ export const FeedbackPanel = () => {
   );
 
   const hidden = useMemo(() => ({ version }), [version]);
-  const excludeImage = useMemo(() => !settings?.enableGitHubIssues, [settings?.enableGitHubIssues]);
 
   useAsyncEffect(
     async (controller) => {
@@ -64,7 +63,7 @@ export const FeedbackPanel = () => {
         <FeedbackForm.Root hidden={hidden} plugins={plugins}>
           <Form.Viewport>
             <Form.Content>
-              <Form.FieldSet filter={excludeImage ? (props) => props.filter((p) => p.name !== 'image') : undefined} />
+              <Form.FieldSet />
               <DownloadLogsAction />
               {/* GH only opens a prefilled URL — independent of PostHog feedback availability. */}
               {/* PostHog + Discord both call `CaptureUserFeedback`, so they share the gate. */}

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/FeedbackSubmitAction.tsx
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/FeedbackSubmitAction.tsx
@@ -13,6 +13,7 @@ import { meta } from '#meta';
 import { SupportOperation } from '#types';
 
 import { formatRequestMessage } from './request';
+import { useScreenshotAttachment } from './useScreenshotAttachment';
 
 export type FeedbackSubmitActionProps = {
   disabled?: boolean;
@@ -24,11 +25,15 @@ export type FeedbackSubmitActionProps = {
  */
 export const FeedbackSubmitAction = ({ disabled }: FeedbackSubmitActionProps) => {
   const { invokePromise } = useOperationInvoker();
+  const attachScreenshot = useScreenshotAttachment();
 
   const handleSave = useCallback<FeedbackSubmitHandler>(
     async (values) => {
+      // Capture before submitting: the collapse + capture must happen while the reported screen is
+      // still on-screen, and a failed attachment never blocks the report.
+      const screenshot = await attachScreenshot(values);
       await invokePromise(SupportOperation.CaptureUserFeedback, {
-        message: formatRequestMessage(values),
+        message: formatRequestMessage(values, screenshot.url),
         includeLogs: values.includeLogs,
       });
       await invokePromise(LayoutOperation.UpdateComplementary, {
@@ -38,12 +43,14 @@ export const FeedbackSubmitAction = ({ disabled }: FeedbackSubmitActionProps) =>
         id: `${meta.profile.key}.feedback-success`,
         icon: 'ph--paper-plane-tilt--regular',
         title: ['feedback-toast.label', { ns: meta.profile.key }],
-        description: ['feedback-toast.description', { ns: meta.profile.key }],
+        description: screenshot.failed
+          ? ['feedback-toast-no-screenshot.description', { ns: meta.profile.key }]
+          : ['feedback-toast.description', { ns: meta.profile.key }],
         closeLabel: ['close.label', { ns: osTranslations }],
         duration: 3_000,
       });
     },
-    [invokePromise],
+    [invokePromise, attachScreenshot],
   );
 
   return <FeedbackForm.SubmitPosthog onSubmit={handleSave} disabled={disabled} />;

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/GitHubAction.tsx
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/GitHubAction.tsx
@@ -6,9 +6,7 @@ import React, { useCallback } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import * as LayoutOperation from '@dxos/app-toolkit/LayoutOperation';
-import { EdgeServiceName, getEdgeServiceEndpoint } from '@dxos/config';
 import { log } from '@dxos/log';
-import { useConfig } from '@dxos/react-client';
 import { osTranslations } from '@dxos/ui-theme';
 
 import { FeedbackForm, type FeedbackSubmitHandler } from '#components';
@@ -16,7 +14,7 @@ import { meta } from '#meta';
 import { SupportOperation } from '#types';
 
 import { GITHUB_NEW_ISSUE_URL } from '../../constants';
-import { captureScreenshot, uploadScreenshot } from './screenshot';
+import { useScreenshotAttachment } from './useScreenshotAttachment';
 
 const CUSTOM_LABEL = 'Composer';
 
@@ -83,11 +81,7 @@ const buildGitHubIssueUrl = (values: SupportOperation.SupportRequest, screenshot
  */
 export const GitHubAction = () => {
   const { invokePromise } = useOperationInvoker();
-  const config = useConfig();
-  // Shared with @dxos/plugin-crm (same Edge service, same multipart contract).
-  const imageServiceUrl =
-    (config.values.runtime?.app?.env?.DX_IMAGE_SERVICE_URL as string | undefined) ??
-    getEdgeServiceEndpoint(config, EdgeServiceName.Image);
+  const attachScreenshot = useScreenshotAttachment();
 
   const handleGitHub = useCallback<FeedbackSubmitHandler>(
     async (values) => {
@@ -110,44 +104,16 @@ export const GitHubAction = () => {
         bodyLength: values.body.length,
       });
 
-      // Collapse the help companion before capture so the screenshot reflects
-      // what the user is reporting (the screen behind the form), not the form
-      // itself. A short layout tick lets the deck animation settle before
-      // html-to-image walks the DOM.
-      await invokePromise(LayoutOperation.UpdateComplementary, { state: 'collapsed' });
-      await new Promise((resolve) => setTimeout(resolve, 150));
-
-      // Best-effort screenshot — only when the user opts in via the `image`
-      // toggle in the form. Failures (capture or upload) drop through to the
-      // no-image flow rather than blocking the report — filing the issue
-      // matters more than the attachment, but we toast the failure so the
-      // user knows the screenshot didn't make it.
-      let screenshotUrl: string | undefined;
-      let imageRequestedButFailed = false;
-      if (values.image) {
-        log.info('github-issue: capturing screenshot');
-        const blob = await captureScreenshot();
-        if (!blob) {
-          log.warn('github-issue: capture returned no blob');
-          imageRequestedButFailed = true;
-        } else {
-          log.info('github-issue: capture ok, uploading', { bytes: blob.size });
-          screenshotUrl = await uploadScreenshot(blob, imageServiceUrl);
-          if (!screenshotUrl) {
-            log.warn('github-issue: upload returned no url');
-            imageRequestedButFailed = true;
-          } else {
-            // URL is public but still identifies the user's screenshot; log a flag, not the URL.
-            log.info('github-issue: upload ok');
-          }
-        }
-      }
+      // Best-effort screenshot — only when the user opts in via the `image` toggle. Failures drop
+      // through to the no-image flow rather than blocking the report, but we toast the failure so
+      // the user knows the screenshot didn't make it.
+      const screenshot = await attachScreenshot(values);
 
       // Phase 1: prefilled URL only. Authenticated submission via plugin-connector
       // is a follow-up — when present, POST to /repos/dxos/dxos/issues using the
       // stored AccessToken and open the resulting `html_url` instead.
-      const url = buildGitHubIssueUrl(values, screenshotUrl);
-      log.info('github-issue: opening', { hasScreenshot: !!screenshotUrl, urlLength: url.length });
+      const url = buildGitHubIssueUrl(values, screenshot.url);
+      log.info('github-issue: opening', { hasScreenshot: !!screenshot.url, urlLength: url.length });
       // If the synchronous open was blocked, `popup` is null; show a distinct toast so the user
       // knows the tab didn't appear rather than leaving them with a misleading success message.
       if (!popup) {
@@ -172,13 +138,13 @@ export const GitHubAction = () => {
         icon: 'ph--github-logo--regular',
         duration: 5000,
         title: ['github-issue-toast.label', { ns: meta.profile.key }],
-        description: imageRequestedButFailed
+        description: screenshot.failed
           ? ['github-issue-toast-no-screenshot.description', { ns: meta.profile.key }]
           : ['github-issue-toast.description', { ns: meta.profile.key }],
         closeLabel: ['close.label', { ns: osTranslations }],
       });
     },
-    [invokePromise, imageServiceUrl],
+    [invokePromise, attachScreenshot],
   );
 
   return <FeedbackForm.SubmitGitHub onSubmit={handleGitHub} />;

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/request.test.ts
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/request.test.ts
@@ -1,0 +1,28 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, test } from 'vitest';
+
+import { type SupportOperation } from '#types';
+
+import { formatRequestMessage } from './request';
+
+const values: SupportOperation.SupportRequest = {
+  type: 'bug',
+  severity: 'Low priority',
+  title: 'Broken',
+  body: 'It broke.',
+};
+
+describe('formatRequestMessage', () => {
+  test('omits the image when no screenshot url is supplied', () => {
+    expect(formatRequestMessage(values)).not.toContain('![Screenshot]');
+  });
+
+  test('embeds the screenshot above the body', () => {
+    const message = formatRequestMessage(values, 'https://images.dxos.org/abc.jpg');
+    expect(message).toContain('![Screenshot](https://images.dxos.org/abc.jpg)');
+    expect(message.indexOf('![Screenshot]')).toBeLessThan(message.indexOf('It broke.'));
+  });
+});

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/request.ts
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/request.ts
@@ -8,9 +8,10 @@ import { SupportOperation } from '#types';
  * Collapse a {@link SupportOperation.SupportRequest} into the legacy `{ message, includeLogs }`
  * shape consumed by the Observability backend and the Discord help-thread service. Triage
  * metadata (type/severity/area/version) is embedded as a Markdown trailer so the
- * single-string `message` carries the full context.
+ * single-string `message` carries the full context. `screenshotUrl`, when supplied, is
+ * embedded as a Markdown image so the attachment survives the single-string channel.
  */
-export const formatRequestMessage = (values: SupportOperation.SupportRequest): string => {
+export const formatRequestMessage = (values: SupportOperation.SupportRequest, screenshotUrl?: string): string => {
   const trailer = [
     `**Type:** ${values.type}`,
     `**Severity:** ${values.severity}`,
@@ -20,5 +21,6 @@ export const formatRequestMessage = (values: SupportOperation.SupportRequest): s
     .filter(Boolean)
     .join('\n');
   const heading = `# ${values.title}`;
-  return [heading, values.body, '---', trailer].filter(Boolean).join('\n\n');
+  const image = screenshotUrl && `![Screenshot](${screenshotUrl})`;
+  return [heading, image, values.body, '---', trailer].filter(Boolean).join('\n\n');
 };

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/useScreenshotAttachment.ts
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/useScreenshotAttachment.ts
@@ -1,0 +1,69 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { useCallback } from 'react';
+
+import { useOperationInvoker } from '@dxos/app-framework/ui';
+import * as LayoutOperation from '@dxos/app-toolkit/LayoutOperation';
+import { EdgeServiceName, getEdgeServiceEndpoint } from '@dxos/config';
+import { log } from '@dxos/log';
+import { useConfig } from '@dxos/react-client';
+
+import { type SupportOperation } from '#types';
+
+import { captureScreenshot, uploadScreenshot } from './screenshot';
+
+/** Lets the deck animation settle after collapsing the companion, before html-to-image walks the DOM. */
+const SETTLE_DELAY = 150;
+
+export type ScreenshotAttachment = {
+  /** Public image-service URL, absent when capture was not requested or failed. */
+  url?: string;
+  /** True when the user opted in but capture/upload failed — callers surface this in their toast. */
+  failed: boolean;
+};
+
+/**
+ * Shared "attach screenshot" step for every FeedbackPanel submit path (PostHog, Discord, GitHub).
+ *
+ * Collapses the help companion first so the capture shows the screen being reported rather than
+ * the form itself, then captures and uploads. Best-effort throughout: a failure yields
+ * `{ failed: true }` instead of throwing, since filing the report matters more than the image.
+ */
+export const useScreenshotAttachment = () => {
+  const { invokePromise } = useOperationInvoker();
+  const config = useConfig();
+  // Shared with @dxos/plugin-crm (same Edge service, same multipart contract).
+  const imageServiceUrl =
+    (config.values.runtime?.app?.env?.DX_IMAGE_SERVICE_URL as string | undefined) ??
+    getEdgeServiceEndpoint(config, EdgeServiceName.Image);
+
+  return useCallback(
+    async (values: SupportOperation.SupportRequest): Promise<ScreenshotAttachment> => {
+      if (!values.image) {
+        return { failed: false };
+      }
+
+      await invokePromise(LayoutOperation.UpdateComplementary, { state: 'collapsed' });
+      await new Promise((resolve) => setTimeout(resolve, SETTLE_DELAY));
+
+      const blob = await captureScreenshot();
+      if (!blob) {
+        log.warn('feedback: screenshot capture returned no blob');
+        return { failed: true };
+      }
+
+      const url = await uploadScreenshot(blob, imageServiceUrl);
+      if (!url) {
+        log.warn('feedback: screenshot upload returned no url');
+        return { failed: true };
+      }
+
+      // URL is public but still identifies the user's screenshot; log a flag, not the URL.
+      log.info('feedback: screenshot attached', { bytes: blob.size });
+      return { url, failed: false };
+    },
+    [invokePromise, imageServiceUrl],
+  );
+};

--- a/packages/plugins/plugin-support/src/translations.ts
+++ b/packages/plugins/plugin-support/src/translations.ts
@@ -63,6 +63,8 @@ export const translations = [
         'download-logs.label': 'Download logs',
         'feedback-toast.label': 'Thank you for your feedback!',
         'feedback-toast.description': 'We will review your feedback and get back to you as soon as possible.',
+        'feedback-toast-no-screenshot.description':
+          'We will review your feedback and get back to you as soon as possible. (Screenshot could not be attached.)',
         'discord-feedback-toast.label': 'Help thread started in Discord',
         'discord-feedback-toast.description': 'Your thread is now open in Discord.',
         // Welcome tour + keyboard shortcuts (absorbed from plugin-help).

--- a/packages/plugins/plugin-support/src/types/SupportOperation.ts
+++ b/packages/plugins/plugin-support/src/types/SupportOperation.ts
@@ -58,8 +58,8 @@ export const SupportRequest = Schema.Struct({
   severity: Severity,
   image: Schema.Boolean.pipe(
     Schema.annotate({
-      title: 'Attach screenshot (GitHub only)',
-      description: 'Capture the current view and attach it to the GitHub issue. Form fields are obscured for privacy.',
+      title: 'Attach screenshot',
+      description: 'Capture the current view and attach it to the report. Form fields are obscured for privacy.',
     }),
     Schema.optional,
   ),


### PR DESCRIPTION
Closes DX-1193.

The feedback panel already had an `image` toggle, but it was hidden unless `enableGitHubIssues` was set and only the GitHub path honoured it. It is now a first-class option next to "Include debug logs" and applies to all three submit paths.

## Changes

- New `useScreenshotAttachment` hook (`containers/FeedbackPanel/`) — collapses the help companion, waits for the deck animation, then captures + uploads via the existing `screenshot.ts` helpers. Best-effort: returns `{ failed: true }` rather than throwing, so a failed attachment never blocks the report.
- `FeedbackSubmitAction` (PostHog) and `DiscordAction` now attach the screenshot; `formatRequestMessage` embeds it as `[Screenshot](url)` above the body so it survives the single-string message channel.
- `GitHubAction` refactored onto the shared hook (behaviour unchanged).
- `FeedbackPanel` no longer filters the `image` field out; schema title/description reworded to drop "GitHub only".
- Added `feedback-toast-no-screenshot.description` for the capture-failed case, mirroring the GitHub toast.
- Unit test for the screenshot embedding in `request.test.ts`; changeset added.

## Verification

```
moon run plugin-support:build   # ok
moon run plugin-support:lint    # ok
moon run plugin-support:test    # 2 files, 9 tests passed
pnpm format
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyy888pgBGXTnQqseg4Kp4


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uyy888pgBGXTnQqseg4Kp4)_