### PR TITLE
build: run dx-trace-imports under bun

### DIFF
--- a/packages/devtools/cli/moon.yml
+++ b/packages/devtools/cli/moon.yml
@@ -10,7 +10,7 @@ tasks:
   # to live in a react-ui package. None of them were visible without tracing the graph.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --from src/bin.ts
       --to "{react,react-dom}"
       --conditions node

--- a/packages/plugins/plugin-assistant/moon.yml
+++ b/packages/plugins/plugin-assistant/moon.yml
@@ -13,7 +13,7 @@ tasks:
     # Fail when the ./plugin export pulls in `@dxos/react-ui`. The plugin entry must
     # remain UI-free under workerd so it can load in non-DOM environments.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./AssistantPlugin
       --to "@dxos/react-ui"
       --conditions workerd,worker

--- a/packages/plugins/plugin-atproto/moon.yml
+++ b/packages/plugins/plugin-atproto/moon.yml
@@ -10,7 +10,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./AtprotoPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-attention/moon.yml
+++ b/packages/plugins/plugin-attention/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./AttentionPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-blogger/moon.yml
+++ b/packages/plugins/plugin-blogger/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./BloggerPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-bluesky/moon.yml
+++ b/packages/plugins/plugin-bluesky/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./BlueskyPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-board/moon.yml
+++ b/packages/plugins/plugin-board/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./BoardPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-bookmarks/moon.yml
+++ b/packages/plugins/plugin-bookmarks/moon.yml
@@ -10,7 +10,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./BookmarksPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-brain/moon.yml
+++ b/packages/plugins/plugin-brain/moon.yml
@@ -10,7 +10,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./BrainPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-calls/moon.yml
+++ b/packages/plugins/plugin-calls/moon.yml
@@ -11,7 +11,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./CallsPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-chess-com/moon.yml
+++ b/packages/plugins/plugin-chess-com/moon.yml
@@ -11,7 +11,7 @@ tasks:
   # bundler walking into a React surface — only node-conditioned `#capabilities`/`#operations` do.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ChessComPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-chess/moon.yml
+++ b/packages/plugins/plugin-chess/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ChessPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-claude/moon.yml
+++ b/packages/plugins/plugin-claude/moon.yml
@@ -10,7 +10,7 @@ tasks:
     # The plugin generates node and workerd capability barrels, so its headless entry must stay
     # UI-free: fail if React ever becomes reachable from it under either condition.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ClaudePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-client/moon.yml
+++ b/packages/plugins/plugin-client/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ClientPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-code/moon.yml
+++ b/packages/plugins/plugin-code/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./CodePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-commerce/moon.yml
+++ b/packages/plugins/plugin-commerce/moon.yml
@@ -12,7 +12,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./CommercePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-computer/moon.yml
+++ b/packages/plugins/plugin-computer/moon.yml
@@ -10,7 +10,7 @@ tasks:
   # import graph proves the two halves stay apart.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export .
       --to "node:child_process"
       --conditions source,browser,import

--- a/packages/plugins/plugin-conductor/moon.yml
+++ b/packages/plugins/plugin-conductor/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ConductorPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-connector/moon.yml
+++ b/packages/plugins/plugin-connector/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ConnectorPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-crm/moon.yml
+++ b/packages/plugins/plugin-crm/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./CrmPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-crx/moon.yml
+++ b/packages/plugins/plugin-crx/moon.yml
@@ -8,7 +8,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./CrxPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-debug/moon.yml
+++ b/packages/plugins/plugin-debug/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./DebugPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-deck/moon.yml
+++ b/packages/plugins/plugin-deck/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./DeckPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-devtools/moon.yml
+++ b/packages/plugins/plugin-devtools/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./DevtoolsPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-discord/moon.yml
+++ b/packages/plugins/plugin-discord/moon.yml
@@ -8,7 +8,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./DiscordPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-doctor/moon.yml
+++ b/packages/plugins/plugin-doctor/moon.yml
@@ -8,7 +8,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./DoctorPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-duffel/moon.yml
+++ b/packages/plugins/plugin-duffel/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./DuffelPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-excalidraw/moon.yml
+++ b/packages/plugins/plugin-excalidraw/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ExcalidrawPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-explorer/moon.yml
+++ b/packages/plugins/plugin-explorer/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ExplorerPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-file-system/moon.yml
+++ b/packages/plugins/plugin-file-system/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./FileSystemPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-file/moon.yml
+++ b/packages/plugins/plugin-file/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # bundler walking into a React surface — only node-conditioned `#capabilities`/`#operations` do.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./FilePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-freeq/moon.yml
+++ b/packages/plugins/plugin-freeq/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./FreeqPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-game/moon.yml
+++ b/packages/plugins/plugin-game/moon.yml
@@ -11,7 +11,7 @@ tasks:
     # The plugin now generates node/workerd capability barrels, so the headless entry must stay
     # UI-free: fail if React ever becomes reachable from it under either condition.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./GamePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-github/moon.yml
