### PR TITLE
composer-app: memory footprint log for the native app and a macOS soak script

### DIFF
--- a/.agents/projects/memory-usage/TASKS.md
+++ b/.agents/projects/memory-usage/TASKS.md
@@ -21,6 +21,11 @@ RESEARCH.md.
 - [x] Harness landed at `packages/apps/composer-app/scripts/memory/` with a
       README covering which quantity each tool measures and what must be held
       constant between runs.
+- [x] Native app: `native-soak.mjs` samples the installed macOS app's
+      WebContent/GPU/Networking footprints and dirty-memory categories, and
+      the Tauri host logs the same series once a minute to
+      `~/Library/Logs/org.dxos.composer.<channel>/memory.ndjson`. WKWebView
+      exposes no JS heap, so process footprint is the only trajectory.
 
 ## Phase 2: Data-proportional retention
 

--- a/packages/apps/composer-app/scripts/memory/README.md
+++ b/packages/apps/composer-app/scripts/memory/README.md
@@ -148,3 +148,19 @@ WebContent's dirty split at rest: WebKit malloc 734, graphics 235, JS VM
 Gigacage 116, JIT 52; none of them moved over the half hour, so the 30-minute
 slope is zero and the growth to a kill happens on a longer clock or on a
 different event.
+
+The boot peak, sampled every 2 s on a second hidden launch (this one rested
+at 976 MB; resting footprint varies by ~180 MB between launches):
+
+| t    | Footprint MB | WebKit malloc | Graphics | JS VM Gigacage | JIT |
+| ---- | ------------ | ------------- | -------- | -------------- | --- |
+| 2 s  | 247          | 133           | 121      | 4              | 6   |
+| 4 s  | 2,023        | 1,313         | 435      | 169            | 35  |
+| 15 s | 1,054        | 833           | 117      | 37             | 51  |
+| 3 m  | 976          | 756           | 117      | 35             | 53  |
+
+Half of WebContent's resting footprint is bmalloc, which holds JSC's GC heap,
+the DOM and CSS together and is opaque from outside the process; at rest
+another ~1 GB of it is reclaimable (freed but not yet returned). The Web
+Inspector's heap snapshot (Safari, Develop menu, the app's window) is the
+only breakdown of the JS part in WebKit.

--- a/packages/apps/composer-app/scripts/memory/README.md
+++ b/packages/apps/composer-app/scripts/memory/README.md
@@ -49,6 +49,7 @@ alongside any number:
 | `boot-census.mjs`        | What a tab loads and executes: bytes per package via sourcemaps, execution ratio via precise coverage, and the module-activation roster split into boot and idle waves |
 | `snapshot-diff.mjs`      | Which constructors grew between two points — the way to find an accumulator          |
 | `retainers.mjs`          | Retainer chains for the largest strings in a snapshot — the way to find who holds them |
+| `native-soak.mjs`        | Footprint over time of the installed macOS app: WebContent, GPU, Networking and the host process, with WebContent's dirty-memory categories; also reports the app's own host log |
 
 ## Running
 
@@ -86,3 +87,64 @@ node scripts/memory/retainers.mjs ./tmp/snaps/baseline-page.heapsnapshot --min 4
 Snapshots, traces and result files are large and are build output; write them
 somewhere ignored, not into the package. `measure.mjs` defaults its result to
 `./tmp/memory-last-run.json` under the working directory (`--out` to override).
