### PR TITLE
plugin-assistant: report completed connect and enable flows back into the chat

### DIFF
--- a/.changeset/lucky-hoops-report.md
+++ b/.changeset/lucky-hoops-report.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-assistant': patch
+---
+
+Inline chat prompts now report their completed flow back to the agent: connecting a service posts a user turn naming the service and the new credential's URI, and enabling a plugin posts one naming the plugin.

--- a/.changeset/lucky-hoops-report.md
+++ b/.changeset/lucky-hoops-report.md
@@ -2,4 +2,4 @@
 '@dxos/plugin-assistant': patch
 ---
 
-Inline chat prompts now report their completed flow back to the agent: connecting a service posts a user turn naming the service and the new credential's URI, and enabling a plugin posts one naming the plugin.
+Inline chat prompts now report their completed flow back to the agent as a synthetic turn, so the conversation resumes instead of stalling on a click the agent cannot observe: connecting a service reports the connector and the new credential's URI once it is in the space, and enabling a plugin reports the plugin.

--- a/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
+++ b/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
@@ -50,7 +50,13 @@ import {
   type ChatPromptProps as NaturalChatPromptProps,
 } from '../ChatPrompt';
 import { ChatQueue as NaturalChatQueue, type ChatQueueProps as NaturalChatQueueProps } from '../ChatQueue';
-import { ChatContextProvider, type ChatContextValue, type ChatRequestTiming, useChatContext } from './context';
+import {
+  ChatContextProvider,
+  type ChatContextValue,
+  ChatReportContextProvider,
+  type ChatRequestTiming,
+  useChatContext,
+} from './context';
 import { type ChatEvent } from './events';
 import { SurfaceWidget } from './SurfaceWidget';
 import { projectAlarms, projectThread, resolveRewind } from './thread';
@@ -273,6 +279,10 @@ const ChatRoot = ({
     // them the handler would keep resolving rewinds against whatever was mounted first.
   }, [event, dump, processor, streaming, active, onEvent, onSubmit, getContext, feed, messages, chat, db]);
 
