### PR TITLE
mcp: fix typename queries, task-set load timeouts, and getOutline type guard

### DIFF
--- a/.changeset/mcp-operation-surface-fixes.md
+++ b/.changeset/mcp-operation-surface-fixes.md
@@ -1,8 +1,6 @@
 ---
-'@dxos/plugin-space': patch
-'@dxos/plugin-tasks': patch
-'@dxos/types': patch
 '@dxos/echo': patch
+'@dxos/plugin-markdown': patch
 ---
 
 Three fixes to the operation surface the MCP server projects.

--- a/.changeset/mcp-operation-surface-fixes.md
+++ b/.changeset/mcp-operation-surface-fixes.md
@@ -1,0 +1,16 @@
+---
+'@dxos/plugin-space': patch
+'@dxos/plugin-tasks': patch
+'@dxos/types': patch
+'@dxos/echo': patch
+---
+
+Three fixes to the operation surface the MCP server projects.
+
+`space.queryObjects` with a `typename` filter under-returned, nondeterministically: the typename was resolved to one registered `Type` entity and the filter built from that entity's identity — a versioned `dxn:` for a static declaration, an `echo:` id for a copy persisted in the space. Objects of the same typename written under any other registration did not match, and which registration was picked depended on the order the registry query happened to return, so the same call could answer with every object, some of them, or none. The typename now filters as the bare-typename DXN `Filter.type` documents for this case; the registry is consulted only to reject a typename nothing declares.
+
+`projects.get` and `tasks.list` timed out on a task set with members. Loading a set's tasks resolved the refs one at a time, each a separate indexed query, and an unresolvable ref does not fail — it waits out the resolver's own 30s timeout. Materialized refs are now read from the working set, the cold remainder resolves concurrently, and a ref that does not resolve within 5s is treated as gone.
+
+`tasks.getOutline` given a ref to something that is not an outline now fails with a typed `InvalidOperationInput` naming the actual typename, rather than throwing `TypeError: Cannot read properties of undefined (reading 'tryLoad')`.
+
+Adds `Database.makeRef`, the Effect wrapper around `db.makeRef`.

--- a/packages/core/echo/echo/src/Database.ts
+++ b/packages/core/echo/echo/src/Database.ts
@@ -484,6 +484,15 @@ export const load: <T>(ref: Ref<T>) => Effect.Effect<T, Error.EntityNotFoundErro
 export const peek = <T>(ref: Ref<T>): T | undefined => ref.peek();
 
 /**
+ * Makes a reference to an object addressed by URI, resolvable against this database.
+ * @see {@link Database.makeRef}
+ */
+export const makeRef = <T extends Entity.Unknown = Entity.Unknown>(
+  uri: URI.URI,
+): Effect.Effect<Ref<T>, never, Service> =>
+  Service.pipe(Effect.map(({ db }) => db.makeRef<T>(uri))).pipe(Effect.withSpan('Database.makeRef'), withSpaceId);
+
+/**
  * Adds an object or relation to the database.
  * @see {@link Database.add}
  */

--- a/packages/plugins/plugin-projects/src/operations/get-project.test.ts
+++ b/packages/plugins/plugin-projects/src/operations/get-project.test.ts
@@ -9,6 +9,7 @@ import * as Instructions from '@dxos/compute/Instructions';
 import * as Project from '@dxos/compute/Project';
 import { Database, Obj, Ref } from '@dxos/echo';
 import { TestDatabaseLayer } from '@dxos/echo-client/testing';
+import { URI } from '@dxos/keys';
 import { Text } from '@dxos/schema';
 import { Outline, Task, TaskSet } from '@dxos/types';
 
@@ -48,6 +49,24 @@ describe('get-project', () => {
       expect(result.taskSet).toEqual({ id: taskSet.id, name: 'Sprint', openCount: 1, totalCount: 2 });
       expect(result.outline?.content).toContain('- [ ] first');
       expect(result.artifacts).toHaveLength(1);
+    }).pipe(Effect.provide(testLayer())),
+  );
+
+  it.effect('completes on a task set holding an unresolvable ref', () =>
+    Effect.gen(function* () {
+      const taskSet = yield* Database.add(TaskSet.make({ name: 'Sprint' }));
+      const open = yield* Database.add(Task.make({ [Obj.Parent]: taskSet, title: 'Open', status: 'todo' }));
+      // A member whose object is not in this space: the shape that stalled the whole read.
+      const dangling = yield* Database.makeRef<Task.Task>(URI.make('echo:///01M122P4GNVZ1P982K1K0QG8AY'));
+      Obj.update(taskSet, (taskSet) => {
+        taskSet.tasks = [Ref.make(open), dangling];
+      });
+      const project = yield* Database.add(Project.make({ name: 'Spring Blend', taskSet: Ref.make(taskSet) }));
+      yield* Database.flush();
+
+      const result = yield* getProject.handler({ project: Ref.make(project) });
+
+      expect(result.taskSet).toEqual({ id: taskSet.id, name: 'Sprint', openCount: 1, totalCount: 1 });
     }).pipe(Effect.provide(testLayer())),
   );
 

