### PR TITLE
composer-app: QA scripts driven through the debug port (chapters 2–4) and the operations they need

### DIFF
--- a/.agents/skills/qa/SKILL.md
+++ b/.agents/skills/qa/SKILL.md
@@ -37,7 +37,7 @@ Through the Browser pane, `preview_start` with the `composer-qa` launch configur
 background:
 
 ```bash
-moon run composer-app:serve-qa -- --port 5182 --strictPort
+moon run composer-app:serve-qa -- --port 5182 --strictPort &
 ```
 
 **Run the page in the headless browser helper, not the Browser pane.** The pane's tab is hidden
@@ -46,7 +46,7 @@ Chromium page counts as visible and mounts in seconds. Close the pane's tab firs
 share the port's session), then, in the background from the repo root:
 
 ```bash
-node packages/apps/composer-app/testing/scripts/bin/qa-browser.mjs http://localhost:5182/
+node packages/apps/composer-app/testing/scripts/bin/qa-browser.mjs http://localhost:5182/ &
 ```
 
 It prints `mounted` once the app is up and page errors as `[page] …`; it stays alive until you stop

--- a/.agents/skills/qa/SKILL.md
+++ b/.agents/skills/qa/SKILL.md
@@ -41,14 +41,17 @@ moon run composer-app:serve-qa -- --port 5182 --strictPort
 ```
 
 `DX_DEBUG_PORT=true` (set by the task) mints a session as the app boots and publishes it to
-**`temp/debug-port.json` at the repo root** (`{ session, pid, port, url }`); the server's own log
-prints it as `Debug port session: <uuid>`. The task builds the app's dependency graph first, which
-takes minutes on a cold worktree.
+**`temp/debug-port.json` at the repo root** (`{ session, pid, port, url }`), written once when the
+server starts listening — do not delete it to "wait for a fresh one". The server's own log prints
+the same id as `Debug port session: <uuid>` (`preview_logs` with `search`), which is the reliable
+read. The task builds the app's dependency graph first, which takes minutes on a cold worktree.
 
-**Boot is visibility-gated.** A background tab sits on the boot screen forever with `composer.*`
-answering underneath. Front the tab (`tabs_select`, or `navigate` to the URL) before waiting on
-boot, and wait for the app to mount rather than for the port to answer — a `snapshot` that returns
-`layout` is mounted. If `composer.snapshot` is missing, the debug plugin is not enabled on this
+**Boot needs a visible tab, or patience.** A hidden tab boots slowly (background-tab timer
+throttling stretches the loading state machine to minutes) or not at all, with `composer.*`
+answering underneath. Front the tab (`tabs_select`) before waiting on boot, and wait for the app
+to mount rather than for the port to answer — `document.querySelectorAll('[data-scope]').length > 0`
+from `javascript_tool`, or a `snapshot` that returns `layout`. Never leave a port call pending
+while the app is still booting: it will time out and wedge the loop (below). If `composer.snapshot` is missing, the debug plugin is not enabled on this
 profile: `invoke org.dxos.operation.registry.enablePlugins { ids: ["org.dxos.plugin.debug"] }`.
 
 If 5182 is already listening, it is someone's server: check whose worktree it serves before

--- a/.agents/skills/qa/SKILL.md
+++ b/.agents/skills/qa/SKILL.md
@@ -33,12 +33,25 @@ yes for that origin.
 ## 3. Start the server and open the port
 
 Through the Browser pane, `preview_start` with the `composer-qa` launch configuration starts
-`moon run composer-app:serve-qa` on port 5182 and opens the tab; from a shell the same task, in
-the background:
+`moon run composer-app:serve-qa` on port 5182 and opens a tab; from a shell the same task, in the
+background:
 
 ```bash
 moon run composer-app:serve-qa -- --port 5182 --strictPort
 ```
+
+**Run the page in the headless browser helper, not the Browser pane.** The pane's tab is hidden
+whenever the user is not looking at it, and a hidden page boots slowly or not at all; a headless
+Chromium page counts as visible and mounts in seconds. Close the pane's tab first (two pages would
+share the port's session), then, in the background from the repo root:
+
+```bash
+node packages/apps/composer-app/testing/scripts/bin/qa-browser.mjs http://localhost:5182/
+```
+
+It prints `mounted` once the app is up and page errors as `[page] …`; it stays alive until you stop
+it. The headless profile is fresh every launch, so its Given always starts from a clean default
+space, and the debug plugin needs enabling on it (below).
 
 `DX_DEBUG_PORT=true` (set by the task) mints a session as the app boots and publishes it to
 **`temp/debug-port.json` at the repo root** (`{ session, pid, port, url }`), written once when the
@@ -46,13 +59,13 @@ server starts listening — do not delete it to "wait for a fresh one". The serv
 the same id as `Debug port session: <uuid>` (`preview_logs` with `search`), which is the reliable
 read. The task builds the app's dependency graph first, which takes minutes on a cold worktree.
 
-**Boot needs a visible tab, or patience.** A hidden tab boots slowly (background-tab timer
-throttling stretches the loading state machine to minutes) or not at all, with `composer.*`
-answering underneath. Front the tab (`tabs_select`) before waiting on boot, and wait for the app
-to mount rather than for the port to answer — `document.querySelectorAll('[data-scope]').length > 0`
-from `javascript_tool`, or a `snapshot` that returns `layout`. Never leave a port call pending
-while the app is still booting: it will time out and wedge the loop (below). If `composer.snapshot` is missing, the debug plugin is not enabled on this
-profile: `invoke org.dxos.operation.registry.enablePlugins { ids: ["org.dxos.plugin.debug"] }`.
+**Wait for the mount, not for the port.** The port answers while the app is still on the boot
+screen. Wait for the helper's `mounted` line (or, in a pane tab, front it and poll
+`document.querySelectorAll('[data-scope]').length > 0` from `javascript_tool`). Never leave a port
+call pending while the app is still booting: it will time out and wedge the loop (below). If
+`composer.snapshot` is missing, the debug plugin is not enabled on this profile:
+`invoke org.dxos.operation.registry.enablePlugins { ids: ["org.dxos.plugin.debug"] }` and wait for
+it to appear.
 
 If 5182 is already listening, it is someone's server: check whose worktree it serves before
 reusing it (`lsof -a -p <pid> -d cwd -Fn`) and never kill it. Pick another port with `--port` if in
@@ -122,14 +135,14 @@ the snapshot operation rather than scripting the page.
 
 ## 7. Stop what you started
 
-Stop the server you started (`preview_stop`, or the background task) when the run is done, and
-tell the user the port is closed. Leave a server you did not start alone.
+Stop the browser helper and the server you started (`preview_stop`, or the background tasks) when
+the run is done, and tell the user the port is closed. Leave a server you did not start alone.
 
 ## Checklist
 
 ```markdown
 - [ ] Script and chapter read in full, including Given and Teardown
-- [ ] Server started by me on a disposable profile; tab fronted before waiting on boot
+- [ ] Server started by me on a disposable profile; page opened in the headless helper and mounted
 - [ ] runId and start timestamp noted; debug plugin active
 - [ ] Given verified from a snapshot, QA: artifacts confirmed absent
 - [ ] Each step one operation call; each Expect judged from a snapshot or query

