### PR TITLE
client: map the recover-identity union onto the oneof the service dispatches on

### DIFF
--- a/.changeset/recover-identity-oneof-mapping.md
+++ b/.changeset/recover-identity-oneof-mapping.md
@@ -1,0 +1,11 @@
+---
+'@dxos/client': patch
+---
+
+Fix every identity recovery path — passkey, recovery code, email token and OAuth proof — failing in
+the client before a request reached EDGE.
+
+`HaloProxy.recoverIdentity` forwarded the caller's `RecoverIdentityArgs` union straight to the rpc,
+where the payload codec encodes `RecoverIdentityRequest` and throws on a message whose `request`
+oneof was never selected. The proxy maps the union onto that oneof again, as it did before the buf
+migration; the public API is unchanged.

--- a/packages/sdk/client/src/halo/halo-proxy.test.ts
+++ b/packages/sdk/client/src/halo/halo-proxy.test.ts
@@ -1,0 +1,87 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { toBinary } from '@bufbuild/protobuf';
+import * as Effect from 'effect/Effect';
+import { describe, expect, test } from 'vitest';
+
+import { type ClientServicesProvider } from '@dxos/client-protocol';
+import { PublicKey } from '@dxos/keys';
+import { buf, fromPublicKey } from '@dxos/protocols/buf';
+import {
+  type Identity,
+  type RecoverIdentityRequest,
+  RecoverIdentityRequest_ExternalSignatureSchema,
+  RecoverIdentityRequestSchema,
+} from '@dxos/protocols/buf/dxos/client/services_pb';
+
+import { HaloProxy } from './halo-proxy';
+
+/**
+ * A proxy over a service provider that records the request rather than serving it. The rpc payload
+ * codec encodes with `toBinary`, which throws on a message whose `request` oneof was never
+ * selected, so each case is checked for encodability alongside its tag.
+ */
+const recordRecoverIdentity = () => {
+  let request: RecoverIdentityRequest | undefined;
+  const serviceProvider = {
+    rpc: {
+      'IdentityService.recoverIdentity': (value: RecoverIdentityRequest) => {
+        request = value;
+        return Effect.succeed({} as Identity);
+      },
+    },
+  } as unknown as ClientServicesProvider;
+
+  return { halo: new HaloProxy(serviceProvider), sent: () => request };
+};
+
+describe('HaloProxy', () => {
+  describe('recoverIdentity', () => {
+    test('recovery code selects its case', async () => {
+      const { halo, sent } = recordRecoverIdentity();
+      await halo.recoverIdentity({ recoveryCode: 'ripe pear' });
+
+      const request = sent()!;
+      expect(request.request.case).to.equal('recoveryCode');
+      expect(toBinary(RecoverIdentityRequestSchema, request).length).to.be.greaterThan(0);
+    });
+
+    test('recovery proof selects its case', async () => {
+      const { halo, sent } = recordRecoverIdentity();
+      await halo.recoverIdentity({ recoveryProof: 'abcd' });
+
+      const request = sent()!;
+      expect(request.request.case).to.equal('recoveryProof');
+      expect(toBinary(RecoverIdentityRequestSchema, request).length).to.be.greaterThan(0);
+    });
+
+    test('token selects its case', async () => {
+      const { halo, sent } = recordRecoverIdentity();
+      await halo.recoverIdentity({ token: 'efgh' });
+
+      const request = sent()!;
+      expect(request.request.case).to.equal('token');
+      expect(toBinary(RecoverIdentityRequestSchema, request).length).to.be.greaterThan(0);
+    });
+
+    test('external signature carries the assertion', async () => {
+      const { halo, sent } = recordRecoverIdentity();
+      const external = buf.create(RecoverIdentityRequest_ExternalSignatureSchema, {
+        lookupKey: fromPublicKey(PublicKey.random()),
+        deviceKey: fromPublicKey(PublicKey.random()),
+        controlFeedKey: fromPublicKey(PublicKey.random()),
+        signature: new Uint8Array([1, 2, 3]),
+      });
+      await halo.recoverIdentity({ external });
+
+      const request = sent()!;
+      expect(request.request.case).to.equal('external');
+      expect(request.request.case === 'external' && request.request.value.signature).to.deep.equal(
+        new Uint8Array([1, 2, 3]),
+      );
+      expect(toBinary(RecoverIdentityRequestSchema, request).length).to.be.greaterThan(0);
+    });
+  });
+});

