### PR TITLE
react-focus: scope-aware hotkey conflict detection

### DIFF
--- a/.changeset/hotkey-scope-aware-conflicts.md
+++ b/.changeset/hotkey-scope-aware-conflicts.md
@@ -1,0 +1,7 @@
+---
+'@dxos/react-focus': patch
+---
+
+Hotkey conflict warnings now account for scopes. Registering a binding goes through the new `registerHotkey` export, which reports a collision only when the two commands' scopes can be active at once — the same scope, an ancestor against a descendant, or an unscoped command against anything.
+
+Ark's own check compares the hotkey and the DOM target only, so one action bound per space (`space.rename` on `shift+F6`, say) warned once per pair of spaces on every graph sync. `createHotkeyStore` is now a DXOS wrapper that puts the store on `conflictBehavior: 'allow'` so those warnings come from `registerHotkey` instead.

--- a/packages/plugins/plugin-navtree/src/capabilities/keyboard.ts
+++ b/packages/plugins/plugin-navtree/src/capabilities/keyboard.ts
@@ -12,7 +12,7 @@ import * as AppCapabilities from '@dxos/app-toolkit/AppCapabilities';
 import { debounce } from '@dxos/async';
 import * as GraphNode from '@dxos/graph/GraphNode';
 import { runAction } from '@dxos/plugin-graph';
-import { hotkeyStore, initHotkeys, setHotkeyScope } from '@dxos/react-focus/store';
+import { hotkeyStore, initHotkeys, registerHotkey, setHotkeyScope } from '@dxos/react-focus/store';
 import { getHostPlatform } from '@dxos/util';
 
 import { KEY_BINDING } from '#meta';
