### PR TITLE
claude: add /autonomous mode — pinned task, no questions, Stop-hook enforcement

### DIFF
--- a/.agents/skills/autonomous-mode/SKILL.md
+++ b/.agents/skills/autonomous-mode/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: autonomous-mode
+description: >-
+  Working under AUTONOMOUS MODE — a pinned task the session must drive to a written
+  definition of done without asking the user anything. Use when an `AUTONOMOUS MODE` block
+  appears in the turn's context, when `/autonomous` is invoked, when you are about to ask a
+  clarifying question about scope or PR size and cannot, when a blocker looks like a reason
+  to stop, or before ending a run (the adversarial review and the stop command).
+---
+
+# Autonomous mode
+
+A run is one pinned task plus a definition of done, and a standing instruction:
+**do not ask, decide.** The mechanism is `/autonomous [task]`; this skill is how
+to behave while it is on.
+
+The state and the two logs live under `.claude/` (all untracked, per-worktree):
+
+| File                  | Written by                     | What it is                      |
+| --------------------- | ------------------------------ | ------------------------------- |
+| `.autonomous`         | the `UserPromptSubmit` hook    | the pinned task                 |
+| `.autonomous-dod`     | **you**, once, before working  | the definition of done          |
+| `.autonomous-user.md` | the hook, every turn, verbatim | every message the user has sent |
+| `.autonomous-log.md`  | **you**, as you decide         | the decision log                |
+
+Everything is driven through one script:
+
+```bash
+bash .claude/scripts/autonomous.sh dod set '1. … 2. …'   # once, first
+bash .claude/scripts/autonomous.sh log add 'chose X over Y — Z'
+bash .claude/scripts/autonomous.sh user show             # what the user actually said
+bash .claude/scripts/autonomous.sh stop 'done: …'        # the only clean exit
+```
+
+## 1. Write the definition of done before you touch anything
+
+A DoD is a checklist of **verifiable conditions**, not intentions. "Refactor the
+query layer" is a task; "`moon run echo:test` passes, no `as any` added, one
+changeset, PR opened" is a definition of done. Test: could a reviewer who has
+never seen this conversation check every item without asking you what you meant?
+If not, it is too vague — and it is what the Stop hook will quote back at you.
+
+Derive it from the task and the evidence in §2, store it, and do not silently
+widen or narrow it later. A change of scope is a logged decision:
+
+```bash
+bash .claude/scripts/autonomous.sh log add 'dropped item 4 (storybook screenshots) — no server reachable in the sandbox; DoD updated'
+bash .claude/scripts/autonomous.sh dod set '<the new checklist>'
+```
+
+## 2. Resolve questions from evidence, in this order
+
+The user is not available. Ambiguity is still resolvable — in almost every case
+the answer already exists:
+
+1. **The user log — read it first.** `autonomous.sh user show` is every message
+   the user has sent this session, verbatim, oldest first. **Scoping and PR-size
+   questions are what it is for.** "Should this also fix the adjacent bug?"
+   "One PR or three?" "Do they want the migration too?" — the user has almost
+   always already said, in an aside three turns before the task existed. Grep it
+   before you decide anything about what is in or out:
+
+   ```bash
+   grep -inE 'scope|small|minimal|separate|one PR|split|just |only |don.t bother' .claude/.autonomous-user.md
+   ```
+
+   The log is gitignored and never leaves the worktree, but it is a verbatim
+   copy of the conversation — never paste its contents into a commit message, a
+   PR body, or anywhere outbound, for the same reason `AGENTS.md` keeps
+   credentials out of chat in the first place.
+
+   Their stated _preferences_ count as much as their instructions: someone who
+   said "keep PRs small" earlier has answered a scoping question you were about
+   to ask.
+
+2. **The repo.** `AGENTS.md`, `.claude/CLAUDE.md`, the skill for the area, and —
+   most decisive — the existing code and its tests. A convention already
+   followed by ten call sites is the answer; do not invent an eleventh.
+
+3. **The most reversible option that keeps the task moving.** When evidence runs
+   out, prefer the choice that is cheapest to undo — a narrower change, a new
+   file over a rewritten one, a flag defaulted to today's behaviour — take it,
+   log it, and carry on.
+
+**What "do not ask" does and does not mean.** No clarifying questions, no
+confirmations, no menus, no "should I proceed?". It does **not** mean hiding
+choices: state the decision and its reason in the reply, briefly, so the user
+can veto it if they are watching. Announcing is not asking.
+
+## 3. Log decisions as you take them
+
+One line each, at the moment of choosing — a log written at the end is a
+reconstruction, and the reason it existed is already gone. Log:
+
+- any choice between real alternatives (library, layer, file layout, algorithm);
+- anything inferred from the user log rather than instructed, with the quote;
+- every scope change, in or out;
+- every route tried around a blocker, including the ones that failed;
+- the adversarial review verdict.
+
+Do not log routine mechanics — files read, tests run, commits made. The diff and
+the transcript already have those.
+
+## 4. A blocker is work, not an exit
+
+Before "I cannot do this" is even a candidate, try **at least two independent
+routes** and log each:
+
+- read the failing code or test rather than the error message;
+- a different tool for the same job (the sandbox has no `gh` — the
+  `mcp__github__*` tools do the same work; `moon` may not load — typecheck
+  against sources, see the `cloud-sandbox` skill);
+- a narrower scope that still satisfies the DoD;
+- the fallback the relevant skill documents for exactly this failure;
+- a subagent, when the blocker is breadth of search rather than depth.
+
+Missing credentials, a network-refused host, or a genuinely absent decision only
+the user can make are the real dead ends — and they are dead ends only after the
+routes above are logged as tried.
+
+## 5. Adversarial review before stopping
+
+Never end a run on your own satisfaction. Attack the change first:
+
+- `/code-review` on the diff, or the `agentic-review` skill for the repo's
+  `.mdl` rules;
+- or a subagent asked to find what CI and a hostile reviewer would reject;
+- plus the checks that actually gate: `pnpm format`, the package's lint and
+  tests, and a re-read of your own diff for casts, stray comments, and
+  compatibility shims (the `code-style` skill's pre-commit audit).
+
+Fix what it finds — that is part of the task, not follow-up work — then log the
+verdict.
+
+## 6. Stopping
+
+Exactly two grounds, and both end the run explicitly:
+
+```bash
+bash .claude/scripts/autonomous.sh stop 'done: <what was verified, against which DoD items>'
+bash .claude/scripts/autonomous.sh stop 'blocked: <what, and the routes that failed>'
+```
+
+That command clears the state, which is what silences the `Stop` hook. Go quiet
+without it and the hook blocks the turn and hands the task straight back, up to
+three times per user turn; after that it tells the **user** the run was
+abandoned. There is no third option and no partial credit: an unmet DoD item is
+either worked or logged as blocked.
+
+The user can end a run at any time with `/autonomous off [reason]`.
+
+## 7. What autonomous mode never overrides
+
+Autonomy is about questions, not permissions. Still binding, and grounds to stop
+with that as the logged reason if the task requires crossing one:
+
+- the `AGENTS.md` non-negotiables — never edit on `main`, never create, rename
+  or switch worktrees or branches, no casts to silence the type-checker, never
+  suppress unhandled errors, never touch a copyright notice, format before every
+  commit;
+- destructive or irreversible actions outside the task's own scope — force
+  pushes to shared branches, deletes the DoD does not name, anything that leaves
+  the machine (publishing, sending, posting) beyond what the task explicitly is;
+- honesty about outcomes. A failing test is reported as failing, with its
+  output. "Done" means verified.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -42,6 +42,34 @@
 - The rules themselves are canonical in `AGENTS.md` → "Responding to the user";
   the machinery is documented in `.claude/README.md`.
 
+## Autonomous mode
+
+- **`/autonomous [task]`** pins a task the session must drive to completion
+  **without asking any questions**; `/autonomous off [reason]` ends it, and
+  `/autonomous status` reports. With no task on the line the hook adopts the
+  previous user instruction (same derivation as `/mode focus`). It must lead the
+  message, as a slash command does.
+- It is orthogonal to the verbosity mode — a run can be `terse` or `normal`, and
+  `/mode` never touches it.
+- `.claude/hooks/autonomous.sh` (`UserPromptSubmit`) writes the state and injects
+  the `AUTONOMOUS MODE` block; `.claude/hooks/autonomous-stop.sh` (`Stop`) blocks
+  the turn from ending while a run is active, at most three times per user turn.
+- The state is four untracked files: `.claude/.autonomous` (task, hook-written),
+  `.claude/.autonomous-dod` (definition of done, **agent-written, first thing**),
+  `.claude/.autonomous-user.md` (every user message verbatim, hook-written every
+  turn) and `.claude/.autonomous-log.md` (the decision log, agent-written).
+- **Answer scoping and PR-size questions from the user log**
+  (`bash .claude/scripts/autonomous.sh user show`) rather than asking — that is
+  what it is for.
+- The only clean exit is `bash .claude/scripts/autonomous.sh stop '<reason>'`,
+  with the DoD met or the blocker established; run an adversarial review of the
+  diff before you do.
+- `bash .claude/scripts/autonomous.test.sh` exercises both hooks and the backend.
+  Run it after touching any of them.
+- Doctrine lives in the `autonomous-mode` skill
+  (`.agents/skills/autonomous-mode/SKILL.md`); the machinery is documented in
+  `.claude/README.md`.
+
 ## Task planning
 
 - One command: `/dxos:project VERB [ARGS]`, leading the message (bare `/project`

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -70,6 +70,8 @@ stdout as context the agent reads. Every other event needs
 | `~/.claude/hooks/guard-branch.sh`, `deny-git-worktree-add.sh`                                                     | `PreToolUse(Bash)`        | deny           | derived                                   |
 | `~/.claude/hooks/guard-worktree.sh` + [repo copy](./hooks/guard-worktree.sh)                                      | `PreToolUse(Edit\|Write)` | deny           | derived                                   |
 | [`hooks/mode.sh`](./hooks/mode.sh) → [`scripts/mode.sh`](./scripts/mode.sh)   | `UserPromptSubmit`        | agent          | **persisted** `.claude/.mode` + `.claude/.focus` |
+| [`hooks/autonomous.sh`](./hooks/autonomous.sh) → [`scripts/autonomous.sh`](./scripts/autonomous.sh) | `UserPromptSubmit`        | agent          | **persisted** `.claude/.autonomous*` (task, DoD, two logs) |
+| [`hooks/autonomous-stop.sh`](./hooks/autonomous-stop.sh)                                                          | `Stop`                    | block          | reads the same state                      |
 | `dxos` plugin → `hooks/track.sh` ([tools/claude/plugins/dxos](../tools/claude/plugins/dxos))                            | `UserPromptSubmit`        | agent          | persisted, backend-resolved (registry)    |
 | [`AGENTS.md`](../AGENTS.md) (+ `CLAUDE.md` / `GEMINI.md` symlinks), [`CLAUDE.md`](./CLAUDE.md)                    | —                         | agent          | static                                    |
 | `skills/` → `../.agents/skills/` (25)                                                                             | —                         | agent          | on demand                                 |
@@ -148,6 +150,7 @@ A sentinel is a **marker typed inside a normal message** that a
 | ------------------------------- | ------------------------------------ | ---------------------------------------------------------- |
 | `/mode terse` / `/mode normal`  | [`hooks/mode.sh`](./hooks/mode.sh)   | sets response verbosity mode (see aliases below)            |
 | `/mode focus [task]`            | [`hooks/mode.sh`](./hooks/mode.sh)   | terse, plus one pinned task the session is confined to      |
+| `/autonomous [task]`            | [`hooks/autonomous.sh`](./hooks/autonomous.sh) | pins a task the session must finish without asking questions |
 | `/dxos:project VERB [ARGS]`       | `dxos` plugin (see below)              | task-planning: list / tasks / new / end / track / hydrate / resume |
 
 They exist because a hook can act on them **before the model runs**, which makes
@@ -211,6 +214,47 @@ the guidance files in play". Carrying it per turn as well made every reply open
 with a restatement — noise, and duplicated state the two channels could disagree
 about. Per-turn injection is a strong channel; putting a once-per-session rule on
 it is a misuse.
+
+**`/autonomous [task]` is the same recipe applied to the _work_ rather than the
+reply.** `focus` narrows what the agent may work on; `autonomous` removes its
+ability to hand the work back. The hook writes the task, the per-turn injection
+carries the directives (no questions, log decisions, a blocker is work, finish
+against the definition of done), and — the part that cannot be argued with — a
+**`Stop` hook** blocks the turn from ending while a run is active, quoting the
+agent's own definition of done back at it. That placement is the whole design:
+kinds 1–2 decay as the session fills, and stopping early is precisely the
+failure that shows up late in a long session.
+
+Its state is four files, split by writer. The hook owns the task
+(`.autonomous`) and the **user log** (`.autonomous-user.md`, every user message
+verbatim, appended on every turn whether or not a run is active); the agent owns
+the **definition of done** (`.autonomous-dod`) and the **decision log**
+(`.autonomous-log.md`). The two logs are not one file on purpose: the user log
+is evidence, the decision log is accountability, and mixing them would let a
+summary of what the user said sit where the quote belongs. An agent that may not
+ask a question still has to answer scoping and PR-size questions somehow, and
+the user has almost always already said — three turns earlier, in an aside — so
+the log it greps must be what they actually typed. Starting a run mid-session
+backfills the log from the event's `transcript_path`, for the same reason the
+focus pin is derived there: a record on disk is mechanism, an agent asked to
+remember is not.
+
+The clean exit is `autonomous.sh stop <reason>` — the reason is mandatory and
+logged, because a run that ends without one is indistinguishable from one that
+was abandoned. It clears the state, which is what silences the `Stop` hook. The
+block is **bounded at three per user turn** and the counter is reset by every
+`UserPromptSubmit`: an unbounded `Stop` block is an infinite loop, since an
+agent cannot be argued into a capability it does not have, and a session that
+can never end is worse than a task honestly reported unfinished. On the fourth
+attempt the hook lets the turn end and tells the **user** — via `systemMessage`,
+the only channel they read — that the run is still open.
+
+[`scripts/autonomous.test.sh`](./scripts/autonomous.test.sh) drives both hooks
+with the JSON their events carry, against a throwaway `CLAUDE_PROJECT_DIR`.
+The doctrine — how to resolve a question from evidence, what counts as trying
+to get around a blocker, the adversarial review expected before stopping — is
+the `autonomous-mode` skill, not the injection, which stays short enough to
+survive being read every turn.
 
 > **Caveat — keep the grammar unambiguous.** The hook greps raw message text and
 > cannot tell a command from a mention of one. Both markers were bitten by this

--- a/.claude/commands/autonomous.md
+++ b/.claude/commands/autonomous.md
@@ -1,0 +1,54 @@
+---
+description: Run a task to completion without asking questions (autonomous mode)
+argument-hint: '[task | off [reason] | status]'
+allowed-tools: Bash
+---
+
+Arguments: `$ARGUMENTS`
+
+**Never set the state yourself.** `.claude/hooks/autonomous.sh` runs on
+`UserPromptSubmit`, which carries the raw `/autonomous …` text and fires before
+this expansion reaches you, so the write is already done. The `AUTONOMOUS MODE`
+block in this turn's context is the source of truth for what is pinned.
+
+**If `$ARGUMENTS` named a task** (or was empty, in which case the task was
+adopted from your previous instruction), the run is now ON. Before touching
+anything:
+
+1. Restate the task in one line — with a derived task this is the user's only
+   chance to correct it.
+2. Write a **definition of done**: a short checklist of _verifiable_ conditions,
+   not intentions. What builds, what test passes, what a reviewer can see, what
+   is committed. Store it, because the Stop hook quotes it back to you:
+
+   ```bash
+   bash .claude/scripts/autonomous.sh dod set '1. … 2. … 3. …'
+   ```
+
+3. Then work it to completion. Ask nothing. Every non-obvious choice gets a line
+   in the decision log as you make it:
+
+   ```bash
+   bash .claude/scripts/autonomous.sh log add '<decision> — <why>'
+   ```
+
+Read the `autonomous-mode` skill (`.agents/skills/autonomous-mode/SKILL.md`) for
+how to resolve a question without asking, what counts as trying to get around a
+blocker, and the adversarial review expected before you stop.
+
+**If `$ARGUMENTS` began with `off`, `stop` or `end`**, the run is already over
+and the reason is in the log. Confirm in one line and report where the task
+stands — what is done, what is not, what you would do next.
+
+**If `$ARGUMENTS` was `status`**, report from the `AUTONOMOUS MODE` block plus:
+
+```bash
+bash .claude/scripts/autonomous.sh get; bash .claude/scripts/autonomous.sh dod get; bash .claude/scripts/autonomous.sh log show 20
+```
+
+If no `AUTONOMOUS MODE` block appears in this turn, no run is active — say so.
+
+**If nothing could be pinned** (no task on the line and no previous
+instruction), the hook says so and started nothing. Say that in one line and ask
+what the task is — this is the one question autonomous mode permits, because
+there is no run yet to forbid it.

--- a/.claude/hooks/autonomous-stop.sh
+++ b/.claude/hooks/autonomous-stop.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 DXOS.org
+#
+# Stop hook for AUTONOMOUS MODE. While a run is active, ending the turn is
+# treated as an unfinished task: the hook blocks the stop and hands the task
+# back with the definition of done attached.
+#
+# This is the mechanism half of the feature. Every other part is text the agent
+# may drift away from as the session fills (see .claude/README.md §A); this one
+# fires at the moment the drift becomes visible — the agent trying to stop.
+#
+# The legitimate exits are NOT blocked, because they clear the state first:
+# `autonomous.sh stop <reason>` (DoD met, or no route exists, logged either way)
+# and `/autonomous off` from the user. With no state, this hook sees nothing to
+# do and the turn ends normally.
+#
+# Bounded on purpose. `reminders` counts blocks and is reset by every
+# UserPromptSubmit, so a run can be nudged at most $cap times per user turn.
+# An unbounded Stop block is an infinite loop: the agent cannot be argued into a
+# capability it does not have, and a session that can never end is worse than a
+# task reported unfinished.
+
+set -euo pipefail
+
+root="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+script="$root/.claude/scripts/autonomous.sh"
+cap=3
+
+input=$(cat)
+stop_hook_active=$(printf '%s' "$input" | jq -r '.stop_hook_active // false' 2>/dev/null || printf 'false')
+
+bash "$script" active >/dev/null 2>&1 || exit 0
+
+task=$(bash "$script" get 2>/dev/null || printf '')
+dod=$(bash "$script" dod get 2>/dev/null || printf '')
+count=$(bash "$script" reminders bump 2>/dev/null || printf '%s' "$cap")
+case "$count" in ('' | *[!0-9]*) count=$cap ;; esac
+
+# Out of budget: let the turn end, but tell the USER the run is still open —
+# systemMessage reaches them, and a run abandoned silently is the failure mode
+# this hook exists to make visible.
+if [ "$count" -gt "$cap" ]; then
+  jq -nc --arg task "$task" \
+    '{systemMessage: ("AUTONOMOUS MODE is still ON and the agent stopped after \($task | .[0:120]) — reminder budget spent for this turn. Say `/autonomous off` to end the run, or reply to resume it.")}'
+  exit 0
+fi
+
+if [ -n "$dod" ]; then
+  dod_line="Definition of done (yours, from earlier in this run): $dod"
+else
+  dod_line="You never wrote a definition of done. Write one now and store it with \`bash .claude/scripts/autonomous.sh dod set '<checklist>'\`."
+fi
+
+# `stop_hook_active` means this turn is already a continuation of a previous
+# block, so the reminder is trimmed to the decision rather than repeating the
+# doctrine the agent has just been given.
+if [ "$stop_hook_active" = 'true' ]; then
+  reason=$(printf 'AUTONOMOUS MODE is still ON.\n\nTASK: %s\n%s\n\nYou stopped again without ending the run. Do exactly one of these, now:\n1. Keep working — the next unfinished item of the definition of done.\n2. If every item is met: run the adversarial review of your diff, fix what it finds, then `bash .claude/scripts/autonomous.sh stop "done: <what was verified>"`.\n3. If no route exists: log the routes you tried, then `bash .claude/scripts/autonomous.sh stop "blocked: <what, and the two routes that failed>"`.\n' "$task" "$dod_line")
+else
+  reason=$(printf 'AUTONOMOUS MODE is still ON — you cannot end the turn by going quiet.\n\nTASK: %s\n%s\n\nDo NOT ask the user a question to get out of this. Resolve ambiguity from evidence:\n- `bash .claude/scripts/autonomous.sh user show` — every message the user has sent, verbatim. Scope and PR-size questions are answered there.\n- the repo: AGENTS.md, the relevant skill, existing code and tests.\n\nThen take the next step:\n1. Any DoD item unmet -> keep working on it. A blocker is work: try two independent routes around it and `autonomous.sh log add` each attempt.\n2. All items met -> run an adversarial review of your own diff first (`/code-review`, the `agentic-review` skill, or a subagent asked to attack the change), fix what it finds, log the verdict, then end the run:\n   `bash .claude/scripts/autonomous.sh stop "done: <what was verified>"`\n3. Genuinely no route -> log what you tried and end the run:\n   `bash .claude/scripts/autonomous.sh stop "blocked: <what, and the routes that failed>"`\n\nEnding the run via that command is the ONLY clean exit; it clears the state so this hook stops firing. Reminder %s of %s for this turn.\n' "$task" "$dod_line" "$count" "$cap")
+fi
+
+jq -nc --arg reason "$reason" '{decision: "block", reason: $reason}'

--- a/.claude/hooks/autonomous.sh
+++ b/.claude/hooks/autonomous.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 DXOS.org
+#
+# UserPromptSubmit hook for AUTONOMOUS MODE. Three jobs, in order:
+#
+# 1. Log the user's message verbatim. Doing this here, mechanically, is the
+#    whole point: the agent is told not to ask questions, so it needs evidence
+#    of what the user already said — especially about scope and PR size — and an
+#    agent asked to remember that would be persuasion, not a record.
+#    This happens on EVERY turn, autonomous or not, so a run started mid-session
+#    already has its upstream context on disk.
+# 2. Toggle: `/autonomous [task]` starts a run, `/autonomous off` ends one. This
+#    event carries the RAW typed text and runs before the model, so the write is
+#    deterministic — the command's own expansion would land too late to gate the
+#    turn it appears in.
+# 3. Enforce: inject the autonomous directives, but only while a run is active.
+#
+# Deliberately a sibling of ./mode.sh rather than part of it: verbosity and
+# autonomy are independent (a run can be terse or normal), and two hooks under
+# one settings.json key both fire.
+
+set -euo pipefail
+
+root="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+script="$root/.claude/scripts/autonomous.sh"
+user_log="$root/.claude/.autonomous-user.md"
+
+# Whether the user log predates this turn, captured BEFORE step 1 appends to it:
+# a log that already exists has been fed by this hook since the session began, so
+# a run starting now needs no backfill and would only duplicate its own tail.
+seeded='no'
+[ -e "$user_log" ] && seeded='yes'
+
+input=$(cat)
+prompt=$(printf '%s' "$input" | jq -r '.prompt // empty' 2>/dev/null || printf '')
+transcript=$(printf '%s' "$input" | jq -r '.transcript_path // empty' 2>/dev/null || printf '')
+
+# Every user message the transcript holds, oldest first, excluding tool results,
+# harness meta turns, and this turn's own prompt. Used to seed the user log when
+# a run starts partway through a session.
+prior_user_messages() {
+  local file=$1 current=$2
+  [ -f "$file" ] || return 0
+  jq -rs --arg current "$current" '
+    [ .[]
+      | select(.type == "user" and (.isMeta | not))
+      | .message.content
+      | if type == "string" then .
+        elif type == "array" then ([ .[] | select(.type == "text") | .text ] | join("\n"))
+        else empty end
+      | select(type == "string" and . != "")
+    ]
+    | map(select(. != $current))
+    | .[-50:]
+    | .[]
+  ' "$file" 2>/dev/null || printf ''
+}
+
+# The last user instruction that is not this turn's prompt and not a slash
+# command — i.e. what a bare `/autonomous` means to pin.
+previous_instruction() {
+  local file=$1 current=$2
+  [ -f "$file" ] || return 0
+  prior_user_messages "$file" "$current" | grep -v '^[[:space:]]*/' | tail -1 || printf ''
+}
+
+# 1. Record the message. A failure here must not swallow the turn, so the
+#    warning is surfaced and the hook carries on.
+if [ -n "$prompt" ]; then
+  bash "$script" user add "$prompt" >/dev/null 2>&1 \
+    || printf 'WARNING: could not append this message to the autonomous user log.\n'
+fi
+
+# A new user turn resets the stop-reminder budget: the hook's job is to stop an
+# agent walking away from a task, not to fight a user who has retaken the wheel.
+bash "$script" reminders reset >/dev/null 2>&1 || true
+
+# `/autonomous …`, leading, as a slash command must be. Anchoring to the first
+# line is what keeps prose about the command — or a path like `src/autonomous
+# off.ts` — from starting a run. The trailing boundary is required: without it
+# `/autonomousx` prefix-matches.
+first_line=$(printf '%s' "$prompt" | head -1)
+sentinel=$(printf '%s\n' "$first_line" | grep -ioE "^[[:space:]]*/autonomous([[:space:]]|$)" | head -1 || true)
+
+if [ -n "$sentinel" ]; then
+  args=$(printf '%s' "$first_line" \
+    | sed -E 's@^[[:space:]]*/[^[:space:]]+[[:space:]]*@@' \
+    | sed -E 's/[[:space:]]+$//')
+  verb=$(printf '%s' "$args" | awk '{print tolower($1)}')
+
+  case "$verb" in
+    off | stop | end)
+      reason=$(printf '%s' "$args" | sed -E 's@^[^[:space:]]+[[:space:]]*@@')
+      [ -n "$reason" ] || reason='stopped by the user'
+      if bash "$script" stop "$reason" >/dev/null 2>&1; then
+        printf 'Autonomous mode is now OFF (recorded in the decision log). Do not run the script yourself. Confirm in one line, and report where the task stands.\n'
+      else
+        printf 'Autonomous mode was not active, or its state could not be cleared. Say which in one line.\n'
+      fi
+      ;;
+    status)
+      printf 'Autonomous status was requested. Report it from the AUTONOMOUS MODE block below (or say it is off if no block follows) plus `bash .claude/scripts/autonomous.sh log show`.\n'
+      ;;
+    *)
+      task=$args
+      derived=''
+      if [ -z "$task" ]; then
+        task=$(previous_instruction "$transcript" "$prompt")
+        derived='yes'
+      fi
+
+      if [ -z "$task" ]; then
+        printf 'AUTONOMOUS MODE was requested with no task on the line and no previous instruction to adopt, so NOTHING was started. Do not run the script yourself. Say so in one line and ask what the task is.\n'
+      elif bash "$script" set "$task" >/dev/null 2>&1; then
+        # Seed the user log from the transcript, but only when this hook was not
+        # already logging this session — so the first scoping decision of a run
+        # started in a fresh session has the same evidence a long-running one
+        # would, without re-appending turns already on disk.
+        if [ "$seeded" = 'no' ]; then
+          while IFS= read -r message; do
+            [ -n "$message" ] || continue
+            bash "$script" user add "$message" >/dev/null 2>&1 || true
+          done < <(prior_user_messages "$transcript" "$prompt")
+        fi
+
+        if [ -n "$derived" ]; then
+          printf 'AUTONOMOUS MODE is now ON, with the task adopted from your previous instruction. Do not run the script yourself. Restate the task and your definition of done in one short block, store the DoD with `autonomous.sh dod set`, then work it to completion without asking anything further.\n'
+        else
+          printf 'AUTONOMOUS MODE is now ON with the task on that line. Do not run the script yourself. State your definition of done in one short block, store it with `autonomous.sh dod set`, then work it to completion without asking anything further.\n'
+        fi
+      else
+        printf 'WARNING: AUTONOMOUS MODE could not be started (state write failed), so the session is NOT autonomous. Tell the user.\n'
+      fi
+      ;;
+  esac
+fi
+
+# 3. Inert when no run is active — a non-autonomous session must look exactly as
+#    it did before this hook existed.
+exec bash "$script" context

