### PR TITLE
storybook: stop the shared preview pre-bundling the plugin stack

### DIFF
--- a/packages/sdk/app-framework/src/testing/withPluginManager.stories.tsx
+++ b/packages/sdk/app-framework/src/testing/withPluginManager.stories.tsx
@@ -4,6 +4,7 @@
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React from 'react';
+import { expect, waitFor, within } from 'storybook/test';
 
 import { ThrowError } from '@dxos/react-ui';
 import { withTheme } from '@dxos/react-ui/testing';
@@ -58,9 +59,11 @@ export const Default: Story = {};
  * the usual "Copy" action.
  */
 export const Crashes: Story = {
-  render: () => <ThrowError />,
-  play: async () => {
-    // This story intentionally renders an ErrorBoundary fallback; clear the smoke-test error flag.
+  render: () => <ThrowError delay={0} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => expect(canvas.getByRole('button', { name: 'Download logs' })).toBeInTheDocument());
+    // Clear the smoke-test flag only once the intended fallback has been asserted.
     (window as any).__ERROR_BOUNDARY_ERRORS__ = [];
   },
 };

--- a/packages/sdk/app-framework/src/testing/withPluginManager.tsx
+++ b/packages/sdk/app-framework/src/testing/withPluginManager.tsx
@@ -18,16 +18,15 @@ import { type ActivationEvent, Capability, CapabilityManager, Plugin, PluginMana
 import { type UseAppOptions, useApp } from '../ui';
 import { activateDemandGatedModules } from './demand-gated';
 
-let defaultFallback: NonNullable<UseAppOptions['fallback']> = ErrorFallback;
-
 /**
- * Sets the fallback a crashed story renders, overridable per story via `withPluginManager({ fallback })`.
- * The storybook preview points this at the logger addon's, which a value import cannot reach from the
- * published `./testing` entrypoint.
+ * The fallback a crashed story renders, overridable per story via `withPluginManager({ fallback })`.
+ * A global because importing `./testing` from the storybook preview drags the plugin core into every
+ * project's dependency pre-bundle.
  */
-export const setStoryErrorFallback = (fallback: NonNullable<UseAppOptions['fallback']>) => {
-  defaultFallback = fallback;
-};
+declare global {
+  // eslint-disable-next-line no-var
+  var __STORY_ERROR_FALLBACK__: NonNullable<UseAppOptions['fallback']> | undefined;
+}
 
 /**
  * Builds a plugin manager for test hosts. Stories go through {@link withPluginManager}; headless
@@ -187,7 +186,11 @@ const WithPluginManagerApp = ({
     [fireEvents, pluginManager, storyId],
   );
 
-  const App = useApp({ pluginManager, setupEvents, fallback: fallback ?? defaultFallback });
+  const App = useApp({
+    pluginManager,
+    setupEvents,
+    fallback: fallback ?? globalThis.__STORY_ERROR_FALLBACK__ ?? ErrorFallback,
+  });
   return activated ? <App /> : <></>;
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23804,9 +23804,6 @@ importers:
       '@dxos/agent-claude':
         specifier: workspace:*
         version: link:../../packages/core/compute/agent-claude
-      '@dxos/app-framework':
-        specifier: workspace:*
-        version: link:../../packages/sdk/app-framework
       '@dxos/log':
         specifier: workspace:*
         version: link:../../packages/common/log

--- a/tools/storybook-react/.storybook/preview.ts
+++ b/tools/storybook-react/.storybook/preview.ts
@@ -19,13 +19,12 @@ import './cubes.css';
 import { withThemeByClassName } from '@storybook/addon-themes';
 import { type Preview } from '@storybook/react-vite';
 
-import { setStoryErrorFallback } from '@dxos/app-framework/testing';
 import { StorybookErrorFallback } from '@dxos/storybook-addon-logger/StorybookErrorFallback';
 
 import { docsTheme } from './theme';
 
 // Restores the "Download logs" action on a crashed story.
-setStoryErrorFallback(StorybookErrorFallback);
+globalThis.__STORY_ERROR_FALLBACK__ = StorybookErrorFallback;
 
 /**
  * Configure Storybook rendering.

--- a/tools/storybook-react/.storybook/typings.ts
+++ b/tools/storybook-react/.storybook/typings.ts
@@ -7,3 +7,9 @@ declare module '@dxos-theme';
 
 /** Side-effect CSS imports in Storybook config (e.g. `./cubes.css`). */
 declare module '*.css';
+
+/** Read by `@dxos/app-framework`'s `withPluginManager`; declared here so the preview needs no import of it. */
+// eslint-disable-next-line no-var
+declare var __STORY_ERROR_FALLBACK__:
+  | typeof import('@dxos/storybook-addon-logger/StorybookErrorFallback').StorybookErrorFallback
+  | undefined;

--- a/tools/storybook-react/package.json
+++ b/tools/storybook-react/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@dxos/agent-claude": "workspace:*",
-    "@dxos/app-framework": "workspace:*",
     "@dxos/log": "workspace:*",
     "@dxos/storybook-addon-logger": "workspace:*",
     "@dxos/ui-theme": "workspace:*",

--- a/tools/storybook-react/tsconfig.json
+++ b/tools/storybook-react/tsconfig.json
@@ -24,9 +24,6 @@
       "path": "../../packages/core/compute/agent-claude"
     },
     {
-      "path": "../../packages/sdk/app-framework"
-    },
-    {
       "path": "../../packages/ui/ui-theme"
     },
     {


### PR DESCRIPTION
## What

`tools/storybook-react/.storybook/preview.ts` no longer value-imports `@dxos/app-framework/testing`. The error fallback is handed to `withPluginManager` through `globalThis.__STORY_ERROR_FALLBACK__` instead.

**`ui-theme`'s storybook pre-bundle drops from 132 optimized deps to 43.**

## Why

`preview.ts` is shared by all 140 packages that have stories. Vite crawls the module graph from it and esbuild-bundles every bare `node_modules` import into that package's `sb-vitest/deps`, cold, once per package. So one value import there is paid 140 times in CI before a single test runs.

The import existed only to call `setStoryErrorFallback`. That barrel reaches the whole of `@dxos/app-framework`: `compute`, `compute-runtime`, `edge-client`, `graph`, `operation`, `protocols`, `react-ui`, plus `esbuild`, `solid-js` and `@babel/core`. `ui-theme` has no DXOS runtime dependencies of its own and its two stories render colour swatches and sizing boxes, yet it was pre-bundling the entire plugin stack to do that.

A smaller graph also means fewer mid-run re-optimizations. That churn invalidates every issued `?v=<hash>` URL and kills in-flight dynamic imports, which is what `ignoreOutdatedRequests` in `main.ts` works around and what #12783 was about.

## Why a global rather than a typed registry

A module-scope registry (in `@dxos/react-error-boundary`, say) only works if the preview and app-framework resolve the same module instance. Under a misbehaving dep optimizer, which is the thing being fixed, that is not guaranteed. A `globalThis` slot is immune to duplication, and this harness already does exactly this with `window.__ERROR_BOUNDARY_ERRORS__` in `vitest.setup.ts`. It also adds no API to any published package, which an earlier attempt at a new `@dxos/app-framework` subpath export did.

The global is typed on both sides: `declare global` in `withPluginManager.tsx`, and in `.storybook/typings.ts` from `StorybookErrorFallback` itself, so the preview needs neither a value nor a type import of app-framework.

## Drive-by: the `Crashes` story was passing without testing anything

`ThrowError` defaults to a 1000 ms delay, and `play` cleared the error flag and returned roughly a second before the boundary rendered. Any regression in the fallback wiring would have gone unnoticed. It now throws immediately and asserts the "Download logs" button. Verified as a real regression test: commenting out the preview assignment makes it fail with `Unable to find role="button" and name "Download logs"`.

`@dxos/app-framework` is now unreferenced by `storybook-react`, so the devDependency is dropped and `pnpm toolbox` pulled the tsconfig project reference.

## Verification

Storybook cache cleared, `--force` on every run.

| | tests | pre-bundled deps |
|---|---|---|
| `ui-theme` | 11/11 | **43** (was 132) |
| `app-framework` | 8/8 | 145 (unchanged, it genuinely uses app-framework) |

Lint clean on both packages, `app-framework:build` passes. `knip` could not be run locally (`globSync is not a function` loading `.config/knip.ts`), so the devDependency removal is unverified against that gate.

## Follow-up, not in this PR

The remaining 43 are the log pipeline, not slack. `DxosLogPlugin()` injects `@dxos/log` into every storybook, and `@dxos/util`'s barrel re-exports `json.ts`/`human-hash.ts` (→ `@dxos/keys` → `ulidx`, `base32-*`, `effect/Schema`), `defer.ts` (→ `@hazae41/symbol-dispose-polyfill`) and `download.ts` (→ `@tauri-apps/plugin-fs`, `plugin-dialog`). `@dxos/log` uses only eight small helpers from `@dxos/util`, so moving those to a leaf would cut roughly 7 more. That touches two of the most-depended-on packages in the repo and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)