### PR TITLE
echo: key the directory-update context by space, not by root document

### DIFF
--- a/.changeset/space-context-per-space.md
+++ b/.changeset/space-context-per-space.md
@@ -1,0 +1,6 @@
+---
+'@dxos/echo-host': patch
+'@dxos/client-services': patch
+---
+
+Fix a space's directory-update context being torn down by another space that shares its root document, and keep an accepted space's anchor retry alive after the invitation context is disposed.

--- a/packages/core/echo/echo-host/src/db-host/space-state-manager.test.ts
+++ b/packages/core/echo/echo-host/src/db-host/space-state-manager.test.ts
@@ -7,6 +7,7 @@ import { rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, onTestFinished, test } from 'vitest';
 
+import { sleep } from '@dxos/async';
 import { Context } from '@dxos/context';
 import {
   type DatabaseDirectory,
@@ -16,6 +17,7 @@ import {
   isSpaceRoot,
 } from '@dxos/echo-protocol';
 import { PublicKey, SpaceId } from '@dxos/keys';
+import { openAndClose } from '@dxos/test-utils';
 
 import { AutomergeHost } from '../automerge';
 import { createTestSqliteRuntime } from '../testing';
@@ -370,5 +372,47 @@ describe('SpaceStateManager and EchoHost persistent space store', () => {
       await host.close();
       await dispose();
     }
+  });
+
+  test('two spaces sharing one root keep independent contexts', async ({ expect }) => {
+    // The contexts are per space, not per document: keyed by the root's id, removing either space
+    // would tear down the listener the other one still reads its directory through.
+    const { runtime, dispose } = createTestSqliteRuntime();
+    onTestFinished(() => dispose());
+    const automergeHost = new AutomergeHost({ runtime });
+    await openAndClose(automergeHost);
+    const manager = new SpaceStateManager({ runtime });
+    await openAndClose(manager);
+
+    using created = await automergeHost.createDoc<DatabaseDirectory>({
+      version: SpaceDocVersion.CURRENT,
+      objects: {},
+      links: {},
+    });
+    const spaceA = SpaceId.random();
+    const spaceB = SpaceId.random();
+    await manager.assignRootToSpace(spaceA, automergeHost.acquireDoc<DatabaseDirectory>(created.documentId));
+    const rootB = await manager.assignRootToSpace(
+      spaceB,
+      automergeHost.acquireDoc<DatabaseDirectory>(created.documentId),
+    );
+
+    const updates: SpaceId[] = [];
+    manager.spaceDocumentListUpdated.on(({ spaceId }) => {
+      updates.push(spaceId);
+    });
+
+    await manager.removeSpace(spaceA);
+
+    // The surviving space still reports its documents, which requires both its context and the root.
+    expect(rootB.isLoaded).toBe(true);
+    created.change((doc) => {
+      doc.links = { ...(doc.links ?? {}), someObject: `automerge:${created.documentId}` };
+    });
+    await expect.poll(() => updates.includes(spaceB), { timeout: 2_000 }).toBe(true);
+    // The scheduler the removed space owned runs on the same tick as the survivor's: give it room to
+    // fire, so a context that outlived its space surfaces here rather than after the test.
+    await sleep(200);
+    expect(updates).not.toContain(spaceA);
   });
 });

