### PR TITLE
echo: push a feed query's limit down to the index scan

### DIFF
--- a/.changeset/feed-limit-pushdown.md
+++ b/.changeset/feed-limit-pushdown.md
@@ -1,0 +1,10 @@
+---
+'@dxos/index-core': minor
+'@dxos/echo-host': minor
+---
+
+A feed query with a `limit` now reads bounded work: the planner pushes the cap into the index scan (`ORDER BY objectId … LIMIT n`, with the deleted filter folded in), so asking a feed for 10 items reads 10 rows and decodes 10 snapshots instead of materialising every block in the feed to hand back 10. Measured on a 40-item feed, the two tail reads `Cursor.seedDedupSet` issues per sync go from 40 index hits and 40 decoded documents each to 5 and 5.
+
+The cap moves into the scan only where the planner can prove it sound — a feed-only scope, a natural (insertion-order) ordering in either direction, and no step between the select and the limit that would prune the page. Anything else keeps the previous behaviour.
+
+`QueueWindow` in `@dxos/index-core` is now a tagged union: `{ kind: 'cursor', after, before?, limit? }` for a positional cursor read (its previous shape, plus the tag) and `{ kind: 'natural', direction, limit, deleted? }` for a bounded natural read. A new `objectMeta(queueId, objectId)` index backs the latter.

--- a/.changeset/feed-limit-pushdown.md
+++ b/.changeset/feed-limit-pushdown.md
@@ -7,4 +7,6 @@ A feed query with a `limit` now reads bounded work: the planner pushes the cap i
 
 The cap moves into the scan only where the planner can prove it sound — a feed-only scope, a natural (insertion-order) ordering in either direction, and no step between the select and the limit that would prune the page. Anything else keeps the previous behaviour.
 
-`QueueWindow` in `@dxos/index-core` is now a tagged union: `{ kind: 'cursor', after, before?, limit? }` for a positional cursor read (its previous shape, plus the tag) and `{ kind: 'natural', direction, limit, deleted? }` for a bounded natural read. A new `objectMeta(queueId, objectId)` index backs the latter.
+A queue read is now scoped by the space that owns the queue. `objectMeta` and the FTS index previously matched a feed on `queueId` alone, so a queue id occurring in two spaces would have read both spaces' rows; the feed URI already carries the space, and the query now uses it. An unqualified feed URI (`echo:///<id>`) names no space to scope to and still matches on the id alone.
+
+`QueueWindow` in `@dxos/index-core` is now a tagged union: `{ kind: 'cursor', after, before?, limit? }` for a positional cursor read (its previous shape, plus the tag) and `{ kind: 'natural', direction, limit, deleted? }` for a bounded natural read. `queryAll` / `queryTypes` / the FTS query take `queues: QueueRef[]` (`{ queueId, spaceId? }`) in place of `queueIds: string[]`, and a new `objectMeta(spaceId, queueId, objectId)` index backs the natural read.

--- a/packages/core/compute/link/src/Cursor.ts
+++ b/packages/core/compute/link/src/Cursor.ts
@@ -789,8 +789,8 @@ const seedDedupSet = (
   foreignKeySource: string,
   tail: number,
 ): Effect.Effect<Set<string>, never, Database.Service> =>
-  // `limit` selects the newest/oldest N by insertion order (a limited feed query still decodes the
-  // whole feed to apply the limit — a query-engine limitation tracked separately).
+  // `limit` selects the newest/oldest N by insertion order, and the query engine pushes it into the
+  // feed scan, so each read costs its tail rather than the whole feed.
   Effect.all([
     Feed.query(feed, Query.select(Filter.everything()).orderBy(Order.natural('desc')).limit(tail)).run,
     Feed.query(feed, Query.select(Filter.everything()).orderBy(Order.natural('asc')).limit(tail)).run,

--- a/packages/core/echo/echo-client-e2e/src/feed-query-pagination.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/feed-query-pagination.test.ts
@@ -251,6 +251,45 @@ describe('Feed query pagination', () => {
     }
   });
 
+  // The scan itself is capped for these (see `feedScanForLimit`), so they double as the regression
+  // gate on the pushdown returning the same rows the unpushed plan did.
+  test('natural desc with a limit returns the newest items', async ({ expect }) => {
+    const titles = ['a', 'b', 'c', 'd', 'e'];
+    const { db, feed } = await setupFeedWithTasks(builder, titles);
+
+    const newest = await db
+      .query(Query.select(Filter.everything()).orderBy(Order.natural('desc')).limit(2).from(feed))
+      .run();
+
+    expect(newest.map((obj) => (obj as TestSchema.Task).title)).toEqual(['e', 'd']);
+  });
+
+  test('a limited read still sees a deleted item as absent, and still returns the limit', async ({ expect }) => {
+    const titles = ['a', 'b', 'c', 'd'];
+    const { db, feed } = await setupFeedWithTasks(builder, titles);
+
+    const all = await db.query(Query.select(Filter.everything()).orderBy(Order.natural()).from(feed)).run();
+    await db.deleteFromFeed(feed, [all[0]]);
+    await db.flush();
+
+    const oldest = await db.query(Query.select(Filter.everything()).orderBy(Order.natural()).limit(2).from(feed)).run();
+
+    expect(oldest.map((obj) => (obj as TestSchema.Task).title)).toEqual(['b', 'c']);
+  });
+
+  test('a limited read covers items appended after the last flush', async ({ expect }) => {
+    const { db, feed } = await setupFeedWithTasks(builder, ['a', 'b']);
+    await db.flush();
+    // Unpositioned until a position authority assigns one — a natural read still has to see it.
+    await db.appendToFeed(feed, [Obj.make(TestSchema.Task, { title: 'c' })]);
+
+    const newest = await db
+      .query(Query.select(Filter.everything()).orderBy(Order.natural('desc')).limit(1).from(feed))
+      .run();
+
+    expect(newest.map((obj) => (obj as TestSchema.Task).title)).toEqual(['c']);
+  });
+
   test('feed scope excludes space objects when paginating', async ({ expect }) => {
     const peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Task] });
     const db = await peer.createDatabase();

--- a/packages/core/echo/echo-client-e2e/src/feed-query-pagination.test.ts
+++ b/packages/core/echo/echo-client-e2e/src/feed-query-pagination.test.ts
@@ -264,6 +264,16 @@ describe('Feed query pagination', () => {
     expect(newest.map((obj) => (obj as TestSchema.Task).title)).toEqual(['e', 'd']);
   });
 
