### PR TITLE
echo: add Annotation.SetParent for owned ref fields

### DIFF
--- a/.agents/skills/agentic-review/rules/code-style.mdl
+++ b/.agents/skills/agentic-review/rules/code-style.mdl
@@ -38,6 +38,30 @@ rule namespace-service-layers: Layer constructors are module-level exports, neve
   severity: warn
 ```
 
+```mdl
+rule no-trivial-wrappers-over-official-apis: Do not extract a helper that only forwards to an official API
+  A one-line local helper whose body is a single call to a public API
+  (`const makeBody = (text: string) => Obj.make(Body, { text })`, and then
+  `makeBody('x')` at four call sites) does not remove duplication — it renames
+  the API. The reader now has to jump to the definition to learn which API is
+  under test and what it was passed, and a file with several of these grows an
+  ad-hoc DSL that only its author can read. Inline it: `Obj.make(Body, { text:
+  'x' })` at the call site is longer and clearer, and it keeps the API being
+  exercised visible in the assertion's own scope. This is most acute in tests,
+  where the call being made IS the thing under test, but it applies anywhere.
+  Flag a module- or describe-local arrow/function whose body is one expression
+  wrapping a single call, adding no branching, no error handling, no derived
+  values, and no non-trivial defaults. A helper that composes several calls,
+  encodes a non-obvious setup sequence, or is exported for reuse across files
+  is NOT a violation, and neither is a named factory that a package publishes
+  as its own API (`Obj.make` wrappers such as `File.make`).
+  scope: repo
+  files:
+    - packages/**/*.ts
+    - packages/**/*.tsx
+  severity: warn
+```
+
 ## Appendix
 
 ```mdl

--- a/.agents/skills/code-style/SKILL.md
+++ b/.agents/skills/code-style/SKILL.md
@@ -207,4 +207,11 @@ readonly over mutable.
   `TestLayer(opts?)` can be parametrized so tests configure it.
 - Place test layer, configuration, and main definitions at the top of the suite;
   helpers at the bottom.
+- **Never wrap an official API in a trivial local helper.** A one-liner like
+  `const makeBody = (text: string) => Obj.make(Body, { text })` renames the API
+  rather than removing duplication: the reader has to jump to the definition to
+  see what is under test, and several of them turn a suite into an ad-hoc DSL.
+  Inline the real call — `Obj.make(Body, { text: 'x' })` — so the API being
+  exercised stays visible next to the assertion. A helper earns its place only
+  when it composes several calls or encodes a non-obvious setup sequence.
 - Avoid sleep and polling. Use events and `TestClock` instead.