--- a/.claude/scripts/autonomous.sh
+++ b/.claude/scripts/autonomous.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 DXOS.org
+#
+# State backend for AUTONOMOUS MODE — a pinned task the session must drive to a
+# written definition of done without asking the user anything.
+#
+# It is deliberately shaped like ../scripts/mode.sh: a state script with two
+# callers (`.claude/commands/autonomous.md` reports, the hooks mutate and
+# inject), so the same read/write discipline applies — a file that exists but
+# cannot be read is NOT the same as an absent one, and only the latter is safe
+# to treat as "inactive".
+#
+# Four pieces of state, in four files, because they have four different writers:
+#
+#   .autonomous            the task           <- hook, from the raw `/autonomous` line
+#   .autonomous-dod        definition of done <- the agent, once, before working
+#   .autonomous-user.md    every user message <- hook, verbatim, append-only
+#   .autonomous-log.md     decisions taken    <- the agent, as it takes them
+#
+# The user log is written by the hook rather than the agent for the same reason
+# the focus pin is derived in a hook: an agent asked to remember what the user
+# said is persuasion, while a transcript on disk is evidence it can grep. It is
+# the intended answer to a scoping question ("how big should this PR be?") —
+# the user has almost always already said, somewhere upstream.
+#
+#   autonomous.sh get              -> print the task, or nothing when inactive
+#   autonomous.sh active           -> exit 0 iff a task is pinned
+#   autonomous.sh set <task>       -> start (or replace) a run; resets dod, logs, reminders
+#   autonomous.sh dod get|set <text>
+#   autonomous.sh log add <text>   -> append a timestamped decision
+#   autonomous.sh log show [n]     -> tail the decision log
+#   autonomous.sh user add <text>  -> append a user message (hook only)
+#   autonomous.sh user show [n]    -> tail the user log
+#   autonomous.sh reminders get|bump|reset
+#   autonomous.sh stop <reason>    -> end the run; the reason is required and logged
+#   autonomous.sh context          -> the block injected into every prompt
+#
+# State is per-worktree runtime, not repo policy: every file is untracked and
+# ignored via the root .gitignore.
+
+set -euo pipefail
+
+root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+task_file="$root/.claude/.autonomous"
+dod_file="$root/.claude/.autonomous-dod"
+user_log="$root/.claude/.autonomous-user.md"
+decision_log="$root/.claude/.autonomous-log.md"
+reminders="$root/.claude/.autonomous-reminders"
+
+# Cap on how long any single stored field may be. A pinned task or a log entry
+# long enough to crowd the turn is one nobody reads.
+max_len=4000
+
+now() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
+
+truncate_text() {
+  local text=$1
+  if [ "${#text}" -gt "$max_len" ]; then
+    printf '%s… (truncated)' "${text:0:$max_len}"
+  else
+    printf '%s' "$text"
+  fi
+}
+
+# Write via a temp file in the same directory so a reader never observes the
+# truncate-then-write window and concludes the run is over.
+write_file() {
+  local target=$1 value=$2 tmp
+  tmp=$(mktemp "$target.XXXXXX" 2>/dev/null) || return 1
+  if printf '%s' "$value" > "$tmp" 2>/dev/null && mv -f "$tmp" "$target" 2>/dev/null; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null || true
+  return 1
+}
+
+# Exists-but-unreadable exits 1 so mutating callers can refuse; absent prints
+# nothing and succeeds.
+read_file() {
+  [ -e "$1" ] || return 0
+  cat "$1" 2>/dev/null || return 1
+}
+
+# Read-only callers degrade to inactive rather than wedging the session into a
+# task it can never leave.
+current_task() {
+  local value
+  if ! value=$(read_file "$task_file"); then
+    printf 'WARNING: %s exists but could not be read; treating the session as NOT autonomous.\n' "$task_file" >&2
+    return 0
+  fi
+  printf '%s' "$value"
+}
+
+current_dod() { read_file "$dod_file" 2>/dev/null || printf ''; }
+
+append_log() {
+  local file=$1 entry=$2
+  # A log that cannot be appended to is a silent loss of the audit trail, so
+  # callers are told; the run itself is not aborted over it.
+  printf '%s\n' "$entry" >> "$file" 2>/dev/null || return 1
+}
+
+clear_run() {
+  rm -f "$task_file" "$dod_file" "$reminders" 2>/dev/null || return 1
+  return 0
+}
+
+case "${1:-get}" in
+  get)
+    value=$(current_task)
+    if [ -n "$value" ]; then printf '%s\n' "$value"; fi
+    ;;
+
+  active)
+    [ -n "$(current_task)" ] || exit 1
+    ;;
+
+  set)
+    text=$(truncate_text "${2:-}")
+    [ -n "$text" ] || { printf 'usage: autonomous.sh set <task>\n' >&2; exit 2; }
+    write_file "$task_file" "$text" || { printf 'ERROR: could not write %s\n' "$task_file" >&2; exit 1; }
+    # A new run must not inherit the previous run's definition of done or
+    # reminder budget; the logs are append-only history and are kept.
+    rm -f "$dod_file" "$reminders" 2>/dev/null || true
+    append_log "$decision_log" "$(printf '\n## Run started %s\n\n- TASK: %s\n' "$(now)" "$text")" \
+      || printf 'WARNING: could not append to %s\n' "$decision_log" >&2
+    printf 'Autonomous: %s\n' "$text"
+    ;;
+
+  dod)
+    case "${2:-get}" in
+      get)
+        value=$(current_dod)
+        if [ -n "$value" ]; then printf '%s\n' "$value"; fi
+        ;;
+      set)
+        text=$(truncate_text "${3:-}")
+        [ -n "$text" ] || { printf 'usage: autonomous.sh dod set <text>\n' >&2; exit 2; }
+        write_file "$dod_file" "$text" || { printf 'ERROR: could not write %s\n' "$dod_file" >&2; exit 1; }
+        append_log "$decision_log" "$(printf -- '- DOD %s: %s\n' "$(now)" "$text")" \
+          || printf 'WARNING: could not append to %s\n' "$decision_log" >&2
+        printf 'Definition of done: %s\n' "$text"
+        ;;
+      *) printf 'usage: autonomous.sh dod {get|set <text>}\n' >&2; exit 2 ;;
+    esac
+    ;;
+
+  log)
+    case "${2:-show}" in
+      add)
+        text=$(truncate_text "${3:-}")
+        [ -n "$text" ] || { printf 'usage: autonomous.sh log add <text>\n' >&2; exit 2; }
+        append_log "$decision_log" "$(printf -- '- %s: %s' "$(now)" "$text")" \
+          || { printf 'ERROR: could not append to %s\n' "$decision_log" >&2; exit 1; }
+        printf 'Logged.\n'
+        ;;
+      show)
+        [ -e "$decision_log" ] || exit 0
+        tail -n "${3:-40}" "$decision_log" 2>/dev/null || true
+        ;;
+      path) printf '%s\n' "$decision_log" ;;
+      *) printf 'usage: autonomous.sh log {add <text>|show [n]|path}\n' >&2; exit 2 ;;
+    esac
+    ;;
+
+  user)
+    case "${2:-show}" in
+      add)
+        text=${3:-}
+        [ -n "$text" ] || exit 0
+        # Verbatim and unsummarised — the value of this log is that it is what
+        # the user actually typed, not what the agent took from it. Fenced so a
+        # message containing markdown cannot corrupt the file's structure.
+        append_log "$user_log" "$(printf '\n### %s\n\n```\n%s\n```\n' "$(now)" "$text")" \
+          || { printf 'ERROR: could not append to %s\n' "$user_log" >&2; exit 1; }
+        ;;
+      show)
+        [ -e "$user_log" ] || exit 0
+        tail -n "${3:-80}" "$user_log" 2>/dev/null || true
+        ;;
+      path) printf '%s\n' "$user_log" ;;
+      *) printf 'usage: autonomous.sh user {add <text>|show [n]|path}\n' >&2; exit 2 ;;
+    esac
+    ;;
+
+  reminders)
+    case "${2:-get}" in
+      get) printf '%s\n' "$(read_file "$reminders" 2>/dev/null || printf '')" ;;
+      bump)
+        value=$(read_file "$reminders" 2>/dev/null || printf '')
+        case "$value" in ('' | *[!0-9]*) value=0 ;; esac
+        value=$((value + 1))
+        write_file "$reminders" "$value" || { printf 'ERROR: could not write %s\n' "$reminders" >&2; exit 1; }
+        printf '%s\n' "$value"
+        ;;
+      reset) rm -f "$reminders" 2>/dev/null || true ;;
+      *) printf 'usage: autonomous.sh reminders {get|bump|reset}\n' >&2; exit 2 ;;
+    esac
+    ;;
+
+  stop)
+    reason=$(truncate_text "${2:-}")
+    # A run that ends without a recorded reason is indistinguishable from one
+    # that was abandoned, which is the failure this whole mechanism exists to
+    # prevent — so the reason is mandatory.
+    [ -n "$reason" ] || { printf 'usage: autonomous.sh stop <reason>\n' >&2; exit 2; }
+    if [ -z "$(current_task)" ]; then
+      printf 'Autonomous mode was not active.\n'
+      exit 0
+    fi
+    append_log "$decision_log" "$(printf -- '- STOP %s: %s\n' "$(now)" "$reason")" \
+      || printf 'WARNING: could not append to %s\n' "$decision_log" >&2
+    clear_run || { printf 'ERROR: could not clear autonomous state under %s/.claude\n' "$root" >&2; exit 1; }
+    printf 'Autonomous mode: OFF (%s)\n' "$reason"
+    ;;
+
+  context)
+    task=$(current_task)
+    [ -n "$task" ] || exit 0
+    dod=$(current_dod)
+    printf 'AUTONOMOUS MODE (re-injected every turn; this governs the WORK, not the reply).\n'
+    printf -- '- TASK: %s\n' "$task"
+    if [ -n "$dod" ]; then
+      printf -- '- DEFINITION OF DONE: %s\n' "$dod"
+    else
+      cat <<'EOF'
+- DEFINITION OF DONE: NOT YET WRITTEN. Before anything else, write one as a
+  short checklist of verifiable conditions (what builds, what passes, what a
+  reviewer can see) and store it:
+  `bash .claude/scripts/autonomous.sh dod set '<checklist>'`
+EOF
+    fi
+    cat <<'EOF'
+- DO NOT ASK THE USER ANYTHING. No clarifying questions, no confirmations, no
+  menus of options. Pick the option that best advances the task, state the
+  choice, and proceed. Ambiguity is resolved by evidence, in this order:
+  1. the user log — `bash .claude/scripts/autonomous.sh user show` — which is
+     every message the user has sent, verbatim. Scope and PR-size questions are
+     almost always already answered there; grep it before deciding anything
+     about what is in or out of this change.
+  2. the repo itself (AGENTS.md, the relevant skill, existing code and tests).
+  3. the most reversible option that keeps the task moving.
+- LOG EVERY NON-OBVIOUS DECISION, as you take it, one line each:
+  `bash .claude/scripts/autonomous.sh log add '<decision> — <why>'`
+- A BLOCKER IS WORK, NOT AN EXIT. Try at least two independent routes around it
+  (a different tool, a narrower scope that still satisfies the DoD, reading the
+  failing code, a fallback documented in the relevant skill) and log each
+  attempt before concluding anything is impossible.
+- FINISH THE WHOLE TASK against the definition of done — every item, tested,
+  formatted, committed. Partial work is not done.
+- BEFORE STOPPING, run an adversarial review of your own diff: re-read it
+  looking for what a hostile reviewer or CI would reject, and fix what you find.
+  `/code-review` or the `agentic-review` skill counts; so does a subagent asked
+  to attack the change. Log the verdict.
+- STOPPING IS EXPLICIT AND HAS EXACTLY TWO GROUNDS: the DoD is fully met, or
+  you have established and logged that no route exists. Either way, end the run
+  yourself first — `bash .claude/scripts/autonomous.sh stop '<which ground, and why>'`
+  — or the Stop hook will hand this task straight back to you.
+- This does NOT override safety: destructive or irreversible actions outside the
+  task, and the AGENTS.md non-negotiables (never edit on main, never create or
+  switch worktrees/branches, no casts to silence the type-checker, never
+  suppress unhandled errors, format before committing) still bind. If the task
+  itself requires crossing one of those, stop with that as the logged reason.
+EOF
+    ;;
+
+  *)
+    printf 'usage: autonomous.sh {get|active|set <task>|dod {get|set <text>}|log {add <text>|show [n]}|user {add <text>|show [n]}|reminders {get|bump|reset}|stop <reason>|context}\n' >&2
+    exit 2
+    ;;
+esac

