### PR TITLE
Increase soak test command count from 200 to 800

### DIFF
--- a/.depot/workflows/edge-nightly.yml
+++ b/.depot/workflows/edge-nightly.yml
@@ -45,10 +45,12 @@ on:
         type: string
         description: 'Soak: wall-clock budget in minutes'
         default: '60'
+      # Sized so the run keeps issuing commands for at least half an hour: a healthy command costs
+      # ~3s against preview, and overshooting is free because `maxRuntimeMs` stops the run early.
       soak_commands:
         type: string
         description: 'Soak: executable commands to plan'
-        default: '200'
+        default: '800'
 
 permissions:
   contents: read
@@ -169,7 +171,7 @@ jobs:
         env:
           EDGE: ${{ inputs.edge || 'preview' }}
           MINUTES: ${{ inputs.soak_minutes || '60' }}
-          COMMANDS: ${{ inputs.soak_commands || '200' }}
+          COMMANDS: ${{ inputs.soak_commands || '800' }}
         run: |
           SEED="soak-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "Seed: $SEED"


### PR DESCRIPTION
## Summary
Increases the default number of executable commands in the edge-nightly soak test from 200 to 800 to ensure the test maintains sufficient load for at least 30 minutes.

## Changes
- Updated `soak_commands` default parameter from `200` to `800` in the workflow input definition
- Updated the corresponding environment variable default in the soak job from `200` to `800`
- Added explanatory comment clarifying the sizing rationale: ~3s per command against preview, with `maxRuntimeMs` providing early termination safety

## Details
The increased command count ensures the soak test continues issuing commands for the full 30-minute minimum duration. Since each command costs approximately 3 seconds against the preview environment and overshooting is safe (the `maxRuntimeMs` parameter stops the run early), 800 commands provides adequate headroom for sustained testing.

https://claude.ai/code/session_018gPVT7MufEntNjEAiA4Xkx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the nightly edge stress test run from 200 to 800 commands for broader coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13019-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
