### PR TITLE
plugin-claude-agents: rename plugin to "Claude"

### DIFF
--- a/.changeset/claude-managed-agents-plugin.md
+++ b/.changeset/claude-managed-agents-plugin.md
@@ -2,4 +2,4 @@
 '@dxos/plugin-claude-agents': minor
 ---
 
-Add the Claude Agents plugin: a `ClaudeManagedAgent` type for configuring an Anthropic-hosted managed agent, a `ClaudeAgentSession` type recording each run, and an assistant skill that can create, deploy, run and read back those agents.
+Add the Claude plugin: a `ClaudeManagedAgent` type for configuring an Anthropic-hosted managed agent, a `ClaudeAgentSession` type recording each run, and an assistant skill that can create, deploy, run and read back those agents.

--- a/packages/plugins/plugin-claude-agents/dx.config.ts
+++ b/packages/plugins/plugin-claude-agents/dx.config.ts
@@ -8,7 +8,7 @@ import { trim } from '@dxos/util';
 export default Config2.make({
   plugin: {
     key: 'org.dxos.plugin.claudeAgents',
-    name: 'Claude Agents',
+    name: 'Claude',
     author: 'DXOS',
     description: trim`
       Model Anthropic Claude managed agents as first-class objects in your space. A ClaudeManagedAgent

--- a/packages/plugins/plugin-claude-agents/src/translations.ts
+++ b/packages/plugins/plugin-claude-agents/src/translations.ts
@@ -31,7 +31,7 @@ export const translations = [
         'delete-object.label': 'Delete session',
       },
       [meta.profile.key]: {
-        'plugin.name': 'Claude Agents',
+        'plugin.name': 'Claude',
       },
     },
   },


### PR DESCRIPTION
Renames the plugin's display name from **Claude Agents** to **Claude**, and confirms both it and `plugin-deepseek` render Rich's `px` logos.

## Changes

- `dx.config.ts` — `name: 'Claude Agents'` → `'Claude'`.
- `src/translations.ts` — `plugin.name` follows.
- `.changeset/claude-managed-agents-plugin.md` — wording follows (the changeset is unreleased).

Deliberately unchanged: the object typenames (`Claude Agent`, `Agent Session`), the skill name, and the `List Claude Agents` operation — those name the agents, not the plugin.

## Logos

No code change was needed. Rich's glyphs landed in [#12820](https://github.com/dxos/dxos/pull/12820) as `packages/ui/ui-icons/assets/{anthropic,deepseek}.svg`, are registered in `PxIcons`, and both plugins already reference them:

| Plugin | `icon` |
| --- | --- |
| `org.dxos.plugin.claudeAgents` | `{ key: 'px--anthropic--regular', hue: 'yellow' }` |
| `org.dxos.plugin.deepseek` | `{ key: 'px--deepseek--regular', hue: 'blue' }` |

## Proof

Captured from this PR's own Composer preview deploy — the real plugin registry, Labs category, at `https://pr-12822-composer-dev.dxos.workers.dev`.

[Composer plugin registry, Labs category, showing the Claude card](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-08-28-claude-plugin-rename-logos/live-view-claude.png)

The renamed **Claude** card sorts under C between Chess.com and Code, carrying the Anthropic glyph on its yellow panel.

[The Claude plugin card close up](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-08-28-claude-plugin-rename-logos/live-row-claude.png)

[The DeepSeek plugin card close up](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-08-28-claude-plugin-rename-logos/live-row-deepseek.png)

[Composer plugin registry showing the DeepSeek card in place](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-08-28-claude-plugin-rename-logos/live-view-deepseek.png)

Both glyphs resolve through the sprite and sit correctly on their `hue` panel. A standalone render at 16/24/40px in light and dark, checking they hold up at small sizes:

[Claude and DeepSeek rows at 16, 24 and 40px, light and dark](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-08-28-claude-plugin-rename-logos/plugin-logos.png)