### PR TITLE
feed: detect server replacement and re-sync from scratch

### DIFF
--- a/.changeset/feed-sync-server-token.md
+++ b/.changeset/feed-sync-server-token.md
@@ -5,12 +5,17 @@
 Feed sync now detects that the server was replaced or its storage wiped, and re-syncs the affected
 namespace from scratch instead of stalling on positions that no longer exist.
 
-Query responses carry the serving store's `serverToken`, clients remember it in `sync_state`, and
-each query request echoes it back as `expectedServerToken` so a server that no longer recognises it
-serves the namespace from the start in the same round-trip. On a mismatch the client drops the
-global position from every block of that space/namespace, restarts pull progress under the new
-token, and re-pushes; blocks are de-duplicated by `(actorId, sequence)`, so nothing is lost or
-duplicated.
+A position authority reports its store token on query and append responses, clients remember it in
+`sync_state` alongside their pull progress, and every query request echoes it back as
+`expectedServerToken` — a server that does not recognise the token ignores `position` and serves the
+namespace from the start, so recovery costs no extra round-trip. On a mismatch the client drops the
+global position from every block of that space/namespace, restarts progress under the new token, and
+re-pushes; blocks are de-duplicated by `(actorId, sequence)`, so nothing is lost or duplicated.
+
+Pull progress written before this release carries no token, and its server may already have been
+replaced, so the first token such a client observes triggers the same reset rather than being
+adopted — one extra pull per space/namespace, once, in exchange for not silently skipping every
+block below the stale position. Progress with nothing pulled yet just records the token.
 
 All protocol fields are optional: older clients keep working against a new server (their `position`
 is honoured verbatim), and a new client against an older server behaves exactly as before.

--- a/.changeset/feed-sync-server-token.md
+++ b/.changeset/feed-sync-server-token.md
@@ -1,0 +1,16 @@
+---
+'@dxos/echo': minor
+---
+
+Feed sync now detects that the server was replaced or its storage wiped, and re-syncs the affected
+namespace from scratch instead of stalling on positions that no longer exist.
+
+Query responses carry the serving store's `serverToken`, clients remember it in `sync_state`, and
+each query request echoes it back as `expectedServerToken` so a server that no longer recognises it
+serves the namespace from the start in the same round-trip. On a mismatch the client drops the
+global position from every block of that space/namespace, restarts pull progress under the new
+token, and re-pushes; blocks are de-duplicated by `(actorId, sequence)`, so nothing is lost or
+duplicated.
+
+All protocol fields are optional: older clients keep working against a new server (their `position`
+is honoured verbatim), and a new client against an older server behaves exactly as before.

--- a/packages/core/echo/feed/src/feed-store.test.ts
+++ b/packages/core/echo/feed/src/feed-store.test.ts
@@ -764,6 +764,108 @@ describe('Feed V2', () => {
   );
 });
 