--- a/.changeset/composer-qa-scripts.md
+++ b/.changeset/composer-qa-scripts.md
@@ -1,0 +1,11 @@
+---
+'@dxos/plugin-review': minor
+'@dxos/ui-editor': patch
+---
+
+Operations that let an agent drive Composer end to end through the debug port, and two fixes found by doing so.
+
+- `review.create` accepts `range: { from, to }` (character offsets, converted to the editor's cursor anchor), and `text` + `sender` to submit the thread with a first message; it now returns `{ threadId, anchorId }`.
+- `assistant.runPromptInChat` accepts `companionTo` in place of `chat`, resolving and persisting the object's companion chat the way the companion's own submit does. `ensureCompanionChat` and `runPromptInChat` activate the assistant plugin themselves, so they work before the assistant UI has been opened.
+- `debug.snapshot` reports spaces, toasts, errors since a timestamp, comment threads per plank and a markdown document's text; `debug.revertLast` undoes the last undoable operation as the undo toast does; `composer.invoke` forwards a `spaceId`.
+- The editor's comments extension no longer throws from a state update when a thread's anchor is not a valid cursor pair (`Cursor.getRangeFromCursor` returns `undefined`).

--- a/packages/apps/composer-app/testing/REMOTE.md
+++ b/packages/apps/composer-app/testing/REMOTE.md
@@ -23,11 +23,14 @@ Environment, in order:
 1. Confirm `moon` runs (`pnpm exec moon --version`). If the toolchain plugin cannot load (the
    cloud-sandbox skill's `plugin::loader::registry::load_failure`), stop and report that the
    sandbox cannot build; do not improvise a build.
-2. Start the QA dev server in the background and wait for it (first start builds the graph, budget
-   15 minutes):
-     DX_DEBUG_PORT_SESSION=$(node -e 'console.log(crypto.randomUUID())') \
-       pnpm exec moon run composer-app:serve-qa -- --port 5182 --strictPort --host 127.0.0.1 > /tmp/qa-server.log 2>&1 &
-   Choosing the session yourself (DX_DEBUG_PORT_SESSION) means you never need the sidecar.
+2. Choose the debug-port session up front and export it, so the same shell can pass it to every
+   later command (an inline assignment would reach only the server):
+     export DX_DEBUG_PORT_SESSION=$(node -e 'console.log(crypto.randomUUID())')
+   Then start the QA dev server in the background, keeping its PID for cleanup, and wait for it
+   (first start builds the graph, budget 15 minutes):
+     pnpm exec moon run composer-app:serve-qa -- --port 5182 --strictPort --host 127.0.0.1 > /tmp/qa-server.log 2>&1 &
+     SERVER_PID=$!
+   Choosing the session yourself means you never need the sidecar.
    Wait until `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:5182/` prints 200.
 3. Open the app in the repo's headless browser helper, which stays alive for the whole run.
    Loopback is unproxied, so localhost needs no proxy flags; a headless page counts as visible, so
@@ -35,6 +38,7 @@ Environment, in order:
    at it:
      PW_CHROMIUM_PATH=/opt/pw-browsers/chromium \
        node packages/apps/composer-app/testing/scripts/bin/qa-browser.mjs http://127.0.0.1:5182/ > /tmp/qa-browser.log 2>&1 &
+     BROWSER_PID=$!
    Wait for `mounted` in /tmp/qa-browser.log. If the app never mounts, attach the log to the
    report and stop.
 4. Drive every step through the port exactly as the README's notation translates it:
@@ -59,7 +63,8 @@ The run:
   push, so the run leaves an artifact.
 - When the app contradicted the script (a key moved, a return shape changed), fix the script in
   the same commit and say what changed in the report's Findings.
-- Finish by stopping the server and the browser you started, and reply with the step table and the
+- Finish by stopping the browser and the server you started (`kill $BROWSER_PID $SERVER_PID`, then
+  confirm nothing listens on 5182 with `lsof -ti :5182`), and reply with the step table and the
   report path. A defect is reported, not fixed, unless the task says otherwise.
 ```
 

--- a/packages/apps/composer-app/testing/REMOTE.md
+++ b/packages/apps/composer-app/testing/REMOTE.md
@@ -26,7 +26,7 @@ Environment, in order:
 2. Start the QA dev server in the background and wait for it (first start builds the graph, budget
    15 minutes):
      DX_DEBUG_PORT_SESSION=$(node -e 'console.log(crypto.randomUUID())') \
-       pnpm exec moon run composer-app:serve-qa -- --port 5182 --strictPort --host 127.0.0.1
+       pnpm exec moon run composer-app:serve-qa -- --port 5182 --strictPort --host 127.0.0.1 > /tmp/qa-server.log 2>&1 &
    Choosing the session yourself (DX_DEBUG_PORT_SESSION) means you never need the sidecar.
    Wait until `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:5182/` prints 200.
 3. Open the app in the repo's headless browser helper, which stays alive for the whole run.

--- a/packages/apps/composer-app/testing/REMOTE.md
+++ b/packages/apps/composer-app/testing/REMOTE.md
@@ -1,0 +1,85 @@
+# Remote QA run — prompt for a cloud agent
+
+Paste the block below as the task for a Claude Code cloud session (a scheduled routine or a
+one-off remote session) on the `dxos/dxos` repository. It runs one QA script from
+`packages/apps/composer-app/testing/scripts` against a dev server inside the sandbox, drives it
+through the agent debug port from a headless Chromium, and files the report. Everything it needs is
+in the repo; the sandbox has no display, so the browser is headless and there is no Browser pane.
+
+Fill in the script (and optionally a chapter) before pasting.
+
+---
+
+```text
+Run the Composer QA script `basics` (all chapters) and file a report.
+
+You are in the Claude Code cloud sandbox: read `.agents/skills/cloud-sandbox/SKILL.md` first
+(tooling, proxy, headless Chromium), then `.agents/skills/qa/SKILL.md` and
+`packages/apps/composer-app/testing/scripts/README.md`. The script is
+`packages/apps/composer-app/testing/scripts/basics.md`.
+
+Environment, in order:
+
+1. Confirm `moon` runs (`pnpm exec moon --version`). If the toolchain plugin cannot load (the
+   cloud-sandbox skill's `plugin::loader::registry::load_failure`), stop and report that the
+   sandbox cannot build; do not improvise a build.
+2. Start the QA dev server in the background and wait for it (first start builds the graph, budget
+   15 minutes):
+     DX_DEBUG_PORT_SESSION=$(node -e 'console.log(crypto.randomUUID())') \
+       pnpm exec moon run composer-app:serve-qa -- --port 5182 --strictPort --host 127.0.0.1
+   Choosing the session yourself (DX_DEBUG_PORT_SESSION) means you never need the sidecar.
+   Wait until `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:5182/` prints 200.
+3. Open the app in the repo's headless browser helper, which stays alive for the whole run.
+   Loopback is unproxied, so localhost needs no proxy flags; a headless page counts as visible, so
+   boot is not gated. The sandbox ships an older Chromium than Playwright's pin, so point the helper
+   at it:
+     PW_CHROMIUM_PATH=/opt/pw-browsers/chromium \
+       node packages/apps/composer-app/testing/scripts/bin/qa-browser.mjs http://127.0.0.1:5182/ > /tmp/qa-browser.log 2>&1 &
+   Wait for `mounted` in /tmp/qa-browser.log. If the app never mounts, attach the log to the
+   report and stop.
+4. Drive every step through the port exactly as the README's notation translates it:
+     node .agents/skills/composer-forensics/scripts/composer-recovery.js --session "$DX_DEBUG_PORT_SESSION" '<snippet>'
+   with COMPOSER_RECOVERY_TIMEOUT=600000 on every call. Never kill a call while a snippet is
+   pending. If `composer.snapshot` is missing, enable the debug plugin first
+   (`org.dxos.operation.registry.enablePlugins { ids: ["org.dxos.plugin.debug"] }`).
+
+The run:
+
+- Take `<start>` before the first step and pass it as `since` to every snapshot.
+- Establish each chapter's Given from a snapshot; abort a chapter whose Given cannot be met and
+  say which precondition failed.
+- Run the chapters in order, one operation call per Agent line, judging every Expect from a
+  snapshot or a query operation, never from a return value. Run each chapter's Teardown even when a
+  step failed.
+- Chapter 4 needs an AI provider; if the prompt operation fails for lack of one, report the chapter
+  as blocked, not failed, with the error text.
+- Write the report to `packages/apps/composer-app/testing/reports/<YYYY-MM-DD-HHMM>-basics.md` from
+  `../reports/TEMPLATE.md`, and include /tmp/qa-browser.log's error lines and the server's stderr
+  under "Server log". Reports are gitignored, so commit it with `git add -f` on this branch and
+  push, so the run leaves an artifact.
+- When the app contradicted the script (a key moved, a return shape changed), fix the script in
+  the same commit and say what changed in the report's Findings.
+- Finish by stopping the server and the browser you started, and reply with the step table and the
+  report path. A defect is reported, not fixed, unless the task says otherwise.
+```
+
+---
+
+## Why this works remotely
+
+- The debug port is loopback (`127.0.0.1:9321`): the page polls it, the recovery script serves it,
+  and neither leaves the container. The sandbox's egress proxy does not apply to loopback.
+- `DX_DEBUG_PORT_SESSION` fixes the session id up front, so the agent does not depend on the
+  `temp/debug-port.json` sidecar or on reading the server log.
+- A headless Chromium page is "visible" as far as timers and `requestAnimationFrame` are concerned,
+  so the app boots without anyone fronting a tab.
+- The snapshot operation (`org.dxos.operation.debug.snapshot`) carries the state the script judges
+  by — layout, planks and their comments, spaces, toasts, errors since a timestamp — so no page
+  scripting is needed.
+
+## Scheduling
+
+A routine is the same prompt on a schedule (Claude Code scheduled tasks, or a CI job that starts a
+cloud session). Pick a chapter subset for a quick smoke (`basics 1`) and the full script for a
+nightly run. Keep the reports committed on a dedicated branch or read them from the session's
+transcript; the `Findings` section is what a human reviews.

--- a/packages/apps/composer-app/testing/scripts/README.md
+++ b/packages/apps/composer-app/testing/scripts/README.md
@@ -15,7 +15,7 @@ journey across plugins, written in plain markdown so anyone can add a chapter wi
 
 | Script                 | Chapters               | Last run          |
 | ---------------------- | ---------------------- | ----------------- |
-| [basics.md](basics.md) | 1 Spaces and documents | see `../reports/` |
+| [basics.md](basics.md) | 1 Spaces and documents; 2 Rename, undo and a second space | see `../reports/` |
 
 ## Anatomy of a script
 
@@ -45,6 +45,7 @@ run did not create.** A name match is not evidence of ownership; abort and say w
 | `invoke <key> <input> in <spaceId>`  | The same, resolved against that space (database-backed operations).     |
 | `snapshot [<input>]`                 | `org.dxos.operation.debug.snapshot` — the live UI state, see below.     |
 | `object <uri>`                       | The live object at an `echo://<spaceId>/<objectId>` URI.                |
+| `ref <uri>`                          | A reference to that object, for operations whose input is a `Ref`.      |
 | `space <spaceId>`                    | The live space, for operations that take a `space`.                     |
 | → capture `field` as `<name>`        | Keep a field of the result for later steps' placeholders.               |
 
@@ -63,6 +64,7 @@ and the translation is mechanical. The body runs inside `async () => { … }` wi
 | `invoke K I in S`           | `return composer.invoke('K', I, { spaceId: 'S' })`                       |
 | `snapshot I`                | `return composer.snapshot(I)`                                            |
 | `object echo://S/O`         | `dxos.spaces('S').db.getObjectById('O')`                                 |
+| `ref echo://S/O`            | `dxos.Ref.make(dxos.spaces('S').db.getObjectById('O'))`                  |
 | `space S` (inside an input) | `dxos.spaces('S')`                                                       |
 
 `composer.invoke` validates the input against the operation's schema and forwards the space id;

--- a/packages/apps/composer-app/testing/scripts/README.md
+++ b/packages/apps/composer-app/testing/scripts/README.md
@@ -100,7 +100,7 @@ The port lives in a page. Open it with the headless helper rather than a pane ta
 boots slowly or not at all, and a headless page mounts in seconds on a fresh profile.
 
 ```bash
-node packages/apps/composer-app/testing/scripts/bin/qa-browser.mjs http://localhost:5182/
+node packages/apps/composer-app/testing/scripts/bin/qa-browser.mjs http://localhost:5182/ &
 ```
 
 ## Reports

--- a/packages/apps/composer-app/testing/scripts/README.md
+++ b/packages/apps/composer-app/testing/scripts/README.md
@@ -15,7 +15,7 @@ journey across plugins, written in plain markdown so anyone can add a chapter wi
 
 | Script                 | Chapters               | Last run          |
 | ---------------------- | ---------------------- | ----------------- |
-| [basics.md](basics.md) | 1 Spaces and documents; 2 Rename, undo and a second space | see `../reports/` |
+| [basics.md](basics.md) | 1 Spaces and documents; 2 Rename, undo and a second space; 3 Comments; 4 The assistant edits the document | see `../reports/` |
 
 ## Anatomy of a script
 
@@ -80,8 +80,9 @@ agent's eyes. One call returns:
 
 - `layout` — mode, sidebars, `workspace`, and `active` (the graph paths of the open planks, which
   `appToolkit.open` and `switchWorkspace` accept).
-- `planks` — each open plank with its resolved `label`, `subject` (`dxn`, `typename`, `name`) and
-  the graph `actions` the UI offers for it, with their operation keys.
+- `planks` — each open plank with its resolved `label`, `subject` (`dxn`, `typename`, `name`), the
+  graph `actions` the UI offers for it, with their operation keys, and the `comments` threads
+  anchored to its subject (id, anchor, status, messages).
 - `spaces` — id, name, `SpaceState` name, and which is the default.
 - `toasts` — what is on screen: title, description and button labels.
 - `errors` — error-level log entries since `since` (a timestamp; default the last minute). Uncaught
@@ -92,6 +93,15 @@ agent's eyes. One call returns:
 
 When a script needs something the snapshot does not report, extend the snapshot
 (`packages/plugins/plugin-debug/src/operations/snapshot.ts`) rather than scripting the page.
+
+## The page
+
+The port lives in a page. Open it with the headless helper rather than a pane tab: a hidden tab
+boots slowly or not at all, and a headless page mounts in seconds on a fresh profile.
+
+```bash
+node packages/apps/composer-app/testing/scripts/bin/qa-browser.mjs http://localhost:5182/
+```
 
 ## Reports
 

--- a/packages/apps/composer-app/testing/scripts/basics.md
+++ b/packages/apps/composer-app/testing/scripts/basics.md
@@ -84,3 +84,68 @@ Removes only what this run created: the two remaining documents, then the space.
      have this workspace" meanwhile.
 - **Expect**: `snapshot` lists no space whose name starts with `QA:`, `layout.workspace` is the
   default space, and `errors` is empty.
+
+## Chapter 2: Rename, undo and a second space
+
+Independent of Chapter 1: its setup creates what it needs.
+
+### Given
+
+- **Agent**: `snapshot { since: <start> }`
+- **Expect**: as Chapter 1 — a `SPACE_READY` default space, no `QA:` space, `errors` empty.
+
+### Setup
+
+- **Do**: Create a space `QA: Undo <runId>` (the navtree switches to it), then a document named
+  `QA: Note` in it.
+- **Agent**:
+  1. `invoke org.dxos.operation.space.create { name: "QA: Undo <runId>" }` → capture `id` as `<spaceId>`.
+  2. `invoke org.dxos.operation.appToolkit.switchWorkspace { subject: "root/<spaceId>" }`
+  3. `invoke org.dxos.operation.markdown.create { name: "QA: Note", content: "# QA: Note\n\nRun <runId>.\n" } in <spaceId>`
+     → capture `id` as `<note>`.
+
+### Steps
+
+#### 1. Rename the document
+
+- **Do**: Open the `⋮` menu on `QA: Note` in the navtree, choose **Rename**, enter `QA: Note (renamed)`.
+- **Agent**: `invoke org.dxos.operation.space.updateObject { object: ref <note>, properties: { name: "QA: Note (renamed)" } } in <spaceId>`
+  — the menu's own operation only opens the rename dialog; the update is what the dialog commits.
+- **Expect**: `invoke org.dxos.operation.space.queryObjects { typename: "org.dxos.type.document" } in <spaceId>`
+  returns the one document labelled `QA: Note (renamed)`, and the navtree row reads the same.
+
+#### 2. Open, delete, undo
+
+- **Do**: Click the document to open it. Delete it from its `⋮` menu. Click **Undo** in the
+  **Document deleted** toast.
+- **Agent**:
+  1. `invoke org.dxos.operation.appToolkit.open { subject: ["root/<spaceId>/content/collections/<objectId of note>"] }`
+  2. `invoke org.dxos.operation.space.removeObjects { objects: [object <note>] }`
+  3. `invoke org.dxos.operation.debug.revertLast {}` — the toast's Undo, as an operation.
+- **Expect**: After 2, `snapshot` shows the **Document deleted** toast and no active plank. After 3,
+  `queryObjects` lists the document again, `layout.active` holds its path once more (the restore
+  reopens what was open), and `errors` is empty. Clicking **Undo** also dismisses the toast; the
+  operation bypasses the toast, so for the agent it stays until it times out.
+
+#### 3. A second space
+
+- **Do**: Create a space `QA: Undo B <runId>`; the navtree switches to it and shows no documents.
+  Switch back to `QA: Undo <runId>` from the space list.
+- **Agent**:
+  1. `invoke org.dxos.operation.space.create { name: "QA: Undo B <runId>" }` → capture `id` as `<spaceB>`.
+  2. `invoke org.dxos.operation.appToolkit.switchWorkspace { subject: "root/<spaceB>" }`
+  3. `invoke org.dxos.operation.space.queryObjects { typename: "org.dxos.type.document" } in <spaceB>`
+  4. `invoke org.dxos.operation.appToolkit.switchWorkspace { subject: "root/<spaceId>" }`
+- **Expect**: After 2, `snapshot.layout.workspace` is `root/<spaceB>` and `spaces` lists both `QA:`
+  spaces `SPACE_READY`. Step 3 returns no documents. After 4, the workspace is `root/<spaceId>`
+  again and its document is still listed.
+
+### Teardown
+
+- **Do**: Delete the document, then both spaces from their settings; pick the default space.
+- **Agent**:
+  1. `invoke org.dxos.operation.space.removeObjects { objects: [object <note>] }`
+  2. `invoke org.dxos.operation.space.delete { space: space <spaceId> }`
+  3. `invoke org.dxos.operation.space.delete { space: space <spaceB> }`
+  4. `invoke org.dxos.operation.appToolkit.switchWorkspace { subject: "root/<default space id>" }`
+- **Expect**: `snapshot` lists no `QA:` space, the workspace is the default space, `errors` is empty.

--- a/packages/apps/composer-app/testing/scripts/basics.md
+++ b/packages/apps/composer-app/testing/scripts/basics.md
@@ -149,3 +149,126 @@ Independent of Chapter 1: its setup creates what it needs.
   3. `invoke org.dxos.operation.space.delete { space: space <spaceB> }`
   4. `invoke org.dxos.operation.appToolkit.switchWorkspace { subject: "root/<default space id>" }`
 - **Expect**: `snapshot` lists no `QA:` space, the workspace is the default space, `errors` is empty.
+
+## Chapter 3: Comments
+
+Create, reply to, resolve, and delete comments on a document. The human works in the comments
+companion; the agent drives the same review operations and reads the threads off the `snapshot`
+(`planks[].comments`).
+
+### Given
+
+- **Agent**: `snapshot { since: <start> }`
+- **Expect**: a `SPACE_READY` default space, no `QA:` space, `errors` empty.
+
+### Setup
+
+- **Do**: Create a space `QA: Comments <runId>`, a document `QA: Draft` in it whose first line reads
+  `Comments go here.`, and open the document.
+- **Agent**:
+  1. `invoke org.dxos.operation.space.create { name: "QA: Comments <runId>" }` → capture `id` as `<spaceId>`.
+  2. `invoke org.dxos.operation.appToolkit.switchWorkspace { subject: "root/<spaceId>" }`
+  3. `invoke org.dxos.operation.markdown.create { name: "QA: Draft", content: "# QA: Draft\n\nComments go here.\n" } in <spaceId>`
+     → capture `id` as `<doc>`.
+  4. `invoke org.dxos.operation.appToolkit.open { subject: ["root/<spaceId>/content/collections/<objectId of doc>"] }`
+
+### Steps
+
+#### 1. Create a comment
+
+- **Do**: Select the words `Comments go here` in the editor, click **Comment** in the toolbar, type
+  `First comment` and send it. The comments companion opens with the thread.
+- **Agent**: `invoke org.dxos.operation.review.create { subject: object <doc>, range: { from: 12, to: 28 }, text: "First comment", sender: { name: "QA" } }`
+  → capture `threadId` as `<thread>` and `anchorId` as `<anchor>`. The range is the selection's
+  character offsets, which the operation turns into the editor's cursor anchor; a first `text`
+  submits the thread, as the send button does.
+- **Expect**: `snapshot` shows the document plank with one entry in `comments`: status `active`,
+  one message `First comment` from `QA`, and a cursor `anchor`. `errors` is empty.
+
+#### 2. Reply
+
+- **Do**: Type `Second comment` into the thread's reply box and send.
+- **Agent**: `invoke org.dxos.operation.review.addMessage { subject: object <doc>, anchor: object echo://<spaceId>/<anchor>, sender: { name: "QA" }, text: "Second comment" }`
+- **Expect**: the thread in `snapshot` now has two messages, `First comment` then `Second comment`.
+
+#### 3. Resolve, then reopen
+
+- **Do**: Click the thread's **Resolve** control; the thread moves to the resolved state. Click it
+  again to reopen.
+- **Agent**:
+  1. `invoke org.dxos.operation.review.setResolved { thread: object echo://<spaceId>/<thread>, resolved: true }`
+  2. `invoke org.dxos.operation.review.setResolved { thread: object echo://<spaceId>/<thread>, resolved: false }`
+- **Expect**: `snapshot` reports the thread's status `resolved` after 1 and `active` after 2.
+
+#### 4. Delete the reply
+
+- **Do**: Open the second message's menu and choose **Delete**.
+- **Agent**: `invoke org.dxos.operation.review.deleteMessage { subject: object <doc>, anchor: object echo://<spaceId>/<anchor>, messageId: "<id of the second message, from the snapshot>" }`
+- **Expect**: the thread has one message again, `First comment`; a **Comment deleted** toast may
+  show. `errors` is empty.
+
+#### 5. Delete the thread
+
+- **Do**: Open the thread's menu and choose **Delete**.
+- **Agent**: `invoke org.dxos.operation.review.delete { subject: object <doc>, anchor: object echo://<spaceId>/<anchor> }`
+- **Expect**: `snapshot` shows the plank with no `comments`, and `errors` is empty.
+
+### Teardown
+
+- **Agent**:
+  1. `invoke org.dxos.operation.space.removeObjects { objects: [object <doc>] }`
+  2. `invoke org.dxos.operation.space.delete { space: space <spaceId> }`
+  3. `invoke org.dxos.operation.appToolkit.switchWorkspace { subject: "root/<default space id>" }`
+- **Expect**: no `QA:` space; the workspace is the default space; `errors` is empty.
+
+## Chapter 4: The assistant edits the document
+
+Ask the document's assistant to change part of the text in place. This chapter needs an AI provider
+the app can reach (the assistant settings' provider, EDGE by default); without one, the prompt fails
+and the chapter reports blocked rather than failed.
+
+### Given
+
+- **Agent**: `snapshot { since: <start> }`
+- **Expect**: a `SPACE_READY` default space, no `QA:` space, `errors` empty.
+
+### Setup
+
+- **Do**: Create a space `QA: Assistant <runId>` and a document `QA: Essay` with three short English
+  paragraphs; open it.
+- **Agent**:
+  1. `invoke org.dxos.operation.space.create { name: "QA: Assistant <runId>" }` → capture `id` as `<spaceId>`.
+  2. `invoke org.dxos.operation.appToolkit.switchWorkspace { subject: "root/<spaceId>" }`
+  3. `invoke org.dxos.operation.markdown.create { name: "QA: Essay", content: "# QA: Essay\n\nThe first paragraph stays in English.\n\nThe second paragraph is about the weather. It is sunny today and the sky is blue.\n\nThe third paragraph also stays in English.\n" } in <spaceId>`
+     → capture `id` as `<doc>`.
+  4. `invoke org.dxos.operation.appToolkit.open { subject: ["root/<spaceId>/content/collections/<objectId of doc>"] }`
+
+### Steps
+
+#### 1. Open the document's assistant
+
+- **Do**: Click the assistant companion on the document plank. A chat bound to the document opens
+  beside it.
+- **Agent**: `invoke org.dxos.operation.assistant.ensureCompanionChat { companionTo: object <doc> } in <spaceId>`
+- **Expect**: the result names a chat (`persisted: false` until its first message); `errors` is
+  empty.
+
+#### 2. Translate the second paragraph in place
+
+- **Do**: In the chat, send: `Translate the second paragraph of this document into French, in place.
+Leave the other paragraphs unchanged.` Wait for the reply; the editor updates the paragraph.
+- **Agent**: `invoke org.dxos.operation.assistant.runPromptInChat { companionTo: object <doc>, prompt: "Translate the second paragraph of this document into French, in place. Leave the other paragraphs unchanged." } in <spaceId>`
+  — `companionTo` names the document's own chat, which is not in the database until its first
+  message, so an id cannot name it — then `snapshot` until the open plank's `subject.text` changes
+  (up to two minutes).
+- **Expect**: the document's text keeps the first and third paragraphs verbatim and the second
+  paragraph is now French (it mentions `soleil` or `ciel`, and no longer `sunny`). `errors` is empty.
+
+### Teardown
+
+- **Agent**:
+  1. `invoke org.dxos.operation.space.removeObjects { objects: [object <doc>] }` — the companion chat
+     is the document's child and goes with it.
+  2. `invoke org.dxos.operation.space.delete { space: space <spaceId> }`
+  3. `invoke org.dxos.operation.appToolkit.switchWorkspace { subject: "root/<default space id>" }`
+- **Expect**: no `QA:` space; the workspace is the default space; `errors` is empty.

--- a/packages/apps/composer-app/testing/scripts/bin/qa-browser.mjs
+++ b/packages/apps/composer-app/testing/scripts/bin/qa-browser.mjs
@@ -1,0 +1,28 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// Keeps a headless Chromium page on the QA server so the app boots without a visible pane; the
+// agent debug port runs inside this page. Stays alive until killed.
+//   node packages/apps/composer-app/testing/scripts/bin/qa-browser.mjs [url]
+import { chromium } from '@playwright/test';
+
+const url = process.argv[2] ?? 'http://localhost:5182/';
+// `PW_CHROMIUM_PATH` for a host whose Chromium is not the one Playwright pinned (the cloud sandbox).
+const browser = await chromium.launch({
+  headless: true,
+  executablePath: process.env.PW_CHROMIUM_PATH || undefined,
+  args: process.env.PW_CHROMIUM_PATH ? ['--no-sandbox'] : [],
+});
+const context = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+const page = await context.newPage();
+page.on('console', (message) => {
+  if (message.type() === 'error') {
+    console.error('[page]', message.text().slice(0, 300));
+  }
+});
+page.on('pageerror', (error) => console.error('[pageerror]', String(error).slice(0, 300)));
+await page.goto(url);
+await page.waitForFunction(() => document.querySelectorAll('[data-scope]').length > 0, null, { timeout: 600000 });
+console.log('mounted');
+await new Promise(() => {});

--- a/packages/plugins/plugin-assistant/package.json
+++ b/packages/plugins/plugin-assistant/package.json
@@ -240,6 +240,7 @@
     "@dxos/echo-react": "workspace:*",
     "@dxos/edge-client": "workspace:*",
     "@dxos/effect": "workspace:*",
+    "@dxos/errors": "workspace:*",
     "@dxos/graph": "workspace:*",
     "@dxos/halo-react": "workspace:*",
     "@dxos/invariant": "workspace:*",

--- a/packages/plugins/plugin-assistant/src/errors.ts
+++ b/packages/plugins/plugin-assistant/src/errors.ts
@@ -1,0 +1,8 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { BaseError } from '@dxos/errors';
+
+/** `runPromptInChat` was given neither a chat nor an object whose companion chat should run it. */
+export class ChatNotSpecifiedError extends BaseError.extend('ChatNotSpecifiedError', 'Pass `chat` or `companionTo`.') {}

--- a/packages/plugins/plugin-assistant/src/operations/ensure-companion-chat.ts
+++ b/packages/plugins/plugin-assistant/src/operations/ensure-companion-chat.ts
@@ -3,18 +3,28 @@
 //
 
 import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
 
 import * as Capabilities from '@dxos/app-framework/Capabilities';
+import * as Plugin from '@dxos/app-framework/Plugin';
 import * as Chat from '@dxos/assistant/Chat';
 import * as Operation from '@dxos/compute/Operation';
 import { Database, Filter, Obj, Query } from '@dxos/echo';
 
-import { AssistantCapabilities, AssistantOperation } from '#types';
+import { AssistantCapabilities, AssistantEvents, AssistantOperation } from '#types';
 
 const handler: Operation.WithHandler<typeof AssistantOperation.EnsureCompanionChat> =
   AssistantOperation.EnsureCompanionChat.pipe(
     Operation.withHandler(
       Effect.fnUntraced(function* ({ companionTo }) {
+        // Activation first: the state and session providers this reads come from lazy modules that
+        // otherwise activate only once the assistant UI has been opened, so a caller arriving through
+        // an operation alone (an agent) would find them missing.
+        const pluginManager = yield* Effect.serviceOption(Plugin.Service);
+        yield* Option.match(pluginManager, {
+          onNone: () => Effect.void,
+          onSome: (manager) => manager.activate(AssistantEvents.Start),
+        });
         const { db } = yield* Database.Service;
         const companionUri = Obj.getURI(companionTo);
 

--- a/packages/plugins/plugin-assistant/src/operations/run-prompt-in-chat.ts
+++ b/packages/plugins/plugin-assistant/src/operations/run-prompt-in-chat.ts
@@ -7,17 +7,46 @@ import * as Option from 'effect/Option';
 
 import * as Capabilities from '@dxos/app-framework/Capabilities';
 import * as Capability from '@dxos/app-framework/Capability';
+import * as Plugin from '@dxos/app-framework/Plugin';
+import * as Chat from '@dxos/assistant/Chat';
 import { getSession } from '@dxos/compute/AgentService';
 import * as Operation from '@dxos/compute/Operation';
+import { Obj } from '@dxos/echo';
+import * as SpaceOperation from '@dxos/plugin-space/SpaceOperation';
 
-import { AssistantCapabilities, AssistantOperation } from '#types';
+import { AssistantCapabilities, AssistantEvents, AssistantOperation } from '#types';
 
 import { defaultPreset } from '../processor';
 
 const handler: Operation.WithHandler<typeof AssistantOperation.RunPromptInChat> =
   AssistantOperation.RunPromptInChat.pipe(
     Operation.withHandler(
-      Effect.fnUntraced(function* ({ chat, prompt }) {
+      Effect.fnUntraced(function* ({ chat: chatProp, companionTo, prompt }) {
+        // Activation first: the state and session providers this reads come from lazy modules that
+        // otherwise activate only once the assistant UI has been opened, so a caller arriving through
+        // an operation alone (an agent) would find them missing.
+        const pluginManager = yield* Effect.serviceOption(Plugin.Service);
+        yield* Option.match(pluginManager, {
+          onNone: () => Effect.void,
+          onSome: (manager) => manager.activate(AssistantEvents.Start),
+        });
+        const companion =
+          chatProp === undefined && companionTo !== undefined
+            ? yield* Operation.invoke(AssistantOperation.EnsureCompanionChat, { companionTo })
+            : undefined;
+        const chat = chatProp ?? companion?.chat;
+        if (chat === undefined) {
+          return yield* Effect.fail(new Error('Pass `chat` or `companionTo`.'));
+        }
+        // As the companion's own submit does: a transient chat is persisted under its subject before
+        // the first request, so the agent process can resolve a durable conversation feed and space.
+        const db = companionTo !== undefined ? Obj.getDatabase(companionTo) : undefined;
+        if (companionTo !== undefined && db && !Obj.getDatabase(chat)) {
+          Chat.linkCompanion({ chat, subject: companionTo });
+          yield* Operation.invoke(SpaceOperation.AddObject, { object: chat }, { spaceId: db.spaceId });
+          yield* Operation.invoke(AssistantOperation.SetCurrentChat, { companionTo, chat });
+          yield* Effect.promise(() => db.flush());
+        }
         const preset = yield* chatPreset;
         const session = yield* getSession(chat, {
           model: preset?.model,

--- a/packages/plugins/plugin-assistant/src/operations/run-prompt-in-chat.ts
+++ b/packages/plugins/plugin-assistant/src/operations/run-prompt-in-chat.ts
@@ -16,6 +16,7 @@ import * as SpaceOperation from '@dxos/plugin-space/SpaceOperation';
 
 import { AssistantCapabilities, AssistantEvents, AssistantOperation } from '#types';
 
+import { ChatNotSpecifiedError } from '../errors';
 import { defaultPreset } from '../processor';
 
 const handler: Operation.WithHandler<typeof AssistantOperation.RunPromptInChat> =
@@ -36,7 +37,7 @@ const handler: Operation.WithHandler<typeof AssistantOperation.RunPromptInChat> 
             : undefined;
         const chat = chatProp ?? companion?.chat;
         if (chat === undefined) {
-          return yield* Effect.fail(new Error('Pass `chat` or `companionTo`.'));
+          return yield* Effect.fail(new ChatNotSpecifiedError());
         }
         // As the companion's own submit does: a transient chat is persisted under its subject before
         // the first request, so the agent process can resolve a durable conversation feed and space.

--- a/packages/plugins/plugin-assistant/src/types/AssistantOperation.ts
+++ b/packages/plugins/plugin-assistant/src/types/AssistantOperation.ts
@@ -141,7 +141,10 @@ export const RunPromptInChat = Operation.make({
   },
   services: [Capability.Service, Database.Service, AgentService],
   input: Schema.Struct({
-    chat: Type.getSchema(Chat.Chat),
+    chat: Schema.optional(Type.getSchema(Chat.Chat)),
+    // The object whose companion chat should run the prompt — the way to name a companion chat that
+    // has not been persisted yet, which a caller outside the page (an agent) cannot hold.
+    companionTo: Schema.optional(Obj.Unknown),
     prompt: Schema.String,
   }),
   output: Schema.Void,

--- a/packages/plugins/plugin-debug/src/errors.ts
+++ b/packages/plugins/plugin-debug/src/errors.ts
@@ -18,3 +18,6 @@ export class SampleSpaceApplyError extends BaseError.extend(
   'SampleSpaceApplyError',
   'Failed to apply the sample space.',
 ) {}
+
+/** The history tracker has no undoable operation to revert. */
+export class NothingToUndoError extends BaseError.extend('NothingToUndoError', 'Nothing to undo.') {}

--- a/packages/plugins/plugin-debug/src/operations/DebugOperationHandlerSet.ts
+++ b/packages/plugins/plugin-debug/src/operations/DebugOperationHandlerSet.ts
@@ -11,4 +11,5 @@ export const handlers = OperationHandlerSet.lazy([
   DebugOperation.InsertLoremIpsum.pipe(Operation.lazyHandler(() => import('./insert-lorem-ipsum'))),
   DebugOperation.Snapshot.pipe(Operation.lazyHandler(() => import('./snapshot'))),
   DebugOperation.CreateSampleSpace.pipe(Operation.lazyHandler(() => import('./create-sample-space'))),
+  DebugOperation.Undo.pipe(Operation.lazyHandler(() => import('./undo'))),
 ]);

--- a/packages/plugins/plugin-debug/src/operations/snapshot.ts
+++ b/packages/plugins/plugin-debug/src/operations/snapshot.ts
@@ -13,13 +13,15 @@ import * as AppGraphNode from '@dxos/app-graph/AppGraphNode';
 import * as AppCapabilities from '@dxos/app-toolkit/AppCapabilities';
 import * as AppSpace from '@dxos/app-toolkit/AppSpace';
 import * as Operation from '@dxos/compute/Operation';
-import { Obj } from '@dxos/echo';
+import { Filter, Obj, Query, Relation } from '@dxos/echo';
 import { LogLevel } from '@dxos/log';
 import * as AttentionCapabilities from '@dxos/plugin-attention/AttentionCapabilities';
 import * as ClientCapabilities from '@dxos/plugin-client/ClientCapabilities';
+import * as Markdown from '@dxos/plugin-markdown/Markdown';
 import { SpaceState } from '@dxos/protocols/proto/dxos/client/services';
 // UI-free subpath: the root barrel reaches the panel components.
 import { logBuffer } from '@dxos/react-ui-debug/log-buffer';
+import { AnchoredTo, type Message, type Thread } from '@dxos/types';
 
 import { DebugOperation } from '#types';
 
@@ -48,12 +50,48 @@ const summarizeSubject = (data: unknown) => {
       dxn: String(Obj.getURI(data)),
       typename: Obj.getTypename(data),
       name: Obj.getLabel(data),
+      // Bounded by the one open document, so the snapshot stays O(planks).
+      text: Obj.instanceOf(Markdown.Document, data) ? data.content.target?.content : undefined,
     };
   }
   if ('id' in data && typeof data.id === 'string') {
     return { id: data.id };
   }
   return undefined;
+};
+
+/** The comment threads on an object, with their messages loaded — the review companion's view of it. */
+const collectComments = async (subject: unknown) => {
+  if (!Obj.isObject(subject)) {
+    return undefined;
+  }
+  const db = Obj.getDatabase(subject);
+  if (!db) {
+    return undefined;
+  }
+  const anchors: AnchoredTo.AnchoredTo[] = await db
+    .query(Query.select(Filter.id(subject.id)).targetOf(AnchoredTo.AnchoredTo))
+    .run();
+  return Promise.all(
+    anchors.map(async (anchor) => {
+      const thread = Relation.getSource(anchor) as Thread.Thread;
+      const messages: Message.Message[] = await Promise.all(thread.messages.map((ref) => ref.load()));
+      return {
+        id: thread.id,
+        anchorId: anchor.id,
+        anchor: anchor.anchor,
+        status: thread.status,
+        messages: messages.map((message) => ({
+          id: message.id,
+          sender: message.sender.name ?? message.sender.identityDid,
+          text: message.blocks
+            .map((block) => (block._tag === 'text' ? block.text : undefined))
+            .filter((text): text is string => text !== undefined)
+            .join('\n'),
+        })),
+      };
+    }),
+  );
 };
 
 const OPERATION_DXN = /dxn:[^/]+/;
@@ -143,16 +181,21 @@ const handler: Operation.WithHandler<typeof DebugOperation.Snapshot> = DebugOper
       const layout = Option.getOrUndefined(Option.map(layoutAtom, (atom) => registry.get(atom)));
       const graph = Option.getOrUndefined(Option.map(graphBuilder, (builder) => builder.graph));
 
-      const planks = (layout?.active ?? []).map((id) => {
-        const node = graph ? Option.getOrUndefined(AppGraph.getNode(graph, id)) : undefined;
-        return {
-          id,
-          label: node ? translate(node.properties?.label) : undefined,
-          type: node?.type,
-          subject: node ? summarizeSubject(node.data) : undefined,
-          actions: graph ? collectActions(graph, translate, id) : [],
-        };
-      });
+      const planks = yield* Effect.promise(() =>
+        Promise.all(
+          (layout?.active ?? []).map(async (id) => {
+            const node = graph ? Option.getOrUndefined(AppGraph.getNode(graph, id)) : undefined;
+            return {
+              id,
+              label: node ? translate(node.properties?.label) : undefined,
+              type: node?.type,
+              subject: node ? summarizeSubject(node.data) : undefined,
+              actions: graph ? collectActions(graph, translate, id) : [],
+              comments: node ? await collectComments(node.data) : undefined,
+            };
+          }),
+        ),
+      );
 
       const spaces = Option.match(client, {
         onNone: () => [],

--- a/packages/plugins/plugin-debug/src/operations/undo.test.ts
+++ b/packages/plugins/plugin-debug/src/operations/undo.test.ts
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import * as Operation from '@dxos/compute/Operation';
+import { createComposerTestApp } from '@dxos/plugin-testing/harness';
+
+import { DebugPlugin } from '#plugin';
+import { DebugOperation } from '#types';
+
+describe('DebugOperation.Undo', () => {
+  test('fails when there is nothing to undo', async ({ expect }) => {
+    await using harness = await createComposerTestApp({ plugins: [DebugPlugin()] });
+
+    await expect(harness.runPromise(Operation.invoke(DebugOperation.Undo, {}))).rejects.toThrow('Nothing to undo');
+  });
+});

--- a/packages/plugins/plugin-debug/src/operations/undo.ts
+++ b/packages/plugins/plugin-debug/src/operations/undo.ts
@@ -10,12 +10,14 @@ import * as Operation from '@dxos/compute/Operation';
 
 import { DebugOperation } from '#types';
 
+import { NothingToUndoError } from '../errors';
+
 const handler: Operation.WithHandler<typeof DebugOperation.Undo> = DebugOperation.Undo.pipe(
   Operation.withHandler(
     Effect.fnUntraced(function* () {
       const tracker = yield* Capability.get(Capabilities.HistoryTracker);
       if (!tracker.canUndo()) {
-        return yield* Effect.fail(new Error('Nothing to undo.'));
+        return yield* Effect.fail(new NothingToUndoError());
       }
       yield* tracker.undo();
       return { undone: true };

--- a/packages/plugins/plugin-debug/src/operations/undo.ts
+++ b/packages/plugins/plugin-debug/src/operations/undo.ts
@@ -1,0 +1,26 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import * as Capabilities from '@dxos/app-framework/Capabilities';
+import * as Capability from '@dxos/app-framework/Capability';
+import * as Operation from '@dxos/compute/Operation';
+
+import { DebugOperation } from '#types';
+
+const handler: Operation.WithHandler<typeof DebugOperation.Undo> = DebugOperation.Undo.pipe(
+  Operation.withHandler(
+    Effect.fnUntraced(function* () {
+      const tracker = yield* Capability.get(Capabilities.HistoryTracker);
+      if (!tracker.canUndo()) {
+        return yield* Effect.fail(new Error('Nothing to undo.'));
+      }
+      yield* tracker.undo();
+      return { undone: true };
+    }),
+  ),
+);
+
+export default handler;

--- a/packages/plugins/plugin-debug/src/types/DebugOperation.ts
+++ b/packages/plugins/plugin-debug/src/types/DebugOperation.ts
@@ -133,6 +133,24 @@ export const Snapshot = Operation.make({
   }),
 }).pipe(Operation.mutation('none'));
 
+/**
+ * Undoes the last undoable operation — what the notification toast's **Undo** button does — so an
+ * agent driving the app through operations can exercise the undo path it cannot click.
+ */
+export const Undo = Operation.make({
+  meta: {
+    key: DXN.make('org.dxos.operation.debug.revertLast'),
+    name: 'Revert last operation',
+    description: 'Undoes the last undoable operation, as the undo toast does. Fails when there is nothing to undo.',
+    icon: 'ph--arrow-counter-clockwise--regular',
+  },
+  services: [Capability.Service],
+  input: Schema.Struct({}),
+  output: Schema.Struct({
+    undone: Schema.Boolean,
+  }),
+});
+
 const SampleSpaceSummary = Schema.Struct({
   id: Schema.String,
   label: Schema.String,

--- a/packages/plugins/plugin-debug/src/types/DebugOperation.ts
+++ b/packages/plugins/plugin-debug/src/types/DebugOperation.ts
@@ -48,6 +48,9 @@ const SubjectSummary = Schema.Struct({
   dxn: Schema.optional(Schema.String),
   typename: Schema.optional(Schema.String),
   name: Schema.optional(Schema.String),
+  text: Schema.optional(Schema.String).annotate({
+    description: 'The current text of a markdown document, so an edit can be judged without the editor.',
+  }),
 });
 
 const ActionSummary = Schema.Struct({
@@ -61,12 +64,31 @@ const ActionSummary = Schema.Struct({
   group: Schema.optional(Schema.Boolean),
 });
 
+const CommentMessageSummary = Schema.Struct({
+  id: Schema.String,
+  sender: Schema.optional(Schema.String),
+  text: Schema.optional(Schema.String),
+});
+
+const CommentThreadSummary = Schema.Struct({
+  id: Schema.String,
+  anchorId: Schema.String.annotate({
+    description: 'Id of the `AnchoredTo` relation that ties the thread to the subject.',
+  }),
+  anchor: Schema.optional(Schema.String),
+  status: Schema.optional(Schema.String),
+  messages: Schema.Array(CommentMessageSummary),
+});
+
 const PlankSummary = Schema.Struct({
   id: Schema.String,
   label: Schema.optional(Schema.String),
   type: Schema.optional(Schema.String),
   subject: Schema.optional(SubjectSummary),
   actions: Schema.Array(ActionSummary),
+  comments: Schema.optional(Schema.Array(CommentThreadSummary)).annotate({
+    description: "Comment threads anchored to the plank's subject, when it is a database object.",
+  }),
 });
 
 const SurfaceSummary = Schema.Struct({
@@ -107,7 +129,7 @@ export const Snapshot = Operation.make({
     description:
       'Returns a JSON snapshot of the live UI state: layout (mode, sidebars, open planks), attended ' +
       'items, each open plank with its subject object and the actions the UI offers for it (with ' +
-      'their operation keys), the mounted surfaces, the spaces, the visible toasts, the errors ' +
+      'their operation keys) and the comment threads on it, the mounted surfaces, the spaces, the visible toasts, the errors ' +
       'logged since `since` (a timestamp; default: the last minute), and plugin counts. Read-only.',
     icon: 'ph--camera--regular',
   },

--- a/packages/plugins/plugin-review/package.json
+++ b/packages/plugins/plugin-review/package.json
@@ -173,6 +173,7 @@
     "@dxos/echo-doc": "workspace:*",
     "@dxos/echo-react": "workspace:*",
     "@dxos/effect": "workspace:*",
+    "@dxos/errors": "workspace:*",
     "@dxos/graph": "workspace:*",
     "@dxos/halo": "workspace:*",
     "@dxos/halo-adapter-client": "workspace:*",

--- a/packages/plugins/plugin-review/src/errors.ts
+++ b/packages/plugins/plugin-review/src/errors.ts
@@ -1,0 +1,23 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { BaseError } from '@dxos/errors';
+
+/** A range anchor was requested on a subject that is not a markdown document. */
+export class RangeAnchorSubjectError extends BaseError.extend(
+  'RangeAnchorSubjectError',
+  'A range anchor needs a markdown document as the subject.',
+) {}
+
+/** The requested comment range is not a pair of ordered integer offsets inside the document. */
+export class InvalidCommentRangeError extends BaseError.extend(
+  'InvalidCommentRangeError',
+  'The comment range must be ordered integer offsets within the document.',
+) {}
+
+/** Submitting the thread's first message left no persisted relation to report. */
+export class CommentNotPersistedError extends BaseError.extend(
+  'CommentNotPersistedError',
+  'The comment thread was not persisted.',
+) {}

--- a/packages/plugins/plugin-review/src/operations/create.ts
+++ b/packages/plugins/plugin-review/src/operations/create.ts
@@ -8,7 +8,9 @@ import * as Capabilities from '@dxos/app-framework/Capabilities';
 import * as Capability from '@dxos/app-framework/Capability';
 import * as LayoutOperation from '@dxos/app-toolkit/LayoutOperation';
 import * as Operation from '@dxos/compute/Operation';
-import { Obj, Relation } from '@dxos/echo';
+import { Filter, Obj, Query, Relation } from '@dxos/echo';
+import { toCursorRange } from '@dxos/echo-client';
+import { Doc } from '@dxos/echo-doc';
 import * as Markdown from '@dxos/plugin-markdown/Markdown';
 import * as MarkdownCapabilities from '@dxos/plugin-markdown/MarkdownCapabilities';
 import { Attention } from '@dxos/react-ui-attention/types';
@@ -18,7 +20,8 @@ import { CommentCapabilities, CommentOperation } from '#types';
 
 const handler: Operation.WithHandler<typeof CommentOperation.Create> = CommentOperation.Create.pipe(
   Operation.withHandler(
-    Effect.fnUntraced(function* ({ name, anchor: _anchor, subject, branch }) {
+    Effect.fnUntraced(function* ({ name, anchor: anchorProp, range, subject, branch, text, sender }) {
+      const _anchor = range ? yield* anchorFromRange(subject, range) : anchorProp;
       const registry = yield* Capability.get(Capabilities.AtomRegistry);
       const stateAtom = yield* Capability.get(CommentCapabilities.State);
       const subjectId = Obj.getURI(subject);
@@ -58,8 +61,37 @@ const handler: Operation.WithHandler<typeof CommentOperation.Create> = CommentOp
       yield* Operation.invoke(LayoutOperation.UpdateCompanion, {
         subject: Attention.linkedSegment('comments'),
       });
+      if (text === undefined) {
+        return { threadId: thread.id, anchorId: anchor.id };
+      }
+
+      yield* Operation.invoke(CommentOperation.AddMessage, { subject, anchor, sender: sender ?? {}, text });
+      // Submitting persists a new relation in place of the draft, so the id a caller can act on is
+      // the one now in the database.
+      const db = Obj.getDatabase(subject);
+      const persisted = db
+        ? (yield* Effect.promise(() =>
+            db.query(Query.select(Filter.id(subject.id)).targetOf(AnchoredTo.AnchoredTo)).run(),
+          )).find((candidate: AnchoredTo.AnchoredTo) => {
+            try {
+              return Relation.getSource(candidate).id === thread.id;
+            } catch {
+              return false;
+            }
+          })
+        : undefined;
+      return { threadId: thread.id, anchorId: persisted?.id ?? anchor.id };
     }),
   ),
 );
 
 export default handler;
+
+/** The cursor anchor for a character range of a markdown document, as the editor's comment action makes it. */
+const anchorFromRange = Effect.fnUntraced(function* (subject: Obj.Unknown, range: { from: number; to: number }) {
+  if (!Obj.instanceOf(Markdown.Document, subject)) {
+    return yield* Effect.fail(new Error('A range anchor needs a markdown document as the subject.'));
+  }
+  const content = yield* Effect.promise(() => subject.content.load());
+  return toCursorRange(Doc.createAccessor(content, ['content']), range.from, range.to);
+});

--- a/packages/plugins/plugin-review/src/operations/create.ts
+++ b/packages/plugins/plugin-review/src/operations/create.ts
@@ -18,6 +18,8 @@ import { AnchoredTo, Thread } from '@dxos/types';
 
 import { CommentCapabilities, CommentOperation } from '#types';
 
+import { CommentNotPersistedError, InvalidCommentRangeError, RangeAnchorSubjectError } from '../errors';
+
 const handler: Operation.WithHandler<typeof CommentOperation.Create> = CommentOperation.Create.pipe(
   Operation.withHandler(
     Effect.fnUntraced(function* ({ name, anchor: anchorProp, range, subject, branch, text, sender }) {
@@ -80,7 +82,10 @@ const handler: Operation.WithHandler<typeof CommentOperation.Create> = CommentOp
             }
           })
         : undefined;
-      return { threadId: thread.id, anchorId: persisted?.id ?? anchor.id };
+      if (!persisted) {
+        return yield* Effect.fail(new CommentNotPersistedError());
+      }
+      return { threadId: thread.id, anchorId: persisted.id };
     }),
   ),
 );
@@ -90,8 +95,13 @@ export default handler;
 /** The cursor anchor for a character range of a markdown document, as the editor's comment action makes it. */
 const anchorFromRange = Effect.fnUntraced(function* (subject: Obj.Unknown, range: { from: number; to: number }) {
   if (!Obj.instanceOf(Markdown.Document, subject)) {
-    return yield* Effect.fail(new Error('A range anchor needs a markdown document as the subject.'));
+    return yield* Effect.fail(new RangeAnchorSubjectError());
   }
   const content = yield* Effect.promise(() => subject.content.load());
-  return toCursorRange(Doc.createAccessor(content, ['content']), range.from, range.to);
+  const { from, to } = range;
+  const length = content.content.length;
+  if (!Number.isInteger(from) || !Number.isInteger(to) || from < 0 || from > to || to > length) {
+    return yield* Effect.fail(new InvalidCommentRangeError());
+  }
+  return toCursorRange(Doc.createAccessor(content, ['content']), from, to);
 });

--- a/packages/plugins/plugin-review/src/types/CommentOperation.ts
+++ b/packages/plugins/plugin-review/src/types/CommentOperation.ts
@@ -26,11 +26,22 @@ export const Create = Operation.make({
   input: Schema.Struct({
     name: Schema.optional(Schema.String),
     anchor: Schema.optional(Schema.String),
+    // Character offsets into a markdown document's text, converted to the cursor anchor the editor
+    // uses; a caller without an editor (an agent) cannot mint cursors itself.
+    range: Schema.optional(Schema.Struct({ from: Schema.Number, to: Schema.Number })),
     subject: Obj.Unknown,
+    // A first message submits the thread at once, as the composer's send does; without it the thread
+    // stays a draft in the companion, which only the UI can reach.
+    text: Schema.optional(Schema.String),
+    sender: Schema.optional(Actor.Actor),
     /** Branch the comment pertains to (a branch-review comment); undefined = main/unbranched. */
     branch: Schema.optional(Schema.String),
   }),
-  output: Schema.Void,
+  output: Schema.Struct({
+    threadId: Schema.String,
+    // The persisted relation's id when a first message was given, otherwise the draft's.
+    anchorId: Schema.String,
+  }),
 });
 
 export const DeleteOutput = Schema.Struct({

--- a/packages/ui/ui-editor/src/util/cursor.test.ts
+++ b/packages/ui/ui-editor/src/util/cursor.test.ts
@@ -7,26 +7,38 @@ import { describe, test } from 'vitest';
 
 import { Cursor } from './cursor';
 
-// A converter in the shape of the automerge one: opaque cursors it minted decode, anything else throws.
-const converter = {
-  toCursor: (position: number) => `c${position}`,
-  fromCursor: (cursor: string) => {
-    if (!/^c\d+$/.test(cursor)) {
-      throw new RangeError('cursor format is invalid');
-    }
-    return Number(cursor.slice(1));
-  },
-};
-
 describe('Cursor', () => {
+  // A converter in the shape of the automerge one: opaque cursors it minted decode, anything else throws.
+  const converter = {
+    toCursor: (position: number) => `c${position}`,
+    fromCursor: (cursor: string) => {
+      if (!/^c\d+$/.test(cursor)) {
+        throw new RangeError('cursor format is invalid');
+      }
+      return Number(cursor.slice(1));
+    },
+  };
+  const withConverter = () => EditorState.create({ doc: 'hello world', extensions: [Cursor.converter.of(converter)] });
+  const withDefault = () => EditorState.create({ doc: 'hello world' });
+
   test('a range round-trips through the converter', ({ expect }) => {
-    const state = EditorState.create({ doc: 'hello world', extensions: [Cursor.converter.of(converter)] });
+    const state = withConverter();
     const cursor = Cursor.getCursorFromRange(state, { from: 2, to: 7 });
     expect(Cursor.getRangeFromCursor(state, cursor)).toEqual({ from: 2, to: 7 });
   });
 
-  test('a malformed cursor decodes to undefined rather than throwing', ({ expect }) => {
-    const state = EditorState.create({ doc: 'hello world', extensions: [Cursor.converter.of(converter)] });
-    expect(Cursor.getRangeFromCursor(state, '12:28')).toBeUndefined();
+  test('a cursor the converter throws on decodes to undefined', ({ expect }) => {
+    expect(Cursor.getRangeFromCursor(withConverter(), '12:28')).toBeUndefined();
+  });
+
+  test('the default converter round-trips and rejects anything but canonical decimals', ({ expect }) => {
+    const state = withDefault();
+    expect(Cursor.getRangeFromCursor(state, Cursor.getCursorFromRange(state, { from: 2, to: 7 }))).toEqual({
+      from: 2,
+      to: 7,
+    });
+    expect(Cursor.getRangeFromCursor(state, 'bad:cursor')).toBeUndefined();
+    expect(Cursor.getRangeFromCursor(state, '2bad:7')).toBeUndefined();
+    expect(Cursor.getRangeFromCursor(state, '2')).toBeUndefined();
   });
 });

--- a/packages/ui/ui-editor/src/util/cursor.test.ts
+++ b/packages/ui/ui-editor/src/util/cursor.test.ts
@@ -1,0 +1,32 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { EditorState } from '@codemirror/state';
+import { describe, test } from 'vitest';
+
+import { Cursor } from './cursor';
+
+// A converter in the shape of the automerge one: opaque cursors it minted decode, anything else throws.
+const converter = {
+  toCursor: (position: number) => `c${position}`,
+  fromCursor: (cursor: string) => {
+    if (!/^c\d+$/.test(cursor)) {
+      throw new RangeError('cursor format is invalid');
+    }
+    return Number(cursor.slice(1));
+  },
+};
+
+describe('Cursor', () => {
+  test('a range round-trips through the converter', ({ expect }) => {
+    const state = EditorState.create({ doc: 'hello world', extensions: [Cursor.converter.of(converter)] });
+    const cursor = Cursor.getCursorFromRange(state, { from: 2, to: 7 });
+    expect(Cursor.getRangeFromCursor(state, cursor)).toEqual({ from: 2, to: 7 });
+  });
+
+  test('a malformed cursor decodes to undefined rather than throwing', ({ expect }) => {
+    const state = EditorState.create({ doc: 'hello world', extensions: [Cursor.converter.of(converter)] });
+    expect(Cursor.getRangeFromCursor(state, '12:28')).toBeUndefined();
+  });
+});

--- a/packages/ui/ui-editor/src/util/cursor.ts
+++ b/packages/ui/ui-editor/src/util/cursor.ts
@@ -44,12 +44,18 @@ export class Cursor {
     return [from, to].join(':');
   };
 
+  // Undefined rather than a throw for a cursor the converter rejects: anchors arrive from the
+  // database, and one malformed anchor would otherwise fail the state update for every comment.
   static readonly getRangeFromCursor = (state: EditorState, cursor: string) => {
     const cursorConverter = state.facet(Cursor.converter);
 
     const parts = cursor.split(':');
-    const from = cursorConverter.fromCursor(parts[0]);
-    const to = cursorConverter.fromCursor(parts[1]);
-    return from !== undefined && to !== undefined ? { from, to } : undefined;
+    try {
+      const from = cursorConverter.fromCursor(parts[0]);
+      const to = cursorConverter.fromCursor(parts[1]);
+      return from !== undefined && to !== undefined ? { from, to } : undefined;
+    } catch {
+      return undefined;
+    }
   };
 }

--- a/packages/ui/ui-editor/src/util/cursor.ts
+++ b/packages/ui/ui-editor/src/util/cursor.ts
@@ -31,7 +31,8 @@ export interface CursorConverter {
 
 const defaultCursorConverter: CursorConverter = {
   toCursor: (position) => position.toString(),
-  fromCursor: (cursor) => parseInt(cursor),
+  // Only a canonical decimal decodes; `parseInt` would read `2bad` as 2 and pass a wrong range on.
+  fromCursor: (cursor) => (/^\d+$/.test(cursor) ? Number(cursor) : Number.NaN),
 };
 
 export class Cursor {
@@ -44,16 +45,21 @@ export class Cursor {
     return [from, to].join(':');
   };
 
-  // Undefined rather than a throw for a cursor the converter rejects: anchors arrive from the
-  // database, and one malformed anchor would otherwise fail the state update for every comment.
-  static readonly getRangeFromCursor = (state: EditorState, cursor: string) => {
+  /**
+   * Decodes a `from:to` cursor pair into a range.
+   *
+   * Returns `undefined`, rather than throwing, for a cursor the converter rejects or that decodes to
+   * anything but integer positions: anchors arrive from the database, and one malformed anchor would
+   * otherwise fail the state update for every comment.
+   */
+  static readonly getRangeFromCursor = (state: EditorState, cursor: string): Range | undefined => {
     const cursorConverter = state.facet(Cursor.converter);
 
     const parts = cursor.split(':');
     try {
       const from = cursorConverter.fromCursor(parts[0]);
       const to = cursorConverter.fromCursor(parts[1]);
-      return from !== undefined && to !== undefined ? { from, to } : undefined;
+      return Number.isInteger(from) && Number.isInteger(to) ? { from, to } : undefined;
     } catch {
       return undefined;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7491,6 +7491,9 @@ importers:
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../common/effect
+      '@dxos/errors':
+        specifier: workspace:*
+        version: link:../../common/errors
       '@dxos/graph':
         specifier: workspace:*
         version: link:../../common/graph
@@ -13984,6 +13987,9 @@ importers:
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../common/effect
+      '@dxos/errors':
+        specifier: workspace:*
+        version: link:../../common/errors
       '@dxos/graph':
         specifier: workspace:*
         version: link:../../common/graph


### PR DESCRIPTION
## Summary

Composer QA scripts that an agent runs through the debug port, chapters 2–4 of `basics.md`, and the operations and fixes needed to run them without page scripting. (Chapter 1, the `/qa` command, the `qa` skill and the first snapshot extensions landed in #12961.)

- **Chapters** in `packages/apps/composer-app/testing/scripts/basics.md`: 2 rename / undo / second space, 3 comments (create, reply, resolve, delete message, delete thread), 4 the assistant translates a paragraph in place. Every Agent line is an operation call; every Expect is judged from `debug.snapshot` or a query operation.
- **Headless page** `testing/scripts/bin/qa-browser.mjs`: a Browser-pane tab boots only while visible; a headless Chromium page mounts in seconds. `testing/REMOTE.md` is a prompt for running a script from a cloud session.
- **Operations**: `review.create` takes `range`, `text`, `sender` and returns ids; `assistant.runPromptInChat` takes `companionTo` and persists a transient companion chat; the assistant operations activate the plugin themselves; `debug.snapshot` gains spaces, toasts, errors-since, per-plank comments and document text; `debug.revertLast`; `composer.invoke` forwards `spaceId`.
- **Fixes found by the runs**: `ensureCompanionChat` failed before the assistant UI had been opened (capability from a not-yet-activated module); the editor's comments extension threw `cursor format is invalid` from a state update on a malformed anchor.

## Test plan

- [x] Chapters 1–4 run end to end on a disposable dev profile; reports in `testing/reports/` (gitignored): all steps pass, no snapshot errors.
- [x] `plugin-debug` snapshot + revert tests, `ui-editor` cursor test, `plugin-assistant` operation tests, `plugin-theme` context test pass locally.
- [ ] Check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added undo support for the most recent undoable action.
  - Comment creation now supports text ranges and returns thread and anchor details.
  - Assistant prompts can target companion chats, including chats created during the operation.
  - Debug snapshots now include document text and comment threads.

- **Bug Fixes**
  - Prevented malformed comment anchors from causing editor errors.

- **Documentation**
  - Added Composer QA workflows covering spaces, documents, comments, undo, and assistant edits.
  - Added guidance for headless browser testing and remote QA sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12971-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
