### PR TITLE
compute-runtime: name the ProcessManager lifecycle spans after their methods

### DIFF
--- a/.changeset/process-manager-span-names.md
+++ b/.changeset/process-manager-span-names.md
@@ -1,0 +1,5 @@
+---
+'@dxos/compute-runtime': patch
+---
+
+Fixed two `ProcessManager` spans that reported under the wrong name: process rehydration was exported as `ProcessManager.shutdown` and persisted-record discard as `ProcessManager.startup`. They are now `ProcessManager.rehydrate` and `ProcessManager.discardRecord`.

--- a/packages/core/compute/compute-runtime/src/ProcessManager.ts
+++ b/packages/core/compute/compute-runtime/src/ProcessManager.ts
@@ -894,7 +894,7 @@ export class ProcessManagerImpl implements Manager {
       }
 
       return handle;
-    }).pipe(Effect.withSpan('ProcessManager.shutdown'));
+    }).pipe(Effect.withSpan('ProcessManager.rehydrate'));
   }
 
   #hydrateFromDefinition<I, O, Rpcs extends Rpc.Any = never>(
@@ -969,7 +969,7 @@ export class ProcessManagerImpl implements Manager {
           yield* this.#store.deleteProcess(pid);
         }
       }
-    }).pipe(Effect.withSpan('ProcessManager.startup'));
+    }).pipe(Effect.withSpan('ProcessManager.discardRecord'));
   }
 
   attach<I, O, Rpcs extends Rpc.Any = never>(id: Process.ID): Effect.Effect<Handle<I, O, Rpcs>> {


### PR DESCRIPTION
Two `ProcessManager` spans were named after methods they do not belong to:

| Method | Span name (before) | Span name (after) |
| --- | --- | --- |
| `#rehydrate` — rehydrates a persisted record into a live handle | `ProcessManager.shutdown` | `ProcessManager.rehydrate` |
| `#discardRecord` — deletes a dormant record and its descendants | `ProcessManager.startup` | `ProcessManager.discardRecord` |

Both read as copy-paste slips. `ProcessManager.spawn` and `ProcessManager.hydrate` were already correct.

## The second one wasn't in the original report

I was asked to fix the `#rehydrate` slip and to confirm the sibling spans were fine. They were not — `#discardRecord` has the identical defect, found by checking. Same file, same cause, one line; fixing only the first would have knowingly shipped half of it.

## `shutdown()` and `startup()` have no spans at all

This is the part worth flagging. The real `shutdown()` (`ProcessManager.ts:449`) and `startup()` (`:471`) never opened a span. So `ProcessManager.shutdown` in the backend was not *ambiguous* between shutdowns and rehydrations — it was **exclusively** rehydrations, and `ProcessManager.startup` exclusively record discards. Nothing was ever emitted under either name by the method it names.

I did not add spans to `shutdown()`/`startup()`. That is new telemetry rather than a fix to a slip, and it is a call for whoever owns the sampling budget. Happy to follow up if wanted.

## Nothing keys off the old names

Checked against the live SigNoz tenant:

- **Dashboards** (7 total) — none query these span names; they cover EDGE workers, identities, client metrics, and session lifecycle.
- **Alert rules** (1 total) — "EDGE worker error ratio > 30%", metric-based, unrelated (and currently disabled under DX-1242).
- **Saved trace views** (3 total) — all filter on `status_code_string`/`duration_nano`, none on `name`.

There is also no historical data to lose: a `count` grouped by `name` over the last 7 days returns **zero rows** for `ProcessManager.shutdown`, `.startup`, `.spawn`, and `.hydrate`. That is expected — these spans only started reaching the backend with dxos/dxos#12914, which landed a few minutes ago. So the rename changes no dashboard, breaks no query, and orphans no data.

## Validation

```
compute-runtime:build   pass
compute-runtime:lint    pass
compute-runtime:test    19 files, 193 passed | 1 skipped
```

Found while auditing comments on dxos/dxos#12914 (DX-1236). Pre-existing on `main` and unrelated to that change, so it was deliberately left out of that PR rather than widening it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bm1y2k33qi2BhRWKdV6uik

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bm1y2k33qi2BhRWKdV6uik)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected diagnostic trace names for process rehydration and persisted-record discard operations, improving the accuracy of monitoring and troubleshooting data.

- **Chores**
  - Documented the update in the package release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->