### PR TITLE
observability: capture the SDK version on every PostHog event (DX-1256)

### DIFF
--- a/.changeset/wide-pugs-hammer.md
+++ b/.changeset/wide-pugs-hammer.md
@@ -1,0 +1,5 @@
+---
+'@dxos/observability': patch
+---
+
+Every PostHog event now carries the SDK version as `sdkVersion`, alongside the existing app-level `release` property.

--- a/packages/sdk/observability/src/extensions/posthog/extension.ts
+++ b/packages/sdk/observability/src/extensions/posthog/extension.ts
@@ -11,6 +11,7 @@ import { type IdbLogStore } from '@dxos/log-store-idb';
 import { isNode } from '@dxos/util';
 
 import * as ObservabilityExtension from '../../ObservabilityExtension';
+import { DXOS_VERSION } from '../../version';
 import { stubExtension } from '../stub';
 import {
   AI_GENERATION_EVENT,
@@ -146,12 +147,13 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Observabi
             cross_subdomain_cookie: false,
             ...posthogConfig,
           });
-          if (release || environment) {
-            posthog.register({
-              ...(release ? { release } : {}),
-              ...(environment ? { environment } : {}),
-            });
-          }
+          // `sdkVersion` is unconditional: it gates EDGE deprecation, so a host that omits `release`
+          // must still be attributable to an SDK version.
+          posthog.register({
+            sdkVersion: DXOS_VERSION,
+            ...(release ? { release } : {}),
+            ...(environment ? { environment } : {}),
+          });
           unregisterPosthogProcessors?.();
           const removePosthogLog = log.addProcessor(logProcessor);
           unregisterPosthogProcessors = () => {

--- a/packages/sdk/observability/src/extensions/posthog/extension.ts
+++ b/packages/sdk/observability/src/extensions/posthog/extension.ts
@@ -147,8 +147,6 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Observabi
             cross_subdomain_cookie: false,
             ...posthogConfig,
           });
-          // `sdkVersion` is unconditional: it gates EDGE deprecation, so a host that omits `release`
-          // must still be attributable to an SDK version.
           posthog.register({
             sdkVersion: DXOS_VERSION,
             ...(release ? { release } : {}),

--- a/packages/sdk/observability/src/extensions/posthog/node.test.ts
+++ b/packages/sdk/observability/src/extensions/posthog/node.test.ts
@@ -8,6 +8,7 @@ import { Config } from '@dxos/config';
 import { EffectEx } from '@dxos/effect';
 
 import * as ObservabilityExtension from '../../ObservabilityExtension';
+import { DXOS_VERSION } from '../../version';
 import { extensions } from './node';
 
 const DID = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
@@ -57,7 +58,7 @@ describe('posthog node extension', () => {
       {
         distinctId: INSTALLATION_ID,
         event: 'cli.command',
-        properties: { release: '1.2.3', command: 'space list' },
+        properties: { sdkVersion: DXOS_VERSION, release: '1.2.3', command: 'space list' },
       },
     ]);
 

--- a/packages/sdk/observability/src/extensions/posthog/node.ts
+++ b/packages/sdk/observability/src/extensions/posthog/node.ts
@@ -9,6 +9,7 @@ import { log } from '@dxos/log';
 
 import buildSecrets from '../../cli-observability-secrets.json';
 import * as ObservabilityExtension from '../../ObservabilityExtension';
+import { DXOS_VERSION } from '../../version';
 import { stubExtension } from '../stub';
 import { type ExtensionsOptions } from './extension';
 
@@ -58,6 +59,7 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Observabi
     const client = new PostHogMCP(apiKey, { host, enableExceptionAutocapture: true });
 
     const superProperties: ObservabilityExtension.Attributes = {
+      sdkVersion: DXOS_VERSION,
       ...(release ? { release } : {}),
       ...(environment ? { environment } : {}),
     };

--- a/packages/sdk/observability/src/version.ts
+++ b/packages/sdk/observability/src/version.ts
@@ -2,5 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-// Stamped by `scripts/sync-versions.mjs` during `changeset:version`.
 export const DXOS_VERSION = '0.11.1';

--- a/packages/sdk/observability/src/version.ts
+++ b/packages/sdk/observability/src/version.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// Stamped by `scripts/sync-versions.mjs` during `changeset:version`.
+export const DXOS_VERSION = '0.11.1';

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -5,7 +5,8 @@
 
 // Stamps source version files from their owning package's version, so generated artifacts match the
 // version Changesets assigned. Run inside `changeset:version`:
-//   - `version.ts` (DXOS_VERSION) for @dxos/client, @dxos/client-services (Group A) and @dxos/cli (Group B).
+//   - `version.ts` (DXOS_VERSION) for @dxos/client, @dxos/client-services, @dxos/observability (Group A)
+//     and @dxos/cli (Group B).
 //   - `tauri.conf.json` ($.version) for the Composer desktop build (composer-app's own independent line).
 //
 // Each target tracks the version of the package it lives in — no group assumption — so it stays correct
@@ -19,7 +20,12 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const CHECK = process.argv.includes('--check');
 
 // Each version.ts tracks the version of the package directory it lives in.
-const VERSION_TS = ['packages/sdk/client', 'packages/sdk/client-services', 'packages/devtools/cli'].map((pkgDir) => ({
+const VERSION_TS = [
+  'packages/sdk/client',
+  'packages/sdk/client-services',
+  'packages/sdk/observability',
+  'packages/devtools/cli',
+].map((pkgDir) => ({
   versionFile: join(ROOT, pkgDir, 'src/version.ts'),
   packageFile: join(ROOT, pkgDir, 'package.json'),
 }));


### PR DESCRIPTION
Registers `sdkVersion` as a PostHog super property in both the browser and node transports, so every event carries the version of the SDK that produced it.

## Why the SDK version

We want to know which SDK version every device of every identity last ran, and when that device was last seen, so deprecations rest on evidence rather than guesswork. The version that matters is the client's feature set, not the EDGE wire protocol and not the app release. Those already diverge: composer is at 0.11.3 while the SDK is at 0.11.1.

`release` (the app version) stays. "Did the 0.11.3 release break something" is a separate question worth keeping.

## Why now, ahead of the rollup

The property has to exist before any version rollup is built. History accumulated under the app version can't be converted to SDK versions after the fact, because the mapping isn't recoverable from the event. Every week without this is a week of data that can't answer the question.

## Notes on the implementation

The version comes from a local `packages/sdk/observability/src/version.ts` rather than importing `DXOS_VERSION` from `@dxos/client`. That keeps the client barrel out of the browser bundle for what is one string, and matches the existing note in `providers/client-observability.ts` about not reaching values through the client barrels. `scripts/sync-versions.mjs` stamps it alongside the three version files that already exist.

`posthog.register()` in the browser transport was previously gated on `release || environment`. It's now unconditional, since a host that sets neither still needs to be attributable to an SDK version.

`node.test.ts` asserts the exact registered property set, so it needed updating. Good sign the mechanism is actually covered.

## Not in this PR

The per-device rollup needs a device key that's reliably present on events, and `deviceKey` is currently session-scoped and truncated to 8 hex chars. That, the EDGE-side `/auth` inventory, the served version policy, and the client's deprecated/unsupported handling are all written up in DX-1256.

Part of DX-1256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostHog events now include the observability SDK version alongside existing release and environment details.
  * SDK version information is included consistently across web and Node.js integrations.

* **Chores**
  * Added the observability SDK to the project’s version synchronization process.
  * Updated observability package metadata for the patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12953-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
