### PR TITLE
echo: document deletion semantics and dangling-ref handling (docs-first)

### DIFF
--- a/packages/core/echo/echo-react/API.md
+++ b/packages/core/echo/echo-react/API.md
@@ -5,7 +5,6 @@
 ```ts
 import {
   useObject, // Subscribe to a single Echo object or Ref
-  useObjects, // Subscribe to multiple Refs
   useQuery, // Reactive query subscription
   useType, // Type (schema registry) subscription
 } from '@dxos/echo-react';
@@ -34,11 +33,15 @@ const [name, setName] = useObject(obj, 'name');
 
 ### Subscribing to a Ref
 
-Automatically dereferences the Ref and handles async loading.
+Automatically dereferences the Ref and handles async loading. A deleted target reads as `undefined`,
+the same as a target that has not loaded — deleted objects are invisible by default throughout the
+API.
 
 ```ts
 const [assignee, setAssignee] = useObject(task.assignee);
-assignee?.name; // undefined until the Ref loads
+assignee?.name; // undefined until the Ref loads, and undefined if the target is deleted
+
+const [ghost] = useObject(task.assignee, { deleted: 'include' }); // resolves a tombstoned target
 ```
 
 ### Updating objects
@@ -70,17 +73,6 @@ const [target] = useObject(maybeRef); // Obj.Snapshot<T> | undefined
 
 ---
 
-## useObjects
-
-Subscribe to multiple Refs' target objects. Returns loaded snapshots, filtering out unloaded refs.
-
-```ts
-const snapshots = useObjects(task.watchers);
-snapshots.length; // only includes refs that have loaded
-```
-
----
-
 ## useQuery
 
 Create a reactive subscription to a database query or filter.
@@ -102,6 +94,20 @@ const tasks = useQuery(space.db, Filter.type(Task, { completed: false }));
 - Accepts both `Query` and `Filter` objects (filters are converted to queries internally).
 - The query is memoized based on its AST -- no need to wrap with `useMemo`.
 - Returns an empty array when `resource` is `undefined`.
+- Deleted objects are excluded by default; opt in with `Query.type(Task).options({ deleted: 'include' })`.
+
+### Counting
+
+Cardinality is a query, order is the array: when the UI shows a count, take it from a `useQuery`
+result, never from the length of a ref array. The query count is answered from the index and only
+moves on real writes and replication; a ref array's length varies with which targets happen to be
+loaded locally.
+
+```ts
+const members = useQuery(space.db, Filter.childOf(taskSet));
+members.length; // stable count, deletion respected
+taskSet.tasks.length; // locally visible entries -- not a number to display
+```
 
 ---
 
@@ -139,23 +145,18 @@ interface ObjectPropUpdateCallback<T> {
 
 ### useObject signatures
 
-| Signature                  | Input                        | Return                                                    |
-| -------------------------- | ---------------------------- | --------------------------------------------------------- |
-| `useObject(ref)`           | `Ref.Ref<T>`                 | `[Obj.Snapshot<T> \| undefined, ObjectUpdateCallback<T>]` |
-| `useObject(ref)`           | `Ref.Ref<T> \| undefined`    | `[Obj.Snapshot<T> \| undefined, ObjectUpdateCallback<T>]` |
-| `useObject(obj)`           | `T`                          | `[Obj.Snapshot<T>, ObjectUpdateCallback<T>]`              |
-| `useObject(obj)`           | `T \| undefined`             | `[Obj.Snapshot<T> \| undefined, ObjectUpdateCallback<T>]` |
-| `useObject(objOrRef)`      | `T \| Ref.Ref<T>`            | `[Obj.Snapshot<T> \| undefined, ObjectUpdateCallback<T>]` |
-| `useObject(obj, property)` | `T, K`                       | `[T[K], ObjectPropUpdateCallback<T[K]>]`                  |
-| `useObject(obj, property)` | `T \| undefined, K`          | `[T[K] \| undefined, ObjectPropUpdateCallback<T[K]>]`     |
-| `useObject(ref, property)` | `Ref.Ref<T>, K`              | `[T[K] \| undefined, ObjectPropUpdateCallback<T[K]>]`     |
-| `useObject(ref, property)` | `Ref.Ref<T> \| undefined, K` | `[T[K] \| undefined, ObjectPropUpdateCallback<T[K]>]`     |
-
-### useObjects signature
-
-| Signature          | Input                   | Return              |
-| ------------------ | ----------------------- | ------------------- |
-| `useObjects(refs)` | `readonly Ref.Ref<T>[]` | `Obj.Snapshot<T>[]` |
+| Signature                  | Input                                | Return                                                    |
+| -------------------------- | ------------------------------------ | --------------------------------------------------------- |
+| `useObject(ref)`           | `Ref.Ref<T>`                         | `[Obj.Snapshot<T> \| undefined, ObjectUpdateCallback<T>]` |
+| `useObject(ref)`           | `Ref.Ref<T> \| undefined`            | `[Obj.Snapshot<T> \| undefined, ObjectUpdateCallback<T>]` |
+| `useObject(obj)`           | `T`                                  | `[Obj.Snapshot<T>, ObjectUpdateCallback<T>]`              |
+| `useObject(obj)`           | `T \| undefined`                     | `[Obj.Snapshot<T> \| undefined, ObjectUpdateCallback<T>]` |
+| `useObject(objOrRef)`      | `T \| Ref.Ref<T>`                    | `[Obj.Snapshot<T> \| undefined, ObjectUpdateCallback<T>]` |
+| `useObject(obj, property)` | `T, K`                               | `[T[K], ObjectPropUpdateCallback<T[K]>]`                  |
+| `useObject(obj, property)` | `T \| undefined, K`                  | `[T[K] \| undefined, ObjectPropUpdateCallback<T[K]>]`     |
+| `useObject(ref, property)` | `Ref.Ref<T>, K`                      | `[T[K] \| undefined, ObjectPropUpdateCallback<T[K]>]`     |
+| `useObject(ref, property)` | `Ref.Ref<T> \| undefined, K`         | `[T[K] \| undefined, ObjectPropUpdateCallback<T[K]>]`     |
+| `useObject(ref, options)`  | `Ref.Ref<T>, { deleted: 'include' }` | `[Obj.Snapshot<T> \| undefined, ObjectUpdateCallback<T>]` |
 
 ### useQuery signatures
 

--- a/packages/core/echo/echo/API.md
+++ b/packages/core/echo/echo/API.md
@@ -65,6 +65,25 @@ const Task = Schema.Struct({
 type Task = Type.InstanceType<typeof Task>;
 ```
 
