### PR TITLE
client-services: add debug logs to Pipeline.consume iterations

### DIFF
--- a/packages/sdk/client-services/src/packlets/pipeline/pipeline.ts
+++ b/packages/sdk/client-services/src/packlets/pipeline/pipeline.ts
@@ -376,11 +376,15 @@ export class Pipeline implements PipelineAccessor {
     let lastFeedSetIterator = this._feedSetIterator;
     let iterable = lastFeedSetIterator[Symbol.asyncIterator]();
 
+    // Iteration counter to make a busy loop visible in debug logs.
+    let iteration = 0;
     while (!this._isStopping) {
+      log('consume iteration', { iteration: iteration++ });
       await this._pauseTrigger.wait();
 
       // Iterator might have been changed while we were waiting for the processing to complete.
       if (lastFeedSetIterator !== this._feedSetIterator) {
+        log('consume: iterator changed while paused', { iteration });
         invariant(this._feedSetIterator, 'Iterator not initialized.');
         lastFeedSetIterator = this._feedSetIterator;
         iterable = lastFeedSetIterator[Symbol.asyncIterator]();
@@ -390,6 +394,7 @@ export class Pipeline implements PipelineAccessor {
       const { done, value } = await iterable.next();
       if (!done) {
         const block = value ?? failUndefined();
+        log('consume block', { iteration, feedKey: PublicKey.from(block.feedKey).truncate(), seq: block.seq });
         this._processingTrigger.reset();
         this._timeframeClock.updatePendingTimeframe(PublicKey.from(block.feedKey), block.seq);
         yield block;
@@ -400,14 +405,17 @@ export class Pipeline implements PipelineAccessor {
         // set the iterator running, or the iterator is being swapped by `setCursor`. Polling the
         // finished generator would spin the microtask queue forever (starving the whole thread),
         // so wait for the iterator to (re)start or be replaced, then take a fresh generator.
+        log('consume: generator ended; waiting for iterator restart or swap', { iteration });
         if (lastFeedSetIterator === this._feedSetIterator) {
           await Promise.race([lastFeedSetIterator.waitUntilRunning(), this._iteratorChanged.wait()]);
         }
         invariant(this._feedSetIterator, 'Iterator not initialized.');
         lastFeedSetIterator = this._feedSetIterator;
         iterable = lastFeedSetIterator[Symbol.asyncIterator]();
+        log('consume: resuming with fresh generator', { iteration });
       }
     }
+    log('consume: stopped', { iteration });
 
     // TODO(burdon): Test re-entrant?
     this._isBeingConsumed = false;

--- a/packages/sdk/client-services/src/packlets/pipeline/pipeline.ts
+++ b/packages/sdk/client-services/src/packlets/pipeline/pipeline.ts
@@ -379,7 +379,8 @@ export class Pipeline implements PipelineAccessor {
     // Iteration counter to make a busy loop visible in debug logs.
     let iteration = 0;
     while (!this._isStopping) {
-      log('consume iteration', { iteration: iteration++ });
+      iteration += 1;
+      log('consume iteration', { iteration });
       await this._pauseTrigger.wait();
 
       // Iterator might have been changed while we were waiting for the processing to complete.


### PR DESCRIPTION
Adds debug-level logs to each pass of the `Pipeline.consume` loop in `packages/sdk/client-services/src/packlets/pipeline/pipeline.ts`.

We previously had a bug where `consume` entered a busy loop; with these logs a runaway loop is visible in captured debug logs instead of silently starving the thread.

- An `iteration` counter logged at the top of every loop pass (`consume iteration`).
- `consume block` with the truncated feed key and sequence number when a block is yielded.
- Log lines around the finished-generator branch (`generator ended; waiting for iterator restart or swap` / `resuming with fresh generator`) — the branch that previously spun — plus iterator-swap and loop-exit markers.

All logs are plain `log(...)` (debug level), so they are filtered out unless debug logging is enabled.

Verified: `moon run client-services:build` and `moon run client-services:test -- src/packlets/pipeline` pass (4 tests passed, 1 skipped); the new lines appear at level `D` in the captured `test.log`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtLjQdTtj1AE1h42y9Nt6E)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Diagnostics**
  * Added detailed debug logging to pipeline processing, including iteration progress, pauses, resumptions, generator restarts, and shutdown.
  * No changes to processing behavior or control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->