### PR TITLE
agents: gate the demo driver, and make its trimmer fail and estimate honestly

### DIFF
--- a/.agents/skills/recording-demos/SKILL.md
+++ b/.agents/skills/recording-demos/SKILL.md
@@ -57,11 +57,14 @@ node .agents/skills/recording-demos/scripts/driver.mjs \
   --port 7333 --url http://localhost:4173 --out /tmp/demo &
 ```
 
-It launches Chromium, opens one recording context, and listens on loopback. Every gesture is one HTTP
-call, so each is a separate agent turn:
+It launches Chromium, opens one recording context, and listens on loopback behind a per-process token
+(printed at startup and written to `<out>/token`). Loopback alone is not access control — any page the
+browser has open can POST here cross-origin in `no-cors` mode, and the command would run even though the
+response is opaque to it; a token in a non-safelisted header cannot be set by such a request. Every
+gesture is one HTTP call, so each is a separate agent turn:
 
 ```bash
-C() { curl -sS localhost:7333/cmd -d "$1"; echo; }
+C() { curl -sS -H "x-demo-token: $(cat /tmp/demo/token)" localhost:7333/cmd -d "$1"; echo; }
 C '{"op":"goto"}'
 C '{"op":"click","selector":"[data-testid=\"treeView.pluginRegistry\"]"}'
 C '{"op":"screenshot","name":"01-registry.png"}'

