### PR TITLE
ci: fix the tauri desktop and iOS builds

### DIFF
--- a/.github/workflows/deploy-tauri.yaml
+++ b/.github/workflows/deploy-tauri.yaml
@@ -40,9 +40,7 @@ permissions:
 
 env:
   CN_APPLICATION: dxos/composer
-  # Nothing here wants a brew that rewrites itself mid-job: an auto-update is minutes of git against a tree
-  # no step asked to change, and when it fails it takes the install that triggered it down with it. That is
-  # what broke every desktop build from 2026-09-06 on, inside setup-rust-toolchain's own `brew install bash`.
+  # A brew auto-update can fail and take the `brew install` that triggered it down with it.
   HOMEBREW_NO_AUTO_UPDATE: '1'
   HOMEBREW_NO_ENV_HINTS: '1'
   # Released binaries are built from source, never restored from a cache any CI job can write to.
@@ -147,11 +145,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y jq webkit2gtk-4.1
-
-      # No Homebrew step: the cairo/pango/librsvg set this used to install is tauri's *Linux* prerequisite
-      # list, and the crate links none of it (rustls, no openssl, no GTK). Everything the workflow actually
-      # shells out to — jq, git, unzip, gzip, xz — ships in the runner image. See build_tauri_ios for why
-      # installing them anyway was worse than installing nothing.
 
       - name: Update tauri.conf.json
         uses: ./.github/actions/cn-config
@@ -363,11 +356,7 @@ jobs:
           filter: blob:none
           ref: ${{ inputs.ref || github.sha }}
 
-      # xcodegen is the one tool the image lacks; ios-init.sh runs it to generate the Xcode project.
-      # This was actions-use-homebrew-tools with tauri's Linux prerequisite list, which cached its tools by
-      # untarring a whole /opt/homebrew snapshot back as root. On a cache hit that froze brew at whenever
-      # the snapshot was written; on the first miss (2026-09-08) the fontconfig/glib/gdk-pixbuf/librsvg
-      # postinstall hooks failed and took `brew install`'s exit code with them. The crate links none of it.
+      # The only tool ios-init.sh needs that the runner image does not ship.
       - name: Install xcodegen
         run: brew install xcodegen
 

--- a/.github/workflows/deploy-tauri.yaml
+++ b/.github/workflows/deploy-tauri.yaml
@@ -40,6 +40,13 @@ permissions:
 
 env:
   CN_APPLICATION: dxos/composer
+  # actions-use-homebrew-tools restores its tool cache by untarring a snapshot of /opt/homebrew back as
+  # root, so brew's own tree ends up owned by root and pinned to whenever that cache was written. The
+  # next `brew` call auto-updates, half-writes the newer vendored gems before hitting permission denied,
+  # and then aborts on the two sorbet versions it just loaded. That is what broke every desktop build
+  # from 2026-09-06 on, inside setup-rust-toolchain's own `brew install bash`.
+  HOMEBREW_NO_AUTO_UPDATE: '1'
+  HOMEBREW_NO_ENV_HINTS: '1'
   # Released binaries are built from source, never restored from a cache any CI job can write to.
   # Empty disables moon's remote cache; set here rather than via the setup action's
   # `remote-cache` input because this workflow does not use that action.

--- a/.github/workflows/deploy-tauri.yaml
+++ b/.github/workflows/deploy-tauri.yaml
@@ -40,11 +40,9 @@ permissions:
 
 env:
   CN_APPLICATION: dxos/composer
-  # actions-use-homebrew-tools restores its tool cache by untarring a snapshot of /opt/homebrew back as
-  # root, so brew's own tree ends up owned by root and pinned to whenever that cache was written. The
-  # next `brew` call auto-updates, half-writes the newer vendored gems before hitting permission denied,
-  # and then aborts on the two sorbet versions it just loaded. That is what broke every desktop build
-  # from 2026-09-06 on, inside setup-rust-toolchain's own `brew install bash`.
+  # Nothing here wants a brew that rewrites itself mid-job: an auto-update is minutes of git against a tree
+  # no step asked to change, and when it fails it takes the install that triggered it down with it. That is
+  # what broke every desktop build from 2026-09-06 on, inside setup-rust-toolchain's own `brew install bash`.
   HOMEBREW_NO_AUTO_UPDATE: '1'
   HOMEBREW_NO_ENV_HINTS: '1'
   # Released binaries are built from source, never restored from a cache any CI job can write to.
@@ -150,10 +148,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq webkit2gtk-4.1
 