+
+## The native app (macOS, WebKit)
+
+The Chrome tools above do not apply to the Tauri app: WKWebView has no
+`performance.memory`, no `measureUserAgentSpecificMemory`, and no CDP, so a
+page cannot measure its own heap. What macOS does expose, unprivileged, is the
+footprint of every process: `proc_pid_rusage` for the number WebKit's own
+memory-kill logic uses (`phys_footprint`), and `footprint`/`vmmap` for the
+dirty memory per category. Two categories stand in for the realms:
+
+| Category                                        | Holds                                                       |
+| ----------------------------------------------- | ----------------------------------------------------------- |
+| `WebKit malloc`                                 | JSC's GC heap plus DOM, CSS and every other bmalloc client  |
+| `JS VM Gigacage`                                | ArrayBuffers and typed arrays (wasm memories, Automerge)    |
+| `JS JIT generated code`                         | compiled JS                                                 |
+| `Owned physical footprint (unmapped) (graphics)` | IOSurfaces and layer backing stores, even while hidden      |
+
+`native-soak.mjs` samples the running app (or launches it hidden with
+`--launch`, the state in which WebKit throttles and, under memory pressure,
+kills WebContent), attributes the WebKit helpers to it through the
+responsibility API, and appends one NDJSON line per process per sample:
+
+```bash
+node scripts/memory/native-soak.mjs --app "Composer Dev" --launch --minutes 480 --interval 30
+```
+
+A WebContent pid change is logged as a `pid-change` event with the last
+footprint seen before it, which is the number to compare against the kill.
+The Networking helper's `disk_written` delta is the idle disk churn.
+
+The app writes the same line shape itself, once a minute for as long as it
+runs, to `~/Library/Logs/org.dxos.composer.<channel>/memory.ndjson`
+(`src-tauri/src/memory_log.rs`), so an overnight incident has its trajectory
+without anyone having started a soak:
+
+```bash
+node scripts/memory/native-soak.mjs --report ~/Library/Logs/org.dxos.composer.dev/memory.ndjson
+```
+
+To join a trajectory with the app's own logs, download the log bundle from
+the app after the soak and query it with `scripts/query-logs.mjs` over the
+same wall-clock window; the bundle keeps roughly the last 25 minutes.
+
+Hidden-boot baseline of 0.11.3-dev.12 on 2026-09-04 (macOS 26.5.2, 5 spaces,
+~485 documents), 30 minutes hidden starting two minutes after launch:
+
+| Process    | Resting MB | Max sampled MB | Lifetime peak MB | CPU s / 30 min | Disk write KB/s |
+| ---------- | ---------- | -------------- | ---------------- | -------------- | --------------- |
+| WebContent | 1,152      | 1,294          | 2,187            | 291            | 0               |
+| GPU        | 31         | 254            | 284              | 4              | 0               |
+| Networking | 41         | 70             | 178              | 166            | 129             |
+| host app   | 84         | 85             | 97               | 3              | 0               |
+
+The lifetime peak is the kernel's `ri_lifetime_max_phys_footprint`; WebContent
+reached 2.2 GB before sampling began, so boot itself passes the 1.86 GB at
+which macOS killed it on 2026-09-03. Between +5.5 and +16.5 minutes it held a
+1,270 MB plateau while the GPU helper rose to 254 MB, then both fell back.
+WebContent's dirty split at rest: WebKit malloc 734, graphics 235, JS VM
+Gigacage 116, JIT 52; none of them moved over the half hour, so the 30-minute
+slope is zero and the growth to a kill happens on a longer clock or on a
+different event.

