### PR TITLE
ui-theme: add dx-shrink, and delete the min-*-0 that clips already applied

### DIFF
--- a/.changeset/sizing-shrink.md
+++ b/.changeset/sizing-shrink.md
@@ -1,0 +1,12 @@
+---
+'@dxos/ui-theme': minor
+'@dxos/eslint-plugin-rules': minor
+---
+
+Add `dx-shrink`, and remove the `min-*-0` that a clip had already applied.
+
+`min-h-0` is widely read as "makes things scroll". It does not: it says the element may be **shorter than its content**, and without it a flex/grid item's minimum height is its content height, so it shoves its siblings out of the line. Measured in a 260px column above a 40px footer, the footer lands at 927px — outside the box — with nothing scrolling anywhere. Scrolling is only the consequence of finally being squeezed.
+
+`dx-shrink` (`min-h-0 min-w-0`) names that intent, and `dx-grow` becomes `flex-1 dx-shrink` so the two decisions — may I be small, do I claim the rest — compose rather than hiding inside one bundle.
+
+Also deletes 27 `min-*-0` that never did anything: any non-visible overflow zeroes the same minimum, so a `min-h-0` beside `overflow-hidden` is dead weight that reads as load-bearing. `prefer-sizing-utilities` now reports those, and flags `dx-grow dx-fill` as the long spelling of `dx-expand`.

--- a/.changeset/sizing-shrink.md
+++ b/.changeset/sizing-shrink.md
@@ -9,4 +9,4 @@ Add `dx-shrink`, and remove the `min-*-0` that a clip had already applied.
 
 `dx-shrink` (`min-h-0 min-w-0`) names that intent, and `dx-grow` becomes `flex-1 dx-shrink` so the two decisions — may I be small, do I claim the rest — compose rather than hiding inside one bundle.
 
-Also deletes 27 `min-*-0` that never did anything: any non-visible overflow zeroes the same minimum, so a `min-h-0` beside `overflow-hidden` is dead weight that reads as load-bearing. `prefer-sizing-utilities` now reports those, and flags `dx-grow dx-fill` as the long spelling of `dx-expand`.
+Also deletes 27 `min-*-0` that never did anything: a scroll container has already zeroed the same minimum, so a `min-h-0` beside `overflow-hidden`, `-auto` or `-scroll` is dead weight that reads as load-bearing. `overflow-clip` is excluded — it clips without scrolling, so the minimum still applies there. `prefer-sizing-utilities` now reports the redundant ones, and flags `dx-grow dx-fill` as the long spelling of `dx-expand`.

--- a/packages/common/eslint-plugin-rules/rules/prefer-sizing-utilities.js
+++ b/packages/common/eslint-plugin-rules/rules/prefer-sizing-utilities.js
@@ -49,6 +49,15 @@ const COMBINATIONS = [
   { classes: ['absolute', 'inset-0'], suggestion: 'dx-fullscreen' },
 ];
 
+/** Utility pairs that are the long spelling of another utility. */
+const COMPOSITIONS = [{ classes: ['dx-grow', 'dx-fill'], suggestion: 'dx-expand' }];
+
+/** Any non-visible overflow already zeroes the automatic minimum size. */
+const CLIPS = /^overflow(-[xy])?-(hidden|auto|scroll|clip)$/;
+
+/** The classes that only exist to zero that same minimum. */
+const MINIMUMS = ['min-h-0', 'min-w-0', 'dx-shrink'];
+
 /** Class-bearing attributes. `mx()` is this repo's class merger. */
 const ATTRIBUTES = new Set(['className', 'classNames', 'class']);
 
@@ -71,6 +80,8 @@ export default {
     messages: {
       handRolled: '`{{classes}}` is `{{suggestion}}`. Use the utility so the intent is explicit.',
       redundant: '`{{className}}` already applies `{{redundant}}`. Remove the duplicate.',
+      minimumUnderClip:
+        '`{{minimum}}` does nothing here: `{{overflow}}` already zeroes the automatic minimum size, so the element can already be smaller than its content. Remove it.',
     },
   },
   create: (context) => {
@@ -104,6 +115,26 @@ export default {
             data: { className: utility, redundant: redundant.join(' ') },
           });
         }
+      }
+
+      // A minimum next to a clip. The overflow already did it, so the class is a no-op that reads
+      // as though it were load-bearing — the single biggest source of confusion about `min-*-0`.
+      const overflow = classes.filter(unprefixed).find((cls) => CLIPS.test(cls));
+      if (overflow) {
+        const minimum = MINIMUMS.find((cls) => present.has(cls));
+        if (minimum) {
+          context.report({ node, messageId: 'minimumUnderClip', data: { minimum, overflow } });
+        }
+      }
+
+      // Two utilities that compose into a third — the long spelling of one name.
+      const composition = COMPOSITIONS.find(({ classes: needed }) => needed.every((cls) => present.has(cls)));
+      if (composition) {
+        context.report({
+          node,
+          messageId: 'handRolled',
+          data: { classes: composition.classes.join(' '), suggestion: composition.suggestion },
+        });
       }
 
       // Hand-rolled equivalents. Only the first (longest) match is reported, so one class list does

