### PR TITLE
react-ui: stop clicks falling through toasts onto the UI beneath

### DIFF
--- a/.changeset/toast-pointer-events.md
+++ b/.changeset/toast-pointer-events.md
@@ -1,0 +1,7 @@
+---
+'@dxos/react-ui': patch
+---
+
+Toasts consume clicks over their own surface again: while a modal menu or dialog is open, a toast is
+no longer transparent to hit-testing, so clicks landing on it can no longer fall through to the UI it
+covers. The toast viewport itself stays click-through, so the surrounding app remains interactive.

--- a/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
@@ -4,9 +4,11 @@
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React, { type ReactNode, useState } from 'react';
+import { expect, userEvent, waitFor } from 'storybook/test';
 
 import { withTheme } from '../../testing';
-import { Button } from '../Button';
+import { Button, IconButton } from '../Button';
+import { DropdownMenu } from '../Menu';
 import { Toast } from './Toast';
 
 type ActionTriggerProps = { altText: string; trigger: ReactNode };
@@ -54,6 +56,57 @@ const DefaultStory = ({
   );
 };
 
+/**
+ * The layering the status bar produces: a toast is already showing when a status indicator's
+ * (modal) menu opens over the same corner, so the menu's items sit underneath the toast.
+ */
+const OverModalMenuStory = () => (
+  <Toast.Provider>
+    {/* Bottom-end corner, where the status bar's indicators are; `side='left'` puts the menu over the toast. */}
+    <div className='fixed bottom-2 end-2'>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <IconButton
+            data-testid='story.menuTrigger'
+            variant='ghost'
+            icon='ph--info--regular'
+            iconOnly
+            label='Open status menu'
+          />
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content data-testid='story.menu' side='left' align='end'>
+            <DropdownMenu.Viewport>
+              {['One', 'Two', 'Three', 'Four', 'Five', 'Six'].map((label) => (
+                <DropdownMenu.Item key={label}>
+                  <span className='grow'>{label}</span>
+                </DropdownMenu.Item>
+              ))}
+            </DropdownMenu.Viewport>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+    </div>
+    <Toast.Viewport />
+    <Toast.Root data-testid='story.toast' open duration={100_000}>
+      <Toast.Title icon='ph--sparkle--regular'>Toast over the menu</Toast.Title>
+      <Toast.Description>Clicks on this toast must not reach the menu underneath it.</Toast.Description>
+      <Toast.Actions>
+        <Button variant='primary'>Reload</Button>
+      </Toast.Actions>
+    </Toast.Root>
+  </Toast.Provider>
+);
+
+/** Throws rather than returning null so `waitFor` retries until the element mounts. */
+const getByTestId = (testId: string): HTMLElement => {
+  const element = document.querySelector(`[data-testid="${testId}"]`);
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`Not rendered: ${testId}`);
+  }
+  return element;
+};
+
 const meta = {
   title: 'ui/react-ui-core/components/Toast',
   component: Toast as any,
@@ -90,5 +143,36 @@ export const WithAction: Story = {
         trigger: <Button variant='primary'>Reload</Button>,
       },
     ],
+  },
+};
+
+/**
+ * A modal menu marks every dismissable layer beneath it inert, which used to include the toast —
+ * leaving it painted on top but transparent to hit-testing, so clicks fell through to the menu.
+ */
+export const OverModalMenu: Story = {
+  render: OverModalMenuStory,
+  play: async () => {
+    const toast = await waitFor(() => getByTestId('story.toast'));
+    // The toast slides in, so its box is only where it appears once the animation has settled.
+    await waitFor(() => expect(getComputedStyle(toast).transform).toEqual('none'));
+
+    await userEvent.click(await waitFor(() => getByTestId('story.menuTrigger')));
+    const menu = await waitFor(() => getByTestId('story.menu'));
+
+    const toastRect = toast.getBoundingClientRect();
+    const menuRect = menu.getBoundingClientRect();
+    const overlap = {
+      left: Math.max(toastRect.left, menuRect.left),
+      right: Math.min(toastRect.right, menuRect.right),
+      top: Math.max(toastRect.top, menuRect.top),
+      bottom: Math.min(toastRect.bottom, menuRect.bottom),
+    };
+    // Guards the premise: with no overlap the hit test below would prove nothing.
+    await expect(overlap.right).toBeGreaterThan(overlap.left);
+    await expect(overlap.bottom).toBeGreaterThan(overlap.top);
+
+    const hit = document.elementFromPoint((overlap.left + overlap.right) / 2, (overlap.top + overlap.bottom) / 2);
+    await expect(toast.contains(hit)).toBe(true);
   },
 };

--- a/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
+++ b/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
@@ -13,12 +13,18 @@ const viewport: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
     'inset-start-[calc(env(safe-area-inset-left)+1rem)] inset-end-[calc(env(safe-area-inset-right)+1rem)]',
     'w-auto md:end-[calc(env(safe-area-inset-right)+4rem)] md:left-auto md:w-full md:max-w-sm',
     'rounded-md flex flex-col gap-2',