--- a/.claude/scripts/autonomous.test.sh
+++ b/.claude/scripts/autonomous.test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 DXOS.org
+#
+# Tests for the autonomous-mode hooks and their state backend, by feeding each
+# hook the same JSON its event carries. Run it by hand:
+#
+#   bash .claude/scripts/autonomous.test.sh
+#
+# The real scripts run against a throwaway `CLAUDE_PROJECT_DIR`, so a run can
+# never touch the state of the session running it — clobbering a live run's
+# pinned task or logs would be an invisible failure.
+
+set -uo pipefail
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+sandbox=$(mktemp -d)
+trap 'rm -rf "$sandbox"' EXIT
+
+mkdir -p "$sandbox/.claude"
+ln -s "$repo/.claude/hooks" "$sandbox/.claude/hooks"
+ln -s "$repo/.claude/scripts" "$sandbox/.claude/scripts"
+
+export CLAUDE_PROJECT_DIR="$sandbox"
+hook="$repo/.claude/hooks/autonomous.sh"
+stop_hook="$repo/.claude/hooks/autonomous-stop.sh"
+script="$repo/.claude/scripts/autonomous.sh"
+task_file="$sandbox/.claude/.autonomous"
+user_log="$sandbox/.claude/.autonomous-user.md"
+decision_log="$sandbox/.claude/.autonomous-log.md"
+
+pass=0
+fail=0
+
+check() {
+  local label=$1 expected=$2 actual=$3
+  if [ "$expected" = "$actual" ]; then
+    printf 'PASS  %s\n' "$label"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL  %s\n        expected: %s\n        actual:   %s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+contains() {
+  local label=$1 needle=$2 haystack=$3
+  case "$haystack" in
+    *"$needle"*)
+      printf 'PASS  %s\n' "$label"
+      pass=$((pass + 1))
+      ;;
+    *)
+      printf 'FAIL  %s\n        expected to contain: %s\n        actual:   %s\n' "$label" "$needle" "$haystack"
+      fail=$((fail + 1))
+      ;;
+  esac
+}
+
+run() { printf '%s' "$1" | bash "$hook" 2>/dev/null; }
+stop_run() { printf '%s' "$1" | bash "$stop_hook" 2>/dev/null; }
+payload() { jq -nc --arg p "$1" --arg t "${2:-}" '{prompt: $p, transcript_path: $t}'; }
+stop_payload() { jq -nc --argjson a "${1:-false}" '{stop_hook_active: $a}'; }
+reset() { rm -f "$sandbox"/.claude/.autonomous*; }
+state() { [ -e "$task_file" ] && printf 'active' || printf 'inactive'; }
+
+transcript="$sandbox/transcript.jsonl"
+cat > "$transcript" <<'JSONL'
+{"type":"user","message":{"role":"user","content":"keep the PR small, one package only"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}
+{"type":"user","message":{"role":"user","content":"fix the flaky echo test"}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"stdout"}]}}
+JSONL
+
+# --- inert unless started -----------------------------------------------------
+
+reset
+out=$(run "$(payload 'just a normal message')")
+check 'no run: no AUTONOMOUS block injected' '' "$out"
+check 'no run: state stays inactive' 'inactive' "$(state)"
+contains 'no run: user message still logged' 'just a normal message' "$(cat "$user_log" 2>/dev/null)"
+
+reset
+out=$(run "$(payload 'we could use /autonomous here one day')")
+check 'mention in prose does not start a run' 'inactive' "$(state)"
+out=$(run "$(payload '/autonomousx foo')")
+check 'prefix match does not start a run' 'inactive' "$(state)"
+out=$(run "$(payload 'read src/autonomous off.ts')")
+check 'path mention does not start a run' 'inactive' "$(state)"
+
+# --- starting -----------------------------------------------------------------
+
+reset
+out=$(run "$(payload '/autonomous land the release PR' "$transcript")")
+check 'explicit task: run is active' 'active' "$(state)"
+check 'explicit task: task stored verbatim' 'land the release PR' "$(bash "$script" get)"
+contains 'explicit task: hook announces ON' 'AUTONOMOUS MODE is now ON' "$out"
+contains 'explicit task: block injected' '- TASK: land the release PR' "$out"
+contains 'explicit task: DoD demanded first' 'DEFINITION OF DONE: NOT YET WRITTEN' "$out"
+contains 'explicit task: no-questions rule injected' 'DO NOT ASK THE USER ANYTHING' "$out"
+contains 'explicit task: user log seeded from transcript' 'keep the PR small, one package only' "$(cat "$user_log")"
+contains 'explicit task: start recorded in decision log' 'Run started' "$(cat "$decision_log")"
+
+reset
+run "$(payload 'earlier aside about scope' "$transcript")" >/dev/null
+run "$(payload '/autonomous land it' "$transcript")" >/dev/null
+check 'mid-session start does not re-backfill the user log' '1' \
+  "$(grep -c 'earlier aside about scope' "$user_log")"
+check 'mid-session start skips the transcript backfill' '0' \
+  "$(grep -c 'keep the PR small' "$user_log")"
+
+reset
+out=$(run "$(payload '/autonomous' "$transcript")")
+check 'bare verb: adopts previous instruction' 'fix the flaky echo test' "$(bash "$script" get)"
+contains 'bare verb: says the task was derived' 'adopted from your previous instruction' "$out"
+
+reset
+empty="$sandbox/empty.jsonl"
+printf '{"type":"user","message":{"role":"user","content":"/mode terse"}}\n' > "$empty"
+out=$(run "$(payload '/autonomous' "$empty")")
+check 'nothing pinnable: no run started' 'inactive' "$(state)"
+contains 'nothing pinnable: said out loud' 'NOTHING was started' "$out"
+
+# --- definition of done -------------------------------------------------------
+
+reset
+run "$(payload '/autonomous fix the lint job')" >/dev/null
+bash "$script" dod set '1. lint green 2. formatted' >/dev/null
+out=$(run "$(payload 'carry on')")
+contains 'stored DoD is injected' 'DEFINITION OF DONE: 1. lint green 2. formatted' "$out"
+contains 'stored DoD replaces the demand' 'DO NOT ASK' "$out"
+check 'DoD is readable back' '1. lint green 2. formatted' "$(bash "$script" dod get)"
+
+# --- logs ---------------------------------------------------------------------
+
+reset
+run "$(payload '/autonomous ship it')" >/dev/null
+bash "$script" log add 'chose vitest over jest — repo standard' >/dev/null
+contains 'decision log records the entry' 'chose vitest over jest' "$(bash "$script" log show)"
+run "$(payload 'and keep it to one package')" >/dev/null
+contains 'user log is verbatim and append-only' 'and keep it to one package' "$(cat "$user_log")"
+check 'user log kept separate from decisions' '' "$(grep -c 'chose vitest' "$user_log" | sed 's/^0$//')"
+
+# --- stop hook ----------------------------------------------------------------
+
+reset
+out=$(stop_run "$(stop_payload false)")
+check 'stop hook inert when no run is active' '' "$out"
+
+run "$(payload '/autonomous fix the flaky test')" >/dev/null
+out=$(stop_run "$(stop_payload false)")
+check 'stop is blocked while a run is active' 'block' "$(printf '%s' "$out" | jq -r '.decision')"
+reason=$(printf '%s' "$out" | jq -r '.reason')
+contains 'block quotes the task' 'fix the flaky test' "$reason"
+contains 'block forbids asking a way out' 'Do NOT ask the user a question' "$reason"
+contains 'block points at the user log' 'autonomous.sh user show' "$reason"
+contains 'block requires the adversarial review' 'adversarial review' "$reason"
+contains 'block names the clean exit' 'autonomous.sh stop' "$reason"
+contains 'block reports missing DoD' 'never wrote a definition of done' "$reason"
+
+bash "$script" dod set 'tests pass' >/dev/null
+out=$(stop_run "$(stop_payload false)")
+contains 'block quotes a stored DoD' 'tests pass' "$(printf '%s' "$out" | jq -r '.reason')"
+
+out=$(stop_run "$(stop_payload true)")
+contains 'continuation block is trimmed' 'You stopped again' "$(printf '%s' "$out" | jq -r '.reason')"
+
+# Budget: reminders were bumped by each block above; the cap is 3 per user turn.
+out=$(stop_run "$(stop_payload false)")
+check 'budget spent: stop is allowed' 'null' "$(printf '%s' "$out" | jq -r '.decision // "null"')"
+contains 'budget spent: the USER is told' 'AUTONOMOUS MODE is still ON' "$(printf '%s' "$out" | jq -r '.systemMessage')"
+check 'budget spent: run is still active' 'active' "$(state)"
+
+out=$(run "$(payload 'keep going')")
+out=$(stop_run "$(stop_payload false)")
+check 'a user turn resets the budget' 'block' "$(printf '%s' "$out" | jq -r '.decision')"
+
+# --- stopping -----------------------------------------------------------------
+
+reset
+run "$(payload '/autonomous ship the fix')" >/dev/null
+check 'stop without a reason is refused' '2' "$(bash "$script" stop >/dev/null 2>&1; printf '%s' $?)"
+check 'refused stop leaves the run active' 'active' "$(state)"
+bash "$script" stop 'done: tests pass on CI' >/dev/null
+check 'explicit stop clears the run' 'inactive' "$(state)"
+contains 'explicit stop is logged with its reason' 'STOP' "$(cat "$decision_log")"
+check 'cleared run silences the stop hook' '' "$(stop_run "$(stop_payload false)")"
+out=$(run "$(payload 'anything')")
+check 'cleared run injects nothing' '' "$out"
+
+reset
+run "$(payload '/autonomous ship the fix')" >/dev/null
+out=$(run "$(payload '/autonomous off changed my mind')")
+check 'user off switch clears the run' 'inactive' "$(state)"
+contains 'user off switch is announced' 'now OFF' "$out"
+contains 'user off switch logs the reason' 'changed my mind' "$(cat "$decision_log")"
+
+reset
+run "$(payload '/autonomous ship the fix')" >/dev/null
+out=$(run "$(payload '/autonomous status')")
+contains 'status asks for a report' 'Autonomous status was requested' "$out"
+check 'status does not end the run' 'active' "$(state)"
+
+# --- restarting ---------------------------------------------------------------
+
+bash "$script" dod set 'old checklist' >/dev/null
+run "$(payload '/autonomous a different task')" >/dev/null
+check 'restart replaces the task' 'a different task' "$(bash "$script" get)"
+check 'restart drops the stale DoD' '' "$(bash "$script" dod get)"
+contains 'restart keeps the log history' 'old checklist' "$(cat "$decision_log")"
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,25 @@
             "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}/.claude/hooks/mode.sh\""
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}/.claude/hooks/autonomous.sh\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}/.claude/hooks/autonomous-stop.sh\"",
+            "statusMessage": "Checking autonomous mode"
+          }
+        ]
       }
     ]
   },

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,16 @@
 # Transitional: pre-rename state file, deleted on first mode.sh run.
 .claude/.response-mode
 
