### PR TITLE
feat(cli): send the passkey prompt to the auth origin, not the hub API host

### DIFF
--- a/.changeset/cli-passkey-auth-url.md
+++ b/.changeset/cli-passkey-auth-url.md
@@ -1,0 +1,10 @@
+---
+'@dxos/protocols': minor
+'@dxos/plugin-client': minor
+---
+
+Send `dx account login --method passkey` to the auth origin rather than the hub's API host.
+
+A passkey is bound to the WebAuthn relying party it was registered against, and Composer pins that to `composer.space` rather than the page host, so only an origin under that domain can present one. The hub answers on its API host as well, where the prompt renders, returns 200, and then fails in the browser with `SecurityError` and nothing else to go on. MCP avoided this by pinning `DX_AUTH_BASE_URL` to a blessed hostname, an unwritten constraint each new caller had to rediscover.
+
+`Runtime.Services.Hub` gains `auth_url`, resolved by `Account.getAuthUrl` the same way `url` is resolved by `getHubUrl`: `DX_AUTH_URL`, then `runtime.services.hub.authUrl`, then `DEFAULT_AUTH_URL` (`https://account.composer.space`). The `dev` and `local` CLI profiles set it to the dev hub's own serving origin.

--- a/packages/core/protocols/src/proto/dxos/config.proto
+++ b/packages/core/protocols/src/proto/dxos/config.proto
@@ -469,7 +469,13 @@ message Runtime {
 
     message Ai { optional string server = 1; }
 
-    message Hub { optional string url = 1; }
+    /// `url` is the API host. `auth_url` is where a browser is sent for a passkey prompt, which
+    /// must be an origin covered by the WebAuthn relying party the credential was registered
+    /// against — a page on any other host cannot use the passkey, whatever it serves.
+    message Hub {
+      optional string url = 1;
+      optional string auth_url = 2;
+    }
 
     /// Canonical descriptor for an EDGE (Cloudflare Worker) service.
     /// Entries in `Services.edge_services` consolidate the per-service URL

--- a/packages/core/protocols/src/proto/dxos/config.proto
+++ b/packages/core/protocols/src/proto/dxos/config.proto
@@ -469,11 +469,10 @@ message Runtime {
 
     message Ai { optional string server = 1; }
 
-    /// `url` is the API host. `auth_url` is where a browser is sent for a passkey prompt, which
-    /// must be an origin covered by the WebAuthn relying party the credential was registered
-    /// against — a page on any other host cannot use the passkey, whatever it serves.
     message Hub {
       optional string url = 1;
+      /// Origin serving the passkey prompt. Must be covered by the WebAuthn relying party the
+      /// credential was registered against; the API host is not.
       optional string auth_url = 2;
     }
 

--- a/packages/devtools/cli/config/config-dev.yml
+++ b/packages/devtools/cli/config/config-dev.yml
@@ -16,6 +16,9 @@ runtime:
     # to -- a hub from another environment mints magic links no redemption can resolve.
     hub:
       url: https://dev.dxos.network/hub/
+      # Where a passkey prompt is served. Not the hub's API host: a passkey is bound to the
+      # relying party it was registered against, and only an origin under it can present one.
+      authUrl: https://account.dev.composer.space
     edge:
       url: https://dev.dxos.network/
     iceProviders:

--- a/packages/devtools/cli/config/config-dev.yml
+++ b/packages/devtools/cli/config/config-dev.yml
@@ -16,8 +16,6 @@ runtime:
     # to -- a hub from another environment mints magic links no redemption can resolve.
     hub:
       url: https://dev.dxos.network/hub/
-      # Where a passkey prompt is served. Not the hub's API host: a passkey is bound to the
-      # relying party it was registered against, and only an origin under it can present one.
       authUrl: https://account.dev.composer.space
     edge:
       url: https://dev.dxos.network/

--- a/packages/devtools/cli/config/config-local.yml
+++ b/packages/devtools/cli/config/config-local.yml
@@ -15,6 +15,9 @@ runtime:
     # Deployed: hub-service is not part of the local edge dev setup.
     hub:
       url: https://dev.dxos.network/hub/
+      # Where a passkey prompt is served. Not the hub's API host: a passkey is bound to the
+      # relying party it was registered against, and only an origin under it can present one.
+      authUrl: https://account.dev.composer.space
     edge:
       url: http://localhost:8787/
     # Production even though `edge` is localhost: a local edge has no TURN token to mint with.

--- a/packages/devtools/cli/config/config-local.yml
+++ b/packages/devtools/cli/config/config-local.yml
@@ -15,8 +15,6 @@ runtime:
     # Deployed: hub-service is not part of the local edge dev setup.
     hub:
       url: https://dev.dxos.network/hub/
-      # Where a passkey prompt is served. Not the hub's API host: a passkey is bound to the
-      # relying party it was registered against, and only an origin under it can present one.
       authUrl: https://account.dev.composer.space
     edge:
       url: http://localhost:8787/

--- a/packages/plugins/plugin-client/src/commands/account/login/login.ts
+++ b/packages/plugins/plugin-client/src/commands/account/login/login.ts
@@ -158,9 +158,9 @@ const loginWithPasskey = (client: Client) =>
     });
 
     return yield* Effect.gen(function* () {
-      // Addressed to the hub itself: it redirects the browser on to whichever origin its relying
-      // party covers, so the CLI needs no knowledge of that hostname.
-      const url = new URL('/auth/verify', Account.getHubUrl(client));
+      // The auth origin, not the hub's API host. Both serve this page, but a passkey is bound to the
+      // relying party it was registered against, so only the former can present one.
+      const url = new URL('/auth/verify', Account.getAuthUrl(client));
       url.searchParams.set('purpose', 'device');
       url.searchParams.set('callback', server.origin);
 

--- a/packages/plugins/plugin-client/src/commands/account/login/login.ts
+++ b/packages/plugins/plugin-client/src/commands/account/login/login.ts
@@ -158,8 +158,6 @@ const loginWithPasskey = (client: Client) =>
     });
 
     return yield* Effect.gen(function* () {
-      // The auth origin, not the hub's API host. Both serve this page, but a passkey is bound to the
-      // relying party it was registered against, so only the former can present one.
       const url = new URL('/auth/verify', Account.getAuthUrl(client));
       url.searchParams.set('purpose', 'device');
       url.searchParams.set('callback', server.origin);

--- a/packages/sdk/app-toolkit/src/account/Account.ts
+++ b/packages/sdk/app-toolkit/src/account/Account.ts
@@ -114,7 +114,7 @@ export const accountErrorType = (error: unknown): AccountErrorType | undefined =
 export const getHubUrl = (client: Pick<Client, 'config'>): string =>
   getEnvString(client.config, 'DX_HUB_URL') ?? client.config.values?.runtime?.services?.hub?.url ?? DEFAULT_HUB_URL;
 
-/** Origin to send a browser to for a passkey prompt. Resolved like {@link getHubUrl}. */
+/** Origin to send a browser to for a passkey prompt. */
 export const getAuthUrl = (client: Pick<Client, 'config'>): string =>
   getEnvString(client.config, 'DX_AUTH_URL') ??
   client.config.values?.runtime?.services?.hub?.authUrl ??

--- a/packages/sdk/app-toolkit/src/account/Account.ts
+++ b/packages/sdk/app-toolkit/src/account/Account.ts
@@ -114,15 +114,7 @@ export const accountErrorType = (error: unknown): AccountErrorType | undefined =
 export const getHubUrl = (client: Pick<Client, 'config'>): string =>
   getEnvString(client.config, 'DX_HUB_URL') ?? client.config.values?.runtime?.services?.hub?.url ?? DEFAULT_HUB_URL;
 
-/**
- * Origin to send a browser to for a passkey prompt. Resolved like {@link getHubUrl}, and separate
- * from it because the two are different hosts in every deployed environment.
- *
- * A passkey is bound to the relying party it was registered against, and Composer pins that to
- * `composer.space` rather than the page host, so only an origin under that domain can present one.
- * The hub serves the prompt on its API host as well, where it renders, returns 200, and then fails
- * in the browser with `SecurityError` — which is why this cannot be derived from the hub URL.
- */
+/** Origin to send a browser to for a passkey prompt. Resolved like {@link getHubUrl}. */
 export const getAuthUrl = (client: Pick<Client, 'config'>): string =>
   getEnvString(client.config, 'DX_AUTH_URL') ??
   client.config.values?.runtime?.services?.hub?.authUrl ??

--- a/packages/sdk/app-toolkit/src/account/Account.ts
+++ b/packages/sdk/app-toolkit/src/account/Account.ts
@@ -9,7 +9,7 @@ import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 
 import { type Client } from '@dxos/client';
-import { DEFAULT_HUB_URL } from '@dxos/client-protocol';
+import { DEFAULT_AUTH_URL, DEFAULT_HUB_URL } from '@dxos/client-protocol';
 import { type Identity } from '@dxos/client/halo';
 import { getEnvString } from '@dxos/config';
 import { Context as DxContext } from '@dxos/context';
@@ -113,6 +113,20 @@ export const accountErrorType = (error: unknown): AccountErrorType | undefined =
  */
 export const getHubUrl = (client: Pick<Client, 'config'>): string =>
   getEnvString(client.config, 'DX_HUB_URL') ?? client.config.values?.runtime?.services?.hub?.url ?? DEFAULT_HUB_URL;
+
+/**
+ * Origin to send a browser to for a passkey prompt. Resolved like {@link getHubUrl}, and separate
+ * from it because the two are different hosts in every deployed environment.
+ *
+ * A passkey is bound to the relying party it was registered against, and Composer pins that to
+ * `composer.space` rather than the page host, so only an origin under that domain can present one.
+ * The hub serves the prompt on its API host as well, where it renders, returns 200, and then fails
+ * in the browser with `SecurityError` — which is why this cannot be derived from the hub URL.
+ */
+export const getAuthUrl = (client: Pick<Client, 'config'>): string =>
+  getEnvString(client.config, 'DX_AUTH_URL') ??
+  client.config.values?.runtime?.services?.hub?.authUrl ??
+  DEFAULT_AUTH_URL;
 
 /** Client for the configured hub-service (accounts, invitations, email verification). */
 export const createHubClient = (clientOrUrl: Client | string): HubHttpClient =>

--- a/packages/sdk/client-protocol/src/config.ts
+++ b/packages/sdk/client-protocol/src/config.ts
@@ -29,10 +29,9 @@ export const DEFAULT_HUB_URL = 'https://dxos.network/hub/';
  * Where a browser is sent for a passkey prompt, used when neither `runtime.app.env.DX_AUTH_URL` nor
  * `runtime.services.hub.authUrl` is configured.
  *
- * Distinct from {@link DEFAULT_HUB_URL} rather than derived from it. WebAuthn resolves a credential
- * by relying party, and Composer registers passkeys against `composer.space` rather than the page
- * host, so only an origin under that domain can present one. The hub answers on its API host too,
- * where the same page renders and then fails in the browser with `SecurityError`.
+ * Not derived from {@link DEFAULT_HUB_URL}: Composer registers passkeys against `composer.space`, so
+ * only an origin under that relying party can present one — the hub's API host serves the same page
+ * and then fails in the browser with `SecurityError`.
  */
 export const DEFAULT_AUTH_URL = 'https://account.composer.space';
 

--- a/packages/sdk/client-protocol/src/config.ts
+++ b/packages/sdk/client-protocol/src/config.ts
@@ -26,12 +26,8 @@ export const defaultConfig = { version: 1 };
 export const DEFAULT_HUB_URL = 'https://dxos.network/hub/';
 
 /**
- * Where a browser is sent for a passkey prompt, used when neither `runtime.app.env.DX_AUTH_URL` nor
- * `runtime.services.hub.authUrl` is configured.
- *
- * Not derived from {@link DEFAULT_HUB_URL}: Composer registers passkeys against `composer.space`, so
- * only an origin under that relying party can present one — the hub's API host serves the same page
- * and then fails in the browser with `SecurityError`.
+ * Passkey prompt origin, not derived from {@link DEFAULT_HUB_URL} because only an origin under the
+ * `composer.space` relying party can present a passkey.
  */
 export const DEFAULT_AUTH_URL = 'https://account.composer.space';
 

--- a/packages/sdk/client-protocol/src/config.ts
+++ b/packages/sdk/client-protocol/src/config.ts
@@ -25,6 +25,17 @@ export const defaultConfig = { version: 1 };
  */
 export const DEFAULT_HUB_URL = 'https://dxos.network/hub/';
 
+/**
+ * Where a browser is sent for a passkey prompt, used when neither `runtime.app.env.DX_AUTH_URL` nor
+ * `runtime.services.hub.authUrl` is configured.
+ *
+ * Distinct from {@link DEFAULT_HUB_URL} rather than derived from it. WebAuthn resolves a credential
+ * by relying party, and Composer registers passkeys against `composer.space` rather than the page
+ * host, so only an origin under that domain can present one. The hub answers on its API host too,
+ * where the same page renders and then fails in the browser with `SecurityError`.
+ */
+export const DEFAULT_AUTH_URL = 'https://account.composer.space';
+
 // TODO(burdon): Allow override via env? Generalize since currently NodeJS only.
 const HOME = typeof process !== 'undefined' ? (process?.env?.HOME ?? '') : '';
 


### PR DESCRIPTION
Follow-up to [#12786](https://github.com/dxos/dxos/pull/12786), which shipped `dx account login --method passkey`. The command works, but sends the browser to a host where the passkey can never be offered.

## The bug

Running it against production opens the prompt and then fails with `The operation is insecure.`

A passkey is bound to the WebAuthn relying party it was registered against. Composer pins that to `composer.space` rather than the page host:

```ts
// NativePasskey.ts:52
return hostname === APP_DOMAIN || hostname.endsWith(`.${APP_DOMAIN}`) ? APP_DOMAIN : hostname;
```

So only an origin under `composer.space` can present one. The CLI built its URL from `Account.getHubUrl`, which returns `hub.dxos.network`, an unrelated domain.

Nothing about the response says so. Cloudflare custom domains route the whole worker, so `/auth/verify` answers on all three of the hub's hostnames, renders the same page, and returns 200 on each. It fails only when the browser evaluates the assertion.

## Why config rather than a redirect

I first wrote this as a hub-side redirect to the RP-covered origin. That's the wrong layer: the hub cannot know whether a given caller wants the API or a browser prompt, and bouncing every mismatched request assumes the answer. The existing MCP flow already picks its origin by config (`DX_AUTH_BASE_URL`), and this makes the CLI consistent with it.

## The change

`Runtime.Services.Hub` gains a second field:

```proto
message Hub {
  optional string url = 1;
  optional string auth_url = 2;
}
```

`Account.getAuthUrl` resolves it exactly as `getHubUrl` resolves `url` — `DX_AUTH_URL`, then `runtime.services.hub.authUrl`, then `DEFAULT_AUTH_URL` (`https://account.composer.space`). The `dev` and `local` CLI profiles set it explicitly.

`**/proto/gen` is gitignored, so the generated `authUrl` is not in the diff. It comes from `moon run protocols:prebuild` and `protocols:gen-buf`.

## Testing

`tsc --noEmit` clean on `app-toolkit` and `plugin-client`; `oxfmt` clean; `check-changesets` passes at one entry.

Not covered by automated tests — the failure is a browser-side WebAuthn check that needs a real authenticator and a real domain. I verified the mechanism by hand instead: `hub.dxos.network`, `auth.dxos.network`, and `account.composer.space` all serve the page and return 200, and only the last is a suffix match on the relying party.

## Known gap, not fixed here

`account.dev.composer.space` does not resolve:

```
account.dev.composer.space      NXDOMAIN
account.preview.composer.space  104.20.26.162
account.composer.space          172.66.162.85
```

It is declared in hub-service's dev `routes` and is the only entry in dev's `DX_AUTH_ALLOWED_ORIGINS`, but the DNS record was never created. The `dev` and `local` profiles point at it regardless, since it is what dev's own config declares and any other host would be rejected by the hub's origin check. Dev passkey login starts working when the record exists. Preview and production both resolve.

Separately, MCP's `DX_AUTH_BASE_URL` points at `hub.<env>.dxos.network` on dev and preview, which is neither a suffix match nor listed in `composer.space/.well-known/webauthn`. MCP passkey auth cannot work in those environments today. That is an edge-side fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passkey sign-in now opens through a dedicated authentication origin.
  * Authentication URLs can be configured through environment or runtime settings, with a secure default fallback.
  * Development and local environments now use the development authentication origin.

* **Bug Fixes**
  * Improved passkey sign-in reliability by ensuring authentication prompts use the correct security origin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->