### PR TITLE
teleport: guard control extension lifecycle against abort before open

### DIFF
--- a/.changeset/teleport-control-abort-before-open.md
+++ b/.changeset/teleport-control-abort-before-open.md
@@ -1,0 +1,7 @@
+---
+'@dxos/teleport': patch
+---
+
+Fixed a `TypeError: Cannot read properties of undefined (reading 'abort')` thrown from `ControlExtension.onAbort` when a Teleport session is aborted while its handshake is still in flight.
+
+`Teleport` registers the control extension before opening it, and `abort()`/`destroy()` invoke the lifecycle hooks of every registered extension — so an abort racing `onOpen` (for example a swarm renegotiating and closing the connection from `Peer.onOffer`) reached `this._rpc.abort()` before `_rpc` had been assigned. The RPC peer and extension context are now optional-typed and guarded in `onAbort`, `onClose`, the context error handler and the heartbeat's `RpcClosedError` branch, matching the pattern `RpcExtension` already used. The thrown error previously masked the real reason the connection was closing.

--- a/packages/core/mesh/teleport/src/control-extension.test.ts
+++ b/packages/core/mesh/teleport/src/control-extension.test.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, test } from 'vitest';
+
+import { PublicKey } from '@dxos/keys';
+
+import { ControlExtension } from './control-extension';
+
+const createExtension = () =>
+  new ControlExtension(
+    { heartbeatInterval: 10_000, heartbeatTimeout: 60_000, onTimeout: () => {} },
+    PublicKey.random(),
+    PublicKey.random(),
+  );
+
+describe('ControlExtension', () => {
+  // Teleport aborts every registered extension, including one whose `onOpen` has not completed.
+  test('onAbort before onOpen does not throw', async () => {
+    await createExtension().onAbort();
+  });
+
+  test('onClose before onOpen does not throw', async () => {
+    await createExtension().onClose();
+  });
+
+  test('registerExtension before onOpen throws a descriptive error', async () => {
+    await expect(createExtension().registerExtension('test')).rejects.toThrow(/not open/);
+  });
+});

--- a/packages/core/mesh/teleport/src/control-extension.test.ts
+++ b/packages/core/mesh/teleport/src/control-extension.test.ts
@@ -8,13 +8,6 @@ import { PublicKey } from '@dxos/keys';
 
 import { ControlExtension } from './control-extension';
 
