### PR TITLE
client: move the network carrier group to buf types

### DIFF
--- a/.changeset/network-status-buf-types.md
+++ b/.changeset/network-status-buf-types.md
@@ -1,0 +1,18 @@
+---
+'@dxos/client': minor
+---
+
+Move the network carrier group to buf types
+
+`NetworkService` and `EdgeAgentService` now speak buf messages, so the types they carry change
+shape for consumers:
+
+- `MeshProxy.networkStatus` reports the buf `NetworkStatus`. Its `swarm` field uses the buf
+  `ConnectionState` enum, imported from `@dxos/protocols/buf/dxos/client/services_pb` rather than
+  `@dxos/protocols/proto/dxos/client/services`.
+- Nested enums flatten: `EdgeStatus.ConnectionState.X` becomes `EdgeStatus_ConnectionState.X`, and
+  `QueryAgentStatusResponse.AgentStatus.X` becomes `QueryAgentStatusResponse_AgentStatus.X`.
+- Building one of these messages by object literal no longer typechecks; construct it with
+  `create(NetworkStatusSchema, { … })` from `@bufbuild/protobuf`.
+
+Both codecs produce identical wire bytes, so no persisted or in-flight data changes.

--- a/packages/core/protocols/src/EdgeAgentService.ts
+++ b/packages/core/protocols/src/EdgeAgentService.ts
@@ -7,7 +7,11 @@ import * as Rpc from 'effect/unstable/rpc/Rpc';
 import type * as RpcClient from 'effect/unstable/rpc/RpcClient';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 
-import { protoMessage, serviceError } from './service-rpc.ts';
+import {
+  QueryAgentStatusResponseSchema,
+  QueryEdgeStatusResponseSchema,
+} from './buf/proto/gen/dxos/client/services_pb.ts';
+import { bufMessage, serviceError } from './service-rpc.ts';
 
 /**
  * Effect RPC definitions for the EDGE agent service (formerly `dxos.client.services.EdgeAgentService`).
@@ -16,7 +20,7 @@ import { protoMessage, serviceError } from './service-rpc.ts';
  */
 export class Rpcs extends RpcGroup.make(
   Rpc.make('queryEdgeStatus', {
-    success: protoMessage('dxos.client.services.QueryEdgeStatusResponse'),
+    success: bufMessage(QueryEdgeStatusResponseSchema),
     error: serviceError,
     stream: true,
   }),
@@ -24,7 +28,7 @@ export class Rpcs extends RpcGroup.make(
     error: serviceError,
   }),
   Rpc.make('queryAgentStatus', {
-    success: protoMessage('dxos.client.services.QueryAgentStatusResponse'),
+    success: bufMessage(QueryAgentStatusResponseSchema),
     error: serviceError,
     stream: true,
   }),

--- a/packages/core/protocols/src/NetworkService.ts
+++ b/packages/core/protocols/src/NetworkService.ts
@@ -8,7 +8,15 @@ import * as Rpc from 'effect/unstable/rpc/Rpc';
 import type * as RpcClient from 'effect/unstable/rpc/RpcClient';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 
-import { protoMessage, serviceError } from './service-rpc.ts';
+import { NetworkStatusSchema } from './buf/proto/gen/dxos/client/services_pb.ts';
+import { PeerSchema, SwarmResponseSchema } from './buf/proto/gen/dxos/edge/messenger_pb.ts';
+import {
+  JoinRequestSchema,
+  LeaveRequestSchema,
+  MessageSchema,
+  QueryRequestSchema,
+} from './buf/proto/gen/dxos/edge/signal_pb.ts';
+import { bufMessage, serviceError } from './service-rpc.ts';
 import { mutableArray, publicKey } from './service-schemas.ts';
 
 //
@@ -33,7 +41,7 @@ export interface SubscribeSwarmStateRequest extends Schema.Schema.Type<typeof Su
 
 export const SubscribeMessagesRequest = Schema.Struct({
   /** The subscribing peer; point-to-point messages addressed to this peerKey are always delivered. */
-  peer: protoMessage('dxos.edge.messenger.Peer'),
+  peer: bufMessage(PeerSchema),
   /** OR-subscription: deliver any broadcast message whose tags intersect this set. */
   tags: Schema.optional(mutableArray(Schema.String)),
 });
