### PR TITLE
devtools: move the last convertible protobuf enums to buf, correct #5's scope

### DIFF
--- a/.changeset/devtools-buf-enum-stragglers.md
+++ b/.changeset/devtools-buf-enum-stragglers.md
@@ -1,0 +1,6 @@
+---
+'@dxos/cli-util': patch
+'@dxos/plugin-debug': patch
+---
+
+Move the last two top-level protobuf enum imports in devtools-owned packages onto buf: `EdgeReplicationSetting` in `cli-util`'s space helpers and `ConnectionState` in `plugin-debug`'s `DebugStatus`. Both enums are value-identical between the two generators and TypeScript relates enum types by name, so the swap needs no call-site change.

--- a/docs/audits/protobufjs-to-buf.md
+++ b/docs/audits/protobufjs-to-buf.md
@@ -243,6 +243,60 @@ an identically-valued `enum DifferentName` raises `TS2367`. So:
   `EdgePanel` cannot be fixed ahead of its type move, and it generalises to any nested enum
   elsewhere in the migration.
 
+## `#2`: split by fate before converting, and most of it dies at teardown
+
+`#2`'s nominal file list spans four places. Judged per file rather than per directory, almost none
+of it is worth converting -- the packages that own it are what the teardown slice deletes.
+
+**Dies at teardown -- leave on protobuf.js:**
+
+| File                                                                          | Why                                                                                                                                                                                                                     |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `codec-protobuf/test/codec.node.test.ts` + its three `example/testing` protos | Exercises `@dxos/codec-protobuf` itself.                                                                                                                                                                                |
+| `codec-protobuf/src/substitutions/struct.test.ts`                             | Tests the legacy substitution table.                                                                                                                                                                                    |
+| `protobuf-compiler/test/*` (12 files)                                         | Tests the legacy generator's output.                                                                                                                                                                                    |
+| `protobuf-compiler/src/namespaces.test.ts`                                    | Same.                                                                                                                                                                                                                   |
+| **`tools/protobuf-test` (whole package)**                                     | Reads as a standalone fixture and is not: its own header says "Imported by protobuf-compiler tests", and `protobuf-compiler/test/types.test.ts:19` is its only reference in the repo. It goes with `protobuf-compiler`. |
+
+**Gated on `#8.2`, not `#2`:** the `example/testing/rpc` importers -- `rpc/service.test.ts`,
+`rpc/service-type-url.test.ts`, `teleport/testing/test-extension.ts`,
+`teleport/testing/test-extension-with-streams.ts`, `teleport/muxing/muxer.test.ts`,
+`websocket-rpc/e2e.node.test.ts`, `rpc-tunnel-e2e/test-client.ts`, `rpc-tunnel-e2e/test-worker.ts`.
+These already take their _descriptor_ from `getBufService`, but still import the protobuf.js
+**service interface** as the type argument. Deriving that interface from buf's `GenService` is
+`#8.2`'s remaining work; the methods have to move to buf shapes at the same time, because
+`BufServiceDescriptor` still hands back compat-shaped values.
+
+**Nothing left to migrate.** `example/testing/{data,rpc}.proto` are already buf-generated
+(`buf/proto/gen/example/testing/`), `buf/registry.ts` already consumes them, and there are no
+message-only consumers to move. `#2`'s remaining value is the ledger above, not a conversion.
+
+## Proto-guard: the downgrade leg needs its own dependency closure
+
+The dated snapshot proves old bytes decode on new code. The reverse -- bytes this codec writes being
+readable by a build already in the field -- is the direction that strands a rollback, and it is not
+covered.
+
+**Pin: `@dxos/protocols@0.11.1`, published 2026-08-05.** Derived as the last stable release
+preceding the first buf-migration commit on main (`bdb02cd3a1`, "protocols: audit protobuf.js usage
+and start the buf migration", 2026-08-24). The only thing published in between is a
+`1.0.0-next-<sha>` CI snapshot on 2026-08-10, which is not a release. The codec itself did not move
+until `48eb05d613` (2026-08-26), so either reading of "first buf-migration commit" selects the same
+version. Write it as a literal, never resolve "latest before X" at runtime -- that drifts silently.
+
+**It cannot be imported in-process.** `@dxos/protocols@0.11.1` pulls `@dxos/keys@0.11.1`, which is
+built against `effect@3.x` and calls `Schema.filter`; against the workspace's `effect@4.0.0-rc.108`
+that is `TypeError: Schema.filter is not a function`, thrown at import time before any test body
+runs. Aliasing the package into the workspace does not work.
+
+**It does work in an isolated closure**, which is what a downgrade test should use anyway -- a build
+in the field has its own dependency graph. Verified: an `npm install @dxos/protocols@0.11.1` in a
+scratch directory resolves `effect@3.21.4` and its codec round-trips
+(`dxos.echo.query.Heads` -> `0a04613162320a0463336434`). The remaining work is the harness: install
+the pinned version into a gitignored fixture directory and spawn it to decode bytes the current
+codec wrote. Assert shape and round-trip, not byte identity -- protobuf.js writes `nanos: 0` where
+buf omits the proto3 default, which is wire-compatible and expected.
+
 ## `#8` is the last milestone-sized thread, and it is not a rider
 
 Everything above landed behind an interface that hides which codec carried a value, which is why it

--- a/docs/audits/protobufjs-to-buf.md
+++ b/docs/audits/protobufjs-to-buf.md
@@ -411,6 +411,55 @@ the pinned version into a gitignored fixture directory and spawn it to decode by
 codec wrote. Assert shape and round-trip, not byte identity -- protobuf.js writes `nanos: 0` where
 buf omits the proto3 default, which is wire-compatible and expected.
 
+## `#9c` `EchoMetadata` is blocked on a scope decision, not in progress
+
+The metadata _codec_ has already moved -- both stores are on `compatCodec`, so the bytes are buf
+today. What `#9c` moves is the **type the store exposes**, and that is where it stops.
+
+**Containment breaks through `invitations`.** `EchoMetadata.invitations` is
+`repeated dxos.client.services.Invitation` (`metadata.proto:35`) -- a **concrete message field, not
+an `Any`**, so `preserveAny` does not apply and moving `EchoMetadata` makes the field a buf
+`Invitation[]` by construction. Not a prediction; the build says so:
+
+```
+metadata-store.ts(231,36): error TS2345: Argument of type
+  '.../buf/proto/gen/dxos/client/invitation_pb").Invitation' is not assignable to parameter of type
+  '.../proto/gen/dxos/client/services").Invitation'
+```
+
+`dxos.client.services.Invitation` has **55 importers across 7 packages** (client-services 23,
+client 8, client-protocol 7, client-e2e 6, halo 2, shell 1, observability 1) and is itself a
+`protoMessage` carrier on `InvitationsService`. That is a milestone-sized slice.
+
+**A per-field carve-out is not available.** `EchoMetadata` is one generated type; its `invitations`
+field _is_ `Invitation[]` from the buf module. Leaving that one field on the protobuf.js type would
+need a structural alias, and a half-migrated message is worse than an unmigrated one because it
+looks finished. `SpaceMetadata` and `IdentityRecord` cannot be split off either -- both are children
+of `EchoMetadata`, so the container's type determines theirs.
+
+Note for scoping: the raw importer count for `@dxos/protocols/proto/dxos/echo/metadata` is 29, but
+**21 of those import only `EdgeReplicationSetting`**, a top-level enum that moves independently and
+already has. The message-type surface is 8 files in `packages/sdk/client-services` -- true of the
+imports, and _not_ a description of what moving `EchoMetadata` costs, which is the containment
+above.
+
+### Where the proto does draw a line
+
+`EchoMetadata` and `LargeSpaceMetadata` are **two independent persisted records with separate
+codecs** in the store. `LargeSpaceMetadata` -> `ControlPipelineSnapshot` ->
+`{PublicKey feed_key, Credential credential}` + `TimeframeVector` references **neither `Invitation`
+nor anything else out of scope**, beyond the sanctioned two-site `Credential` boundary decode at
+`control-pipeline.ts:148` and `:165`. Consumer surface: three files. That record can move on its own
+whenever the scope decision lands.
+
+### An `Invitation` move obliges a guard re-run
+
+`invitations` appears in **four entries of the cross-codec ledger** (`['invitations']` twice,
+`['metadata.invitations', 'metadata.spaces']`, and `['invitations', 'spaces']`). Changing
+`Invitation`'s type reshapes those, so that slice carries a guard re-run with the 42 count and the
+staleness check reconfirmed. Visible here so it is priced before anyone commits to it, rather than
+discovered inside it.
+
 ## `#8` is the last milestone-sized thread, and it is not a rider
 
 Everything above landed behind an interface that hides which codec carried a value, which is why it

--- a/docs/audits/protobufjs-to-buf.md
+++ b/docs/audits/protobufjs-to-buf.md
@@ -276,6 +276,44 @@ the workspace copy over the pin. It _does_ load in an isolated closure -- verifi
 downgrade guard would need: a spawned process with its own dependency graph, because that is what a
 build in the field actually is.
 
+### The clearest evidence in this migration that a green test run is not proof
+
+The guard reported **518/518 passing while silently skipping every repeated field.** Its field walk
+branched on `field.repeated`, which does not exist on buf's descriptors: buf models a repeated field
+as its own `fieldKind: 'list'` carrying a `listKind` discriminant, so every `list` field fell
+through the walk's `default` and was never populated.
+
+vitest ran the file green. The type error sat in a branch no generated case ever reached, so nothing
+executed it. Only `protocols:build` rejected it. Nothing about the test output distinguished a guard
+walking 258 messages properly from one walking them with every repeated field missing -- the case
+count was identical either way, because the cases are per message, not per field.
+
+Correcting the walk raised the ledger from **19 entries to 42**, with **zero new error classes**:
+the same single root cause reaching further, now through repeated members (`spaces`, `signatures`,
+`invitations`, `parents`, `credentials`, `contacts`). Nothing new was wrong; more of what was
+already wrong became visible.
+
+Two things follow, and they are the reason this is recorded here rather than left in a commit
+message. `moon build` belongs on every package a change touches, including the ones where the only
+change is a test file. And a coverage claim should be checked against what the generator actually
+emitted, not against the number of cases it produced -- 518 was true and meant less than it looked.
+
+### What the ledger is, and is not
+
+**42 recorded divergences.** Not a tolerance budget and not a list of things that are fine: a
+ledger of one root cause -- protobuf.js's decoder materialising an _absent_ singular message field
+with unsubstituted defaults, which its own encoder then rejects -- observed at 42 message/field
+sites. Each entry is keyed on the message **and the exact field paths**, so a listed message that
+starts diverging somewhere new goes red. A no-growth assertion pins the count, and a staleness check
+fails a listed message that stops diverging, since a stale entry would silence a future regression
+on a message that is currently clean. Entries are expected to disappear as messages move to buf.
+
+Headline figures, in the order they should be read: the guard went **483/517 -> 518/518** once the
+19 real divergences were separated from three generator artefacts, then **19 -> 42** once the
+repeated-field miss was corrected. `encodeCompat`/`decodeCompat` handling all 258 messages is
+recorded beside that, never instead of it -- the finding is that protobuf.js's decoder and its
+encoder disagree, not that the compat path is clean.
+
 ### Divergence 1: protobuf.js cannot re-encode its own decode output
 
 Its decoder materialises an _absent_ singular nested message with **unsubstituted** defaults, which

--- a/docs/audits/protobufjs-to-buf.md
+++ b/docs/audits/protobufjs-to-buf.md
@@ -243,6 +243,82 @@ an identically-valued `enum DifferentName` raises `TS2367`. So:
   `EdgePanel` cannot be fixed ahead of its type move, and it generalises to any nested enum
   elsewhere in the migration.
 
+## The cross-codec guard: what it proves, and the two divergences it found
+
+Built against the current tree rather than a released build, because both codecs are in the
+workspace right now. It walks the buf registry programmatically -- 258 messages, 517 generated
+cases -- synthesises a fully populated value per message, and asserts that the two decoders agree on
+the same bytes and the two encoders agree on the same value.
+
+**It is not a downgrade or compatibility guard, and must not be cited as one.** Both sides
+regenerate from the same `src/proto` tree, so a wire-incompatible edit to a `.proto` moves them
+together and passes here unnoticed -- which is precisely the failure a comparison against a
+_released_ build would catch. What this does give is continuous agreement between the two codecs on
+every CI run as declarations move, which the one-shot historical comparison never could. The two are
+complements, not substitutes.
+
+**It dies with protobuf.js.** The guard exists only while both codecs do; the teardown slice deletes
+it along with `@dxos/codec-protobuf`. Noted here so it is not later found and puzzled over.
+
+### Rejected: pinning a released version
+
+`@dxos/protocols@0.11.1` (published 2026-08-05) is the last stable release preceding the first
+buf-migration commit on main (`bdb02cd3a1`, 2026-08-24); the only thing published in between is a
+`1.0.0-next-<sha>` CI snapshot, and the codec did not move until `48eb05d613` (2026-08-26), so both
+readings of the cutoff select it. The derivation holds and is worth keeping.
+
+What killed it is a finding in its own right: **the pin cannot be loaded in-process.**
+`@dxos/protocols@0.11.1` pulls `@dxos/keys@0.11.1`, built against effect 3.x, which calls
+`Schema.filter`; under the workspace's `effect@4.0.0-rc.108` that throws at import time, before any
+test body runs. Aliasing it into the workspace also fails, because pnpm's `packages/**/*` glob links
+the workspace copy over the pin. It _does_ load in an isolated closure -- verified, `effect@3.21.4`,
+`dxos.echo.query.Heads` round-tripping to `0a04613162320a0463336434` -- which is the shape a real
+downgrade guard would need: a spawned process with its own dependency graph, because that is what a
+build in the field actually is.
+
+### Divergence 1: protobuf.js cannot re-encode its own decode output
+
+Its decoder materialises an _absent_ singular nested message with **unsubstituted** defaults, which
+its own encoder then rejects. On `Chain.credential`:
+
+```
+chain = {"credential":{"issuer":{"data":{}},
+                       "issuanceDate":{"seconds":"0","nanos":0},
+                       "subject":{"id":{"data":{}},"assertion":{"type_url":"","value":{}}}}}
+re-encode -> TypeError: value.getTime is not a function
+```
+
+`issuer` comes back as `{data:{}}` rather than a `PublicKey`, `issuanceDate` as `{seconds,nanos}`
+rather than a `Date`. Seventeen messages are affected, all of them ones that can contain an absent
+nested message. This is the legacy codec's own asymmetry and predates the migration; the compat
+layer does not have it -- `encodeCompat`/`decodeCompat` handled all 258 messages. That is
+reassuring, but it is not the headline: the headline is that protobuf.js's decoder and its encoder
+disagree, and the guard records each affected message with the _specific_ field and error rather
+than muting the message wholesale.
+
+### Divergence 2: `Timestamp` -> `Date` loses sub-millisecond precision
+
+The substitution target is a JS `Date`, which is millisecond-resolution, so a `nanos` value that is
+not a multiple of 1,000,000 cannot survive a round-trip (`nanos: 102` returns as `0`). The guard
+deliberately generates only millisecond-representable timestamps, so **it does not exercise this
+case** -- otherwise every message carrying a timestamp would fail for this one reason and mask
+everything else. Recorded here because the guard no longer says it.
+
+**Checked against signed data, and it is not reachable.** Two independent reasons:
+
+1. Every timestamp on a signed credential is set from `new Date()` --
+   `credential-factory.ts:58` (`issuanceDate`), `credential-factory.ts:66` and
+   `presentations/presentation.ts:29` (`creationDate`). A JS `Date` cannot hold sub-millisecond
+   precision, so `nanos` is always a multiple of 1,000,000 by construction.
+2. The signature is not computed over protobuf bytes at all. `getCredentialProofPayload` returns
+   `canonicalStringify(copy)`, and the replacer has no `Date` branch, so a date reaches the payload
+   through `JSON.stringify` -> `Date.prototype.toJSON()` -> an ISO-8601 string truncated to
+   milliseconds. The `nanos` field never enters a signature even in principle, and a re-encode that
+   changes `nanos` cannot change a signature.
+
+So the byte difference is real but confined to the wire, where it is the ordinary proto3-default
+omission and readable in both directions.
+
 ## `#2`: split by fate before converting, and most of it dies at teardown
 
 `#2`'s nominal file list spans four places. Judged per file rather than per directory, almost none

--- a/docs/audits/protobufjs-to-buf.md
+++ b/docs/audits/protobufjs-to-buf.md
@@ -12,7 +12,7 @@ at the bottom — read those before picking up a thread.
 | 2   | Test/example protos                     | todo     | Untouched — `#3`'s harness was built against real dxos messages instead. |
 | 3   | Shape-compat layer                      | **done** | `@dxos/protocols/buf-shape-compat` + conformance harness (15 tests).     |
 | 4   | `dxos.config`                           | **done** | Converted natively; `@dxos/config` inputs are `ConfigInit`, values buf.  |
-| 5   | devtools                                | **part** | Enums, `JsonView`, and two mis-annotated imports moved; 14 left.         |
+| 5   | devtools                                | **part** | Enums (incl. the `cli-util`/`plugin-debug` stragglers) done; 15 blocked. |
 | 6   | `Stream` extraction                     | **done** | Moved to `@dxos/async`; generator emits it from there.                   |
 | 7   | `protoMessage()` / `serviceError` → buf | **done** | All 45 types route through buf, once `#3` learned to resolve `Any`.      |
 | 8   | Remaining `ServiceDescriptor` RPC       | todo     | 21 production sites / 11 services, all cross-peer; 36 more are tests.    |
@@ -21,11 +21,11 @@ at the bottom — read those before picking up a thread.
 | 9c  | `echo/metadata` + `echo/feed`           | **part** | Both metadata stores swapped; `pipeline/codec` held back for `#9d`.      |
 | 9d  | credentials signing/verification        | **part** | Signature stability proven by test; the type sweep is what is left.      |
 
-**Next up, in order:** `#8` (the last `ServiceDescriptor` RPC, ~1.5-2 weeks and the only remaining
-milestone-sized thread), then the import sweep that `#5`'s and `#9d`'s remainders both decompose
-into, then `pipeline/codec` as the tail of `#9c`/`#9d`. `#2` is independent and can slot in
-anywhere. `Any` support is done, so nothing is gated any more -- what is left is volume, not
-blockers.
+**Next up, in order:** `#8` (the last `ServiceDescriptor` RPC and the only remaining
+milestone-sized thread), then `pipeline/codec` as the tail of `#9c`/`#9d`, then `#9d`'s type sweep.
+`#5`'s remainder is **not** an independent sweep and must follow `#9c`/`#9d` -- see the correction
+under `#5` below. `#2` is independent and can slot in anywhere. `Any` support is done, so nothing
+is gated any more -- what is left is volume, not blockers.
 
 Deleting `protobuf-compiler`/`codec-protobuf` and dropping `protobufjs` from the catalog is the
 last step, and needs every thread above done.
@@ -173,17 +173,75 @@ simply pointing at the wrong type, and the fix is to point it at the Effect type
 declares.
 
 Two moved that way -- `KeyRecord` and `ConnectionInfo`, both to `DevtoolsHost.*` -- and
-`devtools:build` is the proof, per the attempt-and-let-`tsc`-rule habit below. `NetworkPanel`'s
-`PeerState` looked like a third and is not: `SpaceSyncState.PeerState` in `DataService` is a _sync_
-peer, unrelated to `dxos.mesh.presence.PeerState`, and `tsc` said so rather than the two silently
-unifying. Fourteen declarations remain, and those are the genuinely blocked ones: values whose wire
-type is `protoMessage`-carried (`SubscribeToSpacesResponse`, `SubscribeToFeedBlocksResponse`,
-`SubscribeToMetadataResponse`, `SignalResponse`, `Credential`, `Contact`, `LogEntry`,
-`QueryLogsRequest`, `QueryEdgeStatusResponse`, `Space`, `PeerState`). Each needs its type moved to `bufMessage`,
-which rewrites that type's consumers -- and `QueryEdgeStatusResponse` embeds `EdgeStatus`, which
-reaches **22 source files** across edge-client, echo-host, client-services and plugin-space's sync
-UI. `EdgePanel`'s nested-enum access (`WsStatus.ConnectionState.CONNECTED`, which buf emits as
-`EdgeStatus_ConnectionState`) is a one-line fix gated behind that slice.
+`devtools:build` is the proof, per the attempt-and-let-`tsc`-rule habit below.
+
+### Correction: `#5` does not ride on `#7`, and `NetworkPanel` was described backwards
+
+Two claims in the paragraph above were wrong, and both were measured against main `32584c984a` by
+applying all 15 remaining conversions at once and reading `dx-build`'s 64 errors.
+
+**`NetworkPanel`'s `PeerState` is `dxos.mesh.presence.PeerState`.** The earlier note had it as
+`SpaceSyncState.PeerState` from `DataService`; it is not. `NetworkPanel.tsx:7` imports
+`type PeerState` from `@dxos/protocols/proto/dxos/mesh/presence` and uses it at line 18. That
+message _is_ generated as a bufMessage (`PeerStateSchema` in `buf/dxos/mesh/presence_pb`), so
+codegen is not the blocker. The blocker is the **producer**: `teleport-extension-gossip`'s
+`Presence` still emits the protobuf.js-substituted shape, so `peerId` is a `@dxos/keys` `PublicKey`
+(hence `.truncate()` at line 98) rather than buf's `PublicKey` _message_. Nothing in the repo
+currently assigns `NetworkGraphNode.peer`, so converting it would type-check after adapting
+`.truncate()` -- and would be describing a shape no producer emits. It is gated on `#8.4`
+(teleport extensions), not on a missing bufMessage.
+
+**`#7` unblocked nothing here.** `protoMessage` is still typed
+`Schema.Codec<TYPES[K], Uint8Array>` over the protobuf.js `src/proto/gen` barrel; `#7` routed the
+_bytes_ through buf via the compat layer while deliberately preserving the protobuf.js type and
+substituted runtime shape. That is the whole point of the shape-compat layer -- call sites do not
+change when a codec is swapped -- so there is nothing for a devtools type sweep to ride on. Only
+`bufMessage` exposes a buf type, and just one `DevtoolsHost` field uses it today
+(`SignedMessageSchema`).
+
+All 15 remaining declarations are therefore blocked, in four mechanically distinct ways:
+
+- **Missing `$typeName`.** Every buf type is `Message<"name"> & {...}`, so a protobuf.js-shaped
+  value is never assignable to it. This is what breaks `useCredentials`, `useStats`' probe and
+  `LoggingPanel`.
+- **Substituted fields.** `Credential.id` is `@dxos/keys` `PublicKey` on protobuf.js and a
+  `PublicKey` _message_ on buf; likewise `Date` vs `Timestamp` (`.getTime()`), `Timeframe` vs
+  `TimeframeVector` (`.get()`), and `Any` vs a `['@type']`-indexable bag.
+- **`oneof` modelling.** buf emits a discriminated union, so `SignalResponse.swarmEvent` and
+  `.message` simply do not exist -- 17 of the 64 errors are this one difference in
+  `SignalMessageTable`.
+- **Optionality.** buf marks singular message fields optional (`metadata?`), protobuf.js does not.
+
+Two files -- `useStats.ts` and `EdgePanel.tsx` -- _compile_ after conversion, but only because
+`Object.assign({}, stats, { edge })` erases the mismatch. A direct probe
+(`const x: BufResp = protoShapedValue`) fails with the missing-`$typeName` error, so converting
+them would annotate buf types over protobuf.js values: a silent lie rather than a migration. They
+are counted as blocked.
+
+Each carrier would have to move `protoMessage` -> `bufMessage`, and tracing what that pulls in
+shows `#5`'s remainder is downstream of `#9c`/`#9d`, not of `#7`:
+`SubscribeToMetadataResponse` embeds `EchoMetadata` (the metadata store is on `compatCodec`, so its
+exposed type is still protobuf.js), `SubscribeToFeedBlocksResponse.Block` embeds `FeedMessage`
+(`pipeline/codec`, explicitly held back), and `SubscribeToSpacesResponse.SpaceInfo` embeds
+`Space.PipelineState` -> `TimeframeVector` + `Credential`. `QueryEdgeStatusResponse` embeds
+`EdgeStatus`, which reaches **22 source files** across edge-client, echo-host, client-services and
+plugin-space's sync UI. `EdgePanel`'s nested-enum access
+(`WsStatus.ConnectionState.CONNECTED`) is a one-line fix gated behind that slice.
+
+### Enums move iff the name survives
+
+`tsc` relates enum types by **name**, not by declaration — verified with a local probe: a bare
+`enum SameName` and a `namespace Outer { export enum SameName }` compare without complaint, while
+an identically-valued `enum DifferentName` raises `TS2367`. So:
+
+- **Top-level enums** keep their name under buf and convert with no call-site change. The last two
+  stragglers moved on that basis: `EdgeReplicationSetting` in `cli-util/src/util/space.ts` and
+  `ConnectionState` in `plugin-debug`'s `DebugStatus.tsx`, both value-identical
+  (`0`/`1`) and green under `cli-util:build` / `plugin-debug:build`.
+- **Nested enums** are flattened by buf (`EdgeStatus.ConnectionState` -> `EdgeStatus_ConnectionState`),
+  the name changes, and every `===` against the protobuf.js-typed field breaks. That is why
+  `EdgePanel` cannot be fixed ahead of its type move, and it generalises to any nested enum
+  elsewhere in the migration.
 
 ## `#8` is the last milestone-sized thread, and it is not a rider
 
