### PR TITLE
echo: skip write validation when an object's schema does not resolve

### DIFF
--- a/.changeset/quiet-moons-listen.md
+++ b/.changeset/quiet-moons-listen.md
@@ -1,0 +1,5 @@
+---
+'@dxos/echo-client': patch
+---
+
+Writing to an object whose type is not registered in the current runtime no longer throws `Schema not found in schema registry`. Such an object — one written before its type's version bump, or replicated from a peer carrying a type this runtime lacks — was readable but rejected every mutation; writes now skip validation instead, as they already did for untyped objects.

--- a/.changeset/quiet-moons-listen.md
+++ b/.changeset/quiet-moons-listen.md
@@ -2,4 +2,4 @@
 '@dxos/echo-client': patch
 ---
 
-Writing to an object whose type is not registered in the current runtime no longer throws `Schema not found in schema registry`. Such an object — one written before its type's version bump, or replicated from a peer carrying a type this runtime lacks — was readable but rejected every mutation; writes now skip validation instead, as they already did for untyped objects.
+Writing to an object whose type is not registered in the current runtime no longer throws `Schema not found in schema registry`. Such an object — one written before its type's version bump, or replicated from a peer carrying a type this runtime lacks — was readable, but assigning a property or inserting into an array failed; those writes now skip validation instead, as they already did for untyped objects.

--- a/packages/core/echo/echo-client/src/echo-handler/echo-handler.ts
+++ b/packages/core/echo/echo-client/src/echo-handler/echo-handler.ts
@@ -357,12 +357,10 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
     throwIfCustomClass(path[path.length - 1], value);
     const rootObjectSchema = getSchema(target);
     if (rootObjectSchema == null) {
-      const typeRef = target[symbolInternals].getType();
-      if (typeRef) {
-        // The object has schema, but we can't access it to validate the value being set.
-        throw new Error(`Schema not found in schema registry: ${EncodedReference.toURI(typeRef)}`);
-      }
-
+      // An untyped object, or a typed one whose schema does not resolve in this runtime (written
+      // before a type's version bump, or replicated from a peer that has a type this one lacks):
+      // writes pass through unvalidated, since refusing them would make the object unusable
+      // wherever its schema happens to be absent.
       return value;
     }
 