--- a/packages/plugins/plugin-space/src/operations/query-objects.test.ts
+++ b/packages/plugins/plugin-space/src/operations/query-objects.test.ts
@@ -6,17 +6,70 @@ import { describe, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
 import * as Operation from '@dxos/compute/Operation';
-import { Database, Feed, Obj, Ref } from '@dxos/echo';
+import { Database, Feed, Obj, Ref, Type } from '@dxos/echo';
 import { TestHelpers } from '@dxos/effect/testing';
 
 import { SpaceOperation } from '#types';
 
+import AddTypeHandler from './add-type.ts';
 import QueryObjectsHandler from './query-objects.ts';
 import { TestObject, labelOf, makeTestLayer } from './testing.ts';
 
-const TestLayer = makeTestLayer(QueryObjectsHandler);
+const TestLayer = makeTestLayer(QueryObjectsHandler, AddTypeHandler);
 
 describe('SpaceOperation.QueryObjects', () => {
+  it.effect(
+    'a typename-only query returns every object of the type at any limit',
+    Effect.fnUntraced(
+      function* ({ expect }) {
+        const count = 5;
+        for (let index = 0; index < count; index++) {
+          yield* Database.add(Obj.make(TestObject, { name: `typed-${index}` }));
+        }
+        yield* Database.flush();
+
+        // A limit above the result count must not truncate, and must not vary run to run.
+        for (const limit of [3, count, count + 1, 200]) {
+          const { results } = yield* Operation.invoke(SpaceOperation.QueryObjects, {
+            typename: Type.getTypename(TestObject),
+            limit,
+          });
+          expect(results).toHaveLength(Math.min(limit, count));
+        }
+
+        // `includeContent` changes the shape of a row, never which rows match.
+        const { results } = yield* Operation.invoke(SpaceOperation.QueryObjects, {
+          typename: Type.getTypename(TestObject),
+          includeContent: true,
+          limit: 200,
+        });
+        expect(results).toHaveLength(count);
+
+        // A second registration of the same typename persisted in the space. Resolving the typename
+        // to one registration and filtering on that pinned the query to whichever copy the registry
+        // returned first, so the objects — written under the static declaration — stopped matching.
+        yield* Operation.invoke(SpaceOperation.AddType, {
+          typename: Type.getTypename(TestObject),
+          name: 'Test Object',
+          jsonSchema: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            title: 'Test Object',
+            properties: { name: { type: 'string' } },
+          },
+        });
+
+        const { results: afterShadow } = yield* Operation.invoke(SpaceOperation.QueryObjects, {
+          typename: Type.getTypename(TestObject),
+          limit: 200,
+        });
+        expect(afterShadow).toHaveLength(count);
+      },
+      Effect.provide(TestLayer),
+      TestHelpers.provideTestContext,
+    ),
+  );
+
   it.effect(
     'finds feed content only with includeQueues',
     Effect.fnUntraced(

--- a/packages/plugins/plugin-space/src/operations/query-objects.ts
+++ b/packages/plugins/plugin-space/src/operations/query-objects.ts
@@ -6,7 +6,7 @@ import * as Effect from 'effect/Effect';
 import * as Match from 'effect/Match';
 
 import * as Operation from '@dxos/compute/Operation';
-import { Database, Filter, Obj, Query, Scope, Type } from '@dxos/echo';
+import { Database, DXN, Filter, Obj, Query, Scope, Type } from '@dxos/echo';
 
 import { SpaceOperation } from '#types';
 
@@ -26,11 +26,11 @@ const handler: Operation.WithHandler<typeof SpaceOperation.QueryObjects> = Space
       const selected = yield* Match.value({ text, typename }).pipe(
         Match.withReturnType<Effect.Effect<Query.Any, Error, Database.Service>>(),
         Match.when({ text: present, typename: present }, ({ text, typename }) =>
-          resolveType(typename).pipe(Effect.map((type) => fullText(text).select(Filter.type(type)))),
+          typeFilter(typename).pipe(Effect.map((filter) => fullText(text).select(filter))),
         ),
         Match.when({ text: present }, ({ text }) => Effect.succeed(fullText(text))),
         Match.when({ typename: present }, ({ typename }) =>
-          resolveType(typename).pipe(Effect.map((type) => Query.select(Filter.type(type)))),
+          typeFilter(typename).pipe(Effect.map((filter) => Query.select(filter))),
         ),
         Match.orElse(() => Effect.succeed(Query.select(Filter.everything()))),
       );
@@ -60,14 +60,23 @@ const fullText = (text: string): Query.Any =>
   Query.all(...text.split(' ').map((term) => Query.select(Filter.text(term, { type: 'full-text' }))));
 
 /**
- * Resolves a typename against the types registered for the space, so the filter uses the same type
- * identity the registry reports rather than a bare string.
+ * The filter for a caller-supplied typename: a bare-typename DXN, which is what `Filter.type`
+ * documents for this case.
+ *
+ * Resolving the typename to a registered `Type` entity first and filtering on THAT pinned the
+ * filter to one registration — a versioned `dxn:` for a static declaration, an `echo:` id for a
+ * copy persisted in the space — so objects of the same typename written under any other
+ * registration did not match, and which registration was picked depended on the order the registry
+ * query happened to return. That is the under-return: a space holding both forms answered the same
+ * call with all of its objects, some of them, or none, run to run.
+ *
+ * The registry is still consulted, but only to reject a typename nothing declares; it no longer
+ * decides what the filter matches.
  */
-const resolveType = Effect.fnUntraced(function* (typename: string) {
+const typeFilter = Effect.fnUntraced(function* (typename: string) {
   const types = yield* Database.query(Query.select(Filter.type(Type.Type)).from(Scope.space(), Scope.registry())).run;
-  const schema = types.find((type) => Type.getTypename(type) === typename);
-  if (!schema) {
+  if (!types.some((type) => Type.getTypename(type) === typename)) {
     return yield* Effect.fail(new Error(`Schema not found: ${typename}`));
   }
-  return schema;
+  return Filter.type(DXN.make(typename));
 });

--- a/packages/plugins/plugin-tasks/src/operations/get-outline.test.ts
+++ b/packages/plugins/plugin-tasks/src/operations/get-outline.test.ts
@@ -5,12 +5,13 @@
 import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
-import { Database, Obj, Ref } from '@dxos/echo';
+import { Database, Obj, Ref, Type } from '@dxos/echo';
 import { TestDatabaseLayer } from '@dxos/echo-client/testing';
 import { URI } from '@dxos/keys';
 import { Text } from '@dxos/schema';
 import { Outline } from '@dxos/types';
 
+import { InvalidOperationInput } from '../errors.ts';
 import getOutline from './get-outline.ts';
 
 describe('get-outline', () => {
@@ -37,11 +38,12 @@ describe('get-outline', () => {
       // Built from the URI rather than the object: the caller is a model passing an id, which is
       // exactly the shape the ref's static type cannot vouch for.
       const ref = yield* Database.makeRef<Outline.Outline>(URI.make(Obj.getURI(other)));
-      const exit = yield* Effect.exit(getOutline.handler({ outline: ref }));
+      // A raw `TypeError: Cannot read properties of undefined (reading 'tryLoad')` is the regression,
+      // so the assertion is on the error's type and its whole message, not on a substring.
+      const error = yield* Effect.flip(getOutline.handler({ outline: ref }));
 
-      expect(exit._tag).toBe('Failure');
-      // A raw `TypeError: Cannot read properties of undefined (reading 'tryLoad')` is the regression.
-      expect(String(exit)).toContain('Not an outline');
+      expect(error).toBeInstanceOf(InvalidOperationInput);
+      expect(error.message).toBe(`Not an outline: ${Type.getTypename(Text.Text)}.`);
     }).pipe(Effect.provide(TestDatabaseLayer({ types: [Outline.Outline, Text.Text] }))),
   );
 });

--- a/packages/plugins/plugin-tasks/src/operations/get-outline.test.ts
+++ b/packages/plugins/plugin-tasks/src/operations/get-outline.test.ts
@@ -5,8 +5,9 @@
 import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
-import { Database, Ref } from '@dxos/echo';
+import { Database, Obj, Ref } from '@dxos/echo';
 import { TestDatabaseLayer } from '@dxos/echo-client/testing';
+import { URI } from '@dxos/keys';
 import { Text } from '@dxos/schema';
 import { Outline } from '@dxos/types';
 
@@ -25,6 +26,22 @@ describe('get-outline', () => {
         { title: 'first', done: false },
         { title: 'second', done: true },
       ]);
+    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Outline.Outline, Text.Text] }))),
+  );
+
+  it.effect('fails with a typed error when the ref is not an outline', () =>
+    Effect.gen(function* () {
+      const other = yield* Database.add(Text.make({ content: 'not an outline' }));
+      yield* Database.flush();
+
+      // Built from the URI rather than the object: the caller is a model passing an id, which is
+      // exactly the shape the ref's static type cannot vouch for.
+      const ref = yield* Database.makeRef<Outline.Outline>(URI.make(Obj.getURI(other)));
+      const exit = yield* Effect.exit(getOutline.handler({ outline: ref }));
+
+      expect(exit._tag).toBe('Failure');
+      // A raw `TypeError: Cannot read properties of undefined (reading 'tryLoad')` is the regression.
+      expect(String(exit)).toContain('Not an outline');
     }).pipe(Effect.provide(TestDatabaseLayer({ types: [Outline.Outline, Text.Text] }))),
   );
 });