@@ -47,10 +47,9 @@ export default Capability.makeModule(
         const scope = path.slice(0, -1).join('/');
         const id = `${scope}:${node.id}`;
         seen.add(id);
-        // Unregister first: the store warns on a duplicate id rather than replacing, and this
-        // re-runs on every graph change.
-        hotkeyStore.unregister(id);
-        hotkeyStore.register({
+        // One binding per node, so the same shortcut recurs across sibling spaces; `registerHotkey`
+        // is what keeps those out of the conflict warnings.
+        registerHotkey({
           id,
           hotkey: shortcut,
           scopes: [scope],

--- a/packages/ui/react-primitives/react-focus/src/hotkey-store.ts
+++ b/packages/ui/react-primitives/react-focus/src/hotkey-store.ts
@@ -7,11 +7,27 @@
 // the active scope), and `check-module-structure` fails the build if those transitively import
 // React. The React layer lives in `./hotkeys`.
 
-import { type HotkeyStore, createHotkeyStore } from '@zag-js/hotkeys';
+import {
+  type CommandDefinition,
+  type HotkeyStore,
+  type HotkeyStoreOptions,
+  createHotkeyStore as createStore,
+  normalizeHotkey,
+} from '@zag-js/hotkeys';
 
-export { createHotkeyStore, formatHotkey, normalizeHotkey, parseHotkey } from '@zag-js/hotkeys';
+export { formatHotkey, normalizeHotkey, parseHotkey } from '@zag-js/hotkeys';
 
 export type { CommandDefinition, HotkeyCommand, HotkeyOptions, HotkeyStore, ParsedHotkey } from '@zag-js/hotkeys';
+
+/**
+ * A store that leaves conflict reporting to `registerHotkey`.
+ *
+ * Ark compares only the hotkey and the DOM target, so bindings that can never both be active — one
+ * `space.rename` per space, each scoped to its own — warn against each other, once per pair, on
+ * every graph sync. Scopes are what decide a collision here, and only `registerHotkey` knows them.
+ */
+export const createHotkeyStore = (options?: HotkeyStoreOptions): HotkeyStore =>
+  createStore({ ...options, conflictBehavior: 'allow' });
 
 /**
  * The one store every DXOS binding registers on.
@@ -81,6 +97,9 @@ export const GRAPH_ROOT_ID = 'root';
 /** Scope separator, matching the graph paths bindings are registered under. */
 const SEPARATOR = '/';
 
+/** The store's always-active scope, which is also what an unscoped command registers under. */
+export const WILDCARD_SCOPE = '*';
+
 /**
  * Nest an attendable segment under the graph root so a plank's scope also activates root-level
  * bindings. An empty or absent segment resolves to the graph root itself.
@@ -112,7 +131,7 @@ export const setHotkeyScope = (path?: string, store: HotkeyStore = hotkeyStore):
   const next = new Set(path ? scopeChain(path) : []);
   for (const scope of store.getActiveScopes()) {
     // The wildcard is the store's own always-active scope; it is not ours to retire.
-    if (scope !== '*' && !next.has(scope)) {
+    if (scope !== WILDCARD_SCOPE && !next.has(scope)) {
       store.removeScope(scope);
     }
   }
@@ -128,5 +147,53 @@ export const setHotkeyScope = (path?: string, store: HotkeyStore = hotkeyStore):
 export const getHotkeyScope = (store: HotkeyStore = hotkeyStore): string | undefined =>
   store
     .getActiveScopes()
-    .filter((scope: string) => scope !== '*')
+    .filter((scope: string) => scope !== WILDCARD_SCOPE)
     .sort((a: string, b: string) => b.length - a.length)[0];
+
+/**
+ * Whether two scopes can be active at the same moment.
+ *
+ * `setHotkeyScope` activates a whole chain, so an ancestor is live whenever its descendant is —
+ * `root` and `root/plank-1` collide. Siblings never are.
+ */
+const scopesIntersect = (left: string, right: string): boolean =>
+  left === WILDCARD_SCOPE ||
+  right === WILDCARD_SCOPE ||
+  left === right ||
+  left.startsWith(`${right}${SEPARATOR}`) ||
+  right.startsWith(`${left}${SEPARATOR}`);
+
+/** A command's scopes as the store stores them; Ark accepts a bare string and defaults to the wildcard. */
+const scopesOf = (scopes: string | readonly string[] | undefined): readonly string[] =>
+  typeof scopes === 'string' ? [scopes] : scopes?.length ? scopes : [WILDCARD_SCOPE];
+
+/**
+ * Register a command, warning only about a hotkey that can actually fire alongside another.
+ *
+ * Registration goes through here rather than `store.register` so the store can stay on
+ * `conflictBehavior: 'allow'`; see `createHotkeyStore`.
+ */
+export const registerHotkey = (command: CommandDefinition, store: HotkeyStore = hotkeyStore): void => {
+  // Unregister first: the store warns on a duplicate id rather than replacing, and both callers
+  // re-register the same ids whenever their source changes.
+  store.unregister(command.id);
+
+  const hotkey = normalizeHotkey(command.hotkey);
+  const scopes = scopesOf(command.scopes);
+  for (const existing of store.getState().commands.values()) {
+    if (
+      normalizeHotkey(existing.hotkey) !== hotkey ||
+      existing.options?.target !== command.options?.target ||
+      !scopesOf(existing.scopes).some((scope) => scopes.some((other) => scopesIntersect(scope, other)))
+    ) {
+      continue;
+    }
+
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[hotkeys] Conflict: "${hotkey}" is already registered by command "${existing.id}" in an overlapping scope. Command "${command.id}" will also respond to this hotkey.`,
+    );
+  }
+
+  store.register({ ...command, hotkey });
+};

--- a/packages/ui/react-primitives/react-focus/src/hotkeys.test.tsx
+++ b/packages/ui/react-primitives/react-focus/src/hotkeys.test.tsx
@@ -4,13 +4,15 @@
 
 import { act, cleanup, render } from '@testing-library/react';
 import React from 'react';
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
   GRAPH_ROOT_ID,
   type HotkeyStore,
+  createHotkeyStore,
   hotkeyStore,
   nestHotkeyScope,
+  registerHotkey,
   scopeChain,
   setHotkeyScope,
   useActiveHotkeys,
@@ -170,8 +172,74 @@ describe('hotkey scopes', () => {
     setHotkeyScope('root/plank-1', store);
     press('d');
     // Both, not one: the path-scan this replaced fired only the most specific match, so asserting
-    // the pair is what catches a regression back to it. `conflictBehavior: 'warn'` surfaces the
-    // collision that the old scan would have hidden.
+    // the pair is what catches a regression back to it.
     expect(fired).toEqual(['root', 'plank']);
+  });
+});
+
+describe('hotkey conflicts', () => {
+  const withWarnings = (register: (store: HotkeyStore) => void): string[] => {
+    const warnings: string[] = [];
+    const spy = vi.spyOn(console, 'warn').mockImplementation((message) => void warnings.push(String(message)));
+    try {
+      register(createHotkeyStore());
+    } finally {
+      spy.mockRestore();
+    }
+    return warnings;
+  };
+
+  test('sibling scopes binding the same hotkey are not a conflict', () => {
+    // One `space.rename` per space is the case that flooded the console: Ark compares the hotkey
+    // and the DOM target only, so every pair of spaces warned, on every graph sync.
+    const warnings = withWarnings((store) => {
+      for (const space of ['space-1', 'space-2', 'space-3']) {
+        registerHotkey(
+          { id: `${space}:rename`, hotkey: 'shift+F6', scopes: [`root/${space}`], action: () => {} },
+          store,
+        );
+      }
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  test('an ancestor scope binding the same hotkey is a conflict', () => {
+    const warnings = withWarnings((store) => {
+      registerHotkey({ id: 'root:rename', hotkey: 'shift+F6', scopes: [GRAPH_ROOT_ID], action: () => {} }, store);
+      registerHotkey({ id: 'space:rename', hotkey: 'shift+F6', scopes: ['root/space-1'], action: () => {} }, store);
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('root:rename');
+    expect(warnings[0]).toContain('space:rename');
+  });
+
+  test('an unscoped binding conflicts with every scope', () => {
+    const warnings = withWarnings((store) => {
+      registerHotkey({ id: 'global', hotkey: 'shift+F6', action: () => {} }, store);
+      registerHotkey({ id: 'scoped', hotkey: 'shift+F6', scopes: ['root/space-1'], action: () => {} }, store);
+    });
+
+    expect(warnings).toHaveLength(1);
+  });
+
+  test('re-registering the same id is not a conflict with itself', () => {
+    const warnings = withWarnings((store) => {
+      for (let index = 0; index < 3; index++) {
+        registerHotkey({ id: 'rename', hotkey: 'shift+F6', scopes: ['root/space-1'], action: () => {} }, store);
+      }
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  test('different hotkeys in the same scope are not a conflict', () => {
+    const warnings = withWarnings((store) => {
+      registerHotkey({ id: 'one', hotkey: 'shift+F6', scopes: ['root/space-1'], action: () => {} }, store);
+      registerHotkey({ id: 'two', hotkey: 'shift+F7', scopes: ['root/space-1'], action: () => {} }, store);
+    });
+
+    expect(warnings).toEqual([]);
   });
 });

--- a/packages/ui/react-primitives/react-focus/src/hotkeys.ts
+++ b/packages/ui/react-primitives/react-focus/src/hotkeys.ts
@@ -2,10 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
-import { type CommandDefinition, type HotkeyCommand, type HotkeyStore, normalizeHotkey } from '@zag-js/hotkeys';
+import { type CommandDefinition, type HotkeyCommand, type HotkeyStore } from '@zag-js/hotkeys';
 import { useCallback, useEffect, useId, useRef, useSyncExternalStore } from 'react';
 
-import { holdHotkeyScope, hotkeyStore } from './hotkey-store';
+import { holdHotkeyScope, hotkeyStore, registerHotkey } from './hotkey-store';
 
 export * from './hotkey-store';
 
@@ -50,19 +50,18 @@ export const useHotkeys = ({ commands, id, store = hotkeyStore }: UseHotkeysProp
 
     const ids = commandsRef.current.map(resolveId);
     commandsRef.current.forEach((command, index) => {
-      const commandId = ids[index];
-      // Unregister first: the store warns on a duplicate id rather than replacing.
-      store.unregister(commandId);
-      store.register({
-        ...command,
-        id: commandId,
-        hotkey: normalizeHotkey(command.hotkey),
-        action: (event) => commandsRef.current[index]?.action(event),
-        enabled: () => {
-          const enabled = commandsRef.current[index]?.enabled;
-          return typeof enabled === 'function' ? enabled() : (enabled ?? true);
+      registerHotkey(
+        {
+          ...command,
+          id: ids[index],
+          action: (event) => commandsRef.current[index]?.action(event),
+          enabled: () => {
+            const enabled = commandsRef.current[index]?.enabled;
+            return typeof enabled === 'function' ? enabled() : (enabled ?? true);
+          },
         },
-      });
+        store,
+      );
     });
 
     return () => {


### PR DESCRIPTION
Fixes the flood of `[hotkeys] Conflict: "shift+F6" is already registered by …` warnings in the console.

## Root cause

`@zag-js/hotkeys` `detectConflicts` compares only the hotkey string and `options.target`. It ignores `scopes` entirely (its own comment, "same hotkey scoped to different targets is not a conflict", is about the DOM target, not scopes).

`plugin-navtree`'s keyboard capability registers one binding per graph action node, scoped to that node's path — so every space gets its own `space.rename` on `shift+F6` under `root/root/<spaceId>`. Those bindings can never fire together, but zag warns for every pair, and `syncBindings` re-registers on every graph change. The noise grows quadratically in the number of spaces.

## Change

- `createHotkeyStore` is now a DXOS wrapper that pins `conflictBehavior: 'allow'`, so zag stops reporting.
- New `registerHotkey(command, store)` does the check itself: same normalized hotkey, same DOM target, **and** scopes that can be active at once — identical, ancestor against descendant (`setHotkeyScope` activates the whole chain), or either one unscoped. Real collisions still warn; siblings don't.
- `useHotkeys` and the navtree capability both register through it, which also centralizes the unregister-before-register each of them was doing.

## Testing

```
✓ |node| src/hotkeys.test.tsx (13 tests) 42ms
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Five new cases: sibling scopes (no warning), ancestor overlap (warns), unscoped vs scoped (warns), re-registering the same id (no warning), different hotkeys in one scope (no warning). The single warning still printed during the run comes from the pre-existing `root` + `root/plank-1` test, which is a genuine overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2g1Pk81yTybDnYrp73Xpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2g1Pk81yTybDnYrp73Xpm)_

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12946-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
