### PR TITLE
ci: seed the event uuid on the commit and the timestamp both

### DIFF
--- a/scripts/ci-event.mjs
+++ b/scripts/ci-event.mjs
@@ -116,21 +116,34 @@ export const captureCiEvents = async (events, { historical = false } = {}) => {
     return false;
   }
 
-  const batch = events.map(({ event, properties, timestamp, dedup }) => ({
-    event,
-    timestamp: timestamp ?? new Date().toISOString(),
-    // `dedup` distinguishes several facts emitted from one run, which would otherwise share a commit
-    // and so a uuid, leaving them separated by timestamp alone. Absent, the seed is unchanged, so an
-    // event keyed by its commit still resolves a rerun onto the same row.
-    uuid: uuidV5([event, properties.commitSha ?? timestamp, dedup].filter((part) => part !== undefined).join('|')),
-    properties: {
-      distinct_id: DISTINCT_ID,
-      // Without this every event mints a person, and a person per commit pollutes every
-      // person-scoped insight in the project for no gain.
-      $process_person_profile: false,
-      ...Object.fromEntries(Object.entries(properties).map(([key, value]) => [namespaced(key), value])),
-    },
-  }));
+  const batch = events.map(({ event, properties, timestamp, dedup }) => {
+    const at = timestamp ?? new Date().toISOString();
+    return {
+      event,
+      timestamp: at,
+      properties: {
+        distinct_id: DISTINCT_ID,
+        // Without this every event mints a person, and a person per commit pollutes every
+        // person-scoped insight in the project for no gain.
+        $process_person_profile: false,
+        ...Object.fromEntries(Object.entries(properties).map(([key, value]) => [namespaced(key), value])),
+      },
+      /**
+       * Seeded on the commit AND the resolved timestamp, plus `dedup` where several facts come from
+       * one run.
+       *
+       * The commit alone is not enough: a schedule fires against whatever main happens to be, so two
+       * nights with no merge between them measure different deployments under one sha and would
+       * share a uuid. The timestamp alone is not enough either: an event dated by its commit — which
+       * is what keys `ci.boot-budget` — must survive a rerun onto the same row, and two commits can
+       * carry the same committer date. Together, each addresses the other's collision.
+       *
+       * It is the resolved timestamp rather than the supplied one, so `--timestamp now` seeds on the
+       * moment it actually sent rather than dropping out of the seed entirely.
+       */
+      uuid: uuidV5([event, properties.commitSha, at, dedup].filter((part) => part !== undefined).join('|')),
+    };
+  });
 
   for (let offset = 0; offset < batch.length; offset += BATCH_SIZE) {
     const chunk = batch.slice(offset, offset + BATCH_SIZE);


### PR DESCRIPTION
Follow-up to [#13045](https://github.com/dxos/dxos/pull/13045), which merged before this review comment could be addressed.

CodeRabbit flagged that the uuid seed prefers `commitSha` over the supplied timestamp, so two nightly runs against the same commit collide. That is right for the run event, and worth fixing — a schedule fires against whatever `main` happens to be, so two nights with no merge between them measure different deployments under one sha.

## Why not the suggested diff

The proposal was `timestamp ?? properties.commitSha`, which drops the commit from the seed entirely whenever a timestamp exists — and one always does for `ci.boot-budget`, whose timestamp *is* the commit date. That trades one collision for another: two commits sharing a committer date would then share a uuid, and the commit-keyed rerun idempotency #12999 built the seed for would be keyed on something that is no longer unique per commit.

Seeding on **both**, plus the existing `dedup`, leaves each covering the other's collision. The seed also uses the resolved timestamp rather than the supplied one, so `--timestamp now` seeds on the moment it actually sent instead of dropping out of the seed.

## Scope correction

The comment also said the per-joiner uuids collide. They do not — `dedup: joiner-N` already entered the seed in #13045, so the five joiner rows of a run are distinct today. The exposure was the run event alone, one row per night, carrying `ok` / `agents` / `seedMs` / `joinersOk`.

## Testing

Exercised against a local sink, all four properties holding at once:

| case | expected | result |
| :-- | :-- | :-- |
| Two nights, same commit | distinct uuids | ✅ |
| Three joiners of one run | distinct uuids | ✅ |
| Two commits sharing a committer date | distinct uuids | ✅ |
| `ci.boot-budget` rerun, same commit and date | **same** uuid, idempotent | ✅ |

## One transition cost

Events sent before this carry the old seed, so a rerun of a commit already measured writes a second row rather than replacing the first. It applies only to those commits, and only to a rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CI event identity generation for events without commit identifiers.
  - Ensured event timestamps are consistently resolved and used when creating event identifiers.
  - Preserved optional deduplication distinctions when generating event identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13047-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