+++ b/packages/plugins/plugin-github/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./GitHubPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-google/moon.yml
+++ b/packages/plugins/plugin-google/moon.yml
@@ -10,7 +10,7 @@ tasks:
     # A provider plugin is headless: no React, no UI packages. Fail if the plugin entry ever reaches
     # one, so the constraint is enforced rather than assumed.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./GooglePlugin
       --to "@dxos/react-ui"
       --to react

--- a/packages/plugins/plugin-ibkr/moon.yml
+++ b/packages/plugins/plugin-ibkr/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./IbkrPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-illustrator/moon.yml
+++ b/packages/plugins/plugin-illustrator/moon.yml
@@ -11,7 +11,7 @@ tasks:
     # The plugin now generates node/workerd capability barrels, so the headless entry must stay
     # UI-free: fail if React ever becomes reachable from it under either condition.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./IllustratorPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-inbox/moon.yml
+++ b/packages/plugins/plugin-inbox/moon.yml
@@ -15,7 +15,7 @@ tasks:
     # Fail when the ./plugin export pulls in `@dxos/react-ui`. The plugin entry must
     # remain UI-free under workerd so it can load in non-DOM environments.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./InboxPlugin
       --to "@dxos/react-ui"
       --conditions workerd,worker

--- a/packages/plugins/plugin-jmap/moon.yml
+++ b/packages/plugins/plugin-jmap/moon.yml
@@ -10,7 +10,7 @@ tasks:
     # A provider plugin is headless: no React, no UI packages. Fail if the plugin entry ever reaches
     # one, so the constraint is enforced rather than assumed.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./JmapPlugin
       --to "@dxos/react-ui"
       --to react

--- a/packages/plugins/plugin-kanban/moon.yml
+++ b/packages/plugins/plugin-kanban/moon.yml
@@ -15,7 +15,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./KanbanPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-lametric/moon.yml
+++ b/packages/plugins/plugin-lametric/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./LaMetricPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-library/moon.yml
+++ b/packages/plugins/plugin-library/moon.yml
@@ -10,7 +10,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./LibraryPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-linear/moon.yml
+++ b/packages/plugins/plugin-linear/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./LinearPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-lingo/moon.yml
+++ b/packages/plugins/plugin-lingo/moon.yml
@@ -12,7 +12,7 @@ tasks:
     # The plugin generates node and workerd capability barrels, so its headless entry must stay
     # UI-free: fail if React ever becomes reachable from it under either condition.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./LingoPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-magazine/moon.yml
+++ b/packages/plugins/plugin-magazine/moon.yml
@@ -12,7 +12,7 @@ tasks:
     # Fail when the ./plugin export pulls in `@dxos/react-ui`.
     # The plugin entry must remain UI-free under workerd so it can load in non-DOM environments.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./MagazinePlugin
       --to "@dxos/react-ui"
       --conditions workerd,worker

--- a/packages/plugins/plugin-map/moon.yml
+++ b/packages/plugins/plugin-map/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./MapPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-markdown/moon.yml
+++ b/packages/plugins/plugin-markdown/moon.yml
@@ -12,7 +12,7 @@ tasks:
     # Fail when the ./plugin export pulls in `@dxos/react-ui`. The plugin entry must
     # remain UI-free under workerd so it can load in non-DOM environments.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./MarkdownPlugin
       --to "@dxos/react-ui"
       --conditions workerd,worker

