### PR TITLE
plugin-registry: ship the registry in curated builds, gated to bundled plugins

### DIFF
--- a/.changeset/registry-external-plugins-option.md
+++ b/.changeset/registry-external-plugins-option.md
@@ -1,0 +1,7 @@
+---
+'@dxos/plugin-registry': minor
+---
+
+`RegistryPlugin.make` takes an `externalPlugins` option (default `true`). With it off, the plugin lists only what the build bundled: no public catalog category, no load-by-URL action or dialog, no dev-server plugin loader, and no registry settings panel.
+
+Registry categories with no members are no longer rendered. Which categories have members depends on the plugin set — a curated build ships no labs plugins, for instance — so the labs and catalog sections now disappear instead of showing an empty list.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -98,8 +98,3 @@ only on the dev server (`DX_MOBILE=1 moon run composer-app:serve`), not in the o
 - `plugin-deck`'s own `PLUGIN.mdl` still describes the mobile rendering that moved out to
   `plugin-mobile`; its mobile prose needs a refresh to point at the new package instead of
   re-describing behaviour deck no longer owns.
-- A `DX_PLUGIN_SET=mobile` build still emits a handful of tiny inert chunks referencing the registry
-  (e.g. `open-plugin-registry-*.js`, an "open registry" Settings operation-handler) even though
-  `RegistryPlugin` itself is not part of the set and nothing in the UI can trigger loading them —
-  confirmed via `vite build` + `vite preview` that no Registry entry or catalog is reachable. Worth
-  chasing to full parity with the `production` set, which presumably has the same characteristic.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -25,12 +25,12 @@ resolve error — reload once.
 
 Mobile rendering itself now lives in `@dxos/plugin-mobile` (a renderer over deck state, owning
 none of its own); `plugin-deck` stays headless on mobile — no React root, no mobile surfaces. The
-`mobile` plugin set (`DX_PLUGIN_SET=mobile`) has **no plugin registry**: it is a fixed set — core
-(`isExtensible: false`, dropping `RegistryPlugin`) plus Assistant/Markdown/Projects/Transcription —
-so there is no Registry entry in Settings and no catalog to browse, anywhere. The full dev registry
+`mobile` plugin set (`DX_PLUGIN_SET=mobile`) is fixed — core (`externalPlugins: false`) plus
+Assistant/Markdown/Projects/Transcription. Its registry lists those and nothing else: no public
+catalog, no load-by-URL, and no Registry entry in Settings. The full dev registry
 (`plugin-defs.tsx`) used by the plain `moon run composer-app:serve` dev server is unaffected and
-still extensible; `DX_MOBILE=1` there only swaps the _layout_, not the plugin set, so a Registry
-entry is still reachable in dev — the fixed-set assertion below only holds when built/served with
+still extensible; `DX_MOBILE=1` there only swaps the _layout_, not the plugin set, so the catalog is
+still reachable in dev — the fixed-set assertion below only holds when built/served with
 `DX_PLUGIN_SET=mobile`.
 
 ## A. Fixed on the branch — verify on device
@@ -52,10 +52,9 @@ entry is still reachable in dev — the fixed-set assertion below only holds whe
 | A13 | Registry plugin list — **dev-server only, see note**                            | Cards visibly distinct from the panel background.                                                                                   |
 | A14 | Any list panel on touch                                                         | First row is not highlighted at rest (keyboard selection unaffected on desktop).                                                    |
 
-**Note (A12/A13):** the `mobile` plugin set built for device/simulator has no `RegistryPlugin` at
-all (see Setup above), so there is nothing to navigate to on device — these two rows only exercise
-the dev-server's full, extensible registry (`DX_MOBILE=1 moon run composer-app:serve`), not the
-on-device build.
+**Note (A12/A13):** the `mobile` plugin set built for device/simulator carries `RegistryPlugin` but
+lists only the four plugins it ships (see Setup above), so the catalog rows these exercise exist
+only on the dev server (`DX_MOBILE=1 moon run composer-app:serve`), not in the on-device build.
 
 ## B. Simulator-verified, needs a human/device pass
 

