### PR TITLE
plugin-archify: add Archify architecture diagrams

### DIFF
--- a/.changeset/archify-composer-plugin.md
+++ b/.changeset/archify-composer-plugin.md
@@ -1,0 +1,5 @@
+---
+'@dxos/plugin-markdown': minor
+---
+
+Add `@dxos/plugin-archify`: Archify system-architecture diagrams in Composer. A new `Diagram` ECHO object stores the typed Archify IR (components, boundaries, connections, guided views, legend cards) structurally, so an agent authors the same document the renderer consumes. A deterministic validator produces machine-readable diagnostics — rule code, subject, evidence, and the IR fields that can clear it — covering schema, placement, grid collisions, component overlap, route clearance through third components, and edge-label clearance; `archify.write` rejects a document with an error-level finding and leaves the stored diagram untouched. The article, card, section and slide surfaces render the IR to SVG in Archify's palette, with authored guided views and click-to-trace reachability. Operations: `archify.create`, `archify.read`, `archify.verify`, `archify.write`, exposed to agents through the Archify skill.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -234,6 +234,7 @@
     ],
     [
       "@dxos/cli",
+      "@dxos/plugin-archify",
       "@dxos/plugin-assistant",
       "@dxos/plugin-atproto",
       "@dxos/plugin-attention",

--- a/packages/apps/composer-app/package.json
+++ b/packages/apps/composer-app/package.json
@@ -53,6 +53,7 @@
     "@dxos/log-store-idb": "workspace:*",
     "@dxos/migrations": "workspace:*",
     "@dxos/observability": "workspace:*",
+    "@dxos/plugin-archify": "workspace:*",
     "@dxos/plugin-assistant": "workspace:*",
     "@dxos/plugin-atproto": "workspace:*",
     "@dxos/plugin-attention": "workspace:*",

--- a/packages/apps/composer-app/src/plugin-defs.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.tsx
@@ -3,6 +3,7 @@
 //
 
 import type * as Plugin from '@dxos/app-framework/Plugin';
+import * as ArchifyPlugin from '@dxos/plugin-archify/ArchifyPlugin';
 import * as AssistantPlugin from '@dxos/plugin-assistant/AssistantPlugin';
 import * as BloggerPlugin from '@dxos/plugin-blogger/BloggerPlugin';
 import * as BlueskyPlugin from '@dxos/plugin-bluesky/BlueskyPlugin';
@@ -111,6 +112,7 @@ export const getDefaults = ({ isDev, isLocal, isMobile }: PluginConfig): string[
     MarkdownPlugin.meta.profile.key,
     SheetPlugin.meta.profile.key,
     IllustratorPlugin.meta.profile.key,
+    ArchifyPlugin.meta.profile.key,
     TldrawPlugin.meta.profile.key,
     ExcalidrawPlugin.meta.profile.key,
     TablePlugin.meta.profile.key,
@@ -179,6 +181,7 @@ export const getPlugins = (config: PluginConfig): Plugin.Plugin[] => {
   const { logStore, isDev, isLocal, isTauri, isPopover, isMobile } = config;
   return [
     ...getCorePlugins(config),
+    ArchifyPlugin.make(),
     AssistantPlugin.make(),
     BoardPlugin.make(),
     BookmarksPlugin.make(),

--- a/packages/apps/composer-app/tsconfig.json
+++ b/packages/apps/composer-app/tsconfig.json
@@ -94,6 +94,9 @@
       "path": "../../devtools/devtools"
     },
     {
+      "path": "../../plugins/plugin-archify"
+    },
+    {
       "path": "../../plugins/plugin-assistant"
     },
     {

--- a/packages/plugins/plugin-archify/.storybook/main.mts
+++ b/packages/plugins/plugin-archify/.storybook/main.mts
@@ -1,0 +1,9 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { createConfig } from '../../../../tools/storybook-react/.storybook/main.ts';
+
+export const stories = ['../src/**/*.stories.tsx'];
+
+export default createConfig({ stories });

--- a/packages/plugins/plugin-archify/.storybook/manager-head.html
+++ b/packages/plugins/plugin-archify/.storybook/manager-head.html
@@ -1,0 +1,1 @@
+../../../../tools/storybook/.storybook/manager-head.html

--- a/packages/plugins/plugin-archify/.storybook/preview-head.html
+++ b/packages/plugins/plugin-archify/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+../../../../tools/storybook/.storybook/preview-head.html

--- a/packages/plugins/plugin-archify/.storybook/preview.mts
+++ b/packages/plugins/plugin-archify/.storybook/preview.mts
@@ -1,0 +1,8 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { preview } from '../../../../tools/storybook-react/.storybook/preview.ts';
+
+export * from '../../../../tools/storybook-react/.storybook/preview.ts';
+export default preview;

--- a/packages/plugins/plugin-archify/LICENSE
+++ b/packages/plugins/plugin-archify/LICENSE
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, ALv2 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2026 DXOS
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/plugins/plugin-archify/PLUGIN.mdl
+++ b/packages/plugins/plugin-archify/PLUGIN.mdl
@@ -1,0 +1,98 @@
+---
+id: org.dxos.plugin.archify
+name: ArchifyPlugin
+version: 0.1.0
+---
+
+Archify system-architecture diagrams inside `DXOS` Composer. An agent authors a typed JSON IR;
+a deterministic validator accepts or rejects it with machine-readable repair codes; the same IR
+compiles to SVG on the article, card, section and slide surfaces.
+
+Layout is authored rather than inferred — positions come from explicit coordinates or a fixed
+grid, and routes honour the endpoint sides and waypoints the author chose. The validator's job is
+to check those judgements, not to overrule them.
+
+## Extensions
+
+The following extension dialects are used in this document.
+
+| Term        | URI                          |
+|-------------|------------------------------|
+| `type`      | `org.dxos.mdl.type@1.0`      |
+| `component` | `org.dxos.mdl.component@1.0` |
+| `op`        | `org.dxos.mdl.op@1.1`        |
+| `flow`      | `org.dxos.mdl.flow@1.0`      |
+
+## Types
+
+```mdl
+type Diagram
+  desc: An Archify diagram: a name and the typed IR that renders it.
+  fields:
+    name?: string
+    source: Architecture   # the IR, stored structurally so ECHO merges edits field by field
+```
+
+## Components
+
+```mdl
+component Ir
+  desc: Effect schemas for the architecture IR (components, boundaries, connections, guided
+        views, legend cards), transcribed from archify/schemas.
+
+component Layout
+  desc: Deterministic geometry — grid/absolute placement, boundary frames derived from members,
+        side-honouring routes with rounded corners, measured viewBox, and reachability.
+
+component Validate
+  desc: Rule engine producing diagnostics of {code, severity, message, subject, evidence,
+        supportedFixes}. Schema rules run first; geometric rules only once every component
+        resolves to a rect.
+
+component ArchifySvg
+  desc: Pure SVG renderer for a resolved diagram, with focus dimming and selection.
+```
+
+## Operations
+
+```mdl
+op create
+  key: org.dxos.operation.archify.create
+  desc: Creates a diagram, optionally seeded with an IR document; returns its validation report.
+
+op read
+  key: org.dxos.operation.archify.read
+  desc: Returns the stored IR plus its current validation report.
+
+op validate
+  key: org.dxos.operation.archify.validate
+  desc: Checks a candidate IR without storing it, so a draft can be repaired before delivery.
+
+op write
+  key: org.dxos.operation.archify.write
+  desc: Replaces a diagram's IR. Rejected when validation reports an error — the stored diagram
+        is left untouched and the diagnostics describe the repair.
+```
+
+## Flows
+
+```mdl
+flow author
+  desc: The agent loop Archify is built around.
+  steps:
+    - draft the IR from the description or the codebase
+    - validate; repair the field named by each diagnostic's supportedFixes; re-validate
+    - create or write — only a passing document replaces the target
+```
+
+## QA
+
+```mdl
+flow QA-1
+  desc: Agent builds a diagram and it renders in the article.
+  steps:
+    - ask the assistant to diagram a system
+    - the assistant validates a draft, then creates the diagram
+    - open the diagram: the article shows the SVG, the guided views, and the legend cards
+    - select a component: the diagram dims everything it does not reach
+```

--- a/packages/plugins/plugin-archify/dx.config.ts
+++ b/packages/plugins/plugin-archify/dx.config.ts
@@ -1,0 +1,33 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Config2 } from '@dxos/app-framework/config';
+import { trim } from '@dxos/util';
+
+export default Config2.make({
+  plugin: {
+    key: 'org.dxos.plugin.archify',
+    name: 'Archify',
+    author: 'DXOS',
+    description: trim`
+      System-architecture diagrams built the Archify way: an agent authors a typed JSON
+      intermediate representation (components, boundaries, connections, guided views, legend
+      cards), a deterministic validator rejects it with machine-readable repair codes when the
+      layout would render badly, and the same IR compiles to SVG in the article, card, section
+      and slide surfaces.
+
+      Layout is authored, not inferred. Positions come from explicit coordinates or a fixed grid,
+      routes from explicit sides and waypoints — Archify's premise is that an agent that can read
+      a codebase can also make layout judgements, and that the tool's job is to check them rather
+      than to overrule them with a generic auto-layout pass.
+
+      The diagram is an ECHO object, so it replicates, merges, and is editable by agent operations
+      (create, read, write, validate) exposed through the Archify skill.
+    `,
+    source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-archify',
+    icon: { key: 'ph--tree-structure--regular', hue: 'cyan' },
+    spec: 'PLUGIN.mdl',
+    tags: ['alpha'],
+  },
+});

--- a/packages/plugins/plugin-archify/dx.config.ts
+++ b/packages/plugins/plugin-archify/dx.config.ts
@@ -23,7 +23,7 @@ export default Config2.make({
       than to overrule them with a generic auto-layout pass.
 
       The diagram is an ECHO object, so it replicates, merges, and is editable by agent operations
-      (create, read, write, validate) exposed through the Archify skill.
+      (create, read, write, verify) exposed through the Archify skill.
     `,
     source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-archify',
     icon: { key: 'ph--tree-structure--regular', hue: 'cyan' },

--- a/packages/plugins/plugin-archify/moon.yml
+++ b/packages/plugins/plugin-archify/moon.yml
@@ -1,0 +1,9 @@
+layer: library
+language: typescript
+tags:
+  - composer-plugin
+  - ts-vite-build
+  - ts-test
+  - pack
+  - storybook
+  - ts-test-storybook

--- a/packages/plugins/plugin-archify/package.json
+++ b/packages/plugins/plugin-archify/package.json
@@ -141,7 +141,6 @@
     "@dxos/compute": "workspace:*",
     "@dxos/echo": "workspace:*",
     "@dxos/echo-react": "workspace:*",
-    "@dxos/invariant": "workspace:*",
     "@dxos/keys": "workspace:*",
     "@dxos/plugin-space": "workspace:*",
     "@dxos/react-ui": "workspace:*",

--- a/packages/plugins/plugin-archify/package.json
+++ b/packages/plugins/plugin-archify/package.json
@@ -1,0 +1,172 @@
+{
+  "name": "@dxos/plugin-archify",
+  "version": "0.11.1",
+  "private": true,
+  "description": "Archify system-architecture diagrams for DXOS Composer: typed JSON IR, deterministic validation, SVG rendering.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dxos/dxos"
+  },
+  "license": "FSL-1.1-Apache-2.0",
+  "author": "DXOS.org",
+  "sideEffects": true,
+  "type": "module",
+  "imports": {
+    "#capabilities": {
+      "source": {
+        "workerd": "./src/capabilities/gen/workerd.ts",
+        "node": "./src/capabilities/gen/node.ts",
+        "default": "./src/capabilities/index.ts"
+      },
+      "types": "./dist/types/src/capabilities/index.d.ts",
+      "workerd": "./dist/lib/capabilities.workerd.mjs",
+      "node": "./dist/lib/capabilities.node.mjs",
+      "default": "./dist/lib/capabilities.mjs"
+    },
+    "#components": {
+      "source": "./src/components/index.ts",
+      "types": "./dist/types/src/components/index.d.ts",
+      "default": "./dist/lib/components.mjs"
+    },
+    "#containers": {
+      "source": "./src/containers/index.ts",
+      "types": "./dist/types/src/containers/index.d.ts",
+      "default": "./dist/lib/containers.mjs"
+    },
+    "#meta": {
+      "source": "./src/meta.ts",
+      "types": "./dist/types/src/meta.d.ts",
+      "default": "./dist/lib/meta.mjs"
+    },
+    "#model": {
+      "source": "./src/model/index.ts",
+      "types": "./dist/types/src/model/index.d.ts",
+      "default": "./dist/lib/model.mjs"
+    },
+    "#operations": {
+      "source": "./src/operations/index.ts",
+      "types": "./dist/types/src/operations/index.d.ts",
+      "default": "./dist/lib/operations.mjs"
+    },
+    "#skills": {
+      "source": "./src/skills/index.ts",
+      "types": "./dist/types/src/skills/index.d.ts",
+      "default": "./dist/lib/skills.mjs"
+    },
+    "#translations": {
+      "source": "./src/translations.ts",
+      "types": "./dist/types/src/translations.d.ts",
+      "default": "./dist/lib/translations.mjs"
+    },
+    "#types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "default": "./dist/lib/types.mjs"
+    },
+    "#plugin": {
+      "source": "./src/plugin.tsx",
+      "types": "./dist/types/src/plugin.d.ts",
+      "default": "./dist/lib/plugin.mjs"
+    }
+  },
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/types/src/index.d.ts",
+      "import": "./dist/lib/index.mjs"
+    },
+    "./assets/PLUGIN.mdl": "./PLUGIN.mdl",
+    "./model": {
+      "source": "./src/model/index.ts",
+      "types": "./dist/types/src/model/index.d.ts",
+      "import": "./dist/lib/model.mjs"
+    },
+    "./translations": {
+      "source": "./src/translations.ts",
+      "types": "./dist/types/src/translations.d.ts",
+      "import": "./dist/lib/translations.mjs"
+    },
+    "./package.json": "./package.json",
+    "./ArchifyPlugin": {
+      "source": "./src/ArchifyPlugin.ts",
+      "types": "./dist/types/src/ArchifyPlugin.d.ts",
+      "import": "./dist/lib/ArchifyPlugin.mjs"
+    },
+    "./Diagram": {
+      "source": "./src/types/Diagram.ts",
+      "types": "./dist/types/src/types/Diagram.d.ts",
+      "import": "./dist/lib/Diagram.mjs"
+    },
+    "./DiagramOperation": {
+      "source": "./src/types/DiagramOperation.ts",
+      "types": "./dist/types/src/types/DiagramOperation.d.ts",
+      "import": "./dist/lib/DiagramOperation.mjs"
+    },
+    "./ArchifyModel": {
+      "source": "./src/model/index.ts",
+      "types": "./dist/types/src/model/index.d.ts",
+      "import": "./dist/lib/model.mjs"
+    },
+    "./ArchifyEvents": {
+      "source": "./src/types/ArchifyEvents.ts",
+      "types": "./dist/types/src/types/ArchifyEvents.d.ts",
+      "import": "./dist/lib/ArchifyEvents.mjs"
+    }
+  },
+  "types": "dist/types/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "Diagram": [
+        "dist/types/src/types/Diagram.d.ts"
+      ],
+      "DiagramOperation": [
+        "dist/types/src/types/DiagramOperation.d.ts"
+      ],
+      "ArchifyEvents": [
+        "dist/types/src/types/ArchifyEvents.d.ts"
+      ]
+    }
+  },
+  "files": [
+    "dist",
+    "dx.config.ts",
+    "src",
+    "PLUGIN.mdl"
+  ],
+  "dependencies": {
+    "@dxos/app-framework": "workspace:*",
+    "@dxos/app-toolkit": "workspace:*",
+    "@dxos/compute": "workspace:*",
+    "@dxos/echo": "workspace:*",
+    "@dxos/echo-react": "workspace:*",
+    "@dxos/invariant": "workspace:*",
+    "@dxos/keys": "workspace:*",
+    "@dxos/plugin-space": "workspace:*",
+    "@dxos/react-ui": "workspace:*",
+    "@dxos/schema": "workspace:*",
+    "@dxos/util": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@dxos/plugin-client": "workspace:*",
+    "@dxos/plugin-testing": "workspace:*",
+    "@dxos/ui-theme": "workspace:*",
+    "@storybook/react-vite": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "vite": "catalog:"
+  },
+  "peerDependencies": {
+    "@dxos/react-ui": "workspace:^",
+    "@dxos/ui-theme": "workspace:^",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugins/plugin-archify/src/ArchifyPlugin.ts
+++ b/packages/plugins/plugin-archify/src/ArchifyPlugin.ts
@@ -1,0 +1,15 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as Plugin from '@dxos/app-framework/Plugin';
+
+import { meta as pluginMeta } from '#meta';
+
+/** Plugin metadata, available without loading the plugin body. */
+export const meta = pluginMeta;
+
+/** Constructs the plugin; the body loads on first enable. */
+export const make = Plugin.lazy(meta, () => import('#plugin'));

--- a/packages/plugins/plugin-archify/src/capabilities/create-object.ts
+++ b/packages/plugins/plugin-archify/src/capabilities/create-object.ts
@@ -1,0 +1,30 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Capability from '@dxos/app-framework/Capability';
+import * as Operation from '@dxos/compute/Operation';
+import { Type } from '@dxos/echo';
+import * as SpaceCapabilities from '@dxos/plugin-space/SpaceCapabilities';
+import * as SpaceOperation from '@dxos/plugin-space/SpaceOperation';
+
+import { Diagram } from '#types';
+
+export default Capability.makeModule(
+  Effect.fnUntraced(function* () {
+    return Capability.contribute(SpaceCapabilities.CreateObjectEntry, {
+      id: Type.getTypename(Diagram.Diagram),
+      createObject: (props: { name?: string }, options) =>
+        Effect.gen(function* () {
+          const object = Diagram.make(props);
+          return yield* Operation.invoke(
+            SpaceOperation.AddObject,
+            { object, target: options.target },
+            { spaceId: options.db.spaceId },
+          );
+        }),
+    });
+  }),
+);

--- a/packages/plugins/plugin-archify/src/capabilities/index.ts
+++ b/packages/plugins/plugin-archify/src/capabilities/index.ts
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as ActivationEvents from '@dxos/app-framework/ActivationEvents';
+import * as AppCapability from '@dxos/app-toolkit/AppCapability';
+import * as SpaceCapability from '@dxos/plugin-space/SpaceCapability';
+
+import { meta } from '#meta';
+import { translations } from '#translations';
+
+// eslint-disable-next-line import/no-relative-packages
+import pluginSpec from '../../PLUGIN.mdl?raw';
+
+export const CreateObject = SpaceCapability.createObject(() => import('./create-object'));
+export const OperationHandler = AppCapability.operationHandler(() => import('./operation-handler'), {
+  activatesOn: ActivationEvents.Idle,
+});
+export const ReactSurface = AppCapability.surface(() => import('./react-surface'), {
+  roles: ['org.dxos.role.article', 'org.dxos.role.cardContent', 'org.dxos.role.section', 'org.dxos.role.slide'],
+});
+export const Schema = AppCapability.schema(() => import('./schema'));
+export const SkillDefinition = AppCapability.skillDefinition(() => import('./skill-definition'), {
+  environments: ['node'],
+});
+export const PluginAsset = AppCapability.pluginAsset({
+  pluginId: meta.profile.key,
+  path: 'PLUGIN.mdl',
+  content: pluginSpec,
+  mimeType: 'application/x-mdl',
+});
+export const Translations = AppCapability.translations(translations, {
+  environments: ['node'],
+});

--- a/packages/plugins/plugin-archify/src/capabilities/operation-handler.ts
+++ b/packages/plugins/plugin-archify/src/capabilities/operation-handler.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Capabilities from '@dxos/app-framework/Capabilities';
+import * as Capability from '@dxos/app-framework/Capability';
+
+import { ArchifyOperationHandlerSet } from '#operations';
+
+export default Capability.makeModule(
+  Effect.fnUntraced(function* () {
+    return Capability.contribute(Capabilities.OperationHandler, ArchifyOperationHandlerSet);
+  }),
+);

--- a/packages/plugins/plugin-archify/src/capabilities/react-surface.ts
+++ b/packages/plugins/plugin-archify/src/capabilities/react-surface.ts
@@ -1,0 +1,36 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Capabilities from '@dxos/app-framework/Capabilities';
+import * as Capability from '@dxos/app-framework/Capability';
+import { Surface } from '@dxos/app-framework/ui';
+import { AppSurface } from '@dxos/app-toolkit/ui';
+
+import { DiagramArticle, DiagramCard } from '#containers';
+import { Diagram } from '#types';
+
+export default Capability.makeModule(() =>
+  Effect.succeed(
+    Capability.contribute(Capabilities.ReactSurface, [
+      Surface.create({
+        id: 'archifyDiagram',
+        filter: AppSurface.oneOf(
+          AppSurface.object(AppSurface.Article, Diagram.Diagram),
+          AppSurface.object(AppSurface.Section, Diagram.Diagram),
+          AppSurface.object(AppSurface.Slide, Diagram.Diagram),
+        ),
+        component: DiagramArticle,
+        props: ({ role, data: { subject, attendableId, extrinsic } }) => ({ role, subject, attendableId, extrinsic }),
+      }),
+      Surface.create({
+        id: 'archifyDiagramCard',
+        filter: AppSurface.object(AppSurface.CardContent, Diagram.Diagram),
+        component: DiagramCard,
+        props: ({ role, data: { subject, editable } }) => ({ role, subject, editable }),
+      }),
+    ]),
+  ),
+);

--- a/packages/plugins/plugin-archify/src/capabilities/schema.ts
+++ b/packages/plugins/plugin-archify/src/capabilities/schema.ts
@@ -1,0 +1,8 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Diagram } from '#types';
+
+/** Schemas this plugin registers, named lazily so they stay out of the plugin body's graph. */
+export default [Diagram.Diagram];

--- a/packages/plugins/plugin-archify/src/capabilities/skill-definition.ts
+++ b/packages/plugins/plugin-archify/src/capabilities/skill-definition.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Capability from '@dxos/app-framework/Capability';
+import * as AppCapabilities from '@dxos/app-toolkit/AppCapabilities';
+
+import { ArchifySkill } from '#skills';
+
+const skillDefinition = () => Effect.succeed([Capability.contribute(AppCapabilities.SkillDefinition, ArchifySkill)]);
+
+export default skillDefinition;

--- a/packages/plugins/plugin-archify/src/components/ArchifySvg.stories.tsx
+++ b/packages/plugins/plugin-archify/src/components/ArchifySvg.stories.tsx
@@ -10,7 +10,6 @@ import { withLayout, withTheme } from '@dxos/react-ui/testing';
 import { Layout } from '#model';
 
 import { webApp } from '../model/testing';
-
 import { ArchifySvg } from './ArchifySvg';
 
 type StoryArgs = {
@@ -26,12 +25,7 @@ const DefaultStory = ({ view: viewId, traceable = true }: StoryArgs) => {
   const focus = selected ? Layout.reach(webApp, [selected], 'both') : view ? new Set(view.focus) : undefined;
 
   return (
-    <ArchifySvg
-      diagram={webApp}
-      focus={focus}
-      selected={selected}
-      onSelect={traceable ? setSelected : undefined}
-    />
+    <ArchifySvg diagram={webApp} focus={focus} selected={selected} onSelect={traceable ? setSelected : undefined} />
   );
 };
 

--- a/packages/plugins/plugin-archify/src/components/ArchifySvg.stories.tsx
+++ b/packages/plugins/plugin-archify/src/components/ArchifySvg.stories.tsx
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import React, { useState } from 'react';
+
+import { withLayout, withTheme } from '@dxos/react-ui/testing';
+
+import { Layout } from '#model';
+
+import { webApp } from '../model/testing';
+
+import { ArchifySvg } from './ArchifySvg';
+
+type StoryArgs = {
+  /** Guided view to focus, by id; unset shows the whole diagram. */
+  view?: string;
+  /** Whether clicking a component traces what it reaches. */
+  traceable?: boolean;
+};
+
+const DefaultStory = ({ view: viewId, traceable = true }: StoryArgs) => {
+  const [selected, setSelected] = useState<string>();
+  const view = webApp.meta.views?.find((entry) => entry.id === viewId);
+  const focus = selected ? Layout.reach(webApp, [selected], 'both') : view ? new Set(view.focus) : undefined;
+
+  return (
+    <ArchifySvg
+      diagram={webApp}
+      focus={focus}
+      selected={selected}
+      onSelect={traceable ? setSelected : undefined}
+    />
+  );
+};
+
+const meta = {
+  title: 'plugins/plugin-archify/components/ArchifySvg',
+  render: DefaultStory,
+  decorators: [withTheme(), withLayout({ layout: 'fullscreen' })],
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    view: { control: 'select', options: [undefined, ...(webApp.meta.views ?? []).map((view) => view.id)] },
+  },
+} satisfies Meta<typeof DefaultStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Archify's reference document. Click a component to trace everything it reaches. */
+export const Default: Story = { args: {} };
+
+/** A guided view: only the components its author listed stay at full strength. */
+export const GuidedView: Story = { args: { view: 'request-path', traceable: false } };

--- a/packages/plugins/plugin-archify/src/components/ArchifySvg.stories.tsx
+++ b/packages/plugins/plugin-archify/src/components/ArchifySvg.stories.tsx
@@ -22,7 +22,7 @@ type StoryArgs = {
 const DefaultStory = ({ view: viewId, traceable = true }: StoryArgs) => {
   const [selected, setSelected] = useState<string>();
   const view = webApp.meta.views?.find((entry) => entry.id === viewId);
-  const focus = selected ? Layout.reach(webApp, [selected], 'both') : view ? new Set(view.focus) : undefined;
+  const focus = selected ? Layout.reach(webApp, [selected], 'downstream') : view ? new Set(view.focus) : undefined;
 
   return (
     <ArchifySvg diagram={webApp} focus={focus} selected={selected} onSelect={traceable ? setSelected : undefined} />

--- a/packages/plugins/plugin-archify/src/components/ArchifySvg.stories.tsx
+++ b/packages/plugins/plugin-archify/src/components/ArchifySvg.stories.tsx
@@ -4,6 +4,7 @@
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React, { useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
 
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 
@@ -48,3 +49,19 @@ export const Default: Story = { args: {} };
 
 /** A guided view: only the components its author listed stay at full strength. */
 export const GuidedView: Story = { args: { view: 'request-path', traceable: false } };
+
+/** Tracing is reachable from the keyboard, not only the mouse. */
+export const KeyboardSelection: Story = {
+  args: {},
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const api = canvas.getByRole('button', { name: /API Server/ });
+
+    api.focus();
+    await userEvent.keyboard('{Enter}');
+    await expect(api).toHaveAttribute('aria-pressed', 'true');
+
+    await userEvent.keyboard(' ');
+    await expect(api).toHaveAttribute('aria-pressed', 'false');
+  },
+};

--- a/packages/plugins/plugin-archify/src/components/ArchifySvg.tsx
+++ b/packages/plugins/plugin-archify/src/components/ArchifySvg.tsx
@@ -52,11 +52,13 @@ export const ArchifySvg = ({ classNames, diagram, focus, selected, onSelect, hid
   const prefix = useId().replace(/:/g, '');
 
   const dimmed = (id: string) => !!focus && focus.size > 0 && !focus.has(id);
+  const toggle = (id: string) => onSelect?.(id === selected ? undefined : id);
   const variants: Ir.Variant[] = ['default', 'emphasis', 'security', 'dashed'];
 
   return (
     <svg
-      role='img'
+      // Selectable components are focusable buttons, so the SVG is a group rather than one image.
+      role={onSelect ? 'group' : 'img'}
       aria-label={diagram.meta.title}
       viewBox={resolved.viewBox}
       preserveAspectRatio='xMidYMid meet'
@@ -136,9 +138,20 @@ export const ArchifySvg = ({ classNames, diagram, focus, selected, onSelect, hid
               key={component.id}
               opacity={faded ? DIM_OPACITY : 1}
               className={onSelect ? 'cursor-pointer' : undefined}
+              role={onSelect ? 'button' : undefined}
+              tabIndex={onSelect ? 0 : undefined}
+              aria-pressed={onSelect ? component.id === selected : undefined}
+              aria-label={onSelect ? [component.label, component.sublabel].filter(Boolean).join(' — ') : undefined}
               onClick={(event) => {
                 event.stopPropagation();
-                onSelect?.(component.id === selected ? undefined : component.id);
+                toggle(component.id);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  toggle(component.id);
+                }
               }}
             >
               {/* Opaque plate: component fills are translucent, so a route underneath would

--- a/packages/plugins/plugin-archify/src/components/ArchifySvg.tsx
+++ b/packages/plugins/plugin-archify/src/components/ArchifySvg.tsx
@@ -1,0 +1,231 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React, { useId, useMemo } from 'react';
+
+import { type ThemedClassName, useThemeContext } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+import { type Ir, Layout, Palette } from '#model';
+
+/**
+ * Renders an Archify architecture IR as SVG.
+ *
+ * Pure and deterministic: geometry comes from `Layout.resolve`, colour from the palette, and the
+ * only inputs beyond the IR are the reader's focus set and the theme. Nothing here reads or writes
+ * ECHO, so the same component serves the article, card, section and slide surfaces.
+ */
+export type ArchifySvgProps = ThemedClassName<{
+  diagram: Ir.Architecture;
+  /** Component ids to keep at full strength; everything else recedes. Empty means "all". */
+  focus?: ReadonlySet<string>;
+  /** Component the reader has picked out, drawn with a halo. */
+  selected?: string;
+  onSelect?: (id: string | undefined) => void;
+  /** Hide the type legend (cards and boundaries already carry it in dense embeds). */
+  hideLegend?: boolean;
+}>;
+
+const DIM_OPACITY = 0.22;
+
+const arrowMarker = (id: string, color: string) => (
+  <marker
+    key={id}
+    id={id}
+    viewBox='0 0 10 10'
+    refX='9'
+    refY='5'
+    markerWidth='7'
+    markerHeight='7'
+    orient='auto-start-reverse'
+  >
+    <path d='M 0 1 L 9 5 L 0 9 z' fill={color} />
+  </marker>
+);
+
+export const ArchifySvg = ({ classNames, diagram, focus, selected, onSelect, hideLegend }: ArchifySvgProps) => {
+  const { themeMode } = useThemeContext();
+  const palette = useMemo(() => Palette.paletteFor(themeMode === 'dark' ? 'dark' : 'light'), [themeMode]);
+  const resolved = useMemo(() => Layout.resolve(diagram), [diagram]);
+  // Markers are referenced by fragment id, and several diagrams may share one page.
+  const prefix = useId().replace(/:/g, '');
+
+  const dimmed = (id: string) => !!focus && focus.size > 0 && !focus.has(id);
+  const variants: Ir.Variant[] = ['default', 'emphasis', 'security', 'dashed'];
+
+  return (
+    <svg
+      role='img'
+      aria-label={diagram.meta.title}
+      viewBox={resolved.viewBox}
+      preserveAspectRatio='xMidYMid meet'
+      className={mx('dx-fill', classNames)}
+      onClick={() => onSelect?.(undefined)}
+    >
+      <title>{diagram.meta.title}</title>
+      <defs>
+        {variants.map((variant) =>
+          arrowMarker(`${prefix}-arrow-${variant}`, Palette.connectionStyle(palette, variant).stroke),
+        )}
+      </defs>
+
+      {resolved.boundaries.map((boundary, index) => (
+        <g key={`${boundary.label}-${index}`} opacity={boundary.wraps.every(dimmed) ? DIM_OPACITY : 1}>
+          <rect
+            x={boundary.x}
+            y={boundary.y}
+            width={boundary.width}
+            height={boundary.height}
+            rx={12}
+            fill={palette.lane.fill}
+            stroke={palette.lane.stroke}
+            strokeWidth={1}
+            strokeDasharray={boundary.kind === 'security-group' ? '5 4' : undefined}
+          />
+          <text
+            x={boundary.x + 12}
+            y={boundary.y + Layout.DEFAULTS.boundaryLabelBaseline}
+            fontSize={10}
+            fill={palette.textDim}
+            letterSpacing={0.4}
+          >
+            {boundary.label}
+          </text>
+        </g>
+      ))}
+
+      {resolved.connections.map(({ key, connection, path, label }) => {
+        const style = Palette.connectionStyle(palette, connection.variant, connection.width);
+        const faded = dimmed(connection.from) || dimmed(connection.to);
+        return (
+          <g key={key} opacity={faded ? DIM_OPACITY : 1}>
+            <path
+              d={path}
+              fill='none'
+              stroke={style.stroke}
+              strokeWidth={style.width}
+              strokeDasharray={style.dash}
+              strokeLinecap='round'
+              strokeLinejoin='round'
+              markerEnd={`url(#${prefix}-arrow-${connection.variant ?? 'default'})`}
+            />
+            {label && (
+              <text
+                x={label.at[0]}
+                y={label.at[1]}
+                textAnchor='middle'
+                fontSize={9}
+                fill={Palette.labelColor(palette, connection.variant)}
+              >
+                {label.text}
+              </text>
+            )}
+          </g>
+        );
+      })}
+
+      {resolved.components
+        .filter((component) => Number.isFinite(component.x))
+        .map((component) => {
+          const swatch = palette.component[component.type];
+          const faded = dimmed(component.id);
+          const hasSublabel = !!component.sublabel;
+          return (
+            <g
+              key={component.id}
+              opacity={faded ? DIM_OPACITY : 1}
+              className={onSelect ? 'cursor-pointer' : undefined}
+              onClick={(event) => {
+                event.stopPropagation();
+                onSelect?.(component.id === selected ? undefined : component.id);
+              }}
+            >
+              {/* Opaque plate: component fills are translucent, so a route underneath would
+                  otherwise read as passing through the box. */}
+              <rect
+                x={component.x}
+                y={component.y}
+                width={component.width}
+                height={component.height}
+                rx={8}
+                fill={palette.mask}
+              />
+              <rect
+                x={component.x}
+                y={component.y}
+                width={component.width}
+                height={component.height}
+                rx={8}
+                fill={swatch.fill}
+                stroke={swatch.stroke}
+                strokeWidth={component.id === selected ? 2.5 : 1.5}
+              />
+              <text
+                x={component.cx}
+                y={hasSublabel ? component.cy - 4 : component.cy}
+                textAnchor='middle'
+                dominantBaseline='central'
+                fontSize={11}
+                fontWeight={600}
+                fill={palette.text}
+              >
+                {component.label}
+              </text>
+              {component.sublabel && (
+                <text
+                  x={component.cx}
+                  y={component.cy + 10}
+                  textAnchor='middle'
+                  dominantBaseline='central'
+                  fontSize={8}
+                  fill={palette.textMuted}
+                >
+                  {component.sublabel}
+                </text>
+              )}
+              {component.tag && (
+                <text
+                  x={component.cx}
+                  y={component.y - 5}
+                  textAnchor='middle'
+                  fontSize={7}
+                  fill={swatch.stroke}
+                  letterSpacing={0.3}
+                >
+                  {component.tag}
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+      {!hideLegend && diagram.meta.legend?.mode !== 'hidden' && resolved.usedTypes.length > 1 && (
+        <g>
+          {resolved.usedTypes.map((type, index) => {
+            const [minX, minY, , height] = resolved.viewBox.split(' ').map(Number);
+            const x = minX + 16 + index * 92;
+            const y = minY + height - 22;
+            return (
+              <g key={type}>
+                <rect
+                  x={x}
+                  y={y}
+                  width={14}
+                  height={9}
+                  rx={2}
+                  fill={palette.component[type].fill}
+                  stroke={palette.component[type].stroke}
+                  strokeWidth={1}
+                />
+                <text x={x + 20} y={y + 8} fontSize={8} fill={palette.textDim}>
+                  {Palette.LEGEND_LABELS[type]}
+                </text>
+              </g>
+            );
+          })}
+        </g>
+      )}
+    </svg>
+  );
+};

--- a/packages/plugins/plugin-archify/src/components/index.ts
+++ b/packages/plugins/plugin-archify/src/components/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './ArchifySvg';

--- a/packages/plugins/plugin-archify/src/containers/DiagramArticle/DiagramArticle.tsx
+++ b/packages/plugins/plugin-archify/src/containers/DiagramArticle/DiagramArticle.tsx
@@ -1,0 +1,109 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React, { useCallback, useMemo, useState } from 'react';
+
+import { useObject } from '@dxos/echo-react';
+import { Button, Icon, Panel, Toolbar, useTranslation } from '@dxos/react-ui';
+
+import { ArchifySvg } from '#components';
+import { meta } from '#meta';
+import { Layout } from '#model';
+import { type Diagram } from '#types';
+
+export type DiagramArticleProps = {
+  subject: Diagram.Diagram;
+  role?: string;
+  attendableId?: string;
+  extrinsic?: boolean;
+};
+
+/**
+ * Article/section/slide surface. The reading affordances are Archify's: step through the authored
+ * guided views, or pick a component and trace what it reaches. Both are pure view state — neither
+ * touches the stored IR, so reading a diagram never edits it.
+ */
+export const DiagramArticle = ({ subject }: DiagramArticleProps) => {
+  const { t } = useTranslation(meta.profile.key);
+  const [snapshot] = useObject(subject);
+  const [viewId, setViewId] = useState<string>();
+  const [selected, setSelected] = useState<string>();
+
+  const source = snapshot?.source;
+  const views = source?.meta.views ?? [];
+  const view = views.find((entry) => entry.id === viewId);
+
+  const focus = useMemo(() => {
+    if (!source) {
+      return undefined;
+    }
+    if (selected) {
+      return Layout.reach(source, [selected], 'both');
+    }
+    return view ? new Set(view.focus) : undefined;
+  }, [source, view, selected]);
+
+  const onSelect = useCallback((id: string | undefined) => setSelected(id), []);
+
+  if (!source) {
+    return null;
+  }
+
+  return (
+    <Panel.Root classNames='dx-fill'>
+      {(views.length > 0 || selected) && (
+        <Toolbar.Root>
+          <Button
+            variant={!viewId && !selected ? 'primary' : 'ghost'}
+            onClick={() => {
+              setViewId(undefined);
+              setSelected(undefined);
+            }}
+          >
+            {t('view.all.label')}
+          </Button>
+          {views.map((entry) => (
+            <Button
+              key={entry.id}
+              variant={entry.id === viewId && !selected ? 'primary' : 'ghost'}
+              onClick={() => {
+                setSelected(undefined);
+                setViewId(entry.id === viewId ? undefined : entry.id);
+              }}
+            >
+              {entry.label}
+            </Button>
+          ))}
+          {selected && (
+            <div role='none' className='flex items-center gap-1 text-description text-sm'>
+              <Icon icon='ph--path--regular' size={4} />
+              <span>{t('trace.label', { id: selected })}</span>
+            </div>
+          )}
+        </Toolbar.Root>
+      )}
+      <Panel.Content asChild>
+        <div role='none' className='dx-attention-surface dx-fill grid grid-rows-[1fr_auto] overflow-hidden'>
+          <ArchifySvg classNames='min-h-0' diagram={source} focus={focus} selected={selected} onSelect={onSelect} />
+          {(view?.note || (source.cards?.length ?? 0) > 0) && (
+            <div role='none' className='p-2 grid gap-2 grid-cols-[repeat(auto-fit,minmax(14rem,1fr))]'>
+              {view?.note && <p className='text-description text-sm col-span-full'>{view.note}</p>}
+              {!view &&
+                source.cards?.map((card) => (
+                  <section key={card.title} className='p-2 rounded border border-separator'>
+                    <h3 className='text-sm font-medium mb-1'>{card.title}</h3>
+                    <ul className='text-description text-xs grid gap-0.5'>
+                      {card.items.map((item, index) => (
+                        <li key={index}>{item}</li>
+                      ))}
+                    </ul>
+                  </section>
+                ))}
+            </div>
+          )}
+        </div>
+      </Panel.Content>
+    </Panel.Root>
+  );
+};

--- a/packages/plugins/plugin-archify/src/containers/DiagramArticle/DiagramArticle.tsx
+++ b/packages/plugins/plugin-archify/src/containers/DiagramArticle/DiagramArticle.tsx
@@ -39,7 +39,9 @@ export const DiagramArticle = ({ subject, role }: DiagramArticleProps) => {
       return undefined;
     }
     if (selected) {
-      return Layout.reach(source, [selected], 'both');
+      // Downstream, not the whole connected component: on a request path every node reaches
+      // every other one through `both`, which lights the diagram up and says nothing.
+      return Layout.reach(source, [selected], 'downstream');
     }
     return view ? new Set(view.focus) : undefined;
   }, [source, view, selected]);

--- a/packages/plugins/plugin-archify/src/containers/DiagramArticle/DiagramArticle.tsx
+++ b/packages/plugins/plugin-archify/src/containers/DiagramArticle/DiagramArticle.tsx
@@ -24,7 +24,7 @@ export type DiagramArticleProps = {
  * guided views, or pick a component and trace what it reaches. Both are pure view state — neither
  * touches the stored IR, so reading a diagram never edits it.
  */
-export const DiagramArticle = ({ subject }: DiagramArticleProps) => {
+export const DiagramArticle = ({ subject, role }: DiagramArticleProps) => {
   const { t } = useTranslation(meta.profile.key);
   const [snapshot] = useObject(subject);
   const [viewId, setViewId] = useState<string>();
@@ -51,37 +51,39 @@ export const DiagramArticle = ({ subject }: DiagramArticleProps) => {
   }
 
   return (
-    <Panel.Root classNames='dx-fill'>
+    <Panel.Root role={role}>
       {(views.length > 0 || selected) && (
-        <Toolbar.Root>
-          <Button
-            variant={!viewId && !selected ? 'primary' : 'ghost'}
-            onClick={() => {
-              setViewId(undefined);
-              setSelected(undefined);
-            }}
-          >
-            {t('view.all.label')}
-          </Button>
-          {views.map((entry) => (
+        <Panel.Toolbar asChild>
+          <Toolbar.Root>
             <Button
-              key={entry.id}
-              variant={entry.id === viewId && !selected ? 'primary' : 'ghost'}
+              variant={!viewId && !selected ? 'primary' : 'ghost'}
               onClick={() => {
+                setViewId(undefined);
                 setSelected(undefined);
-                setViewId(entry.id === viewId ? undefined : entry.id);
               }}
             >
-              {entry.label}
+              {t('view.all.label')}
             </Button>
-          ))}
-          {selected && (
-            <div role='none' className='flex items-center gap-1 text-description text-sm'>
-              <Icon icon='ph--path--regular' size={4} />
-              <span>{t('trace.label', { id: selected })}</span>
-            </div>
-          )}
-        </Toolbar.Root>
+            {views.map((entry) => (
+              <Button
+                key={entry.id}
+                variant={entry.id === viewId && !selected ? 'primary' : 'ghost'}
+                onClick={() => {
+                  setSelected(undefined);
+                  setViewId(entry.id === viewId ? undefined : entry.id);
+                }}
+              >
+                {entry.label}
+              </Button>
+            ))}
+            {selected && (
+              <div role='none' className='flex items-center gap-1 text-description text-sm'>
+                <Icon icon='ph--path--regular' size={4} />
+                <span>{t('trace.label', { id: selected })}</span>
+              </div>
+            )}
+          </Toolbar.Root>
+        </Panel.Toolbar>
       )}
       <Panel.Content asChild>
         <div role='none' className='dx-attention-surface dx-fill grid grid-rows-[1fr_auto] overflow-hidden'>

--- a/packages/plugins/plugin-archify/src/containers/DiagramArticle/index.ts
+++ b/packages/plugins/plugin-archify/src/containers/DiagramArticle/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './DiagramArticle';

--- a/packages/plugins/plugin-archify/src/containers/DiagramCard/DiagramCard.tsx
+++ b/packages/plugins/plugin-archify/src/containers/DiagramCard/DiagramCard.tsx
@@ -1,0 +1,26 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React from 'react';
+
+import { useObject } from '@dxos/echo-react';
+
+import { ArchifySvg } from '#components';
+import { type Diagram } from '#types';
+
+export type DiagramCardProps = {
+  subject: Diagram.Diagram;
+  role?: string;
+  editable?: boolean;
+};
+
+/** Card surface: the diagram alone, with the legend dropped — a card has no room to read it. */
+export const DiagramCard = ({ subject }: DiagramCardProps) => {
+  const [snapshot] = useObject(subject);
+  if (!snapshot?.source) {
+    return null;
+  }
+
+  return <ArchifySvg classNames='aspect-video' diagram={snapshot.source} hideLegend />;
+};

--- a/packages/plugins/plugin-archify/src/containers/DiagramCard/index.ts
+++ b/packages/plugins/plugin-archify/src/containers/DiagramCard/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './DiagramCard';

--- a/packages/plugins/plugin-archify/src/containers/index.ts
+++ b/packages/plugins/plugin-archify/src/containers/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './DiagramArticle';
+export * from './DiagramCard';

--- a/packages/plugins/plugin-archify/src/index.ts
+++ b/packages/plugins/plugin-archify/src/index.ts
@@ -1,0 +1,10 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * as ArchifyModel from '#model';
+export * as ArchifyPlugin from './ArchifyPlugin';
+export * from '#meta';
+export * from '#operations';
+export * from '#skills';
+export * from '#types';

--- a/packages/plugins/plugin-archify/src/meta.ts
+++ b/packages/plugins/plugin-archify/src/meta.ts
@@ -1,0 +1,9 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Plugin from '@dxos/app-framework/Plugin';
+
+import config from '../dx.config';
+
+export const meta = Plugin.getMetaFromConfig(config);

--- a/packages/plugins/plugin-archify/src/model/Ir.ts
+++ b/packages/plugins/plugin-archify/src/model/Ir.ts
@@ -1,0 +1,149 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as Schema from 'effect/Schema';
+
+/**
+ * The Archify architecture intermediate representation (schema version 1), transcribed from
+ * `archify/schemas/{common,architecture}.schema.json` (https://github.com/tt-a1i/archify).
+ *
+ * Everything a diagram needs is in here: the agent writes this and nothing else, and the renderer
+ * derives geometry from it deterministically — the same IR always produces the same SVG.
+ */
+
+/** Ids are referenced from connections, boundaries and views, so they must be stable slugs. */
+export const Id = Schema.String.check(Schema.isPattern(/^[a-zA-Z][a-zA-Z0-9_-]*$/));
+
+export const Point = Schema.Tuple([Schema.Number, Schema.Number]);
+export type Point = Schema.Schema.Type<typeof Point>;
+
+export const Size = Schema.Tuple([Schema.Number, Schema.Number]);
+
+export const Side = Schema.Literals(['left', 'right', 'top', 'bottom']);
+export type Side = Schema.Schema.Type<typeof Side>;
+
+/** The seven semantic roles Archify gives a node; each owns a fill/stroke pair in the palette. */
+export const ComponentType = Schema.Literals([
+  'frontend',
+  'backend',
+  'database',
+  'cloud',
+  'security',
+  'messagebus',
+  'external',
+]);
+export type ComponentType = Schema.Schema.Type<typeof ComponentType>;
+
+/** Relationship vocabulary: the only four ways a connection may be drawn. */
+export const Variant = Schema.Literals(['default', 'emphasis', 'security', 'dashed']);
+export type Variant = Schema.Schema.Type<typeof Variant>;
+
+export const Route = Schema.Literals(['auto', 'straight', 'orthogonal-h', 'orthogonal-v']);
+export type Route = Schema.Schema.Type<typeof Route>;
+
+export const DotColor = Schema.Literals(['cyan', 'emerald', 'violet', 'amber', 'rose', 'orange', 'slate']);
+export type DotColor = Schema.Schema.Type<typeof DotColor>;
+
+export const Component = Schema.Struct({
+  id: Id,
+  type: ComponentType,
+  label: Schema.String.check(Schema.isNonEmpty()),
+  sublabel: Schema.optional(Schema.String),
+  tag: Schema.optional(Schema.String).annotate({ description: 'Small stamp above the box, e.g. a port or protocol.' }),
+  row: Schema.optional(Schema.Number.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0))),
+  col: Schema.optional(Schema.Number.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0))),
+  pos: Schema.optional(Point).annotate({ description: 'Absolute [x, y] in diagram units; wins over row/col.' }),
+  size: Schema.optional(Size).annotate({ description: 'Box [width, height]; defaults to [120, 60].' }),
+});
+export type Component = Schema.Schema.Type<typeof Component>;
+
+export const Boundary = Schema.Struct({
+  kind: Schema.Literals(['region', 'security-group']),
+  label: Schema.String.check(Schema.isNonEmpty()),
+  wraps: Schema.Array(Id).check(Schema.isMinLength(1)),
+  pad: Schema.optional(Schema.Number.check(Schema.isGreaterThanOrEqualTo(0))),
+});
+export type Boundary = Schema.Schema.Type<typeof Boundary>;
+
+export const Connection = Schema.Struct({
+  id: Schema.optional(Id),
+  from: Id,
+  to: Id,
+  label: Schema.optional(Schema.String),
+  variant: Schema.optional(Variant),
+  fromSide: Schema.optional(Side),
+  toSide: Schema.optional(Side),
+  route: Schema.optional(Route),
+  via: Schema.optional(Schema.Array(Point)).annotate({ description: 'Explicit waypoints between the endpoints.' }),
+  labelAt: Schema.optional(Point),
+  labelDx: Schema.optional(Schema.Number),
+  labelDy: Schema.optional(Schema.Number),
+  labelSegment: Schema.optional(Schema.Number.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0))),
+  width: Schema.optional(Schema.Number.check(Schema.isGreaterThanOrEqualTo(0.5))),
+});
+export type Connection = Schema.Schema.Type<typeof Connection>;
+
+export const Card = Schema.Struct({
+  dot: DotColor,
+  title: Schema.String.check(Schema.isNonEmpty()),
+  items: Schema.Array(Schema.String),
+});
+export type Card = Schema.Schema.Type<typeof Card>;
+
+/** A named subset of the diagram the reader can step through; at most five, as upstream. */
+export const View = Schema.Struct({
+  id: Id,
+  label: Schema.String.check(Schema.isNonEmpty(), Schema.isMaxLength(48)),
+  focus: Schema.Array(Id).check(Schema.isMinLength(1)),
+  note: Schema.optional(Schema.String.check(Schema.isMaxLength(140))),
+});
+export type View = Schema.Schema.Type<typeof View>;
+
+export const Legend = Schema.Struct({
+  mode: Schema.optional(Schema.Literals(['auto', 'all', 'hidden'])),
+});
+export type Legend = Schema.Schema.Type<typeof Legend>;
+
+export const Meta = Schema.Struct({
+  title: Schema.String.check(Schema.isNonEmpty()),
+  subtitle: Schema.optional(Schema.String),
+  views: Schema.optional(Schema.Array(View).check(Schema.isMaxLength(5))),
+  legend: Schema.optional(Legend),
+  viewBox: Schema.optional(Size).annotate({ description: 'Overrides the measured canvas size.' }),
+});
+export type Meta = Schema.Schema.Type<typeof Meta>;
+
+export const Layout = Schema.Struct({
+  mode: Schema.Literal('grid'),
+  origin: Schema.optional(Point),
+  cols: Schema.optional(Schema.Number.check(Schema.isInt(), Schema.isBetween({ minimum: 1, maximum: 12 }))),
+  gapX: Schema.optional(Schema.Number.check(Schema.isGreaterThanOrEqualTo(0))),
+  gapY: Schema.optional(Schema.Number.check(Schema.isGreaterThanOrEqualTo(0))),
+  cellW: Schema.optional(Schema.Number.check(Schema.isGreaterThanOrEqualTo(40))),
+  cellH: Schema.optional(Schema.Number.check(Schema.isGreaterThanOrEqualTo(24))),
+});
+export type Layout = Schema.Schema.Type<typeof Layout>;
+
+/** The whole diagram source. `diagram_type`/`schema_version` keep Archify's snake case. */
+export const Architecture = Schema.Struct({
+  schema_version: Schema.Literal(1),
+  diagram_type: Schema.Literal('architecture'),
+  meta: Meta,
+  layout: Schema.optional(Layout),
+  components: Schema.Array(Component).check(Schema.isMinLength(1)),
+  boundaries: Schema.optional(Schema.Array(Boundary)),
+  connections: Schema.optional(Schema.Array(Connection)),
+  cards: Schema.optional(Schema.Array(Card)),
+});
+export type Architecture = Schema.Schema.Type<typeof Architecture>;
+
+/** A diagram that renders and validates on day one, so a new object is never a blank canvas. */
+export const emptyArchitecture = (title: string): Architecture => ({
+  schema_version: 1,
+  diagram_type: 'architecture',
+  meta: { title },
+  components: [{ id: 'placeholder', type: 'backend', label: title, pos: [40, 80], size: [160, 64] }],
+});

--- a/packages/plugins/plugin-archify/src/model/Layout.test.ts
+++ b/packages/plugins/plugin-archify/src/model/Layout.test.ts
@@ -8,14 +8,6 @@ import * as Ir from './Ir';
 import * as Layout from './Layout';
 import { webApp } from './testing';
 
-const minimal = (components: Ir.Architecture['components'], rest: Partial<Ir.Architecture> = {}): Ir.Architecture => ({
-  schema_version: 1,
-  diagram_type: 'architecture',
-  meta: { title: 'test' },
-  components,
-  ...rest,
-});
-
 describe('layout', () => {
   test('grid cells resolve to fixed coordinates and absolute pos wins over them', ({ expect }) => {
     const [ox, oy] = Layout.DEFAULT_GRID.origin;
@@ -101,6 +93,22 @@ describe('layout', () => {
     }
   });
 
+  test('a label pinned away from its route is still inside the viewBox', ({ expect }) => {
+    const resolved = Layout.resolve(
+      minimal(
+        [
+          { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+          { id: 'b', type: 'backend', label: 'b', pos: [400, 0], size: [100, 50] },
+        ],
+        { connections: [{ from: 'a', to: 'b', label: 'far', labelAt: [250, -400] }] },
+      ),
+    );
+
+    const [, minY, , height] = resolved.viewBox.split(' ').map(Number);
+    expect(minY).toBeLessThanOrEqual(-400);
+    expect(minY + height).toBeGreaterThan(0);
+  });
+
   test('reach walks connections in the requested direction', ({ expect }) => {
     expect([...Layout.reach(webApp, ['lb'], 'downstream')].sort()).toEqual([
       'api',
@@ -112,4 +120,12 @@ describe('layout', () => {
     ]);
     expect([...Layout.reach(webApp, ['lb'], 'upstream')].sort()).toEqual(['cdn', 'lb', 'users']);
   });
+});
+
+const minimal = (components: Ir.Architecture['components'], rest: Partial<Ir.Architecture> = {}): Ir.Architecture => ({
+  schema_version: 1,
+  diagram_type: 'architecture',
+  meta: { title: 'test' },
+  components,
+  ...rest,
 });

--- a/packages/plugins/plugin-archify/src/model/Layout.test.ts
+++ b/packages/plugins/plugin-archify/src/model/Layout.test.ts
@@ -1,0 +1,108 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import * as Ir from './Ir';
+import * as Layout from './Layout';
+import { webApp } from './testing';
+
+const minimal = (components: Ir.Architecture['components'], rest: Partial<Ir.Architecture> = {}): Ir.Architecture => ({
+  schema_version: 1,
+  diagram_type: 'architecture',
+  meta: { title: 'test' },
+  components,
+  ...rest,
+});
+
+describe('layout', () => {
+  test('grid cells resolve to fixed coordinates and absolute pos wins over them', ({ expect }) => {
+    const [ox, oy] = Layout.DEFAULT_GRID.origin;
+    expect(Layout.resolvePos({ id: 'a', type: 'backend', label: 'a', row: 1, col: 2 }, Layout.DEFAULT_GRID)).toEqual([
+      ox + 2 * (Layout.DEFAULT_GRID.cellW + Layout.DEFAULT_GRID.gapX),
+      oy + 1 * (Layout.DEFAULT_GRID.cellH + Layout.DEFAULT_GRID.gapY),
+    ]);
+    expect(Layout.resolvePos({ id: 'a', type: 'backend', label: 'a', row: 1, col: 2, pos: [7, 9] }, Layout.DEFAULT_GRID)).toEqual([
+      7, 9,
+    ]);
+    // Without a grid there is nothing to place a row/col component against.
+    expect(Layout.resolvePos({ id: 'a', type: 'backend', label: 'a', row: 1, col: 2 })).toEqual([NaN, NaN]);
+  });
+
+  test('a boundary frame is derived from its members, never authored', ({ expect }) => {
+    const { boundaries } = Layout.resolve(
+      minimal(
+        [
+          { id: 'a', type: 'backend', label: 'a', pos: [100, 100], size: [100, 50] },
+          { id: 'b', type: 'backend', label: 'b', pos: [300, 200], size: [100, 50] },
+        ],
+        { boundaries: [{ kind: 'region', label: 'vpc', wraps: ['a', 'b'] }] },
+      ),
+    );
+
+    expect(boundaries).toHaveLength(1);
+    const [frame] = boundaries;
+    expect(frame.x).toBe(70);
+    expect(frame.x + frame.width).toBe(430);
+    // Top padding clears the label baseline; the bottom carries the extra 20px.
+    expect(frame.y).toBe(70);
+    expect(frame.y + frame.height).toBe(270);
+  });
+
+  test('a route leaves the chosen side and arrives against the target side', ({ expect }) => {
+    const { connections } = Layout.resolve(
+      minimal(
+        [
+          { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+          { id: 'b', type: 'backend', label: 'b', pos: [300, 200], size: [100, 50] },
+        ],
+        { connections: [{ from: 'a', to: 'b', fromSide: 'right', toSide: 'left' }] },
+      ),
+    );
+
+    const [{ points }] = connections;
+    expect(points[0]).toEqual([100, 25]);
+    expect(points[points.length - 1]).toEqual([300, 225]);
+    // Leaves rightwards, arrives from the left: a horizontal-first dogleg.
+    expect(points[1][0]).toBeGreaterThan(points[0][0]);
+  });
+
+  test('explicit waypoints are used verbatim', ({ expect }) => {
+    const { connections } = Layout.resolve(
+      minimal(
+        [
+          { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+          { id: 'b', type: 'backend', label: 'b', pos: [300, 0], size: [100, 50] },
+        ],
+        { connections: [{ from: 'a', to: 'b', via: [[200, -80]] }] },
+      ),
+    );
+
+    expect(connections[0].points).toEqual([
+      [100, 25],
+      [200, -80],
+      [300, 25],
+    ]);
+  });
+
+  test('the same document always resolves to the same geometry', ({ expect }) => {
+    expect(Layout.resolve(webApp)).toEqual(Layout.resolve(webApp));
+  });
+
+  test('the viewBox covers every rect and route', ({ expect }) => {
+    const resolved = Layout.resolve(webApp);
+    const [minX, minY, width, height] = resolved.viewBox.split(' ').map(Number);
+    for (const component of resolved.components) {
+      expect(component.x).toBeGreaterThanOrEqual(minX);
+      expect(component.y).toBeGreaterThanOrEqual(minY);
+      expect(component.x + component.width).toBeLessThanOrEqual(minX + width);
+      expect(component.y + component.height).toBeLessThanOrEqual(minY + height);
+    }
+  });
+
+  test('reach walks connections in the requested direction', ({ expect }) => {
+    expect([...Layout.reach(webApp, ['lb'], 'downstream')].sort()).toEqual(['api', 'cache', 'db', 'lb', 'queue', 'worker']);
+    expect([...Layout.reach(webApp, ['lb'], 'upstream')].sort()).toEqual(['cdn', 'lb', 'users']);
+  });
+});

--- a/packages/plugins/plugin-archify/src/model/Layout.test.ts
+++ b/packages/plugins/plugin-archify/src/model/Layout.test.ts
@@ -23,9 +23,9 @@ describe('layout', () => {
       ox + 2 * (Layout.DEFAULT_GRID.cellW + Layout.DEFAULT_GRID.gapX),
       oy + 1 * (Layout.DEFAULT_GRID.cellH + Layout.DEFAULT_GRID.gapY),
     ]);
-    expect(Layout.resolvePos({ id: 'a', type: 'backend', label: 'a', row: 1, col: 2, pos: [7, 9] }, Layout.DEFAULT_GRID)).toEqual([
-      7, 9,
-    ]);
+    expect(
+      Layout.resolvePos({ id: 'a', type: 'backend', label: 'a', row: 1, col: 2, pos: [7, 9] }, Layout.DEFAULT_GRID),
+    ).toEqual([7, 9]);
     // Without a grid there is nothing to place a row/col component against.
     expect(Layout.resolvePos({ id: 'a', type: 'backend', label: 'a', row: 1, col: 2 })).toEqual([NaN, NaN]);
   });
@@ -102,7 +102,14 @@ describe('layout', () => {
   });
 
   test('reach walks connections in the requested direction', ({ expect }) => {
-    expect([...Layout.reach(webApp, ['lb'], 'downstream')].sort()).toEqual(['api', 'cache', 'db', 'lb', 'queue', 'worker']);
+    expect([...Layout.reach(webApp, ['lb'], 'downstream')].sort()).toEqual([
+      'api',
+      'cache',
+      'db',
+      'lb',
+      'queue',
+      'worker',
+    ]);
     expect([...Layout.reach(webApp, ['lb'], 'upstream')].sort()).toEqual(['cdn', 'lb', 'users']);
   });
 });

--- a/packages/plugins/plugin-archify/src/model/Layout.ts
+++ b/packages/plugins/plugin-archify/src/model/Layout.ts
@@ -303,10 +303,15 @@ export const resolve = (diagram: Ir.Architecture): ResolvedDiagram => {
     xs.push(rect.x, rect.x + rect.width);
     ys.push(rect.y, rect.y + rect.height);
   }
-  for (const { points } of connections) {
+  for (const { points, label } of connections) {
     for (const [x, y] of points) {
       xs.push(x);
       ys.push(y);
+    }
+    // A label pinned with labelAt/labelDx/labelDy can sit off the route; it must still be inside.
+    if (label) {
+      xs.push(label.at[0]);
+      ys.push(label.at[1]);
     }
   }
   const minX = Math.min(0, ...xs) - DEFAULTS.margin;

--- a/packages/plugins/plugin-archify/src/model/Layout.ts
+++ b/packages/plugins/plugin-archify/src/model/Layout.ts
@@ -1,0 +1,347 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as Ir from './Ir';
+
+/**
+ * Deterministic geometry for the architecture IR: the same source always resolves to the same
+ * rects, routes and viewBox. Nothing here invents a layout — coordinates come from the author
+ * (absolute `pos`, or a fixed grid cell) and routes honour the sides the author chose.
+ */
+
+export const DEFAULT_GRID = {
+  origin: [40, 80] as Ir.Point,
+  cols: 4,
+  gapX: 30,
+  gapY: 40,
+  cellW: 130,
+  cellH: 64,
+};
+
+export const DEFAULTS = {
+  width: 120,
+  height: 60,
+  margin: 40,
+  /** Archify's 30/50 rule: 30px of padding, with 20px extra below the members. */
+  boundaryPad: 30,
+  boundaryExtraBottom: 20,
+  boundaryLabelBaseline: 18,
+  boundaryLabelClearance: 4,
+  cornerRadius: 8,
+};
+
+export type Rect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  cx: number;
+  cy: number;
+};
+
+export type ComponentRect = Rect & Ir.Component;
+
+export type BoundaryRect = Rect & Ir.Boundary & { memberTop: number };
+
+export type ResolvedConnection = {
+  key: string;
+  connection: Ir.Connection;
+  points: readonly Ir.Point[];
+  /** SVG path with rounded corners at the waypoints. */
+  path: string;
+  label?: { text: string; at: Ir.Point };
+};
+
+export type ResolvedDiagram = {
+  components: readonly ComponentRect[];
+  boundaries: readonly BoundaryRect[];
+  connections: readonly ResolvedConnection[];
+  /** `minX minY width height`, padded by `DEFAULTS.margin`. */
+  viewBox: string;
+  /** Component types actually present, in the palette's canonical order. */
+  usedTypes: readonly Ir.Component['type'][];
+};
+
+const gridOf = (diagram: Ir.Architecture) =>
+  diagram.layout?.mode === 'grid' ? { ...DEFAULT_GRID, ...diagram.layout } : undefined;
+
+/** Absolute `pos` wins; otherwise the fixed grid cell. NaN signals an unplaceable component. */
+export const resolvePos = (component: Ir.Component, grid?: typeof DEFAULT_GRID): Ir.Point => {
+  if (component.pos) {
+    return component.pos;
+  }
+  const { row, col } = component;
+  if (!grid || !Number.isInteger(row) || !Number.isInteger(col)) {
+    return [NaN, NaN];
+  }
+  const [ox, oy] = grid.origin;
+  return [ox + (col ?? 0) * (grid.cellW + grid.gapX), oy + (row ?? 0) * (grid.cellH + grid.gapY)];
+};
+
+const measure = (component: Ir.Component, grid?: typeof DEFAULT_GRID): ComponentRect => {
+  const [x, y] = resolvePos(component, grid);
+  const [width, height] = component.size ?? [DEFAULTS.width, DEFAULTS.height];
+  return { ...component, x, y, width, height, cx: x + width / 2, cy: y + height / 2 };
+};
+
+const boundaryRect = (boundary: Ir.Boundary, byId: Map<string, ComponentRect>): BoundaryRect | undefined => {
+  const members = boundary.wraps.map((id) => byId.get(id)).filter((member): member is ComponentRect => !!member);
+  if (!members.length) {
+    return undefined;
+  }
+  const minX = Math.min(...members.map((member) => member.x));
+  const minY = Math.min(...members.map((member) => member.y));
+  const maxX = Math.max(...members.map((member) => member.x + member.width));
+  const maxY = Math.max(...members.map((member) => member.y + member.height));
+  const pad = boundary.pad ?? DEFAULTS.boundaryPad;
+  // The label sits on the boundary's top rail, so the top pad has to clear its baseline.
+  const topPad = Math.max(pad, DEFAULTS.boundaryLabelBaseline + DEFAULTS.boundaryLabelClearance);
+  const x = minX - pad;
+  const y = minY - topPad;
+  const width = maxX - minX + pad * 2;
+  const height = maxY - minY + topPad + DEFAULTS.boundaryExtraBottom;
+  return { ...boundary, x, y, width, height, cx: x + width / 2, cy: y + height / 2, memberTop: minY };
+};
+
+export const anchor = (rect: Rect, side: Ir.Side): Ir.Point => {
+  switch (side) {
+    case 'left':
+      return [rect.x, rect.cy];
+    case 'right':
+      return [rect.x + rect.width, rect.cy];
+    case 'top':
+      return [rect.cx, rect.y];
+    case 'bottom':
+      return [rect.cx, rect.y + rect.height];
+  }
+};
+
+/** The side a connection leaves from when the author did not choose one. */
+export const defaultFromSide = (from: Rect, to: Rect): Ir.Side => {
+  if (to.cx < from.cx) {
+    return 'left';
+  }
+  if (to.cx > from.cx) {
+    return 'right';
+  }
+  return to.cy > from.cy ? 'bottom' : 'top';
+};
+
+export const defaultToSide = (from: Rect, to: Rect): Ir.Side => {
+  if (to.cx < from.cx) {
+    return 'right';
+  }
+  if (to.cx > from.cx) {
+    return 'left';
+  }
+  return to.cy > from.cy ? 'top' : 'bottom';
+};
+
+const OUTWARD: Record<Ir.Side, Ir.Point> = { left: [-1, 0], right: [1, 0], top: [0, -1], bottom: [0, 1] };
+
+const leaves = (from: Ir.Point, to: Ir.Point, side: Ir.Side): boolean => {
+  const [dx, dy] = OUTWARD[side];
+  return (to[0] - from[0]) * dx + (to[1] - from[1]) * dy >= -0.0001;
+};
+
+/** A route is only acceptable if it exits along `fromSide` and arrives against `toSide`. */
+const honorsSides = (points: readonly Ir.Point[], fromSide: Ir.Side, toSide: Ir.Side): boolean =>
+  points.length >= 2 &&
+  leaves(points[0], points[1], fromSide) &&
+  leaves(points[points.length - 1], points[points.length - 2], toSide);
+
+const via = (connection: Ir.Connection, start: Ir.Point, end: Ir.Point, fromSide: Ir.Side, toSide: Ir.Side): Ir.Point[] => {
+  if (connection.via?.length) {
+    return connection.via.map((point) => [point[0], point[1]] as Ir.Point);
+  }
+  const midX = (start[0] + end[0]) / 2;
+  const midY = (start[1] + end[1]) / 2;
+  const horizontalFirst: Ir.Point[] = [
+    [midX, start[1]],
+    [midX, end[1]],
+  ];
+  const verticalFirst: Ir.Point[] = [
+    [start[0], midY],
+    [end[0], midY],
+  ];
+  switch (connection.route ?? 'auto') {
+    case 'straight':
+      return [];
+    case 'orthogonal-h':
+      return horizontalFirst;
+    case 'orthogonal-v':
+      return verticalFirst;
+    default: {
+      // A straight line is the least noisy route whenever the anchors already line up.
+      const alignedEnough = Math.abs(start[0] - end[0]) < 4 || Math.abs(start[1] - end[1]) < 4;
+      if (alignedEnough && honorsSides([start, end], fromSide, toSide)) {
+        return [];
+      }
+      const candidate = [horizontalFirst, verticalFirst].find((points) =>
+        honorsSides([start, ...points, end], fromSide, toSide),
+      );
+      return candidate ?? horizontalFirst;
+    }
+  }
+};
+
+/** Drops duplicate and collinear waypoints so corner rounding has real corners to work with. */
+const normalize = (points: readonly Ir.Point[]): Ir.Point[] => {
+  const result: Ir.Point[] = [];
+  for (const point of points) {
+    const previous = result.at(-1);
+    if (previous && Math.abs(point[0] - previous[0]) < 0.0001 && Math.abs(point[1] - previous[1]) < 0.0001) {
+      continue;
+    }
+    while (result.length >= 2) {
+      const [ax, ay] = result[result.length - 2];
+      const [bx, by] = result[result.length - 1];
+      const cross = (bx - ax) * (point[1] - by) - (by - ay) * (point[0] - bx);
+      const forward = (bx - ax) * (point[0] - bx) + (by - ay) * (point[1] - by) >= -0.0001;
+      if (Math.abs(cross) > 0.0001 || !forward) {
+        break;
+      }
+      result.pop();
+    }
+    result.push(point);
+  }
+  return result;
+};
+
+export const roundedPath = (points: readonly Ir.Point[], radius: number): string => {
+  if (points.length < 3 || radius <= 0) {
+    return points.map(([x, y], index) => `${index === 0 ? 'M' : 'L'} ${x} ${y}`).join(' ');
+  }
+  const commands = [`M ${points[0][0]} ${points[0][1]}`];
+  for (let index = 1; index < points.length - 1; index++) {
+    const [px, py] = points[index - 1];
+    const [cx, cy] = points[index];
+    const [nx, ny] = points[index + 1];
+    const previousLength = Math.hypot(cx - px, cy - py);
+    const nextLength = Math.hypot(nx - cx, ny - cy);
+    const r = Math.min(radius, previousLength / 2, nextLength / 2);
+    if (r < 1) {
+      commands.push(`L ${cx} ${cy}`);
+      continue;
+    }
+    commands.push(`L ${cx - ((cx - px) / previousLength) * r} ${cy - ((cy - py) / previousLength) * r}`);
+    commands.push(`Q ${cx} ${cy} ${cx + ((nx - cx) / nextLength) * r} ${cy + ((ny - cy) / nextLength) * r}`);
+  }
+  const [endX, endY] = points[points.length - 1];
+  commands.push(`L ${endX} ${endY}`);
+  return commands.join(' ');
+};
+
+/** Label anchor: explicit `labelAt`, else the midpoint of the chosen segment, nudged up 10px. */
+export const labelPoint = (connection: Ir.Connection, points: readonly Ir.Point[]): Ir.Point => {
+  if (connection.labelAt) {
+    return [connection.labelAt[0], connection.labelAt[1]];
+  }
+  const dx = connection.labelDx ?? 0;
+  const dy = connection.labelDy ?? 0;
+  if (points.length === 2) {
+    return [(points[0][0] + points[1][0]) / 2 + dx, points[0][1] - 10 + dy];
+  }
+  const index = Math.min(points.length - 2, Math.max(0, connection.labelSegment ?? 1));
+  const [ax, ay] = points[index];
+  const [bx, by] = points[index + 1];
+  return [(ax + bx) / 2 + dx, (ay + by) / 2 - 10 + dy];
+};
+
+const TYPE_ORDER: Ir.Component['type'][] = [
+  'frontend',
+  'backend',
+  'database',
+  'cloud',
+  'security',
+  'messagebus',
+  'external',
+];
+
+/** Resolves an IR document into everything the SVG renderer needs, and nothing more. */
+export const resolve = (diagram: Ir.Architecture): ResolvedDiagram => {
+  const grid = gridOf(diagram);
+  const components = diagram.components.map((component) => measure(component, grid));
+  const byId = new Map(components.map((component) => [component.id, component]));
+  const boundaries = (diagram.boundaries ?? [])
+    .map((boundary) => boundaryRect(boundary, byId))
+    .filter((boundary): boundary is BoundaryRect => !!boundary);
+
+  const connections: ResolvedConnection[] = [];
+  for (const [index, connection] of (diagram.connections ?? []).entries()) {
+    const from = byId.get(connection.from);
+    const to = byId.get(connection.to);
+    if (!from || !to || !Number.isFinite(from.x) || !Number.isFinite(to.x)) {
+      continue;
+    }
+    const fromSide = connection.fromSide ?? defaultFromSide(from, to);
+    const toSide = connection.toSide ?? defaultToSide(from, to);
+    const start = anchor(from, fromSide);
+    const end = anchor(to, toSide);
+    const points = normalize([start, ...via(connection, start, end, fromSide, toSide), end]);
+    connections.push({
+      key: connection.id ?? `${connection.from}-${connection.to}-${index}`,
+      connection,
+      points,
+      path: roundedPath(points, DEFAULTS.cornerRadius),
+      label: connection.label ? { text: connection.label, at: labelPoint(connection, points) } : undefined,
+    });
+  }
+
+  const xs: number[] = [];
+  const ys: number[] = [];
+  for (const rect of [...components.filter((component) => Number.isFinite(component.x)), ...boundaries]) {
+    xs.push(rect.x, rect.x + rect.width);
+    ys.push(rect.y, rect.y + rect.height);
+  }
+  for (const { points } of connections) {
+    for (const [x, y] of points) {
+      xs.push(x);
+      ys.push(y);
+    }
+  }
+  const minX = Math.min(0, ...xs) - DEFAULTS.margin;
+  const minY = Math.min(0, ...ys) - DEFAULTS.margin;
+  const maxX = Math.max(DEFAULTS.margin, ...xs) + DEFAULTS.margin;
+  const maxY = Math.max(DEFAULTS.margin, ...ys) + DEFAULTS.margin;
+  const [boxW, boxH] = diagram.meta.viewBox ?? [maxX - minX, maxY - minY];
+
+  const present = new Set(components.map((component) => component.type));
+  return {
+    components,
+    boundaries,
+    connections,
+    viewBox: `${minX} ${minY} ${boxW} ${boxH}`,
+    usedTypes: TYPE_ORDER.filter((type) => present.has(type)),
+  };
+};
+
+/** Ids reachable from `roots` by following connections in the given direction. */
+export const reach = (
+  diagram: Ir.Architecture,
+  roots: readonly string[],
+  direction: 'downstream' | 'upstream' | 'both',
+): Set<string> => {
+  const edges = diagram.connections ?? [];
+  const seen = new Set(roots);
+  const queue = [...roots];
+  for (let cursor = 0; cursor < queue.length; cursor++) {
+    const id = queue[cursor];
+    for (const edge of edges) {
+      const next =
+        direction !== 'upstream' && edge.from === id
+          ? edge.to
+          : direction !== 'downstream' && edge.to === id
+            ? edge.from
+            : undefined;
+      if (next && !seen.has(next)) {
+        seen.add(next);
+        queue.push(next);
+      }
+    }
+  }
+  return seen;
+};

--- a/packages/plugins/plugin-archify/src/model/Layout.ts
+++ b/packages/plugins/plugin-archify/src/model/Layout.ts
@@ -153,7 +153,13 @@ const honorsSides = (points: readonly Ir.Point[], fromSide: Ir.Side, toSide: Ir.
   leaves(points[0], points[1], fromSide) &&
   leaves(points[points.length - 1], points[points.length - 2], toSide);
 
-const via = (connection: Ir.Connection, start: Ir.Point, end: Ir.Point, fromSide: Ir.Side, toSide: Ir.Side): Ir.Point[] => {
+const via = (
+  connection: Ir.Connection,
+  start: Ir.Point,
+  end: Ir.Point,
+  fromSide: Ir.Side,
+  toSide: Ir.Side,
+): Ir.Point[] => {
   if (connection.via?.length) {
     return connection.via.map((point) => [point[0], point[1]] as Ir.Point);
   }

--- a/packages/plugins/plugin-archify/src/model/Palette.ts
+++ b/packages/plugins/plugin-archify/src/model/Palette.ts
@@ -1,0 +1,119 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as Ir from './Ir';
+
+/**
+ * Archify's classic preset, transcribed from `archify/assets/template.html`. Colours are literal
+ * rather than theme tokens on purpose: the seven component roles and four relationship variants
+ * are a fixed semantic vocabulary — a reader who learns "violet means storage" in one diagram must
+ * read the next one the same way, so they cannot follow a workspace accent hue.
+ */
+export type Swatch = { fill: string; stroke: string };
+
+export type Palette = {
+  grid: string;
+  text: string;
+  textMuted: string;
+  textDim: string;
+  /** Opaque colour painted behind translucent component fills so routes do not show through. */
+  mask: string;
+  arrow: string;
+  arrowEmphasis: string;
+  lane: Swatch;
+  component: Record<Ir.ComponentType, Swatch>;
+  dot: Record<Ir.DotColor, string>;
+};
+
+const DARK: Palette = {
+  grid: '#1e293b',
+  text: '#e2e8f0',
+  textMuted: '#94a3b8',
+  textDim: '#64748b',
+  mask: '#0f172a',
+  arrow: '#64748b',
+  arrowEmphasis: '#34d399',
+  lane: { fill: 'rgba(15, 23, 42, 0.22)', stroke: '#334155' },
+  component: {
+    frontend: { fill: 'rgba(8, 51, 68, 0.4)', stroke: '#22d3ee' },
+    backend: { fill: 'rgba(6, 78, 59, 0.4)', stroke: '#34d399' },
+    database: { fill: 'rgba(76, 29, 149, 0.4)', stroke: '#a78bfa' },
+    cloud: { fill: 'rgba(120, 53, 15, 0.3)', stroke: '#fbbf24' },
+    security: { fill: 'rgba(136, 19, 55, 0.4)', stroke: '#fb7185' },
+    messagebus: { fill: 'rgba(251, 146, 60, 0.3)', stroke: '#fb923c' },
+    external: { fill: 'rgba(30, 41, 59, 0.5)', stroke: '#94a3b8' },
+  },
+  dot: {
+    cyan: '#22d3ee',
+    emerald: '#34d399',
+    violet: '#a78bfa',
+    amber: '#fbbf24',
+    rose: '#fb7185',
+    orange: '#fb923c',
+    slate: '#94a3b8',
+  },
+};
+
+const LIGHT: Palette = {
+  grid: '#e2e8f0',
+  text: '#0f172a',
+  textMuted: '#64748b',
+  textDim: '#94a3b8',
+  mask: '#ffffff',
+  arrow: '#94a3b8',
+  arrowEmphasis: '#059669',
+  lane: { fill: 'rgba(248, 250, 252, 0.65)', stroke: '#cbd5e1' },
+  component: {
+    frontend: { fill: 'rgba(34, 211, 238, 0.15)', stroke: '#0891b2' },
+    backend: { fill: 'rgba(52, 211, 153, 0.18)', stroke: '#059669' },
+    database: { fill: 'rgba(167, 139, 250, 0.2)', stroke: '#7c3aed' },
+    cloud: { fill: 'rgba(251, 191, 36, 0.18)', stroke: '#d97706' },
+    security: { fill: 'rgba(251, 113, 133, 0.15)', stroke: '#e11d48' },
+    messagebus: { fill: 'rgba(251, 146, 60, 0.15)', stroke: '#ea580c' },
+    external: { fill: 'rgba(148, 163, 184, 0.18)', stroke: '#64748b' },
+  },
+  dot: {
+    cyan: '#0891b2',
+    emerald: '#059669',
+    violet: '#7c3aed',
+    amber: '#d97706',
+    rose: '#e11d48',
+    orange: '#ea580c',
+    slate: '#64748b',
+  },
+};
+
+export const paletteFor = (themeMode: 'dark' | 'light'): Palette => (themeMode === 'dark' ? DARK : LIGHT);
+
+/** Stroke colour, dash pattern and width for each relationship variant. */
+export const connectionStyle = (palette: Palette, variant: Ir.Variant = 'default', width?: number) => {
+  switch (variant) {
+    case 'emphasis':
+      return { stroke: palette.arrowEmphasis, dash: undefined, width: width ?? 2 };
+    case 'security':
+      return { stroke: palette.component.security.stroke, dash: undefined, width: width ?? 1.5 };
+    case 'dashed':
+      return { stroke: palette.component.messagebus.stroke, dash: '6 4', width: width ?? 1.5 };
+    default:
+      return { stroke: palette.arrow, dash: undefined, width: width ?? 1.5 };
+  }
+};
+
+/** Edge labels take the variant's accent so the label reads as part of the relationship. */
+export const labelColor = (palette: Palette, variant: Ir.Variant = 'default'): string =>
+  connectionStyle(palette, variant).stroke === palette.arrow
+    ? palette.textMuted
+    : connectionStyle(palette, variant).stroke;
+
+export const LEGEND_LABELS: Record<Ir.ComponentType, string> = {
+  frontend: 'Frontend',
+  backend: 'Backend',
+  database: 'Data store',
+  cloud: 'Cloud service',
+  security: 'Security',
+  messagebus: 'Message bus',
+  external: 'External',
+};

--- a/packages/plugins/plugin-archify/src/model/Palette.ts
+++ b/packages/plugins/plugin-archify/src/model/Palette.ts
@@ -86,6 +86,7 @@ const LIGHT: Palette = {
   },
 };
 
+/** The palette for a theme mode; the two are the same vocabulary at different luminance. */
 export const paletteFor = (themeMode: 'dark' | 'light'): Palette => (themeMode === 'dark' ? DARK : LIGHT);
 
 /** Stroke colour, dash pattern and width for each relationship variant. */

--- a/packages/plugins/plugin-archify/src/model/Validate.test.ts
+++ b/packages/plugins/plugin-archify/src/model/Validate.test.ts
@@ -1,0 +1,117 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import * as Ir from './Ir';
+import { webApp } from './testing';
+import * as Validate from './Validate';
+
+const codes = (source: unknown) => Validate.validate(source).diagnostics.map((diagnostic) => diagnostic.code);
+
+const minimal = (rest: Partial<Ir.Architecture> = {}): Ir.Architecture => ({
+  schema_version: 1,
+  diagram_type: 'architecture',
+  meta: { title: 'test' },
+  components: [
+    { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+    { id: 'b', type: 'backend', label: 'b', pos: [400, 0], size: [100, 50] },
+  ],
+  connections: [{ from: 'a', to: 'b' }],
+  ...rest,
+});
+
+describe('validate', () => {
+  test('upstream’s own reference document passes', ({ expect }) => {
+    const { ok, diagnostics } = Validate.validate(webApp);
+    expect(diagnostics.filter((diagnostic) => diagnostic.severity === 'error')).toEqual([]);
+    expect(ok).toBe(true);
+  });
+
+  test('a malformed document reports the field, not a stack trace', ({ expect }) => {
+    const { ok, diagnostics } = Validate.validate({ schema_version: 1, diagram_type: 'architecture', meta: {}, components: [] });
+    expect(ok).toBe(false);
+    expect(diagnostics.every((diagnostic) => diagnostic.code === 'schema/invalid')).toBe(true);
+    expect(diagnostics.some((diagnostic) => diagnostic.subject.path === 'meta.title')).toBe(true);
+  });
+
+  test('an unplaced component blocks, and suppresses the geometric rules', ({ expect }) => {
+    const result = Validate.validate(minimal({ components: [{ id: 'a', type: 'backend', label: 'a' }], connections: [] }));
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(['layout/unplaced']);
+    expect(result.diagnostics[0].supportedFixes).toContain('components[].pos');
+  });
+
+  test('grid collisions and overflow are caught before anything is drawn', ({ expect }) => {
+    expect(
+      codes(
+        minimal({
+          layout: { mode: 'grid', cols: 2 },
+          components: [
+            { id: 'a', type: 'backend', label: 'a', row: 0, col: 0 },
+            { id: 'b', type: 'backend', label: 'b', row: 0, col: 0 },
+            { id: 'c', type: 'backend', label: 'c', row: 0, col: 5 },
+          ],
+          connections: [],
+        }),
+      ),
+    ).toEqual(expect.arrayContaining(['layout/grid-collision', 'layout/grid-overflow']));
+  });
+
+  test('a connection to a component that does not exist is named with both ends', ({ expect }) => {
+    const [diagnostic] = Validate.validate(minimal({ connections: [{ id: 'x', from: 'a', to: 'ghost' }] })).diagnostics;
+    expect(diagnostic.code).toBe('connection/unknown-endpoint');
+    expect(diagnostic.subject).toMatchObject({ connection: 'x', end: 'to' });
+  });
+
+  test('overlapping components fail', ({ expect }) => {
+    expect(
+      codes(
+        minimal({
+          components: [
+            { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+            { id: 'b', type: 'backend', label: 'b', pos: [50, 20], size: [100, 50] },
+          ],
+        }),
+      ),
+    ).toContain('layout/component-overlap');
+  });
+
+  test('a route through a third component is a repairable error', ({ expect }) => {
+    const [diagnostic] = Validate.validate(
+      minimal({
+        components: [
+          { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+          { id: 'blocker', type: 'backend', label: 'blocker', pos: [200, 0], size: [100, 50] },
+          { id: 'b', type: 'backend', label: 'b', pos: [400, 0], size: [100, 50] },
+        ],
+        connections: [{ id: 'through', from: 'a', to: 'b', fromSide: 'right', toSide: 'left' }],
+      }),
+    ).diagnostics;
+
+    expect(diagnostic.code).toBe('route/crosses-component');
+    expect(diagnostic.subject).toMatchObject({ connection: 'through', component: 'blocker' });
+    expect(diagnostic.supportedFixes).toContain('connections[].via');
+  });
+
+  test('a disconnected component warns without blocking the write', ({ expect }) => {
+    const result = Validate.validate(
+      minimal({
+        components: [
+          { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+          { id: 'b', type: 'backend', label: 'b', pos: [400, 0], size: [100, 50] },
+          { id: 'lonely', type: 'external', label: 'lonely', pos: [0, 400], size: [100, 50] },
+        ],
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain('graph/orphan');
+  });
+
+  test('the decoded document is returned so callers store what was checked', ({ expect }) => {
+    const { document } = Validate.validate({ ...webApp, meta: { ...webApp.meta, output: 'ignored.html' } });
+    expect(document?.meta).not.toHaveProperty('output');
+  });
+});

--- a/packages/plugins/plugin-archify/src/model/Validate.test.ts
+++ b/packages/plugins/plugin-archify/src/model/Validate.test.ts
@@ -37,19 +37,17 @@ describe('validate', () => {
   });
 
   test('grid collisions and overflow are caught before anything is drawn', ({ expect }) => {
-    expect(
-      codes(
-        minimal({
-          layout: { mode: 'grid', cols: 2 },
-          components: [
-            { id: 'a', type: 'backend', label: 'a', row: 0, col: 0 },
-            { id: 'b', type: 'backend', label: 'b', row: 0, col: 0 },
-            { id: 'c', type: 'backend', label: 'c', row: 0, col: 5 },
-          ],
-          connections: [],
-        }),
-      ),
-    ).toEqual(expect.arrayContaining(['layout/grid-collision', 'layout/grid-overflow']));
+    const source = minimal({
+      layout: { mode: 'grid', cols: 2 },
+      components: [
+        { id: 'a', type: 'backend', label: 'a', row: 0, col: 0 },
+        { id: 'b', type: 'backend', label: 'b', row: 0, col: 0 },
+        { id: 'c', type: 'backend', label: 'c', row: 0, col: 5 },
+      ],
+      connections: [],
+    });
+
+    expect(codes(source)).toEqual(expect.arrayContaining(['layout/grid-collision', 'layout/grid-overflow']));
   });
 
   test('a connection to a component that does not exist is named with both ends', ({ expect }) => {
@@ -59,29 +57,25 @@ describe('validate', () => {
   });
 
   test('overlapping components fail', ({ expect }) => {
-    expect(
-      codes(
-        minimal({
-          components: [
-            { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
-            { id: 'b', type: 'backend', label: 'b', pos: [50, 20], size: [100, 50] },
-          ],
-        }),
-      ),
-    ).toContain('layout/component-overlap');
+    const source = minimal({
+      components: [
+        { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+        { id: 'b', type: 'backend', label: 'b', pos: [50, 20], size: [100, 50] },
+      ],
+    });
+
+    expect(codes(source)).toContain('layout/component-overlap');
   });
 
   test('components closer than the minimum gap fail even when they do not intersect', ({ expect }) => {
-    expect(
-      codes(
-        minimal({
-          components: [
-            { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
-            { id: 'b', type: 'backend', label: 'b', pos: [110, 0], size: [100, 50] },
-          ],
-        }),
-      ),
-    ).toContain('layout/component-overlap');
+    const source = minimal({
+      components: [
+        { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+        { id: 'b', type: 'backend', label: 'b', pos: [110, 0], size: [100, 50] },
+      ],
+    });
+
+    expect(codes(source)).toContain('layout/component-overlap');
   });
 
   test('a label sitting over the lower half of a component is still caught', ({ expect }) => {
@@ -119,15 +113,15 @@ describe('validate', () => {
   });
 
   test('a disconnected component warns without blocking the write', ({ expect }) => {
-    const result = Validate.validate(
-      minimal({
-        components: [
-          { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
-          { id: 'b', type: 'backend', label: 'b', pos: [400, 0], size: [100, 50] },
-          { id: 'lonely', type: 'external', label: 'lonely', pos: [0, 400], size: [100, 50] },
-        ],
-      }),
-    );
+    const source = minimal({
+      components: [
+        { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+        { id: 'b', type: 'backend', label: 'b', pos: [400, 0], size: [100, 50] },
+        { id: 'lonely', type: 'external', label: 'lonely', pos: [0, 400], size: [100, 50] },
+      ],
+    });
+
+    const result = Validate.validate(source);
 
     expect(result.ok).toBe(true);
     expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain('graph/orphan');

--- a/packages/plugins/plugin-archify/src/model/Validate.test.ts
+++ b/packages/plugins/plugin-archify/src/model/Validate.test.ts
@@ -30,14 +30,21 @@ describe('validate', () => {
   });
 
   test('a malformed document reports the field, not a stack trace', ({ expect }) => {
-    const { ok, diagnostics } = Validate.validate({ schema_version: 1, diagram_type: 'architecture', meta: {}, components: [] });
+    const { ok, diagnostics } = Validate.validate({
+      schema_version: 1,
+      diagram_type: 'architecture',
+      meta: {},
+      components: [],
+    });
     expect(ok).toBe(false);
     expect(diagnostics.every((diagnostic) => diagnostic.code === 'schema/invalid')).toBe(true);
     expect(diagnostics.some((diagnostic) => diagnostic.subject.path === 'meta.title')).toBe(true);
   });
 
   test('an unplaced component blocks, and suppresses the geometric rules', ({ expect }) => {
-    const result = Validate.validate(minimal({ components: [{ id: 'a', type: 'backend', label: 'a' }], connections: [] }));
+    const result = Validate.validate(
+      minimal({ components: [{ id: 'a', type: 'backend', label: 'a' }], connections: [] }),
+    );
     expect(result.ok).toBe(false);
     expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(['layout/unplaced']);
     expect(result.diagnostics[0].supportedFixes).toContain('components[].pos');

--- a/packages/plugins/plugin-archify/src/model/Validate.test.ts
+++ b/packages/plugins/plugin-archify/src/model/Validate.test.ts
@@ -8,20 +8,6 @@ import * as Ir from './Ir';
 import { webApp } from './testing';
 import * as Validate from './Validate';
 
-const codes = (source: unknown) => Validate.validate(source).diagnostics.map((diagnostic) => diagnostic.code);
-
-const minimal = (rest: Partial<Ir.Architecture> = {}): Ir.Architecture => ({
-  schema_version: 1,
-  diagram_type: 'architecture',
-  meta: { title: 'test' },
-  components: [
-    { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
-    { id: 'b', type: 'backend', label: 'b', pos: [400, 0], size: [100, 50] },
-  ],
-  connections: [{ from: 'a', to: 'b' }],
-  ...rest,
-});
-
 describe('validate', () => {
   test('upstream’s own reference document passes', ({ expect }) => {
     const { ok, diagnostics } = Validate.validate(webApp);
@@ -85,6 +71,36 @@ describe('validate', () => {
     ).toContain('layout/component-overlap');
   });
 
+  test('components closer than the minimum gap fail even when they do not intersect', ({ expect }) => {
+    expect(
+      codes(
+        minimal({
+          components: [
+            { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+            { id: 'b', type: 'backend', label: 'b', pos: [110, 0], size: [100, 50] },
+          ],
+        }),
+      ),
+    ).toContain('layout/component-overlap');
+  });
+
+  test('a label sitting over the lower half of a component is still caught', ({ expect }) => {
+    const [diagnostic] = Validate.validate(
+      minimal({
+        components: [
+          { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+          { id: 'b', type: 'backend', label: 'b', pos: [400, 0], size: [100, 50] },
+          { id: 'under', type: 'external', label: 'under', pos: [200, 200], size: [120, 60] },
+        ],
+        // Pinned so the label's lower edge, not its baseline, is what covers "under".
+        connections: [{ id: 'edge', from: 'a', to: 'b', label: 'covered', labelAt: [260, 198] }],
+      }),
+    ).diagnostics;
+
+    expect(diagnostic.code).toBe('label/clearance');
+    expect(diagnostic.subject).toMatchObject({ component: 'under' });
+  });
+
   test('a route through a third component is a repairable error', ({ expect }) => {
     const [diagnostic] = Validate.validate(
       minimal({
@@ -121,4 +137,18 @@ describe('validate', () => {
     const { document } = Validate.validate({ ...webApp, meta: { ...webApp.meta, output: 'ignored.html' } });
     expect(document?.meta).not.toHaveProperty('output');
   });
+});
+
+const codes = (source: unknown) => Validate.validate(source).diagnostics.map((diagnostic) => diagnostic.code);
+
+const minimal = (rest: Partial<Ir.Architecture> = {}): Ir.Architecture => ({
+  schema_version: 1,
+  diagram_type: 'architecture',
+  meta: { title: 'test' },
+  components: [
+    { id: 'a', type: 'backend', label: 'a', pos: [0, 0], size: [100, 50] },
+    { id: 'b', type: 'backend', label: 'b', pos: [400, 0], size: [100, 50] },
+  ],
+  connections: [{ from: 'a', to: 'b' }],
+  ...rest,
 });

--- a/packages/plugins/plugin-archify/src/model/Validate.ts
+++ b/packages/plugins/plugin-archify/src/model/Validate.ts
@@ -50,7 +50,12 @@ const rect = (component: Layout.ComponentRect) => ({
   height: Math.round(component.height),
 });
 
-const overlaps = (a: Layout.ComponentRect, b: Layout.ComponentRect, gap = 0): boolean =>
+/** Archify's boxes need air between them to read as separate; this is the enforced minimum. */
+const MIN_COMPONENT_GAP = 30;
+
+type Box = { x: number; y: number; width: number; height: number };
+
+const overlaps = (a: Box, b: Box, gap = 0): boolean =>
   a.x < b.x + b.width + gap && b.x < a.x + a.width + gap && a.y < b.y + b.height + gap && b.y < a.y + a.height + gap;
 
 /** Whether a segment enters a rect, used for both route clearance and label clearance. */
@@ -205,11 +210,11 @@ const geometric = (diagram: Ir.Architecture, resolved: Layout.ResolvedDiagram): 
 
   for (let i = 0; i < placed.length; i++) {
     for (let j = i + 1; j < placed.length; j++) {
-      if (overlaps(placed[i], placed[j])) {
+      if (overlaps(placed[i], placed[j], MIN_COMPONENT_GAP)) {
         diagnostics.push({
           code: 'layout/component-overlap',
           severity: 'error',
-          message: `Components "${placed[i].id}" and "${placed[j].id}" overlap; move one at least 30px clear.`,
+          message: `Components "${placed[i].id}" and "${placed[j].id}" are less than ${MIN_COMPONENT_GAP}px apart; move one at least ${MIN_COMPONENT_GAP}px clear.`,
           subject: { component: placed[i].id, other: placed[j].id },
           evidence: { a: rect(placed[i]), b: rect(placed[j]) },
           supportedFixes: ['components[].pos', 'components[].size'],
@@ -244,9 +249,8 @@ const geometric = (diagram: Ir.Architecture, resolved: Layout.ResolvedDiagram): 
 
     if (label) {
       const box = labelBox(label.at, label.text);
-      const blocker = placed.find((component) =>
-        segmentHitsRect([box.x, box.y], [box.x + box.width, box.y], component),
-      );
+      // The whole label rect, not just its top edge: a component under the lower half hides it too.
+      const blocker = placed.find((component) => overlaps(box, component));
       if (blocker) {
         const below = Math.round(blocker.y + blocker.height + 14);
         diagnostics.push({

--- a/packages/plugins/plugin-archify/src/model/Validate.ts
+++ b/packages/plugins/plugin-archify/src/model/Validate.ts
@@ -1,0 +1,311 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as Result from 'effect/Result';
+import * as Schema from 'effect/Schema';
+import * as SchemaIssue from 'effect/SchemaIssue';
+
+import * as Ir from './Ir';
+import * as Layout from './Layout';
+
+/**
+ * Archify's contract is that a diagram is checked before it is shown, and that a rejection is a
+ * repair instruction rather than an opinion: every diagnostic names a rule `code`, the `subject`
+ * it is about, the `evidence` that produced it, and the `supportedFixes` — the IR fields the
+ * author may change to clear it. The agent loop depends on that: it edits the named field and
+ * re-validates, instead of guessing.
+ */
+export type Diagnostic = {
+  code: string;
+  severity: 'error' | 'warning';
+  message: string;
+  subject: Record<string, string | number>;
+  evidence: Record<string, unknown>;
+  supportedFixes: readonly string[];
+};
+
+export type ValidationResult = {
+  ok: boolean;
+  diagnostics: readonly Diagnostic[];
+  /** The decoded document, present whenever the source parsed — callers store this, not the input. */
+  document?: Ir.Architecture;
+};
+
+/** Effect 4's standard-schema formatter flattens the issue tree into `{ message, path }`. */
+const formatIssue = SchemaIssue.makeFormatterStandardSchemaV1();
+
+const formatPath = (path: readonly (PropertyKey | { readonly key: PropertyKey })[] | undefined): string =>
+  (path ?? [])
+    .map((segment) => String(typeof segment === 'object' ? segment.key : segment))
+    .map((segment) => (/^\d+$/.test(segment) ? `[${segment}]` : segment))
+    .join('.') || 'architecture';
+
+const rect = (component: Layout.ComponentRect) => ({
+  x: Math.round(component.x),
+  y: Math.round(component.y),
+  width: Math.round(component.width),
+  height: Math.round(component.height),
+});
+
+const overlaps = (a: Layout.ComponentRect, b: Layout.ComponentRect, gap = 0): boolean =>
+  a.x < b.x + b.width + gap && b.x < a.x + a.width + gap && a.y < b.y + b.height + gap && b.y < a.y + a.height + gap;
+
+/** Whether a segment enters a rect, used for both route clearance and label clearance. */
+const segmentHitsRect = (
+  [x1, y1]: Ir.Point,
+  [x2, y2]: Ir.Point,
+  box: { x: number; y: number; width: number; height: number },
+): boolean => {
+  const steps = 32;
+  for (let step = 0; step <= steps; step++) {
+    const t = step / steps;
+    const x = x1 + (x2 - x1) * t;
+    const y = y1 + (y2 - y1) * t;
+    if (x > box.x && x < box.x + box.width && y > box.y && y < box.y + box.height) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/** Rough text box for an edge label; SVG has no measurement outside a document. */
+const labelBox = ([x, y]: Ir.Point, text: string) => {
+  const width = text.length * 5.4 + 10;
+  return { x: x - width / 2, y: y - 12, width, height: 16 };
+};
+
+const structural = (diagram: Ir.Architecture): Diagnostic[] => {
+  const diagnostics: Diagnostic[] = [];
+  const seen = new Set<string>();
+  for (const component of diagram.components) {
+    if (seen.has(component.id)) {
+      diagnostics.push({
+        code: 'id/duplicate',
+        severity: 'error',
+        message: `Two components share the id "${component.id}"; connections and views cannot address either one.`,
+        subject: { component: component.id },
+        evidence: { id: component.id },
+        supportedFixes: ['components[].id'],
+      });
+    }
+    seen.add(component.id);
+  }
+
+  const grid = diagram.layout?.mode === 'grid';
+  const cells = new Map<string, string>();
+  for (const component of diagram.components) {
+    const placed = !!component.pos || (grid && Number.isInteger(component.row) && Number.isInteger(component.col));
+    if (!placed) {
+      diagnostics.push({
+        code: 'layout/unplaced',
+        severity: 'error',
+        message: `Component "${component.id}" has no position: give it pos [x, y], or row/col under layout.mode "grid".`,
+        subject: { component: component.id },
+        evidence: { hasLayout: grid },
+        supportedFixes: ['components[].pos', 'components[].row', 'components[].col', 'layout'],
+      });
+      continue;
+    }
+    if (!grid || component.pos) {
+      continue;
+    }
+    const cols = diagram.layout?.cols ?? 4;
+    if ((component.col ?? 0) >= cols) {
+      diagnostics.push({
+        code: 'layout/grid-overflow',
+        severity: 'error',
+        message: `Component "${component.id}" sits in col ${component.col}, outside layout.cols ${cols} (valid: 0..${cols - 1}).`,
+        subject: { component: component.id },
+        evidence: { col: component.col ?? 0, cols },
+        supportedFixes: ['components[].col', 'layout.cols'],
+      });
+    }
+    const key = `${component.row},${component.col}`;
+    const occupant = cells.get(key);
+    if (occupant) {
+      diagnostics.push({
+        code: 'layout/grid-collision',
+        severity: 'error',
+        message: `Components "${occupant}" and "${component.id}" both claim grid cell row ${component.row} col ${component.col}.`,
+        subject: { component: component.id, other: occupant },
+        evidence: { row: component.row ?? 0, col: component.col ?? 0 },
+        supportedFixes: ['components[].row', 'components[].col'],
+      });
+    } else {
+      cells.set(key, component.id);
+    }
+  }
+
+  for (const [index, connection] of (diagram.connections ?? []).entries()) {
+    for (const [end, id] of [
+      ['from', connection.from],
+      ['to', connection.to],
+    ] as const) {
+      if (!seen.has(id)) {
+        diagnostics.push({
+          code: 'connection/unknown-endpoint',
+          severity: 'error',
+          message: `Connection ${connection.id ?? `#${index}`} points at "${id}", which is not a component id.`,
+          subject: { connection: connection.id ?? `#${index}`, end },
+          evidence: { id, known: [...seen] },
+          supportedFixes: [`connections[].${end}`, 'components[].id'],
+        });
+      }
+    }
+    if (connection.from === connection.to) {
+      diagnostics.push({
+        code: 'connection/self',
+        severity: 'error',
+        message: `Connection ${connection.id ?? `#${index}`} starts and ends at "${connection.from}".`,
+        subject: { connection: connection.id ?? `#${index}` },
+        evidence: { id: connection.from },
+        supportedFixes: ['connections[].from', 'connections[].to'],
+      });
+    }
+  }
+
+  for (const boundary of diagram.boundaries ?? []) {
+    const unknown = boundary.wraps.filter((id) => !seen.has(id));
+    if (unknown.length) {
+      diagnostics.push({
+        code: 'boundary/unknown-member',
+        severity: 'error',
+        message: `Boundary "${boundary.label}" wraps ${unknown.map((id) => `"${id}"`).join(', ')}, which are not components.`,
+        subject: { boundary: boundary.label },
+        evidence: { unknown },
+        supportedFixes: ['boundaries[].wraps'],
+      });
+    }
+  }
+
+  for (const view of diagram.meta.views ?? []) {
+    const unknown = view.focus.filter((id) => !seen.has(id));
+    if (unknown.length) {
+      diagnostics.push({
+        code: 'view/unknown-focus',
+        severity: 'error',
+        message: `Guided view "${view.id}" focuses ${unknown.map((id) => `"${id}"`).join(', ')}, which are not components.`,
+        subject: { view: view.id },
+        evidence: { unknown },
+        supportedFixes: ['meta.views[].focus'],
+      });
+    }
+  }
+
+  return diagnostics;
+};
+
+/** Rules that need resolved geometry: overlaps, route clearance, label clearance. */
+const geometric = (diagram: Ir.Architecture, resolved: Layout.ResolvedDiagram): Diagnostic[] => {
+  const diagnostics: Diagnostic[] = [];
+  const placed = resolved.components.filter((component) => Number.isFinite(component.x));
+
+  for (let i = 0; i < placed.length; i++) {
+    for (let j = i + 1; j < placed.length; j++) {
+      if (overlaps(placed[i], placed[j])) {
+        diagnostics.push({
+          code: 'layout/component-overlap',
+          severity: 'error',
+          message: `Components "${placed[i].id}" and "${placed[j].id}" overlap; move one at least 30px clear.`,
+          subject: { component: placed[i].id, other: placed[j].id },
+          evidence: { a: rect(placed[i]), b: rect(placed[j]) },
+          supportedFixes: ['components[].pos', 'components[].size'],
+        });
+      }
+    }
+  }
+
+  for (const { key, connection, points, label } of resolved.connections) {
+    for (const component of placed) {
+      if (component.id === connection.from || component.id === connection.to) {
+        continue;
+      }
+      const hit = points.slice(0, -1).some((point, index) => segmentHitsRect(point, points[index + 1], component));
+      if (hit) {
+        diagnostics.push({
+          code: 'route/crosses-component',
+          severity: 'error',
+          message: `Connection ${key} runs through component "${component.id}"; route it around with via waypoints or different endpoint sides.`,
+          subject: { connection: key, component: component.id },
+          evidence: { component: rect(component), points },
+          supportedFixes: [
+            'connections[].via',
+            'connections[].fromSide',
+            'connections[].toSide',
+            'connections[].route',
+          ],
+        });
+        break;
+      }
+    }
+
+    if (label) {
+      const box = labelBox(label.at, label.text);
+      const blocker = placed.find((component) =>
+        segmentHitsRect([box.x, box.y], [box.x + box.width, box.y], component),
+      );
+      if (blocker) {
+        const below = Math.round(blocker.y + blocker.height + 14);
+        diagnostics.push({
+          code: 'label/clearance',
+          severity: 'warning',
+          message: `Label "${label.text}" on ${key} sits over component "${blocker.id}"; nudge it with labelDy ${below - Math.round(label.at[1])} or pin it with labelAt.`,
+          subject: { connection: key, component: blocker.id },
+          evidence: { label: box, component: rect(blocker) },
+          supportedFixes: ['connections[].labelAt', 'connections[].labelDx', 'connections[].labelDy'],
+        });
+      }
+    }
+  }
+
+  const orphans = new Set(diagram.components.map((component: Ir.Component) => component.id));
+  for (const connection of diagram.connections ?? []) {
+    orphans.delete(connection.from);
+    orphans.delete(connection.to);
+  }
+  if (diagram.components.length > 1 && orphans.size) {
+    diagnostics.push({
+      code: 'graph/orphan',
+      severity: 'warning',
+      message: `${[...orphans].map((id) => `"${id}"`).join(', ')} have no connections; a reader cannot tell how they participate.`,
+      subject: { components: [...orphans].join(', ') },
+      evidence: { orphans: [...orphans] },
+      supportedFixes: ['connections', 'components'],
+    });
+  }
+
+  return diagnostics;
+};
+
+/**
+ * Validates unknown input end to end: schema first (a shape error makes every geometric rule
+ * meaningless), then structure, then geometry.
+ */
+export const validate = (source: unknown): ValidationResult => {
+  const decoded = Schema.decodeUnknownResult(Ir.Architecture)(source, { errors: 'all' });
+  if (Result.isFailure(decoded)) {
+    return {
+      ok: false,
+      diagnostics: formatIssue(decoded.failure.issue).issues.map(({ message, path }) => ({
+        code: 'schema/invalid',
+        severity: 'error' as const,
+        message,
+        subject: { path: formatPath(path) },
+        evidence: {},
+        supportedFixes: [formatPath(path)],
+      })),
+    };
+  }
+
+  const diagram = decoded.success;
+  const diagnostics = structural(diagram);
+  // Geometry is only meaningful once every component resolves to a rect.
+  const blocking = diagnostics.some(
+    (diagnostic) => diagnostic.severity === 'error' && diagnostic.code.startsWith('layout/'),
+  );
+  const all = blocking ? diagnostics : [...diagnostics, ...geometric(diagram, Layout.resolve(diagram))];
+  return { ok: !all.some((diagnostic) => diagnostic.severity === 'error'), diagnostics: all, document: diagram };
+};

--- a/packages/plugins/plugin-archify/src/model/index.ts
+++ b/packages/plugins/plugin-archify/src/model/index.ts
@@ -1,0 +1,8 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * as Ir from './Ir';
+export * as Layout from './Layout';
+export * as Palette from './Palette';
+export * as Validate from './Validate';

--- a/packages/plugins/plugin-archify/src/model/testing.ts
+++ b/packages/plugins/plugin-archify/src/model/testing.ts
@@ -1,0 +1,228 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Ir } from '#model';
+
+/**
+ * Archify's own `web-app.architecture.json` sample, minus the CLI-only meta keys (`output`,
+ * `quality_profile`). Kept verbatim otherwise so the renderer and validator are exercised against
+ * upstream's reference document rather than something shaped to pass them.
+ */
+export const webApp: Ir.Architecture = {
+  schema_version: 1,
+  diagram_type: 'architecture',
+  meta: {
+    title: 'Sample Web App',
+    views: [
+      {
+        id: 'request-path',
+        label: 'Primary request path',
+        focus: ['users', 'cdn', 'lb', 'api', 'db'],
+        note: 'Follow the primary customer request from the edge to durable state.',
+      },
+      {
+        id: 'identity-and-cache',
+        label: 'Identity and cache',
+        focus: ['auth', 'api', 'cache'],
+        note: 'Isolate authentication and the read-through cache beside the request path.',
+      },
+      {
+        id: 'async-work',
+        label: 'Static and async work',
+        focus: ['cdn', 's3', 'api', 'queue', 'worker'],
+        note: 'See the two secondary paths without adding noise to the main request.',
+      },
+    ],
+  },
+  components: [
+    {
+      id: 'users',
+      type: 'external',
+      label: 'Users',
+      sublabel: 'Browser / Mobile',
+      pos: [40, 300],
+      size: [120, 60],
+    },
+    {
+      id: 'auth',
+      type: 'security',
+      label: 'Auth Provider',
+      sublabel: 'OAuth 2.0',
+      pos: [40, 110],
+      size: [120, 64],
+      tag: 'JWT + PKCE',
+    },
+    {
+      id: 'cdn',
+      type: 'cloud',
+      label: 'CloudFront',
+      sublabel: 'CDN',
+      pos: [250, 300],
+      size: [130, 60],
+    },
+    {
+      id: 'lb',
+      type: 'cloud',
+      label: 'Load Balancer',
+      sublabel: 'HTTPS :443',
+      pos: [460, 300],
+      size: [130, 60],
+    },
+    {
+      id: 'api',
+      type: 'backend',
+      label: 'API Server',
+      sublabel: 'FastAPI :8000',
+      pos: [670, 300],
+      size: [130, 60],
+    },
+    {
+      id: 'cache',
+      type: 'database',
+      label: 'Redis',
+      sublabel: 'cache :6379',
+      pos: [670, 150],
+      size: [130, 60],
+    },
+    {
+      id: 'db',
+      type: 'database',
+      label: 'PostgreSQL',
+      sublabel: 'primary :5432',
+      pos: [880, 300],
+      size: [130, 60],
+    },
+    {
+      id: 's3',
+      type: 'cloud',
+      label: 'S3',
+      sublabel: 'static assets',
+      pos: [250, 440],
+      size: [130, 60],
+      tag: 'OAI protected',
+    },
+    {
+      id: 'queue',
+      type: 'messagebus',
+      label: 'SQS',
+      sublabel: 'job queue',
+      pos: [670, 440],
+      size: [130, 60],
+    },
+    {
+      id: 'worker',
+      type: 'backend',
+      label: 'Worker',
+      sublabel: 'async jobs',
+      pos: [880, 440],
+      size: [130, 60],
+    },
+  ],
+  boundaries: [
+    {
+      kind: 'region',
+      label: 'AWS Region: us-west-2',
+      wraps: ['cdn', 'lb', 'api', 'cache', 'db', 's3', 'queue', 'worker'],
+    },
+    {
+      kind: 'security-group',
+      label: 'sg-api :443/:8000',
+      wraps: ['lb', 'api'],
+    },
+  ],
+  connections: [
+    {
+      id: 'users-to-cdn',
+      from: 'users',
+      to: 'cdn',
+      label: 'HTTPS',
+      variant: 'emphasis',
+    },
+    {
+      id: 'jwt-verification',
+      from: 'auth',
+      to: 'api',
+      label: 'verify JWT',
+      variant: 'security',
+      fromSide: 'right',
+      toSide: 'top',
+      via: [
+        [620, 142],
+        [620, 246],
+        [735, 246],
+      ],
+    },
+    {
+      id: 'cdn-to-lb',
+      from: 'cdn',
+      to: 'lb',
+    },
+    {
+      id: 'static-assets',
+      from: 'cdn',
+      to: 's3',
+      label: 'static',
+      variant: 'dashed',
+      fromSide: 'bottom',
+      toSide: 'top',
+      labelDy: 58,
+    },
+    {
+      id: 'lb-to-api',
+      from: 'lb',
+      to: 'api',
+    },
+    {
+      id: 'cache-read-through',
+      from: 'api',
+      to: 'cache',
+      label: 'read-through',
+      fromSide: 'top',
+      toSide: 'bottom',
+      labelDy: -68,
+    },
+    {
+      id: 'api-sql',
+      from: 'api',
+      to: 'db',
+      label: 'SQL',
+    },
+    {
+      id: 'enqueue-job',
+      from: 'api',
+      to: 'queue',
+      label: 'enqueue',
+      variant: 'dashed',
+      fromSide: 'bottom',
+      toSide: 'top',
+      labelDy: 58,
+    },
+    {
+      id: 'queue-to-worker',
+      from: 'queue',
+      to: 'worker',
+    },
+  ],
+  cards: [
+    {
+      dot: 'cyan',
+      title: 'Edge',
+      items: ['CloudFront CDN fronts all traffic', 'S3 serves static assets via OAI'],
+    },
+    {
+      dot: 'emerald',
+      title: 'Application',
+      items: [
+        'FastAPI behind an HTTPS load balancer',
+        'Redis read-through cache',
+        'Async work drained from SQS by a worker',
+      ],
+    },
+    {
+      dot: 'rose',
+      title: 'Security',
+      items: ['OAuth 2.0 with JWT + PKCE', 'API + LB isolated in a security group'],
+    },
+  ],
+};

--- a/packages/plugins/plugin-archify/src/operations/create.ts
+++ b/packages/plugins/plugin-archify/src/operations/create.ts
@@ -1,0 +1,23 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Operation from '@dxos/compute/Operation';
+
+import { Validate } from '#model';
+import { Diagram, DiagramOperation } from '#types';
+
+const handler: Operation.WithHandler<typeof DiagramOperation.Create> = DiagramOperation.Create.pipe(
+  Operation.withHandler(
+    Effect.fnUntraced(function* ({ name, source }) {
+      const object = Diagram.make({ name, source });
+      // Report on what was actually stored, so a seeded diagram never looks clean by omission.
+      const { ok, diagnostics } = Validate.validate(object.source);
+      return { object, ok, diagnostics };
+    }),
+  ),
+);
+
+export default handler;

--- a/packages/plugins/plugin-archify/src/operations/index.ts
+++ b/packages/plugins/plugin-archify/src/operations/index.ts
@@ -1,0 +1,15 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Operation from '@dxos/compute/Operation';
+import * as OperationHandlerSet from '@dxos/compute/OperationHandlerSet';
+
+import { DiagramOperation } from '#types';
+
+export const ArchifyOperationHandlerSet = OperationHandlerSet.lazy([
+  DiagramOperation.Create.pipe(Operation.lazyHandler(() => import('./create'))),
+  DiagramOperation.Read.pipe(Operation.lazyHandler(() => import('./read'))),
+  DiagramOperation.Verify.pipe(Operation.lazyHandler(() => import('./verify'))),
+  DiagramOperation.Write.pipe(Operation.lazyHandler(() => import('./write'))),
+]);

--- a/packages/plugins/plugin-archify/src/operations/read.ts
+++ b/packages/plugins/plugin-archify/src/operations/read.ts
@@ -1,0 +1,23 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Operation from '@dxos/compute/Operation';
+import { Database } from '@dxos/echo';
+
+import { Validate } from '#model';
+import { DiagramOperation } from '#types';
+
+const handler: Operation.WithHandler<typeof DiagramOperation.Read> = DiagramOperation.Read.pipe(
+  Operation.withHandler(
+    Effect.fnUntraced(function* ({ diagram }) {
+      const object = yield* Database.load(diagram);
+      const { ok, diagnostics } = Validate.validate(object.source);
+      return { source: object.source, ok, diagnostics };
+    }),
+  ),
+);
+
+export default handler;

--- a/packages/plugins/plugin-archify/src/operations/verify.ts
+++ b/packages/plugins/plugin-archify/src/operations/verify.ts
@@ -1,0 +1,21 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Operation from '@dxos/compute/Operation';
+
+import { Validate } from '#model';
+import { DiagramOperation } from '#types';
+
+const handler: Operation.WithHandler<typeof DiagramOperation.Verify> = DiagramOperation.Verify.pipe(
+  Operation.withHandler(
+    Effect.fnUntraced(function* ({ source }) {
+      const { ok, diagnostics } = Validate.validate(source);
+      return { ok, diagnostics };
+    }),
+  ),
+);
+
+export default handler;

--- a/packages/plugins/plugin-archify/src/operations/write.ts
+++ b/packages/plugins/plugin-archify/src/operations/write.ts
@@ -1,0 +1,33 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Operation from '@dxos/compute/Operation';
+import { Database } from '@dxos/echo';
+
+import { Validate } from '#model';
+import { DiagramOperation } from '#types';
+
+/**
+ * Archify's delivery rule: checking happens before the target is replaced, and only a passing
+ * artifact replaces it. A rejected write leaves the previous diagram intact and hands back the
+ * diagnostics that describe the repair.
+ */
+const handler: Operation.WithHandler<typeof DiagramOperation.Write> = DiagramOperation.Write.pipe(
+  Operation.withHandler(
+    Effect.fnUntraced(function* ({ diagram, source }) {
+      const { ok, diagnostics, document } = Validate.validate(source);
+      if (!ok || !document) {
+        return { ok, diagnostics, written: false };
+      }
+      const object = yield* Database.load(diagram);
+      // The decoded document is stored, never the raw input: decoding is what strips unknown keys.
+      object.source = document;
+      return { ok, diagnostics, written: true };
+    }),
+  ),
+);
+
+export default handler;

--- a/packages/plugins/plugin-archify/src/plugin.test.ts
+++ b/packages/plugins/plugin-archify/src/plugin.test.ts
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import * as AppCapabilities from '@dxos/app-toolkit/AppCapabilities';
+import { Type } from '@dxos/echo';
+import * as ClientPlugin from '@dxos/plugin-client/ClientPlugin';
+import { createComposerTestApp } from '@dxos/plugin-testing/harness';
+
+import { ArchifyPlugin } from '#plugin';
+import { Diagram } from '#types';
+
+describe('ArchifyPlugin', () => {
+  test('registers the Diagram schema', async ({ expect }) => {
+    await using harness = await createComposerTestApp({
+      plugins: [ClientPlugin.make({}), ArchifyPlugin()],
+    });
+
+    const typenames = harness
+      .getAll(AppCapabilities.Schema)
+      .flat()
+      .map((schema) => Type.getTypename(schema));
+    expect(typenames).toEqual(expect.arrayContaining([Type.getTypename(Diagram.Diagram)]));
+  });
+});

--- a/packages/plugins/plugin-archify/src/plugin.tsx
+++ b/packages/plugins/plugin-archify/src/plugin.tsx
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Plugin from '@dxos/app-framework/Plugin';
+
+import {
+  CreateObject,
+  OperationHandler,
+  PluginAsset,
+  ReactSurface,
+  Schema,
+  SkillDefinition,
+  Translations,
+} from '#capabilities';
+import { meta } from '#meta';
+
+export const ArchifyPlugin = Plugin.define(meta).pipe(
+  Plugin.addModule(CreateObject),
+  Plugin.addModule(OperationHandler),
+  Plugin.addModule(PluginAsset),
+  Plugin.addModule(ReactSurface),
+  Plugin.addModule(Schema),
+  Plugin.addModule(SkillDefinition),
+  Plugin.addModule(Translations),
+  Plugin.make,
+);
+
+export default ArchifyPlugin;

--- a/packages/plugins/plugin-archify/src/skills/archify-skill.ts
+++ b/packages/plugins/plugin-archify/src/skills/archify-skill.ts
@@ -1,0 +1,82 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Operation from '@dxos/compute/Operation';
+import * as Skill from '@dxos/compute/Skill';
+import * as Template from '@dxos/compute/Template';
+import { trim } from '@dxos/util';
+
+import { DiagramOperation } from '#types';
+
+const SKILL_KEY = 'org.dxos.skill.archify';
+
+const operations = [DiagramOperation.Create, DiagramOperation.Read, DiagramOperation.Verify, DiagramOperation.Write];
+
+const make = () =>
+  Skill.make({
+    key: SKILL_KEY,
+    name: 'Archify',
+    tools: Skill.toolDefinitions({ operations }),
+    instructions: Template.make({
+      source: trim`
+        {{! Archify }}
+
+        You turn a system description — or a codebase you have just read — into an architecture
+        diagram, by authoring a typed JSON document and letting the validator check your layout.
+
+        ## The model
+
+        A diagram is one IR document:
+
+        - "components": the boxes. Each has an "id" (a stable slug), a "type" from
+          frontend | backend | database | cloud | security | messagebus | external, a "label", and
+          usually a "sublabel" (the concrete thing: "FastAPI :8000", "primary :5432"). "tag" is a
+          small stamp above the box for a protocol or guarantee.
+        - "connections": directed relationships. "variant" is the vocabulary — "default" for plain
+          flow, "emphasis" for the primary path, "security" for auth/trust, "dashed" for async.
+        - "boundaries": a labelled frame around a set of component ids ("wraps") — a region, a VPC,
+          a security group. Frames are derived from their members, so you never size them.
+        - "meta.views": up to five guided views, each focusing a handful of ids, so a reader can
+          step through the diagram one story at a time.
+        - "cards": short prose panels beside the diagram, grouped by a colour dot.
+
+        ## Layout is yours
+
+        There is no auto-layout, and that is deliberate: you know which component is the subject and
+        which is supporting, and a generic layered pass does not. Place every component either with
+        "pos": [x, y] (absolute, y grows DOWN) or with "row"/"col" under "layout": { "mode": "grid" }.
+
+        - Read left-to-right along the primary request path, top-to-bottom for depth. Keep 60-80px
+          of gap between boxes; the default box is 120x60.
+        - Set "fromSide"/"toSide" when the automatic choice would route a line across the diagram,
+          and add "via" waypoints when a connection has to go around something.
+        - Move a label with "labelDy" (or pin it with "labelAt") rather than moving the component.
+
+        ## Workflow
+
+        1. Draft the IR. Start from the primary path — the sequence a request actually takes — then
+           hang the secondary paths off it.
+        2. Call ${Operation.toolName(DiagramOperation.Verify)} on the draft. Every finding names a
+           rule "code", the "subject" it is about, and "supportedFixes" — the exact IR fields you may
+           change to clear it. Fix the named field and re-validate; do not restructure the diagram
+           to dodge a finding.
+        3. ${Operation.toolName(DiagramOperation.Create)} a new diagram, or
+           ${Operation.toolName(DiagramOperation.Write)} to replace an existing one. A write with an
+           error-level finding is REJECTED and the diagram on screen is left alone — so validate
+           first rather than discovering it at the write.
+        4. ${Operation.toolName(DiagramOperation.Read)} before editing an existing diagram: it
+           returns the stored IR plus its current report, so your edit builds on what is really there.
+
+        Warnings ("label/clearance", "graph/orphan") do not block a write, but they are the
+        difference between a diagram that renders and one worth reading — clear them too.
+      `,
+    }),
+  });
+
+const skill: Skill.Definition = {
+  key: SKILL_KEY,
+  make,
+};
+
+export default skill;

--- a/packages/plugins/plugin-archify/src/skills/archify-skill.ts
+++ b/packages/plugins/plugin-archify/src/skills/archify-skill.ts
@@ -17,6 +17,9 @@ const make = () =>
   Skill.make({
     key: SKILL_KEY,
     name: 'Archify',
+    // Diagramming is additive and reversible (a rejected write changes nothing), so the agent may
+    // turn the skill on for itself rather than stalling on a settings round trip.
+    agentCanEnable: true,
     tools: Skill.toolDefinitions({ operations }),
     instructions: Template.make({
       source: trim`

--- a/packages/plugins/plugin-archify/src/skills/index.ts
+++ b/packages/plugins/plugin-archify/src/skills/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export { default as ArchifySkill } from './archify-skill';

--- a/packages/plugins/plugin-archify/src/translations.ts
+++ b/packages/plugins/plugin-archify/src/translations.ts
@@ -1,0 +1,32 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Type } from '@dxos/echo';
+import { type Resource } from '@dxos/react-ui';
+
+import { meta } from '#meta';
+import { Diagram } from '#types';
+
+export const translations = [
+  {
+    'en-US': {
+      [Type.getTypename(Diagram.Diagram)]: {
+        'typename.label': 'Diagram',
+        'typename.label_zero': 'Diagrams',
+        'typename.label_one': 'Diagram',
+        'typename.label_other': 'Diagrams',
+        'object-name.placeholder': 'New diagram',
+        'add-object.label': 'Add diagram',
+        'rename-object.label': 'Rename diagram',
+        'delete-object.label': 'Delete diagram',
+        'object-deleted.label': 'Diagram deleted',
+      },
+      [meta.profile.key]: {
+        'plugin.name': 'Archify',
+        'view.all.label': 'Whole diagram',
+        'trace.label': 'Tracing {{id}}',
+      },
+    },
+  },
+] as const satisfies Resource[];

--- a/packages/plugins/plugin-archify/src/translations.ts
+++ b/packages/plugins/plugin-archify/src/translations.ts
@@ -25,7 +25,7 @@ export const translations = [
       [meta.profile.key]: {
         'plugin.name': 'Archify',
         'view.all.label': 'Whole diagram',
-        'trace.label': 'Tracing {{id}}',
+        'trace.label': 'Downstream of {{id}}',
       },
     },
   },

--- a/packages/plugins/plugin-archify/src/types/ArchifyEvents.ts
+++ b/packages/plugins/plugin-archify/src/types/ArchifyEvents.ts
@@ -1,0 +1,12 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as ActivationEvent from '@dxos/app-framework/ActivationEvent';
+
+import { meta } from '#meta';
+
+/** The feature's start event; start-gated modules activate here. */
+export const Start = ActivationEvent.pluginStart(meta.profile.key);

--- a/packages/plugins/plugin-archify/src/types/Diagram.ts
+++ b/packages/plugins/plugin-archify/src/types/Diagram.ts
@@ -44,4 +44,5 @@ export type MakeOptions = {
 export const make = ({ name, source }: MakeOptions = {}): Diagram =>
   Obj.make(Diagram, { name, source: source ?? Ir.emptyArchitecture(name ?? 'Untitled diagram') });
 
+/** Type guard for {@link Diagram} objects. */
 export const isDiagram = (object: unknown): object is Diagram => Obj.instanceOf(Diagram, object);

--- a/packages/plugins/plugin-archify/src/types/Diagram.ts
+++ b/packages/plugins/plugin-archify/src/types/Diagram.ts
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as Schema from 'effect/Schema';
+import * as Struct from 'effect/Struct';
+
+import { Annotation, DXN, Obj, Type } from '@dxos/echo';
+import { LabelAnnotation } from '@dxos/echo/Annotation';
+import { CardAnnotation, CollectionItemAnnotation } from '@dxos/schema';
+
+import { Ir } from '#model';
+
+/**
+ * An Archify diagram: a name and the typed IR that produces it.
+ *
+ * The IR is stored structurally rather than as a JSON blob so that ECHO merges concurrent edits
+ * field by field, and so the agent's tool schema is the diagram schema — the model authors the
+ * same document the renderer consumes, with no serialization step in between.
+ */
+export class Diagram extends Type.makeObject<Diagram>(DXN.make('org.dxos.type.archify.diagram', '0.1.0'))(
+  Schema.Struct({
+    name: Schema.optional(Schema.String),
+    source: Ir.Architecture.annotate({ description: 'The Archify architecture IR rendered by this diagram.' }),
+  })
+    // Agents replace the whole document on every write, so both fields must be assignable.
+    .mapFields(Struct.map(Schema.mutableKey))
+    .pipe(
+      LabelAnnotation.set(['name']),
+      Annotation.IconAnnotation.set({ icon: 'ph--tree-structure--regular', hue: 'cyan' }),
+      CardAnnotation.set(true),
+      CollectionItemAnnotation.set(true),
+    ),
+) {}
+
+export type MakeOptions = {
+  name?: string;
+  source?: Ir.Architecture;
+};
+
+/** Creates a diagram; without a source it starts from a single placeholder component. */
+export const make = ({ name, source }: MakeOptions = {}): Diagram =>
+  Obj.make(Diagram, { name, source: source ?? Ir.emptyArchitecture(name ?? 'Untitled diagram') });
+
+export const isDiagram = (object: unknown): object is Diagram => Obj.instanceOf(Diagram, object);

--- a/packages/plugins/plugin-archify/src/types/DiagramOperation.ts
+++ b/packages/plugins/plugin-archify/src/types/DiagramOperation.ts
@@ -74,7 +74,7 @@ export const Verify = Operation.make({
     icon: 'ph--check-circle--regular',
   },
   input: Schema.Struct({
-    source: Schema.Unknown.annotate({ description: 'The candidate IR document.' }),
+    source: Ir.Architecture.annotate({ description: 'The candidate IR document.' }),
   }),
   output: Schema.Struct(Report),
   services: [],
@@ -90,7 +90,7 @@ export const Write = Operation.make({
   },
   input: Schema.Struct({
     diagram: Ref.Ref(Diagram.Diagram).annotate({ description: 'The diagram to replace.' }),
-    source: Schema.Unknown.annotate({ description: 'The complete replacement IR document.' }),
+    source: Ir.Architecture.annotate({ description: 'The complete replacement IR document.' }),
   }),
   output: Schema.Struct({
     ...Report,

--- a/packages/plugins/plugin-archify/src/types/DiagramOperation.ts
+++ b/packages/plugins/plugin-archify/src/types/DiagramOperation.ts
@@ -1,0 +1,100 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as Schema from 'effect/Schema';
+
+import * as Operation from '@dxos/compute/Operation';
+import { Database, Ref, Type } from '@dxos/echo';
+import { DXN } from '@dxos/keys';
+
+import { Ir } from '#model';
+
+import * as Diagram from './Diagram';
+
+/** One validator finding, shaped so the caller can repair the named field and retry. */
+const Diagnostic = Schema.Struct({
+  code: Schema.String.annotate({ description: 'Rule code, e.g. "route/crosses-component".' }),
+  severity: Schema.Literals(['error', 'warning']),
+  message: Schema.String,
+  subject: Schema.Record(Schema.String, Schema.Unknown).annotate({ description: 'What the finding is about.' }),
+  evidence: Schema.Record(Schema.String, Schema.Unknown).annotate({ description: 'Measurements behind it.' }),
+  supportedFixes: Schema.Array(Schema.String).annotate({ description: 'IR fields that can clear it.' }),
+});
+
+const Report = {
+  ok: Schema.Boolean.annotate({ description: 'False when any diagnostic has severity "error".' }),
+  diagnostics: Schema.Array(Diagnostic),
+};
+
+export const Create = Operation.make({
+  meta: {
+    key: DXN.make('org.dxos.operation.archify.create'),
+    name: 'Create Diagram',
+    description: 'Creates an Archify architecture diagram, optionally seeded with an IR document.',
+    icon: 'ph--tree-structure--regular',
+  },
+  input: Schema.Struct({
+    name: Schema.optional(Schema.String),
+    source: Schema.optional(Ir.Architecture).annotate({ description: 'Initial IR; a placeholder is used if omitted.' }),
+  }),
+  output: Schema.Struct({
+    object: Type.getSchema(Diagram.Diagram),
+    ...Report,
+  }),
+  services: [Database.Service],
+});
+
+export const Read = Operation.make({
+  meta: {
+    key: DXN.make('org.dxos.operation.archify.read'),
+    name: 'Read Diagram',
+    description:
+      'Returns a diagram’s current IR together with its validation report. Call before editing so edits are made against what is actually stored.',
+    icon: 'ph--eye--regular',
+  },
+  input: Schema.Struct({
+    diagram: Ref.Ref(Diagram.Diagram).annotate({ description: 'The diagram to read.' }),
+  }),
+  output: Schema.Struct({
+    source: Ir.Architecture,
+    ...Report,
+  }),
+  services: [Database.Service],
+});
+
+export const Verify = Operation.make({
+  meta: {
+    key: DXN.make('org.dxos.operation.archify.verify'),
+    name: 'Verify Diagram',
+    description:
+      'Checks an IR document without storing it: schema, placement, route clearance and label clearance. Use it to iterate on a draft before writing.',
+    icon: 'ph--check-circle--regular',
+  },
+  input: Schema.Struct({
+    source: Schema.Unknown.annotate({ description: 'The candidate IR document.' }),
+  }),
+  output: Schema.Struct(Report),
+  services: [],
+});
+
+export const Write = Operation.make({
+  meta: {
+    key: DXN.make('org.dxos.operation.archify.write'),
+    name: 'Write Diagram',
+    description:
+      'Replaces a diagram’s IR. The write is rejected when validation reports an error, so a diagram on screen is always one that passed its checks.',
+    icon: 'ph--pencil-simple-line--regular',
+  },
+  input: Schema.Struct({
+    diagram: Ref.Ref(Diagram.Diagram).annotate({ description: 'The diagram to replace.' }),
+    source: Schema.Unknown.annotate({ description: 'The complete replacement IR document.' }),
+  }),
+  output: Schema.Struct({
+    ...Report,
+    written: Schema.Boolean.annotate({ description: 'False when the diagram was left untouched.' }),
+  }),
+  services: [Database.Service],
+});

--- a/packages/plugins/plugin-archify/src/types/index.ts
+++ b/packages/plugins/plugin-archify/src/types/index.ts
@@ -1,0 +1,7 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * as ArchifyEvents from './ArchifyEvents';
+export * as Diagram from './Diagram';
+export * as DiagramOperation from './DiagramOperation';

--- a/packages/plugins/plugin-archify/src/vite-env.d.ts
+++ b/packages/plugins/plugin-archify/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+//
+// Copyright 2026 DXOS.org
+//
+
+declare module '*.mdl?raw' {
+  const content: string;
+  export default content;
+}

--- a/packages/plugins/plugin-archify/tsconfig.json
+++ b/packages/plugins/plugin-archify/tsconfig.json
@@ -19,9 +19,6 @@
   ],
   "references": [
     {
-      "path": "../../common/invariant"
-    },
-    {
       "path": "../../common/keys"
     },
     {

--- a/packages/plugins/plugin-archify/tsconfig.json
+++ b/packages/plugins/plugin-archify/tsconfig.json
@@ -1,0 +1,64 @@
+{
+  "extends": [
+    "../../../tsconfig.base.json"
+  ],
+  "compilerOptions": {
+    "types": [
+      "node"
+    ]
+  },
+  "exclude": [
+    "*.t.ts",
+    "vite.config.ts"
+  ],
+  "include": [
+    "dx.config.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../common/invariant"
+    },
+    {
+      "path": "../../common/keys"
+    },
+    {
+      "path": "../../common/util"
+    },
+    {
+      "path": "../../core/compute/compute"
+    },
+    {
+      "path": "../../core/echo/echo"
+    },
+    {
+      "path": "../../core/echo/echo-react"
+    },
+    {
+      "path": "../../sdk/app-framework"
+    },
+    {
+      "path": "../../sdk/app-toolkit"
+    },
+    {
+      "path": "../../sdk/schema"
+    },
+    {
+      "path": "../../ui/react-ui"
+    },
+    {
+      "path": "../../ui/ui-theme"
+    },
+    {
+      "path": "../plugin-client"
+    },
+    {
+      "path": "../plugin-space"
+    },
+    {
+      "path": "../plugin-testing"
+    }
+  ]
+}

--- a/packages/plugins/plugin-archify/vite.config.ts
+++ b/packages/plugins/plugin-archify/vite.config.ts
@@ -23,5 +23,5 @@ export default defineConfig({
     types: 'src/types/index.ts',
   },
   jsx: 'react',
-  test: { node: true },
+  test: { node: true, storybook: true },
 });

--- a/packages/plugins/plugin-archify/vite.config.ts
+++ b/packages/plugins/plugin-archify/vite.config.ts
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { defineConfig } from '../../../vite.base.config.ts';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    ArchifyPlugin: 'src/ArchifyPlugin.ts',
+    plugin: 'src/plugin.tsx',
+    capabilities: 'src/capabilities/index.ts',
+    components: 'src/components/index.ts',
+    containers: 'src/containers/index.ts',
+    meta: 'src/meta.ts',
+    model: 'src/model/index.ts',
+    operations: 'src/operations/index.ts',
+    skills: 'src/skills/index.ts',
+    translations: 'src/translations.ts',
+    ArchifyEvents: 'src/types/ArchifyEvents.ts',
+    Diagram: 'src/types/Diagram.ts',
+    DiagramOperation: 'src/types/DiagramOperation.ts',
+    types: 'src/types/index.ts',
+  },
+  jsx: 'react',
+  test: { node: true },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7578,9 +7578,6 @@ importers:
       '@dxos/echo-react':
         specifier: workspace:*
         version: link:../../core/echo/echo-react
-      '@dxos/invariant':
-        specifier: workspace:*
-        version: link:../../common/invariant
       '@dxos/keys':
         specifier: workspace:*
         version: link:../../common/keys

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2388,6 +2388,9 @@ importers:
       '@dxos/observability':
         specifier: workspace:*
         version: link:../../sdk/observability
+      '@dxos/plugin-archify':
+        specifier: workspace:*
+        version: link:../../plugins/plugin-archify
       '@dxos/plugin-assistant':
         specifier: workspace:*
         version: link:../../plugins/plugin-assistant
@@ -7557,6 +7560,73 @@ importers:
       react-dom:
         specifier: ~19.2.7
         version: 19.2.7(react@19.2.7)
+
+  packages/plugins/plugin-archify:
+    dependencies:
+      '@dxos/app-framework':
+        specifier: workspace:*
+        version: link:../../sdk/app-framework
+      '@dxos/app-toolkit':
+        specifier: workspace:*
+        version: link:../../sdk/app-toolkit
+      '@dxos/compute':
+        specifier: workspace:*
+        version: link:../../core/compute/compute
+      '@dxos/echo':
+        specifier: workspace:*
+        version: link:../../core/echo/echo
+      '@dxos/echo-react':
+        specifier: workspace:*
+        version: link:../../core/echo/echo-react
+      '@dxos/invariant':
+        specifier: workspace:*
+        version: link:../../common/invariant
+      '@dxos/keys':
+        specifier: workspace:*
+        version: link:../../common/keys
+      '@dxos/plugin-space':
+        specifier: workspace:*
+        version: link:../plugin-space
+      '@dxos/react-ui':
+        specifier: workspace:*
+        version: link:../../ui/react-ui
+      '@dxos/schema':
+        specifier: workspace:*
+        version: link:../../sdk/schema
+      '@dxos/util':
+        specifier: workspace:*
+        version: link:../../common/util
+      effect:
+        specifier: 4.0.0-rc.108
+        version: 4.0.0-rc.108
+    devDependencies:
+      '@dxos/plugin-client':
+        specifier: workspace:*
+        version: link:../plugin-client
+      '@dxos/plugin-testing':
+        specifier: workspace:*
+        version: link:../plugin-testing
+      '@dxos/ui-theme':
+        specifier: workspace:*
+        version: link:../../ui/ui-theme
+      '@storybook/react-vite':
+        specifier: 'catalog:'
+        version: 10.5.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@3.30.0)(storybook@10.5.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.6.2)(react@19.2.7))(vite@8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@types/react':
+        specifier: ~19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ~19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      react:
+        specifier: ~19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ~19.2.7
+        version: 19.2.7(react@19.2.7)
+      vite:
+        specifier: '>=8.2.1'
+        version: 8.2.1(@types/node@22.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/plugins/plugin-assistant:
     dependencies:

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -349,6 +349,9 @@
       "path": "packages/core/compute/pipeline-transcription/tsconfig.json"
     },
     {
+      "path": "packages/plugins/plugin-archify/tsconfig.json"
+    },
+    {
       "path": "packages/plugins/plugin-assistant/tsconfig.json"
     },
     {


### PR DESCRIPTION
Brings [Archify](https://github.com/tt-a1i/archify) into Composer as `@dxos/plugin-archify`: the agent authors a typed JSON IR, a deterministic validator accepts or rejects it with machine-readable repair codes, and the same IR renders to SVG in the article, card, section and slide surfaces.

## Demo

Composer's own assistant builds the diagram and it renders in the article — agent-driven against a local dev server, no scripted data.

[Watch the demo (1:33, 1.8 MB, .webm)](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-09-04-plugin-archify/archify-final.webm)

[Contact sheet — twelve frames from the run](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-09-04-plugin-archify/sheet2.png)

Ask for a diagram in English → the agent drafts the IR, runs `archify-verify`, then `archify-write` → the article shows the diagram with the boundary, the legend and the cards the agent wrote → the guided views it put in `meta.views` filter the reading → clicking a component traces what it reaches downstream.

[Still: the downstream trace in the article](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-09-04-plugin-archify/article-trace.png)

## Why this shape

Archify's premise is that layout is a judgement, not a computation — an agent that can read a codebase can also decide what the subject is, and the tool's job is to check that judgement rather than overrule it with a generic auto-layout pass. Everything below follows from that:

- **The IR is stored, not a rendering.** `Diagram.source` holds the Archify document structurally (not a JSON blob), so ECHO merges edits field by field and the agent's tool schema *is* the diagram schema — no serialization step between what the model writes and what the renderer reads.
- **Placement is authored.** Components carry `pos` or a fixed grid `row`/`col`; boundary frames are derived from their members; routes honour the `fromSide`/`toSide`/`via` the author chose. There is no layout engine to disagree with.
- **A rejection is a repair instruction.** Each diagnostic carries `code`, `subject`, `evidence` and `supportedFixes` — the exact IR fields that clear it — so the agent edits the named field and re-validates instead of guessing.
- **Only a passing artifact replaces the target.** `archify.write` validates first; an error-level finding leaves the stored diagram untouched.

## What was reused, and what wasn't

`plugin-illustrator` was the closest neighbour and this follows its plugin structure throughout: capability layout, subpath `#imports`, lazy plugin entry, article/card surface pairing, skill + operation-handler wiring, `PLUGIN.mdl`.

It is deliberately **not** an illustrator variant. That contract is built around a canvas record store plus a `DrawingBuilder` that compiles the scene DSL onto renderer records; Archify has neither — its IR is a whole document with its own validator and its own delivery rule. Forcing it into a variant would have meant a builder that does nothing and a canvas that stores something that is not canvas records.

## Contents

| Module | What it does |
| --- | --- |
| `model/Ir` | Effect schemas transcribed from `archify/schemas/{common,architecture}.schema.json` |
| `model/Layout` | Grid/absolute placement, member-derived boundary frames, side-honouring routes with rounded corners, measured viewBox, reachability |
| `model/Validate` | Schema, placement, grid collision/overflow, component clearance, route-through-component, label clearance, orphan components |
| `model/Palette` | Archify's classic light/dark palette, kept as literal colours — the seven roles are a fixed reading vocabulary, not a workspace accent |
| `components/ArchifySvg` | Pure SVG renderer with focus dimming and keyboard-reachable selection |
| `containers/*` | Article (guided views, click-to-trace, legend cards) and Card surfaces |
| `operations/*` | `archify.create`, `archify.read`, `archify.verify`, `archify.write` |
| `skills/archify-skill` | The draft → validate → repair → write loop |

Scope: the **architecture** diagram type, upstream's flagship. The model is arranged so the other four (workflow, sequence, dataflow, lifecycle) slot in as sibling IR + layout modules behind the same validator and surface plumbing; they are not in this PR.

## Three bugs the demo found

Driving the real app caught what the tests could not:

1. `verify`/`write` typed `source` as `Schema.Unknown`, which emits an **empty** tool schema — the document never reached the handler, and every input came back as the same `schema/invalid — Expected object`, including a bare string. Typed as the IR now, so the model is shown the whole diagram schema.
2. The skill was not `agentCanEnable`, so the assistant reported Archify as unusable and offered mermaid instead.
3. A bare `Toolbar.Root` inside `Panel.Root` painted its surface over the entire content area — the SVG was rendered, on-screen, and completely invisible. It belongs in `Panel.Toolbar`.

Also from watching it back: click-to-trace used `both`, which walks the whole connected component and lights up every node on a request path. It traces downstream now.

## Review round

From CodeRabbit, each with a regression test where it changed behaviour: the overlap rule now enforces the 30px clearance its message promised (a named `MIN_COMPONENT_GAP`, previously the check was bare intersection); label clearance tests the whole label rect rather than its top edge; pinned label coordinates count toward the measured viewBox so a `labelAt` label is not clipped; component selection is keyboard-reachable (labelled buttons, Enter/Space, `aria-pressed`) with a story that drives it from the keyboard.

Two findings were answered rather than applied — see the threads. CodeRabbit verified and withdrew the `agentCanEnable` one itself (`DatabaseSkill` auto-enables and exposes arbitrary object updates; a diagram write is strictly narrower, and mutation confirmation belongs in the shared invoker). The translations `environments` one is still open and I disagree with it: `environments` names the *additional* non-browser runtimes, and the demo shows those very labels rendering in the browser.

## Tests

`moon run plugin-archify:test` — 20 passing, plus 3 storybook tests. Geometry and validation are exercised against upstream's own `web-app.architecture.json` reference document rather than fixtures shaped to pass:

```
Test Files  3 passed (3)
     Tests  20 passed (20)
```

Lint, format, `knip`, `moon run plugin-archify:build` and `moon run composer-app:build` all pass locally, and CI is green on the head commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdrS7VUCLzzRhCxLRVvnju