### PR TITLE
storybook-react: stop optimizer churn wedging long dev sessions

### DIFF
--- a/tools/storybook-react/.storybook/main.ts
+++ b/tools/storybook-react/.storybook/main.ts
@@ -23,7 +23,8 @@ const isFastBundle = isTrue(process.env.DX_FASTBUNDLE);
 // Single-pass `vitest run` (not `vitest watch`); `VITEST` is set in both and `VITEST_MODE` is
 // worker-only, so read the run subcommand (first positional token, not any `run`-named filter).
 const vitestSubcommand = process.argv.slice(2).find((arg) => !arg.startsWith('-'));
-const isVitestRun = isTrue(process.env.VITEST) && (vitestSubcommand === 'run' || process.argv.includes('--run'));
+const isVitest = isTrue(process.env.VITEST);
+const isVitestRun = isVitest && (vitestSubcommand === 'run' || process.argv.includes('--run'));
 
 // Browsers targeted for syntax transforms (also applied to `oxc` below so that dev-server
 // transforms downlevel syntax WebKit doesn't parse yet, e.g. `using`/`await using`).
@@ -67,6 +68,52 @@ export const content = [
 if (isTrue(process.env.DX_DEBUG)) {
   console.log(JSON.stringify({ stories, content }, null, 2));
 }
+
+/**
+ * Externals pre-bundled ahead of the crawler under `DX_FASTBUNDLE`.
+ *
+ * Vite resolves these from this package's own root, so only its direct dependency graph can be
+ * named here. The heavy libraries this list once also carried — codemirror, radix, automerge,
+ * atlaskit, `@effect/platform` — belong to the individual story packages, not to storybook-react;
+ * under pnpm's strict layout they never resolved, so Vite skipped all 30 with a "Failed to resolve
+ * dependency" warning. The cold-start scan covers them instead: it crawls every story file and
+ * finds ~450 deps unaided.
+ */
+const optimizeDepsInclude = [
+  // React.
+  'react',
+  'react-dom',
+  'react/jsx-runtime',
+  // Effect (with subpath imports).
+  'effect',
+  'effect/Effect',
+  'effect/Array',
+  'effect/Ref',
+  'effect/Option',
+  'effect/Cause',
+  'effect/Exit',
+  'effect/Layer',
+  'effect/Runtime',
+  'effect/Fiber',
+  'effect/Deferred',
+  'effect/Function',
+  'effect/HashSet',
+  'effect/PubSub',
+  'effect/Schema',
+  'effect/Context',
+  'effect/Stream',
+  'effect/Console',
+];
+
+/**
+ * Paths the dev server must not watch, appended to Vite's own defaults (`.git`, `node_modules`,
+ * `test-results`, the cache dir).
+ *
+ * Storybook resolves `@dxos/**` from source, so build output is not in the module graph — but a
+ * `moon run :build` during an editing session still writes thousands of files under these trees,
+ * and every write costs a chokidar event on a watcher already spanning the monorepo.
+ */
+const watchIgnored = ['**/dist/**', '**/out/**', '**/.moon/**', '**/temp/**', '**/.playwright-mcp/**'];
 
 // Minimal structural view of a Babel AST node for a dependency-free traversal.
 type AstNode = { type: string } & Record<string, unknown>;
@@ -220,6 +267,11 @@ export const createConfig = ({
       console.log(JSON.stringify({ config, options }, null, 2));
     }
 
+    // A human-driven `storybook dev`, as opposed to `storybook build` or the browser-mode vitest
+    // suites. Only the former survives long enough for optimizer churn to matter, and only there is
+    // an automatic reload acceptable — under vitest it would sever the test harness's connection.
+    const isInteractiveDev = options.configType !== 'PRODUCTION' && !isVitest;
+
     // NOTE: Dynamic imports seem to help avoid conflicts with storybook's internal esbuild-register usage & Vite 7.
     const { default: react } = await import('@vitejs/plugin-react');
     const { mergeConfig } = await import('vite');
@@ -288,73 +340,17 @@ export const createConfig = ({
           },
           // Vite leaks the file watcher's handles on close, hanging single-pass teardown; disable it
           // in run mode only, so interactive `storybook dev` (local + e2e) and `vitest watch` keep HMR.
-          ...(isVitestRun ? { watch: null } : {}),
+          ...(isVitestRun ? { watch: null } : { watch: { ignored: watchIgnored } }),
         },
         optimizeDeps: {
           // WASM modules.
           exclude: ['@dxos/wa-sqlite', 'manifold-3d'],
-          ...(isFastBundle && {
-            include: [
-              // React.
-              'react',
-              'react-dom',
-              'react/jsx-runtime',
-              // Effect (with subpath imports).
-              'effect',
-              'effect/Effect',
-              'effect/Array',
-              'effect/Ref',
-              'effect/Option',
-              'effect/Cause',
-              'effect/Exit',
-              'effect/Layer',
-              'effect/Runtime',
-              'effect/Fiber',
-              'effect/Deferred',
-              'effect/Function',
-              'effect/HashSet',
-              'effect/PubSub',
-              'effect/Schema',
-              'effect/Context',
-              'effect/Stream',
-              'effect/Console',
-              '@effect/platform',
-              '@effect/platform-browser',
-              // Effect AI (absorbed into the core train under `effect/unstable/ai`).
-              '@effect/ai-anthropic',
-              '@effect/ai-anthropic/AnthropicClient',
-              '@effect/ai-anthropic/AnthropicLanguageModel',
-              '@effect/ai-anthropic/AnthropicTool',
-              '@effect/ai-openai',
-              '@effect/ai-openai/OpenAiClient',
-              '@effect/ai-openai/OpenAiLanguageModel',
-              // Automerge.
-              '@automerge/automerge',
-              '@automerge/automerge-repo',
-              // CodeMirror (many files in HAR).
-              'codemirror',
-              '@codemirror/state',
-              '@codemirror/view',
-              '@codemirror/language',
-              '@codemirror/commands',
-              '@codemirror/autocomplete',
-              '@codemirror/lang-javascript',
-              '@codemirror/lang-json',
-              '@codemirror/lang-markdown',
-              '@codemirror/theme-one-dark',
-              // Radix (many requests in HAR).
-              '@radix-ui/react-dialog',
-              '@radix-ui/react-dropdown-menu',
-              '@radix-ui/react-tooltip',
-              '@radix-ui/react-scroll-area',
-              '@radix-ui/react-popover',
-              '@radix-ui/react-slot',
-              '@radix-ui/react-context-menu',
-              // Atlaskit drag-and-drop.
-              '@atlaskit/pragmatic-drag-and-drop',
-              '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator',
-            ],
-          }),
+          ...(isFastBundle && { include: optimizeDepsInclude }),
+          // A re-optimize invalidates every previously issued `?v=<hash>` URL, so a story that is
+          // mid dynamic-import when one lands dies with "Failed to fetch dynamically imported
+          // module" and renders blank until reloaded by hand. Serving the stale chunk instead lets
+          // that import finish; the full reload Vite queues right after replaces it anyway.
+          ...(isInteractiveDev && { ignoreOutdatedRequests: true }),
         },
         worker: {
           format: 'es',

--- a/tools/storybook-react/.storybook/preview.ts
+++ b/tools/storybook-react/.storybook/preview.ts
@@ -4,6 +4,10 @@
 
 import './suppress-storybook-deprecation-warnings';
 
+import { installSelfHeal } from './self-heal';
+
+installSelfHeal();
+
 // Suppress Lit dev mode warning (https://lit.dev/msg/dev-mode).
 // Pre-populating this set prevents Lit from issuing the warning on load.
 (globalThis as any).litIssuedWarnings ??= new Set();

--- a/tools/storybook-react/.storybook/self-heal.ts
+++ b/tools/storybook-react/.storybook/self-heal.ts
@@ -32,6 +32,9 @@ const MAX_RELOADS = 2;
 const WINDOW_MS = 30_000;
 const STORAGE_KEY = 'dx.storybook.selfHeal';
 
+/** Marks the listeners as attached, so an HMR re-evaluation does not stack a second set. */
+const INSTALLED_KEY = '__dxStorybookSelfHealInstalled';
+
 /**
  * Reload budget, kept in `sessionStorage` so it survives the reload it is counting. A story broken
  * for its own reasons therefore reloads twice and then stays put with its error on screen, rather
@@ -83,7 +86,9 @@ const healIfRecoverable = (message: string): void => {
 const onStoryMissing = async (storyId: string): Promise<void> => {
   try {
     const index = await (await fetch('./index.json')).json();
-    if (!index?.entries?.[storyId]) {
+    // An own-property check, since a hand-typed `?id=toString` would otherwise find
+    // `Object.prototype`'s member and spend the reload budget on a URL that was never a story.
+    if (!index?.entries || !Object.hasOwn(index.entries, storyId)) {
       return;
     }
   } catch {
@@ -99,6 +104,14 @@ export const installSelfHeal = (): void => {
   if (typeof window === 'undefined' || '__vitest_browser_runner__' in window) {
     return;
   }
+
+  // Storybook re-evaluates the preview annotations on HMR, which would stack a second set of
+  // listeners; each one spends its own slot, so a single failure would drain the budget below. The
+  // flag lives on `window` because the module itself is re-instantiated by that same HMR pass.
+  if (INSTALLED_KEY in window) {
+    return;
+  }
+  Object.defineProperty(window, INSTALLED_KEY, { value: true, configurable: true });
 
   // The channel does not exist yet while preview annotations are evaluating.
   void addons.ready().then(

--- a/tools/storybook-react/.storybook/self-heal.ts
+++ b/tools/storybook-react/.storybook/self-heal.ts
@@ -1,0 +1,115 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { STORY_MISSING } from 'storybook/internal/core-events';
+import { addons } from 'storybook/preview-api';
+
+/**
+ * Recovers a story whose module graph was pulled out from under it.
+ *
+ * Vite's dependency optimizer re-runs whenever it meets a dep it has not pre-bundled — during an
+ * editing session, typically the moment a new `import` is typed — and every module URL it had
+ * already issued is invalidated at that instant. A request in flight then rejects with "Failed to
+ * fetch dynamically imported module" and the iframe stays blank until someone reloads it by hand.
+ *
+ * `optimizeDeps.ignoreOutdatedRequests` (see `main.ts`) covers the pre-bundled `deps/*` half of
+ * this. A story's own `?t=<timestamp>` source URL can still lose the race, and Storybook swallows
+ * that rejection — it reaches neither `window` nor its own error events, surfacing only as
+ * `STORY_MISSING`. Hence the index check below rather than an error listener.
+ */
+
+/** Message fragments every browser uses when a dynamic import's module request fails. */
+const RECOVERABLE = [
+  'failed to fetch dynamically imported module',
+  'failed to load module script',
+  'error loading dynamically imported module',
+  'importing a module script failed',
+];
+
+/** Reloads allowed inside `WINDOW_MS`, above which the failure is the code's fault, not the optimizer's. */
+const MAX_RELOADS = 2;
+const WINDOW_MS = 30_000;
+const STORAGE_KEY = 'dx.storybook.selfHeal';
+
+/**
+ * Reload budget, kept in `sessionStorage` so it survives the reload it is counting. A story broken
+ * for its own reasons therefore reloads twice and then stays put with its error on screen, rather
+ * than looping.
+ */
+const consumeReloadBudget = (): boolean => {
+  let stamps: unknown;
+  try {
+    stamps = JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? '[]');
+  } catch {
+    stamps = [];
+  }
+  const now = Date.now();
+  const recent = (Array.isArray(stamps) ? stamps : []).filter(
+    (stamp: unknown) => typeof stamp === 'number' && now - stamp < WINDOW_MS,
+  );
+  if (recent.length >= MAX_RELOADS) {
+    return false;
+  }
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify([...recent, now]));
+  } catch {
+    // Without storage there is no way to bound the loop, so decline rather than risk one.
+    return false;
+  }
+  return true;
+};
+
+const reload = (reason: string): void => {
+  if (!consumeReloadBudget()) {
+    console.warn(`[dxos] Story kept failing to load; not reloading again.\n${reason}`);
+    return;
+  }
+  console.warn(`[dxos] Story module went stale (dependency re-optimize); reloading.\n${reason}`);
+  window.location.reload();
+};
+
+const healIfRecoverable = (message: string): void => {
+  const lower = message.toLowerCase();
+  if (RECOVERABLE.some((fragment) => lower.includes(fragment))) {
+    reload(message);
+  }
+};
+
+/**
+ * Storybook reports a story as missing both when the id does not exist and when its module failed
+ * to load; only the latter is worth reloading, and the index is what tells them apart.
+ */
+const onStoryMissing = async (storyId: string): Promise<void> => {
+  try {
+    const index = await (await fetch('./index.json')).json();
+    if (!index?.entries?.[storyId]) {
+      return;
+    }
+  } catch {
+    return;
+  }
+  reload(`Story "${storyId}" is indexed but its module did not load.`);
+};
+
+export const installSelfHeal = (): void => {
+  // Never under browser-mode vitest, where a reload would sever the harness's connection. Elsewhere
+  // the budget below is the only guard needed: a built Storybook has no optimizer to race, and there
+  // a story that is indexed but will not load is a stale chunk, which reloading also fixes.
+  if (typeof window === 'undefined' || '__vitest_browser_runner__' in window) {
+    return;
+  }
+
+  // The channel does not exist yet while preview annotations are evaluating.
+  void addons.ready().then(
+    (channel) => channel.on(STORY_MISSING, onStoryMissing),
+    (error) => console.warn('[dxos] Self-heal could not attach to the Storybook channel.', error),
+  );
+
+  // Nets for the failures that do reach the page rather than being swallowed by Storybook.
+  window.addEventListener('unhandledrejection', (event) =>
+    healIfRecoverable(String(event.reason?.message ?? event.reason ?? '')),
+  );
+  window.addEventListener('error', (event) => healIfRecoverable(String(event.message ?? '')));
+  window.addEventListener('vite:preloadError', () => reload('Vite reported a preload failure.'));
+};


