### PR TITLE
ci: link nightly Discord reports to the Depot run

### DIFF
--- a/.depot/actions/test-report/send-test-report.sh
+++ b/.depot/actions/test-report/send-test-report.sh
@@ -11,7 +11,11 @@ ROLE_ID=1166483404066402414
 GREEN=4783872
 ORANGE=16744192
 RED=16711680
-GH_BUILD_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+# The nightly runs on Depot CI, so `$GITHUB_RUN_ID` names a run GitHub never created and the Actions URL
+# built from it 404s. `DEPOT_JOB_URL` is this job's page in the Depot UI, which is where the run and its
+# other jobs are reachable; the Actions URL remains the fallback for a caller on GitHub's own runner.
+BUILD_URL="${DEPOT_JOB_URL:-$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID}"
 
 # Workflow commands are newline-delimited, so an unescaped webhook response could forge annotations.
 function escape() {
@@ -31,7 +35,7 @@ function notify() {
   local message response status body
   message=$(
     printf '{ "content": %s, "embeds": [{ "title": %s, "description": %s, "color": %s }] }' \
-      "\"$1\"" "\"$2: $NAME\"" "\"$GH_BUILD_URL\"" "$3"
+      "\"$1\"" "\"$2: $NAME\"" "\"$BUILD_URL\"" "$3"
   )
   echo "$message"
   response=$(


### PR DESCRIPTION
The nightly test report posted to Discord embedded a GitHub Actions run URL built from `$GITHUB_RUN_ID`. Check runs on Depot CI, not on GitHub's orchestrator, so that id names a run GitHub never created and the link goes nowhere.

`send-test-report.sh` now uses `DEPOT_JOB_URL`, which Depot sets in every job as a direct link to that job's page in the Depot UI ([docs](https://depot.dev/docs/environment-variables)); the run and its other jobs are reachable from there. The Actions URL stays as the fallback, since the composite action lives under `.depot/actions/` and workflows in `.github/workflows/` call actions from that directory by path.

Verified by running the script against a local HTTP stub standing in for the webhook, once with `DEPOT_JOB_URL` set and once without:

```
{ "content": "⚠️ <@&…>", "embeds": [{ "title": "Daily testing failed: test-24.11.1",
  "description": "https://depot.dev/orgs/dxos/ci/runs/abc123/jobs/report", "color": 16711680 }] }
{ "content": "🌈✨✅", "embeds": [{ "title": "Daily testing successful: e2e",
  "description": "https://github.com/dxos/dxos/actions/runs/999", "color": 4783872 }] }
```

`bash -n` and `oxfmt --check .depot/` both pass. No changeset: nothing published changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uVabPH8YpMrfaHUXC48oH

---
_Generated by [Claude Code](https://claude.ai/code/session_017uVabPH8YpMrfaHUXC48oH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Test reports now link to the relevant Depot job when available.
  - GitHub Actions run links remain available as a fallback when a Depot job URL cannot be provided.
  - Discord test report notifications now use the updated report link consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12947-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
