### PR TITLE
echo: demote diverged-document subduction log to verbose

### DIFF
--- a/packages/core/echo/echo-host/src/automerge/automerge-host.ts
+++ b/packages/core/echo/echo-host/src/automerge/automerge-host.ts
@@ -1287,7 +1287,9 @@ export class AutomergeHost extends Resource {
       // `_documentsToSync` feeds a share policy Subduction does not consult, so a diverged
       // document reaching here gets no retry from either — the diff simply repeats next pass.
       if (this._useSubduction && getHandleState(this._repo, documentId) === 'ready' && different.includes(documentId)) {
-        log.warn('diverged document has no subduction retry path', {
+        // Verbose: this fires on every diff pass for docs that are in practice fully synced,
+        // so at warn level it floods the console without indicating a real fault.
+        log.verbose('diverged document has no subduction retry path', {
           collectionId,
           peerId,
           documentId,


### PR DESCRIPTION
`diverged document has no subduction retry path` was logged at `warn`, and it fires on every collection-diff pass for documents that are in practice fully synced — so it floods the browser console with hundreds of identical entries while sync works fine.

Demoted to `log.verbose` and added a comment recording why (spams despite sync working).

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3LCUzf2ivSrhXhVzQxUH2)_