### PR TITLE
ci: publish production to CrabNebula's default channel again

### DIFF
--- a/.github/actions/cn-channel/action.yml
+++ b/.github/actions/cn-channel/action.yml
@@ -23,10 +23,10 @@ runs:
           echo 'cn-channel: environment input is required' >&2
           exit 1
         fi
-        # Production keeps the `main` channel it has always shipped on: every build bakes its channel into the
-        # updater endpoint, so moving it to the primary channel would strand installs still polling `main`.
+        # Empty for production, which ships on CrabNebula's default channel — the one the public releases
+        # page lists and the download button serves. A channel here publishes where nobody can reach it.
         if [ "$ENVIRONMENT" = 'production' ]; then
-          echo 'channel=main' >> "$GITHUB_OUTPUT"
+          echo 'channel=' >> "$GITHUB_OUTPUT"
         else
           echo "channel=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/actions/cn-config/action.yml
+++ b/.github/actions/cn-config/action.yml
@@ -46,12 +46,17 @@ runs:
         fi
       shell: bash
 
+    # The channel is baked in here for the life of the install, so an install only ever polls the channel it
+    # was built for. Production omits the parameter and polls the default channel.
     - name: Update endpoints in tauri.conf.json
+      env:
+        CHANNEL: ${{ steps.release-channel.outputs.channel }}
       run: |
         jq \
-          --arg channel "${{ steps.release-channel.outputs.channel }}" \
+          --arg channel "$CHANNEL" \
           '.plugins.updater.endpoints = [
-            "https://cdn.crabnebula.app/update/dxos/composer/{{target}}-{{arch}}/{{current_version}}?channel=\($channel)"
+            "https://cdn.crabnebula.app/update/dxos/composer/{{target}}-{{arch}}/{{current_version}}"
+              + (if $channel == "" then "" else "?channel=" + $channel end)
           ]' \
           "${{ steps.find-tauri-config.outputs.tauri_conf_json_path }}" > "${{ steps.find-tauri-config.outputs.tauri_conf_json_path }}.tmp" && \
         mv "${{ steps.find-tauri-config.outputs.tauri_conf_json_path }}.tmp" "${{ steps.find-tauri-config.outputs.tauri_conf_json_path }}"

--- a/.github/actions/cn-release/action.yml
+++ b/.github/actions/cn-release/action.yml
@@ -31,6 +31,7 @@ runs:
 
     - uses: FabianLars-crabnebula/cloud-release@e0bb6ccebcb78f71883ebde2320f76aae6b9eb92
       with:
-        command: release ${{ inputs.command }} ${{ inputs.application }} --framework ${{ inputs.framework }} --channel ${{ steps.release-channel.outputs.channel }}
+        # An empty channel means the default one, which the CLI selects by being given no `--channel` at all.
+        command: release ${{ inputs.command }} ${{ inputs.application }} --framework ${{ inputs.framework }}${{ steps.release-channel.outputs.channel != '' && format(' --channel {0}', steps.release-channel.outputs.channel) || '' }}
         api-key: ${{ inputs.api-key }}
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
The Composer download page has offered **0.9.1-13, from June 22** ever since [#12359](https://github.com/dxos/dxos/pull/12359) landed on 2026-07-27. Every production release since — 0.10.1 through 0.11.3 — built, signed, notarized and published fine, into a channel nothing routes anyone to.

## What happened

[#11924](https://github.com/dxos/dxos/pull/11924) put production on CrabNebula's default channel on purpose ("publish production branch to default CrabNebula channel"). #12359 then derived every channel from the environment and sent production to `main`, on this reasoning:

> Production keeps the `main` channel it has always shipped on

That was wrong. Production had never shipped on `main`, and the updater endpoint says so:

| Channel | Version | Published |
|---|---|---|
| *(default)* | 0.9.1-13 | 2026-06-23 |
| `main` | 0.11.3 | 2026-09-03 |
| `preview` | 0.11.4-preview.1 | 2026-09-05 |
| `dev` | 0.11.4-dev.10 | 2026-09-08 |
| `production` | — never existed | |

```bash
curl "https://cdn.crabnebula.app/update/dxos/composer/darwin-aarch64/0.0.1"
curl "https://cdn.crabnebula.app/update/dxos/composer/darwin-aarch64/0.0.1?channel=main"
```

The default channel is what the public releases page lists and what its download button serves. So for the last six weeks: new users downloaded June's build, and installs older than 07-27 — which poll the default channel — were offered nothing newer.

## The change

An empty channel now means the default one. Production emits no channel; `cn-release` drops `--channel` and `cn-config` drops `?channel=` from the baked updater endpoint. `dev`, `preview` and `staging` are untouched.

## Who this moves

The channel is baked into each build's updater endpoint for the life of the install, so this decides which cohort keeps getting updates:

- **Installs older than 07-27** poll the default channel. Stranded on 0.9.1-13 today; the next production release reaches them.
- **0.10.1 – 0.11.3** poll `?channel=main` and stop receiving updates.

The second group should be close to empty, because there was no route into it. Reaching 0.10.1+ meant downloading it directly, and the page never offered it — it served 0.9.1-13 the whole time, and a 0.9.1-13 install polls the default channel, which had nothing newer. Auto-update could not carry anyone onto `main`, and neither could the download button. Worth a sanity check against CrabNebula's own download numbers before the next production deploy, since I could not measure the install base from here.

## Verification

Not exercised in CI — this only takes effect on a production deploy, and a production deploy cuts a real release. What I checked directly:

- The jq expression, against all four environments, produces the endpoint with `?channel=` for the three prerelease channels and without it for production.
- The channel script emits an empty value for production and the environment name otherwise.
- The `--channel` argument disappears from the CLI invocation when the channel is empty and is unchanged otherwise.

The first production deploy after this merges is what proves it end to end. It should land on the releases page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Management**
  - Production releases now use the platform’s default release channel automatically.
  - Production updater endpoints no longer include an unnecessary channel parameter.
  - Non-production environments continue using their designated release channels.
  - Release commands now omit the channel option when the default channel should be used, ensuring consistent publishing and update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13002-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