-      - uses: tecolicom/actions-use-homebrew-tools@v1
-        if: matrix.os == 'depot-macos-latest'
-        with:
-          tools: cairo giflib git-lfs jpeg jq libpng librsvg pango pkg-config python-setuptools git unzip gzip xz
+      # No Homebrew step: the cairo/pango/librsvg set this used to install is tauri's *Linux* prerequisite
+      # list, and the crate links none of it (rustls, no openssl, no GTK). Everything the workflow actually
+      # shells out to — jq, git, unzip, gzip, xz — ships in the runner image. See build_tauri_ios for why
+      # installing them anyway was worse than installing nothing.
 
       - name: Update tauri.conf.json
         uses: ./.github/actions/cn-config
@@ -365,9 +363,13 @@ jobs:
           filter: blob:none
           ref: ${{ inputs.ref || github.sha }}
 
-      - uses: tecolicom/actions-use-homebrew-tools@v1
-        with:
-          tools: cairo giflib git-lfs jpeg jq libpng librsvg pango pkg-config python-setuptools git unzip gzip xz xcodegen
+      # xcodegen is the one tool the image lacks; ios-init.sh runs it to generate the Xcode project.
+      # This was actions-use-homebrew-tools with tauri's Linux prerequisite list, which cached its tools by
+      # untarring a whole /opt/homebrew snapshot back as root. On a cache hit that froze brew at whenever
+      # the snapshot was written; on the first miss (2026-09-08) the fontconfig/glib/gdk-pixbuf/librsvg
+      # postinstall hooks failed and took `brew install`'s exit code with them. The crate links none of it.
+      - name: Install xcodegen
+        run: brew install xcodegen
 
       - name: Update tauri.conf.json
         uses: ./.github/actions/cn-config


### PR DESCRIPTION
Every scheduled desktop build since 2026-09-06 died in `Install Rust toolchain`, and iOS was one cache eviction away from the same fate. Both failures trace back to the same Homebrew step.

## Desktop

`actions-rust-lang/setup-rust-toolchain@v1` has an "Unbork mac" step that shells out to `brew install bash`. On the depot macOS runner that triggered an auto-update, which failed:

```
error: unable to create file .github/scripts/Dockerfile.long_runner: Permission denied
error: cannot rebase: You have unstaged changes.
##[error]Attempted to redefine prop :requirement on class Cask::Quarantine::SigningIdentity
```

The cause was upstream of that step. `tecolicom/actions-use-homebrew-tools` restores its tool cache with `sudo tar -C /`, unpacking a whole `/opt/homebrew` snapshot as root — the archive in the failing run was dated Aug 10. Brew's own tree was then root-owned and a month stale. Auto-update installed the newer vendored gems, could not unlink the old ones, and brew died loading sorbet-runtime 0.6.13386 and 0.6.13454 together.

`HOMEBREW_NO_AUTO_UPDATE=1` at the workflow level stops brew rewriting itself mid-job.

## iOS

Verifying the desktop fix surfaced a second break that the stale cache had been hiding. On the first cache miss, `brew install` actually ran:

```
==> Installing librsvg dependency: fontconfig
##[warning]The post-install step did not complete successfully
  brew postinstall fontconfig        (same for glib, gdk-pixbuf, librsvg)
##[error]Process completed with exit code 1
```

Every bottle poured; four postinstall hooks failed and brew took their exit code.

The tool list — `cairo giflib jpeg libpng librsvg pango pkg-config …` — is tauri's **Linux** prerequisite list. The crate links none of it: rustls, no openssl, no GTK. So the action is gone from both jobs. Desktop installs nothing (jq, git, unzip, gzip, xz all ship in the runner image); iOS installs `xcodegen`, which `ios-init.sh` genuinely needs.

That also retires the root-owned snapshot, which would have gone on freezing brew at whenever the cache was last written.

## Verification

Dispatched Deploy Apps at `dev` from this branch.

- [Run 34273955735](https://github.com/dxos/dxos/actions/runs/34273955735), the env var alone — `build_tauri` green in 11m31s, against 11m34s for the last good run on 09-05. `publish_tauri` green. `build_tauri_ios` red, which is what exposed the second problem.
- [Run 34277039207](https://github.com/dxos/dxos/actions/runs/34277039207), with the Homebrew step removed — in flight.

Worth a reviewer's eye: desktop builds without the cached tool snapshot for the first time in this second run. If something in that list mattered after all, it shows up there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS and iOS desktop build process to provide more consistent packaging and release builds.
  * Streamlined required build-tool installation during iOS builds.
  * Reduced unnecessary automated environment updates during build execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13001-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
