### PR TITLE
compute-runtime: trace operations invoked through the promise entry point (DX-1236)

### DIFF
--- a/.changeset/operation-span-tracer.md
+++ b/.changeset/operation-span-tracer.md
@@ -1,5 +1,5 @@
 ---
-'@dxos/echo': patch
+'@dxos/compute-runtime': patch
 ---
 
 Operations invoked through `invokePromise` are now traced on the runtime's tracer instead of Effect's native one, so their spans reach the observability backend and nest under the caller's span rather than each opening its own trace.

--- a/.changeset/operation-span-tracer.md
+++ b/.changeset/operation-span-tracer.md
@@ -1,0 +1,5 @@
+---
+'@dxos/echo': patch
+---
+
+Operations invoked through `invokePromise` are now traced on the runtime's tracer instead of Effect's native one, so their spans reach the observability backend and nest under the caller's span rather than each opening its own trace.

--- a/packages/core/compute/compute-runtime/src/ProcessManager.test.ts
+++ b/packages/core/compute/compute-runtime/src/ProcessManager.test.ts
@@ -387,8 +387,6 @@ const alarmSpans: Tracer.Span[] = [];
 const rearmSpans: Tracer.Span[] = [];
 const runtimeSpans: Tracer.Span[] = [];
 const callerSpans: Tracer.Span[] = [];
