### PR TITLE
protocols, lint: make every Any producer name its type_url convention

### DIFF
--- a/.changeset/any-pack-convention-lint.md
+++ b/.changeset/any-pack-convention-lint.md
@@ -1,0 +1,16 @@
+---
+'@dxos/echo': patch
+---
+
+`Any` producers now name their `type_url` convention explicitly.
+
+`@dxos/protocols/buf` exports `anyPackPrefixed` alongside `anyPackBare`, and a new
+`@dxos/rules/no-raw-any-pack` lint rule rejects raw `anyPack`. Both forms are required at the EDGE
+boundary by different readers — credential assertions resolve by bare type name, while the router and
+messenger strip a `type.googleapis.com/` prefix — and neither reader errors on the wrong form, so the
+choice now has to be made at the call site rather than inherited from buf's default.
+
+Existing call sites moved to whichever helper preserves their current behaviour, so there is no wire
+change. One exception: `@dxos/plugin-script`'s `getAccessCredential` packed its `ServiceAccess`
+assertion with the prefix, which EDGE's registry does not resolve; it now emits the bare form like
+every other assertion emitter.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -46,6 +46,7 @@
     "@dxos/eslint-plugin-rules/no-bare-dot-imports": "error",
     "@dxos/eslint-plugin-rules/no-dead-tailwind-logical": "error",
     "@dxos/eslint-plugin-rules/no-effect-run-promise": "error",
+    "@dxos/eslint-plugin-rules/no-raw-any-pack": "error",
     "@dxos/eslint-plugin-rules/operation-key-shape": "error",
     "@dxos/eslint-plugin-rules/prefer-sizing-utilities": "warn",
     "@dxos/eslint-plugin-rules/no-empty-promise-catch": "error",

--- a/packages/common/eslint-plugin-rules/index.js
+++ b/packages/common/eslint-plugin-rules/index.js
@@ -16,6 +16,7 @@ import noBareDotImports from './rules/no-bare-dot-imports.js';
 import noDeadTailwindLogical from './rules/no-dead-tailwind-logical.js';
 import noEffectRunPromise from './rules/no-effect-run-promise.js';
 import noEmptyPromiseCatch from './rules/no-empty-promise-catch.js';
+import noRawAnyPack from './rules/no-raw-any-pack.js';
 import operationKeyShape from './rules/operation-key-shape.js';
 import preferSizingUtilities from './rules/prefer-sizing-utilities.js';
 import translationKeyFormat from './rules/translation-key-format.js';
@@ -40,6 +41,7 @@ const plugin = {
     'no-bare-dot-imports': noBareDotImports,
     'no-dead-tailwind-logical': noDeadTailwindLogical,
     'no-effect-run-promise': noEffectRunPromise,
+    'no-raw-any-pack': noRawAnyPack,
     'operation-key-shape': operationKeyShape,
     'prefer-sizing-utilities': preferSizingUtilities,
     'no-empty-promise-catch': noEmptyPromiseCatch,
@@ -56,6 +58,7 @@ const plugin = {
         'dxos-plugin/import-as-namespace': 'error',
         'dxos-plugin/no-bare-dot-imports': 'error',
         'dxos-plugin/no-effect-run-promise': 'error',
+        'dxos-plugin/no-raw-any-pack': 'error',
         'dxos-plugin/no-empty-promise-catch': 'error',
         // TODO(dmaretskyi): Turned off due to large number of errors and no auto-fix.
         // 'dxos-plugin/comment': 'error',

--- a/packages/common/eslint-plugin-rules/rules/no-raw-any-pack.js
+++ b/packages/common/eslint-plugin-rules/rules/no-raw-any-pack.js
@@ -1,0 +1,60 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+'use strict';
+
+/**
+ * ESLint rule forcing every `Any` producer to name its `type_url` convention.
+ *
+ * `anyPack` writes the spec form `type.googleapis.com/<name>`, but the registries on both sides of
+ * the EDGE boundary are split: credential assertions are keyed by the bare name, while the router
+ * and messenger read the type out with `split('/')[1]` and need the prefix. Neither reader errors on
+ * the wrong form — one 500s in production, the other silently yields `undefined` — so the choice has
+ * to be visible at the call site rather than inherited from buf's default.
+ * @example
+ * // bad
+ * anyPack(SomeSchema, message);
+ * bufWkt.anyPack(SomeSchema, message);
+ *
+ * // good
+ * anyPackBare(SomeSchema, message); // registries keyed by the bare type name
+ * anyPackPrefixed(SomeSchema, message); // readers that strip a `type.googleapis.com/` prefix
+ */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow raw anyPack; require anyPackBare or anyPackPrefixed from @dxos/protocols/buf.',
+      recommended: true,
+    },
+    messages: {
+      noRawAnyPack:
+        'Use anyPackBare or anyPackPrefixed from @dxos/protocols/buf instead of anyPack, so the type_url convention is explicit.',
+    },
+    schema: [],
+  },
+  create(context) {
+    const report = (node) => context.report({ node, messageId: 'noRawAnyPack' });
+
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+        if (callee.type === 'Identifier' && callee.name === 'anyPack') {
+          report(node);
+          return;
+        }
+
+        // The namespace form, `bufWkt.anyPack(...)`, is how @dxos/protocols re-exports reach callers.
+        if (
+          callee.type === 'MemberExpression' &&
+          !callee.computed &&
+          callee.property.type === 'Identifier' &&
+          callee.property.name === 'anyPack'
+        ) {
+          report(node);
+        }
+      },
+    };
+  },
+};