@@ -438,7 +496,11 @@ with no casts. What remains in devtools needs `#7` first:
 protobuf.js `src/proto/gen` barrel — so every value the effect-rpc services hand devtools is
 protobuf.js-shaped. Re-pointing devtools' type imports at `@dxos/protocols/buf/*` while that
 holds would type buf shapes over protobuf.js values, and the only way to compile it is the casts
-the repo forbids. #5 is therefore ordered strictly after #7, not merely helped by it.
+the repo forbids.
+
+This still holds with `#7` landed: `#7` changed which codec writes the bytes, not the type
+`protoMessage` exposes nor the substituted shape it decodes to. `#5` is ordered after the type
+moves to `bufMessage` — i.e. after `#9c`/`#9d` — not after `#7`. See the correction under `#5`.
 
 ### Where buf and protobuf.js bytes actually differ
 

--- a/packages/core/mesh/teleport-extension-gossip/package.json
+++ b/packages/core/mesh/teleport-extension-gossip/package.json
@@ -28,6 +28,7 @@
     "check": "true"
   },
   "dependencies": {
+    "@bufbuild/protobuf": "catalog:",
     "@dxos/async": "workspace:*",
     "@dxos/codec-protobuf": "workspace:*",
     "@dxos/context": "workspace:*",

--- a/packages/core/mesh/teleport-extension-gossip/src/presence.ts
+++ b/packages/core/mesh/teleport-extension-gossip/src/presence.ts
@@ -2,13 +2,16 @@
 // Copyright 2022 DXOS.org
 //
 
+import { create, fromBinary, toBinary } from '@bufbuild/protobuf';
+
 import { Event, scheduleTaskInterval } from '@dxos/async';
-import { type WithTypeUrl } from '@dxos/codec-protobuf';
 import { Resource } from '@dxos/context';
 import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
-import { type PeerState } from '@dxos/protocols/proto/dxos/mesh/presence';
+import { fromPublicKey, toPublicKey } from '@dxos/protocols/buf';
+import { decodeCompat, encodeCompat } from '@dxos/protocols/buf-shape-compat';
+import { type PeerState, PeerStateSchema } from '@dxos/protocols/buf/dxos/mesh/presence_pb';
 import { type GossipMessage } from '@dxos/protocols/proto/dxos/mesh/teleport/gossip';
 import { ComplexMap } from '@dxos/util';
 
@@ -35,6 +38,15 @@ export type PresenceProps = {
 
 const PRESENCE_CHANNEL_ID = 'dxos.mesh.presence.Presence';
 
+const PEER_STATE_TYPE_URL = 'dxos.mesh.presence.PeerState';
+
+/** A received announce, decoded once on arrival rather than on every read. */
+type PresenceRecord = {
+  peerId: PublicKey;
+  timestamp: Date;
+  state: PeerState;
+};
+
 /**
  * Presence manager.
  * Keeps track of all peers that are connected to the local peer.
@@ -45,8 +57,8 @@ export class Presence extends Resource {
   public readonly updated = new Event<void>();
   public readonly newPeer = new Event<PeerState>();
 
-  private readonly _peerStates = new ComplexMap<PublicKey, GossipMessage>(PublicKey.hash);
-  private readonly _peersByIdentityKey = new ComplexMap<PublicKey, GossipMessage[]>(PublicKey.hash);
+  private readonly _peerStates = new ComplexMap<PublicKey, PresenceRecord>(PublicKey.hash);
+  private readonly _peersByIdentityKey = new ComplexMap<PublicKey, PresenceRecord[]>(PublicKey.hash);
 
   // remotePeerId -> PresenceExtension
 
@@ -67,12 +79,7 @@ export class Presence extends Resource {
     scheduleTaskInterval(
       this._ctx,
       async () => {
-        const peerState: WithTypeUrl<PeerState> = {
-          '@type': 'dxos.mesh.presence.PeerState',
-          'identityKey': this._params.identityKey,
-          'connections': this._params.gossip.getConnections(),
-        };
-        this._params.gossip.postMessage(PRESENCE_CHANNEL_ID, peerState);
+        this._params.gossip.postMessage(PRESENCE_CHANNEL_ID, this._toAnnounce(this.getLocalState()));
       },
       this._params.announceInterval,
     );
@@ -88,10 +95,10 @@ export class Presence extends Resource {
 
     // Remove peer state when connection is closed.
     this._params.gossip.connectionClosed.on(this._ctx, (peerId) => {
-      const peerState = this._peerStates.get(peerId);
-      if (peerState != null) {
+      const record = this._peerStates.get(peerId);
+      if (record != null) {
         this._peerStates.delete(peerId);
-        this._removePeerFromIdentityKeyIndex(peerState);
+        this._removePeerFromIdentityKeyIndex(record);
         this.updated.emit();
       }
     });
@@ -101,66 +108,99 @@ export class Presence extends Resource {
     log.catch(err);
   }
 
+  /** The local identity, as the domain key type callers compare against. */
+  get localIdentityKey(): PublicKey {
+    return this._params.identityKey;
+  }
+
   getPeers(): PeerState[] {
-    return Array.from(this._peerStates.values()).map((message) => message.payload);
+    return Array.from(this._peerStates.values()).map((record) => record.state);
   }
 
   getPeersByIdentityKey(key: PublicKey): PeerState[] {
-    return (this._peersByIdentityKey.get(key) ?? []).filter(this._isOnline).map((m) => m.payload);
+    return (this._peersByIdentityKey.get(key) ?? []).filter(this._isOnline).map((record) => record.state);
   }
 
   getPeersOnline(): PeerState[] {
     return Array.from(this._peerStates.values())
       .filter(this._isOnline)
-      .map((message) => message.payload);
+      .map((record) => record.state);
   }
 
-  private _isOnline = (message: GossipMessage): boolean => {
-    return message.timestamp.getTime() > Date.now() - this._params.offlineTimeout;
+  private _isOnline = (record: PresenceRecord): boolean => {
+    return record.timestamp.getTime() > Date.now() - this._params.offlineTimeout;
   };
 
   getLocalState(): PeerState {
+    return create(PeerStateSchema, {
+      identityKey: fromPublicKey(this._params.identityKey),
+      connections: this._params.gossip.getConnections().map(fromPublicKey),
+      peerId: fromPublicKey(this._params.gossip.localPeerId),
+    });
+  }
+
+  /**
+   * Gossip resolves `Any` payloads generically for every channel, so presence converts at its own
+   * channel edge. Routed through the codec rather than a field map so the substitution table stays
+   * the single definition of the two shapes.
+   */
+  private _toAnnounce(state: PeerState): unknown {
     return {
-      identityKey: this._params.identityKey,
-      connections: this._params.gossip.getConnections(),
-      peerId: this._params.gossip.localPeerId,
+      ...decodeCompat<object>(PeerStateSchema, toBinary(PeerStateSchema, state)),
+      '@type': PEER_STATE_TYPE_URL,
     };
   }
 
   private _receiveAnnounces(message: GossipMessage): void {
     invariant(message.channelId === PRESENCE_CHANNEL_ID, `Invalid channel ID: ${message.channelId}`);
-    const oldPeerState = this._peerStates.get(message.peerId);
-    if (!oldPeerState || oldPeerState.timestamp.getTime() < message.timestamp.getTime()) {
-      // Assign peer id to payload.
-      (message.payload as PeerState).peerId = message.peerId;
-
-      this._peerStates.set(message.peerId, message);
-      this._updatePeerInIdentityKeyIndex(message);
-      this.updated.emit();
+    const previous = this._peerStates.get(message.peerId);
+    if (previous && previous.timestamp.getTime() >= message.timestamp.getTime()) {
+      return;
     }
+
+    const record: PresenceRecord = {
+      peerId: message.peerId,
+      timestamp: message.timestamp,
+      state: {
+        ...fromBinary(PeerStateSchema, encodeCompat(PeerStateSchema, message.payload)),
+        // The announcing peer omits its own peer id, so it is taken from the envelope.
+        peerId: fromPublicKey(message.peerId),
+      },
+    };
+
+    this._peerStates.set(message.peerId, record);
+    this._updatePeerInIdentityKeyIndex(record);
+    this.updated.emit();
   }
 
-  private _removePeerFromIdentityKeyIndex(peerState: GossipMessage): void {
-    const identityPeerList = this._peersByIdentityKey.get((peerState.payload as PeerState).identityKey) ?? [];
-    const peerIdIndex = identityPeerList.findIndex((id) => id.peerId?.equals(peerState.peerId));
+  private _removePeerFromIdentityKeyIndex(record: PresenceRecord): void {
+    const identityKey = toPublicKey(record.state.identityKey);
+    if (!identityKey) {
+      return;
+    }
+    const identityPeerList = this._peersByIdentityKey.get(identityKey) ?? [];
+    const peerIdIndex = identityPeerList.findIndex((peer) => peer.peerId.equals(record.peerId));
     if (peerIdIndex >= 0) {
       identityPeerList.splice(peerIdIndex, 1);
     }
   }
 
-  private _updatePeerInIdentityKeyIndex(newState: GossipMessage): void {
-    const identityKey = (newState.payload as PeerState).identityKey;
+  private _updatePeerInIdentityKeyIndex(newRecord: PresenceRecord): void {
+    const identityKey = toPublicKey(newRecord.state.identityKey);
+    if (!identityKey) {
+      return;
+    }
     const identityKeyPeers = this._peersByIdentityKey.get(identityKey) ?? [];
-    const existingIndex = identityKeyPeers.findIndex((p) => p.peerId && newState.peerId?.equals(p.peerId));
+    const existingIndex = identityKeyPeers.findIndex((peer) => peer.peerId.equals(newRecord.peerId));
     if (existingIndex >= 0) {
-      const oldState = identityKeyPeers.splice(existingIndex, 1, newState)[0];
-      if (!this._isOnline(oldState)) {
-        this.newPeer.emit(newState.payload);
+      const oldRecord = identityKeyPeers.splice(existingIndex, 1, newRecord)[0];
+      if (!this._isOnline(oldRecord)) {
+        this.newPeer.emit(newRecord.state);
       }
     } else {
       this._peersByIdentityKey.set(identityKey, identityKeyPeers);
-      identityKeyPeers.push(newState);
-      this.newPeer.emit(newState.payload);
+      identityKeyPeers.push(newRecord);
+      this.newPeer.emit(newRecord.state);
     }
   }
 }

--- a/packages/core/mesh/teleport-extension-gossip/src/testing.ts
+++ b/packages/core/mesh/teleport-extension-gossip/src/testing.ts
@@ -44,9 +44,7 @@ export class TestAgent extends TestPeerBase {
     invariant(agents.length > 0, 'At least one agent is required.'); // We will wait for .updated event from the agent itself. And with zero connections it will never happen.
     return asyncTimeout(
       this.presence.updated.waitFor(() => {
-        const connections = this.presence.getPeersOnline().map((state) => state.identityKey.toHex());
-        const expectedConnections = agents.map((agent) => agent.peerId.toHex());
-        return expectedConnections.every((value) => connections.includes(value));
+        return agents.every((agent) => this.presence.getPeersByIdentityKey(agent.peerId).length > 0);
       }),
       timeout,
     );

--- a/packages/core/protocols/src/DevtoolsHost.ts
+++ b/packages/core/protocols/src/DevtoolsHost.ts
@@ -7,7 +7,7 @@ import * as Rpc from 'effect/unstable/rpc/Rpc';
 import type * as RpcClient from 'effect/unstable/rpc/RpcClient';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 
-import { SignalResponseSchema } from './buf/proto/gen/dxos/devtools/host_pb.ts';
+import { SignalResponseSchema, SubscribeToSpacesResponseSchema } from './buf/proto/gen/dxos/devtools/host_pb.ts';
 import { SignedMessageSchema } from './buf/proto/gen/dxos/halo/signed_pb.ts';
 import { SignalState } from './proto/gen/dxos/mesh/signal.ts';
 import { bufMessage, protoMessage, serviceError } from './service-rpc.ts';
@@ -337,7 +337,7 @@ export class Rpcs extends RpcGroup.make(
   }),
   Rpc.make('subscribeToSpaces', {
     payload: SubscribeToSpacesRequest,
-    success: protoMessage('dxos.devtools.host.SubscribeToSpacesResponse'),
+    success: bufMessage(SubscribeToSpacesResponseSchema),
     error: serviceError,
     stream: true,
   }),

--- a/packages/core/protocols/src/DevtoolsHost.ts
+++ b/packages/core/protocols/src/DevtoolsHost.ts
@@ -7,6 +7,7 @@ import * as Rpc from 'effect/unstable/rpc/Rpc';
 import type * as RpcClient from 'effect/unstable/rpc/RpcClient';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 
+import { SignalResponseSchema } from './buf/proto/gen/dxos/devtools/host_pb.ts';
 import { SignedMessageSchema } from './buf/proto/gen/dxos/halo/signed_pb.ts';
 import { SignalState } from './proto/gen/dxos/mesh/signal.ts';
 import { bufMessage, protoMessage, serviceError } from './service-rpc.ts';
@@ -393,7 +394,7 @@ export class Rpcs extends RpcGroup.make(
     stream: true,
   }),
   Rpc.make('subscribeToSignal', {
-    success: protoMessage('dxos.devtools.host.SignalResponse'),
+    success: bufMessage(SignalResponseSchema),
     error: serviceError,
     stream: true,
   }),

--- a/packages/core/protocols/src/LoggingService.ts
+++ b/packages/core/protocols/src/LoggingService.ts
@@ -7,7 +7,8 @@ import * as Rpc from 'effect/unstable/rpc/Rpc';
 import type * as RpcClient from 'effect/unstable/rpc/RpcClient';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 
-import { protoMessage, serviceError } from './service-rpc.ts';
+import { LogEntrySchema, QueryLogsRequestSchema } from './buf/proto/gen/dxos/client/logging_pb.ts';
+import { bufMessage, serviceError } from './service-rpc.ts';
 import { mutableArray, protoTimestamp } from './service-schemas.ts';
 
 //
@@ -84,8 +85,8 @@ export class Rpcs extends RpcGroup.make(
     stream: true,
   }),
   Rpc.make('queryLogs', {
-    payload: protoMessage('dxos.client.services.QueryLogsRequest'),
-    success: protoMessage('dxos.client.services.LogEntry'),
+    payload: bufMessage(QueryLogsRequestSchema),
+    success: bufMessage(LogEntrySchema),
     error: serviceError,
     stream: true,
   }),

--- a/packages/core/protocols/src/buf/cross-codec.test.ts
+++ b/packages/core/protocols/src/buf/cross-codec.test.ts
@@ -63,24 +63,44 @@ const populate = (desc: DescMessage, depth = 0): Record<string, unknown> | undef
 
   const init: Record<string, unknown> = {};
   let salt = 0;
+
+  const messageValue = (message: DescMessage): unknown => {
+    if (message.typeName === 'google.protobuf.Any') {
+      const payload = bufRegistry.getMessage(ANY_PAYLOAD_TYPE);
+      return payload === undefined
+        ? undefined
+        : { typeUrl: ANY_PAYLOAD_TYPE, value: toBinary(payload, create(payload, { hashes: ['any-payload'] })) };
+    }
+    return populate(message, depth + 1);
+  };
+
+  const lastEnumValue = (field: DescField & { enum: { values: { number: number }[] } }): number =>
+    field.enum.values[field.enum.values.length - 1]?.number ?? 0;
+
   const valueFor = (field: DescField): unknown => {
     salt += 1;
     switch (field.fieldKind) {
       case 'scalar':
         return scalarFor(field, salt);
       case 'enum':
-        return field.enum.values[field.enum.values.length - 1]?.number ?? 0;
-      case 'message': {
-        if (field.message.typeName === 'google.protobuf.Any') {
-          const payload = bufRegistry.getMessage(ANY_PAYLOAD_TYPE);
-          return payload === undefined
-            ? undefined
-            : {
-                typeUrl: ANY_PAYLOAD_TYPE,
-                value: toBinary(payload, create(payload, { hashes: ['any-payload'] })),
-              };
+        return lastEnumValue(field);
+      case 'message':
+        return messageValue(field.message);
+      // Repeated fields are their own kind in buf's descriptors, not a flag on the others — they
+      // were silently skipped until `moon build` rejected the `field.repeated` this replaced.
+      case 'list': {
+        switch (field.listKind) {
+          case 'scalar':
+            return [scalarFor(field, salt)];
+          case 'enum':
+            return [lastEnumValue(field)];
+          case 'message': {
+            const element = messageValue(field.message);
+            return element === undefined ? undefined : [element];
+          }
+          default:
+            return undefined;
         }
-        return populate(field.message, depth + 1);
       }
       default:
         return undefined;
@@ -101,7 +121,7 @@ const populate = (desc: DescMessage, depth = 0): Record<string, unknown> | undef
       }
       continue;
     }
-    init[field.localName] = field.repeated ? [value] : value;
+    init[field.localName] = value;
   }
   // An empty nested message is worse than an absent one: protobuf.js materialises absent
   // submessages with unsubstituted defaults, which is divergence 1 below.
@@ -167,7 +187,17 @@ const outcomeOf = (run: () => string[]): { paths: string[]; error?: string } => 
   }
 };
 
-const legacyCodec = (typeName: string) => schema.getCodecForType(typeName as never);
+type LegacyCodec = {
+  encode(value: unknown): Uint8Array;
+  decode(bytes: Uint8Array): unknown;
+};
+
+/**
+ * `getCodecForType` is keyed on the protobuf.js type union, which a registry walk cannot narrow to,
+ * so the codec is taken at the surface this file uses. Method syntax keeps the parameters bivariant
+ * and the assignment honest, matching `Substitution` in `shape-compat.ts`.
+ */
+const legacyCodec = (typeName: string): LegacyCodec => schema.getCodecForType(typeName as never);
 
 const knownToLegacy = (typeName: string): boolean => {
   try {
@@ -195,38 +225,114 @@ const covered = [...bufRegistry]
  */
 const KNOWN_DIVERGENCES: { typeName: string; decode: string[]; encode: string[] }[] = [
   {
+    typeName: 'dxos.client.services.ContactBook',
+    decode: ['contacts'],
+    encode: [],
+  },
+  {
     typeName: 'dxos.client.services.JoinSpaceResponse',
-    decode: ['space.pipeline.appliedEpoch.subject', 'space.pipeline.currentEpoch.subject'],
+    decode: ['space.members', 'space.pipeline.appliedEpoch.subject', 'space.pipeline.currentEpoch.subject'],
     encode: ['space.pipeline.appliedEpoch.subject', 'space.pipeline.currentEpoch.subject'],
   },
   {
-    typeName: 'dxos.devtools.host.GetSpaceSnapshotResponse',
-    decode: ['snapshot.database'],
-    encode: ['snapshot.database'],
+    typeName: 'dxos.client.services.LoadPersistentInvitationsResponse',
+    decode: ['invitations'],
+    encode: [],
   },
   {
-    typeName: 'dxos.devtools.host.SaveSpaceSnapshotResponse',
-    decode: ['snapshot.database'],
-    encode: ['snapshot.database'],
+    typeName: 'dxos.client.services.NetworkStatus',
+    decode: ['connectionInfo'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.client.services.QueryInvitationsResponse',
+    decode: ['invitations'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.client.services.QuerySpacesResponse',
+    decode: ['spaces'],
+    encode: ['spaces'],
+  },
+  {
+    typeName: 'dxos.client.services.Space',
+    decode: ['members'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.config.Config',
+    decode: ['package.modules'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.config.Module',
+    decode: ['deps'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.config.Package',
+    decode: ['modules'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.devtools.host.SubscribeToFeedBlocksResponse',
+    decode: ['blocks'],
+    encode: ['blocks'],
   },
   {
     typeName: 'dxos.devtools.host.SubscribeToFeedBlocksResponse.Block',
-    decode: ['data'],
-    encode: ['data'],
+    decode: ['data.payload'],
+    encode: ['data.payload'],
+  },
+  {
+    typeName: 'dxos.devtools.host.SubscribeToMetadataResponse',
+    decode: ['metadata.invitations', 'metadata.spaces'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.devtools.host.SubscribeToSpacesResponse',
+    decode: ['spaces'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.devtools.swarm.ConnectionInfo',
+    decode: ['streams'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.devtools.swarm.SwarmInfo',
+    decode: ['connections'],
+    encode: [],
   },
   {
     typeName: 'dxos.echo.feed.FeedMessage',
-    decode: ['payload.credential.credential.subject', 'timeframe'],
-    encode: ['payload.payload.value.credential.subject', 'timeframe'],
+    decode: ['payload.credential.credential.subject'],
+    encode: ['payload.payload.value.credential.subject'],
   },
   {
     typeName: 'dxos.echo.metadata.ControlPipelineSnapshot',
-    decode: ['timeframe'],
-    encode: ['timeframe'],
+    decode: ['messages'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.echo.metadata.EchoMetadata',
+    decode: ['invitations', 'spaces'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.echo.metadata.LargeSpaceMetadata',
+    decode: ['controlPipelineSnapshot.messages'],
+    encode: ['controlPipelineSnapshot.messages'],
   },
   {
     typeName: 'dxos.echo.object.EchoObject',
-    decode: ['snapshot.model.@type', 'snapshot.model.hashes', 'snapshot.model.type_url', 'snapshot.model.value'],
+    decode: [
+      'mutations',
+      'snapshot.model.@type',
+      'snapshot.model.hashes',
+      'snapshot.model.type_url',
+      'snapshot.model.value',
+    ],
     encode: [],
   },
   {
@@ -240,9 +346,19 @@ const KNOWN_DIVERGENCES: { typeName: string; decode: string[]; encode: string[] 
     encode: [],
   },
   {
+    typeName: 'dxos.echo.query.QueryResponse',
+    decode: ['objects', 'results'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.echo.snapshot.EchoSnapshot',
+    decode: ['items'],
+    encode: [],
+  },
+  {
     typeName: 'dxos.echo.snapshot.SpaceSnapshot',
-    decode: ['database'],
-    encode: ['database'],
+    decode: ['database.items'],
+    encode: [],
   },
   {
     typeName: 'dxos.edge.calls.Activity',
@@ -255,14 +371,39 @@ const KNOWN_DIVERGENCES: { typeName: string; decode: string[]; encode: string[] 
     encode: [],
   },
   {
+    typeName: 'dxos.edge.messenger.Message',
+    decode: ['target'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.edge.messenger.SwarmResponse',
+    decode: ['inactivePeers', 'peers'],
+    encode: [],
+  },
+  {
     typeName: 'dxos.halo.credentials.Credential',
     decode: ['proof.chain.credential.subject'],
     encode: ['proof.chain.credential.subject'],
   },
   {
-    typeName: 'dxos.halo.credentials.Epoch',
-    decode: ['timeframe'],
-    encode: ['timeframe'],
+    typeName: 'dxos.halo.credentials.Presentation',
+    decode: ['credentials', 'proofs'],
+    encode: ['proofs'],
+  },
+  {
+    typeName: 'dxos.halo.signed.KeyChain',
+    decode: ['message.signatures', 'parents'],
+    encode: ['message.signatures', 'parents'],
+  },
+  {
+    typeName: 'dxos.halo.signed.SignedMessage',
+    decode: ['signatures'],
+    encode: ['signatures'],
+  },
+  {
+    typeName: 'dxos.halo.signed.SignedMessage.Signature',
+    decode: ['keyChain.message.signatures', 'keyChain.parents'],
+    encode: ['keyChain.parents'],
   },
   {
     typeName: 'dxos.mesh.bridge.BridgeEvent.SignalEvent',
@@ -285,9 +426,19 @@ const KNOWN_DIVERGENCES: { typeName: string; decode: string[]; encode: string[] 
     encode: ['payload'],
   },
   {
+    typeName: 'dxos.mesh.teleport.notarization.NotarizeRequest',
+    decode: ['credentials'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.mesh.teleport.replicator.UpdateFeedsRequest',
+    decode: ['feeds'],
+    encode: [],
+  },
+  {
     typeName: 'dxos.service.agentmanager.Authentication',
-    decode: ['presentation'],
-    encode: ['presentation'],
+    decode: ['presentation.credentials', 'presentation.proofs'],
+    encode: [],
   },
 ];
 
@@ -301,7 +452,7 @@ describe('cross-codec agreement (current tree)', () => {
   });
 
   test('the divergence ledger does not grow, and holds no stale entries', () => {
-    expect(KNOWN_DIVERGENCES.length).toBe(19);
+    expect(KNOWN_DIVERGENCES.length).toBe(42);
     // A ledger entry for a message that no longer diverges is as much a defect as a missing one:
     // it would silence a future regression on a message that is currently clean.
     const names = new Set(covered.map((desc) => desc.typeName));

--- a/packages/core/protocols/src/buf/cross-codec.test.ts
+++ b/packages/core/protocols/src/buf/cross-codec.test.ts
@@ -1,0 +1,340 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type DescField, type DescMessage, create, fromBinary, toBinary } from '@bufbuild/protobuf';
+import { describe, expect, test } from 'vitest';
+
+import { schema } from '../proto/index.ts';
+import { bufRegistry } from './registry.ts';
+import { decodeCompat, encodeCompat } from './shape-compat.ts';
+
+// Cross-codec agreement, checked against the current tree because both codecs are in the workspace.
+//
+// WHAT THIS IS NOT. Both sides regenerate from the same `src/proto` tree, so a wire-incompatible
+// edit to a `.proto` moves them together and passes here unnoticed. This is *not* a downgrade or
+// compatibility guard and must not be cited as one — catching that needs bytes from a build
+// predating the edit (see `docs/audits/protobufjs-to-buf.md` for the rejected historical pin).
+// What it does give is continuous agreement between the two codecs on every CI run.
+//
+// This guard exists only while both codecs do, and is deleted with protobuf.js at teardown.
+
+const ANY_PAYLOAD_TYPE = 'dxos.echo.query.Heads';
+
+/** Distinctive per-field values: an all-defaults message survives almost any encoding bug. */
+const scalarFor = (field: DescField, salt: number): unknown => {
+  switch (field.scalar) {
+    case 1:
+    case 2:
+      return 1.5 + salt;
+    case 3:
+    case 4:
+    case 6:
+    case 16:
+    case 18:
+      return BigInt(1000 + salt);
+    case 8:
+      return true;
+    case 9:
+      return `value-${salt}`;
+    case 12:
+      return new Uint8Array(Array.from({ length: 32 }, (_, index) => (salt + index) & 0xff));
+    default:
+      return 100 + salt;
+  }
+};
+
+/** Builds a message with every field populated, so the round-trip exercises real encodings. */
+const populate = (desc: DescMessage, depth = 0): Record<string, unknown> | undefined => {
+  // Substituted for classes that reject an empty value, so always filled.
+  if (desc.typeName === 'dxos.keys.PublicKey' || desc.typeName === 'dxos.keys.PrivateKey') {
+    return { data: new Uint8Array(Array.from({ length: 32 }, (_, index) => (index * 7 + 1) & 0xff)) };
+  }
+  // `Timestamp` is substituted for `Date`, which is millisecond-resolution. Sub-millisecond `nanos`
+  // cannot survive that round-trip, so only representable values are generated — see the audit doc,
+  // where the lossiness is recorded as a divergence in its own right precisely because this guard
+  // deliberately stops exercising it.
+  if (desc.typeName === 'google.protobuf.Timestamp') {
+    return { seconds: BigInt(1700000000 + depth), nanos: 123_000_000 };
+  }
+  if (depth > 3) {
+    return undefined;
+  }
+
+  const init: Record<string, unknown> = {};
+  let salt = 0;
+  const valueFor = (field: DescField): unknown => {
+    salt += 1;
+    switch (field.fieldKind) {
+      case 'scalar':
+        return scalarFor(field, salt);
+      case 'enum':
+        return field.enum.values[field.enum.values.length - 1]?.number ?? 0;
+      case 'message': {
+        if (field.message.typeName === 'google.protobuf.Any') {
+          const payload = bufRegistry.getMessage(ANY_PAYLOAD_TYPE);
+          return payload === undefined
+            ? undefined
+            : {
+                typeUrl: ANY_PAYLOAD_TYPE,
+                value: toBinary(payload, create(payload, { hashes: ['any-payload'] })),
+              };
+        }
+        return populate(field.message, depth + 1);
+      }
+      default:
+        return undefined;
+    }
+  };
+
+  for (const field of desc.fields) {
+    if (field.fieldKind === 'map') {
+      continue;
+    }
+    const value = valueFor(field);
+    if (value === undefined) {
+      continue;
+    }
+    if (field.oneof) {
+      if (init[field.oneof.localName] === undefined) {
+        init[field.oneof.localName] = { case: field.localName, value };
+      }
+      continue;
+    }
+    init[field.localName] = field.repeated ? [value] : value;
+  }
+  // An empty nested message is worse than an absent one: protobuf.js materialises absent
+  // submessages with unsubstituted defaults, which is divergence 1 below.
+  return Object.keys(init).length > 0 ? init : undefined;
+};
+
+/**
+ * Compares byte content rather than view class.
+ *
+ * protobuf.js returns Node `Buffer`s for bytes fields where buf returns `Uint8Array`. The
+ * distinction is not observable on the wire and cannot reach a signature — `canonicalStringify`
+ * normalises both to hex — so it is not treated as a divergence.
+ */
+const byBytes = (value: unknown): unknown => {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  if (value instanceof Uint8Array) {
+    return Array.from(value);
+  }
+  if (value instanceof Date) {
+    return { $date: value.toISOString() };
+  }
+  if (Array.isArray(value)) {
+    return value.map(byBytes);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, byBytes(entry)]));
+  }
+  return value;
+};
+
+/** Field paths at which two decoded shapes disagree, so a divergence is keyed on where it happens. */
+const divergingPaths = (left: unknown, right: unknown, path = ''): string[] => {
+  if (JSON.stringify(byBytes(left)) === JSON.stringify(byBytes(right))) {
+    return [];
+  }
+  const bothObjects =
+    left !== null &&
+    right !== null &&
+    typeof left === 'object' &&
+    typeof right === 'object' &&
+    !Array.isArray(left) &&
+    !Array.isArray(right);
+  if (!bothObjects) {
+    return [path || '.'];
+  }
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  return [...keys].flatMap((key) =>
+    divergingPaths(
+      (left as Record<string, unknown>)[key],
+      (right as Record<string, unknown>)[key],
+      path ? `${path}.${key}` : key,
+    ),
+  );
+};
+
+const outcomeOf = (run: () => string[]): { paths: string[]; error?: string } => {
+  try {
+    return { paths: run() };
+  } catch (err) {
+    return { paths: [], error: err instanceof Error ? err.message : String(err) };
+  }
+};
+
+const legacyCodec = (typeName: string) => schema.getCodecForType(typeName as never);
+
+const knownToLegacy = (typeName: string): boolean => {
+  try {
+    legacyCodec(typeName);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const covered = [...bufRegistry]
+  .filter((desc): desc is DescMessage => desc.kind === 'message')
+  .filter((desc) => knownToLegacy(desc.typeName));
+
+/**
+ * Divergences between the two codecs, keyed on the message **and the exact field paths** at which
+ * they disagree — not on the message alone. A message listed here still fails if it diverges
+ * somewhere new, so this is a ledger rather than a mute button.
+ *
+ * All nineteen share one root cause: protobuf.js's decoder materialises an *absent* singular
+ * message field with unsubstituted defaults (`issuer: {data:{}}`, a bare `{seconds,nanos}` where a
+ * `Date` is expected), where the compat layer leaves it absent. It is the legacy codec's own
+ * asymmetry — its encoder then rejects what its decoder produced — and predates this migration.
+ * Entries are expected to disappear as messages move to buf, never to be added.
+ */
+const KNOWN_DIVERGENCES: { typeName: string; decode: string[]; encode: string[] }[] = [
+  {
+    typeName: 'dxos.client.services.JoinSpaceResponse',
+    decode: ['space.pipeline.appliedEpoch.subject', 'space.pipeline.currentEpoch.subject'],
+    encode: ['space.pipeline.appliedEpoch.subject', 'space.pipeline.currentEpoch.subject'],
+  },
+  {
+    typeName: 'dxos.devtools.host.GetSpaceSnapshotResponse',
+    decode: ['snapshot.database'],
+    encode: ['snapshot.database'],
+  },
+  {
+    typeName: 'dxos.devtools.host.SaveSpaceSnapshotResponse',
+    decode: ['snapshot.database'],
+    encode: ['snapshot.database'],
+  },
+  {
+    typeName: 'dxos.devtools.host.SubscribeToFeedBlocksResponse.Block',
+    decode: ['data'],
+    encode: ['data'],
+  },
+  {
+    typeName: 'dxos.echo.feed.FeedMessage',
+    decode: ['payload.credential.credential.subject', 'timeframe'],
+    encode: ['payload.payload.value.credential.subject', 'timeframe'],
+  },
+  {
+    typeName: 'dxos.echo.metadata.ControlPipelineSnapshot',
+    decode: ['timeframe'],
+    encode: ['timeframe'],
+  },
+  {
+    typeName: 'dxos.echo.object.EchoObject',
+    decode: ['snapshot.model.@type', 'snapshot.model.hashes', 'snapshot.model.type_url', 'snapshot.model.value'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.echo.object.EchoObject.Mutation',
+    decode: ['model.@type', 'model.hashes', 'model.type_url', 'model.value'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.echo.object.EchoObject.Snapshot',
+    decode: ['model.@type', 'model.hashes', 'model.type_url', 'model.value'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.echo.snapshot.SpaceSnapshot',
+    decode: ['database'],
+    encode: ['database'],
+  },
+  {
+    typeName: 'dxos.edge.calls.Activity',
+    decode: ['payload'],
+    encode: ['payload'],
+  },
+  {
+    typeName: 'dxos.edge.calls.UserState',
+    decode: ['activities'],
+    encode: [],
+  },
+  {
+    typeName: 'dxos.halo.credentials.Credential',
+    decode: ['proof.chain.credential.subject'],
+    encode: ['proof.chain.credential.subject'],
+  },
+  {
+    typeName: 'dxos.halo.credentials.Epoch',
+    decode: ['timeframe'],
+    encode: ['timeframe'],
+  },
+  {
+    typeName: 'dxos.mesh.bridge.BridgeEvent.SignalEvent',
+    decode: ['payload'],
+    encode: ['payload'],
+  },
+  {
+    typeName: 'dxos.mesh.bridge.SignalRequest',
+    decode: ['signal'],
+    encode: ['signal'],
+  },
+  {
+    typeName: 'dxos.mesh.bridge.StatsResponse',
+    decode: ['stats'],
+    encode: ['stats'],
+  },
+  {
+    typeName: 'dxos.mesh.swarm.Signal',
+    decode: ['payload'],
+    encode: ['payload'],
+  },
+  {
+    typeName: 'dxos.service.agentmanager.Authentication',
+    decode: ['presentation'],
+    encode: ['presentation'],
+  },
+];
+
+const divergenceFor = (typeName: string) => KNOWN_DIVERGENCES.find((entry) => entry.typeName === typeName);
+
+describe('cross-codec agreement (current tree)', () => {
+  test('the registry is actually being walked', () => {
+    // Guards against a filter silently reducing the cases below to nothing while still reporting
+    // green.
+    expect(covered.length).toBeGreaterThan(100);
+  });
+
+  test('the divergence ledger does not grow, and holds no stale entries', () => {
+    expect(KNOWN_DIVERGENCES.length).toBe(19);
+    // A ledger entry for a message that no longer diverges is as much a defect as a missing one:
+    // it would silence a future regression on a message that is currently clean.
+    const names = new Set(covered.map((desc) => desc.typeName));
+    expect(KNOWN_DIVERGENCES.filter((entry) => !names.has(entry.typeName))).toEqual([]);
+  });
+
+  for (const desc of covered) {
+    const known = divergenceFor(desc.typeName);
+
+    // The guarantee the migration rests on: reading the same bytes with either decoder yields the
+    // same substituted shape, so a call site cannot tell which codec carried its value.
+    test(`${desc.typeName}: both decoders agree on the same bytes`, () => {
+      const bytes = toBinary(desc, create(desc, populate(desc)));
+      const observed = outcomeOf(() =>
+        divergingPaths(decodeCompat(desc, bytes), legacyCodec(desc.typeName).decode(bytes)),
+      );
+      expect(observed.error).toBeUndefined();
+      expect(observed.paths.sort()).toEqual(known?.decode ?? []);
+    });
+
+    // And the encoders: a value in the substituted shape must reach the wire identically whichever
+    // side writes it, which is what makes swapping a codec at a call site safe.
+    test(`${desc.typeName}: both encoders agree on the same value`, () => {
+      const bytes = toBinary(desc, create(desc, populate(desc)));
+      const observed = outcomeOf(() => {
+        const substituted = decodeCompat(desc, bytes);
+        return divergingPaths(
+          fromBinary(desc, encodeCompat(desc, substituted)),
+          fromBinary(desc, legacyCodec(desc.typeName).encode(substituted)),
+        );
+      });
+      expect(observed.error).toBeUndefined();
+      expect(observed.paths.sort()).toEqual(known?.encode ?? []);
+    });
+  }
+});

--- a/packages/core/protocols/src/buf/index.ts
+++ b/packages/core/protocols/src/buf/index.ts
@@ -2,7 +2,25 @@
 // Copyright 2024 DXOS.org
 //
 
+import { create } from '@bufbuild/protobuf';
+
+import { PublicKey } from '@dxos/keys';
+
+import { type PublicKey as BufPublicKey, PublicKeySchema } from './proto/gen/dxos/keys_pb.ts';
+
 export * as buf from '@bufbuild/protobuf';
 export * as bufWkt from '@bufbuild/protobuf/wkt';
 
 export { create as createBuf } from '@bufbuild/protobuf';
+
+/**
+ * Reads `dxos.keys.PublicKey` as the domain key type.
+ *
+ * buf generates the key as an ordinary message where protobuf.js substituted the `PublicKey`
+ * class, so buf-native code converts explicitly. This is the direction of travel — not a compat
+ * shim — and it is shared so the substitution is spelled one way everywhere.
+ */
+export const toPublicKey = (key: BufPublicKey | undefined): PublicKey | undefined => key && PublicKey.from(key.data);
+
+/** Writes the domain key type as `dxos.keys.PublicKey`. */
+export const fromPublicKey = (key: PublicKey): BufPublicKey => create(PublicKeySchema, { data: key.asUint8Array() });

--- a/packages/core/protocols/src/buf/index.ts
+++ b/packages/core/protocols/src/buf/index.ts
@@ -5,7 +5,9 @@
 import { create } from '@bufbuild/protobuf';
 
 import { PublicKey } from '@dxos/keys';
+import { Timeframe } from '@dxos/timeframe';
 
+import { type TimeframeVector, TimeframeVectorSchema } from './proto/gen/dxos/echo/timeframe_pb.ts';
 import { type PublicKey as BufPublicKey, PublicKeySchema } from './proto/gen/dxos/keys_pb.ts';
 
 export * as buf from '@bufbuild/protobuf';
@@ -24,3 +26,20 @@ export const toPublicKey = (key: BufPublicKey | undefined): PublicKey | undefine
 
 /** Writes the domain key type as `dxos.keys.PublicKey`. */
 export const fromPublicKey = (key: PublicKey): BufPublicKey => create(PublicKeySchema, { data: key.asUint8Array() });
+
+/**
+ * Reads `dxos.echo.timeframe.TimeframeVector` as the domain type.
+ *
+ * `Timeframe` carries the behaviour callers need (`merge`, `totalMessages`, `newMessages`); the
+ * generated message is its wire form and has none of it. Converting at the boundary keeps the
+ * domain class as the domain type rather than teaching the message to behave like one. Mirrors the
+ * substitution in `shape-compat.ts` so the two agree.
+ */
+export const toTimeframe = (vector: TimeframeVector | undefined): Timeframe =>
+  new Timeframe((vector?.frames ?? []).map((frame) => [PublicKey.from(frame.feedKey), frame.seq]));
+
+/** Writes the domain type as `dxos.echo.timeframe.TimeframeVector`. */
+export const fromTimeframe = (timeframe: Timeframe): TimeframeVector =>
+  create(TimeframeVectorSchema, {
+    frames: timeframe.frames().map(([feedKey, seq]) => ({ feedKey: feedKey.asUint8Array(), seq })),
+  });

--- a/packages/devtools/cli-util/src/util/space.ts
+++ b/packages/devtools/cli-util/src/util/space.ts
@@ -14,7 +14,7 @@ import { type Space } from '@dxos/client/echo';
 import { Database, type Key } from '@dxos/echo';
 import { BaseError, type BaseErrorOptions } from '@dxos/errors';
 import { log } from '@dxos/log';
-import { EdgeReplicationSetting } from '@dxos/protocols/proto/dxos/echo/metadata';
+import { EdgeReplicationSetting } from '@dxos/protocols/buf/dxos/echo/metadata_pb';
 import { isBun } from '@dxos/util';
 
 import { CommandConfig } from '../services';

--- a/packages/devtools/devtools/moon.yml
+++ b/packages/devtools/devtools/moon.yml
@@ -3,6 +3,7 @@ language: typescript
 tags:
   - ts-build
   - ts-test
+  - typetest
   - pack
   - storybook
 tasks:

--- a/packages/devtools/devtools/package.json
+++ b/packages/devtools/devtools/package.json
@@ -25,6 +25,7 @@
     "proxy": "vite-node scripts/proxy.ts"
   },
   "dependencies": {
+    "@bufbuild/protobuf": "catalog:",
     "@dxos/ai": "workspace:*",
     "@dxos/app-framework": "workspace:*",
     "@dxos/app-toolkit": "workspace:*",

--- a/packages/devtools/devtools/src/containers/DataSpaceSelector.tsx
+++ b/packages/devtools/devtools/src/containers/DataSpaceSelector.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 
 import { invariant } from '@dxos/invariant';
 import { SpaceId } from '@dxos/keys';
+import { toPublicKey } from '@dxos/protocols/buf';
 import { type Space, useSpaces } from '@dxos/react-client/echo';
 import { useAsyncEffect } from '@dxos/react-hooks';
 import { Select } from '@dxos/react-ui';
@@ -22,7 +23,7 @@ export const DataSpaceSelector = () => {
   const handleSelect = (spaceId?: SpaceId) => {
     const space = spaceId ? spaces.find((space) => space.id === spaceId) : undefined;
     // TODO(dmaretskyi): Expose id in space info.
-    const spaceInfo = space ? spacesInfo.find((spaceInfo) => spaceInfo.key.equals(space.key)) : undefined;
+    const spaceInfo = space ? spacesInfo.find((spaceInfo) => toPublicKey(spaceInfo.key)?.equals(space.key)) : undefined;
     setState((state) => ({
       ...state,
       space,

--- a/packages/devtools/devtools/src/containers/SpaceSelector.tsx
+++ b/packages/devtools/devtools/src/containers/SpaceSelector.tsx
@@ -5,6 +5,7 @@
 import * as localForage from 'localforage';
 import React from 'react';
 
+import { toPublicKey } from '@dxos/protocols/buf';
 import { PublicKey } from '@dxos/react-client';
 import { useSpaces } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
@@ -30,7 +31,9 @@ export const SpaceSelector = () => {
         return {
           ...state,
           space: spaceKey ? spaces.find((space) => space.key.equals(spaceKey)) : undefined,
-          spaceInfo: spaceKey ? spacesInfo.find((spaceInfo) => spaceInfo.key.equals(spaceKey)) : undefined,
+          spaceInfo: spaceKey
+            ? spacesInfo.find((spaceInfo) => toPublicKey(spaceInfo.key)?.equals(spaceKey))
+            : undefined,
           haloSpaceKey: undefined,
         };
       }

--- a/packages/devtools/devtools/src/hooks/useSignal.tst.ts
+++ b/packages/devtools/devtools/src/hooks/useSignal.tst.ts
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, it } from 'tstyche';
+
+import { type SignalResponse } from '@dxos/protocols/buf/dxos/devtools/host_pb';
+import { type SignalResponse as LegacySignalResponse } from '@dxos/protocols/proto/dxos/devtools/host';
+
+import { useSignal } from './useSignal';
+
+// `SignalResponse` moved to `bufMessage` on `DevtoolsHost.subscribeToSignal`, so these pin the
+// carrier's exposed type rather than the annotation the panel happens to write. A green build
+// would not distinguish the two.
+
+declare const response: SignalResponse;
+
+describe('SignalResponse', () => {
+  it('reaches the hook as the buf message', () => {
+    expect(useSignal()).type.toBe<SignalResponse[]>();
+    expect(response.$typeName).type.toBe<'dxos.devtools.host.SignalResponse'>();
+  });
+
+  it('models the oneof as a discriminated union', () => {
+    // protobuf.js exposed `swarmEvent` and `message` as independent optional properties; reading
+    // either off the buf message is a type error, which is what the 17 call sites had to change.
+    expect(response.data.case).type.toBe<'swarmEvent' | 'message' | undefined>();
+    expect(response).type.not.toBeAssignableTo<{ swarmEvent: unknown }>();
+  });
+
+  it('carries `receivedAt` as a Timestamp, not a Date', () => {
+    expect(response.receivedAt).type.not.toBeAssignableTo<Date | undefined>();
+    expect(response.receivedAt?.seconds).type.toBe<bigint | undefined>();
+  });
+
+  it('leaves the message payload packed', () => {
+    // Resolving a `type_url` on the consumer is what the panel must not do; the payload stays an
+    // `Any` and the views dispatch on `typeUrl`.
+    const message = response.data.case === 'message' ? response.data.value : undefined;
+    expect(message?.payload?.typeUrl).type.toBe<string | undefined>();
+    expect(message?.payload?.value).type.toBe<Uint8Array | undefined>();
+  });
+
+  it('is no longer the protobuf.js type', () => {
+    expect<LegacySignalResponse>().type.not.toBeAssignableTo<SignalResponse>();
+  });
+});

--- a/packages/devtools/devtools/src/hooks/useSignal.tsx
+++ b/packages/devtools/devtools/src/hooks/useSignal.tsx
@@ -2,21 +2,27 @@
 // Copyright 2023 DXOS.org
 //
 
-import { useMemo } from 'react';
+import { useEffect, useState } from 'react';
 
-import { type SignalResponse } from '@dxos/protocols/proto/dxos/devtools/host';
+import { type SignalResponse } from '@dxos/protocols/buf/dxos/devtools/host_pb';
 import { useDevtools } from '@dxos/react-client/devtools';
 
-export const useSignal = () => {
+export const useSignal = (): SignalResponse[] => {
   const devtoolsHost = useDevtools();
-  const signalResponses = useMemo(() => {
-    const signalOutput = devtoolsHost.subscribeToSignal();
-    const signalResponses: SignalResponse[] = [];
-    signalOutput.subscribe((response: SignalResponse) => {
-      signalResponses.push(response);
-      return [...signalResponses];
+  const [responses, setResponses] = useState<SignalResponse[]>([]);
+
+  useEffect(() => {
+    const stream = devtoolsHost.subscribeToSignal();
+    const received: SignalResponse[] = [];
+    stream.subscribe((response) => {
+      received.push(response);
+      setResponses([...received]);
     });
+
+    return () => {
+      void stream.close();
+    };
   }, []);
 
-  return signalResponses;
+  return responses;
 };

--- a/packages/devtools/devtools/src/hooks/useSpacesInfo.tsx
+++ b/packages/devtools/devtools/src/hooks/useSpacesInfo.tsx
@@ -2,16 +2,20 @@
 // Copyright 2023 DXOS.org
 //
 
+import { create } from '@bufbuild/protobuf';
+
+import { toPublicKey } from '@dxos/protocols/buf';
+import { SubscribeToSpacesResponseSchema } from '@dxos/protocols/buf/dxos/devtools/host_pb';
 import { useDevtools, useStream } from '@dxos/react-client/devtools';
 
 export const useSpacesInfo = () => {
   const devtoolsHost = useDevtools();
-  const spaces = useStream(() => devtoolsHost.subscribeToSpaces({}), {}).spaces ?? [];
+  const spaces = useStream(() => devtoolsHost.subscribeToSpaces({}), create(SubscribeToSpacesResponseSchema)).spaces;
   return spaces;
 };
 
 export const useSpaceInfo = (spaceKey: string) => {
   const spaces = useSpacesInfo();
-  const space = spaces.find((space) => space.key.equals(spaceKey));
+  const space = spaces.find((space) => toPublicKey(space.key)?.equals(spaceKey));
   return space;
 };

--- a/packages/devtools/devtools/src/panels/client/LoggingPanel/LoggingPanel.tst.ts
+++ b/packages/devtools/devtools/src/panels/client/LoggingPanel/LoggingPanel.tst.ts
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, it } from 'tstyche';
+
+import { type LogEntry, type QueryLogsRequest } from '@dxos/protocols/buf/dxos/client/logging_pb';
+import {
+  type LogEntry as LegacyLogEntry,
+  type QueryLogsRequest as LegacyRequest,
+} from '@dxos/protocols/proto/dxos/client/services';
+
+// Carrier group E: `LoggingService.queryLogs` moved to `bufMessage` on both the payload and the
+// response, so this pins both directions — the panel builds the request as well as reading entries.
+
+declare const entry: LogEntry;
+declare const request: QueryLogsRequest;
+
+describe('LogEntry / QueryLogsRequest (group E)', () => {
+  it('carry `$typeName`', () => {
+    expect(entry.$typeName).type.toBe<'dxos.client.services.LogEntry'>();
+    expect(request.$typeName).type.toBe<'dxos.client.services.QueryLogsRequest'>();
+  });
+
+  it('carries `timestamp` as a Timestamp, not a Date', () => {
+    // protobuf.js substituted `google.protobuf.Timestamp` for `Date`; the panel now converts with
+    // `timestampDate` at the point it renders.
+    expect(entry.timestamp).type.not.toBeAssignableTo<Date | undefined>();
+    expect(entry.timestamp?.nanos).type.toBe<number | undefined>();
+  });
+
+  it('exposes the nested enum under its flattened name', () => {
+    // buf flattens `QueryLogsRequest.MatchingOptions` to `QueryLogsRequest_MatchingOptions`, which
+    // is why every `===` against it had to move rather than being left alone.
+    expect(request.options).type.not.toBeAssignableTo<LegacyRequest['options']>();
+  });
+
+  it('are no longer the protobuf.js types', () => {
+    expect<LegacyLogEntry>().type.not.toBeAssignableTo<LogEntry>();
+    expect<LegacyRequest>().type.not.toBeAssignableTo<QueryLogsRequest>();
+  });
+});

--- a/packages/devtools/devtools/src/panels/client/LoggingPanel/LoggingPanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/LoggingPanel/LoggingPanel.tsx
@@ -2,12 +2,19 @@
 // Copyright 2023 DXOS.org
 //
 
+import { create } from '@bufbuild/protobuf';
+import { timestampDate, timestampFromDate } from '@bufbuild/protobuf/wkt';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Format } from '@dxos/echo/Format';
 import { levels, parseFilter } from '@dxos/log';
-import { LogLevel } from '@dxos/protocols/buf/dxos/client/logging_pb';
-import { type LogEntry, type QueryLogsRequest } from '@dxos/protocols/proto/dxos/client/services';
+import {
+  type LogEntry,
+  LogEntrySchema,
+  LogLevel,
+  type QueryLogsRequest,
+  QueryLogsRequestSchema,
+} from '@dxos/protocols/buf/dxos/client/logging_pb';
 import { useClient } from '@dxos/react-client';
 import { useStream } from '@dxos/react-client/devtools';
 import { Panel, Toolbar, useFileDownload } from '@dxos/react-ui';
@@ -17,7 +24,11 @@ import { MasterDetailTable, Searchbar, Select } from '../../../components';
 
 const MAX_LOGS = 2_000;
 
-const defaultEntry: LogEntry = { level: LogLevel.DEBUG, message: '', timestamp: new Date(0) };
+const defaultEntry: LogEntry = create(LogEntrySchema, {
+  level: LogLevel.DEBUG,
+  message: '',
+  timestamp: timestampFromDate(new Date(0)),
+});
 
 const shortFile = (file?: string) => file?.split('/').slice(-1).join('/');
 
@@ -32,14 +43,14 @@ export const LoggingPanel = () => {
   // Filtering.
   const [text, setText] = useState('');
   // TODO(burdon): Store in context.
-  const [query, setQuery] = useState<QueryLogsRequest>({});
+  const [query, setQuery] = useState<QueryLogsRequest>(create(QueryLogsRequestSchema));
   const handleSearchChange = useCallback((text: string) => {
     setText(text);
     if (!text) {
-      setQuery({});
+      setQuery(create(QueryLogsRequestSchema));
     }
 
-    setQuery({ filters: parseFilter(text) });
+    setQuery(create(QueryLogsRequestSchema, { filters: parseFilter(text) }));
   }, []);
 
   // Logs.
@@ -92,8 +103,8 @@ export const LoggingPanel = () => {
 
   const tableData = useMemo(() => {
     return logs.map((entry, index) => ({
-      id: `${entry.timestamp}-${index}`, // Stable ID based on position and timestamp
-      timestamp: entry.timestamp,
+      id: `${entry.timestamp?.seconds}-${index}`, // Stable ID based on position and timestamp
+      timestamp: entry.timestamp && timestampDate(entry.timestamp),
       level: Object.entries(levels)
         .find(([, level]) => level === entry.level)?.[0]
         .toUpperCase(),

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
@@ -6,8 +6,10 @@ import React, { type FC, useCallback, useMemo } from 'react';
 
 import { Format } from '@dxos/echo/Format';
 import { PublicKey } from '@dxos/keys';
+import { toPublicKey } from '@dxos/protocols/buf';
+import { type SubscribeToSpacesResponse_SpaceInfo } from '@dxos/protocols/buf/dxos/devtools/host_pb';
+import { type PublicKey as BufPublicKey } from '@dxos/protocols/buf/dxos/keys_pb';
 import { type Space as SpaceProto } from '@dxos/protocols/proto/dxos/client/services';
-import { type SubscribeToSpacesResponse } from '@dxos/protocols/proto/dxos/devtools/host';
 import { DynamicTable, type TableFeatures, type TablePropertyDefinition } from '@dxos/react-ui-table';
 import { Timeframe } from '@dxos/timeframe';
 import { ComplexSet } from '@dxos/util';
@@ -29,7 +31,7 @@ export type PipelineTableRow = {
 
 export type PipelineTableProps = {
   state: SpaceProto.PipelineState;
-  metadata: SubscribeToSpacesResponse.SpaceInfo | undefined;
+  metadata: SubscribeToSpacesResponse_SpaceInfo | undefined;
   onSelect?: (feed: PipelineTableRow | undefined) => void;
 };
 
@@ -62,10 +64,14 @@ export const PipelineTable: FC<PipelineTableProps> = ({ state, metadata, onSelec
   );
 
   const getType = (feedKey: PublicKey) => {
+    const matches = (key: BufPublicKey | undefined) => {
+      const other = toPublicKey(key);
+      return other !== undefined && feedKey.equals(other);
+    };
     if (metadata) {
       return {
-        genesis: feedKey.equals(metadata?.genesisFeed),
-        own: feedKey.equals(metadata?.controlFeed) || feedKey.equals(metadata?.dataFeed),
+        genesis: matches(metadata?.genesisFeed),
+        own: matches(metadata?.controlFeed) || matches(metadata?.dataFeed),
       };
     }
 

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SpaceInfo.tst.ts
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SpaceInfo.tst.ts
@@ -1,0 +1,45 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, it } from 'tstyche';
+
+import { type SubscribeToSpacesResponse_SpaceInfo } from '@dxos/protocols/buf/dxos/devtools/host_pb';
+import { type SubscribeToSpacesResponse as LegacyResponse } from '@dxos/protocols/proto/dxos/devtools/host';
+
+import { useSpacesInfo } from '../../../hooks';
+import { type PipelineTableProps } from './PipelineTable';
+import { SpaceProperties } from './SpaceProperties';
+
+// Carrier group A: `DevtoolsHost.subscribeToSpaces` moved to `bufMessage`, so these pin the type the
+// carrier hands over rather than the annotation the panels happen to write.
+
+declare const info: SubscribeToSpacesResponse_SpaceInfo;
+
+describe('SubscribeToSpacesResponse.SpaceInfo (group A)', () => {
+  it('reaches both panels as the buf message', () => {
+    expect(useSpacesInfo()).type.toBe<SubscribeToSpacesResponse_SpaceInfo[]>();
+    expect<PipelineTableProps['metadata']>().type.toBe<SubscribeToSpacesResponse_SpaceInfo | undefined>();
+    expect(SpaceProperties).type.toBeAssignableTo<
+      (props: { space: any; metadata: SubscribeToSpacesResponse_SpaceInfo }) => any
+    >();
+  });
+
+  it('carries `$typeName`', () => {
+    expect(info.$typeName).type.toBe<'dxos.devtools.host.SubscribeToSpacesResponse.SpaceInfo'>();
+  });
+
+  it('carries the substituted fields as buf shapes, not domain classes', () => {
+    // `key` was a `@dxos/keys` `PublicKey` under protobuf.js; `timeframe` was a `Timeframe` with
+    // arithmetic on it. Both are now plain messages, which is why the call sites convert.
+    expect(info.key).type.not.toBeAssignableTo<{ equals: (other: unknown) => boolean } | undefined>();
+    expect(info.key?.data).type.toBe<Uint8Array | undefined>();
+    expect(info.timeframe).type.not.toBeAssignableTo<{ totalMessages: () => number } | undefined>();
+    expect(info.timeframe?.frames[0].feedKey).type.toBe<Uint8Array | undefined>();
+    expect(info.timeframe?.$typeName).type.toBe<'dxos.echo.timeframe.TimeframeVector' | undefined>();
+  });
+
+  it('is no longer the protobuf.js type', () => {
+    expect<LegacyResponse['spaces']>().type.not.toBeAssignableTo<SubscribeToSpacesResponse_SpaceInfo[]>();
+  });
+});

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SpaceInfoPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SpaceInfoPanel.tsx
@@ -5,6 +5,7 @@
 import React, { type FC, useMemo, useState } from 'react';
 
 import { MulticastObservable } from '@dxos/async';
+import { toPublicKey } from '@dxos/protocols/buf';
 import { SpaceState } from '@dxos/protocols/buf/dxos/client/invitation_pb';
 import { EdgeReplicationSetting } from '@dxos/protocols/buf/dxos/echo/metadata_pb';
 import { type Space } from '@dxos/react-client/echo';
@@ -32,7 +33,7 @@ export const SpaceInfoPanel: FC<SpaceInfoPanelProps> = (props) => {
 
   // TODO(dmaretskyi): We don't need SpaceInfo anymore?
   const spacesInfo = useSpacesInfo();
-  const metadata = space?.key && spacesInfo.find((info) => info.key.equals(space?.key));
+  const metadata = space?.key && spacesInfo.find((info) => toPublicKey(info.key)?.equals(space?.key));
   const pipelineState = useMulticastObservable(space?.pipeline ?? MulticastObservable.empty());
 
   const toggleActive = async () => {

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SpaceProperties.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SpaceProperties.tsx
@@ -6,14 +6,15 @@ import React, { type FC, useMemo } from 'react';
 
 import { MulticastObservable } from '@dxos/async';
 import { type Space } from '@dxos/client/echo';
+import { toPublicKey } from '@dxos/protocols/buf';
 import { SpaceState } from '@dxos/protocols/buf/dxos/client/invitation_pb';
-import { type SubscribeToSpacesResponse } from '@dxos/protocols/proto/dxos/devtools/host';
+import { type SubscribeToSpacesResponse_SpaceInfo } from '@dxos/protocols/buf/dxos/devtools/host_pb';
 import { useMulticastObservable } from '@dxos/react-hooks';
 import { Timeframe } from '@dxos/timeframe';
 
 import { PropertiesTable, PropertySchemaFormat } from '../../../components';
 
-export const SpaceProperties: FC<{ space: Space; metadata: SubscribeToSpacesResponse.SpaceInfo }> = ({
+export const SpaceProperties: FC<{ space: Space; metadata: SubscribeToSpacesResponse_SpaceInfo }> = ({
   space,
   metadata,
 }) => {
@@ -45,7 +46,7 @@ export const SpaceProperties: FC<{ space: Space; metadata: SubscribeToSpacesResp
     const startupTime = open && ready && ready.getTime() - open.getTime();
 
     return {
-      key: metadata.key,
+      key: toPublicKey(metadata.key),
       state: SpaceState[space.state.get()],
       startupTime,
       controlProgress,

--- a/packages/devtools/devtools/src/panels/mesh/NetworkPanel/NetworkPanel.tst.ts
+++ b/packages/devtools/devtools/src/panels/mesh/NetworkPanel/NetworkPanel.tst.ts
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, it } from 'tstyche';
+
+import { type PeerState } from '@dxos/protocols/buf/dxos/mesh/presence_pb';
+import { type PeerState as LegacyPeerState } from '@dxos/protocols/proto/dxos/mesh/presence';
+
+import { type NetworkGraphNode } from './NetworkPanel';
+
+// A green build only proves the annotation compiles. These pin that the annotated type is the buf
+// message — `$typeName` is the discriminator a structurally similar protobuf.js value cannot carry
+// — and that the substituted field moved with it.
+
+declare const node: NetworkGraphNode;
+declare const peer: NonNullable<NetworkGraphNode['peer']>;
+
+describe('NetworkPanel PeerState', () => {
+  it('is the buf message', () => {
+    expect(node.peer).type.toBeAssignableTo<PeerState | undefined>();
+    expect(peer.$typeName).type.toBe<'dxos.mesh.presence.PeerState'>();
+  });
+
+  it('carries `peerId` as the buf key message, not the domain key class', () => {
+    // protobuf.js substituted `dxos.keys.PublicKey` for the `PublicKey` class, which is why
+    // `.truncate()` at the call site had to move to an explicit conversion.
+    expect(peer.peerId).type.toBeAssignableTo<{ data: Uint8Array } | undefined>();
+    expect(peer.peerId).type.not.toBeAssignableTo<{ truncate: () => string } | undefined>();
+  });
+
+  it('is no longer the protobuf.js type', () => {
+    // Guards against the two types being structurally interchangeable, which would make the
+    // conversion above vacuous.
+    expect<LegacyPeerState>().type.not.toBeAssignableTo<PeerState>();
+  });
+});

--- a/packages/devtools/devtools/src/panels/mesh/NetworkPanel/NetworkPanel.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/NetworkPanel/NetworkPanel.tsx
@@ -4,7 +4,8 @@
 
 import React, { useMemo, useRef } from 'react';
 
-import { type PeerState } from '@dxos/protocols/proto/dxos/mesh/presence';
+import { toPublicKey } from '@dxos/protocols/buf';
+import { type PeerState } from '@dxos/protocols/buf/dxos/mesh/presence_pb';
 import { type Space, type SpaceMember, useMembers } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
 import { Panel, Toolbar } from '@dxos/react-ui';
@@ -95,7 +96,7 @@ export const NetworkPanel = (props: { space?: Space }) => {
                   node.data!.member?.identity.profile?.displayName ??
                   node.data!.member?.identity.identityKey.truncate();
 
-                const peer = node.data!.peer?.peerId?.truncate();
+                const peer = toPublicKey(node.data!.peer?.peerId)?.truncate();
                 return `${peer} [${identity}]`;
               },
             }}

--- a/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalMessageTable.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalMessageTable.tsx
@@ -2,11 +2,17 @@
 // Copyright 2023 DXOS.org
 //
 
+import { fromBinary } from '@bufbuild/protobuf';
+import { timestampDate } from '@bufbuild/protobuf/wkt';
 import React, { type FC, useEffect, useMemo, useState } from 'react';
 
 import { Format } from '@dxos/echo/Format';
+import { toPublicKey } from '@dxos/protocols/buf';
+import { bufRegistry } from '@dxos/protocols/buf-registry';
 import { ConnectionState } from '@dxos/protocols/buf/dxos/client/services_pb';
-import { type SignalResponse } from '@dxos/protocols/proto/dxos/devtools/host';
+import { type SignalResponse } from '@dxos/protocols/buf/dxos/devtools/host_pb';
+import { AcknowledgementSchema, ReliablePayloadSchema } from '@dxos/protocols/buf/dxos/mesh/messaging_pb';
+import { type Message as SignalMessage, type SwarmEvent } from '@dxos/protocols/buf/dxos/mesh/signal_pb';
 import { PublicKey, useClient } from '@dxos/react-client';
 import { useDevtools } from '@dxos/react-client/devtools';
 import { useNetworkStatus } from '@dxos/react-client/mesh';
@@ -14,6 +20,49 @@ import { Toolbar } from '@dxos/react-ui';
 import { type TablePropertyDefinition } from '@dxos/react-ui-table';
 
 import { MasterDetailTable, Searchbar, Select } from '../../../components';
+
+const ACKNOWLEDGEMENT = 'dxos.mesh.messaging.Acknowledgement';
+const RELIABLE_PAYLOAD = 'dxos.mesh.messaging.ReliablePayload';
+
+const swarmEventOf = (response: SignalResponse): SwarmEvent | undefined =>
+  response.data.case === 'swarmEvent' ? response.data.value : undefined;
+
+const messageOf = (response: SignalResponse): SignalMessage | undefined =>
+  response.data.case === 'message' ? response.data.value : undefined;
+
+const receivedAtOf = (response: SignalResponse): Date | undefined =>
+  response.receivedAt && timestampDate(response.receivedAt);
+
+/** Reads the message id out of the still-packed payload; the envelope only carries bytes. */
+const messageIdOf = (message: SignalMessage | undefined): string | undefined => {
+  switch (message?.payload?.typeUrl) {
+    case RELIABLE_PAYLOAD:
+      return toPublicKey(fromBinary(ReliablePayloadSchema, message.payload.value).messageId)?.toString();
+    case ACKNOWLEDGEMENT:
+      return toPublicKey(fromBinary(AcknowledgementSchema, message.payload.value).messageId)?.toString();
+    default:
+      return undefined;
+  }
+};
+
+/**
+ * Reads `topic` off the payload nested inside a `ReliablePayload`.
+ *
+ * Display only, and resolved against the registry rather than assumed: the inner payload is an
+ * `Any` whose type varies by sender, and nothing here re-encodes what it decodes.
+ */
+const topicOf = (message: SignalMessage | undefined): unknown => {
+  if (message?.payload?.typeUrl !== RELIABLE_PAYLOAD) {
+    return undefined;
+  }
+  const inner = fromBinary(ReliablePayloadSchema, message.payload.value).payload;
+  const desc = inner && bufRegistry.getMessage(inner.typeUrl);
+  if (!desc || !inner) {
+    return undefined;
+  }
+  const decoded: Record<string, unknown> = fromBinary(desc, inner.value);
+  return decoded.topic;
+};
 
 export type View<T> = {
   id: string;
@@ -28,9 +77,7 @@ const views: View<SignalResponse>[] = [
   {
     id: 'swarm-event',
     title: 'SwarmEvent',
-    filter: (response: SignalResponse) => {
-      return !!response.swarmEvent;
-    },
+    filter: (response: SignalResponse) => swarmEventOf(response)?.event.case !== undefined,
 
     // TODO(burdon): Fixed width for date.
     // TODO(burdon): Add id property (can't use date?) Same for swarm panel.
@@ -58,24 +105,24 @@ const views: View<SignalResponse>[] = [
       { name: 'since', format: Format.TypeFormat.DateTime, size: 194 },
       { name: 'topic', format: Format.TypeFormat.DID },
     ],
-    dataTransform: (response: SignalResponse) => ({
-      id: `${response.receivedAt?.getTime()}-${Math.random()}`,
-      receivedAt: response.receivedAt,
-      response: response.swarmEvent?.peerAvailable ? 'Available' : response.swarmEvent?.peerLeft ? 'Left' : undefined,
-      peer:
-        (response.swarmEvent!.peerAvailable && PublicKey.from(response.swarmEvent!.peerAvailable.peer).toString()) ||
-        (response.swarmEvent!.peerLeft && PublicKey.from(response.swarmEvent!.peerLeft.peer).toString()),
-      since: response.swarmEvent!.peerAvailable?.since ?? new Date(),
-      topic: response.topic && PublicKey.from(response.topic).toString(),
-      _original: response,
-    }),
+    dataTransform: (response: SignalResponse) => {
+      const event = swarmEventOf(response)?.event;
+      const receivedAt = receivedAtOf(response);
+      return {
+        id: `${receivedAt?.getTime()}-${Math.random()}`,
+        receivedAt,
+        response: event?.case === 'peerAvailable' ? 'Available' : event?.case === 'peerLeft' ? 'Left' : undefined,
+        peer: event?.value && PublicKey.from(event.value.peer).toString(),
+        since: (event?.case === 'peerAvailable' && event.value.since && timestampDate(event.value.since)) || new Date(),
+        topic: response.topic && PublicKey.from(response.topic).toString(),
+        _original: response,
+      };
+    },
   },
   {
     id: 'message',
     title: 'Message',
-    filter: (response: SignalResponse) => {
-      return !!response.message;
-    },
+    filter: (response: SignalResponse) => messageOf(response) !== undefined,
     properties: [
       {
         name: 'receivedAt',
@@ -88,22 +135,25 @@ const views: View<SignalResponse>[] = [
       { name: 'message', format: Format.TypeFormat.DID },
       { name: 'topic', format: Format.TypeFormat.DID },
     ],
-    dataTransform: (response: SignalResponse) => ({
-      id: `${response.receivedAt?.getTime()}-${Math.random()}`,
-      receivedAt: response.receivedAt,
-      author: PublicKey.from(response.message!.author).toString(),
-      recipient: PublicKey.from(response.message!.recipient).toString(),
-      message: response.message!.payload.messageId,
-      topic: response.message!.payload?.payload?.topic,
-      _original: response,
-    }),
+    dataTransform: (response: SignalResponse) => {
+      const message = messageOf(response);
+      const receivedAt = receivedAtOf(response);
+      return {
+        id: `${receivedAt?.getTime()}-${Math.random()}`,
+        receivedAt,
+        author: message && PublicKey.from(message.author).toString(),
+        recipient: message && PublicKey.from(message.recipient).toString(),
+        message: messageIdOf(message),
+        topic: topicOf(message),
+        _original: response,
+      };
+    },
   },
   {
     id: 'ack',
     title: 'Acknowledgement',
-    filter: (response: SignalResponse) => {
-      return response.message?.payload['@type'] === 'dxos.mesh.messaging.Acknowledgement';
-    },
+    // The payload stays packed, so the discriminator is its `type_url` rather than a decoded tag.
+    filter: (response: SignalResponse) => messageOf(response)?.payload?.typeUrl === ACKNOWLEDGEMENT,
     properties: [
       {
         name: 'receivedAt',
@@ -115,14 +165,18 @@ const views: View<SignalResponse>[] = [
       { name: 'recipient', format: Format.TypeFormat.DID },
       { name: 'message', format: Format.TypeFormat.DID },
     ],
-    dataTransform: (response: SignalResponse) => ({
-      id: `${response.receivedAt?.getTime()}-${Math.random()}`,
-      receivedAt: response.receivedAt,
-      author: PublicKey.from(response.message!.author).toString(),
-      recipient: PublicKey.from(response.message!.recipient).toString(),
-      message: response.message!.payload.messageId,
-      _original: response,
-    }),
+    dataTransform: (response: SignalResponse) => {
+      const message = messageOf(response);
+      const receivedAt = receivedAtOf(response);
+      return {
+        id: `${receivedAt?.getTime()}-${Math.random()}`,
+        receivedAt,
+        author: message && PublicKey.from(message.author).toString(),
+        recipient: message && PublicKey.from(message.recipient).toString(),
+        message: messageIdOf(message),
+        _original: response,
+      };
+    },
   },
 ];
 

--- a/packages/plugins/plugin-debug/src/containers/DebugStatus/DebugStatus.tsx
+++ b/packages/plugins/plugin-debug/src/containers/DebugStatus/DebugStatus.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { TimeoutError } from '@dxos/async';
 import { StatusBar } from '@dxos/plugin-status-bar/components';
-import { ConnectionState } from '@dxos/protocols/proto/dxos/client/services';
+import { ConnectionState } from '@dxos/protocols/buf/dxos/client/services_pb';
 import { useNetworkStatus } from '@dxos/react-client/mesh';
 import { IconButton } from '@dxos/react-ui';
 

--- a/packages/sdk/client-protocol/src/service.ts
+++ b/packages/sdk/client-protocol/src/service.ts
@@ -7,6 +7,7 @@ import type { Stream } from '@dxos/async';
 import type { RequestOptions } from '@dxos/codec-protobuf';
 import { getBufService } from '@dxos/protocols/buf-service';
 import { Config } from '@dxos/protocols/buf/dxos/config_pb';
+import type { SignalResponse } from '@dxos/protocols/buf/dxos/devtools/host_pb';
 import type {
   CreateEpochResponse,
   Device,
@@ -27,7 +28,6 @@ import type {
 import type {
   GetSpaceSnapshotResponse,
   SaveSpaceSnapshotResponse,
-  SignalResponse,
   SubscribeToFeedBlocksResponse,
   SubscribeToMetadataResponse,
   SubscribeToSpacesResponse,

--- a/packages/sdk/client-protocol/src/service.ts
+++ b/packages/sdk/client-protocol/src/service.ts
@@ -6,6 +6,7 @@ import { type Event } from '@dxos/async';
 import type { Stream } from '@dxos/async';
 import type { RequestOptions } from '@dxos/codec-protobuf';
 import { getBufService } from '@dxos/protocols/buf-service';
+import type { LogEntry, QueryLogsRequest } from '@dxos/protocols/buf/dxos/client/logging_pb';
 import { Config } from '@dxos/protocols/buf/dxos/config_pb';
 import type { SignalResponse, SubscribeToSpacesResponse } from '@dxos/protocols/buf/dxos/devtools/host_pb';
 import type {
@@ -14,13 +15,11 @@ import type {
   Identity,
   Invitation,
   JoinSpaceResponse,
-  LogEntry,
   NetworkStatus,
   Platform,
   QueryAgentStatusResponse,
   QueryEdgeStatusResponse,
   QueryInvitationsResponse,
-  QueryLogsRequest,
   QuerySpacesResponse,
   RecoverIdentityRequest,
   Space,

--- a/packages/sdk/client-protocol/src/service.ts
+++ b/packages/sdk/client-protocol/src/service.ts
@@ -7,7 +7,7 @@ import type { Stream } from '@dxos/async';
 import type { RequestOptions } from '@dxos/codec-protobuf';
 import { getBufService } from '@dxos/protocols/buf-service';
 import { Config } from '@dxos/protocols/buf/dxos/config_pb';
-import type { SignalResponse } from '@dxos/protocols/buf/dxos/devtools/host_pb';
+import type { SignalResponse, SubscribeToSpacesResponse } from '@dxos/protocols/buf/dxos/devtools/host_pb';
 import type {
   CreateEpochResponse,
   Device,
@@ -30,7 +30,6 @@ import type {
   SaveSpaceSnapshotResponse,
   SubscribeToFeedBlocksResponse,
   SubscribeToMetadataResponse,
-  SubscribeToSpacesResponse,
 } from '@dxos/protocols/proto/dxos/devtools/host';
 import type { IndexConfig } from '@dxos/protocols/proto/dxos/echo/indexing';
 import type {

--- a/packages/sdk/client-services/src/packlets/devices/devices-service.ts
+++ b/packages/sdk/client-services/src/packlets/devices/devices-service.ts
@@ -36,7 +36,7 @@ export class DevicesServiceImpl implements DevicesService.Handlers {
           void emit.single({ devices: [] });
         } else {
           invariant(this._identityManager.identity?.presence, 'presence not present');
-          const peers = this._identityManager.identity.presence.getPeersOnline();
+          const identityPresence = this._identityManager.identity.presence;
           void emit.single({
             devices: Array.from(deviceKeys.entries()).map(([key, profile]) => {
               const isMe = this._identityManager.identity?.deviceKey.equals(key);
@@ -49,9 +49,10 @@ export class DevicesServiceImpl implements DevicesService.Handlers {
                     ? Device.PresenceState.ONLINE
                     : Device.PresenceState.OFFLINE;
               } else {
-                presence = peers.some((peer) => peer.identityKey.equals(key))
-                  ? Device.PresenceState.ONLINE
-                  : Device.PresenceState.OFFLINE;
+                presence =
+                  identityPresence.getPeersByIdentityKey(key).length > 0
+                    ? Device.PresenceState.ONLINE
+                    : Device.PresenceState.OFFLINE;
               }
 
               return {

--- a/packages/sdk/client-services/src/packlets/devtools/devtools.ts
+++ b/packages/sdk/client-services/src/packlets/devtools/devtools.ts
@@ -9,13 +9,12 @@ import { Event as AsyncEvent } from '@dxos/async';
 import { type Config } from '@dxos/config';
 import { Context } from '@dxos/context';
 import { EffectEx } from '@dxos/effect';
-import { type SignalResponse } from '@dxos/protocols/buf/dxos/devtools/host_pb';
+import { type SignalResponse, type SubscribeToSpacesResponse } from '@dxos/protocols/buf/dxos/devtools/host_pb';
 import {
   type GetSpaceSnapshotResponse,
   type SaveSpaceSnapshotResponse,
   type SubscribeToFeedBlocksResponse,
   type SubscribeToMetadataResponse,
-  type SubscribeToSpacesResponse,
 } from '@dxos/protocols/proto/dxos/devtools/host';
 import { type DevtoolsHost } from '@dxos/protocols/rpc';
 

--- a/packages/sdk/client-services/src/packlets/devtools/devtools.ts
+++ b/packages/sdk/client-services/src/packlets/devtools/devtools.ts
@@ -9,10 +9,10 @@ import { Event as AsyncEvent } from '@dxos/async';
 import { type Config } from '@dxos/config';
 import { Context } from '@dxos/context';
 import { EffectEx } from '@dxos/effect';
+import { type SignalResponse } from '@dxos/protocols/buf/dxos/devtools/host_pb';
 import {
   type GetSpaceSnapshotResponse,
   type SaveSpaceSnapshotResponse,
-  type SignalResponse,
   type SubscribeToFeedBlocksResponse,
   type SubscribeToMetadataResponse,
   type SubscribeToSpacesResponse,

--- a/packages/sdk/client-services/src/packlets/devtools/network.ts
+++ b/packages/sdk/client-services/src/packlets/devtools/network.ts
@@ -2,6 +2,8 @@
 // Copyright 2020 DXOS.org
 //
 
+import { type MessageInitShape, create } from '@bufbuild/protobuf';
+import { AnySchema, timestampFromDate } from '@bufbuild/protobuf/wkt';
 import * as Effect from 'effect/Effect';
 import * as EffectStream from 'effect/Stream';
 
@@ -11,7 +13,8 @@ import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { type SignalManager, type UnsubscribeCallback } from '@dxos/messaging';
 import { type SwarmNetworkManager } from '@dxos/network-manager';
-import { type SignalResponse } from '@dxos/protocols/proto/dxos/devtools/host';
+import { type SignalResponse, SignalResponseSchema } from '@dxos/protocols/buf/dxos/devtools/host_pb';
+import { SwarmEventSchema } from '@dxos/protocols/buf/dxos/mesh/signal_pb';
 import { type DevtoolsHost } from '@dxos/protocols/rpc';
 
 export const subscribeToNetworkStatus = ({
@@ -54,16 +57,26 @@ export const subscribeToSignal = ({
         .subscribeMessages({
           peer,
           onMessage: (message) => {
-            emit.single({
-              message: {
-                author: PublicKey.from(message.author.peerKey).asUint8Array(),
-                recipient: message.recipient
-                  ? PublicKey.from(message.recipient.peerKey).asUint8Array()
-                  : new Uint8Array(),
-                payload: message.payload,
-              },
-              receivedAt: new Date(),
-            });
+            emit.single(
+              create(SignalResponseSchema, {
+                data: {
+                  case: 'message',
+                  value: {
+                    author: PublicKey.from(message.author.peerKey).asUint8Array(),
+                    recipient: message.recipient
+                      ? PublicKey.from(message.recipient.peerKey).asUint8Array()
+                      : new Uint8Array(),
+                    // Messaging keeps payloads packed and dispatches on `type_url`, so this is a
+                    // field map — the payload is never resolved here.
+                    payload: create(AnySchema, {
+                      typeUrl: message.payload.type_url,
+                      value: message.payload.value,
+                    }),
+                  },
+                },
+                receivedAt: timestampFromDate(new Date()),
+              }),
+            );
           },
         })
         .then((unsub) => {
@@ -77,18 +90,26 @@ export const subscribeToSignal = ({
     }
 
     signalManager.swarmEvent.on(ctx, (swarmEvent) => {
-      emit.single({
-        swarmEvent: swarmEvent.peerAvailable
-          ? {
-              peerAvailable: {
-                peer: PublicKey.from(swarmEvent.peerAvailable.peer.peerKey).asUint8Array(),
-                since: swarmEvent.peerAvailable.since,
-              },
-            }
-          : { peerLeft: { peer: PublicKey.from(swarmEvent.peerLeft!.peer.peerKey).asUint8Array() } },
-        topic: swarmEvent.topic.asUint8Array(),
-        receivedAt: new Date(),
-      });
+      const { peerAvailable, peerLeft } = swarmEvent;
+      const event: MessageInitShape<typeof SwarmEventSchema>['event'] = peerAvailable
+        ? {
+            case: 'peerAvailable',
+            value: {
+              peer: PublicKey.from(peerAvailable.peer.peerKey).asUint8Array(),
+              since: peerAvailable.since && timestampFromDate(peerAvailable.since),
+            },
+          }
+        : peerLeft
+          ? { case: 'peerLeft', value: { peer: PublicKey.from(peerLeft.peer.peerKey).asUint8Array() } }
+          : { case: undefined };
+
+      emit.single(
+        create(SignalResponseSchema, {
+          data: { case: 'swarmEvent', value: create(SwarmEventSchema, { event }) },
+          topic: swarmEvent.topic.asUint8Array(),
+          receivedAt: timestampFromDate(new Date()),
+        }),
+      );
     });
 
     return Effect.promise(async () => {

--- a/packages/sdk/client-services/src/packlets/devtools/spaces.ts
+++ b/packages/sdk/client-services/src/packlets/devtools/spaces.ts
@@ -2,11 +2,18 @@
 // Copyright 2020 DXOS.org
 //
 
+import { create } from '@bufbuild/protobuf';
 import * as Effect from 'effect/Effect';
 import * as EffectStream from 'effect/Stream';
 
 import { EffectEx } from '@dxos/effect';
-import { type SubscribeToSpacesResponse } from '@dxos/protocols/proto/dxos/devtools/host';
+import { fromPublicKey, fromTimeframe } from '@dxos/protocols/buf';
+import {
+  type SubscribeToSpacesResponse,
+  type SubscribeToSpacesResponse_SpaceInfo,
+  SubscribeToSpacesResponseSchema,
+  SubscribeToSpacesResponse_SpaceInfoSchema,
+} from '@dxos/protocols/buf/dxos/devtools/host_pb';
 import { type SpaceMetadata } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { type DevtoolsHost } from '@dxos/protocols/rpc';
 
@@ -26,22 +33,26 @@ export const subscribeToSpaces = (
         (space) => !spaceKeys?.length || spaceKeys.some((spaceKey) => spaceKey.equals(space.key)),
       );
 
-      emit.single({
-        spaces: filteredSpaces.map((space): SubscribeToSpacesResponse.SpaceInfo => {
-          const spaceMetadata = context.metadataStore.spaces.find((spaceMetadata: SpaceMetadata) =>
-            spaceMetadata.key.equals(space.key),
-          );
+      emit.single(
+        create(SubscribeToSpacesResponseSchema, {
+          spaces: filteredSpaces.map((space): SubscribeToSpacesResponse_SpaceInfo => {
+            const spaceMetadata = context.metadataStore.spaces.find((spaceMetadata: SpaceMetadata) =>
+              spaceMetadata.key.equals(space.key),
+            );
 
-          return {
-            key: space.key,
-            isOpen: space.isOpen,
-            timeframe: spaceMetadata?.dataTimeframe,
-            genesisFeed: space.genesisFeedKey,
-            controlFeed: space.controlFeedKey!, // TODO(dmaretskyi): Those keys may be missing.
-            dataFeed: space.dataFeedKey!,
-          };
+            return create(SubscribeToSpacesResponse_SpaceInfoSchema, {
+              key: fromPublicKey(space.key),
+              isOpen: space.isOpen,
+              timeframe: spaceMetadata?.dataTimeframe && fromTimeframe(spaceMetadata.dataTimeframe),
+              genesisFeed: fromPublicKey(space.genesisFeedKey),
+              // The write feeds are absent until the space is opened for writing; buf makes that
+              // presence explicit where the protobuf.js shape let it pass as a non-null assertion.
+              controlFeed: space.controlFeedKey && fromPublicKey(space.controlFeedKey),
+              dataFeed: space.dataFeedKey && fromPublicKey(space.dataFeedKey),
+            });
+          }),
         }),
-      });
+      );
     };
 
     const timeout = setTimeout(async () => {

--- a/packages/sdk/client-services/src/packlets/diagnostics/diagnostics.ts
+++ b/packages/sdk/client-services/src/packlets/diagnostics/diagnostics.ts
@@ -178,7 +178,7 @@ const getSpaceStats = async (space: DataSpace): Promise<SpaceStats> => {
           },
         },
         presence:
-          space.presence.getPeersOnline().filter(({ identityKey }) => identityKey.equals(member.key)).length > 0
+          space.presence.getPeersByIdentityKey(member.key).length > 0
             ? SpaceMember.PresenceState.ONLINE
             : SpaceMember.PresenceState.OFFLINE,
       })),

--- a/packages/sdk/client-services/src/packlets/logging/logging-service.ts
+++ b/packages/sdk/client-services/src/packlets/logging/logging-service.ts
@@ -2,6 +2,8 @@
 // Copyright 2022 DXOS.org
 //
 
+import { create } from '@bufbuild/protobuf';
+import { timestampFromDate } from '@bufbuild/protobuf/wkt';
 import * as Effect from 'effect/Effect';
 import * as EffectStream from 'effect/Stream';
 
@@ -10,7 +12,13 @@ import { Context } from '@dxos/context';
 import { EffectEx } from '@dxos/effect';
 import { PublicKey } from '@dxos/keys';
 import { type LogLevel, type LogProcessor, type LogEntry as NaturalLogEntry, log } from '@dxos/log';
-import { type LogEntry, QueryLogsRequest } from '@dxos/protocols/proto/dxos/client/services';
+import {
+  type LogEntry,
+  LogEntrySchema,
+  type QueryLogsRequest,
+  type QueryLogsRequest_Filter,
+  QueryLogsRequest_MatchingOptions,
+} from '@dxos/protocols/buf/dxos/client/logging_pb';
 import { type LoggingService } from '@dxos/protocols/rpc';
 import { numericalValues, tracer } from '@dxos/util';
 
@@ -118,11 +126,11 @@ export class LoggingServiceImpl implements LoggingService.Handlers {
           recordContext.error = entry.computedError;
         }
 
-        const record: LogEntry = {
+        const record: LogEntry = create(LogEntrySchema, {
           level: entry.level,
           message: entry.message ?? entry.computedError ?? '',
           context: recordContext,
-          timestamp: new Date(entry.timestamp),
+          timestamp: timestampFromDate(new Date(entry.timestamp)),
           meta: {
             // TODO(dmaretskyi): Fix proto.
             file: filename ?? '',
@@ -133,7 +141,7 @@ export class LoggingServiceImpl implements LoggingService.Handlers {
               name: scopeName ?? '',
             },
           },
-        };
+        });
 
         try {
           LOG_PROCESSING++;
@@ -154,15 +162,15 @@ export class LoggingServiceImpl implements LoggingService.Handlers {
 }
 
 const matchFilter = (
-  filter: QueryLogsRequest.Filter,
+  filter: QueryLogsRequest_Filter,
   level: LogLevel,
   path: string,
-  options: QueryLogsRequest.MatchingOptions,
+  options: QueryLogsRequest_MatchingOptions,
 ) => {
   switch (options) {
-    case QueryLogsRequest.MatchingOptions.INCLUSIVE:
+    case QueryLogsRequest_MatchingOptions.INCLUSIVE:
       return level >= filter.level && (!filter.pattern || path.includes(filter.pattern));
-    case QueryLogsRequest.MatchingOptions.EXPLICIT:
+    case QueryLogsRequest_MatchingOptions.EXPLICIT:
       return level === filter.level && (!filter.pattern || path.includes(filter.pattern));
   }
 };
@@ -171,12 +179,18 @@ const matchFilter = (
  * Determines if the current line should be logged (called by the processor).
  */
 const shouldLog = (entry: NaturalLogEntry, request: QueryLogsRequest): boolean => {
-  const options = request.options ?? QueryLogsRequest.MatchingOptions.INCLUSIVE;
-  if (request.filters === undefined) {
-    return options === QueryLogsRequest.MatchingOptions.INCLUSIVE;
-  } else {
-    return request.filters.some((filter) => matchFilter(filter, entry.level, entry.meta?.F ?? '', options));
+  // buf represents an unset `repeated` as `[]` and an unset enum as its zero value, never
+  // `undefined`, so absence is read off those rather than off `undefined` — the previous
+  // `filters === undefined` branch is unreachable here and an empty filter list would otherwise
+  // flip "log everything" into "log nothing".
+  const options =
+    request.options === undefined || request.options === QueryLogsRequest_MatchingOptions.NONE
+      ? QueryLogsRequest_MatchingOptions.INCLUSIVE
+      : request.options;
+  if (request.filters.length === 0) {
+    return options === QueryLogsRequest_MatchingOptions.INCLUSIVE;
   }
+  return request.filters.some((filter) => matchFilter(filter, entry.level, entry.meta?.F ?? '', options));
 };
 
 /**

--- a/packages/sdk/client-services/src/packlets/logging/logging.test.ts
+++ b/packages/sdk/client-services/src/packlets/logging/logging.test.ts
@@ -2,6 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
+import { create } from '@bufbuild/protobuf';
 import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
 import * as Option from 'effect/Option';
@@ -10,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import { EffectEx } from '@dxos/effect';
 import { LogLevel, log } from '@dxos/log';
+import { QueryLogsRequestSchema } from '@dxos/protocols/buf/dxos/client/logging_pb';
 
 import { LoggingServiceImpl } from './logging-service';
 
@@ -45,7 +47,10 @@ describe('LoggingService', () => {
   test('queryLogs streams logs', async () => {
     const message = 'Hello World!';
     const entry = await EffectEx.runPromise(
-      readWhileEmitting(Stream.runHead(loggingService['LoggingService.queryLogs']({})), () => log(message)),
+      readWhileEmitting(
+        Stream.runHead(loggingService['LoggingService.queryLogs'](create(QueryLogsRequestSchema))),
+        () => log(message),
+      ),
     );
     expect(entry.message).to.eq(message);
     expect(entry.level).to.eq(LogLevel.DEBUG);
@@ -55,7 +60,11 @@ describe('LoggingService', () => {
     const message = 'This is a failure';
     const entry = await EffectEx.runPromise(
       readWhileEmitting(
-        Stream.runHead(loggingService['LoggingService.queryLogs']({ filters: [{ level: LogLevel.ERROR }] })),
+        Stream.runHead(
+          loggingService['LoggingService.queryLogs'](
+            create(QueryLogsRequestSchema, { filters: [{ level: LogLevel.ERROR }] }),
+          ),
+        ),
         () => {
           log('debugging something');
           log.error(message);

--- a/packages/sdk/client-services/src/packlets/space/space-protocol.browser.test.ts
+++ b/packages/sdk/client-services/src/packlets/space/space-protocol.browser.test.ts
@@ -37,12 +37,8 @@ describe('space/space-protocol', () => {
     onTestFinished(() => protocol1.stop(Context.default()));
     onTestFinished(() => protocol2.stop(Context.default()));
 
-    await expect
-      .poll(() => presence1.getPeersOnline().some(({ identityKey }) => identityKey.equals(peer2.identityKey)))
-      .toBeTruthy();
-    await expect
-      .poll(() => presence2.getPeersOnline().some(({ identityKey }) => identityKey.equals(peer1.identityKey)))
-      .toBeTruthy();
+    await expect.poll(() => presence1.getPeersByIdentityKey(peer2.identityKey).length > 0).toBeTruthy();
+    await expect.poll(() => presence2.getPeersByIdentityKey(peer1.identityKey).length > 0).toBeTruthy();
   });
 
   test('replicates a feed', async () => {

--- a/packages/sdk/client-services/src/packlets/space/space-protocol.test.ts
+++ b/packages/sdk/client-services/src/packlets/space/space-protocol.test.ts
@@ -41,12 +41,12 @@ describe('space/space-protocol', () => {
     onTestFinished(() => protocol2.stop(Context.default()));
 
     await expect
-      .poll(() => presence1.getPeersOnline().some(({ identityKey }) => identityKey.equals(peer2.identityKey)), {
+      .poll(() => presence1.getPeersByIdentityKey(peer2.identityKey).length > 0, {
         timeout: 1_000,
       })
       .toBeTruthy();
     await expect
-      .poll(() => presence2.getPeersOnline().some(({ identityKey }) => identityKey.equals(peer1.identityKey)), {
+      .poll(() => presence2.getPeersByIdentityKey(peer1.identityKey).length > 0, {
         timeout: 1_000,
       })
       .toBeTruthy();

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
@@ -49,7 +49,9 @@ import { type KeyringApi, KeyringApiService } from '@dxos/keyring';
 import { PublicKey, type SpaceId } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { AlreadyJoinedError } from '@dxos/protocols';
+import { toPublicKey } from '@dxos/protocols/buf';
 import { type Runtime_Client_EdgeFeatures } from '@dxos/protocols/buf/dxos/config_pb';
+import { type PeerState } from '@dxos/protocols/buf/dxos/mesh/presence_pb';
 import { Invitation, SpaceState } from '@dxos/protocols/proto/dxos/client/services';
 import { type FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { EdgeReplicationSetting, type SpaceMetadata } from '@dxos/protocols/proto/dxos/echo/metadata';
@@ -60,7 +62,6 @@ import {
   SpaceMember,
 } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { type DelegateSpaceInvitation } from '@dxos/protocols/proto/dxos/halo/invitations';
-import { type PeerState } from '@dxos/protocols/proto/dxos/mesh/presence';
 import { type Teleport } from '@dxos/teleport';
 import { Gossip, Presence } from '@dxos/teleport-extension-gossip';
 import { type Timeframe } from '@dxos/timeframe';
@@ -1030,11 +1031,14 @@ export class DataSpaceManager extends Resource {
   private _handleMemberRoleChanges(presence: Presence, spaceProtocol: SpaceProtocol, memberInfo: MemberInfo[]): void {
     let closedSessions = 0;
     for (const member of memberInfo) {
-      if (member.key.equals(presence.getLocalState().identityKey)) {
+      if (member.key.equals(presence.localIdentityKey)) {
         continue;
       }
       const peers = presence.getPeersByIdentityKey(member.key);
-      const sessions = peers.map((p) => p.peerId && spaceProtocol.sessions.get(p.peerId));
+      const sessions = peers.map((peer) => {
+        const peerId = toPublicKey(peer.peerId);
+        return peerId && spaceProtocol.sessions.get(peerId);
+      });
       const sessionsToClose = sessions.filter((s): s is SpaceProtocolSession => {
         return (s && (member.role === SpaceMember.Role.REMOVED) !== (s.authStatus === AuthStatus.FAILURE)) ?? false;
       });
@@ -1053,11 +1057,18 @@ export class DataSpaceManager extends Resource {
   }
 
   private _handleNewPeerConnected(space: Space, peerState: PeerState): void {
-    const role = space.spaceState.getMemberRole(peerState.identityKey);
+    // `PeerState` is the wire message the gossip channel carries; the space state machine and
+    // the session map are keyed by the domain key type.
+    const identityKey = toPublicKey(peerState.identityKey);
+    const peerId = toPublicKey(peerState.peerId);
+    if (!identityKey) {
+      return;
+    }
+    const role = space.spaceState.getMemberRole(identityKey);
     if (role === SpaceMember.Role.REMOVED) {
-      const session = peerState.peerId && space.protocol.sessions.get(peerState.peerId);
+      const session = peerId && space.protocol.sessions.get(peerId);
       if (session != null) {
-        log('closing a session with a removed peer', { peerId: peerState.peerId });
+        log('closing a session with a removed peer', { peerId });
         void session.close().catch(log.error);
       }
     }

--- a/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
@@ -3,6 +3,7 @@
 //
 
 import type { AutomergeUrl } from '@automerge/automerge-repo';
+import { toBinary } from '@bufbuild/protobuf';
 import * as Effect from 'effect/Effect';
 import * as EffectStream from 'effect/Stream';
 
@@ -31,6 +32,8 @@ import {
   encodeError,
   makeInProcessClient,
 } from '@dxos/protocols';
+import { decodeCompat } from '@dxos/protocols/buf-shape-compat';
+import { PeerStateSchema } from '@dxos/protocols/buf/dxos/mesh/presence_pb';
 import {
   type ContactAdmission,
   type CreateEpochResponse,
@@ -525,7 +528,7 @@ export class SpacesServiceImpl implements SpacesService.Handlers {
       },
       members: await Promise.all(
         Array.from(space.inner.spaceState.members.values()).map(async (member) => {
-          const peers = space.presence.getPeersOnline().filter(({ identityKey }) => identityKey.equals(member.key));
+          const peers = space.presence.getPeersByIdentityKey(member.key);
           const isMe = this._identityManager.identity?.identityKey.equals(member.key);
 
           if (isMe) {
@@ -540,7 +543,9 @@ export class SpacesServiceImpl implements SpacesService.Handlers {
             },
             role: member.role,
             presence: peers.length > 0 ? SpaceMember.PresenceState.ONLINE : SpaceMember.PresenceState.OFFLINE,
-            peerStates: peers,
+            // `Space` is still `protoMessage`-carried, so presence's buf messages convert back
+            // here — one boundary, via the codec rather than a hand-written field map.
+            peerStates: peers.map((peer) => decodeCompat(PeerStateSchema, toBinary(PeerStateSchema, peer))),
           };
         }),
       ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3508,7 +3508,7 @@ importers:
     dependencies:
       debug:
         specifier: 'catalog:'
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       domain-browser:
         specifier: 'catalog:'
         version: 4.22.0
@@ -6960,6 +6960,9 @@ importers:
 
   packages/devtools/devtools:
     dependencies:
+      '@bufbuild/protobuf':
+        specifier: 'catalog:'
+        version: 2.11.0
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6539,6 +6539,9 @@ importers:
 
   packages/core/mesh/teleport-extension-gossip:
     dependencies:
+      '@bufbuild/protobuf':
+        specifier: 'catalog:'
+        version: 2.11.0
       '@dxos/async':
         specifier: workspace:*
         version: link:../../../common/async


### PR DESCRIPTION
## Status: in progress — do not merge

Second pass on **#5**, layered onto the two already-landed commits. The PR's original framing
("2 converted, 15 blocked") was a correct diagnosis under the old mandate; the mandate then changed
to *fix* the blockers. This body tracks current state and is rewritten as work lands.

Commit order is deliberate: upstream/producer moves first, devtools conversions on top, so a
reviewer can see the panels only compile *because* the upstream moved.

---

## #5 — 6 of 15 declarations converted

**Read the carrier column, not the count.** Two of the three landed by moving a *carrier*, not by
editing a panel, and several remaining declarations share one. 12 declarations remain across **8
carrier groups**, so the work lands in jumps rather than one file at a time.

| # | File | Declaration | Carrier | Status |
| --- | --- | --- | --- | --- |
| 5 | `hooks/useSignal.tsx` | `SignalResponse` | `DevtoolsHost.subscribeToSignal` | ✅ `bufMessage` |
| 15 | `panels/mesh/SignalPanel/SignalMessageTable.tsx` | `SignalResponse` | ↑ same carrier | ✅ |
| 14 | `panels/mesh/NetworkPanel/NetworkPanel.tsx` | `PeerState` | gossip `Presence` (producer) | ✅ buf at producer |
| 10 | `panels/echo/SpaceInfoPanel/PipelineTable.tsx` | `SubscribeToSpacesResponse` | `DevtoolsHost.subscribeToSpaces` | ✅ group A |
| 11 | `panels/echo/SpaceInfoPanel/SpaceProperties.tsx` | `SubscribeToSpacesResponse` | ↑ same carrier | ✅ group A |
| 3 | `hooks/useFeedMessages.tsx` | `SubscribeToFeedBlocksResponse` | `DevtoolsHost.ts:358` | ⬜ group B — embeds `FeedMessage` (#9c) |
| 8 | `panels/echo/FeedsPanel/FeedsPanel.tsx` | `SubscribeToFeedBlocksResponse` | ↑ same carrier | ⬜ group B |
| 4 | `hooks/useMetadata.tsx` | `SubscribeToMetadataResponse` | `DevtoolsHost.ts:363` | ⬜ group C — embeds `EchoMetadata` (#9c) |
| 1 | `components/performance/panels/EdgePanel.tsx` | `QueryEdgeStatusResponse`, `EdgeStatus` | `EdgeAgentService.ts:19` | ⬜ group D — **23 files** via `EdgeStatus` |
| 6 | `hooks/useStats.ts` | `QueryEdgeStatusResponse` | ↑ same carrier | ⬜ group D |
| 7 | `panels/client/LoggingPanel/LoggingPanel.tsx` | `LogEntry`, `QueryLogsRequest` | `LoggingService.queryLogs` | ✅ group E |
| 9 | `panels/echo/FeedsPanel/FeedsPanel.tsx` | `Contact` | `ContactsService.ts:18` | ⬜ group F — ~10 files, crosses `client.halo.contacts` |
| 12 | `panels/echo/SpaceInfoPanel/PipelineTable.tsx` | `Space.PipelineState` | `SpacesService.ts:202` | ⬜ group G — embeds `Credential` + `TimeframeVector` |
| 2 | `hooks/useCredentials.tsx` | `Credential` | `SpacesService.queryCredentials` | ⬜ group H — boundary decode (#9d out of scope) |
| 13 | `panels/halo/CredentialsPanel/CredentialsPanel.tsx` | `Credential` | ↑ same carrier | ⬜ group H |

Probes are tstyche type-tests (`moon run devtools:test-types`), not build output: each asserts
`$typeName`, the substituted-field shape, and that the protobuf.js type is **not** assignable to the
buf one — so a conversion passing only because two types are structurally interchangeable fails.
**8 tests / 14 assertions, EXIT=0.**

---

## Commits

**`a5bd17d081`** — devtools enum stragglers (`cli-util`, `plugin-debug`) + audit corrections.

**`e1a31022c3`** — `PeerState` to buf **at the producer** (#8.4). `preserveAny` on the gossip
extension was tried and **reverted**: it forces every channel to hand over a pre-packed `Any`,
breaking the app-facing `space.postMessage` path (`spaces-service.ts:237`) — caught by
`gossip-extension.test.ts`, not by argument. **Wire format unchanged.** Consumer ripple collapsed
rather than papered over: most sites were re-implementing `getPeersByIdentityKey`, which already
takes a domain `PublicKey`. Three genuine boundaries remain.

**`1699294b54`** — `SignalResponse` to `bufMessage`; 17 `swarmEvent` errors handled as
`{case, value}`. No casts; the pre-existing `response.swarmEvent!` assertions disappear because the
union narrows honestly. `Message.payload` is a real `Any` and **stays packed**. Wire unchanged.
Also fixes `useSignal`, whose `useMemo` returned void and shadowed its accumulator.

**`873a4ae3da`** — #2 fate-split + proto-guard pin derivation.

**`ea3965e9b8`** — cross-codec guard scope and its two divergences.

---

## Cross-codec guard — landed (`17465dce27`, corrected by `276ea8db5d`)

Walks the buf registry programmatically: **258 messages, 518 generated cases**, fully-populated
synthesised values. **483/517 → 518/518** once the real divergences were separated from three
generator artefacts.

**What it is not — read this before citing it.** Both codecs regenerate from the same `src/proto`
tree, so a wire-incompatible edit to a `.proto` moves them together and passes here unnoticed. It is
**not a downgrade or compatibility guard** and must not be described as one, or listed alongside
one. Catching a schema break needs bytes from a build predating the edit; the rejected
historical-pin approach and why it failed are in the audit doc. What this does give is continuous
agreement between the two codecs on every CI run. **It dies with protobuf.js at teardown.**

**A defect in the guard itself, found by `moon build` and not by vitest.** It reported 518/518 while
silently skipping **every repeated field**: the walk branched on `field.repeated`, which does not
exist on buf's descriptors — buf models repeated as `fieldKind: 'list'` with a `listKind`
discriminant, so every list field fell through to `default`. vitest was green because the type error
sat in a branch no generated case reached, and the case count is per message, not per field, so
nothing in the output distinguished a correct walk from a broken one. This is the clearest evidence
in the migration that a green test run is not proof.

**The ledger: 42 entries, all one root cause.** Correcting the walk took it 19 → 42 with **zero new
error classes** — protobuf.js's decoder materialising an *absent* singular message field with
unsubstituted defaults, which its own encoder then rejects, now reaching through repeated members
(`spaces`, `signatures`, `invitations`, `parents`, `credentials`, `contacts`). Not a tolerance
budget: each entry is keyed on message **and exact field paths**, so a listed message diverging
somewhere new goes red (verified by perturbation → exactly one failure). A no-growth assertion pins
the count; a staleness check fails a listed message that *stops* diverging, since a stale entry
would silence a future regression on a message that is currently clean.

`encodeCompat`/`decodeCompat` handled all 258 messages. Recorded beside the above, not instead of
it — the finding is that protobuf.js's decoder and its encoder disagree, not that the compat path
is clean.

---

## #9c — `EchoMetadata`: the codec has already moved; what remains is the exposed type

Both metadata stores are already on `compatCodec`, so the **bytes** are buf today. What `#9c` moves
is the **type** the store exposes.

**Scope, corrected against the tree.** `EchoMetadata` was scoped at 27 importers spanning
`echo-pipeline` and `echo-db`. Neither package exists in this tree — that code now lives under
`client-services/src/packlets/{space,pipeline}`, which is why the boundary sites
(`control-pipeline.ts:148,165`) are `client-services` paths. Enumerated at HEAD with
`grep -rl "@dxos/protocols/proto/dxos/echo/metadata" --include=*.ts --include=*.tsx packages/`:
**29 raw importers, of which 21 import only `EdgeReplicationSetting`** — a top-level enum that moves
independently and was already proven to (commit 1, `cli-util`/`plugin-debug`). The message-type
surface is **8 files, all in `packages/sdk/client-services`**.

Type move applied; `client-services:build` reports **151 errors** to work through, all in that one
package: 77 `PublicKey` (class vs message), 36 optionality, 24 `Timestamp`/`Date`, 12 `Timeframe`
vs `TimeframeVector`. In progress.

---

## #9c — route (b) holds; (c) off the table

`preserveAny` is **inapplicable** to all three `#9c` messages — the mechanism only fires for
`google.protobuf.Any` fields (`shape-compat.ts:206-215`), and these name `Credential` **directly**
(`feed.proto:37`, `metadata.proto:92`, `services.proto:170,173`).

Route (b) for `FeedMessage`: **9 sites**, none a logic change to credentials core.
`EchoMetadata` / `Space.PipelineState` counts still outstanding.

---

## #2 — split by fate; nothing left to migrate

`tools/protobuf-test` reads as a standalone fixture but its header says "Imported by
protobuf-compiler tests" and that is its only reference — it goes at teardown. The eight
`example/testing/rpc` importers are gated on **#8.2**, not #2. Full ledger in the audit doc.

---

## Verification

| Command | Result |
| --- | --- |
| `devtools:test-types` | EXIT=0 — 8 tests / 14 assertions |
| `devtools:build` / `client-services:build` / `client-protocol:build` | EXIT=0 |
| `teleport-extension-gossip:build` | EXIT=0 |
| `teleport-extension-gossip:test` | EXIT=0 — 9 passed, 1 skipped |
| `protocols:test` | EXIT=0 — **52 passed** |
| `client-services:test` | EXIT=0 — **182 passed, 3 skipped** |
| `oxfmt --check` | clean |

## Known unfixed

buf's `Timestamp.seconds` is a **`bigint`** and `JsonView` renders through a `JSON.stringify`
replacer, which throws on `BigInt`. `MetadataPanel` is the first panel to hit it. Lands with the
panel that needs it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved mesh presence tracking and peer discovery by identity.
  * Enhanced signal monitoring with richer event, timestamp, and message details.
  * Added more reliable live signal updates and cleanup when leaving the view.
  * Improved display of peer identities in the network panel.

* **Bug Fixes**
  * Improved consistency when handling presence, peer-state, and signal data across the application.

* **Documentation**
  * Expanded protocol migration audit documentation with compatibility considerations and testing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12901-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