+    // Toasts are non-modal, so only a toast's own box may intercept — never the gaps between them.
+    'pointer-events-none',
     ...etc,
   );
 
 const root: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
   mx(
     'dx-popover-surface rounded-md p-1',
+    // Importance overrides the inline `pointer-events: none` Radix's dismissable layer writes onto
+    // every layer beneath an open modal menu or dialog, which leaves the toast painted on top yet
+    // transparent to hit-testing — passing clicks through to whatever it covers.
+    'pointer-events-auto!',
     surfaceShadow({ elevation: 'toast' }),
     'radix-state-open:animate-toast-slide-in-bottom md:radix-state-open:animate-toast-slide-in-right',
     'radix-state-closed:animate-toast-hide',


### PR DESCRIPTION
## Defect

"Status indicators clicking through toasts." With a toast on screen and a status-indicator menu open
in the same bottom-end corner, the toast was painted over the menu but did not consume clicks: a
click on the toast's surface activated the menu item underneath it.

Reproduced in the running app (`composer-app` dev server, 1440×900): show a toast, then open the
`HelpMenu` status indicator (the ⓘ item in the R0 rail, which opens `side='left'` straight over the
toast area) and click a point the toast visually covers.

- `document.elementFromPoint` at that point returned a `role="menuitem"` element, not the toast.
- A real `page.mouse.click` there landed on the menu's **About Composer** item.

## Root cause

Not the toast viewport's own styling — neither the viewport nor the root carried
`pointer-events-none`. The inertness comes from Radix's dismissable-layer coordination:

1. `DropdownMenu` in `@dxos/react-ui` defaults to `modal = true`, so its content layer sets
   `disableOutsidePointerEvents`. That writes `document.body { pointer-events: none }`.
2. A toast (`ToastPrimitive.Root`) is itself a `DismissableLayer.Root`. Every layer *below* the
   topmost layer with `disableOutsidePointerEvents` gets an inline `pointer-events: none`, so an
   already-open toast is marked inert the moment the menu opens.
3. The menu content keeps `pointer-events: auto`, and the toast still paints above it
   (`z-40` viewport vs `z-20` menu) — so the toast was visible, inert, and the interactive menu sat
   directly beneath it. Hence clicks "through" the toast.

Measured on the live page before the fix:
`body: none`, toast inline `none`, computed `none`, viewport `none`, menu `auto`.

The order matters, which is why this looked intermittent: a toast that appears *after* the menu is
the higher layer and behaved correctly; a toast already on screen when the menu opens did not.

## Fix

`packages/ui/react-ui/src/components/Toast/Toast.theme.ts` — in the package that owns the toast, not
at a call site:

- `toast.root`: `pointer-events-auto!`. Importance is required to override the *inline* style Radix
  writes on the layer; a plain utility loses to it. The toast therefore always consumes clicks on its
  own box.
- `toast.viewport`: `pointer-events-none`. The viewport spans the whole stack's bounding box, so
  without this it would swallow clicks in the gaps between stacked toasts. Toasts are non-modal, so
  only a toast's own surface intercepts and the rest of the viewport stays click-through — matching
  Radix's documented viewport/toast pattern.

## Files touched

- `packages/ui/react-ui/src/components/Toast/Toast.theme.ts` — the fix.
- `packages/ui/react-ui/src/components/Toast/Toast.stories.tsx` — new `OverModalMenu` story +
  regression assertion (a toast, then a modal status-style menu over it; asserts the hit test at the
  overlap resolves inside the toast).
- `.changeset/toast-pointer-events.md`.

## Verification

Storybook browser test (`moon run react-ui:test-storybook`, real chromium):

- `OverModalMenu` passes with the fix; reverting only `Toast.theme.ts` makes it fail, and the element
  hit at the overlap is a `DropdownMenu.Item` — i.e. the test reproduces the reported defect.
- Full package suite green: 59 files / 187 tests.

Live app (`composer-app` dev server), after the fix:

- Toast + `HelpMenu` (modal, over the toast): hit test resolves inside the toast; a real mouse click
  lands on the toast, no longer on "About Composer". Toast inline `pointer-events` is still `none`,
  computed is `auto` — the important utility does override it.
- Toast over the `plugin-progress` R0 popover (non-modal, 6 active providers so it overlaps): still
  consumed by the toast — no regression.
- The toast's own close button still dismisses it with the viewport now click-through.
- The 8px gap between two stacked toasts now passes clicks to the popover beneath, and the app
  remains interactive with toasts up (clicked the account item while two toasts were showing) — the
  fix does not make the viewport a click blocker.

Repo checks for the package touched: `react-ui:build` (emits types, so this is the typecheck),
`react-ui:lint`, `react-ui:test`, `react-ui:test-storybook` — all green.

## Not verified

- Touch behaviour: swipe-to-dismiss and hover-to-pause were not exercised. They should be unaffected
  (both listen on the toast `li` / Radix's wrapper, which keep pointer events), but I did not test
  them.
- Behaviour change worth a reviewer's eye: while a **modal dialog** is open, a toast is now clickable
  rather than inert. That follows the stated expectation ("clicks landing on a toast are consumed by
  the toast"), and a toast's action/close is arguably always meant to work — but it is a deliberate
  divergence from Radix's default layer inertness, so say the word if dialogs should instead keep
  toasts inert-but-blocking.
- No mobile/`plugin-mobile` layout run, and no e2e spec added (the regression lives as a storybook
  browser test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toasts now reliably receive clicks on their visible surface when overlapping an open menu or dialog.
  * Empty areas around toasts remain click-through, preserving interaction with the surrounding app.

* **Tests**
  * Added coverage for toast interaction when displayed over a modal menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12934-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