+# Autonomous-mode run state: the pinned task, its definition of done, and the
+# block budget the Stop hook spends. Per-worktree runtime, like the mode.
+.claude/.autonomous
+.claude/.autonomous-dod
+.claude/.autonomous-reminders
+# Its two logs. Both are session evidence, not source: the user log is a verbatim
+# transcript of what the user typed, the decision log is what the agent chose.
+.claude/.autonomous-user.md
+.claude/.autonomous-log.md
+
 # Logs
 logs/
 npm-debug.log*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,11 @@ Do not paste real credential values into any shell command, and do not paste the
   [`.agents/projects/sql-migrations/DESIGN.md`](.agents/projects/sql-migrations/DESIGN.md).
   Read it before reaching for Prisma: there is no driver adapter for the
   browser client, which is why the schema is hand-written SQL.
+- **Working a task with no questions asked** — `/autonomous [task]` pins a task the
+  session must finish against a written definition of done, resolving scope from a
+  verbatim log of what the user already said → `autonomous-mode` skill
+  (`.agents/skills/autonomous-mode/SKILL.md`); Claude-harness specifics in
+  `.claude/CLAUDE.md`.
 - **`REPOSITORY_GUIDE.md`** — toolchain setup, prerequisites, and how to run
   apps/services (Composer, Tasks, Docs).
 - **`OPS_GUIDE.md`** / **`TROUBLESHOOTING.md`** — operations and common issues.