+describe('FeedStore server token', () => {
+  const seed = (feed: FeedStore, spaceId: SpaceId, feedId: string, count: number) =>
+    feed.appendLocal(
+      Array.from({ length: count }, (_unused, index) => ({
+        spaceId,
+        feedId,
+        feedNamespace: WellKnownNamespaces.data,
+        data: new Uint8Array([index]),
+      })),
+    );
+
+  it.effect('reports its own token from a position authority', () =>
+    Effect.gen(function* () {
+      const spaceId = SpaceId.random();
+      const feed = new FeedStore({ localActorId: ALICE, assignPositions: true });
+      yield* feed.migrate();
+
+      const token = yield* feed.getServerToken(spaceId);
+      const response = yield* feed.query({ spaceId, feedNamespace: WellKnownNamespaces.data });
+      expect(response.serverToken).toBe(token);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  // A replica's own token says nothing about the ordering it caches, and reporting it would make a
+  // client treat its peer as the position authority.
+  it.effect('reports no token from a store that does not assign positions', () =>
+    Effect.gen(function* () {
+      const spaceId = SpaceId.random();
+      const feed = new FeedStore({ localActorId: ALICE, assignPositions: false });
+      yield* feed.migrate();
+
+      const response = yield* feed.query({ spaceId, feedNamespace: WellKnownNamespaces.data });
+      expect(response.serverToken).toBeUndefined();
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect('honours position for a client that sends a matching token or none', () =>
+    Effect.gen(function* () {
+      const spaceId = SpaceId.random();
+      const feedId = EntityId.random();
+      const feed = new FeedStore({ localActorId: ALICE, assignPositions: true });
+      yield* feed.migrate();
+      yield* seed(feed, spaceId, feedId, 5);
+      const token = yield* feed.getServerToken(spaceId);
+
+      const legacyClient = yield* feed.query({ spaceId, feedNamespace: WellKnownNamespaces.data, position: 2 });
+      expect(legacyClient.blocks.map((block) => block.position)).toEqual([3, 4]);
+
+      const currentClient = yield* feed.query({
+        spaceId,
+        feedNamespace: WellKnownNamespaces.data,
+        position: 2,
+        expectedServerToken: token,
+      });
+      expect(currentClient.blocks.map((block) => block.position)).toEqual([3, 4]);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect('ignores position when the client expected a different server', () =>
+    Effect.gen(function* () {
+      const spaceId = SpaceId.random();
+      const feedId = EntityId.random();
+      const feed = new FeedStore({ localActorId: ALICE, assignPositions: true });
+      yield* feed.migrate();
+      yield* seed(feed, spaceId, feedId, 5);
+
+      const response = yield* feed.query({
+        spaceId,
+        feedNamespace: WellKnownNamespaces.data,
+        position: 2,
+        expectedServerToken: 'token-of-a-server-that-is-gone',
+      });
+      expect(response.blocks.map((block) => block.position)).toEqual([0, 1, 2, 3, 4]);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect('resetSyncState strips positions and restarts progress under the new token', () =>
+    Effect.gen(function* () {
+      const spaceId = SpaceId.random();
+      const feedId = EntityId.random();
+      const feed = new FeedStore({ localActorId: ALICE, assignPositions: true });
+      yield* feed.migrate();
+      yield* seed(feed, spaceId, feedId, 3);
+      yield* feed.setSyncState({
+        spaceId,
+        feedNamespace: WellKnownNamespaces.data,
+        lastPulledPosition: 2,
+        serverToken: 'old',
+      });
+
+      yield* feed.resetSyncState({ spaceId, feedNamespace: WellKnownNamespaces.data, serverToken: 'new' });
+
+      expect(yield* feed.getSyncState({ spaceId, feedNamespace: WellKnownNamespaces.data })).toEqual({
+        lastPulledPosition: -1,
+        serverToken: 'new',
+      });
+      const { blocks } = yield* feed.query({ spaceId, feedNamespace: WellKnownNamespaces.data });
+      expect(blocks.map((block) => block.position)).toEqual([null, null, null]);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+});
+
 describe('FeedStore encryption', () => {
   const PLAINTEXT = new Uint8Array([9, 8, 7, 6, 5]);
   const makeCypher = () => createInMemoryKeyProvider().then((keyProvider) => createWebCryptoCypher({ keyProvider }));

--- a/packages/core/echo/feed/src/feed-store.test.ts
+++ b/packages/core/echo/feed/src/feed-store.test.ts
@@ -765,16 +765,6 @@ describe('Feed V2', () => {
 });
 
 describe('FeedStore server token', () => {
-  const seed = (feed: FeedStore, spaceId: SpaceId, feedId: string, count: number) =>
-    feed.appendLocal(
-      Array.from({ length: count }, (_unused, index) => ({
-        spaceId,
-        feedId,
-        feedNamespace: WellKnownNamespaces.data,
-        data: new Uint8Array([index]),
-      })),
-    );
-
   it.effect('reports its own token from a position authority', () =>
     Effect.gen(function* () {
       const spaceId = SpaceId.random();
@@ -864,6 +854,16 @@ describe('FeedStore server token', () => {
       expect(blocks.map((block) => block.position)).toEqual([null, null, null]);
     }).pipe(Effect.provide(TestLayer)),
   );
+
+  const seed = (feed: FeedStore, spaceId: SpaceId, feedId: string, count: number) =>
+    feed.appendLocal(
+      Array.from({ length: count }, (_unused, index) => ({
+        spaceId,
+        feedId,
+        feedNamespace: WellKnownNamespaces.data,
+        data: new Uint8Array([index]),
+      })),
+    );
 });
 
 describe('FeedStore encryption', () => {

--- a/packages/core/echo/feed/src/feed-store.ts
+++ b/packages/core/echo/feed/src/feed-store.ts
@@ -50,6 +50,19 @@ export interface FeedStoreOptions {
 }
 
 /**
+ * Client-side pull progress for one space/namespace.
+ */
+export type SyncState = {
+  /** Highest global position pulled from the server, or -1 when nothing has been pulled. */
+  lastPulledPosition: number;
+  /**
+   * Token of the server that assigned {@link lastPulledPosition}. Undefined before the first
+   * response carrying one, which is also the case for state written by earlier releases.
+   */
+  serverToken: string | undefined;
+};
+
+/**
  * Effect service tag for {@link FeedStore}.
  */
 export class FeedStoreService extends EffectContext.Service<FeedStoreService, FeedStore>()('@dxos/feed/FeedStore') {}
@@ -135,6 +148,14 @@ export class FeedStore {
         return token;
       }).pipe(Effect.withSpan('FeedStore.ensureCursorToken'), SpanAttributes.annotateSpace(spaceId)),
   );
+
+  /**
+   * Identity of this store's storage, as reported to sync clients so they can detect that the
+   * server they had been syncing with was swapped or wiped. Created on first use and stable
+   * thereafter, so it only changes when the underlying storage is recreated.
+   */
+  getServerToken = (spaceId: string): Effect.Effect<string, SqlError.SqlError, SqlClient.SqlClient> =>
+    this.#ensureCursorToken(spaceId);
 
   /**
    * Seals block payloads for a batch, returning storage columns aligned by input index. A block
@@ -236,6 +257,9 @@ export class FeedStore {
 
         // Validate Token if cursor used.
         const validCursorToken = yield* this.#ensureCursorToken(request.spaceId);
+        // Only a position authority's token is meaningful to a sync client -- it names the store
+        // whose positions the client is caching.
+        const serverToken = this.#options.assignPositions ? validCursorToken : undefined;
         if (request.cursor && cursorToken !== validCursorToken) {
           return yield* Effect.die(new Error(`Cursor token mismatch`));
         }
@@ -252,7 +276,11 @@ export class FeedStore {
            We prioritize `cursor`.
         */
 
-        const position = request.position ?? -1;
+        // A client whose remembered positions were assigned by a different store names slots that
+        // no longer exist, so serve the namespace from the start rather than from a meaningless
+        // offset — recovering in the same round-trip the client already paid for.
+        const serverChanged = request.expectedServerToken != null && request.expectedServerToken !== validCursorToken;
+        const position = serverChanged ? -1 : (request.position ?? -1);
 
         // Resolve subscriptions or feed IDs.
         if (request.query && 'subscriptionId' in request.query) {
@@ -283,6 +311,7 @@ export class FeedStore {
             blocks: [],
             nextCursor: FeedCursor.make(`${validCursorToken}|-1`),
             hasMore: false,
+            serverToken,
           };
         }
 
@@ -342,7 +371,7 @@ export class FeedStore {
           }
         }
 
-        return { requestId: request.requestId, blocks, nextCursor, hasMore } satisfies QueryResponse;
+        return { requestId: request.requestId, blocks, nextCursor, hasMore, serverToken } satisfies QueryResponse;
       }).pipe(Effect.withSpan('FeedStore.query'), SpanAttributes.annotateSpace(request.spaceId)),
   );
 
@@ -382,38 +411,83 @@ export class FeedStore {
   );
 
   /**
-   * Get the last pulled position for the given space and namespace.
-   * Returns -1 if no sync state exists yet.
+   * Get the pull progress for the given space and namespace.
+   * `lastPulledPosition` is -1 and `serverToken` undefined when no sync state exists yet.
    */
   getSyncState = (opts: {
     spaceId: SpaceId;
     feedNamespace: string;
-  }): Effect.Effect<number, SqlError.SqlError, SqlClient.SqlClient> =>
+  }): Effect.Effect<SyncState, SqlError.SqlError, SqlClient.SqlClient> =>
     Effect.gen({ self: this }, function* () {
       const sql = yield* SqlClient.SqlClient;
-      const rows = yield* sql<{ lastPulledPosition: number }>`
-        SELECT lastPulledPosition FROM sync_state
+      const rows = yield* sql<{ lastPulledPosition: number; serverToken: string | null }>`
+        SELECT lastPulledPosition, serverToken FROM sync_state
         WHERE spaceId = ${opts.spaceId} AND feedNamespace = ${opts.feedNamespace}
       `;
-      return rows[0]?.lastPulledPosition ?? -1;
+      return {
+        lastPulledPosition: rows[0]?.lastPulledPosition ?? -1,
+        serverToken: rows[0]?.serverToken ?? undefined,
+      };
     }).pipe(Effect.withSpan('FeedStore.getSyncState'), SpanAttributes.annotateSpace(opts.spaceId));
 
   /**
-   * Update the last pulled position for the given space and namespace.
+   * Update the pull progress for the given space and namespace.
    */
   setSyncState = (opts: {
     spaceId: SpaceId;
     feedNamespace: string;
     lastPulledPosition: number;
+    /** Token of the server that assigned `lastPulledPosition`; leaves the stored token as-is when omitted. */
+    serverToken?: string;
   }): Effect.Effect<void, SqlError.SqlError, SqlClient.SqlClient> =>
     Effect.gen({ self: this }, function* () {
       const sql = yield* SqlClient.SqlClient;
+      const serverToken = opts.serverToken ?? null;
       yield* sql`
-        INSERT INTO sync_state (spaceId, feedNamespace, lastPulledPosition)
-        VALUES (${opts.spaceId}, ${opts.feedNamespace}, ${opts.lastPulledPosition})
-        ON CONFLICT (spaceId, feedNamespace) DO UPDATE SET lastPulledPosition = ${opts.lastPulledPosition}
+        INSERT INTO sync_state (spaceId, feedNamespace, lastPulledPosition, serverToken)
+        VALUES (${opts.spaceId}, ${opts.feedNamespace}, ${opts.lastPulledPosition}, ${serverToken})
+        ON CONFLICT (spaceId, feedNamespace) DO UPDATE SET
+          lastPulledPosition = ${opts.lastPulledPosition},
+          serverToken = COALESCE(${serverToken}, sync_state.serverToken)
       `;
     }).pipe(Effect.withSpan('FeedStore.setSyncState'), SpanAttributes.annotateSpace(opts.spaceId));
+
+  /**
+   * Discards everything derived from a server that no longer exists: strips the global position
+   * from every block of the space/namespace and restarts pull progress under the new server's
+   * token, so the next pull replays the namespace from the start.
+   *
+   * Blocks themselves are kept -- they are re-pushed and de-duplicated by (actorId, sequence) -- so
+   * locally authored history survives a server swap.
+   */
+  resetSyncState = (opts: {
+    spaceId: SpaceId;
+    feedNamespace: string;
+    serverToken: string;
+  }): Effect.Effect<void, SqlError.SqlError, SqlClient.SqlClient | SqlTransaction.SqlTransaction> =>
+    Effect.gen({ self: this }, function* () {
+      const sqlTransaction = yield* SqlTransaction.SqlTransaction;
+      yield* sqlTransaction.withTransaction(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql`
+            UPDATE blocks SET position = NULL
+            WHERE feedPrivateId IN (
+              SELECT feedPrivateId FROM feeds
+              WHERE spaceId = ${opts.spaceId} AND feedNamespace = ${opts.feedNamespace}
+            )
+          `;
+          yield* sql`
+            DELETE FROM sync_state
+            WHERE spaceId = ${opts.spaceId} AND feedNamespace = ${opts.feedNamespace}
+          `;
+          yield* sql`
+            INSERT INTO sync_state (spaceId, feedNamespace, lastPulledPosition, serverToken)
+            VALUES (${opts.spaceId}, ${opts.feedNamespace}, -1, ${opts.serverToken})
+          `;
+        }),
+      );
+    }).pipe(Effect.withSpan('FeedStore.resetSyncState'), SpanAttributes.annotateSpace(opts.spaceId));
 
   /**
    * Returns the number of blocks pending push (no global position yet) in a space/namespace.
@@ -593,6 +667,16 @@ export class FeedStore {
           // namespace position counter. Otherwise the response contains wasted slots that
           // sync clients will try to UPDATE local rows to, tripping the
           // (feedPrivateId, position) UNIQUE constraint and stalling sync indefinitely.
+          // On a replica, a pulled block the store already holds is the same block by
+          // (actorId, sequence): adopt the server's position for it, which is what re-attaches
+          // locally authored history to the new ordering after a server swap wiped positions.
+          // A position authority must keep DO NOTHING -- the assignment path below distinguishes a
+          // fresh row from a duplicate by whether the insert wrote one.
+          const onConflict = this.#options.assignPositions
+            ? sql`ON CONFLICT(feedPrivateId, sequence, actorId) DO NOTHING`
+            : sql`ON CONFLICT(feedPrivateId, sequence, actorId) DO UPDATE SET position = excluded.position
+                  WHERE blocks.position IS NULL AND excluded.position IS NOT NULL`;
+
           const positions: number[] = [];
           for (const [blockIndex, block] of request.blocks.entries()) {
             const key = block.feedId!;
@@ -614,7 +698,7 @@ export class FeedStore {
                 ${feedPrivateId}, ${positionToInsert}, ${block.sequence}, ${block.actorId},
                 ${block.prevSequence}, ${block.prevActorId}, ${block.timestamp}, ${data}, ${encryptionKeyId}, ${iv}
               )
-              ON CONFLICT(feedPrivateId, sequence, actorId) DO NOTHING
+              ${onConflict}
               RETURNING position
             `;
 
@@ -660,7 +744,8 @@ export class FeedStore {
 
       this.onNewBlocks.emit();
 
-      return { requestId: request.requestId, positions };
+      const serverToken = this.#options.assignPositions ? yield* this.#ensureCursorToken(request.spaceId) : undefined;
+      return { requestId: request.requestId, positions, serverToken };
     }).pipe(Effect.withSpan('FeedStore.append'));
 
   /**

--- a/packages/core/echo/feed/src/migrations/0003_sync_state_server_token.sql
+++ b/packages/core/echo/feed/src/migrations/0003_sync_state_server_token.sql
@@ -1,0 +1,14 @@
+--
+-- Records which server assigned the positions a client has pulled. `serverToken` is the serving
+-- store's own token, echoed back on every query response; a mismatch means the server was swapped
+-- or its storage wiped, so every remembered `lastPulledPosition` is meaningless and the namespace
+-- must be re-synced from scratch.
+--
+-- NULL on rows written before this migration: those clients have no observation to compare against,
+-- so the first token they see is adopted without a re-sync.
+--
+-- Not idempotent, by design: `feed_migrations` guarantees it runs exactly once. Immutable once
+-- shipped — change the schema by adding the next numbered migration.
+--
+-- AlterTable
+ALTER TABLE "sync_state" ADD COLUMN "serverToken" TEXT;

--- a/packages/core/echo/feed/src/migrations/index.ts
+++ b/packages/core/echo/feed/src/migrations/index.ts
@@ -6,6 +6,7 @@ import { SqlMigrations } from '@dxos/sql-sqlite';
 
 import init from './0001_init.sql?raw';
 import blockEncryption from './0002_block_encryption.sql?raw';
+import syncStateServerToken from './0003_sync_state_server_token.sql?raw';
 
 /**
  * Feed store migrations, keyed `<id>_<name>` as `@effect/sql`'s `Migrator.fromRecord` expects.
@@ -21,6 +22,7 @@ import blockEncryption from './0002_block_encryption.sql?raw';
 export const MIGRATIONS = {
   '0001_init': SqlMigrations.apply(init),
   '0002_block_encryption': SqlMigrations.apply(blockEncryption),
+  '0003_sync_state_server_token': SqlMigrations.apply(syncStateServerToken),
 };
 
 /**

--- a/packages/core/echo/feed/src/sync-client.test.ts
+++ b/packages/core/echo/feed/src/sync-client.test.ts
@@ -60,4 +60,67 @@ describe('SyncClient', () => {
 
     await runtime.dispose();
   });
+
+  // A server that predates the token reports none; treating that as a change would wipe positions
+  // on every pull.
+  test('keeps pulling incrementally from a server that reports no token', async () => {
+    const runtime = ManagedRuntime.make(TestLayer);
+    const spaceId = SpaceId.random();
+    const feedStore = new FeedStore({ localActorId: 'alice', assignPositions: false });
+    await runtime.runPromise(feedStore.migrate());
+    await runtime.runPromise(
+      feedStore.setSyncState({
+        spaceId,
+        feedNamespace: WellKnownNamespaces.data,
+        lastPulledPosition: 2,
+        serverToken: 'token-from-a-newer-server',
+      }),
+    );
+
+    const requests: FeedProtocol.QueryRequest[] = [];
+    const syncClient: SyncClient = new SyncClient({
+      peerId: 'client-peer',
+      feedStore,
+      sendMessage: (_ctx, message) => {
+        if (message._tag !== 'QueryRequest') {
+          return Effect.void;
+        }
+        requests.push(message);
+        return syncClient.handleMessage({
+          _tag: 'QueryResponse',
+          requestId: message.requestId,
+          nextCursor: FeedProtocol.FeedCursor.make('legacy|-1'),
+          hasMore: false,
+          blocks: [
+            {
+              feedId: 'feed-1',
+              actorId: 'bob',
+              sequence: 0,
+              prevActorId: null,
+              prevSequence: null,
+              position: 3,
+              timestamp: 0,
+              data: new Uint8Array([1]),
+            },
+          ],
+          senderPeerId: 'server-peer',
+          recipientPeerId: 'client-peer',
+        });
+      },
+    });
+
+    const ctx = new Context();
+    onTestFinished(() => void ctx.dispose());
+
+    expect(
+      await runtime.runPromise(syncClient.pull(ctx, { spaceId, feedNamespace: WellKnownNamespaces.data })),
+    ).toEqual({ done: false });
+    expect(requests[0].expectedServerToken).toEqual('token-from-a-newer-server');
+    // Position advanced from the stored one rather than restarting, and the token was kept.
+    expect(
+      await runtime.runPromise(feedStore.getSyncState({ spaceId, feedNamespace: WellKnownNamespaces.data })),
+    ).toEqual({ lastPulledPosition: 3, serverToken: 'token-from-a-newer-server' });
+
+    await runtime.dispose();
+  });
 });

--- a/packages/core/echo/feed/src/sync-client.ts
+++ b/packages/core/echo/feed/src/sync-client.ts
@@ -174,7 +174,7 @@ export class SyncClient {
   ): Effect.Effect<{ done: boolean }, unknown, SqlClient.SqlClient | SqlTransaction.SqlTransaction> {
     const self = this;
     return Effect.gen(function* () {
-      const lastPulledPosition = yield* self.#feedStore.getSyncState({
+      const { lastPulledPosition, serverToken } = yield* self.#feedStore.getSyncState({
         spaceId: opts.spaceId,
         feedNamespace: opts.feedNamespace,
       });
@@ -196,6 +196,7 @@ export class SyncClient {
         feedNamespace: opts.feedNamespace,
         position: lastPulledPosition,
         limit: opts.limit,
+        expectedServerToken: serverToken,
       };
       log('feed sync client pull rpc sending', {
         requestId,
@@ -213,6 +214,9 @@ export class SyncClient {
         rpcTag: 'QueryRequest',
       });
       const response = yield* self.#expectResponse<QueryResponse>(requestId, message, 'QueryResponse');
+      // The server answered with `position` ignored, so the batch restarts the namespace.
+      const serverChanged = yield* self.#reconcileServerToken(opts, serverToken, response.serverToken);
+      const basePosition = serverChanged ? -1 : lastPulledPosition;
       if (response.blocks.length === 0) {
         log.trace('feed sync client pull done (empty batch)', {
           requestId,
@@ -230,12 +234,13 @@ export class SyncClient {
       // Update sync state with the max position from the pulled batch.
       const maxPulledPosition = response.blocks.reduce(
         (max, block) => (block.position != null && block.position > max ? block.position : max),
-        lastPulledPosition,
+        basePosition,
       );
       yield* self.#feedStore.setSyncState({
         spaceId: opts.spaceId,
         feedNamespace: opts.feedNamespace,
         lastPulledPosition: maxPulledPosition,
+        serverToken: response.serverToken,
       });
 
       log('feed sync client pull applied batch', {
@@ -264,7 +269,7 @@ export class SyncClient {
   ): Effect.Effect<{ blocksToPull: number }, unknown, SqlClient.SqlClient | SqlTransaction.SqlTransaction> {
     const self = this;
     return Effect.gen(function* () {
-      const lastPulledPosition = yield* self.#feedStore.getSyncState({
+      const { lastPulledPosition, serverToken } = yield* self.#feedStore.getSyncState({
         spaceId: opts.spaceId,
         feedNamespace: opts.feedNamespace,
       });
@@ -286,6 +291,7 @@ export class SyncClient {
         feedNamespace: opts.feedNamespace,
         position: lastPulledPosition,
         limit: opts.limit,
+        expectedServerToken: serverToken,
       };
       yield* self.#sendMessage(ctx, self.#withPeerIds(request)).pipe(
         Effect.tapCause(() => Effect.sync(() => self.#disposeHandler(requestId, cleanupDispose))),
@@ -356,6 +362,22 @@ export class SyncClient {
         rpcTag: 'AppendRequest',
       });
       const response = yield* self.#expectResponse<AppendResponse>(requestId, message, 'AppendResponse');
+      // Positions in the response belong to the responding server, so any stale local ones have to
+      // go before they are applied.
+      const { lastPulledPosition, serverToken } = yield* self.#feedStore.getSyncState({
+        spaceId: opts.spaceId,
+        feedNamespace: opts.feedNamespace,
+      });
+      const serverChanged = yield* self.#reconcileServerToken(opts, serverToken, response.serverToken);
+      if (!serverChanged && response.serverToken != null) {
+        // Recorded on push too, so a client that only ever writes still notices the next swap.
+        yield* self.#feedStore.setSyncState({
+          spaceId: opts.spaceId,
+          feedNamespace: opts.feedNamespace,
+          lastPulledPosition,
+          serverToken: response.serverToken,
+        });
+      }
       yield* self.#feedStore.setPosition({
         spaceId: opts.spaceId,
         blocks: Array.zipWith(response.positions, unpositioned.blocks, (position, block) => ({
@@ -373,6 +395,39 @@ export class SyncClient {
         positionCount: response.positions.length,
       });
       return { done: false };
+    });
+  }
+
+  /**
+   * Compares the token the server reports against the one the local sync state was written under.
+   * Returns true when they differ -- the server was swapped or wiped -- having first dropped every
+   * position derived from the old server so the namespace re-syncs from scratch.
+   *
+   * A first observation (no stored token, including state written before servers reported one) is
+   * adopted without a reset: there is nothing to contradict it.
+   */
+  #reconcileServerToken(
+    opts: { spaceId: SpaceId; feedNamespace: string },
+    storedToken: string | undefined,
+    reportedToken: string | undefined,
+  ): Effect.Effect<boolean, unknown, SqlClient.SqlClient | SqlTransaction.SqlTransaction> {
+    const self = this;
+    return Effect.gen(function* () {
+      if (reportedToken == null || storedToken == null || reportedToken === storedToken) {
+        return false;
+      }
+      log.warn('feed sync server changed, resyncing namespace from scratch', {
+        spaceId: opts.spaceId,
+        feedNamespace: opts.feedNamespace,
+        storedToken,
+        reportedToken,
+      });
+      yield* self.#feedStore.resetSyncState({
+        spaceId: opts.spaceId,
+        feedNamespace: opts.feedNamespace,
+        serverToken: reportedToken,
+      });
+      return true;
     });
   }
 

--- a/packages/core/echo/feed/src/sync-client.ts
+++ b/packages/core/echo/feed/src/sync-client.ts
@@ -214,9 +214,18 @@ export class SyncClient {
         rpcTag: 'QueryRequest',
       });
       const response = yield* self.#expectResponse<QueryResponse>(requestId, message, 'QueryResponse');
-      // The server answered with `position` ignored, so the batch restarts the namespace.
-      const serverChanged = yield* self.#reconcileServerToken(opts, serverToken, response.serverToken);
-      const basePosition = serverChanged ? -1 : lastPulledPosition;
+      const reconciliation = yield* self.#reconcileServerToken(
+        { ...opts, lastPulledPosition },
+        serverToken,
+        response.serverToken,
+      );
+      if (reconciliation === 'restart') {
+        // This batch was served from a position that is no longer meaningful; the next pull, now
+        // carrying the recorded token, replays the namespace from the start.
+        return { done: false };
+      }
+      // On a reset the server ignored the stale `position`, so the batch restarts the namespace.
+      const basePosition = reconciliation === 'reset' ? -1 : lastPulledPosition;
       if (response.blocks.length === 0) {
         log.trace('feed sync client pull done (empty batch)', {
           requestId,
@@ -368,16 +377,10 @@ export class SyncClient {
         spaceId: opts.spaceId,
         feedNamespace: opts.feedNamespace,
       });
-      const serverChanged = yield* self.#reconcileServerToken(opts, serverToken, response.serverToken);
-      if (!serverChanged && response.serverToken != null) {
-        // Recorded on push too, so a client that only ever writes still notices the next swap.
-        yield* self.#feedStore.setSyncState({
-          spaceId: opts.spaceId,
-          feedNamespace: opts.feedNamespace,
-          lastPulledPosition,
-          serverToken: response.serverToken,
-        });
-      }
+      // Reconciling here too means a client that only ever writes still notices the next swap:
+      // a first observation with nothing pulled records the token, and a mismatch drops the stale
+      // positions before the response's -- which belong to the responding server -- are applied.
+      yield* self.#reconcileServerToken({ ...opts, lastPulledPosition }, serverToken, response.serverToken);
       yield* self.#feedStore.setPosition({
         spaceId: opts.spaceId,
         blocks: Array.zipWith(response.positions, unpositioned.blocks, (position, block) => ({
@@ -399,35 +402,54 @@ export class SyncClient {
   }
 
   /**
-   * Compares the token the server reports against the one the local sync state was written under.
-   * Returns true when they differ -- the server was swapped or wiped -- having first dropped every
-   * position derived from the old server so the namespace re-syncs from scratch.
+   * Reconciles the token the server reports against the one the local sync state was written under,
+   * dropping everything derived from a server that is no longer there.
    *
-   * A first observation (no stored token, including state written before servers reported one) is
-   * adopted without a reset: there is nothing to contradict it.
+   * - `'unchanged'`: the tokens agree, or the server reports none (it predates the token).
+   * - `'reset'`: they disagree, so the server was swapped or wiped. The request carried the stale
+   *   token, so the response already restarts the namespace and the caller applies it as-is.
+   * - `'restart'`: progress exists under no token at all -- state written before this protocol,
+   *   whose server may already have been replaced. The request carried no token, so the response
+   *   was served from the stale position and must be discarded rather than applied; the caller
+   *   re-pulls, now under the recorded token.
+   *
+   * Positions are dropped in both the `'reset'` and `'restart'` cases: a token the client never
+   * observed cannot confirm the ordering it is holding, and adopting it silently would leave the
+   * namespace permanently missing everything below the stale position.
    */
   #reconcileServerToken(
-    opts: { spaceId: SpaceId; feedNamespace: string },
+    opts: { spaceId: SpaceId; feedNamespace: string; lastPulledPosition: number },
     storedToken: string | undefined,
     reportedToken: string | undefined,
-  ): Effect.Effect<boolean, unknown, SqlClient.SqlClient | SqlTransaction.SqlTransaction> {
+  ): Effect.Effect<'unchanged' | 'reset' | 'restart', unknown, SqlClient.SqlClient | SqlTransaction.SqlTransaction> {
     const self = this;
     return Effect.gen(function* () {
-      if (reportedToken == null || storedToken == null || reportedToken === storedToken) {
-        return false;
+      if (reportedToken == null || reportedToken === storedToken) {
+        return 'unchanged';
       }
-      log.warn('feed sync server changed, resyncing namespace from scratch', {
+      if (storedToken == null && opts.lastPulledPosition < 0) {
+        // Nothing pulled yet, so there is no ordering to distrust: just record who is serving.
+        yield* self.#feedStore.setSyncState({
+          spaceId: opts.spaceId,
+          feedNamespace: opts.feedNamespace,
+          lastPulledPosition: opts.lastPulledPosition,
+          serverToken: reportedToken,
+        });
+        return 'unchanged';
+      }
+      log.warn("feed sync positions are not the serving store's, resyncing namespace from scratch", {
         spaceId: opts.spaceId,
         feedNamespace: opts.feedNamespace,
         storedToken,
         reportedToken,
+        lastPulledPosition: opts.lastPulledPosition,
       });
       yield* self.#feedStore.resetSyncState({
         spaceId: opts.spaceId,
         feedNamespace: opts.feedNamespace,
         serverToken: reportedToken,
       });
-      return true;
+      return storedToken == null ? 'restart' : 'reset';
     });
   }
 

--- a/packages/core/echo/feed/src/sync.test.ts
+++ b/packages/core/echo/feed/src/sync.test.ts
@@ -19,14 +19,6 @@ describe('Sync', () => {
   const spaceId = SpaceId.random();
   const feedId = EntityId.random();
 
-  const seedBlocks = (peer: TestPeer, blocks: Uint8Array[]) =>
-    peer.appendLocal(blocks.map((data) => ({ spaceId, feedId, feedNamespace: WellKnownNamespaces.data, data })));
-
-  const blockPositions = async (peer: TestPeer) => {
-    const { blocks } = await peer.query({ spaceId, feedNamespace: WellKnownNamespaces.data });
-    return blocks.map((block) => block.position);
-  };
-
   test('pull blocks from server', async () => {
     await using builder = await new TestBuilder({ numPeers: 2, spaceId, logSql: LOG_SQL }).open();
     const [server, client] = builder.peers;
@@ -219,6 +211,40 @@ describe('Sync', () => {
       expect(await blockPositions(client)).toEqual([0, 1, 2, 3, 4]);
     });
 
+    // Sync state written before servers reported a token carries progress but no token. Its server
+    // may already have been replaced, so the first token a client sees cannot be trusted to
+    // describe the ordering that progress came from.
+    test('replays the namespace when adopting a token over untokened progress', async () => {
+      await using builder = await new TestBuilder({ numPeers: 2, spaceId, logSql: LOG_SQL }).open();
+      const [server, client] = builder.peers;
+
+      await seedBlocks(server, generateTestBlocks(0, 5));
+      await builder.pull(client);
+      expect(await blockPositions(client)).toEqual([0, 1, 2, 3, 4]);
+      await client.setSyncState({ spaceId, feedNamespace: WellKnownNamespaces.data, lastPulledPosition: 2 });
+      await client.clearServerToken({ spaceId, feedNamespace: WellKnownNamespaces.data });
+
+      // The replacement holds a different feed, so anything below the stale position that the
+      // client fails to replay is data it never sees.
+      const replacementFeedId = EntityId.random();
+      const replacement = await builder.replaceServer();
+      await seedBlocks(replacement, generateTestBlocks(10, 8), replacementFeedId);
+
+      // The batch this pull received was served from the stale position, so it is discarded.
+      expect(await builder.pull(client)).toEqual({ done: false });
+      expect(await client.getSyncState({ spaceId, feedNamespace: WellKnownNamespaces.data })).toEqual({
+        lastPulledPosition: -1,
+        serverToken: await replacement.getServerToken(spaceId),
+      });
+
+      // Replaying now reaches every block, including those below the stale position.
+      let done = false;
+      while (!done) {
+        ({ done } = await builder.pull(client));
+      }
+      expect(await blockPositions(client, replacementFeedId)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    });
+
     test('does not duplicate blocks pulled from a replacement server', async () => {
       await using builder = await new TestBuilder({ numPeers: 3, spaceId, logSql: LOG_SQL }).open();
       const [, client1, client2] = builder.peers;
@@ -244,6 +270,18 @@ describe('Sync', () => {
       expect(blocks.map((block) => block.position)).toEqual(serverBlocks.map((block) => block.position));
     });
   });
+
+  const seedBlocks = (peer: TestPeer, blocks: Uint8Array[], feed = feedId) =>
+    peer.appendLocal(blocks.map((data) => ({ spaceId, feedId: feed, feedNamespace: WellKnownNamespaces.data, data })));
+
+  const blockPositions = async (peer: TestPeer, feed?: string) => {
+    const { blocks } = await peer.query({
+      spaceId,
+      feedNamespace: WellKnownNamespaces.data,
+      ...(feed != null ? { query: { feedIds: [feed] } } : {}),
+    });
+    return blocks.map((block) => block.position);
+  };
 });
 
 const generateTestBlocks = (start: number, count: number) => range(count, (i) => new Uint8Array([start + i]));

--- a/packages/core/echo/feed/src/sync.test.ts
+++ b/packages/core/echo/feed/src/sync.test.ts
@@ -9,7 +9,7 @@ import { EntityId, SpaceId } from '@dxos/keys';
 import { FeedProtocol } from '@dxos/protocols';
 import { range } from '@dxos/util';
 
-import { TestBuilder } from './testing';
+import { TestBuilder, type TestPeer } from './testing';
 
 const WellKnownNamespaces = FeedProtocol.WellKnownNamespaces;
 
@@ -18,6 +18,14 @@ describe('Sync', () => {
 
   const spaceId = SpaceId.random();
   const feedId = EntityId.random();
+
+  const seedBlocks = (peer: TestPeer, blocks: Uint8Array[]) =>
+    peer.appendLocal(blocks.map((data) => ({ spaceId, feedId, feedNamespace: WellKnownNamespaces.data, data })));
+
+  const blockPositions = async (peer: TestPeer) => {
+    const { blocks } = await peer.query({ spaceId, feedNamespace: WellKnownNamespaces.data });
+    return blocks.map((block) => block.position);
+  };
 
   test('pull blocks from server', async () => {
     await using builder = await new TestBuilder({ numPeers: 2, spaceId, logSql: LOG_SQL }).open();
@@ -157,6 +165,84 @@ describe('Sync', () => {
       .pipe(RuntimeProvider.runPromise(client2.runtime.contextEffect));
     expect(client1Blocks).toEqual(client2Blocks);
     expect(client1Blocks.every((block) => block.position != null)).toBe(true);
+  });
+
+  describe('server replacement', () => {
+    test('records the server token on first pull without disturbing positions', async () => {
+      await using builder = await new TestBuilder({ numPeers: 2, spaceId, logSql: LOG_SQL }).open();
+      const [server, client] = builder.peers;
+
+      await seedBlocks(server, generateTestBlocks(0, 5));
+      await builder.pull(client);
+
+      const serverToken = await server.getServerToken(spaceId);
+      expect(await client.getSyncState({ spaceId, feedNamespace: WellKnownNamespaces.data })).toEqual({
+        lastPulledPosition: 4,
+        serverToken,
+      });
+
+      const positions = await blockPositions(client);
+      expect(positions).toEqual([0, 1, 2, 3, 4]);
+
+      // Same server: nothing to re-sync.
+      await builder.pull(client);
+      expect(await blockPositions(client)).toEqual(positions);
+    });
+
+    test('re-syncs from scratch when the server is wiped', async () => {
+      await using builder = await new TestBuilder({ numPeers: 2, spaceId, logSql: LOG_SQL }).open();
+      const [server, client] = builder.peers;
+
+      const testBlocks = generateTestBlocks(0, 5);
+      await seedBlocks(client, testBlocks);
+      await builder.push(client);
+      await builder.pull(client);
+      const staleToken = await server.getServerToken(spaceId);
+      expect(await blockPositions(client)).toEqual([0, 1, 2, 3, 4]);
+
+      const replacement = await builder.replaceServer();
+      const freshToken = await replacement.getServerToken(spaceId);
+      expect(freshToken).not.toEqual(staleToken);
+
+      // The pull detects the swap and drops every position the old server assigned.
+      await builder.pull(client);
+      expect(await blockPositions(client)).toEqual([null, null, null, null, null]);
+      expect(await client.getSyncState({ spaceId, feedNamespace: WellKnownNamespaces.data })).toEqual({
+        lastPulledPosition: -1,
+        serverToken: freshToken,
+      });
+
+      // Blocks survived the reset and are re-pushed to the new server.
+      await builder.push(client);
+      const { blocks: serverBlocks } = await replacement.query({ spaceId, feedNamespace: WellKnownNamespaces.data });
+      expect(serverBlocks.map((block) => block.data)).toEqual(testBlocks);
+      expect(await blockPositions(client)).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    test('does not duplicate blocks pulled from a replacement server', async () => {
+      await using builder = await new TestBuilder({ numPeers: 3, spaceId, logSql: LOG_SQL }).open();
+      const [, client1, client2] = builder.peers;
+
+      const testBlocks = generateTestBlocks(0, 5);
+      await seedBlocks(client1, testBlocks);
+      await builder.push(client1);
+      await builder.pull(client2);
+      expect(await blockPositions(client2)).toEqual([0, 1, 2, 3, 4]);
+
+      // The replacement re-assigns positions for the same blocks, republished by their author.
+      const replacement = await builder.replaceServer();
+      // The author notices the swap on pull, which strips its stale positions, and re-pushes.
+      await builder.pull(client1);
+      await builder.push(client1);
+
+      // client2 already holds every block by (actorId, sequence): the resync repositions them
+      // rather than inserting copies.
+      await builder.pull(client2);
+      const { blocks } = await client2.query({ spaceId, feedNamespace: WellKnownNamespaces.data });
+      expect(blocks.map((block) => block.data)).toEqual(testBlocks);
+      const { blocks: serverBlocks } = await replacement.query({ spaceId, feedNamespace: WellKnownNamespaces.data });
+      expect(blocks.map((block) => block.position)).toEqual(serverBlocks.map((block) => block.position));
+    });
   });
 });
 

--- a/packages/core/echo/feed/src/testing/test-builder.ts
+++ b/packages/core/echo/feed/src/testing/test-builder.ts
@@ -30,6 +30,7 @@ export class TestBuilder extends Resource {
   #peers: TestPeer[] = [];
   readonly #spaceId: SpaceId;
   readonly #feedNamespace: string;
+  readonly #logSql: boolean;
 
   constructor({
     numPeers,
@@ -45,6 +46,7 @@ export class TestBuilder extends Resource {
     super();
     this.#spaceId = spaceId;
     this.#feedNamespace = feedNamespace;
+    this.#logSql = logSql;
     this.#peers = Array.makeBy(
       numPeers,
       (i) =>
@@ -72,6 +74,24 @@ export class TestBuilder extends Resource {
 
   protected override async _close(): Promise<void> {
     await Promise.all(this.#peers.map((peer) => peer.close()));
+  }
+
+  /**
+   * Swaps the server for one with empty storage, keeping its peer id, so clients keep addressing
+   * the same peer while everything it had assigned is gone. Models a redeployed or wiped server.
+   */
+  async replaceServer(): Promise<TestPeer> {
+    const previous = this.#peers[0];
+    await previous.close();
+    const replacement = new TestPeer({
+      isServer: true,
+      actorId: previous.peerId,
+      sendMessage: (ctx, msg) => this.#routeMessage(ctx, msg),
+      logSql: this.#logSql,
+    });
+    this.#peers[0] = replacement;
+    await replacement.open();
+    return replacement;
   }
 
   async pull(client: TestPeer, { limit = 10 }: { limit?: number } = {}): Promise<{ done: boolean }> {
@@ -191,10 +211,18 @@ export class TestPeer extends Resource {
     }).pipe(RuntimeProvider.runPromise(this.#runtime.contextEffect));
   }
 
+  getServerToken(spaceId: SpaceId) {
+    return this.#feedStore.getServerToken(spaceId).pipe(RuntimeProvider.runPromise(this.#runtime.contextEffect));
+  }
+
   getSyncState({ spaceId, feedNamespace }: { spaceId: SpaceId; feedNamespace: string }) {
     return this.#feedStore
       .getSyncState({ spaceId, feedNamespace })
       .pipe(RuntimeProvider.runPromise(this.#runtime.contextEffect));
+  }
+
+  setSyncState(opts: { spaceId: SpaceId; feedNamespace: string; lastPulledPosition: number; serverToken?: string }) {
+    return this.#feedStore.setSyncState(opts).pipe(RuntimeProvider.runPromise(this.#runtime.contextEffect));
   }
 
   query(req: QueryRequest) {

--- a/packages/core/echo/feed/src/testing/test-builder.ts
+++ b/packages/core/echo/feed/src/testing/test-builder.ts
@@ -6,7 +6,7 @@ import * as Array from 'effect/Array';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as ManagedRuntime from 'effect/ManagedRuntime';
-import type * as SqlClient from 'effect/unstable/sql/SqlClient';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import * as Statement from 'effect/unstable/sql/Statement';
 
 import { Context, Resource } from '@dxos/context';
@@ -223,6 +223,20 @@ export class TestPeer extends Resource {
 
   setSyncState(opts: { spaceId: SpaceId; feedNamespace: string; lastPulledPosition: number; serverToken?: string }) {
     return this.#feedStore.setSyncState(opts).pipe(RuntimeProvider.runPromise(this.#runtime.contextEffect));
+  }
+
+  /**
+   * Strips the recorded server token while leaving pull progress intact, reproducing sync state
+   * written before servers reported one. No production path writes this shape.
+   */
+  clearServerToken({ spaceId, feedNamespace }: { spaceId: SpaceId; feedNamespace: string }) {
+    return Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        UPDATE sync_state SET serverToken = NULL
+        WHERE spaceId = ${spaceId} AND feedNamespace = ${feedNamespace}
+      `;
+    }).pipe(RuntimeProvider.runPromise(this.#runtime.contextEffect));
   }
 
   query(req: QueryRequest) {

--- a/packages/core/protocols/src/FeedProtocol.ts
+++ b/packages/core/protocols/src/FeedProtocol.ts
@@ -161,6 +161,18 @@ export const QueryRequest = Schema.Struct({
    * Maximum number of blocks to return.
    */
   limit: Schema.optional(Schema.Number),
+
+  /**
+   * Token identifying the store the client believes it is talking to, as last reported in
+   * {@link QueryResponse.serverToken}.
+   *
+   * When it does not match the serving store's own token — the server was swapped or its storage
+   * wiped — every `position` the client remembers names a slot in a store that no longer exists, so
+   * the server ignores `position` and serves the namespace from the start. That keeps recovery to
+   * the same single round-trip as an ordinary pull. Omitted by clients that predate the token, for
+   * which the server keeps honouring `position` verbatim.
+   */
+  expectedServerToken: Schema.optional(Schema.String),
 });
 export interface QueryRequest extends Schema.Schema.Type<typeof QueryRequest> {}
 
@@ -187,6 +199,16 @@ export const QueryResponse = Schema.Struct({
    * Returned blocks for the current page.
    */
   blocks: Schema.Array(Block),
+
+  /**
+   * Identity of the store that assigned the positions in this response. Stable for the life of the
+   * store's storage and regenerated when that storage is recreated, which is how a client detects
+   * that its remembered positions are no longer meaningful.
+   *
+   * Only set by a position authority (a server); absent on responses from a store that does not
+   * assign positions, and on responses from servers that predate the token.
+   */
+  serverToken: Schema.optional(Schema.String),
 });
 export interface QueryResponse extends Schema.Schema.Type<typeof QueryResponse> {}
 
@@ -271,6 +293,11 @@ export const AppendResponse = Schema.Struct({
    * Assigned global positions for appended blocks.
    */
   positions: Schema.Array(Schema.Number),
+
+  /**
+   * Identity of the store that assigned `positions`. See {@link QueryResponse.serverToken}.
+   */
+  serverToken: Schema.optional(Schema.String),
 });
 export interface AppendResponse extends Schema.Schema.Type<typeof AppendResponse> {}
 


### PR DESCRIPTION
## Problem

A feed sync client caches the global `position` each block was assigned by the server, plus a per-namespace `lastPulledPosition`. When the server is swapped out or its storage is wiped, those positions name slots in a store that no longer exists and `lastPulledPosition` sits past everything the new server holds — so pulls come back empty forever and sync stalls silently.

## Approach

The server's store already mints a stable per-space token (`cursor_tokens`, created on first use and regenerated only when the storage is). That token is now the server's identity on the wire:

- `QueryResponse.serverToken` / `AppendResponse.serverToken` — reported by a position authority only.
- `sync_state.serverToken` (migration `0003`) — the client remembers which server assigned the progress it is holding, recorded on pull *and* push, so a write-only client also notices the next swap.
- `QueryRequest.expectedServerToken` — the client echoes what it remembers. A server that does not recognise it **ignores `position` and serves the namespace from the start**, so recovery costs no extra round-trip and no new message type.

On a mismatch the client, in one transaction, strips the global position from every block of that space/namespace, drops the stale progress row, and restarts under the new token; the next push republishes the blocks. A replica now adopts the server's position for a block it already holds by `(actorId, sequence)` (`ON CONFLICT … DO UPDATE … WHERE position IS NULL`), which is what keeps the resync from duplicating anything.

Scope is space + namespace, matching the deployment: edge shards a `FeedSpace` DO per `(space, namespace)`, so each has its own token and only the affected shard resets.

### Progress that predates the token

Sync state written before this change has a position but no token, and its server may *already* have been replaced — so the first token such a client sees cannot be trusted to describe that progress. Adopting it silently would leave the namespace permanently missing everything below the stale position. That case therefore also drops the positions, records the token, and discards the page in hand (it was served from the stale position, since the request carried no token) so the next pull replays from the start. It costs one extra pull, once per space/namespace ever; a client with nothing pulled yet has no ordering to distrust and just records the token.

## Backwards compatibility

Every new field is optional.

- **Old client → new server**: sends no `expectedServerToken`, so `position` is honoured verbatim; behaviour unchanged.
- **New client → old server**: no token reported, so nothing is compared and no reset is triggered. Covered by a test.

## Tests

`moon run feed:test` — 47 passed. New coverage:

- `sync.test.ts`: token recorded on first pull without disturbing positions; full recovery after the server is wiped (new `TestBuilder.replaceServer()`); replay when adopting a token over untokened progress (fails on the earlier behaviour with `lastPulledPosition` 7 instead of −1); no duplicate blocks when a second client resyncs against a replacement.
- `sync-client.test.ts`: keeps pulling incrementally from a server that reports no token.
- `feed-store.test.ts`: token reported only by a position authority; `position` honoured for a matching/absent token and ignored for a stale one; `resetSyncState` semantics.

`client-services:test` and `echo-host:test` also run clean (one unrelated flake in `automerge-host-subduction.test.ts` under the full parallel run, green on its own both with and without this change).

End-to-end against a real edge shard — seeded, pulled, storage wiped, re-seeded, recovered — in dxos/edge#1018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqsUtzCQVg8ZyQYdkfrVPQ

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12942-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved feed synchronization when a server is replaced or its stored data is reset.
  * Clients now detect server changes and automatically restart synchronization from the beginning when needed.
  * Synchronization progress is preserved during compatible incremental updates.
  * Older clients and servers remain compatible with the updated synchronization protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->