### PR TITLE
client-services: move identity, contacts, devices and spaces RPCs to buf

### DIFF
--- a/.changeset/buf-credentials-service-rpcs.md
+++ b/.changeset/buf-credentials-service-rpcs.md
@@ -1,0 +1,9 @@
+---
+'@dxos/protocols': patch
+'@dxos/client': patch
+'@dxos/client-services': patch
+---
+
+Move the identity, contacts, devices and spaces service RPCs to buf messages. The credential
+subsystem keeps its protobuf.js shapes — the payloads cross the RPC boundary as their shared wire
+bytes — so `@dxos/client`'s public API is unchanged.

--- a/.changeset/buf-credentials-service-rpcs.md
+++ b/.changeset/buf-credentials-service-rpcs.md
@@ -1,9 +1,11 @@
 ---
 '@dxos/protocols': patch
+'@dxos/client-protocol': patch
 '@dxos/client': patch
 '@dxos/client-services': patch
 ---
 
-Move the identity, contacts, devices and spaces service RPCs to buf messages. The credential
-subsystem keeps its protobuf.js shapes — the payloads cross the RPC boundary as their shared wire
-bytes — so `@dxos/client`'s public API is unchanged.
+Move the identity, contacts, devices and spaces service RPCs to buf messages, and correct
+`ClientServices` to declare the buf shapes those methods actually carry. The credential subsystem
+keeps its protobuf.js shapes — the payloads cross the RPC boundary as their shared wire bytes — so
+`@dxos/client`'s public API is unchanged.

--- a/packages/apps/composer-app/src/util/halo.ts
+++ b/packages/apps/composer-app/src/util/halo.ts
@@ -3,6 +3,9 @@
 //
 
 import { invariant } from '@dxos/invariant';
+import { buf } from '@dxos/protocols/buf';
+import { decodeCompat } from '@dxos/protocols/buf-shape-compat';
+import { CredentialSchema } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
 import { type Client } from '@dxos/react-client';
 import { type Credential } from '@dxos/react-client/halo';
 
