### PR TITLE
protocols: move the RPC service contract out of codec-protobuf

### DIFF
--- a/.changeset/protobuf-rpc-service-contract.md
+++ b/.changeset/protobuf-rpc-service-contract.md
@@ -1,0 +1,7 @@
+---
+'@dxos/protocols': minor
+---
+
+**Breaking:** the RPC service contract (`RequestOptions`, `AnyEnvelope`, `TaggedType`, `ServiceBackend`, `ServiceProvider`, `ServiceDescriptorLike`) now lives in `@dxos/protocols/service-contract`; import it from there instead of `@dxos/codec-protobuf`. `ServiceDescriptorLike.createClient`/`createServer` take the compat layer's `CompatOptions` rather than protobuf.js's `EncodingOptions`, and `@dxos/codec-protobuf`'s `ServiceDescriptor.createClient` is declared to return the service type alone rather than intersected with its internal stub holder.
+
+`@dxos/rpc`, `@dxos/client-protocol`, `@dxos/messaging` and `@dxos/blade-runner` no longer depend on `@dxos/codec-protobuf`.

--- a/packages/common/codec-protobuf/src/service.ts
+++ b/packages/common/codec-protobuf/src/service.ts
@@ -50,7 +50,12 @@ export class ServiceDescriptor<S> implements ServiceDescriptorLike<S> {
     return this._service.fullName.slice(1);
   }
 
-  createClient(backend: ServiceBackend, encodingOptions?: EncodingOptions): Service & S {
+  /**
+   * Declared as `S` rather than `Service & S`: `Service` is this file's dynamic stub holder and
+   * contributes nothing a caller can name, while leaking it makes a service bundle infer
+   * `Service & S`, which no plain handler object can then satisfy.
+   */
+  createClient(backend: ServiceBackend, encodingOptions?: EncodingOptions): S {
     return new Service(backend, this._service, this._schema, encodingOptions) as Service & S;
   }
 

--- a/packages/core/mesh/messaging/package.json
+++ b/packages/core/mesh/messaging/package.json
@@ -32,7 +32,6 @@
   ],
   "dependencies": {
     "@dxos/async": "workspace:*",
-    "@dxos/codec-protobuf": "workspace:*",
     "@dxos/context": "workspace:*",
     "@dxos/edge-client": "workspace:*",
     "@dxos/invariant": "workspace:*",

--- a/packages/core/mesh/messaging/src/messenger.ts
+++ b/packages/core/mesh/messaging/src/messenger.ts
@@ -3,7 +3,6 @@
 //
 
 import { TimeoutError, scheduleExponentialBackoffTaskInterval, scheduleTask, scheduleTaskInterval } from '@dxos/async';
-import { type Any } from '@dxos/codec-protobuf';
 import { Context } from '@dxos/context';
 import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
@@ -12,6 +11,7 @@ import { TimeoutError as ProtocolTimeoutError } from '@dxos/protocols';
 import { compatCodec } from '@dxos/protocols/buf-shape-compat';
 import { AcknowledgementSchema, ReliablePayloadSchema } from '@dxos/protocols/buf/dxos/mesh/messaging_pb';
 import { type Acknowledgement, type ReliablePayload } from '@dxos/protocols/proto/dxos/mesh/messaging';
+import { type AnyEnvelope } from '@dxos/protocols/service-contract';
 import { ComplexMap, ComplexSet } from '@dxos/util';
 
 import { MessengerMonitor } from './messenger-monitor';
@@ -292,7 +292,7 @@ export class Messenger {
     });
   }
 
-  private async _handleAcknowledgement({ payload }: { payload: Any }): Promise<void> {
+  private async _handleAcknowledgement({ payload }: { payload: AnyEnvelope }): Promise<void> {
     invariant(payload.type_url === 'dxos.mesh.messaging.Acknowledgement');
     this._onAckCallbacks.get(Acknowledgement.decode(payload.value).messageId)?.();
   }

--- a/packages/core/mesh/messaging/src/signal-manager/memory-signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/memory-signal-manager.ts
@@ -3,7 +3,6 @@
 //
 
 import { Event, Trigger } from '@dxos/async';
-import { type Any } from '@dxos/codec-protobuf';
 import { Context } from '@dxos/context';
 import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
@@ -13,6 +12,7 @@ import { ReliablePayloadSchema } from '@dxos/protocols/buf/dxos/mesh/messaging_p
 import { type SwarmResponse } from '@dxos/protocols/proto/dxos/edge/messenger';
 import { type QueryRequest } from '@dxos/protocols/proto/dxos/edge/signal';
 import { type ReliablePayload } from '@dxos/protocols/proto/dxos/mesh/messaging';
+import { type AnyEnvelope } from '@dxos/protocols/service-contract';
 import { ComplexMap, ComplexSet } from '@dxos/util';
 
 import {
@@ -251,7 +251,7 @@ export class MemorySignalManager implements SignalManager {
       });
   }
 }
