### PR TITLE
plugin-debug: stop advertising `report` in the console banner

### DIFF
--- a/packages/plugins/plugin-debug/src/containers/DebugConsole/DebugConsole.tsx
+++ b/packages/plugins/plugin-debug/src/containers/DebugConsole/DebugConsole.tsx
@@ -19,8 +19,6 @@ const RESET = '\x1b[0m';
 /** Sizes a host that has no size of its own; a host with a definite size passes `fit` instead. */
 const FIXED_GRID = { cols: 100, rows: 24 };
 
-// `report` is deliberately absent: it files straight into Linear over a route that cannot yet tell
-// who is calling, so it stays unadvertised until that route is authenticated. `help` still lists it.
 const BANNER = `${BOLD}Debug console${RESET}\n${DIM}snapshot · plugins · enable · disable · ops · invoke · eval · port — "help" for details.${RESET}`;
 
 export type DebugConsoleProps = {

--- a/packages/plugins/plugin-debug/src/containers/DebugConsole/DebugConsole.tsx
+++ b/packages/plugins/plugin-debug/src/containers/DebugConsole/DebugConsole.tsx
@@ -19,7 +19,9 @@ const RESET = '\x1b[0m';
 /** Sizes a host that has no size of its own; a host with a definite size passes `fit` instead. */
 const FIXED_GRID = { cols: 100, rows: 24 };
 
-const BANNER = `${BOLD}Debug console${RESET}\n${DIM}snapshot · plugins · enable · disable · ops · invoke · eval · report · port — "help" for details.${RESET}`;
+// `report` is deliberately absent: it files straight into Linear over a route that cannot yet tell
+// who is calling, so it stays unadvertised until that route is authenticated. `help` still lists it.
+const BANNER = `${BOLD}Debug console${RESET}\n${DIM}snapshot · plugins · enable · disable · ops · invoke · eval · port — "help" for details.${RESET}`;
 
 export type DebugConsoleProps = {
   /** Rendered as a close button in the toolbar when provided (the popover host closes itself). */

--- a/packages/plugins/plugin-debug/src/containers/DebugConsole/cli.ts
+++ b/packages/plugins/plugin-debug/src/containers/DebugConsole/cli.ts
@@ -232,7 +232,7 @@ const makeCommand = (options: DebugCliOptions = {}) => {
         const issue = result as { issueIdentifier?: string; issueUrl?: string } | undefined;
         yield* print(issue?.issueUrl ? `${issue.issueIdentifier} ${issue.issueUrl}` : result);
       }),
-  ).pipe(Command.withDescription('File a Linear issue with the logs attached (internal accounts only).'));
+  ).pipe(Command.withDescription('File a Linear issue with the logs attached.'));
 
   const port = Command.make(
     'port',

--- a/packages/plugins/plugin-debug/src/containers/DebugConsole/cli.ts
+++ b/packages/plugins/plugin-debug/src/containers/DebugConsole/cli.ts
@@ -232,10 +232,7 @@ const makeCommand = (options: DebugCliOptions = {}) => {
         const issue = result as { issueIdentifier?: string; issueUrl?: string } | undefined;
         yield* print(issue?.issueUrl ? `${issue.issueIdentifier} ${issue.issueUrl}` : result);
       }),
-  ).pipe(
-    Command.withDescription('File a Linear issue with the logs attached.'),
-    Command.unlisted,
-  );
+  ).pipe(Command.withDescription('File a Linear issue with the logs attached.'), Command.unlisted);
 
   const port = Command.make(
     'port',

--- a/packages/plugins/plugin-debug/src/containers/DebugConsole/cli.ts
+++ b/packages/plugins/plugin-debug/src/containers/DebugConsole/cli.ts
@@ -232,7 +232,10 @@ const makeCommand = (options: DebugCliOptions = {}) => {
         const issue = result as { issueIdentifier?: string; issueUrl?: string } | undefined;
         yield* print(issue?.issueUrl ? `${issue.issueIdentifier} ${issue.issueUrl}` : result);
       }),
-  ).pipe(Command.withDescription('File a Linear issue with the logs attached.'));
+  ).pipe(
+    Command.withDescription('File a Linear issue with the logs attached.'),
+    Command.unlisted,
+  );
 
   const port = Command.make(
     'port',

--- a/packages/plugins/plugin-support/src/types/SupportOperation.ts
+++ b/packages/plugins/plugin-support/src/types/SupportOperation.ts
@@ -91,7 +91,7 @@ export const SubmitIssue = Operation.make({
   meta: {
     key: DXN.make('org.dxos.operation.support.submitIssue'),
     name: 'File Linear Issue',
-    description: 'Files a report as a Linear issue with logs attached. Internal accounts only.',
+    description: 'Files a report as a Linear issue with logs attached.',
     icon: 'ph--bug--regular',
   },
   services: [Capability.Service],


### PR DESCRIPTION
The `report` command files straight into Linear over a route that cannot yet tell who is calling, so it is no longer advertised.

`Command.unlisted` does the work: the command is omitted from help, shell completions and "did you mean?" suggestions, while staying invocable by exact name. The console banner drops it too.

This buys quiet, not protection. The command still runs and the endpoint is reachable by anyone with the bundle. It stops `report` being the first thing a curious user sees on opening the console, until dxos/edge#1050's TODO is paid off and the route is authenticated.

Its description also said "internal accounts only". That gate is removed on the service side in dxos/edge#1050, so the claim was about to become false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * The debug console’s displayed command list no longer advertises the `report` command.
  * The `report` command remains available as an unlisted command for filing issues with attached logs.
  * Issue submission is no longer described as restricted to internal accounts, making the support operation available without that stated limitation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13046-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
