### PR TITLE
ci: increase test shard matrix from 4 to 6

### DIFF
--- a/.depot/workflows/check.yml
+++ b/.depot/workflows/check.yml
@@ -375,7 +375,7 @@ jobs:
   # (`:test-storybook`) and the Cloudflare Workers runtime (`:test-workerd`). They used to be three
   # jobs split by flavour, which fixed each shard's size to its flavour's total — storybook alone ran
   # far longer than workerd, and no amount of runners helped. `moon exec --job N --job-total` partitions
-  # the whole target set instead, so the four cells are sized by work rather than by kind and a new
+  # the whole target set instead, so the six cells are sized by work rather than by kind and a new
   # suite lands wherever there is room. File parallelism stays disabled — overloaded runners flake — so
   # the win is concurrency across machines, not within one. `--on-failure continue` because moon's
   # default bail drops a failing cell's remaining targets, hiding what they cost.
@@ -384,9 +384,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version: ['24.11.1']
-        # 0-based: `--job` is an index. Four cells against the ~13m the three flavour jobs' critical
+        # 0-based: `--job` is an index. Six cells against the ~13m the three flavour jobs' critical
         # path took, over ~160s of fixed per-cell setup.
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5]
     runs-on: depot-ubuntu-24.04-8
     container:
       image: ghcr.io/dxos/gh-actions:${{ matrix.node-version }}
@@ -444,13 +444,13 @@ jobs:
           quarantine: true
           run: >-
             moon exec --on-failure continue :test :test-browser :test-storybook :test-workerd
-            --job ${{ matrix.shard }} --job-total 4 -- --no-file-parallelism
+            --job ${{ matrix.shard }} --job-total 6 -- --no-file-parallelism
 
       - name: Test (no analytics)
         if: ${{ env.TRUNK_TOKEN == '' }}
         run: >-
           moon exec --on-failure continue :test :test-browser :test-storybook :test-workerd
-          --job ${{ matrix.shard }} --job-total 4 -- --no-file-parallelism
+          --job ${{ matrix.shard }} --job-total 6 -- --no-file-parallelism
 
       - name: Upload Test Results
         if: always()


### PR DESCRIPTION
Widens the `test` job's shard matrix in `.depot/workflows/check.yml` from 4 to 6 runners:

- `shard: [0, 1, 2, 3]` → `shard: [0, 1, 2, 3, 4, 5]`
- `moon exec ... --job-total 4` → `--job-total 6` in both the Trunk-analytics and no-analytics Test steps
- comment updated to say six cells

`moon exec --job/--job-total` partitions the whole target set, so no per-suite assignment changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GWu7iMdT2mrsiThfgxBhz

---
_Generated by [Claude Code](https://claude.ai/code/session_013GWu7iMdT2mrsiThfgxBhz)_

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13040-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
