### PR TITLE
react-ui: count down a toast's remaining time in a bar

### DIFF
--- a/.changeset/toast-countdown-bar.md
+++ b/.changeset/toast-countdown-bar.md
@@ -1,0 +1,6 @@
+---
+'@dxos/react-ui': minor
+---
+
+Toasts that close on a timer now draw a bar that empties as their time runs out, and hold it while
+the pointer is over them. `Progress` gains the `countdown` and `paused` props behind it.

--- a/packages/plugins/plugin-deck/src/containers/Overlays/Toast.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Overlays/Toast.tsx
@@ -9,7 +9,6 @@ import { Button, Toast as NaturalToast, type ToastRootProps, toLocalizedString, 
 
 import { meta } from '#meta';
 
-// TODO(wittjosiah): Render remaining duration as a progress bar within the toast.
 export const Toast = ({
   id,
   title,

--- a/packages/ui/react-ui/src/components/Progress/Progress.stories.tsx
+++ b/packages/ui/react-ui/src/components/Progress/Progress.stories.tsx
@@ -106,10 +106,6 @@ const DefaultStory = ({ indeterminate, error, ...props }: StoryArgs) => {
   );
 };
 
-/**
- * A deadline rather than a task: the bar starts full and empties over `countdown` ms. **Pause**
- * holds it where it is, the way a toast holds its close timer while the pointer is over it.
- */
 const CountdownStory = ({ countdown, ...props }: StoryArgs) => {
   const [paused, setPaused] = useState(false);
   const [run, setRun] = useState(0);
@@ -162,8 +158,7 @@ export const Indeterminate: Story = {
 };
 
 /**
- * Counts down to a deadline the host owns, so the bar empties rather than fills. It carries no
- * value for assistive technology: the host announces what is about to happen.
+ * Counts down to a deadline the host owns, so the bar empties rather than fills.
  */
 export const Countdown: Story = {
   render: CountdownStory,

--- a/packages/ui/react-ui/src/components/Progress/Progress.stories.tsx
+++ b/packages/ui/react-ui/src/components/Progress/Progress.stories.tsx
@@ -106,6 +106,31 @@ const DefaultStory = ({ indeterminate, error, ...props }: StoryArgs) => {
   );
 };
 
+/**
+ * A deadline rather than a task: the bar starts full and empties over `countdown` ms. **Pause**
+ * holds it where it is, the way a toast holds its close timer while the pointer is over it.
+ */
+const CountdownStory = ({ countdown, ...props }: StoryArgs) => {
+  const [paused, setPaused] = useState(false);
+  const [run, setRun] = useState(0);
+
+  return (
+    <Panel.Root>
+      <Panel.Toolbar asChild>
+        <Toolbar.Root>
+          <Toolbar.Button onClick={() => setRun((run) => run + 1)}>Restart</Toolbar.Button>
+          <Toolbar.Button onClick={() => setPaused((paused) => !paused)}>{paused ? 'Resume' : 'Pause'}</Toolbar.Button>
+        </Toolbar.Root>
+      </Panel.Toolbar>
+      <Panel.Content classNames='h-6' />
+      <Panel.Statusbar>
+        {/* Remounting is what restarts a CSS animation, so the run counter is the key. */}
+        <Progress key={run} {...props} countdown={countdown} paused={paused} />
+      </Panel.Statusbar>
+    </Panel.Root>
+  );
+};
+
 const meta = {
   title: 'ui/react-ui-core/components/Progress',
   component: Progress,
@@ -133,5 +158,16 @@ export const Default: Story = {};
 export const Indeterminate: Story = {
   args: {
     indeterminate: true,
+  },
+};
+
+/**
+ * Counts down to a deadline the host owns, so the bar empties rather than fills. It carries no
+ * value for assistive technology: the host announces what is about to happen.
+ */
+export const Countdown: Story = {
+  render: CountdownStory,
+  args: {
+    countdown: 10_000,
   },
 };

--- a/packages/ui/react-ui/src/components/Progress/Progress.theme.ts
+++ b/packages/ui/react-ui/src/components/Progress/Progress.theme.ts
@@ -7,6 +7,8 @@ import type { ComponentFunction, Theme } from '@dxos/ui-types';
 
 export type ProgressStyleProps = {
   indeterminate?: boolean;
+  /** Empties the fill over the caller's duration, for a deadline rather than a task. */
+  countdown?: boolean;
   /** Draws the fill in the error colour, for a run that stopped where it got to. */
   error?: boolean;
 };
@@ -16,14 +18,16 @@ const root: ComponentFunction<ProgressStyleProps> = (_props, ...etc) =>
   // painted in one is invisible against its host.
   mx('block h-1 relative rounded-full overflow-hidden bg-separator', ...etc);
 
-const bar: ComponentFunction<ProgressStyleProps> = ({ indeterminate, error }, ...etc) =>
+const bar: ComponentFunction<ProgressStyleProps> = ({ indeterminate, countdown, error }, ...etc) =>
   mx(
     'absolute inset-y-0 block rounded-full',
     error ? 'bg-error-surface' : 'bg-primary-surface',
     indeterminate
       ? 'animate-progress-indeterminate'
-      : // Ease the width between updates so incremental advances glide rather than jump.
-        'start-0 transition-[width] duration-200 ease-linear',
+      : countdown
+        ? 'start-0 animate-progress-countdown'
+        : // Ease the width between updates so incremental advances glide rather than jump.
+          'start-0 transition-[width] duration-200 ease-linear',
     ...etc,
   );
 

--- a/packages/ui/react-ui/src/components/Progress/Progress.tsx
+++ b/packages/ui/react-ui/src/components/Progress/Progress.tsx
@@ -13,7 +13,7 @@ export type ProgressProps = ThemedClassName<
     Omit<ProgressStyleProps, 'countdown'> & {
       /** How far through, 0..1. Ignored when `indeterminate` or `countdown`. */
       progress?: number;
-      /** Milliseconds to empty the bar over, for a deadline rather than a task. */
+      /** Milliseconds to empty the bar over, for a deadline rather than a task; hidden from AT. */
       countdown?: number;
       /** Holds a `countdown` where it is, for a deadline that has stopped running down. */
       paused?: boolean;
@@ -31,7 +31,6 @@ export const Progress = forwardRef<HTMLSpanElement, ProgressProps>(
     // is being reported is the failure, not a fraction. It stops sweeping for the same reason —
     // motion after the run is over reads as still working.
     const sweeping = !!indeterminate && !error;
-    // A countdown that never ends has nothing to show, and one already spent has nothing left.
     const counting = !!countdown && Number.isFinite(countdown) && countdown > 0 && !indeterminate && !error;
     const fraction = indeterminate ? (error ? 1 : 0) : progress;
     // An advance eases; a rewind snaps. Sliding the fill backwards animates a run that never
@@ -44,10 +43,8 @@ export const Progress = forwardRef<HTMLSpanElement, ProgressProps>(
 
     return (
       <span
-        // A countdown empties in CSS, so its value never reaches assistive technology; the deadline
-        // it illustrates belongs to the host, which announces it. An indeterminate bar is a
-        // progressbar with no value — that is what the role means, so it needs no separate
-        // live-region role.
+        // An indeterminate bar is a progressbar with no value — that is what the role means, so it
+        // needs no separate live-region role.
         {...props}
         {...(counting ? { 'aria-hidden': true } : { role: 'progressbar' })}
         {...(!indeterminate && !counting && { 'aria-valuemin': 0, 'aria-valuemax': 1, 'aria-valuenow': progress })}

--- a/packages/ui/react-ui/src/components/Progress/Progress.tsx
+++ b/packages/ui/react-ui/src/components/Progress/Progress.tsx
@@ -10,9 +10,13 @@ import { type ThemedClassName } from '../../util';
 
 export type ProgressProps = ThemedClassName<
   ComponentPropsWithRef<'span'> &
-    ProgressStyleProps & {
-      /** How far through, 0..1. Ignored when `indeterminate`. */
+    Omit<ProgressStyleProps, 'countdown'> & {
+      /** How far through, 0..1. Ignored when `indeterminate` or `countdown`. */
       progress?: number;
+      /** Milliseconds to empty the bar over, for a deadline rather than a task. */
+      countdown?: number;
+      /** Holds a `countdown` where it is, for a deadline that has stopped running down. */
+      paused?: boolean;
     }
 >;
 
@@ -21,12 +25,14 @@ export type ProgressProps = ThemedClassName<
  * chrome. {@link Stepper} draws a plan instead, and `ProgressMeter` is the readout built from both.
  */
 export const Progress = forwardRef<HTMLSpanElement, ProgressProps>(
-  ({ classNames, children, progress = 0, indeterminate, error, ...props }, forwardedRef) => {
+  ({ classNames, children, progress = 0, indeterminate, countdown, paused, error, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
     // A run with nothing to count cannot say how far it got, so a failure fills the whole bar: what
     // is being reported is the failure, not a fraction. It stops sweeping for the same reason —
     // motion after the run is over reads as still working.
     const sweeping = !!indeterminate && !error;
+    // A countdown that never ends has nothing to show, and one already spent has nothing left.
+    const counting = !!countdown && Number.isFinite(countdown) && countdown > 0 && !indeterminate && !error;
     const fraction = indeterminate ? (error ? 1 : 0) : progress;
     // An advance eases; a rewind snaps. Sliding the fill backwards animates a run that never
     // happened, and a reset that takes half a second to land reads as still-running.
@@ -38,19 +44,23 @@ export const Progress = forwardRef<HTMLSpanElement, ProgressProps>(
 
     return (
       <span
-        // An indeterminate bar is a progressbar with no value — that is what the role means, so it
-        // needs no separate live-region role.
-        role='progressbar'
-        {...(!indeterminate && { 'aria-valuemin': 0, 'aria-valuemax': 1, 'aria-valuenow': progress })}
+        // A countdown empties in CSS, so its value never reaches assistive technology; the deadline
+        // it illustrates belongs to the host, which announces it. An indeterminate bar is a
+        // progressbar with no value — that is what the role means, so it needs no separate
+        // live-region role.
+        {...(counting ? { 'aria-hidden': true } : { role: 'progressbar' })}
+        {...(!indeterminate && !counting && { 'aria-valuemin': 0, 'aria-valuemax': 1, 'aria-valuenow': progress })}
         {...props}
-        className={tx('progress.root', { indeterminate: sweeping, error }, classNames)}
+        className={tx('progress.root', { indeterminate: sweeping, countdown: counting, error }, classNames)}
         ref={forwardedRef}
       >
         <span
-          className={tx('progress.bar', { indeterminate: sweeping, error })}
-          {...(!sweeping && {
-            style: { width: `${Math.round(fraction * 100)}%`, ...(rewound && { transition: 'none' }) },
-          })}
+          className={tx('progress.bar', { indeterminate: sweeping, countdown: counting, error })}
+          {...(counting
+            ? { style: { animationDuration: `${countdown}ms`, animationPlayState: paused ? 'paused' : 'running' } }
+            : !sweeping && {
+                style: { width: `${Math.round(fraction * 100)}%`, ...(rewound && { transition: 'none' }) },
+              })}
         />
         {children}
       </span>

--- a/packages/ui/react-ui/src/components/Progress/Progress.tsx
+++ b/packages/ui/react-ui/src/components/Progress/Progress.tsx
@@ -48,9 +48,9 @@ export const Progress = forwardRef<HTMLSpanElement, ProgressProps>(
         // it illustrates belongs to the host, which announces it. An indeterminate bar is a
         // progressbar with no value — that is what the role means, so it needs no separate
         // live-region role.
+        {...props}
         {...(counting ? { 'aria-hidden': true } : { role: 'progressbar' })}
         {...(!indeterminate && !counting && { 'aria-valuemin': 0, 'aria-valuemax': 1, 'aria-valuenow': progress })}
-        {...props}
         className={tx('progress.root', { indeterminate: sweeping, countdown: counting, error }, classNames)}
         ref={forwardedRef}
       >

--- a/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
@@ -71,8 +71,8 @@ export const Default: Story = {
     openTrigger: 'Open toast',
     icon: 'ph--sparkle--regular',
     title: 'This is a toast',
-    description: 'This goes away on its own with a timer.',
-    duration: 100_000,
+    description: 'The bar below counts down to when this closes; it stops while the pointer is over the toast.',
+    duration: 8_000,
   },
 };
 
@@ -82,8 +82,8 @@ export const WithAction: Story = {
     openTrigger: 'Open toast',
     icon: 'ph--sparkle--regular',
     title: 'This is a toast',
-    description: 'This goes away on its own with a timer.',
-    duration: 100_000,
+    description: 'The bar below counts down to when this closes; it stops while the pointer is over the toast.',
+    duration: 8_000,
     actionTriggers: [
       {
         altText: 'Press F5 to reload the page',

--- a/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
@@ -65,6 +65,10 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+/**
+ * The bar under the toast empties over the toast's duration. It holds while the pointer is over the
+ * toast, on the same pause that holds the close timer.
+ */
 export const Default: Story = {
   args: {
     defaultOpen: true,
@@ -73,6 +77,21 @@ export const Default: Story = {
     title: 'This is a toast',
     description: 'The bar below counts down to when this closes; it stops while the pointer is over the toast.',
     duration: 8_000,
+  },
+};
+
+/**
+ * A toast with no deadline draws no countdown: there is nothing to count, and an empty track would
+ * imply a close that never comes. It waits for the close button.
+ */
+export const Persistent: Story = {
+  args: {
+    defaultOpen: true,
+    openTrigger: 'Open toast',
+    icon: 'ph--sparkle--regular',
+    title: 'This is a toast',
+    description: 'This one stays until you dismiss it, so there is no bar below.',
+    duration: Infinity,
   },
 };
 

--- a/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
@@ -65,10 +65,6 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-/**
- * The bar under the toast empties over the toast's duration. It holds while the pointer is over the
- * toast, on the same pause that holds the close timer.
- */
 export const Default: Story = {
   args: {
     defaultOpen: true,
@@ -80,10 +76,6 @@ export const Default: Story = {
   },
 };
 
-/**
- * A toast with no deadline draws no countdown: there is nothing to count, and an empty track would
- * imply a close that never comes. It waits for the close button.
- */
 export const Persistent: Story = {
   args: {
     defaultOpen: true,

--- a/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
+++ b/packages/ui/react-ui/src/components/Toast/Toast.theme.ts
@@ -40,6 +40,8 @@ const description: ComponentFunction<ToastStyleProps> = (_props, ...etc) =>
 
 const actions: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('flex gap-2 mt-1', ...etc);
 
+const countdown: ComponentFunction<ToastStyleProps> = (_props, ...etc) => mx('mx-1', ...etc);
+
 export const toastTheme: Theme<ToastStyleProps> = {
   viewport,
   root,
@@ -48,4 +50,5 @@ export const toastTheme: Theme<ToastStyleProps> = {
   title,
   description,
   actions,
+  countdown,
 };

--- a/packages/ui/react-ui/src/components/Toast/Toast.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.tsx
@@ -3,7 +3,7 @@
 //
 
 import * as ToastPrimitive from '@radix-ui/react-toast';
-import React, { type ComponentPropsWithRef, forwardRef } from 'react';
+import React, { type ComponentPropsWithRef, createContext, forwardRef, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { translationKey } from '#translations';
@@ -14,14 +14,28 @@ import { type ThemedClassName } from '../../util';
 import { IconButton } from '../Button';
 import { Column } from '../Column';
 import { Icon } from '../Icon';
+import { Progress } from '../Progress';
 
 //
 // Provider
 //
 
+/** Radix's own default, restated here so `Toast.Root` can size its countdown without the scoped context. */
+const DEFAULT_DURATION = 5_000;
+
+const DurationContext = createContext(DEFAULT_DURATION);
+
 type ToastProviderProps = ToastPrimitive.ToastProviderProps;
 
-const ToastProvider = ToastPrimitive.Provider;
+const ToastProvider = ({ duration = DEFAULT_DURATION, children, ...props }: ToastProviderProps) => (
+  <DurationContext.Provider value={duration}>
+    <ToastPrimitive.Provider duration={duration} {...props}>
+      {children}
+    </ToastPrimitive.Provider>
+  </DurationContext.Provider>
+);
+
+ToastProvider.displayName = 'Toast.Provider';
 
 //
 // Viewport
@@ -42,16 +56,40 @@ ToastViewport.displayName = 'Toast.Viewport';
 
 type ToastRootProps = ThemedClassName<ToastPrimitive.ToastProps>;
 
-const ToastRoot = forwardRef<HTMLLIElement, ToastRootProps>(({ classNames, children, ...props }, forwardedRef) => {
-  const { tx } = useThemeContext();
-  return (
-    <ToastPrimitive.Root {...props} className={tx('toast.root', {}, classNames)} ref={forwardedRef}>
-      <ElevationProvider elevation='toast'>
-        <Column.Root classNames={tx('toast.grid', {})}>{children}</Column.Root>
-      </ElevationProvider>
-    </ToastPrimitive.Root>
-  );
-});
+const ToastRoot = forwardRef<HTMLLIElement, ToastRootProps>(
+  ({ classNames, children, duration, onPause, onResume, ...props }, forwardedRef) => {
+    const { tx } = useThemeContext();
+    const providerDuration = useContext(DurationContext);
+    // A toast that never times out has no deadline to draw.
+    const countdown = duration ?? providerDuration;
+    const timed = Number.isFinite(countdown) && countdown > 0;
+    // Radix's close timer stops while the viewport is hovered or focused and while the window is
+    // blurred, so the bar stops with it rather than promising a close that isn't coming.
+    const [paused, setPaused] = useState(false);
+
+    return (
+      <ToastPrimitive.Root
+        {...props}
+        duration={duration}
+        onPause={() => {
+          setPaused(true);
+          onPause?.();
+        }}
+        onResume={() => {
+          setPaused(false);
+          onResume?.();
+        }}
+        className={tx('toast.root', {}, classNames)}
+        ref={forwardedRef}
+      >
+        <ElevationProvider elevation='toast'>
+          <Column.Root classNames={tx('toast.grid', {})}>{children}</Column.Root>
+          {timed && <Progress countdown={countdown} paused={paused} classNames={tx('toast.countdown', {})} />}
+        </ElevationProvider>
+      </ToastPrimitive.Root>
+    );
+  },
+);
 
 ToastRoot.displayName = 'Toast.Root';
 

--- a/packages/ui/react-ui/src/components/Toast/Toast.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.tsx
@@ -60,11 +60,10 @@ const ToastRoot = forwardRef<HTMLLIElement, ToastRootProps>(
   ({ classNames, children, duration, onPause, onResume, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
     const providerDuration = useContext(DurationContext);
-    // A toast that never times out has no deadline to draw.
     const countdown = duration ?? providerDuration;
     const timed = Number.isFinite(countdown) && countdown > 0;
-    // Radix's close timer stops while the viewport is hovered or focused and while the window is
-    // blurred, so the bar stops with it rather than promising a close that isn't coming.
+    // Radix pauses its close timer while the viewport is hovered or focused and while the window is
+    // blurred.
     const [paused, setPaused] = useState(false);
 
     return (

--- a/packages/ui/ui-theme/src/css/theme/animation.css
+++ b/packages/ui/ui-theme/src/css/theme/animation.css
@@ -246,7 +246,17 @@
       width: 0%;
     }
   }
+  @keyframes progress-countdown {
+    from {
+      width: 100%;
+    }
+    to {
+      width: 0%;
+    }
+  }
   --animate-progress-indeterminate: progress-indeterminate 2s ease-out infinite;
+  /* Each countdown lasts as long as whatever it is counting, so the caller sets the duration inline. */
+  --animate-progress-countdown: progress-countdown 5s linear forwards;
 
   /** 
    * Border trail 

--- a/packages/ui/ui-theme/src/css/theme/animation.css
+++ b/packages/ui/ui-theme/src/css/theme/animation.css
@@ -255,7 +255,6 @@
     }
   }
   --animate-progress-indeterminate: progress-indeterminate 2s ease-out infinite;
-  /* Each countdown lasts as long as whatever it is counting, so the caller sets the duration inline. */
   --animate-progress-countdown: progress-countdown 5s linear forwards;
 
   /** 


### PR DESCRIPTION
Toasts close on a timer with nothing on screen saying so, which is the TODO this picks up
(`plugin-deck/containers/Overlays/Toast.tsx`).

`Progress` grows a countdown mode: pass `countdown` in milliseconds and the bar starts full and
empties over that span, driven by a CSS animation rather than per-frame React state. `Toast.Root`
draws one for every toast with a finite duration, and `Toast.Provider` now publishes its default
duration on a context so a Root that sets no `duration` of its own still knows what to draw.

Pausing is wired to Radix's own `onPause` / `onResume`, which fire when the toast viewport is
hovered or focused and when the window blurs. Those are the same signals that stop Radix's close
timer, so the bar cannot promise a close that isn't coming. A countdown carries no value for
assistive technology (the animation is in CSS, so `aria-valuenow` would never update) and the toast
already announces itself, so the bar is `aria-hidden` in that mode.

An `Infinity` duration draws nothing at all: no bar, no empty track, no `progressbar` role.

![A toast counting down](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-09-04-toast-countdown/01-counting.png)

![A persistent toast, with no bar](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-09-04-toast-countdown/04-persistent.png)

[Demo — countdown, pause on hover, resume, and the Infinity case (0:43, 194 KB webm)](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-09-04-toast-countdown/toast-countdown.webm)

## Verification

Driven in Storybook and measured off the DOM: the bar runs 368px to 0 over the full duration, holds
at 231px across 5s of hover, then resumes to 190px once the pointer leaves. The `Persistent` story
reports zero countdown bars and zero elements with `role="progressbar"`.

`react-ui` typechecks and its tests pass, as do `ui-theme`, `plugin-deck` and `plugin-space`; repo
lint and format are clean.

## Known gap

If a toast mounts while Radix's timer is *already* paused (the window blurred while other toasts
were on screen), Radix starts no timer and emits no pause event, so the bar empties while the toast
stays put. Radix exposes no way to read that flag, and inferring it from `document.hasFocus()` gets
it wrong in the opposite, more common direction. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timed toasts now display a countdown bar showing their remaining duration.
  * Countdown bars pause when a toast is hovered, focused, or the window loses focus.
  * Progress countdowns support pausing, resuming, and restarting.
  * Persistent toasts remain without a countdown bar and require manual dismissal.
* **Documentation**
  * Added examples demonstrating countdown, pause, resume, restart, and persistent toast behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12954-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
