### PR TITLE
composer-app: fix the drag-into-collection e2e assertion after the Tree rebuild

### DIFF
--- a/packages/apps/composer-app/src/playwright/collections.spec.ts
+++ b/packages/apps/composer-app/src/playwright/collections.spec.ts
@@ -57,9 +57,11 @@ test.describe('Collection tests', () => {
 
     await host.toggleCollectionCollapsed(1);
     await host.dragTo(host.getObjectByName('Collection 1'), host.getObjectByName('Collection 2'), { x: 0, y: 0 });
-    // Collection 1 is now inside the Collection 2.
-    const collection1 = await host.getObjectByName('Collection 1').getAttribute('id');
-    expect(await host.getObjectByName('Collection 2').getAttribute('aria-owns')).toEqual(collection1);
+    // Collection 1 is now inside Collection 2: a row's `data-object-id` is the object's canonical
+    // graph path, so Collection 1's parent path is exactly Collection 2's path.
+    const collection1 = await host.getObjectByName('Collection 1').getAttribute('data-object-id');
+    const collection2 = await host.getObjectByName('Collection 2').getAttribute('data-object-id');
+    expect(collection1?.split('/').slice(0, -1).join('/')).toEqual(collection2);
   });
 
   test('delete a collection', async () => {


### PR DESCRIPTION
## What

`collections.spec.ts > Collection tests > drag object into collection` has failed on **every** main push since [#12873](https://github.com/dxos/dxos/pull/12873) ("react-ui-list: rebuild Tree on @ark-ui/react TreeView"). It is the only non-flaky e2e failure on main. Green through `947640696e`, red from `928e0b22c1` onward.

Both chromium shards report it. Firefox and webkit are green only because the test skips itself on those (`test.skip(browserName !== 'chromium')`).

## Why it broke

The old `Treegrid.Row` stamped `aria-owns={parentOf}` on each row:

```tsx
{...(parentOf && { 'aria-expanded': open, 'aria-owns': parentOf })}
id={id}
```

The rebuild deleted `Treegrid` entirely. Ark's `TreeView` nests children as real DOM descendants inside `BranchContent`, so it needs no `aria-owns`, and nothing in the repo emits that attribute any more. The test's only assertion read it, so it got `null` on every run.

**The drag itself never broke.** In the failure output, Collection 1's own path id after the drop is already `.../content/collections/<Collection 2>/<Collection 1>`, so the drop nested it correctly. Only the assertion was reading a DOM attribute that no longer exists.

## The fix

Assert on `data-object-id`, which the new row still carries and which holds the object's canonical graph path (`root/<spaceId>/content/collections/<ancestors…>/<objectId>`):

```ts
const collection1 = await host.getObjectByName('Collection 1').getAttribute('data-object-id');
const collection2 = await host.getObjectByName('Collection 2').getAttribute('data-object-id');
expect(collection1?.split('/').slice(0, -1).join('/')).toEqual(collection2);
```

Stricter than the original: Collection 1's parent path must be *exactly* Collection 2, where `aria-owns` only asserted ownership. It also reads a DXOS-owned attribute rather than the Ark-generated `id`, so a library upgrade cannot silently null it again.

## Verification

Local chromium run against a production `bundle-e2e`:

- Original assertion reproduces the CI failure exactly (`Expected: "tree:_r_4f_:node:root+…"`, `Received: null`).
- With the fix, the whole spec passes: **5/5, no retries**.

## Why CI did not catch this in the originating PR

`e2e` runs on pushes to main, the changesets release PR, and explicit dispatch, never on an ordinary PR. `check.yml` says as much at line 180. Worth revisiting separately.

## Not addressed here

Two other things showed up while digging, both out of scope:

1. `collaboration.spec.ts:59 > guest joins host's space` is genuinely flaky on chromium (fails twice, passes on retry #2, same on `928e0b22c1` and HEAD). Trunk has it at `63d246b1-bedc-5fdc-bc6b-c08557808977`. No Linear issue tracks it.
2. `Model Fixture / model-fixture` is red on main for an unrelated reason: two assistant-toolkit tests fail with "No memoized conversation found for the given prompt".

🤖 Generated with [Claude Code](https://claude.com/claude-code)