--- a/packages/common/eslint-plugin-rules/rules/prefer-sizing-utilities.js
+++ b/packages/common/eslint-plugin-rules/rules/prefer-sizing-utilities.js
@@ -52,8 +52,15 @@ const COMBINATIONS = [
 /** Utility pairs that are the long spelling of another utility. */
 const COMPOSITIONS = [{ classes: ['dx-grow', 'dx-fill'], suggestion: 'dx-expand' }];
 
-/** Any non-visible overflow already zeroes the automatic minimum size. */
-const CLIPS = /^overflow(-[xy])?-(hidden|auto|scroll|clip)$/;
+/**
+ * Overflow values that already zero the automatic minimum size — the ones that make the box a
+ * scroll container.
+ *
+ * `overflow-clip` is deliberately absent: it clips without scrolling, so it is NOT a scroll
+ * container and the minimum still applies. Measured in a 200px column over a 40px footer, a 500px
+ * child leaves the footer at 500 under both `clip` and `visible`, and at 160 under `hidden`/`auto`.
+ */
+const CLIPS = /^overflow(-[xy])?-(hidden|auto|scroll)$/;
 
 /** The classes that only exist to zero that same minimum. */
 const MINIMUMS = ['min-h-0', 'min-w-0', 'dx-shrink'];

--- a/packages/common/eslint-plugin-rules/src/prefer-sizing-utilities.test.ts
+++ b/packages/common/eslint-plugin-rules/src/prefer-sizing-utilities.test.ts
@@ -94,6 +94,48 @@ describe('prefer-sizing-utilities', () => {
     });
   });
 
