### PR TITLE
assistant-evals: make Scorer.make the base case every variant builds on

### DIFF
--- a/packages/core/compute/assistant-evals/src/Scorer.ts
+++ b/packages/core/compute/assistant-evals/src/Scorer.ts
@@ -39,7 +39,7 @@ export type Result = number | boolean;
 export type Scorer<A> = {
   readonly name: string;
   readonly description?: string;
-  readonly query: Effect.Effect<A, unknown, Services | Memo>;
+  readonly query: Effect.Effect<A, unknown, Services>;
   readonly score: (value: A, run: Run) => Result;
 };
 
@@ -55,39 +55,42 @@ export type Score = {
 export type Scores = Record<string, Score>;
 
 /**
- * Per-run memo for work several scorers share, keyed by name. Variants of one eval run concurrently
- * in one process, so the cache is the run's and never the module's.
+ * Per-run memo for the queries several scorers share, keyed by the query effect itself. Variants of
+ * one eval run concurrently in one process, so the cache is the run's and never the module's.
  */
-export class Memo extends Context.Service<Memo, { readonly cache: Map<string, Exit.Exit<any, any>> }>()(
+class Memo extends Context.Service<Memo, { readonly cache: Map<unknown, Exit.Exit<any, any>> }>()(
   '@dxos/assistant-evals/Scorer/Memo',
 ) {}
 
 /**
- * Runs `effect` once per run and hands every later caller the same value. For a query that costs
- * something to answer — a handshake with a deployed server, a feed read — and that more than one
- * scorer needs.
+ * The base case: a scorer that reads nothing of the space, only what the run itself reports. Given
+ * a `query`, the query's value is what the verdict reads instead.
  */
-export const once = <A, E, R>(key: string, effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R | Memo> =>
-  Effect.gen(function* () {
-    const { cache } = yield* Memo;
-    const cached = cache.get(key);
-    if (cached !== undefined) {
-      return yield* cached;
-    }
-    // The exit, not the value: a shared query that failed has still been asked, and re-asking it
-    // per scorer would run the probe again and report a different answer to each.
-    const exit = yield* Effect.exit(effect);
-    cache.set(key, exit);
-    return yield* exit;
-  });
-
-/** A scorer over any query of the live space; the query's value is what the verdict reads. */
-export const make = <A, E, R extends Services | Memo>(options: {
-  name: string;
-  description?: string;
-  query: Effect.Effect<A, E, R>;
-  score: (value: A, run: Run) => Result;
-}): Scorer<A> => options;
+export const make: {
+  <A, E, R extends Services>(options: {
+    name: string;
+    description?: string;
+    query: Effect.Effect<A, E, R>;
+    score: (value: A, run: Run) => Result;
+  }): Scorer<A>;
+  (options: { name: string; description?: string; score: (run: Run) => Result }): Scorer<void>;
+} = (
+  options:
+    | {
+        name: string;
+        description?: string;
+        query: Effect.Effect<unknown, unknown, Services>;
+        // Method syntax: the verdict is written against the query's own value, so the two halves
+        // are checked bivariantly here rather than against this erased shape.
+        score(value: unknown, run: Run): Result;
+      }
+    | { name: string; description?: string; score(run: Run): Result },
+): Any => {
+  const { name, description } = options;
+  return 'query' in options
+    ? { name, description, query: options.query, score: (value, run) => options.score(value, run) }
+    : { name, description, query: Effect.void, score: (_value, run) => options.score(run) };
+};
 
 /**
  * A scorer over an ECHO query: the query runs against the session's space and its results are the
@@ -98,55 +101,60 @@ export const database = <Q extends Query.Any>(options: {
   description?: string;
   query: Q;
   score: (results: readonly Query.Type<Q>[], run: Run) => Result;
-}): Scorer<readonly Query.Type<Q>[]> => ({
-  name: options.name,
-  description: options.description,
-  query: Database.query(options.query).run,
-  score: options.score,
-});
+}): Scorer<readonly Query.Type<Q>[]> => {
+  const query: Effect.Effect<readonly Query.Type<Q>[], unknown, Services> = Database.query(options.query).run;
+  return make({
+    name: options.name,
+    description: options.description,
+    query,
+    score: options.score,
+  });
+};
 
-/** The tool calls the session made, paired with their results, in order; read once per run. */
-export const invocations: Effect.Effect<readonly ToolInvocation[], unknown, Services | Memo> = once(
-  'toolInvocations',
-  toolInvocations(),
-);
+/**
+ * The tool calls the session made, paired with their results, in order. One effect value shared by
+ * every scorer that reads it, so the feed is read once per run.
+ */
+export const invocations: Effect.Effect<readonly ToolInvocation[], unknown, Services> = toolInvocations();
 
 /** A scorer over the tool calls the session made. */
 export const toolCalls = (options: {
   name: string;
   description?: string;
   score: (invocations: readonly ToolInvocation[], run: Run) => Result;
-}): Scorer<readonly ToolInvocation[]> => ({
-  name: options.name,
-  description: options.description,
-  query: invocations,
-  score: options.score,
-});
+}): Scorer<readonly ToolInvocation[]> =>
+  make({
+    name: options.name,
+    description: options.description,
+    query: invocations,
+    score: options.score,
+  });
 
 /**
  * A scorer over the session's wall clock: full marks up to `targetMinutes`, falling linearly to
  * nothing at `budgetMinutes`. `when` gates it, so a run that never produced the thing being timed
  * scores nothing rather than being rewarded for stopping early.
  */
-export const duration = <A, E, R extends Services | Memo>(options: {
+export const duration = <A, E, R extends Services>(options: {
   name: string;
   description?: string;
   targetMinutes: number;
   budgetMinutes: number;
   when: Effect.Effect<A, E, R>;
   delivered: (value: A) => boolean;
-}): Scorer<A> => ({
-  name: options.name,
-  description: options.description,
-  query: options.when,
-  score: (value, { durationMillis }) => {
-    if (!options.delivered(value)) {
-      return 0;
-    }
-    const minutes = durationMillis / 60_000;
-    return (options.budgetMinutes - minutes) / (options.budgetMinutes - options.targetMinutes);
-  },
-});
+}): Scorer<A> =>
+  make({
+    name: options.name,
+    description: options.description,
+    query: options.when,
+    score: (value, { durationMillis }) => {
+      if (!options.delivered(value)) {
+        return 0;
+      }
+      const minutes = durationMillis / 60_000;
+      return (options.budgetMinutes - minutes) / (options.budgetMinutes - options.targetMinutes);
+    },
+  });
 
 /** Booleans are a mark or none; fractions are clamped, so a scorer cannot spend more than its one. */
 const normalize = (result: Result): number =>
@@ -155,9 +163,27 @@ const normalize = (result: Result): number =>
 const describe = (cause: Cause.Cause<unknown>): string => Cause.pretty(cause);
 
 /**
- * Scores every dimension against the open space, in order, sharing whatever {@link once} memoizes.
- * A query that fails scores nothing and reports why, rather than failing the run: a scorer reading
- * state a timed-out session never reached is a result, not an error.
+ * Runs each distinct query at most once per run, keyed by the effect itself: scorers that read the
+ * same value share one answer, and an expensive probe is not paid for by each of them. The exit,
+ * not the value: a shared query that failed has still been asked, and re-asking it would run the
+ * probe again and report a different answer to each scorer.
+ */
+const memoized = <A>(query: Effect.Effect<A, unknown, Services>): Effect.Effect<A, unknown, Services | Memo> =>
+  Effect.gen(function* () {
+    const { cache } = yield* Memo;
+    const cached = cache.get(query);
+    if (cached !== undefined) {
+      return yield* cached;
+    }
+    const exit = yield* Effect.exit(query);
+    cache.set(query, exit);
+    return yield* exit;
+  });
+
+/**
+ * Scores every dimension against the open space, in order, sharing the answer to any query more
+ * than one of them names. A query that fails scores nothing and reports why, rather than failing
+ * the run: a scorer reading state a timed-out session never reached is a result, not an error.
  */
 export const runAll = (scorers: readonly Any[], run: Run): Effect.Effect<Scores, never, Services> =>
   Effect.gen(function* () {
@@ -166,7 +192,7 @@ export const runAll = (scorers: readonly Any[], run: Run): Effect.Effect<Scores,
       // The verdict runs inside the same boundary as the query: a scorer that throws on an
       // unexpected shape scores nothing and says so, rather than taking the other nine with it.
       const exit = yield* Effect.exit(
-        scorer.query.pipe(
+        memoized(scorer.query).pipe(
           Effect.flatMap((value) =>
             Effect.try(() => normalize(scorer.score(value, run))).pipe(Effect.map((score) => ({ score, value }))),
           ),
@@ -175,7 +201,7 @@ export const runAll = (scorers: readonly Any[], run: Run): Effect.Effect<Scores,
       scores[scorer.name] = Exit.isSuccess(exit) ? exit.value : { score: 0, error: describe(exit.cause) };
     }
     return scores;
-  }).pipe(Effect.provideService(Memo, { cache: new Map<string, Exit.Exit<any, any>>() }));
+  }).pipe(Effect.provideService(Memo, { cache: new Map<unknown, Exit.Exit<any, any>>() }));
 
 /** The evalite side of the same list: each dimension reads the mark the run already recorded. */
 export const toEvalite = (scorers: readonly Any[]) =>

--- a/packages/core/compute/assistant-evals/src/evals/chess-mcp.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/chess-mcp.eval.ts
@@ -148,105 +148,96 @@ const namesAScore = (answer: string | undefined): boolean =>
   !/error/i.test(answer.slice(0, 40));
 
 //
-// What the session left, read once and shared: the scorers below each ask their own question of
-// the space, and `Scorer.once` keeps the expensive answers — the artifact text, the handshake with
-// the deployed Worker — from being paid for again by every scorer that needs them.
+// What the session left, read once and shared: each query below is one effect value, and a run
+// answers a given query once however many scorers name it — so the expensive ones, the handshake
+// with the deployed Worker above all, are not paid for again by each scorer that reads them.
 //
 
 /** Everything the session filed on the project, as text, with what a reader looks for in it. */
-const filedArtifacts = Scorer.once(
-  'artifacts',
-  Effect.gen(function* () {
-    const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-    if (!project) {
-      return { filed: '', design: undefined, workerUrls: [] as string[] };
-    }
-    const artifacts = yield* Effect.forEach(project.artifacts, (ref) =>
-      Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
-    );
-    const documents = artifacts.filter((candidate): candidate is Markdown.Document =>
-      Obj.instanceOf(Markdown.Document, candidate),
-    );
-    const texts = yield* Effect.forEach(documents, (document) =>
-      Database.load(document.content).pipe(
-        Effect.map((text) => ({ name: document.name ?? '', content: text.content })),
-        Effect.orElseSucceed(() => ({ name: document.name ?? '', content: '' })),
-      ),
-    );
-    const filed = texts.map(({ content }) => content).join('\n');
-    return {
-      filed,
-      design: texts.find(({ name, content }) => /design/i.test(name) || /^#.*design/im.test(content)),
-      workerUrls: [...new Set((filed.match(WORKER_URL) ?? []).map((url) => url.replace(/[.,)]+$/, '')))],
-    };
-  }),
-);
+const filedArtifacts = Effect.gen(function* () {
+  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+  if (!project) {
+    return { filed: '', design: undefined, workerUrls: [] as string[] };
+  }
+  const artifacts = yield* Effect.forEach(project.artifacts, (ref) =>
+    Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
+  );
+  const documents = artifacts.filter((candidate): candidate is Markdown.Document =>
+    Obj.instanceOf(Markdown.Document, candidate),
+  );
+  const texts = yield* Effect.forEach(documents, (document) =>
+    Database.load(document.content).pipe(
+      Effect.map((text) => ({ name: document.name ?? '', content: text.content })),
+      Effect.orElseSucceed(() => ({ name: document.name ?? '', content: '' })),
+    ),
+  );
+  const filed = texts.map(({ content }) => content).join('\n');
+  return {
+    filed,
+    design: texts.find(({ name, content }) => /design/i.test(name) || /^#.*design/im.test(content)),
+    workerUrls: [...new Set((filed.match(WORKER_URL) ?? []).map((url) => url.replace(/[.,)]+$/, '')))],
+  };
+});
 
 /**
  * The handshake, from the sandbox the session built in: a temporary deployment challenges clients
  * it takes for bots and the eval process is one. Candidates are every Worker URL it filed, bare
  * host first, then with the paths it mentioned and the conventional `/mcp`.
  */
-const engine = Scorer.once(
-  'engine',
-  Effect.gen(function* () {
-    const { workerUrls } = yield* filedArtifacts;
-    const sandbox = yield* findObject(Sandbox.Sandbox, () => true);
-    // Named in the value so the container, which outlives the run, can be inspected afterwards.
-    const sandboxId = sandbox?.id;
-    if (workerUrls.length === 0 || !sandbox) {
-      return { sandboxId, probe: undefined as Probe | undefined };
-    }
-    const spaceId = yield* Database.spaceId;
-    const hosts = [...new Set(workerUrls.map((url) => new URL(url).origin))];
-    const candidates = [...new Set([...workerUrls, ...hosts.map((host) => `${host}/mcp`), ...hosts])];
-    const command = `cat > /tmp/mcp-probe.mjs <<'PROBE'\n${MCP_PROBE}\nPROBE\nnode /tmp/mcp-probe.mjs '${SEEDED_FEN}' ${candidates.map((url) => `'${url}'`).join(' ')}`;
-    const result = yield* Operation.invoke(
-      SandboxOperation.Exec,
-      { sandbox: Ref.make(sandbox), command, timeout: 3 * 60 * 1_000 },
-      { spaceId },
-    ).pipe(Effect.orElseSucceed(() => undefined));
-    return { sandboxId, probe: result ? parseProbe(result.stdout) : undefined };
-  }),
-);
+const engine = Effect.gen(function* () {
+  const { workerUrls } = yield* filedArtifacts;
+  const sandbox = yield* findObject(Sandbox.Sandbox, () => true);
+  // Named in the value so the container, which outlives the run, can be inspected afterwards.
+  const sandboxId = sandbox?.id;
+  if (workerUrls.length === 0 || !sandbox) {
+    return { sandboxId, probe: undefined as Probe | undefined };
+  }
+  const spaceId = yield* Database.spaceId;
+  const hosts = [...new Set(workerUrls.map((url) => new URL(url).origin))];
+  const candidates = [...new Set([...workerUrls, ...hosts.map((host) => `${host}/mcp`), ...hosts])];
+  const command = `cat > /tmp/mcp-probe.mjs <<'PROBE'\n${MCP_PROBE}\nPROBE\nnode /tmp/mcp-probe.mjs '${SEEDED_FEN}' ${candidates.map((url) => `'${url}'`).join(' ')}`;
+  const result = yield* Operation.invoke(
+    SandboxOperation.Exec,
+    { sandbox: Ref.make(sandbox), command, timeout: 3 * 60 * 1_000 },
+    { spaceId },
+  ).pipe(Effect.orElseSucceed(() => undefined));
+  return { sandboxId, probe: result ? parseProbe(result.stdout) : undefined };
+});
 
 /** The checklist as the session left it: the three stages it was given, and the work that was not. */
-const checklist = Scorer.once(
-  'checklist',
-  Effect.gen(function* () {
-    const empty = {
-      delegated: [] as (Task.Task | undefined)[],
-      readerSteps: [] as (Task.Task | undefined)[],
-      later: [] as (Task.Task | undefined)[],
-    };
-    const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-    if (!project?.taskSet) {
-      return empty;
-    }
-    const taskSet = yield* Database.load(project.taskSet).pipe(Effect.orElseSucceed(() => undefined));
-    if (!taskSet) {
-      return empty;
-    }
-    const tasks = yield* Effect.forEach(taskSet.tasks, (ref) =>
-      Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
-    );
-    const delegated = DELEGATED_STAGES.map((title) => tasks.find((candidate) => candidate?.title === title));
-    return {
-      delegated,
-      readerSteps: tasks.filter((candidate) => candidate?.assignee?.role === 'user'),
-      later: tasks.filter((candidate) => {
-        const parentTask = candidate?.parentTask;
-        return (
-          parentTask !== undefined &&
-          candidate?.assignee?.role !== 'assistant' &&
-          candidate?.assignee?.role !== 'user' &&
-          !DELEGATED_STAGES.includes(candidate?.title ?? '') &&
-          !delegated.some((stage) => stage && Task.refEntityId(parentTask) === stage.id)
-        );
-      }),
-    };
-  }),
-);
+const checklist = Effect.gen(function* () {
+  const empty = {
+    delegated: [] as (Task.Task | undefined)[],
+    readerSteps: [] as (Task.Task | undefined)[],
+    later: [] as (Task.Task | undefined)[],
+  };
+  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+  if (!project?.taskSet) {
+    return empty;
+  }
+  const taskSet = yield* Database.load(project.taskSet).pipe(Effect.orElseSucceed(() => undefined));
+  if (!taskSet) {
+    return empty;
+  }
+  const tasks = yield* Effect.forEach(taskSet.tasks, (ref) =>
+    Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
+  );
+  const delegated = DELEGATED_STAGES.map((title) => tasks.find((candidate) => candidate?.title === title));
+  return {
+    delegated,
+    readerSteps: tasks.filter((candidate) => candidate?.assignee?.role === 'user'),
+    later: tasks.filter((candidate) => {
+      const parentTask = candidate?.parentTask;
+      return (
+        parentTask !== undefined &&
+        candidate?.assignee?.role !== 'assistant' &&
+        candidate?.assignee?.role !== 'user' &&
+        !DELEGATED_STAGES.includes(candidate?.title ?? '') &&
+        !delegated.some((stage) => stage && Task.refEntityId(parentTask) === stage.id)
+      );
+    }),
+  };
+});
 
 /**
  * Where the hour went: each call with when it started (seconds into the run), how long the tool


### PR DESCRIPTION
Follow-up to #13048, on the `Scorer` API.

- **`Scorer.make` is the base case**: a name and a verdict read from the run, no query at all. The query-bearing form stays as its second overload, so nothing at the call sites changes.
- **Every variant goes through it.** `database`, `toolCalls` and `duration` build their scorer with `make` rather than assembling the record themselves.
- **`Scorer.once` is gone from the public surface.** A run memoizes each query by the effect value itself, so scorers that name the same query share one answer without the caller inventing a cache key; `Memo` is now module-private and a scorer's query requires only `Services`.

The chess-MCP eval drops its three `Scorer.once(...)` wrappers — `filedArtifacts`, `engine` and `checklist` are plain effect values now, shared by reference.

Verified: `moon run assistant-evals:build` and `assistant-evals:lint` pass; `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PAnpPBsiSXRRwypNmtAzH

---
_Generated by [Claude Code](https://claude.ai/code/session_013PAnpPBsiSXRRwypNmtAzH)_

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13061-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
