### PR TITLE
blade-runner: recover an edge-stress checkpoint from a stalled flush

### DIFF
--- a/packages/e2e/blade-runner/src/spec/edge-stress/system.ts
+++ b/packages/e2e/blade-runner/src/spec/edge-stress/system.ts
@@ -218,6 +218,36 @@ export const joinPendingSpaces = async (model: Model, real: Real, client: Client
 const SYNC_BARRIER_MS = 30_000;
 
 /**
+ * `flush` proves nothing about the connection beyond its transport: EDGE answers the client's own
+ * keepalive ping via `setWebSocketAutoResponse` at the runtime level, without waking or routing
+ * through the Durable Object actually serving the request, so a peer stuck behind a stalled
+ * dependency downstream of the router still looks fully connected to the client's own heartbeat —
+ * that heartbeat is the client's only signal to restart a dead connection, so it never fires and the
+ * peer never reconnects on its own. A `flush` that blows through the full quiescence budget is
+ * therefore not proof the peer is unrecoverable, only that this connection made no progress; force a
+ * hard reconnect (which redials from scratch, unlike the SDK's own reconnect logic that this incident
+ * showed does not trigger) and give the peer one more full attempt before treating the stall as real.
+ */
+const flushOrReconnect = async (real: Real, client: ClientIndex, spaceSlot: number): Promise<void> => {
+  const label = `flush(client ${client}, space ${spaceSlot})`;
+  try {
+    await withDeadline(
+      label,
+      real.spec.quiescenceTimeoutMs,
+      real.replicants[client].brain.flush({ spaceId: real.spaceIds[spaceSlot] }),
+    );
+  } catch (err) {
+    log.warn('flush stalled; forcing a reconnect and retrying once', { client, space: spaceSlot, err });
+    await real.replicants[client].brain.restart();
+    await withDeadline(
+      `${label} after reconnect`,
+      real.spec.quiescenceTimeoutMs,
+      real.replicants[client].brain.flush({ spaceId: real.spaceIds[spaceSlot] }),
+    );
+  }
+};
+
+/**
  * Wait until every named device reports the EDGE peer fully caught up, and report whether it did.
  *
  * Deliberately not an assertion. `getSyncState` is unreliable between EDGE and the client
@@ -230,11 +260,7 @@ export const quiesce = async (real: Real, spaceSlot: number, clients: ClientInde
   const pending = new Map<ClientIndex, string>();
 
   for (const client of clients) {
-    await withDeadline(
-      `flush(client ${client}, space ${spaceSlot})`,
-      real.spec.quiescenceTimeoutMs,
-      real.replicants[client].brain.flush({ spaceId: real.spaceIds[spaceSlot] }),
-    );
+    await flushOrReconnect(real, client, spaceSlot);
   }
 
   while (Date.now() < deadline) {


### PR DESCRIPTION
## Summary

- `quiesce()`'s per-client `flush()` call in the edge-stress soak plan now retries once, forcing a hard reconnect (`brain.restart()`) first, instead of failing the whole run on a single stalled attempt.

## Root cause

Debugging a red `EDGE nightly` **soak** run against `preview` (Depot run `pkmv0352l7`): `Checkpoint()` failed because `flush(client 1, space 4)` blocked for the full 90s `quiescenceTimeoutMs` budget.

Cross-referencing the run's own artifacts (`command-trace.jsonl`, `replicant.out.log`) against SigNoz logs for the same window:

- The client's log showed the device's EDGE websocket close abnormally, then repeated `space root doc did not arrive; resetting stalled sync and retrying` backoff — but that retry only nudges the automerge-repo sync layer, it never forces the underlying `EdgeClient`/`EdgeWsConnection` to fully redial.
- Server-side, SigNoz shows **no activity at all** for that connection for the ~4 minutes spanning the stall, while the client's own ping/pong heartbeat kept reporting the connection healthy — no `inactivity_timeout` restart ever fired.
- Root cause (detailed in the companion `dxos/edge` PR below): EDGE answers the client's keepalive ping via Cloudflare's `setWebSocketAutoResponse`, which the runtime handles without waking the Durable Object serving the request or anything it depends on. A downstream DO can stall indefinitely and the client's liveness check stays green throughout, so its own reconnect logic never triggers — the peer just sits there, and a `flush()` (or any other RPC) against it hangs until *something else* gives up.

Given that blind spot exists in the SDK's own heartbeat for any RPC, blade-runner can't rely on the client noticing a stall on its own. This change makes the *test* resilient to it: a stalled `flush()` now forces a genuine reconnect via `brain.restart()` (already used elsewhere in this file to recover a `'down'` client) and gets one more full attempt before the checkpoint is allowed to fail for real.

Paired with **dxos/edge#1063** (router: bound the replicator sink RPC with a timeout), which closes the server-side half of the same gap so a wedged Durable Object's RPC eventually rejects instead of hanging forever.

## Test plan

- [x] `moon run blade-runner:build`
- [x] `moon run blade-runner:lint`
- [x] `pnpm format` — no changes needed.
- Not run: an actual `edgeStress` soak against a live `preview`/`dev` deployment (needs the full blade-runner harness, Redis, and a fleet of client processes — out of scope to spin up for this change). This package has no unit tests for `edge-stress/system.ts` today; verification here is build + lint + manual review of the retry logic against the existing `'down'` → `restart()` recovery pattern already used a few lines below in `assertFullyReplicated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVvo2qt9uBVYSyBQNT3kWw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVvo2qt9uBVYSyBQNT3kWw)_

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13072-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
