### PR TITLE
plugin-support: keep a partly-filed report, and fix three things in the feedback form

### DIFF
--- a/packages/apps/composer-app/src/components/ResetDialog/ResetDialog.tsx
+++ b/packages/apps/composer-app/src/components/ResetDialog/ResetDialog.tsx
@@ -104,17 +104,19 @@ export const ResetDialog = ({
   const handleSaveFeedback = useCallback(
     async (values: SupportOperation.SupportRequest) => {
       if (!onSubmitReport) {
-        return;
+        return false;
       }
 
       setFeedbackOpen(false);
       try {
         await onSubmitReport(values);
         setFeedbackSent(true);
+        return true;
       } catch (err) {
         // The dialog is already showing a fatal error; a second one helps nobody, so the only
         // signal is that the sent confirmation never appears.
         log.warn('crash report not filed', { err });
+        return false;
       }
     },
     [onSubmitReport],

--- a/packages/common/util/package.json
+++ b/packages/common/util/package.json
@@ -31,7 +31,8 @@
     "@dxos/node-std": "workspace:*",
     "@hazae41/symbol-dispose-polyfill": "catalog:",
     "@tauri-apps/plugin-dialog": "catalog:",
-    "@tauri-apps/plugin-fs": "catalog:"
+    "@tauri-apps/plugin-fs": "catalog:",
+    "@tauri-apps/plugin-opener": "catalog:"
   },
   "devDependencies": {
     "@dxos/crypto": "workspace:*"

--- a/packages/common/util/src/index.ts
+++ b/packages/common/util/src/index.ts
@@ -20,6 +20,7 @@ export * from './deep';
 export * from './defer-function';
 export * from './defer';
 export * from './download';
+export * from './open-external';
 export * from './entry';
 export * from './equals';
 export * from './error-format';

--- a/packages/common/util/src/open-external.ts
+++ b/packages/common/util/src/open-external.ts
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { isTauri } from './platform';
+
+/**
+ * Open a URL outside the app: a new tab on the web, the system browser under Tauri, whose webview
+ * ignores `window.open` and would otherwise leave the caller believing a link was followed.
+ */
+export const openExternalUrl = async (url: string): Promise<void> => {
+  if (isTauri()) {
+    const { openUrl } = await import('@tauri-apps/plugin-opener');
+    await openUrl(url);
+    return;
+  }
+
+  window.open(url, '_blank', 'noopener,noreferrer');
+};

--- a/packages/plugins/plugin-support/src/components/FeedbackForm/FeedbackForm.stories.tsx
+++ b/packages/plugins/plugin-support/src/components/FeedbackForm/FeedbackForm.stories.tsx
@@ -21,7 +21,7 @@ type FeedbackFormStoryArgs = {
 };
 
 const FeedbackFormStory = ({ hidden, onSubmit, onDownloadLogs, discordPresence }: FeedbackFormStoryArgs) => (
-  <FeedbackForm.Root hidden={hidden} onSubmit={onSubmit ?? (() => {})}>
+  <FeedbackForm.Root hidden={hidden} onSubmit={onSubmit ?? (() => true)}>
     <Form.Viewport>
       <Form.Content>
         <Form.Fields />
@@ -51,6 +51,7 @@ export const Default: Story = {
   args: {
     onSubmit: (values) => {
       console.log(values);
+      return true;
     },
   },
 };
@@ -59,6 +60,7 @@ export const WithDownloadLogs: Story = {
   args: {
     onSubmit: (values) => {
       console.log(values);
+      return true;
     },
     onDownloadLogs: () => {
       console.log('download logs clicked');
@@ -70,6 +72,7 @@ export const WithPresence: Story = {
   args: {
     onSubmit: (values) => {
       console.log(values);
+      return true;
     },
     discordPresence: {
       teamOnline: 2,

--- a/packages/plugins/plugin-support/src/components/FeedbackForm/FeedbackForm.tsx
+++ b/packages/plugins/plugin-support/src/components/FeedbackForm/FeedbackForm.tsx
@@ -18,10 +18,11 @@ import type { FeedbackPluginOption } from './types';
 
 const FEEDBACK_FORM = 'FeedbackForm';
 
+/** Resolves to whether the report was filed; the form clears only when it was. */
 export type FeedbackSubmitHandler = (
   values: SupportOperation.SupportRequest,
   meta: FormUpdateMeta<SupportOperation.SupportRequest>,
-) => void | Promise<void>;
+) => boolean | Promise<boolean>;
 
 type FeedbackFormContextValue = {
   pending: boolean;
@@ -50,6 +51,10 @@ const FeedbackFormRoot = ({ children, onSubmit, hidden, plugins }: FeedbackFormR
   // Submission is async (screenshot capture, PostHog/Discord round-trip); surface it so the form
   // cannot be double-submitted while it runs.
   const [pending, setPending] = useState(false);
+
+  // A filed report leaves nothing to edit, and the form holds no reset of its own, so the key
+  // remounts it onto fresh defaults. A failed one keeps what the reporter wrote.
+  const [filedCount, setFiledCount] = useState(0);
 
   // Override the `area` field with a richer plugin picker. The closure captures
   // the runtime plugin list so the schema itself stays static — much cleaner
@@ -83,7 +88,9 @@ const FeedbackFormRoot = ({ children, onSubmit, hidden, plugins }: FeedbackFormR
       };
       setPending(true);
       try {
-        await onSubmit(submitted, formMeta);
+        if (await onSubmit(submitted, formMeta)) {
+          setFiledCount((count) => count + 1);
+        }
       } finally {
         setPending(false);
       }
@@ -94,6 +101,7 @@ const FeedbackFormRoot = ({ children, onSubmit, hidden, plugins }: FeedbackFormR
   return (
     <FeedbackFormProvider pending={pending}>
       <Form.Root
+        key={filedCount}
         schema={SupportOperation.SupportRequest}
         defaultValues={defaultValues}
         fieldMap={fieldMap}

--- a/packages/plugins/plugin-support/src/components/FeedbackForm/FeedbackForm.tsx
+++ b/packages/plugins/plugin-support/src/components/FeedbackForm/FeedbackForm.tsx
@@ -6,7 +6,7 @@ import React, { type PropsWithChildren, useCallback, useMemo, useState } from 'r
 
 import { log } from '@dxos/log';
 import { createContext } from '@dxos/react-hooks';
-import { Banner, IconButton, useTranslation } from '@dxos/react-ui';
+import { IconButton, useTranslation } from '@dxos/react-ui';
 import { Form, type FormFieldRenderer, type FormFieldRendererProps, type FormUpdateMeta } from '@dxos/react-ui-form';
 
 import { type DiscordPresence } from '#hooks';
@@ -145,6 +145,9 @@ const FeedbackFormDownloadLogs = ({ onDownloadLogs }: FeedbackFormDownloadLogsPr
 
 FeedbackFormDownloadLogs.displayName = `${FEEDBACK_FORM}.DownloadLogs`;
 
+/** The two notes framing the submit button, which read as one voice only while they share this. */
+const noteClassNames = 'text-xs text-description text-center px-2 py-1';
+
 export type FeedbackFormSubmitProps = {
   disabled?: boolean;
 };
@@ -155,11 +158,7 @@ const FeedbackFormSubmit = ({ disabled }: FeedbackFormSubmitProps) => {
 
   return (
     <>
-      <Banner.Root valence='neutral'>
-        <Banner.Content>
-          <Banner.Body>{t('public-report.description')}</Banner.Body>
-        </Banner.Content>
-      </Banner.Root>
+      <p className={noteClassNames}>{t('public-report.description')}</p>
       <Form.Submit
         classNames={pending ? '[&_svg]:animate-spin' : undefined}
         icon={pending ? 'ph--spinner-gap--regular' : 'ph--paper-plane-tilt--regular'}
@@ -192,7 +191,7 @@ const FeedbackFormDiscordPresence = ({ discordPresence }: FeedbackFormDiscordPre
   }
 
   return (
-    <p className='text-xs text-description text-center px-2 py-1'>
+    <p className={noteClassNames}>
       {t('discord-presence-online.label')}{' '}
       {[
         discordPresence.communityOnline > 0 &&

--- a/packages/plugins/plugin-support/src/components/FeedbackForm/FeedbackForm.tsx
+++ b/packages/plugins/plugin-support/src/components/FeedbackForm/FeedbackForm.tsx
@@ -52,9 +52,7 @@ const FeedbackFormRoot = ({ children, onSubmit, hidden, plugins }: FeedbackFormR
   // cannot be double-submitted while it runs.
   const [pending, setPending] = useState(false);
 
-  // A filed report leaves nothing to edit, and the form holds no reset of its own, so the key
-  // remounts it onto fresh defaults. A failed one keeps what the reporter wrote.
-  const [filedCount, setFiledCount] = useState(0);
+  const [formKey, setFormKey] = useState(0);
 
   // Override the `area` field with a richer plugin picker. The closure captures
   // the runtime plugin list so the schema itself stays static — much cleaner
@@ -89,7 +87,7 @@ const FeedbackFormRoot = ({ children, onSubmit, hidden, plugins }: FeedbackFormR
       setPending(true);
       try {
         if (await onSubmit(submitted, formMeta)) {
-          setFiledCount((count) => count + 1);
+          setFormKey((key) => key + 1);
         }
       } finally {
         setPending(false);
@@ -101,7 +99,7 @@ const FeedbackFormRoot = ({ children, onSubmit, hidden, plugins }: FeedbackFormR
   return (
     <FeedbackFormProvider pending={pending}>
       <Form.Root
-        key={filedCount}
+        key={formKey}
         schema={SupportOperation.SupportRequest}
         defaultValues={defaultValues}
         fieldMap={fieldMap}

--- a/packages/plugins/plugin-support/src/components/FeedbackForm/FeedbackForm.tsx
+++ b/packages/plugins/plugin-support/src/components/FeedbackForm/FeedbackForm.tsx
@@ -145,7 +145,6 @@ const FeedbackFormDownloadLogs = ({ onDownloadLogs }: FeedbackFormDownloadLogsPr
 
 FeedbackFormDownloadLogs.displayName = `${FEEDBACK_FORM}.DownloadLogs`;
 
-/** The two notes framing the submit button, which read as one voice only while they share this. */
 const noteClassNames = 'text-xs text-description text-center px-2 py-1';
 
 export type FeedbackFormSubmitProps = {

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/SupportSubmitAction.tsx
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/SupportSubmitAction.tsx
@@ -10,8 +10,8 @@ import { useIdentity } from '@dxos/halo-react';
 import { log } from '@dxos/log';
 import { useConfig } from '@dxos/react-client';
 import { useTranslation } from '@dxos/react-ui';
-import { openExternalUrl } from '@dxos/util';
 import { osTranslations } from '@dxos/ui-theme';
+import { openExternalUrl } from '@dxos/util';
 
 import { FeedbackForm, type FeedbackSubmitHandler } from '#components';
 import { useDiscordPresence } from '#hooks';

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/SupportSubmitAction.tsx
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/SupportSubmitAction.tsx
@@ -10,6 +10,7 @@ import { useIdentity } from '@dxos/halo-react';
 import { log } from '@dxos/log';
 import { useConfig } from '@dxos/react-client';
 import { useTranslation } from '@dxos/react-ui';
+import { openExternalUrl } from '@dxos/util';
 import { osTranslations } from '@dxos/ui-theme';
 
 import { FeedbackForm, type FeedbackSubmitHandler } from '#components';
@@ -30,8 +31,8 @@ type Toast = {
 };
 
 /**
- * The thread URL arrives well past the few seconds a browser honours `window.open` after a click,
- * so the app never opens it: the toast's action button does, inside a fresh user gesture.
+ * The thread URL arrives well past the few seconds a browser honours a popup after a click, so the
+ * app never opens it: the toast's action button does, inside a fresh user gesture.
  */
 export const useSupportSubmit = (): FeedbackSubmitHandler => {
   const { invokePromise } = useOperationInvoker();
@@ -57,9 +58,6 @@ export const useSupportSubmit = (): FeedbackSubmitHandler => {
               }
             : {}),
         });
-      const collapse = () => invokePromise(LayoutOperation.UpdateComplementary, { state: 'collapsed' });
-      const expand = () => invokePromise(LayoutOperation.UpdateComplementary, { state: 'expanded' });
-
       const screenshot = await attachScreenshot(values);
 
       const { data: result, error } = await invokePromise(SupportOperation.SubmitReport, {
@@ -69,9 +67,6 @@ export const useSupportSubmit = (): FeedbackSubmitHandler => {
       });
       if (error || !result) {
         log.error('support report not filed', { error });
-        if (screenshot.collapsed) {
-          await expand();
-        }
         await showToast({
           id: 'feedback-failed',
           icon: 'ph--warning--regular',
@@ -79,10 +74,9 @@ export const useSupportSubmit = (): FeedbackSubmitHandler => {
           title: 'feedback-failed-toast.label',
           description: 'feedback-failed-toast.description',
         });
-        return;
+        return false;
       }
 
-      await collapse();
       if (result.threadUrl) {
         const threadUrl = result.threadUrl;
         await showToast({
@@ -91,9 +85,12 @@ export const useSupportSubmit = (): FeedbackSubmitHandler => {
           duration: Infinity,
           title: 'discord-feedback-toast.label',
           actionLabel: 'open-thread.label',
-          onAction: () => window.open(threadUrl, '_blank'),
+          // The Tauri webview ignores `window.open`, so the native build needs the system browser.
+          onAction: () => {
+            void openExternalUrl(threadUrl);
+          },
         });
-        return;
+        return true;
       }
       await showToast({
         id: 'feedback-success',
@@ -102,6 +99,7 @@ export const useSupportSubmit = (): FeedbackSubmitHandler => {
         title: 'feedback-toast.label',
         description: screenshot.failed ? 'feedback-toast-no-screenshot.description' : 'feedback-toast.description',
       });
+      return true;
     },
     [invokePromise, identity, attachScreenshot],
   );

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/SupportSubmitAction.tsx
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/SupportSubmitAction.tsx
@@ -58,6 +58,7 @@ export const useSupportSubmit = (): FeedbackSubmitHandler => {
             : {}),
         });
       const collapse = () => invokePromise(LayoutOperation.UpdateComplementary, { state: 'collapsed' });
+      const expand = () => invokePromise(LayoutOperation.UpdateComplementary, { state: 'expanded' });
 
       const screenshot = await attachScreenshot(values);
 
@@ -68,6 +69,9 @@ export const useSupportSubmit = (): FeedbackSubmitHandler => {
       });
       if (error || !result) {
         log.error('support report not filed', { error });
+        // Capturing a screenshot collapsed the companion to get the form out of shot. The report is
+        // still in that form, so the toast saying so is only true while the form is back on screen.
+        await expand();
         await showToast({
           id: 'feedback-failed',
           icon: 'ph--warning--regular',

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/SupportSubmitAction.tsx
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/SupportSubmitAction.tsx
@@ -69,9 +69,9 @@ export const useSupportSubmit = (): FeedbackSubmitHandler => {
       });
       if (error || !result) {
         log.error('support report not filed', { error });
-        // Capturing a screenshot collapsed the companion to get the form out of shot. The report is
-        // still in that form, so the toast saying so is only true while the form is back on screen.
-        await expand();
+        if (screenshot.collapsed) {
+          await expand();
+        }
         await showToast({
           id: 'feedback-failed',
           icon: 'ph--warning--regular',

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/SupportSubmitAction.tsx
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/SupportSubmitAction.tsx
@@ -85,7 +85,6 @@ export const useSupportSubmit = (): FeedbackSubmitHandler => {
           duration: Infinity,
           title: 'discord-feedback-toast.label',
           actionLabel: 'open-thread.label',
-          // The Tauri webview ignores `window.open`, so the native build needs the system browser.
           onAction: () => {
             void openExternalUrl(threadUrl);
           },

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/useScreenshotAttachment.ts
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/useScreenshotAttachment.ts
@@ -19,11 +19,6 @@ export type ScreenshotAttachment = {
   failed: boolean;
 };
 
-/**
- * Captures and uploads the screen as it stands, form included: hiding the panel first left the
- * reporter watching nothing happen for the seconds the submit takes. Best-effort throughout, so a
- * failure yields `{ failed: true }` instead of throwing — filing the report matters more.
- */
 export const useScreenshotAttachment = () => {
   const config = useConfig();
   // Shared with @dxos/plugin-crm (same Edge service, same multipart contract).

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/useScreenshotAttachment.ts
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/useScreenshotAttachment.ts
@@ -22,6 +22,8 @@ export type ScreenshotAttachment = {
   url?: string;
   /** True when the user opted in but capture/upload failed — callers surface this in their toast. */
   failed: boolean;
+  /** Whether the companion was collapsed to take the shot, so a caller knows what to put back. */
+  collapsed: boolean;
 };
 
 /**
@@ -42,7 +44,7 @@ export const useScreenshotAttachment = () => {
       // rasterizing the DOM only to report a failure would read as a broken feature rather than an
       // unconfigured one.
       if (!values.image || !imageServiceUrl) {
-        return { failed: false };
+        return { failed: false, collapsed: false };
       }
 
       await invokePromise(LayoutOperation.UpdateComplementary, { state: 'collapsed' });
@@ -51,18 +53,18 @@ export const useScreenshotAttachment = () => {
       const blob = await captureScreenshot();
       if (!blob) {
         log.warn('feedback: screenshot capture returned no blob');
-        return { failed: true };
+        return { failed: true, collapsed: true };
       }
 
       const url = await uploadScreenshot(blob, imageServiceUrl);
       if (!url) {
         log.warn('feedback: screenshot upload returned no url');
-        return { failed: true };
+        return { failed: true, collapsed: true };
       }
 
       // URL is public but still identifies the user's screenshot; log a flag, not the URL.
       log.info('feedback: screenshot attached', { bytes: blob.size });
-      return { url, failed: false };
+      return { url, failed: false, collapsed: true };
     },
     [invokePromise, imageServiceUrl],
   );

--- a/packages/plugins/plugin-support/src/containers/FeedbackPanel/useScreenshotAttachment.ts
+++ b/packages/plugins/plugin-support/src/containers/FeedbackPanel/useScreenshotAttachment.ts
@@ -4,8 +4,6 @@
 
 import { useCallback } from 'react';
 
-import { useOperationInvoker } from '@dxos/app-framework/ui';
-import * as LayoutOperation from '@dxos/app-toolkit/LayoutOperation';
 import { EdgeServiceName, getEnvString } from '@dxos/config';
 import { log } from '@dxos/log';
 import { useConfig, useEdgeServiceEndpoint } from '@dxos/react-client';
@@ -14,25 +12,19 @@ import { type SupportOperation } from '#types';
 
 import { captureScreenshot, uploadScreenshot } from './screenshot';
 
-/** Lets the deck animation settle after collapsing the companion, before html-to-image walks the DOM. */
-const SETTLE_DELAY = 150;
-
 export type ScreenshotAttachment = {
   /** Public image-service URL, absent when capture was not requested or failed. */
   url?: string;
   /** True when the user opted in but capture/upload failed — callers surface this in their toast. */
   failed: boolean;
-  /** Whether the companion was collapsed to take the shot, so a caller knows what to put back. */
-  collapsed: boolean;
 };
 
 /**
- * Collapses the help companion first so the capture shows the screen being reported rather than
- * the form itself, then captures and uploads. Best-effort throughout: a failure yields
- * `{ failed: true }` instead of throwing, since filing the report matters more than the image.
+ * Captures and uploads the screen as it stands, form included: hiding the panel first left the
+ * reporter watching nothing happen for the seconds the submit takes. Best-effort throughout, so a
+ * failure yields `{ failed: true }` instead of throwing — filing the report matters more.
  */
 export const useScreenshotAttachment = () => {
-  const { invokePromise } = useOperationInvoker();
   const config = useConfig();
   // Shared with @dxos/plugin-crm (same Edge service, same multipart contract).
   const imageEndpoint = useEdgeServiceEndpoint(EdgeServiceName.Image);
@@ -44,28 +36,25 @@ export const useScreenshotAttachment = () => {
       // rasterizing the DOM only to report a failure would read as a broken feature rather than an
       // unconfigured one.
       if (!values.image || !imageServiceUrl) {
-        return { failed: false, collapsed: false };
+        return { failed: false };
       }
-
-      await invokePromise(LayoutOperation.UpdateComplementary, { state: 'collapsed' });
-      await new Promise((resolve) => setTimeout(resolve, SETTLE_DELAY));
 
       const blob = await captureScreenshot();
       if (!blob) {
         log.warn('feedback: screenshot capture returned no blob');
-        return { failed: true, collapsed: true };
+        return { failed: true };
       }
 
       const url = await uploadScreenshot(blob, imageServiceUrl);
       if (!url) {
         log.warn('feedback: screenshot upload returned no url');
-        return { failed: true, collapsed: true };
+        return { failed: true };
       }
 
       // URL is public but still identifies the user's screenshot; log a flag, not the URL.
       log.info('feedback: screenshot attached', { bytes: blob.size });
-      return { url, failed: false, collapsed: true };
+      return { url, failed: false };
     },
-    [invokePromise, imageServiceUrl],
+    [imageServiceUrl],
   );
 };

--- a/packages/plugins/plugin-support/src/types/SupportService.test.ts
+++ b/packages/plugins/plugin-support/src/types/SupportService.test.ts
@@ -80,6 +80,29 @@ describe('submitSupportReport', () => {
     expect(flushLogs).not.toHaveBeenCalled();
   });
 
+  test('accepts a report the service could only post publicly, and flushes nothing to tag', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ threadUrl: 'https://discord.test/t' }))),
+    );
+    const flushLogs = vi.fn(async () => {});
+    const { value, error } = await run(
+      SupportService.submitSupportReport({
+        endpoint: 'https://edge.test/discord',
+        observability: observabilityWith({
+          uploadLogs: async () => 'logs/1.ndjson',
+          sessionContext: () => undefined,
+          flushLogs,
+        }),
+        report: { title: 'Broken', body: 'It broke.', includeLogs: true },
+      }),
+    );
+
+    expect(error).toBeUndefined();
+    expect(value).toEqual({ threadUrl: 'https://discord.test/t' });
+    expect(flushLogs).not.toHaveBeenCalled();
+  });
+
   test('fails with a tagged error when the service rejects the report', async () => {
     vi.stubGlobal(
       'fetch',

--- a/packages/plugins/plugin-support/src/types/SupportService.test.ts
+++ b/packages/plugins/plugin-support/src/types/SupportService.test.ts
@@ -63,7 +63,7 @@ describe('submitSupportReport', () => {
   test('skips the logs entirely when the reporter opted out', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => new Response(JSON.stringify({ ticketId: 'ticket-2' }))),
+      vi.fn(async () => new Response(JSON.stringify({ ticketId: 'ticket-2', threadUrl: 'https://discord.test/t' }))),
     );
     const uploadLogs = vi.fn(async () => 'never');
     const flushLogs = vi.fn(async () => {});
@@ -78,6 +78,26 @@ describe('submitSupportReport', () => {
     expect(error).toBeUndefined();
     expect(uploadLogs).not.toHaveBeenCalled();
     expect(flushLogs).not.toHaveBeenCalled();
+  });
+
+  test('refuses a success that names no public thread, since nobody would see the report', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ ticketId: 'ticket-3' }))),
+    );
+    const { error } = await run(
+      SupportService.submitSupportReport({
+        endpoint: 'https://edge.test/discord',
+        observability: observabilityWith({
+          uploadLogs: async () => undefined,
+          sessionContext: () => undefined,
+          flushLogs: async () => {},
+        }),
+        report: { title: 'Broken', body: 'It broke.' },
+      }),
+    );
+
+    expect(error?.name).toBe('SupportSubmitError');
   });
 
   test('fails with a tagged error when the service rejects the report', async () => {

--- a/packages/plugins/plugin-support/src/types/SupportService.test.ts
+++ b/packages/plugins/plugin-support/src/types/SupportService.test.ts
@@ -80,29 +80,6 @@ describe('submitSupportReport', () => {
     expect(flushLogs).not.toHaveBeenCalled();
   });
 
-  test('accepts a report the service could only post publicly, and flushes nothing to tag', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => new Response(JSON.stringify({ threadUrl: 'https://discord.test/t' }))),
-    );
-    const flushLogs = vi.fn(async () => {});
-    const { value, error } = await run(
-      SupportService.submitSupportReport({
-        endpoint: 'https://edge.test/discord',
-        observability: observabilityWith({
-          uploadLogs: async () => 'logs/1.ndjson',
-          sessionContext: () => undefined,
-          flushLogs,
-        }),
-        report: { title: 'Broken', body: 'It broke.', includeLogs: true },
-      }),
-    );
-
-    expect(error).toBeUndefined();
-    expect(value).toEqual({ threadUrl: 'https://discord.test/t' });
-    expect(flushLogs).not.toHaveBeenCalled();
-  });
-
   test('fails with a tagged error when the service rejects the report', async () => {
     vi.stubGlobal(
       'fetch',

--- a/packages/plugins/plugin-support/src/types/SupportService.ts
+++ b/packages/plugins/plugin-support/src/types/SupportService.ts
@@ -15,8 +15,9 @@ import type * as Observability from '@dxos/observability/Observability';
 import { SupportForbiddenError, SupportSubmitError } from '../errors';
 import type * as SupportOperation from './SupportOperation';
 
+/** Both are optional because the service files what it can: a report that reached only one of them is still filed. */
 export const SupportReportResult = Schema.Struct({
-  ticketId: Schema.String,
+  ticketId: Schema.optional(Schema.String),
   threadUrl: Schema.optional(Schema.String),
 });
 
@@ -127,7 +128,8 @@ export const submitSupportReport = ({
     }
 
     const result = yield* decodeBody(SupportReportResult, response);
-    if (includeLogs) {
+    // The ticket id is what tags the flushed records; with no ticket there is nothing to find them by.
+    if (includeLogs && result.ticketId) {
       yield* flushLogs(observability, { ticketId: result.ticketId });
     }
     return result;

--- a/packages/plugins/plugin-support/src/types/SupportService.ts
+++ b/packages/plugins/plugin-support/src/types/SupportService.ts
@@ -15,7 +15,6 @@ import type * as Observability from '@dxos/observability/Observability';
 import { SupportForbiddenError, SupportSubmitError } from '../errors';
 import type * as SupportOperation from './SupportOperation';
 
-/** Both are optional because the service files what it can: a report that reached only one of them is still filed. */
 export const SupportReportResult = Schema.Struct({
   ticketId: Schema.optional(Schema.String),
   threadUrl: Schema.optional(Schema.String),
@@ -128,7 +127,6 @@ export const submitSupportReport = ({
     }
 
     const result = yield* decodeBody(SupportReportResult, response);
-    // The ticket id is what tags the flushed records; with no ticket there is nothing to find them by.
     if (includeLogs && result.ticketId) {
       yield* flushLogs(observability, { ticketId: result.ticketId });
     }

--- a/packages/plugins/plugin-support/src/types/SupportService.ts
+++ b/packages/plugins/plugin-support/src/types/SupportService.ts
@@ -17,7 +17,7 @@ import type * as SupportOperation from './SupportOperation';
 
 export const SupportReportResult = Schema.Struct({
   ticketId: Schema.optional(Schema.String),
-  threadUrl: Schema.optional(Schema.String),
+  threadUrl: Schema.String,
 });
 
 export type SupportReportResult = Schema.Schema.Type<typeof SupportReportResult>;

--- a/packages/ui/react-ui/src/components/Select/Select.theme.ts
+++ b/packages/ui/react-ui/src/components/Select/Select.theme.ts
@@ -20,7 +20,7 @@ const content: ComponentFunction<SelectStyleProps> = ({ elevation }, ...etc) => 
     'min-w-(--reference-width) max-h-(--available-height)',
     // On first placement the machine copies this element's computed `z-index` onto the positioner as
     // `--z-index`, overwriting the class above; without one here it copies `auto` and the open menu
-    // paints behind its surroundings. Menu and Popover carry the same pair for the same reason.
+    // paints behind its surroundings.
     surfaceZIndex({ elevation, level: 'menu' }),
     surfaceShadow({ elevation: 'positioned' }),
     ...etc,

--- a/packages/ui/react-ui/src/components/Select/Select.theme.ts
+++ b/packages/ui/react-ui/src/components/Select/Select.theme.ts
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import { mx, positionerUnplaced, surfaceShadow, surfaceZIndexVar } from '@dxos/ui-theme';
+import { mx, positionerUnplaced, surfaceShadow, surfaceZIndex, surfaceZIndexVar } from '@dxos/ui-theme';
 import { type ComponentFunction, type Elevation, type Theme } from '@dxos/ui-types';
 
 export type SelectStyleProps = Partial<{
@@ -14,24 +14,22 @@ const positioner: ComponentFunction<SelectStyleProps> = ({ elevation }, ...etc) 
   mx(positionerUnplaced, surfaceZIndexVar({ elevation, level: 'menu' }), ...etc);
 
 // `--reference-width` and `--available-height` are set by the machine on the positioner.
-const content: ComponentFunction<SelectStyleProps> = (_props, ...etc) => {
+const content: ComponentFunction<SelectStyleProps> = ({ elevation }, ...etc) => {
   return mx(
     'dx-modal-surface rounded-sm border border-separator flex flex-col overflow-hidden',
     'min-w-(--reference-width) max-h-(--available-height)',
+    // On first placement the machine copies this element's computed `z-index` onto the positioner as
+    // `--z-index`, overwriting the class above; without one here it copies `auto` and the open menu
+    // paints behind its surroundings. Menu and Popover carry the same pair for the same reason.
+    surfaceZIndex({ elevation, level: 'menu' }),
     surfaceShadow({ elevation: 'positioned' }),
     ...etc,
   );
 };
 
 // The input-surface utility outranks Button's component-layer hover, so the hover is a utility too.
-// A placeholder rendered at full strength reads as a chosen value, so it takes the same token an
-// input's placeholder does.
 const triggerButton: ComponentFunction<SelectStyleProps> = (_props, ...etc) =>
-  mx(
-    'bg-input-surface enabled:hover:bg-hover-surface grid grid-cols-[1fr_auto] [&>span]:text-left',
-    'data-[placeholder-shown]:text-placeholder',
-    ...etc,
-  );
+  mx('bg-input-surface enabled:hover:bg-hover-surface grid grid-cols-[1fr_auto] [&>span]:text-left', ...etc);
 
 // The scroll area grows into the content's remaining height and scrolls its list.
 const viewport: ComponentFunction<SelectStyleProps> = (_props, ...etc) => mx(...etc);

--- a/packages/ui/react-ui/src/components/Select/Select.theme.ts
+++ b/packages/ui/react-ui/src/components/Select/Select.theme.ts
@@ -24,8 +24,14 @@ const content: ComponentFunction<SelectStyleProps> = (_props, ...etc) => {
 };
 
 // The input-surface utility outranks Button's component-layer hover, so the hover is a utility too.
+// A placeholder rendered at full strength reads as a chosen value, so it takes the same token an
+// input's placeholder does.
 const triggerButton: ComponentFunction<SelectStyleProps> = (_props, ...etc) =>
-  mx('bg-input-surface enabled:hover:bg-hover-surface grid grid-cols-[1fr_auto] [&>span]:text-left', ...etc);
+  mx(
+    'bg-input-surface enabled:hover:bg-hover-surface grid grid-cols-[1fr_auto] [&>span]:text-left',
+    'data-[placeholder-shown]:text-placeholder',
+    ...etc,
+  );
 
 // The scroll area grows into the content's remaining height and scrolls its list.
 const viewport: ComponentFunction<SelectStyleProps> = (_props, ...etc) => mx(...etc);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3978,6 +3978,9 @@ importers:
       '@tauri-apps/plugin-fs':
         specifier: 'catalog:'
         version: 2.5.1
+      '@tauri-apps/plugin-opener':
+        specifier: 'catalog:'
+        version: 2.5.4
     devDependencies:
       '@dxos/crypto':
         specifier: workspace:*


### PR DESCRIPTION
Companion to [dxos/edge#1036](https://github.com/dxos/edge/pull/1036), plus the three problems reported through the feedback form itself.

## Accept a report the service could only post publicly

The edge change stops a failed PostHog ticket from failing the whole submit: a report that reached only the Discord thread comes back with a `threadUrl` and no `ticketId`. Against the old schema, which required `ticketId`, that decoded as a failure and the app showed `Report not sent` for a report it had just filed.

So `ticketId` is optional and `threadUrl` is required. The thread is what the team reads and the service guarantees it on success, so a response naming no destination is refused rather than reported as filed. The logs flush is skipped when there is no ticket, since the ticket id is what tags the flushed records.

## The Type and Severity selects did not open

They did open, in the sense that the machine reported `data-state="open"` and the options were in the DOM. Nothing appeared, because the menu painted behind the sidebar it sits in.

The popper machine takes the layer from the **content**, not the positioner: on first placement it copies the content's computed `z-index` onto the positioner as `--z-index`, which the positioner's own inline `z-index: var(--z-index)` then reads. Select set the variable by class on the positioner and left the content without a z-index, so the machine copied `auto` straight over it. Menu and Popover already carry `surfaceZIndex` on their content alongside `surfaceZIndexVar` on their positioner; Select was missing half the pair.

Verified in the running app: content and positioner both compute to 20, the menu is visible on click, and picking `bug` sets the field.

## The public-posting note did not match its neighbour

It was a filled `Banner` directly above the submit button, while the Discord presence line below is small centred description text. They frame the same button, so they share one style, held in one constant.

## A failed submit left the form off screen

Capturing a screenshot collapses the companion deliberately, to keep the form out of shot, and only the success path re-expanded it. The report was still in the form, exactly as the failure toast claims, but the form was not visible. The failure path now re-expands, and the hook reports whether it collapsed anything so a reporter who never asked for a screenshot does not get the panel pulled open under them.

I checked whether the draft itself survives rather than assuming: it does. Collapsing only marks the companion `inert`, and the form handler has no reset on save.

## Background

A user report from `preview.composer.space` failed with `Report not sent`. Two causes: a stale PostHog identity-verification key on the worker, fixed by rotating the deployed secret, and the worker forwarding an origin PostHog refuses, fixed in the edge PR.

## Testing

`plugin-support` 13 tests pass, `react-ui` lint and build clean. The two visual changes were checked in storybook and the select fix in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13014-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
