### PR TITLE
echo-client: sweep object-core pins by timestamp instead of a timer per touch

### DIFF
--- a/.changeset/object-core-registry-pin-sweep.md
+++ b/.changeset/object-core-registry-pin-sweep.md
@@ -1,5 +1,6 @@
 ---
 '@dxos/echo-client': patch
+'@dxos/plugin-debug': patch
 ---
 
-Object core pinning no longer installs a timer per registry touch — a single sweep timer expires pins by last-touch timestamp, removing the dominant timer churn of a bulk object load.
+Object core pinning no longer installs a timer per registry touch — a single sweep timer expires pins by monotonic last-touch timestamp, removing the dominant timer churn of a bulk object load. The debug plugin's schema table now owns the generator promise it starts: the row shows the work in flight, refuses a concurrent click, and reports a failure instead of leaving it unhandled.

--- a/.changeset/object-core-registry-pin-sweep.md
+++ b/.changeset/object-core-registry-pin-sweep.md
@@ -1,0 +1,5 @@
+---
+'@dxos/echo-client': patch
+---
+
+Object core pinning no longer installs a timer per registry touch — a single sweep timer expires pins by last-touch timestamp, removing the dominant timer churn of a bulk object load.

--- a/packages/core/echo/echo-client/src/core-db/object-core-registry.test.ts
+++ b/packages/core/echo/echo-client/src/core-db/object-core-registry.test.ts
@@ -1,0 +1,79 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ObjectCore } from './object-core';
+import { ObjectCoreRegistry, PIN_TTL } from './object-core-registry';
+
+describe('ObjectCoreRegistry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('holds one instance per id', () => {
+    const registry = new ObjectCoreRegistry();
+    const core = new ObjectCore();
+    registry.set(core.id, core);
+    expect(registry.get(core.id)).to.eq(core);
+    expect(registry.has(core.id)).to.be.true;
+    expect(registry.keys()).to.deep.eq([core.id]);
+  });
+
+  test('a touch does not arm a timer per call', () => {
+    const registry = new ObjectCoreRegistry();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    for (let i = 0; i < 100; i++) {
+      const core = new ObjectCore();
+      registry.set(core.id, core);
+      registry.get(core.id);
+    }
+    expect(setTimeoutSpy).toHaveBeenCalledOnce();
+  });
+
+  test('the sweep stops once nothing is pinned', () => {
+    const registry = new ObjectCoreRegistry();
+    const core = new ObjectCore();
+    registry.set(core.id, core);
+    vi.advanceTimersByTime(PIN_TTL);
+    expect(vi.getTimerCount()).to.eq(0);
+  });
+
+  test('a touch inside the window keeps the sweep running', () => {
+    const registry = new ObjectCoreRegistry();
+    const core = new ObjectCore();
+    registry.set(core.id, core);
+    vi.advanceTimersByTime(PIN_TTL - 1);
+    registry.get(core.id);
+    // The first sweep sees a fresh touch, so it re-arms rather than draining.
+    vi.advanceTimersByTime(1);
+    expect(vi.getTimerCount()).to.eq(1);
+    vi.advanceTimersByTime(2 * PIN_TTL);
+    expect(vi.getTimerCount()).to.eq(0);
+  });
+
+  test('clear drops the index and disarms the sweep', () => {
+    const registry = new ObjectCoreRegistry();
+    const core = new ObjectCore();
+    registry.set(core.id, core);
+    registry.clear();
+    expect(vi.getTimerCount()).to.eq(0);
+    expect(registry.size).to.eq(0);
+    expect(registry.get(core.id)).to.be.undefined;
+  });
+
+  test('delete drops the entry without notifying onRelease', () => {
+    const released: string[] = [];
+    const registry = new ObjectCoreRegistry({ onRelease: (id) => released.push(id) });
+    const core = new ObjectCore();
+    registry.set(core.id, core);
+    expect(registry.delete(core.id)).to.be.true;
+    expect(registry.get(core.id)).to.be.undefined;
+    expect(released).to.deep.eq([]);
+  });
+});

