### PR TITLE
testing: let the local suite pass on a plain checkout

### DIFF
--- a/packages/apps/composer-app/src/vite/channel-branding.test.ts
+++ b/packages/apps/composer-app/src/vite/channel-branding.test.ts
@@ -5,7 +5,7 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, test } from 'vitest';
+import { afterEach, describe, test, vi } from 'vitest';
 
 import { applyChannelFavicons, bootMarkPath, channelVariant } from './channel-branding';
 
@@ -22,6 +22,7 @@ const scratches: string[] = [];
 
 afterEach(() => {
   scratches.splice(0).forEach((dir) => rmSync(dir, { recursive: true, force: true }));
+  vi.unstubAllEnvs();
 });
 
 describe('channelVariant', () => {
@@ -30,6 +31,9 @@ describe('channelVariant', () => {
   });
 
   test('an unset environment is a local build, not a channel', ({ expect }) => {
+    // `environment` defaults to `process.env.DX_ENVIRONMENT`, so passing `undefined` reads the
+    // ambient value — a developer who exports one (a machine name, say) fails this otherwise.
+    vi.stubEnv('DX_ENVIRONMENT', '');
     expect(channelVariant('build', '')).toBeUndefined();
     expect(channelVariant('build', undefined)).toBeUndefined();
   });

--- a/packages/core/compute/pipeline-discord/src/testing/replay-fixture.test.ts
+++ b/packages/core/compute/pipeline-discord/src/testing/replay-fixture.test.ts
@@ -54,6 +54,11 @@ describe('replay over the crawled SQLite fixture', () => {
           const targets = yield* StateStore.listTargets();
           const agents = yield* AgentRegistry.list();
 
+          // What the snapshot actually asks, so the extraction assertion can be about this fixture
+          // rather than about chat in general.
+          const perTarget = yield* Effect.forEach(targets, (target) => MessageStore.listByTarget(target.id));
+          const asked = perTarget.flat().filter((message) => message.text.includes('?')).length;
+
           const replay = replayStream().pipe(extractQuestionsStage(), Pipeline.run({ sink: () => Effect.void }));
           yield* replay;
           const questions = yield* ExtractedQuestionStore.list();
@@ -62,7 +67,7 @@ describe('replay over the crawled SQLite fixture', () => {
           yield* replay;
           const again = yield* ExtractedQuestionStore.list();
 
-          return { stored, targets, agents, questions, again };
+          return { stored, targets, agents, asked, questions, again };
         }).pipe(Effect.provide(layer)),
       );
 
@@ -84,8 +89,11 @@ describe('replay over the crawled SQLite fixture', () => {
       expect(result.agents.length).toBeGreaterThan(0);
       // No target is left mid-crawl in a captured snapshot.
       expect(result.targets.every((target) => target.status === 'done' || target.status === 'error')).toBe(true);
-      // Real chat always contains questions; every tuple is fully attributed.
-      expect(result.questions.length).toBeGreaterThan(0);
+      // Extraction is asserted against what the fixture actually holds, not against an assumption
+      // that real chat always asks something: the committed snapshot has no question marks at all,
+      // so demanding tuples unconditionally failed on a correct extraction. Regenerating the
+      // fixture needs a DISCORD_TOKEN, which a checkout does not have.
+      expect(result.questions.length).toBeGreaterThanOrEqual(result.asked > 0 ? 1 : 0);
       for (const question of result.questions) {
         expect(question.authorId.length).toBeGreaterThan(0);
         expect(question.targetId.length).toBeGreaterThan(0);


### PR DESCRIPTION
## What

Fixes two tests that fail on a plain checkout, so `moon run :test` is usable as a local gate.

Neither failed in CI, so neither was visible there — both were found while reproducing an unrelated CI failure locally.

## `channel-branding` — reads the ambient environment

```ts
test('an unset environment is a local build, not a channel', ({ expect }) => {
  expect(channelVariant('build', undefined)).toBeUndefined();
});
```

`channelVariant`'s signature is `(command, environment = process.env.DX_ENVIRONMENT)`, so passing `undefined` **triggers the default and reads the ambient value**. Any developer who exports `DX_ENVIRONMENT` — a machine name, a scratch profile — gets `'rust'` and fails the assertion. CI exports nothing, hence green.

Stubbed with `vi.stubEnv('DX_ENVIRONMENT', '')` for that test, with `vi.unstubAllEnvs()` in the existing `afterEach`. Verified both ways: passes with the variable unset **and** with `DX_ENVIRONMENT=…` exported, which is the condition that used to fail.

## `replay-fixture` — asserted more than its fixture holds

```ts
// Real chat always contains questions; every tuple is fully attributed.
expect(result.questions.length).toBeGreaterThan(0);
```

The committed snapshot contains **no question mark at all** — 10 messages, and `select count(*) from message where text like '%?%'` returns `0`. So `extractQuestionsStage` correctly extracted nothing and the assertion failed on a working pipeline. The comment's premise simply doesn't hold for this fixture.

The test already had a skip guard (`existsSync(fixturePath) && !process.env.CI`), so this wasn't a missing-fixture problem — the fixture is committed and populated, just question-free.

Now it counts what the fixture actually asks and requires extraction to keep up with that, rather than asserting a property of chat in general. Regenerating the fixture needs a `DISCORD_TOKEN`, which a checkout doesn't have, so tightening the fixture wasn't an option.

## Verification

- `composer-app:test src/vite/channel-branding.test.ts` — 12 pass, both with and without `DX_ENVIRONMENT` exported.
- `pipeline-discord:test` — 10 files, 41 tests pass (was 1 failing).
- `pipeline-discord:lint`, `composer-app:lint` — clean.
- `oxfmt --check` — clean.
- No changeset: `check-changesets` reports OK at 0 for a test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by preventing ambient environment settings from affecting results.
  * Updated replay fixture validation to reflect whether the fixture contains question-mark messages.
  * Reduced false test failures while preserving relevant extraction checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->