### PR TITLE
echo-client: stop feed appends retrying a closed endpoint; fix invitation e2e flakes

### DIFF
--- a/.changeset/feed-append-closed-endpoint.md
+++ b/.changeset/feed-append-closed-endpoint.md
@@ -1,0 +1,7 @@
+---
+'@dxos/echo-client': patch
+---
+
+A feed append that fails because the client services endpoint has closed (identity reset, worker handover) is no longer retried on the next tick forever; background flushes are also capped at ten per second. Previously a closed endpoint turned the retry into a busy loop of `RpcClosedError` that could stall the page — most visibly as a device invitation that never reloaded into the join shell after "Join existing identity".
+
+The in-process `MemoryTransport` now waits 10s (was 1s) for the initiator's handshake signal, matching the connection's own transport budget, so a test that signals through a deployed edge router no longer fails ~3.5% of invitations on latency alone.

--- a/.changeset/feed-append-closed-endpoint.md
+++ b/.changeset/feed-append-closed-endpoint.md
@@ -4,4 +4,4 @@
 
 A feed append that fails because the client services endpoint has closed (identity reset, worker handover) is no longer retried on the next tick forever; background flushes are also capped at ten per second. Previously a closed endpoint turned the retry into a busy loop of `RpcClosedError` that could stall the page — most visibly as a device invitation that never reloaded into the join shell after "Join existing identity".
 
-The in-process `MemoryTransport` now waits 10s (was 1s) for the initiator's handshake signal, matching the connection's own transport budget, so a test that signals through a deployed edge router no longer fails ~3.5% of invitations on latency alone.
+The in-process `MemoryTransport` now waits 2s (was 1s) for the initiator's handshake signal, enough for two signaling round trips through a deployed edge router, so a test that signals through one no longer fails ~3.5% of invitations on latency alone.

--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -31,6 +31,12 @@ const WORKSPACE_KEY = 'w';
 /** Builds the pair-chain base for a workspace: `/<anchor>/<workspace>`. */
 const workspaceUrl = (workspace: string) => `${INITIAL_URL.replace(/\/$/, '')}/${WORKSPACE_KEY}/${workspace}`;
 
+/** The workspace segment of a `/<anchor>/<workspace>` pathname; undefined off the workspace route. */
+const workspaceOf = (url: URL): string | undefined => {
+  const [, key, workspace] = url.pathname.split('/');
+  return key === WORKSPACE_KEY && workspace ? workspace : undefined;
+};
+
 // Only the default space is seeded on every new identity. The exemplar space is skipped on
 // localhost (see OnboardingPlugin `generateSampleSpace`), which is where e2e tests run.
 export const INITIAL_SPACE_COUNT = 1;
