### PR TITLE
tasks: quote the resume command, and bind all-spaces scopes structurally

### DIFF
--- a/.changeset/session-reporting-hypergraph.md
+++ b/.changeset/session-reporting-hypergraph.md
@@ -1,7 +1,5 @@
 ---
-'@dxos/echo-client': patch
 '@dxos/echo': minor
-'@dxos/types': minor
 '@dxos/plugin-tasks': minor
 ---
 

--- a/packages/core/echo/echo-client/src/hypergraph.ts
+++ b/packages/core/echo/echo-client/src/hypergraph.ts
@@ -894,20 +894,15 @@ const isAllSpacesScope = (ast: QueryAST.Query): boolean => {
   return found;
 };
 
-/** Replaces every empty scope clause with one naming the given spaces. */
-const bindAllSpacesScope = (ast: QueryAST.Query, scopes: QueryAST.SpaceScope[]): QueryAST.Query => {
-  const transform = (value: unknown): unknown => {
-    if (Array.isArray(value)) {
-      return value.map(transform);
-    }
-    if (value !== null && typeof value === 'object') {
-      const record = value as Record<string, unknown>;
-      if (record._tag === 'scope' && Array.isArray(record.scopes) && record.scopes.length === 0) {
-        return { ...record, scopes };
-      }
-      return Object.fromEntries(Object.entries(record).map(([key, child]) => [key, transform(child)]));
-    }
-    return value;
-  };
-  return transform(ast) as QueryAST.Query;
-};
+/**
+ * Replaces every empty scope clause with one naming the given spaces.
+ *
+ * `QueryAST.map` rather than a walk over every value: a filter literal can itself be an object
+ * carrying `_tag` and `scopes`, and rewriting one would silently change what the query matches.
+ */
+const bindAllSpacesScope = (ast: QueryAST.Query, scopes: QueryAST.SpaceScope[]): QueryAST.Query =>
+  QueryAST.map(ast, (node) =>
+    node.type === 'from' && node.from._tag === 'scope' && node.from.scopes.length === 0
+      ? { ...node, from: { ...node.from, scopes } }
+      : node,
+  );

--- a/packages/devtools/cli/src/util/runtime.ts
+++ b/packages/devtools/cli/src/util/runtime.ts
@@ -26,6 +26,7 @@ export type AiChatServices =
   | AiService.AiService
   | Credential.CredentialsService
   | Database.Service
+  | Hypergraph.Service
   | Operation.Service
   | Registry.Service
   | Trace.TraceService;

--- a/packages/plugins/plugin-projects/src/skills/project/project-skill.md
+++ b/packages/plugins/plugin-projects/src/skills/project/project-skill.md
@@ -135,7 +135,8 @@ you hold is a bare object id, and then write the full URI: `{"/": "echo:///" + i
 - **Assignee** — a task's `assignee` is an actor, not a label. For a person, name them
   (`contact` ref, `identityDid`, `email`); for a non-person — an agent session, a service, a bot —
   set `subject` to a ref to the object that actor _is_. Assigning work to **yourself** means
-  `{"role": "assistant", "subject": {"/": "echo:///<your-session-id>"}}`: find your own session with
+  `{"role": "assistant", "subject": {"/": "echo:///<session-object-id>"}}`, where the id is the `id`
+  of the session OBJECT, not the harness session id it is filed under: find your own session with
   `tasks-list-sessions { sessionId: "<the harness session id>" }` and use the object it returns.
   A bare `{"role": "assistant"}` with a name string is wrong — it records that _an_ assistant owns
   the task, not _which_ run, so nobody can tell later who was actually working it. When no session

--- a/packages/plugins/plugin-sandbox/tsconfig.json
+++ b/packages/plugins/plugin-sandbox/tsconfig.json
@@ -24,6 +24,9 @@
       "path": "../../common/keys"
     },
     {
+      "path": "../../common/log"
+    },
+    {
       "path": "../../common/util"
     },
     {
@@ -37,6 +40,9 @@
     },
     {
       "path": "../../core/echo/echo"
+    },
+    {
+      "path": "../../core/mesh/edge-client"
     },
     {
       "path": "../../sdk/app-framework"

--- a/packages/plugins/plugin-tasks/src/containers/RemoteSessionCard/RemoteSessionCard.tsx
+++ b/packages/plugins/plugin-tasks/src/containers/RemoteSessionCard/RemoteSessionCard.tsx
@@ -10,8 +10,13 @@ import { RemoteSession } from '@dxos/types';
 
 export type RemoteSessionCardProps = AppSurface.ObjectCardProps<RemoteSession.RemoteSession>;
 
-/** Resuming by id is a CLI invocation, so the card offers the command rather than a link. */
-const resumeCommand = (sessionId: string): string => `claude --resume ${sessionId}`;
+/**
+ * Resuming by id is a CLI invocation, so the card offers the command rather than a link.
+ *
+ * Single-quoted: the id is a foreign key any MCP caller can write, so an unquoted one would carry
+ * whatever shell syntax it contains into the terminal the reader pastes it into.
+ */
+const resumeCommand = (sessionId: string): string => `claude --resume '${sessionId.replaceAll("'", String.raw`'\''`)}'`;
 
 const stateOption = (state: RemoteSession.State) => RemoteSession.StateOptions.find(({ id }) => id === state);
 