+A ref to a deleted object resolves as if the object were absent, and ref arrays hide such entries
+automatically — see [Working with Refs](#working-with-refs).
+
+### Owned children
+
+Ownership is declared on the ref field with `Annotation.SetParent`. Writing a ref into an annotated
+field sets the target's parent, so the child cascade-deletes and deep-clones with its holder; there
+is no imperative parent API.
+
+```ts
+const Doc = Schema.Struct({
+  content: Ref.Ref(Text).pipe(Annotation.SetParent.set(true)),
+  sections: Ref.Array(Ref.Ref(Section)).pipe(Annotation.SetParent.set(true)),
+}).pipe(Type.makeObject(DXN.make('com.example.type.doc', '0.1.0')));
+```
+
+Do not annotate a field whose targets may be parented elsewhere (e.g. a membership array where a
+sub-item's parent is another item) — every write to the holder would re-parent them to it.
+
 ---
 
 ## Working with Objects
@@ -111,6 +130,51 @@ Relation.getSource(rel);
 Relation.getTarget(rel);
 ```
 
+## Working with Refs
+
+```ts
+// Create
+const ref = Ref.make(alice);
+
+// Dereference synchronously (working set only).
+task.assignee.target; // undefined until loaded — and undefined if the target is deleted
+
+// Load through the resolver.
+await task.assignee.load(); // throws when the target is unavailable or deleted
+await task.assignee.load({ deleted: 'include' }); // resolves a tombstoned target
+
+// Effect forms.
+const program = Effect.gen(function* () {
+  const assignee = yield* Database.load(task.assignee); // fails with EntityNotFoundError
+  const watchers = yield* Ref.loadAll(task.watchers); // order kept, deduped by id, deleted skipped
+});
+```
+
+A ref to a deleted object keeps its URI — id comparison and grouping keep working — but its target
+behaves as absent everywhere.
+
+### Ref arrays
+
+An array-of-refs property presents a filtered view: entries whose target is known-deleted are
+hidden, automatically, for every ref-array field. Deleting an object makes it vanish from every
+array that references it; no holder is swept.
+
+```ts
+task.watchers; // hides entries whose target is deleted
+Obj.update(task, (t) => {
+  t.watchers.splice(index, 1); // splice the view; hidden entries are unaffected
+});
+```
+
+- The filter applies to every read path — live proxy, snapshots, atoms. Storage, sync, and `toJSON`
+  keep the raw array, and property reads on results of a `{ deleted: 'include' }` query present it
+  too.
+- Filtering is lazy against the working set and triggers no loads: an entry whose target was never
+  loaded locally stays visible until something loads it. Use `Ref.loadAll` when completeness
+  matters.
+- Wholesale reassignment (`t.watchers = [...]`) is literal: it stores exactly what was assigned,
+  hidden entries lost. It is also a reactivity anti-pattern — splice instead.
+
 ## Querying
 
 ```ts
@@ -134,10 +198,25 @@ query
 Query.all(query1, query2);
 Query.without(source, exclude);
 
+// Deleted objects are excluded by default; opt in per query.
+Query.type(Task).options({ deleted: 'include' });
+Query.type(Task).options({ deleted: 'only' }); // trash view
+
 // Execute against a database
 const result = db.query(Query.type(Task));
 const items = await result.run();
 result.subscribe((r) => console.log(r.results));
+```
+
+### Counting
+
+Cardinality is a query; order is the array. A ref array's `length` reflects only locally visible
+entries (it shrinks as deleted targets load), so displayed counts come from a query — answered from
+the index, moving only on real writes and replication:
+
+```ts
+const members = await db.query(Filter.childOf(taskSet)).run();
+members.length; // stable count, deletion respected
 ```
 
 ## Database Operations
@@ -146,7 +225,7 @@ result.subscribe((r) => console.log(r.results));
 const db: Database.Database = space.db;
 
 db.add(obj);
-db.remove(obj);
+db.remove(obj); // Soft delete: reversible with db.add(obj) until garbage collection
 db.getObjectById(id);
 db.query(Query.type(Task));
 db.query(Filter.type(Task));
@@ -155,24 +234,44 @@ await db.flush();
 await db.flush({ indexes: true, updates: true });
 ```
 
+## Deletion
+
+`db.remove(obj)` is a soft delete: a tombstone that replicates like any other edit. Data stays
+intact and `db.add(obj)` restores the object, until garbage collection permanently destroys it.
+Deletion cascades transitively — children (via the parent edge declared with `Annotation.SetParent`,
+see [Owned children](#owned-children)) and relations (via either endpoint) of a deleted object read
+as deleted, by the same rule at every surface.
+
+Deleted objects are invisible by default across the entire API: queries exclude them (see
+[Querying](#querying)), ref targets read as absent, and ref arrays hide their entries (see
+[Working with Refs](#working-with-refs)). Every opt-in uses the same shape:
+`{ deleted: 'include' }`.
+
+```ts
+// Permanent destruction; also prunes hidden array entries pointing at collected objects.
+await db.runGarbageCollection({ pruneDanglingRefs: true });
+```
+
 ## Feed Operations
 
 ```ts
 const feed = Feed.make({ name: 'notifications', kind: 'plugin/v1' });
 
-// Effectful operations (require Database.Service)
-yield * Feed.append(feed, [item]);
-yield * Feed.remove(feed, [item]);
+// Effectful operations (require Database.Service).
+const program = Effect.gen(function* () {
+  yield* Feed.append(feed, [item]);
+  yield* Feed.remove(feed, [item]);
 
-// Feed.query chains like Database.query: yield it for a subscribable QueryResult,
-// or use the .run / .first shorthands to execute once.
-const result = yield * Feed.query(feed, Filter.type(Person));
-result.subscribe(() => {});
-const items = yield * Feed.query(feed, Filter.type(Person)).run;
-const first = yield * Feed.query(feed, Filter.type(Person)).first; // Option<Person>
+  // Feed.query chains like Database.query: yield it for a subscribable QueryResult,
+  // or use the .run / .first shorthands to execute once.
+  const result = yield* Feed.query(feed, Filter.type(Person));
+  result.subscribe(() => {});
+  const items = yield* Feed.query(feed, Filter.type(Person)).run;
+  const first = yield* Feed.query(feed, Filter.type(Person)).first; // Option<Person>
 
-// Data-last (curried) form composes with `pipe`.
-const piped = yield * pipe(feed, Feed.query(Filter.type(Person))).run;
+  // Data-last (curried) form composes with `pipe`.
+  const piped = yield* pipe(feed, Feed.query(Filter.type(Person))).run;
+});
 ```
 
 ## Live Objects vs Snapshots


### PR DESCRIPTION
Docs-first presentation of the dangling-refs design: the `API.md` files for `@dxos/echo` and `@dxos/echo-react` now describe the target API for refs whose target has been deleted. **The new sections are ahead of the implementation** — they are the spec to review; the code lands in follow-up PRs.

## The design

Deleted objects are invisible by default across the entire API, with one opt-in shape: `{ deleted: 'include' }`, the option queries already have.

- **Single refs** keep returning the `Ref` (URIs stay comparable); the target reads as absent: `.target` is `undefined`, `load()` fails, and `load({ deleted: 'include' })` resolves the tombstone.
- **Ref arrays hide entries whose target is known-deleted**, automatically and for every ref-array field. Deleting an object makes it vanish from every array that references it — no holder is swept, which is what currently forces verbs like DeleteTask to hand-sweep membership arrays (and still miss holders they don't know about). Filtering is lazy against the working set; `Ref.loadAll` closes the gap when completeness matters.
- **Writes are literal.** Splice the view (hidden entries unaffected); wholesale reassignment stores exactly what was assigned and is a reactivity anti-pattern besides.
- **One deletion rule**: the array filter uses the same transitive cascade (parent edge, relation endpoints) as queries and `Obj.isDeleted`, so no two surfaces disagree about membership.
- **Cardinality is a query, order is the array**: displayed counts come from `useQuery`/`db.query` (index-answered, no working-set flicker), never from a ref array's length.
- **GC prunes**: `runGarbageCollection({ pruneDanglingRefs: true })` physically removes hidden entries once the target is destroyed and undelete is impossible.

Deliberately absent: any API distinguishing "deleted" from "not yet synced" (state probes, error reasons, skip counts) — dropped in review as API weight without a proven consumer.

## Also in this PR

- Removed the deprecated `useObjects` hook from the echo-react doc.
- Wrapped the Effect snippets in `Effect.gen` — bare `yield *` outside a generator parses as multiplication, which is why oxfmt kept reformatting `yield*` to `yield *`.
- Documented `Annotation.SetParent` as the parenting API (declared on the ref field); `Obj.setParent` is slated for removal and is not documented.

## Not yet implemented

Everything under "Working with Refs" beyond today's `.target`/`.load()` behavior: `load({ deleted: 'include' })`, `Ref.loadAll`, array filtering and its write semantics, the `useObject(ref, { deleted: 'include' })` overload, and `pruneDanglingRefs`. Queries excluding deleted objects and `Query.options({ deleted })` already work today.

Docs-only change; the `pipeline-discord` replay-fixture test failure reproduces on main and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)