--- a/packages/core/echo/echo-host/src/db-host/space-state-manager.ts
+++ b/packages/core/echo/echo-host/src/db-host/space-state-manager.ts
@@ -33,7 +33,8 @@ export class SpaceStateManager extends Resource {
 
   private readonly _roots = new Map<DocumentId, DatabaseRoot>();
   private readonly _rootBySpace = new Map<SpaceId, DocumentId>();
-  private readonly _perRootContext = new Map<DocumentId, Context>();
+  /** Keyed by space, not by root document: two spaces can share one root and must tear down apart. */
+  private readonly _perSpaceContext = new Map<SpaceId, Context>();
   private readonly _lastSpaceDocumentList = new Map<SpaceId, DocumentId[]>();
   private readonly _spaceRootRefs = new Map<SpaceId, SpaceRootRefs>();
   /** Re-runs a space's document-list check; the anchor documents enter the list only once refs exist. */
@@ -69,15 +70,15 @@ export class SpaceStateManager extends Resource {
   }
 
   protected override async _close(ctx: Context): Promise<void> {
-    for (const [_, rootCtx] of this._perRootContext) {
-      await rootCtx.dispose();
+    for (const [_, spaceCtx] of this._perSpaceContext) {
+      await spaceCtx.dispose();
     }
     for (const root of this._roots.values()) {
       root[Symbol.dispose]();
     }
     this._roots.clear();
     this._rootBySpace.clear();
-    this._perRootContext.clear();
+    this._perSpaceContext.clear();
     this._lastSpaceDocumentList.clear();
     this._spaceRootRefs.clear();
   }
@@ -156,10 +157,10 @@ export class SpaceStateManager extends Resource {
     this._lastSpaceDocumentList.delete(spaceId);
     this._spaceRootRefs.delete(spaceId);
 
-    const rootCtx = this._perRootContext.get(documentId);
-    if (rootCtx) {
-      await rootCtx.dispose();
-      this._perRootContext.delete(documentId);
+    const spaceCtx = this._perSpaceContext.get(spaceId);
+    if (spaceCtx) {
+      await spaceCtx.dispose();
+      this._perSpaceContext.delete(spaceId);
     }
     // Kept while another space still reads through the same root, whose lease it shares.
     if (!this._isRootReferenced(documentId)) {
@@ -191,7 +192,7 @@ export class SpaceStateManager extends Resource {
       this._roots.set(lease.documentId, root);
     }
 
-    if (this._rootBySpace.get(spaceId) === root.documentId && this._perRootContext.has(root.documentId)) {
+    if (this._rootBySpace.get(spaceId) === root.documentId && this._perSpaceContext.has(spaceId)) {
       return root;
     }
 
@@ -199,8 +200,8 @@ export class SpaceStateManager extends Resource {
     if (prevRootId) {
       // Awaited: the context detaches the root's `change` listener, which needs the lease disposed
       // below to still be live.
-      await this._perRootContext.get(prevRootId)?.dispose();
-      this._perRootContext.delete(prevRootId);
+      await this._perSpaceContext.get(spaceId)?.dispose();
+      this._perSpaceContext.delete(spaceId);
     }
 
     this._rootBySpace.set(spaceId, root.documentId);
@@ -217,7 +218,7 @@ export class SpaceStateManager extends Resource {
 
     const ctx = new Context();
 
-    this._perRootContext.set(root.documentId, ctx);
+    this._perSpaceContext.set(spaceId, ctx);
 
     const documentListCheckScheduler = new UpdateScheduler(
       ctx,

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.test.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.test.ts
@@ -214,7 +214,9 @@ describe('DataSpaceManager', () => {
     expect(attempts.length).to.be.greaterThan(1);
   });
 
-  test('an accepted space anchors on a root that replicates after the invitation context is gone', async () => {
+  test('an accepted space anchors on a root that replicates after the invitation context is gone', async ({
+    expect,
+  }) => {
     const builder = new TestBuilder();
 
     const peer1 = builder.createPeer({ dataSpaceProps: { automergeCredentials: true } });

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.test.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.test.ts
@@ -214,6 +214,42 @@ describe('DataSpaceManager', () => {
     expect(attempts.length).to.be.greaterThan(1);
   });
 
+  test('an accepted space anchors on a root that replicates after the invitation context is gone', async () => {
+    const builder = new TestBuilder();
+
+    const peer1 = builder.createPeer({ dataSpaceProps: { automergeCredentials: true } });
+    await peer1.createIdentity();
+    const peer2 = builder.createPeer({ dataSpaceProps: { automergeCredentials: true } });
+    await peer2.createIdentity();
+    await openAndClose(peer1.echoHost, peer1.dataSpaceManager, peer2.echoHost, peer2.dataSpaceManager);
+
+    const space1 = await peer1.dataSpaceManager.createSpace(new Context());
+    await space1.inner.controlPipeline.state.waitUntilTimeframe(space1.inner.controlPipeline.state.endTimeframe);
+
+    const memberCredential = await peer1.dataSpaceManager.admitMember({
+      spaceKey: space1.key,
+      identityKey: peer2.identity.identityKey,
+      role: SpaceMember.Role.ADMIN,
+    });
+    const assertion = getCredentialAssertion(memberCredential) as SpaceMemberAssertion;
+
+    // Accepted before the peers can replicate, so the named root cannot be adopted on the first
+    // attempt: only a retry that outlives the invitation can anchor this space.
+    const invitationCtx = new Context();
+    const space2 = await peer2.dataSpaceManager.acceptSpace(invitationCtx, {
+      spaceKey: space1.key,
+      genesisFeedKey: space1.inner.genesisFeedKey,
+      spaceRootUrl: assertion.spaceRootUrl,
+    });
+    await invitationCtx.dispose();
+    expect(peer2.echoHost.getSpaceRootRefs(space2.id)).to.be.undefined;
+
+    await connectReplicators([peer1, peer2]);
+    await expect
+      .poll(() => peer2.echoHost.getSpaceRootRefs(space2.id)?.spaceRootDocUrl, { timeout: 10_000 })
+      .to.equal(assertion.spaceRootUrl);
+  });
+
   test('a legacy hypercore space migrates onto a space root document, keeping its id', async () => {
     const builder = new TestBuilder();
 

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
@@ -239,6 +239,12 @@ export class DataSpaceManager extends Resource {
   /** Roots named by an inviter, to adopt once they replicate; see {@link _anchorSpaceOnRootDocument}. */
   private readonly _pendingSpaceRootUrls = new Map<SpaceId, AutomergeUrl>();
 
+  /**
+   * Spaces whose close has begun. `DataSpace.isOpen` reads the inner space, which closes last, so it
+   * still reads open through `preClose` — the window the anchor's background work resumes in.
+   */
+  private readonly _closingSpaces = new Set<SpaceId>();
+
   private readonly _spaceManager: SpaceManager;
   private readonly _metadataStore: IMetadataStore;
   private readonly _keyring: KeyringApi;
@@ -572,7 +578,7 @@ export class DataSpaceManager extends Resource {
 
       // Re-checked after the adopt/migrate await: the anchor now runs on the manager's context, so a
       // space that started closing during it would otherwise still gain credentials and be reported.
-      if (!space.isOpen) {
+      if (!this._isSpaceLive(space)) {
         return false;
       }
 
@@ -583,6 +589,11 @@ export class DataSpaceManager extends Resource {
       log.warn('failed to anchor space on a root document', { spaceId: space.id, err });
       return false;
     }
+  }
+
+  /** Whether the anchor's background work may still act on this space. */
+  private _isSpaceLive(space: DataSpace): boolean {
+    return space.isOpen && !this._closingSpaces.has(space.id);
   }
 
   /**
@@ -602,7 +613,7 @@ export class DataSpaceManager extends Resource {
     const report = async (): Promise<void> => {
       // A retry outlives the attempt that scheduled it, so it has to re-check: a space closed or
       // removed in between must not be named to edge.
-      if (!space.isOpen) {
+      if (!this._isSpaceLive(space)) {
         return;
       }
       try {
@@ -637,7 +648,7 @@ export class DataSpaceManager extends Resource {
       // write — the same reason `initializeDataPipelineAsync` is parented here.
       const ctx = this._ctx;
       const store = await openCredentialsDocument(ctx, this._echoHost, space.id);
-      if (!space.isOpen) {
+      if (!this._isSpaceLive(space)) {
         return;
       }
       for (const credential of space.inner.spaceState.credentials) {
@@ -927,6 +938,7 @@ export class DataSpaceManager extends Resource {
       }
     });
     dataSpace.preClose.append(async () => {
+      this._closingSpaces.add(dataSpace.id);
       const setting = dataSpace.getEdgeReplicationSetting();
       if (!setting || setting === EdgeReplicationSetting.ENABLED) {
         await this._echoEdgeReplicator?.disconnectFromSpace(dataSpace.id);
@@ -942,6 +954,14 @@ export class DataSpaceManager extends Resource {
     if (metadata.controlTimeframe) {
       dataSpace.inner.controlPipeline.state.setTargetTimeframe(metadata.controlTimeframe);
     }
+
+    // Cleared on the way back up: a closed space can be activated again, and a stale mark would
+    // leave it unanchorable for the session.
+    dataSpace.stateUpdate.on(this._ctx, () => {
+      if (dataSpace.isOpen) {
+        this._closingSpaces.delete(dataSpace.id);
+      }
+    });
 
     // Anchoring materializes credential state, so it waits for the space to be open: a closed space
     // must stay unmaterialized or lazy loading is defeated. Every path that opens a space — load and

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
@@ -582,7 +582,11 @@ export class DataSpaceManager extends Resource {
         return false;
       }
 
-      await this._mirrorCredentialsToDocument(space);
+      // Unsettled when the mirror bailed on a closing space: latching would leave the credentials
+      // half-written with nothing to retry it, since an anchored space never attempts again.
+      if (!(await this._mirrorCredentialsToDocument(space))) {
+        return false;
+      }
       this._reportSpaceRootToEdge(space);
       return true;
     } catch (err) {
@@ -641,7 +645,7 @@ export class DataSpaceManager extends Resource {
    * credentials backfills the existing chain and dual-writes new ones through one path, since the
    * control pipeline replays the whole feed on open.
    */
-  private async _mirrorCredentialsToDocument(space: DataSpace): Promise<void> {
+  private async _mirrorCredentialsToDocument(space: DataSpace): Promise<boolean> {
     {
       // The manager's own context, not the caller's: the invitation flow disposes its context as
       // soon as `acceptSpace` returns, and a store bound to it would be released before its first
@@ -649,7 +653,7 @@ export class DataSpaceManager extends Resource {
       const ctx = this._ctx;
       const store = await openCredentialsDocument(ctx, this._echoHost, space.id);
       if (!this._isSpaceLive(space)) {
-        return;
+        return false;
       }
       for (const credential of space.inner.spaceState.credentials) {
         store.append(credential);
@@ -661,6 +665,7 @@ export class DataSpaceManager extends Resource {
       // by credential id, so during the migration window both sources can run without conflict — a
       // space that has flipped simply stops gaining feed credentials.
       store.subscribe(ctx, (credential) => space.inner.processDocumentCredential(credential));
+      return true;
     }
   }
 

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
@@ -943,7 +943,10 @@ export class DataSpaceManager extends Resource {
       }
 
       anchoring = true;
-      void this._anchorSpaceOnRootDocument(ctx, dataSpace)
+      // The manager's context, not the caller's: an accepted space arrives with the invitation's
+      // context, which `acceptSpace` disposes on return, and the anchor's own awaits would be
+      // cancelled under it.
+      void this._anchorSpaceOnRootDocument(this._ctx, dataSpace)
         .then((settled) => {
           anchored = settled;
           if (settled) {
@@ -963,7 +966,10 @@ export class DataSpaceManager extends Resource {
         });
     };
 
-    ctx.onDispose(dataSpace.stateUpdate.on(attemptAnchor));
+    // Subscribed for the space's lifetime rather than the caller's: a root named by an inviter can
+    // replicate long after the invitation context is gone, and its state update is what retries.
+    const unsubscribeFromStateUpdate = dataSpace.stateUpdate.on(this._ctx, attemptAnchor);
+    dataSpace.preClose.append(async () => unsubscribeFromStateUpdate());
 
     this._spaces.set(metadata.key, dataSpace);
     return dataSpace;

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
@@ -570,6 +570,12 @@ export class DataSpaceManager extends Resource {
         }
       }
 
+      // Re-checked after the adopt/migrate await: the anchor now runs on the manager's context, so a
+      // space that started closing during it would otherwise still gain credentials and be reported.
+      if (!space.isOpen) {
+        return false;
+      }
+
       await this._mirrorCredentialsToDocument(space);
       this._reportSpaceRootToEdge(space);
       return true;

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
@@ -600,6 +600,11 @@ export class DataSpaceManager extends Resource {
     // its ctx the moment `acceptSpace` returns, which would cancel every pending retry.
     let delay = SPACE_ROOT_REPORT_RETRY_INITIAL;
     const report = async (): Promise<void> => {
+      // A retry outlives the attempt that scheduled it, so it has to re-check: a space closed or
+      // removed in between must not be named to edge.
+      if (!space.isOpen) {
+        return;
+      }
       try {
         await this._edgeHttpClient!.recordSpaceRoot(this._ctx, space.id, {
           rootDocumentUrl: refs.spaceRootDocUrl,
@@ -632,6 +637,9 @@ export class DataSpaceManager extends Resource {
       // write — the same reason `initializeDataPipelineAsync` is parented here.
       const ctx = this._ctx;
       const store = await openCredentialsDocument(ctx, this._echoHost, space.id);
+      if (!space.isOpen) {
+        return;
+      }
       for (const credential of space.inner.spaceState.credentials) {
         store.append(credential);
       }


### PR DESCRIPTION
The two follow-ups flagged during #12777's review, now that it has landed.

## The bug: one root, two spaces, one context

`SpaceStateManager` kept a `Context` per **root document id**, holding that space's `change` listener and its document-list scheduler. Two spaces can legitimately share a root, and then the second `assignRootToSpace` overwrote the first space's context. Removing either space disposed whichever context the map happened to hold, and the retired scheduler kept firing against a root whose lease had since been released:

```
Error: invariant violation [doc] at packages/core/echo/echo-host/src/db-host/database-root.ts:134
  × two spaces sharing one root keep independent contexts
```

That is the new test running against `main`; it passes with the context keyed by `SpaceId` instead. The surviving space keeps receiving directory updates, and the removed one stops emitting.

This predates #12777 — that PR only renamed `root.handle.documentId` to `root.documentId` here — but the lease made the consequence loud instead of silent, which is how it surfaced.

## Hardening, not a fixed bug: the anchor retry's context

An accepted space's anchor retry was subscribed with the **invitation's** context, which `acceptSpace` disposes as soon as it returns, and `_anchorSpaceOnRootDocument` was handed that same context for its own awaits. The listener now lives for the space's lifetime (dropped in `preClose`) and the anchor runs on the manager's context — the reasoning `initializeDataPipelineAsync` already applies one line away.

**I could not write a case that fails without it.** The retry chain already self-schedules on `this._ctx` once a first attempt has run, and a first attempt always runs while the invitation context is still alive, so the disposed listener never turned into a stuck space in anything I could construct. The added test (`an accepted space anchors on a root that replicates after the invitation context is gone`) passes on `main` too — it is coverage for a path that had none, not a regression test. I kept the change because passing a disposed context into work that awaits is wrong on its face, but it should be read as hardening.

## Verification

`echo-host` 311 passed, `client-services` 181, `echo-client` 530, `echo-client-e2e` 324, `client` 30; build, lints and `pnpm format` clean. Both new tests re-run with their fix reverted in place — the shared-root one fails, the anchor one does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPs1AUJhyPcANfeqfNB3ME

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPs1AUJhyPcANfeqfNB3ME)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed independent lifecycle handling for spaces that share the same root document.
  - Prevented updates from being stopped for an active space when another shared-root space is removed.
  - Improved accepted-space anchoring when root replication completes after the invitation flow ends.
  - Kept anchoring and root-reporting retries active until the space is properly closed.
  - Prevented in-progress synchronization from continuing after a space has been closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->