### PR TITLE
agents: changesets summarize the whole PR, written at open and before landing

### DIFF
--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -138,6 +138,17 @@ Use `mcp__github__pull_request_read` to check for unresolved review threads. For
 
 ---
 
+## Step 7.5 — Rewrite the changeset
+
+Before enqueueing, reread the PR's `.changeset/*.md` against the whole diff as it stands now
+(`git diff origin/main...HEAD`). Review rounds and scope changes since the PR opened make the
+body stale; when it no longer summarizes the PR, rewrite the body from scratch (never append a
+sentence per fix), commit with `scope: description`, and push. A body that still describes the PR
+stays as it is. Rules for the body and bump level:
+[`agents/instructions/changesets.md`](../../../agents/instructions/changesets.md).
+
+---
+
 ## Step 8 — Enable auto-merge (merge queue)
 
 Once all required checks pass and there are no blocking reviews, enable auto-merge so the PR enters the merge queue automatically:

--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -141,7 +141,8 @@ Use `mcp__github__pull_request_read` to check for unresolved review threads. For
 ## Step 7.5 — Rewrite the changeset
 
 Before enqueueing, reread the PR's `.changeset/*.md` against the whole diff as it stands now
-(`git diff origin/main...HEAD`). Review rounds and scope changes since the PR opened make the
+(`git diff origin/<baseRefName>...HEAD`, the base from Step 2 — a stacked child diffs against its
+parent's branch, never `main`). Review rounds and scope changes since the PR opened make the
 body stale; when it no longer summarizes the PR, rewrite the body from scratch (never append a
 sentence per fix), commit with `scope: description`, and push. A body that still describes the PR
 stays as it is. Rules for the body and bump level:

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -24,8 +24,10 @@ runs in. To land (merge) an existing PR, use the `land` skill.
 2. **Format.** Run `pnpm format` (oxfmt — CI checks `oxfmt --check`).
 3. **Lint.** `moon run :lint -- --fix` must succeed.
 4. **Test.** `moon run :test` must pass.
-5. **Changeset.** If the change is consumer-relevant, add a `.changeset/*.md`
-   — see
+5. **Changeset.** If the change is consumer-relevant, write one `.changeset/*.md`
+   now, from the whole diff against the base: a summary of what the PR changes
+   for a consumer, not a log of the commits. If a file already exists, rewrite
+   its body rather than appending. See
    [`agents/instructions/changesets.md`](../../../agents/instructions/changesets.md)
    for when one is needed, which package to name, and bump levels.
 6. **Account for every file.** `git status`; commit ALL modified/untracked

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,8 +213,9 @@ Deeper conventions:
 - Commit hygiene → see "Commit nothing silently" in Non-negotiables.
 - Creating or landing a PR is a procedure — use the `submit-pr` and `land`
   skills. Always surface the Composer preview URL next to the PR link.
-- Consumer-relevant changes need a `.changeset/*.md` before opening the PR —
-  see [`agents/instructions/changesets.md`](agents/instructions/changesets.md)
+- Consumer-relevant changes need a `.changeset/*.md`: written when opening the
+  PR and rewritten before landing, as a summary of the whole PR — see
+  [`agents/instructions/changesets.md`](agents/instructions/changesets.md)
   for when to add one, which package to name, and bump levels.
 
 ## Handing an agent a credential

--- a/agents/instructions/changesets.md
+++ b/agents/instructions/changesets.md
@@ -38,8 +38,10 @@ A `minor` does **not** cascade the group to `1.0.0` (the tooling keeps standard 
 
 Write the changeset at two moments, each time from the **whole diff** against the merge base:
 
-1. **Opening the PR** — after the code is done, read `git diff origin/main...HEAD` and write the body
-   from what the PR changes as a whole.
+1. **Opening the PR** — after the code is done, read `git diff origin/<base>...HEAD` and write the
+   body from what the PR changes as a whole. `<base>` is the branch the PR targets: `main` for a
+   standalone PR, the parent PR's head branch for a stacked one — diffing a stacked child against
+   `main` folds the parent's changes into this PR's changelog entry.
 2. **Before landing** — reread the file against the diff as it stands now. If the PR moved (review
    fixes, scope changes), **rewrite the file from scratch**; a body that still describes the PR stays
    as it is.

--- a/agents/instructions/changesets.md
+++ b/agents/instructions/changesets.md
@@ -34,9 +34,24 @@ A `minor` does **not** cascade the group to `1.0.0` (the tooling keeps standard 
 
 **`major` is rejected by CI while we are pre-1.0** (`pnpm check-changesets`, a gate in **Check**). The groups are `fixed`, so one stray `major` versions all ~300 packages to `1.0.0` in a single release — and nothing surfaces the mistake until `changeset version` runs on `main`. Write `minor` and describe the break in the body.
 
+## When to write it
+
+Write the changeset at two moments, each time from the **whole diff** against the merge base:
+
+1. **Opening the PR** — after the code is done, read `git diff origin/main...HEAD` and write the body
+   from what the PR changes as a whole.
+2. **Before landing** — reread the file against the diff as it stands now. If the PR moved (review
+   fixes, scope changes), **rewrite the file from scratch**; a body that still describes the PR stays
+   as it is.
+
+Those two moments are the only ones: the file is a **summary** of the finished PR, and a reader of
+`CHANGELOG.md` wants what changed for them, not the order it was built in. Every update replaces
+the whole body. A body grown a sentence per commit or per review round ("Add X. Also fix Y. Rename
+Z per review.") is a **log**, and leaks process into the release notes.
+
 ## Body + format
 
-`.changeset/<slug>.md` (any unique slug). One or two sentences, **changelog quality** — the body ships verbatim in `CHANGELOG.md` (via `@changesets/changelog-git`), so write it from the **consumer's** point of view and end with a period.
+`.changeset/<slug>.md` (any unique slug). One or two sentences, **changelog quality** — the body ships verbatim in `CHANGELOG.md` (via `@changesets/changelog-git`), so write it from the **consumer's** point of view and end with a period. Describe the net effect of the PR: what the consumer can now do, or what stopped happening.
 
 ```md
 ---
@@ -46,7 +61,7 @@ A `minor` does **not** cascade the group to `1.0.0` (the tooling keeps standard 
 Fix subscription leak in the query handler.
 ```
 
-✅ `Add streaming variant of Query.run().` &nbsp;&nbsp; ❌ `refactored stuff` / `addresses review comments` / `WIP`
+✅ `Add streaming variant of Query.run().` &nbsp;&nbsp; ❌ `refactored stuff` / `addresses review comments` / `WIP` / `Add streaming query. Also fix the leak found in review.`
 
 Packages from _different_ groups in one PR → one line each **in the same file** (each still bumps its whole group):
 
@@ -65,8 +80,7 @@ Add streaming query API and surface it in the markdown plugin.
 check-changesets` in **Check** fails a PR that adds more than one `.changeset/*.md`, counted against
 the merge base. A changeset is a changelog entry, so the question is how many entries a reader wants —
 not how many packages, groups, or commits you touched. Work spanning two groups is still one story and
-belongs in one file with a line per group, as above; so does a fix that took five commits. When a PR
-grows and you have accumulated a file per commit, consolidate before opening it.
+belongs in one file with a line per group, as above; so does a fix that took five commits.
 
 Add a second file **only when the PR genuinely addresses two unrelated things** a reader would look up
 separately — e.g. a query-planner fix that happens to ride along with an unrelated toolbar change. If you


### PR DESCRIPTION
Agent-instruction change only. A changeset is a summary of the finished PR, and it gets written at two moments: when the PR opens, and again before landing, both times from the whole diff against the merge base. Any update rewrites the body rather than appending a sentence per commit or review round.

- `agents/instructions/changesets.md`: new "When to write it" section with the two moments and the summary-versus-log rule. The body section now asks for the net effect of the PR, and the bad-example list gains an appended-style body. Dropped the "consolidate a file per commit" sentence, since the new rule means those files never accumulate.
- `.agents/skills/submit-pr/SKILL.md`: step 5 now writes the changeset from the whole diff and rewrites an existing body instead of appending.
- `.agents/skills/land/SKILL.md`: new step 7.5 rereads the changeset against the current diff before enqueueing and rewrites it when it has gone stale.
- `AGENTS.md`: the pointer line names both moments and the summary rule.

No changeset for this PR: it touches agent docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBWHX7N2DxA6uVv3Bv7kCF

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBWHX7N2DxA6uVv3Bv7kCF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance for creating and maintaining changesets.
  * Changesets now describe the completed pull request and its consumer-visible impact, rather than development history.
  * Clarified when changesets should be written or rewritten, including guidance for standalone and stacked pull requests.
  * Clarified that multi-commit fixes should remain represented in a single changeset.
  * Added guidance to review changesets against the complete pull request before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->