### PR TITLE
client: assign the invitation proxy before awaiting

### DIFF
--- a/.changeset/invitation-proxy-assign-order.md
+++ b/.changeset/invitation-proxy-assign-order.md
@@ -1,0 +1,5 @@
+---
+'@dxos/echo': patch
+---
+
+`SpaceList` now assigns its invitation proxy before awaiting, so `join()` cannot observe a window where the proxy is missing while the space list opens.

--- a/packages/sdk/client/src/echo/space-list.ts
+++ b/packages/sdk/client/src/echo/space-list.ts
@@ -92,9 +92,8 @@ export class SpaceList extends MulticastObservable<Space[]> implements Echo {
       this._setupSpacesStream();
     });
 
-    // Not awaited: the proxy is assigned synchronously (so `share`/`join` work immediately) and
-    // its own initial snapshot is not needed to use spaces. Awaiting it put the whole app boot
-    // behind the invitations stream, so a stalled snapshot made the app unbootable.
+    // Not awaited: its initial snapshot is not needed to use spaces, and awaiting it put the whole
+    // app boot behind the invitations stream, so a stalled snapshot made the app unbootable.
     void this._setupInvitationProxy().catch((error) => log.warn('failed to open invitation proxy', { error }));
 
     // Subscribe to spaces and create proxies.
@@ -112,8 +111,10 @@ export class SpaceList extends MulticastObservable<Space[]> implements Echo {
    * Set up the invitation proxy. Called on initial open and reconnect.
    */
   private async _setupInvitationProxy(): Promise<void> {
-    await this._invitationProxy?.close();
     invariant(this._serviceProvider.services.InvitationsService, 'InvitationsService is not available.');
+    const previous = this._invitationProxy;
+    // Assigned before the first await: the caller no longer waits for this method, so `join` would
+    // otherwise see a window where the proxy is missing and throw 'Client not open.'.
     this._invitationProxy = new InvitationsProxy(
       this._serviceProvider.services.InvitationsService,
       this._serviceProvider.services.IdentityService,
@@ -121,6 +122,7 @@ export class SpaceList extends MulticastObservable<Space[]> implements Echo {
         kind: Invitation.Kind.SPACE,
       }),
     );
+    await previous?.close();
     await this._invitationProxy.open();
   }
 


### PR DESCRIPTION
Follow-up to #12801, found by re-reading that diff while it sat in the merge queue (it was already queued, so it could not be amended there).

## Problem

#12801 stopped `SpaceList._open` from awaiting `_setupInvitationProxy`, so the app boot no longer blocks on the invitations stream. But that method awaited `close()` on the previous proxy **before** assigning the new one:

```ts
await this._invitationProxy?.close();   // <- await, then
this._invitationProxy = new InvitationsProxy(...);
```

So `this._invitationProxy` stays `undefined` across that await, and `join()` throws `ApiError('Client not open.')` for anyone who lands in the window. While the caller awaited the method this was unreachable; now that it does not, the field's lifetime is worth making explicit.

The comment I left in #12801 also claimed the assignment was synchronous. It was not — that is corrected here.

## Not a live bug

No caller can reach the window today: `_open` still awaits `gotInitialUpdate.wait()` (a full `querySpaces` round trip) after kicking off the proxy setup, which is orders of magnitude longer than the one microtask involved. This changes what makes the code safe from incidental ordering to the assignment itself.

## Change

Construct and assign the proxy before any await; close the previous one afterwards. Reconnect behaviour is unchanged — the old proxy is still closed before the new one opens.

## Test

`pnpm format` / `oxfmt --check` clean, `client:build`, `client:lint`, `client:test` — 34 passed, 1 expected fail, 2 skipped, on top of the merged `10b1239d`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RK73L8N38r7Yj4YZfKMu8X)_