--- a/.agents/skills/recording-demos/scripts/driver.mjs
+++ b/.agents/skills/recording-demos/scripts/driver.mjs
@@ -20,6 +20,7 @@
  */
 
 import { chromium } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
 import { mkdirSync, readdirSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import path from 'node:path';
@@ -37,6 +38,15 @@ const parseArgs = () => {
 
 const options = parseArgs();
 mkdirSync(options.out, { recursive: true });
+
+/**
+ * Binding to loopback is not access control: any page the browser has open can POST here cross-origin
+ * in `no-cors` mode, and while the response is opaque to it the command still runs — `eval` and `goto`
+ * included. A token in a non-safelisted header cannot be set by such a request (it would force a
+ * preflight, which this server never approves), so requiring one closes that path.
+ */
+const TOKEN_HEADER = 'x-demo-token';
+const token = randomUUID();
 
 // The cloud sandbox needs a pinned executable, the egress proxy passed as an arg, and a TLS 1.2 cap;
 // gated so a real desktop run is never silently downgraded (see the `cloud-sandbox` skill).
@@ -195,7 +205,8 @@ const handlers = {
     return {};
   },
   screenshot: async (command) => {
-    const file = path.join(options.out, command.name ?? `shot-${Date.now()}.png`);
+    // `basename` because a caller-supplied name is not a path: `../` would escape the output directory.
+    const file = path.join(options.out, path.basename(command.name ?? `shot-${Date.now()}.png`));
     await page.screenshot({ path: file, fullPage: !!command.fullPage });
     return { file };
   },
@@ -221,6 +232,11 @@ const server = createServer((request, response) => {
       return response.end(JSON.stringify({ ok: false, error: `bad json: ${error.message}` }));
     }
 
+    if (request.headers[TOKEN_HEADER] !== token) {
+      response.writeHead(403, { 'content-type': 'application/json' });
+      return response.end(JSON.stringify({ ok: false, error: `missing or bad ${TOKEN_HEADER}` }));
+    }
+
     const handler = handlers[command.op];
     if (!handler) {
       response.writeHead(400, { 'content-type': 'application/json' });
@@ -232,11 +248,17 @@ const server = createServer((request, response) => {
     try {
       const result = await handler(command);
       response.writeHead(200, { 'content-type': 'application/json' });
-      response.end(JSON.stringify({ ok: true, ...result }));
-      if (command.op === 'stop') {
-        server.close();
-        process.exit(0);
-      }
+      // Shutdown runs from the write callback: exiting as soon as `end` returns can cut the response
+      // off before it flushes, and that response carries the video path.
+      response.end(JSON.stringify({ ok: true, ...result }), () => {
+        if (command.op === 'stop') {
+          // Exit from inside `close`, and drop keep-alive sockets so it can actually complete: dropping
+          // the exit entirely leaves the process alive on an idle client socket, and exiting before the
+          // write callback truncates the response that carries the video path.
+          server.close(() => process.exit(0));
+          server.closeAllConnections();
+        }
+      });
     } catch (error) {
       // Errors are reported, never fatal: a failed gesture is a finding the agent acts on, and killing
       // the driver would lose the recording of the failure.
@@ -246,7 +268,10 @@ const server = createServer((request, response) => {
   });
 });
 
-// Loopback only — this server drives a real browser and takes arbitrary `eval`.
+// Loopback only, and token-gated — this server drives a real browser and takes arbitrary `eval`.
 server.listen(options.port, '127.0.0.1', () => {
+  // Also written to the output directory so a caller can read it without scraping stdout.
+  writeFileSync(path.join(options.out, 'token'), token);
   console.log(`driver ready on http://127.0.0.1:${options.port} out=${options.out}`);
+  console.log(`token ${token}`);
 });

--- a/.agents/skills/recording-demos/scripts/trim-static.mjs
+++ b/.agents/skills/recording-demos/scripts/trim-static.mjs
@@ -65,6 +65,15 @@ const parseArgs = () => {
   return options;
 };
 
+/** The viewer is a local file, but caption text is arbitrary and lands in markup. */
+const escapeHtml = (value) =>
+  String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
 const options = parseArgs();
 if (!options.in || !existsSync(options.in)) {
   console.error('usage: node trim-static.mjs --in <video> [--out <video>] [--max-static 1.5] [--fps 15]');
@@ -90,7 +99,10 @@ const probe = async (file) => {
   };
 };
 
-const { width, height, seconds } = await probe(options.in);
+const { width, height, seconds } = await probe(options.in).catch((error) => {
+  console.error(`cannot read ${options.in}: ${error.message.split('\n')[0]}`);
+  process.exit(1);
+});
 
 /**
  * Caption times as the driver recorded them, in source frames. `timeline.json` is written by
@@ -153,7 +165,11 @@ if (options.report) {
   let run = 0;
   let frames = 0;
   let motion = 0;
+  // Each run carries where it began, because a run that starts inside a caption's reading window is
+  // priced at `--caption-hold`, not at the cap being swept. Ignoring that made the estimate read ~10s
+  // under the truth on a 9-caption demo.
   const runs = [];
+  let runStart = 0;
   for await (const chunk of decoder.stdout) {
     pending = pending.length ? Buffer.concat([pending, chunk]) : chunk;
     while (pending.length >= frameBytes) {
@@ -162,9 +178,10 @@ if (options.report) {
       frames++;
       if (!previous || moved(frame, previous)) {
         if (run) {
-          runs.push(run);
+          runs.push({ length: run, start: runStart });
         }
         run = 0;
+        runStart = frames;
         motion++;
       } else {
         run++;
@@ -173,12 +190,28 @@ if (options.report) {
     }
   }
   if (run) {
-    runs.push(run);
+    runs.push({ length: run, start: runStart });
   }
-  await once(decoder, 'close');
+  const [decoderStatus] = await once(decoder, 'close');
+  if (decoderStatus !== 0) {
+    console.error(`ffmpeg decode failed (exit ${decoderStatus}) — statistics would be partial`);
+    process.exit(1);
+  }
 
   const seconds = (count) => +(count / options.fps).toFixed(1);
-  const capped = (cap) => runs.reduce((total, length) => total + Math.min(length, cap * options.fps), 0);
+  const captionHold = Math.max(1, Math.round(options['caption-hold'] * options.fps));
+  const captionFrames = new Set();
+  for (const caption of captions) {
+    for (let offset = 0; offset <= captionHold; offset++) {
+      captionFrames.add(caption.frame + offset);
+    }
+  }
+  const capped = (cap) =>
+    runs.reduce(
+      (total, { length, start }) =>
+        total + Math.min(length, captionFrames.has(start) ? captionHold : cap * options.fps),
+      0,
+    );
   console.log(
     JSON.stringify(
       {
@@ -187,9 +220,11 @@ if (options.report) {
         motionSeconds: seconds(motion),
         stillRuns: runs.length,
         stillSeconds: seconds(frames - motion),
-        longestStillRun: seconds(Math.max(0, ...runs)),
-        // What each candidate cap would leave, motion included: the still runs are the only part a cap
-        // can shrink, and there are enough of them that the cap dominates the result.
+        longestStillRun: seconds(Math.max(0, ...runs.map((entry) => entry.length))),
+        captions: captions.length,
+        captionHold: `${options['caption-hold']}s`,
+        // What each candidate `--max-static` would leave, motion and caption holds included: the still
+        // runs are the only part a cap can shrink, and there are enough of them that it dominates.
         atCap: Object.fromEntries(
           [0.3, 0.5, 0.8, 1.0, 1.5, 2.0].map((cap) => [`${cap}s`, seconds(motion + capped(cap))]),
         ),
@@ -258,7 +293,9 @@ for await (const chunk of decoder.stdout) {
     longestRun = Math.max(longestRun, staticRun);
 
     const cap = readingWindow.has(index) ? captionHoldFrames : holdFrames;
-    if (staticRun < cap) {
+    // Inclusive: `--report` prices a run at `min(length, cap)`, and an exclusive test would keep one
+    // frame fewer than it promised, so the estimate could never be trusted for tuning.
+    if (staticRun <= cap) {
       if (!encoder.stdin.write(frame)) {
         await once(encoder.stdin, 'drain');
       }
@@ -271,7 +308,12 @@ for await (const chunk of decoder.stdout) {
 }
 
 encoder.stdin.end();
-await once(encoder, 'close');
+const [encoderStatus] = await once(encoder, 'close');
+const [decodeStatus] = decoder.exitCode === null ? await once(decoder, 'close') : [decoder.exitCode];
+if (decodeStatus !== 0 || encoderStatus !== 0) {
+  console.error(`ffmpeg failed (decode ${decodeStatus}, encode ${encoderStatus}) — output is unusable`);
+  process.exit(1);
+}
 
 /**
  * Time-range annotations, so the steps survive outside the burned-in banner: Matroska chapters (which
@@ -346,7 +388,7 @@ const annotate = async () => {
     viewer,
     `<!doctype html>
 <meta charset="utf-8">
-<title>${path.basename(base)}</title>
+<title>${escapeHtml(path.basename(base))}</title>
 <style>
   body { margin: 0; background: #111; color: #eee; font: 14px/1.5 ui-sans-serif, system-ui, sans-serif; display: flex; gap: 16px; padding: 16px; align-items: flex-start; flex-wrap: wrap; }
   video { flex: 3 1 480px; min-width: 0; max-width: 100%; background: #000; }
@@ -357,15 +399,15 @@ const annotate = async () => {
   small { display: block; opacity: .6; }
   code { opacity: .5; font-size: 12px; }
 </style>
-<video id="v" controls src="${path.basename(annotated)}">
-  <track kind="chapters" srclang="en" src="${path.basename(vttFile)}" default>
+<video id="v" controls src="${escapeHtml(path.basename(annotated))}">
+  <track kind="chapters" srclang="en" src="${escapeHtml(path.basename(vttFile))}" default>
 </video>
 <ol id="steps">${marks
       .map(
         (mark, index) =>
-          `<li data-at="${mark.start.toFixed(3)}"><code>${clock(mark.start).slice(3, 8)}</code> ${
-            mark.text
-          }${mark.subtitle ? `<small>${mark.subtitle}</small>` : ''}</li>`,
+          `<li data-at="${mark.start.toFixed(3)}"><code>${clock(mark.start).slice(3, 8)}</code> ${escapeHtml(
+            mark.text,
+          )}${mark.subtitle ? `<small>${escapeHtml(mark.subtitle)}</small>` : ''}</li>`,
       )
       .join('\n')}</ol>
 <script>


### PR DESCRIPTION
Follow-up to #12776, which merged while these were in progress. Five review findings from that PR, all verified against the code and all real.

## Security

**Loopback is not access control.** Any page the browser has open can POST to the driver cross-origin in `no-cors` mode; the response is opaque to it, but the command still runs — `eval`, `goto`, `stop` and `screenshot` included. Commands now require a per-process token in a non-safelisted header, which such a request cannot set (it would force a preflight this server never approves). The token is printed at startup and written to `<out>/token`.

Verified:

| request | result |
| --- | --- |
| no header | `403 missing or bad x-demo-token` |
| wrong token | `403` |
| correct token | `{"ok":true,"value":4}` |
| `screenshot` with `name: "../../escaped.png"` | written inside the output dir; nothing created outside |

`screenshot` takes `basename` of the caller's name, so `../` cannot escape `--out`.

Caption text also reaches the generated viewer HTML escaped — it came from `timeline.json` and was interpolated raw.

## Shutdown

`stop` called `process.exit(0)` immediately after `response.end`, which can truncate the response that carries the video path. It now exits from the write callback.

Worth noting for the reviewer: the suggested fix — dropping the exit entirely and letting the server end naturally — **hangs**. I measured it: the process stays alive on an idle keep-alive client socket. The working form is `server.close(() => process.exit(0))` plus `closeAllConnections()`, so the response flushes first and shutdown still completes.

## The trimmer lied in two directions

- **Both ffmpeg exit codes were ignored.** A failed decode printed partial statistics; a failed encode reported success. Both are now checked, and an unreadable input gives one clean line and exit 1 instead of a stack trace.
- **`--report` disagreed with the output.** The retention test was exclusive while the report priced runs inclusively, and the report ignored `--caption-hold` altogether — it estimated **35.9s for a run that actually produced 46.1s**. With per-run caption-hold pricing, the report now reads `46.1s` at `--max-static 0.5` and the output is 46.1s: equal to the frame, so the estimate can be trusted for tuning.

## Verified

`node --check` on both scripts, `pnpm run format-check` clean (13,611 files), plus the live driver checks tabled above and a full trim of the chess QA-1 recording (46.1s out, 9 chapters, viewer written, exit 0).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtNonUc3fC9GC86J9FRvqf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added authentication for demo-control requests, with unauthorized requests rejected.
  * Improved protection against unsafe screenshot output paths.

* **Reliability**
  * Improved shutdown handling to ensure responses and connections close cleanly.
  * Added clearer failure reporting for media processing and decoding errors.

* **Demo Output**
  * Improved generated viewer safety through HTML escaping.
  * Enhanced caption timing, frame retention, and report metadata.
  * Authentication credentials are now saved with demo output for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->