### PR TITLE
introspect: stop the cache fixture copy racing build-index

### DIFF
--- a/packages/reflect/introspect/src/cache.test.ts
+++ b/packages/reflect/introspect/src/cache.test.ts
@@ -18,6 +18,7 @@ import { createIntrospector } from './introspector';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_SRC = join(__dirname, '__fixtures__');
+const CACHE_DIR = join('node_modules', '.cache');
 
 // Each test gets its own temp copy of the fixture so the cache file lands at
 // a known path we control. The cache lives under <root>/node_modules/.cache/
@@ -32,7 +33,9 @@ describe('symbol cache reuse', { timeout: 30_000 }, () => {
     // Mirror the fixture monorepo into the temp dir, then nuke any stale
     // cache that came along from a prior run of any other test.
     const { cp } = await import('node:fs/promises');
-    await cp(FIXTURE_SRC, root, { recursive: true });
+    // `build-index.test.ts` writes and rmSync's the cache under the source fixture, which races
+    // this walk when the two files run in parallel; the copy never needs it.
+    await cp(FIXTURE_SRC, root, { recursive: true, filter: (source) => !source.includes(CACHE_DIR) });
     await rm(join(root, 'node_modules/.cache'), { recursive: true, force: true }).catch(() => undefined);
   });
 


### PR DESCRIPTION
A flaky test that only fails under file parallelism — which is how CI runs, and why it is invisible to the local sweep `AGENTS.md` prescribes (`--no-file-parallelism`). It took down shard 2 on #12967, whose diff does not touch this package.

## The race

```
FAIL |node| src/cache.test.ts > symbol cache reuse > editing one package invalidates only that package
Error: ENOENT: no such file or directory, lstat
  '.../packages/reflect/introspect/src/__fixtures__/node_modules/.cache/dxos-introspect'
  ❯ src/cache.test.ts:35:5   await cp(FIXTURE_SRC, root, { recursive: true });
```

Two test files use the same on-disk fixture in incompatible ways:

- **`cache.test.ts`** copies `src/__fixtures__` into a temp dir in `beforeEach`.
- **`build-index.test.ts`** points the build-index script at `src/__fixtures__` *itself*, so the run writes `__fixtures__/node_modules/.cache/dxos-introspect` — and its own setup `rmSync`s that directory (lines 18–26).

Run in parallel, `cp` readdirs `dxos-introspect` and then `lstat`s it after the other file has removed it. Serial runs never interleave the two, so the suite passes 27/29 on its own.

The directory is real and untracked — it appears under `src/__fixtures__/node_modules/.cache/` with an mtime from the test run.

## The fix

Filter the cache out of the copy. Those bytes are never wanted: the next line deletes the cache in the destination anyway, so the walk was copying a directory only to remove it.

```ts
await cp(FIXTURE_SRC, root, { recursive: true, filter: (source) => !source.includes(CACHE_DIR) });
```

A deeper fix would stop `build-index.test.ts` writing into the checked-in fixture at all (point it at a temp copy too). That is a larger change to a different test's design; this one removes the race without touching it, and stays correct either way.

## Validation

- Reproduced first: full sweep with parallelism (`moon run :test --force`) → `introspect` fails as above. Same sweep with `--no-file-parallelism` → green, which is why it hid.
- After the fix, the same parallel sweep: `introspect` **27 passed | 2 skipped**.
- Also ran the suite 3× with the source cache deliberately repopulated (`__fixtures__/node_modules/.cache/dxos-introspect/core.json` present) — 3/3 green.
- `oxfmt` clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7

---
_Generated by [Claude Code](https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test isolation by preventing generated cache files from being copied between fixture setups.
  - Reduced the risk of parallel test interference and inconsistent test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12969-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
