### PR TITLE
skills: route stacked-PR work through GitHub native gh stack

### DIFF
--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -31,6 +31,9 @@ Use `mcp__github__pull_request_read` with `{ owner: "dxos", repo: "dxos", pullNu
 
 If the PR is already merged or closed, tell the user and stop.
 
+If `baseRefName` is not `main`, the PR is part of a stack (GitHub native
+stacked PRs) or targets one — see **Stacked PRs** below before Step 8.
+
 ---
 
 ## Step 3 — Check out the branch locally
@@ -233,6 +236,22 @@ git log HEAD..origin/main --oneline
 If behind, merge and push before the next fix commit. This prevents merge conflicts from accumulating.
 
 ---
+
+## Stacked PRs
+
+A stacked PR (GitHub native stacks, `gh stack` — public preview since 2026-07,
+postdates model training) merges through its stack, not through this skill's
+auto-merge step. The fix loop (Steps 4–7) applies unchanged; for merging:
+
+- Enable auto-merge only on a PR whose base is `main`. For a mid-stack PR,
+  green it, then ask the user whether to merge the whole stack.
+- The stack merges as one all-or-nothing operation: `gh stack merge` locally
+  (it enqueues the stack when a merge queue is active), or the stack merge
+  control on the PR page. `gh stack` is a gh CLI extension
+  (`gh extension install github/gh-stack`) — in remote environments without
+  `gh`, hand the merge to the user.
+- Sync against the PR's own base branch, not `main`, when resolving conflicts
+  on a mid-stack PR; `gh stack rebase` cascades the whole stack locally.
 
 ## Rules
 

--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -31,8 +31,10 @@ Use `mcp__github__pull_request_read` with `{ owner: "dxos", repo: "dxos", pullNu
 
 If the PR is already merged or closed, tell the user and stop.
 
-If `baseRefName` is not `main`, the PR is part of a stack (GitHub native
-stacked PRs) or targets one — see **Stacked PRs** below before Step 8.
+Check whether the PR belongs to a stack (GitHub native stacked PRs): the stack
+map on the PR page is the test — `baseRefName` ≠ `main` is only a hint, and a
+stack's bottom PR targets `main`. For any stack member, see **Stacked PRs**
+below before Step 8.
 
 ---
 
@@ -243,11 +245,18 @@ A stacked PR (GitHub native stacks, `gh stack` — public preview since 2026-07,
 postdates model training) merges through its stack, not through this skill's
 auto-merge step. The fix loop (Steps 4–7) applies unchanged; for merging:
 
-- Enable auto-merge only on a PR whose base is `main`. For a mid-stack PR,
-  green it, then ask the user whether to merge the whole stack.
-- The stack merges as one all-or-nothing operation: `gh stack merge` locally
-  (it enqueues the stack when a merge queue is active), or the stack merge
-  control on the PR page. `gh stack` is a gh CLI extension
+- Membership: the stack map on the PR page (or `gh stack view` locally) is the
+  test. `baseRefName` is only a hint — a stack's bottom PR targets `main`, and
+  a PR based on another PR's branch is not necessarily in a stack.
+- Skip `enable_pr_auto_merge` for every stack member, the bottom PR included.
+  Green the PR, then ask the user which contiguous group of the stack to merge.
+- Merging happens through the stack: `gh stack merge` locally, or the stack
+  merge control on the PR page. A direct merge is atomic for the selected
+  contiguous group starting at the lowest unmerged PR — merging just the bottom
+  of a stack is supported. With a merge queue the stack is enqueued instead,
+  and a large stack is split across consecutive merge groups: earlier groups
+  can land while a later one fails, so recheck the stack state after a queued
+  merge. `gh stack` is a gh CLI extension
   (`gh extension install github/gh-stack`) — in remote environments without
   `gh`, hand the merge to the user.
 - Sync against the PR's own base branch, not `main`, when resolving conflicts

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -16,8 +16,11 @@ runs in. To land (merge) an existing PR, use the `land` skill.
 
 ## Steps
 
-1. **Sync with base.** Merge `origin/main` into the current branch and resolve
-   any conflicts.
+1. **Sync with base.** Merge the branch's base into it and resolve any
+   conflicts: `origin/main` for a standalone or bottom-of-stack branch; for a
+   branch stacked on another open PR, merge that parent PR's head branch
+   instead — merging `main` into a stacked child duplicates the parent's
+   commits into its PR.
 2. **Format.** Run `pnpm format` (oxfmt — CI checks `oxfmt --check`).
 3. **Lint.** `moon run :lint -- --fix` must succeed.
 4. **Test.** `moon run :test` must pass.
@@ -59,7 +62,10 @@ Arguments run bottom-to-top; each may be a PR number, PR URL, or branch name.
 `link` pushes the branch, creates its PR if missing, chains the base branches,
 and registers the stack with GitHub — stack map in the PR UI, CI as if
 targeting `main`, one-click whole-stack merge. Linking is what makes it a
-stack; a PR merely based on another PR's branch is not one. Docs:
+stack; a PR merely based on another PR's branch is not one. A PR that `link`
+creates gets an auto-generated title and body — follow up with
+`gh pr edit <pr> --title --body` so it meets step 8's standards (scope-prefixed
+title, summary, reasoning, Linear link). Docs:
 <https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests>.
 
 ## Composer PR deploy URL — always surface

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Create and submit a pull request from the current branch — sync with main,
   format/lint/test, commit all changes, push, monitor the Check workflow, and
   surface the Composer PR deploy URL. Use when the user asks to open, submit, or