### PR DESCRIPTION
## What

`/autonomous [task]` pins a task the session must drive to a **written definition of done** without asking the user anything. It is the work-side counterpart to `/mode focus`: focus narrows *what* may be worked on, autonomous removes the agent's ability to hand the work back.

```
/autonomous land the release PR      # start; task on the line
/autonomous                          # start; adopts the previous user instruction
/autonomous status                   # report task, DoD, decision log
/autonomous off changed my mind      # end the run (reason logged)
```

## How

Same recipe as `/mode` (documented in `.claude/README.md` §Sentinels), plus one new mechanism:

| Piece | Event | Job |
| --- | --- | --- |
| `.claude/hooks/autonomous.sh` | `UserPromptSubmit` | logs the user's message verbatim, greps the raw `/autonomous …` text (so the state write is deterministic), injects the directives every turn |
| `.claude/hooks/autonomous-stop.sh` | `Stop` | **blocks the turn from ending** while a run is active, quoting the agent's own DoD back at it |
| `.claude/scripts/autonomous.sh` | — | state backend: task, DoD, both logs, reminder budget, `context` |
| `.claude/commands/autonomous.md` | — | thin command body; registers the name and shapes the reply |
| `.agents/skills/autonomous-mode/SKILL.md` | — | the doctrine, kept out of the per-turn injection |

