### PR TITLE
plugin-support: log the endpoint when a screenshot upload fails

### DIFF
--- a/.changeset/feedback-screenshot-upload-log-endpoint.md
+++ b/.changeset/feedback-screenshot-upload-log-endpoint.md
@@ -1,0 +1,8 @@
+---
+'@dxos/plugin-support': patch
+---
+
+Feedback screenshot upload failures now log the image-service endpoint and the blob size alongside
+the error. A browser reports every CORS rejection, DNS failure, and offline attempt as the same
+opaque `TypeError: Failed to fetch`, so the previous log line could not distinguish them or even
+name the host that was refused — diagnosing DX-1203 required re-deriving the endpoint from config.

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/screenshot.ts
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/screenshot.ts
@@ -159,25 +159,31 @@ export const uploadScreenshot = async (
   const ext = blob.type === 'image/jpeg' ? 'jpg' : 'png';
   form.append('file', blob, `composer-${Date.now()}.${ext}`);
 
+  // Logged on every failure path: a bare `Failed to fetch` names neither the host nor the reason,
+  // and triaging DX-1203 needed the endpoint to discover the CORS preflight was the rejection.
+  const endpoint = new URL('upload', `${serviceUrl.replace(/\/+$/, '')}/`);
+
   try {
-    const res = await fetch(new URL('upload', `${serviceUrl.replace(/\/+$/, '')}/`), {
+    const res = await fetch(endpoint, {
       method: 'POST',
       body: form,
       // 15s aligns with plugin-crm's external-fetch timeout.
       signal: AbortSignal.timeout(15_000),
     });
     if (!res.ok) {
-      log.warn('image-service rejected upload', { status: res.status });
+      log.warn('image-service rejected upload', { endpoint: endpoint.href, status: res.status });
       return undefined;
     }
     const json = (await res.json()) as { url?: string };
     if (!json.url) {
-      log.warn('image-service returned no url', { json });
+      log.warn('image-service returned no url', { endpoint: endpoint.href, json });
       return undefined;
     }
     return json.url;
   } catch (err) {
-    log.warn('screenshot upload failed', { err });
+    // `TypeError: Failed to fetch` covers CORS rejection, DNS failure, and offline alike, and the
+    // browser deliberately withholds which. `bytes` separates a size-driven failure from the rest.
+    log.warn('screenshot upload failed', { endpoint: endpoint.href, bytes: blob.size, err });
     return undefined;
   }
 };


### PR DESCRIPTION
Part of DX-1203. The service-side fix is [dxos/edge#984](https://github.com/dxos/edge/pull/984).

## Why

DX-1203's debug bundle recorded the screenshot upload failure like this:

```
12:42:29.501  W  screenshot upload failed  screenshot.ts:180  TypeError: Failed to fetch
```

A browser reports CORS rejection, DNS failure, and offline as that same opaque `TypeError`, and deliberately withholds which. Because the log carried only `{ err }`, triage had to re-derive the image-service endpoint from `dx.yml` and `EDGE_SERVICE_DEFAULTS` by hand before it could reproduce the preflight and find that the service was refusing the origin.

## Change

`uploadScreenshot` resolves the endpoint once, up front, and logs it on all three failure paths (non-ok status, missing url, throw). The throw path also logs `bytes`, which separates a size-driven failure from a transport one.

No behaviour change — the same requests are made and the same values returned.

## Validation

- `tsc --noEmit` against sources on `plugin-support`: the 9 `src/` errors are unchanged from the pre-edit baseline (all `@dxos/config` / `@dxos/observability` resolution failures from unbuilt codegen packages, plus pre-existing ones) — verified by diffing the two runs, which are identical.
- `oxfmt` and `oxlint` on the changed file: clean.

Not run: the `moon` build/test graph — the moon toolchain is unavailable in this environment (see `cloud-sandbox` skill). CI is the check on that.

Changeset added (`@dxos/plugin-support` patch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPs8ns9c2bKNLt4pzV1Q4Y)_