### PR TITLE
plugin-deepseek: add harness skill running DeepSeek in a sandbox

### DIFF
--- a/.changeset/deepseek-harness-skill.md
+++ b/.changeset/deepseek-harness-skill.md
@@ -1,0 +1,6 @@
+---
+'@dxos/plugin-deepseek': minor
+'@dxos/plugin-sandbox': patch
+---
+
+Add a DeepSeek harness skill: provisions a sandbox with the space's DeepSeek credential bound to it, installs the harness CLI, and runs it on a prompt. The sandbox plugin now exports its operation definitions as `@dxos/plugin-sandbox/SandboxOperation`.

--- a/packages/plugins/plugin-deepseek/PLUGIN.mdl
+++ b/packages/plugins/plugin-deepseek/PLUGIN.mdl
@@ -5,11 +5,14 @@ version: 0.1.0
 ---
 
 A **headless** Composer plugin that makes [DeepSeek](https://platform.deepseek.com)
-connectable. It has no React/UI surfaces and contributes one thing: a
-**Connector** entry (`source: "deepseek.com"`) with an API-key credential form,
-so the user connects DeepSeek through the generic `plugin-connector` UI. On
-submit the key is stored as an `AccessToken` (source `deepseek.com`) plus a
-`Connection` in ECHO, resolvable later via `CredentialsService`.
+connectable and runnable. It has no React/UI surfaces and contributes two things:
+
+1. A **Connector** entry (`source: "deepseek.com"`) with an API-key credential form, so the user
+   connects DeepSeek through the generic `plugin-connector` UI. On submit the key is stored as an
+   `AccessToken` (source `deepseek.com`) plus a `Connection` in ECHO.
+2. A **Skill** (`org.dxos.skill.deepseek`, `agentCanEnable: true`) that runs the DeepSeek harness
+   — DeepSeek's own coding agent — inside a `plugin-sandbox` container, with that credential bound
+   to the container by reference.
 
 ## Extensions
 
@@ -18,6 +21,7 @@ submit the key is stored as an `AccessToken` (source `deepseek.com`) plus a
 | `feat` | `org.dxos.mdl.feat@1.0` |
 | `test` | `org.dxos.mdl.test@1.0` |
 | `flow` | `org.dxos.mdl.flow@1.0` |
+| `op`   | `org.dxos.mdl.op@1.1`   |
 
 ## Connector
 
@@ -40,6 +44,61 @@ feat DeepSeekConnector
       { kind: "complete", accessToken, connection }.
 ```
 
+## Harness skill
+
+```mdl
+feat DeepSeekSkill
+  desc: >
+    Contributes an AppCapabilities.SkillDefinition. The skill's tools are the two operations
+    below; `agentCanEnable: true`, so the agent turns the skill on mid-task rather than the user
+    enabling it up front. The harness itself is not bundled — it is installed into the sandbox
+    on provision, so nothing DeepSeek-specific runs in the browser.
+  key: org.dxos.skill.deepseek
+```
+
+```mdl
+op installHarness
+  key: org.dxos.operation.deepseek.installHarness
+  desc: >
+    Creates a sandbox via op:createSandbox, binds the space's deepseek.com AccessToken to it as
+    the DEEPSEEK_API_KEY credential (by REFERENCE — the sandbox resolves it per exec, so the key
+    never enters an operation result or a transcript), then installs the harness CLI via op:exec.
+  input:
+    name?: string
+    baseImage?: string
+    harnessPackage?: string     # defaults to the plugin's pinned npm package
+  output:
+    sandboxId: string           # ECHO object URI of the sandbox
+    installOutput: string
+  errors:
+    - MissingCredentialError    # no deepseek.com AccessToken in the space
+    - HarnessInstallError       # the install command exited non-zero
+  effects: [echo:read, echo:write, sandbox:create, sandbox:exec]
+```
+
+```mdl
+op runHarness
+  key: org.dxos.operation.deepseek.runHarness
+  desc: >
+    Runs the harness on a prompt in a provisioned sandbox via op:exec. The prompt is the final
+    positional argument and is shell-quoted; model and API host travel as environment
+    (DEEPSEEK_MODEL, DEEPSEEK_BASE_URL) rather than as CLI flags this plugin would have to guess.
+  input:
+    sandbox: Ref<Sandbox>
+    prompt: string
+    model?: string
+    args?: string[]
+    harnessBin?: string
+    cwd?: string
+    timeout?: number
+  output:
+    stdout: string
+    stderr: string
+    exitCode: number
+    success: boolean
+  effects: [sandbox:exec]
+```
+
 ## Acceptance
 
 ```mdl
@@ -57,6 +116,20 @@ test T-2: Empty token rejected
   given: the DeepSeek ConnectorEntry
   when: credentialForm.onSubmit runs with { token: "  " }
   then: it throws (no AccessToken / Connection created)
+```
+
+```mdl
+test T-3: Install fails cleanly with no credential
+  given: a space with no deepseek.com AccessToken
+  when: op:installHarness runs
+  then: it fails with MissingCredentialError (no sandbox is created)
+```
+
+```mdl
+test T-4: The prompt is shell-quoted
+  given: a prompt containing shell metacharacters
+  when: the run command is built
+  then: the prompt is a single quoted argument, with embedded quotes escaped
 ```
 
 ## QA
@@ -127,8 +200,41 @@ flow QA-1: Connect DeepSeek with an API key
         The delete action in the connection's own panel routes through that operation anyway.
 ```
 
+```mdl
+flow QA-2: Run the harness in a sandbox
+  desc: >
+    The skill end to end — provision a sandbox against a connected DeepSeek account and run the
+    harness on a trivial prompt.
+  actors: agent
+  status: unverified
+  given:
+    - QA-1 has run, so a deepseek.com credential exists in the space
+    - plugin-deepseek and plugin-sandbox are both enabled
+    - the sandbox service is reachable
+  test:
+    - name: Install the harness
+      do: Ask the assistant to set up the DeepSeek harness.
+      invoke: [op:installHarness] { name: "QA Harness" }
+      capture: installed
+      expect: a sandbox exists with the DeepSeek credential bound and the harness CLI installed
+      assert: return !!$installed.sandboxId
+    - name: Run a prompt
+      do: Ask the assistant to have DeepSeek print the files in the working directory.
+      invoke: [op:runHarness] { sandbox: { "/": $installed.sandboxId }, prompt: "list the files here" }
+      expect: the harness runs and its output comes back
+      assert: return $result.exitCode === 0
+  after:
+    - name: Delete the sandbox
+      do: Right-click "QA Harness" in the navtree and choose Delete.
+      invoke: org.dxos.operation.space.removeObjects { refs: [{ "/": $installed.sandboxId }], target: $given.space }
+```
+
 ## Out of scope (v1)
 
-- Any DeepSeek API client / model provider; this version only stores the credential.
+- Any in-browser DeepSeek API client / model provider; the harness runs in the sandbox.
 - OAuth (DeepSeek uses a static API key).
 - Multi-account configuration.
+- Streaming harness output; a run returns once, when the command exits.
+- Pinning the harness CLI's distribution. The npm package and binary names are constants with
+  per-call overrides (`harnessPackage`, `harnessBin`) precisely because DeepSeek's CLI release
+  channel is not something this plugin can guarantee.

--- a/packages/plugins/plugin-deepseek/README.md
+++ b/packages/plugins/plugin-deepseek/README.md
@@ -3,11 +3,24 @@
 License: [FSL-1.1-Apache-2.0](./LICENSE) Copyright 2022 © DXOS
 
 Headless DXOS Composer plugin that lets the user connect their
-[DeepSeek](https://platform.deepseek.com) account by pasting an API key.
+[DeepSeek](https://platform.deepseek.com) account by pasting an API key, and lets
+the assistant run the DeepSeek harness with it.
 
-It contributes a single **Connector** entry (`source: "deepseek.com"`) with an
-API-key credential form, rendered by the generic Connector UI. On submit the key
-is stored as an `AccessToken` plus a `Connection` in ECHO, resolvable by other
-plugins through `CredentialsService`.
+It contributes:
+
+- A **Connector** entry (`source: "deepseek.com"`) with an API-key credential
+  form, rendered by the generic Connector UI. On submit the key is stored as an
+  `AccessToken` plus a `Connection` in ECHO.
+- A **Skill** (`org.dxos.skill.deepseek`) with two operations. `InstallHarness`
+  creates a `plugin-sandbox` container, binds that `AccessToken` to it as the
+  `DEEPSEEK_API_KEY` credential — by reference, so the key is resolved into the
+  container's environment per exec and never enters a tool result or transcript —
+  and installs the harness CLI. `RunHarness` runs the harness on a prompt in that
+  sandbox and returns its stdout, stderr and exit code. The skill sets
+  `agentCanEnable: true`, so the agent turns it on mid-task.
+
+The harness CLI is installed into the sandbox, not bundled: the npm package
+(`DEFAULT_HARNESS_PACKAGE`) and binary (`DEFAULT_HARNESS_BIN`) are defaults that
+each call can override via `harnessPackage` / `harnessBin`.
 
 No React/UI surfaces. See [`PLUGIN.mdl`](./PLUGIN.mdl) for the specification.

--- a/packages/plugins/plugin-deepseek/package.json
+++ b/packages/plugins/plugin-deepseek/package.json
@@ -15,8 +15,14 @@
   "type": "module",
   "imports": {
     "#capabilities": {
-      "source": "./src/capabilities/index.ts",
+      "source": {
+        "workerd": "./src/capabilities/gen/workerd.ts",
+        "node": "./src/capabilities/gen/node.ts",
+        "default": "./src/capabilities/index.ts"
+      },
       "types": "./dist/types/src/capabilities/index.d.ts",
+      "workerd": "./dist/lib/capabilities.workerd.mjs",
+      "node": "./dist/lib/capabilities.node.mjs",
       "default": "./dist/lib/capabilities.mjs"
     },
     "#meta": {
@@ -28,6 +34,11 @@
       "source": "./src/plugin.ts",
       "types": "./dist/types/src/plugin.d.ts",
       "default": "./dist/lib/plugin.mjs"
+    },
+    "#skills": {
+      "source": "./src/skills/index.ts",
+      "types": "./dist/types/src/skills/index.d.ts",
+      "default": "./dist/lib/skills.mjs"
     }
   },
   "exports": {
@@ -51,12 +62,20 @@
   ],
   "dependencies": {
     "@dxos/app-framework": "workspace:*",
+    "@dxos/app-toolkit": "workspace:*",
+    "@dxos/compute": "workspace:*",
     "@dxos/echo": "workspace:*",
     "@dxos/effect": "workspace:*",
+    "@dxos/errors": "workspace:*",
+    "@dxos/keys": "workspace:*",
     "@dxos/link": "workspace:*",
     "@dxos/plugin-connector": "workspace:*",
+    "@dxos/plugin-sandbox": "workspace:*",
     "@dxos/util": "workspace:*",
     "effect": "catalog:"
+  },
+  "devDependencies": {
+    "vitest": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugins/plugin-deepseek/src/capabilities/index.ts
+++ b/packages/plugins/plugin-deepseek/src/capabilities/index.ts
@@ -2,7 +2,9 @@
 // Copyright 2026 DXOS.org
 //
 
+import * as ActivationEvents from '@dxos/app-framework/ActivationEvents';
 import * as Capability from '@dxos/app-framework/Capability';
+import * as AppCapability from '@dxos/app-toolkit/AppCapability';
 import * as ConnectorEvents from '@dxos/plugin-connector/ConnectorEvents';
 import * as ConnectorSpec from '@dxos/plugin-connector/ConnectorSpec';
 
@@ -11,3 +13,9 @@ export const Connector = Capability.lazyModule(
   { provides: [ConnectorSpec.Connector], activatesOn: ConnectorEvents.Start },
   () => import('./connector'),
 );
+
+export const SkillDefinition = AppCapability.skillDefinition(() => import('./skill-definition'));
+
+export const OperationHandler = AppCapability.operationHandler(() => import('./operation-handler'), {
+  activatesOn: ActivationEvents.Idle,
+});

--- a/packages/plugins/plugin-deepseek/src/capabilities/operation-handler.ts
+++ b/packages/plugins/plugin-deepseek/src/capabilities/operation-handler.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Capabilities from '@dxos/app-framework/Capabilities';
+import * as Capability from '@dxos/app-framework/Capability';
+
+import { DeepSeekHandlers } from '#skills';
+
+export default Capability.makeModule(
+  Effect.fnUntraced(function* () {
+    return Capability.contribute(Capabilities.OperationHandler, DeepSeekHandlers);
+  }),
+);

--- a/packages/plugins/plugin-deepseek/src/capabilities/skill-definition.ts
+++ b/packages/plugins/plugin-deepseek/src/capabilities/skill-definition.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Capability from '@dxos/app-framework/Capability';
+import * as AppCapabilities from '@dxos/app-toolkit/AppCapabilities';
+
+import { DeepSeekSkill } from '#skills';
+
+const skillDefinition = () => Effect.succeed([Capability.contribute(AppCapabilities.SkillDefinition, DeepSeekSkill)]);
+
+export default skillDefinition;

--- a/packages/plugins/plugin-deepseek/src/constants.ts
+++ b/packages/plugins/plugin-deepseek/src/constants.ts
@@ -7,3 +7,33 @@ export const DEEPSEEK_CONNECTOR_ID = 'org.dxos.plugin.deepseek.connector';
 
 /** Matches `AccessToken.source`, which is how `CredentialsService` resolves the API key. */
 export const DEEPSEEK_SOURCE = 'deepseek.com';
+
+/** `Skill.key` for the DeepSeek harness skill. */
+export const DEEPSEEK_SKILL_KEY = 'org.dxos.skill.deepseek';
+
+/** Environment variable the harness reads the API key from inside the sandbox. */
+export const DEEPSEEK_API_KEY_ENV = 'DEEPSEEK_API_KEY';
+
+/** Environment variable naming the API host, so a harness defaulting to another vendor is redirected. */
+export const DEEPSEEK_BASE_URL_ENV = 'DEEPSEEK_BASE_URL';
+
+/** DeepSeek's OpenAI-compatible API host. */
+export const DEEPSEEK_BASE_URL = 'https://api.deepseek.com';
+
+/** Environment variable naming the model, so the model is chosen without guessing a CLI flag. */
+export const DEEPSEEK_MODEL_ENV = 'DEEPSEEK_MODEL';
+
+/**
+ * npm package installed into the sandbox to provide the harness CLI. Overridable per call:
+ * DeepSeek's CLI distribution is not pinned by this plugin.
+ */
+export const DEFAULT_HARNESS_PACKAGE = 'deepseek-cli';
+
+/** Executable the harness package installs on PATH. */
+export const DEFAULT_HARNESS_BIN = 'deepseek';
+
+/** Name given to the sandbox provisioned for the harness. */
+export const DEFAULT_SANDBOX_NAME = 'DeepSeek harness';
+
+/** Bounds one harness run; a coding harness is far slower than a shell command, so well above exec's default. */
+export const DEFAULT_RUN_TIMEOUT_MS = 600_000;

--- a/packages/plugins/plugin-deepseek/src/errors.ts
+++ b/packages/plugins/plugin-deepseek/src/errors.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { BaseError } from '@dxos/errors';
+
+/** No DeepSeek credential is stored in the space, so the harness has nothing to authenticate with. */
+export class MissingCredentialError extends BaseError.extend(
+  'MissingCredentialError',
+  'No DeepSeek API credential is connected in this space.',
+) {}
+
+/** Installing the harness CLI into the sandbox failed, so there is nothing to run. */
+export class HarnessInstallError extends BaseError.extend(
+  'HarnessInstallError',
+  'The DeepSeek harness could not be installed in the sandbox.',
+) {}

--- a/packages/plugins/plugin-deepseek/src/index.ts
+++ b/packages/plugins/plugin-deepseek/src/index.ts
@@ -5,3 +5,6 @@
 export * as DeepSeekPlugin from './DeepSeekPlugin';
 export * from './events';
 export * from '#meta';
+export * from '#skills';
+export * from './constants';
+export * from './errors';

--- a/packages/plugins/plugin-deepseek/src/plugin.ts
+++ b/packages/plugins/plugin-deepseek/src/plugin.ts
@@ -4,9 +4,14 @@
 
 import * as Plugin from '@dxos/app-framework/Plugin';
 
-import { Connector } from '#capabilities';
+import { Connector, OperationHandler, SkillDefinition } from '#capabilities';
 import { meta } from '#meta';
 
-export const DeepSeekPlugin = Plugin.define(meta).pipe(Plugin.addModule(Connector), Plugin.make);
+export const DeepSeekPlugin = Plugin.define(meta).pipe(
+  Plugin.addModule(Connector),
+  Plugin.addModule(OperationHandler),
+  Plugin.addModule(SkillDefinition),
+  Plugin.make,
+);
 
 export default DeepSeekPlugin;

--- a/packages/plugins/plugin-deepseek/src/skills/deepseek-skill.ts
+++ b/packages/plugins/plugin-deepseek/src/skills/deepseek-skill.ts
@@ -1,0 +1,63 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Skill from '@dxos/compute/Skill';
+import * as Template from '@dxos/compute/Template';
+import { trim } from '@dxos/util';
+
+import { DEEPSEEK_API_KEY_ENV, DEEPSEEK_SKILL_KEY, DEEPSEEK_SOURCE } from '../constants';
+import { InstallHarness, RunHarness } from './operations';
+
+const make = () =>
+  Skill.make({
+    key: DEEPSEEK_SKILL_KEY,
+    name: 'DeepSeek',
+    description: 'Run the DeepSeek harness in a sandbox container using the space’s DeepSeek API key.',
+    // Enabled by the agent on demand: the harness is a tool it reaches for mid-task, and the
+    // credential is already connected by the time it matters.
+    agentCanEnable: true,
+    tools: Skill.toolDefinitions({ operations: [InstallHarness, RunHarness] }),
+    instructions: Template.make({
+      source: trim`
+        The DeepSeek harness is DeepSeek's own coding agent, run inside a sandbox container — an
+        isolated shell environment the sandbox service provisions on first use. Use it to hand a
+        self-contained coding or analysis task to DeepSeek and read back what it produced.
+
+        ## The shape of the flow
+        1. Install DeepSeek Harness — creates the sandbox, binds the space's DeepSeek credential
+           to it, and installs the harness CLI. Returns a \`sandboxId\`; do this once per sandbox,
+           not once per prompt.
+        2. Run DeepSeek Harness — runs the harness on a prompt in that sandbox and returns its
+           stdout, stderr and exit code. Re-run it as often as needed with the same \`sandboxId\`;
+           the sandbox keeps its filesystem between runs, so a follow-up prompt sees the earlier
+           run's output on disk.
+
+        Reuse the sandbox from a previous install when you still have its id. Installing again
+        creates a second container and reinstalls the CLI for nothing.
+
+        ## Credentials
+        The API key is never passed to a tool and never enters the conversation. It is bound to the
+        sandbox by reference and resolved into the container's ${DEEPSEEK_API_KEY_ENV} on each run.
+
+        When Install DeepSeek Harness fails with MissingCredentialError the DeepSeek account is
+        not connected yet. That is a setup gap, not an error to report and stop on:
+        1. Emit the connector prompt so the user can connect inline:
+           \`<surface role='integration-prompt' data='{"service":"${DEEPSEEK_SOURCE}"}' />\`
+        2. Say that connecting DeepSeek lets you continue, then stop and wait — do not retry in the
+           same turn, and never ask the user to paste a key into the conversation.
+
+        ## Reading a result
+        A non-zero \`exitCode\` is the harness's own failure, not a transport error: report its
+        \`stderr\` rather than retrying blindly. Long runs are bounded by a timeout; if a run is cut
+        off, narrow the prompt rather than raising the timeout indefinitely.
+      `,
+    }),
+  });
+
+const skill: Skill.Definition = {
+  key: DEEPSEEK_SKILL_KEY,
+  make,
+};
+
+export default skill;

--- a/packages/plugins/plugin-deepseek/src/skills/index.ts
+++ b/packages/plugins/plugin-deepseek/src/skills/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export { default as DeepSeekSkill } from './deepseek-skill';
+export * from './operations';

--- a/packages/plugins/plugin-deepseek/src/skills/operations/definitions.ts
+++ b/packages/plugins/plugin-deepseek/src/skills/operations/definitions.ts
@@ -1,0 +1,81 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+
+import * as Operation from '@dxos/compute/Operation';
+import { Database, Ref } from '@dxos/echo';
+import { DXN } from '@dxos/keys';
+import * as Sandbox from '@dxos/plugin-sandbox/Sandbox';
+
+const SandboxRef = Ref.Ref(Sandbox.Sandbox).annotate({
+  description: 'The sandbox holding the DeepSeek harness, as returned by InstallHarness.',
+});
+
+export const InstallHarness = Operation.make({
+  meta: {
+    key: DXN.make('org.dxos.operation.deepseek.installHarness'),
+    name: 'InstallDeepSeekHarness',
+    description:
+      'Creates a sandbox, binds the space’s DeepSeek API key to it, and installs the DeepSeek harness CLI in it.',
+    icon: 'px--deepseek--regular',
+  },
+  input: Schema.Struct({
+    name: Schema.optional(Schema.String).annotate({
+      description: 'Display name for the sandbox.',
+    }),
+    baseImage: Schema.optional(Schema.String).annotate({
+      description: 'Base container image. Defaults to the sandbox service default.',
+    }),
+    harnessPackage: Schema.optional(Schema.String).annotate({
+      description: 'npm package providing the harness CLI. Defaults to the plugin’s pinned package.',
+    }),
+  }),
+  output: Schema.Struct({
+    sandboxId: Schema.String.annotate({
+      description: 'ECHO object URI of the sandbox; pass it as `sandbox` to RunHarness.',
+    }),
+    installOutput: Schema.String.annotate({
+      description: 'Combined output of the install step, for diagnosing an unexpected harness version.',
+    }),
+  }),
+  services: [Database.Service],
+});
+
+export const RunHarness = Operation.make({
+  meta: {
+    key: DXN.make('org.dxos.operation.deepseek.runHarness'),
+    name: 'RunDeepSeekHarness',
+    description:
+      'Runs the DeepSeek harness on a prompt inside a sandbox the install operation prepared and returns its output.',
+    icon: 'ph--terminal-window--regular',
+  },
+  input: Schema.Struct({
+    sandbox: SandboxRef,
+    prompt: Schema.String.annotate({
+      description: 'The task handed to the harness, as the operator would type it.',
+    }),
+    model: Schema.optional(Schema.String).annotate({
+      description: 'DeepSeek model id, e.g. "deepseek-chat". Passed as DEEPSEEK_MODEL.',
+    }),
+    args: Schema.optional(Schema.Array(Schema.String)).annotate({
+      description: 'Extra CLI arguments, inserted before the prompt.',
+    }),
+    harnessBin: Schema.optional(Schema.String).annotate({
+      description: 'Harness executable name. Defaults to the plugin’s pinned binary.',
+    }),
+    cwd: Schema.optional(Schema.String).annotate({
+      description: 'Absolute working directory for the run.',
+    }),
+    timeout: Schema.optional(Schema.Number).annotate({
+      description: 'Timeout in milliseconds.',
+    }),
+  }),
+  output: Schema.Struct({
+    stdout: Schema.String,
+    stderr: Schema.String,
+    exitCode: Schema.Number,
+    success: Schema.Boolean,
+  }),
+});

--- a/packages/plugins/plugin-deepseek/src/skills/operations/harness-command.test.ts
+++ b/packages/plugins/plugin-deepseek/src/skills/operations/harness-command.test.ts
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { buildInstallCommand, buildRunCommand, shellQuote } from './harness-command';
+
+describe('harness command', () => {
+  test('quotes a prompt so shell metacharacters are not executed', ({ expect }) => {
+    expect(shellQuote('rm -rf / && echo $HOME')).toBe(`'rm -rf / && echo $HOME'`);
+  });
+
+  test('escapes embedded single quotes', ({ expect }) => {
+    expect(shellQuote("it's fine")).toBe(`'it'\\''s fine'`);
+  });
+
+  test('run command puts the prompt last, after any extra args', ({ expect }) => {
+    expect(buildRunCommand({ bin: 'deepseek', prompt: 'fix the build', args: ['--yes'] })).toBe(
+      `deepseek '--yes' 'fix the build'`,
+    );
+  });
+
+  test('install command quotes the package name', ({ expect }) => {
+    expect(buildInstallCommand('deepseek-cli')).toBe(`npm install --global --no-fund --no-audit 'deepseek-cli'`);
+  });
+});

--- a/packages/plugins/plugin-deepseek/src/skills/operations/harness-command.ts
+++ b/packages/plugins/plugin-deepseek/src/skills/operations/harness-command.ts
@@ -1,0 +1,28 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+/**
+ * Quotes a value for `sh -c`: the command reaches the sandbox as a single string, so an
+ * unquoted prompt would be split on whitespace and its metacharacters executed.
+ */
+export const shellQuote = (value: string): string => `'${value.replaceAll("'", `'\\''`)}'`;
+
+/** Installs the harness CLI globally so the run command finds it on PATH. */
+export const buildInstallCommand = (harnessPackage: string): string =>
+  `npm install --global --no-fund --no-audit ${shellQuote(harnessPackage)}`;
+
+/**
+ * Builds the harness invocation: the prompt is the final positional argument, and everything
+ * else (model, API key, host) travels as environment rather than as flags this plugin would
+ * have to guess for a CLI it does not ship.
+ */
+export const buildRunCommand = ({
+  bin,
+  prompt,
+  args = [],
+}: {
+  bin: string;
+  prompt: string;
+  args?: readonly string[];
+}): string => [bin, ...args.map(shellQuote), shellQuote(prompt)].join(' ');

--- a/packages/plugins/plugin-deepseek/src/skills/operations/index.ts
+++ b/packages/plugins/plugin-deepseek/src/skills/operations/index.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Operation from '@dxos/compute/Operation';
+import * as OperationHandlerSet from '@dxos/compute/OperationHandlerSet';
+
+import { InstallHarness, RunHarness } from './definitions';
+
+export * from './definitions';
+export * from './harness-command';
+
+export const DeepSeekHandlers = OperationHandlerSet.lazy([
+  InstallHarness.pipe(Operation.lazyHandler(() => import('./install-harness'))),
+  RunHarness.pipe(Operation.lazyHandler(() => import('./run-harness'))),
+]);

--- a/packages/plugins/plugin-deepseek/src/skills/operations/install-harness.ts
+++ b/packages/plugins/plugin-deepseek/src/skills/operations/install-harness.ts
@@ -1,0 +1,61 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Operation from '@dxos/compute/Operation';
+import { Database, Filter, Obj, Ref, URI } from '@dxos/echo';
+import { AccessToken } from '@dxos/link';
+import * as Sandbox from '@dxos/plugin-sandbox/Sandbox';
+import * as SandboxOperation from '@dxos/plugin-sandbox/SandboxOperation';
+
+import {
+  DEEPSEEK_API_KEY_ENV,
+  DEEPSEEK_SOURCE,
+  DEFAULT_HARNESS_PACKAGE,
+  DEFAULT_RUN_TIMEOUT_MS,
+  DEFAULT_SANDBOX_NAME,
+} from '../../constants';
+import { HarnessInstallError, MissingCredentialError } from '../../errors';
+import { InstallHarness } from './definitions';
+import { buildInstallCommand } from './harness-command';
+
+export default InstallHarness.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ name, baseImage, harnessPackage }) {
+      const accessTokens = yield* Database.query(Filter.type(AccessToken.AccessToken)).run;
+      const accessToken = accessTokens.find(
+        (accessToken) => accessToken.source === DEEPSEEK_SOURCE && accessToken.token.length > 0,
+      );
+      if (!accessToken) {
+        return yield* Effect.fail(new MissingCredentialError());
+      }
+
+      const { sandboxId } = yield* Operation.invoke(SandboxOperation.CreateSandbox, {
+        name: name ?? DEFAULT_SANDBOX_NAME,
+        baseImage,
+      });
+      const sandbox = yield* Database.resolve(URI.make(sandboxId), Sandbox.Sandbox);
+
+      // Bound by reference, never by value: exec resolves the token at call time, so the key
+      // reaches the container's environment without passing through an operation result.
+      Obj.update(sandbox, (sandbox) => {
+        sandbox.credentials = [{ env: DEEPSEEK_API_KEY_ENV, token: Ref.make(accessToken) }];
+      });
+
+      const install = yield* Operation.invoke(SandboxOperation.Exec, {
+        sandbox: Ref.make(sandbox),
+        command: buildInstallCommand(harnessPackage ?? DEFAULT_HARNESS_PACKAGE),
+        timeout: DEFAULT_RUN_TIMEOUT_MS,
+      });
+      if (!install.success) {
+        return yield* Effect.fail(
+          new HarnessInstallError({ context: { exitCode: install.exitCode, stderr: install.stderr } }),
+        );
+      }
+
+      return { sandboxId, installOutput: [install.stdout, install.stderr].filter(Boolean).join('\n') };
+    }),
+  ),
+);

--- a/packages/plugins/plugin-deepseek/src/skills/operations/run-harness.ts
+++ b/packages/plugins/plugin-deepseek/src/skills/operations/run-harness.ts
@@ -1,0 +1,39 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Operation from '@dxos/compute/Operation';
+import * as SandboxOperation from '@dxos/plugin-sandbox/SandboxOperation';
+
+import {
+  DEEPSEEK_BASE_URL,
+  DEEPSEEK_BASE_URL_ENV,
+  DEEPSEEK_MODEL_ENV,
+  DEFAULT_HARNESS_BIN,
+  DEFAULT_RUN_TIMEOUT_MS,
+} from '../../constants';
+import { RunHarness } from './definitions';
+import { buildRunCommand } from './harness-command';
+
+export default RunHarness.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ sandbox, prompt, model, args, harnessBin, cwd, timeout }) {
+      // The API key is not passed here: it is bound to the sandbox as a credential ref by
+      // InstallHarness and merged into the exec environment on the sandbox side.
+      const env: Record<string, string> = { [DEEPSEEK_BASE_URL_ENV]: DEEPSEEK_BASE_URL };
+      if (model) {
+        env[DEEPSEEK_MODEL_ENV] = model;
+      }
+
+      return yield* Operation.invoke(SandboxOperation.Exec, {
+        sandbox,
+        command: buildRunCommand({ bin: harnessBin ?? DEFAULT_HARNESS_BIN, prompt, args }),
+        cwd,
+        env,
+        timeout: timeout ?? DEFAULT_RUN_TIMEOUT_MS,
+      });
+    }),
+  ),
+);

--- a/packages/plugins/plugin-deepseek/tsconfig.json
+++ b/packages/plugins/plugin-deepseek/tsconfig.json
@@ -22,7 +22,16 @@
       "path": "../../common/effect"
     },
     {
+      "path": "../../common/errors"
+    },
+    {
+      "path": "../../common/keys"
+    },
+    {
       "path": "../../common/util"
+    },
+    {
+      "path": "../../core/compute/compute"
     },
     {
       "path": "../../core/compute/link"
@@ -34,7 +43,13 @@
       "path": "../../sdk/app-framework"
     },
     {
+      "path": "../../sdk/app-toolkit"
+    },
+    {
       "path": "../plugin-connector"
+    },
+    {
+      "path": "../plugin-sandbox"
     }
   ]
 }

--- a/packages/plugins/plugin-deepseek/vite.config.ts
+++ b/packages/plugins/plugin-deepseek/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     plugin: 'src/plugin.ts',
     capabilities: 'src/capabilities/index.ts',
     meta: 'src/meta.ts',
+    skills: 'src/skills/index.ts',
   },
   test: { node: true },
 });

--- a/packages/plugins/plugin-sandbox/package.json
+++ b/packages/plugins/plugin-sandbox/package.json
@@ -68,6 +68,11 @@
       "source": "./src/SandboxPlugin.ts",
       "types": "./dist/types/src/SandboxPlugin.d.ts",
       "import": "./dist/lib/SandboxPlugin.mjs"
+    },
+    "./SandboxOperation": {
+      "source": "./src/types/SandboxOperation.ts",
+      "types": "./dist/types/src/types/SandboxOperation.d.ts",
+      "import": "./dist/lib/SandboxOperation.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",
@@ -78,6 +83,9 @@
       ],
       "SandboxEvents": [
         "dist/types/src/types/SandboxEvents.d.ts"
+      ],
+      "SandboxOperation": [
+        "dist/types/src/types/SandboxOperation.d.ts"
       ]
     }
   },

--- a/packages/plugins/plugin-sandbox/src/plugin.test.ts
+++ b/packages/plugins/plugin-sandbox/src/plugin.test.ts
@@ -16,9 +16,7 @@ import { ClientPlugin, initializeIdentity } from '@dxos/plugin-client/testing';
 import { createComposerTestApp } from '@dxos/plugin-testing/harness';
 
 import { SandboxPlugin } from '#plugin';
-import { Sandbox } from '#types';
-
-import { CreateSandbox, Exec } from './skills/functions';
+import { Sandbox, SandboxOperation } from '#types';
 
 /**
  * Prereq: sandbox-service worker at http://localhost:8792 (API at /api/sandbox).
@@ -44,7 +42,7 @@ describe('SandboxPlugin (composer harness)', { tags: ['functions-e2e'] }, () => 
     await harness.runPromise(
       Effect.gen(function* () {
         const { sandboxId } = yield* Operation.invoke(
-          CreateSandbox,
+          SandboxOperation.CreateSandbox,
           { name: 'composer-harness-test' },
           { spaceId: defaultSpace.id },
         );
@@ -54,7 +52,7 @@ describe('SandboxPlugin (composer harness)', { tags: ['functions-e2e'] }, () => 
         expect(sandbox).toBeDefined();
 
         const result = yield* Operation.invoke(
-          Exec,
+          SandboxOperation.Exec,
           {
             sandbox: Ref.make(sandbox),
             command: 'echo hello world',

--- a/packages/plugins/plugin-sandbox/src/skills/functions/create-sandbox.ts
+++ b/packages/plugins/plugin-sandbox/src/skills/functions/create-sandbox.ts
@@ -8,12 +8,11 @@ import { ClientService } from '@dxos/client';
 import * as Operation from '@dxos/compute/Operation';
 import { Database, Obj } from '@dxos/echo';
 
-import { Sandbox } from '#types';
+import { Sandbox, SandboxOperation } from '#types';
 
 import { createSandboxClient } from '../../services/sandbox-url';
-import { CreateSandbox } from './definitions';
 
-export default CreateSandbox.pipe(
+export default SandboxOperation.CreateSandbox.pipe(
   Operation.withHandler(
     Effect.fn(function* ({ name, baseImage }) {
       const { db } = yield* Database.Service;

--- a/packages/plugins/plugin-sandbox/src/skills/functions/download-file.ts
+++ b/packages/plugins/plugin-sandbox/src/skills/functions/download-file.ts
@@ -10,10 +10,11 @@ import * as Operation from '@dxos/compute/Operation';
 import { Blob, Database, Obj, Ref } from '@dxos/echo';
 import { File } from '@dxos/types';
 
-import { createSandboxClient } from '../../services/sandbox-url';
-import { DownloadFile } from './definitions';
+import { SandboxOperation } from '#types';
 
-export default DownloadFile.pipe(
+import { createSandboxClient } from '../../services/sandbox-url';
+
+export default SandboxOperation.DownloadFile.pipe(
   Operation.withHandler(
     Effect.fn(function* ({ sandbox, path, dest }) {
       const { db } = yield* Database.Service;

--- a/packages/plugins/plugin-sandbox/src/skills/functions/exec.ts
+++ b/packages/plugins/plugin-sandbox/src/skills/functions/exec.ts
@@ -8,11 +8,12 @@ import { ClientService } from '@dxos/client';
 import * as Operation from '@dxos/compute/Operation';
 import { Database } from '@dxos/echo';
 
+import { SandboxOperation } from '#types';
+
 import { mergeExecEnv } from '../../services/sandbox-env';
 import { createSandboxClient } from '../../services/sandbox-url';
-import { Exec } from './definitions';
 
-export default Exec.pipe(
+export default SandboxOperation.Exec.pipe(
   Operation.withHandler(
     Effect.fn(function* ({ sandbox, command, cwd, env, timeout }) {
       const { db } = yield* Database.Service;

--- a/packages/plugins/plugin-sandbox/src/skills/functions/index.ts
+++ b/packages/plugins/plugin-sandbox/src/skills/functions/index.ts
@@ -5,13 +5,11 @@
 import * as Operation from '@dxos/compute/Operation';
 import * as OperationHandlerSet from '@dxos/compute/OperationHandlerSet';
 
-import { CreateSandbox, DownloadFile, Exec, UploadFile } from './definitions';
-
-export * from './definitions';
+import { SandboxOperation } from '#types';
 
 export const SandboxHandlers = OperationHandlerSet.lazy([
-  CreateSandbox.pipe(Operation.lazyHandler(() => import('./create-sandbox'))),
-  Exec.pipe(Operation.lazyHandler(() => import('./exec'))),
-  UploadFile.pipe(Operation.lazyHandler(() => import('./upload-file'))),
-  DownloadFile.pipe(Operation.lazyHandler(() => import('./download-file'))),
+  SandboxOperation.CreateSandbox.pipe(Operation.lazyHandler(() => import('./create-sandbox'))),
+  SandboxOperation.Exec.pipe(Operation.lazyHandler(() => import('./exec'))),
+  SandboxOperation.UploadFile.pipe(Operation.lazyHandler(() => import('./upload-file'))),
+  SandboxOperation.DownloadFile.pipe(Operation.lazyHandler(() => import('./download-file'))),
 ]);

--- a/packages/plugins/plugin-sandbox/src/skills/functions/upload-file.ts
+++ b/packages/plugins/plugin-sandbox/src/skills/functions/upload-file.ts
@@ -11,10 +11,11 @@ import { Blob, Database } from '@dxos/echo';
 // eslint-disable-next-line unused-imports/no-unused-imports
 import { type File } from '@dxos/types';
 
-import { createSandboxClient } from '../../services/sandbox-url';
-import { UploadFile } from './definitions';
+import { SandboxOperation } from '#types';
 
-export default UploadFile.pipe(
+import { createSandboxClient } from '../../services/sandbox-url';
+
+export default SandboxOperation.UploadFile.pipe(
   Operation.withHandler(
     Effect.fn(function* ({ sandbox, file, path }) {
       const { db } = yield* Database.Service;

--- a/packages/plugins/plugin-sandbox/src/skills/sandbox-skill.ts
+++ b/packages/plugins/plugin-sandbox/src/skills/sandbox-skill.ts
@@ -6,9 +6,7 @@ import * as Skill from '@dxos/compute/Skill';
 import * as Template from '@dxos/compute/Template';
 import { trim } from '@dxos/util';
 
-import { Sandbox } from '#types';
-
-import { CreateSandbox, DownloadFile, Exec, UploadFile } from './functions';
+import { Sandbox, SandboxOperation } from '#types';
 
 const make = () =>
   Skill.make({
@@ -16,7 +14,12 @@ const make = () =>
     name: 'Sandbox',
     agentCanEnable: true,
     tools: Skill.toolDefinitions({
-      operations: [CreateSandbox, Exec, UploadFile, DownloadFile],
+      operations: [
+        SandboxOperation.CreateSandbox,
+        SandboxOperation.Exec,
+        SandboxOperation.UploadFile,
+        SandboxOperation.DownloadFile,
+      ],
     }),
     instructions: Template.make({
       source: trim`

--- a/packages/plugins/plugin-sandbox/src/testing/SandboxPlugin.test.ts
+++ b/packages/plugins/plugin-sandbox/src/testing/SandboxPlugin.test.ts
@@ -13,9 +13,9 @@ import { TestContextService } from '@dxos/effect/testing';
 import { EntityId } from '@dxos/keys';
 import { File } from '@dxos/types';
 
-import { Sandbox } from '#types';
+import { Sandbox, SandboxOperation } from '#types';
 
-import { CreateSandbox, DownloadFile, Exec, SandboxHandlers, UploadFile } from '../skills/functions';
+import { SandboxHandlers } from '../skills/functions';
 import SandboxSkill from '../skills/sandbox-skill';
 
 EntityId.dangerouslyDisableRandomness();
@@ -32,7 +32,7 @@ describe.skip('SandboxPlugin', () => {
     'create sandbox',
     (ctx) =>
       Effect.gen(function* () {
-        const result = yield* Operation.invoke(CreateSandbox, { name: 'test-sandbox' });
+        const result = yield* Operation.invoke(SandboxOperation.CreateSandbox, { name: 'test-sandbox' });
         expect(result.sandboxId).toBeTruthy();
       }).pipe(Effect.provide(TestLayer), Effect.provideService(TestContextService, ctx)),
     60_000,
@@ -45,7 +45,7 @@ describe.skip('SandboxPlugin', () => {
         const sandbox = Sandbox.make({ name: 'exec-test' });
         yield* Database.add(sandbox);
 
-        const result = yield* Operation.invoke(Exec, {
+        const result = yield* Operation.invoke(SandboxOperation.Exec, {
           sandbox: Ref.make(sandbox),
           command: 'echo hello world',
         });
@@ -69,13 +69,13 @@ describe.skip('SandboxPlugin', () => {
         const fileObj = yield* File.fromBytes(bytes, { name: 'test.txt', type: 'text/plain' });
         yield* Database.add(fileObj);
 
-        yield* Operation.invoke(UploadFile, {
+        yield* Operation.invoke(SandboxOperation.UploadFile, {
           sandbox: Ref.make(sandbox),
           file: Ref.make(fileObj),
           path: '/workspace/test.txt',
         });
 
-        const downloadResult = yield* Operation.invoke(DownloadFile, {
+        const downloadResult = yield* Operation.invoke(SandboxOperation.DownloadFile, {
           sandbox: Ref.make(sandbox),
           path: '/workspace/test.txt',
         });

--- a/packages/plugins/plugin-sandbox/src/types/SandboxOperation.ts
+++ b/packages/plugins/plugin-sandbox/src/types/SandboxOperation.ts
@@ -2,6 +2,8 @@
 // Copyright 2026 DXOS.org
 //
 
+// @import-as-namespace
+
 import * as Schema from 'effect/Schema';
 
 import { ClientService } from '@dxos/client';
@@ -10,7 +12,7 @@ import { Database, Ref } from '@dxos/echo';
 import { DXN } from '@dxos/keys';
 import { File } from '@dxos/types';
 
-import { Sandbox } from '#types';
+import * as Sandbox from './Sandbox';
 
 const SandboxRef = Ref.Ref(Sandbox.Sandbox).annotate({
   description: 'The sandbox object ID.',

--- a/packages/plugins/plugin-sandbox/src/types/index.ts
+++ b/packages/plugins/plugin-sandbox/src/types/index.ts
@@ -4,3 +4,4 @@
 
 export * as Sandbox from './Sandbox';
 export * as SandboxEvents from './SandboxEvents';
+export * as SandboxOperation from './SandboxOperation';

--- a/packages/plugins/plugin-sandbox/vite.config.ts
+++ b/packages/plugins/plugin-sandbox/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     plugin: 'src/plugin.ts',
     Sandbox: 'src/types/Sandbox.ts',
     SandboxEvents: 'src/types/SandboxEvents.ts',
+    SandboxOperation: 'src/types/SandboxOperation.ts',
     types: 'src/types/index.ts',
   },
   test: { node: true },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9941,24 +9941,43 @@ importers:
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
+      '@dxos/app-toolkit':
+        specifier: workspace:*
+        version: link:../../sdk/app-toolkit
+      '@dxos/compute':
+        specifier: workspace:*
+        version: link:../../core/compute/compute
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../core/echo/echo
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../common/effect
+      '@dxos/errors':
+        specifier: workspace:*
+        version: link:../../common/errors
+      '@dxos/keys':
+        specifier: workspace:*
+        version: link:../../common/keys
       '@dxos/link':
         specifier: workspace:*
         version: link:../../core/compute/link
       '@dxos/plugin-connector':
         specifier: workspace:*
         version: link:../plugin-connector
+      '@dxos/plugin-sandbox':
+        specifier: workspace:*
+        version: link:../plugin-sandbox
       '@dxos/util':
         specifier: workspace:*
         version: link:../../common/util
       effect:
         specifier: 4.0.0-rc.108
         version: 4.0.0-rc.108
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(patch_hash=cd5269e90ad2a4447bb2266e101250c008959a6c1168a57c132f6b50281f651b)(@opentelemetry/api@1.9.1)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.7.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.0))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/plugins/plugin-devtools:
     dependencies:


### PR DESCRIPTION
Extends `plugin-deepseek` beyond storing a credential: the assistant can now run the DeepSeek harness in a sandbox container using the space's connected DeepSeek account.

## What's new

A skill, `org.dxos.skill.deepseek`, with `agentCanEnable: true` — the agent turns it on mid-task rather than the user enabling it up front. Two operations:

- **`org.dxos.operation.deepseek.installHarness`** — creates a `plugin-sandbox` container via `op:createSandbox`, binds the space's `deepseek.com` `AccessToken` to it as the `DEEPSEEK_API_KEY` credential, then installs the harness CLI via `op:exec`. Returns the sandbox's ECHO URI. Fails with a typed `MissingCredentialError` when no DeepSeek account is connected, and `HarnessInstallError` when the install exits non-zero.
- **`org.dxos.operation.deepseek.runHarness`** — runs the harness on a prompt in that sandbox and returns stdout, stderr and exit code. The sandbox keeps its filesystem between runs, so follow-up prompts see earlier output.

The credential is bound **by reference**, not by value: `plugin-sandbox` resolves the `AccessToken` into the container's environment on each exec, so the key never appears in an operation result or a transcript. The skill instructions tell the model to emit the connector prompt (`<surface role='integration-prompt' data='{"service":"deepseek.com"}' />`) on `MissingCredentialError` rather than asking the user to paste a key into the conversation.

## plugin-sandbox change

The sandbox operation definitions moved from `src/skills/functions/definitions.ts` to `src/types/SandboxOperation.ts` and are exported as `@dxos/plugin-sandbox/SandboxOperation`, so another plugin can `Operation.invoke` them. All internal call sites were updated in place (no re-export shim). No behaviour change.

## Note on the harness CLI

The harness is installed into the sandbox, not bundled. Its npm package (`DEFAULT_HARNESS_PACKAGE = 'deepseek-cli'`) and binary (`DEFAULT_HARNESS_BIN = 'deepseek'`) are **defaults, and an assumption** — DeepSeek's CLI release channel is not something this plugin can pin — so both are overridable per call via `harnessPackage` / `harnessBin`. Model and API host travel as environment (`DEEPSEEK_MODEL`, `DEEPSEEK_BASE_URL`) rather than as CLI flags that would have to be guessed. Say the word if a different package should be the default.

## Testing

- `moon run plugin-deepseek:build|test|lint` — green (7 tests, including shell-quoting of the prompt so metacharacters cannot escape into the container's shell).
- `moon run plugin-sandbox:build|test|lint` — green.
- `pnpm format` run.
- `PLUGIN.mdl` updated with the two `op` blocks, tests T-3/T-4, and QA-2 (`status: unverified` — the sandbox service is not reachable from this environment).


---
_Generated by [Claude Code](https://claude.ai/code/session_0139RcZvj6PGLwL6dtu6ysfT)_