### PR TITLE
react-ui-table: wait for the cell editor to take focus before typing in e2e

### DIFF
--- a/packages/ui/lit-grid/src/testing/dx-grid-manager.ts
+++ b/packages/ui/lit-grid/src/testing/dx-grid-manager.ts
@@ -23,6 +23,21 @@ export class DxGridManager {
     return this.grid.locator('.dx-grid').waitFor({ state: 'visible' });
   }
 
+  cellEditor(): Locator {
+    return this.page.getByTestId('grid.cell-editor').getByRole('textbox');
+  }
+
+  /**
+   * Resolves once the cell editor can receive keystrokes. Its container paints a frame before the
+   * text editor mounts inside it and takes focus, so keys sent on container visibility alone are
+   * dropped and the edit commits empty.
+   */
+  async cellEditorReady(): Promise<Locator> {
+    const editor = this.cellEditor();
+    await expect(editor).toBeFocused();
+    return editor;
+  }
+
   planes(): Locator {
     return this.grid.locator('.dx-grid [data-dx-grid-plane]');
   }

--- a/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
+++ b/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
@@ -5,6 +5,7 @@
 import { expect, test } from '@playwright/test';
 
 import { type DxGrid } from '@dxos/lit-grid';
+import { DxGridManager } from '@dxos/lit-grid/testing';
 import { random } from '@dxos/random';
 import { setupPage, storybookUrl } from '@dxos/test-utils/playwright';
 
@@ -191,7 +192,7 @@ test.describe('Table', () => {
 
     // Focus should already be on the new row; engage edit mode.
     await page.keyboard.press('Enter');
-    await page.getByTestId('grid.cell-editor').waitFor({ state: 'visible' });
+    await table.grid.cellEditorReady();
 
     // Type text and confirm.
     const cellContent = 'New row content';
@@ -271,6 +272,7 @@ test.describe('Table', () => {
     // The contactModel is used in the second Table.Main component in the story
     const dxGrid = page.locator('dx-grid').nth(1);
     await dxGrid.waitFor({ state: 'visible' });
+    const grid = new DxGridManager(page, dxGrid);
 
     // Scroll to the last column (column 4)
     await dxGrid.evaluate(async (dxGridElement: DxGrid) => {
@@ -314,7 +316,7 @@ test.describe('Table', () => {
     const nonRefCell = dxGrid.locator('[data-dx-grid-plane="grid"] [aria-rowindex="0"][aria-colindex="6"]');
     await nonRefCell.click();
     await page.keyboard.press('Enter');
-    await page.getByTestId('grid.cell-editor').waitFor({ state: 'visible' });
+    await grid.cellEditorReady();
     await page.keyboard.type(nonRefContent, { delay: 500 });
     await page.keyboard.press('Enter');
     await expect(nonRefCell).toHaveText(nonRefContent);


### PR DESCRIPTION
`Table › add row and edit cell` was failing on main, in `e2e (browser=chromium, shard=rest)`. The
cell it asserts on resolved with no text:

```
Locator: locator('dx-grid').locator('.dx-grid [data-dx-grid-plane="grid"] [aria-colindex="0"][aria-rowindex="10"]')
Expected: "New row content"
9 × locator resolved to <div … aria-rowindex="10" aria-selected="true" data-testid="grid.0.10">…</div>
  - unexpected value ""
```

## Cause

The test typed as soon as `grid.cell-editor` became *visible*. That element is only the container
div. CodeMirror mounts inside it and takes focus two effects later, so there is a window where the
container is on screen and nothing can receive keys. Measured in the browser with a MutationObserver:

```
editor-div 6547.1  ->  cm-content 6562.4  ->  cm-focus 6578.0
```

Roughly 30ms. Locally Playwright's next command lands after it. On a loaded CI runner it lands
inside it, the keystrokes go nowhere, and Enter commits an empty editor.

## Fix

`DxGridManager.cellEditorReady()` waits for the editor itself to be focused, and the spec uses it in
place of the container's visibility check.

## Verification

Delaying the autofocus effect by 400ms widens the window enough to make the race deterministic:

| | old wait | new wait |
| --- | --- | --- |
| autofocus delayed 400ms | 2/2 failed with the CI signature | 2/2 passed |

A dispatched Check run with `e2e=true` on this branch is green in all six e2e matrix jobs, including
the one that was red on main:

```
✓ 10 [chromium] › src/playwright/smoke.spec.ts:178:3 › Table › add row and edit cell (6.5s)
3 skipped / 9 passed (48.0s)
```

Run: https://depot.dev/orgs/t8fblrl00n/workflows/109g2v9gjj

## Follow-ups, not in this PR

- `useTextEditor` focuses in a post-paint effect, so the same ~30ms window exists for real users: a
  fast typist entering a grid cell can lose the first keystrokes. Fixing it at the source touches
  every editor in the app.
- `plugin-sheet`'s `sheet-manager.ts` papers over the same race with `waitForTimeout(200)` sleeps
  whose TODOs ask whether they help. `cellEditorReady()` would replace them deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved table smoke-test reliability by waiting for the cell editor to be focused and ready before entering text.
  * Added reusable test support for locating and waiting for grid cell editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12938-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
