### PR TITLE
config: strip protobuf message markers from config sources

### DIFF
--- a/.changeset/config-strip-message-markers.md
+++ b/.changeset/config-strip-message-markers.md
@@ -2,6 +2,8 @@
 '@dxos/config': patch
 ---
 
-`Config` now strips the protobuf-es message markers (`$typeName`, `$unknown`) from every source before merging, so passing an existing message — such as `configPreset(...).values` — no longer produces a `Config.values` that `toBinary` cannot encode.
+`Config` now strips the protobuf-es `$typeName` marker from every source before merging, so passing an existing message — such as `configPreset(...).values` — no longer produces a `Config.values` that `toBinary` cannot encode.
 
 `lodash.defaultsdeep` copied `$typeName` onto plain objects that came from another source; protobuf-es then treated those objects as already-constructed messages and skipped normalising their plain descendants. The malformed tree failed to serialise across the worker RPC boundary, which is how `SystemService.getConfig()` terminated the renderer under `DEDICATED_WORKER`.
+
+Unknown wire fields are preserved: `MessageInitShape` excludes `$unknown`, so `Config` copies those records back onto the normalised message, and a source decoded from the wire keeps fields this build's schema does not know.

--- a/.changeset/config-strip-message-markers.md
+++ b/.changeset/config-strip-message-markers.md
@@ -1,0 +1,7 @@
+---
+'@dxos/config': patch
+---
+
+`Config` now strips the protobuf-es message markers (`$typeName`, `$unknown`) from every source before merging, so passing an existing message — such as `configPreset(...).values` — no longer produces a `Config.values` that `toBinary` cannot encode.
+
+`lodash.defaultsdeep` copied `$typeName` onto plain objects that came from another source; protobuf-es then treated those objects as already-constructed messages and skipped normalising their plain descendants. The malformed tree failed to serialise across the worker RPC boundary, which is how `SystemService.getConfig()` terminated the renderer under `DEDICATED_WORKER`.

--- a/packages/sdk/config/src/config.test.ts
+++ b/packages/sdk/config/src/config.test.ts
@@ -2,13 +2,15 @@
 // Copyright 2021 DXOS.org
 //
 
-import { createRegistry, fromJson, toJson } from '@bufbuild/protobuf';
+import { createRegistry, fromJson, toBinary, toJson } from '@bufbuild/protobuf';
 import { StructSchema, anyPack } from '@bufbuild/protobuf/wkt';
 import { expect, test } from 'vitest';
 
 import { ConfigSchema } from '@dxos/protocols/buf/dxos/config_pb';
 
 import { Config, mapFromKeyValues, mapToKeyValues } from './config';
+import { EDGE_URLS } from './edge-services';
+import { configPreset } from './preset';
 // @ts-ignore
 import defaults from './testing/defaults.js';
 // @ts-ignore
@@ -154,4 +156,34 @@ test.skip('mapToKeyValuesping', () => {
     TEST_CLIENT_ID: 123,
     TEST_CLIENT_TAG: 'testing',
   });
+});
+
+test('message source produces an encodable config', () => {
+  const config = new Config(
+    {
+      runtime: {
+        client: {
+          storage: { persistent: true },
+        },
+      },
+    },
+    configPreset({ edge: 'preview' }).values,
+  );
+
+  expect(() => toBinary(ConfigSchema, config.values)).not.toThrow();
+  expect(config.get('runtime.client.storage.persistent')).to.eq(true);
+  expect(config.get('runtime.services.edge.url')).to.eq(EDGE_URLS.preview);
+});
+
+test('reversed source order produces an encodable config', () => {
+  const config = new Config(configPreset({ edge: 'preview' }).values, {
+    runtime: {
+      client: {
+        storage: { persistent: true },
+      },
+    },
+  });
+
+  expect(() => toBinary(ConfigSchema, config.values)).not.toThrow();
+  expect(config.get('runtime.client.storage.persistent')).to.eq(true);
 });

--- a/packages/sdk/config/src/config.test.ts
+++ b/packages/sdk/config/src/config.test.ts
@@ -2,9 +2,9 @@
 // Copyright 2021 DXOS.org
 //
 
-import { createRegistry, fromJson, toBinary, toJson } from '@bufbuild/protobuf';
+import { create, createRegistry, fromBinary, fromJson, toBinary, toJson } from '@bufbuild/protobuf';
 import { StructSchema, anyPack } from '@bufbuild/protobuf/wkt';
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import { ConfigSchema } from '@dxos/protocols/buf/dxos/config_pb';
 
@@ -158,32 +158,55 @@ test.skip('mapToKeyValuesping', () => {
   });
 });
 