-const createExtension = () =>
-  new ControlExtension(
-    { heartbeatInterval: 10_000, heartbeatTimeout: 60_000, onTimeout: () => {} },
-    PublicKey.random(),
-    PublicKey.random(),
-  );
-
 describe('ControlExtension', () => {
   // Teleport aborts every registered extension, including one whose `onOpen` has not completed.
   test('onAbort before onOpen does not throw', async () => {
@@ -29,3 +22,10 @@ describe('ControlExtension', () => {
     await expect(createExtension().registerExtension('test')).rejects.toThrow(/not open/);
   });
 });
+
+const createExtension = () =>
+  new ControlExtension(
+    { heartbeatInterval: 10_000, heartbeatTimeout: 60_000, onTimeout: () => {} },
+    PublicKey.random(),
+    PublicKey.random(),
+  );

--- a/packages/core/mesh/teleport/src/control-extension.ts
+++ b/packages/core/mesh/teleport/src/control-extension.ts
@@ -7,6 +7,7 @@ import { EmptySchema } from '@bufbuild/protobuf/wkt';
 
 import { TimeoutError as AsyncTimeoutError, asyncTimeout, scheduleTaskInterval } from '@dxos/async';
 import { Context } from '@dxos/context';
+import { invariant } from '@dxos/invariant';
 import { type PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { RpcClosedError } from '@dxos/protocols';
@@ -41,14 +42,15 @@ type ControlExtensionOpts = {
 export class ControlExtension implements TeleportExtension {
   private readonly _ctx = new Context({
     onError: (err) => {
-      this._extensionContext.close(err);
+      this._extensionContext?.close(err);
     },
   });
 
   public readonly onExtensionRegistered = new Callback<(extensionName: string) => void>();
 
-  private _extensionContext!: ExtensionContext;
-  private _rpc!: ProtoRpcPeer<{ Control: ControlService }>;
+  // Assigned in `onOpen`; both remain undefined if the extension is aborted or closed before it opens.
+  private _extensionContext?: ExtensionContext;
+  private _rpc?: ProtoRpcPeer<{ Control: ControlService }>;
 
   constructor(
     private readonly opts: ControlExtensionOpts,
@@ -57,13 +59,14 @@ export class ControlExtension implements TeleportExtension {
   ) {}
 
   async registerExtension(name: string): Promise<void> {
+    invariant(this._rpc, 'Control extension not open.');
     await this._rpc.rpc.Control.registerExtension(create(RegisterExtensionRequestSchema, { name }));
   }
 
   async onOpen(extensionContext: ExtensionContext): Promise<void> {
     this._extensionContext = extensionContext;
 
-    this._rpc = createProtoRpcPeer<ControlRpcBundle, ControlRpcBundle>({
+    const rpc = createProtoRpcPeer<ControlRpcBundle, ControlRpcBundle>({
       requested: {
         Control: getBufService<ControlService>('dxos.mesh.teleport.control.ControlService'),
       },
@@ -95,8 +98,9 @@ export class ControlExtension implements TeleportExtension {
       }),
       timeout: this.opts.heartbeatTimeout,
     });
+    this._rpc = rpc;
 
-    await this._rpc.open();
+    await rpc.open();
 
     scheduleTaskInterval(
       this._ctx,
@@ -104,9 +108,7 @@ export class ControlExtension implements TeleportExtension {
         const reqTS = new Date();
         try {
           const resp = await asyncTimeout(
-            this._rpc.rpc.Control.heartbeat(
-              create(ControlHeartbeatRequestSchema, { requestTimestamp: fromDate(reqTS) }),
-            ),
+            rpc.rpc.Control.heartbeat(create(ControlHeartbeatRequestSchema, { requestTimestamp: fromDate(reqTS) })),
             this.opts.heartbeatTimeout,
           );
           const now = Date.now();
@@ -139,7 +141,7 @@ export class ControlExtension implements TeleportExtension {
           if (err instanceof RpcClosedError) {
             // TODO: expose 'closed' event in Rpc peer to close context as soon the the peer gets closed
             log('ignoring RpcClosedError in heartbeat');
-            this._extensionContext.close(err);
+            this._extensionContext?.close(err);
             return;
           }
           if (err instanceof AsyncTimeoutError) {
@@ -157,11 +159,11 @@ export class ControlExtension implements TeleportExtension {
 
   async onClose(err?: Error): Promise<void> {
     await this._ctx.dispose();
-    await this._rpc.close();
+    await this._rpc?.close();
   }
 
   async onAbort(err?: Error | undefined): Promise<void> {
     await this._ctx.dispose();
-    await this._rpc.abort();
+    await this._rpc?.abort();
   }
 }

--- a/packages/core/mesh/teleport/src/control-extension.ts
+++ b/packages/core/mesh/teleport/src/control-extension.ts
@@ -58,6 +58,10 @@ export class ControlExtension implements TeleportExtension {
     private readonly remotePeerId: PublicKey,
   ) {}
 
+  /**
+   * Announces a local extension to the remote peer.
+   * @throws If called before `onOpen` has initialized the control RPC.
+   */
   async registerExtension(name: string): Promise<void> {
     invariant(this._rpc, 'Control extension not open.');
     await this._rpc.rpc.Control.registerExtension(create(RegisterExtensionRequestSchema, { name }));


### PR DESCRIPTION
Fixes the `TypeError: Cannot read properties of undefined (reading 'abort')` thrown from `ControlExtension.onAbort`:

```
TypeError: Cannot read properties of undefined (reading 'abort')
    at ControlExtension.onAbort (teleport/…)
    at async Teleport.abort (teleport/…)
    at async SpaceProtocolSession.abort (client-services/…)
    at async Connection._closeProtocol (network-manager/…)
    at async Peer.onOffer (network-manager/…)
    at async Swarm.onOffer (network-manager/…)
```

## Root cause

`ControlExtension` declared `_rpc` and `_extensionContext` with definite assignment (`!`), but only assigns them partway through `onOpen` — after an `await extensionContext.createPort(...)`.

`Teleport.open()` inserts the control extension into `_extensions` *before* calling `_openExtension`, and both `abort()` and `destroy()` iterate every registered extension and invoke its lifecycle hook. So an abort that races the handshake — here a swarm renegotiating and closing the connection from `Peer.onOffer` — reaches `this._rpc.abort()` while `_rpc` is still `undefined`.

The thrown `TypeError` was also masking the real reason the connection was closing, since `Teleport.abort` swallows per-extension errors into `log.catch`.

## Changes

- `_rpc` and `_extensionContext` are optional-typed instead of `!`, so the compiler enforces the guards rather than assuming an invariant that does not hold.
- `onAbort` / `onClose` use `this._rpc?.abort()` / `?.close()`.
- The `Context` error handler and the heartbeat's `RpcClosedError` branch use `this._extensionContext?.close(err)` — the same race, and that one would have thrown from inside an error handler.
- The heartbeat loop captures the local `rpc` binding so it never observes the optional field.
- `registerExtension` asserts via `invariant` — calling it before open is a genuine ordering bug and should fail loudly, not with a property-of-undefined.

This matches the pattern `RpcExtension` in the same package already used, which is why every other `TeleportExtension` implementation (all subclasses of it) tolerates the same call order.

Added `control-extension.test.ts` covering abort-before-open, close-before-open, and the `registerExtension` invariant.

## Not addressed

`Teleport.abort()` / `destroy()` invoke lifecycle hooks on extensions that were never opened, which is arguably the contract that should change — `TeleportExtension` implementors have no signal that `onOpen` may be skipped. Every other implementation happens to tolerate it, so this PR fixes the one outlier rather than reworking the contract.

## Verification

```
$ moon run teleport:test
 Test Files  5 passed (5)
      Tests  17 passed (17)

$ npx tsc --noEmit -p tsconfig.json    # clean
$ moon run teleport:lint               # clean
$ pnpm format                          # no changes to the touched files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JLEA5mJExLkqCcqDpCh3i

---
_Generated by [Claude Code](https://claude.ai/code/session_014JLEA5mJExLkqCcqDpCh3i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Teleport session aborts occurring during the handshake, preventing errors when cancellation happens before the session is fully opened.
  - Improved handling when closing or aborting sessions before their connection is ready.
  - Ensured heartbeat and extension registration continue to behave safely throughout the connection lifecycle.

- **Tests**
  - Added coverage for aborting and closing sessions before opening completes.
  - Added validation that extension registration is rejected when the connection is not open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13042-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