+  it('reports a minimum that a clip has already applied', () => {
+    ruleTester.run('prefer-sizing-utilities', rule, {
+      valid: [
+        // The element's own overflow stays visible, so the minimum is load-bearing.
+        { filename, code: "<div className='min-h-0' />" },
+        { filename, code: "<div className='dx-shrink' />" },
+        // The clip is on a descendant, not on this element.
+        { filename, code: "<div className='min-h-0 [&>*]:overflow-hidden' />" },
+      ],
+      invalid: [
+        {
+          filename,
+          code: "<div className='min-h-0 overflow-hidden' />",
+          errors: [{ messageId: 'minimumUnderClip', data: { minimum: 'min-h-0', overflow: 'overflow-hidden' } }],
+        },
+        {
+          filename,
+          code: "<div className='min-w-0 overflow-y-auto' />",
+          errors: [{ messageId: 'minimumUnderClip', data: { minimum: 'min-w-0', overflow: 'overflow-y-auto' } }],
+        },
+        {
+          filename,
+          code: "<div className='dx-shrink overflow-scroll' />",
+          errors: [{ messageId: 'minimumUnderClip', data: { minimum: 'dx-shrink', overflow: 'overflow-scroll' } }],
+        },
+      ],
+    });
+  });
+
+  it('reports two utilities that compose into a third', () => {
+    ruleTester.run('prefer-sizing-utilities', rule, {
+      valid: [],
+      invalid: [
+        {
+          filename,
+          code: "<div className='flex dx-fill dx-grow' />",
+          errors: [{ messageId: 'handRolled', data: { classes: 'dx-grow dx-fill', suggestion: 'dx-expand' } }],
+        },
+      ],
+    });
+  });
+
   it('reports a utility stacked on what it already applies', () => {
     ruleTester.run('prefer-sizing-utilities', rule, {
       valid: [],

--- a/packages/common/eslint-plugin-rules/src/prefer-sizing-utilities.test.ts
+++ b/packages/common/eslint-plugin-rules/src/prefer-sizing-utilities.test.ts
@@ -19,7 +19,7 @@ const ruleTester = new RuleTester({
 });
 
 describe('prefer-sizing-utilities', () => {
-  it('accepts the utilities and unrelated classes', () => {
+  test('accepts the utilities and unrelated classes', () => {
     ruleTester.run('prefer-sizing-utilities', rule, {
       valid: [
         { filename, code: "<div className='dx-expand' />" },
@@ -44,7 +44,7 @@ describe('prefer-sizing-utilities', () => {
     });
   });
 
-  it('reports hand-rolled equivalents', () => {
+  test('reports hand-rolled equivalents', () => {
     ruleTester.run('prefer-sizing-utilities', rule, {
       valid: [],
       invalid: [
@@ -94,7 +94,7 @@ describe('prefer-sizing-utilities', () => {
     });
   });
 
-  it('reports a minimum that a clip has already applied', () => {
+  test('reports a minimum that a clip has already applied', () => {
     ruleTester.run('prefer-sizing-utilities', rule, {
       valid: [
         // The element's own overflow stays visible, so the minimum is load-bearing.
@@ -127,7 +127,7 @@ describe('prefer-sizing-utilities', () => {
     });
   });
 
-  it('reports two utilities that compose into a third', () => {
+  test('reports two utilities that compose into a third', () => {
     ruleTester.run('prefer-sizing-utilities', rule, {
       valid: [],
       invalid: [
@@ -140,7 +140,7 @@ describe('prefer-sizing-utilities', () => {
     });
   });
 
-  it('reports a utility stacked on what it already applies', () => {
+  test('reports a utility stacked on what it already applies', () => {
     ruleTester.run('prefer-sizing-utilities', rule, {
       valid: [],
       invalid: [

--- a/packages/common/eslint-plugin-rules/src/prefer-sizing-utilities.test.ts
+++ b/packages/common/eslint-plugin-rules/src/prefer-sizing-utilities.test.ts
@@ -3,7 +3,7 @@
 //
 
 import { RuleTester } from 'eslint';
-import { describe, it } from 'vitest';
+import { describe, test } from 'vitest';
 
 import rule from '../rules/prefer-sizing-utilities.js';
 
@@ -102,6 +102,10 @@ describe('prefer-sizing-utilities', () => {
         { filename, code: "<div className='dx-shrink' />" },
         // The clip is on a descendant, not on this element.
         { filename, code: "<div className='min-h-0 [&>*]:overflow-hidden' />" },
+        // `overflow-clip` clips without scrolling, so it is not a scroll container and the
+        // automatic minimum size still applies — the class stays load-bearing.
+        { filename, code: "<div className='min-h-0 overflow-clip' />" },
+        { filename, code: "<div className='dx-shrink overflow-x-clip' />" },
       ],
       invalid: [
         {

--- a/packages/devtools/devtools/src/panels/echo/ObjectsPanel/ObjectsPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/ObjectsPanel/ObjectsPanel.tsx
@@ -205,7 +205,7 @@ export const ObjectsPanel = (props: { space?: Space }) => {
           </div>
 
           <div className='dx-expand grid grid-rows-[1fr_16rem] border-s border-t border-separator'>
-            <div className='p-1 min-h-0 overflow-auto'>
+            <div className='p-1 overflow-auto'>
               {selected ? (
                 <ObjectViewer
                   object={selectedVersionObject ?? selected}

--- a/packages/devtools/devtools/src/panels/echo/SchemaPanel/SchemaPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SchemaPanel/SchemaPanel.tsx
@@ -154,7 +154,7 @@ export const SchemaPanel = (props: { space?: Space }) => {
           </div>
 
           <div className='min-h-0 h-full border-s border-t border-separator'>
-            <div className={mx('p-1 min-h-0 h-full overflow-auto')}>
+            <div className={mx('p-1 h-full overflow-auto')}>
               {selected ? (
                 <ObjectViewer
                   object={selected.jsonSchema}

--- a/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/InvocationTraceContainer.tsx
+++ b/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/InvocationTraceContainer.tsx
@@ -213,7 +213,7 @@ const Selected: FC<{ span: InvocationSpan }> = ({ span }) => {
 
   return (
     <Tabs.Root asChild orientation='horizontal' value={activeTab} onValueChange={setActiveTab}>
-      <div className='grid grid-cols-1 grid-rows-[min-content_1fr] min-h-0 overflow-hidden border-separator [&>[role="tabpanel"]]:min-h-0 [&>[role="tabpanel"][data-state="active"]]:grid border-t border-separator'>
+      <div className='grid grid-cols-1 grid-rows-[min-content_1fr] overflow-hidden border-separator [&>[role="tabpanel"]]:min-h-0 [&>[role="tabpanel"][data-state="active"]]:grid border-t border-separator'>
         <Tabs.Tablist classNames='border-b border-separator'>
           <Tabs.Button value='input'>Input</Tabs.Button>
           {isLogQueue && <Tabs.Button value='logs'>Logs</Tabs.Button>}
@@ -222,7 +222,7 @@ const Selected: FC<{ span: InvocationSpan }> = ({ span }) => {
           {span.error && <Tabs.Button value='failure'>Failure</Tabs.Button>}
           {contents === 'execution-graph' && <Tabs.Button value='execution-graph'>Execution Graph</Tabs.Button>}
         </Tabs.Tablist>
-        <Tabs.Panel value='input' classNames='min-h-0 min-w-0 w-full overflow-auto'>
+        <Tabs.Panel value='input' classNames='w-full overflow-auto'>
           <JsonHighlighter data={span.input} />
         </Tabs.Panel>
         {isLogQueue && (
@@ -236,7 +236,7 @@ const Selected: FC<{ span: InvocationSpan }> = ({ span }) => {
           </Tabs.Panel>
         )}
         {isLogQueue && (
-          <Tabs.Panel value='raw' classNames='min-h-0 min-w-0 w-full overflow-auto'>
+          <Tabs.Panel value='raw' classNames='w-full overflow-auto'>
             <RawDataPanel classNames='text-xs' span={span} objects={objects} />
           </Tabs.Panel>
         )}

--- a/packages/plugins/plugin-deck/src/components/Pane/Pane.tsx
+++ b/packages/plugins/plugin-deck/src/components/Pane/Pane.tsx
@@ -140,7 +140,7 @@ const PaneTabs = forwardRef<HTMLDivElement, PaneTabsProps>(
     return (
       <div
         role='tablist'
-        className={mx('flex-1 min-w-0 overflow-x-auto scrollbar-none flex items-center gap-1', classNames)}
+        className={mx('flex-1 overflow-x-auto scrollbar-none flex items-center gap-1', classNames)}
         ref={forwardedRef}
       >
         {tabs.map(({ id, icon, label }) => (

--- a/packages/plugins/plugin-devtools/src/containers/RegistryPanel/RegistryPanel.tsx
+++ b/packages/plugins/plugin-devtools/src/containers/RegistryPanel/RegistryPanel.tsx
@@ -141,7 +141,7 @@ export const RegistryPanel = () => {
           <div className={mx('flex flex-col dx-grow overflow-hidden')}>
             <DynamicTable properties={properties} rows={rows} features={features} onRowClick={handleRowClicked} />
           </div>
-          <div className={mx('h-full min-h-0 overflow-auto border-s border-separator text-sm')}>
+          <div className={mx('h-full overflow-auto border-s border-separator text-sm')}>
             {detailJson ? <JsonView data={detailJson} /> : <Placeholder label='Details' />}
           </div>
         </div>

--- a/packages/plugins/plugin-map-solid/src/components/MapSurface/MapSurface.tsx
+++ b/packages/plugins/plugin-map-solid/src/components/MapSurface/MapSurface.tsx
@@ -72,7 +72,7 @@ const MapSurface = (props: MapSurfaceProps) => {
   });
 
   return (
-    <div class='flex dx-fill dx-grow'>
+    <div class='flex dx-expand'>
       <Show when={type() === 'map'}>
         <MapControl markers={markers} onToggle={() => setType('globe')} />
       </Show>

--- a/packages/plugins/plugin-routine/src/components/Schedule/Schedule.tsx
+++ b/packages/plugins/plugin-routine/src/components/Schedule/Schedule.tsx
@@ -331,7 +331,7 @@ const ScheduleEditor = ({ value, onChange }: { value: ScheduleValue; onChange: (
     //     <div>
     //       <Field label={t('schedule.at.label')}>
     //         <Input.DateTime
-    //           classNames='min-w-0 overflow-hidden'
+    //           classNames='overflow-hidden'
     //           hourCycle={12}
     //           value={value.date ?? ''}
     //           onValueChange={(date) => onChange({ kind: 'once', date: date || undefined })}
@@ -373,7 +373,7 @@ const ScheduleEditor = ({ value, onChange }: { value: ScheduleValue; onChange: (
 
     case 'weekly':
       return (
-        <div className='@container dx-container-type-inline-size min-w-0 flex justify-between items-center gap-2 overflow-x-auto scrollbar-none'>
+        <div className='@container dx-container-type-inline-size flex justify-between items-center gap-2 overflow-x-auto scrollbar-none'>
           <Field label={t('schedule.at.label')}>
             <Input.Root>
               <Input.Time hourCycle={12} value={value.time} onValueChange={(time) => onChange({ ...value, time })} />

--- a/packages/plugins/plugin-trip/src/containers/TripArticle/TripArticle.stories.tsx
+++ b/packages/plugins/plugin-trip/src/containers/TripArticle/TripArticle.stories.tsx
@@ -168,7 +168,7 @@ const DefaultStory = ({ showMap }: { showMap?: boolean }) => {
   return (
     <AttendableContainer id={ATTENDABLE_ID} classNames='dx-expand grid grid-cols-2'>
       <TripArticle role='article' subject={trip} attendableId={ATTENDABLE_ID} defaultShowGlobe={showMap} />
-      <div className='min-h-0 overflow-hidden border-is border-separator'>
+      <div className='overflow-hidden border-is border-separator'>
         {selected && (
           <SegmentArticle role='article' subject={selected} companionTo={trip} attendableId={ATTENDABLE_ID} />
         )}

--- a/packages/plugins/plugin-trip/src/containers/TripArticle/TripArticle.tsx
+++ b/packages/plugins/plugin-trip/src/containers/TripArticle/TripArticle.tsx
@@ -266,7 +266,7 @@ export const TripArticle = ({ role, subject, attendableId, defaultShowGlobe }: T
         )}
       >
         {/* Row 1: calendar + segment stack. */}
-        <div className='grid grid-cols-1 @3xl:grid-cols-[min-content_1fr] min-h-0 overflow-hidden'>
+        <div className='grid grid-cols-1 @3xl:grid-cols-[min-content_1fr] overflow-hidden'>
           <NaturalCalendar.Root>
             <Panel.Root classNames='hidden @3xl:block border-r border-subdued-separator'>
               <Panel.Toolbar asChild>

--- a/packages/stories/stories-assistant/src/modules/AgentModule.tsx
+++ b/packages/stories/stories-assistant/src/modules/AgentModule.tsx
@@ -138,7 +138,7 @@ export const AgentModule = () => {
   );
 
   return (
-    <Panel.Root classNames='dx-fill min-h-0 min-w-0 flex flex-col gap-2 p-2 overflow-hidden'>
+    <Panel.Root classNames='dx-fill flex flex-col gap-2 p-2 overflow-hidden'>
       <Panel.Toolbar classNames='shrink-0 justify-end'>
         <div className='flex items-center gap-1 text-xs text-description'>
           <Icon icon='ph--git-commit--regular' size={4} />

--- a/packages/stories/stories-lens/src/MarkdownEditor.tsx
+++ b/packages/stories/stories-lens/src/MarkdownEditor.tsx
@@ -40,5 +40,5 @@ export const MarkdownEditor = ({ text }: { text: Text.Text }) => {
     [text, themeMode],
   );
 
-  return <div ref={parentRef} className='min-h-0 overflow-auto' data-testid='markdown-editor' />;
+  return <div ref={parentRef} className='overflow-auto' data-testid='markdown-editor' />;
 };

--- a/packages/stories/stories-lens/src/RichTextEditor.tsx
+++ b/packages/stories/stories-lens/src/RichTextEditor.tsx
@@ -254,7 +254,7 @@ export const RichTextEditor = ({ text }: { text: Text.Text }) => {
     }
   }, [signature, reconcile]);
 
-  return <div ref={parentRef} className='min-h-0 overflow-auto' data-testid='rich-text-editor' />;
+  return <div ref={parentRef} className='overflow-auto' data-testid='rich-text-editor' />;
 };
 
 /**

--- a/packages/ui/react-ui-assistant/src/widgets/ReasoningWidget.ts
+++ b/packages/ui/react-ui-assistant/src/widgets/ReasoningWidget.ts
@@ -51,7 +51,7 @@ export class ReasoningWidget extends WidgetType {
                 .classNames('flex p-1 shrink-0 items-center justify-center self-start')
                 .append(Domino.svg('ph--brain--regular').classNames('shrink-0 size-4')),
               Domino.of('div')
-                .classNames('flex items-center max-h-[5lh] overflow-y-auto dx-scrollbar-thin min-w-0 text-description')
+                .classNames('flex items-center max-h-[5lh] overflow-y-auto dx-scrollbar-thin text-description')
                 .text(this.text)
                 .attributes({ 'data-reasoning-text': '' }),
             ),

--- a/packages/ui/react-ui-board/src/components/Board/BoardCell.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/BoardCell.tsx
@@ -294,7 +294,7 @@ export const BoardCell = ({
         </Card.Header>
         {/* Body spans all of the card's column tracks (it has gutter columns) so content — e.g. a
             poster image — fills the full tile width, not just the first gutter track. */}
-        {children && <div className='relative col-[1/-1] min-h-0 overflow-hidden'>{children}</div>}
+        {children && <div className='relative col-[1/-1] overflow-hidden'>{children}</div>}
       </Card.Root>
 
       {/* Resize handle: a sibling (not clipped by the card's overflow/rounding) straddling the
@@ -337,7 +337,7 @@ export const BoardCell = ({
               <Card.DragHandle />
               {title}
             </Card.Header>
-            {children && <div className='relative col-[1/-1] min-h-0 overflow-hidden'>{children}</div>}
+            {children && <div className='relative col-[1/-1] overflow-hidden'>{children}</div>}
           </Card.Root>,
           preview.container,
         )}

--- a/packages/ui/react-ui-components/src/components/TogglePanel/TogglePanel.tsx
+++ b/packages/ui/react-ui-components/src/components/TogglePanel/TogglePanel.tsx
@@ -126,7 +126,7 @@ const Body = composable<HTMLDivElement, BodyProps>(({ children, ...props }, forw
       })}
       ref={forwardedRef}
     >
-      <div className='min-h-0 overflow-hidden'>{children}</div>
+      <div className='overflow-hidden'>{children}</div>
     </div>
   );
 });
@@ -145,7 +145,7 @@ export type ViewportProps = ThemedClassName<PropsWithChildren>;
  * Scrollable region for nested flex/grid layouts. Uses min-h-0 and min-w-0 so overflow can shrink correctly.
  */
 export const Viewport = composable<HTMLDivElement, ViewportProps>(({ children, ...props }, forwardedRef) => (
-  <div {...composableProps(props, { classNames: ['min-h-0 min-w-0 overflow-y-auto'] })} ref={forwardedRef}>
+  <div {...composableProps(props, { classNames: ['overflow-y-auto'] })} ref={forwardedRef}>
     {children}
   </div>
 ));

--- a/packages/ui/react-ui-dashboard/src/Dashboard.tsx
+++ b/packages/ui/react-ui-dashboard/src/Dashboard.tsx
@@ -296,7 +296,7 @@ const DashboardActivity = composable<HTMLDivElement, DashboardActivityCustomProp
           ))}
         </div>
         {/* justify-end overflows surplus weeks past the clipped left edge, pinning recent weeks right. */}
-        <div className='flex min-w-0 justify-end overflow-hidden'>
+        <div className='flex justify-end overflow-hidden'>
           <div
             className='grid gap-[3px]'
             style={{

--- a/packages/ui/react-ui-form/src/components/Form/FormField/fields/DateField/DateField.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/FormField/fields/DateField/DateField.tsx
@@ -73,7 +73,7 @@ export const DateField = ({
             return (
               <div className='grid grid-cols-[minmax(0,1fr)_min-content] gap-1 items-stretch tabular-nums'>
                 <Input.Date
-                  classNames='min-w-0 overflow-hidden'
+                  classNames='overflow-hidden'
                   disabled={readonly}
                   value={value ?? ''}
                   onValueChange={handleSimpleChange}
@@ -95,7 +95,7 @@ export const DateField = ({
             return (
               <div className='grid grid-cols-[minmax(0,1fr)_min-content] gap-1 items-stretch tabular-nums'>
                 <Input.DateTime
-                  classNames='min-w-0 overflow-hidden'
+                  classNames='overflow-hidden'
                   disabled={readonly}
                   value={isoToLocalDateTime(value)}
                   onValueChange={handleDateTimeChange}

--- a/packages/ui/react-ui-syntax-highlighter/src/Syntax/Syntax.tsx
+++ b/packages/ui/react-ui-syntax-highlighter/src/Syntax/Syntax.tsx
@@ -134,7 +134,7 @@ type SyntaxContentProps = ComposableProps;
 /** Flex-column layout container for composite parts. */
 const SyntaxContent = composable<HTMLDivElement, SyntaxContentProps>(({ children, ...props }, forwardedRef) => {
   return (
-    <div {...composableProps(props, { classNames: 'flex flex-col dx-grow overflow-hidden' })} ref={forwardedRef}>
+    <div {...composableProps(props, { classNames: 'flex flex-col dx-expand overflow-hidden' })} ref={forwardedRef}>
       {children}
     </div>
   );

--- a/packages/ui/react-ui-task/src/components/TaskList/TaskList.tsx
+++ b/packages/ui/react-ui-task/src/components/TaskList/TaskList.tsx
@@ -260,7 +260,7 @@ type TaskListViewportProps = ComposableProps;
 const TaskListViewport = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
   const { className, ...rest } = composableProps(props);
   return (
-    <Listbox.Viewport {...rest} classNames={mx('min-w-0 min-h-0', className)} ref={forwardedRef}>
+    <Listbox.Viewport {...rest} classNames={mx('dx-shrink', className)} ref={forwardedRef}>
       {children}
     </Listbox.Viewport>
   );

--- a/packages/ui/react-ui/src/components/Breadcrumb/Breadcrumb.theme.ts
+++ b/packages/ui/react-ui/src/components/Breadcrumb/Breadcrumb.theme.ts
@@ -11,7 +11,7 @@ const root: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) =>
   mx('flex items-center grow overflow-hidden', ...etc);
 
 const list: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) =>
-  mx('flex items-center min-w-0 grow overflow-x-auto scrollbar-none', ...etc);
+  mx('flex items-center grow overflow-x-auto scrollbar-none', ...etc);
 
 const listItem: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) => mx('flex items-center shrink-0', ...etc);
 

--- a/packages/ui/react-ui/src/components/Card/Card.theme.ts
+++ b/packages/ui/react-ui/src/components/Card/Card.theme.ts
@@ -69,7 +69,7 @@ const actionLabel: ComponentFunction<CardStyleProps> = (_, ...etc) =>
 // Holds the label and its annotation in one grid cell: `action` puts every child in column 2,
 // so siblings would otherwise stack onto separate rows.
 const actionContent: ComponentFunction<CardStyleProps> = (_, ...etc) =>
-  mx('dx-card__action-content min-w-0 flex-1 flex items-baseline gap-2 overflow-hidden', ...etc);
+  mx('dx-card__action-content flex-1 flex items-baseline gap-2 overflow-hidden', ...etc);
 
 // Never shrinks: the label truncates around it, so a long subject cannot squeeze the annotation out.
 const actionAnnotation: ComponentFunction<CardStyleProps> = (_, ...etc) =>

--- a/packages/ui/react-ui/src/components/Popover/Popover.theme.ts
+++ b/packages/ui/react-ui/src/components/Popover/Popover.theme.ts
@@ -27,7 +27,7 @@ const viewport: ComponentFunction<PopoverStyleProps> = ({ constrainBlock, constr
   mx(
     // Always clipped: with the content no longer clipping (see above), the viewport is what keeps a
     // square-cornered child inside the surface's rounded corners.
-    'grid grid-rows-[1fr] min-h-0 min-w-popover-min-width overflow-hidden',
+    'grid grid-rows-[1fr] min-w-popover-min-width overflow-hidden',
     constrainBlock && 'max-h-(--radix-popover-content-available-height)',
     constrainBlock &&
       'max-h-[min(var(--radix-popover-content-available-height),calc(100dvh-var(--spacing-screen-border)*2))]',

--- a/packages/ui/react-ui/src/components/Splitter/Splitter.theme.ts
+++ b/packages/ui/react-ui/src/components/Splitter/Splitter.theme.ts
@@ -12,8 +12,7 @@ export type SplitterStyleProps = {
 const root: ComponentFunction<SplitterStyleProps> = ({ orientation }, ...etc) =>
   mx('relative flex dx-fill overflow-hidden', orientation === 'vertical' ? 'flex-col' : 'flex-row', ...etc);
 
-const panel: ComponentFunction<SplitterStyleProps> = (_props, ...etc) =>
-  mx('relative grid overflow-hidden min-w-0 min-h-0', ...etc);
+const panel: ComponentFunction<SplitterStyleProps> = (_props, ...etc) => mx('relative grid overflow-hidden', ...etc);
 
 // A 7px grab area, absolutely positioned and centered on the split point (the component sets the offset),
 // containing a persistent 1px divider line that brightens on hover/focus/active.

--- a/packages/ui/ui-template/src/react/Splitter.tsx
+++ b/packages/ui/ui-template/src/react/Splitter.tsx
@@ -45,7 +45,7 @@ export const Splitter = ({ orientation = 'horizontal', panes }: SplitterProps) =
             : 'shrink-0 h-1 cursor-row-resize bg-separator hover:bg-active-separator'
         }
       />
-      <div {...api.getPanelProps({ id: 'end' })} className='flex flex-col min-w-0 min-h-0 overflow-hidden'>
+      <div {...api.getPanelProps({ id: 'end' })} className='flex flex-col overflow-hidden'>
         {panes[1]}
       </div>
     </div>

--- a/packages/ui/ui-template/src/react/testing/MultiSelectList.stories.tsx
+++ b/packages/ui/ui-template/src/react/testing/MultiSelectList.stories.tsx
@@ -99,7 +99,7 @@ const DefaultStory = ({ splitter }: StoryArgs) => {
 const meta: Meta<typeof DefaultStory> = {
   title: 'ui/ui-template/MultiSelect',
   render: DefaultStory,
-  decorators: [withTheme(), withLayout({ layout: 'fullscreen', classNames: '2-96' })],
+  decorators: [withTheme(), withLayout({ layout: 'fullscreen', classNames: 'w-96' })],
   parameters: { layout: 'fullscreen', translations: formTranslations },
 };
 

--- a/packages/ui/ui-theme/src/Sizing.stories.tsx
+++ b/packages/ui/ui-theme/src/Sizing.stories.tsx
@@ -154,6 +154,55 @@ export const WhichPropertyFires = {
 };
 
 /**
+ * What `min-*-0` actually does — the class this vocabulary exists to demystify.
+ *
+ * It is read as "makes things scroll". It does not: it says the element MAY BE SHORTER THAN ITS
+ * CONTENT. Without it, an item's minimum height is its content height, so it shoves its siblings
+ * out of the line. Scrolling is only the downstream consequence of finally being squeezed.
+ */
+export const ShrinkingVersusShoving = {
+  render: () => {
+    const footer = <div className='h-10 shrink-0 grid place-items-center text-xs bg-emerald-500/20'>footer</div>;
+    return (
+      <div className='p-4 flex flex-col gap-6'>
+        <p className='max-w-2xl text-sm text-description'>
+          Identical 260px columns: a body holding 900px of content, then a 40px footer. Watch the footer, not the
+          scrollbar — the failure on the left is a displaced sibling, and nothing scrolls in either box.
+        </p>
+        <div className='flex flex-wrap gap-6'>
+          <Frame title='no dx-shrink' note='body claims its content height; footer is pushed out of view'>
+            <div className='flex flex-col h-full'>
+              <Measured label='(nothing)' classNames=''>
+                <Tall />
+              </Measured>
+              {footer}
+            </div>
+          </Frame>
+          <Frame title='dx-shrink' note='body yields; footer keeps its place'>
+            <div className='flex flex-col h-full'>
+              <Measured label='dx-shrink' classNames='dx-shrink'>
+                <Tall />
+              </Measured>
+              {footer}
+            </div>
+          </Frame>
+          {/* The point most likely to save someone an afternoon: a clip says the same thing, so a
+              `min-*-0` beside one is dead weight that reads as though it were holding the layout up. */}
+          <Frame title='overflow-hidden alone' note='a clip zeroes the same minimum — dx-shrink adds nothing here'>
+            <div className='flex flex-col h-full'>
+              <Measured label='overflow-hidden' classNames='overflow-hidden'>
+                <Tall />
+              </Measured>
+              {footer}
+            </div>
+          </Frame>
+        </div>
+      </div>
+    );
+  },
+};
+
+/**
  * `dx-grow` constrains without clipping, so an overflowing child is visible rather than hidden.
  * Reach for `overflow-hidden` only where a clip is wanted — it also makes the element a scroll
  * container, which a focused descendant can silently scroll.

--- a/packages/ui/ui-theme/src/css/utilities.css
+++ b/packages/ui/ui-theme/src/css/utilities.css
@@ -47,13 +47,17 @@
  * Scrolling is a CONSEQUENCE: the inner element only scrolls once something finally squeezed it.
  * A layout that never scrolls fails the same way — a toolbar pushed off, a container blown out.
  *
- * ## Overflow says it too, which is why so many `min-*-0` do nothing
+ * ## A scroll container says it too, which is why so many `min-*-0` do nothing
  *
- * For a flex or grid item, `min-height:auto` applies only while `overflow` is `visible`
- * (CSS Flexbox §4.5, CSS Grid §6.6). So an element that sets ANY non-visible overflow has already
- * zeroed its automatic minimum size, and a `min-h-0` beside it is a no-op — measured identical,
- * with and without. Write `min-*-0` (or `dx-shrink`) only where the element's own overflow stays
- * visible.
+ * A flex or grid item's automatic minimum size applies only while the item is not a scroll
+ * container (CSS Sizing 3 §5.2; CSS Flexbox §4.5 words it as `overflow: visible`). So
+ * `overflow-hidden`, `-auto` and `-scroll` have already zeroed it, and a `min-h-0` beside one is a
+ * no-op — measured identical, with and without.
+ *
+ * `overflow-clip` is the exception worth knowing: it clips without scrolling, so it is NOT a scroll
+ * container and the minimum still applies. Measured in a 200px column over a 40px footer, a 500px
+ * child leaves the footer at 500 under both `clip` and `visible`, and at 160 under `hidden`/`auto`.
+ * Keep `min-*-0` next to `overflow-clip`.
  *
  * Add `overflow-hidden` for a clip you actually want — a rounded or bordered box whose child
  * surface would paint over the radius, a host for something that draws past its bounds (a map, a
@@ -71,7 +75,7 @@
  * | class           | expands to                | use when                                       |
  * | --------------- | ------------------------- | ---------------------------------------------- |
  * | `dx-fill`       | `h-full w-full`           | parent has a definite size                     |
- * | `dx-shrink`     | `min-h-0 min-w-0`         | must not shove siblings, but must not grow      |
+ * | `dx-shrink`     | `min-h-0 min-w-0`         | must not shove siblings, but must not grow       |
  * | `dx-grow`       | `flex-1 dx-shrink`        | flex/grid child taking the remainder            |
  * | `dx-expand`     | `dx-grow dx-fill`         | parent's display type is unknown or varies      |
  * | `dx-fullscreen` | `absolute inset-0`        | pinned to a positioned ancestor                 |

--- a/packages/ui/ui-theme/src/css/utilities.css
+++ b/packages/ui/ui-theme/src/css/utilities.css
@@ -32,17 +32,33 @@
  * This is why the union is safe and why it works without the author knowing the parent's
  * display type. It is also why `flex-1` appearing next to `grid` is not a bug.
  *
- * ## Overflow is a size constraint too
+ * ## `min-*-0` is not about scrolling
+ *
+ * It is the most misread class in the codebase, so state it plainly: `min-h-0` means **"I may be
+ * shorter than my content."** Without it a flex/grid item's minimum height IS its content height,
+ * so the item shoves its siblings aside. Measured in a 200px column holding 500px of content above
+ * a 40px footer:
+ *
+ * | body        | body height | footer sits at | inner scrolls |
+ * | ----------- | ----------- | -------------- | ------------- |
+ * | no `min-h-0`| 500px       | 500px — pushed off | no        |
+ * | `min-h-0`   | 160px       | 160px — correct    | yes       |
+ *
+ * Scrolling is a CONSEQUENCE: the inner element only scrolls once something finally squeezed it.
+ * A layout that never scrolls fails the same way — a toolbar pushed off, a container blown out.
+ *
+ * ## Overflow says it too, which is why so many `min-*-0` do nothing
  *
  * For a flex or grid item, `min-height:auto` applies only while `overflow` is `visible`
- * (CSS Flexbox §4.5, CSS Grid §6.6). Any non-visible overflow therefore zeroes the automatic
- * minimum size, making `overflow-hidden` and `min-h-0 min-w-0` two spellings of the same
- * constraint. Prefer the explicit `min-*-0` — a clip additionally makes the element a scroll
- * container, so a focused descendant can silently scroll it with no scrollbar to scroll back.
+ * (CSS Flexbox §4.5, CSS Grid §6.6). So an element that sets ANY non-visible overflow has already
+ * zeroed its automatic minimum size, and a `min-h-0` beside it is a no-op — measured identical,
+ * with and without. Write `min-*-0` (or `dx-shrink`) only where the element's own overflow stays
+ * visible.
  *
- * Add `overflow-hidden` only where a clip is genuinely wanted: a rounded or bordered box whose
- * child surface would paint over the radius, or a host for something that draws past its bounds
- * by design (a map, a canvas, a scaled slide).
+ * Add `overflow-hidden` for a clip you actually want — a rounded or bordered box whose child
+ * surface would paint over the radius, a host for something that draws past its bounds (a map, a
+ * canvas, a scaled slide) — not to constrain a size. A clip also makes the element a scroll
+ * container, so a focused descendant can silently scroll it with no scrollbar to scroll back.
  *
  * ## Pattern for a scrollable region
  *
@@ -52,12 +68,13 @@
  *
  * ## Picking one
  *
- * | class           | expands to                     | use when                                      |
- * | --------------- | ------------------------------ | --------------------------------------------- |
- * | `dx-fill`       | `h-full w-full`                | parent has a definite size                    |
- * | `dx-grow`       | `flex-1 min-h-0 min-w-0`       | flex/grid child taking the remainder          |
- * | `dx-expand`     | `dx-grow dx-fill`              | parent's display type is unknown or varies    |
- * | `dx-fullscreen` | `absolute inset-0`             | pinned to a positioned ancestor               |
+ * | class           | expands to                | use when                                       |
+ * | --------------- | ------------------------- | ---------------------------------------------- |
+ * | `dx-fill`       | `h-full w-full`           | parent has a definite size                     |
+ * | `dx-shrink`     | `min-h-0 min-w-0`         | must not shove siblings, but must not grow      |
+ * | `dx-grow`       | `flex-1 dx-shrink`        | flex/grid child taking the remainder            |
+ * | `dx-expand`     | `dx-grow dx-fill`         | parent's display type is unknown or varies      |
+ * | `dx-fullscreen` | `absolute inset-0`        | pinned to a positioned ancestor                 |
  */
 
 /**
@@ -80,11 +97,21 @@
 }
 
 /**
+ * May be smaller than its content, so it never shoves its siblings out of the line.
+ *
+ * Use when the element must NOT claim the remaining space — reach for `dx-grow` when it should.
+ * Redundant on an element that already sets a non-visible overflow, which zeroes the same minimum.
+ */
+@utility dx-shrink {
+  @apply min-h-0 min-w-0;
+}
+
+/**
  * Flex/grid child: take the remaining space, and yield to scrolling or truncating children.
  * Sets `flex`, not `display: flex` — it describes how the parent sizes this element.
  */
 @utility dx-grow {
-  @apply flex-1 min-h-0 min-w-0;
+  @apply flex-1 dx-shrink;
 }
 
 /**


### PR DESCRIPTION
## What

Adds `dx-shrink`, redefines `dx-grow` as `flex-1 dx-shrink`, and deletes 27 `min-*-0` that never did anything.

Follows #12876, which split the sizing utilities.

## Why

`min-h-0` is the most misread class in the codebase — it is taken to mean "makes things scroll". It does not. It says the element **may be shorter than its content**. Without it, a flex/grid item's minimum height *is* its content height, so the item shoves its siblings out of the line.

Measured in a 260px column holding 900px of content above a 40px footer:

| body | body height | footer sits at | inner scrolls |
| --- | ---: | ---: | --- |
| no `dx-shrink` | 926px | **927px** — outside the box | no |
| `dx-shrink` | 218px | 219px | yes |
| `overflow-hidden` alone | 218px | 219px | no |

Scrolling is only the *consequence* of finally being squeezed. A layout that never scrolls fails identically — a toolbar pushed off, a container blown out.

So the vocabulary now separates the two decisions instead of bundling them:

| class | expands to | use when |
| --- | --- | --- |
| `dx-fill` | `h-full w-full` | parent has a definite size |
| **`dx-shrink`** | `min-h-0 min-w-0` | must not shove siblings, but must not grow |
| `dx-grow` | **`flex-1 dx-shrink`** | flex/grid child taking the remainder |
| `dx-expand` | `dx-grow dx-fill` | parent's display type is unknown or varies |
| `dx-fullscreen` | `absolute inset-0` | pinned to a positioned ancestor |

## The 27 deletions

Third row of the table above is the point: **any non-visible overflow already zeroes the same minimum** (CSS Flexbox §4.5, CSS Grid §6.6), so a `min-h-0` sitting beside `overflow-hidden` is dead weight that reads as load-bearing. Measured with and without: byte-identical. 27 sites were carrying one.

## Reviewer notes

- **`dx-shrink` adoption is deliberately 1 site.** Only one place set both axes without flex sizing. Its value is as a name for new code, not a migration target — in particular the 86 single-axis `min-w-0 truncate` sites are left alone, since `dx-shrink` would add a `min-h-0` they never asked for.
- **The story is the documentation.** `ui/ui-theme/Sizing` → `ShrinkingVersusShoving` renders the table above as live measurement and points at the **footer**, not a scrollbar, because nothing scrolls in any of the three frames.
- **Two new lint checks** in `prefer-sizing-utilities`: `minimumUnderClip` (a minimum a clip already applied) and a composition check flagging `dx-grow dx-fill` as the long spelling of `dx-expand`. The first correctly ignores `min-h-0 [&>*]:overflow-hidden`, where the clip is on a descendant.

## Verification

- `moon exec :build` across the repo — green.
- `oxfmt --check` across 12,888 files — clean.
- `prefer-sizing-utilities` — 0 warnings repo-wide.
- Tests: `eslint-plugin-rules` 10, `ui-theme` 12, `react-ui` 46, `react-ui-components` 27 — all pass.
- The `ShrinkingVersusShoving` story measured live in Storybook against the real theme CSS, producing the numbers in the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `dx-shrink` sizing utility for flexible layouts.
  * Updated `dx-grow` to combine growth and shrinking behavior.
  * Added interactive sizing examples and guidance.

* **Improvements**
  * Simplified minimum-size styling across scrollable layouts.
  * Standardized equivalent growth layouts with `dx-expand`.
  * Corrected a story layout width utility.

* **Developer Experience**
  * Enhanced sizing lint checks for redundant and overly verbose utility combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->