### PR TITLE
tools: correct the dxos plugin's desktop install docs and bump to 0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "dxos",
       "source": "./tools/claude/plugins/dxos",
       "description": "Durable, resumable project and task tracking for coding agents: a committed registry of work-streams plus a TASKS.md ledger per project, driven by one /dxos:project command. Bundles the DXOS Composer connector that serves the `mcp` backend.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "DXOS"
       }

--- a/tools/claude/plugins/dxos/.claude-plugin/plugin.json
+++ b/tools/claude/plugins/dxos/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dxos",
   "displayName": "DXOS Project Tracking",
   "description": "Durable, resumable project and task tracking for coding agents: a committed registry of work-streams plus a TASKS.md ledger per project, driven by one /dxos:project command. Adds /dxos:qa for running the executable QA flows declared in .mdl specs, and bundles the DXOS Composer connector that serves the `mcp` backend (authenticating it needs a Composer account with a passkey).",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "DXOS"
   },

--- a/tools/claude/plugins/dxos/README.md
+++ b/tools/claude/plugins/dxos/README.md
@@ -29,11 +29,6 @@ CLI writes, so either route lands the plugin in the next desktop session.
 That is the whole install for the default `file` backend. `/dxos:project` works
 immediately, against a committed `registry.yml`.
 
-The plugin also ships the `composer` connector, which only the `mcp` backend
-uses. Staying on `file`, run `/mcp`, select `composer`, and toggle it off.
-Toggle it back on if you switch backends, which is what step 1 below
-authenticates.
-
 The Claude **Desktop** app is a different product and does not run plugins at all:
 no hooks, so no `/dxos:project`. You can still add the MCP server there by URL as
 a connector, which gives you the tools without the command.

--- a/tools/claude/plugins/dxos/README.md
+++ b/tools/claude/plugins/dxos/README.md
@@ -20,11 +20,19 @@ claude plugin marketplace add dxos/dxos
 claude plugin install dxos@dxos
 ```
 
-In the Claude Code desktop app, run the same two as slash commands in any session:
-`/plugin marketplace add dxos/dxos`, then `/plugin install dxos@dxos`.
+In the Claude Code desktop app, run the first command in a terminal to register
+the marketplace, then install from the plugin manager: the **+** button beside
+the prompt box, **Plugins**, **Add plugin**, and pick `dxos`. **Manage plugins**
+enables, disables and uninstalls. The app reads the same `~/.claude` config the
+CLI writes, so either route lands the plugin in the next desktop session.
 
 That is the whole install for the default `file` backend. `/dxos:project` works
 immediately, against a committed `registry.yml`.
+
+The plugin also ships the `composer` connector, which only the `mcp` backend
+uses. Staying on `file`, run `/mcp`, select `composer`, and toggle it off.
+Toggle it back on if you switch backends, which is what step 1 below
+authenticates.
 
 The Claude **Desktop** app is a different product and does not run plugins at all:
 no hooks, so no `/dxos:project`. You can still add the MCP server there by URL as


### PR DESCRIPTION
## What

Three changes to the `dxos` Claude Code plugin:

1. **Fix the desktop install instructions.** The README told desktop users to run `/plugin marketplace add dxos/dxos` and `/plugin install dxos@dxos` as slash commands. There is no `/plugin` command in the Claude Code desktop app, which answers `/plugin isn't available in this environment`. The working path is now documented: register the marketplace from a terminal, then install through the plugin manager (**+** button beside the prompt box → **Plugins** → **Add plugin**), with **Manage plugins** for enable/disable/uninstall.
2. **Document turning the bundled connector off.** The plugin ships the `composer` MCP server, which only the `mcp` backend uses. Everyone on the default `file` backend was paying for a connector they never call, with nothing in the README saying they could switch it off.
3. **Bump `0.1.0` → `0.2.0`** in `plugin.json` and the marketplace entry, which have to agree.

## Why

The bad instruction sends a desktop user straight into an error message with no next step. The version bump is overdue: it has not moved since the plugin was renamed in 21643b90, and since then the plugin gained `/dxos:qa`, the `setup` verb, and the bundled Composer connector. That is feature growth, so minor rather than patch.

## Notes for a reviewer

- The desktop UI path is taken from [the desktop docs](https://code.claude.com/docs/en/desktop#install-plugins), which also lists the CLI/desktop equivalence as `/plugin` command ↔ plugin manager UI.
- The terminal `claude plugin marketplace add` step stays first because the plugin browser only offers plugins from marketplaces that are already configured.
- `claude plugin validate` passes on both manifests.
- Users still on the installed snapshot will not see this until it lands and they run `claude plugin marketplace update dxos && claude plugin update dxos@dxos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)