### PR TITLE
react-ui-task: make links in task rows clickable

### DIFF
--- a/.changeset/task-list-clickable-links.md
+++ b/.changeset/task-list-clickable-links.md
@@ -1,0 +1,5 @@
+---
+'@dxos/react-ui-task': patch
+---
+
+Task list rows now render URLs as links: a bare address in a task's title becomes a clickable link, and a link in a description opens in a new tab without also selecting the row.

--- a/packages/ui/react-ui-task/src/components/TaskList/TaskDescription.tsx
+++ b/packages/ui/react-ui-task/src/components/TaskList/TaskDescription.tsx
@@ -8,9 +8,18 @@ import { type ThemedClassName } from '@dxos/react-ui';
 import { MarkdownView } from '@dxos/react-ui-markdown';
 import { mx } from '@dxos/ui-theme';
 
+import { TaskLink } from './TaskLink';
+
 /** A description is a line in a row, not a document: no paragraph block, no heading scale. */
 export const DESCRIPTION_COMPONENTS = {
   p: ({ children }: PropsWithChildren) => <span>{children}</span>,
+  // The view's own anchor selects the row on the way to following the link, because the row is the
+  // selection target; `TaskLink` stops the click at the anchor.
+  a: ({ children, href }: PropsWithChildren<{ href?: string }>) => (
+    <TaskLink href={href} classNames='break-all'>
+      {children}
+    </TaskLink>
+  ),
 };
 
 export type TaskDescriptionProps = ThemedClassName<{ content: string }>;

--- a/packages/ui/react-ui-task/src/components/TaskList/TaskLink.tsx
+++ b/packages/ui/react-ui-task/src/components/TaskList/TaskLink.tsx
@@ -1,0 +1,40 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React, { type PropsWithChildren } from 'react';
+
+import { Link, type ThemedClassName } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+export type TaskLinkProps = ThemedClassName<PropsWithChildren<{ href?: string }>>;
+
+/** Schemes that are safe to hand a new tab; a `javascript:` href would run in the app's origin. */
+const SAFE_SCHEME = /^(https?|mailto):/i;
+
+/**
+ * A link inside a task row — in the title, or in the markdown of a description.
+ *
+ * The row is the selection target, so a bare anchor selected the task on the way to following the
+ * link; the click stops here instead. Focus needs no such guard: the tree only follows focus that
+ * lands on the row element itself.
+ */
+export const TaskLink = ({ href, children, classNames }: TaskLinkProps) => {
+  if (!href || !SAFE_SCHEME.test(href)) {
+    return <span className={mx(classNames)}>{children}</span>;
+  }
+
+  return (
+    <Link
+      href={href}
+      target='_blank'
+      rel='noopener noreferrer'
+      classNames={classNames}
+      onClick={(event) => event.stopPropagation()}
+    >
+      {children}
+    </Link>
+  );
+};
+
+TaskLink.displayName = 'TaskList.Link';

--- a/packages/ui/react-ui-task/src/components/TaskList/TaskList.stories.tsx
+++ b/packages/ui/react-ui-task/src/components/TaskList/TaskList.stories.tsx
@@ -46,6 +46,13 @@ const seedFlat = (): Task.Task[] => [
     description:
       'Draft lives at https://github.com/dxos/dxos/pull/12752 and the preview is https://pr-12752-composer-dev.dxos.workers.dev; blocked on #12431.',
   }),
