### PR TITLE
blade-runner: EDGE-only replication and an agent per client in the nightly plans

### DIFF
--- a/packages/e2e/blade-runner/src/replicants/client-replicant.ts
+++ b/packages/e2e/blade-runner/src/replicants/client-replicant.ts
@@ -142,7 +142,12 @@ export class ClientReplicant {
             // empty and `Restart` tests nothing (observed in every local run — RESULTS.md §5).
             sqliteMode: Runtime_Client_Storage_SqliteMode.FILE,
           },
-          // Edge-only data replication (D7): signaling carries invitations, no client-to-client data path.
+          // Edge-only data replication (D7): signaling carries invitations, no client-to-client data
+          // path. The flag is what actually enforces it — `edgeFeatures` alone leaves the mesh
+          // replicator attached, so peers still swapped documents directly over WebRTC and a run
+          // measured a mixture of both paths (the EDGE-nightly join-latency outlier caught a joiner
+          // syncing against another client's `host-…` peer while its EDGE connection was stalled).
+          disableP2pReplication: true,
           edgeFeatures: { subductionReplicator: true, feedReplicator: true, signaling: true, agents },
         },
       },
@@ -282,7 +287,8 @@ export class ClientReplicant {
 
   /**
    * Host half of a HALO device invitation; the returned code admits another replicant as a second
-   * device of this identity.
+   * device of this identity. Never delegated: `EdgeInvitationHandler` redeems only
+   * `Invitation_Kind.SPACE`, so a device invitation is always admitted by this client.
    */
   @trace.span()
   async inviteDevice(): Promise<{ invitationCode: string }> {

--- a/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
+++ b/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
@@ -95,11 +95,12 @@ export type EdgeJoinLatencyResult = {
    */
   monotonicGrowth: boolean;
   /**
-   * Whether the clients got their EDGE agents, i.e. whether EDGE redeemed the DELEGATED invitations
-   * rather than the seeder admitting each joiner itself. False only for a `agents: false` run, which
-   * measures the slower fallback — latency is comparable across runs only where this matches.
+   * Whether EDGE redeemed the DELEGATED invitations or the seeder admitted each joiner itself.
+   * `disabled` and `failed` are not the same run: the first deliberately measures the slower
+   * fallback, the second is a broken environment whose numbers mean nothing. Latency is comparable
+   * across runs only where this matches.
    */
-  agent: boolean;
+  agents: 'disabled' | 'provisioned' | 'failed';
 };
 
 export const DEFAULT_SPEC: EdgeJoinLatencySpec = {
@@ -117,6 +118,23 @@ export const resolveSpec = (overrides: Partial<EdgeJoinLatencySpec> = {}): EdgeJ
   ...DEFAULT_SPEC,
   ...overrides,
 });
+
+/**
+ * An EDGE agent could not be provisioned. Distinct from a join failure so the per-joiner fallback
+ * can rethrow it: a client without an agent is a broken precondition, not a slow joiner, and
+ * running the remaining joiners against it only spends minutes producing rows that say the same
+ * thing.
+ */
+class AgentProvisioningError extends Error {
+  static is(err: unknown): err is AgentProvisioningError {
+    return err instanceof AgentProvisioningError;
+  }
+
+  constructor(label: string, options: { cause: unknown }) {
+    super(`EDGE agent could not be provisioned for ${label}`, options);
+    this.name = 'AgentProvisioningError';
+  }
+}
 
 //
 // The measurement.
@@ -178,10 +196,10 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
     const measurements: JoinMeasurement[] = [];
     let spaceId: string | undefined;
     let seedMs = 0;
-    // Starts true for an `agents: true` run and is falsified by the first client that cannot get
-    // one. Never the other way round: a later client's failure has to be able to correct it, or the
-    // artifact reports an agent-backed fleet on a run where one client had no agent.
-    let agentsProvisioned = spec.agents;
+    // Falsified by the first client that cannot get an agent, never the other way round: `disabled`
+    // and `failed` describe different runs, and collapsing them would have the summary blame a
+    // broken environment on a config choice.
+    let agents: EdgeJoinLatencyResult['agents'] = spec.agents ? 'provisioned' : 'disabled';
 
     const spawn = async (label: string): Promise<ReplicantBrain<ClientReplicant>> => {
       const replicant = await env.spawn(ClientReplicant, { platform: spec.platform });
@@ -213,10 +231,8 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
         try {
           await replicant.brain.createAgent();
         } catch (err) {
-          // A joiner's failure is caught below and recorded as its own row, so without this the
-          // run would go on and the artifact would still claim `agent: true`.
-          agentsProvisioned = false;
-          throw err;
+          agents = 'failed';
+          throw new AgentProvisioningError(label, { cause: err });
         }
       }
       return replicant;
@@ -289,6 +305,11 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
             error: settled.ok ? undefined : `digest still differed after ${spec.joinTimeoutMs}ms`,
           });
         } catch (err) {
+          // The fallback is for a joiner that failed to sync — one bad row, the rest still measured.
+          // A missing agent is not that: it is the precondition for every remaining joiner too.
+          if (AgentProvisioningError.is(err)) {
+            throw err;
+          }
           measurements.push({
             joiner,
             admittedMs,
@@ -307,7 +328,7 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
         log.info('joiner measured', { ...measurements[measurements.length - 1] });
       }
 
-      const result = this._summarize(edgeUrl, spec, seedMs, measurements, agentsProvisioned);
+      const result = this._summarize(edgeUrl, spec, seedMs, measurements, agents);
       invariant(
         result.ok,
         `joiners failed to sync: ${measurements
@@ -319,7 +340,7 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
     } finally {
       // In `finally` so the artifacts exist however the run ended: a green/red verdict with no
       // numbers behind it is the one output a CI job must never produce.
-      const summary = this._summarize(edgeUrl, spec, seedMs, measurements, agentsProvisioned);
+      const summary = this._summarize(edgeUrl, spec, seedMs, measurements, agents);
       fs.writeFileSync(resultPath, `${JSON.stringify(summary, null, 2)}\n`);
       fs.writeFileSync(path.join(params.outDir, 'summary.md'), renderSummary(summary));
       unregisterCleanup();
@@ -335,7 +356,7 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
     spec: EdgeJoinLatencySpec,
     seedMs: number,
     measurements: JoinMeasurement[],
-    agent: boolean,
+    agents: EdgeJoinLatencyResult['agents'],
   ): EdgeJoinLatencyResult {
     const ok = measurements.filter((measurement) => measurement.ok);
     const median = (pick: (measurement: JoinMeasurement) => number | undefined): number | undefined => {
@@ -362,7 +383,7 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
       // Compared in join order, not sorted: the question is whether each joiner paid more than the
       // one before it.
       monotonicGrowth: synced.length > 1 && synced.every((value, index) => index === 0 || value > synced[index - 1]),
-      agent,
+      agents,
     };
   }
 
@@ -443,7 +464,11 @@ const renderSummary = (result: EdgeJoinLatencyResult): string => {
     `## ${result.ok ? '✅' : '❌'} Join latency — ${result.objects} objects, ${result.joiners} joiners`,
     '',
     `Against \`${result.edge}\`. Seeded and flushed to EDGE in ${ms(result.seedMs)}.${
-      result.agent ? '' : ' ⚠️ Agents off — the seeder admitted every joiner itself, which is slower.'
+      {
+        provisioned: '',
+        disabled: ' ⚠️ Agents off — the seeder admitted every joiner itself, which is slower.',
+        failed: ' ❌ An EDGE agent could not be provisioned; the run stopped and these numbers are partial.',
+      }[result.agents]
     }`,
     '',
     '| | Median | Share of total |',

--- a/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
+++ b/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
@@ -178,7 +178,10 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
     const measurements: JoinMeasurement[] = [];
     let spaceId: string | undefined;
     let seedMs = 0;
-    let agentCreated = false;
+    // Starts true for an `agents: true` run and is falsified by the first client that cannot get
+    // one. Never the other way round: a later client's failure has to be able to correct it, or the
+    // artifact reports an agent-backed fleet on a run where one client had no agent.
+    let agentsProvisioned = spec.agents;
 
     const spawn = async (label: string): Promise<ReplicantBrain<ClientReplicant>> => {
       const replicant = await env.spawn(ClientReplicant, { platform: spec.platform });
@@ -187,6 +190,11 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
       await replicant.brain.init({ edgeUrl, agents: spec.agents, partitions: false });
       const { identityDid } = await replicant.brain.createIdentity({ displayName: label });
       identityDids.push(identityDid);
+      // Tracked from the moment an identity exists, not once the client is fully provisioned:
+      // `_cleanup` walks `spawned`, so a client that fails a later step would otherwise leave its
+      // identity behind in a shared environment. Kept index-aligned with `identityDids`, which
+      // `_cleanup` reads by index to name what it could not delete.
+      spawned.push(replicant);
       // The self-serve cleanup routes 403 an identity with no Hub account; one fixed alias per slot
       // rebinds rather than accumulating rows. It is also what `createAgent` needs — EDGE hosts an
       // agent only for an identity bound to an account.
@@ -202,10 +210,15 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
       // one this plan exists to measure. A green run of the wrong measurement is worse than a red
       // one — the numbers land in a nightly trend that nobody re-reads the caveat for.
       if (spec.agents) {
-        await replicant.brain.createAgent();
-        agentCreated = true;
+        try {
+          await replicant.brain.createAgent();
+        } catch (err) {
+          // A joiner's failure is caught below and recorded as its own row, so without this the
+          // run would go on and the artifact would still claim `agent: true`.
+          agentsProvisioned = false;
+          throw err;
+        }
       }
-      spawned.push(replicant);
       return replicant;
     };
 
@@ -294,7 +307,7 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
         log.info('joiner measured', { ...measurements[measurements.length - 1] });
       }
 
-      const result = this._summarize(edgeUrl, spec, seedMs, measurements, agentCreated);
+      const result = this._summarize(edgeUrl, spec, seedMs, measurements, agentsProvisioned);
       invariant(
         result.ok,
         `joiners failed to sync: ${measurements
@@ -306,7 +319,7 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
     } finally {
       // In `finally` so the artifacts exist however the run ended: a green/red verdict with no
       // numbers behind it is the one output a CI job must never produce.
-      const summary = this._summarize(edgeUrl, spec, seedMs, measurements, agentCreated);
+      const summary = this._summarize(edgeUrl, spec, seedMs, measurements, agentsProvisioned);
       fs.writeFileSync(resultPath, `${JSON.stringify(summary, null, 2)}\n`);
       fs.writeFileSync(path.join(params.outDir, 'summary.md'), renderSummary(summary));
       unregisterCleanup();

--- a/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
+++ b/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
@@ -33,11 +33,13 @@ export type EdgeJoinLatencySpec = {
   /** Peers that accept an invitation, each an identity of its own, each timed independently. */
   joiners: number;
   /**
-   * Give the seeder an EDGE agent.
+   * Give every client an EDGE agent.
    *
    * Required, not cosmetic: `shareSpace` opens a DELEGATED invitation, which EDGE redeems on behalf
    * of a member, and with no agent `EdgeInvitationHandler` answers `No agents in the space.` and
-   * retries until the join fails. Exposed rather than hardcoded so the no-agent path stays testable.
+   * the seeder admits each joiner itself — a different system than this plan measures. Exposed
+   * rather than hardcoded so the no-agent path stays testable; with it on, a client that cannot get
+   * an agent fails the run.
    */
   agents: boolean;
   /**
@@ -93,8 +95,9 @@ export type EdgeJoinLatencyResult = {
    */
   monotonicGrowth: boolean;
   /**
-   * Whether the seeder got its EDGE agent. Without one the DELEGATED invitation is admitted by the
-   * seeder directly, which is slower — so latency is only comparable across runs where this matches.
+   * Whether the clients got their EDGE agents, i.e. whether EDGE redeemed the DELEGATED invitations
+   * rather than the seeder admitting each joiner itself. False only for a `agents: false` run, which
+   * measures the slower fallback — latency is comparable across runs only where this matches.
    */
   agent: boolean;
 };
@@ -177,7 +180,7 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
     let seedMs = 0;
     let agentCreated = false;
 
-    const spawn = async (label: string, agent = false): Promise<ReplicantBrain<ClientReplicant>> => {
+    const spawn = async (label: string): Promise<ReplicantBrain<ClientReplicant>> => {
       const replicant = await env.spawn(ClientReplicant, { platform: spec.platform });
       // Never `partitions`: the offline proxy cannot front an `https:` endpoint, and nothing here
       // cuts a link anyway.
@@ -185,22 +188,22 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
       const { identityDid } = await replicant.brain.createIdentity({ displayName: label });
       identityDids.push(identityDid);
       // The self-serve cleanup routes 403 an identity with no Hub account; one fixed alias per slot
-      // rebinds rather than accumulating rows. On preview the hatch is closed, so this is skipped
-      // and `DX_HUB_API_KEY` is the only way the run's data gets deleted.
+      // rebinds rather than accumulating rows. It is also what `createAgent` needs — EDGE hosts an
+      // agent only for an identity bound to an account.
       if (isDevLikeTarget(spec.edge)) {
         await replicant.brain.bindTestAccount({ hubUrl, email: `test+bladerunner-join-${label}@dxos.org` });
       }
-      if (agent && spec.agents) {
-        try {
-          await replicant.brain.createAgent();
-          agentCreated = true;
-        } catch (err) {
-          // Best-effort, same reasoning as the soak plan: without an agent the DELEGATED invitation
-          // has to be admitted by the seeder itself, which is online throughout, so the join is
-          // slower rather than impossible. Recorded in the result because it changes what the
-          // number means.
-          log.error('agent unavailable; joins will be admitted by the seeder directly', { err });
-        }
+      // The seeder's agent is what makes the invitation an EDGE-redeemed DELEGATED one; the
+      // joiners get one too so every client in the fleet is agent-backed, which is the topology a
+      // real deployment has and the one this measurement is meant to describe.
+      //
+      // Fatal, not best-effort: without an agent `EdgeInvitationHandler` answers `No agents in the
+      // space.` and the seeder admits every joiner directly, which is a different system than the
+      // one this plan exists to measure. A green run of the wrong measurement is worse than a red
+      // one — the numbers land in a nightly trend that nobody re-reads the caveat for.
+      if (spec.agents) {
+        await replicant.brain.createAgent();
+        agentCreated = true;
       }
       spawned.push(replicant);
       return replicant;
@@ -215,8 +218,7 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
     });
 
     try {
-      // The seeder hosts every invitation, so it is the one that needs the agent.
-      const seeder = await spawn('seeder', true);
+      const seeder = await spawn('seeder');
       const created = await seeder.brain.createSpace({ label: 'join-latency' });
       // Kept in a local as well: the outer binding is what `finally` cleans up, but only this one
       // is narrowed to a string for the closures below.
@@ -428,7 +430,7 @@ const renderSummary = (result: EdgeJoinLatencyResult): string => {
     `## ${result.ok ? '✅' : '❌'} Join latency — ${result.objects} objects, ${result.joiners} joiners`,
     '',
     `Against \`${result.edge}\`. Seeded and flushed to EDGE in ${ms(result.seedMs)}.${
-      result.agent ? '' : ' ⚠️ No EDGE agent — the seeder admitted every joiner itself, which is slower.'
+      result.agent ? '' : ' ⚠️ Agents off — the seeder admitted every joiner itself, which is slower.'
     }`,
     '',
     '| | Median | Share of total |',

--- a/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
+++ b/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
@@ -216,8 +216,18 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
       // The self-serve cleanup routes 403 an identity with no Hub account; one fixed alias per slot
       // rebinds rather than accumulating rows. It is also what `createAgent` needs — EDGE hosts an
       // agent only for an identity bound to an account.
+      // Fatal for the same reason `createAgent` is, and counted as the same failure: EDGE hosts an
+      // agent only for an identity bound to an account, so a binding that fails has already decided
+      // the agent cannot exist.
       if (isDevLikeTarget(spec.edge)) {
-        await replicant.brain.bindTestAccount({ hubUrl, email: `test+bladerunner-join-${label}@dxos.org` });
+        try {
+          await replicant.brain.bindTestAccount({ hubUrl, email: `test+bladerunner-join-${label}@dxos.org` });
+        } catch (err) {
+          if (spec.agents) {
+            agents = 'failed';
+          }
+          throw new AgentProvisioningError(label, { cause: err });
+        }
       }
       // The seeder's agent is what makes the invitation an EDGE-redeemed DELEGATED one; the
       // joiners get one too so every client in the fleet is agent-backed, which is the topology a

--- a/packages/e2e/blade-runner/src/spec/edge-stress/plan.ts
+++ b/packages/e2e/blade-runner/src/spec/edge-stress/plan.ts
@@ -335,9 +335,6 @@ export class EdgeStress implements TestPlan<EdgeStressSpec, EdgeStressResult> {
     deviceDids: { client: ClientIndex; identityDid: string }[];
   }> {
     const model = makeFleetModel({ devicesPerIdentity: spec.devicesPerIdentity, limits });
-    // Flipped to false the first time an agent cannot be created, so the rest of the fleet does not
-    // re-attempt a call the environment has already refused.
-    let agentsAvailable = true;
 
     const replicants: ReplicantBrain<ClientReplicant>[] = [];
     for (let index = 0; index < model.clients.length; index++) {
@@ -366,19 +363,13 @@ export class EdgeStress implements TestPlan<EdgeStressSpec, EdgeStressResult> {
           email: `test+bladerunner-${identity}@dxos.org`,
         });
       }
-      if (spec.agents && agentsAvailable) {
-        try {
-          await replicants[owner].brain.createAgent();
-        } catch (err) {
-          // Best-effort: an agent is an always-online member that can admit a joiner when every
-          // device of every member is offline, which `partitions: false` makes unreachable anyway.
-          // Losing it must not cost the whole run — a setup that dies here measures nothing at all,
-          // and the point of running against a deployed environment is to surface its faults, not
-          // to be stopped by them. The model is corrected below so preconditions stay honest.
-          log.error('agent unavailable; continuing without one', { identity, err });
-          agentsAvailable = false;
-          model.limits.agents = false;
-        }
+      // One agent per identity — the agent belongs to the identity, so a second device of the same
+      // identity adds nothing. Fatal, not best-effort: without agents a DELEGATED invitation is
+      // admitted by a member device instead of EDGE, so the fleet the commands run against is not
+      // the one the spec asked for, and a run that quietly measures the fallback is worse than a
+      // red one.
+      if (spec.agents) {
+        await replicants[owner].brain.createAgent();
       }
       for (const device of rest) {
         const { invitationCode } = await replicants[owner].brain.inviteDevice();

--- a/packages/e2e/blade-runner/src/spec/edge-stress/plan.ts
+++ b/packages/e2e/blade-runner/src/spec/edge-stress/plan.ts
@@ -135,12 +135,22 @@ export class EdgeStress implements TestPlan<EdgeStressSpec, EdgeStressResult> {
     trace({ event: 'plan', seed: params.randomSeed, commands: plan.map(describe), plan });
 
     const setupBegin = Date.now();
-    const { replicants, model, identityDids, deviceDids } = await this._setupFleet(
-      env,
-      spec,
-      { edgeUrl, hubUrl },
-      limits,
-    );
+    // Owned here, not by `_setupFleet`, so a throw part-way through still leaves the caller holding
+    // every client that was created. Setup runs before the run's own cleanup registration and
+    // `finally`, so without this a failed setup leaks its identities into a shared environment and
+    // never closes the trace stream. `createAgent` is fatal now, which makes that path reachable.
+    const spawned: ReplicantBrain<ClientReplicant>[] = [];
+    let fleet: Awaited<ReturnType<EdgeStress['_setupFleet']>>;
+    try {
+      fleet = await this._setupFleet(env, spec, { edgeUrl, hubUrl }, limits, spawned);
+    } catch (err) {
+      if (spec.cleanup) {
+        await this._cleanupPartialFleet(edgeUrl, spawned);
+      }
+      traceStream.end();
+      throw err;
+    }
+    const { replicants, model, identityDids, deviceDids } = fleet;
     const setupTimeMs = Date.now() - setupBegin;
     log.info('fleet ready', { setupTimeMs });
     // Same reason as the per-space `spaceId` detail: identities a dead run leaves behind must be
@@ -323,11 +333,36 @@ export class EdgeStress implements TestPlan<EdgeStressSpec, EdgeStressResult> {
    * The topology comes from the same `makeFleetModel` the plan was simulated against, so the fleet
    * cannot be shaped differently from what the plan assumed.
    */
+  /**
+   * Best-effort self-serve delete for a fleet that never finished setting up. `cleanupRun` cannot
+   * be used: it walks the model's identities and indexes `real.replicants` by device, and neither
+   * exists yet when setup throws part-way. No spaces have been created at this point, so each
+   * client only has its own identity to drop.
+   */
+  private async _cleanupPartialFleet(edgeUrl: string, spawned: ReplicantBrain<ClientReplicant>[]): Promise<void> {
+    const refused: string[] = [];
+    for (const [index, replicant] of spawned.entries()) {
+      try {
+        const result = await replicant.brain.deleteOwnData({ spaceIds: [] });
+        refused.push(...result.refused);
+      } catch (err) {
+        log.warn('partial-fleet cleanup threw', { index, err });
+        refused.push(`replicant-${index}`);
+      }
+    }
+    if (refused.length > 0) {
+      // Loud: these are real rows left in a shared environment by a run that never started.
+      log.error('setup left data behind', { edgeUrl, refused });
+    }
+  }
+
   private async _setupFleet(
     env: SchedulerEnvImpl<EdgeStressSpec>,
     spec: EdgeStressSpec,
     urls: { edgeUrl: string; hubUrl: string },
     limits: Model['limits'],
+    /** Filled as each client is spawned, so a caller can clean up a partial fleet; see `run`. */
+    spawned: ReplicantBrain<ClientReplicant>[],
   ): Promise<{
     replicants: ReplicantBrain<ClientReplicant>[];
     model: Model;
@@ -336,7 +371,7 @@ export class EdgeStress implements TestPlan<EdgeStressSpec, EdgeStressResult> {
   }> {
     const model = makeFleetModel({ devicesPerIdentity: spec.devicesPerIdentity, limits });
 
-    const replicants: ReplicantBrain<ClientReplicant>[] = [];
+    const replicants = spawned;
     for (let index = 0; index < model.clients.length; index++) {
       const replicant = await env.spawn(ClientReplicant, { platform: spec.platform });
       await replicant.brain.init({ edgeUrl: urls.edgeUrl, agents: spec.agents, partitions: spec.partitions });


### PR DESCRIPTION
The `EDGE nightly` plans exist to measure EDGE, but the fleet they built was not EDGE-only and not agent-backed — so the 2026-09-08 run measured a different system while reporting green.

## `disableP2pReplication: true`

`edgeFeatures` alone leaves the mesh replicator attached, so peers swapped documents directly over WebRTC. The join-latency artifact shows joiner 3 syncing against another client's `host-…` peer while its EDGE connection was stalled, plus 15 × `Connection timeout waiting 10s for transport to connect` and `SwarmMessenger timeout sending answer to offer` across the fleet. `runtime.client.disableP2pReplication` is the flag that actually enforces what the existing comment already claimed.

## An EDGE agent per client, and a failure is now fatal

Only the seeder was asked for an agent, and a failure to get one was swallowed. Without an agent `EdgeInvitationHandler` answers `No agents in the space.` and the seeder admits every joiner itself — the DELEGATED invitation is never EDGE-redeemed, which is not the system either plan exists to measure. Every client now creates an agent (one per identity in the soak, where the agent belongs to the identity), and a client that cannot get one fails the run rather than quietly downgrading the measurement.

Device invitations stay non-delegated: `EdgeInvitationHandler` redeems only `Invitation_Kind.SPACE`.

## Why the agents were failing, and why this is safe now

Agent creation failed 100% of the time on preview. Root cause was in `dxos/edge`, not here: `identity-service`'s `preview` block bound `HUB_SERVICE` to the **dev** hub, so accounts written to preview's database were looked up in dev's and every identity 403'd as `identity not associated with an account`. Fixed in dxos/edge#1031 along with four other workers carrying the same misbinding.

**Ordering:** that binding fix takes effect on the next deploy of the affected preview workers. Until those are deployed, this PR's fatal-agent behaviour will fail the nightly at setup — which is correct (the run was measuring the wrong thing), but worth landing in that order.

## Testing

`moon run blade-runner:build` and `blade-runner:lint` clean; `pnpm format` applied. No changeset — `@dxos/blade-runner` is private and this is test-harness configuration, not a consumer-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XZXfni8QigysS7qUTLjbu

---
_Generated by [Claude Code](https://claude.ai/code/session_018XZXfni8QigysS7qUTLjbu)_




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Testing**
  - End-to-end scenarios now use EDGE replication consistently for document data while preserving invitation signaling.
  - Device invitations are admitted directly by the client, while space invitations continue through the appropriate handler.
  - Performance and stress scenarios now require agent creation to succeed; setup failures stop runs instead of continuing with reduced coverage.
  - Improved cleanup of partially provisioned clients after setup failures.
  - Clarified reporting for disabled, successfully provisioned, and failed agent states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12996-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
