### PR TITLE
client: move Platform to buf types

### DIFF
--- a/.changeset/platform-buf-types.md
+++ b/.changeset/platform-buf-types.md
@@ -1,0 +1,11 @@
+---
+'@dxos/client': minor
+---
+
+Move `SystemService.getPlatform` to buf types
+
+`Platform` — reachable through `client.diagnostics()` — is now the buf message. Its nested enum
+flattens: `Platform.PLATFORM_TYPE.X` becomes `Platform_PLATFORM_TYPE.X`, imported from
+`@dxos/protocols/buf/dxos/client/services_pb`. Both codecs produce identical wire bytes.
+
+This retires the last `protoMessage` payload in `SystemService`.

--- a/packages/core/protocols/src/SystemService.ts
+++ b/packages/core/protocols/src/SystemService.ts
@@ -7,8 +7,9 @@ import * as Rpc from 'effect/unstable/rpc/Rpc';
 import type * as RpcClient from 'effect/unstable/rpc/RpcClient';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 
+import { PlatformSchema } from './buf/proto/gen/dxos/client/services_pb.ts';
 import { ConfigSchema } from './buf/proto/gen/dxos/config_pb.ts';
-import { bufMessage, protoMessage, serviceError } from './service-rpc.ts';
+import { bufMessage, serviceError } from './service-rpc.ts';
 import { protoStruct, protoTimestamp } from './service-schemas.ts';
 
 //
@@ -100,7 +101,7 @@ export class Rpcs extends RpcGroup.make(
    * Get platform Information.
    */
   Rpc.make('getPlatform', {
-    success: protoMessage('dxos.client.services.Platform'),
+    success: bufMessage(PlatformSchema),
     error: serviceError,
   }),
 ).prefix('SystemService.') {}

--- a/packages/sdk/client-services/src/packlets/diagnostics/diagnostics.ts
+++ b/packages/sdk/client-services/src/packlets/diagnostics/diagnostics.ts
@@ -10,11 +10,11 @@ import { createDidFromIdentityKey, credentialTypeFilter } from '@dxos/credential
 import { invariant } from '@dxos/invariant';
 import { type PublicKey } from '@dxos/keys';
 import { STORAGE_VERSION } from '@dxos/protocols';
+import { type Platform } from '@dxos/protocols/buf/dxos/client/services_pb';
 import {
   type Device,
   type Identity,
   type NetworkStatus,
-  type Platform,
   SpaceMember,
   type Space as SpaceProto,
 } from '@dxos/protocols/proto/dxos/client/services';

--- a/packages/sdk/client-services/src/packlets/services/platform.ts
+++ b/packages/sdk/client-services/src/packlets/services/platform.ts
@@ -2,35 +2,39 @@
 // Copyright 2022 DXOS.org
 //
 
-import { Platform } from '@dxos/protocols/proto/dxos/client/services';
+import { buf } from '@dxos/protocols/buf';
+import { type Platform, Platform_PLATFORM_TYPE, PlatformSchema } from '@dxos/protocols/buf/dxos/client/services_pb';
 
 export const getPlatform = (): Platform => {
   if ((process as any).browser) {
     if (typeof window !== 'undefined') {
       // Browser.
       const { userAgent } = window.navigator;
-      return {
-        type: Platform.PLATFORM_TYPE.BROWSER,
+      return buf.create(PlatformSchema, {
+        type: Platform_PLATFORM_TYPE.BROWSER,
         userAgent,
         uptime: Math.floor((Date.now() - window.performance.timeOrigin) / 1_000),
-      };
+      });
     } else {
       // Dedicated worker.
-      return {
-        type: Platform.PLATFORM_TYPE.DEDICATED_WORKER,
+      return buf.create(PlatformSchema, {
+        type: Platform_PLATFORM_TYPE.DEDICATED_WORKER,
         uptime: Math.floor((Date.now() - performance.timeOrigin) / 1_000),
-      };
+      });
     }
   } else {
     // Node.
     const { platform, version, arch } = process;
-    return {
-      type: Platform.PLATFORM_TYPE.NODE,
+    // `MemoryUsage` is an interface without an index signature, so the Struct field takes the
+    // fields explicitly rather than the object itself.
+    const { rss, heapTotal, heapUsed, external, arrayBuffers } = process.memoryUsage();
+    return buf.create(PlatformSchema, {
+      type: Platform_PLATFORM_TYPE.NODE,
       platform,
       arch,
       runtime: version,
       uptime: Math.floor(process.uptime()),
-      memory: process.memoryUsage(),
-    };
+      memory: { rss, heapTotal, heapUsed, external, arrayBuffers },
+    });
   }
 };

