### PR TITLE
agents: reject unauthorized driver requests before buffering, and never wait on a closed ffmpeg

### DIFF
--- a/.agents/skills/recording-demos/scripts/driver.mjs
+++ b/.agents/skills/recording-demos/scripts/driver.mjs
@@ -220,21 +220,38 @@ const handlers = {
   },
 };
 
+/** A command is a few hundred bytes; anything larger is a mistake or an attempt to exhaust the heap. */
+const MAX_BODY = 64 * 1024;
+
 const server = createServer((request, response) => {
+  // Headers are complete before the first `data` event, so the token is checked before a single byte of
+  // body is buffered — an unauthorized caller cannot make this process accumulate anything.
+  if (request.headers[TOKEN_HEADER] !== token) {
+    response.writeHead(403, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ ok: false, error: `missing or bad ${TOKEN_HEADER}` }));
+    return request.destroy();
+  }
+
   let body = '';
-  request.on('data', (chunk) => (body += chunk));
+  request.on('data', (chunk) => {
+    body += chunk;
+    if (body.length > MAX_BODY) {
+      response.writeHead(413, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ ok: false, error: `body exceeds ${MAX_BODY} bytes` }));
+      request.destroy();
+    }
+  });
   request.on('end', async () => {
+    if (request.destroyed) {
+      return;
+    }
+
     let command;
     try {
       command = JSON.parse(body || '{}');
     } catch (error) {
       response.writeHead(400, { 'content-type': 'application/json' });
       return response.end(JSON.stringify({ ok: false, error: `bad json: ${error.message}` }));
-    }
-
-    if (request.headers[TOKEN_HEADER] !== token) {
-      response.writeHead(403, { 'content-type': 'application/json' });
-      return response.end(JSON.stringify({ ok: false, error: `missing or bad ${TOKEN_HEADER}` }));
     }
 
     const handler = handlers[command.op];

--- a/.agents/skills/recording-demos/scripts/trim-static.mjs
+++ b/.agents/skills/recording-demos/scripts/trim-static.mjs
@@ -159,6 +159,9 @@ const decodeArgs = [
 // capped are what a lower `--max-static` buys, and motion is the floor the trim can never go below.
 if (options.report) {
   const decoder = spawn(FFMPEG, decodeArgs);
+  // Registered at spawn, not after the loop: `once` on a process that has already closed never
+  // resolves, so a late listener turns an ffmpeg crash into a hang.
+  const decoderClosed = once(decoder, 'close');
   decoder.stderr.pipe(process.stderr);
   let pending = Buffer.alloc(0);
   let previous;
@@ -192,7 +195,7 @@ if (options.report) {
   if (run) {
     runs.push({ length: run, start: runStart });
   }
-  const [decoderStatus] = await once(decoder, 'close');
+  const [decoderStatus] = await decoderClosed;
   if (decoderStatus !== 0) {
     console.error(`ffmpeg decode failed (exit ${decoderStatus}) — statistics would be partial`);
     process.exit(1);
@@ -260,6 +263,10 @@ const encoder = spawn(FFMPEG, [
   output,
 ]);
 
+// Both registered before any awaiting, for the reason above.
+const decoderClosed = once(decoder, 'close');
+const encoderClosed = once(encoder, 'close');
+
 decoder.stderr.pipe(process.stderr);
 encoder.stderr.pipe(process.stderr);
 
@@ -308,8 +315,8 @@ for await (const chunk of decoder.stdout) {
 }
 
 encoder.stdin.end();
-const [encoderStatus] = await once(encoder, 'close');
-const [decodeStatus] = decoder.exitCode === null ? await once(decoder, 'close') : [decoder.exitCode];
+const [encoderStatus] = await encoderClosed;
+const [decodeStatus] = await decoderClosed;
 if (decodeStatus !== 0 || encoderStatus !== 0) {
   console.error(`ffmpeg failed (decode ${decodeStatus}, encode ${encoderStatus}) — output is unusable`);
   process.exit(1);
@@ -399,8 +406,8 @@ const annotate = async () => {
   small { display: block; opacity: .6; }
   code { opacity: .5; font-size: 12px; }
 </style>
-<video id="v" controls src="${escapeHtml(path.basename(annotated))}">
-  <track kind="chapters" srclang="en" src="${escapeHtml(path.basename(vttFile))}" default>
+<video id="v" controls src="${escapeHtml(encodeURIComponent(path.basename(annotated)))}">
+  <track kind="chapters" srclang="en" src="${escapeHtml(encodeURIComponent(path.basename(vttFile)))}" default>
 </video>
 <ol id="steps">${marks
       .map(


### PR DESCRIPTION
Follow-up to #12781, which merged one second before this push registered — its head was `af5a17a3`, so these three fixes did not land. `main` has no `MAX_BODY` and no `decoderClosed`, hence this PR.

Three review findings from #12781, all verified against the code.

## The one that matters: an ffmpeg exit could hang the trimmer

`once(encoder, 'close')` was registered *after* the frame loop. `once` on a process that has already closed never resolves, so an ffmpeg that exits early turned into an indefinite wait — introduced by #12781's own exit-code check. Both promises are now created at spawn.

That also removes the `decoder.exitCode === null ? await once(...) : [decoder.exitCode]` branch, which could not distinguish a signal exit (where `exitCode` stays `null`) from a close that had already fired.

## Driver: reject before buffering, and cap the body

The token was checked only after the entire body had been accumulated, so an unauthorized caller could still make the process buffer without limit. Request headers are complete before the first `data` event, so the check now runs before a single byte is read, and an authorized body over 64 KiB is refused with `413`.

## Viewer: URL-encode as well as HTML-escape

`escapeHtml` does not encode URL delimiters, so a `#` or `?` in an output basename would truncate the video or track path. Both are now `encodeURIComponent`'d before escaping.

## Verified

| check | result |
| --- | --- |
| no token | `403`, socket destroyed before any body read |
| 70 KB body, valid token | `413` |
| normal command | `{"ok":true,"value":42}` |
| `stop` | returns the video path, process exits |
| unreadable input | one clean line, `exit=1`, no hang |
| `--report` vs actual output | 46.1s vs 46.1s, 9 chapters, `exit=0` |
| viewer sources | `src="v3.annotated.webm"`, `src="v3.vtt"` |

`node --check` on both scripts and `pnpm run format-check` clean (13,611 files).

## A note on the review loop

This is the second round in which every finding reshapes the previous round's fix — token placement refines the token gate, the close race refines the exit-code check, URL-encoding refines the escaping. All three were valid and cheap, so they are fixed here, but I am treating this as the last bot-driven round on these files: a third round of the same shape wants a human's judgement about scope rather than another push.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtNonUc3fC9GC86J9FRvqf)_