--- a/packages/core/echo/echo-client/src/core-db/object-core-registry.test.ts
+++ b/packages/core/echo/echo-client/src/core-db/object-core-registry.test.ts
@@ -57,6 +57,25 @@ describe('ObjectCoreRegistry', () => {
     expect(vi.getTimerCount()).to.eq(0);
   });
 
+  test('a wall-clock jump does not unpin a core touched moments ago', () => {
+    const registry = new ObjectCoreRegistry();
+    const first = new ObjectCore();
+    registry.set(first.id, first);
+    const second = new ObjectCore();
+    vi.advanceTimersByTime(PIN_TTL - 10);
+    registry.set(second.id, second);
+
+    // An NTP correction moves the wall clock without advancing elapsed time. `second` was touched
+    // 10ms ago, so the sweep the first core's TTL arms must keep it: expiry reads a monotonic clock,
+    // against which the jump is invisible.
+    const wallClock = Date.now;
+    vi.spyOn(Date, 'now').mockImplementation(() => wallClock.call(Date) + 60 * 60 * 1000);
+    vi.advanceTimersByTime(10);
+
+    // A pin remains, so the sweep re-armed rather than draining `second` along with `first`.
+    expect(vi.getTimerCount()).to.eq(1);
+  });
+
   test('clear drops the index and disarms the sweep', () => {
     const registry = new ObjectCoreRegistry();
     const core = new ObjectCore();

--- a/packages/core/echo/echo-client/src/core-db/object-core-registry.ts
+++ b/packages/core/echo/echo-client/src/core-db/object-core-registry.ts
@@ -103,7 +103,9 @@ export class ObjectCoreRegistry {
   }
 
   #pin(core: ObjectCore): void {
-    this.#pinned.set(core, Date.now());
+    // Monotonic: a wall-clock jump forward larger than the TTL would otherwise unpin a core touched
+    // moments ago, dropping an object mid-load.
+    this.#pinned.set(core, performance.now());
     this.#armSweep();
   }
 
@@ -124,7 +126,7 @@ export class ObjectCoreRegistry {
    * for, which is what the load-in-progress guarantee needs.
    */
   #sweep(): void {
-    const expiry = Date.now() - PIN_TTL;
+    const expiry = performance.now() - PIN_TTL;
     for (const [core, touched] of this.#pinned) {
       if (touched <= expiry) {
         this.#pinned.delete(core);

--- a/packages/core/echo/echo-client/src/core-db/object-core-registry.ts
+++ b/packages/core/echo/echo-client/src/core-db/object-core-registry.ts
@@ -31,21 +31,31 @@ export type ObjectCoreRegistryParams = {
   onRelease?: (id: string) => void;
 };
 
+/**
+ * How long a touch keeps a core alive without another holder. Long enough to span a load that
+ * resolves across several turns, short enough that a bulk read is not resident for perceptible time.
+ */
+export const PIN_TTL = 100;
+
 export class ObjectCoreRegistry {
   readonly #cores = new Map<string, WeakRef<ObjectCore>>();
   readonly #onRelease?: (id: string) => void;
 
   /**
-   * Cores touched since the last drain, held strongly.
+   * Recently touched cores, held strongly, each against the time it was last touched.
    *
    * Loading an object and surfacing it span several turns — the query pipeline stores ids and reads
    * the core back once its document has arrived — and in between nothing else refers to the core, so
-   * a collection landing mid-flight would silently drop the object from the result. Every touch
-   * re-pins, so the window covers a load in progress and closes one macrotask after the last read;
-   * a caller who kept the object holds it from then on.
+   * a collection landing mid-flight would silently drop the object from the result. A touch only
+   * writes the timestamp; the sweep below decides when the window has closed, so a caller who kept
+   * the object holds it from then on.
    */
-  #pinned = new Set<ObjectCore>();
-  #drainTimer: ReturnType<typeof setTimeout> | undefined = undefined;
+  readonly #pinned = new Map<ObjectCore, number>();
+
+  // One sweep timer for the whole registry, armed only while something is pinned. Re-arming a timer
+  // per touch instead made timer install/clear the dominant cost of a bulk load — a single trace of
+  // one space opening showed 17k of its 18k timer installs coming from here, against 664 firings.
+  #sweepTimer: ReturnType<typeof setTimeout> | undefined = undefined;
 
   // Prunes the index as cores are collected. Lookup prunes too, so this only bounds ids that are
   // never looked up again — the common case for an object read once and moved past.
@@ -93,14 +103,36 @@ export class ObjectCoreRegistry {
   }
 
   #pin(core: ObjectCore): void {
-    this.#pinned.add(core);
-    // Re-armed on every touch and drained a macrotask later, so the window outlives a load that
-    // resolves across turns however long it takes.
-    clearTimeout(this.#drainTimer);
-    this.#drainTimer = setTimeout(() => {
-      this.#drainTimer = undefined;
-      this.#pinned = new Set();
-    });
+    this.#pinned.set(core, Date.now());
+    this.#armSweep();
+  }
+
+  #armSweep(): void {
+    if (this.#sweepTimer !== undefined) {
+      return;
+    }
+    this.#sweepTimer = setTimeout(() => {
+      this.#sweepTimer = undefined;
+      this.#sweep();
+    }, PIN_TTL);
+  }
+
+  /**
+   * Unpins cores untouched for {@link PIN_TTL}, re-arming while any pin remains.
+   *
+   * A pin therefore lasts between one and two intervals — never less than the window a touch asked
+   * for, which is what the load-in-progress guarantee needs.
+   */
+  #sweep(): void {
+    const expiry = Date.now() - PIN_TTL;
+    for (const [core, touched] of this.#pinned) {
+      if (touched <= expiry) {
+        this.#pinned.delete(core);
+      }
+    }
+    if (this.#pinned.size > 0) {
+      this.#armSweep();
+    }
   }
 
   /** Drops the entry without notifying `onRelease` — the caller is already evicting this id. */