@@ -27,7 +30,8 @@ export const queryAllCredentials = (client: Client) => {
     const credentials: Credential[] = [];
     stream.subscribe(
       (credential) => {
-        credentials.push(credential);
+        // Callers index `subject.assertion` by '@type', which is the protobuf.js Any substitution.
+        credentials.push(decodeCompat(CredentialSchema, buf.toBinary(CredentialSchema, credential)));
       },
       (err) => {
         if (err) {

--- a/packages/core/mesh/messaging/src/signal-manager/utils.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/utils.ts
@@ -7,7 +7,8 @@ import * as Context from 'effect/Context';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 import { subscribeStream } from '@dxos/protocols';
-import { DeviceKind } from '@dxos/protocols/proto/dxos/client/services';
+import { toPublicKey } from '@dxos/protocols/buf';
+import { DeviceKind } from '@dxos/protocols/buf/dxos/client/services_pb';
 import { type DevicesService, type IdentityService } from '@dxos/protocols/rpc';
 
 export const setIdentityTags = ({
@@ -28,7 +29,7 @@ export const setIdentityTags = ({
         return;
       }
 
-      setTag('identityKey', idqr.identity.identityKey.truncate());
+      setTag('identityKey', toPublicKey(idqr.identity.identityKey)?.truncate() ?? '');
     },
   });
 
@@ -45,7 +46,7 @@ export const setIdentityTags = ({
         log('no current device', { device: dqr });
         return;
       }
-      setTag('deviceKey', thisDevice.deviceKey.truncate());
+      setTag('deviceKey', toPublicKey(thisDevice.deviceKey)?.truncate() ?? '');
     },
   });
 };

--- a/packages/core/protocols/src/ContactsService.ts
+++ b/packages/core/protocols/src/ContactsService.ts
@@ -7,7 +7,8 @@ import * as Rpc from 'effect/unstable/rpc/Rpc';
 import type * as RpcClient from 'effect/unstable/rpc/RpcClient';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 
-import { protoMessage, serviceError } from './service-rpc.ts';
+import { ContactBookSchema } from './buf/proto/gen/dxos/client/services_pb.ts';
+import { bufMessage, serviceError } from './service-rpc.ts';
 
 /**
  * Effect RPC definitions for the client contacts service (formerly `dxos.client.services.ContactsService`).
@@ -15,11 +16,11 @@ import { protoMessage, serviceError } from './service-rpc.ts';
  */
 export class Rpcs extends RpcGroup.make(
   Rpc.make('getContacts', {
-    success: protoMessage('dxos.client.services.ContactBook'),
+    success: bufMessage(ContactBookSchema),
     error: serviceError,
   }),
   Rpc.make('queryContacts', {
-    success: protoMessage('dxos.client.services.ContactBook'),
+    success: bufMessage(ContactBookSchema),
     error: serviceError,
     stream: true,
   }),

--- a/packages/core/protocols/src/DevicesService.ts
+++ b/packages/core/protocols/src/DevicesService.ts
@@ -8,7 +8,9 @@ import * as Rpc from 'effect/unstable/rpc/Rpc';
 import type * as RpcClient from 'effect/unstable/rpc/RpcClient';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 
-import { protoMessage, serviceError } from './service-rpc.ts';
+import { DeviceSchema } from './buf/proto/gen/dxos/client/services_pb.ts';
+import { DeviceProfileDocumentSchema } from './buf/proto/gen/dxos/halo/credentials_pb.ts';
+import { bufMessage, serviceError } from './service-rpc.ts';
 import { mutableArray } from './service-schemas.ts';
 
 //
@@ -16,7 +18,7 @@ import { mutableArray } from './service-schemas.ts';
 //
 
 export const QueryDevicesResponse = Schema.Struct({
-  devices: Schema.optional(mutableArray(protoMessage('dxos.client.services.Device'))),
+  devices: Schema.optional(mutableArray(bufMessage(DeviceSchema))),
 });
 export interface QueryDevicesResponse extends Schema.Schema.Type<typeof QueryDevicesResponse> {}
 
@@ -26,8 +28,8 @@ export interface QueryDevicesResponse extends Schema.Schema.Type<typeof QueryDev
  */
 export class Rpcs extends RpcGroup.make(
   Rpc.make('updateDevice', {
-    payload: protoMessage('dxos.halo.credentials.DeviceProfileDocument'),
-    success: protoMessage('dxos.client.services.Device'),
+    payload: bufMessage(DeviceProfileDocumentSchema),
+    success: bufMessage(DeviceSchema),
     error: serviceError,
   }),
   Rpc.make('queryDevices', {

--- a/packages/core/protocols/src/IdentityService.ts
+++ b/packages/core/protocols/src/IdentityService.ts
@@ -8,8 +8,15 @@ import * as Rpc from 'effect/unstable/rpc/Rpc';
 import type * as RpcClient from 'effect/unstable/rpc/RpcClient';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 
+import { IdentitySchema, RecoverIdentityRequestSchema } from './buf/proto/gen/dxos/client/services_pb.ts';
+import {
+  CredentialSchema,
+  DeviceProfileDocumentSchema,
+  PresentationSchema,
+  ProfileDocumentSchema,
+} from './buf/proto/gen/dxos/halo/credentials_pb.ts';
 import { IdentityRecovery } from './proto/gen/dxos/halo/credentials.ts';
-import { protoMessage, serviceError } from './service-rpc.ts';
+import { bufMessage, serviceError } from './service-rpc.ts';
 import { publicKey } from './service-schemas.ts';
 
 //
@@ -17,8 +24,8 @@ import { publicKey } from './service-schemas.ts';
 //
 
 export const CreateIdentityRequest = Schema.Struct({
-  profile: Schema.optional(protoMessage('dxos.halo.credentials.ProfileDocument')),
-  deviceProfile: Schema.optional(protoMessage('dxos.halo.credentials.DeviceProfileDocument')),
+  profile: Schema.optional(bufMessage(ProfileDocumentSchema)),
+  deviceProfile: Schema.optional(bufMessage(DeviceProfileDocumentSchema)),
 });
 export interface CreateIdentityRequest extends Schema.Schema.Type<typeof CreateIdentityRequest> {}
 
@@ -75,12 +82,12 @@ export const CreateRecoveryCredentialResponse = Schema.Struct({
 export interface CreateRecoveryCredentialResponse extends Schema.Schema.Type<typeof CreateRecoveryCredentialResponse> {}
 
 export const QueryIdentityResponse = Schema.Struct({
-  identity: Schema.optional(protoMessage('dxos.client.services.Identity')),
+  identity: Schema.optional(bufMessage(IdentitySchema)),
 });
 export interface QueryIdentityResponse extends Schema.Schema.Type<typeof QueryIdentityResponse> {}
 
 export const SignPresentationRequest = Schema.Struct({
-  presentation: protoMessage('dxos.halo.credentials.Presentation'),
+  presentation: bufMessage(PresentationSchema),
   nonce: Schema.optional(Schema.Uint8Array),
 });
 export interface SignPresentationRequest extends Schema.Schema.Type<typeof SignPresentationRequest> {}
@@ -93,7 +100,7 @@ export interface SignPresentationRequest extends Schema.Schema.Type<typeof SignP
 export class Rpcs extends RpcGroup.make(
   Rpc.make('createIdentity', {
     payload: CreateIdentityRequest,
-    success: protoMessage('dxos.client.services.Identity'),
+    success: bufMessage(IdentitySchema),
     error: serviceError,
   }),
   Rpc.make('requestRecoveryChallenge', {
@@ -101,8 +108,8 @@ export class Rpcs extends RpcGroup.make(
     error: serviceError,
   }),
   Rpc.make('recoverIdentity', {
-    payload: protoMessage('dxos.client.services.RecoverIdentityRequest'),
-    success: protoMessage('dxos.client.services.Identity'),
+    payload: bufMessage(RecoverIdentityRequestSchema),
+    success: bufMessage(IdentitySchema),
     error: serviceError,
   }),
   Rpc.make('createRecoveryCredential', {
@@ -121,17 +128,17 @@ export class Rpcs extends RpcGroup.make(
     stream: true,
   }),
   Rpc.make('updateProfile', {
-    payload: protoMessage('dxos.halo.credentials.ProfileDocument'),
-    success: protoMessage('dxos.client.services.Identity'),
+    payload: bufMessage(ProfileDocumentSchema),
+    success: bufMessage(IdentitySchema),
     error: serviceError,
   }),
   Rpc.make('signPresentation', {
     payload: SignPresentationRequest,
-    success: protoMessage('dxos.halo.credentials.Presentation'),
+    success: bufMessage(PresentationSchema),
     error: serviceError,
   }),
   Rpc.make('createAuthCredential', {
-    success: protoMessage('dxos.halo.credentials.Credential'),
+    success: bufMessage(CredentialSchema),
     error: serviceError,
   }),
 ).prefix('IdentityService.') {}

--- a/packages/core/protocols/src/SpacesService.ts
+++ b/packages/core/protocols/src/SpacesService.ts
@@ -8,7 +8,15 @@ import * as Rpc from 'effect/unstable/rpc/Rpc';
 import type * as RpcClient from 'effect/unstable/rpc/RpcClient';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 
-import { protoMessage, serviceError } from './service-rpc.ts';
+import {
+  ContactSchema,
+  CreateEpochResponseSchema,
+  JoinSpaceResponseSchema,
+  QuerySpacesResponseSchema,
+  SpaceSchema,
+} from './buf/proto/gen/dxos/client/services_pb.ts';
+import { CredentialSchema } from './buf/proto/gen/dxos/halo/credentials_pb.ts';
+import { bufMessage, protoMessage, serviceError } from './service-rpc.ts';
 import { mutableArray, publicKey } from './service-schemas.ts';
 
 //
@@ -60,6 +68,8 @@ export interface UpdateSpaceRequest extends Schema.Schema.Type<typeof UpdateSpac
 export const PostMessageRequest = Schema.Struct({
   spaceKey: publicKey,
   channel: Schema.String,
+  // Callers post arbitrary payloads keyed by '@type', which is the protobuf.js Any substitution;
+  // buf's Any carries typeUrl + bytes and would change what a caller passes.
   message: protoMessage('google.protobuf.Any'),
 });
 export interface PostMessageRequest extends Schema.Schema.Type<typeof PostMessageRequest> {}
@@ -72,7 +82,7 @@ export interface SubscribeMessagesRequest extends Schema.Schema.Type<typeof Subs
 
 export const WriteCredentialsRequest = Schema.Struct({
   spaceKey: publicKey,
-  credentials: Schema.optional(mutableArray(protoMessage('dxos.halo.credentials.Credential'))),
+  credentials: Schema.optional(mutableArray(bufMessage(CredentialSchema))),
 });
 export interface WriteCredentialsRequest extends Schema.Schema.Type<typeof WriteCredentialsRequest> {}
 
@@ -110,10 +120,6 @@ export const CreateEpochRequest = Schema.Struct({
 });
 export interface CreateEpochRequest extends Schema.Schema.Type<typeof CreateEpochRequest> {}
 
-// `CreateEpochResponse.controlTimeframe` embeds the `Timeframe` proto substitution (a class with a
-// `frames()` accessor), which cannot be modeled as an inline Effect struct, so the response stays
-// protobuf-encoded (`protoMessage`).
-
 export const SpaceMemberRole = Schema.Enum({
   INVALID: 0,
   ADMIN: 1,
@@ -132,7 +138,7 @@ export const UpdateMemberRoleRequest = Schema.Struct({
 export interface UpdateMemberRoleRequest extends Schema.Schema.Type<typeof UpdateMemberRoleRequest> {}
 
 export const AdmitContactRequest = Schema.Struct({
-  contact: protoMessage('dxos.client.services.Contact'),
+  contact: bufMessage(ContactSchema),
   role: SpaceMemberRole,
   spaceKey: publicKey,
 });
@@ -199,7 +205,7 @@ export interface ImportSpaceResponse extends Schema.Schema.Type<typeof ImportSpa
 export class Rpcs extends RpcGroup.make(
   Rpc.make('createSpace', {
     payload: CreateSpaceRequest,
-    success: protoMessage('dxos.client.services.Space'),
+    success: bufMessage(SpaceSchema),
     error: serviceError,
   }),
   Rpc.make('updateSpace', {
@@ -207,7 +213,7 @@ export class Rpcs extends RpcGroup.make(
     error: serviceError,
   }),
   Rpc.make('querySpaces', {
-    success: protoMessage('dxos.client.services.QuerySpacesResponse'),
+    success: bufMessage(QuerySpacesResponseSchema),
     error: serviceError,
     stream: true,
   }),
@@ -221,7 +227,7 @@ export class Rpcs extends RpcGroup.make(
   }),
   Rpc.make('joinBySpaceKey', {
     payload: JoinBySpaceKeyRequest,
-    success: protoMessage('dxos.client.services.JoinSpaceResponse'),
+    success: bufMessage(JoinSpaceResponseSchema),
     error: serviceError,
   }),
   /**
@@ -236,6 +242,7 @@ export class Rpcs extends RpcGroup.make(
    */
   Rpc.make('subscribeMessages', {
     payload: SubscribeMessagesRequest,
+    // The gossip payload is an arbitrary `Any` a caller keys by '@type', same as `postMessage`.
     success: protoMessage('dxos.mesh.teleport.gossip.GossipMessage'),
     error: serviceError,
     stream: true,
@@ -252,13 +259,13 @@ export class Rpcs extends RpcGroup.make(
    */
   Rpc.make('queryCredentials', {
     payload: QueryCredentialsRequest,
-    success: protoMessage('dxos.halo.credentials.Credential'),
+    success: bufMessage(CredentialSchema),
     error: serviceError,
     stream: true,
   }),
   Rpc.make('createEpoch', {
     payload: CreateEpochRequest,
-    success: protoMessage('dxos.client.services.CreateEpochResponse'),
+    success: bufMessage(CreateEpochResponseSchema),
     error: serviceError,
   }),
   Rpc.make('exportSpace', {

--- a/packages/devtools/devtools/src/hooks/useCredentials.tsx
+++ b/packages/devtools/devtools/src/hooks/useCredentials.tsx
@@ -5,6 +5,9 @@
 import { useEffect, useState } from 'react';
 
 import { type PublicKey } from '@dxos/keys';
+import { buf } from '@dxos/protocols/buf';
+import { decodeCompat } from '@dxos/protocols/buf-shape-compat';
+import { CredentialSchema } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
 import { type Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { useClient } from '@dxos/react-client';
 
@@ -25,7 +28,8 @@ export const useCredentials = ({ spaceKey }: { spaceKey?: PublicKey }) => {
     const newCredentials: Credential[] = [];
     const stream = spacesService.queryCredentials({ spaceKey });
     stream.subscribe((credential) => {
-      newCredentials.push(credential);
+      // The panels index `subject.assertion` by '@type', which is the protobuf.js Any substitution.
+      newCredentials.push(decodeCompat(CredentialSchema, buf.toBinary(CredentialSchema, credential)));
       setCredentials([...newCredentials]);
     });
 

--- a/packages/plugins/plugin-assistant/tsconfig.json
+++ b/packages/plugins/plugin-assistant/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../../common/effect"
     },
     {
+      "path": "../../common/errors"
+    },
+    {
       "path": "../../common/graph"
     },
     {

--- a/packages/plugins/plugin-client/src/commands/device/update/update.ts
+++ b/packages/plugins/plugin-client/src/commands/device/update/update.ts
@@ -10,6 +10,11 @@ import * as Options from 'effect/unstable/cli/Flag';
 import { CommandConfig } from '@dxos/cli-util';
 import { print } from '@dxos/cli-util';
 import { ClientService } from '@dxos/client';
+import { buf } from '@dxos/protocols/buf';
+import { decodeCompat, encodeCompat } from '@dxos/protocols/buf-shape-compat';
+import { DeviceSchema } from '@dxos/protocols/buf/dxos/client/services_pb';
+import { DeviceProfileDocumentSchema } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
+import { type Device } from '@dxos/protocols/proto/dxos/client/services';
 
 import { printDevice } from '../util';
 
@@ -41,7 +46,17 @@ export const handler = Effect.fn(function* ({ label }: { label: string }) {
     return;
   }
 
-  const updatedDevice = yield* Effect.tryPromise(() => devicesService.updateDevice(updatedProfile));
+  const updatedDevice = decodeCompat<Device>(
+    DeviceSchema,
+    buf.toBinary(
+      DeviceSchema,
+      yield* Effect.tryPromise(() =>
+        devicesService.updateDevice(
+          buf.fromBinary(DeviceProfileDocumentSchema, encodeCompat(DeviceProfileDocumentSchema, updatedProfile)),
+        ),
+      ),
+    ),
+  );
 
   if (json) {
     yield* Console.log(

--- a/packages/plugins/plugin-client/src/commands/halo/update/update.ts
+++ b/packages/plugins/plugin-client/src/commands/halo/update/update.ts
@@ -26,21 +26,7 @@ export const handler = Effect.fn(function* ({ displayName }: { displayName: stri
     return;
   }
 
-  const identityService = client.services.services.IdentityService;
-  if (!identityService) {
-    if (json) {
-      yield* Console.log(JSON.stringify({ error: 'IdentityService not found' }, null, 2));
-    } else {
-      yield* Console.log('IdentityService not found.');
-    }
-    return;
-  }
-
-  const updatedIdentity = yield* Effect.tryPromise(() =>
-    identityService.updateProfile({
-      displayName,
-    }),
-  );
+  const updatedIdentity = yield* Effect.tryPromise(() => client.halo.updateProfile({ displayName }));
 
   if (json) {
     yield* Console.log(

--- a/packages/plugins/plugin-onboarding/src/capabilities/oauth-recovery-redirect.ts
+++ b/packages/plugins/plugin-onboarding/src/capabilities/oauth-recovery-redirect.ts
@@ -16,6 +16,8 @@ import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 import * as ClientCapabilities from '@dxos/plugin-client/ClientCapabilities';
 import { ClientOperation } from '@dxos/plugin-client/ClientOperation';
+import { buf } from '@dxos/protocols/buf';
+import { RecoverIdentityRequestSchema } from '@dxos/protocols/buf/dxos/client/services_pb';
 
 import { OnboardingOperation } from '../operations';
 import {
@@ -265,7 +267,10 @@ const finalizeRedirect = Effect.fnUntraced(function* (
     invariant(identityService, 'IdentityService not available');
     const recoveryProof = params.recoveryProof;
     yield* Effect.tryPromise(() =>
-      identityService.recoverIdentity({ recoveryProof }, { timeout: RECOVER_IDENTITY_RPC_TIMEOUT }),
+      identityService.recoverIdentity(
+        buf.create(RecoverIdentityRequestSchema, { request: { case: 'recoveryProof', value: recoveryProof } }),
+        { timeout: RECOVER_IDENTITY_RPC_TIMEOUT },
+      ),
     );
     yield* invoker.schedule(ClientOperation.CreateAgent);
     yield* closeDialog;

--- a/packages/plugins/plugin-onboarding/src/util.ts
+++ b/packages/plugins/plugin-onboarding/src/util.ts
@@ -6,6 +6,9 @@ import { type Client } from '@dxos/client';
 import { type Credential } from '@dxos/client/halo';
 import { invariant } from '@dxos/invariant';
 import { InvalidRecoveryTokenError } from '@dxos/protocols';
+import { buf } from '@dxos/protocols/buf';
+import { decodeCompat } from '@dxos/protocols/buf-shape-compat';
+import { CredentialSchema } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
 
 /**
  * Whether a failed recovery was EDGE refusing the token itself — walks the wrapper chain because
@@ -69,7 +72,8 @@ export const queryAllCredentials = (client: Client) => {
     const credentials: Credential[] = [];
     stream.subscribe(
       (credential) => {
-        credentials.push(credential);
+        // Callers index `subject.assertion` by '@type', which is the protobuf.js Any substitution.
+        credentials.push(decodeCompat(CredentialSchema, buf.toBinary(CredentialSchema, credential)));
       },
       (err) => {
         if (err) {

--- a/packages/plugins/plugin-review/tsconfig.json
+++ b/packages/plugins/plugin-review/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../../common/effect"
     },
     {
+      "path": "../../common/errors"
+    },
+    {
       "path": "../../common/graph"
     },
     {

--- a/packages/plugins/plugin-space/src/containers/InlineSyncStatus/InlineSyncStatus.tsx
+++ b/packages/plugins/plugin-space/src/containers/InlineSyncStatus/InlineSyncStatus.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 
 import * as GraphPath from '@dxos/app-toolkit/GraphPath';
-import { EdgeStatus } from '@dxos/protocols/proto/dxos/client/services';
+import { EdgeStatus_ConnectionState } from '@dxos/protocols/buf/dxos/client/services_pb';
 import { EdgeReplicationSetting } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { type Space, useSpaceSyncState } from '@dxos/react-client/echo';
 import { Tooltip, useTranslation } from '@dxos/react-ui';
@@ -21,7 +21,7 @@ export const InlineSyncStatus = ({ space, open }: { space: Space; open?: boolean
   const { hasAttention, isAncestor, isRelated } = useAttention(qualifiedId);
   const attended = hasAttention || isRelated;
   const containsAttended = isAncestor && !open;
-  const connectedToEdge = useEdgeStatus().state === EdgeStatus.ConnectionState.CONNECTED;
+  const connectedToEdge = useEdgeStatus().state === EdgeStatus_ConnectionState.CONNECTED;
   // TODO(wittjosiah): This is not reactive.
   const edgeSyncEnabled = space.internal.data.edgeReplication === EdgeReplicationSetting.ENABLED;
   const syncState = useSpaceSyncState(space);

--- a/packages/plugins/plugin-space/src/containers/SyncStatus/SyncStatus.stories.tsx
+++ b/packages/plugins/plugin-space/src/containers/SyncStatus/SyncStatus.stories.tsx
@@ -6,7 +6,12 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { expect, within } from 'storybook/test';
 
 import { SpaceId } from '@dxos/keys';
-import { EdgeStatus } from '@dxos/protocols/proto/dxos/client/services';
+import { buf } from '@dxos/protocols/buf';
+import {
+  type EdgeStatus,
+  EdgeStatus_ConnectionState,
+  EdgeStatusSchema,
+} from '@dxos/protocols/buf/dxos/client/services_pb';
 import { type PeerSyncState, type SpaceSyncStateMap } from '@dxos/react-client/echo';
 import { withClientProvider } from '@dxos/react-client/testing';
 import { withTheme } from '@dxos/react-ui/testing';
@@ -16,16 +21,17 @@ import { translations } from '#translations';
 
 import { SyncStatusIndicator } from './SyncStatus';
 
-const createEdgeStatus = (props: Partial<EdgeStatus> = {}): EdgeStatus => ({
-  state: EdgeStatus.ConnectionState.CONNECTED,
-  rtt: 32,
-  uptime: 60_000,
-  rateBytesUp: 0,
-  rateBytesDown: 0,
-  messagesSent: 128,
-  messagesReceived: 256,
-  ...props,
-});
+const createEdgeStatus = (props: Partial<EdgeStatus> = {}): EdgeStatus =>
+  buf.create(EdgeStatusSchema, {
+    state: EdgeStatus_ConnectionState.CONNECTED,
+    rtt: 32,
+    uptime: 60_000,
+    rateBytesUp: 0,
+    rateBytesDown: 0,
+    messagesSent: 128,
+    messagesReceived: 256,
+    ...props,
+  });
 
 const createSyncState = (props: Partial<PeerSyncState> = {}): SpaceSyncStateMap => ({
   [SpaceId.random()]: {
@@ -74,7 +80,7 @@ export const Offline: Story = {
   args: {
     state: {},
     saved: true,
-    edgeStatus: createEdgeStatus({ state: EdgeStatus.ConnectionState.NOT_CONNECTED }),
+    edgeStatus: createEdgeStatus({ state: EdgeStatus_ConnectionState.NOT_CONNECTED }),
   },
 };
 
@@ -114,6 +120,6 @@ export const Disconnected: Story = {
   args: {
     state: createSyncState({ missingOnRemote: 20, unsyncedDocumentCount: 20 }),
     saved: true,
-    edgeStatus: createEdgeStatus({ state: EdgeStatus.ConnectionState.NOT_CONNECTED }),
+    edgeStatus: createEdgeStatus({ state: EdgeStatus_ConnectionState.NOT_CONNECTED }),
   },
 };

--- a/packages/plugins/plugin-space/src/containers/SyncStatus/SyncStatus.tsx
+++ b/packages/plugins/plugin-space/src/containers/SyncStatus/SyncStatus.tsx
@@ -5,7 +5,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { StatusBar } from '@dxos/plugin-status-bar/components';
-import { EdgeStatus } from '@dxos/protocols/proto/dxos/client/services';
+import { type EdgeStatus, EdgeStatus_ConnectionState } from '@dxos/protocols/buf/dxos/client/services_pb';
 import { useClient } from '@dxos/react-client';
 import { type SpaceSyncStateMap, getSyncSummary, useSyncState } from '@dxos/react-client/echo';
 import { Flex, Grid, Icon, IconButton, Popover, useTranslation } from '@dxos/react-ui';
@@ -40,7 +40,7 @@ export const SyncStatusIndicator = ({
   const { t } = useTranslation(meta.profile.key);
   const summary = getSyncSummary(state);
   // Absent peer sync state is indistinguishable from having no connection.
-  const offline = edgeStatus.state !== EdgeStatus.ConnectionState.CONNECTED || Object.values(state).length === 0;
+  const offline = edgeStatus.state !== EdgeStatus_ConnectionState.CONNECTED || Object.values(state).length === 0;
   const needsToUpload = summary.differentDocuments > 0 || summary.missingOnRemote > 0;
   const needsToDownload = summary.differentDocuments > 0 || summary.missingOnLocal > 0;
 
@@ -75,7 +75,7 @@ const EdgeConnectionPopover = ({ status }: { status: EdgeStatus }) => {
   const { t } = useTranslation(meta.profile.key);
   const client = useClient();
 
-  const isConnected = status.state === EdgeStatus.ConnectionState.CONNECTED;
+  const isConnected = status.state === EdgeStatus_ConnectionState.CONNECTED;
   const edgeUrl = client.config.get('runtime.services.edge.url');
 
   return (

--- a/packages/plugins/plugin-space/src/hooks/useEdgeStatus.ts
+++ b/packages/plugins/plugin-space/src/hooks/useEdgeStatus.ts
@@ -5,18 +5,23 @@
 import { useEffect, useState } from 'react';
 
 import { log } from '@dxos/log';
-import { EdgeStatus } from '@dxos/protocols/proto/dxos/client/services';
+import { buf } from '@dxos/protocols/buf';
+import {
+  type EdgeStatus,
+  EdgeStatus_ConnectionState,
+  EdgeStatusSchema,
+} from '@dxos/protocols/buf/dxos/client/services_pb';
 import { useClient } from '@dxos/react-client';
 
-const NOT_CONNECTED: EdgeStatus = {
-  state: EdgeStatus.ConnectionState.NOT_CONNECTED,
+const NOT_CONNECTED: EdgeStatus = buf.create(EdgeStatusSchema, {
+  state: EdgeStatus_ConnectionState.NOT_CONNECTED,
   rtt: 0,
   uptime: 0,
   rateBytesUp: 0,
   rateBytesDown: 0,
   messagesSent: 0,
   messagesReceived: 0,
-};
+});
 
 /**
  * Subscribes to the EDGE connection status, which the client refreshes about once a second while connected.
@@ -27,7 +32,7 @@ export const useEdgeStatus = (): EdgeStatus => {
   useEffect(() => {
     const stream = client.services.services.EdgeAgentService?.queryEdgeStatus();
     stream?.subscribe(
-      ({ status }) => setStatus(status),
+      ({ status }) => setStatus(status ?? NOT_CONNECTED),
       (err) => err && log.catch(err),
     );
 

--- a/packages/sdk/client-e2e/src/halo-profile.test.ts
+++ b/packages/sdk/client-e2e/src/halo-profile.test.ts
@@ -9,6 +9,8 @@ import { Client } from '@dxos/client';
 import { performInvitation } from '@dxos/client-services/testing';
 import { TestBuilder } from '@dxos/client/testing';
 import { invariant } from '@dxos/invariant';
+import { buf } from '@dxos/protocols/buf';
+import { DeviceProfileDocumentSchema } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
 import { DeviceKind } from '@dxos/protocols/proto/dxos/client/services';
 
 describe('Halo', () => {
@@ -199,9 +201,9 @@ describe('Halo', () => {
     expect(await client2.halo.devices.get()).to.have.lengthOf(2);
 
     invariant(client1.services.services?.DevicesService, 'DevicesService is not available');
-    await client1?.services?.services?.DevicesService?.updateDevice({
-      label: 'updated-device-profile',
-    });
+    await client1?.services?.services?.DevicesService?.updateDevice(
+      buf.create(DeviceProfileDocumentSchema, { label: 'updated-device-profile' }),
+    );
 
     const trigger = new Trigger();
     client2.halo.devices.subscribe((devices) => {

--- a/packages/sdk/client-protocol/src/service.ts
+++ b/packages/sdk/client-protocol/src/service.ts
@@ -8,8 +8,6 @@ import { getBufService } from '@dxos/protocols/buf-service';
 import type { Invitation } from '@dxos/protocols/buf/dxos/client/invitation_pb';
 import type { LogEntry, QueryLogsRequest } from '@dxos/protocols/buf/dxos/client/logging_pb';
 import type { QueryInvitationsResponse } from '@dxos/protocols/buf/dxos/client/services_pb';
-import { Config } from '@dxos/protocols/buf/dxos/config_pb';
-import type { SignalResponse, SubscribeToSpacesResponse } from '@dxos/protocols/buf/dxos/devtools/host_pb';
 import type {
   CreateEpochResponse,
   Device,
@@ -22,7 +20,15 @@ import type {
   QuerySpacesResponse,
   RecoverIdentityRequest,
   Space,
-} from '@dxos/protocols/proto/dxos/client/services';
+} from '@dxos/protocols/buf/dxos/client/services_pb';
+import { Config } from '@dxos/protocols/buf/dxos/config_pb';
+import type { SignalResponse, SubscribeToSpacesResponse } from '@dxos/protocols/buf/dxos/devtools/host_pb';
+import type {
+  Credential,
+  DeviceProfileDocument,
+  Presentation,
+  ProfileDocument,
+} from '@dxos/protocols/buf/dxos/halo/credentials_pb';
 import type {
   GetSpaceSnapshotResponse,
   SaveSpaceSnapshotResponse,
@@ -41,12 +47,6 @@ import type {
   LeaveRequest,
   Message,
 } from '@dxos/protocols/proto/dxos/edge/signal';
-import type {
-  Credential,
-  DeviceProfileDocument,
-  Presentation,
-  ProfileDocument,
-} from '@dxos/protocols/proto/dxos/halo/credentials';
 import type { AppService, ShellService } from '@dxos/protocols/proto/dxos/iframe';
 import type { GossipMessage } from '@dxos/protocols/proto/dxos/mesh/teleport/gossip';
 import type {

--- a/packages/sdk/client-services/src/packlets/devices/devices-service.test.ts
+++ b/packages/sdk/client-services/src/packlets/devices/devices-service.test.ts
@@ -10,7 +10,9 @@ import { Context } from '@dxos/context';
 import { EffectEx } from '@dxos/effect';
 import { log } from '@dxos/log';
 import { subscribeStream } from '@dxos/protocols';
-import { type Device } from '@dxos/protocols/proto/dxos/client/services';
+import { buf } from '@dxos/protocols/buf';
+import { type Device } from '@dxos/protocols/buf/dxos/client/services_pb';
+import { DeviceProfileDocumentSchema } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
 
 import { type ServiceContext } from '../services';
 import { createServiceContext } from '../testing';
@@ -33,7 +35,11 @@ describe('DevicesService', () => {
   describe('updateDevice', () => {
     test.skip('updates device profile', async () => {
       const stream = devicesService['DevicesService.queryDevices']();
-      const device = await EffectEx.runPromise(devicesService['DevicesService.updateDevice']({ label: 'test-device' }));
+      const device = await EffectEx.runPromise(
+        devicesService['DevicesService.updateDevice'](
+          buf.create(DeviceProfileDocumentSchema, { label: 'test-device' }),
+        ),
+      );
       const result = new Trigger<Device[] | undefined>();
       const cleanup = subscribeStream(EffectContext.empty(), stream, {
         onData: ({ devices }) => result.wake(devices),

--- a/packages/sdk/client-services/src/packlets/devices/devices-service.ts
+++ b/packages/sdk/client-services/src/packlets/devices/devices-service.ts
@@ -9,11 +9,23 @@ import { SubscriptionList } from '@dxos/async';
 import { type EdgeConnection } from '@dxos/edge-client';
 import { EffectEx } from '@dxos/effect';
 import { invariant } from '@dxos/invariant';
-import { Device, DeviceKind, EdgeStatus } from '@dxos/protocols/proto/dxos/client/services';
-import { type DeviceProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
+import { buf, fromPublicKey } from '@dxos/protocols/buf';
+import { encodeCompat } from '@dxos/protocols/buf-shape-compat';
+import {
+  type Device,
+  Device_PresenceState,
+  DeviceKind,
+  DeviceSchema,
+} from '@dxos/protocols/buf/dxos/client/services_pb';
+import { type DeviceProfileDocument } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
+import { EdgeStatus, type Device as LegacyDevice } from '@dxos/protocols/proto/dxos/client/services';
 import { type DevicesService } from '@dxos/protocols/rpc';
 
 import { type IdentityManager } from '../identity';
+import { fromBufDeviceProfileDocument, toBufDeviceProfileDocument } from '../services/credentials-codec';
+
+/** Reads a device from the identity manager as the buf message the service returns. */
+const toBufDevice = (device: LegacyDevice): Device => buf.fromBinary(DeviceSchema, encodeCompat(DeviceSchema, device));
 
 export class DevicesServiceImpl implements DevicesService.Handlers {
   'constructor'(
@@ -23,7 +35,8 @@ export class DevicesServiceImpl implements DevicesService.Handlers {
 
   ['DevicesService.updateDevice'](request: DeviceProfileDocument): Effect.Effect<Device, Error> {
     return Effect.tryPromise({
-      try: async () => this._identityManager.updateDeviceProfile(request),
+      try: async () =>
+        toBufDevice(await this._identityManager.updateDeviceProfile(fromBufDeviceProfileDocument(request))),
       catch: (error) => error as Error,
     });
   }
@@ -42,25 +55,25 @@ export class DevicesServiceImpl implements DevicesService.Handlers {
               const isMe = this._identityManager.identity?.deviceKey.equals(key);
               let presence;
               if (isMe) {
-                presence = Device.PresenceState.ONLINE;
+                presence = Device_PresenceState.ONLINE;
               } else if (profile.os?.toUpperCase() === 'EDGE') {
                 presence =
                   this._edgeConnection?.status.state === EdgeStatus.ConnectionState.CONNECTED
-                    ? Device.PresenceState.ONLINE
-                    : Device.PresenceState.OFFLINE;
+                    ? Device_PresenceState.ONLINE
+                    : Device_PresenceState.OFFLINE;
               } else {
                 presence =
                   identityPresence.getPeersByIdentityKey(key).length > 0
-                    ? Device.PresenceState.ONLINE
-                    : Device.PresenceState.OFFLINE;
+                    ? Device_PresenceState.ONLINE
+                    : Device_PresenceState.OFFLINE;
               }
 
-              return {
-                deviceKey: key,
+              return buf.create(DeviceSchema, {
+                deviceKey: fromPublicKey(key),
                 kind: this._identityManager.identity?.deviceKey.equals(key) ? DeviceKind.CURRENT : DeviceKind.TRUSTED,
-                profile,
+                profile: toBufDeviceProfileDocument(profile),
                 presence,
-              };
+              });
             }),
           });
         }

--- a/packages/sdk/client-services/src/packlets/diagnostics/diagnostics.ts
+++ b/packages/sdk/client-services/src/packlets/diagnostics/diagnostics.ts
@@ -10,20 +10,22 @@ import { createDidFromIdentityKey, credentialTypeFilter } from '@dxos/credential
 import { invariant } from '@dxos/invariant';
 import { type PublicKey } from '@dxos/keys';
 import { STORAGE_VERSION } from '@dxos/protocols';
-import { type Platform } from '@dxos/protocols/buf/dxos/client/services_pb';
+import { buf, fromPublicKey } from '@dxos/protocols/buf';
 import {
   type Device,
   type Identity,
+  IdentitySchema,
   type NetworkStatus,
-  SpaceMember,
-  type Space as SpaceProto,
-} from '@dxos/protocols/proto/dxos/client/services';
+  type Platform,
+} from '@dxos/protocols/buf/dxos/client/services_pb';
+import { SpaceMember, type Space as SpaceProto } from '@dxos/protocols/proto/dxos/client/services';
 import { type SwarmInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
 import { type Epoch } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { type DevtoolsHost, type LoggingService } from '@dxos/protocols/rpc';
 
 import { DXOS_VERSION } from '../../version';
 import { type ServiceContext } from '../services';
+import { toBufProfileDocument } from '../services/credentials-codec';
 import { getPlatform } from '../services/platform';
 import { type DataSpace } from '../spaces';
 
@@ -106,12 +108,12 @@ export const createDiagnostics = async (
       const identity = serviceContext.identityManager.identity;
       if (identity) {
         // Identity.
-        diagnostics.identity = {
+        diagnostics.identity = buf.create(IdentitySchema, {
           did: identity.did,
-          identityKey: identity.identityKey,
-          spaceKey: identity.space.key,
-          profile: identity.profileDocument,
-        };
+          identityKey: fromPublicKey(identity.identityKey),
+          spaceKey: fromPublicKey(identity.space.key),
+          profile: toBufProfileDocument(identity.profileDocument),
+        });
 
         // Devices.
         const { devices } =

--- a/packages/sdk/client-services/src/packlets/identity/contacts-service.ts
+++ b/packages/sdk/client-services/src/packlets/identity/contacts-service.ts
@@ -10,10 +10,17 @@ import { Context } from '@dxos/context';
 import { type MemberInfo } from '@dxos/credentials';
 import { EffectEx } from '@dxos/effect';
 import { PublicKey } from '@dxos/keys';
-import { type Contact, type ContactBook } from '@dxos/protocols/proto/dxos/client/services';
+import { buf, fromPublicKey } from '@dxos/protocols/buf';
+import {
+  type Contact,
+  type ContactBook,
+  ContactBookSchema,
+  ContactSchema,
+} from '@dxos/protocols/buf/dxos/client/services_pb';
 import { type ContactsService } from '@dxos/protocols/rpc';
 import { ComplexMap, ComplexSet } from '@dxos/util';
 
+import { toBufProfileDocument } from '../services/credentials-codec';
 import { type SpaceManager } from '../space';
 import { type DataSpaceManager } from '../spaces';
 import { type IdentityManager } from './identity-manager';
@@ -66,7 +73,7 @@ export class ContactsServiceImpl implements ContactsService.Handlers {
   #getContacts(): ContactBook {
     const identity = this._identityManager.identity;
     if (identity == null) {
-      return { contacts: [] };
+      return buf.create(ContactBookSchema, { contacts: [] });
     }
     const contacts = [...this._spaceManager.spaces.values()]
       .flatMap((s) => [...s.spaceState.members.values()].map((m) => [s.key, m]))
@@ -77,19 +84,20 @@ export class ContactsServiceImpl implements ContactsService.Handlers {
         }
         const existing = acc.get(memberInfo.key);
         if (existing != null) {
-          existing.profile ??= memberInfo.profile;
-          existing.commonSpaces?.push(spaceKey);
+          existing.profile ??= toBufProfileDocument(memberInfo.profile);
+          existing.commonSpaces.push(fromPublicKey(spaceKey));
         } else {
-          acc.set(memberInfo.key, {
-            identityKey: memberInfo.key,
-            profile: memberInfo.profile,
-            commonSpaces: [spaceKey],
-          });
+          acc.set(
+            memberInfo.key,
+            buf.create(ContactSchema, {
+              identityKey: fromPublicKey(memberInfo.key),
+              profile: toBufProfileDocument(memberInfo.profile),
+              commonSpaces: [fromPublicKey(spaceKey)],
+            }),
+          );
         }
         return acc;
       }, new ComplexMap<PublicKey, Contact>(PublicKey.hash));
-    return {
-      contacts: [...contacts.values()],
-    };
+    return buf.create(ContactBookSchema, { contacts: [...contacts.values()] });
   }
 }

--- a/packages/sdk/client-services/src/packlets/identity/identity-service.test.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-service.test.ts
@@ -10,7 +10,9 @@ import { Context } from '@dxos/context';
 import { EffectEx } from '@dxos/effect';
 import { PublicKey } from '@dxos/keys';
 import { subscribeStream } from '@dxos/protocols';
-import { type Identity } from '@dxos/protocols/proto/dxos/client/services';
+import { buf, toPublicKey } from '@dxos/protocols/buf';
+import { type Identity } from '@dxos/protocols/buf/dxos/client/services_pb';
+import { ProfileDocumentSchema } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
 import { IdentityRecovery } from '@dxos/protocols/proto/dxos/halo/credentials';
 
 import { type ServiceContext } from '../services';
@@ -35,17 +37,19 @@ describe('IdentityService', () => {
     test('creates a new identity', async () => {
       const identity = await EffectEx.runPromise(identityService['IdentityService.createIdentity']({}));
 
-      expect(identity.identityKey).to.be.instanceof(PublicKey);
-      expect(identity.spaceKey).to.be.instanceof(PublicKey);
+      expect(toPublicKey(identity.identityKey)).to.be.instanceof(PublicKey);
+      expect(toPublicKey(identity.spaceKey)).to.be.instanceof(PublicKey);
     });
 
     test('creates a new identity with a display name', async () => {
       const identity = await EffectEx.runPromise(
-        identityService['IdentityService.createIdentity']({ profile: { displayName: 'Example' } }),
+        identityService['IdentityService.createIdentity']({
+          profile: buf.create(ProfileDocumentSchema, { displayName: 'Example' }),
+        }),
       );
 
-      expect(identity.identityKey).to.be.instanceof(PublicKey);
-      expect(identity.spaceKey).to.be.instanceof(PublicKey);
+      expect(toPublicKey(identity.identityKey)).to.be.instanceof(PublicKey);
+      expect(toPublicKey(identity.spaceKey)).to.be.instanceof(PublicKey);
       expect(identity.profile?.displayName).to.equal('Example');
     });
 
@@ -114,7 +118,7 @@ describe('IdentityService', () => {
       expect(identity.profile?.displayName).to.be.undefined;
 
       const updatedIdentity = await EffectEx.runPromise(
-        identityService['IdentityService.updateProfile']({ displayName: 'Example' }),
+        identityService['IdentityService.updateProfile'](buf.create(ProfileDocumentSchema, { displayName: 'Example' })),
       );
       expect(updatedIdentity.profile?.displayName).to.equal('Example');
     });

--- a/packages/sdk/client-services/src/packlets/identity/identity-service.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-service.ts
@@ -10,16 +10,43 @@ import { createCredential, signPresentation } from '@dxos/credentials';
 import { EffectEx } from '@dxos/effect';
 import { invariant } from '@dxos/invariant';
 import { type KeyringApi } from '@dxos/keyring';
+import { buf, fromPublicKey } from '@dxos/protocols/buf';
+import { decodeCompat } from '@dxos/protocols/buf-shape-compat';
 import {
   type Identity as IdentityProto,
+  IdentitySchema,
   type RecoverIdentityRequest,
-} from '@dxos/protocols/proto/dxos/client/services';
-import { type Credential, type Presentation, type ProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
+  type RecoverIdentityRequest_ExternalSignature,
+  RecoverIdentityRequest_ExternalSignatureSchema,
+} from '@dxos/protocols/buf/dxos/client/services_pb';
+import { type Credential, type Presentation, type ProfileDocument } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
+import { type RecoverIdentityRequest as LegacyRecoverIdentityRequest } from '@dxos/protocols/proto/dxos/client/services';
+import { type ProfileDocument as LegacyProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { type IdentityService } from '@dxos/protocols/rpc';
 
+import {
+  fromBufDeviceProfileDocument,
+  fromBufPresentation,
+  fromBufProfileDocument,
+  toBufCredential,
+  toBufPresentation,
+  toBufProfileDocument,
+} from '../services/credentials-codec';
 import { type Identity } from './identity';
 import { type CreateIdentityOptions, type IdentityManager } from './identity-manager';
 import { type EdgeIdentityRecoveryManager } from './identity-recovery-manager';
+
+/**
+ * Reads the external signature as the shape the recovery manager expects.
+ * Its keys arrive as buf messages where the manager calls `toHex` on the domain key.
+ */
+const fromBufExternalSignature = (
+  external: RecoverIdentityRequest_ExternalSignature,
+): LegacyRecoverIdentityRequest.ExternalSignature =>
+  decodeCompat(
+    RecoverIdentityRequest_ExternalSignatureSchema,
+    buf.toBinary(RecoverIdentityRequest_ExternalSignatureSchema, external),
+  );
 
 export class IdentityServiceImpl extends Resource implements IdentityService.Handlers {
   'constructor'(
@@ -27,7 +54,7 @@ export class IdentityServiceImpl extends Resource implements IdentityService.Han
     private readonly _recoveryManager: EdgeIdentityRecoveryManager,
     private readonly _keyring: KeyringApi,
     private readonly _createIdentity: (params: CreateIdentityOptions, ctx?: Context) => Promise<Identity>,
-    private readonly _onProfileUpdate?: (profile: ProfileDocument | undefined) => Promise<void>,
+    private readonly _onProfileUpdate?: (profile: LegacyProfileDocument | undefined) => Promise<void>,
   ) {
     super();
   }
@@ -38,7 +65,13 @@ export class IdentityServiceImpl extends Resource implements IdentityService.Han
     return Effect.tryPromise({
       try: async () => {
         const ctx = Context.default();
-        await this._createIdentity({ profile: request.profile, deviceProfile: request.deviceProfile }, ctx);
+        await this._createIdentity(
+          {
+            profile: request.profile && fromBufProfileDocument(request.profile),
+            deviceProfile: request.deviceProfile && fromBufDeviceProfileDocument(request.deviceProfile),
+          },
+          ctx,
+        );
         return this._getIdentity()!;
       },
       catch: (error) => error as Error,
@@ -64,7 +97,7 @@ export class IdentityServiceImpl extends Resource implements IdentityService.Han
     return Effect.tryPromise({
       try: async () => {
         invariant(this._identityManager.identity, 'Identity not initialized.');
-        await this._identityManager.updateProfile(profile);
+        await this._identityManager.updateProfile(fromBufProfileDocument(profile));
         await this._onProfileUpdate?.(this._identityManager.identity.profileDocument);
         return this._getIdentity()!;
       },
@@ -104,16 +137,25 @@ export class IdentityServiceImpl extends Resource implements IdentityService.Han
     return Effect.tryPromise({
       try: async () => {
         const ctx = Context.default();
-        if (request.recoveryCode) {
-          await this._recoveryManager.recoverIdentity(ctx, { recoveryCode: request.recoveryCode });
-        } else if (request.external) {
-          await this._recoveryManager.recoverIdentityWithExternalSignature(ctx, request.external);
-        } else if (request.token) {
-          await this._recoveryManager.recoverIdentityWithToken(ctx, { token: request.token });
-        } else if (request.recoveryProof) {
-          await this._recoveryManager.recoverIdentityWithToken(ctx, { recoveryProof: request.recoveryProof });
-        } else {
-          throw new Error('Invalid request.');
+        // buf models the `request` oneof as a tagged union, so the cases are exhaustive here.
+        switch (request.request.case) {
+          case 'recoveryCode':
+            await this._recoveryManager.recoverIdentity(ctx, { recoveryCode: request.request.value });
+            break;
+          case 'external':
+            await this._recoveryManager.recoverIdentityWithExternalSignature(
+              ctx,
+              fromBufExternalSignature(request.request.value),
+            );
+            break;
+          case 'token':
+            await this._recoveryManager.recoverIdentityWithToken(ctx, { token: request.request.value });
+            break;
+          case 'recoveryProof':
+            await this._recoveryManager.recoverIdentityWithToken(ctx, { recoveryProof: request.request.value });
+            break;
+          case undefined:
+            throw new Error('Invalid request.');
         }
 
         return this._getIdentity()!;
@@ -131,13 +173,15 @@ export class IdentityServiceImpl extends Resource implements IdentityService.Han
         const { presentation, nonce } = request;
         invariant(this._identityManager.identity, 'Identity not initialized.');
 
-        return await signPresentation({
-          presentation,
-          signer: this._keyring,
-          signerKey: this._identityManager.identity.deviceKey,
-          chain: this._identityManager.identity.deviceCredentialChain,
-          nonce,
-        });
+        return toBufPresentation(
+          await signPresentation({
+            presentation: fromBufPresentation(presentation),
+            signer: this._keyring,
+            signerKey: this._identityManager.identity.deviceKey,
+            chain: this._identityManager.identity.deviceCredentialChain,
+            nonce,
+          }),
+        );
       },
       catch: (error) => error as Error,
     });
@@ -150,14 +194,16 @@ export class IdentityServiceImpl extends Resource implements IdentityService.Han
 
         invariant(identity, 'Identity not initialized.');
 
-        return await createCredential({
-          assertion: { '@type': 'dxos.halo.credentials.Auth' },
-          issuer: identity.identityKey,
-          subject: identity.identityKey,
-          chain: identity.deviceCredentialChain,
-          signingKey: identity.deviceKey,
-          signer: this._keyring,
-        });
+        return toBufCredential(
+          await createCredential({
+            assertion: { '@type': 'dxos.halo.credentials.Auth' },
+            issuer: identity.identityKey,
+            subject: identity.identityKey,
+            chain: identity.deviceCredentialChain,
+            signingKey: identity.deviceKey,
+            signer: this._keyring,
+          }),
+        );
       },
       catch: (error) => error as Error,
     });
@@ -168,11 +214,11 @@ export class IdentityServiceImpl extends Resource implements IdentityService.Han
       return undefined;
     }
 
-    return {
+    return buf.create(IdentitySchema, {
       did: this._identityManager.identity.did,
-      identityKey: this._identityManager.identity.identityKey,
-      spaceKey: this._identityManager.identity.space.key,
-      profile: this._identityManager.identity.profileDocument,
-    };
+      identityKey: fromPublicKey(this._identityManager.identity.identityKey),
+      spaceKey: fromPublicKey(this._identityManager.identity.space.key),
+      profile: toBufProfileDocument(this._identityManager.identity.profileDocument),
+    });
   }
 }

--- a/packages/sdk/client-services/src/packlets/services/credentials-codec.ts
+++ b/packages/sdk/client-services/src/packlets/services/credentials-codec.ts
@@ -1,0 +1,63 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { buf } from '@dxos/protocols/buf';
+import { decodeCompat, encodeCompat } from '@dxos/protocols/buf-shape-compat';
+import {
+  type Credential,
+  CredentialSchema,
+  type DeviceProfileDocument,
+  DeviceProfileDocumentSchema,
+  type Presentation,
+  PresentationSchema,
+  type ProfileDocument,
+  ProfileDocumentSchema,
+} from '@dxos/protocols/buf/dxos/halo/credentials_pb';
+import {
+  type Credential as LegacyCredential,
+  type DeviceProfileDocument as LegacyDeviceProfileDocument,
+  type Presentation as LegacyPresentation,
+  type ProfileDocument as LegacyProfileDocument,
+} from '@dxos/protocols/proto/dxos/halo/credentials';
+
+//
+// The client services speak buf while `@dxos/credentials` keeps the protobuf.js shapes — the
+// credential is signed over its protobuf.js encoding, so converting it there would change what is
+// verified. These bridges carry the payloads across as their shared wire bytes instead, which
+// leaves the credential subsystem untouched.
+//
+
+/** Reads a profile from `@dxos/credentials` as the buf message the services carry. */
+export const toBufProfileDocument = (profile: LegacyProfileDocument | undefined): ProfileDocument | undefined =>
+  profile && buf.fromBinary(ProfileDocumentSchema, encodeCompat(ProfileDocumentSchema, profile));
+
+/** Writes a buf profile back as the shape `@dxos/credentials` expects. */
+export const fromBufProfileDocument = (profile: ProfileDocument): LegacyProfileDocument =>
+  decodeCompat(ProfileDocumentSchema, buf.toBinary(ProfileDocumentSchema, profile));
+
+/** Reads a credential from `@dxos/credentials` as the buf message the services carry. */
+export const toBufCredential = (credential: LegacyCredential): Credential =>
+  buf.fromBinary(CredentialSchema, encodeCompat(CredentialSchema, credential));
+
+/** Writes a buf credential back as the shape `@dxos/credentials` expects. */
+export const fromBufCredential = (credential: Credential): LegacyCredential =>
+  decodeCompat(CredentialSchema, buf.toBinary(CredentialSchema, credential));
+
+/** Reads a device profile from `@dxos/credentials` as the buf message the services carry. */
+export const toBufDeviceProfileDocument = (
+  profile: LegacyDeviceProfileDocument | undefined,
+): DeviceProfileDocument | undefined =>
+  profile && buf.fromBinary(DeviceProfileDocumentSchema, encodeCompat(DeviceProfileDocumentSchema, profile));
+
+/** Writes a buf device profile back as the shape `@dxos/credentials` expects. */
+export const fromBufDeviceProfileDocument = (profile: DeviceProfileDocument): LegacyDeviceProfileDocument =>
+  decodeCompat(DeviceProfileDocumentSchema, buf.toBinary(DeviceProfileDocumentSchema, profile));
+
+/** Reads a presentation as the shape `signPresentation` expects. */
+export const fromBufPresentation = (presentation: Presentation): LegacyPresentation =>
+  decodeCompat(PresentationSchema, buf.toBinary(PresentationSchema, presentation));
+
+/** Reads a signed presentation as the buf message the services return. */
+export const toBufPresentation = (presentation: LegacyPresentation): Presentation =>
+  buf.fromBinary(PresentationSchema, encodeCompat(PresentationSchema, presentation));

--- a/packages/sdk/client-services/src/packlets/services/effect-rpc.test.ts
+++ b/packages/sdk/client-services/src/packlets/services/effect-rpc.test.ts
@@ -30,7 +30,7 @@ import {
 import { EffectEx } from '@dxos/effect';
 import { PublicKey } from '@dxos/keys';
 import { IdentityNotInitializedError, TimeoutError } from '@dxos/protocols';
-import { buf, fromPublicKey } from '@dxos/protocols/buf';
+import { buf, fromPublicKey, toPublicKey } from '@dxos/protocols/buf';
 import {
   Invitation,
   Invitation_AuthMethod,
@@ -39,6 +39,7 @@ import {
   Invitation_Type,
   InvitationSchema,
 } from '@dxos/protocols/buf/dxos/client/invitation_pb';
+import { SpaceSchema } from '@dxos/protocols/buf/dxos/client/services_pb';
 import {
   QueryInvitationsResponse,
   QueryInvitationsResponse_Action,
@@ -142,20 +143,21 @@ describe('client services effect-rpc', () => {
     const proxy = await setup(() => ({
       SpacesService: mockService<SpacesService.Handlers>({
         ['SpacesService.createSpace']: () =>
-          Effect.succeed({
-            id: 'test-space',
-            spaceKey,
-            state: SpaceState.SPACE_READY,
-            membershipPolicy: MembershipPolicy.INVITE,
-            metrics: {},
-          }),
+          Effect.succeed(
+            buf.create(SpaceSchema, {
+              id: 'test-space',
+              spaceKey: fromPublicKey(spaceKey),
+              state: SpaceState.SPACE_READY,
+              membershipPolicy: MembershipPolicy.INVITE,
+            }),
+          ),
       }),
     }));
 
     const space = await proxy.SpacesService!.createSpace({ membershipPolicy: MembershipPolicy.INVITE });
     expect(space.id).toEqual('test-space');
-    expect(space.spaceKey).toBeInstanceOf(PublicKey);
-    expect(space.spaceKey.equals(spaceKey)).toBe(true);
+    expect(toPublicKey(space.spaceKey)).toBeInstanceOf(PublicKey);
+    expect(toPublicKey(space.spaceKey)?.equals(spaceKey)).toBe(true);
   });
 
   test('streaming call round trip', async ({ expect }) => {

--- a/packages/sdk/client-services/src/packlets/services/service-host.test.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-host.test.ts
@@ -15,14 +15,17 @@ import { Config } from '@dxos/config';
 import { Context } from '@dxos/context';
 import { verifyPresentation } from '@dxos/credentials';
 import { EffectEx } from '@dxos/effect';
+import { failedInvariant } from '@dxos/invariant';
 import { type PublicKey } from '@dxos/keys';
 import { MemorySignalManagerContext } from '@dxos/messaging';
-import { type Identity } from '@dxos/protocols/proto/dxos/client/services';
+import { buf, toPublicKey } from '@dxos/protocols/buf';
+import { type Identity } from '@dxos/protocols/buf/dxos/client/services_pb';
+import { type Credential, PresentationSchema } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
 import { MembershipPolicy } from '@dxos/protocols/proto/dxos/halo/credentials';
-import { type Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { isNode } from '@dxos/util';
 
 import { createMockCredential, createServiceHost } from '../testing';
+import { fromBufPresentation, toBufCredential } from './credentials-codec';
 
 /**
  * Bridges a host's effect-rpc {@link ClientServices} handlers to the Promise/`Stream` shaped
@@ -57,9 +60,11 @@ describe('ClientServicesHost', () => {
     const services = await makeProxyServices(host);
 
     await services.IdentityService!.createIdentity({});
-    const { spaceKey } = await services.SpacesService!.createSpace({ membershipPolicy: MembershipPolicy.INVITE });
+    const space = await services.SpacesService!.createSpace({ membershipPolicy: MembershipPolicy.INVITE });
 
-    const stream = services.SpacesService!.queryCredentials({ spaceKey });
+    const stream = services.SpacesService!.queryCredentials({
+      spaceKey: toPublicKey(space.spaceKey) ?? failedInvariant(),
+    });
     const [done, tick] = latch({ count: 3 });
     stream.subscribe((credential) => {
       tick();
@@ -86,20 +91,21 @@ describe('ClientServicesHost', () => {
     // Test if Identity exposes haloSpace key.
     const haloSpace = new Trigger<PublicKey>();
     services.IdentityService!.queryIdentity()!.subscribe(({ identity }) => {
-      if (identity?.spaceKey) {
-        haloSpace.wake(identity.spaceKey);
+      const spaceKey = toPublicKey(identity?.spaceKey);
+      if (spaceKey) {
+        haloSpace.wake(spaceKey);
       }
     });
 
     await services.SpacesService?.writeCredentials({
       spaceKey: await haloSpace.wait(),
-      credentials: [testCredential],
+      credentials: [toBufCredential(testCredential)],
     });
 
     const credentials = services.SpacesService!.queryCredentials({ spaceKey: await haloSpace.wait() });
     const queriedCredential = new Trigger<Credential>();
     credentials.subscribe((credential) => {
-      if (credential.subject.id.equals(testCredential.subject.id)) {
+      if (toPublicKey(credential.subject?.id)?.equals(testCredential.subject.id)) {
         queriedCredential.wake(credential);
       }
     });
@@ -124,14 +130,14 @@ describe('ClientServicesHost', () => {
     const nonce = new Uint8Array([0, 0, 0, 0]);
 
     const presentation = await services.IdentityService!.signPresentation({
-      presentation: {
-        credentials: [testCredential],
-      },
+      presentation: buf.create(PresentationSchema, {
+        credentials: [toBufCredential(testCredential)],
+      }),
       nonce,
     });
 
     expect(presentation.proofs?.[0].nonce).to.deep.equal(nonce);
-    expect(await verifyPresentation(presentation)).to.deep.equal({
+    expect(await verifyPresentation(fromBufPresentation(presentation))).to.deep.equal({
       kind: 'pass',
     });
   });

--- a/packages/sdk/client-services/src/packlets/spaces/spaces-service.test.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/spaces-service.test.ts
@@ -10,7 +10,8 @@ import { Context } from '@dxos/context';
 import { EffectEx } from '@dxos/effect';
 import { PublicKey } from '@dxos/keys';
 import { subscribeStream } from '@dxos/protocols';
-import { type Space } from '@dxos/protocols/proto/dxos/client/services';
+import { toPublicKey } from '@dxos/protocols/buf';
+import { type Space } from '@dxos/protocols/buf/dxos/client/services_pb';
 import { MembershipPolicy } from '@dxos/protocols/proto/dxos/halo/credentials';
 
 import { type ServiceContext } from '../services';
@@ -52,7 +53,7 @@ describe('SpacesService', () => {
         spacesService['SpacesService.createSpace']({ membershipPolicy: MembershipPolicy.INVITE }),
       );
       expect(space).to.exist;
-      expect(space.spaceKey).to.be.instanceof(PublicKey);
+      expect(toPublicKey(space.spaceKey)).to.be.instanceof(PublicKey);
     });
   });
 
@@ -111,7 +112,7 @@ describe('SpacesService', () => {
       );
       const spaces = await result.wait();
       expect(spaces).to.be.length(1);
-      expect(spaces?.[0].spaceKey.equals(space.spaceKey)).to.be.true;
+      expect(toPublicKey(spaces?.[0].spaceKey)?.toHex()).to.equal(toPublicKey(space.spaceKey)?.toHex());
     });
 
     test.skip('updates when space is updated', async () => {});

--- a/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
@@ -32,24 +32,33 @@ import {
   encodeError,
   makeInProcessClient,
 } from '@dxos/protocols';
-import { decodeCompat } from '@dxos/protocols/buf-shape-compat';
+import { buf, fromTimeframe, toPublicKey } from '@dxos/protocols/buf';
+import { decodeCompat, encodeCompat } from '@dxos/protocols/buf-shape-compat';
+import {
+  type CreateEpochResponse,
+  CreateEpochResponseSchema,
+  type JoinSpaceResponse,
+  JoinSpaceResponseSchema,
+  type QuerySpacesResponse,
+  QuerySpacesResponseSchema,
+  type Space,
+  SpaceSchema,
+} from '@dxos/protocols/buf/dxos/client/services_pb';
+import { type Credential } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
 import { PeerStateSchema } from '@dxos/protocols/buf/dxos/mesh/presence_pb';
 import {
   type ContactAdmission,
-  type CreateEpochResponse,
-  type JoinSpaceResponse,
-  type QuerySpacesResponse,
-  type Space,
+  type Space as LegacySpace,
   SpaceMember,
   SpaceState,
 } from '@dxos/protocols/proto/dxos/client/services';
-import { type Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { type GossipMessage } from '@dxos/protocols/proto/dxos/mesh/teleport/gossip';
 import { FeedService, SpacesService } from '@dxos/protocols/rpc';
 import { trace } from '@dxos/tracing';
 import { type Provider } from '@dxos/util';
 
 import { type IdentityManager } from '../identity';
+import { fromBufCredential, toBufCredential } from '../services/credentials-codec';
 import { type SpaceManager } from '../space';
 import {
   SpaceArchiveWriter,
@@ -61,6 +70,9 @@ import {
 } from '../space-export';
 import { type DataSpace } from './data-space';
 import { type DataSpaceManager } from './data-space-manager';
+
+/** Reads the space as the buf message the service returns. */
+const toBufSpace = (space: LegacySpace): Space => buf.fromBinary(SpaceSchema, encodeCompat(SpaceSchema, space));
 
 export class SpacesServiceImpl implements SpacesService.Handlers {
   'constructor'(
@@ -171,7 +183,7 @@ export class SpacesServiceImpl implements SpacesService.Handlers {
           );
           log('update', () => ({ ids: spaces.map((space) => space.id) }));
           await this._updateMetrics();
-          void emit.single({ spaces });
+          void emit.single(buf.create(QuerySpacesResponseSchema, { spaces }));
         },
         { maxFrequency: process.env.NODE_ENV === 'test' ? undefined : 2 },
       );
@@ -218,7 +230,7 @@ export class SpacesServiceImpl implements SpacesService.Handlers {
       });
 
       if (!this._identityManager.identity) {
-        void emit.single({ spaces: [] });
+        void emit.single(buf.create(QuerySpacesResponseSchema, { spaces: [] }));
       }
 
       return Effect.promise(() => ctx.dispose());
@@ -269,7 +281,7 @@ export class SpacesServiceImpl implements SpacesService.Handlers {
 
       const processor: CredentialProcessor = {
         processCredential: async (credential) => {
-          void emit.single(credential);
+          void emit.single(toBufCredential(credential));
         },
       };
       ctx.onDispose(() => space.spaceState.removeCredentialProcessor(processor));
@@ -291,7 +303,8 @@ export class SpacesServiceImpl implements SpacesService.Handlers {
     return Effect.tryPromise({
       try: async () => {
         const space = this._spaceManager.spaces.get(spaceKey) ?? raise(new SpaceNotFoundError(spaceKey));
-        for (const credential of credentials ?? []) {
+        for (const bufCredential of credentials ?? []) {
+          const credential = fromBufCredential(bufCredential);
           if (credential.proof) {
             await space.controlPipeline.writer.write({ credential: { credential } });
           } else {
@@ -321,7 +334,10 @@ export class SpacesServiceImpl implements SpacesService.Handlers {
         const dataSpaceManager = await this._getDataSpaceManager();
         const space = dataSpaceManager.spaces.get(spaceKey) ?? raise(new SpaceNotFoundError(spaceKey));
         const result = await space.createEpoch({ migration, newAutomergeRoot: automergeRootUrl });
-        return { epochCredential: result?.credential, controlTimeframe: result?.timeframe };
+        return buf.create(CreateEpochResponseSchema, {
+          epochCredential: result?.credential && toBufCredential(result.credential),
+          controlTimeframe: result?.timeframe && fromTimeframe(result.timeframe),
+        });
       },
       catch: (error) => error as Error,
     });
@@ -333,7 +349,7 @@ export class SpacesServiceImpl implements SpacesService.Handlers {
         const dataSpaceManager = await this._getDataSpaceManager();
         await dataSpaceManager.admitMember({
           spaceKey: request.spaceKey,
-          identityKey: request.contact.identityKey,
+          identityKey: toPublicKey(request.contact.identityKey)!,
           role: request.role,
         });
       },
@@ -500,10 +516,18 @@ export class SpacesServiceImpl implements SpacesService.Handlers {
       await myIdentity.controlPipeline.writer.write({ credential: { credential } });
     }
 
-    return { space: await this._serializeSpace(dataSpace) };
+    return buf.create(JoinSpaceResponseSchema, { space: await this._serializeSpace(dataSpace) });
   }
 
   private async '_serializeSpace'(space: DataSpace): Promise<Space> {
+    return toBufSpace(await this.#serializeLegacySpace(space));
+  }
+
+  /**
+   * Builds the space in the protobuf.js shape the domain objects already speak, which
+   * {@link toBufSpace} then carries across in one step rather than field by field.
+   */
+  async #serializeLegacySpace(space: DataSpace): Promise<LegacySpace> {
     return {
       id: space.id,
       spaceKey: space.key,

--- a/packages/sdk/client-services/src/packlets/testing/credential-utils.ts
+++ b/packages/sdk/client-services/src/packlets/testing/credential-utils.ts
@@ -18,11 +18,11 @@ export const createMockCredential = async ({
     signer,
     issuer,
     subject: new PublicKey(Buffer.from('test')),
+    // The assertion must be a real credential type: the services carry credentials as buf messages,
+    // whose registry resolves only the types the schema declares.
     assertion: {
-      '@type': 'example.testing.rpc.MessageWithAny',
-      'payload': {
-        '@type': 'google.protobuf.Any',
-        'value': Buffer.from('test'),
-      },
+      '@type': 'dxos.halo.credentials.AuthorizedDevice',
+      'identityKey': issuer,
+      'deviceKey': issuer,
     },
   });

--- a/packages/sdk/client/src/echo/space-list.ts
+++ b/packages/sdk/client/src/echo/space-list.ts
@@ -32,6 +32,7 @@ import { trace } from '@dxos/tracing';
 
 import { RPC_TIMEOUT } from '../common';
 import { InvitationsProxy } from '../invitations';
+import { fromBufSpace } from '../services/legacy-codec';
 import { SpaceProxy } from './space-proxy';
 
 export class SpaceList extends MulticastObservable<Space[]> implements Echo {
@@ -197,7 +198,9 @@ export class SpaceList extends MulticastObservable<Space[]> implements Echo {
     };
 
     this._streamSubscriptions.add(
-      subscribeStream(this._runtime, this._serviceProvider.rpc['SpacesService.querySpaces'](undefined), { onData }),
+      subscribeStream(this._runtime, this._serviceProvider.rpc['SpacesService.querySpaces'](undefined), {
+        onData: (data) => onData({ spaces: data.spaces.map(fromBufSpace) }),
+      }),
     );
   }
 
@@ -272,13 +275,15 @@ export class SpaceList extends MulticastObservable<Space[]> implements Echo {
     options?: { tags?: string[]; membershipPolicy?: MembershipPolicy },
   ): Promise<Space> {
     log('creating space');
-    const space = await runServiceCall(
-      this._runtime,
-      this._serviceProvider.rpc['SpacesService.createSpace']({
-        tags: options?.tags ?? [],
-        membershipPolicy: options?.membershipPolicy ?? MembershipPolicy.INVITE,
-      }),
-      { timeout: RPC_TIMEOUT, label: 'SpacesService.createSpace' },
+    const space = fromBufSpace(
+      await runServiceCall(
+        this._runtime,
+        this._serviceProvider.rpc['SpacesService.createSpace']({
+          tags: options?.tags ?? [],
+          membershipPolicy: options?.membershipPolicy ?? MembershipPolicy.INVITE,
+        }),
+        { timeout: RPC_TIMEOUT, label: 'SpacesService.createSpace' },
+      ),
     );
 
     await this._spaceCreated.waitForCondition(() => {
@@ -334,12 +339,13 @@ export class SpaceList extends MulticastObservable<Space[]> implements Echo {
       this._serviceProvider.rpc['SpacesService.joinBySpaceKey']({ spaceKey }),
       { label: 'SpacesService.joinBySpaceKey' },
     );
+    const space = fromBufSpace(response.space ?? failedInvariant());
     // The proxy appears via the `querySpaces` stream, not the call's own response, so the two race —
     // same wait `createSpace` and `import` do before resolving their proxy.
     await this._spaceCreated.waitForCondition(() => {
-      return this.get().some(({ key }) => key.equals(response.space.spaceKey));
+      return this.get().some(({ key }) => key.equals(space.spaceKey));
     });
-    return this._findProxy(response.space);
+    return this._findProxy(space);
   }
 
   // Odd way to define methods types from a typedef.

--- a/packages/sdk/client/src/echo/space-proxy.ts
+++ b/packages/sdk/client/src/echo/space-proxy.ts
@@ -41,7 +41,7 @@ import { invariant } from '@dxos/invariant';
 import { type PublicKey, type SpaceId } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { decodeError, runServiceCall, subscribeStream } from '@dxos/protocols';
-import { fromPublicKey } from '@dxos/protocols/buf';
+import { fromPublicKey, toTimeframe } from '@dxos/protocols/buf';
 import { Invitation, Invitation_Kind } from '@dxos/protocols/buf/dxos/client/invitation_pb';
 import {
   type Contact,
@@ -64,6 +64,7 @@ import { trace } from '@dxos/tracing';
 
 import { RPC_TIMEOUT } from '../common';
 import { InvitationsProxy } from '../invitations';
+import { fromBufCredential, toBufContact } from '../services/legacy-codec';
 import { createDeviceLocalBranchStore } from './branch-store';
 
 const EPOCH_CREATION_TIMEOUT = 60_000;
@@ -589,7 +590,7 @@ export class SpaceProxy implements Space, CustomInspectable {
       this._clientServices.rpc['SpacesService.admitContact']({
         spaceKey: this.key,
         role: HaloSpaceMember.Role.ADMIN,
-        contact,
+        contact: toBufContact(contact),
       }),
       { label: 'SpacesService.admitContact' },
     );
@@ -653,7 +654,7 @@ export class SpaceProxy implements Space, CustomInspectable {
     } = {},
   ): Promise<void> {
     log('create epoch', { migration, automergeRootUrl });
-    const { controlTimeframe: targetTimeframe } = await runServiceCall(
+    const { controlTimeframe } = await runServiceCall(
       this._runtime,
       this._clientServices.rpc['SpacesService.createEpoch']({
         spaceKey: this.key,
@@ -662,6 +663,7 @@ export class SpaceProxy implements Space, CustomInspectable {
       }),
       { timeout: EPOCH_CREATION_TIMEOUT, label: 'SpacesService.createEpoch' },
     );
+    const targetTimeframe = toTimeframe(controlTimeframe);
 
     if (targetTimeframe) {
       await warnAfterTimeout(5_000, 'Waiting for the created epoch to be applied', () =>
@@ -680,7 +682,7 @@ export class SpaceProxy implements Space, CustomInspectable {
         EffectStream.runCollect,
       ),
     );
-    return [...credentials];
+    return credentials.map(fromBufCredential);
   }
 
   private async _getEpochs(): Promise<SpecificCredential<Epoch>[]> {

--- a/packages/sdk/client/src/edge/edge-identity.ts
+++ b/packages/sdk/client/src/edge/edge-identity.ts
@@ -6,9 +6,12 @@ import * as Context from 'effect/Context';
 
 import { type EdgeIdentity } from '@dxos/edge-client';
 import { runServiceCall } from '@dxos/protocols';
+import { buf } from '@dxos/protocols/buf';
+import { PresentationSchema } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
 
 import { type Client } from '../client';
 import { RPC_TIMEOUT } from '../common';
+import { fromBufPresentation } from '../services/legacy-codec';
 
 export const createEdgeIdentity = (client: Client): EdgeIdentity => {
   const identity = client.halo.identity.get();
@@ -26,13 +29,15 @@ export const createEdgeIdentity = (client: Client): EdgeIdentity => {
         rpc['IdentityService.createAuthCredential'](undefined),
         { label: 'IdentityService.createAuthCredential' },
       );
-      return runServiceCall(
-        Context.empty(),
-        rpc['IdentityService.signPresentation']({
-          presentation: { credentials: [authCredential] },
-          nonce: challenge,
-        }),
-        { timeout: RPC_TIMEOUT, label: 'IdentityService.signPresentation' },
+      return fromBufPresentation(
+        await runServiceCall(
+          Context.empty(),
+          rpc['IdentityService.signPresentation']({
+            presentation: buf.create(PresentationSchema, { credentials: [authCredential] }),
+            nonce: challenge,
+          }),
+          { timeout: RPC_TIMEOUT, label: 'IdentityService.signPresentation' },
+        ),
       );
     },
   };

--- a/packages/sdk/client/src/halo/halo-proxy.ts
+++ b/packages/sdk/client/src/halo/halo-proxy.ts
@@ -13,7 +13,9 @@ import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { ApiError, runServiceCall, subscribeStream } from '@dxos/protocols';
+import { buf } from '@dxos/protocols/buf';
 import { Invitation, Invitation_Kind } from '@dxos/protocols/buf/dxos/client/invitation_pb';
+import { PresentationSchema } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
 import { type Contact, type Device, DeviceKind, type Identity } from '@dxos/protocols/proto/dxos/client/services';
 import {
   type Credential,
@@ -25,6 +27,17 @@ import { trace } from '@dxos/tracing';
 
 import { RPC_TIMEOUT } from '../common';
 import { InvitationsProxy } from '../invitations';
+import {
+  fromBufContact,
+  fromBufCredential,
+  fromBufDevice,
+  fromBufIdentity,
+  fromBufPresentation,
+  toBufCredential,
+  toBufDeviceProfileDocument,
+  toBufProfileDocument,
+  toBufRecoverIdentityRequest,
+} from '../services/legacy-codec';
 
 export class HaloProxy implements Halo {
   /** Subscriptions for overall lifecycle (reconnected event listener). */
@@ -155,7 +168,7 @@ export class HaloProxy implements Halo {
       this._runtime,
       this._serviceProvider.rpc['SpacesService.queryCredentials']({ spaceKey: identity.spaceKey! }),
       {
-        onData: (data) => this._credentialsChanged.emit([...this._credentials.get(), data]),
+        onData: (data) => this._credentialsChanged.emit([...this._credentials.get(), fromBufCredential(data)]),
       },
     );
     this._haloCredentialStreamCleanup = cleanup;
@@ -185,14 +198,14 @@ export class HaloProxy implements Halo {
               identityKey: data.identity.identityKey,
               displayName: data.identity.profile?.displayName,
             });
-          this._identityChanged.emit(data.identity ?? null);
+          this._identityChanged.emit(data.identity ? fromBufIdentity(data.identity) : null);
         },
       }),
     );
 
     this._streamSubscriptions.add(
       subscribeStream(this._runtime, this._serviceProvider.rpc['ContactsService.queryContacts'](undefined), {
-        onData: (data) => this._contactsChanged.emit(data.contacts ?? []),
+        onData: (data) => this._contactsChanged.emit((data.contacts ?? []).map(fromBufContact)),
       }),
     );
 
@@ -200,7 +213,7 @@ export class HaloProxy implements Halo {
       subscribeStream(this._runtime, this._serviceProvider.rpc['DevicesService.queryDevices'](undefined), {
         onData: (data) => {
           if (data.devices) {
-            this._devicesChanged.emit(data.devices);
+            this._devicesChanged.emit(data.devices.map(fromBufDevice));
             const current = data.devices.find((device) => device.kind === DeviceKind.CURRENT);
             log.trace('dxos.halo.device', {
               deviceKey: current?.deviceKey,
@@ -260,26 +273,26 @@ export class HaloProxy implements Halo {
     const identity = await runServiceCall(
       this._runtime,
       this._serviceProvider.rpc['IdentityService.createIdentity']({
-        profile,
-        deviceProfile: deviceProfileWithDefaults,
+        profile: toBufProfileDocument(profile),
+        deviceProfile: toBufDeviceProfileDocument(deviceProfileWithDefaults),
       }),
       { timeout: RPC_TIMEOUT, label: 'IdentityService.createIdentity' },
     );
-    this._identityChanged.emit(identity);
-    return identity;
+    this._identityChanged.emit(fromBufIdentity(identity));
+    return fromBufIdentity(identity);
   }
 
   async recoverIdentity(args: RecoverIdentityArgs): Promise<Identity> {
     const identity = await runServiceCall(
       this._runtime,
-      this._serviceProvider.rpc['IdentityService.recoverIdentity'](args),
+      this._serviceProvider.rpc['IdentityService.recoverIdentity'](toBufRecoverIdentityRequest(args)),
       {
         timeout: RPC_TIMEOUT,
         label: 'IdentityService.recoverIdentity',
       },
     );
-    this._identityChanged.emit(identity);
-    return identity;
+    this._identityChanged.emit(fromBufIdentity(identity));
+    return fromBufIdentity(identity);
   }
 
   async updateProfile(profile: ProfileDocument): Promise<Identity> {
@@ -290,14 +303,14 @@ export class HaloProxy implements Halo {
   private async _updateProfileInternal(ctx: Context, profile: ProfileDocument): Promise<Identity> {
     const identity = await runServiceCall(
       this._runtime,
-      this._serviceProvider.rpc['IdentityService.updateProfile'](profile),
+      this._serviceProvider.rpc['IdentityService.updateProfile'](toBufProfileDocument(profile)),
       {
         timeout: RPC_TIMEOUT,
         label: 'IdentityService.updateProfile',
       },
     );
-    this._identityChanged.emit(identity);
-    return identity;
+    this._identityChanged.emit(fromBufIdentity(identity));
+    return fromBufIdentity(identity);
   }
 
   /**
@@ -359,7 +372,7 @@ export class HaloProxy implements Halo {
       this._runtime,
       this._serviceProvider.rpc['SpacesService.writeCredentials']({
         spaceKey: identity.spaceKey!,
-        credentials,
+        credentials: credentials.map(toBufCredential),
       }),
       { timeout: RPC_TIMEOUT, label: 'SpacesService.writeCredentials' },
     );
@@ -384,15 +397,16 @@ export class HaloProxy implements Halo {
       AUTH_TIMEOUT,
       new ApiError({ message: 'Timeout while waiting for credentials.' }),
     );
-    return runServiceCall(
+    const presentation = await runServiceCall(
       this._runtime,
       this._serviceProvider.rpc['IdentityService.signPresentation']({
-        presentation: {
-          credentials,
-        },
+        presentation: buf.create(PresentationSchema, {
+          credentials: credentials.map(toBufCredential),
+        }),
         nonce,
       }),
       { timeout: RPC_TIMEOUT, label: 'IdentityService.signPresentation' },
     );
+    return fromBufPresentation(presentation);
   }
 }

--- a/packages/sdk/client/src/services/legacy-codec.ts
+++ b/packages/sdk/client/src/services/legacy-codec.ts
@@ -1,0 +1,106 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type RecoverIdentityArgs } from '@dxos/client-protocol';
+import { buf } from '@dxos/protocols/buf';
+import { decodeCompat, encodeCompat } from '@dxos/protocols/buf-shape-compat';
+import {
+  type Contact,
+  ContactSchema,
+  type Device,
+  DeviceSchema,
+  type Identity,
+  IdentitySchema,
+  type RecoverIdentityRequest,
+  RecoverIdentityRequest_ExternalSignatureSchema,
+  RecoverIdentityRequestSchema,
+  type Space,
+  SpaceSchema,
+} from '@dxos/protocols/buf/dxos/client/services_pb';
+import {
+  type Credential,
+  CredentialSchema,
+  type DeviceProfileDocument,
+  DeviceProfileDocumentSchema,
+  type Presentation,
+  PresentationSchema,
+  type ProfileDocument,
+  ProfileDocumentSchema,
+} from '@dxos/protocols/buf/dxos/halo/credentials_pb';
+import {
+  type Contact as LegacyContact,
+  type Device as LegacyDevice,
+  type Identity as LegacyIdentity,
+  type Space as LegacySpace,
+} from '@dxos/protocols/proto/dxos/client/services';
+import {
+  type Credential as LegacyCredential,
+  type DeviceProfileDocument as LegacyDeviceProfileDocument,
+  type Presentation as LegacyPresentation,
+  type ProfileDocument as LegacyProfileDocument,
+} from '@dxos/protocols/proto/dxos/halo/credentials';
+
+//
+// The client services speak buf while this package's public API still exposes the protobuf.js
+// shapes — notably `Credential.subject.assertion`, which callers index by '@type' and buf carries
+// as a typeUrl. The proxies convert here, at the one boundary, via the shared wire bytes.
+//
+
+/** Reads an identity from the services as the shape the public API exposes. */
+export const fromBufIdentity = (identity: Identity): LegacyIdentity =>
+  decodeCompat(IdentitySchema, buf.toBinary(IdentitySchema, identity));
+
+/** Reads a contact from the services as the shape the public API exposes. */
+export const fromBufContact = (contact: Contact): LegacyContact =>
+  decodeCompat(ContactSchema, buf.toBinary(ContactSchema, contact));
+
+/** Reads a device from the services as the shape the public API exposes. */
+export const fromBufDevice = (device: Device): LegacyDevice =>
+  decodeCompat(DeviceSchema, buf.toBinary(DeviceSchema, device));
+
+/** Reads a credential from the services as the shape the public API exposes. */
+export const fromBufCredential = (credential: Credential): LegacyCredential =>
+  decodeCompat(CredentialSchema, buf.toBinary(CredentialSchema, credential));
+
+/** Reads a presentation from the services as the shape the public API exposes. */
+export const fromBufPresentation = (presentation: Presentation): LegacyPresentation =>
+  decodeCompat(PresentationSchema, buf.toBinary(PresentationSchema, presentation));
+
+/** Reads a space from the services as the shape the public API exposes. */
+export const fromBufSpace = (space: Space): LegacySpace => decodeCompat(SpaceSchema, buf.toBinary(SpaceSchema, space));
+
+/** Writes a credential from the public API as the buf message the services take. */
+export const toBufCredential = (credential: LegacyCredential): Credential =>
+  buf.fromBinary(CredentialSchema, encodeCompat(CredentialSchema, credential));
+
+/** Writes a profile from the public API as the buf message the services take. */
+export const toBufProfileDocument = (profile: LegacyProfileDocument): ProfileDocument =>
+  buf.fromBinary(ProfileDocumentSchema, encodeCompat(ProfileDocumentSchema, profile));
+
+/** Writes a device profile from the public API as the buf message the services take. */
+export const toBufDeviceProfileDocument = (profile: LegacyDeviceProfileDocument): DeviceProfileDocument =>
+  buf.fromBinary(DeviceProfileDocumentSchema, encodeCompat(DeviceProfileDocumentSchema, profile));
+
+/** Writes the public API's recovery argument union as the buf oneof the service takes. */
+export const toBufRecoverIdentityRequest = (args: RecoverIdentityArgs): RecoverIdentityRequest =>
+  buf.create(RecoverIdentityRequestSchema, {
+    request:
+      'recoveryCode' in args
+        ? { case: 'recoveryCode', value: args.recoveryCode }
+        : 'recoveryProof' in args
+          ? { case: 'recoveryProof', value: args.recoveryProof }
+          : 'token' in args
+            ? { case: 'token', value: args.token }
+            : {
+                case: 'external',
+                value: buf.fromBinary(
+                  RecoverIdentityRequest_ExternalSignatureSchema,
+                  encodeCompat(RecoverIdentityRequest_ExternalSignatureSchema, args.external),
+                ),
+              },
+  });
+
+/** Writes a contact from the public API as the buf message the services take. */
+export const toBufContact = (contact: LegacyContact): Contact =>
+  buf.fromBinary(ContactSchema, encodeCompat(ContactSchema, contact));

--- a/packages/sdk/client/src/testing/utils.ts
+++ b/packages/sdk/client/src/testing/utils.ts
@@ -20,7 +20,9 @@ type Options = {
 export const waitForSpace = async (
   client: Client,
   spaceKey: PublicKey,
-  { timeout = 500, ready }: Options = {},
+  // The space arrives over the `querySpaces` stream, so the wait spans a full RPC round trip —
+  // a sub-second budget times out under a loaded CI shard rather than on a real failure.
+  { timeout = 5_000, ready }: Options = {},
 ): Promise<Space> => {
   let space = client.spaces.get(spaceKey);
 

--- a/packages/sdk/observability/src/providers/client-observability.ts
+++ b/packages/sdk/observability/src/providers/client-observability.ts
@@ -10,15 +10,11 @@ import { type Space } from '@dxos/client/echo';
 import { Context } from '@dxos/context';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
+import { toPublicKey } from '@dxos/protocols/buf';
+import { type NetworkStatus, type NetworkStatus_Signal } from '@dxos/protocols/buf/dxos/client/services_pb';
 // Value imports come straight from protocols: reaching them through the `@dxos/client` barrels
 // puts echo-client (and wa-sqlite, automerge-repo with it) in the app's eager boot graph.
-import {
-  ConnectionState,
-  DeviceKind,
-  type NetworkStatus,
-  Platform,
-  SpaceState,
-} from '@dxos/protocols/proto/dxos/client/services';
+import { ConnectionState, DeviceKind, Platform, SpaceState } from '@dxos/protocols/proto/dxos/client/services';
 
 import * as Observability from '../Observability';
 import { type CrossRealmMemory, measureCrossRealmMemory, readHeap, supportsCrossRealmMemory } from './memory';
@@ -66,7 +62,7 @@ export const identityProvider = (clientServices: Partial<ClientServices>): Obser
         return;
       }
 
-      observability.setTags({ deviceKey: thisDevice.deviceKey.truncate() });
+      observability.setTags({ deviceKey: toPublicKey(thisDevice.deviceKey)?.truncate() ?? '' });
       if (thisDevice.profile?.label) {
         observability.setTags({ deviceProfile: thisDevice.profile.label });
       }
@@ -109,7 +105,7 @@ export const networkMetricsProvider = (clientServices: Partial<ClientServices>):
     const updateSignalMetrics = new Event<NetworkStatus>().debounce(NETWORK_METRICS_MIN_INTERVAL);
     updateSignalMetrics.on(ctx, async () => {
       log('send signal metrics');
-      (lastNetworkStatus?.signaling as NetworkStatus.Signal[])?.forEach(({ server, state }) => {
+      (lastNetworkStatus?.signaling as NetworkStatus_Signal[])?.forEach(({ server, state }) => {
         observability.metrics.gauge('dxos.client.network.signal.connectionState', state, { server });
       });
 

--- a/packages/sdk/react-client/package.json
+++ b/packages/sdk/react-client/package.json
@@ -70,6 +70,7 @@
   },
   "devDependencies": {
     "@dxos/invariant": "workspace:*",
+    "@dxos/protocols": "workspace:*",
     "@dxos/random": "workspace:*",
     "@dxos/react-ui": "workspace:*",
     "@dxos/react-ui-syntax-highlighter": "workspace:*",

--- a/packages/sdk/react-client/src/halo/Passkey.stories.tsx
+++ b/packages/sdk/react-client/src/halo/Passkey.stories.tsx
@@ -8,6 +8,11 @@ import React, { useCallback } from 'react';
 import { Config, PublicKey } from '@dxos/client';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
+import { buf, fromPublicKey } from '@dxos/protocols/buf';
+import {
+  RecoverIdentityRequest_ExternalSignatureSchema,
+  RecoverIdentityRequestSchema,
+} from '@dxos/protocols/buf/dxos/client/services_pb';
 import { Button } from '@dxos/react-ui';
 import { JsonHighlighter } from '@dxos/react-ui-syntax-highlighter';
 import { withTheme } from '@dxos/react-ui/testing';
@@ -90,16 +95,21 @@ const Test = () => {
       })
       .catch(log.error);
     const lookupKey = PublicKey.from(new Uint8Array((credential as any).response.userHandle));
-    await client.services.services.IdentityService.recoverIdentity({
-      external: {
-        lookupKey,
-        deviceKey,
-        controlFeedKey,
-        signature: Buffer.from((credential as any).response.signature),
-        clientDataJson: Buffer.from((credential as any).response.clientDataJSON),
-        authenticatorData: Buffer.from((credential as any).response.authenticatorData),
-      },
-    });
+    await client.services.services.IdentityService.recoverIdentity(
+      buf.create(RecoverIdentityRequestSchema, {
+        request: {
+          case: 'external',
+          value: buf.create(RecoverIdentityRequest_ExternalSignatureSchema, {
+            lookupKey: fromPublicKey(lookupKey),
+            deviceKey: fromPublicKey(deviceKey),
+            controlFeedKey: fromPublicKey(controlFeedKey),
+            signature: Buffer.from((credential as any).response.signature),
+            clientDataJson: Buffer.from((credential as any).response.clientDataJSON),
+            authenticatorData: Buffer.from((credential as any).response.authenticatorData),
+          }),
+        },
+      }),
+    );
   }, []);
 
   return (

--- a/packages/sdk/react-client/tsconfig.json
+++ b/packages/sdk/react-client/tsconfig.json
@@ -45,6 +45,9 @@
       "path": "../../core/echo/echo-react"
     },
     {
+      "path": "../../core/protocols"
+    },
+    {
       "path": "../../ui/react-primitives/react-hooks"
     },
     {

--- a/packages/sdk/shell/src/panels/IdentityPanel/useEdgeAgentsHandlers.ts
+++ b/packages/sdk/shell/src/panels/IdentityPanel/useEdgeAgentsHandlers.ts
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import { type CancellableInvitation } from '@dxos/client-protocol';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
-import { QueryAgentStatusResponse } from '@dxos/protocols/proto/dxos/client/services';
+import { QueryAgentStatusResponse_AgentStatus } from '@dxos/protocols/buf/dxos/client/services_pb';
 import { EdgeReplicationSetting } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { useClient } from '@dxos/react-client';
 import { type Identity } from '@dxos/react-client/halo';
@@ -21,24 +21,24 @@ export const useEdgeAgentHandlers = ({
   identity: Identity | null;
 }): AgentFormProps => {
   const [validationMessage, setValidationMessage] = useState('');
-  const [lastReceivedStatus, setLastReceivedStatus] = useState<QueryAgentStatusResponse.AgentStatus>(
-    QueryAgentStatusResponse.AgentStatus.UNKNOWN,
+  const [lastReceivedStatus, setLastReceivedStatus] = useState<QueryAgentStatusResponse_AgentStatus>(
+    QueryAgentStatusResponse_AgentStatus.UNKNOWN,
   );
   const [agentStatus, setAgentStatus] = useState<AgentFormProps['agentStatus']>('getting');
   const client = useClient();
   // TODO(wittjosiah): This should be based on HALO credentials.
   const agentHostingEnabled = Boolean(client.config.values.runtime?.client?.edgeFeatures?.agents);
 
-  const handleStatus = (status: QueryAgentStatusResponse.AgentStatus) => {
+  const handleStatus = (status: QueryAgentStatusResponse_AgentStatus) => {
     switch (status) {
-      case QueryAgentStatusResponse.AgentStatus.ACTIVE:
-      case QueryAgentStatusResponse.AgentStatus.INACTIVE:
+      case QueryAgentStatusResponse_AgentStatus.ACTIVE:
+      case QueryAgentStatusResponse_AgentStatus.INACTIVE:
         setAgentStatus('created');
         break;
-      case QueryAgentStatusResponse.AgentStatus.NOT_FOUND:
+      case QueryAgentStatusResponse_AgentStatus.NOT_FOUND:
         setAgentStatus('creatable');
         break;
-      case QueryAgentStatusResponse.AgentStatus.UNKNOWN:
+      case QueryAgentStatusResponse_AgentStatus.UNKNOWN:
         setAgentStatus('getting');
         break;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18723,6 +18723,9 @@ importers:
       '@dxos/invariant':
         specifier: workspace:*
         version: link:../../common/invariant
+      '@dxos/protocols':
+        specifier: workspace:*
+        version: link:../../core/protocols
       '@dxos/react-ui-syntax-highlighter':
         specifier: workspace:*
         version: link:../../ui/react-ui-syntax-highlighter


### PR DESCRIPTION
Chunk 7 of the protobuf.js → buf teardown: the credentials group.

Flips the `ContactsService`, `DevicesService`, `IdentityService` and `SpacesService` RPC definitions from `protoMessage` to `bufMessage` — 25 calls, leaving **7** repo-wide (`DevtoolsHost` 4, `InvitationsService` 1, `QueryService` 1, `SpacesService` 1).

## Credentials core is untouched

A credential is signed over its protobuf.js encoding, so converting it in `@dxos/credentials` would change what is verified. Instead the payloads cross the RPC boundary as their shared wire bytes, through two new bridge modules:

- `client-services/…/services/credentials-codec.ts` — host side, `@dxos/credentials` shapes ⇄ buf.
- `client/src/services/legacy-codec.ts` — client side, so `@dxos/client`'s **public API is unchanged** (notably `Credential.subject.assertion`, which callers index by `'@type'`).

Both codecs agree byte-for-byte, so the encoding *is* the conversion.

## Two deliberate hold-backs

`SpacesService.postMessage` and `subscribeMessages` stay on protobuf.js. The gossip payload is an arbitrary `Any` a caller keys by `'@type'`; buf carries an `Any` as typeUrl + bytes, which changes what a caller can pass and what the registry can resolve. Flipping `subscribeMessages` broke `spaces.test.ts` ("post and listen to messages") and a subduction e2e — reverted rather than worked around.

## A type/runtime mismatch this surfaced

`client-protocol`'s `ClientServices` promise surface still declared the protobuf.js shapes for methods that already carry buf (from the earlier network and platform chunks). Because `bufMessage` payload schemas accept a structurally-compatible literal, the type-checker never saw it — plain object literals reached `toBinary` and failed at runtime (`ForeignFieldError`). Tightening that interface is what surfaced the consumer updates here: devtools, shell, observability, composer-app, plugin-space, plugin-client, plugin-onboarding, react-client.

## Test fixture

`createMockCredential` asserted `example.testing.rpc.MessageWithAny`, a type the buf registry cannot resolve; it now asserts `dxos.halo.credentials.AuthorizedDevice`, so the round-trip is exercised against a type the schema actually declares.

## Validation

- `moon exec :build` — 0 errors.
- `moon run :lint` — clean.
- `MOON_CONCURRENCY=4 moon run :test` **with file parallelism** (not `--no-file-parallelism`, which hides races) — green apart from one flake, below.
- `oxfmt --check` — clean.

## Known flake (not from this change)

`client`'s `dedicated-worker-client-services.test.ts` fails a *different* leader-election case on different sweeps and passes 3/3 in isolation. This branch touches no leader-election code; it looks load-sensitive on the 4-core sandbox. Flagging rather than fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7

---
_Generated by [Claude Code](https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved compatibility for identity, contact, device, space, and credential data exchanged across services.
  - Enhanced credential and presentation handling while preserving the existing public API.
  - Improved device profile updates and identity recovery with stronger request validation.
  - Improved space and synchronization status handling, including safer defaults when status data is unavailable.
  - Updated service integrations and examples to use consistent protocol representations.
  - Increased the default space-wait timeout to improve reliability during slower operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12978-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