-const dec = (payload: Any) => {
+const dec = (payload: AnyEnvelope) => {
   if (!payload.type_url.endsWith('ReliablePayload')) {
     return {};
   }

--- a/packages/core/mesh/messaging/src/testing/test-messages.ts
+++ b/packages/core/mesh/messaging/src/testing/test-messages.ts
@@ -2,8 +2,8 @@
 // Copyright 2022 DXOS.org
 //
 
-import { type TaggedType } from '@dxos/codec-protobuf';
 import { type TYPES } from '@dxos/protocols/proto';
+import { type TaggedType } from '@dxos/protocols/service-contract';
 
 export const PAYLOAD_1: TaggedType<TYPES, 'google.protobuf.Any'> = {
   '@type': 'google.protobuf.Any',

--- a/packages/core/mesh/messaging/src/testing/utils.ts
+++ b/packages/core/mesh/messaging/src/testing/utils.ts
@@ -3,8 +3,8 @@
 //
 
 import { type Event, asyncTimeout } from '@dxos/async';
-import { type Any } from '@dxos/codec-protobuf';
 import { PublicKey } from '@dxos/keys';
+import { type AnyEnvelope } from '@dxos/protocols/service-contract';
 
 import { type Message, type PeerInfo, type SignalMethods } from '../signal-methods';
 import { PAYLOAD_1 } from './test-messages';
@@ -38,7 +38,7 @@ export const expectReceivedMessage = (event: Event<Message>, expectedMessage: Me
   );
 };
 
-export const createMessage = (author: PeerInfo, recipient: PeerInfo, payload: Any = PAYLOAD_1): Message => ({
+export const createMessage = (author: PeerInfo, recipient: PeerInfo, payload: AnyEnvelope = PAYLOAD_1): Message => ({
   author,
   recipient,
   payload,

--- a/packages/core/mesh/messaging/tsconfig.json
+++ b/packages/core/mesh/messaging/tsconfig.json
@@ -9,9 +9,6 @@
       "path": "../../../common/async"
     },
     {
-      "path": "../../../common/codec-protobuf"
-    },
-    {
       "path": "../../../common/context"
     },
     {

--- a/packages/core/mesh/rpc/package.json
+++ b/packages/core/mesh/rpc/package.json
@@ -26,7 +26,6 @@
   ],
   "dependencies": {
     "@dxos/async": "workspace:*",
-    "@dxos/codec-protobuf": "workspace:*",
     "@dxos/context": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/invariant": "workspace:*",

--- a/packages/core/mesh/rpc/src/rpc.test.ts
+++ b/packages/core/mesh/rpc/src/rpc.test.ts
@@ -6,9 +6,9 @@ import { describe, expect, test } from 'vitest';
 
 import { Trigger, sleep } from '@dxos/async';
 import { Stream } from '@dxos/async';
-import { type Any, type TaggedType } from '@dxos/codec-protobuf';
 import { log } from '@dxos/log';
 import { type TYPES } from '@dxos/protocols/proto';
+import { type AnyEnvelope, type TaggedType } from '@dxos/protocols/service-contract';
 
 import { RpcPeer } from './rpc';
 import { createLinkedPorts, encodeMessage } from './testing';
@@ -354,7 +354,7 @@ describe('RpcPeer', () => {
         streamHandler: (method, msg) => {
           expect(method).toEqual('method');
           expect(msg.value!).toEqual(encodeMessage('request'));
-          return new Stream<Any>(({ next, close }) => {
+          return new Stream<AnyEnvelope>(({ next, close }) => {
             next(createPayload('res1'));
             next(createPayload('res2'));
             close();
@@ -389,7 +389,7 @@ describe('RpcPeer', () => {
         streamHandler: (method, msg) => {
           expect(method).toEqual('method');
           expect(msg.value).toEqual(encodeMessage('request'));
-          return new Stream<Any>(({ next, close }) => {
+          return new Stream<AnyEnvelope>(({ next, close }) => {
             close(new Error('Test error'));
           });
         },
@@ -420,7 +420,7 @@ describe('RpcPeer', () => {
       const alice = new RpcPeer({
         callHandler: async (msg) => createPayload(),
         streamHandler: (method, msg) =>
-          new Stream<Any>(({ next, close }) => () => {
+          new Stream<AnyEnvelope>(({ next, close }) => () => {
             closeTrigger.wake();
           }),
         port: alicePort,
@@ -448,7 +448,7 @@ describe('RpcPeer', () => {
         streamHandler: (method, msg) => {
           expect(method).toEqual('method');
           expect(msg.value!).toEqual(encodeMessage('request'));
-          return new Stream<Any>(({ ready, close }) => {
+          return new Stream<AnyEnvelope>(({ ready, close }) => {
             ready();
             close();
           });
@@ -476,7 +476,7 @@ describe('RpcPeer', () => {
 
       const alice = new RpcPeer({
         callHandler: async (msg) => createPayload(),
-        streamHandler: (method, msg): Stream<Any> => {
+        streamHandler: (method, msg): Stream<AnyEnvelope> => {
           throw new Error('Test error');
         },
         port: alicePort,

--- a/packages/core/mesh/rpc/src/rpc.ts
+++ b/packages/core/mesh/rpc/src/rpc.ts
@@ -4,7 +4,6 @@
 
 import { Trigger, asyncTimeout, synchronized } from '@dxos/async';
 import { Stream } from '@dxos/async';
-import { type Any, type RequestOptions } from '@dxos/codec-protobuf';
 import { type Context, ContextRpcCodec } from '@dxos/context';
 import { StackTrace } from '@dxos/debug';
 import { invariant } from '@dxos/invariant';
@@ -13,6 +12,7 @@ import { RpcClosedError, RpcNotOpenError, encodeError } from '@dxos/protocols';
 import { type CompatCodec, compatCodec } from '@dxos/protocols/buf-shape-compat';
 import { RpcMessageSchema } from '@dxos/protocols/buf/dxos/rpc_pb';
 import { type Request, type Response, type RpcMessage } from '@dxos/protocols/proto/dxos/rpc';
+import { type AnyEnvelope, type RequestOptions } from '@dxos/protocols/service-contract';
 import { exponentialBackoffInterval } from '@dxos/util';
 
 import { decodeRpcError } from './errors';
@@ -32,8 +32,8 @@ export interface RpcPeerOptions {
    */
   timeout?: number;
 
-  callHandler: (method: string, request: Any, options?: RequestOptions) => MaybePromise<Any>;
-  streamHandler?: (method: string, request: Any, options?: RequestOptions) => Stream<Any>;
+  callHandler: (method: string, request: AnyEnvelope, options?: RequestOptions) => MaybePromise<AnyEnvelope>;
+  streamHandler?: (method: string, request: AnyEnvelope, options?: RequestOptions) => Stream<AnyEnvelope>;
 
   /**
    * Do not require or send handshake messages.
@@ -376,7 +376,7 @@ export class RpcPeer {
    * Make RPC call. Will trigger a handler on the other side.
    * Peer should be open before making this call.
    */
-  async call(method: string, request: Any, options?: RequestOptions): Promise<Any> {
+  async call(method: string, request: AnyEnvelope, options?: RequestOptions): Promise<AnyEnvelope> {
     DEBUG_CALLS && log.trace('calling...', { method });
     throwIfNotOpen(this._state);
 
@@ -439,7 +439,7 @@ export class RpcPeer {
    * Will trigger a handler on the other side.
    * Peer should be open before making this call.
    */
-  callStream(method: string, request: Any, options?: RequestOptions): Stream<Any> {
+  callStream(method: string, request: AnyEnvelope, options?: RequestOptions): Stream<AnyEnvelope> {
     throwIfNotOpen(this._state);
     const id = this._nextId++;
 

--- a/packages/core/mesh/rpc/src/service-buf.test.ts
+++ b/packages/core/mesh/rpc/src/service-buf.test.ts
@@ -5,7 +5,6 @@
 import { describe, test } from 'vitest';
 
 import { Stream } from '@dxos/async';
-import { type ServiceDescriptorLike } from '@dxos/codec-protobuf';
 import { getBufService } from '@dxos/protocols/buf-service';
 import { schema } from '@dxos/protocols/proto';
 import {
@@ -13,6 +12,7 @@ import {
   type TestService,
   type TestStreamService,
 } from '@dxos/protocols/proto/example/testing/rpc';
+import { type ServiceDescriptorLike } from '@dxos/protocols/service-contract';
 
 import { type ProtoRpcPeer, createProtoRpcPeer } from './service';
 import { createLinkedPorts } from './testing';

--- a/packages/core/mesh/rpc/src/service.test.ts
+++ b/packages/core/mesh/rpc/src/service.test.ts
@@ -6,7 +6,6 @@ import { beforeEach, describe, expect, test } from 'vitest';
 
 import { latch, sleep } from '@dxos/async';
 import { Stream } from '@dxos/async';
-import { type RequestOptions } from '@dxos/codec-protobuf';
 import { Context, TRACE_SPAN_ATTRIBUTE } from '@dxos/context';
 import { schema } from '@dxos/protocols/proto';
 import {
@@ -14,6 +13,7 @@ import {
   type TestService,
   type TestStreamService,
 } from '@dxos/protocols/proto/example/testing/rpc';
+import { type RequestOptions } from '@dxos/protocols/service-contract';
 
 import { type ProtoRpcPeer, createProtoRpcPeer, createServiceBundle } from './service';
 import { createLinkedPorts, encodeMessage } from './testing';

--- a/packages/core/mesh/rpc/src/service.ts
+++ b/packages/core/mesh/rpc/src/service.ts
@@ -2,13 +2,13 @@
 // Copyright 2021 DXOS.org
 //
 
+import { invariant } from '@dxos/invariant';
+import { type CompatOptions } from '@dxos/protocols/buf-shape-compat';
 import {
-  type EncodingOptions,
   type ServiceBackend,
   type ServiceDescriptorLike,
   type ServiceProvider,
-} from '@dxos/codec-protobuf';
-import { invariant } from '@dxos/invariant';
+} from '@dxos/protocols/service-contract';
 
 import { RpcPeer, type RpcPeerOptions } from './rpc';
 
@@ -71,7 +71,7 @@ export interface ProtoRpcPeerOptions<Client, Server> extends Omit<RpcPeerOptions
   /**
    * Encoding options passed to the underlying proto codec.
    */
-  encodingOptions?: EncodingOptions;
+  encodingOptions?: CompatOptions;
 }
 
 /**

--- a/packages/core/mesh/rpc/tsconfig.json
+++ b/packages/core/mesh/rpc/tsconfig.json
@@ -13,9 +13,6 @@
       "path": "../../../common/async"
     },
     {
-      "path": "../../../common/codec-protobuf"
-    },
-    {
       "path": "../../../common/context"
     },
     {

--- a/packages/core/protocols/package.json
+++ b/packages/core/protocols/package.json
@@ -50,6 +50,10 @@
       "browser": "./dist/src/buf/registry.js",
       "import": "./dist/src/buf/registry.js"
     },
+    "./service-contract": {
+      "browser": "./dist/src/service-contract.js",
+      "import": "./dist/src/service-contract.js"
+    },
     "./buf/*": {
       "browser": "./dist/src/buf/proto/gen/*.js",
       "import": "./dist/src/buf/proto/gen/*.js"
@@ -65,6 +69,7 @@
     "@bufbuild/protobuf": "catalog:",
     "@dxos/async": "workspace:*",
     "@dxos/codec-protobuf": "workspace:*",
+    "@dxos/context": "workspace:*",
     "@dxos/effect": "workspace:*",
     "@dxos/errors": "workspace:*",
     "@dxos/invariant": "workspace:*",

--- a/packages/core/protocols/src/buf/service.ts
+++ b/packages/core/protocols/src/buf/service.ts
@@ -5,18 +5,17 @@
 import { type DescMethod, type DescService } from '@bufbuild/protobuf';
 
 import { Stream } from '@dxos/async';
-import {
-  type Any,
-  type EncodingOptions,
-  type RequestOptions,
-  type ServiceBackend,
-  type ServiceProvider,
-} from '@dxos/codec-protobuf';
 import { invariant } from '@dxos/invariant';
 import { getAsyncProviderValue } from '@dxos/util';
 
+import {
+  type AnyEnvelope,
+  type RequestOptions,
+  type ServiceBackend,
+  type ServiceProvider,
+} from '../service-contract.ts';
 import { bufRegistry } from './registry';
-import { type CompatCodec, compatCodec } from './shape-compat';
+import { type CompatCodec, type CompatOptions, compatCodec } from './shape-compat';
 
 // Buf's descriptors replace protobuf.js's `pb.Service` here. The shapes on either side of the codec
 // are unchanged, so `ServiceBundle` consumers and RPC handlers see the same values as before; see
@@ -52,7 +51,7 @@ export class BufServiceDescriptor<Service> {
     return this._service;
   }
 
-  createClient(backend: ServiceBackend, encodingOptions?: EncodingOptions): Service {
+  createClient(backend: ServiceBackend, encodingOptions?: CompatOptions): Service {
     const client: Record<string, unknown> = {};
     for (const method of this._service.methods) {
       // `localName` is the camelCase key protobuf.js derived by hand, so handler and client names
@@ -64,14 +63,14 @@ export class BufServiceDescriptor<Service> {
     return client as Service;
   }
 
-  createServer(handlers: ServiceProvider<Service>, encodingOptions?: EncodingOptions): BufServiceHandler<Service> {
+  createServer(handlers: ServiceProvider<Service>, encodingOptions?: CompatOptions): BufServiceHandler<Service> {
     return new BufServiceHandler(this._service, this.#methodCodecs(), handlers, encodingOptions);
   }
 
-  #methodStub(method: DescMethod, backend: ServiceBackend, encodingOptions?: EncodingOptions) {
+  #methodStub(method: DescMethod, backend: ServiceBackend, encodingOptions?: CompatOptions) {
     const codecs = this.#methodCodecs().get(method.name);
     invariant(codecs, `Method not found: ${method.name}`);
-    const request = (value: unknown): Any => ({
+    const request = (value: unknown): AnyEnvelope => ({
       value: codecs.request.encode(value, encodingOptions),
       type_url: typeUrlFor(method.input),
     });
@@ -108,10 +107,10 @@ export class BufServiceHandler<Service> implements ServiceBackend {
     private readonly _service: DescService,
     private readonly _methods: Map<string, MethodCodecs>,
     private readonly _handlers: ServiceProvider<Service>,
-    private readonly _encodingOptions?: EncodingOptions,
+    private readonly _encodingOptions?: CompatOptions,
   ) {}
 
-  async call(methodName: string, request: Any, options?: RequestOptions): Promise<Any> {
+  async call(methodName: string, request: AnyEnvelope, options?: RequestOptions): Promise<AnyEnvelope> {
     const { method, request: requestCodec, response: responseCodec } = this.#methodInfo(methodName);
     invariant(method.methodKind === 'unary', `Invalid RPC method call: response streaming mismatch. ${methodName}`);
 
@@ -121,7 +120,7 @@ export class BufServiceHandler<Service> implements ServiceBackend {
     return { value: responseCodec.encode(response, this._encodingOptions), type_url: typeUrlFor(method.output) };
   }
 
-  callStream(methodName: string, request: Any, options?: RequestOptions): Stream<Any> {
+  callStream(methodName: string, request: AnyEnvelope, options?: RequestOptions): Stream<AnyEnvelope> {
     const { method, request: requestCodec, response: responseCodec } = this.#methodInfo(methodName);
     invariant(
       method.methodKind === 'server_streaming',
@@ -133,7 +132,7 @@ export class BufServiceHandler<Service> implements ServiceBackend {
       this.#handler(method).then((handler) => handler(decoded, options) as Stream<unknown>),
     );
 
-    return Stream.map(responses, (data): Any => ({
+    return Stream.map(responses, (data): AnyEnvelope => ({
       value: responseCodec.encode(data, this._encodingOptions),
       type_url: typeUrlFor(method.output),
     }));

--- a/packages/core/protocols/src/buf/service.ts
+++ b/packages/core/protocols/src/buf/service.ts
@@ -51,6 +51,7 @@ export class BufServiceDescriptor<Service> {
     return this._service;
   }
 
+  /** Builds a client whose methods encode onto `backend` and decode its responses. */
   createClient(backend: ServiceBackend, encodingOptions?: CompatOptions): Service {
     const client: Record<string, unknown> = {};
     for (const method of this._service.methods) {
@@ -63,6 +64,7 @@ export class BufServiceDescriptor<Service> {
     return client as Service;
   }
 
+  /** Builds a backend that decodes onto `handlers` and encodes what they return. */
   createServer(handlers: ServiceProvider<Service>, encodingOptions?: CompatOptions): BufServiceHandler<Service> {
     return new BufServiceHandler(this._service, this.#methodCodecs(), handlers, encodingOptions);
   }

--- a/packages/core/protocols/src/service-contract.ts
+++ b/packages/core/protocols/src/service-contract.ts
@@ -1,0 +1,61 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Stream } from '@dxos/async';
+import { type Context } from '@dxos/context';
+
+import { type CompatOptions } from './buf/shape-compat.ts';
+
+/**
+ * The RPC service contract, shared by the buf-backed descriptor in `./buf/service.ts` and the
+ * protobuf.js one that dies with `@dxos/codec-protobuf`.
+ *
+ * It lives here rather than in `@dxos/codec-protobuf` because none of it is about protobuf.js:
+ * `@dxos/rpc` and `@dxos/client-protocol` both depend on this package already, so the contract sits
+ * below every consumer without a package of its own.
+ */
+
+/** Options a caller passes per request; nothing here reaches the wire. */
+export type RequestOptions = {
+  timeout?: number;
+  ctx?: Context;
+};
+
+/**
+ * The still-packed request/response envelope a backend moves.
+ *
+ * `type_url` is snake_case because that is the shape the compat layer produces; it becomes buf's
+ * `typeUrl` when the shape-compat layer retires, not before.
+ */
+export type AnyEnvelope = {
+  type_url: string;
+  value: Uint8Array;
+};
+
+/** A message tagged with its own type name, as an `Any` field decodes to. */
+export type TaggedType<TYPES extends {}, Name extends keyof TYPES> = TYPES[Name] & { '@type': Name };
+
+export interface ServiceBackend {
+  call(method: string, request: AnyEnvelope, requestOptions?: RequestOptions): Promise<AnyEnvelope>;
+  callStream(method: string, request: AnyEnvelope, requestOptions?: RequestOptions): Stream<AnyEnvelope>;
+}
+
+export type ServiceProvider<Service> = Service | (() => Service) | (() => Promise<Service>);
+
+/**
+ * What a service bundle needs of a descriptor, so a bundle can hold either implementation.
+ *
+ * The options are the compat layer's, not protobuf.js's: they exist only while a codec still has to
+ * reproduce protobuf.js's substituted shapes, and go when it does.
+ */
+export interface ServiceDescriptorLike<Service> {
+  readonly name: string;
+  createClient(backend: ServiceBackend, encodingOptions?: CompatOptions): Service;
+  /**
+   * `NoInfer` keeps `createClient` the single source of `Service`: a descriptor built against
+   * `@dxos/codec-protobuf`'s own structurally-identical `ServiceProvider` would otherwise make a
+   * bundle infer the provider union here instead of the service.
+   */
+  createServer(handlers: ServiceProvider<NoInfer<Service>>, encodingOptions?: CompatOptions): ServiceBackend;
+}

--- a/packages/core/protocols/src/service-contract.ts
+++ b/packages/core/protocols/src/service-contract.ts
@@ -36,8 +36,11 @@ export type AnyEnvelope = {
 /** A message tagged with its own type name, as an `Any` field decodes to. */
 export type TaggedType<TYPES extends {}, Name extends keyof TYPES> = TYPES[Name] & { '@type': Name };
 
+/** Moves already-encoded envelopes for one service, leaving the codec to its descriptor. */
 export interface ServiceBackend {
+  /** Invokes a unary method and resolves with the encoded response. */
   call(method: string, request: AnyEnvelope, requestOptions?: RequestOptions): Promise<AnyEnvelope>;
+  /** Invokes a server-streaming method; the stream yields one encoded response per message. */
   callStream(method: string, request: AnyEnvelope, requestOptions?: RequestOptions): Stream<AnyEnvelope>;
 }
 
@@ -50,9 +53,13 @@ export type ServiceProvider<Service> = Service | (() => Service) | (() => Promis
  * reproduce protobuf.js's substituted shapes, and go when it does.
  */
 export interface ServiceDescriptorLike<Service> {
+  /** Fully-qualified proto service name, the key a bundle routes on. */
   readonly name: string;
+  /** Builds a client whose methods encode onto `backend` and decode its responses. */
   createClient(backend: ServiceBackend, encodingOptions?: CompatOptions): Service;
   /**
+   * Builds a backend that decodes onto `handlers` and encodes what they return.
+   *
    * `NoInfer` keeps `createClient` the single source of `Service`: a descriptor built against
    * `@dxos/codec-protobuf`'s own structurally-identical `ServiceProvider` would otherwise make a
    * bundle infer the provider union here instead of the service.

--- a/packages/core/protocols/tsconfig.json
+++ b/packages/core/protocols/tsconfig.json
@@ -15,6 +15,9 @@
       "path": "../../common/codec-protobuf"
     },
     {
+      "path": "../../common/context"
+    },
+    {
       "path": "../../common/effect"
     },
     {

--- a/packages/e2e/blade-runner/package.json
+++ b/packages/e2e/blade-runner/package.json
@@ -36,7 +36,6 @@
     "@bufbuild/protobuf": "catalog:",
     "@dxos/async": "workspace:*",
     "@dxos/client": "workspace:*",
-    "@dxos/codec-protobuf": "workspace:*",
     "@dxos/compute-runtime": "workspace:*",
     "@dxos/config": "workspace:*",
     "@dxos/context": "workspace:*",

--- a/packages/e2e/blade-runner/src/redis/redis.node.test.ts
+++ b/packages/e2e/blade-runner/src/redis/redis.node.test.ts
@@ -6,7 +6,6 @@ import { type Message, type PeerId } from '@automerge/automerge-repo';
 import { Redis, type RedisOptions } from 'ioredis';
 import { describe, expect, onTestFinished, test } from 'vitest';
 
-import { type TaggedType } from '@dxos/codec-protobuf';
 import { Context } from '@dxos/context';
 import {
   EchoTestBuilder,
@@ -16,6 +15,7 @@ import {
 } from '@dxos/echo-client/testing';
 import { PublicKey } from '@dxos/keys';
 import { type TYPES } from '@dxos/protocols';
+import { type TaggedType } from '@dxos/protocols/service-contract';
 import { RpcPeer } from '@dxos/rpc';
 import { openAndClose } from '@dxos/test-utils';
 

--- a/packages/e2e/blade-runner/src/redis/util.ts
+++ b/packages/e2e/blade-runner/src/redis/util.ts
@@ -6,8 +6,8 @@ import { cbor } from '@automerge/automerge-repo';
 import type Redis from 'ioredis';
 
 import { scheduleMicroTask } from '@dxos/async';
-import { type Any } from '@dxos/codec-protobuf';
 import { Context } from '@dxos/context';
+import { type AnyEnvelope } from '@dxos/protocols/service-contract';
 import { type RpcPort } from '@dxos/rpc';
 
 // TODO(mykola): createRpcPort(createRedisReadableStream(...), createRedisWritableStream(...))
@@ -88,9 +88,9 @@ export const subscribeToRedisQueue = ({
 };
 
 export const rpcCodec = {
-  encode: (value: any): Any => ({
+  encode: (value: any): AnyEnvelope => ({
     type_url: 'google.protobuf.Any',
     value: Buffer.from(JSON.stringify(value ?? [undefined])),
   }),
-  decode: (value: Any): any => JSON.parse(Buffer.from(value.value).toString()),
+  decode: (value: AnyEnvelope): any => JSON.parse(Buffer.from(value.value).toString()),
 };

--- a/packages/e2e/blade-runner/tsconfig.json
+++ b/packages/e2e/blade-runner/tsconfig.json
@@ -14,9 +14,6 @@
       "path": "../../common/async"
     },
     {
-      "path": "../../common/codec-protobuf"
-    },
-    {
       "path": "../../common/context"
     },
     {

--- a/packages/sdk/client-protocol/package.json
+++ b/packages/sdk/client-protocol/package.json
@@ -31,7 +31,6 @@
   ],
   "dependencies": {
     "@dxos/async": "workspace:*",
-    "@dxos/codec-protobuf": "workspace:*",
     "@dxos/credentials": "workspace:*",
     "@dxos/echo": "workspace:*",
     "@dxos/echo-client": "workspace:*",

--- a/packages/sdk/client-protocol/src/service-rpc.ts
+++ b/packages/sdk/client-protocol/src/service-rpc.ts
@@ -15,7 +15,6 @@ import * as RpcServer from 'effect/unstable/rpc/RpcServer';
 import * as RpcTest from 'effect/unstable/rpc/RpcTest';
 
 import { Stream as PbStream } from '@dxos/async';
-import { type RequestOptions } from '@dxos/codec-protobuf';
 import { EffectEx } from '@dxos/effect';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
@@ -36,6 +35,7 @@ import {
   SystemService,
   WorkerService,
 } from '@dxos/protocols/rpc';
+import { type RequestOptions } from '@dxos/protocols/service-contract';
 import { type RpcPort, layerProtocolRpcPortClient, layerProtocolRpcPortServer } from '@dxos/rpc';
 import { createIFramePort } from '@dxos/rpc-tunnel';
 

--- a/packages/sdk/client-protocol/src/service.ts
+++ b/packages/sdk/client-protocol/src/service.ts
@@ -4,7 +4,6 @@
 
 import { type Event } from '@dxos/async';
 import type { Stream } from '@dxos/async';
-import type { RequestOptions } from '@dxos/codec-protobuf';
 import { getBufService } from '@dxos/protocols/buf-service';
 import type { LogEntry, QueryLogsRequest } from '@dxos/protocols/buf/dxos/client/logging_pb';
 import { Config } from '@dxos/protocols/buf/dxos/config_pb';
@@ -62,6 +61,7 @@ import type {
   SpacesService as RpcSpacesService,
   SystemService as RpcSystemService,
 } from '@dxos/protocols/rpc';
+import type { RequestOptions } from '@dxos/protocols/service-contract';
 import { type ServiceBundle } from '@dxos/rpc';
 
 import { type ClientServicesRpc } from './service-rpc';

--- a/packages/sdk/client-protocol/tsconfig.json
+++ b/packages/sdk/client-protocol/tsconfig.json
@@ -13,9 +13,6 @@
       "path": "../../common/async"
     },
     {
-      "path": "../../common/codec-protobuf"
-    },
-    {
       "path": "../../common/effect"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6327,9 +6327,6 @@ importers:
       '@dxos/async':
         specifier: workspace:*
         version: link:../../../common/async
-      '@dxos/codec-protobuf':
-        specifier: workspace:*
-        version: link:../../../common/codec-protobuf
       '@dxos/context':
         specifier: workspace:*
         version: link:../../../common/context
@@ -6422,9 +6419,6 @@ importers:
       '@dxos/async':
         specifier: workspace:*
         version: link:../../../common/async
-      '@dxos/codec-protobuf':
-        specifier: workspace:*
-        version: link:../../../common/codec-protobuf
       '@dxos/context':
         specifier: workspace:*
         version: link:../../../common/context
@@ -6678,6 +6672,9 @@ importers:
       '@dxos/codec-protobuf':
         specifier: workspace:*
         version: link:../../common/codec-protobuf
+      '@dxos/context':
+        specifier: workspace:*
+        version: link:../../common/context
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../common/effect
@@ -7286,9 +7283,6 @@ importers:
       '@dxos/client':
         specifier: workspace:*
         version: link:../../sdk/client
-      '@dxos/codec-protobuf':
-        specifier: workspace:*
-        version: link:../../common/codec-protobuf
       '@dxos/compute-runtime':
         specifier: workspace:*
         version: link:../../core/compute/compute-runtime
@@ -18379,9 +18373,6 @@ importers:
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
-      '@dxos/codec-protobuf':
-        specifier: workspace:*
-        version: link:../../common/codec-protobuf
       '@dxos/credentials':
         specifier: workspace:*
         version: link:../../core/halo/credentials


### PR DESCRIPTION
Chunk 2 of the protobuf.js → buf teardown: the RPC seam.

## What

The RPC layer's structural contract — `RequestOptions`, `AnyEnvelope`, `TaggedType`, `ServiceBackend`, `ServiceProvider`, `ServiceDescriptorLike` — moves from `@dxos/codec-protobuf` to a new `@dxos/protocols/service-contract`. None of it is protobuf.js-specific: it is the shape a transport and a generated descriptor agree on. `ServiceDescriptorLike.createClient`/`createServer` now take the compat layer's `CompatOptions` instead of protobuf.js's `EncodingOptions` (the only field either ever carried is `preserveAny`, which `rpc.ts` passes at runtime).

No new package was needed — `rpc → protocols` and `client-protocol → rpc, protocols` already existed.

**Result: packages declaring a dependency on `@dxos/codec-protobuf` drop from 7 to 3** (`protobuf-compiler`, `protocols`, `echo-client`). `@dxos/rpc`, `@dxos/client-protocol`, `@dxos/messaging` and `@dxos/blade-runner` no longer depend on it.

## A latent defect fixed along the way

`codec-protobuf`'s `ServiceDescriptor.createClient` was declared to return `Service & S`, leaking the file's internal dynamic stub-holder class into the public type. With both descriptor flavours in one bundle, TS then inferred `ServiceBundle<{ TestService: Service & TestService }>`, which no plain handler object can satisfy — 19 type errors in `rpc` that vanish once the return type is narrowed to `S`. `Service` contributes nothing a caller can name, so the narrowing loses no information.

`ServiceDescriptorLike.createServer` takes `ServiceProvider<NoInfer<Service>>` so `createClient` stays the single source of `Service`; without it a descriptor built against `codec-protobuf`'s structurally-identical `ServiceProvider` makes the bundle infer the provider union instead of the service.

## Validation

- Full repo build: exit 0, 0 type errors.
- 80 test tasks exit 0 — `protocols` 11, `client-services` 29 passed / 1 skipped, `rpc` 5, `teleport` 4, `messaging` 3, `codec-protobuf` 2, `client-protocol` 1.
- `moon run :lint` clean, `pnpm format` clean over 14,139 files.
- No casts added; `check-changesets` OK.

## Next

Chunks 3–6 remain: the `client/services` barrel (177 sites), the `halo/credentials` barrel (172), `echo/metadata` + `echo/feed` (~110), then deleting both packages and dropping the `protobufjs` catalog pin.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7

---
_Generated by [Claude Code](https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated service-contract module containing shared RPC types and interfaces.
  * Added a public export path for service-contract APIs.
  * RPC clients and servers now support compatibility-layer encoding options.

* **Updates**
  * RPC messaging uses standardized envelope types while preserving the existing wire format.
  * Client creation now exposes the service interface directly, improving compatibility with handler implementations.
  * Shared RPC contract types are now imported from the service-contract module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12950-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