--- a/packages/plugins/plugin-meeting/moon.yml
+++ b/packages/plugins/plugin-meeting/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./MeetingPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-native/moon.yml
+++ b/packages/plugins/plugin-native/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./NativePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-navtree/moon.yml
+++ b/packages/plugins/plugin-navtree/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./NavTreePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-observability/moon.yml
+++ b/packages/plugins/plugin-observability/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ObservabilityPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-onboarding/moon.yml
+++ b/packages/plugins/plugin-onboarding/moon.yml
@@ -7,7 +7,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./OnboardingPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-payments/moon.yml
+++ b/packages/plugins/plugin-payments/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./PaymentsPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-pipeline/moon.yml
+++ b/packages/plugins/plugin-pipeline/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./PipelinePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-presenter/moon.yml
+++ b/packages/plugins/plugin-presenter/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./PresenterPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-preview/moon.yml
+++ b/packages/plugins/plugin-preview/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./PreviewPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-projects/moon.yml
+++ b/packages/plugins/plugin-projects/moon.yml
@@ -13,7 +13,7 @@ tasks:
     # depends on: `./ProjectOperationHandlerSet` for the handler set. Keep it UI-free: a leak here
     # breaks that host at build time, far from here.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ProjectOperationHandlerSet
       --to "@dxos/react-ui"
       --to react

--- a/packages/plugins/plugin-registry/moon.yml
+++ b/packages/plugins/plugin-registry/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./RegistryPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-review/moon.yml
+++ b/packages/plugins/plugin-review/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ReviewPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-routine/moon.yml
+++ b/packages/plugins/plugin-routine/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./RoutinePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-sample/moon.yml
+++ b/packages/plugins/plugin-sample/moon.yml
@@ -10,7 +10,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./SamplePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-sandbox/moon.yml
+++ b/packages/plugins/plugin-sandbox/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./SandboxPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-script/moon.yml
+++ b/packages/plugins/plugin-script/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ScriptPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-search/moon.yml
+++ b/packages/plugins/plugin-search/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./SearchPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-sequencer/moon.yml
+++ b/packages/plugins/plugin-sequencer/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./SequencerPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-settings/moon.yml
+++ b/packages/plugins/plugin-settings/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./SettingsPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-sheet/moon.yml
+++ b/packages/plugins/plugin-sheet/moon.yml
@@ -14,7 +14,7 @@ tasks:
   # bundler walking into a React surface — only node-conditioned `#capabilities`/`#operations` do.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./SheetPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-sidekick/moon.yml
+++ b/packages/plugins/plugin-sidekick/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./SidekickPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-slack/moon.yml
+++ b/packages/plugins/plugin-slack/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./SlackPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-space/moon.yml
+++ b/packages/plugins/plugin-space/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./SpacePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-spacetime/moon.yml
+++ b/packages/plugins/plugin-spacetime/moon.yml
@@ -10,7 +10,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./SpacetimePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-spotlight/moon.yml
+++ b/packages/plugins/plugin-spotlight/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./SpotlightPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-stack/moon.yml
+++ b/packages/plugins/plugin-stack/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./StackPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-stream-deck/moon.yml
+++ b/packages/plugins/plugin-stream-deck/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./StreamDeckPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-studio/moon.yml
+++ b/packages/plugins/plugin-studio/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./StudioPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-support/moon.yml
+++ b/packages/plugins/plugin-support/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./SupportPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-table/moon.yml
+++ b/packages/plugins/plugin-table/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./TablePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-tasks/moon.yml
+++ b/packages/plugins/plugin-tasks/moon.yml
@@ -15,7 +15,7 @@ tasks:
   check-module-structure:
     # Handler set registered by the headless host.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./TasksOperationHandlerSet
       --to "@dxos/react-ui"
       --to react

--- a/packages/plugins/plugin-template/moon.yml
+++ b/packages/plugins/plugin-template/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./TemplatePlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-terra/moon.yml
+++ b/packages/plugins/plugin-terra/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./TerraPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-testing/moon.yml
+++ b/packages/plugins/plugin-testing/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./StorybookPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-thread/moon.yml
+++ b/packages/plugins/plugin-thread/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # bundler walking into a React surface — only node-conditioned `#capabilities`/`#operations` do.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ThreadPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-tldraw/moon.yml
+++ b/packages/plugins/plugin-tldraw/moon.yml
@@ -10,7 +10,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./TldrawPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-transcription/moon.yml
+++ b/packages/plugins/plugin-transcription/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./TranscriptionPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-trello/moon.yml
+++ b/packages/plugins/plugin-trello/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./TrelloPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-trip/moon.yml
+++ b/packages/plugins/plugin-trip/moon.yml
@@ -13,7 +13,7 @@ tasks:
   # surface — only a node-conditioned `#capabilities` barrel does.
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./TripPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-video/moon.yml
+++ b/packages/plugins/plugin-video/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./VideoPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-voxel/moon.yml
+++ b/packages/plugins/plugin-voxel/moon.yml
@@ -11,7 +11,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./VoxelPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-wnfs/moon.yml
+++ b/packages/plugins/plugin-wnfs/moon.yml
@@ -11,7 +11,7 @@ tasks:
     # The plugin generates node and workerd capability barrels, so its headless entry must stay
     # UI-free: fail if React ever becomes reachable from it under either condition.
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./WnfsPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/plugins/plugin-zen/moon.yml
+++ b/packages/plugins/plugin-zen/moon.yml
@@ -9,7 +9,7 @@ tags:
 tasks:
   check-module-structure:
     command: >-
-      pnpm exec dx-trace-imports
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js
       --export ./ZenPlugin
       --to "{react,react-dom}"
       --conditions workerd,worker

--- a/packages/sdk/app-framework/moon.yml
+++ b/packages/sdk/app-framework/moon.yml
@@ -44,7 +44,7 @@ tasks:
     # must exist — catches stale `./workerd` export paths like the removed browser bundle).
     # Then fail when the root export pulls in React; React lives only behind `./ui`.
     script: |
-      pnpm exec dx-trace-imports \
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js \
         --export . \
         --to "{react,react-dom}" \
         --conditions workerd,worker \

--- a/packages/sdk/app-toolkit/moon.yml
+++ b/packages/sdk/app-toolkit/moon.yml
@@ -10,7 +10,7 @@ tasks:
     # Verify headless entrypoints resolve under workerd conditions, then fail when the
     # root export pulls in React (Composer UI lives only behind `./ui`).
     script: |
-      pnpm exec dx-trace-imports \
+      bun $workspaceRoot/tools/dx-trace-imports/cli.js \
         --export . \
         --to "{react,react-dom}" \
         --conditions workerd,worker \


### PR DESCRIPTION
Runs `dx-trace-imports` under bun instead of node, the same shape as #12924.

The 92 `check-module-structure` call sites invoked the tool as `pnpm exec dx-trace-imports`. pnpm's generated `node_modules/.bin/dx-trace-imports` is a shell script ending in `exec node "$basedir/../@dxos/dx-trace-imports/cli.js"` — it hardcodes the interpreter and never consults the target's shebang, so `pnpm exec` cannot select a runtime. Invoking `cli.js` by absolute path under bun is what actually switches it, exactly as `tag-ts-build.yml` documents for `dx-build`/`dx-compile`.

90 sites use `command:` and 2 (`app-framework`, `app-toolkit`) use `script:`. Both forms were verified: moon injects the pinned bun (`.prototools` → 1.3.11) at the front of the task PATH for each, and `$workspaceRoot` is substituted in `script:` as well as `command:`.

## Verification

Baselined under node before changing anything, then compared.

- **Node-vs-node control (2 runs)** — stdout and the emitted graph metafile byte-identical. stderr differs only in `graph: /tmp/trace-imports-graph-<pid>-<ts>.json`, which embeds `process.pid` and `Date.now()` and so is nondeterministic under node alone.
- **node vs bun, `plugin-chess`** — byte-identical stdout, stderr (excluding that path) and 116 KB metafile, across four argument shapes: the real `--fail-on present` guard, a 396-line/26 KB positive trace, `--packages-only`, and the failing `--fail-on present` exit path (exit 1 both).
- **End-to-end under moon** — `plugin-chess` (`command:`, `--export`, two condition sets), `app-framework` (`script:`), and `cli` (`command:`, `--from src/bin.ts`) all pass, output matching the node baseline.
- **Runtime confirmed, not assumed** — a probe task with the same `command:` form resolves bare `bun` to `/root/.proto/tools/bun/1.3.11/bun`.

## One behavioural difference, on the invalid-argument path only

When yargs rejects bad CLI arguments, node writes all 1450 bytes to stderr; bun writes 1449 to stderr and a single `\n` to stdout. Merged output is byte-identical and the exit code is 1 under both. Deterministic on both sides (3 runs each), so it is a genuine runtime difference rather than flake. It is unreachable from these call sites, which pass fixed valid arguments, and nothing in the repo parses the tool's output. Reported rather than papered over.

## Not verified

- Only 3 of the 92 call sites were executed end-to-end; the other 89 are the identical one-line substitution but were not individually run.
- Not run on CI's runner image, macOS, or Windows.
- `.agents/skills/composer-plugins/SKILL.md:642` still documents the `pnpm exec` form for ad-hoc local use. It still works (under node) and was left alone to keep this diff scoped.

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12932-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