--- a/packages/core/halo/credentials/src/credentials/credentials-document.test.ts
+++ b/packages/core/halo/credentials/src/credentials/credentials-document.test.ts
@@ -3,12 +3,11 @@
 //
 
 import { create, toBinary } from '@bufbuild/protobuf';
-import { anyPack } from '@bufbuild/protobuf/wkt';
 import { describe, expect, test } from 'vitest';
 
 import { invariant } from '@dxos/invariant';
 import { PublicKey, SpaceId } from '@dxos/keys';
-import { fromDate, fromPublicKey, requirePublicKey } from '@dxos/protocols/buf';
+import { anyPackPrefixed, fromDate, fromPublicKey, requirePublicKey } from '@dxos/protocols/buf';
 import { bufRegistry } from '@dxos/protocols/buf-registry';
 import { ClaimSchema, type Credential, CredentialSchema } from '@dxos/protocols/buf/dxos/halo/credentials_pb';
 
@@ -106,7 +105,7 @@ const credential = (
     parentCredentialIds: parentCredentialIds.map(fromPublicKey),
     subject: create(ClaimSchema, {
       id: fromPublicKey(PublicKey.random()),
-      assertion: anyPack(desc, create(desc, {})),
+      assertion: anyPackPrefixed(desc, create(desc, {})),
     }),
   });
 };

--- a/packages/core/mesh/edge-client/src/protocol.ts
+++ b/packages/core/mesh/edge-client/src/protocol.ts
@@ -3,7 +3,7 @@
 //
 
 import { invariant } from '@dxos/invariant';
-import { buf, bufWkt } from '@dxos/protocols/buf';
+import { anyPackPrefixed, buf, bufWkt } from '@dxos/protocols/buf';
 import { type Message, MessageSchema, type PeerSchema } from '@dxos/protocols/buf/dxos/edge/messenger_pb';
 import { bufferToArray } from '@dxos/util';
 
@@ -87,7 +87,7 @@ export class Protocol {
       target,
       tags,
       serviceId,
-      payload: payload ? bufWkt.anyPack(type, buf.create(type, payload)) : undefined,
+      payload: payload ? anyPackPrefixed(type, buf.create(type, payload)) : undefined,
     });
   }
 }

--- a/packages/core/mesh/rpc/src/service.test.ts
+++ b/packages/core/mesh/rpc/src/service.test.ts
@@ -3,13 +3,14 @@
 //
 
 import { create } from '@bufbuild/protobuf';
