### PR TITLE
agent-runtime: read the remote process manager from context, never require it

### DIFF
--- a/.changeset/agent-service-remote-optional.md
+++ b/.changeset/agent-service-remote-optional.md
@@ -1,0 +1,9 @@
+---
+'@dxos/echo': patch
+---
+
+`AgentService` reads `RemoteProcessManager` from context instead of requiring it, so a stack that
+hosts only local agents keeps its `AgentService`. A `LayerSpec` stack prunes a provider whose
+requirements are unmet, which dropped `AgentService` entirely wherever no edge runtime was
+provided. `AgentServiceOptions.getRemoteManager` supplies the manager where it cannot be read
+from context.

--- a/packages/core/compute/agent-runtime/src/agent-service/AgentService.ts
+++ b/packages/core/compute/agent-runtime/src/agent-service/AgentService.ts
@@ -7,6 +7,7 @@
 import * as Cause from 'effect/Cause';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
+import * as Option from 'effect/Option';
 import type * as Scope from 'effect/Scope';
 import * as Semaphore from 'effect/Semaphore';
 import * as Atom from 'effect/unstable/reactivity/Atom';
@@ -146,6 +147,10 @@ export const layer = (opts?: AgentServiceOptions): Layer.Layer<AgentService, nev
     AgentService,
     Effect.gen(function* () {
       const processManager = yield* ProcessManager.Service;
+      // Read, never required: a plain layer stack provides the tag beneath this layer, while a
+      // `LayerSpec` stack that declared it would prune this whole provider (and `AgentService` with
+      // it) wherever only local agents are hosted. `getRemoteManager` overrides it for the latter.
+      const remote = yield* Effect.serviceOption(RemoteProcessManager.Service);
 
       // Spaces an edge session has been opened on this run. One remote manager spans them all and
       // each of its verbs takes the space it addresses, so this is what `hydrate` has to walk.
@@ -172,7 +177,8 @@ export const layer = (opts?: AgentServiceOptions): Layer.Layer<AgentService, nev
         if (!spaceId) {
           throw new Error('Agent requested on edge, but its conversation has no space.');
         }
-        const getRemoteManager = opts?.getRemoteManager;
+        const getRemoteManager =
+          opts?.getRemoteManager ?? (Option.isSome(remote) ? () => Effect.succeed(remote.value) : undefined);
         if (!getRemoteManager) {
           throw new Error('Agent requested on edge, but no RemoteProcessManager is available.');
         }


### PR DESCRIPTION
Follow-up to #12765, fixing a mistake I made in it.

## The bug

`AgentService.layer` declared `RemoteProcessManager.Service` as a requirement. A `LayerSpec` stack prunes per spec — any provider whose requirements are unmet is dropped rather than failing the slice — so on a stack that hosts only local agents the entire `AgentService` provider disappeared and every agent call failed:

```
ServiceNotAvailable: Service not available: @dxos/functions-runtime/AgentService
  — application provider spec pruned due to missing deps: @dxos/compute-runtime/RemoteProcessManager
```

`RemoteProcessManager` is needed only for `location: 'edge'`, so requiring it was wrong.

## Why this needs a second commit

#12765's own fix removed the requirement by dropping the context read entirely, leaving `AgentServiceOptions.getRemoteManager` as the only source. That fixed the `LayerSpec` path and broke the other one: a **plain Effect layer stack** provides the tag *beneath* `AgentService.layer` — which is what an app assembles, and what the edge e2e does:

```ts
ProcessMonitor.layer.pipe(
  Layer.provideMerge(AgentRuntimeService.layer()),
  Layer.provideMerge(EdgeProcessManager.fromEdgeProcessClient(new EdgeHttpClient(harness.edgeEndpoint))),
  Layer.provideMerge(ProcessManager.layer()),
  ...
```

That stack then failed with `Agent requested on edge, but no RemoteProcessManager is available.` — caught by the edge e2e in dxos/edge#971 once it was pinned to the merged commit, not by anything on this side.

## The fix

Require nothing; read the tag with `Effect.serviceOption` and let `getRemoteManager` override it. Both shapes work:

- plain layer stack → the tag is read from context, as before #12765;
- `LayerSpec` stack → nothing is declared, so nothing is pruned, and plugin-assistant passes `getRemoteManager` from its own optional read.

## Testing

- `plugin-projects` `delegate-task-to-chat` (the LayerSpec path, no remote provided): 4 passed — this is what regressed.
- `agent-runtime` 44 passed / 22 skipped, `plugin-assistant` 190 passed / 7 skipped.
- The plain-layer path is exercised end-to-end against a live worker by dxos/edge#971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4JXLi6a9Gxs5DNwTwmZXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4JXLi6a9Gxs5DNwTwmZXW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local-only agent stacks now retain their agent service when no remote runtime is available.
  * Remote process management is resolved automatically when available, while still supporting an explicitly provided manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12945-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
