### PR TITLE
assistant-evals: sum the turns, and fail on an empty test discovery

### DIFF
--- a/packages/core/compute/assistant-evals/moon.yml
+++ b/packages/core/compute/assistant-evals/moon.yml
@@ -8,7 +8,9 @@ tasks:
   # `--project=node`, and this package's vitest config has to stay flat for evalite's file discovery
   # to find the scenarios at all, so it defines no projects and the filter matches nothing.
   test:
-    command: pnpm exec dx-killorphans vitest run --passWithNoTests
+    # No `--passWithNoTests`, unlike the inherited task: this package has exactly one test file, so
+    # discovering none is a regression in the config rather than a shard with nothing to run.
+    command: pnpm exec dx-killorphans vitest run
     deps:
       - esbuild-plugins:build
       - node-std:build

--- a/packages/core/compute/assistant-evals/src/claude-harness.ts
+++ b/packages/core/compute/assistant-evals/src/claude-harness.ts
@@ -148,7 +148,8 @@ export const runClaudeEval = async <T>(
     ): Promise<D> =>
       app.runPromise(effect.pipe(Effect.provide(ServiceResolver.provide({ space: spaceId }, Database.Service))));
 
-    // The turns only; the scaffold before them and the scoring after are not the agent's time.
+    // The turns only, summed: the scaffold before them, the queries between them and the scoring
+    // after are the harness's time, not the agent's.
     let durationMillis = 0;
     const score = (scorers: readonly Scorer.Any[]): Promise<Scorer.Scores> =>
       app.runPromise(
@@ -200,18 +201,17 @@ export const runClaudeEval = async <T>(
       });
       const claudeAgent = agent;
 
-      const started = Date.now();
-      const result = await body({
+      return await body({
         spaceId,
         query,
         score,
         send: async (prompt) => {
+          const started = Date.now();
           const turn = await claudeAgent.send(prompt);
-          durationMillis = Date.now() - started;
+          durationMillis += Date.now() - started;
           return turn;
         },
       });
-      return result;
     } finally {
       await EffectEx.runPromise(Scope.close(scope, Exit.void));
     }


### PR DESCRIPTION
Follow-up to #13059, carrying the two review findings that could not be pushed before that PR merged (the branch was locked in the merge queue).

- `claude-harness.ts`: the run's duration was measured from before the scenario body to the end of the last turn, so a `Scorer.duration` graded the harness's own scaffolding and the between-turn queries as the agent's time. Each turn is now timed and the turns summed.
- `assistant-evals/moon.yml`: drop `--passWithNoTests`. The package has exactly one test file, so discovering none is a config regression — the exact failure mode the `ts-test` tag change in #13059 introduced — rather than a shard with nothing to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bce52MMJNMucFANFASmpLQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bce52MMJNMucFANFASmpLQ)_

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13063-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