--- a/.agents/skills/echo/SKILL.md
+++ b/.agents/skills/echo/SKILL.md
@@ -161,6 +161,26 @@ export const make = (props: Obj.MakeProps<typeof Person>): Person => Obj.make(Pe
 export const make = (props: Obj.MakeProps<typeof Person>): Type.InstanceType<typeof Person> => Obj.make(Person, props);
 ```
 
+## Owned children — `Annotation.SetParent`
+
+Declare ownership on the ref field rather than calling `Obj.setParent` next to every write. Writing a
+ref into an annotated field (or creating the holder with one) sets the target's parent, so the child
+cascade-deletes and deep-clones with its holder.
+
+```ts
+Schema.Struct({
+  // Single ref, array of refs, a field nested in a struct, and a member of a union field all work.
+  content: Ref.Ref(Text.Text).pipe(Annotation.SetParent.set(true)),
+  sections: Schema.Array(Ref.Ref(Section)).pipe(Annotation.SetParent.set(true)),
+});
+```
+
+Do NOT annotate a field whose targets may be parented elsewhere (e.g. `TaskSet.tasks`, where a
+sub-task's parent is its parent task) — every write to the holder would re-parent them to it.
+Removing a ref does not clear the target's parent; call `Obj.setParent(child, undefined)` for that.
+Reverse edges (child holds the ref) and ref-in-annotation edges (e.g. `Chat.CompanionChatAnnotation`)
+still need `Obj.setParent`.
+
 ## Related docs in-repo
 
 - Effect runtime patterns: [.cursor/skills/effect/SKILL.md](../effect/SKILL.md).

--- a/.agents/skills/echo/SKILL.md
+++ b/.agents/skills/echo/SKILL.md
@@ -164,8 +164,9 @@ export const make = (props: Obj.MakeProps<typeof Person>): Type.InstanceType<typ
 ## Owned children — `Annotation.SetParent`
 
 Declare ownership on the ref field rather than calling `Obj.setParent` next to every write. Writing a
-ref into an annotated field (or creating the holder with one) sets the target's parent, so the child
-cascade-deletes and deep-clones with its holder.
+ref into an annotated field (or creating the holder with one) sets an object-kind target's parent, so
+that child cascade-deletes and deep-clones with its holder. A ref to anything else (a relation) is
+left alone — only objects can have a parent.
 
 ```ts
 Schema.Struct({

--- a/.agents/skills/echo/SKILL.md
+++ b/.agents/skills/echo/SKILL.md
@@ -177,7 +177,10 @@ Schema.Struct({
 
 Do NOT annotate a field whose targets may be parented elsewhere (e.g. `TaskSet.tasks`, where a
 sub-task's parent is its parent task) — every write to the holder would re-parent them to it.
-Removing a ref does not clear the target's parent; call `Obj.setParent(child, undefined)` for that.
+The annotation updates the parent on write; it is not an invariant that the target's parent IS the
+holder — `Obj.setParent` can re-parent it afterwards, and an unresolved ref is skipped. Read the
+parent with `Obj.getParent`, never from the field. Removing a ref does not clear the target's
+parent; call `Obj.setParent(child, undefined)` for that.
 Reverse edges (child holds the ref) and ref-in-annotation edges (e.g. `Chat.CompanionChatAnnotation`)
 still need `Obj.setParent`.
 

--- a/.changeset/annotation-set-parent.md
+++ b/.changeset/annotation-set-parent.md
@@ -1,0 +1,8 @@
+---
+'@dxos/echo': minor
+'@dxos/plugin-markdown': minor
+---
+
+New `Annotation.SetParent` marks a `Ref` field (or an array-of-`Ref` field) as owning its targets: writing a ref into the field, or creating the holder with one, now sets the target's ECHO parent automatically, so the child cascade-deletes and deep-clones with its holder. Nested struct fields and members of a discriminated union field are covered too.
+
+Types across the repo now declare ownership on the field instead of calling `Obj.setParent` next to every write — `Instructions.text`, `Outline.content`, `Project.{instructions,outline,taskSet,routines}`, `Chat.feed`, `Agent.instructions`, `File.data`, `Channel.backend.config`, `Document.content`, `Mailbox`/`Calendar`/`Search`/`Subscription` feeds and tag indexes, `Routine.{spec.instructions,triggers}`, `Scene.objects`, `Terra.objects`, and `Artifact.variants`. Removing a ref still does not clear the target's parent; call `Obj.setParent(child, undefined)` for that.

--- a/packages/core/compute/assistant-toolkit/src/types/Agent.ts
+++ b/packages/core/compute/assistant-toolkit/src/types/Agent.ts
@@ -58,9 +58,12 @@ export class Agent extends Type.makeObject<Agent>(DXN.make('org.dxos.type.agent'
 
     /**
      * Instructions for the agent — the preset payload (text, skills, objects, commands) a chat
-     * receives when the agent is applied to it.
+     * receives when the agent is applied to it. Owned: `SetParent` cascades it with the agent.
      */
-    instructions: Ref.Ref(Instructions.Instructions).pipe(Schema.annotate({ title: 'Instructions' })),
+    instructions: Ref.Ref(Instructions.Instructions).pipe(
+      Annotation.SetParent.set(true),
+      Schema.annotate({ title: 'Instructions' }),
+    ),
   }).pipe(
     Annotation.LabelAnnotation.set(['name']),
     Annotation.IconAnnotation.set({ icon: 'ph--drone--regular', hue: 'amber' }),
@@ -157,7 +160,6 @@ export const makeInitialized = (
         enabled: props.enabled ?? true,
       }),
     );
-    Obj.setParent(instructions, agent);
     const feed = yield* Database.add(Feed.make());
     const runtime = yield* Effect.context<Database.Service>();
     const contextBinder = yield* EffectEx.acquireReleaseResource(() => new AiContextRuntime.Binder({ feed, runtime }));
@@ -173,7 +175,6 @@ export const makeInitialized = (
       }),
     );
     Chat.linkCompanion({ chat, subject: agent });
-    Obj.setParent(feed, chat);
     yield* Effect.promise(() =>
       contextBinder.bind({
         skills: [Ref.make(agentSkill), ...persistedPropsSkills],
@@ -223,7 +224,6 @@ export const resetChatHistory = (agent: Agent): Effect.Effect<void, EntityNotFou
       }),
     );
     Chat.linkCompanion({ chat, subject: agent });
-    Obj.setParent(feed, chat);
     yield* Effect.promise(() =>
       contextBinder.bind({
         skills,

--- a/packages/core/compute/assistant-toolkit/src/types/Chat.ts
+++ b/packages/core/compute/assistant-toolkit/src/types/Chat.ts
@@ -27,9 +27,9 @@ export class Chat extends Type.makeObject<Chat>(DXN.make('org.dxos.type.assistan
     viewType: Schema.String.pipe(Schema.optional),
 
     /**
-     * Message feed.
+     * Message feed. Owned by the chat: `SetParent` cascades it.
      */
-    feed: Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false)),
+    feed: Ref.Ref(Feed.Feed).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
 
     /**
      * Instructions steering this conversation, rendered into the system prompt at request time.

--- a/packages/core/compute/assistant-toolkit/src/types/Chat.ts
+++ b/packages/core/compute/assistant-toolkit/src/types/Chat.ts
@@ -26,9 +26,7 @@ export class Chat extends Type.makeObject<Chat>(DXN.make('org.dxos.type.assistan
     name: Schema.String.pipe(Schema.optional),
     viewType: Schema.String.pipe(Schema.optional),
 
-    /**
-     * Message feed. Owned by the chat: `SetParent` cascades it.
-     */
+    /** Message feed, owned by the chat so `SetParent` cascades it. */
     feed: Ref.Ref(Feed.Feed).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
 
     /**

--- a/packages/core/compute/compute/src/types/Instructions.ts
+++ b/packages/core/compute/compute/src/types/Instructions.ts
@@ -34,7 +34,9 @@ export class Instructions extends Type.makeObject<Instructions>(DXN.make('org.dx
     output: JsonSchema.JsonSchema.pipe(Annotation.FormInputAnnotation.set(false)).annotate({
       description: 'Output schema',
     }),
+    /** Owned body: `SetParent` cascades it and deep-clones it with the instructions. */
     text: Ref.Ref(Text.Text).pipe(
+      Annotation.SetParent.set(true),
       Format.FormatAnnotation.set(Format.TypeFormat.Markdown),
       Schema.annotate({ title: 'Instructions', description: 'Describe what the agent should do in each session.' }),
     ),
@@ -77,7 +79,7 @@ export const make = ({
   commands,
 }: MakeProps): Instructions => {
   const body = Text.make({ content: text ?? '' });
-  const instructions = Obj.make(Instructions, {
+  return Obj.make(Instructions, {
     name,
     description,
     input: JsonSchema.toJsonSchema(input ?? Schema.Void),
@@ -87,8 +89,4 @@ export const make = ({
     objects,
     commands,
   });
-  // The body is owned by the instructions: it cascade-deletes with it and is cloned alongside it under
-  // `Obj.clone(..., { deep: 'parent' })`.
-  Obj.setParent(body, instructions);
-  return instructions;
 };

--- a/packages/core/compute/compute/src/types/Project.ts
+++ b/packages/core/compute/compute/src/types/Project.ts
@@ -41,7 +41,7 @@ export class Project extends Type.makeObject<Project>(DXN.make('org.dxos.type.pr
     /** Artifacts (documents, outliners, tables, ...) the project owns, in order. */
     artifacts: Schema.Array(Ref.Ref(Obj.Unknown)).pipe(Annotation.FormInputAnnotation.set(false)),
 
-    /** Routines the project owns, in order. Parented, so they cascade-delete with the project. */
+    /** Routines the project owns, in order, parented so they cascade-delete with it. */
     routines: Schema.Array(Ref.Ref(Routine.Routine)).pipe(
       Annotation.SetParent.set(true),
       Annotation.FormInputAnnotation.set(false),

--- a/packages/core/compute/compute/src/types/Project.ts
+++ b/packages/core/compute/compute/src/types/Project.ts
@@ -33,20 +33,25 @@ export class Project extends Type.makeObject<Project>(DXN.make('org.dxos.type.pr
     /** Work-stream lifecycle state. */
     status: Schema.optional(ProjectStatus),
 
-    /** Owned agent instructions (created + parented at the plugin layer). */
-    instructions: Schema.optional(Ref.Ref(Instructions.Instructions).pipe(FormInlineAnnotation.set(true))),
+    /** Owned agent instructions (created at the plugin layer; parented by `SetParent`). */
+    instructions: Schema.optional(
+      Ref.Ref(Instructions.Instructions).pipe(Annotation.SetParent.set(true), FormInlineAnnotation.set(true)),
+    ),
 
     /** Artifacts (documents, outliners, tables, ...) the project owns, in order. */
     artifacts: Schema.Array(Ref.Ref(Obj.Unknown)).pipe(Annotation.FormInputAnnotation.set(false)),
 
     /** Routines the project owns, in order. Parented, so they cascade-delete with the project. */
-    routines: Schema.Array(Ref.Ref(Routine.Routine)).pipe(Annotation.FormInputAnnotation.set(false)),
+    routines: Schema.Array(Ref.Ref(Routine.Routine)).pipe(
+      Annotation.SetParent.set(true),
+      Annotation.FormInputAnnotation.set(false),
+    ),
 
     /** Ad hoc markdown checklist — the scratch surface; project chats write into it. */
-    outline: Schema.optional(Ref.Ref(Outline.Outline)),
+    outline: Schema.optional(Ref.Ref(Outline.Outline).pipe(Annotation.SetParent.set(true))),
 
     /** Owned (or adopted synced) task container, holding the project's tasks and milestones. */
-    taskSet: Schema.optional(Ref.Ref(TaskSet.TaskSet)),
+    taskSet: Schema.optional(Ref.Ref(TaskSet.TaskSet).pipe(Annotation.SetParent.set(true))),
 
     /**
      * Source repository this project's work lands in. Independent of `taskSet`: a project that
@@ -70,8 +75,7 @@ export class Project extends Type.makeObject<Project>(DXN.make('org.dxos.type.pr
  *
  * Materializes the owned task set and scratch outline unless the caller supplies them: there is no UI
  * to add either to a project that lacks one, so a project without them has nowhere to put its tasks
- * and nothing to draft in. Each parent edge is set alongside its ref so both cascade when the project
- * is deleted.
+ * and nothing to draft in. The parent edges follow from the fields' `SetParent` annotation.
  */
 export const make = (
   props: Omit<Partial<Obj.MakeProps<typeof Project>>, 'artifacts' | 'routines'> & {
@@ -81,32 +85,24 @@ export const make = (
   const project = Obj.make(Project, { ...props, artifacts: props.artifacts ?? [], routines: [] });
   if (!props.taskSet) {
     const taskSet = TaskSet.make();
-    // Ref before parent edge: the ref is what declares the edge (see `Obj.isDeclaredParentEdge`).
     Obj.update(project, (project) => {
       project.taskSet = Ref.make(taskSet);
     });
-    Obj.setParent(taskSet, project);
   }
   if (!props.outline) {
     const outline = Outline.make({ name: props.name });
     Obj.update(project, (project) => {
       project.outline = Ref.make(outline);
     });
-    Obj.setParent(outline, project);
-    // The outline's text is a separate object, parented to the outline so it cascades too.
-    if (outline.content.target) {
-      Obj.setParent(outline.content.target, outline);
-    }
   }
   return project;
 };
 
-/** Adds a routine to the project as an owned child: the ref, plus the parent edge that cascades it. */
+/** Adds a routine to the project as an owned child; `SetParent` on the field cascades it. */
 export const addRoutine = (project: Project, routine: Routine.Routine): void => {
   Obj.update(project, (project) => {
     project.routines = [...project.routines, Ref.make(routine)];
   });
-  Obj.setParent(routine, project);
 };
 
 /** Bindings a chat session should receive when running in a project's context. */

--- a/packages/core/compute/compute/src/types/Routine.ts
+++ b/packages/core/compute/compute/src/types/Routine.ts
@@ -25,7 +25,8 @@ const RunnableSpec = Schema.Struct({
 
 const InstructionsSpec = Schema.Struct({
   kind: Schema.Literal('instructions'),
-  instructions: Ref.Ref(Instructions.Instructions),
+  /** Owned by the routine: `SetParent` cascades it. */
+  instructions: Ref.Ref(Instructions.Instructions).pipe(Annotation.SetParent.set(true)),
 });
 
 const RoutineSpec = Schema.Union([RunnableSpec, InstructionsSpec]);
@@ -54,7 +55,7 @@ export class Routine extends Type.makeObject<Routine>(DXN.make('org.dxos.type.ro
      * because the runnable may be a shared registry operation referenced by multiple automations, which would
      * conflate triggers. MVP enforces length <= 1.
      */
-    triggers: Schema.Array(Ref.Ref(Trigger.Trigger)),
+    triggers: Schema.Array(Ref.Ref(Trigger.Trigger)).pipe(Annotation.SetParent.set(true)),
   }).pipe(
     LabelAnnotation.set(['name']),
     Annotation.IconAnnotation.set({ icon: 'ph--lightning--regular', hue: 'amber' }),

--- a/packages/core/echo/echo-client-e2e/src/parent.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/parent.test.ts
@@ -210,9 +210,9 @@ describe('Annotation.SetParent', () => {
       linked: Ref.make(linked),
     });
 
-    expect(Obj.getParent(body)).toBe(container);
-    expect(Obj.getParent(section)).toBe(container);
-    expect(Obj.getParent(config)).toBe(container);
+    expect(Obj.getParent(body)?.id).toBe(container.id);
+    expect(Obj.getParent(section)?.id).toBe(container.id);
+    expect(Obj.getParent(config)?.id).toBe(container.id);
     expect(Obj.getParent(linked)).toBeUndefined();
   });
 
@@ -227,8 +227,8 @@ describe('Annotation.SetParent', () => {
       container.sections = [Ref.make(section)];
     });
 
-    expect(Obj.getParent(body)).toBe(container);
-    expect(Obj.getParent(section)).toBe(container);
+    expect(Obj.getParent(body)?.id).toBe(container.id);
+    expect(Obj.getParent(section)?.id).toBe(container.id);
   });
 
   test('parent is set on write to a database object', async () => {
@@ -252,12 +252,12 @@ describe('Annotation.SetParent', () => {
     Obj.update(container, (container) => {
       container.body = Ref.make(body);
     });
-    expect(Obj.getParent(body)).toBe(container);
+    expect(Obj.getParent(body)?.id).toBe(container.id);
 
     Obj.update(other, (other) => {
       other.body = Ref.make(body);
     });
-    expect(Obj.getParent(body)).toBe(other);
+    expect(Obj.getParent(body)?.id).toBe(other.id);
   });
 
   test('owned child cascade-deletes with its holder', { timeout: 30_000 }, async () => {

--- a/packages/core/echo/echo-client-e2e/src/parent.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/parent.test.ts
@@ -188,8 +188,6 @@ describe('Annotation.SetParent', () => {
     }),
   ) {}
 
-  const makeBody = (text: string) => Obj.make(Body, { text });
-
   let builder: EchoTestBuilder;
 
   beforeEach(async () => {
@@ -201,10 +199,10 @@ describe('Annotation.SetParent', () => {
   });
 
   test('parent is set on creation', async () => {
-    const body = makeBody('body');
-    const section = makeBody('section');
-    const config = makeBody('config');
-    const linked = makeBody('linked');
+    const body = Obj.make(Body, { text: 'body' });
+    const section = Obj.make(Body, { text: 'section' });
+    const config = Obj.make(Body, { text: 'config' });
+    const linked = Obj.make(Body, { text: 'linked' });
     const container = Obj.make(Container, {
       body: Ref.make(body),
       sections: [Ref.make(section)],
@@ -220,8 +218,8 @@ describe('Annotation.SetParent', () => {
 
   test('parent is set on write', async () => {
     const container = Obj.make(Container, { sections: [] });
-    const body = makeBody('body');
-    const section = makeBody('section');
+    const body = Obj.make(Body, { text: 'body' });
+    const section = Obj.make(Body, { text: 'section' });
     expect(Obj.getParent(body)).toBeUndefined();
 
     Obj.update(container, (container) => {
@@ -238,7 +236,7 @@ describe('Annotation.SetParent', () => {
     await using db = await peer.createDatabase();
 
     const container = db.add(Obj.make(Container, { sections: [] }));
-    const body = db.add(makeBody('body'));
+    const body = db.add(Obj.make(Body, { text: 'body' }));
     Obj.update(container, (container) => {
       container.body = Ref.make(body);
     });
@@ -249,7 +247,7 @@ describe('Annotation.SetParent', () => {
   test('re-parents when the ref is replaced', async () => {
     const container = Obj.make(Container, { sections: [] });
     const other = Obj.make(Container, { sections: [] });
-    const body = makeBody('body');
+    const body = Obj.make(Body, { text: 'body' });
 
     Obj.update(container, (container) => {
       container.body = Ref.make(body);
@@ -266,7 +264,7 @@ describe('Annotation.SetParent', () => {
     await using peer = await builder.createPeer({ types: [Body, Container] });
     await using db = await peer.createDatabase();
 
-    const body = db.add(makeBody('body'));
+    const body = db.add(Obj.make(Body, { text: 'body' }));
     const container = db.add(Obj.make(Container, { sections: [], body: Ref.make(body) }));
     await db.flush();
 

--- a/packages/core/echo/echo-client-e2e/src/parent.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/parent.test.ts
@@ -2,13 +2,14 @@
 // Copyright 2024 DXOS.org
 //
 
+import * as Schema from 'effect/Schema';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
-import { Filter, Obj } from '@dxos/echo';
+import { Annotation, Filter, Obj, Ref, Type } from '@dxos/echo';
 import { EchoTestBuilder } from '@dxos/echo-client/testing';
 import { TestSchema } from '@dxos/echo/testing';
 import { invariant } from '@dxos/invariant';
-import { PublicKey } from '@dxos/keys';
+import { DXN, PublicKey } from '@dxos/keys';
 
 describe('Parent Hierarchy', () => {
   let builder: EchoTestBuilder;
@@ -166,5 +167,110 @@ describe('Parent Hierarchy', () => {
       const queryResult = await db.query(Filter.id(childId)).run();
       expect(queryResult.length).to.eq(0);
     }
+  });
+});
+
+describe('Annotation.SetParent', () => {
+  class Body extends Type.makeObject<Body>(DXN.make('com.example.type.body', '0.1.0'))(
+    Schema.Struct({ text: Schema.String }),
+  ) {}
+
+  class Container extends Type.makeObject<Container>(DXN.make('com.example.type.container', '0.1.0'))(
+    Schema.Struct({
+      /** Owned. */
+      body: Schema.optional(Ref.Ref(Body).pipe(Annotation.SetParent.set(true))),
+      /** Owned, ordered. */
+      sections: Schema.Array(Ref.Ref(Body)).pipe(Annotation.SetParent.set(true)),
+      /** Owned, nested inside a plain struct. */
+      backend: Schema.optional(Schema.Struct({ config: Ref.Ref(Body).pipe(Annotation.SetParent.set(true)) })),
+      /** NOT owned — a plain reference. */
+      linked: Schema.optional(Ref.Ref(Body)),
+    }),
+  ) {}
+
+  const makeBody = (text: string) => Obj.make(Body, { text });
+
+  let builder: EchoTestBuilder;
+
+  beforeEach(async () => {
+    builder = await new EchoTestBuilder().open();
+  });
+
+  afterEach(async () => {
+    await builder.close();
+  });
+
+  test('parent is set on creation', async () => {
+    const body = makeBody('body');
+    const section = makeBody('section');
+    const config = makeBody('config');
+    const linked = makeBody('linked');
+    const container = Obj.make(Container, {
+      body: Ref.make(body),
+      sections: [Ref.make(section)],
+      backend: { config: Ref.make(config) },
+      linked: Ref.make(linked),
+    });
+
+    expect(Obj.getParent(body)).toBe(container);
+    expect(Obj.getParent(section)).toBe(container);
+    expect(Obj.getParent(config)).toBe(container);
+    expect(Obj.getParent(linked)).toBeUndefined();
+  });
+
+  test('parent is set on write', async () => {
+    const container = Obj.make(Container, { sections: [] });
+    const body = makeBody('body');
+    const section = makeBody('section');
+    expect(Obj.getParent(body)).toBeUndefined();
+
+    Obj.update(container, (container) => {
+      container.body = Ref.make(body);
+      container.sections = [Ref.make(section)];
+    });
+
+    expect(Obj.getParent(body)).toBe(container);
+    expect(Obj.getParent(section)).toBe(container);
+  });
+
+  test('parent is set on write to a database object', async () => {
+    await using peer = await builder.createPeer({ types: [Body, Container] });
+    await using db = await peer.createDatabase();
+
+    const container = db.add(Obj.make(Container, { sections: [] }));
+    const body = db.add(makeBody('body'));
+    Obj.update(container, (container) => {
+      container.body = Ref.make(body);
+    });
+
+    expect(Obj.getParent(body)?.id).toBe(container.id);
+  });
+
+  test('re-parents when the ref is replaced', async () => {
+    const container = Obj.make(Container, { sections: [] });
+    const other = Obj.make(Container, { sections: [] });
+    const body = makeBody('body');
+
+    Obj.update(container, (container) => {
+      container.body = Ref.make(body);
+    });
+    expect(Obj.getParent(body)).toBe(container);
+
+    Obj.update(other, (other) => {
+      other.body = Ref.make(body);
+    });
+    expect(Obj.getParent(body)).toBe(other);
+  });
+
+  test('owned child cascade-deletes with its holder', { timeout: 30_000 }, async () => {
+    await using peer = await builder.createPeer({ types: [Body, Container] });
+    await using db = await peer.createDatabase();
+
+    const body = db.add(makeBody('body'));
+    const container = db.add(Obj.make(Container, { sections: [], body: Ref.make(body) }));
+    await db.flush();
+
+    db.remove(container);
+    expect(Obj.isDeleted(body)).to.be.true;
   });
 });

--- a/packages/core/echo/echo/src/Annotation.test.ts
+++ b/packages/core/echo/echo/src/Annotation.test.ts
@@ -698,13 +698,11 @@ describe('Annotation', () => {
       }),
     ) {}
 
-    const makeBody = (text: string) => Obj.make(Body, { text });
-
     test('parents the targets of annotated fields on creation', ({ expect }) => {
-      const body = makeBody('body');
-      const section = makeBody('section');
-      const config = makeBody('config');
-      const linked = makeBody('linked');
+      const body = Obj.make(Body, { text: 'body' });
+      const section = Obj.make(Body, { text: 'section' });
+      const config = Obj.make(Body, { text: 'config' });
+      const linked = Obj.make(Body, { text: 'linked' });
       const holder = Obj.make(Holder, {
         body: Ref.make(body),
         sections: [Ref.make(section)],
@@ -722,7 +720,7 @@ describe('Annotation', () => {
     test('parents the target on write, and re-parents when the ref moves', ({ expect }) => {
       const holder = Obj.make(Holder, { sections: [] });
       const other = Obj.make(Holder, { sections: [] });
-      const body = makeBody('body');
+      const body = Obj.make(Body, { text: 'body' });
       expect(Obj.getParent(body)).toBeUndefined();
 
       Obj.update(holder, (holder) => {
@@ -738,7 +736,7 @@ describe('Annotation', () => {
 
     test('appending to an annotated array field parents the appended target', ({ expect }) => {
       const holder = Obj.make(Holder, { sections: [] });
-      const section = makeBody('section');
+      const section = Obj.make(Body, { text: 'section' });
 
       Obj.update(holder, (holder) => {
         holder.sections.push(Ref.make(section));

--- a/packages/core/echo/echo/src/Annotation.test.ts
+++ b/packages/core/echo/echo/src/Annotation.test.ts
@@ -683,4 +683,68 @@ describe('Annotation', () => {
       });
     });
   });
+
+  describe('SetParent', () => {
+    class Body extends Type.makeObject<Body>(DXN.make('com.example.type.setParentBody', '0.1.0'))(
+      Schema.Struct({ text: Schema.String }),
+    ) {}
+
+    class Holder extends Type.makeObject<Holder>(DXN.make('com.example.type.setParentHolder', '0.1.0'))(
+      Schema.Struct({
+        body: Schema.optional(Ref.Ref(Body).pipe(Annotation.SetParent.set(true))),
+        sections: Schema.Array(Ref.Ref(Body)).pipe(Annotation.SetParent.set(true)),
+        nested: Schema.optional(Schema.Struct({ config: Ref.Ref(Body).pipe(Annotation.SetParent.set(true)) })),
+        linked: Schema.optional(Ref.Ref(Body)),
+      }),
+    ) {}
+
+    const makeBody = (text: string) => Obj.make(Body, { text });
+
+    test('parents the targets of annotated fields on creation', ({ expect }) => {
+      const body = makeBody('body');
+      const section = makeBody('section');
+      const config = makeBody('config');
+      const linked = makeBody('linked');
+      const holder = Obj.make(Holder, {
+        body: Ref.make(body),
+        sections: [Ref.make(section)],
+        nested: { config: Ref.make(config) },
+        linked: Ref.make(linked),
+      });
+
+      expect(Obj.getParent(body)).toBe(holder);
+      expect(Obj.getParent(section)).toBe(holder);
+      expect(Obj.getParent(config)).toBe(holder);
+      // An un-annotated ref field is a plain reference, not ownership.
+      expect(Obj.getParent(linked)).toBeUndefined();
+    });
+
+    test('parents the target on write, and re-parents when the ref moves', ({ expect }) => {
+      const holder = Obj.make(Holder, { sections: [] });
+      const other = Obj.make(Holder, { sections: [] });
+      const body = makeBody('body');
+      expect(Obj.getParent(body)).toBeUndefined();
+
+      Obj.update(holder, (holder) => {
+        holder.body = Ref.make(body);
+      });
+      expect(Obj.getParent(body)).toBe(holder);
+
+      Obj.update(other, (other) => {
+        other.body = Ref.make(body);
+      });
+      expect(Obj.getParent(body)).toBe(other);
+    });
+
+    test('appending to an annotated array field parents the appended target', ({ expect }) => {
+      const holder = Obj.make(Holder, { sections: [] });
+      const section = makeBody('section');
+
+      Obj.update(holder, (holder) => {
+        holder.sections.push(Ref.make(section));
+      });
+
+      expect(Obj.getParent(section)).toBe(holder);
+    });
+  });
 });

--- a/packages/core/echo/echo/src/Annotation.test.ts
+++ b/packages/core/echo/echo/src/Annotation.test.ts
@@ -710,9 +710,9 @@ describe('Annotation', () => {
         linked: Ref.make(linked),
       });
 
-      expect(Obj.getParent(body)).toBe(holder);
-      expect(Obj.getParent(section)).toBe(holder);
-      expect(Obj.getParent(config)).toBe(holder);
+      expect(Obj.getParent(body)?.id).toBe(holder.id);
+      expect(Obj.getParent(section)?.id).toBe(holder.id);
+      expect(Obj.getParent(config)?.id).toBe(holder.id);
       // An un-annotated ref field is a plain reference, not ownership.
       expect(Obj.getParent(linked)).toBeUndefined();
     });
@@ -726,12 +726,12 @@ describe('Annotation', () => {
       Obj.update(holder, (holder) => {
         holder.body = Ref.make(body);
       });
-      expect(Obj.getParent(body)).toBe(holder);
+      expect(Obj.getParent(body)?.id).toBe(holder.id);
 
       Obj.update(other, (other) => {
         other.body = Ref.make(body);
       });
-      expect(Obj.getParent(body)).toBe(other);
+      expect(Obj.getParent(body)?.id).toBe(other.id);
     });
 
     test('appending to an annotated array field parents the appended target', ({ expect }) => {
@@ -742,7 +742,7 @@ describe('Annotation', () => {
         holder.sections.push(Ref.make(section));
       });
 
-      expect(Obj.getParent(section)).toBe(holder);
+      expect(Obj.getParent(section)?.id).toBe(holder.id);
     });
   });
 });

--- a/packages/core/echo/echo/src/Annotation.ts
+++ b/packages/core/echo/echo/src/Annotation.ts
@@ -26,6 +26,7 @@ export {
   ReferenceAnnotation,
   ReferenceAnnotationId,
   type ReferenceAnnotationValue,
+  SetParentAnnotation as SetParent,
   TypeAnnotation,
   getDescriptionWithSchema,
   getLabelWithSchema,

--- a/packages/core/echo/echo/src/Obj.ts
+++ b/packages/core/echo/echo/src/Obj.ts
@@ -201,7 +201,7 @@ export function make(input: Type.AnyObj, props: any): OfShape<any> {
     }
   }
 
-  return internal.makeObject(
+  const obj = internal.makeObject(
     schema,
     filterUndefined,
     {
@@ -210,6 +210,9 @@ export function make(input: Type.AnyObj, props: any): OfShape<any> {
     },
     input,
   );
+
+  internal.propagateParentAnnotations(obj);
+  return obj;
 }
 
 /**
@@ -382,6 +385,7 @@ export type Mutable<T> = internal.Mutable<T>;
  */
 export const update = <T extends Unknown>(obj: T, callback: internal.ChangeCallback<T>): T => {
   internal.change(obj, callback);
+  internal.propagateParentAnnotations(obj);
   return obj;
 };
 

--- a/packages/core/echo/echo/src/internal/Annotation/annotations.ts
+++ b/packages/core/echo/echo/src/internal/Annotation/annotations.ts
@@ -560,8 +560,12 @@ export const IconFromRefAnnotation = makeUserAnnotation<string>({
  * Marks a `Ref` field (or an array-of-`Ref` field) as owning its targets: writing a ref into the
  * field, or creating the holder with one, sets the target's parent to the holding object.
  *
- * Removing a ref does NOT clear the target's parent — a move between holders would otherwise
- * lose the edge depending on write order; call `Obj.setParent(child, undefined)` explicitly.
+ * This is NOT an invariant: it does not guarantee that a target held here has this object as its
+ * parent, only that a write through this field updates the parent. Nothing stops `Obj.setParent`
+ * from re-parenting the target afterwards, a ref whose target is not resolved is left alone, and
+ * removing a ref does NOT clear the target's parent — a move between holders would otherwise lose
+ * the edge depending on write order; call `Obj.setParent(child, undefined)` explicitly. Read the
+ * parent with `Obj.getParent`; never infer it from the field.
  *
  * @example
  * ```ts

--- a/packages/core/echo/echo/src/internal/Annotation/annotations.ts
+++ b/packages/core/echo/echo/src/internal/Annotation/annotations.ts
@@ -557,6 +557,25 @@ export const IconFromRefAnnotation = makeUserAnnotation<string>({
 });
 
 /**
+ * Marks a `Ref` field (or an array-of-`Ref` field) as owning its targets: writing a ref into the
+ * field, or creating the holder with one, sets the target's parent to the holding object.
+ *
+ * Removing a ref does NOT clear the target's parent — a move between holders would otherwise
+ * lose the edge depending on write order; call `Obj.setParent(child, undefined)` explicitly.
+ *
+ * @example
+ * ```ts
+ * Schema.Struct({
+ *   body: Ref.Ref(Text.Text).pipe(Annotation.SetParent.set(true)),
+ * })
+ * ```
+ */
+export const SetParentAnnotation = makeUserAnnotation<boolean>({
+  id: 'org.dxos.annotation.setParent',
+  schema: Schema.Boolean,
+});
+
+/**
  * Options for {@link getLabel}.
  */
 export type GetLabelOptions = {

--- a/packages/core/echo/echo/src/internal/Obj/index.ts
+++ b/packages/core/echo/echo/src/internal/Obj/index.ts
@@ -6,6 +6,7 @@ export * from './common';
 export * from './create-object';
 export * from './deleted';
 export * from './json-serializer';
+export * from './parent-annotation';
 export * from './set-value';
 export * from './snapshot';
 export * from './typed-object';

--- a/packages/core/echo/echo/src/internal/Obj/parent-annotation.ts
+++ b/packages/core/echo/echo/src/internal/Obj/parent-annotation.ts
@@ -1,0 +1,105 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Option from 'effect/Option';
+
+import { SchemaAST, SchemaEx } from '@dxos/effect';
+
+import { SetParentAnnotation, getFromAst } from '../Annotation';
+import { KindId, ParentId, getSchema } from '../common/types';
+import { EntityKind } from '../common/types/entity';
+import { Ref } from '../Ref/ref';
+
+/** Path to an owning field, relative to the holder (nested inside plain structs, e.g. `backend.config`). */
+type Path = readonly string[];
+
+/**
+ * Owning-field paths relative to an AST node, per {@link SetParentAnnotation}. Memoized per node —
+ * a schema's annotations do not change once it is built (a dynamic type rebuilds its AST, yielding
+ * fresh keys) — which also keeps the walk linear in nodes over a schema whose nested types repeat.
+ */
+const cache = new WeakMap<SchemaAST.AST, readonly Path[]>();
+
+const isOwning = (ast: SchemaAST.AST): boolean => Option.getOrElse(getFromAst(ast, SetParentAnnotation), () => false);
+
+const collect = (ast: SchemaAST.AST): readonly Path[] => {
+  const cached = cache.get(ast);
+  if (cached) {
+    return cached;
+  }
+  // Seed before recursing: a self-referencing `Schema.suspend` field resolves back to this node, and
+  // an owned field is declared at the level it appears on, so the cycle contributes nothing further.
+  cache.set(ast, []);
+
+  const paths: Path[] = [];
+  // A union of structs (e.g. a discriminated `spec`) contributes each member's fields at this path.
+  if (SchemaAST.isUnion(ast)) {
+    for (const member of ast.types) {
+      paths.push(...collect(member));
+    }
+  } else {
+    for (const property of SchemaAST.getPropertySignatures(ast)) {
+      if (typeof property.name !== 'string') {
+        continue;
+      }
+      // Optionality wraps the field schema in a union; for an array of refs the annotation may sit
+      // on either the array or its element.
+      const unwrapped = SchemaEx.unwrapOptional(property.type);
+      const element = SchemaEx.getArrayElementType(unwrapped);
+      if (isOwning(property.type) || isOwning(unwrapped) || (element != null && isOwning(element))) {
+        paths.push([property.name]);
+      } else {
+        // Recurse into nested structs and unions of structs (a ref is a Declaration, which
+        // terminates the walk).
+        const name = property.name;
+        paths.push(...collect(unwrapped).map((path): Path => [name, ...path]));
+      }
+    }
+  }
+
+  cache.set(ast, paths);
+  return paths;
+};
+
+const setParent = (value: unknown, parent: unknown): void => {
+  if (!Ref.isRef(value)) {
+    return;
+  }
+  // Only an already-resolved target can be re-parented synchronously; an unresolved ref names an
+  // object whose parent edge is either already written or not this holder's to write. `.target`
+  // throws on a ref with neither an inlined target nor a resolver, so gate on `isAvailable`.
+  const target: any = value.isAvailable ? value.target : undefined;
+  if (target == null || target[KindId] !== EntityKind.Object || target[ParentId] === parent) {
+    return;
+  }
+  target[ParentId] = parent;
+};
+
+/**
+ * Propagates the parent edge declared by an object's {@link SetParentAnnotation} fields: every
+ * resolved ref target held in an owning field gets its parent set to the holding object.
+ *
+ * Called after object creation (`Obj.make`) and after every change transaction (`Obj.update`) —
+ * idempotent, so re-running it over unchanged fields is a no-op.
+ */
+export const propagateParentAnnotations = (obj: unknown): void => {
+  const schema = getSchema(obj);
+  if (schema == null) {
+    return;
+  }
+
+  for (const path of collect(schema.ast)) {
+    let value: any = obj;
+    for (const key of path) {
+      value = value?.[key];
+    }
+    if (Array.isArray(value)) {
+      for (const element of value) {
+        setParent(element, obj);
+      }
+    } else {
+      setParent(value, obj);
+    }
+  }
+};

--- a/packages/core/echo/echo/src/internal/Obj/parent-annotation.ts
+++ b/packages/core/echo/echo/src/internal/Obj/parent-annotation.ts
@@ -70,7 +70,13 @@ const setParent = (value: unknown, parent: unknown): void => {
   // object whose parent edge is either already written or not this holder's to write. `.target`
   // throws on a ref with neither an inlined target nor a resolver, so gate on `isAvailable`.
   const target: any = value.isAvailable ? value.target : undefined;
-  if (target == null || target[KindId] !== EntityKind.Object || target[ParentId] === parent) {
+  if (target == null || target[KindId] !== EntityKind.Object) {
+    return;
+  }
+  // By id, not identity: the database resolves a parent edge through the working set, which may
+  // hand back a different proxy for the same entity — an identity compare would miss the
+  // short-circuit and re-write the unchanged edge on every update of the holder.
+  if (target[ParentId]?.id === (parent as any)?.id) {
     return;
   }
   target[ParentId] = parent;

--- a/packages/devtools/cli/src/commands/chat/processor.ts
+++ b/packages/devtools/cli/src/commands/chat/processor.ts
@@ -112,7 +112,6 @@ export class ChatProcessor {
 
     const feed = space.db.add(Feed.make());
     const chat = Chat.make({ feed: Ref.make(feed) });
-    Obj.setParent(feed, chat);
     space.db.add(chat);
 
     const runtime = await EffectEx.runAndForwardErrors(

--- a/packages/plugins/plugin-assistant/src/operations/create-chat.ts
+++ b/packages/plugins/plugin-assistant/src/operations/create-chat.ts
@@ -10,7 +10,7 @@ import { AiContext } from '@dxos/assistant';
 import { AgentWizardSkill, AlarmSkill, Chat, ChatContextSkill } from '@dxos/assistant-toolkit';
 import * as Operation from '@dxos/compute/Operation';
 import * as Skill from '@dxos/compute/Skill';
-import { Database, Feed, Obj, Ref } from '@dxos/echo';
+import { Database, Feed, Ref } from '@dxos/echo';
 import * as DatabaseSkill from '@dxos/plugin-space/DatabaseSkill';
 
 import { AssistantSkill } from '#skills';
@@ -28,7 +28,6 @@ const handler: Operation.WithHandler<typeof AssistantOperation.CreateChat> = Ass
       //  memory too — nothing needs to write to a feed before its chat is in the database.
       const feed = db.add(Feed.make());
       const chat = Chat.make({ name, feed: Ref.make(feed), instructions });
-      Obj.setParent(feed, chat);
 
       // Dynamic import to avoid circular dependency with the barrel that also exports SkillManagerHandlers.
       const { SkillManagerSkill } = yield* Effect.promise(() => import('@dxos/assistant-toolkit'));

--- a/packages/plugins/plugin-blogger/src/types/Blog.ts
+++ b/packages/plugins/plugin-blogger/src/types/Blog.ts
@@ -29,8 +29,9 @@ export class Post extends Type.makeObject<Post>(DXN.make('org.dxos.type.blogger.
     status: PostStatus.pipe(FormInputAnnotation.set(false)),
     outline: Ref.Ref(Text.Text)
       .pipe(Format.FormatAnnotation.set(Format.TypeFormat.Markdown))
-      .annotate({ description: 'Post outline and/or instructions.' }),
-    content: Ref.Ref(Markdown.Document).pipe(FormInputAnnotation.set(false)),
+      .annotate({ description: 'Post outline and/or instructions.' })
+      .pipe(Annotation.SetParent.set(true)),
+    content: Ref.Ref(Markdown.Document).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
   }).pipe(
     LabelAnnotation.set(['name']),
     Annotation.IconAnnotation.set({ icon: 'ph--article--regular', hue: 'indigo' }),
@@ -65,7 +66,8 @@ export class Publication extends Type.makeObject<Publication>(DXN.make('org.dxos
     name: Schema.optional(Schema.String),
     instructions: Ref.Ref(Text.Text)
       .pipe(Format.FormatAnnotation.set(Format.TypeFormat.Markdown))
-      .annotate({ description: 'Publication instructions.' }),
+      .annotate({ description: 'Publication instructions.' })
+      .pipe(Annotation.SetParent.set(true)),
     posts: Schema.Array(Ref.Ref(Post)).pipe(FormInputAnnotation.set(false), Schema.optional),
   }).pipe(
     LabelAnnotation.set(['name']),
@@ -88,22 +90,18 @@ export const makePost = ({
 }: { name?: string; description?: string; content?: string } = {}): Post => {
   const outline = Text.make();
   const body = Markdown.make({ content });
-  const post = Obj.make(Post, {
+  // The outline and body are owned (`SetParent`): both cascade-delete with the post.
+  return Obj.make(Post, {
     name,
     description,
     status: 'draft',
     outline: Ref.make(outline),
     content: Ref.make(body),
   });
-  Obj.setParent(outline, post);
-  Obj.setParent(body, post);
-  return post;
 };
 
 /** Creates a `Publication` with a fresh instructions text and no posts. */
 export const makePublication = ({ name }: { name?: string } = {}): Publication => {
   const instructions = Text.make();
-  const publication = Obj.make(Publication, { name, instructions: Ref.make(instructions), posts: [] });
-  Obj.setParent(instructions, publication);
-  return publication;
+  return Obj.make(Publication, { name, instructions: Ref.make(instructions), posts: [] });
 };

--- a/packages/plugins/plugin-chess-com/src/operations/clear-synced-games.ts
+++ b/packages/plugins/plugin-chess-com/src/operations/clear-synced-games.ts
@@ -28,7 +28,6 @@ export default ChessComOperation.ClearSyncedGames.pipe(
       const states = yield* Feed.query(oldFeed, Filter.type(Chess.State)).run;
 
       const newFeed = yield* Database.add(Feed.make());
-      Obj.setParent(newFeed, account);
       Obj.update(account, (account) => {
         account.games = Ref.make(newFeed);
       });

--- a/packages/plugins/plugin-chess-com/src/types/ChessComAccount.ts
+++ b/packages/plugins/plugin-chess-com/src/types/ChessComAccount.ts
@@ -43,7 +43,7 @@ export class Account extends Type.makeObject<Account>(DXN.make('org.dxos.type.ch
       Schema.optional,
     ),
     /** Backing queue of synced {@link org.dxos.type.game} objects. */
-    games: Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false)),
+    games: Ref.Ref(Feed.Feed).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
   }).pipe(
     LabelAnnotation.set(['username']),
     Annotation.IconAnnotation.set({ icon: 'ph--horse--regular', hue: 'green' }),
@@ -70,13 +70,13 @@ export type AccountProfile = Pick<
 export const makeAccount = (props: Omit<Obj.MakeProps<typeof Account>, 'games'> & { username: string }): Account => {
   const gamesFeed = Feed.make();
   const username = normalizeUsername(props.username);
+  // `SetParent` on `games` makes the feed a child, cascading with the account.
   const account = Obj.make(Account, {
     ...props,
     username,
     games: Ref.make(gamesFeed),
     [Obj.Meta]: { keys: [{ source: CHESS_COM_SOURCE, id: username }] },
   });
-  Obj.setParent(gamesFeed, account);
   return account;
 };
 

--- a/packages/plugins/plugin-chess/src/types/PlayerReview.ts
+++ b/packages/plugins/plugin-chess/src/types/PlayerReview.ts
@@ -22,7 +22,11 @@ export class Review extends Type.makeObject<Review>(DXN.make('org.dxos.type.ches
     playerIdentity: Schema.String.pipe(FormInputAnnotation.set(false), Schema.optional),
     /** Display name fallback when identity is absent (e.g. Chess.com username). */
     playerName: Schema.String.pipe(Schema.optional),
-    positionIndex: Ref.Ref(ChessPositionIndex.PositionIndex).pipe(FormInputAnnotation.set(false)),
+    /** Owned index: `SetParent` cascades it with the review. */
+    positionIndex: Ref.Ref(ChessPositionIndex.PositionIndex).pipe(
+      Annotation.SetParent.set(true),
+      FormInputAnnotation.set(false),
+    ),
   }).pipe(
     LabelAnnotation.set(['name']),
     Annotation.IconAnnotation.set({ icon: 'ph--chart-polar--regular', hue: 'amber' }),
@@ -38,11 +42,9 @@ export type MakeReviewProps = {
 /** Creates a player review with an empty child position index. */
 export const makeReview = (props: MakeReviewProps = {}): Review => {
   const positionIndex = ChessPositionIndex.make();
-  const review = Obj.make(Review, {
+  return Obj.make(Review, {
     ...props,
     name: props.name ?? props.playerName ?? 'Player review',
     positionIndex: Ref.make(positionIndex),
   });
-  Obj.setParent(positionIndex, review);
-  return review;
 };

--- a/packages/plugins/plugin-code/src/types/SourceFile.ts
+++ b/packages/plugins/plugin-code/src/types/SourceFile.ts
@@ -14,7 +14,8 @@ import { meta } from '#meta';
 export class SourceFile extends Type.makeObject<SourceFile>(DXN.make('org.dxos.type.sourceFile', '0.1.0'))(
   Schema.Struct({
     path: Schema.String,
-    content: Ref.Ref(Text.Text),
+    /** Owned body: `SetParent` cascades it with the file. */
+    content: Ref.Ref(Text.Text).pipe(Annotation.SetParent.set(true)),
     mode: Schema.optional(Schema.Number),
   }).pipe(
     Annotation.LabelAnnotation.set(['path']),
@@ -26,11 +27,9 @@ export const isSourceFile = (object: unknown): object is SourceFile =>
   Schema.is(Type.getSchema(SourceFile) as Schema.Schema<SourceFile>)(object);
 
 export const make = ({ path, content = '', mode }: { path: string; content?: string; mode?: number }) => {
-  const file = Obj.make(SourceFile, {
+  return Obj.make(SourceFile, {
     path,
     content: Ref.make(Text.make({ content })),
     ...(mode !== undefined ? { mode } : {}),
   });
-  Obj.setParent(file.content.target!, file);
-  return file;
 };

--- a/packages/plugins/plugin-code/src/types/Spec.ts
+++ b/packages/plugins/plugin-code/src/types/Spec.ts
@@ -16,7 +16,8 @@ import { meta } from '#meta';
 export class Spec extends Type.makeObject<Spec>(DXN.make('org.dxos.type.spec', '0.1.0'))(
   Schema.Struct({
     name: Schema.optional(Schema.String),
-    content: Ref.Ref(Text.Text).pipe(FormInputAnnotation.set(false)),
+    /** Owned body: `SetParent` cascades it with the spec. */
+    content: Ref.Ref(Text.Text).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
   }).pipe(
     Annotation.IconAnnotation.set({ icon: meta.profile.icon?.key ?? 'ph--code--regular', hue: meta.profile.icon?.hue }),
   ),
@@ -26,9 +27,7 @@ export const isSpec = (object: unknown): object is Spec =>
   Schema.is(Type.getSchema(Spec) as Schema.Schema<Spec>)(object);
 
 export const make = ({ content = DEFAULT_SPEC_CONTENT, ...props }: Partial<{ name: string; content: string }> = {}) => {
-  const spec = Obj.make(Spec, { ...props, content: Ref.make(Text.make({ content })) });
-  Obj.setParent(spec.content.target!, spec);
-  return spec;
+  return Obj.make(Spec, { ...props, content: Ref.make(Text.make({ content })) });
 };
 
 const DEFAULT_SPEC_CONTENT = trim`

--- a/packages/plugins/plugin-commerce/src/types/Search.ts
+++ b/packages/plugins/plugin-commerce/src/types/Search.ts
@@ -21,9 +21,9 @@ export class Search extends Type.makeObject<Search>(DXN.make('org.dxos.type.comm
     /** Values for the union of provider fields, keyed by field name. */
     params: Schema.Record(Schema.String, Schema.Unknown).pipe(FormInputAnnotation.set(false)),
     /** Backing ECHO feed (queue) of immutable Result entries appended by each run. */
-    feed: Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false)),
+    feed: Ref.Ref(Feed.Feed).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
     /** Per-Result tags keyed by tag uri → Result ids (the `starred` flag — see {@link STARRED_TAG}). */
-    tags: Ref.Ref(TagIndex.TagIndex).pipe(FormInputAnnotation.set(false)),
+    tags: Ref.Ref(TagIndex.TagIndex).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
     /**
      * Timestamp of the last run; persisted metadata, hidden from forms.
      * Run progress itself is ephemeral UI state (see SearchForm), not a persisted property.
@@ -47,17 +47,14 @@ export const make = (
 ): Search => {
   const feed = Feed.make();
   const tags = TagIndex.make();
-  const search = Obj.make(Search, {
+  // The feed and tag index are children (`SetParent`): both cascade-delete with the search.
+  return Obj.make(Search, {
     ...props,
     providers: props.providers ?? [],
     params: props.params ?? {},
     feed: Ref.make(feed),
     tags: Ref.make(tags),
   });
-  Obj.setParent(feed, search);
-  // Tag index is a child: cascade-deleted with the search.
-  Obj.setParent(tags, search);
-  return search;
 };
 
 /** Resolves the uri of the `starred` {@link Tag} if it exists (does not create one). Async. */

--- a/packages/plugins/plugin-ibkr/src/types/Ibkr.ts
+++ b/packages/plugins/plugin-ibkr/src/types/Ibkr.ts
@@ -229,7 +229,8 @@ export type Report = Type.InstanceType<typeof Report>;
  */
 export const Portfolio = Schema.Struct({
   name: Schema.String.pipe(Schema.optional),
-  feed: Ref.Ref(Feed.Feed),
+  /** Owned feed: `SetParent` cascades it with the portfolio. */
+  feed: Ref.Ref(Feed.Feed).pipe(Annotation.SetParent.set(true)),
 }).pipe(
   Annotation.IconAnnotation.set({ icon: 'ph--chart-line--regular', hue: 'green' }),
   // Offer "Connect Interactive Brokers" in the portfolio toolbar. IBKR has no external-sync Cursor, so
@@ -251,9 +252,7 @@ type PortfolioProps = Omit<Obj.MakeProps<typeof Portfolio>, 'feed'>;
  */
 export const makePortfolio = (props: PortfolioProps = {}): Portfolio => {
   const feed = Feed.make({ name: 'Interactive Brokers', kind: IBKR_FEED_KIND });
-  const portfolio = Obj.make(Portfolio, { feed: Ref.make(feed), ...props });
-  Obj.setParent(feed, portfolio);
-  return portfolio;
+  return Obj.make(Portfolio, { feed: Ref.make(feed), ...props });
 };
 
 /**

--- a/packages/plugins/plugin-inbox/src/types/Calendar.ts
+++ b/packages/plugins/plugin-inbox/src/types/Calendar.ts
@@ -17,10 +17,10 @@ export const SKILL_KEY = 'org.dxos.skill.calendar';
 export class Calendar extends Type.makeObject<Calendar>(DXN.make('org.dxos.type.calendar', '0.1.0'))(
   Schema.Struct({
     name: Schema.String.pipe(Schema.optional),
-    feed: Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false)),
+    feed: Ref.Ref(Feed.Feed).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
     // Inverse tag index for immutable feed Events (e.g. the "starred" tag): events are immutable Queue
     // items, so their tag associations live in this child `TagIndex` rather than in object meta.
-    tags: Ref.Ref(TagIndex.TagIndex).pipe(FormInputAnnotation.set(false)),
+    tags: Ref.Ref(TagIndex.TagIndex).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
   }).pipe(
     FeedAnnotation.set({ property: 'feed' }),
     Annotation.IconAnnotation.set({ icon: 'ph--calendar--regular', hue: 'rose' }),
@@ -47,13 +47,10 @@ type CalendarProps = Omit<Obj.MakeProps<typeof Calendar>, 'feed' | 'tags'>;
 export const make = (props: CalendarProps = {}) => {
   const feed = Feed.make();
   const tags = TagIndex.make();
-  const calendar = Obj.make(Calendar, {
+  // The feed and tag index are children (`SetParent`): both cascade-delete with the calendar.
+  return Obj.make(Calendar, {
     feed: Ref.make(feed),
     tags: Ref.make(tags),
     ...props,
   });
-  // TODO(wittjosiah): Parent should be declarative in the schema.
-  Obj.setParent(feed, calendar);
-  Obj.setParent(tags, calendar);
-  return calendar;
 };

--- a/packages/plugins/plugin-inbox/src/types/Mailbox.ts
+++ b/packages/plugins/plugin-inbox/src/types/Mailbox.ts
@@ -55,7 +55,7 @@ export class Mailbox extends Type.makeObject<Mailbox>(DXN.make('org.dxos.type.ma
     name: Schema.String.pipe(Schema.optional),
 
     /** The durable message log. Every pipeline in `docs/PIPELINE.md` reads from (or writes to) this. */
-    feed: Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false)),
+    feed: Ref.Ref(Feed.Feed).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
 
     /**
      * Append-only feed of derived annotations about the messages in {@link feed} — summaries today
@@ -67,7 +67,11 @@ export class Mailbox extends Type.makeObject<Mailbox>(DXN.make('org.dxos.type.ma
      * old. The primary feed stays pure — no reader has to filter annotations out of the message list.
      * Provisioned lazily on first annotation, like {@link tags}.
      */
-    annotations: Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false), Schema.optional),
+    annotations: Ref.Ref(Feed.Feed).pipe(
+      Annotation.SetParent.set(true),
+      FormInputAnnotation.set(false),
+      Schema.optional,
+    ),
 
     /**
      * Inverse tag index for immutable feed Messages: tag id (a `Tag` object's URI) → message ids.
@@ -76,7 +80,7 @@ export class Mailbox extends Type.makeObject<Mailbox>(DXN.make('org.dxos.type.ma
      * live in a child `TagIndex` object instead (the `meta.tags` augmentation for feed objects). Tag
      * labels and hues live on the `Tag` objects themselves.
      */
-    tags: Ref.Ref(TagIndex.TagIndex).pipe(FormInputAnnotation.set(false)),
+    tags: Ref.Ref(TagIndex.TagIndex).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
 
     /**
      * Which contributed object extractors run over this mailbox, and the confidence a match must
@@ -178,18 +182,13 @@ type MailboxProps = Omit<Obj.MakeProps<typeof Mailbox>, 'feed' | 'tags' | 'filte
 export const make = (props: MailboxProps = {}) => {
   const feed = Feed.make();
   const tags = TagIndex.make();
-  const mailbox = Obj.make(Mailbox, {
+  // The feed and tag index are children (`SetParent`): both cascade-delete with the mailbox.
+  return Obj.make(Mailbox, {
     feed: Ref.make(feed),
     tags: Ref.make(tags),
     filters: [],
     ...props,
   });
-
-  // TODO(wittjosiah): Parent should be declarative in the schema.
-  Obj.setParent(feed, mailbox);
-  // Tag index is a child: cascade-deleted with the mailbox.
-  Obj.setParent(tags, mailbox);
-  return mailbox;
 };
 
 //
@@ -432,7 +431,6 @@ export const findOrCreateAnnotations = (mailbox: Mailbox, db: Pick<Database.Data
   }
 
   const feed = db.add(Feed.make());
-  Obj.setParent(feed, mailbox);
   Obj.update(mailbox, (mailbox) => {
     mailbox.annotations = Ref.make(feed);
   });

--- a/packages/plugins/plugin-magazine/src/types/Magazine.ts
+++ b/packages/plugins/plugin-magazine/src/types/Magazine.ts
@@ -94,13 +94,17 @@ export class Magazine extends Type.makeObject<Magazine>(DXN.make('org.dxos.type.
      * own fields), so the brief is edited there without a custom surface.
      * Optional for backward compatibility; {@link CurateMagazine} and the toolbar require it.
      */
-    instructions: Ref.Ref(Instructions.Instructions).pipe(FormInlineAnnotation.set(true), Schema.optional),
+    instructions: Ref.Ref(Instructions.Instructions).pipe(
+      Annotation.SetParent.set(true),
+      FormInlineAnnotation.set(true),
+      Schema.optional,
+    ),
     /**
      * Per-Post magazine-scoped curation state, keyed by Post id. Shared per-Post state (readAt,
      * star/archive tags) lives on `Subscription`; snippet/imageUrl here are agent-written at
      * curation time and take precedence over the RSS-derived defaults in display.
      */
-    postState: Ref.Ref(StateMap.StateMap).pipe(FormInputAnnotation.set(false)),
+    postState: Ref.Ref(StateMap.StateMap).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
     /**
      * Maximum number of (non-starred) curated Posts retained on the magazine after curation.
      * Older posts beyond this bound are dropped; starred posts are preserved regardless.
@@ -159,12 +163,6 @@ export const make = (props: MakeProps = {}): Magazine => {
     magazine.instructions = Ref.make(instructions);
   });
 
-  // Cascade-delete the Instructions object (and its Text) and the per-Post state with the magazine.
-  Obj.setParent(instructions, magazine);
-  if (instructions.text.target) {
-    Obj.setParent(instructions.text.target, instructions);
-  }
-  Obj.setParent(postState, magazine);
   return magazine;
 };
 

--- a/packages/plugins/plugin-magazine/src/types/Subscription.ts
+++ b/packages/plugins/plugin-magazine/src/types/Subscription.ts
@@ -82,7 +82,7 @@ export class Subscription extends Type.makeObject<Subscription>(DXN.make('org.dx
     /** Opaque sync cursor — protocol-specific. */
     cursor: Schema.String.pipe(FormInputAnnotation.set(false), Schema.optional),
     /** Backing ECHO feed (queue) for Posts: immutable feed entries appended by sync. */
-    feed: Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false)),
+    feed: Ref.Ref(Feed.Feed).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
     /**
      * Backing ECHO feed (queue) for fetched article bodies — one
      * {@link PostContent} entry per Post whose content has been loaded.
@@ -96,20 +96,24 @@ export class Subscription extends Type.makeObject<Subscription>(DXN.make('org.dx
      * that pre-date this feed; new subscriptions always have one via
      * {@link makeSubscription}.
      */
-    contentFeed: Ref.Ref(Feed.Feed).pipe(FormInputAnnotation.set(false), Schema.optional),
+    contentFeed: Ref.Ref(Feed.Feed).pipe(
+      Annotation.SetParent.set(true),
+      FormInputAnnotation.set(false),
+      Schema.optional,
+    ),
     /**
      * Per-Post mutable state keyed by Post id, shared across every Magazine that references the Post.
      * Posts live immutably in the `feed` queue; their `readAt` marker lives here. (`snippet`/`imageUrl`
      * are derived from the Post, or refined onto `contentFeed` entries — not stored here; star/archive
      * are tags — see `tags`.)
      */
-    postState: Ref.Ref(StateMap.StateMap).pipe(FormInputAnnotation.set(false)),
+    postState: Ref.Ref(StateMap.StateMap).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
     /**
      * Per-Post tags keyed by tag uri → Post ids. Boolean flags (starred, archived — see
      * {@link SYSTEM_TAGS}) are modelled as {@link Tag} objects so they
      * participate in the space-wide tag system. Stored as a child {@link TagIndex} object.
      */
-    tags: Ref.Ref(TagIndex.TagIndex).pipe(FormInputAnnotation.set(false)),
+    tags: Ref.Ref(TagIndex.TagIndex).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
   }).pipe(
     LabelAnnotation.set(['name', 'url']),
     Annotation.IconAnnotation.set({ icon: 'ph--rss--regular', hue: 'indigo' }),
@@ -129,19 +133,15 @@ export const makeSubscription = (
   const contentFeed = Feed.make();
   const postState = StateMap.make();
   const tags = TagIndex.make();
-  const subscription = Obj.make(Subscription, {
+  // Feeds, per-Post state and the tag index are children (`SetParent`): all cascade-delete with
+  // the subscription.
+  return Obj.make(Subscription, {
     feed: Ref.make(postFeed),
     contentFeed: Ref.make(contentFeed),
     postState: Ref.make(postState),
     tags: Ref.make(tags),
     ...props,
   });
-  Obj.setParent(postFeed, subscription);
-  Obj.setParent(contentFeed, subscription);
-  // Per-Post state and tag index are children: cascade-deleted with the subscription.
-  Obj.setParent(postState, subscription);
-  Obj.setParent(tags, subscription);
-  return subscription;
 };
 
 /**
@@ -337,7 +337,6 @@ const ensureContentFeed = (subscription: Subscription): Feed.Feed => {
     const mutable = subscription as Obj.Mutable<typeof subscription>;
     mutable.contentFeed = Ref.make(created);
   });
-  Obj.setParent(created, subscription);
   return created;
 };
 

--- a/packages/plugins/plugin-markdown/src/types/Markdown.ts
+++ b/packages/plugins/plugin-markdown/src/types/Markdown.ts
@@ -27,7 +27,8 @@ export class Document extends Type.makeObject<Document>(DXN.make('org.dxos.type.
     name: Schema.optional(Schema.String),
     description: Schema.optional(Schema.String),
     fallbackName: Schema.String.pipe(FormInputAnnotation.set(false), Schema.optional),
-    content: Ref.Ref(Text.Text).pipe(FormInputAnnotation.set(false)),
+    /** Owned body: `SetParent` cascades it with the document. */
+    content: Ref.Ref(Text.Text).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
     history: History.History.pipe(FormInputAnnotation.set(false), Schema.optional),
   }).pipe(
     LabelAnnotation.set(['name', 'fallbackName']),
@@ -47,8 +48,5 @@ export const make = ({
   content = '',
   ...props
 }: Partial<{ name: string; fallbackName: string; content: string }> = {}) => {
-  const doc = Obj.make(Document, { ...props, content: Ref.make(Text.make({ content })) });
-  // TODO(dmaretskyi): We need a better way to set parents when creating hierarchies.
-  Obj.setParent(doc.content.target!, doc);
-  return doc;
+  return Obj.make(Document, { ...props, content: Ref.make(Text.make({ content })) });
 };

--- a/packages/plugins/plugin-routine/src/components/RoutineForm/RoutineForm.tsx
+++ b/packages/plugins/plugin-routine/src/components/RoutineForm/RoutineForm.tsx
@@ -341,7 +341,6 @@ const applyActionKind = (
         routine.spec = { kind: 'instructions', instructions: previousInstructions };
       } else {
         const instructions = Instructions.make({});
-        Obj.setParent(instructions, routine);
         routine.spec = { kind: 'instructions', instructions: Ref.make(instructions) };
       }
     }

--- a/packages/plugins/plugin-routine/src/components/TriggerEditor/TriggerEditor.tsx
+++ b/packages/plugins/plugin-routine/src/components/TriggerEditor/TriggerEditor.tsx
@@ -208,7 +208,6 @@ export const applyTriggerValues = (
     });
   } else {
     const created = Trigger.make({ spec, enabled, remote });
-    Obj.setParent(created, routine);
     Obj.update(routine, (routine) => {
       routine.triggers.push(Ref.make(created));
     });

--- a/packages/plugins/plugin-routine/src/util/wire.ts
+++ b/packages/plugins/plugin-routine/src/util/wire.ts
@@ -57,18 +57,16 @@ export const makeRoutine = ({
   trigger?: Trigger.Trigger;
 }): Routine.Routine => {
   const routine = Routine.make({ ...props, triggers });
-  // Ref before parent edge: the ref is what declares the edge (see `Obj.isDeclaredParentEdge`).
+  // `SetParent` on `spec.instructions` / `triggers` makes each write declare the parent edge too.
   if (instructions) {
     Obj.update(routine, (routine) => {
       routine.spec = { kind: 'instructions', instructions: Ref.make(instructions) };
     });
-    Obj.setParent(instructions, routine);
   }
   if (trigger) {
     Obj.update(routine, (routine) => {
       routine.triggers.push(Ref.make(trigger));
     });
-    Obj.setParent(trigger, routine);
   }
   // Wire every attached trigger (singular or `triggers`) from the action; preserves template-provided
   // input. Gated on `spec`: with no action yet, wiring would null out pre-set trigger runnables.

--- a/packages/plugins/plugin-spacetime/src/components/SpacetimeEditor/import-export.ts
+++ b/packages/plugins/plugin-spacetime/src/components/SpacetimeEditor/import-export.ts
@@ -43,7 +43,6 @@ export const handleImport = ({ scene, hue, importGLBRef, setSelectedObjectId }: 
       Obj.update(scene, (scene) => {
         scene.objects.push(Ref.make(object));
       });
-      Obj.setParent(object, scene);
       const objId = (object as any).id as string | undefined;
       if (objId) {
         setSelectedObjectId(objId);

--- a/packages/plugins/plugin-spacetime/src/tools/actions/add-object.ts
+++ b/packages/plugins/plugin-spacetime/src/tools/actions/add-object.ts
@@ -51,7 +51,6 @@ export class AddObjectAction implements ActionHandler {
     Obj.update(scene, (scene) => {
       scene.objects.push(Ref.make(object));
     });
-    Obj.setParent(object, scene);
 
     const objId = (object as any).id as string | undefined;
     if (objId) {

--- a/packages/plugins/plugin-spacetime/src/tools/actions/join-objects.ts
+++ b/packages/plugins/plugin-spacetime/src/tools/actions/join-objects.ts
@@ -67,7 +67,6 @@ export class JoinObjectsAction implements ActionHandler {
       }
       scene.objects.push(Ref.make(newObject));
     });
-    Obj.setParent(newObject, scene);
 
     for (const objId of objectsToDelete) {
       disposeSceneObject(ctx, objId);

--- a/packages/plugins/plugin-spacetime/src/tools/actions/subtract-objects.ts
+++ b/packages/plugins/plugin-spacetime/src/tools/actions/subtract-objects.ts
@@ -67,7 +67,6 @@ export class SubtractObjectsAction implements ActionHandler {
       }
       scene.objects.push(Ref.make(newObject));
     });
-    Obj.setParent(newObject, scene);
 
     for (const objId of objectsToDelete) {
       disposeSceneObject(ctx, objId);

--- a/packages/plugins/plugin-spacetime/src/types/Scene.ts
+++ b/packages/plugins/plugin-spacetime/src/types/Scene.ts
@@ -14,16 +14,15 @@ import * as Model from './Model';
 export class Scene extends Type.makeObject<Scene>(DXN.make('org.dxos.type.spacetime.scene', '0.1.0'))(
   Schema.Struct({
     name: Schema.optional(Schema.String),
-    objects: Ref.Ref(Model.Object).pipe(Schema.Array, FormInputAnnotation.set(false)),
+    /** Owned objects: `SetParent` cascades each with the scene. */
+    objects: Ref.Ref(Model.Object).pipe(Schema.Array, Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
   }).pipe(Annotation.IconAnnotation.set({ icon: 'ph--cube--regular', hue: 'teal' })),
 ) {}
 
 export const make = (props?: Partial<Omit<Scene, 'objects'>>) => {
   const defaultCube = Model.make({ primitive: 'cube' });
-  const scene = Obj.make(Scene, {
+  return Obj.make(Scene, {
     objects: [Ref.make(defaultCube)],
     ...props,
   });
-  Obj.setParent(defaultCube, scene);
-  return scene;
 };

--- a/packages/plugins/plugin-studio/src/operations/generate.ts
+++ b/packages/plugins/plugin-studio/src/operations/generate.ts
@@ -103,7 +103,6 @@ const handler: Operation.WithHandler<typeof StudioOperation.Generate> = StudioOp
             config,
             generation: makeGeneration(data),
           });
-          Obj.setParent(created, artifactObj);
           yield* Database.add(created);
           Obj.update(artifactObj, (artifactObj) => {
             artifactObj.variants = [...(artifactObj.variants ?? []), Ref.make(created)];
@@ -126,7 +125,6 @@ const handler: Operation.WithHandler<typeof StudioOperation.Generate> = StudioOp
             const enqueued = yield* Effect.tryPromise({ try: () => enqueue(request, options), catch: toError });
             jobId = enqueued.jobId;
             const created = Variant.make({ name, config, jobId });
-            Obj.setParent(created, artifactObj);
             yield* Database.add(created);
             Obj.update(artifactObj, (artifactObj) => {
               artifactObj.variants = [...(artifactObj.variants ?? []), Ref.make(created)];

--- a/packages/plugins/plugin-studio/src/types/Artifact.ts
+++ b/packages/plugins/plugin-studio/src/types/Artifact.ts
@@ -50,7 +50,11 @@ export class Artifact extends Type.makeObject<Artifact>(DXN.make('org.dxos.type.
     /** Chosen GenerationService id for this kind (passed to op:generate as `provider`). */
     generator: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
     /** Owned interchangeable alternatives of the primary output; each records its own generation. */
-    variants: Schema.Array(Ref.Ref(Variant.Variant)).pipe(FormInputAnnotation.set(false), Schema.optional),
+    variants: Schema.Array(Ref.Ref(Variant.Variant)).pipe(
+      Annotation.SetParent.set(true),
+      FormInputAnnotation.set(false),
+      Schema.optional,
+    ),
     /** The chosen/primary variant (used for thumbnails). */
     cover: Schema.optional(Ref.Ref(Variant.Variant).pipe(FormInputAnnotation.set(false))),
     /** Downstream products (transcript, summary, caption, upscale, …). */

--- a/packages/plugins/plugin-terra/src/containers/TerraArticle/TerraArticle.tsx
+++ b/packages/plugins/plugin-terra/src/containers/TerraArticle/TerraArticle.tsx
@@ -294,7 +294,6 @@ export const TerraArticle = ({ role, attendableId, subject: terra }: TerraArticl
 
   const handleAddRandomObject = useCallback(() => {
     const definition = Terra.makeRandomObject(terra, performance.now());
-    Obj.setParent(definition, terra);
     Obj.update(terra, (terra) => {
       terra.objects.push(Ref.make(definition));
     });

--- a/packages/plugins/plugin-terra/src/types/Terra.ts
+++ b/packages/plugins/plugin-terra/src/types/Terra.ts
@@ -47,7 +47,12 @@ export class Terra extends Type.makeObject<Terra>(DXN.make('org.dxos.type.terra'
   Schema.Struct({
     name: Schema.optional(Schema.String),
     config: TerraConfig,
-    objects: Ref.Ref(TerraObject.TerraObject).pipe(Schema.Array, FormInputAnnotation.set(false)),
+    /** Owned objects: `SetParent` cascades each with the world. */
+    objects: Ref.Ref(TerraObject.TerraObject).pipe(
+      Schema.Array,
+      Annotation.SetParent.set(true),
+      FormInputAnnotation.set(false),
+    ),
   }).pipe(
     LabelAnnotation.set(['name']),
     Annotation.IconAnnotation.set({ icon: 'ph--globe-hemisphere-west--regular', hue: 'green' }),
@@ -210,13 +215,11 @@ export const makeDemoWorld = (props?: { name?: string; config?: Partial<TerraCon
     ),
   ];
 
-  const terra = Obj.make(Terra, {
+  return Obj.make(Terra, {
     name: props?.name,
     config,
     objects: definitions.map((definition) => Ref.make(definition)),
   });
-  definitions.forEach((definition) => Obj.setParent(definition, terra));
-  return terra;
 };
 
 /** Every kind `makeRandomObject` may pick, one weight each. */

--- a/packages/sdk/types/src/types/Channel.ts
+++ b/packages/sdk/types/src/types/Channel.ts
@@ -26,8 +26,8 @@ export class Channel extends Type.makeObject<Channel>(DXN.make('org.dxos.type.ch
     backend: Schema.Struct({
       /** Provider id; matches `ChannelBackendProvider.kind`. */
       kind: Schema.String,
-      /** Provider-owned config object (a `Feed` for the default backend). */
-      config: Ref.Ref(Obj.Unknown),
+      /** Provider-owned config object (a `Feed` for the default backend), owned by the channel. */
+      config: Ref.Ref(Obj.Unknown).pipe(Annotation.SetParent.set(true)),
     }).pipe(FormInputAnnotation.set(false)),
   }).pipe(Annotation.IconAnnotation.set({ icon: 'ph--hash--regular', hue: 'rose' })),
 ) {}
@@ -42,13 +42,10 @@ type ChannelProps = Omit<Obj.MakeProps<typeof Channel>, 'backend'> & {
 /** Creates a channel object, defaulting to a local feed-backed backend. */
 export const make = ({ backend, ...rest }: ChannelProps = {}) => {
   const resolved = backend ?? { kind: FeedBackendKind, config: Feed.make() };
-  const channel = Obj.make(Channel, {
+  return Obj.make(Channel, {
     backend: { kind: resolved.kind, config: Ref.make(resolved.config) },
     ...rest,
   });
-  // TODO(wittjosiah): Parent should be declarative in the schema.
-  Obj.setParent(resolved.config, channel);
-  return channel;
 };
 
 /** Returns the backing `Feed` for a feed-backed channel (when loaded), else undefined. */

--- a/packages/sdk/types/src/types/File.ts
+++ b/packages/sdk/types/src/types/File.ts
@@ -18,7 +18,8 @@ import { CollectionItemAnnotation } from '@dxos/schema';
 export class File extends Type.makeObject<File>(DXN.make('org.dxos.type.file', '0.2.0'))(
   Schema.Struct({
     name: Schema.String.pipe(Schema.optional),
-    data: Ref.Ref(Blob.Blob).pipe(FormInputAnnotation.set(false)),
+    /** Owned bytes: `SetParent` cascades the blob with the file. */
+    data: Ref.Ref(Blob.Blob).pipe(Annotation.SetParent.set(true), FormInputAnnotation.set(false)),
     timestamp: Schema.String.pipe(FormInputAnnotation.set(false), Schema.optional),
   }).pipe(
     Annotation.IconAnnotation.set({ icon: 'ph--file--regular', hue: 'indigo' }),
@@ -52,7 +53,6 @@ export const fromBytes = (
   Effect.gen(function* () {
     const blob = yield* Blob.fromBytes(bytes, { type: options.type, storage: options.storage });
     const file = make({ name: options.name, data: Ref.make(blob) });
-    Obj.setParent(blob, file);
     yield* Database.add(blob);
     return file;
   });

--- a/packages/sdk/types/src/types/Outline.ts
+++ b/packages/sdk/types/src/types/Outline.ts
@@ -18,7 +18,8 @@ import * as Task from './Task';
 export class Outline extends Type.makeObject<Outline>(DXN.make('org.dxos.type.outline', '0.2.0'))(
   Schema.Struct({
     name: Schema.optional(Schema.String),
-    content: Ref.Ref(Text.Text),
+    /** Owned body: `SetParent` cascades it with the outline. */
+    content: Ref.Ref(Text.Text).pipe(Annotation.SetParent.set(true)),
   }).pipe(
     Annotation.IconAnnotation.set({ icon: 'ph--tree-structure--regular', hue: 'indigo' }),
     CollectionItemAnnotation.set(true),


### PR DESCRIPTION
## Summary

New `Annotation.SetParent` marks a `Ref` field as **owning** its targets. Writing a ref into such a field — or creating the holder with one — sets the target's ECHO parent to the holder, so the child cascade-deletes and deep-clones with it. Ownership becomes a property of the schema instead of a rule every call site has to remember.

```ts
Schema.Struct({
  content: Ref.Ref(Text.Text).pipe(Annotation.SetParent.set(true)),
  sections: Schema.Array(Ref.Ref(Section)).pipe(Annotation.SetParent.set(true)),
})
```

## Implementation

- `SetParentAnnotation` (`org.dxos.annotation.setParent`) — a `PropertyMeta`-backed boolean annotation, exported as `Annotation.SetParent`.
- `internal/Obj/parent-annotation.ts` — resolves a schema's owning-field paths and writes `[ParentId]` on each resolved ref target. Handles single refs, arrays of refs, fields nested in plain structs (`Channel.backend.config`), and members of a discriminated union field (`Routine.spec.instructions`). Paths are memoized per AST node, so a recursive (`Schema.suspend`) or repeated nested type stays linear rather than exploding combinatorially.
- Hooked into `Obj.make` (after construction) and `Obj.update` (after the change transaction); idempotent, and skips a ref with no resolvable target.

Two deliberate limits, documented on the annotation: removing a ref does **not** clear the target's parent (a two-step move between holders would lose the edge), and only object-kind targets are parented.

## Call-site sweep

Types that previously paired each ref write with `Obj.setParent` now declare it on the field: `Instructions.text`, `Outline.content`, `Project.{instructions,outline,taskSet,routines}`, `Chat.feed`, `Agent.instructions`, `Routine.{spec.instructions,triggers}`, `File.data`, `Channel.backend.config`, `Document.content`, `Spec.content`, `SourceFile.content`, `Mailbox.{feed,annotations,tags}`, `Calendar.{feed,tags}`, `Search.{feed,tags}`, `Subscription.{feed,contentFeed,postState,tags}`, `Magazine.{instructions,postState}`, `Scene.objects`, `Terra.objects`, `Artifact.variants`, `Portfolio.feed`, `ChessComAccount.games`, `PlayerReview.positionIndex`, `Blog.{outline,content,instructions}`. This also fixes sites that wrote the ref *without* setting a parent (`Chat.ensureTaskSet`, `ensureTaskSetSync`).

Left as explicit `Obj.setParent` calls, because the field ref is not what implies the parent:

- Edges whose child may be parented elsewhere — `TaskSet.tasks` (a sub-task's parent is its parent task), trip segments/bookings.
- Reverse edges (the child holds the ref) — `Chat.linkCompanion`, CRM profile relations.
- Ref-in-annotation edges — `Chat.CompanionChatAnnotation`.
- Generic containers (`Collection.objects`), where parenting every member would change semantics repo-wide.
- Ref-less parent edges (IBKR triggers/operations).

## Test plan

- New `Annotation.SetParent` cases in `packages/core/echo/echo/src/Annotation.test.ts` (creation, write, re-parent, array append, un-annotated field stays unparented) — `echo:test` 577 passed.
- New `Annotation.SetParent` describe block in `packages/core/echo/echo-client-e2e/src/parent.test.ts`, including a database write and a cascade-delete case.
- **Verification suite `echo-client-e2e`: 324 passed, 1 expected fail, 11 skipped.**
- Also green: `schema`, `types`, `compute`, `assistant-toolkit`, and the touched plugin suites (`plugin-inbox`, `-magazine`, `-routine`, `-studio`, `-projects`, `-blogger`, `-chess`, `-terra`, `-commerce`, `-spacetime`, `-assistant`, `-code`, `-markdown`, `-tasks`, `-connector`, `-space`, `-trip`).
- Full-repo `:build` clean; `oxfmt` applied; lint clean on every touched package.

Changeset: `.changeset/annotation-set-parent.md` (`@dxos/echo` + `@dxos/plugin-markdown`, minor).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLVDNoJ1HN3bQn3w42zJy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added declarative ownership for referenced content, enabling automatic parent assignment, deep cloning, and cascade deletion across supported records.
  * Ownership now works for nested references, arrays, and union-based fields.
* **Documentation**
  * Added guidance and examples for configuring and using owned references, including limitations and unresolved references.
* **Tests**
  * Added coverage for ownership during creation, updates, replacement, array changes, and deletion.
* **Style**
  * Added a review rule discouraging trivial wrappers around official APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->