--- a/packages/core/echo/echo-client/src/echo-handler/unregistered-type.test.ts
+++ b/packages/core/echo/echo-client/src/echo-handler/unregistered-type.test.ts
@@ -18,9 +18,9 @@ const VersionedV2 = Type.makeObject(DXN.make('com.example.type.versioned', '0.2.
 const V1_URI = DXN.make('com.example.type.versioned', '0.1.0');
 
 /**
- * Locks in the contract documented on `Obj.getType` / `Entity.getType`: an object whose stored
- * type reference does not resolve reports `undefined` rather than throwing, so callers can probe
- * an object of an unknown type.
+ * An object whose stored type reference does not resolve stays fully usable: `Obj.getType` reports
+ * `undefined` (the contract documented there and on `Entity.getType`) and writes skip validation
+ * instead of failing, since there is no schema to validate against.
  *
  * The registry indexes a type under its exact `dxn:<typename>:<version>`, so an object written
  * before a type's version bump becomes unresolvable — which is what these tests reproduce by
@@ -70,24 +70,38 @@ describe('object whose type is absent from the registry', () => {
     expect(Obj.getTypeURI(object)).toEqual(V1_URI);
   });
 
-  test('reads succeed and only writes fail, naming the unresolved type', async () => {
+  test('reads and writes both succeed', async () => {
     const { object } = await setup();
 
     expect(object.name).toEqual('Alice');
-    expect(() =>
-      Obj.update(object, (object) => {
-        object.name = 'Bob';
-      }),
-    ).toThrow(`Schema not found in schema registry: ${V1_URI}`);
+    Obj.update(object, (object) => {
+      object.name = 'Bob';
+    });
+    expect(object.name).toEqual('Bob');
   });
 
-  test('re-registering the type resolves it again without touching the object', async () => {
+  test('writes skip validation rather than failing on the unresolved schema', async () => {
+    const { object } = await setup();
+
+    // There is no schema to validate against, so a value the schema would reject is written as-is.
+    Obj.update(object, (object) => {
+      (object as any).name = 42;
+    });
+    expect((object as any).name).toEqual(42);
+  });
+
+  test('re-registering the type restores validation', async () => {
     const { db, object } = await setup();
     expect(Obj.getType(object)).toBeUndefined();
 
     db.graph.registry.add([VersionedV1]);
 
     expect(Obj.getType(object)).toBe(VersionedV1);
+    expect(() =>
+      Obj.update(object, (object) => {
+        (object as any).name = 42;
+      }),
+    ).toThrow();
     Obj.update(object, (object) => {
       object.name = 'Bob';
     });

--- a/packages/core/echo/echo-client/src/echo-handler/unregistered-type.test.ts
+++ b/packages/core/echo/echo-client/src/echo-handler/unregistered-type.test.ts
@@ -39,25 +39,15 @@ describe('object whose type is absent from the registry', () => {
     await builder.close();
   });
 
-  /** Adds an object of v0.1.0, then unregisters that version, leaving the stored ref dangling. */
-  const setup = async (types: Type.AnyEntity[] = [VersionedV1]) => {
-    const peer = await builder.createPeer({ types });
-    const db = await peer.createDatabase();
-    const object = db.add(Obj.make(VersionedV1, { name: 'Alice' }));
-    await db.flush();
-    expect(db.graph.registry.remove(VersionedV1.id)).toBe(true);
-    return { db, object };
-  };
-
   test('Obj.getType returns undefined when the type is not registered', async () => {
-    const { object } = await setup();
+    const { object } = await setup(builder);
 
     expect(Obj.getType(object)).toBeUndefined();
     expect(Entity.getType(object)).toBeUndefined();
   });
 
   test('Obj.getType returns undefined when only another version of the typename is registered', async () => {
-    const { db, object } = await setup([VersionedV1, VersionedV2]);
+    const { db, object } = await setup(builder, [VersionedV1, VersionedV2]);
 
     // The registry still holds this typename, but only at 0.2.0 — resolution is exact-version.
     expect(db.graph.registry.getByURI(DXN.make('com.example.type.versioned', '0.2.0'))).toBe(VersionedV2);
@@ -65,13 +55,13 @@ describe('object whose type is absent from the registry', () => {
   });
 
   test('the stored type URI survives, so the object stays identifiable', async () => {
-    const { object } = await setup();
+    const { object } = await setup(builder);
 
     expect(Obj.getTypeURI(object)).toEqual(V1_URI);
   });
 
   test('reads and writes both succeed', async () => {
-    const { object } = await setup();
+    const { object } = await setup(builder);
 
     expect(object.name).toEqual('Alice');
     Obj.update(object, (object) => {
@@ -81,7 +71,7 @@ describe('object whose type is absent from the registry', () => {
   });
 
   test('writes skip validation rather than failing on the unresolved schema', async () => {
-    const { object } = await setup();
+    const { object } = await setup(builder);
 
     // There is no schema to validate against, so a value the schema would reject is written as-is.
     Obj.update(object, (object) => {
@@ -91,7 +81,7 @@ describe('object whose type is absent from the registry', () => {
   });
 
   test('re-registering the type restores validation', async () => {
-    const { db, object } = await setup();
+    const { db, object } = await setup(builder);
     expect(Obj.getType(object)).toBeUndefined();
 
     db.graph.registry.add([VersionedV1]);
@@ -108,3 +98,13 @@ describe('object whose type is absent from the registry', () => {
     expect(object.name).toEqual('Bob');
   });
 });
+
+/** Adds an object of v0.1.0, then unregisters that version, leaving the stored ref dangling. */
+const setup = async (builder: EchoTestBuilder, types: Type.AnyEntity[] = [VersionedV1]) => {
+  const peer = await builder.createPeer({ types });
+  const db = await peer.createDatabase();
+  const object = db.add(Obj.make(VersionedV1, { name: 'Alice' }));
+  await db.flush();
+  expect(db.graph.registry.remove(VersionedV1.id)).toBe(true);
+  return { db, object };
+};

--- a/packages/core/echo/echo-client/src/echo-handler/unregistered-type.test.ts
+++ b/packages/core/echo/echo-client/src/echo-handler/unregistered-type.test.ts
@@ -1,0 +1,96 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { Entity, Obj, Type } from '@dxos/echo';
+import { DXN } from '@dxos/keys';
+
+import { EchoTestBuilder } from '../testing';
+
+const fields = Schema.Struct({ name: Schema.optional(Schema.String) });
+
+const VersionedV1 = Type.makeObject(DXN.make('com.example.type.versioned', '0.1.0'))(fields);
+const VersionedV2 = Type.makeObject(DXN.make('com.example.type.versioned', '0.2.0'))(fields);
+
+const V1_URI = DXN.make('com.example.type.versioned', '0.1.0');
+
+/**
+ * Locks in the contract documented on `Obj.getType` / `Entity.getType`: an object whose stored
+ * type reference does not resolve reports `undefined` rather than throwing, so callers can probe
+ * an object of an unknown type.
+ *
+ * The registry indexes a type under its exact `dxn:<typename>:<version>`, so an object written
+ * before a type's version bump becomes unresolvable — which is what these tests reproduce by
+ * unregistering the version the object was written with. `db.add` refuses an unregistered type
+ * up front, so unregistering after the write is the only way to reach this state in-process; in
+ * a real profile it arrives via storage or replication from a peer running the older code.
+ */
+describe('object whose type is absent from the registry', () => {
+  let builder: EchoTestBuilder;
+
+  beforeEach(async () => {
+    builder = await new EchoTestBuilder().open();
+  });
+
+  afterEach(async () => {
+    await builder.close();
+  });
+
+  /** Adds an object of v0.1.0, then unregisters that version, leaving the stored ref dangling. */
+  const setup = async (types: Type.AnyEntity[] = [VersionedV1]) => {
+    const peer = await builder.createPeer({ types });
+    const db = await peer.createDatabase();
+    const object = db.add(Obj.make(VersionedV1, { name: 'Alice' }));
+    await db.flush();
+    expect(db.graph.registry.remove(VersionedV1.id)).toBe(true);
+    return { db, object };
+  };
+
+  test('Obj.getType returns undefined when the type is not registered', async () => {
+    const { object } = await setup();
+
+    expect(Obj.getType(object)).toBeUndefined();
+    expect(Entity.getType(object)).toBeUndefined();
+  });
+
+  test('Obj.getType returns undefined when only another version of the typename is registered', async () => {
+    const { db, object } = await setup([VersionedV1, VersionedV2]);
+
+    // The registry still holds this typename, but only at 0.2.0 — resolution is exact-version.
+    expect(db.graph.registry.getByURI(DXN.make('com.example.type.versioned', '0.2.0'))).toBe(VersionedV2);
+    expect(Obj.getType(object)).toBeUndefined();
+  });
+
+  test('the stored type URI survives, so the object stays identifiable', async () => {
+    const { object } = await setup();
+
+    expect(Obj.getTypeURI(object)).toEqual(V1_URI);
+  });
+
+  test('reads succeed and only writes fail, naming the unresolved type', async () => {
+    const { object } = await setup();
+
+    expect(object.name).toEqual('Alice');
+    expect(() =>
+      Obj.update(object, (object) => {
+        object.name = 'Bob';
+      }),
+    ).toThrow(`Schema not found in schema registry: ${V1_URI}`);
+  });
+
+  test('re-registering the type resolves it again without touching the object', async () => {
+    const { db, object } = await setup();
+    expect(Obj.getType(object)).toBeUndefined();
+
+    db.graph.registry.add([VersionedV1]);
+
+    expect(Obj.getType(object)).toBe(VersionedV1);
+    Obj.update(object, (object) => {
+      object.name = 'Bob';
+    });
+    expect(object.name).toEqual('Bob');
+  });
+});


### PR DESCRIPTION
## Problem

Assigning a property on a typed object whose type reference the registry cannot resolve threw:

```
Error: Schema not found in schema registry: dxn:org.dxos.type.assistant.chat:0.1.0
    at EchoReactiveHandler._validateValue (echo-handler.ts:317)
    at EchoReactiveHandler.set (echo-handler.ts:191)
    at .../plugin-assistant/src/operations/update-chat-name.ts:54
```

Reads work (the read path tolerates an unresolved schema and returns decoded data), and so do mutations that don't assign a value — `_validateValue` is reached only from `set` and the array-insert path, so `deleteProperty`, `arrayPop`, `arrayShift`, `arraySort` and `arrayReverse` were unaffected. But a property assignment or an array insert failed, which is enough to make the object unusable in practice. It is reachable with no corruption involved:

- An object written before its type's version bump. The registry indexes a type under its exact `dxn:{typename}:{version}` (`registry.ts` `getTypeDXN` / `getEntityUris`) and `getByURI` has no version fallback, so a `Chat` stored at `0.1.0` no longer resolves once the type declares `0.2.0`.
- An object replicated from a peer carrying a type this runtime does not have registered.

## Fix

`_validateValue` now returns the value unvalidated when `getSchema` yields nothing, which is what it already did for untyped objects — the typed-but-unresolvable branch was the only one that threw. There is no schema to validate against in that state, and refusing the write only made the object unusable wherever its schema happened to be absent.

## Tests

New `packages/core/echo/echo-client/src/echo-handler/unregistered-type.test.ts`, six tests over an object whose stored type reference no longer resolves:

- `Obj.getType` and `Entity.getType` return `undefined` rather than throwing — the contract already documented on both, previously untested.
- Same when the typename *is* registered but only at another version, i.e. the version-bump case directly.
- The stored type URI survives, so the object stays identifiable.
- Reads and writes both succeed.
- Writes skip validation: a value the schema would reject is written as-is.
- Re-registering the type restores validation, and the rejected value then throws again.

`db.add` refuses an unregistered type up front (`createSchemaNotRegisteredError`), so the tests reach this state by unregistering the type after the write; in a real profile it arrives via storage or replication.

## Verification

The full package suite, not just the new file — this changes a core write path. Run on the head after merging `main` (which had advanced 3 commits, one of them #12920 in this same package):

```
$ moon run echo-client:test
 Test Files  34 passed | 1 skipped (35)
      Tests  549 passed | 7 expected fail | 12 skipped | 2 todo (570)
```

`pnpm format` reports no changes.

## Note on scope

This makes stale-version objects usable again; it does not migrate them. Separately, the `Chat` `0.1.0` → `0.2.0` bump shipped without a `Migration.define`, and `Operation.migrations` (the `PersistentOperation` 0.1.0 → 0.2.0 migration) is exported but contributed to no `ClientCapabilities.Migration`, so it never runs in the app. Both are follow-ups, not addressed here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7ESp8nium74wTNqrYRJSb




## Summary by CodeRabbit

* **Bug Fixes**
  * Objects with unavailable or unregistered types can now be read and updated without errors.
  * Writes to objects lacking a resolvable schema are accepted without validation.
  * Type references remain available even when their schemas cannot be resolved.
  * Exact type-version resolution is preserved, and validation resumes automatically when the type is registered again.

* **Release**
  * Included in a patch release of the Echo client.


---
🚀 Composer preview: https://pr-12922-composer-dev.dxos.workers.dev