-  raise a PR. To land an existing PR, use the `land` skill instead.
+  raise a PR, including stacking a PR on another open PR (`gh stack`). To land
+  an existing PR, use the `land` skill instead.
 ---
 
 # Submit PR
@@ -33,12 +34,33 @@ runs in. To land (merge) an existing PR, use the `land` skill.
 8. **Open the PR** with `gh`. Title uses `scope: description`. In the
    description, summarize the changes and the reasoning behind major
    decisions, and link any Linear issue as `closes DX-123` or `part of DX-123`.
+   If this work builds on another open PR (or the user asked for a stack), see
+   **Stacked PRs** below instead of `gh pr create`.
 9. **Monitor CI every 5 minutes:**
    `gh run list --branch <branch> --limit 3 --workflow "Check"` and
    `pnpm -w gh-action --verify --watch`. Diagnose and, where possible, fix ALL
    CI errors — even ones unrelated to this branch. Never merge around a red
    Check; fix the root cause with `gh run view <id> --log-failed`.
 10. **Address and RESPOND to every PR review comment.**
+
+## Stacked PRs
+
+GitHub has native stacked PRs (public preview since 2026-07, via the `gh-stack`
+CLI extension) — it postdates model training, so follow this section rather than
+prior knowledge. One command covers this skill's case (the branch already
+exists):
+
+```bash
+gh extension install github/gh-stack   # once per machine
+gh stack link <base-pr-number> <current-branch>
+```
+
+Arguments run bottom-to-top; each may be a PR number, PR URL, or branch name.
+`link` pushes the branch, creates its PR if missing, chains the base branches,
+and registers the stack with GitHub — stack map in the PR UI, CI as if
+targeting `main`, one-click whole-stack merge. Linking is what makes it a
+stack; a PR merely based on another PR's branch is not one. Docs:
+<https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests>.
 
 ## Composer PR deploy URL — always surface
 


### PR DESCRIPTION
GitHub's native stacked PRs shipped in public preview 2026-07-30 — after every current model's training cutoff — so agents reliably fall back to the old idiom of pointing one PR's base at another PR's branch and calling it a stack. That idiom no longer produces what GitHub means by a stack (stack map, chained CI, all-or-nothing merge). Docs: https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests

- `submit-pr`: trigger added to the description; new **Stacked PRs** section. Since the skill's contract is "the branch already exists", `gh stack link <base-pr> <branch>` is the entire workflow — it pushes, creates the missing PR, fixes base chaining, and registers the stack.
- `land`: detection cue in Step 2 (`baseRefName` ≠ `main`) and a merge-side guard — auto-merge only on a base-`main` PR; a stack merges all-or-nothing via `gh stack merge` or the PR page's stack control, handed to the user in remote environments without the `gh` CLI.

Skill-only change; no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for identifying and managing stacked pull requests.
  * Clarified merge behavior, including selecting contiguous groups and handling merge queues.
  * Added instructions to recheck stack status after queued merges.
  * Updated stacked child branch guidance to merge from the parent pull request.
  * Added steps to review and update automatically generated pull request titles and descriptions.
  * Clarified when automatic merging is appropriate and when confirmation is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->