@@ -139,9 +171,9 @@ export class ObjectCoreRegistry {
   }
 
   clear(): void {
-    clearTimeout(this.#drainTimer);
-    this.#drainTimer = undefined;
-    this.#pinned = new Set();
+    clearTimeout(this.#sweepTimer);
+    this.#sweepTimer = undefined;
+    this.#pinned.clear();
     for (const [, ref] of this.#cores) {
       const core = ref.deref();
       if (core !== undefined) {

--- a/packages/plugins/plugin-debug/src/components/SchemaTable/SchemaTable.tsx
+++ b/packages/plugins/plugin-debug/src/components/SchemaTable/SchemaTable.tsx
@@ -2,9 +2,10 @@
 // Copyright 2024 DXOS.org
 //
 
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { Type } from '@dxos/echo';
+import { log } from '@dxos/log';
 import { IconButton, ThemedClassName } from '@dxos/react-ui';
 import { mx } from '@dxos/ui-theme';
 
@@ -12,7 +13,8 @@ export type SchemaTableProps = ThemedClassName<{
   types: any[];
   objects?: Record<string, number | undefined>;
   label: string;
-  onClick: (typename: string) => void;
+  /** May be async — the row awaits it, so a generator's failure is reported rather than unowned. */
+  onClick: (typename: string) => Promise<void> | void;
 }>;
 
 /**
@@ -25,6 +27,27 @@ const rowName = (type: any, typename: string | undefined): string =>
   (typeof type.presetLabel === 'string' ? type.presetLabel : undefined) ?? typename ?? '';
 
 export const SchemaTable = ({ classNames, types, objects = {}, label, onClick }: SchemaTableProps) => {
+  // A sample space takes seconds to build. Without holding the row that is running, the click
+  // dropped the handler's promise: nothing showed the work in flight, a second click raced the
+  // first, and a rejection after the panel unmounted surfaced as an unhandled rejection.
+  const [pending, setPending] = useState<string>();
+  const handleClick = useCallback(
+    async (typename: string) => {
+      if (pending !== undefined) {
+        return;
+      }
+      setPending(typename);
+      try {
+        await onClick(typename);
+      } catch (err) {
+        log.catch(err);
+      } finally {
+        setPending(undefined);
+      }
+    },
+    [onClick, pending],
+  );
+
   return (
     <div className={mx('grid grid-cols-[1fr_80px_40px] gap-1 overflow-none', classNames)}>
       <h2 className='p-2'>{label}</h2>
@@ -41,10 +64,11 @@ export const SchemaTable = ({ classNames, types, objects = {}, label, onClick }:
             </div>
             <IconButton
               variant='ghost'
-              icon='ph--plus--regular'
+              icon={pending === typename ? 'ph--spinner--regular' : 'ph--plus--regular'}
               iconOnly
+              disabled={pending !== undefined}
               label={`Create ${rowName(type, typename)}`}
-              onClick={() => typename && onClick(typename)}
+              onClick={() => typename && void handleClick(typename)}
             />
           </div>
         );

--- a/packages/plugins/plugin-debug/src/stories/SampleSpaces.stories.tsx
+++ b/packages/plugins/plugin-debug/src/stories/SampleSpaces.stories.tsx
@@ -51,6 +51,10 @@ const applySampleSpace = async (canvasElement: HTMLElement, label: string, expec
   // `getAllByText`: a sample space may name two objects the same (Tidepool's task set and its
   // project are both "Offline sync v2"), and `getByText` throws on more than one match.
   await waitFor(() => expect(canvas.getAllByText(expected).length).toBeGreaterThan(0), { timeout: 30_000 });
+  // The first object appears long before the world is finished, and the row disables itself for as
+  // long as the generator runs: returning here left writes in flight, and teardown closed the
+  // client's RPC endpoint under them.
+  await waitFor(() => expect(create).toBeEnabled(), { timeout: 30_000 });
 };
 
 const meta = {


### PR DESCRIPTION
## Problem

`ObjectCoreRegistry.#pin` ran a `clearTimeout` + `setTimeout` pair on **every** `get`/`set`. In a DevTools trace of one space opening, **17,201 of the 18,476 `TimerInstall` events came from `#pin`** (against 18,463 `TimerRemove` and only 664 `TimerFire`) — pure install/clear churn, making the pin bookkeeping the dominant timer cost of a bulk object load.

## Change

A touch now only records `Date.now()` against the core (`#pinned: Map<ObjectCore, number>`), and a **single** sweep timer per registry — armed only while something is pinned — expires entries whose last touch is older than `PIN_TTL` (100ms), re-arming while any pin remains.

A pin therefore lasts between one and two intervals: never shorter than the window a touch asks for, so the load-in-progress guarantee (a core that nothing else refers to mid-flight must not be collected) is unchanged, and the strong-hold window stays bounded.

## Tests

New `object-core-registry.test.ts` covers identity-per-id, `delete`/`clear`, that 100 touches arm one timer, that the sweep stops once nothing is pinned, and that a touch inside the window re-arms rather than drains.

```
✓ |node| src/core-db/object-core-registry.test.ts (6 tests) 15ms

# full package suite
Test Files  33 passed | 1 skipped (34)
     Tests  542 passed | 7 expected fail | 12 skipped | 2 todo (563)
```

`echo-client:lint` clean, `pnpm format` (oxfmt) run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6buTxWtxvDUYVXp14bQYh

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6buTxWtxvDUYVXp14bQYh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced timer overhead when managing active objects.
  * Improved resource usage during intensive activity through more efficient pin expiration.

* **Bug Fixes**
  * Improved object pin lifetime handling during repeated access.
  * Prevented recent activity from being affected by system clock changes.
  * Ensured cleanup completes when pins are cleared or objects are deleted.
  * Improved schema creation feedback with progress indicators and safer handling of concurrent or failed operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12920-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