--- a/packages/apps/composer-app/scripts/memory/native-soak.mjs
+++ b/packages/apps/composer-app/scripts/memory/native-soak.mjs
@@ -1,0 +1,236 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+/**
+ * Footprint soak for the installed macOS (Tauri) app: samples the app process and its WebKit
+ * helpers (WebContent, GPU, Networking) with `proc_pid_rusage`, adds a `footprint` category
+ * breakdown of WebContent every few samples, appends NDJSON, and prints slopes at the end.
+ * The app's own host log (`~/Library/Logs/<identifier>/memory.ndjson`) uses the same line shape,
+ * so `--report` reads either.
+ *
+ * Usage: node native-soak.mjs [--app "Composer Dev"] [--launch] [--minutes 480] [--interval 30]
+ *          [--categories-every 10] [--out file.ndjson]
+ *        node native-soak.mjs --report file.ndjson
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+
+const arg = (name, dflt) => {
+  const i = process.argv.indexOf(name);
+  return i > 0 ? process.argv[i + 1] : dflt;
+};
+const flag = (name) => process.argv.includes(name);
+const MB = (bytes) => +(bytes / (1024 * 1024)).toFixed(1);
+
+const HELPER_NAMES = {
+  'com.apple.WebKit.WebContent': 'web',
+  'com.apple.WebKit.GPU': 'gpu',
+  'com.apple.WebKit.Networking': 'networking',
+};
+/** Dirty-memory categories that separate JS, WebKit's DOM/CSS allocator, and graphics. */
+const CATEGORIES = [
+  'WebKit malloc',
+  'JS VM Gigacage',
+  'JS JIT generated code',
+  'MALLOC_SMALL',
+  'MALLOC_LARGE',
+  'MALLOC_TINY',
+  'IOSurface',
+  'Owned physical footprint (unmapped) (graphics)',
+];
+
+const helperBinary = () => {
+  const source = path.join(path.dirname(fileURLToPath(import.meta.url)), 'native', 'procstat.swift');
+  const hash = createHash('sha1').update(readFileSync(source)).digest('hex').slice(0, 12);
+  const binary = path.join(tmpdir(), `composer-procstat-${hash}`);
+  if (!existsSync(binary)) {
+    console.error('compiling procstat helper...');
+    execFileSync('swiftc', ['-O', source, '-o', binary], { stdio: 'inherit' });
+  }
+  return binary;
+};
+
+/** The binary inside every channel's bundle is `app`, so the bundle path is the identity. */
+const appPid = (app) => {
+  const result = spawnSync('pgrep', ['-f', `/${app}.app/Contents/MacOS/`], { encoding: 'utf8' });
+  const pid = parseInt(result.stdout.split('\n')[0], 10);
+  return Number.isFinite(pid) ? pid : undefined;
+};
+
+/** `open -j` launches hidden, the state in which WebKit throttles and kills WebContent. */
+const launchHidden = async (app) => {
+  execFileSync('open', ['-jga', app]);
+  for (let i = 0; i < 60; i++) {
+    const pid = appPid(app);
+    if (pid) {
+      return pid;
+    }
+    await sleep(500);
+  }
+  throw new Error(`${app} did not start`);
+};
+
+const sampleProcesses = (helper, pid, app) =>
+  JSON.parse(execFileSync(helper, [String(pid)], { encoding: 'utf8' })).map((row) => ({
+    ...row,
+    process: row.pid === pid ? 'app' : (HELPER_NAMES[row.name] ?? row.name),
+  }));
+
+const sampleCategories = (pid) => {
+  const file = path.join(tmpdir(), `composer-footprint-${pid}.json`);
+  spawnSync('footprint', ['-p', String(pid), '--json', file], { stdio: 'ignore' });
+  const categories = JSON.parse(readFileSync(file, 'utf8')).processes[0]?.categories ?? {};
+  return Object.fromEntries(
+    Object.entries(categories)
+      .filter(([name]) => CATEGORIES.includes(name))
+      .map(([name, { dirty }]) => [name, dirty]),
+  );
+};
+
+const soak = async () => {
+  const app = arg('--app', 'Composer Dev');
+  const minutes = parseFloat(arg('--minutes', '480'));
+  const intervalS = parseFloat(arg('--interval', '30'));
+  const categoriesEvery = parseInt(arg('--categories-every', '10'), 10);
+  const out = path.resolve(
+    arg('--out', `./tmp/native-soak-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.ndjson`),
+  );
+  mkdirSync(path.dirname(out), { recursive: true });
+
+  const helper = helperBinary();
+  const pid = flag('--launch') ? await launchHidden(app) : appPid(app);
+  if (!pid) {
+    throw new Error(`${app} is not running (pass --launch to start it hidden)`);
+  }
+  console.error(`sampling ${app} pid ${pid} every ${intervalS}s for ${minutes}min -> ${out}`);
+
+  const started = Date.now();
+  const lastPid = new Map();
+  const lastFootprint = new Map();
+  let running = true;
+  process.on('SIGINT', () => (running = false));
+  for (let i = 0; running && Date.now() - started < minutes * 60_000; i++) {
+    if (!appPid(app)) {
+      appendFileSync(out, `${JSON.stringify({ t: Date.now(), event: 'app-exit' })}\n`);
+      console.error('app exited');
+      break;
+    }
+    const t = Date.now();
+    const uptime_s = Math.round((t - started) / 1000);
+    const rows = sampleProcesses(helper, pid, app);
+    for (const row of rows) {
+      const previous = lastPid.get(row.process);
+      if (previous && previous !== row.pid) {
+        const event = {
+          t,
+          event: 'pid-change',
+          process: row.process,
+          from: previous,
+          to: row.pid,
+          last_footprint: lastFootprint.get(row.process),
+        };
+        appendFileSync(out, `${JSON.stringify(event)}\n`);
+        console.error(`${row.process} pid ${previous} -> ${row.pid}, last footprint ${MB(event.last_footprint)} MB`);
+      }
+      lastPid.set(row.process, row.pid);
+      lastFootprint.set(row.process, row.footprint);
+      const categories = row.process === 'web' && i % categoriesEvery === 0 ? sampleCategories(row.pid) : undefined;
+      appendFileSync(out, `${JSON.stringify({ t, uptime_s, ...row, categories })}\n`);
+    }
+    const summary = ['app', 'web', 'gpu', 'networking']
+      .map((name) => rows.find((row) => row.process === name))
+      .filter(Boolean)
+      .map((row) => `${row.process}=${MB(row.footprint)}MB`)
+      .join(' ');
+    console.error(`+${uptime_s}s ${summary}`);
+    await sleep(intervalS * 1000);
+  }
+  report(out);
+};
+
+const slopePerHour = (points) => {
+  if (points.length < 2) {
+    return 0;
+  }
+  const n = points.length;
+  const meanT = points.reduce((sum, [t]) => sum + t, 0) / n;
+  const meanY = points.reduce((sum, [, y]) => sum + y, 0) / n;
+  let covariance = 0;
+  let variance = 0;
+  for (const [t, y] of points) {
+    covariance += (t - meanT) * (y - meanY);
+    variance += (t - meanT) ** 2;
+  }
+  return variance === 0 ? 0 : (covariance / variance) * 3_600_000;
+};
+
+const report = (file) => {
+  const lines = readFileSync(file, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  const samples = lines.filter((line) => line.process && line.footprint !== undefined);
+  const events = lines.filter((line) => line.event);
+  const byProcess = new Map();
+  for (const sample of samples) {
+    if (!byProcess.has(sample.process)) {
+      byProcess.set(sample.process, []);
+    }
+    byProcess.get(sample.process).push(sample);
+  }
+  const first = samples[0]?.t;
+  const last = samples.at(-1)?.t;
+  console.log(
+    `${file}: ${samples.length} samples over ${((last - first) / 3_600_000).toFixed(2)} h, ${events.length} events`,
+  );
+  const table = [];
+  for (const [name, rows] of byProcess) {
+    const pids = new Set(rows.map((row) => row.pid));
+    const disk = rows.at(-1).disk_written - rows[0].disk_written;
+    table.push({
+      'process': name,
+      'pids': pids.size,
+      'first MB': MB(rows[0].footprint),
+      'last MB': MB(rows.at(-1).footprint),
+      'max MB': MB(Math.max(...rows.map((row) => row.footprint))),
+      'peak MB': MB(Math.max(...rows.map((row) => row.peak))),
+      'slope MB/h': +MB(slopePerHour(rows.map((row) => [row.t, row.footprint]))).toFixed(1),
+      'disk write KB/s': +(disk / 1024 / ((rows.at(-1).t - rows[0].t) / 1000 || 1)).toFixed(1),
+      'cpu s': +((rows.at(-1).cpu_ms - rows[0].cpu_ms) / 1000).toFixed(1),
+    });
+  }
+  console.table(table);
+  for (const event of events) {
+    console.log(
+      `${new Date(event.t).toISOString()} ${event.event} ${event.process ?? ''} ${event.from ?? ''}${event.to ? ` -> ${event.to}` : ''}${event.last_footprint ? ` last ${MB(event.last_footprint)} MB` : ''}`,
+    );
+  }
+  const withCategories = (byProcess.get('web') ?? []).filter((row) => row.categories);
+  if (withCategories.length >= 2) {
+    const [a, b] = [withCategories[0].categories, withCategories.at(-1).categories];
+    console.log('WebContent dirty categories, first -> last sample:');
+    console.table(
+      Object.keys(b)
+        .map((name) => ({
+          'category': name,
+          'first MB': MB(a[name] ?? 0),
+          'last MB': MB(b[name]),
+          'delta MB': MB(b[name] - (a[name] ?? 0)),
+        }))
+        .sort((x, y) => Math.abs(y['delta MB']) - Math.abs(x['delta MB'])),
+    );
+  }
+};
+
+if (flag('--report')) {
+  report(path.resolve(arg('--report')));
+} else {
+  await soak();
+}

--- a/packages/apps/composer-app/scripts/memory/native-soak.mjs
+++ b/packages/apps/composer-app/scripts/memory/native-soak.mjs
@@ -77,7 +77,7 @@ const launchHidden = async (app) => {
   throw new Error(`${app} did not start`);
 };
 
-const sampleProcesses = (helper, pid, app) =>
+const sampleProcesses = (helper, pid) =>
   JSON.parse(execFileSync(helper, [String(pid)], { encoding: 'utf8' })).map((row) => ({
     ...row,
     process: row.pid === pid ? 'app' : (HELPER_NAMES[row.name] ?? row.name),
@@ -85,13 +85,20 @@ const sampleProcesses = (helper, pid, app) =>
 
 const sampleCategories = (pid) => {
   const file = path.join(tmpdir(), `composer-footprint-${pid}.json`);
-  spawnSync('footprint', ['-p', String(pid), '--json', file], { stdio: 'ignore' });
-  const categories = JSON.parse(readFileSync(file, 'utf8')).processes[0]?.categories ?? {};
-  return Object.fromEntries(
-    Object.entries(categories)
-      .filter(([name]) => CATEGORIES.includes(name))
-      .map(([name, { dirty }]) => [name, dirty]),
-  );
+  if (spawnSync('footprint', ['-p', String(pid), '--json', file], { stdio: 'ignore' }).status !== 0) {
+    return undefined;
+  }
+  try {
+    const categories = JSON.parse(readFileSync(file, 'utf8')).processes[0]?.categories ?? {};
+    return Object.fromEntries(
+      Object.entries(categories)
+        .filter(([name]) => CATEGORIES.includes(name))
+        .map(([name, { dirty }]) => [name, dirty]),
+    );
+  } catch {
+    // WebContent can exit between the capture and the read; the sample then has no breakdown.
+    return undefined;
+  }
 };
 
 const soak = async () => {
@@ -117,14 +124,15 @@ const soak = async () => {
   let running = true;
   process.on('SIGINT', () => (running = false));
   for (let i = 0; running && Date.now() - started < minutes * 60_000; i++) {
-    if (!appPid(app)) {
+    const currentPid = appPid(app);
+    if (!currentPid) {
       appendFileSync(out, `${JSON.stringify({ t: Date.now(), event: 'app-exit' })}\n`);
       console.error('app exited');
       break;
     }
     const t = Date.now();
     const uptime_s = Math.round((t - started) / 1000);
-    const rows = sampleProcesses(helper, pid, app);
+    const rows = sampleProcesses(helper, currentPid);
     for (const row of rows) {
       const previous = lastPid.get(row.process);
       if (previous && previous !== row.pid) {
@@ -171,6 +179,10 @@ const slopePerHour = (points) => {
   return variance === 0 ? 0 : (covariance / variance) * 3_600_000;
 };
 
+/** Cumulative kernel counters restart with the process, so a delta only spans one pid. */
+const deltaWithinPids = (rows, field) =>
+  rows.reduce((sum, row, i) => (i > 0 && rows[i - 1].pid === row.pid ? sum + row[field] - rows[i - 1][field] : sum), 0);
+
 const report = (file) => {
   const lines = readFileSync(file, 'utf8')
     .split('\n')
@@ -193,7 +205,8 @@ const report = (file) => {
   const table = [];
   for (const [name, rows] of byProcess) {
     const pids = new Set(rows.map((row) => row.pid));
-    const disk = rows.at(-1).disk_written - rows[0].disk_written;
+    const disk = deltaWithinPids(rows, 'disk_written');
+    const cpu = deltaWithinPids(rows, 'cpu_ms');
     table.push({
       'process': name,
       'pids': pids.size,
@@ -203,7 +216,7 @@ const report = (file) => {
       'peak MB': MB(Math.max(...rows.map((row) => row.peak))),
       'slope MB/h': +MB(slopePerHour(rows.map((row) => [row.t, row.footprint]))).toFixed(1),
       'disk write KB/s': +(disk / 1024 / ((rows.at(-1).t - rows[0].t) / 1000 || 1)).toFixed(1),
-      'cpu s': +((rows.at(-1).cpu_ms - rows[0].cpu_ms) / 1000).toFixed(1),
+      'cpu s': +(cpu / 1000).toFixed(1),
     });
   }
   console.table(table);

--- a/packages/apps/composer-app/scripts/memory/native/procstat.swift
+++ b/packages/apps/composer-app/scripts/memory/native/procstat.swift
@@ -1,0 +1,42 @@
+// Prints one JSON object per process the given pid is responsible for (itself included): the
+// WebKit helpers are launchd children, so responsibility is the only link back to the app.
+// Usage: procstat <app pid>
+
+import Foundation
+
+typealias ResponsibleFn = @convention(c) (pid_t) -> pid_t
+guard CommandLine.arguments.count == 2, let root = pid_t(CommandLine.arguments[1]) else {
+  FileHandle.standardError.write("usage: procstat <app pid>\n".data(using: .utf8)!)
+  exit(2)
+}
+guard let symbol = dlsym(dlopen(nil, RTLD_NOW), "responsibility_get_pid_responsible_for_pid") else {
+  FileHandle.standardError.write("responsibility_get_pid_responsible_for_pid unavailable\n".data(using: .utf8)!)
+  exit(3)
+}
+let responsibleFor = unsafeBitCast(symbol, to: ResponsibleFn.self)
+
+var timebase = mach_timebase_info_data_t()
+mach_timebase_info(&timebase)
+let nsPerTick = Double(timebase.numer) / Double(timebase.denom)
+
+let count = Int(proc_listallpids(nil, 0))
+var pids = [pid_t](repeating: 0, count: count + 64)
+let found = Int(proc_listallpids(&pids, Int32(pids.count * MemoryLayout<pid_t>.size)))
+
+var rows: [String] = []
+for pid in pids.prefix(found) where pid == root || responsibleFor(pid) == root {
+  var info = rusage_info_v4()
+  // The C API takes the struct itself cast to `rusage_info_t *`, not a pointer to a pointer.
+  let rc = withUnsafeMutablePointer(to: &info) { pointer in
+    pointer.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) { proc_pid_rusage(pid, RUSAGE_INFO_V4, $0) }
+  }
+  if rc != 0 { continue }
+  var nameBuffer = [CChar](repeating: 0, count: 4096)
+  proc_name(pid, &nameBuffer, UInt32(nameBuffer.count))
+  let name = String(cString: nameBuffer)
+  let cpuMs = UInt64(Double(info.ri_user_time + info.ri_system_time) * nsPerTick / 1_000_000)
+  rows.append(
+    "{\"pid\":\(pid),\"name\":\"\(name)\",\"footprint\":\(info.ri_phys_footprint),\"peak\":\(info.ri_lifetime_max_phys_footprint),\"disk_read\":\(info.ri_diskio_bytesread),\"disk_written\":\(info.ri_diskio_byteswritten),\"cpu_ms\":\(cpuMs)}"
+  )
+}
+print("[\(rows.joined(separator: ","))]")

--- a/packages/apps/composer-app/src-tauri/Cargo.lock
+++ b/packages/apps/composer-app/src-tauri/Cargo.lock
@@ -102,6 +102,7 @@ dependencies = [
  "libc",
  "log",
  "objc2 0.5.2",
+ "objc2 0.6.4",
  "reqwest 0.12.22",
  "serde",
  "serde_json",

--- a/packages/apps/composer-app/src-tauri/Cargo.toml
+++ b/packages/apps/composer-app/src-tauri/Cargo.toml
@@ -69,4 +69,7 @@ tauri-plugin-global-shortcut = "2"
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 tauri-plugin-macos-passkey = "0.1.0"
+# Memory log: WebKit helper pids via private WKWebView selectors, footprints via `proc_pid_rusage`.
+objc2 = "0.6"
+libc = "0.2"
 

--- a/packages/apps/composer-app/src-tauri/src/lib.rs
+++ b/packages/apps/composer-app/src-tauri/src/lib.rs
@@ -11,6 +11,8 @@ mod window_state;
 #[cfg(all(desktop, unix))]
 mod xattr_cmd;
 #[cfg(target_os = "macos")]
+mod memory_log;
+#[cfg(target_os = "macos")]
 mod menubar;
 #[cfg(target_os = "macos")]
 mod spotlight;
@@ -286,6 +288,9 @@ pub fn run() {
                     }
                 }
                 window_state::setup_window_state_tracking(&main_window);
+
+                #[cfg(target_os = "macos")]
+                memory_log::spawn(app.handle(), &main_window);
 
                 #[cfg(target_os = "macos")]
                 {

--- a/packages/apps/composer-app/src-tauri/src/memory_log.rs
+++ b/packages/apps/composer-app/src-tauri/src/memory_log.rs
@@ -1,0 +1,183 @@
+//! Footprint log for the desktop app: this process and the WebKit helpers, sampled from a plain
+//! thread and appended as NDJSON to `<app log dir>/memory.ndjson`, so a memory trajectory survives
+//! a WebContent kill, a reload, and the in-app log store's eviction.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
+use tauri::Manager;
+
+const FILE_NAME: &str = "memory.ndjson";
+const INTERVAL: Duration = Duration::from_secs(60);
+/// Four ~200 B lines a minute reach this after roughly a month; the file then rotates once.
+const MAX_FILE_BYTES: u64 = 32 * 1024 * 1024;
+/// A main thread that does not answer within this is suspended; the last known pids are reused.
+const MAIN_THREAD_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy, Default)]
+struct HostState {
+    web: i32,
+    gpu: i32,
+    networking: i32,
+    hidden: bool,
+}
+
+struct Usage {
+    footprint: u64,
+    peak: u64,
+    disk_read: u64,
+    disk_written: u64,
+    cpu_ms: u64,
+}
+
+pub fn spawn(app: &tauri::AppHandle, window: &tauri::WebviewWindow) {
+    let dir = match app.path().app_log_dir() {
+        Ok(dir) => dir,
+        Err(error) => {
+            log::warn!("memory log disabled: no app log dir ({error})");
+            return;
+        }
+    };
+    let window = window.clone();
+    std::thread::spawn(move || run(dir.join(FILE_NAME), window));
+}
+
+fn run(path: PathBuf, window: tauri::WebviewWindow) {
+    if let Some(dir) = path.parent() {
+        if let Err(error) = fs::create_dir_all(dir) {
+            log::warn!("memory log disabled: {error}");
+            return;
+        }
+    }
+    rotate(&path);
+
+    let started = Instant::now();
+    let timebase = timebase_ns();
+    let mut state = HostState::default();
+    loop {
+        if let Some(fresh) = host_state(&window) {
+            state = fresh;
+        }
+
+        let t = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64;
+        let uptime_s = started.elapsed().as_secs();
+        let processes = [
+            ("app", std::process::id() as i32),
+            ("web", state.web),
+            ("gpu", state.gpu),
+            ("networking", state.networking),
+        ];
+        let mut lines = String::new();
+        for (name, pid) in processes {
+            let Some(usage) = (pid > 0).then(|| rusage(pid, timebase)).flatten() else {
+                continue;
+            };
+            let line = serde_json::json!({
+                "t": t,
+                "uptime_s": uptime_s,
+                "process": name,
+                "pid": pid,
+                "footprint": usage.footprint,
+                "peak": usage.peak,
+                "disk_read": usage.disk_read,
+                "disk_written": usage.disk_written,
+                "cpu_ms": usage.cpu_ms,
+                "hidden": state.hidden,
+            });
+            lines.push_str(&line.to_string());
+            lines.push('\n');
+        }
+        if let Err(error) = OpenOptions::new().create(true).append(true).open(&path).and_then(|mut file| file.write_all(lines.as_bytes())) {
+            log::warn!("memory log write failed: {error}");
+        }
+
+        std::thread::sleep(INTERVAL);
+    }
+}
+
+fn rotate(path: &Path) {
+    if fs::metadata(path).map(|meta| meta.len() > MAX_FILE_BYTES).unwrap_or(false) {
+        let _ = fs::rename(path, path.with_extension("1.ndjson"));
+    }
+}
+
+/// Helper pids and hidden state live on the main thread; `None` when it did not run in time.
+fn host_state(window: &tauri::WebviewWindow) -> Option<HostState> {
+    let (sender, receiver) = mpsc::channel();
+    window
+        .with_webview(move |webview| {
+            // SAFETY: `inner` is the WKWebView, only touched on the main thread.
+            let state = unsafe { read_host_state(webview.inner().cast::<AnyObject>()) };
+            let _ = sender.send(state);
+        })
+        .ok()?;
+    receiver.recv_timeout(MAIN_THREAD_TIMEOUT).ok()
+}
+
+/// The pids come from WebKit's private `_webProcessIdentifier` family; each is probed first so a
+/// WebKit that drops one degrades to a missing series rather than a crash.
+unsafe fn read_host_state(webview: *mut AnyObject) -> HostState {
+    let webview = &*webview;
+    let web = if msg_send![webview, respondsToSelector: sel!(_webProcessIdentifier)] {
+        msg_send![webview, _webProcessIdentifier]
+    } else {
+        0
+    };
+    let gpu = if msg_send![webview, respondsToSelector: sel!(_gpuProcessIdentifier)] {
+        msg_send![webview, _gpuProcessIdentifier]
+    } else {
+        0
+    };
+    let configuration: *mut AnyObject = msg_send![webview, configuration];
+    let store: *mut AnyObject = msg_send![configuration, websiteDataStore];
+    let networking = if !store.is_null() && msg_send![&*store, respondsToSelector: sel!(_networkProcessIdentifier)] {
+        msg_send![&*store, _networkProcessIdentifier]
+    } else {
+        0
+    };
+    let app: *mut AnyObject = msg_send![class!(NSApplication), sharedApplication];
+    let hidden: bool = msg_send![&*app, isHidden];
+    HostState { web, gpu, networking, hidden }
+}
+
+fn rusage(pid: i32, timebase: f64) -> Option<Usage> {
+    // SAFETY: zeroed is a valid `rusage_info_v4`, and the kernel fills exactly that flavor.
+    let mut info: libc::rusage_info_v4 = unsafe { std::mem::zeroed() };
+    let rc = unsafe {
+        libc::proc_pid_rusage(pid, libc::RUSAGE_INFO_V4, (&mut info as *mut libc::rusage_info_v4).cast::<libc::rusage_info_t>())
+    };
+    (rc == 0).then(|| Usage {
+        footprint: info.ri_phys_footprint,
+        peak: info.ri_lifetime_max_phys_footprint,
+        disk_read: info.ri_diskio_bytesread,
+        disk_written: info.ri_diskio_byteswritten,
+        cpu_ms: (((info.ri_user_time + info.ri_system_time) as f64) * timebase / 1_000_000.0) as u64,
+    })
+}
+
+#[repr(C)]
+struct MachTimebaseInfo {
+    numer: u32,
+    denom: u32,
+}
+
+extern "C" {
+    fn mach_timebase_info(info: *mut MachTimebaseInfo) -> libc::c_int;
+}
+
+/// Nanoseconds per Mach time unit; rusage CPU times are reported in those units.
+fn timebase_ns() -> f64 {
+    let mut info = MachTimebaseInfo { numer: 0, denom: 0 };
+    // SAFETY: the struct is a plain out-parameter.
+    unsafe { mach_timebase_info(&mut info) };
+    if info.denom == 0 {
+        1.0
+    } else {
+        info.numer as f64 / info.denom as f64
+    }
+}

--- a/packages/apps/composer-app/src-tauri/src/memory_log.rs
+++ b/packages/apps/composer-app/src-tauri/src/memory_log.rs
@@ -54,8 +54,6 @@ fn run(path: PathBuf, window: tauri::WebviewWindow) {
             return;
         }
     }
-    rotate(&path);
-
     let started = Instant::now();
     let timebase = timebase_ns();
     let mut state = HostState::default();
@@ -92,6 +90,7 @@ fn run(path: PathBuf, window: tauri::WebviewWindow) {
             lines.push_str(&line.to_string());
             lines.push('\n');
         }
+        rotate(&path);
         if let Err(error) = OpenOptions::new().create(true).append(true).open(&path).and_then(|mut file| file.write_all(lines.as_bytes())) {
             log::warn!("memory log write failed: {error}");
         }


### PR DESCRIPTION
## Summary

The native app's "crash when left alone" bug (#12915) had no memory trajectory behind it: the WebContent process was at 1,858 MB when macOS killed it, and nothing recorded how it got there. WKWebView gives a page no `performance.memory`, no `measureUserAgentSpecificMemory` and no CDP, so the Chrome memory harness and the JS heap gauges measure nothing in the Tauri app. macOS does expose every process's footprint unprivileged, and this PR builds on that.

- **`src-tauri/src/memory_log.rs`** (macOS): a plain thread samples the host process and the WebKit helpers (WebContent, GPU, Networking) once a minute with `proc_pid_rusage` (footprint, lifetime peak, disk io, cpu) and appends NDJSON to `~/Library/Logs/org.dxos.composer.<channel>/memory.ndjson`, rotating once at 32 MB. Helper pids come from WebKit's private `_webProcessIdentifier` / `_gpuProcessIdentifier` / `_networkProcessIdentifier`, each probed with `respondsToSelector` so a WebKit that drops one loses a series, not the app. The hidden state (`NSApplication.isHidden`) is on every line. The log runs in release builds, independent of `tauri_plugin_log`, so the next overnight kill has its curve.
- **`scripts/memory/native-soak.mjs`** + `native/procstat.swift`: the same sampling from outside against any installed channel, today, with no rebuild. Attributes the launchd-parented helpers through `responsibility_get_pid_responsible_for_pid`, takes WebContent's dirty-memory categories from `footprint -p` every N samples (WebKit malloc, JS VM Gigacage, JIT, graphics), logs `pid-change` events with the last footprint before a kill, and prints per-process slope, peak, disk write rate and cpu. `--launch` starts the app hidden with `open -j`, the state that triggers throttling and kills. `--report` reads either its own output or the app's host log.
- README section on what the categories mean and what a native run holds constant, plus the measured baseline.

## Baseline (0.11.3-dev.12, hidden, 30 min, macOS 26.5.2)

| Process    | Resting MB | Max sampled MB | Lifetime peak MB | CPU s / 30 min | Disk write KB/s |
| ---------- | ---------- | -------------- | ---------------- | -------------- | --------------- |
| WebContent | 1,152      | 1,294          | 2,187            | 291            | 0               |
| GPU        | 31         | 254            | 284              | 4              | 0               |
| Networking | 41         | 70             | 178              | 166            | 129             |
| host app   | 84         | 85             | 97               | 3              | 0               |

WebContent's lifetime peak of 2.2 GB was reached before sampling began (boot), above the 1.86 GB at which macOS killed it on 2026-09-03. At rest the dirty split is WebKit malloc 734, graphics 235, JS VM Gigacage 116, JIT 52 MB, and none moved over the half hour. So the path to a kill is not a steady slope on a 30-minute clock; the host log is what will show whether it is a slow one or an event.

## Not in this PR

- Feeding the host sample into the app's observability gauges (a Tauri event into `runtimeMetricsProvider`) so preview/prod SigNoz gets the series.
- Correlating growth with the two known churners (subduction diverged-doc loop, `refreshCollection` re-arm); those need counters on the JS side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS desktop builds periodically record app and WebKit process memory, CPU, and disk-usage metrics.
  * Diagnostic memory data is saved in rotating logs within the app’s macOS log directory.
  * Memory-soak reporting includes process footprints, dirty-memory categories, PID changes, and resource-usage trends.

* **Bug Fixes**
  * Improved reliability when memory measurements are temporarily unavailable or processes change during monitoring.

* **Documentation**
  * Added instructions for launching memory measurements, generating reports, and interpreting native app memory logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12957-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