--- a/packages/sdk/client-services/src/packlets/system/system-service.ts
+++ b/packages/sdk/client-services/src/packlets/system/system-service.ts
@@ -9,8 +9,9 @@ import * as EffectStream from 'effect/Stream';
 import { type Event } from '@dxos/async';
 import { type Config } from '@dxos/config';
 import { EffectEx } from '@dxos/effect';
+import { type Platform } from '@dxos/protocols/buf/dxos/client/services_pb';
 import { type Config as ConfigProto, ConfigSchema } from '@dxos/protocols/buf/dxos/config_pb';
-import { type Platform, type SystemStatus } from '@dxos/protocols/proto/dxos/client/services';
+import { type SystemStatus } from '@dxos/protocols/proto/dxos/client/services';
 import { SystemService } from '@dxos/protocols/rpc';
 import { type MaybePromise, jsonKeyReplacer } from '@dxos/util';
 


### PR DESCRIPTION
Chunk 6 of the protobuf.js → buf teardown, and the last one reachable without a decision from you.

`SystemService.getPlatform` moves from `protoMessage` to `bufMessage`. **`SystemService` now has zero `protoMessage` payloads.**

## Why this is a one-call chunk

Starting the next chunk turned up that most of what I previously reported as reachable is not. Corrected inventory after this PR — **31 calls, none reachable**:

| Blocker | Calls |
| --- | ---: |
| Credentials fence — `IdentityService` 11, `SpacesService` 9, `DevicesService` 3, `ContactsService` 2, `InvitationsService` 1 | 26 |
| `Timeframe` class substitution — `DevtoolsHost` snapshot pair + feed blocks, `SpacesService.createEpoch` | 3 |
| `EchoMetadata` group — `DevtoolsHost` | 1 |
| Test fixture — `QueryService.test.ts` | 1 |

Two corrections to what I wrote on #12967:

- **`QueryService` has zero `protoMessage` calls.** The "1" was the word inside a comment explaining why its schemas are hand-authored.
- **`DevtoolsHost` has 4, not 6**, and all four are blocked: the snapshot pair by the `Timeframe` substitution (which `DevtoolsHost.ts:152` already documents as the reason they stay on `protoMessage`), feed blocks by `FeedMessage` embedding both `TimeframeVector` and `CredentialsMessage`, and metadata by `EchoMetadata`.

`Timeframe` is a new blocker and not a policy one: buf has no equivalent of protobuf.js's class substitutions, so a `Timeframe` arriving as a plain message loses its `frames()` accessor. It needs what `PublicKey` got — a bridge at the boundary — which is a design call.

## The one seam

`process.memoryUsage()` returns `MemoryUsage`, an interface with no index signature, so it is not assignable to the `JsonObject` that buf's `google.protobuf.Struct` field expects. The fields are passed explicitly rather than the object — no cast, and it makes what we report visible:

```ts
const { rss, heapTotal, heapUsed, external, arrayBuffers } = process.memoryUsage();
```

## Breaking (see changeset)

`Platform` is reachable through `client.diagnostics()`. Its nested enum flattens — `Platform.PLATFORM_TYPE.X` → `Platform_PLATFORM_TYPE.X`, from `@dxos/protocols/buf/dxos/client/services_pb`. Wire bytes are unchanged.

## Validation

- Full repo build: exit 0, **0 errors**.
- `moon run :lint -- --fix`: exit 0. `pnpm format-check` clean.
- Cast audit over the diff: **empty**.
- Full test sweep **with file parallelism** (`moon run :test --force`) — the mode that catches races, and the one that found the `introspect` bug fixed in #12969. One unrelated failure surfaced: `echo-host`'s `automerge-repo-subduction-policy.test.ts` "authorizeFetch fires on BOTH proactive push and explicit fetch (empirical)", `expected +0 to be above +0`. It passes 3/3 in isolation, its own comment acknowledges the count is non-deterministic ("the bridge may batch or invoke twice per broadcast"), and `echo-host` does not consume `Platform`. Flagging it as a second flaky test rather than fixing it here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7

---
_Generated by [Claude Code](https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated platform diagnostics to use the latest message format while preserving compatibility with existing data.
  * Improved consistency of platform information returned by client diagnostics, including memory usage metrics.
  * Retired the final legacy platform message payload from the system service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12970-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
