### PR TITLE
composer-app: report the build version as the PostHog release

### DIFF
--- a/packages/apps/composer-app/src/util/config.ts
+++ b/packages/apps/composer-app/src/util/config.ts
@@ -79,6 +79,8 @@ const feedbackLogsEndpoint = (config: Config, isTauri: boolean): string | undefi
     ? (getEnvString(config, 'DX_FEEDBACK_LOGS_ENDPOINT') ?? `https://${APP_DOMAIN}${FEEDBACK_LOGS_PATH}`)
     : undefined;
 
+const composerBuildVersion = (config: Config): string | undefined => config.get('runtime.app.build.version');
+
 /** Initialize observability extensions and data providers for Composer. */
 export const initializeObservability = async (
   config: Config,
@@ -103,7 +105,7 @@ export const initializeObservability = async (
     Observability.addExtension(
       ObservabilityExtension.PostHog.extensions({
         config,
-        release: DXOS_VERSION,
+        release: composerBuildVersion(config),
         environment: getEnvString(config, 'DX_ENVIRONMENT') ?? 'unknown',
         logStore,
         feedbackLogMaxSize: LOG_STORE_MAX_BYTES,


### PR DESCRIPTION
## What

PostHog's `release` property was set to `DXOS_VERSION` (`packages/sdk/client/src/version.ts`), the SDK's compile-time constant. It reads `0.11.1` for every deploy, so a preview build is indistinguishable from production in the release dimension.

This sets it to `runtime.app.build.version` instead. The deploy workflow stamps that value into `composer-app/package.json` before `vite build` (the "Stamp the Composer version" step in `deploy-apps.yml`), and it is already what About and the feedback report show.

```diff
+const composerBuildVersion = (config: Config): string | undefined => config.get('runtime.app.build.version');
-        release: DXOS_VERSION,
+        release: composerBuildVersion(config),
```

The named helper is not decoration. `release` sits eleven lines below `serviceVersion: DXOS_VERSION` in the same call chain, and with a bare `config.get('runtime.app.build.version')` the only thing distinguishing the two is a string key. The name does that work instead, matching the `feedbackLogsEndpoint(config, isTauri)` helper directly above it.

## Verification

Both the tab and the dedicated worker resolve the key. The worker does not build its own config: the tab posts `config.values` wholesale (`dedicated-worker-client-services.ts:46`) and `runDedicatedWorker` reconstructs `new Config(configValues)` before `onBeforeStart` (`dedicated-worker.ts:45`). The risk worth checking was `validateConfig`'s protobuf round-trip dropping the field. It does not:

```
tab   : 0.11.2-preview.7
worker: 0.11.2-preview.7
```

`tsc --noEmit` in composer-app is clean for `src/util/config.ts`. `Runtime_App_BuildInfo.version` is `optional string`, which matches `release?: string` on the extension.

## What this does not change

`serviceVersion: DXOS_VERSION` on the OTel extension stays as-is, and I want to flag that it is not clearly correct. `serviceName` is `'composer'`, and OTel defines `service.version` as the version of the service named by `service.name`, so the same argument applies there. Two things argue against changing it in this PR: `serviceVersion` is typed `string` rather than `string | undefined`, so it needs a fallback, and `?? DXOS_VERSION` would silently reintroduce exactly the ambiguity being fixed here. A span tagged `0.11.1` could then mean either "SDK 0.11.1" or "build version missing". Worth a follow-up that either widens the type or fails loudly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostHog observability now reports the configured Composer build version, providing more accurate release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->