### PR TITLE
assistant: fix error flash when opening the companion before its chat is provisioned

### DIFF
--- a/.changeset/assistant-companion-error-flash.md
+++ b/.changeset/assistant-companion-error-flash.md
@@ -2,4 +2,4 @@
 '@dxos/plugin-assistant': patch
 ---
 
-Fixed a momentary "Cannot read properties of null" error flash when opening the assistant companion. The companion renders blank while its chat is being provisioned instead of throwing into the error boundary.
+Fixed two errors when opening the assistant companion: a momentary "Cannot read properties of null" flash while the chat was being provisioned (the companion now renders blank until it exists), and a "RovingFocusGroupItem must be used within RovingFocusGroup" crash when another plugin contributed a plain toolbar action to the prompt (the contributed items now render inside a toolbar context).

--- a/.changeset/assistant-companion-error-flash.md
+++ b/.changeset/assistant-companion-error-flash.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-assistant': patch
+---
+
+Fixed a momentary "Cannot read properties of null" error flash when opening the assistant companion. The companion renders blank while its chat is being provisioned instead of throwing into the error boundary.

--- a/packages/plugins/plugin-assistant/src/capabilities/react-surface.ts
+++ b/packages/plugins/plugin-assistant/src/capabilities/react-surface.ts
@@ -83,10 +83,11 @@ export default Capability.makeModule(() =>
       }),
       Surface.create({
         id: 'companionChat',
+        // While the companion chat is still being provisioned the graph node's data is null; no
+        // candidate matches and the Surface renders nothing until EnsureCompanionChat lands.
         filter: Surface.makeFilter(
           AppSurface.Article,
-          (data) =>
-            Obj.isObject(data.companionTo) && (Obj.instanceOf(Chat.Chat, data.subject) || data.subject === null),
+          (data) => Obj.isObject(data.companionTo) && Obj.instanceOf(Chat.Chat, data.subject),
         ),
         component: ChatCompanion,
         props: ({ role, ref, data: { subject, attendableId, companionTo } }) => ({

--- a/packages/plugins/plugin-assistant/src/capabilities/react-surface.ts
+++ b/packages/plugins/plugin-assistant/src/capabilities/react-surface.ts
@@ -83,8 +83,6 @@ export default Capability.makeModule(() =>
       }),
       Surface.create({
         id: 'companionChat',
-        // While the companion chat is still being provisioned the graph node's data is null; no
-        // candidate matches and the Surface renders nothing until EnsureCompanionChat lands.
         filter: Surface.makeFilter(
           AppSurface.Article,
           (data) => Obj.isObject(data.companionTo) && Obj.instanceOf(Chat.Chat, data.subject),

--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatActions.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatActions.stories.tsx
@@ -10,8 +10,8 @@ import { expect, within } from 'storybook/test';
 import { withPluginManager } from '@dxos/app-framework/testing';
 import * as AppGraphNode from '@dxos/app-graph/AppGraphNode';
 import { corePlugins } from '@dxos/plugin-testing';
-import { withTheme } from '@dxos/react-ui/testing';
 import { type ActionGraphProps } from '@dxos/react-ui-menu';
+import { withTheme } from '@dxos/react-ui/testing';
 
 import { translations } from '#translations';
 

--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatActions.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatActions.stories.tsx
@@ -3,19 +3,22 @@
 //
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
+import * as Atom from 'effect/unstable/reactivity/Atom';
 import React, { useState } from 'react';
 import { expect, within } from 'storybook/test';
 
 import { withPluginManager } from '@dxos/app-framework/testing';
+import * as AppGraphNode from '@dxos/app-graph/AppGraphNode';
 import { corePlugins } from '@dxos/plugin-testing';
 import { withTheme } from '@dxos/react-ui/testing';
+import { type ActionGraphProps } from '@dxos/react-ui-menu';
 
 import { translations } from '#translations';
 
 import { type ChatEvent } from '../Chat';
 import { ChatActions, type ChatActionsProps } from './ChatActions';
 
-type StoryArgs = Pick<ChatActionsProps, 'processing' | 'canSend' | 'tasksVisible' | 'debug'>;
+type StoryArgs = Pick<ChatActionsProps, 'processing' | 'canSend' | 'tasksVisible' | 'debug' | 'customActions'>;
 
 const DefaultStory = ({ tasksVisible: initialTasksVisible, ...args }: StoryArgs) => {
   // Held here rather than fixed by args so the toggle can be clicked and seen to change.
@@ -94,5 +97,34 @@ export const TaskToggleFlips: Story = {
     await expect(toggle).toHaveAttribute('aria-pressed', 'true');
     await userEvent.click(toggle);
     await expect(canvas.getByTestId('assistant.toggle-tasks')).toHaveAttribute('aria-pressed', 'false');
+  },
+};
+
+/** A contributed action with no `custom` render, the way plugin-review files "Add comment". */
+const plainContributedActions = Atom.make<ActionGraphProps>({
+  nodes: [
+    {
+      id: 'story-action',
+      type: AppGraphNode.ActionType,
+      data: () => {},
+      properties: { label: 'Story action', icon: 'ph--chat-text--regular', testId: 'story.contributed-action' },
+    },
+  ],
+  edges: [{ source: 'root', target: 'story-action', relation: 'child' }],
+}).pipe(Atom.keepAlive);
+
+/**
+ * Plain contributed items render `Toolbar.*` primitives, which need the roving-focus context from
+ * the row's `Menu.Toolbar` — without it this story crashes the way the assistant companion did on
+ * commentable objects.
+ */
+export const ContributedPlainAction: Story = {
+  args: { canSend: true, tasksVisible: true },
+  render: (args) => <DefaultStory {...args} customActions={plainContributedActions} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const action = await canvas.findByTestId('story.contributed-action', {}, { timeout: 10_000 });
+    await expect(action).toBeEnabled();
+    await expect(canvas.getByTestId('assistant.send')).toBeInTheDocument();
   },
 };

--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatActions.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatActions.tsx
@@ -123,10 +123,12 @@ const ContributedActions = ({
 }) => {
   const menuActions = useMenuActions(actions);
   return (
-    // `Menu.Items` without `Menu.Toolbar`: the items are container-free, so they take their place
-    // in the prompt's own row rather than bringing a toolbar of their own.
     <Menu.Root {...menuActions} attendableId={attendableId} alwaysActive>
-      <Menu.Items />
+      {/* Plain (non-`custom`) items render `Toolbar.*` primitives, which throw without the roving-focus
+          context `Menu.Toolbar` provides; `contents` keeps the items in the prompt's own row. */}
+      <Menu.Toolbar classNames='contents'>
+        <Menu.Items />
+      </Menu.Toolbar>
     </Menu.Root>
   );
 };

--- a/packages/plugins/plugin-assistant/src/containers/ChatCompanion/ChatCompanion.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatCompanion/ChatCompanion.tsx
@@ -14,7 +14,10 @@ import { AssistantOperation } from '#types';
 
 import ChatArticle from '../ChatArticle';
 
-export type ChatCompanionProps = AppSurface.ArticleProps<Chat.Chat, {}, Obj.Unknown>;
+/** Null until the companion-chat provisioner resolves or creates the chat. */
+type ProvisionableChat = Chat.Chat | null;
+
+export type ChatCompanionProps = AppSurface.ArticleProps<ProvisionableChat, {}, Obj.Unknown>;
 
 export const ChatCompanion = forwardRef<HTMLDivElement, ChatCompanionProps>(
   ({ role = 'article', subject: chat, companionTo, attendableId }, forwardedRef) => {
@@ -38,6 +41,10 @@ export const ChatCompanion = forwardRef<HTMLDivElement, ChatCompanionProps>(
       });
       await db.flush();
     }, [db, chat, companionTo, invokePromise]);
+
+    if (!chat) {
+      return null;
+    }
 
     return (
       <ChatArticle

--- a/packages/plugins/plugin-assistant/src/containers/ChatCompanion/ChatCompanion.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatCompanion/ChatCompanion.tsx
@@ -14,10 +14,7 @@ import { AssistantOperation } from '#types';
 
 import ChatArticle from '../ChatArticle';
 
-/** Null until the companion-chat provisioner resolves or creates the chat. */
-type ProvisionableChat = Chat.Chat | null;
-
-export type ChatCompanionProps = AppSurface.ArticleProps<ProvisionableChat, {}, Obj.Unknown>;
+export type ChatCompanionProps = AppSurface.ArticleProps<Chat.Chat, {}, Obj.Unknown>;
 
 export const ChatCompanion = forwardRef<HTMLDivElement, ChatCompanionProps>(
   ({ role = 'article', subject: chat, companionTo, attendableId }, forwardedRef) => {
@@ -41,10 +38,6 @@ export const ChatCompanion = forwardRef<HTMLDivElement, ChatCompanionProps>(
       });
       await db.flush();
     }, [db, chat, companionTo, invokePromise]);
-
-    if (!chat) {
-      return null;
-    }
 
     return (
       <ChatArticle


### PR DESCRIPTION
## What

Opening the assistant companion could flash or show two different errors. Both are fixed here.

**1. `TypeError: Cannot read properties of null (reading 'Symbol(@dxos/echo/Database)')`** — the companion's chat is provisioned asynchronously (`EnsureCompanionChat`, invoked by the companion-chat provisioner capability), and the `companionChat` surface filter admitted `subject === null` during that window. `ChatCompanion` forwarded the null into `ChatArticle`, which called `Obj.getDatabase(chat)` on it and threw into the ErrorBoundary until the chat arrived.

**2. `RovingFocusGroupItem must be used within RovingFocusGroup`** — the prompt's contributed actions (`ContributedActions` in `ChatActions`) rendered `Menu.Items` with no `Menu.Toolbar`. Plain (non-`custom`) contributed items render Radix `Toolbar.*` primitives, which require the toolbar's roving-focus context — so any plain toolbar action filed on the node (e.g. plugin-review's Add-comment on commentable objects) crashed the companion. The mic survived only because its `variant: 'custom'` item renders plain buttons.

## Fix

- Drop the filter's null admission. The null-subject window dates from when the component initialized the in-memory chat itself; provisioning now lives entirely in the provisioner capability, so nothing needs `ChatCompanion` mounted before the chat exists. With no candidate matching, the Surface renders nothing until the provisioned chat lands, and the component's subject stays honestly non-null (`ChatCompanion` is unchanged from main).
- Wrap the prompt's contributed items in `Menu.Toolbar classNames='contents'` — real toolbar context, same row layout.

## Verification

- New story `ContributedPlainAction` reproduces crash 2 against the old component (`Story rendered ErrorBoundary fallback: RovingFocusGroupItem must be used within RovingFocusGroup`) and passes with the fix; full ChatActions suite 8/8.
- `moon run plugin-assistant:build` green.
- Crash 1 is verified by build + reasoning only: Composer cannot boot in my embedded preview browser (startup timeout in both the local dev server and the PR deploy), so the no-flash behavior on companion open is worth one manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a brief error message that could appear when opening the assistant companion.
  * The companion now displays a blank state while its chat is being prepared.
  * Improved chat surface matching to prevent rendering before a valid chat is available.
  * Fixed a crash when contributed toolbar actions were added to the chat prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->