+  // A title carrying a bare address, which is how a task written by an agent or pasted into quick
+  // entry usually names a PR — the row has to link it, since a title is text rather than markdown.
+  Task.make({
+    title: 'Review https://github.com/dxos/dxos/pull/12924',
+    status: 'todo',
+    description: 'Check that the LFS pre-push hook is bypassed and that Windows `$workspaceRoot` is exercised.',
+  }),
   Task.make({
     title: 'Draft launch email',
     status: 'started',
@@ -460,6 +467,53 @@ export const TestAgentSpinner: Story = {
         .map((row) => row.querySelector('span.truncate')?.textContent ?? '');
 
     await waitFor(async () => expect(spinning()).toEqual(['Draft launch email']), { timeout: 10_000 });
+  },
+};
+
+/**
+ * A URL in a title is a link the reader can follow, and following it does not select the row.
+ *
+ * Both halves matter: a title is plain text, so nothing makes the address an anchor unless the row
+ * splits the string itself; and the row is the selection target, so an anchor that let the click
+ * through would swap the edit pane onto the task on the way out to the browser.
+ */
+export const TestTitleLinks: Story = {
+  args: {
+    showGroupLabels: false,
+    showOrdinals: true,
+  },
+  play: async ({ canvasElement }) => {
+    const rows = () => Array.from(canvasElement.querySelectorAll<HTMLElement>('[data-testid="taskList.item"]'));
+    await waitFor(async () => expect(rows().length).toBeGreaterThan(1));
+
+    // Thrown rather than asserted, so `waitFor` retries until the row mounts and the element is
+    // narrowed for everything below it.
+    const link = await waitFor(() => {
+      const found = canvasElement.querySelector<HTMLAnchorElement>('span.truncate a[href^="https://"]');
+      if (!found) {
+        throw new Error('no title rendered a link');
+      }
+      return found;
+    });
+
+    // The address itself is the link text, and it opens away from the app rather than replacing it.
+    await expect(link.getAttribute('href')).toEqual('https://github.com/dxos/dxos/pull/12924');
+    await expect(link.textContent).toEqual('https://github.com/dxos/dxos/pull/12924');
+    await expect(link.getAttribute('target')).toEqual('_blank');
+    await expect(link.getAttribute('rel')).toContain('noopener');
+    // The words around the address stay text — the row linked the URL, not the title.
+    await expect(link.closest('span.truncate')?.textContent).toEqual('Review https://github.com/dxos/dxos/pull/12924');
+
+    // Navigation is suppressed for the click below; the assertion is about what the row did with
+    // it, and a new tab is not something the test runner should be left holding.
+    const suppress = (event: Event) => event.preventDefault();
+    document.addEventListener('click', suppress, true);
+    try {
+      await userEvent.click(link);
+      await expect(canvasElement.querySelectorAll('[aria-selected="true"]')).toHaveLength(0);
+    } finally {
+      document.removeEventListener('click', suppress, true);
+    }
   },
 };
 

--- a/packages/ui/react-ui-task/src/components/TaskList/TaskTitle.tsx
+++ b/packages/ui/react-ui-task/src/components/TaskList/TaskTitle.tsx
@@ -1,0 +1,43 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React, { Fragment } from 'react';
+
+import { type ThemedClassName } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+import { linkifyText } from './linkify';
+import { TaskLink } from './TaskLink';
+
+export type TaskTitleProps = ThemedClassName<{ title?: string }>;
+
+/**
+ * A task's title as it appears in a row: plain text, with any URL in it rendered as a link.
+ *
+ * Titles are a string rather than markdown — the quick-entry field and the agents that write tasks
+ * both paste addresses straight in ("Review https://github.com/…/pull/12924"), and without this the
+ * reader can see the address but not follow it.
+ */
+export const TaskTitle = ({ title, classNames }: TaskTitleProps) => {
+  const runs = title ? linkifyText(title) : [];
+  return (
+    <span className={mx(classNames)}>
+      {runs.map(({ text, href }, index) => (
+        <Fragment key={index}>
+          {href ? (
+            // `break-all` so a long address wraps inside the row instead of forcing the grid wider
+            // than the pane; the row's own truncation still governs the single-line case.
+            <TaskLink href={href} classNames='break-all'>
+              {text}
+            </TaskLink>
+          ) : (
+            text
+          )}
+        </Fragment>
+      ))}
+    </span>
+  );
+};
+
+TaskTitle.displayName = 'TaskList.Title';

--- a/packages/ui/react-ui-task/src/components/TaskList/TaskTreeContent.tsx
+++ b/packages/ui/react-ui-task/src/components/TaskList/TaskTreeContent.tsx
@@ -23,6 +23,7 @@ import {
 } from './hierarchy';
 import { TaskDescription } from './TaskDescription';
 import { TaskCheckbox, TaskOrdinal, TaskStatusControl } from './TaskRowCells';
+import { TaskTitle } from './TaskTitle';
 import { TASK_TREE_ROOT_ID, type TaskNode, buildTaskForest, buildTaskPaths, createTaskTreeModel } from './tree-model';
 
 /**
@@ -342,7 +343,7 @@ const TaskTreeHeading = ({
           <span className='col-[gutter]' />
         ))}
       <TaskStatusControl task={task} classNames='col-[status]' onTaskUpdate={onTaskUpdate} />
-      <span className='col-[title] self-center min-w-0 truncate'>{current.title}</span>
+      <TaskTitle title={current.title} classNames='col-[title] self-center min-w-0 truncate' />
       {/* The row's second line, spanning from the title to the row's end: it has to clear the
           ordinal and the status control, or it reads as belonging to the row above. */}
       {description && <TaskDescription content={description} classNames='col-[title/tree-row-end] row-start-2 pb-1' />}