+  // An inline surface (connector prompt, plugin prompt) reports its completed flow as an ordinary
+  // user turn, so the agent resumes on the same seam as a typed prompt.
+  const handleReport = useCallback((text: string) => event.emit({ type: 'submit', text }), [event]);
+
   return (
     <ChatContextProvider
       debug={debug}
@@ -291,7 +301,7 @@ const ChatRoot = ({
       setVisibleRange={setVisibleRange}
       {...props}
     >
-      {children}
+      <ChatReportContextProvider submit={handleReport}>{children}</ChatReportContextProvider>
     </ChatContextProvider>
   );
 };

--- a/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
+++ b/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
@@ -240,6 +240,20 @@ const ChatRoot = ({
           break;
         }
 
+        case 'report': {
+          const text = ev.text.trim();
+          if (text.length) {
+            // Same seam as a submitted prompt (persist first, queue while a turn runs), but the
+            // content is synthetic — nobody typed it.
+            void Promise.resolve(onSubmit?.(text)).then(() =>
+              active
+                ? processor.enqueue({ message: text, disposition: 'synthetic' })
+                : processor.request({ message: text, disposition: 'synthetic' }),
+            );
+          }
+          break;
+        }
+
         case 'rewind': {
           // Edit-and-resend: discard the prompt and everything after it, and put its text back in the
           // composer so it can be revised. Recorded on the feed rather than the chat because the
@@ -279,9 +293,9 @@ const ChatRoot = ({
     // them the handler would keep resolving rewinds against whatever was mounted first.
   }, [event, dump, processor, streaming, active, onEvent, onSubmit, getContext, feed, messages, chat, db]);
 
-  // An inline surface (connector prompt, plugin prompt) reports its completed flow as an ordinary
-  // user turn, so the agent resumes on the same seam as a typed prompt.
-  const handleReport = useCallback((text: string) => event.emit({ type: 'submit', text }), [event]);
+  // An inline surface (connector prompt, plugin prompt) reports its completed flow as a synthetic
+  // turn, so the agent resumes without the report reading as something the user typed.
+  const handleReport = useCallback((text: string) => event.emit({ type: 'report', text }), [event]);
 
   return (
     <ChatContextProvider

--- a/packages/plugins/plugin-assistant/src/components/Chat/context.ts
+++ b/packages/plugins/plugin-assistant/src/components/Chat/context.ts
@@ -52,3 +52,18 @@ export type ChatContextValue = {
 // package (e.g. `ChatStreamStatus`) without dragging in `Chat.tsx`'s heavy transitive
 // imports (transcription, etc.).
 export const [ChatContextProvider, useChatContext] = createContext<ChatContextValue>('Chat');
+
+/**
+ * Report path for agent-requested surfaces rendered inside the thread (`<surface>` blocks): a
+ * completed inline flow (a connector authorized, a plugin enabled) has to reach the agent, which
+ * otherwise waits on a click it never observes. `submit` posts the report as an ordinary user turn.
+ */
+export type ChatReportContextValue = {
+  submit: (text: string) => void;
+};
+
+// Defaulted (unlike `ChatContext`) so a surface rendered outside a chat — a storybook, a standalone
+// preview — drops its report instead of throwing.
+export const [ChatReportContextProvider, useChatReportContext] = createContext<ChatReportContextValue>('ChatReport', {
+  submit: () => {},
+});

--- a/packages/plugins/plugin-assistant/src/components/Chat/events.ts
+++ b/packages/plugins/plugin-assistant/src/components/Chat/events.ts
@@ -19,6 +19,15 @@ export type ChatEvent =
       type: 'submit';
       text: string;
     }
+  /**
+   * System-generated turn content — an inline flow (a connector authorized, a plugin enabled)
+   * reporting itself. Submitted as a synthetic block, so it reads as a system note rather than as
+   * words the user typed.
+   */
+  | {
+      type: 'report';
+      text: string;
+    }
   | {
       type: 'retry';
     }

--- a/packages/plugins/plugin-assistant/src/components/ConnectorAuthMenu/ConnectorAuthMenu.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ConnectorAuthMenu/ConnectorAuthMenu.tsx
@@ -3,7 +3,7 @@
 //
 
 import { RegistryContext } from '@effect/atom-react/RegistryContext';
-import React, { useContext, useMemo } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 
 import { useCapabilities } from '@dxos/app-framework/ui';
 import * as AppGraph from '@dxos/app-graph/AppGraph';
@@ -29,6 +29,12 @@ export type ConnectorAuthMenuProps = {
   db: Database.Database | undefined;
   /** Existing local object to wire up as the new connection's first sync target. */
   existingTarget?: Ref.Ref<Obj.Unknown>;
+  /**
+   * Called when the user picks an entry, before the action runs. The flows themselves complete out
+   * of band (an OAuth popup, a credential dialog), so this is the only point at which a caller can
+   * tell that the user started one.
+   */
+  onSelect?: () => void;
 };
 
 /**
@@ -37,7 +43,7 @@ export type ConnectorAuthMenuProps = {
  * {@link Connection}s are offered for reuse (bind inline) alongside a "Connect X" entry per connector
  * with an auth flow. Renders nothing when there is nothing to offer.
  */
-export const ConnectorAuthMenu = ({ connectorIds, db, existingTarget }: ConnectorAuthMenuProps) => {
+export const ConnectorAuthMenu = ({ connectorIds, db, existingTarget, onSelect }: ConnectorAuthMenuProps) => {
   const { t } = useTranslation(meta.profile.key);
   const registry = useContext(RegistryContext);
   const runAction = useActionRunner();
@@ -67,12 +73,20 @@ export const ConnectorAuthMenu = ({ connectorIds, db, existingTarget }: Connecto
   // Read the group's children (reuse / connect entries) as the menu content.
   const menuActions = useGraphMenuActions(graph, ConnectorAuth.GROUP_ID);
 
+  const handleAction = useCallback<typeof runAction>(
+    (action) => {
+      onSelect?.();
+      return runAction(action);
+    },
+    [onSelect, runAction],
+  );
+
   if (!graph) {
     return null;
   }
 
   return (
-    <Menu.Root {...menuActions} onAction={runAction} attendableId={NODE_ID} alwaysActive>
+    <Menu.Root {...menuActions} onAction={handleAction} attendableId={NODE_ID} alwaysActive>
       <Menu.Trigger asChild>
         <IconButton variant='ghost' icon='ph--plugs--regular' label={t('connect.label')} />
       </Menu.Trigger>

--- a/packages/plugins/plugin-assistant/src/containers/IntegrationPrompt/IntegrationPrompt.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/IntegrationPrompt/IntegrationPrompt.tsx
@@ -2,15 +2,22 @@
 // Copyright 2026 DXOS.org
 //
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { useCapabilities } from '@dxos/app-framework/ui';
 import { useActiveSpace } from '@dxos/app-toolkit/ui';
+import { type Database, Filter } from '@dxos/echo';
+import { useQuery } from '@dxos/echo-react';
+import { Connection } from '@dxos/link';
 import * as ConnectorSpec from '@dxos/plugin-connector/ConnectorSpec';
 import { Flex, Icon, useTranslation } from '@dxos/react-ui';
 
 import { ConnectorAuthMenu } from '#components';
 import { meta } from '#meta';
+
+import { useChatReportContext } from '../../components/Chat/context';
+
+const INTEGRATION_PROMPT_NAME = 'IntegrationPrompt';
 
 export type IntegrationPromptProps = {
   /** Service the agent needs access to, e.g. `gmail.com`. */
@@ -33,12 +40,12 @@ export const IntegrationPrompt = ({ service, scopes, reason }: IntegrationPrompt
   const connectors = useCapabilities(ConnectorSpec.Connector).flat();
   const matched = useMemo(() => (service ? matchConnectors(connectors, service) : []), [connectors, service]);
   const connectorIds = useMemo(() => matched.map((connector) => connector.id), [matched]);
+  const label = matched[0]?.label ?? service;
+  const { armReport } = useReportConnection({ connectorIds, db: space?.db, label });
 
   if (!service) {
     return null;
   }
-
-  const label = matched[0]?.label ?? service;
 
   return (
     <Flex role='group' column gap='sm' classNames='my-2 p-3 border border-subdued-separator rounded-sm'>
@@ -67,11 +74,57 @@ export const IntegrationPrompt = ({ service, scopes, reason }: IntegrationPrompt
       )}
       {connectorIds.length > 0 && (
         <Flex justify='end'>
-          <ConnectorAuthMenu connectorIds={connectorIds} db={space?.db} />
+          <ConnectorAuthMenu connectorIds={connectorIds} db={space?.db} onSelect={armReport} />
         </Flex>
       )}
     </Flex>
   );
+};
+
+type UseReportConnectionOptions = {
+  connectorIds: readonly string[];
+  db: Database.Database | undefined;
+  /** Human-readable service name used in the report, e.g. `Anthropic`. */
+  label: string | undefined;
+};
+
+/**
+ * Reports a completed connect flow back into the conversation as a user turn naming the new
+ * credential's URI, so the agent — which cannot observe a click, and whose flows finish out of band
+ * in an OAuth popup or a credential dialog — resumes with the credential it asked for.
+ *
+ * Armed by the user picking an entry rather than by mount: the connection query starts empty and
+ * fills in asynchronously, so a mount-time baseline could not tell a pre-existing connection from
+ * one this flow created. A flow whose prompt unmounts before it finishes goes unreported.
+ */
+const useReportConnection = ({ connectorIds, db, label }: UseReportConnectionOptions) => {
+  const { submit } = useChatReportContext(INTEGRATION_PROMPT_NAME);
+  const connections = useQuery(db, Filter.type(Connection.Connection));
+  const matched = useMemo(
+    () => connections.filter((connection) => !!connection.connectorId && connectorIds.includes(connection.connectorId)),
+    [connections, connectorIds],
+  );
+  // Ids present when the user started the flow; anything beyond them is what the flow produced.
+  const baseline = useRef<Set<string> | undefined>(undefined);
+
+  const armReport = useCallback(() => {
+    baseline.current = new Set(matched.map((connection) => connection.id));
+  }, [matched]);
+
+  useEffect(() => {
+    if (!baseline.current) {
+      return;
+    }
+    const created = matched.find((connection) => !baseline.current?.has(connection.id));
+    if (!created) {
+      return;
+    }
+    // One report per flow: disarm before submitting so a later connection needs a fresh click.
+    baseline.current = undefined;
+    submit(`Connected ${label ?? created.connectorId}. Credential: ${created.accessToken.uri}`);
+  }, [matched, label, submit]);
+
+  return { armReport };
 };
 
 /**

--- a/packages/plugins/plugin-assistant/src/containers/IntegrationPrompt/IntegrationPrompt.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/IntegrationPrompt/IntegrationPrompt.tsx
@@ -116,7 +116,9 @@ const useReportConnection = ({ connectorIds, db, label }: UseReportConnectionOpt
       return;
     }
     const created = matched.find((connection) => !baseline.current?.has(connection.id));
-    if (!created) {
+    // Named only once the credential itself is in the space: the report carries the token's URI, so
+    // an unresolved ref would name something the agent cannot yet read. Stays armed until it is.
+    if (!created || !created.accessToken.peek()) {
       return;
     }
     // One report per flow: disarm before submitting so a later connection needs a fresh click.

--- a/packages/plugins/plugin-assistant/src/containers/IntegrationPrompt/IntegrationPrompt.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/IntegrationPrompt/IntegrationPrompt.tsx
@@ -41,7 +41,7 @@ export const IntegrationPrompt = ({ service, scopes, reason }: IntegrationPrompt
   const matched = useMemo(() => (service ? matchConnectors(connectors, service) : []), [connectors, service]);
   const connectorIds = useMemo(() => matched.map((connector) => connector.id), [matched]);
   const label = matched[0]?.label ?? service;
-  const { armReport } = useReportConnection({ connectorIds, db: space?.db, label });
+  const { armReport } = useReportConnection({ connectors: matched, db: space?.db, service });
 
   if (!service) {
     return null;
@@ -82,10 +82,11 @@ export const IntegrationPrompt = ({ service, scopes, reason }: IntegrationPrompt
 };
 
 type UseReportConnectionOptions = {
-  connectorIds: readonly string[];
+  /** Connectors the prompt offers; the report is named after the one the flow actually used. */
+  connectors: readonly ConnectorSpec.ConnectorEntry[];
   db: Database.Database | undefined;
-  /** Human-readable service name used in the report, e.g. `Anthropic`. */
-  label: string | undefined;
+  /** The requested service, named in the report when the connector carries no label. */
+  service: string | undefined;
 };
 
 /**
@@ -97,12 +98,16 @@ type UseReportConnectionOptions = {
  * fills in asynchronously, so a mount-time baseline could not tell a pre-existing connection from
  * one this flow created. A flow whose prompt unmounts before it finishes goes unreported.
  */
-const useReportConnection = ({ connectorIds, db, label }: UseReportConnectionOptions) => {
+const useReportConnection = ({ connectors, db, service }: UseReportConnectionOptions) => {
   const { submit } = useChatReportContext(INTEGRATION_PROMPT_NAME);
   const connections = useQuery(db, Filter.type(Connection.Connection));
   const matched = useMemo(
-    () => connections.filter((connection) => !!connection.connectorId && connectorIds.includes(connection.connectorId)),
-    [connections, connectorIds],
+    () =>
+      connections.filter(
+        (connection) =>
+          !!connection.connectorId && connectors.some((connector) => connector.id === connection.connectorId),
+      ),
+    [connections, connectors],
   );
   // Ids present when the user started the flow; anything beyond them is what the flow produced.
   const baseline = useRef<Set<string> | undefined>(undefined);
@@ -123,8 +128,12 @@ const useReportConnection = ({ connectorIds, db, label }: UseReportConnectionOpt
     }
     // One report per flow: disarm before submitting so a later connection needs a fresh click.
     baseline.current = undefined;
-    submit(`Connected ${label ?? created.connectorId}. Credential: ${created.accessToken.uri}`);
-  }, [matched, label, submit]);
+    // A fuzzy service match can offer several connectors, so the report names the one that produced
+    // this connection rather than the first of them.
+    const label =
+      connectors.find((connector) => connector.id === created.connectorId)?.label ?? service ?? created.connectorId;
+    submit(`Connected ${label}. Credential: ${created.accessToken.uri}`);
+  }, [matched, connectors, service, submit]);
 
   return { armReport };
 };

--- a/packages/plugins/plugin-assistant/src/containers/PluginPrompt/PluginPrompt.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/PluginPrompt/PluginPrompt.tsx
@@ -11,6 +11,10 @@ import { Button, Flex, Icon, useTranslation } from '@dxos/react-ui';
 
 import { meta } from '#meta';
 
+import { useChatReportContext } from '../../components/Chat/context';
+
+const PLUGIN_PROMPT_NAME = 'PluginPrompt';
+
 export type PluginPromptProps = {
   /** Id of the plugin the agent needs, e.g. `org.dxos.plugin.markdown`. */
   plugin?: string;
@@ -24,6 +28,7 @@ export type PluginPromptProps = {
 export const PluginPrompt = ({ plugin: pluginId }: PluginPromptProps) => {
   const { t } = useTranslation(meta.profile.key);
   const manager = usePluginManager();
+  const { submit } = useChatReportContext(PLUGIN_PROMPT_NAME);
   const { invokePromise } = useOperationInvoker();
   const enabled = useAtomValue(manager.enabled);
   const [pending, setPending] = useState(false);
@@ -47,13 +52,16 @@ export const PluginPrompt = ({ plugin: pluginId }: PluginPromptProps) => {
       const { data, error } = await invokePromise(RegistryOperation.EnablePlugins, { ids: [pluginId] });
       if (error || data?.rejected.some(({ id }) => id === pluginId)) {
         setFailed(true);
+      } else {
+        // The agent is waiting on a click it cannot observe, so the outcome is reported as a turn.
+        submit(`Enabled the plugin \`${pluginId}\`. Continue.`);
       }
     } catch {
       setFailed(true);
     } finally {
       setPending(false);
     }
-  }, [invokePromise, pluginId]);
+  }, [invokePromise, pluginId, submit]);
 
   if (!pluginId) {
     return null;

--- a/packages/plugins/plugin-assistant/src/processor/processor.ts
+++ b/packages/plugins/plugin-assistant/src/processor/processor.ts
@@ -38,7 +38,7 @@ import { UsageQuotaExceededError } from '@dxos/edge-client';
 import { EffectEx } from '@dxos/effect';
 import { DXN } from '@dxos/keys';
 import { log } from '@dxos/log';
-import { Message } from '@dxos/types';
+import { type ContentBlock, Message } from '@dxos/types';
 
 import { AssistantOperation } from '#types';
 
@@ -81,6 +81,8 @@ export type ProcessorRequestOptions = {};
 
 export type ProcessorRequest = {
   message: string;
+  /** `synthetic` marks system-generated turn content (e.g. a completed inline flow reporting itself). */
+  disposition?: ContentBlock.Text['disposition'];
   /** Ephemeral context (e.g. companion-document selection) captured at submit time. */
   context?: ProcessorRequestContext;
   options?: ProcessorRequestOptions;
@@ -351,8 +353,9 @@ export class AiChatProcessor {
         log('chat processor submitPrompt returned, waiting for agent', {});
 
         // On the first message (no name yet), schedule rename immediately so it
-        // runs concurrently with the AI response rather than waiting for completion.
-        if (!this._options.chat?.target?.name) {
+        // runs concurrently with the AI response rather than waiting for completion. A synthetic
+        // turn is system-generated, so it would name the chat after a report nobody wrote.
+        if (!this._options.chat?.target?.name && requestProp.disposition !== 'synthetic') {
           yield* this.#updateChatName(requestProp.message);
         }
 

--- a/packages/plugins/plugin-assistant/src/processor/prompt.test.ts
+++ b/packages/plugins/plugin-assistant/src/processor/prompt.test.ts
@@ -31,6 +31,25 @@ describe('createPromptContent', () => {
     expect(promptBlock.text).toBe('Summarize this.');
   });
 
+  test('a synthetic request becomes a single synthetic block', ({ expect }) => {
+    const content = createPromptContent({
+      message: 'Connected Anthropic.',
+      disposition: 'synthetic',
+      // Selection context is ignored: the report is not a prompt the selection qualifies.
+      context: { selection: { anchors: ['a:b'], text: 'lorem ipsum' } },
+    });
+    if (typeof content === 'string') {
+      throw new Error('expected content blocks');
+    }
+    expect(content).toHaveLength(1);
+    const [block] = content;
+    if (block._tag !== 'text') {
+      throw new Error('expected a text block');
+    }
+    expect(block.disposition).toBe('synthetic');
+    expect(block.text).toBe('Connected Anthropic.');
+  });
+
   test('empty selection text falls back to the bare message', ({ expect }) => {
     expect(createPromptContent({ message: 'hi', context: { selection: { anchors: [], text: '' } } })).toBe('hi');
   });

--- a/packages/plugins/plugin-assistant/src/processor/prompt.ts
+++ b/packages/plugins/plugin-assistant/src/processor/prompt.ts
@@ -17,11 +17,18 @@ export type ProcessorRequestContext = {
 /**
  * Prompt content for a request: the bare message, or — when the request carries selection context —
  * a synthetic block (system-generated user-turn content, hidden from the summary view) ahead of it.
+ * A synthetic request is itself system-generated (a completed inline flow reporting itself), so it
+ * becomes one synthetic block rather than words the reader appears to have typed.
  */
 export const createPromptContent = (request: {
   message: string;
+  disposition?: ContentBlock.Text['disposition'];
   context?: ProcessorRequestContext;
 }): string | ContentBlock.Any[] => {
+  if (request.disposition === 'synthetic') {
+    return [ContentBlock.Text.make({ text: request.message, disposition: 'synthetic' })];
+  }
+
   const selection = request.context?.selection;
   if (!selection?.text.length) {
     return request.message;

--- a/packages/plugins/plugin-assistant/src/skills/plugin-manager/PluginManagerSkill.ts
+++ b/packages/plugins/plugin-assistant/src/skills/plugin-manager/PluginManagerSkill.ts
@@ -63,7 +63,8 @@ export const make = (): Skill.Skill =>
 
           Use the id exactly as the list above spells it. Emit the surface once per plugin, then
           briefly say what enabling it would let you do. When the user enables it, a message
-          reporting that arrives as the next user turn — resume there rather than polling.
+          reporting that the plugin was enabled arrives as the next user turn — resume there rather
+          than polling.
         - Call [query-plugins] to search the whole installed set, or to re-read state after the
           user has enabled something. A plugin's tools appear only once it activates, so confirm
           \`active\` there rather than assuming the capability is ready.

--- a/packages/plugins/plugin-assistant/src/skills/plugin-manager/PluginManagerSkill.ts
+++ b/packages/plugins/plugin-assistant/src/skills/plugin-manager/PluginManagerSkill.ts
@@ -62,7 +62,8 @@ export const make = (): Skill.Skill =>
           <surface role='plugin-prompt' data='{"plugin":"org.dxos.plugin.kanban"}' />
 
           Use the id exactly as the list above spells it. Emit the surface once per plugin, then
-          briefly say what enabling it would let you do.
+          briefly say what enabling it would let you do. When the user enables it, a message
+          reporting that arrives as the next user turn — resume there rather than polling.
         - Call [query-plugins] to search the whole installed set, or to re-read state after the
           user has enabled something. A plugin's tools appear only once it activates, so confirm
           \`active\` there rather than assuming the capability is ready.

--- a/packages/plugins/plugin-claude/src/skills/ClaudeSkill.ts
+++ b/packages/plugins/plugin-claude/src/skills/ClaudeSkill.ts
@@ -56,6 +56,8 @@ export const make = (): Skill.Skill =>
            \`<surface role='integration-prompt' data='{"service":"anthropic.com"}' />\`
         3. Say that connecting Anthropic lets you continue, then stop and wait — do not retry the
            operation in the same turn, and never ask the user to paste a key into the conversation.
+           The completed flow reports itself as the next user turn, naming the new credential's URI;
+           retry the failed operation there.
 
         ## Giving an agent a credential
         An agent's own credentials — a GitHub token, a Stripe key — are bound to the session by

--- a/packages/plugins/plugin-connector/src/skills/ConnectorsSkill.ts
+++ b/packages/plugins/plugin-connector/src/skills/ConnectorsSkill.ts
@@ -26,6 +26,8 @@ const instructions = trim`
 
   Use the service's domain as the 'service' value (for example 'gmail.com', 'slack.com', 'github.com').
   Emit the surface once, then briefly tell the user that connecting the service will let you continue.
+  Do not poll or retry in the same turn: when the flow completes, a message reporting it — naming the
+  service and the new credential's URI — arrives as the next user turn, and that is your cue to resume.
 `;
 
 export const make = (): Skill.Skill =>


### PR DESCRIPTION
The agent emits an inline prompt (`<surface role='integration-prompt' …>` / `role='plugin-prompt'`) and then waits on a click it never observes, so a connector authorized or a plugin enabled left the conversation stalled.

## Changes

- **`ChatReportContext`** (`components/Chat/context.ts`): a `submit(text)` seam provided by `Chat.Root`. It emits a new `report` chat event, which requests (or queues, mid-turn) a **synthetic** turn — one `ContentBlock.Text` with `disposition: 'synthetic'`, carried by a new `disposition` on `ProcessorRequest` and handled in `createPromptContent`. It reads as a system note rather than words the user typed, and a synthetic turn never names an unnamed chat. The context is defaulted, unlike `ChatContext`, so a surface rendered outside a chat (storybook, preview) drops its report instead of throwing.
- **`IntegrationPrompt`**: watches the space's `Connection` objects for the prompt's connectors and reports once one appears **and** its `accessToken` ref resolves, naming the connector that produced it and the credential's URI. Armed by the user picking a menu entry rather than by mount — the connection query starts empty and fills in asynchronously, so a mount-time baseline could not tell a pre-existing connection from one this flow created.
- **`ConnectorAuthMenu`**: new optional `onSelect` — the connect/reuse flows finish out of band (OAuth popup, credential dialog, `finalizePendingEntry`), so entry selection is the only point at which a caller can tell the user started one.
- **`PluginPrompt`**: reports a successful enable (the `rejected`/`error` paths still just show the failure).
- Skill instructions (connectors, plugin-manager, Claude): tell the model the report arrives as the next turn and to resume there rather than polling or retrying in the same turn.

## Testing

- `moon run plugin-assistant:build plugin-claude:build plugin-connector:build` — green
- `moon run plugin-assistant:test` — 20 files passed, 3 skipped; includes a new `createPromptContent` case for the synthetic path
- `moon run plugin-assistant:lint plugin-connector:lint plugin-claude:lint` + `pnpm format` — clean

Not exercised in a live browser: the connect completion path needs a real OAuth round trip.

## Known limitation

Cancelling a connect flow leaves the prompt armed — neither the OAuth popup nor the credential dialog signals cancellation back to the caller. The worst case is one extra, accurate report if a matching connection is created elsewhere afterwards; closing it properly means adding a cancellation signal through plugin-connector (see the open review thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfHa2WX9d9hyvAj6LvYQ3e

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12943-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
