### PR TITLE
assistant: retry requests rejected for insufficient permissions

### DIFF
--- a/.changeset/airequest-retry-insufficient-permissions.md
+++ b/.changeset/airequest-retry-insufficient-permissions.md
@@ -1,0 +1,5 @@
+---
+'@dxos/assistant': patch
+---
+
+Retry a model request the provider rejected with `InsufficientPermissions`. Anthropic returns this while a key's permissions are still propagating, and the failure previously killed the turn outright, leaving the reader with no reply. `AiRequest.runAgentTurn` now re-issues the request up to ten times, spaced two seconds apart with jitter, and only while no block of the turn has been emitted yet — so a retry can never duplicate content. The other authentication kinds (missing, expired, or invalid key) need a credential change and still surface immediately.

--- a/packages/core/compute/assistant/src/request/AiRequest.ts
+++ b/packages/core/compute/assistant/src/request/AiRequest.ts
@@ -9,6 +9,7 @@ import * as Effect from 'effect/Effect';
 import { pipe } from 'effect/Function';
 import * as Option from 'effect/Option';
 import * as Result from 'effect/Result';
+import * as Schedule from 'effect/Schedule';
 import * as Semaphore from 'effect/Semaphore';
 import * as Stream from 'effect/Stream';
 import * as AiError from 'effect/unstable/ai/AiError';
@@ -57,6 +58,30 @@ const isToolNotFound = (error: unknown): error is ToolNotFoundError =>
  * error is raised, so a persistent fault still surfaces.
  */
 const MAX_UNRESOLVED_TOOL_TURNS = 2;
+
+/**
+ * An {@link AiError.AiError} the provider raised while authenticating the request.
+ * Narrowed with a guard rather than a cast: the retry predicate reads the reason's `kind`.
+ */
+type AuthenticationError = AiError.AiError & { readonly reason: AiError.AuthenticationError };
+
+const isAuthenticationError = (error: unknown): error is AuthenticationError =>
+  AiError.isAiError(error) && error.reason._tag === 'AuthenticationError';
+
+/**
+ * Whether the provider rejected the request for permissions that have not yet propagated to the
+ * key. Unlike the other authentication kinds (a missing, expired, or invalid key, which need a
+ * credential change and never recover on their own), this one clears by itself, so it is the only
+ * one worth re-issuing — `AuthenticationError.isRetryable` is `false` for all of them.
+ */
+const isInsufficientPermissions = (error: unknown): boolean =>
+  isAuthenticationError(error) && error.reason.kind === 'InsufficientPermissions';
+
+/** Attempts spent re-issuing a request rejected for insufficient permissions, beyond the first. */
+const INSUFFICIENT_PERMISSIONS_RETRIES = 10;
+
+/** Spaced rather than exponential: a propagation delay is bounded, and ten backed-off waits are not. */
+const INSUFFICIENT_PERMISSIONS_RETRY_DELAY = '2 seconds';
 
 export type RunRequirements =
   | LanguageModel.LanguageModel
@@ -317,6 +342,10 @@ export class Request {
         ? LanguageModel.streamText({ prompt, toolkit, disableToolCallResolution: true })
         : LanguageModel.streamText({ prompt, disableToolCallResolution: true });
 
+      // Set once any block of this attempt has been submitted, after which the request cannot be
+      // re-issued: the messages are already in `_pending` and a second attempt would duplicate them.
+      let emitted = false;
+
       const messages = yield* stream.pipe(
         withoutToolCallParsing,
         AiParser.parseResponse({
@@ -350,6 +379,7 @@ export class Request {
                 const id = currentMessageId;
                 currentMessageId = null;
                 log('emit complete message', { id, type: block._tag });
+                emitted = true;
                 const message = Obj.make(Message.Message, {
                   id,
                   created: new Date().toISOString(),
@@ -363,6 +393,19 @@ export class Request {
         ),
         Stream.filterMap((value) => (Option.isSome(value) ? Result.succeed(value.value) : Result.failVoid)),
         Stream.runCollect,
+        Effect.retry({
+          schedule: Schedule.spaced(INSUFFICIENT_PERMISSIONS_RETRY_DELAY).pipe(
+            Schedule.jittered,
+            Schedule.upTo({ times: INSUFFICIENT_PERMISSIONS_RETRIES }),
+          ),
+          while: (error) => {
+            if (emitted || !isInsufficientPermissions(error)) {
+              return false;
+            }
+            log.warn('insufficient permissions; retrying request', { error });
+            return true;
+          },
+        }),
       );
       log('messages', { messages });
 


### PR DESCRIPTION
Anthropic reports a key whose permissions have not yet propagated as an `InsufficientPermissions` authentication error:

```
AnthropicClient.createMessageStream: InsufficientPermissions: Your API key lacks required permissions
  at AiRequest.runAgentTurn (.../request/AiRequest.ts)
```

The same key succeeds moments later, but the failure killed the turn outright and the reader got no reply at all.

## Changes

- `AiRequest.runAgentTurn` retries the model request up to **10 times, spaced 2 seconds apart with jitter** (`Schedule.spaced(...).pipe(Schedule.jittered, Schedule.upTo({ times: 10 }))`).
- The retry is narrowed to `AuthenticationError` with `kind === 'InsufficientPermissions'`, read off the typed reason rather than matched in text. The other authentication kinds (missing, expired, invalid key) need a credential change and still surface immediately — `AuthenticationError.isRetryable` is `false` for all of them, which is why this is opted into explicitly.
- Retry is additionally gated on nothing having been emitted yet: an `emitted` flag is set when the first complete block of the attempt is submitted, after which the request is not re-issued — the messages are already in `_pending` and a second attempt would duplicate them. In practice the provider raises this at stream open, before any block, so the guard is a safety net rather than the normal path.
- Retries are logged at `warn` so a slow-propagating key is visible rather than silent.

## Testing

- `moon run assistant:build` — clean.
- `oxfmt --check` on the changed file — clean.
- `Check` workflow green on this head: `check`, all four `test` shards, `memory`, `boot-budget`, `changeset-reminder`, `build`.
- `Model Fixture` is red, and not this PR's: 4 `assistant-toolkit` planning-fixture tests fail identically with this PR's code change reverse-applied to `origin/main`. Details and the likely cause are in [a comment below](https://github.com/dxos/dxos/pull/12908#issuecomment-5512500761). That workflow is deliberately outside the required-checks set.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pz6bGSsMg7Bbt1G57Xo6Xm