--- a/packages/ui/react-ui-task/src/components/TaskList/TaskList.tsx
+++ b/packages/ui/react-ui-task/src/components/TaskList/TaskList.tsx
@@ -1071,8 +1071,13 @@ const TaskListAssignee = composable<HTMLSpanElement, TaskListAssigneeProps>(({ a
     <Tag
       ref={tagRef}
       hue={agent ? 'purple' : 'indigo'}
+      // Focus as well as hover: the card is the only place the row says which run owns the task, so
+      // a pointer-only trigger puts that out of reach of a keyboard or a touch device.
+      tabIndex={session ? 0 : undefined}
       onPointerEnter={startHover}
       onPointerLeave={cancelHover}
+      onFocus={startHover}
+      onBlur={cancelHover}
       classNames={session && 'cursor-help'}
     >
       {agent && <Icon icon={icon} size={3} classNames='inline-block me-1' />}


### PR DESCRIPTION
Review findings on [#13062](https://github.com/dxos/dxos/pull/13062), which landed before they were
posted. Two are real defects, not style.

## The two that matter

**A crafted session id could run a command.** `RemoteSessionCard` interpolated `sessionId` into a
`claude --resume` command unquoted. The id is a foreign key any MCP caller can write, and
`RecordSession` stores it verbatim, so `id; rm -rf …` reached the card intact and executed when a
reader pasted the command. Single-quoted now, with the POSIX `'\''` escape so an id containing a
quote cannot close it. Quoting rather than validating: the suite's own ids (`session_abc`) are not
UUIDs, so a format check would reject legitimate ones.

**A scope rewrite could change what a query matched.** `bindAllSpacesScope` — added in #13062 to make
`from('all-accessible-spaces')` name the spaces it spans — walked every value in the AST and replaced
anything shaped `{_tag: 'scope', scopes: []}`. A filter literal of that shape would have been rewritten
silently. `QueryAST.map` visits query nodes only, so filter values are untouched.

## The rest

- **`AiChatServices` omitted `Hypergraph.Service`**, which `chatLayer` provides. `ChatProcessor` holds
  the result as `Context.Context<AiChatServices>`, so an operation declaring the graph — `RecordSession`
  — sat outside the CLI's declared runtime contract.
- **The changeset named `@dxos/echo-client` beside `@dxos/echo`.** Group A is a fixed group with one
  representative; enumerating members misstates the release plan.
- **The task pill opened its session card on hover alone.** That card is the only place the row says
  *which run* owns a task, so keyboard and touch users could not reach it. Focus and blur now trigger
  it too, and the tag is focusable only when a session exists.
- **The self-assignment example in the project skill** used the harness session id where the session
  object's `id` belongs — the two are different, and `echo:///` takes the object's.

Also swept in: `packages/plugins/plugin-sandbox/tsconfig.json` gained two project references the
build's own reference sync regenerated. Pre-existing drift on `main`, unrelated to these fixes, but
it would only regenerate for the next person.

## Verification

| Check | Result |
|---|---|
| `echo-client`, `cli`, `plugin-tasks`, `react-ui-task`, `plugin-projects` builds | clean |
| `echo-client:test` | 555 passed |
| `plugin-tasks:test` | 74 passed |
| lint (same five packages) | clean |
| `pnpm format` | clean |
| `agent-e2e` (manual-tagged, real Claude Code against a real `dx mcp serve`) | **6/6**, re-run after the scope rewrite |

The e2e re-run is the point of the last row: `bindAllSpacesScope` is the code path that made stage 6
pass in the first place, so changing it is only safe once that suite says so again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBKydxDCbnggfEYf3N15bP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBKydxDCbnggfEYf3N15bP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task assignee indicators can now be focused with a keyboard or touch device to open the related session preview.
  * Session information is available across spaces, including improved session reporting and staleness details.

* **Bug Fixes**
  * Corrected all-space query behavior to avoid changing filter values unintentionally.
  * Improved handling of session resume commands containing special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13066-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
