### PR TITLE
types: hide the Milestone type from user-facing surfaces

### DIFF
--- a/.changeset/milestone-hidden-type.md
+++ b/.changeset/milestone-hidden-type.md
@@ -1,0 +1,5 @@
+---
+'@dxos/types': patch
+---
+
+Mark the Milestone type as hidden so it no longer appears in user-facing type lists.

--- a/packages/core/echo/echo/src/internal/Annotation/annotations.ts
+++ b/packages/core/echo/echo/src/internal/Annotation/annotations.ts
@@ -275,6 +275,8 @@ export type SchemaMeta = TypeMeta & { id: string };
 /**
  * Identifies a schema as hidden from user-facing surfaces (like dotfiles — visible only via an advanced setting).
  */
+// TODO(wittjosiah): Invert the default? Hide every type unless it opts in, so a new type is
+//   invisible until someone marks it as user-facing rather than visible until someone hides it.
 export const HiddenAnnotationId = '@dxos/schema/annotation/Hidden';
 export const HiddenAnnotation = createAnnotationHelper<boolean>(HiddenAnnotationId);
 

--- a/packages/sdk/types/src/types/Milestone.ts
+++ b/packages/sdk/types/src/types/Milestone.ts
@@ -7,7 +7,7 @@
 import * as Schema from 'effect/Schema';
 
 import { Annotation, DXN, Format, Obj, Type } from '@dxos/echo';
-import { GeneratorAnnotation, LabelAnnotation } from '@dxos/echo/Annotation';
+import { GeneratorAnnotation, HiddenAnnotation, LabelAnnotation } from '@dxos/echo/Annotation';
 
 /**
  * An ordered span of work within a {@link TaskSet}, mirroring a Linear/GitHub milestone (sync
@@ -26,6 +26,7 @@ export class Milestone extends Type.makeObject<Milestone>(DXN.make('org.dxos.typ
   }).pipe(
     Schema.annotate({ title: 'Milestone' }),
     LabelAnnotation.set(['name']),
+    HiddenAnnotation.set(true),
     Annotation.IconAnnotation.set({ icon: 'ph--flag-banner--regular', hue: 'amber' }),
   ),
 ) {}


### PR DESCRIPTION
## What

- `HiddenAnnotation.set(true)` on the `Milestone` schema.
- A TODO on `HiddenAnnotationId` asking whether the default should be inverted.

## Why

A milestone is always reached through its task set or a task's `milestone` ref. Nothing opens one on its own, so its row in a space's Database section is noise. Thread and Transcript are hidden for the same reason.

The Database section lists a static type only when the space already holds an object of it, so today Milestone appears the moment a project has one. The annotation drops it from that list unless the space's `showHidden` setting is on. Milestone objects stay reachable through their task set and through task refs, and the tasks plugin operations that create, list and delete milestones are untouched.

The TODO records the open question: the annotation defaults to visible, so every internal type has to remember to opt out, and the ones that forget show up in users' type lists. Inverting it would mean marking the user-facing types instead. Tagged to @wittjosiah since it is a call about the annotation's contract, not about this change.

## Review notes

Two lines of annotation and a comment. No behavior beyond what the Database section connector already does with the annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hid the Milestone type from user-facing type lists.
* **Documentation**
  * Added a note about potential future changes to default schema visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13025-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
