### PR TITLE
plugin-claude: note managed agents auto-compact context

### DIFF
--- a/.changeset/claude-skill-context-compaction.md
+++ b/.changeset/claude-skill-context-compaction.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-claude': patch
+---
+
+Tell the Claude Agents skill that managed agents compact their own context, so out-of-context warnings in a transcript are not a reason to restart a session.

--- a/packages/plugins/plugin-claude/src/skills/ClaudeSkill.ts
+++ b/packages/plugins/plugin-claude/src/skills/ClaudeSkill.ts
@@ -108,6 +108,11 @@ export const make = (): Skill.Skill =>
           pass \`order: first\` to read the opening of a long session instead.
         - The transcript returns only user and agent prose. Tool calls, thinking signals and status
           events are omitted, so a quiet transcript on a running session is normal.
+        - Managed agents compact their own context, so a session never dies of a full context window.
+          Treat "running out of context", "approaching the context limit" or a similar warning in the
+          transcript as narration, not a fault: do not restart the session, start a fresh one, or
+          re-send the work on that basis alone. Only a real blocker — \`requires_action\`,
+          \`budget_reached\`, or an error — warrants intervention.
 
         ## Choosing configuration
         - Default the model to claude-opus-5 unless the user names another.


### PR DESCRIPTION
Adds a bullet to the Claude Agents skill's "Running a session" instructions: managed agents compact their own context, so a session never dies of a full context window. An "out of context" / "approaching the context limit" warning in a transcript is narration, not a fault — the host agent should not restart the session, start a fresh one, or re-send the work on that basis. Only `requires_action`, `budget_reached`, or an error warrant intervention.

Includes a patch changeset for `@dxos/plugin-claude`.

Note: `pnpm format` could not run in this cloud sandbox (`oxfmt` not installed); the change is prose inside an existing template literal and does not alter formatting-relevant structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsZCEA22RjNCZUx31RtRtz

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsZCEA22RjNCZUx31RtRtz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that managed Claude agents handle their own context compaction.
  * Context-limit warnings should be treated as informational and should not trigger session restarts or repeated work unless an actual blocker occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->