--- a/packages/sdk/client/src/halo/halo-proxy.ts
+++ b/packages/sdk/client/src/halo/halo-proxy.ts
@@ -17,7 +17,13 @@ import { ApiError, runServiceCall, subscribeStream } from '@dxos/protocols';
 import { buf, bufWkt, requirePublicKey, toPublicKey } from '@dxos/protocols/buf';
 import { Invitation, Invitation_Kind } from '@dxos/protocols/buf/dxos/client/invitation_pb';
 import { DeviceKind } from '@dxos/protocols/buf/dxos/client/services_pb';
-import { type Contact, type Device, type Identity } from '@dxos/protocols/buf/dxos/client/services_pb';
+import {
+  type Contact,
+  type Device,
+  type Identity,
+  type RecoverIdentityRequest,
+  RecoverIdentityRequestSchema,
+} from '@dxos/protocols/buf/dxos/client/services_pb';
 import {
   type Credential,
   type DeviceProfileDocument,
@@ -31,6 +37,23 @@ import { trace } from '@dxos/tracing';
 
 import { RPC_TIMEOUT } from '../common';
 import { InvitationsProxy } from '../invitations';
+
+/**
+ * Selects the `request` oneof from the public union. The service dispatches on the case, and the
+ * rpc payload codec refuses to encode a message that leaves it unset, so the mapping cannot be
+ * skipped by handing the union straight to the wire.
+ */
+const toRecoverIdentityRequest = (args: RecoverIdentityArgs): RecoverIdentityRequest =>
+  buf.create(RecoverIdentityRequestSchema, {
+    request:
+      'recoveryCode' in args
+        ? { case: 'recoveryCode', value: args.recoveryCode }
+        : 'recoveryProof' in args
+          ? { case: 'recoveryProof', value: args.recoveryProof }
+          : 'token' in args
+            ? { case: 'token', value: args.token }
+            : { case: 'external', value: args.external },
+  });
 
 export class HaloProxy implements Halo {
   /** Subscriptions for overall lifecycle (reconnected event listener). */
@@ -283,7 +306,7 @@ export class HaloProxy implements Halo {
   async recoverIdentity(args: RecoverIdentityArgs): Promise<Identity> {
     const identity = await runServiceCall(
       this._runtime,
-      this._serviceProvider.rpc['IdentityService.recoverIdentity'](args),
+      this._serviceProvider.rpc['IdentityService.recoverIdentity'](toRecoverIdentityRequest(args)),
       {
         timeout: RPC_TIMEOUT,
         label: 'IdentityService.recoverIdentity',


### PR DESCRIPTION
Every identity recovery — passkey, recovery code, email token, OAuth proof — fails in the client before a request reaches EDGE. Passkey login surfaces it as `PasskeyRejectedError: Passkey was not accepted`; EDGE only ever sees the challenge round trip, never a signed request.

## Cause

`RecoverIdentityRequest.request` is a oneof, so buf shapes it as `{ request: { case, value } }`, while the public API takes a plain union (`{ token }`, `{ recoveryCode }`, `{ recoveryProof }`, `{ external }`). `toBufRecoverIdentityRequest` used to map one onto the other. #12990 deleted it and had the proxy forward the caller's object verbatim:

```diff
-  rpc['IdentityService.recoverIdentity'](toBufRecoverIdentityRequest(args)),
+  rpc['IdentityService.recoverIdentity'](args),
```

Nothing typed the gap. The rpc payload codec is `bufMessage`, whose encode is `toBinary(RecoverIdentityRequestSchema, value)`, and whose decode side declares `Schema.declare<T>((_): _ is T => true)` — so no validation either. Against the flat shape:

```
create(schema, { external })    → request.case undefined, encodes to 0 bytes
toBinary(schema, { external })  → throws
  "cannot use field dxos.client.services.RecoverIdentityRequest.recovery_code with message undefined"
```

The throw happens in the app, which is why the network shows a challenge, the presentation retry, and then nothing. The service's own `case undefined → 'Invalid request.'` branch is never reached.

The only recovery path that still worked is the OAuth redirect in `plugin-onboarding`, which builds the oneof itself.

## Change

`HaloProxy.recoverIdentity` selects the case again, in a private mapper. The public API keeps its plain union, so no caller constructs a buf message to log in.

## Test

`halo-proxy.test.ts` drives `HaloProxy.recoverIdentity` over a recording service provider and checks each of the four variants for both its tag and encodability under `toBinary` — the step that failed. Restoring the old passthrough fails all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed identity recovery requests for passkeys, recovery codes, email tokens, and OAuth proofs.
  * Recovery requests now reach the service with the correct recovery option and can be encoded successfully.

* **Tests**
  * Added coverage for all supported identity recovery options and request encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13049-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