--- a/packages/ui/react-ui-task/src/components/TaskList/index.ts
+++ b/packages/ui/react-ui-task/src/components/TaskList/index.ts
@@ -3,6 +3,9 @@
 //
 
 export * from './hierarchy';
+export { type TextRun, linkifyText } from './linkify';
 export { STATUS_ICONS, STATUS_ORDER } from './status-icons';
 export * from './TaskList';
+export { TaskLink } from './TaskLink';
+export { TaskTitle } from './TaskTitle';
 export { type TaskNode, buildTaskForest, flattenVisibleTasks } from './tree-model';

--- a/packages/ui/react-ui-task/src/components/TaskList/linkify.test.ts
+++ b/packages/ui/react-ui-task/src/components/TaskList/linkify.test.ts
@@ -1,0 +1,70 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { linkifyText } from './linkify';
+
+describe('linkifyText', () => {
+  test('text with no url is one run', ({ expect }) => {
+    expect(linkifyText('Review the branch')).to.deep.eq([{ text: 'Review the branch' }]);
+  });
+
+  test('empty text is no runs', ({ expect }) => {
+    expect(linkifyText('')).to.deep.eq([]);
+  });
+
+  test('a url is split out of the text around it', ({ expect }) => {
+    expect(linkifyText('Review https://github.com/dxos/dxos/pull/12924')).to.deep.eq([
+      { text: 'Review ' },
+      { text: 'https://github.com/dxos/dxos/pull/12924', href: 'https://github.com/dxos/dxos/pull/12924' },
+    ]);
+  });
+
+  test('text following a url is kept', ({ expect }) => {
+    expect(linkifyText('see http://dxos.org now')).to.deep.eq([
+      { text: 'see ' },
+      { text: 'http://dxos.org', href: 'http://dxos.org' },
+      { text: ' now' },
+    ]);
+  });
+
+  test('every url in the text is linked', ({ expect }) => {
+    expect(linkifyText('https://a.com and https://b.com')).to.deep.eq([
+      { text: 'https://a.com', href: 'https://a.com' },
+      { text: ' and ' },
+      { text: 'https://b.com', href: 'https://b.com' },
+    ]);
+  });
+
+  test('sentence punctuation is left outside the link', ({ expect }) => {
+    expect(linkifyText('Fixed by https://dxos.org/pr/1.')).to.deep.eq([
+      { text: 'Fixed by ' },
+      { text: 'https://dxos.org/pr/1', href: 'https://dxos.org/pr/1' },
+      { text: '.' },
+    ]);
+  });
+
+  test('an unmatched closing bracket is the sentence, not the url', ({ expect }) => {
+    expect(linkifyText('(see https://dxos.org)')).to.deep.eq([
+      { text: '(see ' },
+      { text: 'https://dxos.org', href: 'https://dxos.org' },
+      { text: ')' },
+    ]);
+  });
+
+  test('a matched closing bracket stays in the url', ({ expect }) => {
+    expect(linkifyText('https://en.wikipedia.org/wiki/Bun_(software)')).to.deep.eq([
+      { text: 'https://en.wikipedia.org/wiki/Bun_(software)', href: 'https://en.wikipedia.org/wiki/Bun_(software)' },
+    ]);
+  });
+
+  test('a scheme other than http(s) is not a link', ({ expect }) => {
+    expect(linkifyText('run javascript:alert(1)')).to.deep.eq([{ text: 'run javascript:alert(1)' }]);
+  });
+
+  test('a schemeless host is not a link', ({ expect }) => {
+    expect(linkifyText('deploy to dxos.org today')).to.deep.eq([{ text: 'deploy to dxos.org today' }]);
+  });
+});

