### PR TITLE
shell: stop the bundle task duplicating the vite tag's args

### DIFF
--- a/packages/sdk/shell/moon.yml
+++ b/packages/sdk/shell/moon.yml
@@ -15,6 +15,9 @@ tasks:
     command: pnpm exec vite build -c vite.bundle.config.ts
     options:
       mergeOutputs: replace
+      # Args merge by append, so without this the `vite` tag's own `exec vite build` is concatenated
+      # onto this command's and vite rejects the duplicated positionals.
+      mergeArgs: replace
     inputs:
       - vite.bundle.config.ts
     outputs:


### PR DESCRIPTION
Fixes the `pkg.pr.new` publish, which has failed on every push to `main` since #12976 — so **no build has been published for any commit on main in ~23 hours**, and anything pinning a recent SDK sha is stuck.

## The failure

[`Bundle Shell`](https://github.com/dxos/dxos/actions/runs/34214497399/job/102022938538) (`moon run shell:bundle`):

```
CACError: Unused args: `vite`, `build`
    at Command.checkUnusedArgs (vite/dist/node/cli.js:387:54)
  × Task shell:bundle failed to run.
```

The `Publish to pkg.pr.new` step runs after it, so it never executes.

## Cause

moon merges task `args` by **append**. #12976 gave `shell`'s `bundle` task a `command:` override, but the `vite` tag already defines that task as `pnpm exec vite build`. The two concatenate:

```
$ moon task shell:bundle
  Command: pnpm exec vite build exec vite build -c vite.bundle.config.ts
```

vite's CLI matches `build`, which takes one positional, and rejects the leftover `vite build`.

## Fix

`mergeArgs: replace` on the task's options — the same idiom `composer-app` already applies to its `serve` and `preview` overrides, where the existing comment names this exact hazard.

## Verification

```
$ moon task shell:bundle
  Command: pnpm exec vite build -c vite.bundle.config.ts

$ moon run shell:bundle
Tasks: 80 completed
 Time: 3s 175ms
[exited with code 0]
```

I also checked the two other `command: pnpm exec vite …` overrides in the repo (`composer-app`, `devtools`) — both already resolve correctly, so this is the only affected task.

No changeset: build configuration only, nothing consumer-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uj39jUpZobcaYYTqUmo2jh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uj39jUpZobcaYYTqUmo2jh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the bundle task to prevent duplicate Vite build commands from being appended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12989-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