-// Recorder for the tracer the invoker captured at layer build; asserted empty when a caller
-// brings its own, so the caller's tracer is demonstrably the one in use.
 const unusedRuntimeSpans: Tracer.Span[] = [];
 
 describe('ManagerImpl', () => {
@@ -545,13 +543,10 @@ describe('ManagerImpl', () => {
     Effect.fn(
       function* ({ expect }) {
         const invoker = yield* ProcessManager.ProcessOperationInvoker.Service;
-        // `invokePromise` runs on a fresh fiber with an empty context. Without the invoker
-        // reinstating the runtime's tracer it falls back to Effect's native one, whose spans never
-        // reach a backend — and an OTel span opened under one is exported as its own trace root.
         const { error } = yield* Effect.promise(() => invoker.invokePromise(Traced, undefined));
         expect(error).toBeUndefined();
 
-        expect(ancestry(runtimeSpans, 'Handler.span')).toEqual([
+        expect(spanNamesToRoot(runtimeSpans, 'Handler.span')).toEqual([
           'Handler.span',
           Traced.meta.key.toString(),
           'Process.input',
@@ -572,9 +567,7 @@ describe('ManagerImpl', () => {
           .invoke(Traced, undefined)
           .pipe(Effect.withSpan('Caller.span'), Effect.provideService(Tracer.Tracer, makeRecordingTracer(callerSpans)));
 
-        // The caller's tracer wins over the one the invoker carries, and its span parents the
-        // operation rather than the operation opening a trace of its own.
-        expect(ancestry(callerSpans, 'Handler.span')).toEqual([
+        expect(spanNamesToRoot(callerSpans, 'Handler.span')).toEqual([
           'Handler.span',
           Traced.meta.key.toString(),
           'Process.input',
@@ -2258,8 +2251,7 @@ describe('durability', () => {
   );
 });
 
-/** Span names from the given span up to its trace root. */
-const ancestry = (spans: Tracer.Span[], name: string): string[] => {
+const spanNamesToRoot = (spans: Tracer.Span[], name: string): string[] => {
   const names: string[] = [];
   let span: Tracer.AnySpan | undefined = spans.find((candidate) => candidate.name === name);
   while (span?._tag === 'Span') {

--- a/packages/core/compute/compute-runtime/src/ProcessManager.test.ts
+++ b/packages/core/compute/compute-runtime/src/ProcessManager.test.ts
@@ -385,6 +385,22 @@ const recordedSpans: Tracer.Span[] = [];
 const spaceSpans: Tracer.Span[] = [];
 const alarmSpans: Tracer.Span[] = [];
 const rearmSpans: Tracer.Span[] = [];
+const runtimeSpans: Tracer.Span[] = [];
+const callerSpans: Tracer.Span[] = [];
+// Recorder for the tracer the invoker captured at layer build; asserted empty when a caller
+// brings its own, so the caller's tracer is demonstrably the one in use.
+const unusedRuntimeSpans: Tracer.Span[] = [];
+
+/** Span names from the given span up to its trace root. */
+const ancestry = (spans: Tracer.Span[], name: string): string[] => {
+  const names: string[] = [];
+  let span: Tracer.AnySpan | undefined = spans.find((candidate) => candidate.name === name);
+  while (span?._tag === 'Span') {
+    names.push(span.name);
+    span = Option.getOrUndefined(span.parent);
+  }
+  return names;
+};
 
 describe('ManagerImpl', () => {
   it.effect(
@@ -532,6 +548,54 @@ describe('ManagerImpl', () => {
       },
       Effect.provide(TestLayer),
       Effect.provide(Layer.succeed(Tracer.Tracer, makeRecordingTracer(recordedSpans))),
+    ),
+  );
+
+  it.effect(
+    "traces an operation invoked through the promise entry point on the runtime's tracer",
+    Effect.fn(
+      function* ({ expect }) {
+        const invoker = yield* ProcessManager.ProcessOperationInvoker.Service;
+        // `invokePromise` runs on a fresh fiber with an empty context. Without the invoker
+        // reinstating the runtime's tracer it falls back to Effect's native one, whose spans never
+        // reach a backend — and an OTel span opened under one is exported as its own trace root.
+        const { error } = yield* Effect.promise(() => invoker.invokePromise(Traced, undefined));
+        expect(error).toBeUndefined();
+
+        expect(ancestry(runtimeSpans, 'Handler.span')).toEqual([
+          'Handler.span',
+          Traced.meta.key.toString(),
+          'Process.input',
+          'ProcessOperationInvoker.invoke',
+        ]);
+      },
+      Effect.provide(TestLayer),
+      Effect.provide(Layer.succeed(Tracer.Tracer, makeRecordingTracer(runtimeSpans))),
+    ),
+  );
+
+  it.effect(
+    "nests an operation invoked from a fiber under that fiber's span",
+    Effect.fn(
+      function* ({ expect }) {
+        const invoker = yield* ProcessManager.ProcessOperationInvoker.Service;
+        yield* invoker
+          .invoke(Traced, undefined)
+          .pipe(Effect.withSpan('Caller.span'), Effect.provideService(Tracer.Tracer, makeRecordingTracer(callerSpans)));
+
+        // The caller's tracer wins over the one the invoker carries, and its span parents the
+        // operation rather than the operation opening a trace of its own.
+        expect(ancestry(callerSpans, 'Handler.span')).toEqual([
+          'Handler.span',
+          Traced.meta.key.toString(),
+          'Process.input',
+          'ProcessOperationInvoker.invoke',
+          'Caller.span',
+        ]);
+        expect(unusedRuntimeSpans).toEqual([]);
+      },
+      Effect.provide(TestLayer),
+      Effect.provide(Layer.succeed(Tracer.Tracer, makeRecordingTracer(unusedRuntimeSpans))),
     ),
   );
 

--- a/packages/core/compute/compute-runtime/src/ProcessManager.test.ts
+++ b/packages/core/compute/compute-runtime/src/ProcessManager.test.ts
@@ -391,17 +391,6 @@ const callerSpans: Tracer.Span[] = [];
 // brings its own, so the caller's tracer is demonstrably the one in use.
 const unusedRuntimeSpans: Tracer.Span[] = [];
 
-/** Span names from the given span up to its trace root. */
-const ancestry = (spans: Tracer.Span[], name: string): string[] => {
-  const names: string[] = [];
-  let span: Tracer.AnySpan | undefined = spans.find((candidate) => candidate.name === name);
-  while (span?._tag === 'Span') {
-    names.push(span.name);
-    span = Option.getOrUndefined(span.parent);
-  }
-  return names;
-};
-
 describe('ManagerImpl', () => {
   it.effect(
     'spawns a process and produces output',
@@ -2268,3 +2257,14 @@ describe('durability', () => {
     }, Effect.provide(DurabilityTestLayer)),
   );
 });
+
+/** Span names from the given span up to its trace root. */
+const ancestry = (spans: Tracer.Span[], name: string): string[] => {
+  const names: string[] = [];
+  let span: Tracer.AnySpan | undefined = spans.find((candidate) => candidate.name === name);
+  while (span?._tag === 'Span') {
+    names.push(span.name);
+    span = Option.getOrUndefined(span.parent);
+  }
+  return names;
+};

--- a/packages/core/compute/compute-runtime/src/ProcessManager.ts
+++ b/packages/core/compute/compute-runtime/src/ProcessManager.ts
@@ -497,6 +497,8 @@ export class ProcessManagerImpl implements Manager {
       });
       const scope = yield* Scope.make();
       const dispatchContext = yield* EffectEx.contextWithoutParentSpan();
+      // Handed to the child invoker, whose promise entry point runs on a fresh, empty-context fiber.
+      const tracer = yield* Effect.tracer;
       const outputQueue = yield* Queue.unbounded<ProcessHandle.OutputItem<O>>();
 
       const storage = storageServiceLayer(this.#kvStore, `process/${id}/`);
@@ -580,6 +582,7 @@ export class ProcessManagerImpl implements Manager {
           manager: this,
           handlerSet: this.#handlerSet,
           parentProcessId: id,
+          tracer,
         });
         builtinCtx = Context.add(builtinCtx, Operation.Service, childInvoker);
         builtinCtx = Context.add(builtinCtx, ProcessOperationInvoker.Service, childInvoker);
@@ -722,6 +725,8 @@ export class ProcessManagerImpl implements Manager {
 
       const scope = yield* Scope.make();
       const dispatchContext = yield* EffectEx.contextWithoutParentSpan();
+      // Handed to the child invoker, whose promise entry point runs on a fresh, empty-context fiber.
+      const tracer = yield* Effect.tracer;
       const outputQueue = yield* Queue.unbounded<ProcessHandle.OutputItem<any>>();
       const storage = storageServiceLayer(this.#kvStore, `process/${id}/`);
 
@@ -788,6 +793,7 @@ export class ProcessManagerImpl implements Manager {
           manager: this,
           handlerSet: this.#handlerSet,
           parentProcessId: id,
+          tracer,
         });
         builtinCtx = Context.add(builtinCtx, Operation.Service, childInvoker);
         builtinCtx = Context.add(builtinCtx, ProcessOperationInvoker.Service, childInvoker);

--- a/packages/core/compute/compute-runtime/src/ProcessManager.ts
+++ b/packages/core/compute/compute-runtime/src/ProcessManager.ts
@@ -487,7 +487,6 @@ export class ProcessManagerImpl implements Manager {
     options?: SpawnOptions,
   ): Effect.Effect<Handle<I, O, _Rpcs>> {
     return Effect.gen({ self: this }, function* () {
-      // Captured from the ambient runtime so alarms are driven by the same `Clock` (incl. `TestClock`).
       const id = this.#idGenerator();
       log('lifecycle: spawn', {
         pid: id,
@@ -497,7 +496,6 @@ export class ProcessManagerImpl implements Manager {
       });
       const scope = yield* Scope.make();
       const dispatchContext = yield* EffectEx.contextWithoutParentSpan();
-      // Handed to the child invoker, whose promise entry point runs on a fresh, empty-context fiber.
       const tracer = yield* Effect.tracer;
       const outputQueue = yield* Queue.unbounded<ProcessHandle.OutputItem<O>>();
 
@@ -719,13 +717,11 @@ export class ProcessManagerImpl implements Manager {
     definition: Process.Process<any, any, any, any>,
   ): Effect.Effect<ProcessHandle.ProcessHandleImpl<any, any, any>> {
     return Effect.gen({ self: this }, function* () {
-      // Captured from the ambient runtime so alarms are driven by the same `Clock` (incl. `TestClock`).
       const id = record.id;
       log('lifecycle: rehydrate', { pid: id, key: record.key });
 
       const scope = yield* Scope.make();
       const dispatchContext = yield* EffectEx.contextWithoutParentSpan();
-      // Handed to the child invoker, whose promise entry point runs on a fresh, empty-context fiber.
       const tracer = yield* Effect.tracer;
       const outputQueue = yield* Queue.unbounded<ProcessHandle.OutputItem<any>>();
       const storage = storageServiceLayer(this.#kvStore, `process/${id}/`);

--- a/packages/core/compute/compute-runtime/src/ProcessOperationInvoker.ts
+++ b/packages/core/compute/compute-runtime/src/ProcessOperationInvoker.ts
@@ -15,6 +15,7 @@ import * as Option from 'effect/Option';
 import * as PubSub from 'effect/PubSub';
 import * as Ref from 'effect/Ref';
 import * as Stream from 'effect/Stream';
+import * as Tracer from 'effect/Tracer';
 
 import * as Operation from '@dxos/compute/Operation';
 import * as OperationHandlerSet from '@dxos/compute/OperationHandlerSet';
@@ -109,13 +110,29 @@ const fiberFromProcess = <T>(handle: ProcessManager.Handle<any, T, never>): Effe
  * When `remoteInvoker` is supplied, invocations requesting edge execution (`InvokeOptions.on === 'edge'`)
  * are dispatched to the remote runtime by the operation's `meta.deployedId` instead of spawning a local
  * process. Absent a remote invoker, edge invocations die with a descriptive error.
+ *
+ * `tracer` is the runtime's tracer, reinstated on every invocation (see {@link withTracer}).
  */
 export const make = (opts: {
   manager: ProcessManager.Manager;
   handlerSet: OperationHandlerSet.OperationHandlerSet;
   parentProcessId?: Process.ID;
   remoteInvoker?: RemoteOperationInvoker.Invoker;
+  tracer?: Tracer.Tracer;
 }): Operation.OperationService & OperationInvoker.OperationInvokerInternal & ProcessOperationInvoker => {
+  const tracerContext = opts.tracer !== undefined ? Context.make(Tracer.Tracer, opts.tracer) : undefined;
+
+  /**
+   * Installs the runtime's tracer beneath the caller's context, because `invokePromise` runs on a
+   * fresh fiber whose empty context otherwise falls back to Effect's native tracer — whose spans
+   * never reach OpenTelemetry, and beneath which an OTel span is exported as its own trace root.
+   * Beneath, so a caller that already carries a tracer keeps it and stays the parent span.
+   */
+  const withTracer = <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> =>
+    tracerContext === undefined
+      ? effect
+      : effect.pipe(Effect.updateContext((context: Context.Context<never>) => Context.merge(tracerContext, context)));
+
   const pubsub = Effect.runSync(PubSub.unbounded<OperationInvoker.InvocationEvent>());
   const pendingCount = Effect.runSync(Ref.make(0));
   const pendingFibers = new Set<Fiber.Fiber<any>>();
@@ -187,6 +204,7 @@ export const make = (opts: {
           log('operation interrupted', { opKey: op.meta.key });
         }),
       ),
+      withTracer,
     );
 
   const attachFiber = <T>(pid: Process.ID): Effect.Effect<OperationFiber<T>> =>
@@ -204,7 +222,7 @@ export const make = (opts: {
       const newFiber = yield* fiberFromProcess(handle);
       fiberCache.set(pid, newFiber);
       return newFiber;
-    });
+    }).pipe(withTracer);
 
   const invoke: Operation.OperationService['invoke'] = <I, O>(
     op: Operation.Definition<I, O>,
@@ -219,6 +237,7 @@ export const make = (opts: {
       log('invoking operation on edge', { opKey: op.meta.key, deployedId: op.meta.deployedId });
       return invokeRemote<I, O>(op, input).pipe(
         Effect.tap((output) => PubSub.publish(pubsub, { operation: op, input, output, timestamp: Date.now() })),
+        withTracer,
       );
     }
 
@@ -252,6 +271,7 @@ export const make = (opts: {
           log.error('operation invocation failed', { opKey: op.meta.key, cause: Cause.pretty(cause) });
         }),
       ),
+      withTracer,
     );
   };
 
@@ -277,7 +297,7 @@ export const make = (opts: {
         fiber.addObserver(() => {
           pendingFibers.delete(fiber);
         });
-      });
+      }).pipe(withTracer);
     }
 
     const traceMeta = options?.tracing as Trace.Meta | undefined;
@@ -322,6 +342,7 @@ export const make = (opts: {
           log('operation schedule interrupted', { opKey: op.meta.key });
         }),
       ),
+      withTracer,
     );
   };
 
@@ -373,7 +394,9 @@ export const layer: Layer.Layer<
     // Optional: edge dispatch (`InvokeOptions.on === 'edge'`) is only available when a
     // `RemoteOperationInvoker.Service` is present in context; otherwise edge invocations die.
     const remoteInvoker = yield* Effect.serviceOption(RemoteOperationInvoker.Service);
-    const service = make({ manager, handlerSet, remoteInvoker: Option.getOrUndefined(remoteInvoker) });
+    // Captured here rather than read per-invocation: `invokePromise` has no fiber to read it from.
+    const tracer = yield* Effect.tracer;
+    const service = make({ manager, handlerSet, remoteInvoker: Option.getOrUndefined(remoteInvoker), tracer });
     return Layer.mergeAll(Layer.succeed(Operation.Service, service), Layer.succeed(Service, service));
   }),
 );

--- a/packages/core/compute/compute-runtime/src/ProcessOperationInvoker.ts
+++ b/packages/core/compute/compute-runtime/src/ProcessOperationInvoker.ts
@@ -111,27 +111,21 @@ const fiberFromProcess = <T>(handle: ProcessManager.Handle<any, T, never>): Effe
  * are dispatched to the remote runtime by the operation's `meta.deployedId` instead of spawning a local
  * process. Absent a remote invoker, edge invocations die with a descriptive error.
  *
- * `tracer` is the runtime's tracer, reinstated on every invocation (see {@link withTracer}).
+ * `tracer` is the runtime's tracer, applied as a fallback on every invocation.
  */
 export const make = (opts: {
   manager: ProcessManager.Manager;
   handlerSet: OperationHandlerSet.OperationHandlerSet;
   parentProcessId?: Process.ID;
   remoteInvoker?: RemoteOperationInvoker.Invoker;
-  tracer?: Tracer.Tracer;
+  tracer: Tracer.Tracer;
 }): Operation.OperationService & OperationInvoker.OperationInvokerInternal & ProcessOperationInvoker => {
-  const tracerContext = opts.tracer !== undefined ? Context.make(Tracer.Tracer, opts.tracer) : undefined;
+  const tracerContext = Context.make(Tracer.Tracer, opts.tracer);
 
-  /**
-   * Installs the runtime's tracer beneath the caller's context, because `invokePromise` runs on a
-   * fresh fiber whose empty context otherwise falls back to Effect's native tracer — whose spans
-   * never reach OpenTelemetry, and beneath which an OTel span is exported as its own trace root.
-   * Beneath, so a caller that already carries a tracer keeps it and stays the parent span.
-   */
-  const withTracer = <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> =>
-    tracerContext === undefined
-      ? effect
-      : effect.pipe(Effect.updateContext((context: Context.Context<never>) => Context.merge(tracerContext, context)));
+  // Beneath the caller's context: `invokePromise` starts a fresh, empty-context fiber that would
+  // otherwise fall back to Effect's native tracer, whose spans never reach OpenTelemetry.
+  const withFallbackTracer = <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> =>
+    effect.pipe(Effect.updateContext((context: Context.Context<never>) => Context.merge(tracerContext, context)));
 
   const pubsub = Effect.runSync(PubSub.unbounded<OperationInvoker.InvocationEvent>());
   const pendingCount = Effect.runSync(Ref.make(0));
@@ -204,7 +198,7 @@ export const make = (opts: {
           log('operation interrupted', { opKey: op.meta.key });
         }),
       ),
-      withTracer,
+      withFallbackTracer,
     );
 
   const attachFiber = <T>(pid: Process.ID): Effect.Effect<OperationFiber<T>> =>
@@ -222,7 +216,7 @@ export const make = (opts: {
       const newFiber = yield* fiberFromProcess(handle);
       fiberCache.set(pid, newFiber);
       return newFiber;
-    }).pipe(withTracer);
+    }).pipe(withFallbackTracer);
 
   const invoke: Operation.OperationService['invoke'] = <I, O>(
     op: Operation.Definition<I, O>,
@@ -237,7 +231,7 @@ export const make = (opts: {
       log('invoking operation on edge', { opKey: op.meta.key, deployedId: op.meta.deployedId });
       return invokeRemote<I, O>(op, input).pipe(
         Effect.tap((output) => PubSub.publish(pubsub, { operation: op, input, output, timestamp: Date.now() })),
-        withTracer,
+        withFallbackTracer,
       );
     }
 
@@ -271,7 +265,7 @@ export const make = (opts: {
           log.error('operation invocation failed', { opKey: op.meta.key, cause: Cause.pretty(cause) });
         }),
       ),
-      withTracer,
+      withFallbackTracer,
     );
   };
 
@@ -297,7 +291,7 @@ export const make = (opts: {
         fiber.addObserver(() => {
           pendingFibers.delete(fiber);
         });
-      }).pipe(withTracer);
+      }).pipe(withFallbackTracer);
     }
 
     const traceMeta = options?.tracing as Trace.Meta | undefined;
@@ -342,7 +336,7 @@ export const make = (opts: {
           log('operation schedule interrupted', { opKey: op.meta.key });
         }),
       ),
-      withTracer,
+      withFallbackTracer,
     );
   };
 
@@ -394,7 +388,6 @@ export const layer: Layer.Layer<
     // Optional: edge dispatch (`InvokeOptions.on === 'edge'`) is only available when a
     // `RemoteOperationInvoker.Service` is present in context; otherwise edge invocations die.
     const remoteInvoker = yield* Effect.serviceOption(RemoteOperationInvoker.Service);
-    // Captured here rather than read per-invocation: `invokePromise` has no fiber to read it from.
     const tracer = yield* Effect.tracer;
     const service = make({ manager, handlerSet, remoteInvoker: Option.getOrUndefined(remoteInvoker), tracer });
     return Layer.mergeAll(Layer.succeed(Operation.Service, service), Layer.succeed(Service, service));


### PR DESCRIPTION
Fixes [DX-1236](https://linear.app/dxos/issue/DX-1236/operation-spans-are-unparented-so-every-operation-is-its-own-trace).

## What was actually wrong

Not the fiber boundary the ticket names. `ProcessManager.spawn` carries the caller's parent span fine — a caller span, `ProcessOperationInvoker.invoke`, `ProcessManager.spawn`, `Process.input`, the operation span and the handler's own spans all chain correctly, and a nested `Operation.invoke` from inside a handler chains through both processes. I verified that with a recording tracer before changing anything.

What breaks is the **tracer**, not the parent. `ProcessOperationInvoker.invokePromise` runs the invocation with a bare `Effect.runPromiseExit`, so the fiber starts with an empty context and `Tracer.Tracer` resolves to Effect's default `NativeSpan` tracer. Two consequences:

1. Nothing in that invocation reaches OpenTelemetry — the whole chain above is recorded natively and dropped.
2. A `NativeSpan` has trace id `"native"`. `@effect/opentelemetry`'s `OtelSpan` passes it to `trace.setSpanContext`, the collector rejects it as an invalid parent, and the span is exported as a root — `Parent span ID: 0000000000000000`, exactly the symptom reported.

Every operation dispatched from the UI takes that path: `useOperationCallback` → `useOperationInvoker().invokePromise`.

The ticket's second item, the missing browser `ContextManager`, already landed in a78a66db (`traces-browser.ts` registers a `StackContextManager`; the node side gets an async-hooks one from `tracerProvider.register()`). Nothing to do there.

## The change

`ProcessOperationInvoker.make` takes the runtime's tracer, captured in `layer` where a fiber still has one, and merges it **beneath** the caller's context on every entry point (`invoke`, `schedule`, `invokeFiber`, `attachFiber`). Beneath matters: a fiber that already carries a tracer — a handler invoking a nested operation, a test supplying its own — keeps it, and the invocation stays nested under the caller's span rather than starting a trace of its own. The child invokers `ProcessManager.spawn` and `#rehydrate` install get the spawning fiber's tracer for the same reason.

Because the OTel tracer is now on the fiber, `@effect/opentelemetry`'s context hook also keeps the OTel context active inside operations, so `@dxos/tracing`'s `@trace.span()` spans nest under them too.

## Not covered

Cross-realm traces (page ↔ dedicated worker). The RPC proto has a `traceparent` field but only `edge-client` populates it, so realms stay independent trace scopes. The ticket calls this out as separate; it still is.

## Tests

Two added to `ProcessManager.test.ts`:

- `traces an operation invoked through the promise entry point on the runtime's tracer` — asserts the full ancestry `Handler.span` → the operation's own span → `Process.input` → `ProcessOperationInvoker.invoke`. Fails on `main` with an empty span list.
- `nests an operation invoked from a fiber under that fiber's span` — two distinct recording tracers, asserting the caller's wins and the layer's records nothing. Guards the merge order.

```
compute-runtime:test   19 files, 193 passed | 1 skipped
agent-runtime:test      9 files, 43 passed | 22 skipped
app-framework:test     23 files, 255 passed
operation:test          3 files, 32 passed
```

`compute-runtime:build` and `compute-runtime:lint` clean; `pnpm format` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bm1y2k33qi2BhRWKdV6uik

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracing for operations invoked through promises.
  * Operation spans now nest correctly under the caller’s span and appear in runtime observability traces.
  * Preserved caller-provided tracing context across local, detached, and remote operation execution.
  * Ensured operations use the appropriate tracer when no caller context is available.

* **Tests**
  * Added coverage verifying span ancestry, tracer precedence, and promise-based invocation tracing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->