### PR DESCRIPTION
Long `moon run storybook-react:serve` sessions wedge: a story renders blank with
`Failed to fetch dynamically imported module` and stays that way until reloaded by hand.

## What actually triggers it

Not browsing. The cold-start scan crawls all 1562 story files and finds all 447 deps up
front — opening ten stories across ten packages discovered **zero** new deps and left
`browserHash` unchanged. The trigger is **typing a new `import` during an editing session**:
that is the mid-session discovery, and it makes Vite re-run the dependency optimizer, which
invalidates every module URL it had already issued. A request in flight at that moment dies.

## The fix

The failing URLs split two ways, so the fix does too:

- **`deps/*?v=<hash>`** (pre-bundled) — `optimizeDeps.ignoreOutdatedRequests` serves the
  stale chunk so the in-flight import completes. The full reload Vite queues right after
  replaces it anyway. Interactive dev only, never under vitest.
- **the story's own `?t=<ts>` source URL** — not covered by the above. Storybook *swallows*
  this rejection: it reaches neither `window` nor `storyThrewException`/`storyErrored`, and
  surfaces only as `STORY_MISSING`. `self-heal.ts` keys on that, reloading once when the id
  is still present in `index.json` (an unknown id means a genuinely bad URL, not a stale
  module) and declining after two reloads in 30s.