The `Stop` hook is the point of the change. Every other channel is text the agent may drift away from as the session fills (`.claude/README.md` §A); this one fires at the moment the drift becomes visible — the agent trying to stop. It is **bounded at three blocks per user turn**, reset by every `UserPromptSubmit`: an unbounded `Stop` block is an infinite loop, since an agent cannot be argued into a capability it does not have, and a session that can never end is worse than a task honestly reported unfinished. On the fourth attempt it lets the turn end and tells the *user* — via `systemMessage`, the only channel they read — that the run is still open.

## Two logs, split by writer

Both untracked, per-worktree, gitignored alongside `.mode`/`.focus`:

- **`.claude/.autonomous-user.md`** — every user message, verbatim, appended by the hook on every turn (autonomous or not), and backfilled from the event's `transcript_path` when a run starts in a fresh session. An agent forbidden from asking still has to answer scoping and PR-size questions; the user has usually already said, in an aside three turns before the task existed. A record on disk is mechanism, where an agent asked to remember is persuasion.
- **`.claude/.autonomous-log.md`** — the decisions the agent took, and why. Kept separate on purpose: the user log is evidence, the decision log is accountability, and merging them would let a summary of what the user said sit where the quote belongs.

## Behaviour while a run is active

The injected block: don't ask; resolve ambiguity from the user log → the repo → the most reversible option; log every non-obvious decision as you take it; **a blocker is work, not an exit** (two independent routes, each logged, before "impossible"); finish the whole DoD; **run an adversarial review of your own diff before stopping**. The only clean exit is `autonomous.sh stop <reason>` — the reason is mandatory and logged, because a run that ends without one is indistinguishable from one that was abandoned.