@@ -49,39 +57,39 @@ export class Rpcs extends RpcGroup.make(
     error: serviceError,
   }),
   Rpc.make('queryStatus', {
-    success: protoMessage('dxos.client.services.NetworkStatus'),
+    success: bufMessage(NetworkStatusSchema),
     error: serviceError,
     stream: true,
   }),
   Rpc.make('joinSwarm', {
-    payload: protoMessage('dxos.edge.signal.JoinRequest'),
+    payload: bufMessage(JoinRequestSchema),
     error: serviceError,
   }),
   Rpc.make('leaveSwarm', {
-    payload: protoMessage('dxos.edge.signal.LeaveRequest'),
+    payload: bufMessage(LeaveRequestSchema),
     error: serviceError,
   }),
   /**
    * Query the swarm state without joining it.
    */
   Rpc.make('querySwarm', {
-    payload: protoMessage('dxos.edge.signal.QueryRequest'),
-    success: protoMessage('dxos.edge.messenger.SwarmResponse'),
+    payload: bufMessage(QueryRequestSchema),
+    success: bufMessage(SwarmResponseSchema),
     error: serviceError,
   }),
   Rpc.make('subscribeSwarmState', {
     payload: SubscribeSwarmStateRequest,
-    success: protoMessage('dxos.edge.messenger.SwarmResponse'),
+    success: bufMessage(SwarmResponseSchema),
     error: serviceError,
     stream: true,
   }),
   Rpc.make('sendMessage', {
-    payload: protoMessage('dxos.edge.signal.Message'),
+    payload: bufMessage(MessageSchema),
     error: serviceError,
   }),
   Rpc.make('subscribeMessages', {
     payload: SubscribeMessagesRequest,
-    success: protoMessage('dxos.edge.signal.Message'),
+    success: bufMessage(MessageSchema),
     error: serviceError,
     stream: true,
   }),

--- a/packages/sdk/client-services/src/packlets/agents/edge-agent-service.ts
+++ b/packages/sdk/client-services/src/packlets/agents/edge-agent-service.ts
@@ -9,11 +9,18 @@ import { Context } from '@dxos/context';
 import { type EdgeConnection } from '@dxos/edge-client';
 import { EffectEx } from '@dxos/effect';
 import { EdgeAgentStatus } from '@dxos/protocols';
+import { buf } from '@dxos/protocols/buf';
 import {
-  EdgeStatus,
-  QueryAgentStatusResponse,
+  type EdgeStatus,
+  EdgeStatus_ConnectionState,
+  EdgeStatusSchema,
+  type QueryAgentStatusResponse,
+  QueryAgentStatusResponse_AgentStatus,
+  QueryAgentStatusResponseSchema,
   type QueryEdgeStatusResponse,
-} from '@dxos/protocols/proto/dxos/client/services';
+  QueryEdgeStatusResponseSchema,
+} from '@dxos/protocols/buf/dxos/client/services_pb';
+import { EdgeStatus as LegacyEdgeStatus } from '@dxos/protocols/proto/dxos/client/services';
 import { type EdgeAgentService } from '@dxos/protocols/rpc';
 
 import { type EdgeAgentManager } from './edge-agent-manager';
