### PR TITLE
blade-runner: trend EDGE join latency in PostHog

### DIFF
--- a/.depot/workflows/edge-nightly.yml
+++ b/.depot/workflows/edge-nightly.yml
@@ -122,8 +122,8 @@ jobs:
         working-directory: packages/e2e/blade-runner
         run: cat "$(ls -td out/results/*/ | head -1)summary.md" >> "$GITHUB_STEP_SUMMARY" || true
 
-      # Whole output tree: `join-latency.json`, `summary.md`, and one `replicant.out.log` per peer —
-      # what an agent needs to explain a red run without reproducing it.
+      # Whole output tree: `join-latency.json`, `summary.md`, `join-latency.metrics.json`, and one
+      # `replicant.out.log` per peer — what an agent needs to explain a red run without reproducing it.
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v7
@@ -131,6 +131,28 @@ jobs:
           name: edge-join-latency
           path: packages/e2e/blade-runner/out
           retention-days: 14
+
+      # Last, and bounded: `captureCiEvents` posts without a request deadline, so a hung capture
+      # ahead of the upload would cost the artifacts — the half of a red run's output that cannot be
+      # recreated. `continue-on-error` because telemetry must never redden a build, and `always()`
+      # because the run that crossed a threshold is the one the series most needs.
+      #
+      # `--timestamp now` departs from `ci.boot-budget`, which dates each event by the commit it
+      # measured. That is right for a per-push measurement and wrong here: the schedule fires against
+      # whatever main happens to be, so two nights with no merge between them would share a commit,
+      # and with it both the default timestamp and the dedup uuid — collapsing onto one point. What
+      # this measures is deployed EDGE at 02:00 UTC, whose date is the run's, not the commit's.
+      - name: Trend the join latency
+        if: always()
+        continue-on-error: true
+        timeout-minutes: 2
+        env:
+          DX_POSTHOG_API_KEY: ${{ secrets.COMPOSER_APP_PROD_POSTHOG_API_KEY }}
+        run: |
+          node scripts/ci-event.mjs \
+            --event ci.edge-join-latency \
+            --timestamp now \
+            --properties "$(ls -td packages/e2e/blade-runner/out/results/*/ | head -1)join-latency.metrics.json"
 
   # An hour of randomized commands against a fleet of real peers, asserted against an in-memory
   # model. Independent of `join-latency`: a red soak should not withhold a latency number.

--- a/.depot/workflows/edge-nightly.yml
+++ b/.depot/workflows/edge-nightly.yml
@@ -122,7 +122,7 @@ jobs:
         working-directory: packages/e2e/blade-runner
         run: cat "$(ls -td out/results/*/ | head -1)summary.md" >> "$GITHUB_STEP_SUMMARY" || true
 
-      # Whole output tree: `join-latency.json`, `summary.md`, `join-latency.metrics.json`, and one
+      # Whole output tree: `join-latency.json`, `summary.md`, `join-latency.events.ndjson`, and one
       # `replicant.out.log` per peer — what an agent needs to explain a red run without reproducing it.
       - name: Upload results
         if: always()
@@ -137,11 +137,14 @@ jobs:
       # recreated. `continue-on-error` because telemetry must never redden a build, and `always()`
       # because the run that crossed a threshold is the one the series most needs.
       #
-      # `--timestamp now` departs from `ci.boot-budget`, which dates each event by the commit it
-      # measured. That is right for a per-push measurement and wrong here: the schedule fires against
-      # whatever main happens to be, so two nights with no merge between them would share a commit,
-      # and with it both the default timestamp and the dedup uuid — collapsing onto one point. What
-      # this measures is deployed EDGE at 02:00 UTC, whose date is the run's, not the commit's.
+      # The plan writes one event per joiner plus one for the run, each already carrying its own
+      # timestamp, so the statistics are computed where they are read rather than shipped precomputed.
+      #
+      # Those timestamps are the run's, departing from `ci.boot-budget`, which dates each event by the
+      # commit it measured. That is right for a per-push measurement and wrong here: the schedule
+      # fires against whatever main happens to be, so two nights with no merge between them would
+      # share a commit, and with it the default timestamp — collapsing onto one point. What this
+      # measures is deployed EDGE at 02:00 UTC, whose date is the run's, not the commit's.
       - name: Trend the join latency
         if: always()
         continue-on-error: true