-test('message source produces an encodable config', () => {
-  const config = new Config(
-    {
+describe('Config sources', () => {
+  test('message source produces an encodable config', () => {
+    const config = new Config(
+      {
+        runtime: {
+          client: {
+            storage: { persistent: true },
+          },
+        },
+      },
+      configPreset({ edge: 'preview' }).values,
+    );
+
+    expect(() => toBinary(ConfigSchema, config.values)).not.toThrow();
+    expect(config.get('runtime.client.storage.persistent')).to.eq(true);
+    expect(config.get('runtime.services.edge.url')).to.eq(EDGE_URLS.preview);
+  });
+
+  test('reversed source order produces an encodable config', () => {
+    const config = new Config(configPreset({ edge: 'preview' }).values, {
       runtime: {
         client: {
           storage: { persistent: true },
         },
       },
-    },
-    configPreset({ edge: 'preview' }).values,
-  );
+    });
 
-  expect(() => toBinary(ConfigSchema, config.values)).not.toThrow();
-  expect(config.get('runtime.client.storage.persistent')).to.eq(true);
-  expect(config.get('runtime.services.edge.url')).to.eq(EDGE_URLS.preview);
-});
-
-test('reversed source order produces an encodable config', () => {
-  const config = new Config(configPreset({ edge: 'preview' }).values, {
-    runtime: {
-      client: {
-        storage: { persistent: true },
-      },
-    },
+    expect(() => toBinary(ConfigSchema, config.values)).not.toThrow();
+    expect(config.get('runtime.client.storage.persistent')).to.eq(true);
   });
 
-  expect(() => toBinary(ConfigSchema, config.values)).not.toThrow();
-  expect(config.get('runtime.client.storage.persistent')).to.eq(true);
+  test('unknown wire fields survive a source round-trip', () => {
+    // A varint field this build's schema does not know, as `fromBinary` would leave it on the message.
+    const unknown = { no: 9999, wireType: 0, data: new Uint8Array([42]) };
+    const source = create(ConfigSchema, { version: 1 });
+    source.$unknown = [unknown];
+
+    const config = new Config(source, {
+      runtime: {
+        client: {
+          storage: { persistent: true },
+        },
+      },
+    });
+
+    expect(config.values.$unknown).to.deep.eq([unknown]);
+    expect(config.get('runtime.client.storage.persistent')).to.eq(true);
+
+    const decoded = fromBinary(ConfigSchema, toBinary(ConfigSchema, config.values));
+    expect(decoded.$unknown).to.deep.eq([unknown]);
+  });
 });

--- a/packages/sdk/config/src/config.ts
+++ b/packages/sdk/config/src/config.ts
@@ -91,33 +91,62 @@ export const mapToKeyValues = (spec: MappingSpec, values: any) => {
   return config;
 };
 
+/** A plain object in a config tree, narrowed by predicate so `$unknown` stays reachable. */
+type ConfigNode = { $unknown?: unknown } & Record<string, unknown>;
+
+const isPlainNode = (value: unknown): value is ConfigNode =>
+  value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype;
+
 /**
- * Removes the protobuf-es message markers (`$typeName`, `$unknown`) from a config tree.
+ * Removes the protobuf-es `$typeName` marker from a config tree.
  *
  * `defaultsDeep` copies `$typeName` onto plain objects that came from another source, and
  * protobuf-es then treats those objects as already-constructed messages and skips normalising
  * their plain descendants -- producing a `Config.values` that `toBinary` cannot encode.
  */
-export const stripMessageMarkers = <T>(value: T): T => {
+export const stripTypeNames = <T>(value: T): T => {
   if (Array.isArray(value)) {
-    return value.map((item) => stripMessageMarkers(item)) as T;
+    return value.map((item) => stripTypeNames(item)) as T;
   }
 
   // Bytes, timestamps and other non-plain leaves are values, not message subtrees.
-  if (value === null || typeof value !== 'object' || Object.getPrototypeOf(value) !== Object.prototype) {
+  if (!isPlainNode(value)) {
     return value;
   }
 
-  const result: Record<string, any> = {};
+  const result: Record<string, unknown> = {};
   for (const [key, item] of Object.entries(value)) {
-    if (key === '$typeName' || key === '$unknown') {
+    if (key === '$typeName') {
       continue;
     }
 
-    result[key] = stripMessageMarkers(item);
+    // `$unknown` holds raw wire records, which are values rather than a message subtree.
+    result[key] = key === '$unknown' ? item : stripTypeNames(item);
   }
 
   return result as T;
+};
+
+/**
+ * Copies `$unknown` records from a merged config tree onto the message `create` built from it.
+ *
+ * `MessageInitShape` excludes `$unknown`, so normalising a tree whose `$typeName` markers were
+ * stripped drops the wire fields a source decoded but this build's schema does not know.
+ */
+export const restoreUnknownFields = (target: unknown, source: unknown): void => {
+  if (!isPlainNode(target) || !isPlainNode(source)) {
+    return;
+  }
+
+  if (source.$unknown !== undefined) {
+    target.$unknown = source.$unknown;
+  }
+
+  for (const [key, value] of Object.entries(source)) {
+    if (key !== '$unknown') {
+      restoreUnknownFields(target[key], value);
+    }
+  }
 };
 
 /**
@@ -169,9 +198,9 @@ export class Config {
    * @constructor
    */
   constructor(config: ConfigInit = {}, ...objects: ConfigInit[]) {
-    this._config = validateConfig(
-      defaultsDeep(stripMessageMarkers(config), ...objects.map(stripMessageMarkers), { version: 1 }),
-    );
+    const merged = defaultsDeep(stripTypeNames(config), ...objects.map(stripTypeNames), { version: 1 });
+    this._config = validateConfig(merged);
+    restoreUnknownFields(this._config, merged);
   }
 
   /**

--- a/packages/sdk/config/src/config.ts
+++ b/packages/sdk/config/src/config.ts
@@ -92,6 +92,35 @@ export const mapToKeyValues = (spec: MappingSpec, values: any) => {
 };
 
 /**
+ * Removes the protobuf-es message markers (`$typeName`, `$unknown`) from a config tree.
+ *
+ * `defaultsDeep` copies `$typeName` onto plain objects that came from another source, and
+ * protobuf-es then treats those objects as already-constructed messages and skips normalising
+ * their plain descendants -- producing a `Config.values` that `toBinary` cannot encode.
+ */
+export const stripMessageMarkers = <T>(value: T): T => {
+  if (Array.isArray(value)) {
+    return value.map((item) => stripMessageMarkers(item)) as T;
+  }
+
+  // Bytes, timestamps and other non-plain leaves are values, not message subtrees.
+  if (value === null || typeof value !== 'object' || Object.getPrototypeOf(value) !== Object.prototype) {
+    return value;
+  }
+
+  const result: Record<string, any> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (key === '$typeName' || key === '$unknown') {
+      continue;
+    }
+
+    result[key] = stripMessageMarkers(item);
+  }
+
+  return result as T;
+};
+
+/**
  * Validates a config object and normalises it into a buf message.
  * Field types are checked by the compiler through `ConfigInit`, which is why this no longer runs the
  * protobuf.js `verify` pass; loaders that read untrusted YAML validate as they parse.
@@ -140,7 +169,9 @@ export class Config {
    * @constructor
    */
   constructor(config: ConfigInit = {}, ...objects: ConfigInit[]) {
-    this._config = validateConfig(defaultsDeep(config, ...objects, { version: 1 }));
+    this._config = validateConfig(
+      defaultsDeep(stripMessageMarkers(config), ...objects.map(stripMessageMarkers), { version: 1 }),
+    );
   }
 
   /**


### PR DESCRIPTION
Fixes #12923

## Problem

`Config` merges its sources with `lodash.defaultsdeep`. When one source is a protobuf-es message (e.g. `configPreset(...).values`, or the message returned by `parseConfig`), `defaultsDeep` copies `$typeName` onto plain objects that came from the other sources. `create(ConfigSchema, merged)` then treats those objects as already-constructed messages and skips normalising their plain descendants, so `Config.values` is a tree `toBinary` cannot encode:

```
cannot use field dxos.config.Runtime.Client.Storage.persistent with message undefined
```

Direct field access hides this; `SystemService.getConfig()` exposes it, since its return value crosses the worker RPC boundary — which is how it terminated the Chromium renderer under `DEDICATED_WORKER`.

## Change

In `packages/sdk/config/src/config.ts`:

- `stripTypeNames()` recursively removes `$typeName` from plain objects and arrays, leaving non-plain leaves (bytes, dates) untouched. `Config`'s constructor applies it to every source before merging — which, as a side effect, stops `defaultsDeep` mutating the caller's object.
- `restoreUnknownFields()` copies `$unknown` records from the merged tree back onto the created message, at every level. This is needed because `MessageInitShape` excludes `$unknown`: once `$typeName` is gone, `create` normalises a plain init and drops the wire fields a source decoded but this build's schema does not know. Preserving the records through the merge alone is *not* sufficient — I verified that `config.values.$unknown` still came back `undefined`.

Three cases in `config.test.ts`, under `describe('Config sources', ...)`: a plain init merged with `configPreset(...).values` encodes in either source order, and an unknown varint field on a message source survives construction plus a `toBinary` → `fromBinary` round trip.

## Verification

`moon run config:test -- src/config.test.ts` — `Test Files 1 passed (1)`, `Tests 6 passed | 2 skipped (8)`.

With the marker stripping reverted, the two ordering tests fail with the exact error from the issue: `ForeignFieldError: cannot use field dxos.config.Runtime.Client.Storage.persistent with message undefined`.

`oxfmt --check` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tYQbpeJMqKDty9kjgwFxu

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12931-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
