### PR TITLE
ci: code-own the boot budget and record the target to get it back down

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,7 @@
 # What composer.space actually ships. Adding or removing a plugin here changes the production app's
 # surface area and its bundle, so it is always reviewed.
 packages/apps/composer-app/src/plugin-defs.production.tsx @wittjosiah
+
+# The eager boot graph's ceiling. Raising it accepts startup cost for every user, so the increase
+# has to be motivated in review rather than merged to make a build pass.
+packages/apps/composer-app/scripts/check-boot-budget.mjs @wittjosiah

--- a/packages/apps/composer-app/scripts/check-boot-budget.mjs
+++ b/packages/apps/composer-app/scripts/check-boot-budget.mjs
@@ -76,6 +76,11 @@ const MAX_PRELOAD_ENTRIES = 25;
  * with `react-toast` still holding the Radix layer. Phase 4b (Toast) measured 4,546,844 with no
  * `@radix-ui` bytes left in the graph: the Zag machines are the new floor, ~186 KB above the
  * 2026-08-31 figure, so the ceiling stays where the Phase 3 re-baseline put it.
+ *
+ * This constant is code-owned: raising it needs a strong, written motivation for the growth being
+ * accepted, not a passing build.
+ *
+ * TODO(wittjosiah): Bring this back to at least 4.25 MB, the lowest ceiling this budget has held.
  */
 const MAX_PRELOAD_BYTES = 4.55 * 1024 * 1024;
 


### PR DESCRIPTION
## What

- `.github/CODEOWNERS`: `@wittjosiah` now owns `packages/apps/composer-app/scripts/check-boot-budget.mjs`.
- `check-boot-budget.mjs`: the doc block on `MAX_PRELOAD_BYTES` states that raising it needs a written motivation for the growth being accepted, and carries `TODO(wittjosiah)` naming 4.25 MB — the lowest ceiling this budget has held — as the number to work back to.

The ceiling itself is unchanged at 4.55 MB.

## Why

The budget has been re-baselined upward five times since it was introduced (6.00 → 4.25 → 4.45 → 4.35 → 4.55 MB, with cuts in between). Raising the constant is always the cheapest way to get a build green, and nothing in the repo made that a decision someone had to defend. Code ownership makes the raise go through review, and the TODO keeps a target on the record rather than leaving the current number as the de facto floor.

## Notes for the reviewer

No behavior change: the check computes and fails exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13000-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified ownership and review guidance for the application’s startup budget.
  - Documented that increasing the preload limit requires written justification due to potential startup-cost impact.
  - Added a note to track restoring the budget ceiling to at least 4.25 MB.

- **Chores**
  - Updated code ownership information for the startup budget check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->