### PR TITLE
chore: drop depot ci migrate's auto-generated diary comments from check.yml

### DIFF
--- a/.depot/workflows/check.yml
+++ b/.depot/workflows/check.yml
@@ -1,10 +1,3 @@
-# Depot CI Migration
-# Source: .github/workflows/check.yml
-#
-# Changes made:
-# - Rewrote .github/ path references to .depot/
-# - Changed GitHub runs-on labels to their Depot equivalents
-
 name: Check
 on:
   pull_request:
@@ -582,7 +575,7 @@ jobs:
   cli-foreign:
     needs: cli
     if: ${{ !cancelled() && needs.cli.result == 'success' }}
-    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Download packed CLI
@@ -644,7 +637,7 @@ jobs:
   changeset-reminder:
     if: >-
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    runs-on: depot-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

Small follow-up: `check.yml` was migrated to Depot CI in #12771, before this cleanup pattern (applied in #12779 and dxos/edge#975) existed. Strips the same two categories of auto-generated noise `depot ci migrate` leaves behind:

- The "# Depot CI Migration / Source: ... / Changes made: ..." header — restates what git already tracks.
- The inline "# was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent." notes on `runs-on:` lines — same thing.

No other content touched — everything carried over from the original `.github/workflows/check.yml` stays exactly as it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up workflow configuration comments and annotations.
  * No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->