@@ -150,9 +153,7 @@ jobs:
           DX_POSTHOG_API_KEY: ${{ secrets.COMPOSER_APP_PROD_POSTHOG_API_KEY }}
         run: |
           node scripts/ci-event.mjs \
-            --event ci.edge-join-latency \
-            --timestamp now \
-            --properties "$(ls -td packages/e2e/blade-runner/out/results/*/ | head -1)join-latency.metrics.json"
+            --batch "$(ls -td packages/e2e/blade-runner/out/results/*/ | head -1)join-latency.events.ndjson"
 
   # An hour of randomized commands against a fleet of real peers, asserted against an in-memory
   # model. Independent of `join-latency`: a red soak should not withhold a latency number.

--- a/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
+++ b/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
@@ -73,6 +73,12 @@ export type JoinMeasurement = {
   msPerObject: number | undefined;
   ok: boolean;
   error?: string;
+  /**
+   * When this joiner finished, not when the run did. Joiners are measured one after another, so
+   * these differ by seconds — which is what keeps their events apart in a store that deduplicates
+   * on (uuid, timestamp), the uuid being shared by everything from one commit.
+   */
+  at: string;
 };
 
 export type EdgeJoinLatencyResult = {
@@ -88,8 +94,6 @@ export type EdgeJoinLatencyResult = {
   medianSpaceReadyMs: number | undefined;
   medianReplicationMs: number | undefined;
   medianSyncedMs: number | undefined;
-  /** Fastest and slowest joiner: the whiskers either side of the mean's spread. */
-  minSyncedMs: number | undefined;
   maxSyncedMs: number | undefined;
   /**
    * Mean and sample spread of `syncedMs` across the joiners that finished. Trended nightly rather
@@ -322,6 +326,7 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
             msPerObject: replicationMs !== undefined && spec.objects > 0 ? replicationMs / spec.objects : undefined,
             ok: settled.ok,
             error: settled.ok ? undefined : `digest still differed after ${spec.joinTimeoutMs}ms`,
+            at: new Date().toISOString(),
           });
         } catch (err) {
           // The fallback is for a joiner that failed to sync — one bad row, the rest still measured.
@@ -342,6 +347,7 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
             // threw nor the cause under it, and the replicant never logged it because the error
             // crossed the RPC boundary. The artifact has to carry what a local repro would show.
             error: describeError(err),
+            at: new Date().toISOString(),
           });
         }
         log.info('joiner measured', { ...measurements[measurements.length - 1] });
@@ -367,8 +373,10 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
         fs.writeFileSync(resultPath, `${JSON.stringify(summary, null, 2)}\n`);
         fs.writeFileSync(path.join(params.outDir, 'summary.md'), renderSummary(summary));
         fs.writeFileSync(
-          path.join(params.outDir, 'join-latency.metrics.json'),
-          `${JSON.stringify(renderMetrics(summary), null, 2)}\n`,
+          path.join(params.outDir, 'join-latency.events.ndjson'),
+          renderEvents(summary, new Date().toISOString())
+            .map((event) => `${JSON.stringify(event)}\n`)
+            .join(''),
         );
       } finally {
         unregisterCleanup();
@@ -416,7 +424,6 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
       medianSpaceReadyMs: median((measurement) => measurement.spaceReadyMs),
       medianReplicationMs: median((measurement) => measurement.replicationMs),
       medianSyncedMs: median((measurement) => measurement.syncedMs),
-      minSyncedMs: synced.length > 0 ? Math.min(...synced) : undefined,
       maxSyncedMs: synced.length > 0 ? Math.max(...synced) : undefined,
       meanSyncedMs,
       stddevSyncedMs,
@@ -473,32 +480,57 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
 }
 
 /**
- * The run as a flat record for `scripts/ci-event.mjs`, which flattens one level and namespaces every
- * key. Separate from `join-latency.json` because that one embeds `measurements`, and an array of
- * per-joiner objects lands in an event store as one opaque property rather than as a series.
+ * The run as the events `scripts/ci-event.mjs --batch` posts: one fact per joiner, and one for the
+ * run itself.
  *
- * Undefined fields are dropped by `JSON.stringify`, so a run that produced no number sends no
- * property rather than a zero the trend would average in.
+ * Per joiner rather than a precomputed mean and spread, so the statistics are derived where they are
+ * read. An event store computes `avg`, `stddevSamp` and `quantile` over rows, which means a night
+ * that ran twice aggregates as one population of joiners instead of as an average of averages, and a
+ * question nobody asked yet does not need a new field shipped and backfilled before it can be.
+ *
+ * The run event is not redundant with them: `seedMs` and `agents` describe the run, not any joiner,
+ * and a run whose joiners all failed emits no joiner events at all — without it that night would be
+ * invisible rather than red.
+ *
+ * Undefined fields are dropped by `JSON.stringify`, so a joiner that produced no number sends no
+ * property rather than a zero an average would quietly absorb.
  */
-const renderMetrics = (result: EdgeJoinLatencyResult) => ({
-  ok: result.ok,
-  edge: result.edge,
-  objects: result.objects,
-  joiners: result.joiners,
-  joinersOk: result.measurements.filter((measurement) => measurement.ok).length,
-  // Latency is comparable across runs only where this matches; the trend filters on it.
-  agents: result.agents,
-  seedMs: result.seedMs,
-  meanSyncedMs: result.meanSyncedMs,
-  stddevSyncedMs: result.stddevSyncedMs,
-  medianSyncedMs: result.medianSyncedMs,
-  minSyncedMs: result.minSyncedMs,
-  maxSyncedMs: result.maxSyncedMs,
-  medianAdmittedMs: result.medianAdmittedMs,
-  medianReplicationMs: result.medianReplicationMs,
-  medianSpaceReadyMs: result.medianSpaceReadyMs,
-  monotonicGrowth: result.monotonicGrowth,
-});
+const renderEvents = (result: EdgeJoinLatencyResult, at: string) => [
+  {
+    event: 'ci.edge-join-latency',
+    timestamp: at,
+    properties: {
+      ok: result.ok,
+      edge: result.edge,
+      objects: result.objects,
+      joiners: result.joiners,
+      joinersOk: result.measurements.filter((measurement) => measurement.ok).length,
+      agents: result.agents,
+      seedMs: result.seedMs,
+    },
+  },
+  ...result.measurements.map((measurement) => ({
+    event: 'ci.edge-join-latency.joiner',
+    timestamp: measurement.at,
+    // Five joiners share the run's commit, and so would share a dedup uuid without this.
+    dedup: `joiner-${measurement.joiner}`,
+    properties: {
+      joiner: measurement.joiner,
+      ok: measurement.ok,
+      admittedMs: measurement.admittedMs,
+      spaceReadyMs: measurement.spaceReadyMs,
+      replicationMs: measurement.replicationMs,
+      syncedMs: measurement.syncedMs,
+      msPerObject: measurement.msPerObject,
+      error: measurement.error,
+      // Carried from the run so a query over joiners can filter on comparability without joining
+      // back to it: latency is only comparable where the deployment, the size and `agents` match.
+      edge: result.edge,
+      objects: result.objects,
+      agents: result.agents,
+    },
+  })),
+];
 
 /**
  * The run as a CI job summary. Written by the plan rather than by a workflow script so the same

--- a/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
+++ b/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
@@ -88,7 +88,16 @@ export type EdgeJoinLatencyResult = {
   medianSpaceReadyMs: number | undefined;
   medianReplicationMs: number | undefined;
   medianSyncedMs: number | undefined;
+  /** Fastest and slowest joiner: the whiskers either side of the mean's spread. */
+  minSyncedMs: number | undefined;
   maxSyncedMs: number | undefined;
+  /**
+   * Mean and sample spread of `syncedMs` across the joiners that finished. Trended nightly rather
+   * than the median, because a band needs a centre and a width and a median has no width: a run
+   * whose mean held while its spread doubled is a regression the medians above cannot show.
+   */
+  meanSyncedMs: number | undefined;
+  stddevSyncedMs: number | undefined;
   /**
    * Whether each successive joiner took longer than the last. Flat is the expected shape; a rising
    * one means joiners are contending — measured against a degraded local stack, never against dev.
@@ -353,6 +362,10 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
       const summary = this._summarize(edgeUrl, spec, seedMs, measurements, agents);
       fs.writeFileSync(resultPath, `${JSON.stringify(summary, null, 2)}\n`);
       fs.writeFileSync(path.join(params.outDir, 'summary.md'), renderSummary(summary));
+      fs.writeFileSync(
+        path.join(params.outDir, 'join-latency.metrics.json'),
+        `${JSON.stringify(renderMetrics(summary), null, 2)}\n`,
+      );
       unregisterCleanup();
       if (spec.cleanup) {
         await this._cleanup(edgeUrl, spawned, spaceId, identityDids);
@@ -378,6 +391,14 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
       return values.length > 0 ? values[Math.floor(values.length / 2)] : undefined;
     };
     const synced = ok.map((measurement) => measurement.syncedMs ?? 0);
+    const meanSyncedMs =
+      synced.length > 0 ? synced.reduce((total, value) => total + value, 0) / synced.length : undefined;
+    // Sample rather than population: five joiners estimate a spread, they do not constitute one.
+    // Undefined below two, where there is nothing to be spread apart.
+    const stddevSyncedMs =
+      meanSyncedMs === undefined || synced.length < 2
+        ? undefined
+        : Math.sqrt(synced.reduce((total, value) => total + (value - meanSyncedMs) ** 2, 0) / (synced.length - 1));
     return {
       ok: measurements.length === spec.joiners && measurements.every((measurement) => measurement.ok),
       edge: edgeUrl,
@@ -389,7 +410,10 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
       medianSpaceReadyMs: median((measurement) => measurement.spaceReadyMs),
       medianReplicationMs: median((measurement) => measurement.replicationMs),
       medianSyncedMs: median((measurement) => measurement.syncedMs),
+      minSyncedMs: synced.length > 0 ? Math.min(...synced) : undefined,
       maxSyncedMs: synced.length > 0 ? Math.max(...synced) : undefined,
+      meanSyncedMs,
+      stddevSyncedMs,
       // Compared in join order, not sorted: the question is whether each joiner paid more than the
       // one before it.
       monotonicGrowth: synced.length > 1 && synced.every((value, index) => index === 0 || value > synced[index - 1]),
@@ -443,6 +467,34 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
 }
 
 /**
+ * The run as a flat record for `scripts/ci-event.mjs`, which flattens one level and namespaces every
+ * key. Separate from `join-latency.json` because that one embeds `measurements`, and an array of
+ * per-joiner objects lands in an event store as one opaque property rather than as a series.
+ *
+ * Undefined fields are dropped by `JSON.stringify`, so a run that produced no number sends no
+ * property rather than a zero the trend would average in.
+ */
+const renderMetrics = (result: EdgeJoinLatencyResult) => ({
+  ok: result.ok,
+  edge: result.edge,
+  objects: result.objects,
+  joiners: result.joiners,
+  joinersOk: result.measurements.filter((measurement) => measurement.ok).length,
+  // Latency is comparable across runs only where this matches; the trend filters on it.
+  agents: result.agents,
+  seedMs: result.seedMs,
+  meanSyncedMs: result.meanSyncedMs,
+  stddevSyncedMs: result.stddevSyncedMs,
+  medianSyncedMs: result.medianSyncedMs,
+  minSyncedMs: result.minSyncedMs,
+  maxSyncedMs: result.maxSyncedMs,
+  medianAdmittedMs: result.medianAdmittedMs,
+  medianReplicationMs: result.medianReplicationMs,
+  medianSpaceReadyMs: result.medianSpaceReadyMs,
+  monotonicGrowth: result.monotonicGrowth,
+});
+
+/**
  * The run as a CI job summary. Written by the plan rather than by a workflow script so the same
  * table appears locally, and so nothing has to re-derive the verdict from the JSON.
  */
@@ -488,7 +540,7 @@ const renderSummary = (result: EdgeJoinLatencyResult): string => {
     `| — of which, space available | ${ms(result.medianSpaceReadyMs)} | |`,
     `| **Accept to fully synced** | **${ms(result.medianSyncedMs)}** | |`,
     '',
-    `Slowest joiner ${ms(result.maxSyncedMs)}.${
+    `Slowest joiner ${ms(result.maxSyncedMs)}, mean ${ms(result.meanSyncedMs)} ± ${ms(result.stddevSyncedMs)}.${
       result.monotonicGrowth
         ? ' ⚠️ Every joiner took longer than the one before it — joiners are contending, or the stack is degrading.'
         : ''

--- a/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
+++ b/packages/e2e/blade-runner/src/spec/edge-join-latency/plan.ts
@@ -357,18 +357,24 @@ export class EdgeJoinLatency implements TestPlan<EdgeJoinLatencySpec, EdgeJoinLa
       );
       return result;
     } finally {
-      // In `finally` so the artifacts exist however the run ended: a green/red verdict with no
-      // numbers behind it is the one output a CI job must never produce.
-      const summary = this._summarize(edgeUrl, spec, seedMs, measurements, agents);
-      fs.writeFileSync(resultPath, `${JSON.stringify(summary, null, 2)}\n`);
-      fs.writeFileSync(path.join(params.outDir, 'summary.md'), renderSummary(summary));
-      fs.writeFileSync(
-        path.join(params.outDir, 'join-latency.metrics.json'),
-        `${JSON.stringify(renderMetrics(summary), null, 2)}\n`,
-      );
-      unregisterCleanup();
-      if (spec.cleanup) {
-        await this._cleanup(edgeUrl, spawned, spaceId, identityDids);
+      // Nested so no artifact can cost the cleanup: these run against a shared deployment, and a
+      // write that threw here — a full disk, a missing `outDir` — would strand this run's identities
+      // and its space on it. Losing the numbers is recoverable; leaking the state is not.
+      try {
+        // In `finally` so the artifacts exist however the run ended: a green/red verdict with no
+        // numbers behind it is the one output a CI job must never produce.
+        const summary = this._summarize(edgeUrl, spec, seedMs, measurements, agents);
+        fs.writeFileSync(resultPath, `${JSON.stringify(summary, null, 2)}\n`);
+        fs.writeFileSync(path.join(params.outDir, 'summary.md'), renderSummary(summary));
+        fs.writeFileSync(
+          path.join(params.outDir, 'join-latency.metrics.json'),
+          `${JSON.stringify(renderMetrics(summary), null, 2)}\n`,
+        );
+      } finally {
+        unregisterCleanup();
+        if (spec.cleanup) {
+          await this._cleanup(edgeUrl, spawned, spaceId, identityDids);
+        }
       }
     }
   }

--- a/scripts/ci-event.mjs
+++ b/scripts/ci-event.mjs
@@ -42,6 +42,10 @@ const UUID_NAMESPACE = '6f2b1a54-9c3d-4e77-9a1f-0d5c8b7e4a21';
  * PostHog deduplicates on the tuple (uuid, timestamp, event, distinct_id), so a stable uuid only
  * suppresses a rerun's duplicate if the timestamp is stable too — which is why events default to the
  * COMMIT's date rather than the run's.
+ *
+ * A batch whose entries share a commit would otherwise share a uuid, leaving them separated by
+ * timestamp alone; an entry's optional `dedup` discriminator enters the seed to keep them apart. It
+ * is a sibling of `timestamp` on the entry rather than one of its properties, so it never ships.
  */
 export const uuidV5 = (name) => {
   const namespace = Buffer.from(UUID_NAMESPACE.replaceAll('-', ''), 'hex');
@@ -112,10 +116,13 @@ export const captureCiEvents = async (events, { historical = false } = {}) => {
     return false;
   }
 
-  const batch = events.map(({ event, properties, timestamp }) => ({
+  const batch = events.map(({ event, properties, timestamp, dedup }) => ({
     event,
     timestamp: timestamp ?? new Date().toISOString(),
-    uuid: uuidV5(`${event}|${properties.commitSha ?? timestamp}`),
+    // `dedup` distinguishes several facts emitted from one run, which would otherwise share a commit
+    // and so a uuid, leaving them separated by timestamp alone. Absent, the seed is unchanged, so an
+    // event keyed by its commit still resolves a rerun onto the same row.
+    uuid: uuidV5([event, properties.commitSha ?? timestamp, dedup].filter((part) => part !== undefined).join('|')),
     properties: {
       distinct_id: DISTINCT_ID,
       // Without this every event mints a person, and a person per commit pollutes every
@@ -154,10 +161,16 @@ const main = async () => {
   });
 
   if (values.batch) {
+    // The GitHub context is attached here rather than by the producer, same as the single-event
+    // path: a plan that writes the batch runs inside the job but has no business reading its
+    // environment. An entry's own properties win, so a backfill can carry the context of the run it
+    // is replaying rather than the one replaying it.
+    const context = ciContext();
     const events = readFileSync(values.batch, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
-      .map((line) => JSON.parse(line));
+      .map((line) => JSON.parse(line))
+      .map((entry) => ({ ...entry, properties: { ...context, ...entry.properties } }));
     await captureCiEvents(events, { historical: values.historical });
     return;
   }


### PR DESCRIPTION
The EDGE nightly measures how long a peer takes to join a 100-object space and hold all of it, prints a table into the job summary, and throws the number away. Nothing records where it has been going.

This wires the `join-latency` job into the generic sender [#12999](https://github.com/dxos/dxos/pull/12999) added for the boot budget, so the series costs a workflow step and no sender code.

**Dashboard: https://eu.posthog.com/project/126171/dashboard/943558**

## What changed

`plan.ts` gains the two statistics a trend needs and did not have — the mean across a run's joiners and their sample standard deviation — plus `minSyncedMs` alongside the existing `maxSyncedMs` so the distribution has both ends. Medians stay the headline in `summary.md`, which now also prints `mean ± sd`.

It writes a third artifact, `join-latency.metrics.json`, holding flat scalars only. `join-latency.json` cannot be fed to the sender directly: it embeds `measurements`, and `flattenOnce` would ship five nested objects as one opaque property rather than as a series.

`.depot/workflows/edge-nightly.yml` gains a `Trend the join latency` step posting `ci.edge-join-latency`.

## Notes for review

- **`--timestamp now` departs from `ci.boot-budget`.** That event dates each measurement by the commit it measured, which is right per-push and wrong for a schedule: the nightly fires against whatever main happens to be, so two nights with no merge between them would share a commit — and with it both the default timestamp and the dedup uuid, collapsing onto one point. What this measures is deployed EDGE at 02:00 UTC, whose date is the run's.
- **The step runs last, and is bounded at two minutes.** `captureCiEvents` posts with no request deadline (CodeRabbit flagged this on #12999; still unfixed). Ahead of `Upload results`, a hung capture would cost the artifacts — the half of a red run's output that cannot be recreated.
- **`always()` and `continue-on-error`**, for the same reasons as the boot budget: the run that crossed a threshold is the one the series most needs, and telemetry must never redden a build.
- **Failed and off-target runs are sent, not suppressed**, and filtered at the query instead. The dashboard requires `ciOk`, `ciAgents = 'provisioned'`, `ciEdge = preview` and `ciObjects = 100` — the plan itself notes latency is comparable only where `agents` matches, and a `workflow_dispatch` can target `local` or `dev`.
- **No changeset.** `@dxos/blade-runner` is `private`, and the other file is CI infrastructure. #12999 shipped none either.
- **No new secret.** `COMPOSER_APP_PROD_POSTHOG_API_KEY` already exists at repo level and is imported into Depot.

## Testing

Verified end to end against preview by Depot run `kg4268zvm3`, which applied this diff and ran `join-latency`. The step reported `captured 1 event(s): ci.edge-join-latency` and the point landed on the dashboard (mean 9.16s, sd 6.73s, slowest 21.07s).

Seven historical runs were recovered from Depot artifacts and backfilled — every join-latency run that has ever produced measurements, the job having landed 2026-09-07. The one scheduled run among them predates the `agents` field and measured the seeder-admitted fallback at 62.7s ± 75.4s; the dashboard's filter correctly excludes it, which is the filter earning its keep.

Statistics were checked against independently computed values (mean 8150, sample sd √70000), including the single-joiner and zero-joiner cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Monitoring**
  * Edge join-latency reports include minimum, average, standard deviation, and maximum timing metrics.
  * Nightly edge test results upload detailed, timestamped latency events for analysis.
  * Join-latency trends are sent to monitoring after each nightly test run, including runs that encounter failures.
  * Test summaries provide a clearer view of typical and variable join times, not only the slowest joiner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13045-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