--- a/packages/apps/composer-app/scripts/check-plugin-set.mjs
+++ b/packages/apps/composer-app/scripts/check-plugin-set.mjs
@@ -16,10 +16,6 @@
  * build emits five HTML entries and `devtools.html` IS the devtools app — its graph carries
  * plugin-devtools in every environment, which a whole-directory scan reports as a leak.
  *
- * The set is read from the two source files, so a plugin core carries for both sets counts as shipped
- * — plugin-registry, for instance, whose lazy chunk a curated build emits and never imports (the
- * `isExtensible` flag withholds the plugin, `DX_PLUGIN_SET` is what keeps code out of the graph).
- *
  * What counts as evidence: a plugin's BODY module (`src/plugin.tsx` and its platform variants),
  * which is what `#plugin` resolves to and what `Plugin.lazy` imports on first enable. That module is
  * package-internal — nothing outside a plugin imports another plugin's body — so its presence means

--- a/packages/apps/composer-app/src/plugin-defs.core.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.core.tsx
@@ -52,11 +52,7 @@ export type State = {
 export type PluginConfig = State & {
   /** Raises a fatal client-initialization failure to the entry point (see `onFatalError` in main.tsx). */
   onFatalError?: (error: unknown) => void;
-  /**
-   * Whether this build exposes the plugin registry — the catalog, its settings surface and the dev
-   * plugin loader. Defaults to true; the curated set (`plugin-defs.production.tsx`) turns it off.
-   */
-  isExtensible?: boolean;
+  externalPlugins?: boolean;
   isDev?: boolean;
   isLocal?: boolean;
   isPwa?: boolean;
@@ -88,7 +84,7 @@ export const getCorePlugins = ({
   observability,
   logStore,
   onFatalError,
-  isExtensible = true,
+  externalPlugins = true,
   isLocal,
   isPwa,
   isTauri,
@@ -157,7 +153,7 @@ export const getCorePlugins = ({
     ProcessManagerPlugin(),
     ProgressPlugin.make(),
     !isTauri && isPwa && PwaPlugin.make(),
-    isExtensible && RegistryPlugin.make(),
+    RegistryPlugin.make({ externalPlugins }),
     RoutinePlugin.make(),
     SearchPlugin.make(),
     SettingsPlugin.make(),

--- a/packages/apps/composer-app/src/plugin-defs.mobile.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.mobile.tsx
@@ -14,14 +14,13 @@ import { type PluginConfig, getCorePlugins } from './plugin-defs.core';
 export type { PluginConfig, State } from './plugin-defs.core';
 
 /**
- * Fixed mobile set — not extensible, no registry: core infrastructure (with `isMobile` selecting
- * headless Deck + `MobilePlugin` as the root renderer) plus Assistant (chat), Markdown (chat
- * content), Projects with the Tasks it declares as a dependency, and Transcription (voice input).
- * Selection is build-time — swapping this file in via `DX_PLUGIN_SET=mobile` — rather than a
- * runtime flag, so a plugin with no mobile surface never enters the bundle.
+ * Fixed mobile set: core infrastructure (with `isMobile` selecting headless Deck + `MobilePlugin` as
+ * the root renderer) plus Assistant, Markdown, Projects with the Tasks it declares as a dependency,
+ * and Transcription. Selection is build-time — swapping this file in via `DX_PLUGIN_SET=mobile` —
+ * rather than a runtime flag, so a plugin with no mobile surface never enters the bundle.
  */
 export const getPlugins = (config: PluginConfig): Plugin.Plugin[] => [
-  ...getCorePlugins({ ...config, isExtensible: false }),
+  ...getCorePlugins({ ...config, externalPlugins: false }),
   // `Agent` and `Sequence` are unfinished, so the mobile set does not offer creating them either.
   AssistantPlugin.make({ experimentalTypes: false }),
   MarkdownPlugin.make(),

--- a/packages/apps/composer-app/src/plugin-defs.production.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.production.tsx
@@ -21,7 +21,7 @@ export type { PluginConfig, State } from './plugin-defs.core';
  * enters the bundle.
  */
 export const getPlugins = (config: PluginConfig): Plugin.Plugin[] => [
-  ...getCorePlugins({ ...config, isExtensible: false }),
+  ...getCorePlugins({ ...config, externalPlugins: false }),
   // `Agent` and `Sequence` are unfinished, so the curated set does not offer creating them.
   AssistantPlugin.make({ experimentalTypes: false }),
   MarkdownPlugin.make(),
@@ -32,7 +32,4 @@ export const getPlugins = (config: PluginConfig): Plugin.Plugin[] => [
   TranscriptionPlugin.make(),
 ];
 
-/**
- * Derived from {@link getPlugins} rather than listed again: with no registry, bundled == enabled.
- */
 export const getDefaults = (config: PluginConfig): string[] => getPlugins(config).map(({ meta }) => meta.profile.key);

--- a/packages/plugins/plugin-registry/src/RegistryPlugin.ts
+++ b/packages/plugins/plugin-registry/src/RegistryPlugin.ts
@@ -7,9 +7,12 @@
 import * as Plugin from '@dxos/app-framework/Plugin';
 
 import { meta as pluginMeta } from '#meta';
+import type { RegistryPluginOptions } from '#types';
 
 /** Plugin metadata, available without loading the plugin body. */
 export const meta = pluginMeta;
 
 /** Constructs the plugin; the body loads on first enable. */
-export const make = Plugin.lazy(meta, () => import('#plugin'));
+export const make = Plugin.lazy<RegistryPluginOptions>(meta, () => import('#plugin'));
+
+export type { RegistryPluginOptions };

--- a/packages/plugins/plugin-registry/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-registry/src/capabilities/app-graph-builder.ts
@@ -18,9 +18,9 @@ import { DXN } from '@dxos/keys';
 import { Position } from '@dxos/util';
 
 import { meta } from '#meta';
-import { LOAD_PLUGIN_DIALOG } from '#types';
+import { LOAD_PLUGIN_DIALOG, type RegistryPluginOptions } from '#types';
 
-import { getCategoryPredicate, getRemotePluginIds } from '../categories';
+import { getCategoryPredicate, getPopulatedCategories, getRemotePluginIds } from '../categories';
 import { REGISTRY_ID } from '../paths';
 
 /**
@@ -47,7 +47,7 @@ const toDisplayPlugin = (entry: Plugin.Meta): Plugin.Plugin =>
   }) as Plugin.Plugin;
 
 export default Capability.makeModule(
-  Effect.fnUntraced(function* () {
+  Effect.fnUntraced(function* ({ externalPlugins = true }: RegistryPluginOptions = {}) {
     // Hoisted so connector bodies read reactively via `get(...)` instead of a sync
     // `Capability.get`, establishing a dependency that heals once the capability lands.
     const pluginManagerAtom = yield* Capability.atom(Capabilities.PluginManager);
@@ -104,94 +104,55 @@ export default Capability.makeModule(
             enabled: get(manager.enabled),
             remoteIds: getRemotePluginIds(),
           };
-          const categoryCount = (category: string) =>
-            plugins.filter(getCategoryPredicate(category, filterContext)).length;
-          const registryCount = get(manager.pluginRegistry.plugins).entries.length;
+          const categoryCount = (category: string) => {
+            if (category !== 'registry') {
+              return plugins.filter(getCategoryPredicate(category, filterContext)).length;
+            }
+            return externalPlugins ? get(manager.pluginRegistry.plugins).entries.length : 0;
+          };
 
-          return Effect.succeed([
-            AppGraphNode.make({
-              id: 'bundled',
-              type: 'category',
-              data: 'bundled',
-              properties: {
-                label: ['bundled-plugins.label', { ns: meta.profile.key }],
-                icon: 'ph--squares-four--regular',
-                testId: 'pluginRegistry.bundled',
-                count: categoryCount('bundled'),
-              },
-            }),
-            AppGraphNode.make({
-              id: 'installed',
-              type: 'category',
-              data: 'installed',
-              properties: {
-                label: ['installed-plugins.label', { ns: meta.profile.key }],
-                icon: 'ph--check--regular',
-                testId: 'pluginRegistry.installed',
-                count: categoryCount('installed'),
-              },
-            }),
-            AppGraphNode.make({
-              id: 'recommended',
-              type: 'category',
-              data: 'recommended',
-              properties: {
-                label: ['recommended-plugins.label', { ns: meta.profile.key }],
-                icon: 'ph--star--regular',
-                testId: 'pluginRegistry.recommended',
-                count: categoryCount('recommended'),
-              },
-            }),
-            AppGraphNode.make({
-              id: 'labs',
-              type: 'category',
-              data: 'labs',
-              properties: {
-                label: ['labs-plugins.label', { ns: meta.profile.key }],
-                icon: 'ph--flask--regular',
-                testId: 'pluginRegistry.labs',
-                count: categoryCount('labs'),
-              },
-            }),
-            ...(registryCount > 0
-              ? [
-                  AppGraphNode.make({
-                    id: 'registry',
-                    type: 'category',
-                    data: 'registry',
-                    properties: {
-                      label: ['registry-plugins.label', { ns: meta.profile.key }],
-                      icon: 'ph--users-three--regular',
-                      testId: 'pluginRegistry.registry',
-                      count: registryCount,
-                    },
-                  }),
-                ]
-              : []),
-          ]);
+          return Effect.succeed(
+            getPopulatedCategories(categoryCount).map(({ id, labelKey, icon, testId, count }) =>
+              AppGraphNode.make({
+                id,
+                type: 'category',
+                data: id,
+                properties: {
+                  label: [labelKey, { ns: meta.profile.key }],
+                  icon,
+                  testId,
+                  count,
+                },
+              }),
+            ),
+          );
         },
       }),
-      AppGraphBuilder.createExtension({
-        id: 'actions',
-        match: GraphNodeMatcher.whenId(`root/${REGISTRY_ID}`),
-        actions: () =>
-          Effect.succeed([
-            {
-              id: 'loadByUrl',
-              data: Effect.fnUntraced(function* () {
-                yield* Operation.invoke(LayoutOperation.UpdateDialog, {
-                  subject: LOAD_PLUGIN_DIALOG,
-                  state: true,
-                });
-              }),
-              properties: {
-                label: ['load-by-url.label', { ns: meta.profile.key }],
-                icon: 'ph--cloud-arrow-down--regular',
-                disposition: 'list-item-primary',
-              },
-            },
-          ]),
-      }),
+      ...(externalPlugins
+        ? [
+            AppGraphBuilder.createExtension({
+              id: 'actions',
+              match: GraphNodeMatcher.whenId(`root/${REGISTRY_ID}`),
+              actions: () =>
+                Effect.succeed([
+                  {
+                    id: 'loadByUrl',
+                    data: Effect.fnUntraced(function* () {
+                      yield* Operation.invoke(LayoutOperation.UpdateDialog, {
+                        subject: LOAD_PLUGIN_DIALOG,
+                        state: true,
+                      });
+                    }),
+                    properties: {
+                      label: ['load-by-url.label', { ns: meta.profile.key }],
+                      icon: 'ph--cloud-arrow-down--regular',
+                      disposition: 'list-item-primary',
+                    },
+                  },
+                ]),
+            }),
+          ]
+        : []),
       AppGraphBuilder.createExtension({
         id: 'plugins',
         url: { key: 'registry', kind: 'item', path: [] },
@@ -216,7 +177,7 @@ export default Capability.makeModule(
             }),
           );
 
-          const registryEntries = get(manager.pluginRegistry.plugins).entries;
+          const registryEntries = externalPlugins ? get(manager.pluginRegistry.plugins).entries : [];
           const registryNodes = registryEntries
             // `profile.key` is the bare NSID on both sides; comparing against a `dxn:`-prefixed
             // URI here would never match and would duplicate every installed plugin's node.

--- a/packages/plugins/plugin-registry/src/capabilities/dev-plugin-loader.ts
+++ b/packages/plugins/plugin-registry/src/capabilities/dev-plugin-loader.ts
@@ -8,7 +8,7 @@ import * as Capabilities from '@dxos/app-framework/Capabilities';
 import * as Capability from '@dxos/app-framework/Capability';
 import { log } from '@dxos/log';
 
-import { RegistryCapabilities } from '#types';
+import { RegistryCapabilities, type RegistryPluginOptions } from '#types';
 
 /**
  * Startup module that auto-loads a locally-served dev plugin when the user has
@@ -17,7 +17,11 @@ import { RegistryCapabilities } from '#types';
  * the toggle stays on, the next reload retries.
  */
 export default Capability.makeModule(
-  Effect.fnUntraced(function* () {
+  Effect.fnUntraced(function* ({ externalPlugins = true }: RegistryPluginOptions = {}) {
+    if (!externalPlugins) {
+      return [];
+    }
+
     const manager = yield* Capabilities.PluginManager;
     const registry = yield* Capabilities.AtomRegistry;
     const settingsAtom = yield* RegistryCapabilities.Settings;

--- a/packages/plugins/plugin-registry/src/capabilities/react-surface.ts
+++ b/packages/plugins/plugin-registry/src/capabilities/react-surface.ts
@@ -14,13 +14,35 @@ import { AppSurface } from '@dxos/app-toolkit/ui';
 import { DisableDependentsAlert } from '#components';
 import { LoadPluginDialog, PluginArticle, PublicRegistryArticle, RegistrySettingsContainer } from '#containers';
 import { meta } from '#meta';
-import { LOAD_PLUGIN_DIALOG } from '#types';
+import { LOAD_PLUGIN_DIALOG, type RegistryPluginOptions } from '#types';
 
 import { DISABLE_DEPENDENTS_DIALOG } from '../constants';
 import { RegistryCategoryArticle } from './RegistryCategoryArticle';
 
-export default Capability.makeModule(() =>
-  Effect.succeed(
+export default Capability.makeModule(({ externalPlugins = true }: RegistryPluginOptions = {}) => {
+  const externalPluginSurfaces = externalPlugins
+    ? [
+        Surface.create({
+          id: 'registry',
+          filter: AppSurface.literal(AppSurface.Article, 'registry'),
+          component: PublicRegistryArticle,
+          props: () => ({ id: 'registry' }),
+        }),
+        Surface.create({
+          id: LOAD_PLUGIN_DIALOG,
+          filter: AppSurface.component(AppSurface.Dialog, LOAD_PLUGIN_DIALOG),
+          component: LoadPluginDialog,
+        }),
+        Surface.create({
+          id: 'pluginSettings',
+          filter: AppSurface.settings(AppSurface.Article, meta.profile.key),
+          component: RegistrySettingsContainer,
+          props: ({ data: { subject } }) => ({ subject }),
+        }),
+      ]
+    : [];
+
+  return Effect.succeed(
     Capability.contribute(Capabilities.ReactSurface, [
       Surface.create({
         id: 'bundled',
@@ -47,21 +69,10 @@ export default Capability.makeModule(() =>
         props: () => ({ category: 'labs' }),
       }),
       Surface.create({
-        id: 'registry',
-        filter: AppSurface.literal(AppSurface.Article, 'registry'),
-        component: PublicRegistryArticle,
-        props: () => ({ id: 'registry' }),
-      }),
-      Surface.create({
         id: 'pluginDetails',
         filter: AppSurface.subject(AppSurface.Article, Plugin.isPlugin),
         component: PluginArticle,
         props: ({ data: { subject } }) => ({ subject }),
-      }),
-      Surface.create({
-        id: LOAD_PLUGIN_DIALOG,
-        filter: AppSurface.component(AppSurface.Dialog, LOAD_PLUGIN_DIALOG),
-        component: LoadPluginDialog,
       }),
       Surface.create({
         id: DISABLE_DEPENDENTS_DIALOG,
@@ -72,12 +83,7 @@ export default Capability.makeModule(() =>
         component: DisableDependentsAlert,
         props: ({ data: { props } }) => ({ ...props }),
       }),
-      Surface.create({
-        id: 'pluginSettings',
-        filter: AppSurface.settings(AppSurface.Article, meta.profile.key),
-        component: RegistrySettingsContainer,
-        props: ({ data: { subject } }) => ({ subject }),
-      }),
+      ...externalPluginSurfaces,
     ]),
-  ),
-);
+  );
+});

--- a/packages/plugins/plugin-registry/src/capabilities/settings.ts
+++ b/packages/plugins/plugin-registry/src/capabilities/settings.ts
@@ -10,11 +10,11 @@ import * as AppCapabilities from '@dxos/app-toolkit/AppCapabilities';
 import { createKvsStore } from '@dxos/effect';
 
 import { meta } from '#meta';
-import { RegistryCapabilities, RegistrySettingsSchema } from '#types';
+import { RegistryCapabilities, type RegistryPluginOptions, RegistrySettingsSchema } from '#types';
 
 const DEFAULT_DEV_PLUGIN_URL = `http://localhost:${PLUGIN_DEV_SERVER_PORT}/manifest.json`;
 
-export default Capability.makeModule(() =>
+export default Capability.makeModule(({ externalPlugins = true }: RegistryPluginOptions = {}) =>
   Effect.sync(() => {
     const settingsAtom = createKvsStore({
       key: meta.profile.key,
@@ -24,11 +24,15 @@ export default Capability.makeModule(() =>
 
     return [
       Capability.contribute(RegistryCapabilities.Settings, settingsAtom),
-      Capability.contribute(AppCapabilities.Settings, {
-        prefix: meta.profile.key,
-        schema: RegistrySettingsSchema,
-        atom: settingsAtom,
-      }),
+      ...(externalPlugins
+        ? [
+            Capability.contribute(AppCapabilities.Settings, {
+              prefix: meta.profile.key,
+              schema: RegistrySettingsSchema,
+              atom: settingsAtom,
+            }),
+          ]
+        : []),
     ];
   }),
 );

--- a/packages/plugins/plugin-registry/src/categories.test.ts
+++ b/packages/plugins/plugin-registry/src/categories.test.ts
@@ -6,7 +6,7 @@ import { describe, test } from 'vitest';
 
 import * as Plugin from '@dxos/app-framework/Plugin';
 
-import { getCategoryPredicate } from './categories';
+import { REGISTRY_CATEGORIES, getCategoryPredicate, getPopulatedCategories } from './categories';
 
 const context = { core: [], enabled: [], remoteIds: new Set<string>() };
 
@@ -38,6 +38,22 @@ describe('getCategoryPredicate', () => {
     const predicate = getCategoryPredicate('labs', { ...context, core: [key] });
     expect(predicate(makePlugin(key, ['labs']))).toBe(true);
     expect(predicate(makePlugin('alpha-plugin', ['alpha']))).toBe(false);
+  });
+});
+
+describe('getPopulatedCategories', () => {
+  test('drops categories with no members', ({ expect }) => {
+    const counts: Record<string, number> = { bundled: 3, installed: 1 };
+    expect(getPopulatedCategories((category) => counts[category] ?? 0).map(({ id }) => id)).toEqual([
+      'bundled',
+      'installed',
+    ]);
+  });
+
+  test('keeps display order and carries the count', ({ expect }) => {
+    const populated = getPopulatedCategories(() => 2);
+    expect(populated.map(({ id }) => id)).toEqual(REGISTRY_CATEGORIES.map(({ id }) => id));
+    expect(populated.every(({ count }) => count === 2)).toBe(true);
   });
 });
 

--- a/packages/plugins/plugin-registry/src/categories.ts
+++ b/packages/plugins/plugin-registry/src/categories.ts
@@ -44,6 +44,51 @@ export const getCategoryPredicate = (
   }
 };
 
+export type RegistryCategory = {
+  id: string;
+  labelKey: string;
+  icon: string;
+  testId: string;
+};
+
+export const REGISTRY_CATEGORIES: readonly RegistryCategory[] = [
+  {
+    id: 'bundled',
+    labelKey: 'bundled-plugins.label',
+    icon: 'ph--squares-four--regular',
+    testId: 'pluginRegistry.bundled',
+  },
+  {
+    id: 'installed',
+    labelKey: 'installed-plugins.label',
+    icon: 'ph--check--regular',
+    testId: 'pluginRegistry.installed',
+  },
+  {
+    id: 'recommended',
+    labelKey: 'recommended-plugins.label',
+    icon: 'ph--star--regular',
+    testId: 'pluginRegistry.recommended',
+  },
+  {
+    id: 'labs',
+    labelKey: 'labs-plugins.label',
+    icon: 'ph--flask--regular',
+    testId: 'pluginRegistry.labs',
+  },
+  {
+    id: 'registry',
+    labelKey: 'registry-plugins.label',
+    icon: 'ph--users-three--regular',
+    testId: 'pluginRegistry.registry',
+  },
+];
+
+export const getPopulatedCategories = (
+  count: (category: string) => number,
+): readonly (RegistryCategory & { count: number })[] =>
+  REGISTRY_CATEGORIES.map((category) => ({ ...category, count: count(category.id) })).filter(({ count }) => count > 0);
+
 /** Set of plugin ids known to originate from a remote URL (not bundled). */
 export const getRemotePluginIds = (): ReadonlySet<string> =>
   new Set(UrlLoader.getRemoteEntries().map((entry) => entry.id));

--- a/packages/plugins/plugin-registry/src/plugin.tsx
+++ b/packages/plugins/plugin-registry/src/plugin.tsx
@@ -15,8 +15,9 @@ import {
   Translations,
 } from '#capabilities';
 import { meta } from '#meta';
+import type { RegistryPluginOptions } from '#types';
 
-export const RegistryPlugin = Plugin.define(meta).pipe(
+export const RegistryPlugin = Plugin.define<RegistryPluginOptions>(meta).pipe(
   Plugin.addModule(AppGraphBuilder),
   Plugin.addModule(Commands),
   Plugin.addModule(DevPluginLoader),

--- a/packages/plugins/plugin-registry/src/types.ts
+++ b/packages/plugins/plugin-registry/src/types.ts
@@ -15,6 +15,14 @@ import { meta } from '#meta';
 // cannot live in the dialog component's module without dragging React in behind it.
 export const LOAD_PLUGIN_DIALOG = DXN.make(`${meta.profile.key}.loadPluginDialog`);
 
+export type RegistryPluginOptions = {
+  /**
+   * Whether the build can install plugins it did not bundle: the public catalog category, the
+   * load-by-URL dialog and the dev-server loader.
+   */
+  externalPlugins?: boolean;
+};
+
 export const RegistrySettingsSchema = Schema.Struct({
   experimental: Schema.optional(Schema.Boolean),
   /**


### PR DESCRIPTION
## What

The production and mobile plugin sets dropped `RegistryPlugin` entirely, so those builds gave the user no way to see or toggle the plugins they do ship. Both now load it with a new `externalPlugins: false` option, and empty registry categories are dropped instead of rendered empty.

## Changes

`RegistryPlugin.make` takes `{ externalPlugins }` (default `true`). With it off, the plugin withholds every path that installs something the build did not bundle:

- the public catalog category and its article surface, plus the catalog's graph nodes
- the load-by-URL action and dialog
- the dev-server plugin loader
- the registry settings panel — it is the dev loader's UI and nothing else, so an entry with an empty panel would be worse than no entry

Empty categories are dropped. The category table moved into `categories.ts` behind `getPopulatedCategories`, which filters on count. The catalog counts 0 when `externalPlugins` is off, so the gate and the empty-section rule are one mechanism rather than two.

`PluginConfig.isExtensible` is renamed `externalPlugins`, matching the option it feeds — the call site is now `RegistryPlugin.make({ externalPlugins })`.

## Verification

Ran the curated build (`serve-prod`): Bundled 7, Enabled 7, Recommended 7. No Labs section, no catalog section, no load-by-URL button, and no registry entry in the plugin settings list. The default dev set still shows all five (Bundled 77, Enabled 17, Recommended 25, Labs 52, Registry 1) with the URL loader intact.

`plugin-registry:test` passes (20 tests, two new ones covering the empty-category rule), lint is clean on both packages, and `tsc` is clean on `plugin-registry` and every `plugin-defs` file.

## For the reviewer

- Mobile now matches production — it ships the registry, gated the same way. Its containers are built for the desktop deck, so how they look inside the mobile shell is unverified.
- `docs/TESTING.md` claimed the mobile set has no `RegistryPlugin` at all. That is now false, so the Setup paragraph and the A12/A13 note are updated.
- `moon run composer-app:build` fails at `plugin-map-solid:build` on missing `@dxos/echo-solid` type declarations. That is pre-existing and unrelated, but it meant `composer-app:check-plugin-set` could not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to limit the plugin registry to plugins bundled with the app.
  - When external plugins are disabled, catalog browsing, loading plugins by URL, registry settings, and development-server plugin loading are unavailable.
  - Registry categories with no available plugins are now hidden automatically.
- **Bug Fixes**
  - Improved registry displays so empty labs and catalog sections no longer appear.
- **Documentation**
  - Updated testing guidance to clarify mobile and on-device registry limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->