### PR TITLE
ci: trend the boot graph in PostHog

### DIFF
--- a/.depot/workflows/check.yml
+++ b/.depot/workflows/check.yml
@@ -217,6 +217,17 @@ jobs:
         continue-on-error: true
         run: moon run composer-app:check-boot-budget
 
+      - name: Trend the boot graph
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        env:
+          DX_POSTHOG_API_KEY: ${{ secrets.COMPOSER_APP_PROD_POSTHOG_API_KEY }}
+        run: |
+          node scripts/ci-event.mjs \
+            --event ci.boot-budget \
+            --properties packages/apps/composer-app/out/boot-budget.json \
+            --property app=composer
+
       - name: Record this PR's measurement
         id: head
         if: env.COMPARE == 'true'

--- a/scripts/ci-event.mjs
+++ b/scripts/ci-event.mjs
@@ -1,0 +1,193 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+/**
+ * Records a CI measurement in PostHog as a product-analytics event.
+ *
+ *   node scripts/ci-event.mjs --event ci.boot-budget \
+ *     --properties packages/apps/composer-app/out/boot-budget.json
+ *
+ *   node scripts/ci-event.mjs --batch <file.ndjson> --historical
+ *
+ * Nested objects in the report are flattened one level (`budget.bytes` -> `ciBudgetBytes`) so the
+ * properties stay queryable in HogQL without JSONExtract.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+/** Ingestion host, which is not the app host. Overridable for the US region or a test project. */
+const HOST = process.env.DX_POSTHOG_INGEST_HOST ?? 'https://eu.i.posthog.com';
+
+/**
+ * One id for every CI event. Person profiles are off (see `$process_person_profile` below), so this
+ * never becomes a person; it exists because the capture API requires the field.
+ */
+const DISTINCT_ID = 'ci';
+
+/**
+ * Every property this script sends is namespaced into camelCase, matching the convention the app's
+ * own events use (`spaceId`, `subjectId`). The target is Composer's production analytics project,
+ * where property definitions are global: unprefixed, `bytes` and `count` would sit in the same
+ * autocomplete list as the product's own properties, permanently.
+ */
+const namespaced = (key) => `ci${key[0].toUpperCase()}${key.slice(1)}`;
+
+const UUID_NAMESPACE = '6f2b1a54-9c3d-4e77-9a1f-0d5c8b7e4a21';
+
+/**
+ * PostHog deduplicates on the tuple (uuid, timestamp, event, distinct_id), so a stable uuid only
+ * suppresses a rerun's duplicate if the timestamp is stable too — which is why events default to the
+ * COMMIT's date rather than the run's.
+ */
+export const uuidV5 = (name) => {
+  const namespace = Buffer.from(UUID_NAMESPACE.replaceAll('-', ''), 'hex');
+  const hash = createHash('sha1')
+    .update(Buffer.concat([namespace, Buffer.from(name, 'utf8')]))
+    .digest();
+  hash[6] = (hash[6] & 0x0f) | 0x50;
+  hash[8] = (hash[8] & 0x3f) | 0x80;
+  const hex = hash.subarray(0, 16).toString('hex');
+  return [hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16), hex.slice(16, 20), hex.slice(20, 32)].join('-');
+};
+
+/** Committer date of `sha`, or undefined outside a checkout that has the commit. */
+export const commitTimestamp = (sha) => {
+  try {
+    return execFileSync('git', ['show', '-s', '--format=%cI', sha], { encoding: 'utf8' }).trim();
+  } catch {
+    return undefined;
+  }
+};
+
+const defined = (record) => Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
+
+export const ciContext = () => {
+  const sha = process.env.GITHUB_SHA;
+  return defined({
+    commitSha: sha,
+    commitShort: sha?.slice(0, 10),
+    branch: process.env.GITHUB_REF_NAME,
+    repository: process.env.GITHUB_REPOSITORY,
+    workflow: process.env.GITHUB_WORKFLOW,
+    job: process.env.GITHUB_JOB,
+    trigger: process.env.GITHUB_EVENT_NAME,
+    runId: process.env.GITHUB_RUN_ID,
+    runAttempt: process.env.GITHUB_RUN_ATTEMPT,
+    runnerOs: process.env.RUNNER_OS,
+    runnerArch: process.env.RUNNER_ARCH,
+  });
+};
+
+const flattenOnce = (report) => {
+  const flat = {};
+  for (const [key, value] of Object.entries(report)) {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      for (const [innerKey, innerValue] of Object.entries(value)) {
+        flat[`${key}${innerKey[0].toUpperCase()}${innerKey.slice(1)}`] = innerValue;
+      }
+    } else {
+      flat[key] = value;
+    }
+  }
+  return flat;
+};
+
+const BATCH_SIZE = 100;
+
+/**
+ * Posts events to the capture API. `historical` routes them through the migration pipeline, which is
+ * required for anything backdated more than a day and wrong for anything else.
+ *
+ * Returns false when no project token is configured — the case for a local run or a fork PR, where
+ * silently doing nothing is correct.
+ */
+export const captureCiEvents = async (events, { historical = false } = {}) => {
+  const apiKey = process.env.DX_POSTHOG_API_KEY;
+  if (!apiKey) {
+    console.log('::notice::DX_POSTHOG_API_KEY is unset — skipping CI event capture.');
+    return false;
+  }
+
+  const batch = events.map(({ event, properties, timestamp }) => ({
+    event,
+    timestamp: timestamp ?? new Date().toISOString(),
+    uuid: uuidV5(`${event}|${properties.commitSha ?? timestamp}`),
+    properties: {
+      distinct_id: DISTINCT_ID,
+      // Without this every event mints a person, and a person per commit pollutes every
+      // person-scoped insight in the project for no gain.
+      $process_person_profile: false,
+      ...Object.fromEntries(Object.entries(properties).map(([key, value]) => [namespaced(key), value])),
+    },
+  }));
+
+  for (let offset = 0; offset < batch.length; offset += BATCH_SIZE) {
+    const chunk = batch.slice(offset, offset + BATCH_SIZE);
+    const response = await fetch(`${HOST}/batch/`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(defined({ api_key: apiKey, historical_migration: historical || undefined, batch: chunk })),
+    });
+    if (!response.ok) {
+      throw new Error(`PostHog capture failed: ${response.status} ${await response.text()}`);
+    }
+  }
+
+  console.log(`captured ${batch.length} event(s): ${[...new Set(batch.map((entry) => entry.event))].join(', ')}`);
+  return true;
+};
+
+const main = async () => {
+  const { values } = parseArgs({
+    options: {
+      event: { type: 'string' },
+      properties: { type: 'string' },
+      batch: { type: 'string' },
+      property: { type: 'string', multiple: true, default: [] },
+      timestamp: { type: 'string' },
+      historical: { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.batch) {
+    const events = readFileSync(values.batch, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => JSON.parse(line));
+    await captureCiEvents(events, { historical: values.historical });
+    return;
+  }
+
+  if (!values.event) {
+    throw new Error('--event or --batch is required.');
+  }
+
+  const report = values.properties ? flattenOnce(JSON.parse(readFileSync(values.properties, 'utf8'))) : {};
+  const extra = Object.fromEntries(
+    values.property.map((pair) => {
+      const index = pair.indexOf('=');
+      if (index < 0) {
+        throw new Error(`--property expects key=value, got: ${pair}`);
+      }
+      return [pair.slice(0, index), pair.slice(index + 1)];
+    }),
+  );
+
+  const context = ciContext();
+  const timestamp =
+    values.timestamp === 'now'
+      ? undefined
+      : (values.timestamp ?? (context.commitSha ? commitTimestamp(context.commitSha) : undefined));
+
+  await captureCiEvents([{ event: values.event, timestamp, properties: { ...report, ...context, ...extra } }], {
+    historical: values.historical,
+  });
+};
+
+if (import.meta.filename === process.argv[1]) {
+  await main();
+}


### PR DESCRIPTION
The boot budget check answers whether a commit is over the line. It says nothing about where the graph has been going, and the only record of that today is prose: five re-baseline notes in `check-boot-budget.mjs`, written by hand as the ceiling moved.

This adds a generic sender and wires the boot budget into it.

## What changed

`scripts/ci-event.mjs` posts a CI measurement to PostHog as a product-analytics event. It reads any JSON report, attaches the GitHub Actions context, and sends one event. A new check that wants a series adds a workflow step and no code:

```
node scripts/ci-event.mjs --event ci.boot-budget \
  --properties packages/apps/composer-app/out/boot-budget.json
```

`.depot/workflows/check.yml` gains a `Trend the boot graph` step in the existing `boot-budget` job, which already builds the bundle and writes `out/boot-budget.json` on every main push. The measurement was being thrown away.

## Why events and not metrics

Every measurement is keyed by commit. As a metric attribute a SHA is an unbounded series, and PostHog's own docs name that as the thing not to do. More to the point, the questions worth asking of a benchmark are row queries a pre-aggregated time series cannot answer after the fact: which commit moved this, what the spread was across repeats of one commit. Retention is the other half — product-analytics events outlive the logs and metrics windows by years.

## Notes for review

- **Main only.** A branch's boot graph is noise, and the per-PR question is already answered by the base comparison and its PR comment.
- **Runs after a failed check on purpose.** The check step is `continue-on-error` and `check-boot-budget.mjs` writes the report before it exits, so the commit that crossed the line still lands in the series. That is the one it most needs.
- **`continue-on-error` on the send.** Telemetry must never redden a build.
- **No new secret.** `COMPOSER_APP_PROD_POSTHOG_API_KEY` already exists at repo level. It is the public `phc_` project token the web app ships, so a leak means someone can write junk events, not read data.
- **Naming follows the app's own events** — `ci.boot-budget`, dot-separated with camelCase properties, matching `composer.startup` and `space.object.add`. Every property carries a `ci` prefix because property definitions are global in that project and unprefixed `bytes` and `count` would sit in the same autocomplete list as the product's own, permanently.
- **Timestamps are the commit's date, not the run's.** A job retried hours later lands on the commit it measured. PostHog dedupes on `(uuid, timestamp, event, distinct_id)` and the uuid is a v5 hash of `(event, commit)`, so a rerun resolves to the same row rather than a second point.
- **`$process_person_profile: false`**, otherwise every commit mints a person.

## Testing

Both paths were exercised end to end against a local HTTP sink, and the live path against the real project: 36 daily commits on main were measured offline and sent, and the resulting series matches the re-baseline notes, including the Effect 3 to 4 cut showing up a day before the re-baseline that acknowledged it.

Dashboard: https://eu.posthog.com/project/126171/dashboard/941352

The one-off script that produced that backfill is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-12999-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated tracking of Composer app boot-performance measurements from continuous integration runs.
  - Added support for recording individual or batched CI measurements, including timestamps and associated build context.
  - Measurement reporting is non-blocking, so analytics delivery issues do not fail builds.
  - Historical measurement uploads are supported for backfilling existing CI data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->