--- a/packages/ui/react-ui-task/src/components/TaskList/linkify.test.ts
+++ b/packages/ui/react-ui-task/src/components/TaskList/linkify.test.ts
@@ -64,6 +64,18 @@ describe('linkifyText', () => {
     expect(linkifyText('run javascript:alert(1)')).to.deep.eq([{ text: 'run javascript:alert(1)' }]);
   });
 
+  test('a scheme with no host is not a link', ({ expect }) => {
+    expect(linkifyText('go to https://?next now')).to.deep.eq([{ text: 'go to https://?next now' }]);
+  });
+
+  test('a rejected candidate between two links stays text', ({ expect }) => {
+    expect(linkifyText('https://a.com https://?x https://b.com')).to.deep.eq([
+      { text: 'https://a.com', href: 'https://a.com' },
+      { text: ' https://?x ' },
+      { text: 'https://b.com', href: 'https://b.com' },
+    ]);
+  });
+
   test('a schemeless host is not a link', ({ expect }) => {
     expect(linkifyText('deploy to dxos.org today')).to.deep.eq([{ text: 'deploy to dxos.org today' }]);
   });

--- a/packages/ui/react-ui-task/src/components/TaskList/linkify.ts
+++ b/packages/ui/react-ui-task/src/components/TaskList/linkify.ts
@@ -1,0 +1,74 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+/** A run of a plain-text string: bare text, or text that is also a URL. */
+export type TextRun = {
+  text: string;
+  /** Present when the run is a link; equal to `text`. */
+  href?: string;
+};
+
+/**
+ * Only absolute http(s) URLs. A schemeless host (`dxos.org`) is not distinguishable from prose with
+ * a period in it, and anything else — `mailto:`, `javascript:` — is not something a title should be
+ * able to make clickable.
+ */
+const URL_PATTERN = /https?:\/\/[^\s<>]+/g;
+
+/** Sentence punctuation that follows a URL far more often than it belongs to one. */
+const TRAILING_PUNCTUATION = /[.,;:!?'"]+$/;
+
+/**
+ * Trim the punctuation a URL picked up from the sentence around it. A closing bracket is only the
+ * sentence's when the URL carries no matching opener, which is what keeps a wiki-style
+ * `…/Foo_(bar)` intact.
+ */
+const trimUrl = (url: string): string => {
+  let trimmed = url.replace(TRAILING_PUNCTUATION, '');
+  while (trimmed.length > 0) {
+    const last = trimmed.slice(-1);
+    const opener = last === ')' ? '(' : last === ']' ? '[' : undefined;
+    if (!opener) {
+      break;
+    }
+    const opened = trimmed.split(opener).length - 1;
+    const closed = trimmed.split(last).length - 1;
+    if (opened >= closed) {
+      break;
+    }
+    trimmed = trimmed.slice(0, -1).replace(TRAILING_PUNCTUATION, '');
+  }
+  return trimmed;
+};
+
+/**
+ * Split plain text into text and link runs.
+ *
+ * A task's title is a string, not markdown, so a URL pasted into it has no syntax that would make
+ * it a link — the reader sees the address and cannot follow it. Splitting the string is what lets
+ * the row render the address as an anchor; a description takes the markdown path instead.
+ *
+ * Returns a single text run for a string with no URL in it, so a caller never special-cases the
+ * common case.
+ */
+export const linkifyText = (text: string): TextRun[] => {
+  const runs: TextRun[] = [];
+  let index = 0;
+  for (const match of text.matchAll(URL_PATTERN)) {
+    const start = match.index;
+    const url = trimUrl(match[0]);
+    if (url.length === 0) {
+      continue;
+    }
+    if (start > index) {
+      runs.push({ text: text.slice(index, start) });
+    }
+    runs.push({ text: url, href: url });
+    index = start + url.length;
+  }
+  if (index < text.length) {
+    runs.push({ text: text.slice(index) });
+  }
+  return runs;
+};

--- a/packages/ui/react-ui-task/src/components/TaskList/linkify.ts
+++ b/packages/ui/react-ui-task/src/components/TaskList/linkify.ts
@@ -43,6 +43,20 @@ const trimUrl = (url: string): string => {
 };
 
 /**
+ * Whether the candidate is a URL a browser can actually navigate to. The pattern is deliberately
+ * loose, so it also matches shapes that are not addresses at all — `https://?next` has a scheme and
+ * no host — and rendering one as a link gives the reader something that goes nowhere.
+ */
+const isNavigable = (candidate: string): boolean => {
+  try {
+    const url = new URL(candidate);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && url.hostname.length > 0;
+  } catch {
+    return false;
+  }
+};
+
+/**
  * Split plain text into text and link runs.
  *
  * A task's title is a string, not markdown, so a URL pasted into it has no syntax that would make
@@ -58,7 +72,9 @@ export const linkifyText = (text: string): TextRun[] => {
   for (const match of text.matchAll(URL_PATTERN)) {
     const start = match.index;
     const url = trimUrl(match[0]);
-    if (url.length === 0) {
+    // Left in the surrounding text run rather than dropped: the next slice starts where the last
+    // accepted URL ended, so a rejected candidate is still shown as the text it is.
+    if (url.length === 0 || !isNavigable(url)) {
       continue;
     }
     if (start > index) {


### PR DESCRIPTION
A URL in a task row was text the reader could see but not follow.

## What changed

- **Titles.** A task's title is a plain string, not markdown, so a pasted address (`Review https://github.com/dxos/dxos/pull/12924` — how an agent or quick entry usually names a PR) had no syntax that would make it a link. `linkifyText` splits the string into text and link runs and `TaskTitle` renders the URLs as anchors. Only absolute `http(s)` URLs: a schemeless host is not distinguishable from prose with a period in it. Trailing sentence punctuation is left outside the link, and a bracket is only trimmed when the URL carries no matching opener, so `…/Bun_(software)` stays intact.
- **Descriptions.** These already came out of `MarkdownView` as anchors, but the row is the selection target, so following a link also selected the task and swapped the edit pane onto it on the way out to the browser. Both paths now go through one `TaskLink`, which stops the click at the anchor, opens in a new tab (`rel="noopener noreferrer"`), and renders a non-`http(s)`/`mailto` href as plain text rather than a clickable `javascript:`.

The title keeps its `truncate` span, so row geometry and the stories that read titles off it are unchanged.

## Testing

- `linkify.test.ts` — 10 cases (no URL, several URLs, trailing punctuation, brackets, non-http schemes, schemeless hosts).
- `TestTitleLinks` story — asserts the anchor's href/text/target/rel, that the words around the address stay text, and that clicking the link selects no row.
- `moon run react-ui-task:test` → 39 passed; `:test-storybook` → 23 passed; `:build` and `:lint` green.

@wittjosiah for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015azNV2hCRxq5XJJkZwy8oo


---
_Generated by [Claude Code](https://claude.ai/code/session_015azNV2hCRxq5XJJkZwy8oo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Task titles and descriptions now automatically convert supported HTTP(S) and email addresses into clickable links.
  - Links open in a new tab, with long URLs wrapping cleanly.
  - Clicking a link no longer selects the surrounding task row.
  - Unsafe, malformed, or unsupported URL formats remain plain text.
- **Bug Fixes**
  - Improved link handling so surrounding title and description text remains unchanged while valid links are interactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12928-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
