### PR TITLE
e2e: close the browser context a Playwright page object created

### DIFF
--- a/.changeset/playwright-context-close.md
+++ b/.changeset/playwright-context-close.md
@@ -1,0 +1,5 @@
+---
+'@dxos/test-utils': patch
+---
+
+`setupPage` now returns a `close()` that disposes the browser context it created. Closing only the page left the context open, and Playwright re-serialized every live context into each later trace until the writer exceeded V8's string limit and left a truncated `trace.zip` behind.

--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -61,6 +61,7 @@ export class AppManager {
 
   private readonly _inIframe: boolean | undefined = undefined;
   private _initialized = false;
+  private _close?: () => Promise<void>;
   private _invitationCode = new Trigger<string>();
   private _authCode = new Trigger<string>();
   // Rolling tail of console errors: the app reports operation failures generically to the user, and
@@ -80,8 +81,9 @@ export class AppManager {
       return;
     }
 
-    const { page } = await setupPage(this._browser, { url: INITIAL_URL });
+    const { page, close } = await setupPage(this._browser, { url: INITIAL_URL });
     this.page = page;
+    this._close = close;
     this.page.on('console', (message) => this._onConsoleMessage(message));
 
     // Assert boot rather than proceed on a swallowed `false`, so a failed boot fails here instead of as
@@ -95,10 +97,8 @@ export class AppManager {
     this.deck = new DeckManager(this.page);
   }
 
-  async closePage(): Promise<void> {
-    if (this.page !== undefined) {
-      await this.page.close();
-    }
+  async close(): Promise<void> {
+    await this._close?.();
   }
 
   //

--- a/packages/apps/composer-app/src/playwright/basic.spec.ts
+++ b/packages/apps/composer-app/src/playwright/basic.spec.ts
@@ -25,7 +25,7 @@ test.describe('Basic tests', () => {
   });
 
   test.afterEach(async () => {
-    await host.closePage();
+    await host.close();
   });
 
   test('create identity, space is created by default', async () => {

--- a/packages/apps/composer-app/src/playwright/chat.spec.ts
+++ b/packages/apps/composer-app/src/playwright/chat.spec.ts
@@ -36,7 +36,7 @@ test.describe('Chat', () => {
   });
 
   test.afterEach(async () => {
-    await host.closePage();
+    await host.close();
   });
 
   test('sends a message and receives a response', async () => {

--- a/packages/apps/composer-app/src/playwright/collaboration.spec.ts
+++ b/packages/apps/composer-app/src/playwright/collaboration.spec.ts
@@ -51,8 +51,8 @@ test.describe('Collaboration tests', () => {
     // NOTE: `afterEach` even if the test is skipped in the beforeEach!
     // Guard against uninitialized app managers.
     if (host !== undefined && guest !== undefined) {
-      await host.closePage();
-      await guest.closePage();
+      await host.close();
+      await guest.close();
     }
   });
 

--- a/packages/apps/composer-app/src/playwright/collaboration.spec.ts
+++ b/packages/apps/composer-app/src/playwright/collaboration.spec.ts
@@ -51,8 +51,7 @@ test.describe('Collaboration tests', () => {
     // NOTE: `afterEach` even if the test is skipped in the beforeEach!
     // Guard against uninitialized app managers.
     if (host !== undefined && guest !== undefined) {
-      await host.close();
-      await guest.close();
+      await Promise.all([host.close(), guest.close()]);
     }
   });
 

--- a/packages/apps/composer-app/src/playwright/collections.spec.ts
+++ b/packages/apps/composer-app/src/playwright/collections.spec.ts
@@ -15,7 +15,7 @@ test.describe('Collection tests', () => {
   });
 
   test.afterEach(async () => {
-    await host.closePage();
+    await host.close();
   });
 
   test('create collection', async () => {

--- a/packages/apps/composer-app/src/playwright/comments.spec.ts
+++ b/packages/apps/composer-app/src/playwright/comments.spec.ts
@@ -21,7 +21,7 @@ test.describe('Comments tests', () => {
   });
 
   test.afterEach(async () => {
-    await host.closePage();
+    await host.close();
   });
 
   test('create', async () => {

--- a/packages/apps/composer-app/src/playwright/first-run.spec.ts
+++ b/packages/apps/composer-app/src/playwright/first-run.spec.ts
@@ -17,7 +17,7 @@ test.describe.skip('First-run tests', () => {
   });
 
   test.afterEach(async () => {
-    await host.closePage();
+    await host.close();
   });
 
   test('help plugin tooltip displays (eventually) on first run and increments correctly', async () => {

--- a/packages/apps/composer-app/src/playwright/halo.spec.ts
+++ b/packages/apps/composer-app/src/playwright/halo.spec.ts
@@ -33,8 +33,7 @@ test.describe('HALO tests', () => {
   test.afterEach(async () => {
     // Playwright runs `afterEach` even when `beforeEach` skipped, so neither manager may exist.
     if (host !== undefined && guest !== undefined) {
-      await host.close();
-      await guest.close();
+      await Promise.all([host.close(), guest.close()]);
     }
   });
 

--- a/packages/apps/composer-app/src/playwright/halo.spec.ts
+++ b/packages/apps/composer-app/src/playwright/halo.spec.ts
@@ -34,8 +34,8 @@ test.describe('HALO tests', () => {
     // NOTE: `afterEach` even if the test is skipped in the beforeEach!
     // Guard against uninitialized app managers.
     if (host !== undefined || guest !== undefined) {
-      await host.closePage();
-      await guest.closePage();
+      await host.close();
+      await guest.close();
     }
   });
 

--- a/packages/apps/composer-app/src/playwright/halo.spec.ts
+++ b/packages/apps/composer-app/src/playwright/halo.spec.ts
@@ -31,9 +31,8 @@ test.describe('HALO tests', () => {
   });
 
   test.afterEach(async () => {
-    // NOTE: `afterEach` even if the test is skipped in the beforeEach!
-    // Guard against uninitialized app managers.
-    if (host !== undefined || guest !== undefined) {
+    // Playwright runs `afterEach` even when `beforeEach` skipped, so neither manager may exist.
+    if (host !== undefined && guest !== undefined) {
       await host.close();
       await guest.close();
     }

--- a/packages/apps/composer-app/src/playwright/inbox.spec.ts
+++ b/packages/apps/composer-app/src/playwright/inbox.spec.ts
@@ -40,7 +40,7 @@ test.describe.skip('Inbox', () => {
   });
 
   test.afterEach(async () => {
-    await host.closePage();
+    await host.close();
   });
 
   // Create a JMAP-connected mailbox by driving the real credential form; provider HTTP is served by

--- a/packages/apps/composer-app/src/playwright/tables.spec.ts
+++ b/packages/apps/composer-app/src/playwright/tables.spec.ts
@@ -22,7 +22,7 @@ test.describe.skip('Table tests', () => {
   });
 
   test.afterEach(async () => {
-    await host.closePage();
+    await host.close();
   });
 
   test('create', async () => {

--- a/packages/apps/todomvc/src/playwright/app-manager.ts
+++ b/packages/apps/todomvc/src/playwright/app-manager.ts
@@ -17,6 +17,7 @@ export class AppManager {
   shell!: ShellManager;
 
   private _initialized = false;
+  private _close?: () => Promise<void>;
   private _invitationCode = new Trigger<string>();
 
   constructor(private readonly _browser: Browser) {}
@@ -26,13 +27,18 @@ export class AppManager {
       return;
     }
 
-    const { page } = await setupPage(this._browser, { url: INITIAL_URL });
+    const { page, close } = await setupPage(this._browser, { url: INITIAL_URL });
     this.page = page;
+    this._close = close;
     this.page.on('console', (message) => this._onConsoleMessage(message));
     this.shell = new ShellManager(this.page);
     await this.newTodo().waitFor({ state: 'visible' });
     await this.page.getByTestId('placeholder').waitFor({ state: 'hidden' });
     this._initialized = true;
+  }
+
+  async close(): Promise<void> {
+    await this._close?.();
   }
 
   // Getters

--- a/packages/apps/todomvc/src/playwright/basic.spec.ts
+++ b/packages/apps/todomvc/src/playwright/basic.spec.ts
@@ -45,8 +45,8 @@ test.describe('Basic test', () => {
   });
 
   test.afterEach(async () => {
-    await host.page.close();
-    await guest.page.close();
+    await host.close();
+    await guest.close();
   });
 
   test.describe('Default space', () => {

--- a/packages/apps/todomvc/src/playwright/basic.spec.ts
+++ b/packages/apps/todomvc/src/playwright/basic.spec.ts
@@ -45,8 +45,7 @@ test.describe('Basic test', () => {
   });
 
   test.afterEach(async () => {
-    await host.close();
-    await guest.close();
+    await Promise.all([host.close(), guest.close()]);
   });
 
   test.describe('Default space', () => {

--- a/packages/common/test-utils/src/playwright.ts
+++ b/packages/common/test-utils/src/playwright.ts
@@ -141,57 +141,70 @@ export type SetupOptions = {
   viewportSize?: Parameters<Page['setViewportSize']>[0];
 };
 
+/**
+ * Opens a page, creating a context for it unless handed one to borrow.
+ * `close()` disposes whatever this created: the context when it made one, otherwise just the page.
+ */
 export const setupPage = async (browser: Browser | BrowserContext, options: SetupOptions = {}) => {
   const { url, bridgeLogs, viewportSize } = options;
 
   const context = 'newContext' in browser ? await browser.newContext() : browser;
   const ownsContext = context !== browser;
-  const page = await context.newPage();
+  let page: Page | undefined;
 
   // Playwright opens a trace chunk on every live context at test start, so a context left behind by a
   // closed page is re-serialized into every later trace in that worker.
   const close = async (): Promise<void> => {
-    await (ownsContext ? context.close() : page.close());
+    await (ownsContext ? context.close() : page?.close());
   };
 
-  if (viewportSize) {
-    await page.setViewportSize(viewportSize);
-  }
+  try {
+    page = await context.newPage();
 
-  // TODO(wittjosiah): Remove?
-  if (bridgeLogs) {
-    const lock = new Lock();
+    if (viewportSize) {
+      await page.setViewportSize(viewportSize);
+    }
 
-    page.on('pageerror', async (error) => {
-      await lock.executeSynchronized(async () => {
-        // eslint-disable-next-line no-console
-        console.log(error);
-      });
-    });
+    // TODO(wittjosiah): Remove?
+    if (bridgeLogs) {
+      const lock = new Lock();
 
-    page.on('console', async (msg) => {
-      try {
-        const argsPromise = Promise.all(msg.args().map((x) => x.jsonValue()));
+      page.on('pageerror', async (error) => {
         await lock.executeSynchronized(async () => {
-          const args = await argsPromise;
-
-          if (args.length > 0) {
-            console.log(...args);
-          } else {
-            console.log(msg);
-          }
+          // eslint-disable-next-line no-console
+          console.log(error);
         });
-      } catch (err) {
-        console.error('Failed to parse message', err);
-      }
-    });
-  }
+      });
 
-  if (url) {
-    await page.goto(url);
-  }
+      page.on('console', async (msg) => {
+        try {
+          const argsPromise = Promise.all(msg.args().map((x) => x.jsonValue()));
+          await lock.executeSynchronized(async () => {
+            const args = await argsPromise;
 
-  return { context, page, close };
+            if (args.length > 0) {
+              console.log(...args);
+            } else {
+              console.log(msg);
+            }
+          });
+        } catch (err) {
+          console.error('Failed to parse message', err);
+        }
+      });
+    }
+
+    if (url) {
+      await page.goto(url);
+    }
+
+    return { context, page, close };
+  } catch (err) {
+    // The caller never received `close`, so this is the only chance to dispose what got created. The
+    // setup error is the one worth reporting, so a failure to clean up does not displace it.
+    await close().catch(() => {});
+    throw err;
+  }
 };
 
 export const storybookUrl = (storyId: string, port = 9009) =>

--- a/packages/common/test-utils/src/playwright.ts
+++ b/packages/common/test-utils/src/playwright.ts
@@ -148,11 +148,8 @@ export const setupPage = async (browser: Browser | BrowserContext, options: Setu
   const ownsContext = context !== browser;
   const page = await context.newPage();
 
-  // Closing the page is not enough. Playwright never reclaims a context created off the worker-scoped
-  // `browser` fixture, and it opens a trace chunk on every LIVE context when a test starts, so each
-  // leaked context is re-serialized into every later trace in that worker until the writer exceeds
-  // V8's string limit and the run reports `RangeError: Invalid string length` over a truncated
-  // trace.zip instead of the failure it was recording.
+  // Playwright opens a trace chunk on every live context at test start, so a context left behind by a
+  // closed page is re-serialized into every later trace in that worker.
   const close = async (): Promise<void> => {
     await (ownsContext ? context.close() : page.close());
   };

--- a/packages/common/test-utils/src/playwright.ts
+++ b/packages/common/test-utils/src/playwright.ts
@@ -145,7 +145,17 @@ export const setupPage = async (browser: Browser | BrowserContext, options: Setu
   const { url, bridgeLogs, viewportSize } = options;
 
   const context = 'newContext' in browser ? await browser.newContext() : browser;
+  const ownsContext = context !== browser;
   const page = await context.newPage();
+
+  // Closing the page is not enough. Playwright never reclaims a context created off the worker-scoped
+  // `browser` fixture, and it opens a trace chunk on every LIVE context when a test starts, so each
+  // leaked context is re-serialized into every later trace in that worker until the writer exceeds
+  // V8's string limit and the run reports `RangeError: Invalid string length` over a truncated
+  // trace.zip instead of the failure it was recording.
+  const close = async (): Promise<void> => {
+    await (ownsContext ? context.close() : page.close());
+  };
 
   if (viewportSize) {
     await page.setViewportSize(viewportSize);
@@ -184,7 +194,7 @@ export const setupPage = async (browser: Browser | BrowserContext, options: Setu
     await page.goto(url);
   }
 
-  return { context, page };
+  return { context, page, close };
 };
 
 export const storybookUrl = (storyId: string, port = 9009) =>

--- a/packages/e2e/rpc-tunnel-e2e/src/playwright/iframe-worker.spec.ts
+++ b/packages/e2e/rpc-tunnel-e2e/src/playwright/iframe-worker.spec.ts
@@ -12,11 +12,17 @@ const config = {
 
 test.describe('iframe-worker', () => {
   let page: Page;
+  let close: () => Promise<void>;
 
   test.beforeAll(async ({ browser }) => {
     const result = await setupPage(browser, { url: `${config.baseUrl}/iframe-worker.html` });
     page = result.page;
+    close = result.close;
     await page.locator(':text("value")').waitFor({ state: 'visible' });
+  });
+
+  test.afterAll(async () => {
+    await close();
   });
 
   test('loads and connects.', async () => {

--- a/packages/e2e/rpc-tunnel-e2e/src/playwright/iframe-worker.spec.ts
+++ b/packages/e2e/rpc-tunnel-e2e/src/playwright/iframe-worker.spec.ts
@@ -12,7 +12,7 @@ const config = {
 
 test.describe('iframe-worker', () => {
   let page: Page;
-  let close: () => Promise<void>;
+  let close: (() => Promise<void>) | undefined;
 
   test.beforeAll(async ({ browser }) => {
     const result = await setupPage(browser, { url: `${config.baseUrl}/iframe-worker.html` });
@@ -22,7 +22,8 @@ test.describe('iframe-worker', () => {
   });
 
   test.afterAll(async () => {
-    await close();
+    // Playwright runs `afterAll` even when `beforeAll` threw, so setup may never have assigned this.
+    await close?.();
   });
 
   test('loads and connects.', async () => {

--- a/packages/e2e/rpc-tunnel-e2e/src/playwright/iframe.spec.ts
+++ b/packages/e2e/rpc-tunnel-e2e/src/playwright/iframe.spec.ts
@@ -12,11 +12,17 @@ const config = {
 
 test.describe('iframe', () => {
   let page: Page;
+  let close: () => Promise<void>;
 
   test.beforeAll(async ({ browser }) => {
     const result = await setupPage(browser, { url: `${config.baseUrl}/iframe.html` });
     page = result.page;
+    close = result.close;
     await page.locator(':text("value")').waitFor({ state: 'visible' });
+  });
+
+  test.afterAll(async () => {
+    await close();
   });
 
   test('parent and child share source of truth.', async () => {

--- a/packages/e2e/rpc-tunnel-e2e/src/playwright/iframe.spec.ts
+++ b/packages/e2e/rpc-tunnel-e2e/src/playwright/iframe.spec.ts
@@ -12,7 +12,7 @@ const config = {
 
 test.describe('iframe', () => {
   let page: Page;
-  let close: () => Promise<void>;
+  let close: (() => Promise<void>) | undefined;
 
   test.beforeAll(async ({ browser }) => {
     const result = await setupPage(browser, { url: `${config.baseUrl}/iframe.html` });
@@ -22,7 +22,8 @@ test.describe('iframe', () => {
   });
 
   test.afterAll(async () => {
-    await close();
+    // Playwright runs `afterAll` even when `beforeAll` threw, so setup may never have assigned this.
+    await close?.();
   });
 
   test('parent and child share source of truth.', async () => {

--- a/packages/e2e/rpc-tunnel-e2e/src/playwright/multi-worker.spec.ts
+++ b/packages/e2e/rpc-tunnel-e2e/src/playwright/multi-worker.spec.ts
@@ -12,10 +12,16 @@ const config = {
 
 test.describe('multi-worker', () => {
   let page: Page;
+  let close: () => Promise<void>;
 
   test.beforeAll(async ({ browser }) => {
     const result = await setupPage(browser, { url: `${config.baseUrl}/multi-worker.html` });
     page = result.page;
+    close = result.close;
+  });
+
+  test.afterAll(async () => {
+    await close();
   });
 
   test('communicates over multiple independent rpc ports.', async () => {

--- a/packages/e2e/rpc-tunnel-e2e/src/playwright/multi-worker.spec.ts
+++ b/packages/e2e/rpc-tunnel-e2e/src/playwright/multi-worker.spec.ts
@@ -12,7 +12,7 @@ const config = {
 
 test.describe('multi-worker', () => {
   let page: Page;
-  let close: () => Promise<void>;
+  let close: (() => Promise<void>) | undefined;
 
   test.beforeAll(async ({ browser }) => {
     const result = await setupPage(browser, { url: `${config.baseUrl}/multi-worker.html` });
@@ -21,7 +21,8 @@ test.describe('multi-worker', () => {
   });
 
   test.afterAll(async () => {
-    await close();
+    // Playwright runs `afterAll` even when `beforeAll` threw, so setup may never have assigned this.
+    await close?.();
   });
 
   test('communicates over multiple independent rpc ports.', async () => {

--- a/packages/e2e/rpc-tunnel-e2e/src/playwright/worker.spec.ts
+++ b/packages/e2e/rpc-tunnel-e2e/src/playwright/worker.spec.ts
@@ -12,11 +12,17 @@ const config = {
 
 test.describe('worker', () => {
   let page: Page;
+  let close: () => Promise<void>;
 
   test.beforeAll(async ({ browser }) => {
     const result = await setupPage(browser, { url: `${config.baseUrl}/worker.html` });
     page = result.page;
+    close = result.close;
     await page.locator(':text("value")').waitFor({ state: 'visible' });
+  });
+
+  test.afterAll(async () => {
+    await close();
   });
 
   test('loads and connects.', async () => {

--- a/packages/e2e/rpc-tunnel-e2e/src/playwright/worker.spec.ts
+++ b/packages/e2e/rpc-tunnel-e2e/src/playwright/worker.spec.ts
@@ -12,7 +12,7 @@ const config = {
 
 test.describe('worker', () => {
   let page: Page;
-  let close: () => Promise<void>;
+  let close: (() => Promise<void>) | undefined;
 
   test.beforeAll(async ({ browser }) => {
     const result = await setupPage(browser, { url: `${config.baseUrl}/worker.html` });
@@ -22,7 +22,8 @@ test.describe('worker', () => {
   });
 
   test.afterAll(async () => {
-    await close();
+    // Playwright runs `afterAll` even when `beforeAll` threw, so setup may never have assigned this.
+    await close?.();
   });
 
   test('loads and connects.', async () => {

--- a/packages/plugins/plugin-kanban/src/playwright/smoke.spec.ts
+++ b/packages/plugins/plugin-kanban/src/playwright/smoke.spec.ts
@@ -14,6 +14,7 @@ const STORY_URL = storybookUrl('plugins-plugin-kanban-containers-kanban--mutable
 test.describe('Kanban MutableSchema', () => {
   let page: Page;
   let board: BoardManager;
+  let close: (() => Promise<void>) | undefined;
 
   test.beforeEach(async ({ browser, browserName }) => {
     // TODO(wittjosiah): Deferred on webkit — the story intermittently never paints a column within the
@@ -24,15 +25,15 @@ test.describe('Kanban MutableSchema', () => {
     test.skip(browserName === 'webkit');
 
     // Larger viewport to avoid triggering scroll-assist behaviour on simple drag operations.
-    ({ page } = await setupPage(browser, { url: STORY_URL, viewportSize: { width: 1920, height: 1080 } }));
+    ({ page, close } = await setupPage(browser, { url: STORY_URL, viewportSize: { width: 1920, height: 1080 } }));
     board = new BoardManager(page.locator('body'));
     await board.waitUntilReady();
   });
 
   test.afterEach(async () => {
-    // `afterEach` runs even when `beforeEach` skipped, so `page` may never have been assigned —
+    // `afterEach` runs even when `beforeEach` skipped, so the context may never have been created;
     // closing it unconditionally turned every skipped webkit test into a teardown failure.
-    await page?.close();
+    await close?.();
   });
 
   test('rearrange columns', async () => {

--- a/packages/plugins/plugin-kanban/src/playwright/smoke.spec.ts
+++ b/packages/plugins/plugin-kanban/src/playwright/smoke.spec.ts
@@ -31,8 +31,7 @@ test.describe('Kanban MutableSchema', () => {
   });
 
   test.afterEach(async () => {
-    // `afterEach` runs even when `beforeEach` skipped, so the context may never have been created;
-    // closing it unconditionally turned every skipped webkit test into a teardown failure.
+    // Playwright runs `afterEach` even when `beforeEach` skipped, so the context may not exist.
     await close?.();
   });
 

--- a/packages/plugins/plugin-sheet/src/playwright/sheet.spec.ts
+++ b/packages/plugins/plugin-sheet/src/playwright/sheet.spec.ts
@@ -12,6 +12,7 @@ import { SheetManager } from './sheet-manager';
 test.describe('plugin-sheet', () => {
   let page: Page;
   let sheet: SheetManager;
+  let close: () => Promise<void>;
 
   test.beforeEach(async ({ browser }) => {
     const setup = await setupPage(browser, {
@@ -19,12 +20,13 @@ test.describe('plugin-sheet', () => {
       viewportSize: { width: 1280, height: 720 },
     });
     page = setup.page;
+    close = setup.close;
     sheet = new SheetManager(page);
     await sheet.ready();
   });
 
   test.afterEach(async () => {
-    await page.close();
+    await close();
   });
 
   test('basic interactions', async () => {

--- a/packages/sdk/examples/src/playwright/app-manager.ts
+++ b/packages/sdk/examples/src/playwright/app-manager.ts
@@ -9,6 +9,7 @@ import { setupPage } from '@dxos/test-utils/playwright';
 export class AppManager {
   page!: Page;
   private _initialized = false;
+  private _close?: () => Promise<void>;
 
   constructor(private readonly _browser: Browser) {}
 
@@ -17,11 +18,16 @@ export class AppManager {
       return;
     }
 
-    const { page } = await setupPage(this._browser, {});
+    const { page, close } = await setupPage(this._browser, {});
     this.page = page;
+    this._close = close;
     await page.getByTestId('client-0').waitFor({ state: 'visible' });
     await page.getByTestId('client-1').waitFor({ state: 'visible' });
     this._initialized = true;
+  }
+
+  async close(): Promise<void> {
+    await this._close?.();
   }
 
   // Getters

--- a/packages/sdk/examples/src/playwright/basic.spec.ts
+++ b/packages/sdk/examples/src/playwright/basic.spec.ts
@@ -17,6 +17,10 @@ test.describe('Demo', () => {
     await app.init();
   });
 
+  test.afterAll(async () => {
+    await app.close();
+  });
+
   test('peers can see cursors', async () => {
     expect(await app.getCollaboratorCursors().count()).toEqual(0);
 

--- a/packages/ui/lit-grid/src/playwright/dx-grid.spec.ts
+++ b/packages/ui/lit-grid/src/playwright/dx-grid.spec.ts
@@ -19,6 +19,7 @@ const nRows = 8;
 test.describe('dx-grid', () => {
   let page: Page;
   let grid: DxGridManager;
+  let close: () => Promise<void>;
 
   test.beforeEach(async ({ browser }) => {
     const setup = await setupPage(browser, {
@@ -29,12 +30,13 @@ test.describe('dx-grid', () => {
       }, // 336 x 272
     });
     page = setup.page;
+    close = setup.close;
     grid = new DxGridManager(page);
     await grid.ready();
   });
 
   test.afterEach(async () => {
-    await page.close();
+    await close();
   });
 
   test('virtualization & panning', async () => {

--- a/packages/ui/react-ui-mosaic/src/playwright/smoke.spec.ts
+++ b/packages/ui/react-ui-mosaic/src/playwright/smoke.spec.ts
@@ -17,9 +17,10 @@ const BELOW_OFFSET = 50;
 test.describe('Board', () => {
   let page: Page;
   let board: BoardManager;
+  let close: () => Promise<void>;
 
   test.beforeEach(async ({ browser }) => {
-    ({ page } = await setupPage(browser, { url: STORY_URL }));
+    ({ page, close } = await setupPage(browser, { url: STORY_URL }));
     // Generous, and explicit: storybook compiles the story on first request, so whichever test runs
     // first pays it. Waiting here attributes a slow story load to this locator rather than reporting a
     // bare `beforeEach` timeout.
@@ -28,7 +29,7 @@ test.describe('Board', () => {
   });
 
   test.afterEach(async () => {
-    await page.close();
+    await close();
   });
 
   test('rearrange columns', async () => {

--- a/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
+++ b/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
@@ -19,17 +19,17 @@ test.describe('Table', () => {
   test('Loads', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page } = await setupPage(browser, { url: storyUrl });
+    const { page, close } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
     await table.grid.ready();
-    await page.close();
+    await close();
   });
 
   test('sort', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page } = await setupPage(browser, { url: storyUrl });
+    const { page, close } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -40,13 +40,13 @@ test.describe('Table', () => {
     await table.sortColumn(0, 'ascending');
     await expect(table.grid.cell(0, 0, 'grid')).toContainText('Aut.');
     await expect(table.grid.cell(0, 9, 'grid')).toHaveText('Sit.');
-    await page.close();
+    await close();
   });
 
   test('selection', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page } = await setupPage(browser, { url: storyUrl });
+    const { page, close } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -62,26 +62,26 @@ test.describe('Table', () => {
     await expect(table.selection(1)).not.toBeChecked();
     await expect(table.selection(2)).not.toBeChecked();
 
-    await page.close();
+    await close();
   });
 
   test('delete row', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page } = await setupPage(browser, { url: storyUrl });
+    const { page, close } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
     await table.grid.ready();
     await expect(page.getByRole('gridcell', { name: 'Sapiente.' })).toHaveCount(1);
     await table.deleteRow(0);
     await expect(page.getByRole('gridcell', { name: 'Sapiente.' })).toHaveCount(0);
-    await page.close();
+    await close();
   });
 
   test('delete row--select all', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page } = await setupPage(browser, { url: storyUrl });
+    const { page, close } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -93,13 +93,13 @@ test.describe('Table', () => {
     await expect(page.getByRole('gridcell', { name: 'Aut.' })).toHaveCount(0);
     await expect(page.getByRole('gridcell', { name: 'Beatae.' })).toHaveCount(0);
     await expect(table.grid.cellsWithinPlane('grid')).toHaveCount(0);
-    await page.close();
+    await close();
   });
 
   test('delete column', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page } = await setupPage(browser, { url: storyUrl });
+    const { page, close } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -119,13 +119,13 @@ test.describe('Table', () => {
 
     // Ensure that the delete menu item is not visible when there is only one column left.
     await expect(page.getByTestId('column-delete')).toHaveCount(0);
-    await page.close();
+    await close();
   });
 
   test('add column without changing format', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page } = await setupPage(browser, { url: storyUrl });
+    const { page, close } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -134,13 +134,13 @@ test.describe('Table', () => {
     await table.addColumn({ label: newColumnLabel });
 
     await expect(page.getByRole('gridcell', { name: newColumnLabel })).toBeVisible();
-    await page.close();
+    await close();
   });
 
   test('add column with format', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page } = await setupPage(browser, { url: storyUrl });
+    const { page, close } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -149,13 +149,13 @@ test.describe('Table', () => {
     await table.addColumn({ label: newColumnLabel, format: 'Number' });
 
     await expect(page.getByRole('gridcell', { name: newColumnLabel })).toBeVisible();
-    await page.close();
+    await close();
   });
 
   test.skip('test toggles', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page } = await setupPage(browser, { url: storyUrl });
+    const { page, close } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -172,13 +172,13 @@ test.describe('Table', () => {
     await expect(table.grid.cell(0, 0, 'grid')).toHaveText('Aut.');
     await expect(table.grid.cell(0, 1, 'grid')).toHaveText('Beatae.');
 
-    await page.close();
+    await close();
   });
 
   test('add row and edit cell', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page } = await setupPage(browser, { url: storyUrl });
+    const { page, close } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -201,14 +201,14 @@ test.describe('Table', () => {
 
     // Assert the cell content is saved.
     await expect(newCell).toHaveText(cellContent);
-    await page.close();
+    await close();
   });
 
   // TODO(wittjosiah): Remove? Conflicts with story play function which is run as a unit test anyways.
   test.skip('extant relations work as expected', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page } = await setupPage(browser, { url: relationsStoryUrl });
+    const { page, close } = await setupPage(browser, { url: relationsStoryUrl });
 
     // Wait for the page to load
     await page.locator('dx-grid > .dx-grid').nth(1).waitFor({ state: 'visible' });
@@ -256,14 +256,14 @@ test.describe('Table', () => {
     // Assert that the cell element has the org name
     await expect(targetCell).toHaveText(orgName);
 
-    await page.close();
+    await close();
   });
 
   // TODO(wittjosiah): Remove? Conflicts with story play function which is run as a unit test anyways.
   test.skip('new relations work as expected', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page } = await setupPage(browser, { url: relationsStoryUrl });
+    const { page, close } = await setupPage(browser, { url: relationsStoryUrl });
 
     // Wait for the page to load
     await page.locator('dx-grid > .dx-grid').nth(1).waitFor({ state: 'visible' });
@@ -321,6 +321,6 @@ test.describe('Table', () => {
     await page.keyboard.press('Enter');
     await expect(nonRefCell).toHaveText(nonRefContent);
 
-    await page.close();
+    await close();
   });
 });

--- a/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
+++ b/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import { expect, test } from '@playwright/test';
+import { type Page, expect, test } from '@playwright/test';
 
 import { type DxGrid } from '@dxos/lit-grid';
 import { DxGridManager } from '@dxos/lit-grid/testing';
@@ -16,20 +16,29 @@ const relationsStoryUrl = storybookUrl('ui-react-ui-table-relations--default', 9
 
 // NOTE(ZaymonFC): This test suite relies on the random seed being set to 0 in the story.
 test.describe('Table', () => {
+  let page: Page;
+  let close: (() => Promise<void>) | undefined;
+
+  // Cleanup belongs in `afterEach`: a failing assertion skips the rest of the test body, and a context
+  // left open is re-serialized into every later trace in the worker.
+  test.afterEach(async () => {
+    await close?.();
+    close = undefined;
+  });
+
   test('Loads', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page, close } = await setupPage(browser, { url: storyUrl });
+    ({ page, close } = await setupPage(browser, { url: storyUrl }));
     const table = new TableManager(page);
 
     await table.grid.ready();
-    await close();
   });
 
   test('sort', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page, close } = await setupPage(browser, { url: storyUrl });
+    ({ page, close } = await setupPage(browser, { url: storyUrl }));
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -40,13 +49,12 @@ test.describe('Table', () => {
     await table.sortColumn(0, 'ascending');
     await expect(table.grid.cell(0, 0, 'grid')).toContainText('Aut.');
     await expect(table.grid.cell(0, 9, 'grid')).toHaveText('Sit.');
-    await close();
   });
 
   test('selection', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page, close } = await setupPage(browser, { url: storyUrl });
+    ({ page, close } = await setupPage(browser, { url: storyUrl }));
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -61,27 +69,24 @@ test.describe('Table', () => {
     await expect(table.selection(0)).not.toBeChecked();
     await expect(table.selection(1)).not.toBeChecked();
     await expect(table.selection(2)).not.toBeChecked();
-
-    await close();
   });
 
   test('delete row', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page, close } = await setupPage(browser, { url: storyUrl });
+    ({ page, close } = await setupPage(browser, { url: storyUrl }));
     const table = new TableManager(page);
 
     await table.grid.ready();
     await expect(page.getByRole('gridcell', { name: 'Sapiente.' })).toHaveCount(1);
     await table.deleteRow(0);
     await expect(page.getByRole('gridcell', { name: 'Sapiente.' })).toHaveCount(0);
-    await close();
   });
 
   test('delete row--select all', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page, close } = await setupPage(browser, { url: storyUrl });
+    ({ page, close } = await setupPage(browser, { url: storyUrl }));
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -93,13 +98,12 @@ test.describe('Table', () => {
     await expect(page.getByRole('gridcell', { name: 'Aut.' })).toHaveCount(0);
     await expect(page.getByRole('gridcell', { name: 'Beatae.' })).toHaveCount(0);
     await expect(table.grid.cellsWithinPlane('grid')).toHaveCount(0);
-    await close();
   });
 
   test('delete column', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page, close } = await setupPage(browser, { url: storyUrl });
+    ({ page, close } = await setupPage(browser, { url: storyUrl }));
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -119,13 +123,12 @@ test.describe('Table', () => {
 
     // Ensure that the delete menu item is not visible when there is only one column left.
     await expect(page.getByTestId('column-delete')).toHaveCount(0);
-    await close();
   });
 
   test('add column without changing format', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page, close } = await setupPage(browser, { url: storyUrl });
+    ({ page, close } = await setupPage(browser, { url: storyUrl }));
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -134,13 +137,12 @@ test.describe('Table', () => {
     await table.addColumn({ label: newColumnLabel });
 
     await expect(page.getByRole('gridcell', { name: newColumnLabel })).toBeVisible();
-    await close();
   });
 
   test('add column with format', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page, close } = await setupPage(browser, { url: storyUrl });
+    ({ page, close } = await setupPage(browser, { url: storyUrl }));
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -149,13 +151,12 @@ test.describe('Table', () => {
     await table.addColumn({ label: newColumnLabel, format: 'Number' });
 
     await expect(page.getByRole('gridcell', { name: newColumnLabel })).toBeVisible();
-    await close();
   });
 
   test.skip('test toggles', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page, close } = await setupPage(browser, { url: storyUrl });
+    ({ page, close } = await setupPage(browser, { url: storyUrl }));
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -171,14 +172,12 @@ test.describe('Table', () => {
     await expect(page.getByTestId('table-switch').nth(1)).toBeChecked();
     await expect(table.grid.cell(0, 0, 'grid')).toHaveText('Aut.');
     await expect(table.grid.cell(0, 1, 'grid')).toHaveText('Beatae.');
-
-    await close();
   });
 
   test('add row and edit cell', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page, close } = await setupPage(browser, { url: storyUrl });
+    ({ page, close } = await setupPage(browser, { url: storyUrl }));
     const table = new TableManager(page);
 
     await table.grid.ready();
@@ -201,14 +200,13 @@ test.describe('Table', () => {
 
     // Assert the cell content is saved.
     await expect(newCell).toHaveText(cellContent);
-    await close();
   });
 
   // TODO(wittjosiah): Remove? Conflicts with story play function which is run as a unit test anyways.
   test.skip('extant relations work as expected', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page, close } = await setupPage(browser, { url: relationsStoryUrl });
+    ({ page, close } = await setupPage(browser, { url: relationsStoryUrl }));
 
     // Wait for the page to load
     await page.locator('dx-grid > .dx-grid').nth(1).waitFor({ state: 'visible' });
@@ -255,15 +253,13 @@ test.describe('Table', () => {
 
     // Assert that the cell element has the org name
     await expect(targetCell).toHaveText(orgName);
-
-    await close();
   });
 
   // TODO(wittjosiah): Remove? Conflicts with story play function which is run as a unit test anyways.
   test.skip('new relations work as expected', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
-    const { page, close } = await setupPage(browser, { url: relationsStoryUrl });
+    ({ page, close } = await setupPage(browser, { url: relationsStoryUrl }));
 
     // Wait for the page to load
     await page.locator('dx-grid > .dx-grid').nth(1).waitFor({ state: 'visible' });
@@ -320,7 +316,5 @@ test.describe('Table', () => {
     await page.keyboard.type(nonRefContent, { delay: 500 });
     await page.keyboard.press('Enter');
     await expect(nonRefCell).toHaveText(nonRefContent);
-
-    await close();
   });
 });


### PR DESCRIPTION
## What broke

Last night's nightly (`Check` on `96f94c25`, schedule 04:00 UTC) failed in `e2e (browser=chromium, shard=composer)` on `halo.spec.ts:77 › HALO tests › deleting a space replicates across devices`. All three attempts failed, but only the third produced a diagnosis:

| attempt | duration | error |
| --- | --- | --- |
| 0 | 3.2m | `RangeError: Invalid string length` → `browserContext._wrapApiCall: Invalid string length` → `End of central directory record signature not found. Either not a zip file, or file is truncated.` |
| 1 | 3.2m | same |
| 2 | 1.3m | `expect(guest.getSpaceItems()).toHaveCount(2)` received `1` |

Two of the three retries burned 3.2 minutes each and reported a broken trace writer instead of the test's failure.

## Why

`setupPage` calls `browser.newContext()` and returns only the page. Playwright never reclaims a context created off the worker-scoped `browser` fixture, and its artifacts recorder walks `_allContexts()` at the start of **every** test (`willStartTest` → `didCreateBrowserContext` → `startChunk`) and stops them all into that test's `trace.zip` (`didFinishTest` → `leftoverContexts` → `_stopTracing`, which is the `browserContext._wrapApiCall` frame in the error above).

Every suite here closed the page and left the context behind, so the set grows for the life of the worker and each trace re-serializes all of it. The recovered artifact from that run makes it concrete — attempt 2's `trace.zip` holds **9** contexts, and 7 of them carry network logs timestamped 04:04:33–04:06:04 (attempts 0 and 1) with zero recorded actions:

```
ctx0 network entries=1073 first=04:04:33 last=04:04:45   (0 trace actions)
...
ctx6 network entries=1085 first=04:05:54 last=04:06:04   (0 trace actions)
ctx7 network entries=1063 first=04:12:33 last=04:12:37   (445 trace lines — the host)
ctx8 network entries=1904 first=04:12:36 last=04:12:46   (528 trace lines — the guest)
```

Past a point the writer exceeds V8's maximum string length and the zip is left truncated.

## The change

`setupPage` returns a `close()` that disposes the context it created (or just the page when it was handed a context it does not own). Every page object and spec that previously closed a page now calls it:

- `@dxos/test-utils` — `setupPage` returns `close`.
- `composer-app` — `AppManager.closePage()` becomes `AppManager.close()`; all 11 call sites updated.
- `todomvc`, `examples` — `AppManager` gained a `close()`, wired into the suites' teardown (neither closed anything before).
- `rpc-tunnel-e2e` — the four `beforeAll` specs gained an `afterAll` teardown.
- `react-ui-table`, `react-ui-mosaic`, `lit-grid`, `plugin-sheet`, `plugin-kanban` — `page.close()` → `close()`.

## What this does not fix

Attempt 2's failure is real and stands: the guest never saw the host's space replicate, and the guest console shows the WebRTC transport closing right after `authenticateDevice` followed by `Automerge root doc load timeout (DataSpace)`. That is the two-peer stall `halo.spec.ts` already documents as endemic and tracked under DX-1152, which is why the suite carries `retries: 2`. This PR does not make that stall go away — it makes the retries actually retry, and leaves a readable trace when they do not.

## Testing

`pnpm format`, plus builds/typechecks for the touched projects.

The `e2e` jobs are gated to `main`, `changeset-release/*`, or an explicit dispatch, so they are **skipped** on this PR and its own `Check` run does not exercise the change. The full matrix was dispatched against this branch's head `2aefac74` instead (`check.yml` with `e2e=true`, which also sets `DX_E2E_RUN_ID` so the suites execute rather than replay a cache hit): [run `h20h4bjsj3`](https://depot.dev/orgs/t8fblrl00n/workflows/qfm9w237s6?repo=dxos%2Fdxos). All six e2e cells and all four test shards exited 0.

| cell | result |
| --- | --- |
| `e2e` chromium/composer | 37/37 pass. `halo.spec.ts:40 join new identity` failed once (1.5m) and passed on retry #1 in 22.6s — the retry the trace writer used to destroy. |
| `e2e` chromium/rest | 42/42 pass, 2 flaky |
| `e2e` firefox/composer, webkit/composer | 37/37 pass, no retries |
| `e2e` firefox/rest | 42/42 pass, 1 flaky |
| `e2e` webkit/rest | 38 pass, 4 quarantined (`todomvc`) |
| `test` shards 0–3 | pass (shard 3 on its second attempt) |

No `RangeError: Invalid string length` and no truncated `trace.zip` anywhere in the run.

The four quarantined `todomvc` webkit tests are unchanged from `main` — the nightly on `96f94c25` reports the same `Total: 42 Pass: 38 Fail: 0 Quarantined: 4`, the same four tests, and the same signature (`space invitation never reached the auth-code step`, the shell's auth-code input stuck hidden at `connectingSpaceInvitation`). That is DX-1152 again, and this PR's only change to that package is its teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmQMktYvgwQzepygZVkp6h