### PR TITLE
plugin-inbox: fix order-dependent star assertions in Header Spec

### DIFF
--- a/packages/plugins/plugin-inbox/src/components/Header/Header.stories.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Header/Header.stories.tsx
@@ -11,6 +11,7 @@ import { useClientStory, withClientProvider } from '@dxos/react-client/testing';
 import { Card } from '@dxos/react-ui';
 import { Row } from '@dxos/react-ui-card';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
+import { translations as reactUiTranslations } from '@dxos/react-ui/translations';
 import { type Actor, Person } from '@dxos/types';
 
 import { ContactPreview, useContactCreate } from '#testing';
@@ -100,7 +101,7 @@ const meta = {
   ],
   parameters: {
     layout: 'fullscreen',
-    translations,
+    translations: [...translations, ...reactUiTranslations],
   },
 } satisfies Meta<typeof DefaultStory>;
 
@@ -175,13 +176,7 @@ export const Spec: Story = {
       timeout: 5_000,
     });
 
-    // `Row.Star` labels itself from react-ui's own translation namespace, which this isolated story
-    // does not load — so the accessible name is the raw key. Asserting on it still pins the behaviour
-    // under test: the star owns its state, and toggling swaps which action the button offers.
-    // `find`, not `get`: creating the contact re-renders the row, so the star can be briefly absent.
-    await userEvent.click(
-      await canvas.findByRole('button', { name: 'system-button.unstar.label' }, { timeout: 5_000 }),
-    );
-    await canvas.findByRole('button', { name: 'system-button.star.label' }, { timeout: 5_000 });
+    await userEvent.click(await canvas.findByRole('button', { name: 'Unstar' }, { timeout: 5_000 }));
+    await canvas.findByRole('button', { name: 'Star' }, { timeout: 5_000 });
   },
 };


### PR DESCRIPTION
## What

`Header.stories.tsx > Spec` asserted the raw i18n key `system-button.unstar.label`. That only holds while `@dxos/react-ui`'s translations are unregistered, which is not something the story controls.

- `@dxos/i18n`'s `i18n` is a module-level singleton.
- `plugin-inbox` sets `storybook: { isolate: false }` (`vite.config.ts`), sharing one browser module graph across all 19 story files, to avoid cumulative WASM exhaustion.
- Six container stories boot `StorybookPlugin`, which pulls `ThemePlugin`, whose translator module calls `addResources([...reactUiTranslations, ...])`.

So whether the star button is named `system-button.unstar.label` or `Unstar` depends on which story file ran first. Registering react-ui's translations in the story and asserting the rendered labels removes the dependency. Same shape `plugin-tasks` and `plugin-projects` stories already use.

## Evidence

On clean `main`, run as:

```
CI=true VITEST_ENV=node MOON_CONCURRENCY=4 moon run ui-theme:test-storybook plugin-inbox:test-storybook --force -- --no-file-parallelism
```

| | first-attempt result |
|---|---|
| before | 6/6 failed, all `Unable to find role="button" and name "system-button.unstar.label"` |
| after | 6/6 passed, `51 passed (51)` |

Running the file alone always passed, which is why this survived: only moon's task-level retry was saving it. Pairing a container story with it reproduces deterministically, and that pair went from failing at 11542ms (burning both 5s timeouts) to passing at 855ms.

## Not in this PR

While tracing this I confirmed the shard-3 failures on #12883 are a different problem and not that PR's doing: `ui-theme`, `react-ui` and `react-ui-terminal` storybook suites lose their browser connection to vite dep-optimizer re-optimization mid-run. That reproduces on `main` and is being handled separately.

No changeset: test-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the inbox header Storybook test to use translated button labels.
  * Simplified the star and unstar button assertions for improved test readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->