+  test('a skip below the order drops in append order, not from the newest', async ({ expect }) => {
+    const { db, feed } = await setupFeedWithTasks(builder, ['a', 'b', 'c', 'd', 'e', 'f']);
+
+    const window = await db
+      .query(Query.select(Filter.everything()).skip(2).orderBy(Order.natural('desc')).limit(3).from(feed))
+      .run();
+
+    expect(window.map((obj) => (obj as TestSchema.Task).title)).toEqual(['f', 'e', 'd']);
+  });
+
   test('a limited read still sees a deleted item as absent, and still returns the limit', async ({ expect }) => {
     const titles = ['a', 'b', 'c', 'd'];
     const { db, feed } = await setupFeedWithTasks(builder, titles);

--- a/packages/core/echo/echo-host/src/query/plan.ts
+++ b/packages/core/echo/echo-host/src/query/plan.ts
@@ -76,6 +76,25 @@ export namespace QueryPlan {
      * covers positioned blocks only.
      */
     feedCursorRange?: { begin?: string; end?: string };
+
+    /**
+     * Set when the planner has proved the step's {@link limit} can be applied by the feed scan
+     * itself — see `feedScanForLimit`. Absent means the limit must be applied downstream, after the
+     * steps that would otherwise slice candidates out of an already-capped page.
+     */
+    feedScan?: FeedScan;
+  };
+
+  /**
+   * How a feed scan must run for a `limit` pushed into it to keep the same rows the unpushed plan
+   * would have returned.
+   */
+  export type FeedScan = {
+    /** Natural order the scan produces, matching the plan's `OrderStep`. */
+    direction: 'asc' | 'desc';
+
+    /** Deleted state the scan filters to, folding in the plan's `FilterDeletedStep`. */
+    deleted?: boolean;
   };
 
   /**

--- a/packages/core/echo/echo-host/src/query/query-executor.ts
+++ b/packages/core/echo/echo-host/src/query/query-executor.ts
@@ -23,6 +23,7 @@ import {
   type EntityMeta,
   EscapedPropPath,
   type IndexEngine,
+  type QueueRef,
   type QueueWindow,
   type ReverseRef,
 } from '@dxos/index-core';
@@ -777,8 +778,13 @@ export class QueryExecutor extends Resource {
     switch (step.selector._tag) {
       case 'WildcardSelector': {
         const beginIndexQuery = performance.now();
-        const queueIds = extractQueueIds(queues);
-        const metas = await this._queryAllFromSqlIndex(spaces, allQueuesFromSpaces, queueIds, extractQueueWindow(step));
+        const queueRefs = extractQueueRefs(queues);
+        const metas = await this._queryAllFromSqlIndex(
+          spaces,
+          allQueuesFromSpaces,
+          queueRefs,
+          extractQueueWindow(step),
+        );
         trace.indexHits = metas.length;
         trace.indexQueryTime += performance.now() - beginIndexQuery;
 
@@ -819,7 +825,7 @@ export class QueryExecutor extends Resource {
             }
             if (queues.length > 0) {
               const spaceId = extractSpaceIdFromQueue(queues[0]);
-              const queueId = extractQueueIds([queues[0]])?.[0];
+              const queueId = extractQueueRefs([queues[0]])?.[0]?.queueId;
               if (spaceId && queueId) {
                 return this._loadQueueItemById(spaceId, queueId, id);
               }
@@ -840,13 +846,13 @@ export class QueryExecutor extends Resource {
 
       case 'TypeSelector': {
         const beginIndexQuery = performance.now();
-        const queueIds = extractQueueIds(queues);
+        const queueRefs = extractQueueRefs(queues);
         const metas = await this._queryTypesFromSqlIndex(
           spaces,
           step.selector.typename,
           step.selector.inverted,
           allQueuesFromSpaces,
-          queueIds,
+          queueRefs,
           extractQueueWindow(step),
         );
         trace.indexHits = metas.length;
@@ -869,7 +875,7 @@ export class QueryExecutor extends Resource {
 
       case 'TimestampSelector': {
         const beginIndexQuery = performance.now();
-        const queueIds = extractQueueIds(queues);
+        const queueRefs = extractQueueRefs(queues);
         const metas = await this._runInRuntime(
           this._indexEngine.queryByTimeRange({
             spaceIds: spaces,
@@ -878,7 +884,7 @@ export class QueryExecutor extends Resource {
             createdAfter: step.selector.createdAfter,
             createdBefore: step.selector.createdBefore,
             includeAllQueues: allQueuesFromSpaces,
-            queueIds,
+            queues: queueRefs,
           }),
         );
         trace.indexHits = metas.length;
@@ -933,13 +939,13 @@ export class QueryExecutor extends Resource {
         // Full-text search using SQLite FTS5, optionally scoped by type.
         const beginIndexQuery = performance.now();
         invariant(spaces.length <= 1, 'Multiple spaces are not supported for full-text search');
-        const queueIds = extractQueueIds(queues);
+        const queueRefs = extractQueueRefs(queues);
         const textResults = await this._runInRuntime(
           this._indexEngine.queryText({
             query: step.selector.text,
             spaceId: spaces,
             includeAllQueues: allQueuesFromSpaces,
-            queueIds,
+            queues: queueRefs,
             typeDxns: step.selector.typename,
           }),
         );
@@ -1016,7 +1022,7 @@ export class QueryExecutor extends Resource {
             }
             if (item.queueId) {
               return queues.some((queueRef) => {
-                const queueId = extractQueueIds([queueRef])?.[0];
+                const queueId = extractQueueRefs([queueRef])?.[0]?.queueId;
                 const spaceId = extractSpaceIdFromQueue(queueRef);
                 return queueId === item.queueId && spaceId === item.spaceId;
               });
@@ -1193,7 +1199,7 @@ export class QueryExecutor extends Resource {
         spaceIds: spaces,
         ...params,
         includeAllQueues: false,
-        queueIds: [],
+        queues: [],
       }),
     );
     const matchingIds = new Set(metas.map((m) => m.objectId));
@@ -1742,10 +1748,10 @@ export class QueryExecutor extends Resource {
   private async _queryAllFromSqlIndex(
     spaceIds: readonly SpaceId[],
     includeAllQueues: boolean,
-    queueIds: readonly EntityId[] | null,
+    queues: readonly QueueRef[] | null,
     window?: QueueWindow,
   ): Promise<readonly EntityMeta[]> {
-    return await this._runInRuntime(this._indexEngine.queryAll({ spaceIds, includeAllQueues, queueIds, window }));
+    return await this._runInRuntime(this._indexEngine.queryAll({ spaceIds, includeAllQueues, queues, window }));
   }
 
   private async _queryTypesFromSqlIndex(
@@ -1753,11 +1759,11 @@ export class QueryExecutor extends Resource {
     typeDxns: readonly URI.URI[],
     inverted: boolean,
     includeAllQueues: boolean,
-    queueIds: readonly EntityId[] | null,
+    queues: readonly QueueRef[] | null,
     window?: QueueWindow,
   ): Promise<readonly EntityMeta[]> {
     return await this._runInRuntime(
-      this._indexEngine.queryTypes({ spaceIds, typeDxns, inverted, includeAllQueues, queueIds, window }),
+      this._indexEngine.queryTypes({ spaceIds, typeDxns, inverted, includeAllQueues, queues, window }),
     );
   }
 
@@ -2229,16 +2235,29 @@ const parseCursor = (cursor: string, unsatisfiable: number): number => {
   return Number.isSafeInteger(position) ? position : unsatisfiable;
 };
 
-const extractQueueIds = (queues: readonly string[]): EntityId[] | null => {
+/**
+ * The queues a feed scope names, each carrying the space its URI qualifies it with so the index
+ * seek cannot cross spaces — a queue id is unique only within its own. An unqualified URI
+ * (`echo:///<id>`) names no space, and matches on its id alone.
+ */
+const extractQueueRefs = (queues: readonly string[]): QueueRef[] | null => {
   if (queues.length === 0) {
     return null;
   }
   return queues
-    .map((feedUri) => {
+    .map((feedUri): QueueRef | undefined => {
       const echoUri = EID.tryParse(feedUri);
-      return echoUri ? EID.getEntityId(echoUri) : undefined;
+      if (!echoUri) {
+        return undefined;
+      }
+      const queueId = EID.getEntityId(echoUri);
+      if (!queueId) {
+        return undefined;
+      }
+      const spaceId = EID.getSpaceId(echoUri);
+      return spaceId !== undefined ? { queueId, spaceId } : { queueId };
     })
-    .filter((id): id is EntityId => id !== undefined);
+    .filter(isNonNullable);
 };
 
 /**

--- a/packages/core/echo/echo-host/src/query/query-executor.ts
+++ b/packages/core/echo/echo-host/src/query/query-executor.ts
@@ -1670,7 +1670,11 @@ export class QueryExecutor extends Resource {
   private _compareByOrder(a: QueryItem, b: QueryItem, order: QueryAST.Order): number {
     switch (order.kind) {
       case 'natural': {
-        const comparison = a.objectId.localeCompare(b.objectId);
+        // Code-unit order, not `localeCompare`: the feed scan pushes this ordering into SQLite's
+        // `ORDER BY objectId`, which collates BINARY, and an entity id may be lower-case (the
+        // format check is case-insensitive). Under a locale collation the two would disagree on a
+        // mixed-case pair, and the scan's capped page would not be the page this sort produces.
+        const comparison = a.objectId < b.objectId ? -1 : a.objectId > b.objectId ? 1 : 0;
         return order.direction === 'desc' ? -comparison : comparison;
       }
       case 'property': {

--- a/packages/core/echo/echo-host/src/query/query-executor.ts
+++ b/packages/core/echo/echo-host/src/query/query-executor.ts
@@ -2180,8 +2180,9 @@ const extractSpaceIdFromQueue = (feedUri: string): SpaceId | undefined => {
 const BEFORE_FIRST_POSITION = -1;
 
 /**
- * The index-level window for a select bounded by a cursor range: the positions strictly between its
- * bounds, in position order, capped at the pushed-down limit.
+ * The index-level window for a select the storage layer can bound itself, so a bounded query costs
+ * what it asks for rather than the whole feed: a cursor range resumes by position, and a
+ * `feedScan` (set by the planner only where it proved the cap sound) reads in natural order.
  *
  * Every cursor range windows the scan, an empty one included — it bounds nothing but still asks for
  * a cursor read, which is over positioned blocks in position order. A reader that paged the
@@ -2194,7 +2195,15 @@ const BEFORE_FIRST_POSITION = -1;
 const extractQueueWindow = (step: QueryPlan.SelectStep): QueueWindow | undefined => {
   const range = step.feedCursorRange;
   if (range === undefined) {
-    return undefined;
+    if (step.feedScan === undefined || step.limit === undefined) {
+      return undefined;
+    }
+    return {
+      kind: 'natural',
+      direction: step.feedScan.direction,
+      limit: step.limit,
+      ...(step.feedScan.deleted !== undefined ? { deleted: step.feedScan.deleted } : {}),
+    };
   }
 
   // Backstop for the planner's check, which is where a cursor over a space's documents is refused.
@@ -2206,6 +2215,7 @@ const extractQueueWindow = (step: QueryPlan.SelectStep): QueueWindow | undefined
   }
 
   return {
+    kind: 'cursor',
     // The empty string is the start sentinel (`Feed.START`), which bounds nothing.
     after: range.begin ? parseCursor(range.begin, Number.MAX_SAFE_INTEGER) : BEFORE_FIRST_POSITION,
     ...(range.end ? { before: parseCursor(range.end, BEFORE_FIRST_POSITION) } : {}),

--- a/packages/core/echo/echo-host/src/query/query-planner.test.ts
+++ b/packages/core/echo/echo-host/src/query/query-planner.test.ts
@@ -4,11 +4,12 @@
 
 import { describe, expect, test } from 'vitest';
 
-import { Aggregate, Filter, Order, Query, Ref } from '@dxos/echo';
+import { Aggregate, Feed, Filter, Order, Query, Ref } from '@dxos/echo';
 import { type QueryAST } from '@dxos/echo-protocol';
 import { TestSchema } from '@dxos/echo/testing';
 import { EID, EntityId, SpaceId } from '@dxos/keys';
 
+import { type QueryPlan } from './plan';
 import { QueryPlanner, filterContainsInQuery } from './query-planner';
 
 describe('QueryPlanner', () => {
@@ -2232,6 +2233,81 @@ describe('QueryPlanner', () => {
 
       const filterStep = plan.steps[filterStepIndex];
       expect(filterStep).toMatchObject({ filter: { type: 'object', props: { title: { type: 'in-query' } } } });
+    });
+  });
+
+  // A feed scan orders and caps its own rows, so `limit` reaches storage instead of slicing a
+  // working set the whole feed was decoded into.
+  describe('feed limit pushdown', () => {
+    const feedScope: QueryAST.Scope[] = [{ _tag: 'feed', feedUri: QUEUE_DXN }];
+
+    const selectStep = (query: QueryAST.Query): QueryPlan.SelectStep => {
+      const step = planner.createPlan(query).steps.find((step) => step._tag === 'SelectStep');
+      expect(step).toBeDefined();
+      return step as QueryPlan.SelectStep;
+    };
+
+    test('a bounded feed read scans in the requested direction', () => {
+      for (const [direction, order] of [
+        ['asc', Order.natural()],
+        ['desc', Order.natural('desc')],
+      ] as const) {
+        const query = Query.select(Filter.everything()).orderBy(order).limit(5).from(feedScope);
+        expect(selectStep(query.ast)).toMatchObject({
+          limit: 5,
+          feedScan: { direction, deleted: false },
+        });
+      }
+    });
+
+    test('a skip is folded into the scanned page, which the SkipStep then drops from', () => {
+      const query = Query.select(Filter.everything()).orderBy(Order.natural()).skip(2).limit(3).from(feedScope);
+      const plan = planner.createPlan(query.ast);
+
+      expect(plan.steps.find((step) => step._tag === 'SelectStep')).toMatchObject({ limit: 5, feedScan: {} });
+      expect(plan.steps.some((step) => step._tag === 'SkipStep')).toBe(true);
+    });
+
+    test('the typename re-check beside a TypeSelector does not block the scan', () => {
+      const query = Query.select(Filter.type(TestSchema.Task)).limit(5).from(feedScope);
+      expect(selectStep(query.ast)).toMatchObject({ limit: 5, feedScan: { direction: 'asc' } });
+    });
+
+    test('a `deleted: only` read scans the deleted rows, so the cap counts them', () => {
+      const query = Query.select(Filter.everything()).options({ deleted: 'only' }).limit(5).from(feedScope);
+      expect(selectStep(query.ast)).toMatchObject({ feedScan: { deleted: true } });
+    });
+
+    // Each of these prunes the page after the scan, so a cap applied at scan time would return
+    // short of the limit.
+    test('a filter the scan cannot reproduce keeps the limit downstream', () => {
+      const query = Query.select(Filter.type(TestSchema.Task, { title: 'a' }))
+        .limit(5)
+        .from(feedScope);
+      expect(selectStep(query.ast).feedScan).toBeUndefined();
+    });
+
+    test('a content-based order keeps the limit downstream', () => {
+      const query = Query.select(Filter.everything()).orderBy(Order.property('title', 'asc')).limit(5).from(feedScope);
+      const step = selectStep(query.ast);
+      expect(step.feedScan).toBeUndefined();
+      expect(step.limit).toBeUndefined();
+    });
+
+    test('a space scope keeps the limit downstream — only a feed scan is ordered', () => {
+      const query = Query.select(Filter.everything()).orderBy(Order.natural('desc')).limit(5);
+      const step = selectStep(withSpaceIdOptions(query.ast));
+      expect(step.feedScan).toBeUndefined();
+      expect(step.limit).toBeUndefined();
+    });
+
+    test('a cursor read stays a cursor read — it is windowed by position, not natural order', () => {
+      const query = Query.select(Filter.feedCursor({ begin: Feed.Cursor.make('3') }))
+        .limit(5)
+        .from(feedScope);
+      const step = selectStep(query.ast);
+      expect(step.feedScan).toBeUndefined();
+      expect(step).toMatchObject({ limit: 5, feedCursorRange: { begin: '3' } });
     });
   });
 });

--- a/packages/core/echo/echo-host/src/query/query-planner.test.ts
+++ b/packages/core/echo/echo-host/src/query/query-planner.test.ts
@@ -2287,6 +2287,13 @@ describe('QueryPlanner', () => {
       expect(selectStep(query.ast).feedScan).toBeUndefined();
     });
 
+    test('a skip below the order keeps the limit downstream', () => {
+      // `skip(2).orderBy(desc)` drops two rows in scan order and orders what is left; an inflated
+      // scan limit would order first and drop the two NEWEST, which is a different page.
+      const query = Query.select(Filter.everything()).skip(2).orderBy(Order.natural('desc')).limit(3).from(feedScope);
+      expect(selectStep(query.ast).feedScan).toBeUndefined();
+    });
+
     test('a content-based order keeps the limit downstream', () => {
       const query = Query.select(Filter.everything()).orderBy(Order.property('title', 'asc')).limit(5).from(feedScope);
       const step = selectStep(query.ast);

--- a/packages/core/echo/echo-host/src/query/query-planner.ts
+++ b/packages/core/echo/echo-host/src/query/query-planner.ts
@@ -1285,6 +1285,11 @@ const feedScanForLimit = (
         }
         break;
       case 'SkipStep':
+        // A skip below the order composes the other way round: the plan drops rows in scan order
+        // and orders what is left, where an inflated scan limit orders first and drops from that.
+        if (orderStepIndex !== -1 && index < orderStepIndex) {
+          return undefined;
+        }
         break;
       default:
         return undefined;

--- a/packages/core/echo/echo-host/src/query/query-planner.ts
+++ b/packages/core/echo/echo-host/src/query/query-planner.ts
@@ -1085,14 +1085,21 @@ export class QueryPlanner {
       return QueryPlan.Plan.make(processedSteps);
     }
 
+    // A feed scan can be ordered and capped by the storage layer itself, so it takes the limit in
+    // either natural direction — which is the point: a bounded feed query must read bounded work.
+    const feedScan =
+      selectStepIndex !== -1
+        ? feedScanForLimit(processedSteps, selectStepIndex, orderStepIndex, limitStepIndex)
+        : undefined;
+
     // Pushing the limit into the SelectStep is only sound when the scan enumerates candidates in the
-    // requested order, so that the first N of the scan are the first N of the result. The scan runs
-    // in ascending natural order (by id / queue position). A content-based reorder (property or
-    // system timestamp) or a descending natural order does not match that scan order, so slicing at
-    // select time would keep the wrong N; those need the FULL candidate set and only the OrderStep
-    // may apply the limit. Ascending natural and rank (the FTS scan already returns by rank) stay
-    // consistent with the scan, so keep optimizing those.
-    if (orderStepIndex !== -1) {
+    // requested order, so that the first N of the scan are the first N of the result. Absent a feed
+    // scan the select runs in ascending natural order (by id / queue position). A content-based
+    // reorder (property or system timestamp) or a descending natural order does not match that scan
+    // order, so slicing at select time would keep the wrong N; those need the FULL candidate set and
+    // only the OrderStep may apply the limit. Ascending natural and rank (the FTS scan already
+    // returns by rank) stay consistent with the scan, so keep optimizing those.
+    if (orderStepIndex !== -1 && feedScan === undefined) {
       const orderStep = processedSteps[orderStepIndex];
       const scanOrderMismatch =
         orderStep._tag === 'OrderStep' &&
@@ -1130,6 +1137,7 @@ export class QueryPlanner {
       newSteps[selectStepIndex] = {
         ...selectStep,
         limit: limitValue + skipBetween(selectStepIndex),
+        ...(feedScan ? { feedScan } : {}),
       };
     }
 
@@ -1219,6 +1227,127 @@ const createRelationTraversalStep = (direction: QueryPlan.RelationTraversal['dir
     direction,
   },
 });
+
+/**
+ * The scan shape that lets a feed-only SelectStep apply the query's `limit` itself, or `undefined`
+ * when it may not: a bounded feed query is the whole point of pushing the limit into storage, but
+ * a page capped before a step that prunes it would come back short of what the caller asked for.
+ *
+ * Sound only when every step between the select and the limit is one the scan reproduces:
+ * the deleted filter (folded into the returned scan), a residual filter the selector already
+ * enforces, a skip (the caller inflates the limit by it), and the order step the scan matches.
+ */
+const feedScanForLimit = (
+  steps: readonly QueryPlan.Step[],
+  selectStepIndex: number,
+  orderStepIndex: number,
+  limitStepIndex: number,
+): QueryPlan.FeedScan | undefined => {
+  const selectStep = steps[selectStepIndex];
+  if (selectStep._tag !== 'SelectStep') {
+    return undefined;
+  }
+  // Only a feed scan orders and caps its own rows; a space scan has no ordering to cap against,
+  // and a mixed scope has no single ordering at all.
+  if (selectStep.scope.length === 0 || !selectStep.scope.every((scope) => scope._tag === 'feed')) {
+    return undefined;
+  }
+  // A cursor read is already windowed by position, which is a different ordering.
+  if (selectStep.feedCursorRange !== undefined) {
+    return undefined;
+  }
+  // The index seeks by id or type; every other selector reaches rows the window cannot order.
+  if (selectStep.selector._tag !== 'WildcardSelector' && selectStep.selector._tag !== 'TypeSelector') {
+    return undefined;
+  }
+
+  const direction = feedScanDirection(steps, orderStepIndex);
+  if (direction === undefined) {
+    return undefined;
+  }
+
+  let deleted: boolean | undefined;
+  for (let index = selectStepIndex + 1; index < limitStepIndex; index++) {
+    const step = steps[index];
+    switch (step._tag) {
+      case 'FilterDeletedStep':
+        deleted = step.mode === 'only-deleted';
+        break;
+      case 'FilterStep':
+        if (!isSelectorResidualFilter(step.filter, selectStep.selector)) {
+          return undefined;
+        }
+        break;
+      case 'OrderStep':
+        // Only the step `direction` was derived from; a second one would reorder the capped page.
+        if (index !== orderStepIndex) {
+          return undefined;
+        }
+        break;
+      case 'SkipStep':
+        break;
+      default:
+        return undefined;
+    }
+  }
+
+  return deleted === undefined ? { direction } : { direction, deleted };
+};
+
+/**
+ * The natural direction a feed scan must run to satisfy the plan's ordering, or `undefined` when
+ * the ordering is not one the scan can produce (a content-based reorder needs the full candidate
+ * set). An absent order step means natural ascending, which is what the planner inserts.
+ */
+const feedScanDirection = (
+  steps: readonly QueryPlan.Step[],
+  orderStepIndex: number,
+): QueryPlan.FeedScan['direction'] | undefined => {
+  if (orderStepIndex === -1) {
+    return 'asc';
+  }
+  const orderStep = steps[orderStepIndex];
+  if (orderStep._tag !== 'OrderStep') {
+    return undefined;
+  }
+  if (orderStep.order.length === 0) {
+    return 'asc';
+  }
+  // Entity ids are unique, so a secondary order could only break ties the scan never produces.
+  if (orderStep.order.length !== 1 || orderStep.order[0].kind !== 'natural') {
+    return undefined;
+  }
+  return orderStep.order[0].direction === 'desc' ? 'desc' : 'asc';
+};
+
+/**
+ * Whether a residual FilterStep can only re-check what the selector already enforced, so capping
+ * the scan before it cannot drop a row it would have kept. True for the empty filter, and for the
+ * typename re-check `_generateSelectionFromFilter` emits alongside a TypeSelector — the index
+ * matches the same typenames, versioned or not, that `compareTypenameStrings` accepts.
+ */
+const isSelectorResidualFilter = (filter: QueryAST.Filter, selector: QueryPlan.Selector): boolean => {
+  if (filter.type !== 'object') {
+    return false;
+  }
+  const hasOnlyTypename =
+    (filter.id === undefined || filter.id.length === 0) &&
+    (filter.props === undefined || Object.keys(filter.props).length === 0) &&
+    (filter.foreignKeys === undefined || filter.foreignKeys.length === 0) &&
+    filter.metaKey === undefined;
+  if (!hasOnlyTypename) {
+    return false;
+  }
+  if (filter.typename === null) {
+    return true;
+  }
+  return (
+    selector._tag === 'TypeSelector' &&
+    !selector.inverted &&
+    selector.typename.length === 1 &&
+    selector.typename[0] === filter.typename
+  );
+};
 
 /**
  * Returns true if the filter is `child-of` or `has-parent` — the post-select pruning filters —

--- a/packages/core/echo/index-core/src/index-engine.test.ts
+++ b/packages/core/echo/index-core/src/index-engine.test.ts
@@ -148,7 +148,7 @@ describe('IndexEngine', () => {
         query: 'Hello',
         spaceId: null,
         includeAllQueues: false,
-        queueIds: null,
+        queues: null,
       });
       expect(ftsResults1.length).toBeGreaterThan(0);
       expect(ftsResults1.some((row) => row.objectId === obj1.data.id)).toBe(true);
@@ -180,7 +180,7 @@ describe('IndexEngine', () => {
         query: 'World',
         spaceId: null,
         includeAllQueues: false,
-        queueIds: null,
+        queues: null,
       });
       expect(ftsResults2.length).toBeGreaterThan(0);
     }, Effect.provide(TestLayer)),
@@ -254,7 +254,7 @@ describe('IndexEngine', () => {
         query: 'TypeA',
         spaceId: null,
         includeAllQueues: false,
-        queueIds: null,
+        queues: null,
       });
       expect(ftsResults).toHaveLength(2);
     }, Effect.provide(TestLayer)),

--- a/packages/core/echo/index-core/src/index-engine.ts
+++ b/packages/core/echo/index-core/src/index-engine.ts
@@ -21,6 +21,7 @@ import {
   type FtsQueryResult,
   type Index,
   type IndexerObject,
+  type QueueRef,
   type QueueWindow,
   ReverseRefIndex,
   type ReverseRefQuery,
@@ -161,7 +162,7 @@ export class IndexEngine {
   queryAll(query: {
     spaceIds: readonly SpaceId[];
     includeAllQueues?: boolean;
-    queueIds?: readonly string[] | null;
+    queues?: readonly QueueRef[] | null;
     window?: QueueWindow;
   }): Effect.Effect<readonly EntityMeta[], SqlError.SqlError, SqlClient.SqlClient> {
     return this.#objectMetaIndex.queryAll(query);
@@ -196,7 +197,7 @@ export class IndexEngine {
     typeDxns: readonly EntityMeta['typeDXN'][];
     inverted?: boolean;
     includeAllQueues?: boolean;
-    queueIds?: readonly string[] | null;
+    queues?: readonly QueueRef[] | null;
     window?: QueueWindow;
   }): Effect.Effect<readonly EntityMeta[], SqlError.SqlError, SqlClient.SqlClient> {
     return this.#objectMetaIndex.queryTypes(query);
@@ -208,7 +209,7 @@ export class IndexEngine {
     createdAfter?: number;
     createdBefore?: number;
     includeAllQueues?: boolean;
-    queueIds?: readonly string[] | null;
+    queues?: readonly QueueRef[] | null;
   }): Effect.Effect<readonly EntityMeta[], SqlError.SqlError, SqlClient.SqlClient> {
     return this.#objectMetaIndex.queryByTimeRange(query);
   }

--- a/packages/core/echo/index-core/src/index.ts
+++ b/packages/core/echo/index-core/src/index.ts
@@ -12,6 +12,6 @@ export {
 export { type IndexCursor, IndexTracker } from './index-tracker';
 export { type Index, type IndexerObject } from './indexes/interface';
 export { FtsIndex, type FtsQuery } from './indexes/fts-index';
-export { type EntityMeta, EntityMetaIndex, type QueueWindow } from './indexes/entity-meta-index';
+export { type EntityMeta, EntityMetaIndex, type QueueRef, type QueueWindow } from './indexes/entity-meta-index';
 export { type ReverseRef, ReverseRefIndex, type ReverseRefQuery, referenceIndexKey } from './indexes/reverse-ref-index';
 export { type EntityPropPath, EscapedPropPath } from './utils';

--- a/packages/core/echo/index-core/src/indexes/entity-meta-index.test.ts
+++ b/packages/core/echo/index-core/src/indexes/entity-meta-index.test.ts
@@ -600,6 +600,39 @@ describe('EntityMetaIndex', () => {
     }).pipe(Effect.provide(TestLayer)),
   );
 
+  it.effect('the natural cap orders by code unit, which is what the executor sorts by', () =>
+    Effect.gen(function* () {
+      const index = new EntityMetaIndex();
+      yield* index.migrate();
+
+      const spaceId = SpaceId.random();
+      const queueId = EntityId.random();
+      // The id format check is case-insensitive, and BINARY puts every upper-case id before every
+      // lower-case one — the boundary a locale collation would order the other way.
+      const upper = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+      const lower = '01arz3ndektsv4rrffq69g5fab';
+      const makeItem = (objectId: string): IndexerObject => ({
+        spaceId,
+        queueId,
+        queueNamespace: 'data',
+        documentId: null,
+        recordId: null,
+        queuePosition: null,
+        createdAt: null,
+        updatedAt: Date.now(),
+        data: { id: objectId, [ATTR_TYPE]: TYPE_PERSON, [ATTR_DELETED]: false },
+      });
+      yield* index.update([makeItem(upper), makeItem(lower)]);
+
+      const oldest = yield* index.queryAll({
+        spaceIds: [],
+        queues: [{ queueId, spaceId }],
+        window: { kind: 'natural', direction: 'asc', limit: 1 },
+      });
+      expect(oldest.map((row) => row.objectId)).toEqual([upper]);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
   it.effect('a queue read is scoped to its space, so a colliding queue id cannot leak', () =>
     Effect.gen(function* () {
       const index = new EntityMetaIndex();

--- a/packages/core/echo/index-core/src/indexes/entity-meta-index.test.ts
+++ b/packages/core/echo/index-core/src/indexes/entity-meta-index.test.ts
@@ -565,26 +565,26 @@ describe('EntityMetaIndex', () => {
       };
       yield* index.update([...positioned.map(({ item }) => item), unpositioned]);
 
-      const all = yield* index.queryAll({ spaceIds: [], queueIds: [queueId] });
+      const all = yield* index.queryAll({ spaceIds: [], queues: [{ queueId, spaceId }] });
       expect(all).toHaveLength(5);
 
       const afterCursor = yield* index.queryAll({
         spaceIds: [],
-        queueIds: [queueId],
+        queues: [{ queueId, spaceId }],
         window: { kind: 'cursor', after: 1 },
       });
       expect(afterCursor.map((row) => row.queuePosition)).toEqual([2, 3]);
 
       const page = yield* index.queryAll({
         spaceIds: [],
-        queueIds: [queueId],
+        queues: [{ queueId, spaceId }],
         window: { kind: 'cursor', after: 0, limit: 2 },
       });
       expect(page.map((row) => row.queuePosition)).toEqual([1, 2]);
 
       const typed = yield* index.queryTypes({
         spaceIds: [],
-        queueIds: [queueId],
+        queues: [{ queueId, spaceId }],
         typeDxns: [TYPE_PERSON],
         window: { kind: 'cursor', after: 2 },
       });
@@ -593,10 +593,49 @@ describe('EntityMetaIndex', () => {
       // A cursor read never sees the unpositioned block, which has no place in the ordering yet.
       const fromStart = yield* index.queryAll({
         spaceIds: [],
-        queueIds: [queueId],
+        queues: [{ queueId, spaceId }],
         window: { kind: 'cursor', after: -1 },
       });
       expect(fromStart.map((row) => row.queuePosition)).toEqual([0, 1, 2, 3]);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect('a queue read is scoped to its space, so a colliding queue id cannot leak', () =>
+    Effect.gen(function* () {
+      const index = new EntityMetaIndex();
+      yield* index.migrate();
+
+      // The same queue id in two spaces — the case a bare `queueId` match cannot tell apart.
+      const queueId = EntityId.random();
+      const [mine, theirs] = [SpaceId.random(), SpaceId.random()];
+      const makeItem = (spaceId: SpaceId, objectId: string): IndexerObject => ({
+        spaceId,
+        queueId,
+        queueNamespace: 'data',
+        documentId: null,
+        recordId: null,
+        queuePosition: null,
+        createdAt: null,
+        updatedAt: Date.now(),
+        data: { id: objectId, [ATTR_TYPE]: TYPE_PERSON, [ATTR_DELETED]: false },
+      });
+      const mineId = EntityId.random();
+      const theirsId = EntityId.random();
+      yield* index.update([makeItem(mine, mineId), makeItem(theirs, theirsId)]);
+
+      const scoped = yield* index.queryAll({ spaceIds: [], queues: [{ queueId, spaceId: mine }] });
+      expect(scoped.map((row) => row.objectId)).toEqual([mineId]);
+
+      const typed = yield* index.queryTypes({
+        spaceIds: [],
+        queues: [{ queueId, spaceId: mine }],
+        typeDxns: [TYPE_PERSON],
+      });
+      expect(typed.map((row) => row.objectId)).toEqual([mineId]);
+
+      // An unqualified feed URI names no space to scope to, so it still matches on the id alone.
+      const unscoped = yield* index.queryAll({ spaceIds: [], queues: [{ queueId }] });
+      expect(unscoped.map((row) => row.objectId).sort()).toEqual([mineId, theirsId].sort());
     }).pipe(Effect.provide(TestLayer)),
   );
 
@@ -624,21 +663,21 @@ describe('EntityMetaIndex', () => {
 
       const oldest = yield* index.queryAll({
         spaceIds: [],
-        queueIds: [queueId],
+        queues: [{ queueId, spaceId }],
         window: { kind: 'natural', direction: 'asc', limit: 2 },
       });
       expect(oldest.map((row) => row.objectId)).toEqual(objectIds.slice(0, 2));
 
       const newest = yield* index.queryAll({
         spaceIds: [],
-        queueIds: [queueId],
+        queues: [{ queueId, spaceId }],
         window: { kind: 'natural', direction: 'desc', limit: 2 },
       });
       expect(newest.map((row) => row.objectId)).toEqual(objectIds.slice(-2).reverse());
 
       const typed = yield* index.queryTypes({
         spaceIds: [],
-        queueIds: [queueId],
+        queues: [{ queueId, spaceId }],
         typeDxns: [TYPE_PERSON],
         window: { kind: 'natural', direction: 'asc', limit: 3 },
       });
@@ -648,7 +687,7 @@ describe('EntityMetaIndex', () => {
       yield* index.update(objectIds.slice(0, 2).map((objectId) => makeItem(objectId, true)));
       const live = yield* index.queryAll({
         spaceIds: [],
-        queueIds: [queueId],
+        queues: [{ queueId, spaceId }],
         window: { kind: 'natural', direction: 'asc', limit: 2, deleted: false },
       });
       expect(live.map((row) => row.objectId)).toEqual(objectIds.slice(2, 4));

--- a/packages/core/echo/index-core/src/indexes/entity-meta-index.test.ts
+++ b/packages/core/echo/index-core/src/indexes/entity-meta-index.test.ts
@@ -568,23 +568,90 @@ describe('EntityMetaIndex', () => {
       const all = yield* index.queryAll({ spaceIds: [], queueIds: [queueId] });
       expect(all).toHaveLength(5);
 
-      const afterCursor = yield* index.queryAll({ spaceIds: [], queueIds: [queueId], window: { after: 1 } });
+      const afterCursor = yield* index.queryAll({
+        spaceIds: [],
+        queueIds: [queueId],
+        window: { kind: 'cursor', after: 1 },
+      });
       expect(afterCursor.map((row) => row.queuePosition)).toEqual([2, 3]);
 
-      const page = yield* index.queryAll({ spaceIds: [], queueIds: [queueId], window: { after: 0, limit: 2 } });
+      const page = yield* index.queryAll({
+        spaceIds: [],
+        queueIds: [queueId],
+        window: { kind: 'cursor', after: 0, limit: 2 },
+      });
       expect(page.map((row) => row.queuePosition)).toEqual([1, 2]);
 
       const typed = yield* index.queryTypes({
         spaceIds: [],
         queueIds: [queueId],
         typeDxns: [TYPE_PERSON],
-        window: { after: 2 },
+        window: { kind: 'cursor', after: 2 },
       });
       expect(typed.map((row) => row.queuePosition)).toEqual([3]);
 
       // A cursor read never sees the unpositioned block, which has no place in the ordering yet.
-      const fromStart = yield* index.queryAll({ spaceIds: [], queueIds: [queueId], window: { after: -1 } });
+      const fromStart = yield* index.queryAll({
+        spaceIds: [],
+        queueIds: [queueId],
+        window: { kind: 'cursor', after: -1 },
+      });
       expect(fromStart.map((row) => row.queuePosition)).toEqual([0, 1, 2, 3]);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect('caps a queue read in natural order without a cursor', () =>
+    Effect.gen(function* () {
+      const index = new EntityMetaIndex();
+      yield* index.migrate();
+
+      const spaceId = SpaceId.random();
+      const queueId = EntityId.random();
+      const objectIds = Array.from({ length: 5 }, () => EntityId.random()).sort();
+      const makeItem = (objectId: string, deleted: boolean): IndexerObject => ({
+        spaceId,
+        queueId,
+        queueNamespace: 'data',
+        documentId: null,
+        recordId: null,
+        // Unpositioned, as a locally appended block is: a natural read still has to see it.
+        queuePosition: null,
+        createdAt: null,
+        updatedAt: Date.now(),
+        data: { id: objectId, [ATTR_TYPE]: TYPE_PERSON, [ATTR_DELETED]: deleted },
+      });
+      yield* index.update(objectIds.map((objectId) => makeItem(objectId, false)));
+
+      const oldest = yield* index.queryAll({
+        spaceIds: [],
+        queueIds: [queueId],
+        window: { kind: 'natural', direction: 'asc', limit: 2 },
+      });
+      expect(oldest.map((row) => row.objectId)).toEqual(objectIds.slice(0, 2));
+
+      const newest = yield* index.queryAll({
+        spaceIds: [],
+        queueIds: [queueId],
+        window: { kind: 'natural', direction: 'desc', limit: 2 },
+      });
+      expect(newest.map((row) => row.objectId)).toEqual(objectIds.slice(-2).reverse());
+
+      const typed = yield* index.queryTypes({
+        spaceIds: [],
+        queueIds: [queueId],
+        typeDxns: [TYPE_PERSON],
+        window: { kind: 'natural', direction: 'asc', limit: 3 },
+      });
+      expect(typed.map((row) => row.objectId)).toEqual(objectIds.slice(0, 3));
+
+      // The cap counts only rows the caller keeps, so the deleted head does not eat into it.
+      yield* index.update(objectIds.slice(0, 2).map((objectId) => makeItem(objectId, true)));
+      const live = yield* index.queryAll({
+        spaceIds: [],
+        queueIds: [queueId],
+        window: { kind: 'natural', direction: 'asc', limit: 2, deleted: false },
+      });
+      expect(live.map((row) => row.objectId)).toEqual(objectIds.slice(2, 4));
     }).pipe(Effect.provide(TestLayer)),
   );
 });

--- a/packages/core/echo/index-core/src/indexes/entity-meta-index.ts
+++ b/packages/core/echo/index-core/src/indexes/entity-meta-index.ts
@@ -110,14 +110,25 @@ export const EntityMeta = Schema.Struct({
 export interface EntityMeta extends Schema.Schema.Type<typeof EntityMeta> {}
 
 /**
+ * A queue to select from, scoped by the space that owns it.
+ *
+ * `spaceId` is absent only for an unqualified feed URI (`echo:///<id>`), which names no space to
+ * scope to; such a queue matches on its id alone, as every queue read did before scoping existed.
+ */
+export interface QueueRef {
+  readonly queueId: string;
+  readonly spaceId?: string;
+}
+
+/**
  * Builds a SQL condition for filtering by space and queue source.
- * When `includeAllQueues` is false and no `queueIds`, only non-queue objects are returned.
+ * When `includeAllQueues` is false and no `queues`, only non-queue objects are returned.
  */
 const buildSourceCondition = (
   sql: SqlClient.SqlClient,
   spaceIds: readonly string[],
   includeAllQueues: boolean,
-  queueIds: readonly string[] | null,
+  queues: readonly QueueRef[] | null,
 ): Statement.Fragment => {
   const conditions: Statement.Fragment[] = [];
 
@@ -129,8 +140,18 @@ const buildSourceCondition = (
     }
   }
 
-  if (queueIds && queueIds.length > 0) {
-    conditions.push(sql`${sql.in('queueId', queueIds)}`);
+  if (queues && queues.length > 0) {
+    // Each queue carries its own space: a queue id is unique only within one, so matching on the id
+    // alone would admit another space's rows for a colliding id.
+    conditions.push(
+      sql.or(
+        queues.map((queue) =>
+          queue.spaceId !== undefined
+            ? sql`(spaceId = ${queue.spaceId} AND queueId = ${queue.queueId})`
+            : sql`queueId = ${queue.queueId}`,
+        ),
+      ),
+    );
   }
 
   if (conditions.length === 0) {
@@ -243,11 +264,11 @@ export class EntityMetaIndex implements Index {
     (query: {
       spaceIds: readonly EntityMeta['spaceId'][];
       includeAllQueues?: boolean;
-      queueIds?: readonly string[] | null;
+      queues?: readonly QueueRef[] | null;
       window?: QueueWindow;
     }): Effect.Effect<readonly EntityMeta[], SqlError.SqlError, SqlClient.SqlClient> =>
       Effect.gen(function* () {
-        if (query.spaceIds.length === 0 && (!query.queueIds || query.queueIds.length === 0)) {
+        if (query.spaceIds.length === 0 && (!query.queues || query.queues.length === 0)) {
           return [];
         }
 
@@ -256,7 +277,7 @@ export class EntityMetaIndex implements Index {
           sql,
           query.spaceIds,
           query.includeAllQueues ?? false,
-          query.queueIds ?? null,
+          query.queues ?? null,
         );
         const window = buildQueueWindow(sql, query.window);
         const rows = yield* sql<EntityMeta>`SELECT * FROM objectMeta WHERE ${sourceCondition}${window}`;
@@ -273,18 +294,18 @@ export class EntityMetaIndex implements Index {
       typeDxns,
       inverted = false,
       includeAllQueues = false,
-      queueIds = null,
+      queues = null,
       window,
     }: {
       spaceIds: readonly EntityMeta['spaceId'][];
       typeDxns: readonly EntityMeta['typeDXN'][];
       inverted?: boolean;
       includeAllQueues?: boolean;
-      queueIds?: readonly string[] | null;
+      queues?: readonly QueueRef[] | null;
       window?: QueueWindow;
     }): Effect.Effect<readonly EntityMeta[], SqlError.SqlError, SqlClient.SqlClient> =>
       Effect.gen(function* () {
-        if (spaceIds.length === 0 && (!queueIds || queueIds.length === 0)) {
+        if (spaceIds.length === 0 && (!queues || queues.length === 0)) {
           return [];
         }
 
@@ -294,7 +315,7 @@ export class EntityMetaIndex implements Index {
           }
 
           const sql = yield* SqlClient.SqlClient;
-          const sourceCondition = buildSourceCondition(sql, spaceIds, includeAllQueues, queueIds);
+          const sourceCondition = buildSourceCondition(sql, spaceIds, includeAllQueues, queues);
           const rows =
             yield* sql<EntityMeta>`SELECT * FROM objectMeta WHERE ${sourceCondition}${buildQueueWindow(sql, window)}`;
           return rows.map((row) => ({
@@ -303,7 +324,7 @@ export class EntityMetaIndex implements Index {
           }));
         }
         const sql = yield* SqlClient.SqlClient;
-        const sourceCondition = buildSourceCondition(sql, spaceIds, includeAllQueues, queueIds);
+        const sourceCondition = buildSourceCondition(sql, spaceIds, includeAllQueues, queues);
         const typeWhere = buildTypeDxnCondition(sql, typeDxns);
         const queueWindow = buildQueueWindow(sql, window);
         const rows = inverted
@@ -629,10 +650,10 @@ export class EntityMetaIndex implements Index {
       createdAfter?: number;
       createdBefore?: number;
       includeAllQueues?: boolean;
-      queueIds?: readonly string[] | null;
+      queues?: readonly QueueRef[] | null;
     }): Effect.Effect<readonly EntityMeta[], SqlError.SqlError, SqlClient.SqlClient> =>
       Effect.gen(function* () {
-        if (query.spaceIds.length === 0 && (!query.queueIds || query.queueIds.length === 0)) {
+        if (query.spaceIds.length === 0 && (!query.queues || query.queues.length === 0)) {
           return [];
         }
 
@@ -641,7 +662,7 @@ export class EntityMetaIndex implements Index {
           sql,
           query.spaceIds,
           query.includeAllQueues ?? false,
-          query.queueIds ?? null,
+          query.queues ?? null,
         );
 
         const timeConditions: Statement.Fragment[] = [];

--- a/packages/core/echo/index-core/src/indexes/entity-meta-index.ts
+++ b/packages/core/echo/index-core/src/indexes/entity-meta-index.ts
@@ -141,27 +141,62 @@ const buildSourceCondition = (
 };
 
 /**
- * Window over a feed's positioned blocks: resume after a cursor position and cap the page.
- * Only meaningful for a queue-scoped query — `queuePosition` is null for automerge objects, so a
- * caller must not apply this to a query that also selects from a space's documents.
+ * Window over a queue-scoped read: which rows, in what order, and how many.
+ *
+ * Only meaningful for a queue-scoped query — `queuePosition` is null for automerge objects and the
+ * caller-visible orderings differ, so a caller must not apply this to a query that also selects
+ * from a space's documents.
  */
-export interface QueueWindow {
+export type QueueWindow = CursorQueueWindow | NaturalQueueWindow;
+
+/**
+ * Resume a feed after a cursor position: positioned blocks only, in position order.
+ */
+export interface CursorQueueWindow {
+  readonly kind: 'cursor';
   /** Exclusive lower bound: only blocks positioned strictly after this are returned. */
-  after: number;
+  readonly after: number;
   /** Exclusive upper bound: only blocks positioned strictly before this are returned. */
-  before?: number;
-  /** Maximum rows to return, applied after ordering by position. */
-  limit?: number;
+  readonly before?: number;
+  /** Maximum rows to return, applied after ordering. */
+  readonly limit?: number;
 }
 
 /**
- * Trailing `... AND queuePosition > ? ORDER BY queuePosition LIMIT ?` for a windowed queue read.
- * Empty when the window is empty, so the unwindowed query keeps its previous shape (and its
+ * Read the first `limit` rows of a feed in natural order, so a bounded query costs what it asks
+ * for rather than the whole feed. Ordered by `objectId` because that is the key the query
+ * executor's natural comparator uses: the capped page is then exactly the page a full scan
+ * followed by an in-memory sort would have produced.
+ */
+export interface NaturalQueueWindow {
+  readonly kind: 'natural';
+  readonly direction: 'asc' | 'desc';
+  /** Maximum rows to return, applied after ordering. */
+  readonly limit: number;
+  /**
+   * Restrict to rows with this deleted state. Folded in here rather than left to the caller so the
+   * cap counts only rows the caller keeps — a limit applied before the deleted filter would return
+   * short of what the caller asked for.
+   */
+  readonly deleted?: boolean;
+}
+
+/**
+ * Trailing `... AND <bounds> ORDER BY <key> LIMIT ?` for a windowed queue read.
+ * Empty when there is no window, so the unwindowed query keeps its previous shape (and its
  * unspecified row order).
  */
 const buildQueueWindow = (sql: SqlClient.SqlClient, window: QueueWindow | undefined): Statement.Fragment => {
   if (window === undefined) {
     return sql``;
+  }
+
+  if (window.kind === 'natural') {
+    const deleted = window.deleted !== undefined ? sql` AND deleted = ${window.deleted ? 1 : 0}` : sql``;
+    // Unpositioned blocks are in scope here, unlike a cursor read: a natural read is over the feed
+    // as the caller sees it, and a locally appended block is part of that before it is positioned.
+    const order = window.direction === 'desc' ? sql` ORDER BY objectId DESC` : sql` ORDER BY objectId ASC`;
+    return sql`${deleted}${order} LIMIT ${window.limit}`;
   }
 
   // A cursor read is over positioned blocks only — `queuePosition > ?` excludes the nulls, and

--- a/packages/core/echo/index-core/src/indexes/fts-index.test.ts
+++ b/packages/core/echo/index-core/src/indexes/fts-index.test.ts
@@ -78,7 +78,7 @@ describe('FtsIndex', () => {
       yield* metaIndex.lookupRecordIds(objects);
       yield* index.update(objects);
 
-      const match = yield* index.query({ query: 'Effect', spaceId: null, includeAllQueues: false, queueIds: null });
+      const match = yield* index.query({ query: 'Effect', spaceId: null, includeAllQueues: false, queues: null });
       expect(match.length).toBeGreaterThan(0);
       expect(match[0].objectId).toBe(objects[0].data.id);
 
@@ -86,7 +86,7 @@ describe('FtsIndex', () => {
         query: 'DefinitelyNotPresent',
         spaceId: null,
         includeAllQueues: false,
-        queueIds: null,
+        queues: null,
       });
       expect(noMatch).toHaveLength(0);
     }, Effect.provide(TestLayer)),
@@ -122,7 +122,7 @@ describe('FtsIndex', () => {
       yield* metaIndex.lookupRecordIds([obj1]);
       yield* index.update([obj1]);
 
-      let match = yield* index.query({ query: 'Original', spaceId: null, includeAllQueues: false, queueIds: null });
+      let match = yield* index.query({ query: 'Original', spaceId: null, includeAllQueues: false, queues: null });
       expect(match.length).toBe(1);
 
       // Update with same doc id and object id.
@@ -147,11 +147,11 @@ describe('FtsIndex', () => {
       yield* index.update([obj2]);
 
       // Old content should be gone.
-      match = yield* index.query({ query: 'Original', spaceId: null, includeAllQueues: false, queueIds: null });
+      match = yield* index.query({ query: 'Original', spaceId: null, includeAllQueues: false, queues: null });
       expect(match.length).toBe(0);
 
       // New content should exist.
-      match = yield* index.query({ query: 'Updated', spaceId: null, includeAllQueues: false, queueIds: null });
+      match = yield* index.query({ query: 'Updated', spaceId: null, includeAllQueues: false, queues: null });
       expect(match.length).toBe(1);
     }, Effect.provide(TestLayer)),
   );
@@ -219,7 +219,7 @@ describe('FtsIndex', () => {
         query: 'Alpha',
         spaceId: null,
         includeAllQueues: false,
-        queueIds: null,
+        queues: null,
       });
       expect(alphaMatch).toHaveLength(1);
 
@@ -228,7 +228,7 @@ describe('FtsIndex', () => {
         query: 'Document',
         spaceId: null,
         includeAllQueues: false,
-        queueIds: null,
+        queues: null,
       });
       expect(allMatch).toHaveLength(3);
     }, Effect.provide(TestLayer)),
@@ -285,7 +285,7 @@ describe('FtsIndex', () => {
         query: 'Content',
         spaceId: null,
         includeAllQueues: false,
-        queueIds: null,
+        queues: null,
       });
       expect(allMatches).toHaveLength(2);
 
@@ -294,7 +294,7 @@ describe('FtsIndex', () => {
         query: 'Content',
         spaceId: [space1],
         includeAllQueues: false,
-        queueIds: null,
+        queues: null,
       });
       expect(s1Matches).toHaveLength(1);
       expect(s1Matches[0].objectId).toBe(obj1.data.id);
@@ -304,7 +304,7 @@ describe('FtsIndex', () => {
         query: 'Content',
         spaceId: [space2],
         includeAllQueues: false,
-        queueIds: null,
+        queues: null,
       });
       expect(s2Matches).toHaveLength(1);
       expect(s2Matches[0].objectId).toBe(obj2.data.id);
@@ -357,7 +357,7 @@ describe('FtsIndex', () => {
       yield* metaIndex.lookupRecordIds(objects);
       yield* index.update(objects);
 
-      const defaultQuery = { spaceId: null, includeAllQueues: false, queueIds: null } as const;
+      const defaultQuery = { spaceId: null, includeAllQueues: false, queues: null } as const;
 
       // Full word matches exactly.
       const exactMatch = yield* index.query({ query: 'Programming', ...defaultQuery });
@@ -462,7 +462,7 @@ describe('FtsIndex', () => {
         query: 'Content',
         spaceId: null,
         includeAllQueues: false,
-        queueIds: [queue1],
+        queues: [{ queueId: queue1 }],
       });
       expect(q1Matches).toHaveLength(1);
       expect(q1Matches[0].objectId).toBe(queue1Obj.data.id);
@@ -472,7 +472,7 @@ describe('FtsIndex', () => {
         query: 'Content',
         spaceId: null,
         includeAllQueues: false,
-        queueIds: [queue1, queue2],
+        queues: [{ queueId: queue1 }, { queueId: queue2 }],
       });
       expect(bothQueuesMatches).toHaveLength(2);
     }, Effect.provide(TestLayer)),
@@ -528,7 +528,7 @@ describe('FtsIndex', () => {
         query: 'Content',
         spaceId: [spaceId],
         includeAllQueues: false,
-        queueIds: null,
+        queues: null,
       });
       expect(spaceOnlyMatches).toHaveLength(1);
       expect(spaceOnlyMatches[0].objectId).toBe(spaceObj.data.id);
@@ -538,7 +538,7 @@ describe('FtsIndex', () => {
         query: 'Content',
         spaceId: [spaceId],
         includeAllQueues: true,
-        queueIds: null,
+        queues: null,
       });
       expect(allMatches).toHaveLength(2);
     }, Effect.provide(TestLayer)),
@@ -610,7 +610,7 @@ describe('FtsIndex', () => {
         query: 'Content',
         spaceId: [space1],
         includeAllQueues: false,
-        queueIds: [queueInSpace2],
+        queues: [{ queueId: queueInSpace2 }],
       });
       expect(orMatches).toHaveLength(2);
       const objectIds = orMatches.map((m) => m.objectId);
@@ -663,7 +663,7 @@ describe('FtsIndex', () => {
       yield* metaIndex.lookupRecordIds([person, task]);
       yield* index.update([person, task]);
 
-      const defaultQuery = { query: 'Shared', spaceId: null, includeAllQueues: false, queueIds: null } as const;
+      const defaultQuery = { query: 'Shared', spaceId: null, includeAllQueues: false, queues: null } as const;
 
       // No type scope — both match.
       const unscoped = yield* index.query(defaultQuery);

--- a/packages/core/echo/index-core/src/indexes/fts-index.ts
+++ b/packages/core/echo/index-core/src/indexes/fts-index.ts
@@ -15,7 +15,7 @@ import { SqlTransaction } from '@dxos/sql-sqlite';
 
 import { MIGRATIONS, MIGRATIONS_TABLE } from '../migrations/fts';
 import { chunkArray } from '../utils';
-import { type EntityMeta, buildTypeDxnCondition } from './entity-meta-index';
+import { type EntityMeta, type QueueRef, buildTypeDxnCondition } from './entity-meta-index';
 import type { Index, IndexerObject } from './interface';
 
 // SQLite bound-variable limit (SQLITE_LIMIT_VARIABLE_NUMBER) is 999 in most builds.
@@ -44,7 +44,7 @@ export interface FtsQuery {
   /**
    * Queue IDs to search within.
    */
-  queueIds: readonly EntityId[] | null;
+  queues: readonly QueueRef[] | null;
 
   /**
    * Type identifiers to restrict matches to (any form accepted by the meta index — typename
@@ -120,7 +120,7 @@ export class FtsIndex implements Index {
     query,
     spaceId,
     includeAllQueues,
-    queueIds,
+    queues,
     typeDxns,
   }: FtsQuery): Effect.Effect<readonly FtsQueryResult[], SqlError.SqlError, SqlClient.SqlClient> {
     return Effect.gen(function* () {
@@ -166,9 +166,18 @@ export class FtsIndex implements Index {
         }
       }
 
-      if (queueIds && queueIds.length > 0) {
-        // Items from specific queues.
-        sourceConditions.push(sql`m.queueId IN ${sql.in(queueIds)}`);
+      if (queues && queues.length > 0) {
+        // Items from specific queues, each scoped by its own space: a queue id is unique only
+        // within one, so matching on the id alone would admit another space's rows.
+        sourceConditions.push(
+          sql`(${sql.or(
+            queues.map((queue) =>
+              queue.spaceId !== undefined
+                ? sql`(m.spaceId = ${queue.spaceId} AND m.queueId = ${queue.queueId})`
+                : sql`m.queueId = ${queue.queueId}`,
+            ),
+          )})`,
+        );
       }
 
       if (sourceConditions.length > 0) {

--- a/packages/core/echo/index-core/src/indexes/fts-index.ts
+++ b/packages/core/echo/index-core/src/indexes/fts-index.ts
@@ -42,7 +42,8 @@ export interface FtsQuery {
   includeAllQueues: boolean;
 
   /**
-   * Queue IDs to search within.
+   * Queues to search within, each scoped by the space owning it — a queue id is unique only
+   * within its own space. A ref without a `spaceId` matches on the id alone.
    */
   queues: readonly QueueRef[] | null;
 

--- a/packages/core/echo/index-core/src/indexes/fts-index.ts
+++ b/packages/core/echo/index-core/src/indexes/fts-index.ts
@@ -10,7 +10,7 @@ import type * as Statement from 'effect/unstable/sql/Statement';
 
 import type { Obj } from '@dxos/echo';
 import { ATTR_TYPE } from '@dxos/echo/internal';
-import type { EntityId, SpaceId } from '@dxos/keys';
+import type { SpaceId } from '@dxos/keys';
 import { SqlTransaction } from '@dxos/sql-sqlite';
 
 import { MIGRATIONS, MIGRATIONS_TABLE } from '../migrations/fts';

--- a/packages/core/echo/index-core/src/migrations/entity-meta/0005_queue_object_id.sql
+++ b/packages/core/echo/index-core/src/migrations/entity-meta/0005_queue_object_id.sql
@@ -1,0 +1,9 @@
+--
+-- Covering index for a bounded natural read of one feed: `WHERE queueId = ? ORDER BY objectId
+-- LIMIT ?` walks this index and stops at the limit, instead of scanning every row of the feed and
+-- sorting them. `queuePosition` (0004) cannot serve it — natural order is by entity id, and an
+-- unpositioned block has no position to sort on.
+--
+-- Immutable: recorded in `entity_meta_migrations` and never re-run.
+--
+CREATE INDEX IF NOT EXISTS idx_object_index_queueObjectId ON objectMeta(queueId, objectId);

--- a/packages/core/echo/index-core/src/migrations/entity-meta/0005_queue_object_id.sql
+++ b/packages/core/echo/index-core/src/migrations/entity-meta/0005_queue_object_id.sql
@@ -1,9 +1,11 @@
 --
--- Covering index for a bounded natural read of one feed: `WHERE queueId = ? ORDER BY objectId
--- LIMIT ?` walks this index and stops at the limit, instead of scanning every row of the feed and
--- sorting them. `queuePosition` (0004) cannot serve it — natural order is by entity id, and an
--- unpositioned block has no position to sort on.
+-- Covering index for a bounded natural read of one feed: `WHERE spaceId = ? AND queueId = ?
+-- ORDER BY objectId LIMIT ?` walks this index and stops at the limit, instead of scanning every
+-- row of the feed and sorting them. `queuePosition` (0004) cannot serve it — natural order is by
+-- entity id, and an unpositioned block has no position to sort on.
+--
+-- `spaceId` leads so the seek cannot cross spaces: a queue id is unique only within its space.
 --
 -- Immutable: recorded in `entity_meta_migrations` and never re-run.
 --
-CREATE INDEX IF NOT EXISTS idx_object_index_queueObjectId ON objectMeta(queueId, objectId);
+CREATE INDEX IF NOT EXISTS idx_object_index_queueObjectId ON objectMeta(spaceId, queueId, objectId);

--- a/packages/core/echo/index-core/src/migrations/entity-meta/0005_queue_object_id.sql
+++ b/packages/core/echo/index-core/src/migrations/entity-meta/0005_queue_object_id.sql
@@ -1,11 +1,12 @@
 --
--- Covering index for a bounded natural read of one feed: `WHERE spaceId = ? AND queueId = ?
--- ORDER BY objectId LIMIT ?` walks this index and stops at the limit, instead of scanning every
--- row of the feed and sorting them. `queuePosition` (0004) cannot serve it — natural order is by
--- entity id, and an unpositioned block has no position to sort on.
+-- Covering index for a bounded natural read of one feed: `WHERE queueId = ? ORDER BY objectId
+-- LIMIT ?` walks this index and stops at the limit, instead of scanning every row of the feed and
+-- sorting them. `queuePosition` (0004) cannot serve it — natural order is by entity id, and an
+-- unpositioned block has no position to sort on.
 --
--- `spaceId` leads so the seek cannot cross spaces: a queue id is unique only within its space.
+-- Superseded by 0006, which re-creates this index space-first once the read learned to scope by
+-- space. Left as applied: databases already carry it, and a migration is never edited in place.
 --
 -- Immutable: recorded in `entity_meta_migrations` and never re-run.
 --
-CREATE INDEX IF NOT EXISTS idx_object_index_queueObjectId ON objectMeta(spaceId, queueId, objectId);
+CREATE INDEX IF NOT EXISTS idx_object_index_queueObjectId ON objectMeta(queueId, objectId);

--- a/packages/core/echo/index-core/src/migrations/entity-meta/0006_queue_object_id_by_space.sql
+++ b/packages/core/echo/index-core/src/migrations/entity-meta/0006_queue_object_id_by_space.sql
@@ -1,0 +1,11 @@
+--
+-- Re-creates 0005's index space-first, now that a queue read scopes by the space owning the queue:
+-- the seek needs `spaceId` leading to use both equalities. `IF NOT EXISTS` cannot alter an existing
+-- index, so the old shape is dropped first — a database that applied 0005 would otherwise keep
+-- `(queueId, objectId)` and silently fall back to a scan and sort.
+--
+-- Immutable: recorded in `entity_meta_migrations` and never re-run.
+--
+DROP INDEX IF EXISTS idx_object_index_queueObjectId;
+
+CREATE INDEX IF NOT EXISTS idx_object_index_queueObjectId ON objectMeta(spaceId, queueId, objectId);

--- a/packages/core/echo/index-core/src/migrations/entity-meta/index.ts
+++ b/packages/core/echo/index-core/src/migrations/entity-meta/index.ts
@@ -10,6 +10,7 @@ import { SqlMigrations } from '@dxos/sql-sqlite';
 import init from './0001_init.sql?raw';
 import indexes from './0003_indexes.sql?raw';
 import queuePosition from './0004_queue_position.sql?raw';
+import queueObjectId from './0005_queue_object_id.sql?raw';
 
 /**
  * Columns added to `objectMeta` after it first shipped, with the DDL that adds them. Databases in
@@ -48,6 +49,7 @@ export const MIGRATIONS = {
   '0002_missing_columns': addMissingColumns,
   '0003_indexes': SqlMigrations.apply(indexes),
   '0004_queue_position': SqlMigrations.apply(queuePosition),
+  '0005_queue_object_id': SqlMigrations.apply(queueObjectId),
 };
 
 /** Own history table per store, since many stores share the client database. */

--- a/packages/core/echo/index-core/src/migrations/entity-meta/index.ts
+++ b/packages/core/echo/index-core/src/migrations/entity-meta/index.ts
@@ -11,6 +11,7 @@ import init from './0001_init.sql?raw';
 import indexes from './0003_indexes.sql?raw';
 import queuePosition from './0004_queue_position.sql?raw';
 import queueObjectId from './0005_queue_object_id.sql?raw';
+import queueObjectIdBySpace from './0006_queue_object_id_by_space.sql?raw';
 
 /**
  * Columns added to `objectMeta` after it first shipped, with the DDL that adds them. Databases in
@@ -50,6 +51,7 @@ export const MIGRATIONS = {
   '0003_indexes': SqlMigrations.apply(indexes),
   '0004_queue_position': SqlMigrations.apply(queuePosition),
   '0005_queue_object_id': SqlMigrations.apply(queueObjectId),
+  '0006_queue_object_id_by_space': SqlMigrations.apply(queueObjectIdBySpace),
 };
 
 /** Own history table per store, since many stores share the client database. */


### PR DESCRIPTION
Resolves DX-1263.

## The bug

`Feed.query(feed, Query.select(...).limit(N))` bounded the result but not the decode. The select read every row of the feed out of `objectMeta` and loaded every snapshot, then sliced to N — cost O(feed), not O(N).

The planner already propagated `limit` into `SelectStep`, but the executor only turned that into an index-level window when a `Filter.feedCursor` was *also* present (`extractQueueWindow` returned `undefined` without a `feedCursorRange`). Both of the reads `Cursor.seedDedupSet` issues per sync run missed it: the `desc` one was refused by the planner's `scanOrderMismatch` check, and the `asc` one reached the executor with a limit it then ignored.

## The fix

The planner now proves, per select, whether the cap can move into the scan and records it as `SelectStep.feedScan`. The executor turns that into a `NaturalQueueWindow`, which `EntityMetaIndex` emits as `ORDER BY objectId ASC|DESC LIMIT n` with the deleted filter folded in.

Ordering by `objectId` is what makes this behaviour-preserving rather than approximate: it is the key the executor's own natural comparator uses, so the capped page is exactly the page a full scan followed by an in-memory sort would have produced. A new `objectMeta(queueId, objectId)` index (migration 0005) makes it a seek rather than a scan-and-sort.

The proof is deliberately narrow. The cap moves into the scan only for a feed-only scope, a single natural ordering, and when nothing between the select and the limit would prune the page — the deleted filter (folded into the scan, so the cap counts only rows the caller keeps), the redundant typename re-check emitted beside a `TypeSelector`, and a skip already folded into the limit. Anything else keeps applying the limit downstream, so no query changes what it returns.

`QueueWindow` becomes a tagged union. The positional cursor read and this natural read want different bounds and a different ordering; the union makes choosing one a type-level decision rather than a comment.

## Measurement

40-item feed asking for 5, via `DX_TRACE_QUERY_EXECUTION`, for each of the two reads `Cursor.layer` issues:

| | index hits | documents loaded |
| -- | -- | -- |
| before | 40 | 40 |
| after | 5 | 5 |

Same in both natural directions.

## Testing

| suite | result |
| -- | -- |
| `index-core:test` | 50 passed |
| `echo-host:test` | 319 passed |
| `echo-client-e2e:test` | 327 passed |
| `link:test` | 26 passed |

New coverage: the planner's soundness conditions (`query-planner.test.ts`), the natural window's SQL including the deleted fold (`entity-meta-index.test.ts`), and behavioural regression tests for natural-desc-with-limit, a deleted item not eating into the limit, and an unpositioned local append still appearing in a limited read (`feed-query-pagination.test.ts`).

## Companion

`dxos/edge` needs the same fix in its own `db-service` query executor — branch `claude/feed-query-limit-perf-buf901` there. It consumes the new `QueueWindow` from `@dxos/index-core`, so it takes a `scripts/bump-dxos-catalog.mjs` bump to this commit once this lands. Filter pushdown (the `reconcileFilter` half of the ticket) is untouched and still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uj39jUpZobcaYYTqUmo2jh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uj39jUpZobcaYYTqUmo2jh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Limited feed queries now read and decode only the requested items when safe.
  * Supports efficient ascending and descending natural-order reads, including deleted-item filtering.

* **Bug Fixes**
  * Queue reads are scoped to their owning space, preventing cross-space matches.
  * Limited pagination correctly handles deletions and items added after the last flush.
  * Queries with unsupported ordering or intermediate steps retain previous behavior.

* **Tests**
  * Added regression coverage for feed limits, ordering, deletion handling, skip behavior, queue isolation, and pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12984-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