@@ -30,17 +37,9 @@ export class EdgeAgentServiceImpl implements EdgeAgentService.Handlers {
     return EffectEx.streamFromEmitter<QueryEdgeStatusResponse, Error>((emit) => {
       const ctx = Context.default();
       const update = () => {
-        void emit.single({
-          status: this._edgeConnection?.status ?? {
-            state: EdgeStatus.ConnectionState.NOT_CONNECTED,
-            rtt: 0,
-            uptime: 0,
-            rateBytesUp: 0,
-            rateBytesDown: 0,
-            messagesSent: 0,
-            messagesReceived: 0,
-          },
-        });
+        void emit.single(
+          buf.create(QueryEdgeStatusResponseSchema, { status: toBufEdgeStatus(this._edgeConnection?.status) }),
+        );
       };
 
       this._edgeConnection?.statusChanged.on(ctx, update);
@@ -60,11 +59,13 @@ export class EdgeAgentServiceImpl implements EdgeAgentService.Handlers {
   ['EdgeAgentService.queryAgentStatus'](): EffectStream.Stream<QueryAgentStatusResponse, Error> {
     return EffectEx.streamFromEmitter<QueryAgentStatusResponse, Error>((emit) => {
       const ctx = Context.default();
-      void emit.single({ status: QueryAgentStatusResponse.AgentStatus.UNKNOWN });
+      void emit.single(
+        buf.create(QueryAgentStatusResponseSchema, { status: QueryAgentStatusResponse_AgentStatus.UNKNOWN }),
+      );
       void this._agentManagerProvider().then((agentManager) => {
-        void emit.single({ status: mapStatus(agentManager.agentStatus) });
+        void emit.single(buf.create(QueryAgentStatusResponseSchema, { status: mapStatus(agentManager.agentStatus) }));
         agentManager.agentStatusChanged.on(ctx, (newStatus) => {
-          void emit.single({ status: mapStatus(newStatus) });
+          void emit.single(buf.create(QueryAgentStatusResponseSchema, { status: mapStatus(newStatus) }));
         });
       });
 
@@ -73,15 +74,41 @@ export class EdgeAgentServiceImpl implements EdgeAgentService.Handlers {
   }
 }
 
-const mapStatus = (agentStatus: EdgeAgentStatus | undefined): QueryAgentStatusResponse.AgentStatus => {
+/**
+ * Reads the edge connection's status as the buf message the service now returns.
+ * `EdgeConnection` still reports the protobuf.js shape, so the two codecs meet here; remove this
+ * when `@dxos/edge-client` moves to buf.
+ */
+const toBufEdgeStatus = (status: LegacyEdgeStatus | undefined): EdgeStatus =>
+  buf.create(EdgeStatusSchema, {
+    state: toBufConnectionState(status?.state),
+    rtt: status?.rtt ?? 0,
+    uptime: status?.uptime ?? 0,
+    rateBytesUp: status?.rateBytesUp ?? 0,
+    rateBytesDown: status?.rateBytesDown ?? 0,
+    messagesSent: status?.messagesSent ?? 0,
+    messagesReceived: status?.messagesReceived ?? 0,
+  });
+
+const toBufConnectionState = (state: LegacyEdgeStatus.ConnectionState | undefined): EdgeStatus_ConnectionState => {
+  switch (state) {
+    case LegacyEdgeStatus.ConnectionState.CONNECTED:
+      return EdgeStatus_ConnectionState.CONNECTED;
+    case LegacyEdgeStatus.ConnectionState.NOT_CONNECTED:
+    case undefined:
+      return EdgeStatus_ConnectionState.NOT_CONNECTED;
+  }
+};
+
+const mapStatus = (agentStatus: EdgeAgentStatus | undefined): QueryAgentStatusResponse_AgentStatus => {
   switch (agentStatus) {
     case EdgeAgentStatus.ACTIVE:
-      return QueryAgentStatusResponse.AgentStatus.ACTIVE;
+      return QueryAgentStatusResponse_AgentStatus.ACTIVE;
     case EdgeAgentStatus.INACTIVE:
-      return QueryAgentStatusResponse.AgentStatus.INACTIVE;
+      return QueryAgentStatusResponse_AgentStatus.INACTIVE;
     case EdgeAgentStatus.NOT_FOUND:
-      return QueryAgentStatusResponse.AgentStatus.NOT_FOUND;
+      return QueryAgentStatusResponse_AgentStatus.NOT_FOUND;
     case undefined:
-      return QueryAgentStatusResponse.AgentStatus.UNKNOWN;
+      return QueryAgentStatusResponse_AgentStatus.UNKNOWN;
   }
 };

--- a/packages/sdk/client-services/src/packlets/network/network-service.ts
+++ b/packages/sdk/client-services/src/packlets/network/network-service.ts
@@ -10,15 +10,28 @@ import { type EdgeConnection } from '@dxos/edge-client';
 import { EffectEx } from '@dxos/effect';
 import { type SignalManager, type UnsubscribeCallback } from '@dxos/messaging';
 import { type SwarmNetworkManager } from '@dxos/network-manager';
-import { type NetworkStatus } from '@dxos/protocols/proto/dxos/client/services';
-import { type SwarmResponse } from '@dxos/protocols/proto/dxos/edge/messenger';
+import { buf } from '@dxos/protocols/buf';
+import { type NetworkStatus, NetworkStatusSchema } from '@dxos/protocols/buf/dxos/client/services_pb';
+import { type SwarmResponse } from '@dxos/protocols/buf/dxos/edge/messenger_pb';
 import {
   type JoinRequest,
   type LeaveRequest,
   type Message,
   type QueryRequest,
-} from '@dxos/protocols/proto/dxos/edge/signal';
+} from '@dxos/protocols/buf/dxos/edge/signal_pb';
+import { type Message as LegacyMessage } from '@dxos/protocols/proto/dxos/edge/signal';
 import { type NetworkService } from '@dxos/protocols/rpc';
+
+import {
+  fromBufJoinRequest,
+  fromBufLeaveRequest,
+  fromBufMessage,
+  fromBufPeer,
+  fromBufQueryRequest,
+  toBufMessage,
+  toBufSwarmInfo,
+  toBufSwarmResponse,
+} from './utils';
 
 export class NetworkServiceImpl implements NetworkService.Handlers {
   'constructor'(
@@ -31,11 +44,13 @@ export class NetworkServiceImpl implements NetworkService.Handlers {
     return EffectEx.streamFromEmitter<NetworkStatus, Error>((emit) => {
       const ctx = Context.default();
       const update = () => {
-        void emit.single({
-          swarm: this.networkManager.connectionState,
-          connectionInfo: this.networkManager.connectionLog?.swarms,
-          signaling: this.signalManager.getStatus?.().map(({ host, state }) => ({ server: host, state })),
-        });
+        void emit.single(
+          buf.create(NetworkStatusSchema, {
+            swarm: this.networkManager.connectionState,
+            connectionInfo: this.networkManager.connectionLog?.swarms.map(toBufSwarmInfo),
+            signaling: this.signalManager.getStatus?.().map(({ host, state }) => ({ server: host, state })),
+          }),
+        );
       };
 
       this.networkManager.connectionStateChanged.on(ctx, () => update());
@@ -58,7 +73,7 @@ export class NetworkServiceImpl implements NetworkService.Handlers {
   ['NetworkService.joinSwarm'](request: JoinRequest): Effect.Effect<void, Error> {
     return Effect.tryPromise({
       try: async () => {
-        await this.signalManager.join(Context.default(), request);
+        await this.signalManager.join(Context.default(), fromBufJoinRequest(request));
       },
       catch: (error) => error as Error,
     });
@@ -67,7 +82,7 @@ export class NetworkServiceImpl implements NetworkService.Handlers {
   ['NetworkService.leaveSwarm'](request: LeaveRequest): Effect.Effect<void, Error> {
     return Effect.tryPromise({
       try: async () => {
-        await this.signalManager.leave(Context.default(), request);
+        await this.signalManager.leave(Context.default(), fromBufLeaveRequest(request));
       },
       catch: (error) => error as Error,
     });
@@ -76,7 +91,7 @@ export class NetworkServiceImpl implements NetworkService.Handlers {
   ['NetworkService.querySwarm'](request: QueryRequest): Effect.Effect<SwarmResponse, Error> {
     return Effect.tryPromise({
       try: async () => {
-        return this.signalManager.query(Context.default(), request);
+        return toBufSwarmResponse(await this.signalManager.query(Context.default(), fromBufQueryRequest(request)));
       },
       catch: (error) => error as Error,
     });
@@ -89,7 +104,7 @@ export class NetworkServiceImpl implements NetworkService.Handlers {
       const ctx = Context.default();
       this.signalManager.swarmState?.on(ctx, (state) => {
         if (request.topic.equals(state.swarmKey)) {
-          void emit.single(state);
+          void emit.single(toBufSwarmResponse(state));
         }
       });
 
@@ -100,7 +115,7 @@ export class NetworkServiceImpl implements NetworkService.Handlers {
   ['NetworkService.sendMessage'](message: Message): Effect.Effect<void, Error> {
     return Effect.tryPromise({
       try: async () => {
-        await this.signalManager.sendMessage(Context.default(), message);
+        await this.signalManager.sendMessage(Context.default(), fromBufMessage(message));
       },
       catch: (error) => error as Error,
     });
@@ -113,11 +128,10 @@ export class NetworkServiceImpl implements NetworkService.Handlers {
     return EffectEx.streamFromEmitter<Message, Error>((emit) => {
       const ctx = Context.default();
 
-      // This stream crosses the client-services RPC (protobufjs codec, e.g. dedicated worker → main
-      // thread). Its `Message.payload` is a `google.protobuf.Any` without `preserve_any`, and the
-      // codec refuses to encode an Any lacking '@type' — stamping the opaque form
-      // ('@type': 'google.protobuf.Any' + type_url/value) makes it pass through verbatim.
-      const encodableAny = (payload: Message['payload']): Message['payload'] => ({
+      // `toBufMessage` re-encodes through the protobufjs codec, which refuses an Any lacking
+      // '@type' because `Message.payload` has no `preserve_any` — stamping the opaque form makes it
+      // pass through verbatim.
+      const encodableAny = (payload: LegacyMessage['payload']): LegacyMessage['payload'] => ({
         ...payload,
         '@type': 'google.protobuf.Any',
       });
@@ -128,10 +142,10 @@ export class NetworkServiceImpl implements NetworkService.Handlers {
       let unsubscribe: UnsubscribeCallback | undefined;
       void this.signalManager
         .subscribeMessages({
-          peer,
+          peer: fromBufPeer(peer),
           tags,
           onMessage: (message) => {
-            void emit.single({ ...message, payload: encodableAny(message.payload) });
+            void emit.single(toBufMessage({ ...message, payload: encodableAny(message.payload) }));
           },
         })
         .then((unsub) => {

--- a/packages/sdk/client-services/src/packlets/network/utils.ts
+++ b/packages/sdk/client-services/src/packlets/network/utils.ts
@@ -1,0 +1,71 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { buf } from '@dxos/protocols/buf';
+import { decodeCompat, encodeCompat } from '@dxos/protocols/buf-shape-compat';
+import { type SwarmInfo, SwarmInfoSchema } from '@dxos/protocols/buf/dxos/devtools/swarm_pb';
+import {
+  type Peer,
+  PeerSchema,
+  type SwarmResponse,
+  SwarmResponseSchema,
+} from '@dxos/protocols/buf/dxos/edge/messenger_pb';
+import {
+  type JoinRequest,
+  JoinRequestSchema,
+  type LeaveRequest,
+  LeaveRequestSchema,
+  type Message,
+  MessageSchema,
+  type QueryRequest,
+  QueryRequestSchema,
+} from '@dxos/protocols/buf/dxos/edge/signal_pb';
+import { type SwarmInfo as LegacySwarmInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
+import {
+  type Peer as LegacyPeer,
+  type SwarmResponse as LegacySwarmResponse,
+} from '@dxos/protocols/proto/dxos/edge/messenger';
+import {
+  type JoinRequest as LegacyJoinRequest,
+  type LeaveRequest as LegacyLeaveRequest,
+  type Message as LegacyMessage,
+  type QueryRequest as LegacyQueryRequest,
+} from '@dxos/protocols/proto/dxos/edge/signal';
+
+//
+// `SignalManager` is still written against the protobuf.js shapes while the service speaks buf.
+// Both codecs agree byte for byte, which makes the encoding the conversion; these bridges delete
+// themselves when `@dxos/messaging` moves to buf.
+//
+
+/** Reads a join request as the shape `SignalManager` expects. */
+export const fromBufJoinRequest = (request: JoinRequest): LegacyJoinRequest =>
+  decodeCompat(JoinRequestSchema, buf.toBinary(JoinRequestSchema, request));
+
+/** Reads a leave request as the shape `SignalManager` expects. */
+export const fromBufLeaveRequest = (request: LeaveRequest): LegacyLeaveRequest =>
+  decodeCompat(LeaveRequestSchema, buf.toBinary(LeaveRequestSchema, request));
+
+/** Reads a query request as the shape `SignalManager` expects. */
+export const fromBufQueryRequest = (request: QueryRequest): LegacyQueryRequest =>
+  decodeCompat(QueryRequestSchema, buf.toBinary(QueryRequestSchema, request));
+
+/** Reads a message as the shape `SignalManager` expects. */
+export const fromBufMessage = (message: Message): LegacyMessage =>
+  decodeCompat(MessageSchema, buf.toBinary(MessageSchema, message));
+
+/** Reads a subscribing peer as the shape `SignalManager` expects. */
+export const fromBufPeer = (peer: Peer): LegacyPeer => decodeCompat(PeerSchema, buf.toBinary(PeerSchema, peer));
+
+/** Reads a swarm response from `SignalManager` as the buf message the service returns. */
+export const toBufSwarmResponse = (response: LegacySwarmResponse): SwarmResponse =>
+  buf.fromBinary(SwarmResponseSchema, encodeCompat(SwarmResponseSchema, response));
+
+/** Reads a message from `SignalManager` as the buf message the service streams. */
+export const toBufMessage = (message: LegacyMessage): Message =>
+  buf.fromBinary(MessageSchema, encodeCompat(MessageSchema, message));
+
+/** Reads the connection log's swarms as the buf messages the status message carries. */
+export const toBufSwarmInfo = (info: LegacySwarmInfo): SwarmInfo =>
+  buf.fromBinary(SwarmInfoSchema, encodeCompat(SwarmInfoSchema, info));

--- a/packages/sdk/client/src/mesh/index.ts
+++ b/packages/sdk/client/src/mesh/index.ts
@@ -2,5 +2,5 @@
 // Copyright 2023 DXOS.org
 //
 
-export { ConnectionState, type NetworkStatus } from '@dxos/protocols/proto/dxos/client/services';
+export { ConnectionState, type NetworkStatus, NetworkStatusSchema } from '@dxos/protocols/buf/dxos/client/services_pb';
 export { type GossipMessage } from '@dxos/protocols/proto/dxos/mesh/teleport/gossip';

--- a/packages/sdk/client/src/mesh/mesh-proxy.ts
+++ b/packages/sdk/client/src/mesh/mesh-proxy.ts
@@ -8,7 +8,8 @@ import { Event, MulticastObservable, SubscriptionList } from '@dxos/async';
 import { type ClientServicesProvider } from '@dxos/client-protocol';
 import { log } from '@dxos/log';
 import { runServiceCall, subscribeStream } from '@dxos/protocols';
-import { ConnectionState, type NetworkStatus } from '@dxos/protocols/proto/dxos/client/services';
+import { buf } from '@dxos/protocols/buf';
+import { ConnectionState, type NetworkStatus, NetworkStatusSchema } from '@dxos/protocols/buf/dxos/client/services_pb';
 
 import { RPC_TIMEOUT } from '../common';
 
@@ -17,10 +18,10 @@ import { RPC_TIMEOUT } from '../common';
  */
 export class MeshProxy {
   private readonly _networkStatusUpdated = new Event<NetworkStatus>();
-  private readonly _networkStatus = MulticastObservable.from(this._networkStatusUpdated, {
-    swarm: ConnectionState.OFFLINE,
-    signaling: [],
-  });
+  private readonly _networkStatus = MulticastObservable.from(
+    this._networkStatusUpdated,
+    buf.create(NetworkStatusSchema, { swarm: ConnectionState.OFFLINE, signaling: [] }),
+  );
 
   /** Subscriptions for RPC streams that need to be re-established on reconnect. */
   private readonly _streamSubscriptions = new SubscriptionList();


### PR DESCRIPTION
Chunk 4 of the protobuf.js → buf teardown: the network carrier group.

## What

`NetworkService` (10 payloads) and `EdgeAgentService` (3) move from `protoMessage` to `bufMessage`, and their consumers follow. Both codecs produce identical wire bytes, so this changes types without changing what goes over the wire or onto disk.

**13 `protoMessage` calls removed. 8 files.**

## Why this group, and not the one the plan called for

The original chunking put `halo/credentials` next, and I had proposed the identity group (`IdentityService`/`DevicesService`/`ContactsService`) as an alternative outside the credentials fence. **Both are blocked.** `credential-generator.ts` — inside `packages/core/halo/credentials/src/credentials/` — consumes `ProfileDocument` and `DeviceProfileDocument`, and `Identity`, `Device` and `Contact` all embed `ProfileDocument`. `SpacesService` is blocked the same way through its `Contact` and `Credential`.

The network group has no credentials in its type graph, which is what makes it available now.

## `BridgeService` is deliberately excluded

`BridgeService` looks like it belongs here — same mesh area, no credentials — and I flipped it first to measure. **The full build reported zero errors, which is the alarming result, not the reassuring one.**

`packages/sdk/client-protocol/src/bridge-rpc.ts` serves the Effect `Rpcs` group with handlers typed from the protobuf.js `BridgeServiceRpc`, joined by a pre-existing `handlers as never`; consumers resolve the service by name through `getBufService<BridgeService>(...)`, also typed with the legacy interface. So the codec can be swapped underneath handlers still emitting protobuf.js shapes and nothing tells you. Every bridge request carries `dxos.keys.PublicKey proxy_id` — a class instance under protobuf.js, a `{$typeName, data}` message under buf — and `RtcTransportService` keys its proxy map by it. That is the identity-equality failure that caused the `_matchesInvitationContext` bug in #12963, except here with no type error to catch it. `StatsResponse.stats` being a `google.protobuf.Struct` is a second divergence.

I reverted that flip. `BridgeService` gets its own change, where the `as never` is replaced with real types so the compiler polices the seam, and verified through the actual worker↔tab bridge rather than by build alone.

## Seams

Both services sit above code that still speaks protobuf.js, so the codecs meet in total mappers, never casts:

- **`SignalManager`** (`@dxos/messaging`) takes and returns the legacy shapes. `packlets/network/utils.ts` bridges each one through the shared wire format — since both codecs agree byte for byte, the encoding *is* the conversion, the same trick the metadata seam used in #12963. Deletes itself when messaging moves to buf.
- **`EdgeConnection`** reports a protobuf.js `EdgeStatus`. `toBufEdgeStatus` rebuilds it as the buf message, with `toBufConnectionState` an exhaustive switch that breaks loudly if either enum gains a member — which a cast would swallow.
- **`connectionInfo`** carries `dxos.devtools.swarm.SwarmInfo` from the connection log, bridged the same way.

The `encodableAny` stamp in `subscribeMessages` survives but for a different reason, and its comment now says so: it is no longer about the RPC codec (that leg is buf now) but about `toBufMessage` re-encoding through the compat encoder, which still refuses an `Any` lacking `'@type'`.

## Breaking (see changeset)

`MeshProxy.networkStatus` reports the buf `NetworkStatus`; `ConnectionState` and `NetworkStatus` now come from `@dxos/protocols/buf/dxos/client/services_pb`. Nested enums flatten (`EdgeStatus.ConnectionState.X` → `EdgeStatus_ConnectionState.X`, `QueryAgentStatusResponse.AgentStatus.X` → `QueryAgentStatusResponse_AgentStatus.X`), and these messages are built with `create(Schema, …)` rather than object literals.

## Validation

- Full repo build: exit 0, **0 errors**.
- `moon run :lint -- --fix`: exit 0. `pnpm format-check`: clean over 14,154 files — lint first, then format, on the same tree.
- Cast audit over the whole diff: **empty** — no `as any`, `as unknown as`, widened `any`, or `!.`.
- Package suites run below; CI is the arbiter given this sandbox is at load average 15 on 4 cores.

## Next

`BridgeService` on its own (the cast seam above). Then the credentials group, which now blocks more of the remaining work than the original chunking assumed — `IdentityService` (12), `SpacesService` (11), `DevicesService` (4), `ContactsService` (3) all wait behind those two `ProfileDocument` type references. 45 `protoMessage` calls remain.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7

---
_Generated by [Claude Code](https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Network and edge-agent services now use updated generated message formats for improved protocol compatibility.
  - Network status updates support streaming status information.
  - Network and swarm messages are converted consistently across service boundaries.

- **Bug Fixes**
  - Improved handling of missing or disconnected edge-agent status information.
  - Preserved compatibility with existing network message payloads during the protocol transition.

- **Documentation**
  - Added release documentation for the updated client network protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12966-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