Also `server.watch.ignored` for build-output trees.

## Latent bug found in passing

**30 of the 51 `optimizeDeps.include` entries never resolved.** codemirror, radix, automerge,
atlaskit and `@effect/platform` belong to the individual story packages, not to
`storybook-react`; Vite resolves `include` from the config's own root, so under pnpm's strict
layout it skipped every one with a `Failed to resolve dependency` warning. That list has been
~60% dead. Pruned to the 21 that resolve — boot warnings 30 → 0.

It stays gated to `DX_FASTBUNDLE`, where it is genuinely load-bearing: that mode resolves
`@dxos/**` from `dist`, so the crawl stops at the `@dxos` boundary and finds only **7** deps
unaided, missing all 18 `effect` subpaths. Under `serve` the scan is exhaustive, so `include`
adds 3 deps (447 → 450) and is left off.

## Rejected after measuring

- **`optimizeDeps.noDiscovery`** — would need all 447 deps named, and only 21 can be resolved
  from this package root. Unusable here.
- **`holdUntilCrawlEnd: true`** — already the Vite 8 default.
- **Adding the 30 unresolvable packages as devDeps** — buys 3 deps for 30 duplicated catalog pins.

## Verification

8 trials per config, cold cache, identical browser-safe deps:

| | failed dynamic imports | wedged blank stories |
|---|---|---|
| baseline | 2 / 8 | 1 |
| after | **0 / 8** | **0** |

Self-heal checked deterministically: ignores unknown story ids, reloads on an indexed one,
declines after the budget. Source HMR intact (40 hot updates in the final run).
`react-ui:test-storybook` 169 tests and `react-ui-table:test-storybook` 14 tests pass.

The failure is a race, so 8 trials per config is a modest sample — the mechanism is confirmed
(exact invalidated URLs captured on both sides), but the 2→0 counts carry ordinary small-sample
variance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Storybook reliability when stories fail to load after dependency re-optimization by automatically retrying page loads.
  * Limited automatic retries to prevent repeated reloads and disabled the behavior during browser-based tests.
  * Improved story updates during interactive development by reducing unnecessary file-watch activity.

* **Performance**
  * Streamlined Storybook dependency optimization and development server behavior for faster, more consistent startup and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->