### PR TITLE
composer: turn Projects and Tasks on by default and make DeepSeek dev-only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 .vscode/settings.json @dmaretskyi @wittjosiah
 .prototools @dmaretskyi @wittjosiah
-# What composer.space actually ships. Adding or removing a plugin here changes the production app's
-# surface area and its bundle, so it is always reviewed.
-packages/apps/composer-app/src/plugin-defs.production.tsx @wittjosiah
+# Which plugins each build registers and turns on for a fresh profile. Changing a set changes the
+# app's surface area and its bundle, so every set is reviewed.
+packages/apps/composer-app/src/plugin-defs*.tsx @wittjosiah
 
 # The eager boot graph's ceiling. Raising it accepts startup cost for every user, so the increase
 # has to be motivated in review rather than merged to make a build pass.

--- a/packages/apps/composer-app/src/plugin-defs.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.tsx
@@ -110,15 +110,15 @@ export const getDefaults = ({ isDev, isLocal, isMobile }: PluginConfig): string[
     JmapPlugin.meta.profile.key,
     KanbanPlugin.meta.profile.key,
     MarkdownPlugin.meta.profile.key,
+    ProjectsPlugin.meta.profile.key,
+    // Projects declares Tasks as a dependency.
+    TasksPlugin.meta.profile.key,
     SheetPlugin.meta.profile.key,
     IllustratorPlugin.meta.profile.key,
     TldrawPlugin.meta.profile.key,
     ExcalidrawPlugin.meta.profile.key,
     TablePlugin.meta.profile.key,
     ThreadPlugin.meta.profile.key,
-    // Connector-only, so defaulting it on adds no surface — it just puts DeepSeek in the
-    // Connections service list for anyone who has a key.
-    DeepSeekPlugin.meta.profile.key,
 
     // Local
     isLocal && SamplePlugin.meta.profile.key,
@@ -138,6 +138,7 @@ export const getDefaults = ({ isDev, isLocal, isMobile }: PluginConfig): string[
       CommercePlugin.meta.profile.key,
       CrmPlugin.meta.profile.key,
       DebugPlugin.meta.profile.key,
+      DeepSeekPlugin.meta.profile.key,
       DevtoolsPlugin.meta.profile.key,
       DuffelPlugin.meta.profile.key,
       GamePlugin.meta.profile.key,
@@ -158,7 +159,6 @@ export const getDefaults = ({ isDev, isLocal, isMobile }: PluginConfig): string[
       SequencerPlugin.meta.profile.key,
       SidekickPlugin.meta.profile.key,
       StudioPlugin.meta.profile.key,
-      TasksPlugin.meta.profile.key,
       TranscriptionPlugin.meta.profile.key,
       TypefullyPlugin.meta.profile.key,
       VideoPlugin.meta.profile.key,

--- a/packages/apps/composer-app/src/plugin-defs.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.tsx
@@ -111,7 +111,6 @@ export const getDefaults = ({ isDev, isLocal, isMobile }: PluginConfig): string[
     KanbanPlugin.meta.profile.key,
     MarkdownPlugin.meta.profile.key,
     ProjectsPlugin.meta.profile.key,
-    // Projects declares Tasks as a dependency.
     TasksPlugin.meta.profile.key,
     SheetPlugin.meta.profile.key,
     IllustratorPlugin.meta.profile.key,


### PR DESCRIPTION
## Summary

Three changes to the Composer default plugin sets.

- **Projects and Tasks are on by default everywhere.** Both already shipped enabled in the production and mobile sets, but neither appeared in the dev/preview defaults, so a fresh profile on a preview deploy or localhost had to enable them by hand. They move into the base default list, which covers preview, localhost and dev.
- **DeepSeek is dev-only.** It moves from the base list into the `isDev` block. It is a connector for a model most people have no key for, so preview and localhost no longer carry it in the Connections service list.
- **CODEOWNERS covers every plugin set.** The entry was pinned to `plugin-defs.production.tsx`; it is now `plugin-defs*.tsx`, since each of those modules decides what a build registers and turns on for a fresh profile.

## Default sets after this change

| Set | Projects | Tasks | DeepSeek |
| --- | :-: | :-: | :-: |
| production | on | on | not bundled |
| mobile | on | on | not bundled |
| preview | on | on | off |
| localhost | on | on | off |
| dev deploy | on | on | on |

No changeset: `composer-app` is an app, not a published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Projects and Tasks are now enabled by default in the Composer app.

- **Configuration Updates**
  - DeepSeek is now limited to development builds rather than general default configurations.
  - Duplicate Tasks configuration has been removed from development-only defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13071-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