--- a/packages/plugins/plugin-tasks/src/operations/get-outline.ts
+++ b/packages/plugins/plugin-tasks/src/operations/get-outline.ts
@@ -5,15 +5,26 @@
 import * as Effect from 'effect/Effect';
 
 import * as Operation from '@dxos/compute/Operation';
-import { Database } from '@dxos/echo';
+import { Database, Obj } from '@dxos/echo';
 import { Outline } from '@dxos/types';
 
 import { OutlineOperation } from '#types';
+
+import { InvalidOperationInput } from '../errors.ts';
 
 const handler: Operation.WithHandler<typeof OutlineOperation.GetOutline> = OutlineOperation.GetOutline.pipe(
   Operation.withHandler(
     Effect.fnUntraced(function* ({ outline: outlineRef }) {
       const outline = yield* Database.load(outlineRef);
+      // The ref is typed but unvalidated — the caller is a model passing an id it read elsewhere,
+      // and any other object reaches `outline.content` as undefined and throws a raw TypeError.
+      if (!Obj.instanceOf(Outline.Outline, outline)) {
+        return yield* Effect.fail(
+          new InvalidOperationInput({
+            message: `Not an outline: ${Obj.getTypename(outline) ?? 'unknown type'}.`,
+          }),
+        );
+      }
       const text = yield* Database.load(outline.content);
       return {
         id: outline.id,

--- a/packages/sdk/types/src/types/TaskSet.ts
+++ b/packages/sdk/types/src/types/TaskSet.ts
@@ -4,7 +4,9 @@
 
 // @import-as-namespace
 
+import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 
 import { Annotation, Database, DXN, type Error, Filter, Obj, Query, Ref, Type } from '@dxos/echo';
@@ -152,16 +154,42 @@ export const addMilestoneToSet = (taskSet: TaskSet, milestone: Milestone.Milesto
 };
 
 /**
+ * How long one cold ref may take to resolve. An unresolvable ref does not fail — the resolver runs
+ * a query that simply finds nothing and waits out its own 30s timeout — so without a bound of our
+ * own a single dangling entry stalls the whole read past any caller's deadline. Past this, the
+ * entry is treated as gone, which is what an unresolvable ref means to every reader here.
+ */
+const REF_LOAD_TIMEOUT = Duration.seconds(5);
+
+/**
  * Every ref loaded, dropping entries whose object is gone. The arrays may hold cold refs, and the
  * sync `resolveTasks` silently drops those — an incomplete member list here becomes an incomplete
  * subtree sweep or a false membership rejection.
+ *
+ * Materialized refs are taken from the working set and never hit the resolver, and the cold
+ * remainder resolves concurrently: each `Database.load` is a separate indexed query, so resolving a
+ * set of any size one ref at a time multiplies a single round trip by the member count.
  */
 const loadRefs = <T extends Obj.Unknown>(
   refs: ReadonlyArray<Ref.Ref<T>>,
 ): Effect.Effect<T[], never, Database.Service> =>
-  Effect.forEach(refs, (ref) => Database.load(ref).pipe(Effect.orElseSucceed(() => undefined))).pipe(
-    Effect.map((objects) => Task.dedupeById(objects)),
-  );
+  Effect.forEach(
+    refs,
+    (ref): Effect.Effect<T | undefined, never, Database.Service> => {
+      const target = Database.peek(ref);
+      return target
+        ? Effect.succeed(target)
+        : Database.load(ref).pipe(
+            Effect.timeoutOption(REF_LOAD_TIMEOUT),
+            Effect.map(Option.getOrUndefined),
+            Effect.orElseSucceed(() => undefined),
+          );
+    },
+    { concurrency: REF_LOAD_CONCURRENCY },
+  ).pipe(Effect.map((objects) => Task.dedupeById(objects)));
+
+/** Bounded rather than unbounded: a large set must not open one query per member at once. */
+const REF_LOAD_CONCURRENCY = 16;
 
 /** Loads the set's tasks in array order, de-duplicated by id. */
 export const loadTasks = (taskSet: TaskSet): Effect.Effect<Task.Task[], never, Database.Service> =>


### PR DESCRIPTION
Fixes three defects in the operation surface the MCP server projects. Each has a regression test that fails without its fix.

## Defect 1 — `space.queryObjects` typename filter under-returned, nondeterministically

`packages/plugins/plugin-space/src/operations/query-objects.ts`

`resolveType` resolved the caller's typename to **one** registered `Type` entity and built the filter from that entity's identity — a versioned `dxn:` for a static declaration, an `echo:` id for a copy persisted in the space. `Filter.type`'s own docs say a bare typename must be wrapped as `DXN.make(typename)`; passing a resolved entity instead pins the filter to a single registration, so objects of the same typename written under any *other* registration simply do not match. Which registration got picked depended on the order the registry query happened to return, which is why the same call answered with every object, some of them, or none, run to run.

Now filters on `Filter.type(DXN.make(typename))`. The registry is still consulted, but only to reject a typename nothing declares — it no longer decides what matches.

The reported correlation with `limit` was coincidence: the query planner's limit pushdown is a plain prefix slice and is sound here. The variable was the registration, not the limit.

Regression test (`query-objects.test.ts`) persists a second registration of a typename that already has a static declaration and asserts the query still returns every object. Without the fix it returns `[]`:

```
AssertionError: expected [] to have a length of 5 but got +0
```

## Defects 2 and 3 — `projects.get` and `tasks.list` time out

`packages/sdk/types/src/types/TaskSet.ts`

Both go through `TaskSet.loadRefs`, which resolved refs **sequentially**, each `Database.load` a separate indexed query. An unresolvable ref does not fail — the resolver runs a query that finds nothing and waits out its own 30s timeout — so one dangling entry stalls the whole read past any caller's deadline.

This is not a cycle: the `parentTask` / `dependsOn` walks (`effectiveMilestoneIds`, `subtree`, `collectSubtree`, `resolveParentTask`) are already cycle-safe, each carrying its own `visited` set. It also explains why an *empty* task set answered instantly — `forEach` over `[]` does no work.

`loadRefs` now reads materialized refs from the working set, resolves the cold remainder at bounded concurrency, and treats a ref that does not resolve within 5s as gone.

Regression test (`get-project.test.ts`) puts an unresolvable member in a task set and asserts `projects.get` completes with the right counts.

## Related — `tasks.getOutline` on a non-outline

`packages/plugins/plugin-tasks/src/operations/get-outline.ts`

A ref to any other object reached `outline.content` as `undefined` and threw `TypeError: Cannot read properties of undefined (reading 'tryLoad')`. Now guarded, failing with a typed `InvalidOperationInput` naming the actual typename.

## Also

Adds `Database.makeRef`, the Effect wrapper around `db.makeRef`, matching `Database.add` / `Database.load`.

## Not addressed

The suggested fourth fix — surfacing a request id from `invokeOperation` on failure — is out of scope here; it belongs in the MCP transport rather than these three operations. Worth doing separately.

## Test output

```
plugin-space:test    Tests  3 passed (3)
plugin-tasks:test    Test Files  18 passed (18)
                     Tests  72 passed (72)
plugin-projects:test Test Files  18 passed (18)
                     Tests  49 passed | 1 skipped (50)
types:test           Test Files  7 passed (7)
                     Tests  54 passed (54)
```

`pnpm format` run before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV1B7Ve3LUssU45wNgiXgF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FV1B7Ve3LUssU45wNgiXgF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public API for creating database references.

- **Bug Fixes**
  - Type-filtered object queries now return all matching objects consistently.
  - Project and task reads handle missing or unresolved references without stalling.
  - Invalid outline references now return a clear, typed validation error.
  - Reference loading is more resilient, including timeouts and failed lookups.

- **Tests**
  - Added coverage for type filtering, dangling references, reference loading, and invalid outline inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13065-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
