### PR TITLE
composer-app: drop plugin-stream-deck from the dev defaults

### DIFF
--- a/.agents/skills/composer-plugins/MEMORY.md
+++ b/.agents/skills/composer-plugins/MEMORY.md
@@ -542,7 +542,7 @@ Session-logged rules for agents. Append a dated section per session (newest firs
 - `tsconfig.json` (extends `../../../tsconfig.base.json`, `references` per dep) — without it `:build` fails "No tsconfig.json found". References are auto-extended into `composer-app/tsconfig.json` + `release-please-config.json` by the postinstall sync.
 - `src/vite-env.d.ts` declaring `*.mdl?raw` (copy from plugin-chess) — needed for `import pluginSpec from '../PLUGIN.mdl?raw'`.
 - `vitest.config.ts` (`createConfig({ node: true, storybook: true })`) + a `.storybook/` dir (`main.mts`, `preview.mts`, and symlinks `manager-head.html`/`preview-head.html` → `tools/storybook/.storybook/*`) — without these `:test` fails "No projects matched filter 'node'" then storybook `MainFileMissingError`.
-- Register in `composer-app/src/plugin-defs.tsx`: import from `@dxos/plugin-foo/plugin`, add `FooPlugin()` to the instance list and `FooPlugin.meta.id` to a `getDefaults` list (Labs for experimental); add `@dxos/plugin-foo: workspace:*` to composer-app `package.json`.
+- Register in `composer-app/src/plugin-defs.tsx`: import from `@dxos/plugin-foo/plugin`, add `FooPlugin.make()` to `getPlugins` and `FooPlugin.meta.profile.key` to the `isDev` block of `getDefaults` (omit it if the plugin hits a permission-gated API on activation); add `@dxos/plugin-foo: workspace:*` to composer-app `package.json`.
 
 ### Operations import from `@dxos/compute`, not `@dxos/operation`
 

--- a/.agents/skills/composer-plugins/SKILL.md
+++ b/.agents/skills/composer-plugins/SKILL.md
@@ -187,7 +187,7 @@ Phase 1, before the PR. The skeleton should include:
 
 Build and lint the skeleton before adding features.
 Add capabilities incrementally as needed (operations, skills, settings, etc.).
-Register the plugin with `composer-app`.
+Register the plugin with `composer-app`: `FooPlugin.make()` in `getPlugins`, and its key in the `isDev` block of `getDefaults` unless the plugin hits a permission-gated API on activation (rule 5 under **Activation waves**).
 
 Once the plugin contributes a navtree section, apply both rules under **App graph** below — gate the section on a non-empty query, and default the create-object `targetNodeId` to the node that lists the objects.
 
@@ -531,7 +531,7 @@ Modules come from **makers** in `AppCapability` (loader-based) or `Capability.la
 the app is interactive, and is pullable earlier as a dependency. That is the right default for
 almost everything; the exceptions are listed above and are baked into the makers.
 
-Four rules, each learned from a shipped regression:
+Five rules, each learned from a shipped regression:
 
 1. **Use the maker.** A module that builds its spec by hand (`Capability.lazyModule({ provides:
 [Capabilities.ReactContext] })`) bypasses the maker's gate and silently inherits the idle
@@ -549,6 +549,12 @@ Four rules, each learned from a shipped regression:
 4. **Cross-plugin contributions ride the CONSUMING plugin's start event** — a skill rides the
    assistant's, a markdown extension rides markdown's — so the contribution costs nothing until its
    host is in use.
+5. **Permission-gated APIs wait for a user action.** A prompt raised from `activate` has no
+   context to justify it, so the user Blocks it and the block sticks for the whole origin. Covers
+   `getUserMedia`, `getDisplayMedia`, notifications, geolocation, clipboard reads,
+   `bluetooth`/`usb`/`serial`/`hid`/`midi`, `storage.persist()`, and any `fetch` or `WebSocket` to
+   localhost or a LAN address, which raises Chrome's local network prompt with no permission API in
+   the code. Such a plugin also stays out of `getDefaults` in every environment.
 
 A plugin's own `<Plugin>Events.Start` fires on demand: the module loader fires it when one of the
 plugin's modules contributes a `ReactSurface`. An unvisited feature never starts.

--- a/packages/apps/composer-app/src/plugin-defs.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.tsx
@@ -90,6 +90,9 @@ export type { PluginConfig, State } from './plugin-defs.core';
 /**
  * Plugin keys enabled by default for new users, per environment (dev/local).
  *
+ * New keys go in the `isDev` block, and only for plugins that hit no permission-gated API on
+ * activation: a `fetch` or `WebSocket` to localhost raises Chrome's local network prompt at boot.
+ *
  * NOTE: Keep alphabetically sorted.
  */
 export const getDefaults = ({ isDev, isLocal, isMobile }: PluginConfig): string[] =>
@@ -149,7 +152,6 @@ export const getDefaults = ({ isDev, isLocal, isMobile }: PluginConfig): string[
       SandboxPlugin.meta.profile.key,
       SequencerPlugin.meta.profile.key,
       SidekickPlugin.meta.profile.key,
-      StreamDeckPlugin.meta.profile.key,
       StudioPlugin.meta.profile.key,
       TasksPlugin.meta.profile.key,
       TranscriptionPlugin.meta.profile.key,


### PR DESCRIPTION
`dev.composer.space` asks for local network access during boot:

> dev.composer.space wants to **Access other apps and services on this device**

## Cause

`plugin-stream-deck` was in the `isDev` block of `getDefaults`, added in #12749 alongside LaMetric. Its bridge driver is headless, so it activates at startup with no UI involved and dials `ws://127.0.0.1:21435` immediately, retrying on a backoff forever. That WebSocket is what raises Chrome's local network access prompt.

Every `dev.composer.space` visitor got it before opening anything, and almost none of them own a Stream Deck. The natural answer is Block, which sticks for the origin and then breaks the feature for anyone who later enables the plugin deliberately.

## Change

Dropped the key from the `isDev` defaults. The plugin stays in `getPlugins`, so it is still in the registry and still works in the browser. The bridge is unchanged: dialing localhost is correct once someone turns the plugin on, and enabling it is the opt-in.

New profiles only. `getDefaults` is a first-boot seed and `useApp` prefers the cached `localStorage` list, so existing profiles keep it enabled until they turn it off in settings.

## Rule

The habit came from the skill, whose new-plugin checklist told authors to add every plugin's key to a `getDefaults` list. That guidance stays, since defaulting new work on for `isDev` is how the team sees it. What it was missing is the limit:

- `SKILL.md` gains a fifth **Activation waves** rule: permission-gated APIs wait for a user action, and a plugin that prompts on activation stays out of `getDefaults` in every environment. It names the case with no visible API call, where an ordinary `fetch` or `WebSocket` to localhost or a LAN address raises the prompt on its own.
- The registration line and the `getDefaults` docstring in `plugin-defs.tsx` carry the same condition at the point of use.
- The `MEMORY.md` checklist bullet matches, and two stale API names in it are fixed (`FooPlugin()` and `meta.id` become `FooPlugin.make()` and `meta.profile.key`).

## Verification

`pnpm format`, `moon run composer-app:lint --fix`, and `moon run composer-app:test` pass (39 passed, 1 skipped). No changeset: composer-app is an app and the rest is agent docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin registration guidance and activation rules.
  * Clarified when plugins should be included in development defaults, especially those requiring browser permissions or local/LAN network access.
* **Bug Fixes**
  * Stream Deck is no longer enabled by default in development and local environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->