### PR TITLE
storybook-react: take the dev server off chokidar's fsevents backend

### DIFF
--- a/tools/storybook-react/.storybook/main.ts
+++ b/tools/storybook-react/.storybook/main.ts
@@ -138,6 +138,26 @@ const optimizeDepsInclude = [
  */
 const watchIgnored = ['**/dist/**', '**/out/**', '**/.moon/**', '**/temp/**', '**/.playwright-mcp/**'];
 
+/**
+ * Watcher options for the dev server.
+ *
+ * `useFsEvents: false` is the load-bearing one. Vite inlines a patched chokidar 3 into its own
+ * bundle, and chokidar 3's fsevents backend fans every raw event out over one `Set` of listeners
+ * per watched tree, each listener re-building `resolvedPath + sep` and running `indexOf` on the
+ * event path. Vite registers one listener per file it transforms from outside `root`, and serving
+ * every `@dxos/**` package from source puts tens of thousands of files there — measured at 17k
+ * listeners on a single tree, ~1.3ms of main-thread time per raw event, and ~4s of blocked event
+ * loop for one `moon run <pkg>:build`. `watchIgnored` cannot help: chokidar consults it only when
+ * registering a watch, never on the raw-event path. The `fs.watch` backend has no such fan-out.
+ *
+ * This only changes macOS: chokidar's fsevents backend does not exist elsewhere, so Linux (CI, the
+ * e2e config) already runs the `fs.watch` path this selects.
+ *
+ * `usePolling: false` is not redundant — chokidar 3 turns polling ON by default on macOS whenever
+ * `useFsEvents` is false, which would be far worse than what it replaces.
+ */
+const watchOptions = { ignored: watchIgnored, useFsEvents: false, usePolling: false };
+
 // Minimal structural view of a Babel AST node for a dependency-free traversal.
 type AstNode = { type: string } & Record<string, unknown>;
 
@@ -363,7 +383,7 @@ export const createConfig = ({
           },
           // Vite leaks the file watcher's handles on close, hanging single-pass teardown; disable it
           // in run mode only, so interactive `storybook dev` (local + e2e) and `vitest watch` keep HMR.
-          ...(isVitestRun ? { watch: null } : { watch: { ignored: watchIgnored } }),
+          ...(isVitestRun ? { watch: null } : { watch: watchOptions }),
         },
         optimizeDeps: {
           // WASM modules.

--- a/tools/storybook-react/diagnose.sh
+++ b/tools/storybook-react/diagnose.sh
@@ -23,6 +23,8 @@ PORT=9009
 INTERVAL=15
 TIMEOUT=10
 WAIT=600
+# Seconds after the server process starts during which a pegged core is warm-up, not a wedge.
+WARMUP=300
 WATCH=0
 ENSURE=0
 
@@ -254,7 +256,15 @@ while true; do
     # Answering while pegged is the more common shape: the module graph still serves, but the
     # optimizer or the watcher is burning a core, so every navigation crawls. Three in a row rules
     # out a build.
+    # Cold start pegs a core legitimately for minutes while Vite pre-bundles ~2000 deps, and a
+    # capture taken then reports nothing but the optimizer. Only unresponsiveness is a symptom
+    # that early; the CPU heuristic arms once the server is past warm-up.
+    age="$(ps -o etimes= -p "${PID}" 2>/dev/null | tr -d ' ')"
     cpu="$(cpu_of "${PID}")"
+    if [ -n "${age}" ] && [ "${age}" -lt "${WARMUP}" ]; then
+      hot=0
+      cpu=""
+    fi
     if [ -n "${cpu}" ] && [ "${cpu%%.*}" -ge 90 ]; then
       hot=$((hot + 1))
       echo "$(date +%H:%M:%S) cpu ${cpu}% (${hot}/3)"

--- a/tools/storybook-react/diagnose.sh
+++ b/tools/storybook-react/diagnose.sh
@@ -117,7 +117,13 @@ capture() {
     echo
 
     echo "--- descriptors (watcher exhaustion) ---"
-    echo "count: $(lsof -p "${pid}" 2>/dev/null | wc -l | tr -d ' ')  limit: $(ulimit -n)"
+    # `lsof -p` also lists mapped regions and the executable, which inflated this count past the
+    # limit and made every report look like exhaustion; only numeric FD rows are descriptors.
+    echo "open descriptors: $(lsof -p "${pid}" 2>/dev/null | awk 'NR > 1 && $4 ~ /^[0-9]+/' | wc -l | tr -d ' ')"
+    # macOS exposes no per-process rlimit for another process. This watcher is spawned by `serve.sh`
+    # in the server's own shell, so its limit is the server's — but only when armed that way.
+    echo "soft limit (inherited from the shell that armed this watcher): $(ulimit -n)"
+    echo "the dev server watches with fs.watch: one descriptor per watched directory, ~12k here."
     echo
 
     echo "--- tab log stream ---"
@@ -134,8 +140,17 @@ capture() {
 
   echo
   echo "Captured: ${out}"
-  grep -E "^trigger:|index.json:|^count:|deps_temp_\* dirs in flight:" "${out}"
+  grep -E "^trigger:|index.json:|^open descriptors:|^soft limit|deps_temp_\* dirs in flight:" "${out}"
   echo
+  # chokidar 3's fsevents backend fans every raw event out over one listener per watched path and
+  # rebuilds a path prefix in each, which pinned this server at 100% for minutes at a time. The
+  # dev server is configured onto `fs.watch` instead (`.storybook/main.ts`), so this frame
+  # reappearing means that configuration is not in effect for the process that hung.
+  if grep -q "fse_dispatch_event" "${out}"; then
+    echo "VERDICT: the fsevents watcher backend is live and burning the main thread —"
+    echo "  \`useFsEvents: false\` in .storybook/main.ts is not reaching this server."
+    echo
+  fi
   echo "Main thread, deepest named frames (what the CPU is actually in):"
   # Counts are uniform down a single hot stack, so depth — not count — is the signal. The deepest
   # frames separate the candidates outright: GC thrash shows `Heap::CollectGarbage`, a watcher storm

--- a/tools/storybook-react/serve.sh
+++ b/tools/storybook-react/serve.sh
@@ -29,6 +29,21 @@ for arg in "$@"; do
   previous="${arg}"
 done
 
+# The dev server watches with `fs.watch` (see `.storybook/main.ts`), which costs one descriptor per
+# watched directory — ~12k on this monorepo. A server launched from a GUI shell inherits macOS's
+# 256 soft limit and exhausts it within seconds, so raise it here, before the watcher is armed, so
+# that `diagnose.sh` reports the limit the server actually runs under.
+# Descending, because the ceiling is per-machine: the hard limit is usually `unlimited` but the
+# kernel still refuses anything above `kern.maxfilesperproc`.
+for limit in 200000 65536 10240; do
+  if ulimit -Sn "${limit}" 2>/dev/null; then
+    break
+  fi
+done
+if [ "$(ulimit -Sn)" -lt 10240 ] 2>/dev/null; then
+  echo "warning: descriptor limit is only $(ulimit -Sn); the file watcher will exhaust it."
+fi
+
 # Never fatal: a missing watcher is worth a warning, not a storybook that refuses to start.
 bash "${DIR}/diagnose.sh" --ensure --port "${PORT}" || echo "warning: could not arm the hang watcher."
 


### PR DESCRIPTION
## Problem

The storybook dev server pinned a core and wedged after ~20 minutes of an editing session, needing a restart. `tools/storybook-react/diagnose.sh --watch` captured four instances; three share one signature.

`sample` roots the hot stack at:

```
fse_dispatch_event (fsevents.node) -> napi_call_function
  -> Builtins_SetPrototypeForEach
    -> Builtins_StringIndexOf / Builtins_StringSlowFlatten / SearchStringRaw
```

3540 of 3611 main-thread samples in the cleanest capture.

## Cause

Vite **inlines a patched chokidar 3.6.0 into its own bundle** (`vite/dist/node/chunks/node.js`, `patch_hash=…`) — so this is not reachable via a `pnpm.overrides` on chokidar, and chokidar 4/5 would not be a drop-in anyway (it drops glob `ignored`, which Vite's own defaults require).

That backend fans **every raw fsevents event** out over one `Set` of listeners per watched tree, and each listener re-builds `resolvedPath + sep` (a cons-string V8 must flatten) and runs `indexOf` on the event path:

```js
cont.listeners.forEach((list) => list(fullPath, flags, info));
// each listener:
if (fullPath === resolvedPath || !fullPath.indexOf(resolvedPath + sysPath.sep)) …
```

Vite registers one such listener per file it transforms from **outside `root`** (`ensureWatchedFile`), and serving every `@dxos/**` package from source puts tens of thousands of files there.

`server.watch.ignored` cannot help: chokidar consults `_isIgnored` only when *registering* a watch (`fsevents-handler.js`, `_watchWithFsEvents`) and again in `handleEvent`, both **downstream** of this fan-out. The existing ignore list suppresses the HMR reload from a `dist` write but pays full CPU for it.

## Measured

Instrumented the running server with a `--require` preload, reading `cont.listeners.size` out of the fsevents callback's closure via the V8 inspector (the chokidar copy is inlined, so the `Set` is unreachable from module scope). After crawling 6000 modules:

```
fseWatches=144  listeners=[…17665…3680…3140…2730…]  total 48,013
```

- **~1.3 ms of main-thread time per raw fsevents event**
- 2055 events in one 5 s window consumed 2714 ms of main thread
- 100% CPU for ~35 s and the event loop blocked for 16 s, for a single `moon run <pkg>:build`
- RSS 4.1 GB (the captures show 3.7 GB, peak 5.7 GB)

One file write in the watched tree is enough to trigger it once `cont.listeners` has grown; bulk `dist` writes just shorten the fuse.

## Fix

`useFsEvents: false` selects the `fs.watch` backend, which has no fan-out. `usePolling: false` is **not** redundant — chokidar 3 turns polling *on* by default on macOS whenever `useFsEvents` is false, which would be far worse than what it replaces.

Same `--force` build of an 81-task graph, under a server warmed with the same 6000-module crawl:

| | fsevents | fs.watch |
|---|---|---|
| peak CPU | 56% (100% on a smaller cached build) | **8.6%** |
| peak event-loop lag | 217 ms | **4 ms** |
| HMR first update | 217 / 56 / 50 ms | **8 / 3 / 4 ms** |
| server startup | 86 s | **72 s** |
| RSS after build | 4.1 GB | 1.1 GB |
| descriptors | 2392 | 12 093 |

**This changes macOS only.** chokidar's fsevents backend does not exist elsewhere, so Linux — CI, and the `config/e2e` Storybook config which reuses `createConfig` — already takes the `fs.watch` path this selects.

## Descriptors

`fs.watch` costs one descriptor per watched directory (~12k here). `launchctl limit maxfiles` is `256 unlimited`, so a server launched from a GUI shell inherits a 256 soft limit and now dies with `EMFILE` during story indexing — reproduced, then fixed by raising the soft limit in `serve.sh` before the watcher is armed (descending ladder, because the ceiling is `kern.maxfilesperproc` and varies per machine). Verified: from a `ulimit -Sn 256` shell the server previously failed to boot and now runs at 10 000 open descriptors.

This is also the real explanation for a capture reporting `limit: 256`: `diagnose.sh` was printing its own shell's `ulimit -n`, which happens to be the server's only because `serve.sh` spawns it there.

## diagnose.sh

- Count only descriptor rows. It was using `lsof -p | wc -l`, which includes mapped regions and the executable, so every report showed ~2900 against a limit of 256 and looked like exhaustion.
- Label the limit as inherited, since macOS exposes no per-process rlimit for another process.
- Print an explicit `VERDICT:` when `fse_dispatch_event` reappears — that now means the config is not reaching that server.
- Arm the sustained-CPU trigger only after a 300 s warm-up. It was firing on healthy servers still pre-bundling ~2000 deps, producing captures that showed the optimizer and nothing else.

## Reviewer notes

- No changeset: `tools/storybook-react` is not published.
- Considered and **not** taken: raising Vite's `root` to the monorepo root, which would stop `ensureWatchedFile` registering each file individually and take the descriptor count down too. Dropped because it may well make things worse — chokidar would then walk and watch every non-ignored directory in the repo at startup rather than only the ones Vite touched — and I could not get a clean measurement. Worth revisiting with numbers.
- Still open, unrelated: a fourth capture shows a different wedge — main thread idle in `kevent`, CPU on worker threads, `uv__fsevents_cb -> FSEventWrap::OnEvent -> ProcessWrap::Spawn`. That is node's own `fs.watch`, not chokidar's addon; `@storybook/addon-vitest` is the likeliest source. Needs a clean capture with a single server running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Storybook development-server stability on macOS by reducing unintended file-watching activity.
  - Added a startup warm-up period to prevent false-positive hang reports during initial dependency processing.
  - Improved diagnostic accuracy for open file descriptors and watcher behavior.
  - Automatically raises the available file-descriptor limit when possible before monitoring starts, with a warning when limits remain low.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12959-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