-import { anyPack, anyUnpack } from '@bufbuild/protobuf/wkt';
+import { anyUnpack } from '@bufbuild/protobuf/wkt';
 import { AnySchema, EmptySchema } from '@bufbuild/protobuf/wkt';
 import { beforeEach, describe, expect, test } from 'vitest';
 
 import { latch, sleep } from '@dxos/async';
 import { Stream } from '@dxos/async';
 import { Context, TRACE_SPAN_ATTRIBUTE } from '@dxos/context';
+import { anyPackPrefixed } from '@dxos/protocols/buf';
 import { bufRegistry } from '@dxos/protocols/buf-registry';
 import { type BufService, getBufService } from '@dxos/protocols/buf-service';
 import {
@@ -503,7 +504,7 @@ describe('Protobuf service', () => {
               expect(request?.$typeName).toEqual('example.testing.rpc.PingRequest');
               expect((request as PingRequest | undefined)?.nonce).toEqual(5);
               return create(MessageWithAnySchema, {
-                payload: anyPack(PingReponseSchema, create(PingReponseSchema, { nonce: 10 })),
+                payload: anyPackPrefixed(PingReponseSchema, create(PingReponseSchema, { nonce: 10 })),
               });
             },
           },
@@ -522,7 +523,7 @@ describe('Protobuf service', () => {
 
       const response = await client.rpc.TestAnyService.testCall(
         create(MessageWithAnySchema, {
-          payload: anyPack(PingRequestSchema, create(PingRequestSchema, { nonce: 5 })),
+          payload: anyPackPrefixed(PingRequestSchema, create(PingRequestSchema, { nonce: 5 })),
         }),
       );
 

--- a/packages/core/mesh/teleport-extension-gossip/src/gossip-extension.test.ts
+++ b/packages/core/mesh/teleport-extension-gossip/src/gossip-extension.test.ts
@@ -3,12 +3,11 @@
 //
 
 import { create } from '@bufbuild/protobuf';
-import { anyPack } from '@bufbuild/protobuf/wkt';
 import { describe, expect, onTestFinished, test } from 'vitest';
 
 import { Trigger } from '@dxos/async';
 import { PublicKey } from '@dxos/keys';
-import { fromDate, fromPublicKey, requirePublicKey } from '@dxos/protocols/buf';
+import { anyPackPrefixed, fromDate, fromPublicKey, requirePublicKey } from '@dxos/protocols/buf';
 import { PeerStateSchema } from '@dxos/protocols/buf/dxos/mesh/presence_pb';
 import { type GossipMessage, GossipMessageSchema } from '@dxos/protocols/buf/dxos/mesh/teleport/gossip_pb';
 import { TestBuilder, TestPeer } from '@dxos/teleport/testing';
@@ -44,7 +43,7 @@ describe('GossipExtension', () => {
         channelId: 'dxos.mesh.teleport.gossip',
         timestamp: fromDate(new Date()),
         messageId: fromPublicKey(PublicKey.random()),
-        payload: anyPack(
+        payload: anyPackPrefixed(
           PeerStateSchema,
           create(PeerStateSchema, {
             connections: [fromPublicKey(peer2.peerId)],
@@ -60,7 +59,7 @@ describe('GossipExtension', () => {
         channelId: 'dxos.mesh.teleport.gossip',
         timestamp: fromDate(new Date()),
         messageId: fromPublicKey(PublicKey.random()),
-        payload: anyPack(
+        payload: anyPackPrefixed(
           PeerStateSchema,
           create(PeerStateSchema, {
             connections: [fromPublicKey(peer1.peerId)],

--- a/packages/core/mesh/teleport-extension-gossip/src/presence.ts
+++ b/packages/core/mesh/teleport-extension-gossip/src/presence.ts
@@ -3,14 +3,14 @@
 //
 
 import { create } from '@bufbuild/protobuf';
-import { type Any, anyPack, anyUnpack } from '@bufbuild/protobuf/wkt';
+import { type Any, anyUnpack } from '@bufbuild/protobuf/wkt';
 
 import { Event, scheduleTaskInterval } from '@dxos/async';
 import { Resource } from '@dxos/context';
 import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
-import { fromPublicKey, requirePublicKey, toDate, toPublicKey } from '@dxos/protocols/buf';
+import { anyPackPrefixed, fromPublicKey, requirePublicKey, toDate, toPublicKey } from '@dxos/protocols/buf';
 import { type PeerState, PeerStateSchema } from '@dxos/protocols/buf/dxos/mesh/presence_pb';
 import { type GossipMessage } from '@dxos/protocols/buf/dxos/mesh/teleport/gossip_pb';
 import { ComplexMap } from '@dxos/util';
@@ -139,7 +139,7 @@ export class Presence extends Resource {
 
   /** Gossip routes `Any` payloads generically, so presence packs its own channel's state. */
   private _toAnnounce(state: PeerState): Any {
-    return anyPack(PeerStateSchema, state);
+    return anyPackPrefixed(PeerStateSchema, state);
   }
 
   private _receiveAnnounces(message: GossipMessage): void {

--- a/packages/core/protocols/src/buf/index.ts
+++ b/packages/core/protocols/src/buf/index.ts
@@ -65,12 +65,8 @@ export const fromTimeframe = (timeframe: Timeframe): TimeframeVector =>
     frames: timeframe.frames().map(([feedKey, seq]) => ({ feedKey: feedKey.asUint8Array(), seq })),
   });
 
-/**
- * Packs a JSON payload as `google.protobuf.Any` carrying a `Struct`.
- *
- * A gossip channel's payload is opaque to the router, so a caller with a plain JSON message
- * encodes it as the well-known `Struct` rather than declaring a proto for it.
- */
+/* eslint-disable @dxos/rules/no-raw-any-pack -- the sanctioned wrappers below are what the rule points callers to. */
+
 /**
  * The bare type name a `type_url` carries. `anyPack` writes `type.googleapis.com/<name>`, the legacy
  * codec wrote the bare name, and every registry here is keyed by the bare name either way.
@@ -90,6 +86,21 @@ export const anyPackBare = <Desc extends DescMessage>(desc: Desc, message: Messa
   return packed;
 };
 
+/**
+ * Packs a message into an `Any` whose `type_url` carries the `type.googleapis.com/` prefix.
+ *
+ * EDGE's router and messenger read the type out with `split('/')[1]`, so a bare url leaves them
+ * with `undefined`; those wire formats need the spec form the prefix provides.
+ */
+export const anyPackPrefixed = <Desc extends DescMessage>(desc: Desc, message: MessageShape<Desc>): Any =>
+  anyPack(desc, message);
+
+/**
+ * Packs a JSON payload as `google.protobuf.Any` carrying a `Struct`.
+ *
+ * A gossip channel's payload is opaque to the router, so a caller with a plain JSON message
+ * encodes it as the well-known `Struct` rather than declaring a proto for it.
+ */
 export const packJson = (value: JsonObject): Any => anyPack(StructSchema, fromJson(StructSchema, value));
 
 /** Reads a `google.protobuf.Any` packed by {@link packJson}. */

--- a/packages/plugins/plugin-script/src/util/functions.ts
+++ b/packages/plugins/plugin-script/src/util/functions.ts
@@ -9,7 +9,7 @@ import * as Script from '@dxos/compute/Script';
 import { Obj } from '@dxos/echo';
 import { type PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
-import { bufWkt, createBuf, fromDate, fromPublicKey } from '@dxos/protocols/buf';
+import { anyPackBare, createBuf, fromDate, fromPublicKey } from '@dxos/protocols/buf';
 import {
   ClaimSchema,
   type Credential,
@@ -83,7 +83,7 @@ export const getAccessCredential = (identityKey: PublicKey): Credential => {
     issuanceDate: fromDate(new Date()),
     subject: createBuf(ClaimSchema, {
       id: key,
-      assertion: bufWkt.anyPack(
+      assertion: anyPackBare(
         ServiceAccessSchema,
         createBuf(ServiceAccessSchema, {
           serverName: 'hub.dxos.network',

--- a/packages/sdk/config/src/config.test.ts
+++ b/packages/sdk/config/src/config.test.ts
@@ -3,9 +3,10 @@
 //
 
 import { create, createRegistry, fromBinary, fromJson, toBinary, toJson } from '@bufbuild/protobuf';
-import { StructSchema, anyPack } from '@bufbuild/protobuf/wkt';
+import { StructSchema } from '@bufbuild/protobuf/wkt';
 import { describe, expect, test } from 'vitest';
 
+import { anyPackPrefixed } from '@dxos/protocols/buf';
 import { ConfigSchema } from '@dxos/protocols/buf/dxos/config_pb';
 
 import { Config, mapFromKeyValues, mapToKeyValues } from './config';
@@ -61,7 +62,7 @@ test('Runtime and module config', () => {
         modules: [
           {
             name: 'example:app/tasks',
-            record: anyPack(StructSchema, fromJson(StructSchema, { web: { entryPoint: 'main.js' } })),
+            record: anyPackPrefixed(StructSchema, fromJson(StructSchema, { web: { entryPoint: 'main.js' } })),
           },
         ],
       },


### PR DESCRIPTION
Follow-up to #13036, which fixed the production regression but left the underlying hazard in place.

## The hazard

`anyPack` writes the spec form `type.googleapis.com/<name>`. Both forms are *required* at the EDGE
boundary, by different readers:

- **Credential assertions want bare.** EDGE keys its assertion registry by `schema.typeName` and
  emits bare itself. A prefixed url misses the lookup — that was #13036's 500, 24,149 times.
- **Service messages want prefixed.** EDGE's router (`worker/router.ts`) and `messenger-client`
  both read the type out with `split('/')[1]`, which yields `undefined` for a bare url.

Neither reader errors on the wrong form. One 500s in production; the other silently produces
`undefined`. And buf normalizes on read (`typeUrlToName` slices at the last `/`), so an emitter that
picks the wrong convention keeps working against every buf consumer and fails only against the
hand-rolled ones. There is no type error and no test failure — which is exactly how #13036 shipped.

So the fix is not to ban a *form*. It is to ban the *silent default*.

## Change

`@dxos/protocols/buf` now exports both conventions as named helpers, and raw `anyPack` is a lint
error:

```ts
anyPackBare(desc, message);     // registries keyed by the bare type name
anyPackPrefixed(desc, message); // readers that strip a `type.googleapis.com/` prefix
```

`@dxos/rules/no-raw-any-pack` catches both the bare call and the `bufWkt.anyPack(…)` namespace form.
The single `eslint-disable` is in `packages/core/protocols/src/buf/index.ts`, where the two wrappers
are defined — the one place that legitimately calls through to buf's default.

All nine existing call sites were migrated to whichever helper **preserves current behaviour**.
`anyPackPrefixed` is a pass-through, so there is no wire change anywhere in this PR.

One exception, and it is the reason the rule earns its keep: the rule surfaced a **third credential
assertion emitter** the #13036 audit missed — `plugin-script/src/util/functions.ts:86`, which builds
a `ServiceAccess` assertion. It is now `anyPackBare`, matching the other two emitters. It is reached
only from a story today, so this was latent rather than live.

Also fixes a doc comment #13036 orphaned: the `Struct`/gossip block had drifted off `packJson`.

## Validation

- `oxlint packages/ tools/` — **0** `no-raw-any-pack` violations, no errors in any file touched here.
  (The `tools/qa-lint` errors in that output are pre-existing — identical with these changes stashed.)
- `moon run credentials:test config:test rpc:test teleport-extension-gossip:test` — **147 passed**,
  exit 0.
- `pnpm knip` — exit 0.
- `pnpm format` clean.

## Not in this PR

EDGE normalizing on read (`typeNameOf` in its `getAssertionType`) is the change that makes this class
of bug impossible rather than merely currently-absent, but it lives in `dxos/edge` and needs a deploy.
It is in flight there alongside the pin bump off the pre-migration snapshot.

Context: `.agents/projects/protobufjs-to-buf/EDGE-ASSERTION-TYPE-URL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7

---
_Generated by [Claude Code](https://claude.ai/code/session_0199xrm5iqEvapyF8RiEDjq7)_

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13041-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
