### PR TITLE
repo: add pnpm reset to clear stale build state

### DIFF
--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -218,6 +218,24 @@ pnpm i
 
 NOTE: Do not use `pnpm up` since it will update more than the targeted dependencies.
 
+## Resetting stale build state
+
+`pnpm install` reports "Already up to date" in two situations where the workspace is in fact
+broken, because neither is tracked by the lockfile:
+
+- A dependency version bump leaves per-package `node_modules/.bin/*` shims pointing at a store
+  path pnpm has since removed — the build fails with `MODULE_NOT_FOUND` on a path containing the
+  *old* version.
+- Generated sources (e.g. `packages/core/protocols/src/proto/gen`) go stale while moon's cache
+  hash still matches, so every run restores the stale output rather than regenerating it.
+
+```bash
+pnpm reset          # prune dead .bin shims, reinstall, clear .moon/cache, regenerate protobuf
+pnpm reset --deep   # also delete every package dist and reinstall node_modules from scratch
+```
+
+Stop any running dev server first — `reset` reinstalls `node_modules` underneath it.
+
 ## Folders
 
 | Folder                  | Description                                                                                    |

--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -225,7 +225,7 @@ broken, because neither is tracked by the lockfile:
 
 - A dependency version bump leaves per-package `node_modules/.bin/*` shims pointing at a store
   path pnpm has since removed — the build fails with `MODULE_NOT_FOUND` on a path containing the
-  *old* version.
+  _old_ version.
 - Generated sources (e.g. `packages/core/protocols/src/proto/gen`) go stale while moon's cache
   hash still matches, so every run restores the stale output rather than regenerating it.
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "publish-package": "node scripts/publish-package.mjs",
     "publish-unpublished-packages": "node scripts/publish-unpublished-packages.mjs",
     "query-logs": "node scripts/query-logs.mjs",
+    "reset": "./scripts/reset",
     "secrets": "node scripts/secrets.mjs",
     "test": "moon run :test -- --no-file-parallelism",
     "test-browser": "MOON_CONCURRENCY=4 moon run :test-browser -- --no-file-parallelism",

--- a/scripts/reset
+++ b/scripts/reset
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+cd "$(git rev-parse --show-toplevel)"
 
 DEEP=false
 [[ "${1:-}" == "--deep" ]] && DEEP=true

--- a/scripts/reset
+++ b/scripts/reset
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 DXOS.org
+#
+# Clears the stale build state that makes a dev server or build fail in ways `pnpm install`
+# reports as "Already up to date": orphaned per-package `.bin` shims left behind by a dependency
+# version bump, and moon cache entries whose hash still matches while their outputs are stale.
+#
+# Usage: pnpm reset [--deep]
+#   (default) prune stale bin shims, drop the moon cache, force-regenerate codegen outputs.
+#   --deep    also remove every package `dist` and reinstall node_modules from scratch.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DEEP=false
+[[ "${1:-}" == "--deep" ]] && DEEP=true
+
+echo "==> Pruning per-package .bin shims that point at removed store paths"
+pruned=0
+while IFS= read -r shim; do
+  target=$(grep -oE '/node_modules/\.pnpm/[^"'"'"' ]+/node_modules/[^"'"'"' ]+\.(js|mjs|cjs)' "$shim" | head -1 || true)
+  [[ -z "$target" ]] && continue
+  if [[ ! -e "${PWD}${target}" ]]; then
+    rm -f "$shim"
+    pruned=$((pruned + 1))
+  fi
+done < <(find packages tools -type f -path '*/node_modules/.bin/*' -not -path './node_modules/*' 2>/dev/null)
+echo "    removed ${pruned} stale shim(s)"
+
+if $DEEP; then
+  echo "==> Removing package dist directories"
+  find packages tools -maxdepth 4 -type d -name dist -not -path '*/node_modules/*' -exec rm -rf {} +
+  echo "==> Reinstalling node_modules"
+  rm -rf node_modules
+  pnpm install
+else
+  pnpm install
+fi
+
+echo "==> Clearing the moon cache"
+rm -rf .moon/cache
+
+echo "==> Regenerating protobuf output"
+rm -rf packages/core/protocols/src/proto/gen
+moon run protocols:prebuild --force
+
+echo "==> Done. Rebuild with: moon exec --on-failure continue --quiet :build"


### PR DESCRIPTION
## Summary

Adds `pnpm reset` (`scripts/reset`) for recovering a workspace whose build fails on stale local
state that `pnpm install` reports as *Already up to date*, plus a `REPOSITORY_GUIDE.md` section
documenting it.

Motivated by a real failure this week: `moon run composer-app:serve` died with
`MODULE_NOT_FOUND` on `node_modules/.pnpm/vite@8.1.4_.../vite/bin/vite.js`, a store path pnpm had
already removed. 42 packages carried orphaned `node_modules/.bin/vite` shims pointing at it;
`pnpm install` and even `pnpm install --force` left them untouched, because pnpm no longer manages
bins for packages that do not declare the dep. Once past that, `protocols:build` failed with
`Module '"@dxos/codec-protobuf"' has no exported member 'Stream'` — `Stream` moved to `@dxos/async`
in bdb02cd3a1, but moon's cache hash for `protocols:prebuild` still matched, so every run (including
`--force` on `build`) restored the stale generated output instead of regenerating it.

## What it does

```bash
pnpm reset          # prune dead .bin shims, reinstall, clear .moon/cache, regenerate protobuf
pnpm reset --deep   # also delete every package dist and reinstall node_modules from scratch
```

The shim prune is targeted, not a blanket wipe: it parses each shim's exec target and removes the
shim only when that path no longer exists on disk — so a healthy workspace is a no-op.

## Decisions

- The script roots itself via `git rev-parse --show-toplevel` rather than `dirname $0`, so invoking
  it from a worktree resets that worktree, not the primary checkout.
- `protocols:prebuild --force` rather than `build --force`: the codegen is the `prebuild` task's
  output, and forcing `build` alone still restores the cached `prebuild` result.

## Verification

Run against the primary checkout: pruned 33 stale shims (probe: 599 resolvable → 0 stale),
regenerated protobuf with the correct `import type { Stream } from "@dxos/async"` header, after
which `moon run composer-app:serve` came up clean and `http://localhost:5173/` returned 200.

No TypeScript changed, so no changeset — this is repo tooling and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reset command to clear stale build state and restore a clean development environment.
  - Supports a deeper reset that also removes generated build outputs before reinstalling dependencies and regenerating required sources.

- **Documentation**
  - Added guidance for resolving stale dependency shims and cached generated files.
  - Documented stopping development servers before running the reset commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->