Autonomy is about questions, not permissions: the `AGENTS.md` non-negotiables (never edit on `main`, never create/switch worktrees or branches, no casts, no suppressed unhandled errors, format before committing) still bind, and a task that requires crossing one is a logged stop.

## Test

```
$ bash .claude/scripts/autonomous.test.sh
54 passed, 0 failed
$ bash .claude/scripts/mode.test.sh
36 passed, 0 failed          # unchanged
```

Both hooks are driven with the JSON their events actually carry, against a throwaway `CLAUDE_PROJECT_DIR` so a run cannot clobber the state of the session running it. Coverage includes: inert when no run is active (no injection, no `Stop` block), prose/prefix/path mentions not starting a run, task derivation and the nothing-pinnable case, DoD injection, the two logs staying separate, no re-backfill mid-session, every clause of the block reason, the reminder budget and its reset, and stop refusing to run without a reason.

`oxfmt --check` clean. `shellcheck` could not run — its npm package downloads a binary from a host the sandbox's egress gateway answers 403 to — so the scripts are covered by `bash -n` plus the suite above.

No changeset: agent tooling only, no published package touched.

## Docs

`.claude/README.md` (§C control-point table, §Sentinels — including why the `Stop` hook is bounded and why the logs are split), `.claude/CLAUDE.md` (harness specifics), `AGENTS.md` (one pointer under "Where things live").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eidWyvCWncZdPUbAsy412

---
_Generated by [Claude Code](https://claude.ai/code/session_016eidWyvCWncZdPUbAsy412)_

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12993-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an autonomous mode for driving tasks to a written definition of done without requiring ongoing user input.
  * Added commands to start, check, pause, resume, and stop autonomous runs.
  * Added decision, task, completion, and user-message tracking for active runs.
  * Added safeguards for blockers, stop conditions, reminders, and adversarial review.

* **Documentation**
  * Documented autonomous mode, its commands, workflow, safeguards, and configuration.
  * Added guidance describing where autonomous-mode documentation and resources are located.

* **Tests**
  * Added automated coverage for autonomous-mode workflows, state tracking, stopping, restarting, and hook behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->