@@ -395,10 +401,10 @@ export class AppManager {
 
   /** The space id the app is currently showing, read off the `/w/<spaceId>` route. */
   get currentSpaceId(): string {
-    const { pathname } = new URL(this.page.url());
-    const spaceId = pathname.match(/^\/w\/([^/]+)/)?.[1];
+    const url = new URL(this.page.url());
+    const spaceId = workspaceOf(url);
     if (!spaceId) {
-      throw new Error(`app is not in a space workspace: ${pathname}`);
+      throw new Error(`app is not in a space workspace: ${url.pathname}`);
     }
     return spaceId;
   }
@@ -410,7 +416,7 @@ export class AppManager {
    * leaves the joined space's section untouched.
    */
   async waitForSpace(spaceId: string, timeout = 30_000): Promise<void> {
-    await this.page.waitForURL((url) => url.pathname.startsWith(`/w/${spaceId}`), { timeout });
+    await this.page.waitForURL((url) => workspaceOf(url) === spaceId, { timeout });
   }
 
   async navigateToObject(nth = 0, delay = 100): Promise<void> {

--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -393,6 +393,26 @@ export class AppManager {
     await objectForm.getByTestId('save-button').click();
   }
 
+  /** The space id the app is currently showing, read off the `/w/<spaceId>` route. */
+  get currentSpaceId(): string {
+    const { pathname } = new URL(this.page.url());
+    const spaceId = pathname.match(/^\/w\/([^/]+)/)?.[1];
+    if (!spaceId) {
+      throw new Error(`app is not in a space workspace: ${pathname}`);
+    }
+    return spaceId;
+  }
+
+  /**
+   * Waits until the app is showing `spaceId`. Joining a space moves the app between workspaces
+   * asynchronously, and until it does the navtree of the space being left is what answers queries --
+   * so an object assertion made in that window measures the wrong space, and a section toggled in it
+   * leaves the joined space's section untouched.
+   */
+  async waitForSpace(spaceId: string, timeout = 30_000): Promise<void> {
+    await this.page.waitForURL((url) => url.pathname.startsWith(`/w/${spaceId}`), { timeout });
+  }
+
   async navigateToObject(nth = 0, delay = 100): Promise<void> {
     await this.getObjectLinks().nth(nth).click({ delay });
   }

--- a/packages/apps/composer-app/src/playwright/collaboration.spec.ts
+++ b/packages/apps/composer-app/src/playwright/collaboration.spec.ts
@@ -8,12 +8,17 @@ import { AppManager } from './app-manager';
 import { Markdown } from './plugins';
 
 const perfomInvitation = async (host: AppManager, guest: AppManager) => {
+  const spaceId = host.currentSpaceId;
   await host.shareSpace();
   const invitationCode = await host.createSpaceInvitation();
   const authCode = await host.getAuthCode();
   await guest.joinSpace();
   await guest.shell.acceptSpaceInvitation(invitationCode);
   await guest.shell.authenticate(authCode);
+  // Authenticating does not itself move the guest into the space: until the app switches
+  // workspaces the navtree still being rendered is the one the guest is leaving, which answers
+  // object queries with its own contents.
+  await guest.waitForSpace(spaceId);
   await navigateToNewDocument(host);
 };
 
@@ -29,11 +34,6 @@ const navigateToNewDocument = async (app: AppManager) => {
 // these tests stay ENABLED in the meantime, both as sensors for that defect and because skipping one
 // victim of a shared cause just moves the failure to the next test.
 test.describe('Collaboration tests', () => {
-  // TODO(wittjosiah): STRICTLY temporary, remove when DX-1152 lands. Retries here exist solely
-  //   because of the endemic edge stalls named above; the defect is known and tracked, and Trunk
-  //   still records every first-attempt failure. Do not copy this pattern without a tracked issue.
-  test.describe.configure({ retries: 2 });
-
   let host: AppManager;
   let guest: AppManager;
 

--- a/packages/apps/composer-app/src/playwright/halo.spec.ts
+++ b/packages/apps/composer-app/src/playwright/halo.spec.ts
@@ -10,12 +10,6 @@ import { AppManager, INITIAL_SPACE_COUNT, INITIAL_URL } from './app-manager';
 // TODO(wittjosiah): WebRTC only available in chromium browser for testing currently.
 //   https://github.com/microsoft/playwright/issues/2973
 test.describe('HALO tests', () => {
-  // TODO(wittjosiah): STRICTLY temporary, remove when DX-1152 lands. These retries exist solely
-  //   because the production edge's two-peer path stalls endemically (invitations and replication,
-  //   ~2% per operation); the defect is known, tracked, and not maskable — Trunk still records every
-  //   first-attempt failure. Do not copy this pattern to any suite without a tracked issue.
-  test.describe.configure({ retries: 2 });
-
   let host: AppManager;
   let guest: AppManager;
 

--- a/packages/apps/todomvc/src/playwright/basic.spec.ts
+++ b/packages/apps/todomvc/src/playwright/basic.spec.ts
@@ -16,13 +16,6 @@ enum Groceries {
 }
 
 test.describe('Basic test', () => {
-  // TODO(wittjosiah): STRICTLY temporary, remove when DX-1152 lands. Every test here runs a two-peer
-  //   invitation in `beforeEach`, and a controlled comparison measured this suite failing at the same
-  //   rate as composer's collaboration tests with the same signature (the shell's auth-code input
-  //   disabled at `connectingSpaceInvitation`) — the production-edge stall, not this app. Trunk still
-  //   records every first-attempt failure. Do not copy this pattern without a tracked issue.
-  test.describe.configure({ retries: 2 });
-
   let host: AppManager;
   let guest: AppManager;
 

--- a/packages/core/echo/echo-client/src/feed/feed-handle.ts
+++ b/packages/core/echo/echo-client/src/feed/feed-handle.ts
@@ -39,6 +39,15 @@ const FEED_APPEND_BATCH_SIZE = 15;
 const RECONNECT_INITIAL_DELAY = 1_000;
 
 /**
+ * Ceiling on background append flushes per second. A failed send re-queues its cores and
+ * re-triggers the scheduler, so without a ceiling a send that fails instantly -- a closed RPC
+ * endpoint answers before the next tick -- turns the retry into a busy loop that starves the page
+ * (measured at ~10k rejections/s after an identity reset). Coalescing is the scheduler's purpose, so
+ * the happy path is unaffected by a 100ms floor between flushes.
+ */
+const FEED_APPEND_MAX_FLUSH_FREQUENCY = 10;
+
+/**
  * Ceiling for {@link FeedHandle.beginPolling}'s reconnect backoff after a stream error: the delay
  * doubles after each failed attempt, capped here, and resets to {@link RECONNECT_INITIAL_DELAY} the
  * moment a reconnected stream observes data.
@@ -133,7 +142,9 @@ export class FeedHandle {
    * Debounces `Obj.update` mutations on live feed objects into a single background append per
    * flush cycle (coalescing), mirroring `RepoProxy._sendUpdatesJob`'s use of the same primitive.
    */
-  readonly #appendScheduler = new UpdateScheduler(this._ctx, () => this.#flushDirty());
+  readonly #appendScheduler = new UpdateScheduler(this._ctx, () => this.#flushDirty(), {
+    maxFrequency: FEED_APPEND_MAX_FLUSH_FREQUENCY,
+  });
 
   private readonly _spaceId: SpaceId;
   private readonly _feedId: string;
@@ -245,16 +256,7 @@ export class FeedHandle {
     this.#addOptimistic(cores);
 
     const encoded = batch.map(({ json }) => JSON.stringify(json));
-    const sendPromise = this.#sendAppendBatches(encoded).catch((err) => {
-      log.catch(err);
-      this._error = err as Error;
-      this.updated.emit();
-      for (const { core, token } of batch) {
-        core.revertCapture(token);
-        this.#dirtyCores.add(core);
-      }
-      this.#appendScheduler.trigger();
-    });
+    const sendPromise = this.#sendAppendBatches(encoded).catch((err) => this.#onSendFailed(err, batch));
     this.#inFlight.add(sendPromise);
     try {
       await sendPromise;
@@ -398,21 +400,35 @@ export class FeedHandle {
     this.#dirtyCores.clear();
 
     const encoded = batch.map(({ json }) => JSON.stringify(json));
-    const sendPromise = this.#sendAppendBatches(encoded).catch((err) => {
-      log.catch(err);
-      this._error = err as Error;
-      this.updated.emit();
-      for (const { core, token } of batch) {
-        core.revertCapture(token);
-        this.#dirtyCores.add(core);
-      }
-      this.#appendScheduler.trigger();
-    });
+    const sendPromise = this.#sendAppendBatches(encoded).catch((err) => this.#onSendFailed(err, batch));
     this.#inFlight.add(sendPromise);
     try {
       await sendPromise;
     } finally {
       this.#inFlight.delete(sendPromise);
+    }
+  }
+
+  /**
+   * Shared failure path for {@link append} and {@link #flushDirty}: undo the optimistic capture and
+   * surface the error. A closed RPC endpoint ends retries here rather than re-queueing: the handle
+   * holds the service it was built with and is cached per database, so no later attempt can reach a
+   * live endpoint -- re-triggering only spins (see {@link FEED_APPEND_MAX_FLUSH_FREQUENCY}). The
+   * cores stay dirty so the unsent state is still visible through {@link error} and a blocking flush.
+   */
+  #onSendFailed(err: unknown, batch: Array<{ core: FeedObjectCore; token: string }>): void {
+    const closed = err instanceof RpcClosedError;
+    if (!closed) {
+      log.catch(err);
+    }
+    this._error = err as Error;
+    this.updated.emit();
+    for (const { core, token } of batch) {
+      core.revertCapture(token);
+      this.#dirtyCores.add(core);
+    }
+    if (!closed) {
+      this.#appendScheduler.trigger();
     }
   }
 

--- a/packages/core/echo/echo-client/src/feed/feed.test.ts
+++ b/packages/core/echo/echo-client/src/feed/feed.test.ts
@@ -9,7 +9,7 @@ import * as Option from 'effect/Option';
 import * as Scope from 'effect/Scope';
 import { afterEach, beforeEach, describe, onTestFinished, test } from 'vitest';
 
-import { Event } from '@dxos/async';
+import { Event, sleep } from '@dxos/async';
 import { Database, Feed, Scope as FeedScope, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { TestSchema } from '@dxos/echo/testing';
 import { EffectEx } from '@dxos/effect';
@@ -342,6 +342,39 @@ describe('Feed', () => {
       const results = await db.query(Query.select(Filter.everything()).from(FeedScope.feed(feedUri))).run();
       expect(results).toHaveLength(1);
       expect((results[0] as TestSchema.Person).name).toEqual('john');
+    });
+
+    // The production trigger is an identity reset or worker handover closing the services endpoint
+    // under a handle that still has captured writes. An interrupted handler is what the in-process
+    // transport surfaces for that: `runServiceCall` maps an interrupt-only cause to `RpcClosedError`.
+    test('append stops retrying once the RPC endpoint is closed', async ({ expect }) => {
+      await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
+      const db = await peer.createDatabase();
+
+      let callCount = 0;
+      const realHandlers = peer.host.feedService;
+      const closedHandlers: FeedService.Handlers = {
+        ...realHandlers,
+        'FeedService.insertIntoFeed': () => {
+          callCount++;
+          return Effect.interrupt;
+        },
+      };
+      db._setFeedService(await makeFeedClient(closedHandlers));
+
+      const feed = db.add(Feed.make({ name: 'closed' }));
+      const john = Obj.make(TestSchema.Person, { name: 'john' });
+
+      // Best-effort contract: the closed endpoint surfaces through the handle's error, not a throw.
+      await db.appendToFeed(feed, [john]);
+      await db.flush();
+      const settled = callCount;
+      expect(settled).toBeGreaterThanOrEqual(1);
+
+      // Before this guard the failure re-queued and re-triggered on the next tick, so a closed
+      // endpoint produced thousands of attempts in this window.
+      await sleep(300);
+      expect(callCount).toEqual(settled);
     });
 
     test('disposing the feed handle flushes a same-tick update instead of dropping it', async ({ expect }) => {

--- a/packages/core/mesh/network-manager/src/transport/memory-transport.ts
+++ b/packages/core/mesh/network-manager/src/transport/memory-transport.ts
@@ -30,6 +30,15 @@ const createStreamDelay = (delay: number): NodeJS.ReadWriteStream => {
   });
 };
 
+/**
+ * How long the receiving side waits for the initiator's `transportId` signal. That signal only leaves
+ * the initiator after the answer has made its own trip, so the wait spans two signaling round trips:
+ * microseconds in-process, but ~0.6s p50 / ~0.9s p90 per hop over a deployed edge router, where a 1s
+ * default failed ~3.5% of invitation handshakes. Matched to the connection's own 10s transport budget,
+ * which is the outer bound anyway.
+ */
+const MEMORY_TRANSPORT_HANDSHAKE_TIMEOUT = 10_000; // [ms]
+
 export const MemoryTransportFactory: TransportFactory = {
   createTransport: (options) => new MemoryTransport(options),
 };
@@ -86,7 +95,7 @@ export class MemoryTransport implements Transport {
     } else {
       // Don't block the open method.
       this._remote
-        .wait({ timeout: this._options.timeout ?? 1_000 })
+        .wait({ timeout: this._options.timeout ?? MEMORY_TRANSPORT_HANDSHAKE_TIMEOUT })
         .then((remoteId) => {
           if (this._closed) {
             return;

--- a/packages/core/mesh/network-manager/src/transport/memory-transport.ts
+++ b/packages/core/mesh/network-manager/src/transport/memory-transport.ts
@@ -34,10 +34,10 @@ const createStreamDelay = (delay: number): NodeJS.ReadWriteStream => {
  * How long the receiving side waits for the initiator's `transportId` signal. That signal only leaves
  * the initiator after the answer has made its own trip, so the wait spans two signaling round trips:
  * microseconds in-process, but ~0.6s p50 / ~0.9s p90 per hop over a deployed edge router, where a 1s
- * default failed ~3.5% of invitation handshakes. Matched to the connection's own 10s transport budget,
- * which is the outer bound anyway.
+ * default failed ~3.5% of invitation handshakes; 2s covers two p90 hops without hiding a stalled peer
+ * behind the connection's own 10s transport budget.
  */
-const MEMORY_TRANSPORT_HANDSHAKE_TIMEOUT = 10_000; // [ms]
+const MEMORY_TRANSPORT_HANDSHAKE_TIMEOUT = 2_000; // [ms]
 
 export const MemoryTransportFactory: TransportFactory = {
   createTransport: (options) => new MemoryTransport(options),


### PR DESCRIPTION
Part of DX-1152. The two edge-side fixes for the router reset (dxos/edge#1009, #1021) shipped, but the invitation e2e suites kept failing at 15–25% first-attempt against the fixed edge. This PR fixes what was actually failing — none of it was the invitation handshake — and removes the temporary retry masks so CI reports first attempts again.

## What changed

**`@dxos/echo-client` — `FeedHandle` no longer retries a closed endpoint forever.** Both append paths re-queued their cores and re-triggered the flush scheduler on *any* send failure, with no rate limit. Once an identity reset (or a worker handover) closed the services endpoint, `runServiceCall` rejected with `RpcClosedError` before the next tick and the retry became a busy loop — measured at ~9,800 `RpcClosedError`/s (590k in 60s) on a guest that had just run "Join existing identity", pegging the page so the join shell never mounted and inflating Playwright traces until `context.close()` died with `RangeError: Invalid string length`. The failure path is now one method (`#onSendFailed`): on `RpcClosedError` it reverts the optimistic capture, records the error and leaves the cores dirty, but does not re-trigger — a handle captures its service at construction and is cached per database, so no later attempt from it can reach a live endpoint. Every other failure still retries, now bounded by `maxFrequency: 10` on the scheduler. Regression test `append stops retrying once the RPC endpoint is closed` (handler returns `Effect.interrupt`, which is exactly what `runServiceCall` maps to `RpcClosedError`) fails on the old code and passes on this one; the existing generic-retry test still passes.

**`@dxos/network-manager` — `MemoryTransport` handshake wait 1s → 2s.** The receiving side waited `options.timeout ?? 1_000` ms for the initiator's `transportId` signal, which only leaves the initiator after the answer has made its own trip — two signaling round trips. In-process that is microseconds; through a deployed router one `joinSwarm → notifySwarmUpdated` hop measured ~0.6s p50 / ~0.9s p90, and the 1s default failed ~3.5% of invitation handshakes in the edge repo's suite. 2s covers two p90 hops (~1.8s) while still failing well inside the connection's own 10s transport budget; measured 1/260 handshakes over 2s (the first handshake of a fresh process, i.e. cold router connections), against 9/260 at 1s and 0/520 at 10s. Test-only transport; browsers are unaffected.

**composer e2e — `collaboration.spec.ts` asserted on the wrong workspace.** `guest.shell.authenticate()` returns before the app switches workspaces, and the navtree still rendering is the guest's *own* space, which holds exactly one object — so `expect(getObjectLinks()).toHaveCount(1)` passed spuriously and `toggleSection` expanded the wrong tree; whether the switch beat the assertion decided the outcome. `AppManager` gains `currentSpaceId` / `waitForSpace(spaceId)` and `perfomInvitation` waits for the guest to actually arrive.

**Retry masks removed.** The `test.describe.configure({ retries: 2 })` blocks in `halo.spec.ts`, `collaboration.spec.ts` and todomvc `basic.spec.ts` were each tagged "STRICTLY temporary, remove when DX-1152 lands". `e2ePreset` already sets `retries: 0`.

## Verification (all first attempt, retries off, against `dev.dxos.network` on edge `main`)

| suite | before | after |
|---|---|---|
| composer `collaboration` (2 tests) | 8/40 failed | 0/140 |
| composer `halo` (2 device-invitation tests) | 8/40 failed | 5/140 — all in `deleting a space`, see below |
| todomvc `basic.spec.ts` (8 tests, invitation per `beforeEach`) | — | 1/720 |
| edge `client-invitations` (13 tests, in-process peers over the real router) | 9/260 failed (1s wait) | 0/520 at 10s; 1/260 at the landed 2s (one cold first handshake) |
| dxos `client-e2e` invitation suites (in-memory) | — | 0/3,560 |

Edge side across every run (SigNoz + `wrangler tail`): 0 overloads, 0 `swarmNotifyGaveUp`, 0 stub evictions caused by load; the router policy was also A/B'd (immediate eviction vs. an idle TTL) with no difference to any suite, and the TTL was not kept.

## Known residuals, not addressed here

- `halo › deleting a space replicates across devices`: 3/50 in one long run, 0/20 in the next. After the guest's identity reset, one of the host's spaces never appears on the new device (`spacePlugin.space` 2 expected / 1 seen for 60s, one `Automerge root doc load timeout (DataSpace)` warning, 0 `RpcClosedError`). Two-sided tails show the sink registers the device and replies within 0.7s (including a 4.9 KB frame); the device never continues that subduction session while its other space polls normally, and its console shows `worker-connection: leader session failed, backing off and re-watching` — the post-reset leader-handover state `client.ts` describes as "proxies left in a broken state", on a path that does not reload. Client-side; separate issue.
- Same test, 2/50: 30s click timeout in `AppManager.openSpaceSettings` on the host after `page.goto`. UI flake; separate issue.
- todomvc 1/160 in one run: guest stuck at the space-invitation input for 30s, edge silent at warn+. Not reproduced since.

- Pre-existing, unrelated: `client-e2e › spaces.test.ts › post and listen to messages` times out locally ~30% of the time (`Timeout [30,000ms]` at `spaces.test.ts:155`). A/B with the `MemoryTransport` default raised vs 1s gives 3/10 failures either way, so it is not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented infinite feed-append retries when a client service endpoint closes.
  - Limited background feed flushes to 10 per second, reducing excessive retry activity.
  - Improved memory transport connection reliability by allowing up to 2 seconds for handshake signaling.
  - Workspace navigation now waits for an exact workspace match, avoiding incorrect workspace detection.

- **Tests**
  - Updated collaboration, HALO, and TodoMVC test coverage to reflect more reliable workspace synchronization and reduced reliance on automatic retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12964-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
