### PR TITLE
evals: grade every eval with self-contained scorers against a live space

### DIFF
--- a/.agents/skills/agent-eval-tests/SKILL.md
+++ b/.agents/skills/agent-eval-tests/SKILL.md
@@ -50,7 +50,7 @@ const task = createEvalRunner({
   `,
   input: Schema.Struct({ name: Schema.String }),
   output: Schema.Unknown,
-  scorers: SCORERS,
+  scored: true,
 });
 
 evalite('Descriptive scenario name', {
@@ -60,32 +60,34 @@ evalite('Descriptive scenario name', {
 });
 ```
 
-`createEvalRunner` boots a full Composer test harness, invokes the prompt, and — when `scorers` are
-passed — grades each dimension **while the space is still open**, returning
-`{ agentOutput, scores, durationMillis }` instead of the bare agent output. Model precedence:
+`createEvalRunner` boots a full Composer test harness, invokes the prompt, and — with `scored: true`
+— keeps the space **open past the task**, returning `{ runId, agentOutput, durationMillis }` instead
+of the bare agent output. The scorers then run on the evalite side, against that live space; the
+harness is disposed by an `afterAll` the runner registers, once every row of the eval has been
+graded. Model precedence:
 `variant.model` → `options.model` → `com.anthropic.model.claude-opus-5.default`.
 
 ### Scorers (`../Scorer.ts`)
 
-Each scorer is **self-contained**: it carries its own query and the verdict on what that query
-returned, so a dimension can be read, moved or deleted without touching a shared state blob. The
-query's value is reported next to the mark, so a reader of a run sees what the session actually
-left. Queries are memoized per run by effect identity — name one module-level effect and share it
-across scorers, and it runs once.
+Each scorer is **self-contained**: `score` is a single `Effect<number | boolean, _, Scorer.Services>`
+that reads whatever it needs of the open run and returns the mark for it. Reading and judging are one
+step, so a dimension can be read, moved or deleted without touching anything else.
 
-- **`Scorer.make({ name, description?, query, score })`** — the general case; `query` is any
-  `Effect<A, E, Scorer.Services>` and `score: (value, run) => number | boolean`. Omit `query` for a
-  scorer that only reads the run itself (`score: (run) => …`).
-- **`Scorer.database({ name, query, score })`** — `query` is an ECHO `Query`; `score` sees its
-  results.
-- **`Scorer.toolCalls({ name, score })`** — `score` sees the run's `ToolInvocation[]`
-  (`Scorer.invocations` is the same effect, for composing into a larger query).
-- **`Scorer.duration({ name, targetMinutes, budgetMinutes, when, delivered })`** — grades the
-  session's wall clock, gated on the run having produced the thing being timed.
+- **`Scorer.make({ name, description?, score })`** — the general case; `score` is the effect.
+- **`Scorer.database({ name, query, score })`** — `query` is an ECHO `Query`; `score` is a plain
+  function over its results.
+- **`Scorer.toolCalls({ name, score })`** — `score` is a plain function over the run's
+  `ToolInvocation[]` (`Scorer.invocations` is the same effect, for composing into a larger one).
+- **`Scorer.duration({ name, targetMinutes, budgetMinutes, delivered })`** — grades the session's
+  wall clock, gated on `delivered` (an effect) proving the run produced the thing being timed.
+  `Scorer.Run` is the service carrying `durationMillis` for a scorer that wants it directly.
+- **`Scorer.shared(effect)`** — wrap a query several dimensions read so the run pays for it once.
+  Name it at module level and `.pipe(Effect.map(…))` it per scorer; a judge call belongs behind one
+  of these.
 
-A fraction is clamped to `[0, 1]`; a boolean is one mark or none. A query that fails scores nothing
-and reports why rather than failing the run. `Scorer.toEvalite(SCORERS)` turns the same list into
-the evalite scorers that read the recorded marks.
+A fraction is clamped to `[0, 1]`; a boolean is one mark or none. A scorer that fails scores nothing
+and reports why rather than failing the row. `Scorer.toEvalite(SCORERS)` turns the same list into the
+evalite scorers, so a dimension is declared once and wired once.
 
 ### `createEvalRunner` options
 
@@ -107,7 +109,8 @@ the evalite scorers that read the recorded marks.
   per-scenario timeout of its own; this is what actually bounds each eval (`vitest.config.ts`'s
   `testTimeout` is just the outer safety net). Raise it only for scenarios with more tool
   round-trips than a typical eval — e.g. `crm-mailbox.eval.ts`/`planning.eval.ts` use `150_000`.
-- `scorers: readonly Scorer.Any[]` — the graded dimensions; see Scorers above.
+- `scored: true` — keeps the space open past the task so the eval's scorers can query it; see
+  Scorers above. Leave it unset for an eval graded from the agent's output alone (`basic`, `smoke`).
 
 ### Driving a real Claude Code subprocess (`../claude-harness.ts`)
 
@@ -130,7 +133,7 @@ server's tools allowed — no Bash, no file tools, so a prompt the surface canno
 
 ### Assertions (`../assertions.ts`)
 
-All are `Effect<_, _, Database.Service>` — compose freely inside a scorer's `query`:
+All are `Effect<_, _, Database.Service>` — compose freely inside a scorer's `score`:
 
 - **`objectExists(type, predicate)`** / **`findObject(type, predicate)`** — query the DB for a
   matching entity (object or relation). `findObject` returns the match itself (e.g. to load a

--- a/.agents/skills/agent-eval-tests/SKILL.md
+++ b/.agents/skills/agent-eval-tests/SKILL.md
@@ -13,7 +13,8 @@ grading the outcome with a **Scorer** — code that checks the real DB/tool-invo
 supersedes trusting the agent's own self-reported `completedCriteria`.
 
 Package: `packages/core/compute/assistant-evals`. Library: `src/runner.ts` (`createEvalRunner`),
-`src/assertions.ts` (deterministic helpers), `src/judge.ts` (LLM-judge helper). Evals live in
+`src/Scorer.ts` (the scorer constructors), `src/assertions.ts` (deterministic helpers),
+`src/judge.ts` (LLM-judge helper). Evals live in
 `src/evals/*.eval.ts`. See `packages/core/compute/ai/TESTING.md` for how this package is scoped
 (cross-plugin scenarios live here; single-plugin scenarios belong in their own plugin package,
 importing this library). The older memoized/live gated agent-e2e harness is a separate, deprecated
@@ -26,8 +27,21 @@ import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 import { evalite } from 'evalite';
 
-import { objectExists } from '../assertions';
+import { Filter, Query } from '@dxos/echo';
+
 import { createEvalRunner } from '../runner';
+import * as Scorer from '../Scorer';
+
+const ORGANIZATION_NAME = 'Cyberdyne Systems';
+
+const SCORERS = [
+  Scorer.database({
+    name: 'organization-created',
+    description: 'The named Organization object exists in the DB after the run.',
+    query: Query.select(Filter.type(Organization.Organization)),
+    score: (organizations) => organizations.some((org) => org.name === ORGANIZATION_NAME),
+  }),
+];
 
 const task = createEvalRunner({
   instructions: trim`
@@ -35,26 +49,42 @@ const task = createEvalRunner({
   `,
   input: Schema.Struct({ name: Schema.String }),
   output: Schema.Unknown,
-  dbQuery: ({ name }) => objectExists(Organization.Organization, (org) => org.name === name),
+  scorers: SCORERS,
 });
 
 evalite('Descriptive scenario name', {
-  data: [{ input: { name: 'Cyberdyne Systems' } }],
+  data: [{ input: { name: ORGANIZATION_NAME } }],
   task,
-  scorers: [
-    {
-      name: 'organization-created',
-      description: 'The named Organization object exists in the DB after the run.',
-      scorer: ({ output }) => (output.dbQuery ? 1 : 0),
-    },
-  ],
+  scorers: Scorer.toEvalite(SCORERS),
 });
 ```
 
-`createEvalRunner` boots a full Composer test harness, invokes the prompt, and — when `dbQuery` is
-passed — runs a deterministic assertion **while the space is still open**, returning
-`{ agentOutput, dbQuery }` instead of the bare agent output. Model precedence:
-`variant.model` → `options.model` → `com.anthropic.model.claude-opus-4-8.default`.
+`createEvalRunner` boots a full Composer test harness, invokes the prompt, and — when `scorers` are
+passed — grades each dimension **while the space is still open**, returning
+`{ agentOutput, scores, durationMillis }` instead of the bare agent output. Model precedence:
+`variant.model` → `options.model` → `com.anthropic.model.claude-opus-5.default`.
+
+### Scorers (`../Scorer.ts`)
+
+Each scorer is **self-contained**: it carries its own query and the verdict on what that query
+returned, so a dimension can be read, moved or deleted without touching a shared state blob. The
+query's value is reported next to the mark, so a reader of a run sees what the session actually
+left. Queries are memoized per run by effect identity — name one module-level effect and share it
+across scorers, and it runs once.
+
+- **`Scorer.make({ name, description?, query, score })`** — the general case; `query` is any
+  `Effect<A, E, Scorer.Services>` and `score: (value, run) => number | boolean`. Omit `query` for a
+  scorer that only reads the run itself (`score: (run) => …`).
+- **`Scorer.database({ name, query, score })`** — `query` is an ECHO `Query`; `score` sees its
+  results.
+- **`Scorer.toolCalls({ name, score })`** — `score` sees the run's `ToolInvocation[]`
+  (`Scorer.invocations` is the same effect, for composing into a larger query).
+- **`Scorer.duration({ name, targetMinutes, budgetMinutes, when, delivered })`** — grades the
+  session's wall clock, gated on the run having produced the thing being timed.
+
+A fraction is clamped to `[0, 1]`; a boolean is one mark or none. A query that fails scores nothing
+and reports why rather than failing the run. `Scorer.toEvalite(SCORERS)` turns the same list into
+the evalite scorers that read the recorded marks.
 
 ### `createEvalRunner` options
 
@@ -76,7 +106,7 @@ passed — runs a deterministic assertion **while the space is still open**, ret
   per-scenario timeout of its own; this is what actually bounds each eval (`vitest.config.ts`'s
   `testTimeout` is just the outer safety net). Raise it only for scenarios with more tool
   round-trips than a typical eval — e.g. `crm-mailbox.eval.ts`/`planning.eval.ts` use `150_000`.
-- `dbQuery: (input, spaceId) => Effect<D, unknown, Database.Service>` — see Assertions below.
+- `scorers: readonly Scorer.Any[]` — the graded dimensions; see Scorers above.
 
 ### Driving a real Claude Code subprocess (`../claude-harness.ts`)
 
@@ -92,14 +122,14 @@ server's tools allowed — no Bash, no file tools, so a prompt the surface canno
   claims rather than at the end.
 - Needs `DX_ANTHROPIC_API_KEY` and a `claude` binary on PATH; `DX_EVAL_CLAUDE_MODEL` overrides the
   model (default `sonnet`).
-- The scored fields are plain booleans the task returns, so the evalite scorers stay one-liners —
-  see `src/evals/mcp-server.eval.ts`, whose subprocess-server counterpart is the CLI's
+- `score(scorers)` grades a list in the same harness; a staged run records what each turn
+  established and the scorers read it back — see `src/evals/mcp-server.eval.ts`, whose subprocess-server counterpart is the CLI's
   `mcp/agent-e2e.test.ts` (a real Claude Code against `dx mcp serve`).
 - `src/mcp-host.test.ts` covers the server itself deterministically and offline, with no model.
 
 ### Assertions (`../assertions.ts`)
 
-All are `Effect<_, _, Database.Service>` — compose freely inside a `dbQuery`'s `Effect.gen`:
+All are `Effect<_, _, Database.Service>` — compose freely inside a scorer's `query`:
 
 - **`objectExists(type, predicate)`** / **`findObject(type, predicate)`** — query the DB for a
   matching entity (object or relation). `findObject` returns the match itself (e.g. to load a
@@ -145,7 +175,7 @@ routing through Braintrust's proxy, neither of which this repo has wired up.
 only for the specific criterion that needs a content judgment, never as a blanket replacement for a
 deterministic check that already exists — and when you add one, also demonstrate it can fail (a
 judge that only ever passes is worthless as a scorer). See `planning.eval.ts` for the pattern: one
-`dbQuery`-embedded judge call for the real scenario's haiku-quality criterion, plus a second
+judge call behind one scorer's `query` for the real scenario's haiku-quality criterion, plus a second
 `evalite()` case in the same file feeding the same rubric a hand-crafted bad transcript, asserting
 `pass === false`. Don't build a separate meta-test file for the judge mechanism itself, and don't
 convert every eval's checks to judges just because one exists — most criteria in this package
@@ -184,12 +214,12 @@ moon run assistant-evals:evals -- src/evals/planning.eval.ts
 
 ## Common Mistakes
 
-| Mistake                                                       | Fix                                                                                                                 |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Adding a judge for a criterion a `dbQuery` check could grade  | Reach for `judge()` only when the criterion is a genuine content/quality judgment.                                  |
-| A judge with no demonstrated failure case                     | Add a case (in the same eval file) proving it can fail, using a hand-crafted bad input.                             |
-| Matching a tool by `name` instead of `operationKey`           | `name` is a display/toolkit name and varies; `operationKey` is the stable match target.                             |
-| Guessing a tool name/operationKey string instead of checking  | Add a temp debug field to the `dbQuery` output, run once, inspect `cache.sqlite`, fix, remove the debug field.      |
-| Forgetting `sessionChat: true` for a chat-scoped skill's tool | Symptom is a context-resolution error, not "no chat found" — check the skill's operation for `Chat.getFromContext`. |
-| Assuming pre-seeded data without saying so in the prompt      | State the DB starts empty; seed via the database skill's tools at the start of the prompt.                          |
-| Pasting entire eval files in chat when structure is standard  | Point at the file + line range instead.                                                                             |
+| Mistake                                                           | Fix                                                                                                                 |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Adding a judge for a criterion a deterministic scorer could grade | Reach for `judge()` only when the criterion is a genuine content/quality judgment.                                  |
+| A judge with no demonstrated failure case                         | Add a case (in the same eval file) proving it can fail, using a hand-crafted bad input.                             |
+| Matching a tool by `name` instead of `operationKey`               | `name` is a display/toolkit name and varies; `operationKey` is the stable match target.                             |
+| Guessing a tool name/operationKey string instead of checking      | Add a temp scorer whose query returns the invocations, run once, inspect `cache.sqlite`, fix, remove it.            |
+| Forgetting `sessionChat: true` for a chat-scoped skill's tool     | Symptom is a context-resolution error, not "no chat found" — check the skill's operation for `Chat.getFromContext`. |
+| Assuming pre-seeded data without saying so in the prompt          | State the DB starts empty; seed via the database skill's tools at the start of the prompt.                          |
+| Pasting entire eval files in chat when structure is standard      | Point at the file + line range instead.                                                                             |

--- a/.agents/skills/agent-eval-tests/SKILL.md
+++ b/.agents/skills/agent-eval-tests/SKILL.md
@@ -179,7 +179,7 @@ routing through Braintrust's proxy, neither of which this repo has wired up.
 only for the specific criterion that needs a content judgment, never as a blanket replacement for a
 deterministic check that already exists — and when you add one, also demonstrate it can fail (a
 judge that only ever passes is worthless as a scorer). See `planning.eval.ts` for the pattern: one
-judge call behind one scorer's `query` for the real scenario's haiku-quality criterion, plus a second
+judge call behind one scorer's `score` for the real scenario's haiku-quality criterion, plus a second
 `evalite()` case in the same file feeding the same rubric a hand-crafted bad transcript, asserting
 `pass === false`. Don't build a separate meta-test file for the judge mechanism itself, and don't
 convert every eval's checks to judges just because one exists — most criteria in this package

--- a/.agents/skills/agent-eval-tests/SKILL.md
+++ b/.agents/skills/agent-eval-tests/SKILL.md
@@ -23,11 +23,12 @@ package, `@dxos/assistant-e2e` — not covered by this skill; see its own README
 ## Eval File Structure
 
 ```typescript
-import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 import { evalite } from 'evalite';
 
 import { Filter, Query } from '@dxos/echo';
+import { Organization } from '@dxos/types';
+import { trim } from '@dxos/util';
 
 import { createEvalRunner } from '../runner';
 import * as Scorer from '../Scorer';

--- a/packages/core/compute/assistant-evals/src/Scorer.ts
+++ b/packages/core/compute/assistant-evals/src/Scorer.ts
@@ -15,145 +15,136 @@ import { Database, type Query } from '@dxos/echo';
 
 import { type ToolInvocation, toolInvocations } from './assertions.ts';
 
-/**
- * What a scorer's query may reach: the space the session worked in, the trace feed its tools were
- * written to, and the runtime's operations — the same surface the run itself had, while it is still
- * open. A scorer is therefore written against the database rather than against a blob of state some
- * earlier pass had to anticipate.
- */
-export type Services = Database.Service | FeedTraceSink.FeedTraceSink | Capabilities.ProcessManagerRuntimeServices;
+/** What the run itself contributes, for a scorer grading the session rather than what it left. */
+export class Run extends Context.Service<Run, { readonly durationMillis: number }>()(
+  '@dxos/assistant-evals/Scorer/Run',
+) {}
 
-/** What the run contributes, for a scorer grading the session rather than what it left behind. */
-export type Run = {
-  readonly durationMillis: number;
-};
+/**
+ * Per-run memo for the work several scorers share (see {@link shared}). Variants of one eval run
+ * concurrently in one process, so the cache is the run's and never the module's.
+ */
+export class Memo extends Context.Service<Memo, { readonly cache: Map<unknown, Exit.Exit<any, any>> }>()(
+  '@dxos/assistant-evals/Scorer/Memo',
+) {}
+
+/**
+ * What a scorer may reach: the space the session worked in, the trace feed its tools were written
+ * to, the runtime's operations — the same surface the run itself had, while it is still open — plus
+ * what the run reports about itself. A scorer is therefore written against the database rather than
+ * against a blob of state some earlier pass had to anticipate.
+ */
+export type Services =
+  | Database.Service
+  | FeedTraceSink.FeedTraceSink
+  | Capabilities.ProcessManagerRuntimeServices
+  | Run
+  | Memo;
 
 /** A scorer's verdict: a fraction of a mark, or a flag read as one or zero. */
 export type Result = number | boolean;
 
 /**
- * One graded dimension: a query run against the live space, and a verdict on what it returned. The
- * two halves are separate so the query's value can be reported next to the score — a reader of a
- * run needs what the session left, not only the mark it earned for it.
+ * One graded dimension: an effect that reads whatever it needs of the open run and returns the mark
+ * for it. Reading and judging are one step, so a dimension is a single self-contained value that can
+ * be moved or deleted without disturbing anything else.
  */
-export type Scorer<A> = {
+export type Scorer = {
   readonly name: string;
   readonly description?: string;
-  readonly query: Effect.Effect<A, unknown, Services>;
-  readonly score: (value: A, run: Run) => Result;
+  readonly score: Effect.Effect<Result, unknown, Services>;
 };
 
-export type Any = Scorer<any>;
+export type Any = Scorer;
 
-/** A scored dimension, as the task reports it: the mark, the value it was read from, or the failure. */
+/** A scored dimension, as a run reports it: the mark, or the failure that stood in for one. */
 export type Score = {
   readonly score: number;
-  readonly value?: unknown;
   readonly error?: string;
 };
 
 export type Scores = Record<string, Score>;
 
-/**
- * Per-run memo for the queries several scorers share, keyed by the query effect itself. Variants of
- * one eval run concurrently in one process, so the cache is the run's and never the module's.
- */
-class Memo extends Context.Service<Memo, { readonly cache: Map<unknown, Exit.Exit<any, any>> }>()(
-  '@dxos/assistant-evals/Scorer/Memo',
-) {}
+/** The base case: the scorer is its effect. */
+export const make = (options: {
+  name: string;
+  description?: string;
+  score: Effect.Effect<Result, unknown, Services>;
+}): Scorer => options;
 
 /**
- * The base case: a scorer that reads nothing of the space, only what the run itself reports. Given
- * a `query`, the query's value is what the verdict reads instead.
+ * Runs `effect` at most once per run, keyed by the effect itself, so scorers reading the same thing
+ * share one answer and an expensive probe is not paid for by each of them. The exit, not the value:
+ * a shared effect that failed has still been asked, and asking it again would run the probe a second
+ * time and report a different answer to each scorer. Sound because a run's dimensions are graded one
+ * at a time (see {@link Session}), so there is never a second caller to join a call in flight.
  */
-export const make: {
-  <A, E, R extends Services>(options: {
-    name: string;
-    description?: string;
-    query: Effect.Effect<A, E, R>;
-    score: (value: A, run: Run) => Result;
-  }): Scorer<A>;
-  (options: { name: string; description?: string; score: (run: Run) => Result }): Scorer<void>;
-} = (
-  options:
-    | {
-        name: string;
-        description?: string;
-        query: Effect.Effect<unknown, unknown, Services>;
-        // Method syntax: the verdict is written against the query's own value, so the two halves
-        // are checked bivariantly here rather than against this erased shape.
-        score(value: unknown, run: Run): Result;
-      }
-    | { name: string; description?: string; score(run: Run): Result },
-): Any => {
-  const { name, description } = options;
-  return 'query' in options
-    ? { name, description, query: options.query, score: (value, run) => options.score(value, run) }
-    : { name, description, query: Effect.void, score: (_value, run) => options.score(run) };
-};
+export const shared = <A, E, R extends Services>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R | Memo> =>
+  Effect.gen(function* () {
+    const { cache } = yield* Memo;
+    const cached = cache.get(effect);
+    if (cached !== undefined) {
+      return yield* cached as Exit.Exit<A, E>;
+    }
+    const exit = yield* Effect.exit(effect);
+    cache.set(effect, exit);
+    return yield* exit;
+  });
 
-/**
- * A scorer over an ECHO query: the query runs against the session's space and its results are the
- * only thing the verdict sees.
- */
+/** A scorer over an ECHO query: the query runs against the session's space, and its results are judged. */
 export const database = <Q extends Query.Any>(options: {
   name: string;
   description?: string;
   query: Q;
-  score: (results: readonly Query.Type<Q>[], run: Run) => Result;
-}): Scorer<readonly Query.Type<Q>[]> => {
-  const query: Effect.Effect<readonly Query.Type<Q>[], unknown, Services> = Database.query(options.query).run;
-  return make({
+  score: (results: readonly Query.Type<Q>[]) => Result;
+}): Scorer =>
+  make({
     name: options.name,
     description: options.description,
-    query,
-    score: options.score,
+    score: Database.query(options.query).run.pipe(Effect.map(options.score)),
   });
-};
 
 /**
- * The tool calls the session made, paired with their results, in order. One effect value shared by
- * every scorer that reads it, so the feed is read once per run.
+ * The tool calls the session made, paired with their results, in order. Shared, so the feed is read
+ * once per run however many scorers name it.
  */
-export const invocations: Effect.Effect<readonly ToolInvocation[], unknown, Services> = toolInvocations();
+export const invocations: Effect.Effect<readonly ToolInvocation[], unknown, Services> = shared(toolInvocations());
 
 /** A scorer over the tool calls the session made. */
 export const toolCalls = (options: {
   name: string;
   description?: string;
-  score: (invocations: readonly ToolInvocation[], run: Run) => Result;
-}): Scorer<readonly ToolInvocation[]> =>
+  score: (invocations: readonly ToolInvocation[]) => Result;
+}): Scorer =>
   make({
     name: options.name,
     description: options.description,
-    query: invocations,
-    score: options.score,
+    score: invocations.pipe(Effect.map(options.score)),
   });
 
 /**
  * A scorer over the session's wall clock: full marks up to `targetMinutes`, falling linearly to
- * nothing at `budgetMinutes`. `when` gates it, so a run that never produced the thing being timed
- * scores nothing rather than being rewarded for stopping early.
+ * nothing at `budgetMinutes`. `delivered` gates it, so a run that never produced the thing being
+ * timed scores nothing rather than being rewarded for stopping early.
  */
-export const duration = <A, E, R extends Services>(options: {
+export const duration = (options: {
   name: string;
   description?: string;
   targetMinutes: number;
   budgetMinutes: number;
-  when: Effect.Effect<A, E, R>;
-  delivered: (value: A) => boolean;
-}): Scorer<A> =>
+  delivered: Effect.Effect<boolean, unknown, Services>;
+}): Scorer =>
   make({
     name: options.name,
     description: options.description,
-    query: options.when,
-    score: (value, { durationMillis }) => {
-      if (!options.delivered(value)) {
+    score: Effect.gen(function* () {
+      if (!(yield* options.delivered)) {
         return 0;
       }
+      const { durationMillis } = yield* Run;
       const minutes = durationMillis / 60_000;
       return (options.budgetMinutes - minutes) / (options.budgetMinutes - options.targetMinutes);
-    },
+    }),
   });
 
 /** Booleans are a mark or none; fractions are clamped, so a scorer cannot spend more than its one. */
@@ -163,50 +154,85 @@ const normalize = (result: Result): number =>
 const describe = (cause: Cause.Cause<unknown>): string => Cause.pretty(cause);
 
 /**
- * Runs each distinct query at most once per run, keyed by the effect itself: scorers that read the
- * same value share one answer, and an expensive probe is not paid for by each of them. The exit,
- * not the value: a shared query that failed has still been asked, and re-asking it would run the
- * probe again and report a different answer to each scorer.
+ * A run whose space is still open. The harness is disposed by the eval's `afterAll` (see
+ * `runner.ts`) rather than when the task returns, because evalite runs a row's scorers inside that
+ * row's own test, after the task and before the file ends — so a scorer reads what the session
+ * actually left instead of a snapshot an earlier pass had to anticipate.
  */
-const memoized = <A>(query: Effect.Effect<A, unknown, Services>): Effect.Effect<A, unknown, Services | Memo> =>
-  Effect.gen(function* () {
-    const { cache } = yield* Memo;
-    const cached = cache.get(query);
-    if (cached !== undefined) {
-      return yield* cached;
-    }
-    const exit = yield* Effect.exit(query);
-    cache.set(query, exit);
-    return yield* exit;
-  });
+export type Session = {
+  /** Runs a scorer inside the run's own harness, with its space and its {@link Run} provided. */
+  readonly grade: (scorer: Scorer) => Promise<Exit.Exit<Result, unknown>>;
+};
 
 /**
- * Scores every dimension against the open space, in order, sharing the answer to any query more
- * than one of them names. A query that fails scores nothing and reports why, rather than failing
- * the run: a scorer reading state a timed-out session never reached is a result, not an error.
+ * The open sessions, by the id their task reported. Module-level because the scorers run outside the
+ * task that opened the session, and evalite hands them nothing but that task's output.
  */
-export const runAll = (scorers: readonly Any[], run: Run): Effect.Effect<Scores, never, Services> =>
+const sessions = new Map<string, Session>();
+
+export const openSession = (id: string, session: Session): void => {
+  sessions.set(id, session);
+};
+
+export const closeSession = (id: string): void => {
+  sessions.delete(id);
+};
+
+/**
+ * What a session provides its scorers beyond the space itself: what the run reports about its own
+ * wall clock, and the memo the shared reads of that run agree on.
+ */
+export const sessionServices = (run: { durationMillis: number }) => {
+  const cache = new Map<unknown, Exit.Exit<any, any>>();
+  return <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, Exclude<R, Run | Memo>> =>
+    effect.pipe(
+      Effect.provideService(Run, { durationMillis: run.durationMillis }),
+      Effect.provideService(Memo, { cache }),
+    ) as Effect.Effect<A, E, Exclude<R, Run | Memo>>;
+};
+
+/**
+ * Scores every dimension in order against the open space. A scorer that fails scores nothing and
+ * reports why, rather than failing the run: one reading state a timed-out session never reached is a
+ * result, not an error, and must not take the other nine with it.
+ */
+export const runAll = (scorers: readonly Any[]): Effect.Effect<Scores, never, Services> =>
   Effect.gen(function* () {
     const scores: Record<string, Score> = {};
     for (const scorer of scorers) {
-      // The verdict runs inside the same boundary as the query: a scorer that throws on an
-      // unexpected shape scores nothing and says so, rather than taking the other nine with it.
+      // `Effect.try` around the verdict too: a scorer that throws on an unexpected shape scores
+      // nothing and says so.
       const exit = yield* Effect.exit(
-        memoized(scorer.query).pipe(
-          Effect.flatMap((value) =>
-            Effect.try(() => normalize(scorer.score(value, run))).pipe(Effect.map((score) => ({ score, value }))),
-          ),
-        ),
+        scorer.score.pipe(Effect.flatMap((result) => Effect.try(() => normalize(result)))),
       );
-      scores[scorer.name] = Exit.isSuccess(exit) ? exit.value : { score: 0, error: describe(exit.cause) };
+      scores[scorer.name] = Exit.isSuccess(exit) ? { score: exit.value } : { score: 0, error: describe(exit.cause) };
     }
     return scores;
-  }).pipe(Effect.provideService(Memo, { cache: new Map<unknown, Exit.Exit<any, any>>() }));
+  });
 
-/** The evalite side of the same list: each dimension reads the mark the run already recorded. */
+/** What a graded task hands its scorers: a session to grade against, or the marks it already recorded. */
+type Graded = { readonly runId?: string; readonly scores?: Scores };
+
+/**
+ * The evalite side of the same list, so a dimension is declared once and wired once.
+ *
+ * A run that left its space open is graded here, against that space. A staged run has none left to
+ * ask — `claude-harness` disposes its own harness, because the facts it scores are only true between
+ * two of its turns — so it records its marks with {@link runAll} and they are read back instead.
+ */
 export const toEvalite = (scorers: readonly Any[]) =>
-  scorers.map(({ name, description }) => ({
-    name,
-    description,
-    scorer: ({ output }: { output: { scores: Scores } }) => output.scores[name]?.score ?? 0,
+  scorers.map((scorer) => ({
+    name: scorer.name,
+    description: scorer.description,
+    scorer: async ({ output }: { output: Graded }) => {
+      const session = output?.runId === undefined ? undefined : sessions.get(output.runId);
+      if (!session) {
+        const recorded = output?.scores?.[scorer.name];
+        return { score: recorded?.score ?? 0, metadata: { error: recorded?.error } };
+      }
+      const exit = await session.grade(scorer);
+      return Exit.isSuccess(exit)
+        ? { score: normalize(exit.value), metadata: {} }
+        : { score: 0, metadata: { error: describe(exit.cause) } };
+    },
   }));

--- a/packages/core/compute/assistant-evals/src/claude-harness.ts
+++ b/packages/core/compute/assistant-evals/src/claude-harness.ts
@@ -191,7 +191,7 @@ export const runClaudeEval = async <T>(
     let durationMillis = 0;
     const score = (scorers: readonly Scorer.Any[]): Promise<Scorer.Scores> =>
       app.runPromise(
-        Scorer.runAll(scorers, { durationMillis }).pipe(
+        Scorer.sessionServices({ durationMillis })(Scorer.runAll(scorers)).pipe(
           Effect.provide(ServiceResolver.provide({ space: spaceId }, Database.Service, FeedTraceSink.FeedTraceSink)),
         ),
       );

--- a/packages/core/compute/assistant-evals/src/evals/chess-mcp.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/chess-mcp.eval.ts
@@ -154,90 +154,96 @@ const namesAScore = (answer: string | undefined): boolean =>
 //
 
 /** Everything the session filed on the project, as text, with what a reader looks for in it. */
-const filedArtifacts = Effect.gen(function* () {
-  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-  if (!project) {
-    return { filed: '', design: undefined, workerUrls: [] as string[] };
-  }
-  const artifacts = yield* Effect.forEach(project.artifacts, (ref) =>
-    Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
-  );
-  const documents = artifacts.filter((candidate): candidate is Markdown.Document =>
-    Obj.instanceOf(Markdown.Document, candidate),
-  );
-  const texts = yield* Effect.forEach(documents, (document) =>
-    Database.load(document.content).pipe(
-      Effect.map((text) => ({ name: document.name ?? '', content: text.content })),
-      Effect.orElseSucceed(() => ({ name: document.name ?? '', content: '' })),
-    ),
-  );
-  const filed = texts.map(({ content }) => content).join('\n');
-  return {
-    filed,
-    design: texts.find(({ name, content }) => /design/i.test(name) || /^#.*design/im.test(content)),
-    workerUrls: [...new Set((filed.match(WORKER_URL) ?? []).map((url) => url.replace(/[.,)]+$/, '')))],
-  };
-});
+const filedArtifacts = Scorer.shared(
+  Effect.gen(function* () {
+    const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+    if (!project) {
+      return { filed: '', design: undefined, workerUrls: [] as string[] };
+    }
+    const artifacts = yield* Effect.forEach(project.artifacts, (ref) =>
+      Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
+    );
+    const documents = artifacts.filter((candidate): candidate is Markdown.Document =>
+      Obj.instanceOf(Markdown.Document, candidate),
+    );
+    const texts = yield* Effect.forEach(documents, (document) =>
+      Database.load(document.content).pipe(
+        Effect.map((text) => ({ name: document.name ?? '', content: text.content })),
+        Effect.orElseSucceed(() => ({ name: document.name ?? '', content: '' })),
+      ),
+    );
+    const filed = texts.map(({ content }) => content).join('\n');
+    return {
+      filed,
+      design: texts.find(({ name, content }) => /design/i.test(name) || /^#.*design/im.test(content)),
+      workerUrls: [...new Set((filed.match(WORKER_URL) ?? []).map((url) => url.replace(/[.,)]+$/, '')))],
+    };
+  }),
+);
 
 /**
  * The handshake, from the sandbox the session built in: a temporary deployment challenges clients
  * it takes for bots and the eval process is one. Candidates are every Worker URL it filed, bare
  * host first, then with the paths it mentioned and the conventional `/mcp`.
  */
-const engine = Effect.gen(function* () {
-  const { workerUrls } = yield* filedArtifacts;
-  const sandbox = yield* findObject(Sandbox.Sandbox, () => true);
-  // Named in the value so the container, which outlives the run, can be inspected afterwards.
-  const sandboxId = sandbox?.id;
-  if (workerUrls.length === 0 || !sandbox) {
-    return { sandboxId, probe: undefined as Probe | undefined };
-  }
-  const spaceId = yield* Database.spaceId;
-  const hosts = [...new Set(workerUrls.map((url) => new URL(url).origin))];
-  const candidates = [...new Set([...workerUrls, ...hosts.map((host) => `${host}/mcp`), ...hosts])];
-  const command = `cat > /tmp/mcp-probe.mjs <<'PROBE'\n${MCP_PROBE}\nPROBE\nnode /tmp/mcp-probe.mjs '${SEEDED_FEN}' ${candidates.map((url) => `'${url}'`).join(' ')}`;
-  const result = yield* Operation.invoke(
-    SandboxOperation.Exec,
-    { sandbox: Ref.make(sandbox), command, timeout: 3 * 60 * 1_000 },
-    { spaceId },
-  ).pipe(Effect.orElseSucceed(() => undefined));
-  return { sandboxId, probe: result ? parseProbe(result.stdout) : undefined };
-});
+const engine = Scorer.shared(
+  Effect.gen(function* () {
+    const { workerUrls } = yield* filedArtifacts;
+    const sandbox = yield* findObject(Sandbox.Sandbox, () => true);
+    // Named in the value so the container, which outlives the run, can be inspected afterwards.
+    const sandboxId = sandbox?.id;
+    if (workerUrls.length === 0 || !sandbox) {
+      return { sandboxId, probe: undefined as Probe | undefined };
+    }
+    const spaceId = yield* Database.spaceId;
+    const hosts = [...new Set(workerUrls.map((url) => new URL(url).origin))];
+    const candidates = [...new Set([...workerUrls, ...hosts.map((host) => `${host}/mcp`), ...hosts])];
+    const command = `cat > /tmp/mcp-probe.mjs <<'PROBE'\n${MCP_PROBE}\nPROBE\nnode /tmp/mcp-probe.mjs '${SEEDED_FEN}' ${candidates.map((url) => `'${url}'`).join(' ')}`;
+    const result = yield* Operation.invoke(
+      SandboxOperation.Exec,
+      { sandbox: Ref.make(sandbox), command, timeout: 3 * 60 * 1_000 },
+      { spaceId },
+    ).pipe(Effect.orElseSucceed(() => undefined));
+    return { sandboxId, probe: result ? parseProbe(result.stdout) : undefined };
+  }),
+);
 
 /** The checklist as the session left it: the three stages it was given, and the work that was not. */
-const checklist = Effect.gen(function* () {
-  const empty = {
-    delegated: [] as (Task.Task | undefined)[],
-    readerSteps: [] as (Task.Task | undefined)[],
-    later: [] as (Task.Task | undefined)[],
-  };
-  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-  if (!project?.taskSet) {
-    return empty;
-  }
-  const taskSet = yield* Database.load(project.taskSet).pipe(Effect.orElseSucceed(() => undefined));
-  if (!taskSet) {
-    return empty;
-  }
-  const tasks = yield* Effect.forEach(taskSet.tasks, (ref) =>
-    Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
-  );
-  const delegated = DELEGATED_STAGES.map((title) => tasks.find((candidate) => candidate?.title === title));
-  return {
-    delegated,
-    readerSteps: tasks.filter((candidate) => candidate?.assignee?.role === 'user'),
-    later: tasks.filter((candidate) => {
-      const parentTask = candidate?.parentTask;
-      return (
-        parentTask !== undefined &&
-        candidate?.assignee?.role !== 'assistant' &&
-        candidate?.assignee?.role !== 'user' &&
-        !DELEGATED_STAGES.includes(candidate?.title ?? '') &&
-        !delegated.some((stage) => stage && Task.refEntityId(parentTask) === stage.id)
-      );
-    }),
-  };
-});
+const checklist = Scorer.shared(
+  Effect.gen(function* () {
+    const empty = {
+      delegated: [] as (Task.Task | undefined)[],
+      readerSteps: [] as (Task.Task | undefined)[],
+      later: [] as (Task.Task | undefined)[],
+    };
+    const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+    if (!project?.taskSet) {
+      return empty;
+    }
+    const taskSet = yield* Database.load(project.taskSet).pipe(Effect.orElseSucceed(() => undefined));
+    if (!taskSet) {
+      return empty;
+    }
+    const tasks = yield* Effect.forEach(taskSet.tasks, (ref) =>
+      Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
+    );
+    const delegated = DELEGATED_STAGES.map((title) => tasks.find((candidate) => candidate?.title === title));
+    return {
+      delegated,
+      readerSteps: tasks.filter((candidate) => candidate?.assignee?.role === 'user'),
+      later: tasks.filter((candidate) => {
+        const parentTask = candidate?.parentTask;
+        return (
+          parentTask !== undefined &&
+          candidate?.assignee?.role !== 'assistant' &&
+          candidate?.assignee?.role !== 'user' &&
+          !DELEGATED_STAGES.includes(candidate?.title ?? '') &&
+          !delegated.some((stage) => stage && Task.refEntityId(parentTask) === stage.id)
+        );
+      }),
+    };
+  }),
+);
 
 /**
  * Where the hour went: each call with when it started (seconds into the run), how long the tool
@@ -272,68 +278,76 @@ const SCORERS = [
   Scorer.make({
     name: 'design-filed-with-diagram',
     description: 'A design artifact is on the project and carries a mermaid diagram of the request path.',
-    query: filedArtifacts,
-    score: ({ design }) =>
-      [!!design && design.content.length > 200, !!design && /```mermaid/.test(design.content)].filter(Boolean).length /
-      2,
+    score: filedArtifacts.pipe(
+      Effect.map(
+        ({ design }) =>
+          [!!design && design.content.length > 200, !!design && /```mermaid/.test(design.content)].filter(Boolean)
+            .length / 2,
+      ),
+    ),
   }),
   Scorer.make({
     name: 'shell-was-used',
     description: 'The session opened a sandbox and ran commands in it.',
-    // The timeline is the value, so a reader of the run sees where its hour went next to the mark.
-    query: Scorer.invocations.pipe(Effect.map(timelineOf)),
-    score: ({ sandboxCreated, execCalls }) => sandboxCreated && execCalls > 0,
+    score: Scorer.invocations.pipe(
+      Effect.map(timelineOf),
+      Effect.map(({ sandboxCreated, execCalls }) => sandboxCreated && execCalls > 0),
+    ),
   }),
   Scorer.make({
     name: 'worker-url-filed-claim-url-not',
     description: 'A project artifact carries the Worker URL, and none carries the claim URL.',
-    query: filedArtifacts,
     // The claim URL is a bearer credential for the account; the skill says to file it nowhere.
-    score: ({ filed, workerUrls }) => workerUrls.length > 0 && !CLAIM_URL.test(filed),
+    score: filedArtifacts.pipe(Effect.map(({ filed, workerUrls }) => workerUrls.length > 0 && !CLAIM_URL.test(filed))),
   }),
   Scorer.make({
     name: 'mcp-handshake-lists-two-tools',
     description: 'The filed URL answers initialize and tools/list over Streamable HTTP with two tools.',
-    query: engine,
-    score: ({ probe }) => {
-      const listed = probe?.tools.length ?? 0;
-      return listed >= 2 ? 1 : listed > 0 ? 0.5 : 0;
-    },
+    score: engine.pipe(
+      Effect.map(({ probe }) => {
+        const listed = probe?.tools.length ?? 0;
+        return listed >= 2 ? 1 : listed > 0 ? 0.5 : 0;
+      }),
+    ),
   }),
   Scorer.make({
     name: 'best-move-is-legal',
     description: 'The move tool, called with the seeded position, names a move that is legal in it.',
-    query: engine,
-    score: ({ probe }) => namesLegalMove(probe?.bestMove),
+    score: engine.pipe(Effect.map(({ probe }) => namesLegalMove(probe?.bestMove))),
   }),
   Scorer.make({
     name: 'evaluation-returns-a-score',
     description: 'The evaluate tool, called with the seeded position, returns a score.',
-    query: engine,
-    score: ({ probe }) => namesAScore(probe?.evaluation),
+    score: engine.pipe(Effect.map(({ probe }) => namesAScore(probe?.evaluation))),
   }),
   Scorer.make({
     name: 'delegated-stages-in-review',
     description: 'Every stage the session was given is in review (or done) when it finishes.',
-    query: checklist,
     // `done` past a named reviewer lands as `review`; either means the session finished the stage.
     // The denominator is the stages it was given, so renaming one away cannot raise the score.
-    score: ({ delegated }) =>
-      delegated.filter((stage) => stage?.status === 'review' || stage?.status === 'done').length /
-      DELEGATED_STAGES.length,
+    score: checklist.pipe(
+      Effect.map(
+        ({ delegated }) =>
+          delegated.filter((stage) => stage?.status === 'review' || stage?.status === 'done').length /
+          DELEGATED_STAGES.length,
+      ),
+    ),
   }),
   Scorer.make({
     name: 'reader-and-later-work-left-alone',
     description: "The reader's steps and the two undelegated stages are still to do, or marked blocked on the reader.",
-    query: checklist,
-    score: ({ readerSteps, later }) =>
-      [
-        // The model choice, the claim and the GitHub steps are the reader's, and cannot be done here.
-        readerSteps.length > 0 && readerSteps.every((step) => step?.status === 'todo'),
-        // The steps of stages four and five, and the stages themselves, were not delegated. Marking
-        // one blocked on the reader is the Development skill's own instruction, not work on it.
-        later.length > 0 && later.every((step) => step?.status === 'todo' || step?.status === 'blocked'),
-      ].filter(Boolean).length / 2,
+    score: checklist.pipe(
+      Effect.map(
+        ({ readerSteps, later }) =>
+          [
+            // The model choice, the claim and the GitHub steps are the reader's, and cannot be done here.
+            readerSteps.length > 0 && readerSteps.every((step) => step?.status === 'todo'),
+            // The steps of stages four and five, and the stages themselves, were not delegated. Marking
+            // one blocked on the reader is the Development skill's own instruction, not work on it.
+            later.length > 0 && later.every((step) => step?.status === 'todo' || step?.status === 'blocked'),
+          ].filter(Boolean).length / 2,
+      ),
+    ),
   }),
   Scorer.toolCalls({
     name: 'no-tool-errors',
@@ -345,8 +359,7 @@ const SCORERS = [
     description: `Full marks for a working best-move tool within ${TARGET_MINUTES} minutes, falling to none at ${BUDGET_MINUTES}; nothing for a server that does not answer.`,
     targetMinutes: TARGET_MINUTES,
     budgetMinutes: BUDGET_MINUTES,
-    when: engine,
-    delivered: ({ probe }) => namesLegalMove(probe?.bestMove),
+    delivered: engine.pipe(Effect.map(({ probe }) => namesLegalMove(probe?.bestMove))),
   }),
 ];
 
@@ -432,7 +445,7 @@ const task = createEvalRunner({
 
       return { objects: [Ref.make(project)], chat: Ref.make(chat) };
     }),
-  scorers: SCORERS,
+  scored: true,
 });
 
 /**

--- a/packages/core/compute/assistant-evals/src/evals/crm-mailbox.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/crm-mailbox.eval.ts
@@ -69,67 +69,69 @@ const SEED_EMAIL_INPUT = {
 const PERSON_NAME = 'Vishal Sharma';
 const ORGANIZATION_NAME = 'SigNoz';
 
-const person = findObject(Person.Person, (candidate) => candidate.fullName === PERSON_NAME);
-const organization = findObject(Organization.Organization, (candidate) => candidate.name === ORGANIZATION_NAME);
-const employerRelation = findObject(Employer.Employer, (relation) => {
-  const source = Relation.getSource(relation);
-  const target = Relation.getTarget(relation);
-  return source?.fullName === PERSON_NAME && target?.name === ORGANIZATION_NAME;
-});
-const summaryProfile = findObject(ProfileOf.ProfileOf, (relation) => {
-  const target = Relation.getTarget(relation);
-  return Obj.instanceOf(Organization.Organization, target) && target.name === ORGANIZATION_NAME;
-});
+const person = Scorer.shared(findObject(Person.Person, (candidate) => candidate.fullName === PERSON_NAME));
+const organization = Scorer.shared(
+  findObject(Organization.Organization, (candidate) => candidate.name === ORGANIZATION_NAME),
+);
+const employerRelation = Scorer.shared(
+  findObject(Employer.Employer, (relation) => {
+    const source = Relation.getSource(relation);
+    const target = Relation.getTarget(relation);
+    return source?.fullName === PERSON_NAME && target?.name === ORGANIZATION_NAME;
+  }),
+);
+const summaryProfile = Scorer.shared(
+  findObject(ProfileOf.ProfileOf, (relation) => {
+    const target = Relation.getTarget(relation);
+    return Obj.instanceOf(Organization.Organization, target) && target.name === ORGANIZATION_NAME;
+  }),
+);
 
 /** The judge's verdict on whether the records the run created match the email it worked from. */
-const accuracyVerdict = Effect.gen(function* () {
-  const foundPerson = yield* person;
-  const foundOrganization = yield* organization;
-  const foundRelation = yield* employerRelation;
-  const createdRecords = {
-    person: foundPerson ? { fullName: foundPerson.fullName } : null,
-    organization: foundOrganization ? { name: foundOrganization.name } : null,
-    employerRole: foundRelation?.role ?? null,
-  };
-  return yield* judge(ACCURACY_JUDGE_RUBRIC, JSON.stringify({ sourceEmail: SEED_EMAIL_INPUT, createdRecords }));
-});
+const accuracyVerdict = Scorer.shared(
+  Effect.gen(function* () {
+    const foundPerson = yield* person;
+    const foundOrganization = yield* organization;
+    const foundRelation = yield* employerRelation;
+    const createdRecords = {
+      person: foundPerson ? { fullName: foundPerson.fullName } : null,
+      organization: foundOrganization ? { name: foundOrganization.name } : null,
+      employerRole: foundRelation?.role ?? null,
+    };
+    return yield* judge(ACCURACY_JUDGE_RUBRIC, JSON.stringify({ sourceEmail: SEED_EMAIL_INPUT, createdRecords }));
+  }),
+);
 
 const SCORERS = [
   Scorer.make({
     name: 'person-created',
     description: `A Person object for ${PERSON_NAME} exists in the database.`,
-    query: person,
-    score: (person) => !!person,
+    score: person.pipe(Effect.map((person) => !!person)),
   }),
   Scorer.make({
     name: 'organization-created',
     description: `An Organization object named ${ORGANIZATION_NAME} exists in the database.`,
-    query: organization,
-    score: (organization) => !!organization,
+    score: organization.pipe(Effect.map((organization) => !!organization)),
   }),
   Scorer.make({
     name: 'employer-relation-created',
     description: `An Employer relation between ${PERSON_NAME} and ${ORGANIZATION_NAME} exists.`,
-    query: employerRelation,
-    score: (relation) => !!relation,
+    score: employerRelation.pipe(Effect.map((relation) => !!relation)),
   }),
   Scorer.make({
     name: 'employer-role-correct',
     description: 'The Employer relation\'s role is "Founding Engineer", stored as a proper schema field.',
-    query: employerRelation,
-    score: (relation) => relation?.role === 'Founding Engineer',
+    score: employerRelation.pipe(Effect.map((relation) => relation?.role === 'Founding Engineer')),
   }),
   Scorer.make({
     name: 'summary-document-linked',
     description: `A Profile Document is linked to the ${ORGANIZATION_NAME} Organization via a ProfileOf relation.`,
-    query: summaryProfile,
-    score: (profile) => !!profile,
+    score: summaryProfile.pipe(Effect.map((profile) => !!profile)),
   }),
   Scorer.make({
     name: 'crm-data-accurate',
     description: 'An LLM judge confirms the CRM records accurately reflect the source email (not just present).',
-    query: accuracyVerdict,
-    score: (verdict) => verdict.pass,
+    score: accuracyVerdict.pipe(Effect.map((verdict) => verdict.pass)),
   }),
 ];
 
@@ -156,7 +158,7 @@ const task = createEvalRunner({
   // Research (web search) + CRM + markdown tool calls chain across several turns; ~95s alone, and
   // the nightly runs it beside the hour-long scenarios.
   timeout: 300_000,
-  scorers: SCORERS,
+  scored: true,
 });
 
 evalite('CRM Mailbox — processes a mailbox email into CRM profiles and employer relation', {

--- a/packages/core/compute/assistant-evals/src/evals/crm-mailbox.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/crm-mailbox.eval.ts
@@ -17,6 +17,7 @@ import { trim } from '@dxos/util';
 import { findObject } from '../assertions.ts';
 import { judge } from '../judge.ts';
 import { createEvalRunner } from '../runner.ts';
+import * as Scorer from '../Scorer.ts';
 
 // Ported from the gated `CRM Mailbox` scenario (../testing/crm-mailbox.test.ts).
 // Grades the DB effect directly instead of the agent's self-reported `completedCriteria`. Existence
@@ -65,6 +66,73 @@ const SEED_EMAIL_INPUT = {
   created: '2026-06-26T12:00:00.000Z',
 };
 
+const PERSON_NAME = 'Vishal Sharma';
+const ORGANIZATION_NAME = 'SigNoz';
+
+const person = findObject(Person.Person, (candidate) => candidate.fullName === PERSON_NAME);
+const organization = findObject(Organization.Organization, (candidate) => candidate.name === ORGANIZATION_NAME);
+const employerRelation = findObject(Employer.Employer, (relation) => {
+  const source = Relation.getSource(relation);
+  const target = Relation.getTarget(relation);
+  return source?.fullName === PERSON_NAME && target?.name === ORGANIZATION_NAME;
+});
+const summaryProfile = findObject(ProfileOf.ProfileOf, (relation) => {
+  const target = Relation.getTarget(relation);
+  return Obj.instanceOf(Organization.Organization, target) && target.name === ORGANIZATION_NAME;
+});
+
+/** The judge's verdict on whether the records the run created match the email it worked from. */
+const accuracyVerdict = Effect.gen(function* () {
+  const foundPerson = yield* person;
+  const foundOrganization = yield* organization;
+  const foundRelation = yield* employerRelation;
+  const createdRecords = {
+    person: foundPerson ? { fullName: foundPerson.fullName } : null,
+    organization: foundOrganization ? { name: foundOrganization.name } : null,
+    employerRole: foundRelation?.role ?? null,
+  };
+  return yield* judge(ACCURACY_JUDGE_RUBRIC, JSON.stringify({ sourceEmail: SEED_EMAIL_INPUT, createdRecords }));
+});
+
+const SCORERS = [
+  Scorer.make({
+    name: 'person-created',
+    description: `A Person object for ${PERSON_NAME} exists in the database.`,
+    query: person,
+    score: (person) => !!person,
+  }),
+  Scorer.make({
+    name: 'organization-created',
+    description: `An Organization object named ${ORGANIZATION_NAME} exists in the database.`,
+    query: organization,
+    score: (organization) => !!organization,
+  }),
+  Scorer.make({
+    name: 'employer-relation-created',
+    description: `An Employer relation between ${PERSON_NAME} and ${ORGANIZATION_NAME} exists.`,
+    query: employerRelation,
+    score: (relation) => !!relation,
+  }),
+  Scorer.make({
+    name: 'employer-role-correct',
+    description: 'The Employer relation\'s role is "Founding Engineer", stored as a proper schema field.',
+    query: employerRelation,
+    score: (relation) => relation?.role === 'Founding Engineer',
+  }),
+  Scorer.make({
+    name: 'summary-document-linked',
+    description: `A Profile Document is linked to the ${ORGANIZATION_NAME} Organization via a ProfileOf relation.`,
+    query: summaryProfile,
+    score: (profile) => !!profile,
+  }),
+  Scorer.make({
+    name: 'crm-data-accurate',
+    description: 'An LLM judge confirms the CRM records accurately reflect the source email (not just present).',
+    query: accuracyVerdict,
+    score: (verdict) => verdict.pass,
+  }),
+];
+
 const task = createEvalRunner({
   instructions: trim`
     The database starts empty.
@@ -88,82 +156,13 @@ const task = createEvalRunner({
   // Research (web search) + CRM + markdown tool calls chain across several turns; ~95s alone, and
   // the nightly runs it beside the hour-long scenarios.
   timeout: 300_000,
-  dbQuery: () =>
-    Effect.gen(function* () {
-      const person = yield* findObject(Person.Person, (p) => p.fullName === 'Vishal Sharma');
-      const organization = yield* findObject(Organization.Organization, (o) => o.name === 'SigNoz');
-      const employerRelation = yield* findObject(Employer.Employer, (rel) => {
-        const source = Relation.getSource(rel);
-        const target = Relation.getTarget(rel);
-        return source?.fullName === 'Vishal Sharma' && target?.name === 'SigNoz';
-      });
-      const isOrganization = Obj.instanceOf(Organization.Organization);
-      const summaryProfile = yield* findObject(ProfileOf.ProfileOf, (rel) => {
-        const target = Relation.getTarget(rel);
-        return isOrganization(target) && target.name === 'SigNoz';
-      });
-
-      const accuracyVerdict = yield* judge(
-        ACCURACY_JUDGE_RUBRIC,
-        JSON.stringify({
-          sourceEmail: SEED_EMAIL_INPUT,
-          createdRecords: {
-            person: person ? { fullName: person.fullName } : null,
-            organization: organization ? { name: organization.name } : null,
-            employerRole: employerRelation?.role ?? null,
-          },
-        }),
-      );
-
-      return {
-        personExists: !!person,
-        organizationExists: !!organization,
-        employerRelationExists: !!employerRelation,
-        employerRoleCorrect: employerRelation?.role === 'Founding Engineer',
-        summaryDocumentLinked: !!summaryProfile,
-        accuracyVerdict,
-      };
-    }),
+  scorers: SCORERS,
 });
 
 evalite('CRM Mailbox — processes a mailbox email into CRM profiles and employer relation', {
   data: [{ input: null }],
   task,
-  scorers: [
-    {
-      name: 'person-created',
-      description: 'A Person object for Vishal Sharma exists in the database.',
-      scorer: ({ output }) => (output.dbQuery.personExists ? 1 : 0),
-    },
-    {
-      name: 'organization-created',
-      description: 'An Organization object named SigNoz exists in the database.',
-      scorer: ({ output }) => (output.dbQuery.organizationExists ? 1 : 0),
-    },
-    {
-      name: 'employer-relation-created',
-      description: 'An Employer relation between Vishal Sharma and SigNoz exists.',
-      scorer: ({ output }) => (output.dbQuery.employerRelationExists ? 1 : 0),
-    },
-    {
-      name: 'employer-role-correct',
-      description: 'The Employer relation\'s role is "Founding Engineer", stored as a proper schema field.',
-      scorer: ({ output }) => (output.dbQuery.employerRoleCorrect ? 1 : 0),
-    },
-    {
-      name: 'summary-document-linked',
-      description: 'A Profile Document is linked to the SigNoz Organization via a ProfileOf relation.',
-      scorer: ({ output }) => (output.dbQuery.summaryDocumentLinked ? 1 : 0),
-    },
-    {
-      name: 'crm-data-accurate',
-      description: 'An LLM judge confirms the CRM records accurately reflect the source email (not just present).',
-      scorer: ({ output }) => ({
-        score: output.dbQuery.accuracyVerdict.pass ? 1 : 0,
-        metadata: { reasoning: output.dbQuery.accuracyVerdict.reasoning },
-      }),
-    },
-  ],
+  scorers: Scorer.toEvalite(SCORERS),
 });
 
 // A judge that only ever passes would be worthless as a scorer — this demonstrates it correctly

--- a/packages/core/compute/assistant-evals/src/evals/database.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/database.eval.ts
@@ -2,20 +2,38 @@
 // Copyright 2026 DXOS.org
 //
 
-import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 import { evalite } from 'evalite';
 
+import { Filter, Query } from '@dxos/echo';
 import { Organization } from '@dxos/types';
 import { trim } from '@dxos/util';
 
-import { objectExists, toolInvocations } from '../assertions.ts';
 import { createEvalRunner } from '../runner.ts';
+import * as Scorer from '../Scorer.ts';
 
 const QUERY_OPERATION_KEY = 'dxn:org.dxos.operation.space.queryObjects';
 
+/** The organization the run is asked to create; the scorer reads it back by the same name. */
+const ORGANIZATION_NAME = 'Cyberdyne Systems';
+
 // Ported from the gated `Database > create and query` scenario (../testing/database.test.ts).
 // Grades the DB effect directly instead of the agent's own self-reported `completedCriteria`.
+
+const SCORERS = [
+  Scorer.database({
+    name: 'organization-created',
+    description: 'The named Organization object exists in the DB after the run.',
+    query: Query.select(Filter.type(Organization.Organization)),
+    score: (organizations) => organizations.some((organization) => organization.name === ORGANIZATION_NAME),
+  }),
+  Scorer.toolCalls({
+    name: 'database-queried',
+    description: 'The database query operation was actually invoked, not just claimed.',
+    score: (invocations) => invocations.some((invocation) => invocation.operationKey === QUERY_OPERATION_KEY),
+  }),
+];
+
 const task = createEvalRunner({
   instructions: trim`
     Create a new organization called "{{name}}".
@@ -23,31 +41,12 @@ const task = createEvalRunner({
   `,
   input: Schema.Struct({ name: Schema.String }),
   output: Schema.Unknown,
-  dbQuery: ({ name }: { name: string }) =>
-    Effect.gen(function* () {
-      const organizationExists = yield* objectExists(Organization.Organization, (org) => org.name === name);
-      const invocations = yield* toolInvocations();
-      return {
-        organizationExists,
-        queried: invocations.some((invocation) => invocation.operationKey === QUERY_OPERATION_KEY),
-      };
-    }),
+  scorers: SCORERS,
 });
 
 evalite('Database — create and query', {
-  data: [{ input: { name: 'Cyberdyne Systems' } }],
+  data: [{ input: { name: ORGANIZATION_NAME } }],
   trialCount: 3,
   task,
-  scorers: [
-    {
-      name: 'organization-created',
-      description: 'The named Organization object exists in the DB after the run.',
-      scorer: ({ output }) => (output.dbQuery.organizationExists ? 1 : 0),
-    },
-    {
-      name: 'database-queried',
-      description: 'The database query operation was actually invoked, not just claimed.',
-      scorer: ({ output }) => (output.dbQuery.queried ? 1 : 0),
-    },
-  ],
+  scorers: Scorer.toEvalite(SCORERS),
 });

--- a/packages/core/compute/assistant-evals/src/evals/database.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/database.eval.ts
@@ -41,7 +41,7 @@ const task = createEvalRunner({
   `,
   input: Schema.Struct({ name: Schema.String }),
   output: Schema.Unknown,
-  scorers: SCORERS,
+  scored: true,
 });
 
 evalite('Database — create and query', {

--- a/packages/core/compute/assistant-evals/src/evals/diagram.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/diagram.eval.ts
@@ -15,6 +15,7 @@ import { trim } from '@dxos/util';
 
 import { findObject } from '../assertions.ts';
 import { createEvalRunner } from '../runner.ts';
+import * as Scorer from '../Scorer.ts';
 import { getDefaultSkills } from '../skills.ts';
 
 //
@@ -37,6 +38,65 @@ const SYSTEM = trim`
 
 const EXPECTED_NODES = ['Gateway', 'Auth', 'Router', 'Store', 'Indexer', 'Notifier'];
 
+/**
+ * The drawing the run was asked for, analysed by the same `Diagnostics` report that gates our own
+ * layouts. One effect, shared by every scorer below: the analysis is paid for once per run.
+ */
+const relayDrawing = Effect.gen(function* () {
+  const drawing = yield* findObject(Drawing.Drawing, (entry) => entry.name === 'Relay');
+  if (!drawing) {
+    return undefined;
+  }
+  const canvas = yield* Database.load(drawing.canvas);
+  const { scene } = SvgBuilder.read(canvas);
+  const report = Diagnostics.analyze(scene.objects);
+  return {
+    errors: Diagnostics.errors(report).map(({ message }) => message),
+    metrics: report.metrics,
+    nodes: scene.objects.filter((object) => object.id !== 'edges').map(({ id, ref }) => ({ id, ref })),
+  };
+});
+
+const SCORERS = [
+  Scorer.make({
+    name: 'drawing-generated',
+    description: 'A drawing named "Relay" exists and holds at least one node.',
+    query: relayDrawing,
+    score: (drawing) => (drawing?.nodes.length ?? 0) > 0,
+  }),
+  Scorer.make({
+    name: 'no-hard-defects',
+    description: 'Diagnostics report no errors (overlap, route through node, label overflow).',
+    query: relayDrawing,
+    score: (drawing) => !!drawing && drawing.errors.length === 0,
+  }),
+  Scorer.make({
+    name: 'components-present',
+    description: 'Every described component appears as a node (fraction present).',
+    query: relayDrawing,
+    score: (drawing) => {
+      const ids = new Set(drawing?.nodes.map(({ id }) => id) ?? []);
+      return EXPECTED_NODES.filter((id) => ids.has(id)).length / EXPECTED_NODES.length;
+    },
+  }),
+  Scorer.make({
+    name: 'refs-grounded',
+    description: 'Every component node carries the documentation URL it was given (fraction).',
+    query: relayDrawing,
+    score: (drawing) => {
+      const refs = new Map(drawing?.nodes.map(({ id, ref }) => [id, ref]) ?? []);
+      const grounded = EXPECTED_NODES.filter((id) => refs.get(id) === `https://example.com/docs/${id.toLowerCase()}`);
+      return grounded.length / EXPECTED_NODES.length;
+    },
+  }),
+  Scorer.make({
+    name: 'connectors-connected',
+    description: 'Connector count is at least the six described relationships.',
+    query: relayDrawing,
+    score: (drawing) => (drawing?.metrics.connectors ?? 0) >= 6,
+  }),
+];
+
 const task = createEvalRunner({
   instructions: trim`
     The database starts empty.
@@ -53,22 +113,7 @@ const task = createEvalRunner({
   plugins: [IllustratorPlugin.make()],
   skills: [...getDefaultSkills(), Ref.make(UmlSkill.make())],
   timeout: 150_000,
-  dbQuery: () =>
-    Effect.gen(function* () {
-      const drawing = yield* findObject(Drawing.Drawing, (entry) => entry.name === 'Relay');
-      if (!drawing) {
-        return undefined;
-      }
-      const canvas = yield* Database.load(drawing.canvas);
-      const { scene } = SvgBuilder.read(canvas);
-      const report = Diagnostics.analyze(scene.objects);
-      const nodes = scene.objects.filter((object) => object.id !== 'edges').map(({ id, ref }) => ({ id, ref }));
-      return {
-        errors: Diagnostics.errors(report).map(({ message }) => message),
-        metrics: report.metrics,
-        nodes,
-      };
-    }),
+  scorers: SCORERS,
 });
 
 // Skipped: the SVG drawing variant is browser-only (`environments: []` in plugin-illustrator's
@@ -77,38 +122,5 @@ const task = createEvalRunner({
 evalite.skip('Illustrator — diagram a described system as a legible, grounded flowchart', {
   data: [{ input: null }],
   task,
-  scorers: [
-    {
-      name: 'drawing-generated',
-      description: 'A drawing named "Relay" exists and holds at least one node.',
-      scorer: ({ output }) => ((output.dbQuery?.nodes.length ?? 0) > 0 ? 1 : 0),
-    },
-    {
-      name: 'no-hard-defects',
-      description: 'Diagnostics report no errors (overlap, route through node, label overflow).',
-      scorer: ({ output }) => (output.dbQuery && output.dbQuery.errors.length === 0 ? 1 : 0),
-    },
-    {
-      name: 'components-present',
-      description: 'Every described component appears as a node (fraction present).',
-      scorer: ({ output }) => {
-        const ids = new Set(output.dbQuery?.nodes.map(({ id }) => id) ?? []);
-        return EXPECTED_NODES.filter((id) => ids.has(id)).length / EXPECTED_NODES.length;
-      },
-    },
-    {
-      name: 'refs-grounded',
-      description: 'Every component node carries the documentation URL it was given (fraction).',
-      scorer: ({ output }) => {
-        const refs = new Map(output.dbQuery?.nodes.map(({ id, ref }) => [id, ref]) ?? []);
-        const grounded = EXPECTED_NODES.filter((id) => refs.get(id) === `https://example.com/docs/${id.toLowerCase()}`);
-        return grounded.length / EXPECTED_NODES.length;
-      },
-    },
-    {
-      name: 'connectors-connected',
-      description: 'Connector count is at least the six described relationships.',
-      scorer: ({ output }) => ((output.dbQuery?.metrics.connectors ?? 0) >= 6 ? 1 : 0),
-    },
-  ],
+  scorers: Scorer.toEvalite(SCORERS),
 });

--- a/packages/core/compute/assistant-evals/src/evals/diagram.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/diagram.eval.ts
@@ -42,58 +42,59 @@ const EXPECTED_NODES = ['Gateway', 'Auth', 'Router', 'Store', 'Indexer', 'Notifi
  * The drawing the run was asked for, analysed by the same `Diagnostics` report that gates our own
  * layouts. One effect, shared by every scorer below: the analysis is paid for once per run.
  */
-const relayDrawing = Effect.gen(function* () {
-  const drawing = yield* findObject(Drawing.Drawing, (entry) => entry.name === 'Relay');
-  if (!drawing) {
-    return undefined;
-  }
-  const canvas = yield* Database.load(drawing.canvas);
-  const { scene } = SvgBuilder.read(canvas);
-  const report = Diagnostics.analyze(scene.objects);
-  return {
-    errors: Diagnostics.errors(report).map(({ message }) => message),
-    metrics: report.metrics,
-    nodes: scene.objects.filter((object) => object.id !== 'edges').map(({ id, ref }) => ({ id, ref })),
-  };
-});
+const relayDrawing = Scorer.shared(
+  Effect.gen(function* () {
+    const drawing = yield* findObject(Drawing.Drawing, (entry) => entry.name === 'Relay');
+    if (!drawing) {
+      return undefined;
+    }
+    const canvas = yield* Database.load(drawing.canvas);
+    const { scene } = SvgBuilder.read(canvas);
+    const report = Diagnostics.analyze(scene.objects);
+    return {
+      errors: Diagnostics.errors(report).map(({ message }) => message),
+      metrics: report.metrics,
+      nodes: scene.objects.filter((object) => object.id !== 'edges').map(({ id, ref }) => ({ id, ref })),
+    };
+  }),
+);
+
+/** Reads the drawing and turns it into a mark. */
+const drawn = (score: (drawing: Effect.Success<typeof relayDrawing>) => Scorer.Result) =>
+  relayDrawing.pipe(Effect.map(score));
 
 const SCORERS = [
   Scorer.make({
     name: 'drawing-generated',
     description: 'A drawing named "Relay" exists and holds at least one node.',
-    query: relayDrawing,
-    score: (drawing) => (drawing?.nodes.length ?? 0) > 0,
+    score: drawn((drawing) => (drawing?.nodes.length ?? 0) > 0),
   }),
   Scorer.make({
     name: 'no-hard-defects',
     description: 'Diagnostics report no errors (overlap, route through node, label overflow).',
-    query: relayDrawing,
-    score: (drawing) => !!drawing && drawing.errors.length === 0,
+    score: drawn((drawing) => !!drawing && drawing.errors.length === 0),
   }),
   Scorer.make({
     name: 'components-present',
     description: 'Every described component appears as a node (fraction present).',
-    query: relayDrawing,
-    score: (drawing) => {
+    score: drawn((drawing) => {
       const ids = new Set(drawing?.nodes.map(({ id }) => id) ?? []);
       return EXPECTED_NODES.filter((id) => ids.has(id)).length / EXPECTED_NODES.length;
-    },
+    }),
   }),
   Scorer.make({
     name: 'refs-grounded',
     description: 'Every component node carries the documentation URL it was given (fraction).',
-    query: relayDrawing,
-    score: (drawing) => {
+    score: drawn((drawing) => {
       const refs = new Map(drawing?.nodes.map(({ id, ref }) => [id, ref]) ?? []);
       const grounded = EXPECTED_NODES.filter((id) => refs.get(id) === `https://example.com/docs/${id.toLowerCase()}`);
       return grounded.length / EXPECTED_NODES.length;
-    },
+    }),
   }),
   Scorer.make({
     name: 'connectors-connected',
     description: 'Connector count is at least the six described relationships.',
-    query: relayDrawing,
-    score: (drawing) => (drawing?.metrics.connectors ?? 0) >= 6,
+    score: drawn((drawing) => (drawing?.metrics.connectors ?? 0) >= 6),
   }),
 ];
 
@@ -113,7 +114,7 @@ const task = createEvalRunner({
   plugins: [IllustratorPlugin.make()],
   skills: [...getDefaultSkills(), Ref.make(UmlSkill.make())],
   timeout: 150_000,
-  scorers: SCORERS,
+  scored: true,
 });
 
 // Skipped: the SVG drawing variant is browser-only (`environments: []` in plugin-illustrator's

--- a/packages/core/compute/assistant-evals/src/evals/incident-retro.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/incident-retro.eval.ts
@@ -98,55 +98,69 @@ const lower = (text: string | undefined) => (text ?? '').toLowerCase();
 const REQUIRED_TOOLS = ['projects-add-artifact', 'tasks-create'];
 
 /** The documents the session filed on the project, by the name each task asked for. */
-const filedDocuments = Effect.gen(function* () {
-  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-  if (!project) {
-    return { timeline: '', retro: '', notice: '' };
-  }
-  const artifacts = yield* Effect.forEach(project.artifacts, (ref) =>
-    Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
-  );
-  const documents = artifacts.filter((candidate): candidate is Markdown.Document =>
-    Obj.instanceOf(Markdown.Document, candidate),
-  );
-  const textOf = (needle: RegExp) => {
-    const document = documents.find((candidate) => needle.test(candidate.name ?? ''));
-    return document
-      ? Database.load(document.content).pipe(
-          Effect.map((text) => text.content),
-          Effect.orElseSucceed(() => ''),
-        )
-      : Effect.succeed('');
-  };
-  return {
-    timeline: yield* textOf(/timeline/i),
-    retro: yield* textOf(/retro/i),
-    notice: yield* textOf(/notice|customer/i),
-  };
-});
+const filedDocuments = Scorer.shared(
+  Effect.gen(function* () {
+    const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+    if (!project) {
+      return { timeline: '', retro: '', notice: '' };
+    }
+    const artifacts = yield* Effect.forEach(project.artifacts, (ref) =>
+      Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
+    );
+    const documents = artifacts.filter((candidate): candidate is Markdown.Document =>
+      Obj.instanceOf(Markdown.Document, candidate),
+    );
+    const textOf = (needle: RegExp) => {
+      const document = documents.find((candidate) => needle.test(candidate.name ?? ''));
+      return document
+        ? Database.load(document.content).pipe(
+            Effect.map((text) => text.content),
+            Effect.orElseSucceed(() => ''),
+          )
+        : Effect.succeed('');
+    };
+    return {
+      timeline: yield* textOf(/timeline/i),
+      retro: yield* textOf(/retro/i),
+      notice: yield* textOf(/notice|customer/i),
+    };
+  }),
+);
+
+/** Reads the filed documents and turns them into a mark. */
+const filed = (score: (documents: Effect.Success<typeof filedDocuments>) => Scorer.Result) =>
+  filedDocuments.pipe(Effect.map(score));
 
 /** The judge's verdict on the filed retrospective; absent when the session filed none. */
-const retroVerdict = filedDocuments.pipe(
-  Effect.flatMap(({ retro }) =>
-    retro ? judge(RETRO_RUBRIC, retro).pipe(Effect.orElseSucceed(() => undefined)) : Effect.succeed(undefined),
+const retroVerdict = Scorer.shared(
+  filedDocuments.pipe(
+    Effect.flatMap(({ retro }) =>
+      retro ? judge(RETRO_RUBRIC, retro).pipe(Effect.orElseSucceed(() => undefined)) : Effect.succeed(undefined),
+    ),
   ),
 );
 
 /** The project's tasks, split into the four the session was given and the ones it added. */
-const taskLedger = Effect.gen(function* () {
-  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-  const taskSet = project?.taskSet ? yield* Database.load(project.taskSet) : undefined;
-  if (!taskSet) {
-    return { delegated: [] as Task.Task[], created: [] as Task.Task[] };
-  }
-  const tasks = (yield* Effect.forEach(taskSet.tasks, (ref) =>
-    Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
-  )).filter((candidate): candidate is Task.Task => !!candidate);
-  return {
-    delegated: tasks.filter((candidate) => candidate.assignee?.role === 'assistant'),
-    created: tasks.filter((candidate) => candidate.assignee?.role !== 'assistant'),
-  };
-});
+const taskLedger = Scorer.shared(
+  Effect.gen(function* () {
+    const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+    const taskSet = project?.taskSet ? yield* Database.load(project.taskSet) : undefined;
+    if (!taskSet) {
+      return { delegated: [] as Task.Task[], created: [] as Task.Task[] };
+    }
+    const tasks = (yield* Effect.forEach(taskSet.tasks, (ref) =>
+      Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
+    )).filter((candidate): candidate is Task.Task => !!candidate);
+    return {
+      delegated: tasks.filter((candidate) => candidate.assignee?.role === 'assistant'),
+      created: tasks.filter((candidate) => candidate.assignee?.role !== 'assistant'),
+    };
+  }),
+);
+
+/** Reads the project's tasks and turns them into a mark. */
+const ledger = (score: (tasks: Effect.Success<typeof taskLedger>) => Scorer.Result) =>
+  taskLedger.pipe(Effect.map(score));
 
 const about = (task: Task.Task, needle: RegExp) => needle.test(`${task.title ?? ''} ${task.description ?? ''}`);
 
@@ -154,75 +168,72 @@ const SCORERS = [
   Scorer.make({
     name: 'timeline-follows-the-log',
     description: 'A Timeline artifact carries the four times the log fixes.',
-    query: filedDocuments,
-    score: ({ timeline }) => LOG_TIMES.filter((time) => timeline.includes(time)).length / LOG_TIMES.length,
+    score: filed(({ timeline }) => LOG_TIMES.filter((time) => timeline.includes(time)).length / LOG_TIMES.length),
   }),
   Scorer.make({
     name: 'timeline-holds-the-disk-claim-as-a-claim',
     description: 'The second-hand disk claim is absent from the timeline, or marked as unsupported by the log.',
-    query: filedDocuments,
     // The disk claim may appear, but only as a claim: something the record does not bear out.
-    score: ({ timeline }) =>
-      !/disk/i.test(timeline) ||
-      /second.?hand|unverified|not (?:supported|borne out|confirmed)|contradict|rules? (?:this |it )?out|no evidence|held at 41/i.test(
-        timeline,
-      ),
+    score: filed(
+      ({ timeline }) =>
+        !/disk/i.test(timeline) ||
+        /second.?hand|unverified|not (?:supported|borne out|confirmed)|contradict|rules? (?:this |it )?out|no evidence|held at 41/i.test(
+          timeline,
+        ),
+    ),
   }),
   Scorer.make({
     name: 'retro-names-the-cause',
     description: 'A Retrospective artifact is filed and names the expired certificate.',
-    query: filedDocuments,
-    score: ({ retro }) => retro.length > 0 && /certificate/i.test(retro),
+    score: filed(({ retro }) => retro.length > 0 && /certificate/i.test(retro)),
   }),
   Scorer.make({
     name: 'retro-finds-both-process-gaps',
     description: 'The retrospective names the stale alert routing and the unowned renewal.',
-    query: filedDocuments,
-    score: ({ retro }) => [ROUTING_GAP.test(retro), RENEWAL_GAP.test(retro)].filter(Boolean).length / 2,
+    score: filed(({ retro }) => [ROUTING_GAP.test(retro), RENEWAL_GAP.test(retro)].filter(Boolean).length / 2),
   }),
   Scorer.make({
     name: 'retro-grounded-and-blameless',
     description: 'Judge: no deploy freeze, the disk claim not stated as fact, no named person blamed.',
-    query: retroVerdict,
-    score: (verdict) => verdict?.pass ?? false,
+    score: retroVerdict.pipe(Effect.map((verdict) => verdict?.pass ?? false)),
   }),
   Scorer.make({
     name: 'action-items-are-owned-tasks',
     description: "At least two new tasks on the project's set, each assigned to someone from the notes.",
-    query: taskLedger,
-    score: ({ created }) =>
+    score: ledger(({ created }) =>
       created.length >= 2
         ? created.filter((candidate) => CAST.some((name) => lower(candidate.assignee?.name).includes(lower(name))))
             .length / created.length
         : 0,
+    ),
   }),
   Scorer.make({
     name: 'action-items-follow-the-evidence',
     description: 'One item on alert routing, one on renewal ownership, none on deploys or disk.',
-    query: taskLedger,
-    score: ({ created }) =>
-      [
-        created.some((candidate) => about(candidate, ROUTING_GAP)),
-        created.some((candidate) => about(candidate, RENEWAL_GAP)),
-        !created.some((candidate) => DISTRACTOR_ACTIONS.test(candidate.title ?? '')),
-      ].filter(Boolean).length / 3,
+    score: ledger(
+      ({ created }) =>
+        [
+          created.some((candidate) => about(candidate, ROUTING_GAP)),
+          created.some((candidate) => about(candidate, RENEWAL_GAP)),
+          !created.some((candidate) => DISTRACTOR_ACTIONS.test(candidate.title ?? '')),
+        ].filter(Boolean).length / 3,
+    ),
   }),
   Scorer.make({
     name: 'customer-notice-is-plain',
     description: 'A Customer notice artifact names the certificate and carries no internal names or systems.',
-    query: filedDocuments,
-    score: ({ notice }) => notice.length > 0 && /certificate/i.test(notice) && !INTERNAL.test(notice),
+    score: filed(({ notice }) => notice.length > 0 && /certificate/i.test(notice) && !INTERNAL.test(notice)),
   }),
   Scorer.make({
     name: 'delegated-tasks-back-in-review',
     description: 'Every task the session was given is in review (or done) when it finishes.',
-    query: taskLedger,
     // `done` past a named reviewer lands as `review`; either means the session finished the task.
-    score: ({ delegated }) =>
+    score: ledger(({ delegated }) =>
       delegated.length > 0
         ? delegated.filter((candidate) => candidate.status === 'review' || candidate.status === 'done').length /
           delegated.length
         : 0,
+    ),
   }),
   Scorer.toolCalls({
     name: 'project-verbs-reached',
@@ -284,7 +295,7 @@ const task = createEvalRunner({
 
       return { objects: [Ref.make(project)], chat: Ref.make(chat) };
     }),
-  scorers: SCORERS,
+  scored: true,
 });
 
 evalite('Incident retro — a delegated session turns a log and four notes into a filed retro', {

--- a/packages/core/compute/assistant-evals/src/evals/incident-retro.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/incident-retro.eval.ts
@@ -24,9 +24,10 @@ import * as TasksPlugin from '@dxos/plugin-tasks/TasksPlugin';
 import { type Actor, Outline, Task, TaskSet } from '@dxos/types';
 import { trim } from '@dxos/util';
 
-import { findObject, toolInvocations } from '../assertions.ts';
+import { findObject } from '../assertions.ts';
 import { judge } from '../judge.ts';
 import { createEvalRunner } from '../runner.ts';
+import * as Scorer from '../Scorer.ts';
 import { getDefaultSkills } from '../skills.ts';
 
 //
@@ -94,6 +95,145 @@ const REVIEWER: Actor.Actor = { role: 'user', name: 'Eval' };
 
 const lower = (text: string | undefined) => (text ?? '').toLowerCase();
 
+const REQUIRED_TOOLS = ['projects-add-artifact', 'tasks-create'];
+
+/** The documents the session filed on the project, by the name each task asked for. */
+const filedDocuments = Effect.gen(function* () {
+  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+  if (!project) {
+    return { timeline: '', retro: '', notice: '' };
+  }
+  const artifacts = yield* Effect.forEach(project.artifacts, (ref) =>
+    Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
+  );
+  const documents = artifacts.filter((candidate): candidate is Markdown.Document =>
+    Obj.instanceOf(Markdown.Document, candidate),
+  );
+  const textOf = (needle: RegExp) => {
+    const document = documents.find((candidate) => needle.test(candidate.name ?? ''));
+    return document
+      ? Database.load(document.content).pipe(
+          Effect.map((text) => text.content),
+          Effect.orElseSucceed(() => ''),
+        )
+      : Effect.succeed('');
+  };
+  return {
+    timeline: yield* textOf(/timeline/i),
+    retro: yield* textOf(/retro/i),
+    notice: yield* textOf(/notice|customer/i),
+  };
+});
+
+/** The judge's verdict on the filed retrospective; absent when the session filed none. */
+const retroVerdict = filedDocuments.pipe(
+  Effect.flatMap(({ retro }) =>
+    retro ? judge(RETRO_RUBRIC, retro).pipe(Effect.orElseSucceed(() => undefined)) : Effect.succeed(undefined),
+  ),
+);
+
+/** The project's tasks, split into the four the session was given and the ones it added. */
+const taskLedger = Effect.gen(function* () {
+  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+  const taskSet = project?.taskSet ? yield* Database.load(project.taskSet) : undefined;
+  if (!taskSet) {
+    return { delegated: [] as Task.Task[], created: [] as Task.Task[] };
+  }
+  const tasks = (yield* Effect.forEach(taskSet.tasks, (ref) =>
+    Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
+  )).filter((candidate): candidate is Task.Task => !!candidate);
+  return {
+    delegated: tasks.filter((candidate) => candidate.assignee?.role === 'assistant'),
+    created: tasks.filter((candidate) => candidate.assignee?.role !== 'assistant'),
+  };
+});
+
+const about = (task: Task.Task, needle: RegExp) => needle.test(`${task.title ?? ''} ${task.description ?? ''}`);
+
+const SCORERS = [
+  Scorer.make({
+    name: 'timeline-follows-the-log',
+    description: 'A Timeline artifact carries the four times the log fixes.',
+    query: filedDocuments,
+    score: ({ timeline }) => LOG_TIMES.filter((time) => timeline.includes(time)).length / LOG_TIMES.length,
+  }),
+  Scorer.make({
+    name: 'timeline-holds-the-disk-claim-as-a-claim',
+    description: 'The second-hand disk claim is absent from the timeline, or marked as unsupported by the log.',
+    query: filedDocuments,
+    // The disk claim may appear, but only as a claim: something the record does not bear out.
+    score: ({ timeline }) =>
+      !/disk/i.test(timeline) ||
+      /second.?hand|unverified|not (?:supported|borne out|confirmed)|contradict|rules? (?:this |it )?out|no evidence|held at 41/i.test(
+        timeline,
+      ),
+  }),
+  Scorer.make({
+    name: 'retro-names-the-cause',
+    description: 'A Retrospective artifact is filed and names the expired certificate.',
+    query: filedDocuments,
+    score: ({ retro }) => retro.length > 0 && /certificate/i.test(retro),
+  }),
+  Scorer.make({
+    name: 'retro-finds-both-process-gaps',
+    description: 'The retrospective names the stale alert routing and the unowned renewal.',
+    query: filedDocuments,
+    score: ({ retro }) => [ROUTING_GAP.test(retro), RENEWAL_GAP.test(retro)].filter(Boolean).length / 2,
+  }),
+  Scorer.make({
+    name: 'retro-grounded-and-blameless',
+    description: 'Judge: no deploy freeze, the disk claim not stated as fact, no named person blamed.',
+    query: retroVerdict,
+    score: (verdict) => verdict?.pass ?? false,
+  }),
+  Scorer.make({
+    name: 'action-items-are-owned-tasks',
+    description: "At least two new tasks on the project's set, each assigned to someone from the notes.",
+    query: taskLedger,
+    score: ({ created }) =>
+      created.length >= 2
+        ? created.filter((candidate) => CAST.some((name) => lower(candidate.assignee?.name).includes(lower(name))))
+            .length / created.length
+        : 0,
+  }),
+  Scorer.make({
+    name: 'action-items-follow-the-evidence',
+    description: 'One item on alert routing, one on renewal ownership, none on deploys or disk.',
+    query: taskLedger,
+    score: ({ created }) =>
+      [
+        created.some((candidate) => about(candidate, ROUTING_GAP)),
+        created.some((candidate) => about(candidate, RENEWAL_GAP)),
+        !created.some((candidate) => DISTRACTOR_ACTIONS.test(candidate.title ?? '')),
+      ].filter(Boolean).length / 3,
+  }),
+  Scorer.make({
+    name: 'customer-notice-is-plain',
+    description: 'A Customer notice artifact names the certificate and carries no internal names or systems.',
+    query: filedDocuments,
+    score: ({ notice }) => notice.length > 0 && /certificate/i.test(notice) && !INTERNAL.test(notice),
+  }),
+  Scorer.make({
+    name: 'delegated-tasks-back-in-review',
+    description: 'Every task the session was given is in review (or done) when it finishes.',
+    query: taskLedger,
+    // `done` past a named reviewer lands as `review`; either means the session finished the task.
+    score: ({ delegated }) =>
+      delegated.length > 0
+        ? delegated.filter((candidate) => candidate.status === 'review' || candidate.status === 'done').length /
+          delegated.length
+        : 0,
+  }),
+  Scorer.toolCalls({
+    name: 'project-verbs-reached',
+    description: 'Artifacts were filed and tasks created through the project skill, and no tool errored.',
+    score: (invocations) => {
+      const called = new Set(invocations.map(({ name }) => name));
+      return REQUIRED_TOOLS.every((name) => called.has(name)) && invocations.every(({ error }) => !error);
+    },
+  }),
+];
+
 const task = createEvalRunner({
   instructions: OPENING_PROMPT,
   input: Schema.Unknown,
@@ -144,180 +284,13 @@ const task = createEvalRunner({
 
       return { objects: [Ref.make(project)], chat: Ref.make(chat) };
     }),
-  dbQuery: () =>
-    Effect.gen(function* () {
-      const invocations = yield* toolInvocations();
-      const trace = {
-        artifactAddCalled: invocations.some(({ name }) => name === 'projects-add-artifact'),
-        taskCreateCalled: invocations.some(({ name }) => name === 'tasks-create'),
-        erroredTools: invocations.filter(({ error }) => error).map(({ name }) => name),
-      };
-      const empty = {
-        ...trace,
-        timelineTimes: 0,
-        timelineDiskHandled: false,
-        retroFiled: false,
-        retroNamesCertificate: false,
-        retroNamesRoutingGap: false,
-        retroNamesRenewalGap: false,
-        retroJudge: undefined as { pass: boolean; reasoning: string } | undefined,
-        actionItems: 0,
-        actionItemsOwned: 0,
-        actionItemRouting: false,
-        actionItemRenewal: false,
-        actionItemsClean: false,
-        distractorItems: [] as string[],
-        noticeFiled: false,
-        noticeNamesCertificate: false,
-        noticeClean: false,
-        delegatedInReview: 0,
-        delegatedTotal: 4,
-      };
-
-      const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-      const taskSet = project?.taskSet ? yield* Database.load(project.taskSet) : undefined;
-      if (!project || !taskSet) {
-        return empty;
-      }
-
-      // The documents filed on the project, by the name each task asked for.
-      const artifacts = yield* Effect.forEach(project.artifacts, (ref) =>
-        Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
-      );
-      const documents = artifacts.filter((candidate): candidate is Markdown.Document =>
-        Obj.instanceOf(Markdown.Document, candidate),
-      );
-      const textOf = (document: Markdown.Document | undefined) =>
-        document
-          ? Database.load(document.content).pipe(
-              Effect.map((text) => text.content),
-              Effect.orElseSucceed(() => ''),
-            )
-          : Effect.succeed('');
-      const named = (needle: RegExp) => documents.find((document) => needle.test(document.name ?? ''));
-      const timeline = yield* textOf(named(/timeline/i));
-      const retro = yield* textOf(named(/retro/i));
-      const notice = yield* textOf(named(/notice|customer/i));
-
-      // The disk claim may appear, but only as a claim: something the record does not bear out.
-      const timelineDiskHandled =
-        !/disk/i.test(timeline) ||
-        /second.?hand|unverified|not (?:supported|borne out|confirmed)|contradict|rules? (?:this |it )?out|no evidence|held at 41/i.test(
-          timeline,
-        );
-
-      const retroJudge = retro
-        ? yield* judge(RETRO_RUBRIC, retro).pipe(Effect.orElseSucceed(() => undefined))
-        : undefined;
-
-      // Action items: the tasks the session added to the set beyond the four it was given.
-      const allTasks = yield* Effect.forEach(taskSet.tasks, (ref) =>
-        Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
-      );
-      const delegated = allTasks.filter((candidate) => candidate?.assignee?.role === 'assistant');
-      const created = allTasks.filter(
-        (candidate): candidate is Task.Task => !!candidate && candidate.assignee?.role !== 'assistant',
-      );
-      const ownedBy = (candidate: Task.Task) =>
-        CAST.some((name) => lower(candidate.assignee?.name).includes(lower(name)));
-      const about = (candidate: Task.Task, needle: RegExp) =>
-        needle.test(`${candidate.title ?? ''} ${candidate.description ?? ''}`);
-      const distractorItems = created
-        .filter((candidate) => DISTRACTOR_ACTIONS.test(candidate.title ?? ''))
-        .map((candidate) => candidate.title ?? '');
-
-      return {
-        ...trace,
-        timelineTimes: LOG_TIMES.filter((time) => timeline.includes(time)).length,
-        timelineDiskHandled,
-        retroFiled: retro.length > 0,
-        retroNamesCertificate: /certificate/i.test(retro),
-        retroNamesRoutingGap: ROUTING_GAP.test(retro),
-        retroNamesRenewalGap: RENEWAL_GAP.test(retro),
-        retroJudge,
-        actionItems: created.length,
-        actionItemsOwned: created.filter(ownedBy).length,
-        actionItemRouting: created.some((candidate) => about(candidate, ROUTING_GAP)),
-        actionItemRenewal: created.some((candidate) => about(candidate, RENEWAL_GAP)),
-        actionItemsClean: distractorItems.length === 0,
-        distractorItems,
-        noticeFiled: notice.length > 0,
-        noticeNamesCertificate: /certificate/i.test(notice),
-        noticeClean: notice.length > 0 && !INTERNAL.test(notice),
-        // `done` past a named reviewer lands as `review`; either means the session finished the task.
-        delegatedInReview: delegated.filter(
-          (candidate) => candidate?.status === 'review' || candidate?.status === 'done',
-        ).length,
-        delegatedTotal: delegated.length,
-      };
-    }),
+  scorers: SCORERS,
 });
 
 evalite('Incident retro — a delegated session turns a log and four notes into a filed retro', {
   data: [{ input: null }],
   task,
-  scorers: [
-    {
-      name: 'timeline-follows-the-log',
-      description: 'A Timeline artifact carries the four times the log fixes.',
-      scorer: ({ output }) => output.dbQuery.timelineTimes / LOG_TIMES.length,
-    },
-    {
-      name: 'timeline-holds-the-disk-claim-as-a-claim',
-      description: 'The second-hand disk claim is absent from the timeline, or marked as unsupported by the log.',
-      scorer: ({ output }) => (output.dbQuery.timelineDiskHandled ? 1 : 0),
-    },
-    {
-      name: 'retro-names-the-cause',
-      description: 'A Retrospective artifact is filed and names the expired certificate.',
-      scorer: ({ output }) => (output.dbQuery.retroFiled && output.dbQuery.retroNamesCertificate ? 1 : 0),
-    },
-    {
-      name: 'retro-finds-both-process-gaps',
-      description: 'The retrospective names the stale alert routing and the unowned renewal.',
-      scorer: ({ output }) =>
-        [output.dbQuery.retroNamesRoutingGap, output.dbQuery.retroNamesRenewalGap].filter(Boolean).length / 2,
-    },
-    {
-      name: 'retro-grounded-and-blameless',
-      description: 'Judge: no deploy freeze, the disk claim not stated as fact, no named person blamed.',
-      scorer: ({ output }) => (output.dbQuery.retroJudge?.pass ? 1 : 0),
-    },
-    {
-      name: 'action-items-are-owned-tasks',
-      description: "At least two new tasks on the project's set, each assigned to someone from the notes.",
-      scorer: ({ output }) =>
-        output.dbQuery.actionItems >= 2 ? output.dbQuery.actionItemsOwned / output.dbQuery.actionItems : 0,
-    },
-    {
-      name: 'action-items-follow-the-evidence',
-      description: 'One item on alert routing, one on renewal ownership, none on deploys or disk.',
-      scorer: ({ output }) =>
-        [output.dbQuery.actionItemRouting, output.dbQuery.actionItemRenewal, output.dbQuery.actionItemsClean].filter(
-          Boolean,
-        ).length / 3,
-    },
-    {
-      name: 'customer-notice-is-plain',
-      description: 'A Customer notice artifact names the certificate and carries no internal names or systems.',
-      scorer: ({ output }) =>
-        output.dbQuery.noticeFiled && output.dbQuery.noticeNamesCertificate && output.dbQuery.noticeClean ? 1 : 0,
-    },
-    {
-      name: 'delegated-tasks-back-in-review',
-      description: 'Every task the session was given is in review (or done) when it finishes.',
-      scorer: ({ output }) =>
-        output.dbQuery.delegatedTotal > 0 ? output.dbQuery.delegatedInReview / output.dbQuery.delegatedTotal : 0,
-    },
-    {
-      name: 'project-verbs-reached',
-      description: 'Artifacts were filed and tasks created through the project skill, and no tool errored.',
-      scorer: ({ output }) =>
-        output.dbQuery.artifactAddCalled && output.dbQuery.taskCreateCalled && output.dbQuery.erroredTools.length === 0
-          ? 1
-          : 0,
-    },
-  ],
+  scorers: Scorer.toEvalite(SCORERS),
 });
 
 /**

--- a/packages/core/compute/assistant-evals/src/evals/markdown.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/markdown.eval.ts
@@ -35,7 +35,7 @@ const draftTask = createEvalRunner({
   input: Schema.Unknown,
   output: Schema.Unknown,
   plugins: [MarkdownPlugin.make()],
-  scorers: DRAFT_SCORERS,
+  scored: true,
 });
 
 evalite('Markdown — draft a document', {
@@ -62,8 +62,7 @@ const APPEND_SCORERS = [
   Scorer.make({
     name: 'content-matches',
     description: `The "${DOCUMENT_NAME}" document's final content is exactly the appended line.`,
-    query: documentText,
-    score: (content) => content === APPENDED_LINE,
+    score: documentText.pipe(Effect.map((content) => content === APPENDED_LINE)),
   }),
 ];
 
@@ -82,7 +81,7 @@ const appendTask = createEvalRunner({
   input: Schema.Unknown,
   output: Schema.Unknown,
   plugins: [MarkdownPlugin.make()],
-  scorers: APPEND_SCORERS,
+  scored: true,
 });
 
 evalite('Markdown — append text to empty document', {

--- a/packages/core/compute/assistant-evals/src/evals/markdown.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/markdown.eval.ts
@@ -6,16 +6,26 @@ import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 import { evalite } from 'evalite';
 
-import { Database } from '@dxos/echo';
+import { Database, Filter, Query } from '@dxos/echo';
 import * as Markdown from '@dxos/plugin-markdown/Markdown';
 import * as MarkdownPlugin from '@dxos/plugin-markdown/MarkdownPlugin';
 import { trim } from '@dxos/util';
 
-import { findObject, objectExists } from '../assertions.ts';
+import { findObject } from '../assertions.ts';
 import { createEvalRunner } from '../runner.ts';
+import * as Scorer from '../Scorer.ts';
 
 // Ported from the gated `Markdown` scenarios (../testing/markdown.test.ts).
 // Grades the DB effect directly instead of the agent's self-reported `completedCriteria`.
+
+const DRAFT_SCORERS = [
+  Scorer.database({
+    name: 'document-created',
+    description: 'A Markdown Document object exists in the DB after the run.',
+    query: Query.select(Filter.type(Markdown.Document)),
+    score: (documents) => documents.length > 0,
+  }),
+];
 
 const draftTask = createEvalRunner({
   instructions: trim`
@@ -25,57 +35,59 @@ const draftTask = createEvalRunner({
   input: Schema.Unknown,
   output: Schema.Unknown,
   plugins: [MarkdownPlugin.make()],
-  dbQuery: () => objectExists(Markdown.Document, () => true),
+  scorers: DRAFT_SCORERS,
 });
 
 evalite('Markdown — draft a document', {
   data: [{ input: null }],
   trialCount: 3,
   task: draftTask,
-  scorers: [
-    {
-      name: 'document-created',
-      description: 'A Markdown Document object exists in the DB after the run.',
-      scorer: ({ output }) => (output.dbQuery ? 1 : 0),
-    },
-  ],
+  scorers: Scorer.toEvalite(DRAFT_SCORERS),
 });
+
+const DOCUMENT_NAME = 'Empty Notes';
+const APPENDED_LINE = 'Hello from an empty document.';
+
+/** The document's final text, read back outside the agent. */
+const documentText = Effect.gen(function* () {
+  const document = yield* findObject(Markdown.Document, (candidate) => candidate.name === DOCUMENT_NAME);
+  if (!document) {
+    return undefined;
+  }
+  const text = yield* Database.load(document.content);
+  return text.content;
+});
+
+const APPEND_SCORERS = [
+  Scorer.make({
+    name: 'content-matches',
+    description: `The "${DOCUMENT_NAME}" document's final content is exactly the appended line.`,
+    query: documentText,
+    score: (content) => content === APPENDED_LINE,
+  }),
+];
 
 const appendTask = createEvalRunner({
   instructions: trim`
     The database starts empty.
-    Create a new markdown document named "Empty Notes" with empty content (no body text).
+    Create a new markdown document named "${DOCUMENT_NAME}" with empty content (no body text).
     Open the document and confirm its content is empty.
 
     Use the markdown Update operation (org.dxos.operation.markdown.update) to append this exact line
     without providing oldString (omit oldString entirely — do not pass an empty string):
-    "Hello from an empty document."
+    "${APPENDED_LINE}"
 
-    Open the document again and confirm the content is exactly "Hello from an empty document."
+    Open the document again and confirm the content is exactly "${APPENDED_LINE}"
   `,
   input: Schema.Unknown,
   output: Schema.Unknown,
   plugins: [MarkdownPlugin.make()],
-  dbQuery: () =>
-    Effect.gen(function* () {
-      const doc = yield* findObject(Markdown.Document, (d) => d.name === 'Empty Notes');
-      if (!doc) {
-        return undefined;
-      }
-      const text = yield* Database.load(doc.content);
-      return text.content;
-    }),
+  scorers: APPEND_SCORERS,
 });
 
 evalite('Markdown — append text to empty document', {
   data: [{ input: null }],
   trialCount: 3,
   task: appendTask,
-  scorers: [
-    {
-      name: 'content-matches',
-      description: 'The "Empty Notes" document\'s final content is exactly the appended line.',
-      scorer: ({ output }) => (output.dbQuery === 'Hello from an empty document.' ? 1 : 0),
-    },
-  ],
+  scorers: Scorer.toEvalite(APPEND_SCORERS),
 });

--- a/packages/core/compute/assistant-evals/src/evals/mcp-server.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/mcp-server.eval.ts
@@ -80,32 +80,27 @@ const scorers = (staged: Staged): Scorer.Any[] => [
   Scorer.make({
     name: 'scaffold-visible',
     description: 'The seeded ledger is readable outside the agent before the run starts.',
-    query: Effect.succeed(staged.scaffolded),
-    score: (ok) => ok,
+    score: Effect.succeed(staged.scaffolded),
   }),
   Scorer.make({
     name: 'tasks-listed',
     description: 'The agent read both tasks through the server rather than answering from the prompt.',
-    query: Effect.succeed(staged.listed),
-    score: (ok) => ok,
+    score: Effect.succeed(staged.listed),
   }),
   Scorer.make({
     name: 'read-turn-changed-nothing',
     description: 'The read-only turn left every task as it found it.',
-    query: Effect.succeed(staged.readOnly),
-    score: (ok) => ok,
+    score: Effect.succeed(staged.readOnly),
   }),
   Scorer.make({
     name: 'task-completed',
     description: 'The named task is done in the database, and only that task moved.',
-    query: Effect.succeed(staged.completed),
-    score: (ok) => ok,
+    score: Effect.succeed(staged.completed),
   }),
   Scorer.make({
     name: 'follow-up-turn-wrote',
     description: 'A second turn set the other task started with its description, without rolling the first back.',
-    query: Effect.succeed(staged.started),
-    score: (ok) => ok,
+    score: Effect.succeed(staged.started),
   }),
   Scorer.database({
     name: 'ledger-intact',

--- a/packages/core/compute/assistant-evals/src/evals/planning.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/planning.eval.ts
@@ -47,34 +47,33 @@ const checklist = Effect.gen(function* () {
 });
 
 /** The judge's verdict on the haikus the session wrote into the chat feed. */
-const haikuVerdict = completedBlocks().pipe(
-  Effect.map((blocks) =>
-    blocks
-      .filter(({ role, block }) => role === 'assistant' && block._tag === 'text')
-      .map(({ block }) => (block as { text: string }).text)
-      .join('\n'),
+const haikuVerdict = Scorer.shared(
+  completedBlocks().pipe(
+    Effect.map((blocks) =>
+      blocks
+        .filter(({ role, block }) => role === 'assistant' && block._tag === 'text')
+        .map(({ block }) => (block as { text: string }).text)
+        .join('\n'),
+    ),
+    Effect.flatMap((assistantText) => judge(HAIKU_JUDGE_RUBRIC, assistantText)),
   ),
-  Effect.flatMap((assistantText) => judge(HAIKU_JUDGE_RUBRIC, assistantText)),
 );
 
 const SCORERS = [
   Scorer.make({
     name: 'exactly-three-tasks',
     description: 'Exactly 3 checklist items exist for the three haiku topics.',
-    query: checklist,
-    score: (items) => items.length === 3,
+    score: checklist.pipe(Effect.map((items) => items.length === 3)),
   }),
   Scorer.make({
     name: 'all-tasks-done',
     description: 'All 3 tasks are marked done.',
-    query: checklist,
-    score: (items) => items.length === 3 && items.every((item) => item.done),
+    score: checklist.pipe(Effect.map((items) => items.length === 3 && items.every((item) => item.done))),
   }),
   Scorer.make({
     name: 'haikus-well-formed',
     description: 'An LLM judge confirms all three topics have their own well-formed haiku.',
-    query: haikuVerdict,
-    score: (verdict) => verdict.pass,
+    score: haikuVerdict.pipe(Effect.map((verdict) => verdict.pass)),
   }),
   Scorer.toolCalls({
     name: 'used-update-tasks',
@@ -113,7 +112,7 @@ const task = createEvalRunner({
   output: Schema.Unknown,
   // Three sequential subtasks, each a assistant-toolkit-update-tasks call + haiku turn, plus a final judge call.
   timeout: 150_000,
-  scorers: SCORERS,
+  scored: true,
 });
 
 evalite('Planning — create three haiku tasks and complete each one', {

--- a/packages/core/compute/assistant-evals/src/evals/planning.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/planning.eval.ts
@@ -11,9 +11,10 @@ import { EffectEx } from '@dxos/effect';
 import { Outline } from '@dxos/types';
 import { trim } from '@dxos/util';
 
-import { completedBlocks, findObject, toolInvocations } from '../assertions.ts';
+import { completedBlocks, findObject } from '../assertions.ts';
 import { judge } from '../judge.ts';
 import { createEvalRunner } from '../runner.ts';
+import * as Scorer from '../Scorer.ts';
 
 // Ported from the gated `Planning` scenario (../testing/planning.test.ts).
 // Grades the real outline-checklist DB state and tool-invocation trace directly instead of the agent's
@@ -38,6 +39,61 @@ const HAIKU_JUDGE_RUBRIC = trim`
   unbroken sentence instead of a short multi-line poem.
 `;
 
+/** The plan's checklist items, parsed from the outline the session kept. */
+const checklist = Effect.gen(function* () {
+  const outline = yield* findObject(Outline.Outline, () => true);
+  const text = outline ? yield* Database.load(outline.content).pipe(Effect.orElseSucceed(() => undefined)) : undefined;
+  return Outline.parseChecklist(text?.content ?? '');
+});
+
+/** The judge's verdict on the haikus the session wrote into the chat feed. */
+const haikuVerdict = completedBlocks().pipe(
+  Effect.map((blocks) =>
+    blocks
+      .filter(({ role, block }) => role === 'assistant' && block._tag === 'text')
+      .map(({ block }) => (block as { text: string }).text)
+      .join('\n'),
+  ),
+  Effect.flatMap((assistantText) => judge(HAIKU_JUDGE_RUBRIC, assistantText)),
+);
+
+const SCORERS = [
+  Scorer.make({
+    name: 'exactly-three-tasks',
+    description: 'Exactly 3 checklist items exist for the three haiku topics.',
+    query: checklist,
+    score: (items) => items.length === 3,
+  }),
+  Scorer.make({
+    name: 'all-tasks-done',
+    description: 'All 3 tasks are marked done.',
+    query: checklist,
+    score: (items) => items.length === 3 && items.every((item) => item.done),
+  }),
+  Scorer.make({
+    name: 'haikus-well-formed',
+    description: 'An LLM judge confirms all three topics have their own well-formed haiku.',
+    query: haikuVerdict,
+    score: (verdict) => verdict.pass,
+  }),
+  Scorer.toolCalls({
+    name: 'used-update-tasks',
+    description: 'The assistant-toolkit-update-tasks tool was used at least 3 times (once per task).',
+    score: (invocations) =>
+      invocations.filter((invocation) => invocation.operationKey === UPDATE_TASKS_OPERATION_KEY).length >= 3,
+  }),
+  Scorer.toolCalls({
+    name: 'no-direct-plan-manipulation',
+    description: 'The outline was never written via a raw database object-create/update call.',
+    score: (invocations) =>
+      !invocations.some(
+        (invocation) =>
+          OBJECT_WRITE_OPERATION_KEYS.includes(invocation.operationKey ?? '') &&
+          invocation.input.includes(OUTLINE_TYPENAME),
+      ),
+  }),
+];
+
 const task = createEvalRunner({
   sessionChat: true,
   instructions: trim`
@@ -57,74 +113,13 @@ const task = createEvalRunner({
   output: Schema.Unknown,
   // Three sequential subtasks, each a assistant-toolkit-update-tasks call + haiku turn, plus a final judge call.
   timeout: 150_000,
-  dbQuery: () =>
-    Effect.gen(function* () {
-      const outline = yield* findObject(Outline.Outline, () => true);
-      const text = outline
-        ? yield* Database.load(outline.content).pipe(Effect.orElseSucceed(() => undefined))
-        : undefined;
-      const items = Outline.parseChecklist(text?.content ?? '');
-      const invocations = yield* toolInvocations();
-      const blocks = yield* completedBlocks();
-
-      const assistantText = blocks
-        .filter(({ role, block }) => role === 'assistant' && block._tag === 'text')
-        .map(({ block }) => (block as { text: string }).text)
-        .join('\n');
-
-      const updateTasksCalls = invocations.filter(
-        (invocation) => invocation.operationKey === UPDATE_TASKS_OPERATION_KEY,
-      );
-      const directPlanWrites = invocations.filter(
-        (invocation) =>
-          OBJECT_WRITE_OPERATION_KEYS.includes(invocation.operationKey ?? '') &&
-          invocation.input.includes(OUTLINE_TYPENAME),
-      );
-      const haikuVerdict = yield* judge(HAIKU_JUDGE_RUBRIC, assistantText);
-
-      return {
-        taskCount: items.length,
-        allTasksDone: items.length === 3 && items.every((item) => item.done),
-        haikuVerdict,
-        usedUpdateTasks: updateTasksCalls.length >= 3,
-        noDirectPlanManipulation: directPlanWrites.length === 0,
-      };
-    }),
+  scorers: SCORERS,
 });
 
 evalite('Planning — create three haiku tasks and complete each one', {
   data: [{ input: null }],
   task,
-  scorers: [
-    {
-      name: 'exactly-three-tasks',
-      description: 'Exactly 3 checklist items exist for the three haiku topics.',
-      scorer: ({ output }) => (output.dbQuery.taskCount === 3 ? 1 : 0),
-    },
-    {
-      name: 'all-tasks-done',
-      description: 'All 3 tasks are marked done.',
-      scorer: ({ output }) => (output.dbQuery.allTasksDone ? 1 : 0),
-    },
-    {
-      name: 'haikus-well-formed',
-      description: 'An LLM judge confirms all three topics have their own well-formed haiku.',
-      scorer: ({ output }) => ({
-        score: output.dbQuery.haikuVerdict.pass ? 1 : 0,
-        metadata: { reasoning: output.dbQuery.haikuVerdict.reasoning },
-      }),
-    },
-    {
-      name: 'used-update-tasks',
-      description: 'The assistant-toolkit-update-tasks tool was used at least 3 times (once per task).',
-      scorer: ({ output }) => (output.dbQuery.usedUpdateTasks ? 1 : 0),
-    },
-    {
-      name: 'no-direct-plan-manipulation',
-      description: 'The outline was never written via a raw database object-create/update call.',
-      scorer: ({ output }) => (output.dbQuery.noDirectPlanManipulation ? 1 : 0),
-    },
-  ],
+  scorers: Scorer.toEvalite(SCORERS),
 });
 
 // A judge that only ever passes would be worthless as a scorer — this demonstrates it correctly

--- a/packages/core/compute/assistant-evals/src/evals/projects.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/projects.eval.ts
@@ -18,8 +18,9 @@ import * as TasksPlugin from '@dxos/plugin-tasks/TasksPlugin';
 import { Milestone, Outline, Task, TaskSet } from '@dxos/types';
 import { trim } from '@dxos/util';
 
-import { findObject, toolInvocations } from '../assertions.ts';
+import { findObject } from '../assertions.ts';
 import { createEvalRunner } from '../runner.ts';
+import * as Scorer from '../Scorer.ts';
 import { getDefaultSkills } from '../skills.ts';
 
 const PROJECT_NAME = 'Harbor';
@@ -49,6 +50,97 @@ const entityId = (uri: string): string => {
   const eid = EID.tryParse(uri);
   return (eid && EID.getEntityId(eid)) ?? uri;
 };
+
+/** The project, its task set and the tasks on it — the ledger every scorer below reads. */
+const ledger = Effect.gen(function* () {
+  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+  const taskSet = project?.taskSet ? yield* Database.load(project.taskSet) : undefined;
+  if (!project || !taskSet) {
+    return undefined;
+  }
+  const tasks = yield* Effect.forEach(taskSet.tasks, (ref) => Database.load(ref));
+  const matched = PLAN.map((item) => tasks.find((candidate) => candidate.title?.toLowerCase().includes(item.keyword)));
+  return { project, taskSet, tasks, matched };
+});
+
+/** The Alpha milestone, and how many of the planned tasks are filed under it. */
+const milestoneFiling = Effect.gen(function* () {
+  const found = yield* ledger;
+  const milestone = yield* findObject(Milestone.Milestone, (candidate) => candidate.name === MILESTONE_NAME);
+  if (!found || !milestone || !found.taskSet.milestones.some((ref) => entityId(ref.uri) === milestone.id)) {
+    return 0;
+  }
+  return found.matched.filter((candidate) => candidate?.milestone && entityId(candidate.milestone.uri) === milestone.id)
+    .length;
+});
+
+/** What the session filed into the project's artifacts: the outline itself, and the design document. */
+const filedArtifacts = Effect.gen(function* () {
+  const found = yield* ledger;
+  if (!found) {
+    return { outlineFiled: false, designDocFiled: false };
+  }
+  const { project } = found;
+  const outlineId = project.outline ? entityId(project.outline.uri) : undefined;
+  const artifacts = yield* Effect.forEach(project.artifacts, (ref) =>
+    Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
+  );
+  const designDoc = artifacts.find(
+    (candidate) => Obj.instanceOf(Markdown.Document, candidate) && !!candidate.name?.toLowerCase().includes('design'),
+  );
+  const designText =
+    designDoc && Obj.instanceOf(Markdown.Document, designDoc)
+      ? yield* Database.load(designDoc.content).pipe(Effect.orElseSucceed(() => undefined))
+      : undefined;
+  return {
+    outlineFiled: !!outlineId && project.artifacts.some((ref) => entityId(ref.uri) === outlineId),
+    designDocFiled: !!designText?.content.toLowerCase().includes(DESIGN_KEYWORD),
+  };
+});
+
+const SCORERS = [
+  Scorer.make({
+    name: 'tasks-created',
+    description: "One task per open outline item, on the project's own task set.",
+    query: ledger,
+    score: (found) => (found?.matched.filter(Boolean).length ?? 0) / PLAN.length,
+  }),
+  Scorer.make({
+    name: 'filed-under-milestone',
+    description: 'The Alpha milestone is in the set and every created task references it.',
+    query: milestoneFiling,
+    score: (filed) => filed / PLAN.length,
+  }),
+  Scorer.make({
+    name: 'closed-the-right-task',
+    description: 'Exactly one task is done, and it is the schema item.',
+    query: ledger,
+    score: (found) => {
+      const done = found?.tasks.filter((candidate) => candidate.status === 'done') ?? [];
+      return done.length === 1 && !!done[0].title?.toLowerCase().includes(DONE_KEYWORD);
+    },
+  }),
+  Scorer.make({
+    name: 'outline-filed-as-artifact',
+    description: "The outline is in the project's artifacts (projects-add-artifact).",
+    query: filedArtifacts,
+    score: ({ outlineFiled }) => outlineFiled,
+  }),
+  Scorer.make({
+    name: 'design-doc-filed',
+    description: "A design document carrying the finding is in the project's artifacts.",
+    query: filedArtifacts,
+    score: ({ designDocFiled }) => designDocFiled,
+  }),
+  Scorer.toolCalls({
+    name: 'project-verbs-reached',
+    description: 'The outline/task/milestone/artifact verbs were called, and none returned an error.',
+    score: (invocations) => {
+      const called = new Set(invocations.map((invocation) => invocation.name));
+      return REQUIRED_TOOLS.every((name) => called.has(name)) && invocations.every(({ error }) => !error);
+    },
+  }),
+];
 
 const task = createEvalRunner({
   instructions: trim`
@@ -88,107 +180,11 @@ const task = createEvalRunner({
 
       return { objects: [Ref.make(project)], chat: Ref.make(chat) };
     }),
-  dbQuery: () =>
-    Effect.gen(function* () {
-      const invocations = yield* toolInvocations();
-      const called = new Set(invocations.map((invocation) => invocation.name));
-      const trace = {
-        missingTools: REQUIRED_TOOLS.filter((name) => !called.has(name)),
-        erroredTools: invocations.filter((invocation) => invocation.error).map((invocation) => invocation.name),
-      };
-      const empty = {
-        ...trace,
-        matchedTasks: 0,
-        filedUnderMilestone: 0,
-        expected: PLAN.length,
-        closedTheRightOne: false,
-        outlineFiled: false,
-        designDocFiled: false,
-      };
-
-      const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-      const taskSet = project?.taskSet ? yield* Database.load(project.taskSet) : undefined;
-      if (!project || !taskSet) {
-        return empty;
-      }
-
-      const tasks = yield* Effect.forEach(taskSet.tasks, (ref) => Database.load(ref));
-      const matched = PLAN.map((item) =>
-        tasks.find((candidate) => candidate.title?.toLowerCase().includes(item.keyword)),
-      );
-
-      const milestone = yield* findObject(Milestone.Milestone, (candidate) => candidate.name === MILESTONE_NAME);
-      const milestoneInSet = !!milestone && taskSet.milestones.some((ref) => entityId(ref.uri) === milestone.id);
-      const filedUnderMilestone = !milestoneInSet
-        ? 0
-        : matched.filter((candidate) => candidate?.milestone && entityId(candidate.milestone.uri) === milestone.id)
-            .length;
-
-      const doneTasks = tasks.filter((candidate) => candidate.status === 'done');
-      const closedTheRightOne = doneTasks.length === 1 && !!doneTasks[0].title?.toLowerCase().includes(DONE_KEYWORD);
-
-      const outlineId = project.outline ? entityId(project.outline.uri) : undefined;
-      const outlineFiled = !!outlineId && project.artifacts.some((ref) => entityId(ref.uri) === outlineId);
-
-      const artifacts = yield* Effect.forEach(project.artifacts, (ref) =>
-        Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
-      );
-      const designDoc = artifacts.find(
-        (candidate) =>
-          Obj.instanceOf(Markdown.Document, candidate) && !!candidate.name?.toLowerCase().includes('design'),
-      );
-      const designText =
-        designDoc && Obj.instanceOf(Markdown.Document, designDoc)
-          ? yield* Database.load(designDoc.content).pipe(Effect.orElseSucceed(() => undefined))
-          : undefined;
-      const designDocFiled = !!designText?.content.toLowerCase().includes(DESIGN_KEYWORD);
-
-      return {
-        ...trace,
-        matchedTasks: matched.filter(Boolean).length,
-        filedUnderMilestone,
-        expected: PLAN.length,
-        closedTheRightOne,
-        outlineFiled,
-        designDocFiled,
-      };
-    }),
+  scorers: SCORERS,
 });
 
 evalite('Projects — a project chat turns its outline into a task ledger', {
   data: [{ input: null }],
   task,
-  scorers: [
-    {
-      name: 'tasks-created',
-      description: "One task per open outline item, on the project's own task set.",
-      scorer: ({ output }) => output.dbQuery.matchedTasks / output.dbQuery.expected,
-    },
-    {
-      name: 'filed-under-milestone',
-      description: 'The Alpha milestone is in the set and every created task references it.',
-      scorer: ({ output }) => output.dbQuery.filedUnderMilestone / output.dbQuery.expected,
-    },
-    {
-      name: 'closed-the-right-task',
-      description: 'Exactly one task is done, and it is the schema item.',
-      scorer: ({ output }) => (output.dbQuery.closedTheRightOne ? 1 : 0),
-    },
-    {
-      name: 'outline-filed-as-artifact',
-      description: "The outline is in the project's artifacts (projects-add-artifact).",
-      scorer: ({ output }) => (output.dbQuery.outlineFiled ? 1 : 0),
-    },
-    {
-      name: 'design-doc-filed',
-      description: "A design document carrying the finding is in the project's artifacts.",
-      scorer: ({ output }) => (output.dbQuery.designDocFiled ? 1 : 0),
-    },
-    {
-      name: 'project-verbs-reached',
-      description: 'The outline/task/milestone/artifact verbs were called, and none returned an error.',
-      scorer: ({ output }) =>
-        output.dbQuery.missingTools.length === 0 && output.dbQuery.erroredTools.length === 0 ? 1 : 0,
-    },
-  ],
+  scorers: Scorer.toEvalite(SCORERS),
 });

--- a/packages/core/compute/assistant-evals/src/evals/projects.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/projects.eval.ts
@@ -52,85 +52,91 @@ const entityId = (uri: string): string => {
 };
 
 /** The project, its task set and the tasks on it — the ledger every scorer below reads. */
-const ledger = Effect.gen(function* () {
-  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-  const taskSet = project?.taskSet ? yield* Database.load(project.taskSet) : undefined;
-  if (!project || !taskSet) {
-    return undefined;
-  }
-  const tasks = yield* Effect.forEach(taskSet.tasks, (ref) => Database.load(ref));
-  const matched = PLAN.map((item) => tasks.find((candidate) => candidate.title?.toLowerCase().includes(item.keyword)));
-  return { project, taskSet, tasks, matched };
-});
+const ledger = Scorer.shared(
+  Effect.gen(function* () {
+    const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+    const taskSet = project?.taskSet ? yield* Database.load(project.taskSet) : undefined;
+    if (!project || !taskSet) {
+      return undefined;
+    }
+    const tasks = yield* Effect.forEach(taskSet.tasks, (ref) => Database.load(ref));
+    const matched = PLAN.map((item) =>
+      tasks.find((candidate) => candidate.title?.toLowerCase().includes(item.keyword)),
+    );
+    return { project, taskSet, tasks, matched };
+  }),
+);
 
 /** The Alpha milestone, and how many of the planned tasks are filed under it. */
-const milestoneFiling = Effect.gen(function* () {
-  const found = yield* ledger;
-  const milestone = yield* findObject(Milestone.Milestone, (candidate) => candidate.name === MILESTONE_NAME);
-  if (!found || !milestone || !found.taskSet.milestones.some((ref) => entityId(ref.uri) === milestone.id)) {
-    return 0;
-  }
-  return found.matched.filter((candidate) => candidate?.milestone && entityId(candidate.milestone.uri) === milestone.id)
-    .length;
-});
+const milestoneFiling = Scorer.shared(
+  Effect.gen(function* () {
+    const found = yield* ledger;
+    const milestone = yield* findObject(Milestone.Milestone, (candidate) => candidate.name === MILESTONE_NAME);
+    if (!found || !milestone || !found.taskSet.milestones.some((ref) => entityId(ref.uri) === milestone.id)) {
+      return 0;
+    }
+    return found.matched.filter(
+      (candidate) => candidate?.milestone && entityId(candidate.milestone.uri) === milestone.id,
+    ).length;
+  }),
+);
 
 /** What the session filed into the project's artifacts: the outline itself, and the design document. */
-const filedArtifacts = Effect.gen(function* () {
-  const found = yield* ledger;
-  if (!found) {
-    return { outlineFiled: false, designDocFiled: false };
-  }
-  const { project } = found;
-  const outlineId = project.outline ? entityId(project.outline.uri) : undefined;
-  const artifacts = yield* Effect.forEach(project.artifacts, (ref) =>
-    Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
-  );
-  const designDoc = artifacts.find(
-    (candidate) => Obj.instanceOf(Markdown.Document, candidate) && !!candidate.name?.toLowerCase().includes('design'),
-  );
-  const designText =
-    designDoc && Obj.instanceOf(Markdown.Document, designDoc)
-      ? yield* Database.load(designDoc.content).pipe(Effect.orElseSucceed(() => undefined))
-      : undefined;
-  return {
-    outlineFiled: !!outlineId && project.artifacts.some((ref) => entityId(ref.uri) === outlineId),
-    designDocFiled: !!designText?.content.toLowerCase().includes(DESIGN_KEYWORD),
-  };
-});
+const filedArtifacts = Scorer.shared(
+  Effect.gen(function* () {
+    const found = yield* ledger;
+    if (!found) {
+      return { outlineFiled: false, designDocFiled: false };
+    }
+    const { project } = found;
+    const outlineId = project.outline ? entityId(project.outline.uri) : undefined;
+    const artifacts = yield* Effect.forEach(project.artifacts, (ref) =>
+      Database.load(ref).pipe(Effect.orElseSucceed(() => undefined)),
+    );
+    const designDoc = artifacts.find(
+      (candidate) => Obj.instanceOf(Markdown.Document, candidate) && !!candidate.name?.toLowerCase().includes('design'),
+    );
+    const designText =
+      designDoc && Obj.instanceOf(Markdown.Document, designDoc)
+        ? yield* Database.load(designDoc.content).pipe(Effect.orElseSucceed(() => undefined))
+        : undefined;
+    return {
+      outlineFiled: !!outlineId && project.artifacts.some((ref) => entityId(ref.uri) === outlineId),
+      designDocFiled: !!designText?.content.toLowerCase().includes(DESIGN_KEYWORD),
+    };
+  }),
+);
 
 const SCORERS = [
   Scorer.make({
     name: 'tasks-created',
     description: "One task per open outline item, on the project's own task set.",
-    query: ledger,
-    score: (found) => (found?.matched.filter(Boolean).length ?? 0) / PLAN.length,
+    score: ledger.pipe(Effect.map((found) => (found?.matched.filter(Boolean).length ?? 0) / PLAN.length)),
   }),
   Scorer.make({
     name: 'filed-under-milestone',
     description: 'The Alpha milestone is in the set and every created task references it.',
-    query: milestoneFiling,
-    score: (filed) => filed / PLAN.length,
+    score: milestoneFiling.pipe(Effect.map((filed) => filed / PLAN.length)),
   }),
   Scorer.make({
     name: 'closed-the-right-task',
     description: 'Exactly one task is done, and it is the schema item.',
-    query: ledger,
-    score: (found) => {
-      const done = found?.tasks.filter((candidate) => candidate.status === 'done') ?? [];
-      return done.length === 1 && !!done[0].title?.toLowerCase().includes(DONE_KEYWORD);
-    },
+    score: ledger.pipe(
+      Effect.map((found) => {
+        const done = found?.tasks.filter((candidate) => candidate.status === 'done') ?? [];
+        return done.length === 1 && !!done[0].title?.toLowerCase().includes(DONE_KEYWORD);
+      }),
+    ),
   }),
   Scorer.make({
     name: 'outline-filed-as-artifact',
     description: "The outline is in the project's artifacts (projects-add-artifact).",
-    query: filedArtifacts,
-    score: ({ outlineFiled }) => outlineFiled,
+    score: filedArtifacts.pipe(Effect.map(({ outlineFiled }) => outlineFiled)),
   }),
   Scorer.make({
     name: 'design-doc-filed',
     description: "A design document carrying the finding is in the project's artifacts.",
-    query: filedArtifacts,
-    score: ({ designDocFiled }) => designDocFiled,
+    score: filedArtifacts.pipe(Effect.map(({ designDocFiled }) => designDocFiled)),
   }),
   Scorer.toolCalls({
     name: 'project-verbs-reached',
@@ -180,7 +186,7 @@ const task = createEvalRunner({
 
       return { objects: [Ref.make(project)], chat: Ref.make(chat) };
     }),
-  scorers: SCORERS,
+  scored: true,
 });
 
 evalite('Projects — a project chat turns its outline into a task ledger', {

--- a/packages/core/compute/assistant-evals/src/evals/sender-ledger.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/sender-ledger.eval.ts
@@ -68,62 +68,64 @@ const entityId = (uri: string): string => {
 };
 
 /** The ledger tables in the space, and how many of them the project filed as artifacts. */
-const ledgerTables = Effect.gen(function* () {
-  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-  const tables = yield* Database.query(Filter.type(Table.Table)).run;
-  if (!project) {
-    return { tableCount: tables.length, filedCount: 0 };
-  }
-  const tableIds = new Set(tables.map((table) => entityId(Obj.getURI(table))));
-  return {
-    tableCount: tables.length,
-    filedCount: project.artifacts.filter((ref) => tableIds.has(entityId(ref.uri))).length,
-  };
-});
+const ledgerTables = Scorer.shared(
+  Effect.gen(function* () {
+    const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+    const tables = yield* Database.query(Filter.type(Table.Table)).run;
+    if (!project) {
+      return { tableCount: tables.length, filedCount: 0 };
+    }
+    const tableIds = new Set(tables.map((table) => entityId(Obj.getURI(table))));
+    return {
+      tableCount: tables.length,
+      filedCount: project.artifacts.filter((ref) => tableIds.has(entityId(ref.uri))).length,
+    };
+  }),
+);
 
 /**
  * The sender's rows, schema-agnostic: table rows are objects of a table-owned dynamic schema, so
  * every object carrying the sender's email is a candidate and its count/lastSeen are read as
  * properties. Exactly one such row proves the upsert deduped.
  */
-const senderRows = Effect.gen(function* () {
-  const everything = yield* Database.query(Query.select(Filter.everything())).run;
-  return everything.filter(
-    (candidate): candidate is Obj.Unknown & { count?: unknown; lastSeen?: unknown } =>
-      Obj.isObject(candidate) &&
-      !Obj.instanceOf(Table.Table, candidate) &&
-      Object.values(Obj.getSnapshot(candidate)).includes(SENDER_EMAIL),
-  );
-});
+const senderRows = Scorer.shared(
+  Effect.gen(function* () {
+    const everything = yield* Database.query(Query.select(Filter.everything())).run;
+    return everything.filter(
+      (candidate): candidate is Obj.Unknown & { count?: unknown; lastSeen?: unknown } =>
+        Obj.isObject(candidate) &&
+        !Obj.instanceOf(Table.Table, candidate) &&
+        Object.values(Obj.getSnapshot(candidate)).includes(SENDER_EMAIL),
+    );
+  }),
+);
 
 const SCORERS = [
   Scorer.make({
     name: 'ledger-created',
     description: 'At least one Table exists after the run.',
-    query: ledgerTables,
-    score: ({ tableCount }) => tableCount > 0,
+    score: ledgerTables.pipe(Effect.map(({ tableCount }) => tableCount > 0)),
   }),
   Scorer.make({
     name: 'ledger-filed',
     description: "The ledger table is in the project's artifacts.",
-    query: ledgerTables,
-    score: ({ filedCount }) => filedCount > 0,
+    score: ledgerTables.pipe(Effect.map(({ filedCount }) => filedCount > 0)),
   }),
   Scorer.make({
     name: 'ledger-deduped',
     description: 'Exactly one table exists and it is filed exactly once (no duplicate ledger).',
-    query: ledgerTables,
-    score: ({ tableCount, filedCount }) => tableCount === 1 && filedCount === 1,
+    score: ledgerTables.pipe(Effect.map(({ tableCount, filedCount }) => tableCount === 1 && filedCount === 1)),
   }),
   Scorer.make({
     name: 'row-upserted',
     description: 'Exactly one sender row exists, with count 2 and lastSeen from the later message.',
-    query: senderRows,
-    score: (rows) => {
-      const [row] = rows;
-      const count = typeof row?.count === 'string' ? Number(row.count) : row?.count;
-      return rows.length === 1 && count === MESSAGES.length && String(row?.lastSeen ?? '').startsWith('2026-07-02');
-    },
+    score: senderRows.pipe(
+      Effect.map((rows) => {
+        const [row] = rows;
+        const count = typeof row?.count === 'string' ? Number(row.count) : row?.count;
+        return rows.length === 1 && count === MESSAGES.length && String(row?.lastSeen ?? '').startsWith('2026-07-02');
+      }),
+    ),
   }),
 ];
 
@@ -143,7 +145,7 @@ const task = createEvalRunner({
       yield* Database.flush();
       return { objects: [Ref.make(project)] };
     }),
-  scorers: SCORERS,
+  scored: true,
 });
 
 // Skipped: `table.create` fails headless with `Invalid draft for org.dxos.type.table: view: Missing

--- a/packages/core/compute/assistant-evals/src/evals/sender-ledger.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/sender-ledger.eval.ts
@@ -18,6 +18,7 @@ import { trim } from '@dxos/util';
 
 import { findObject } from '../assertions.ts';
 import { createEvalRunner } from '../runner.ts';
+import * as Scorer from '../Scorer.ts';
 import { getDefaultSkills } from '../skills.ts';
 
 // The sender-ledger routine's headless task, run through the same RunInstructions path a
@@ -66,6 +67,66 @@ const entityId = (uri: string): string => {
   return (eid && EID.getEntityId(eid)) ?? uri;
 };
 
+/** The ledger tables in the space, and how many of them the project filed as artifacts. */
+const ledgerTables = Effect.gen(function* () {
+  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+  const tables = yield* Database.query(Filter.type(Table.Table)).run;
+  if (!project) {
+    return { tableCount: tables.length, filedCount: 0 };
+  }
+  const tableIds = new Set(tables.map((table) => entityId(Obj.getURI(table))));
+  return {
+    tableCount: tables.length,
+    filedCount: project.artifacts.filter((ref) => tableIds.has(entityId(ref.uri))).length,
+  };
+});
+
+/**
+ * The sender's rows, schema-agnostic: table rows are objects of a table-owned dynamic schema, so
+ * every object carrying the sender's email is a candidate and its count/lastSeen are read as
+ * properties. Exactly one such row proves the upsert deduped.
+ */
+const senderRows = Effect.gen(function* () {
+  const everything = yield* Database.query(Query.select(Filter.everything())).run;
+  return everything.filter(
+    (candidate): candidate is Obj.Unknown & { count?: unknown; lastSeen?: unknown } =>
+      Obj.isObject(candidate) &&
+      !Obj.instanceOf(Table.Table, candidate) &&
+      Object.values(Obj.getSnapshot(candidate)).includes(SENDER_EMAIL),
+  );
+});
+
+const SCORERS = [
+  Scorer.make({
+    name: 'ledger-created',
+    description: 'At least one Table exists after the run.',
+    query: ledgerTables,
+    score: ({ tableCount }) => tableCount > 0,
+  }),
+  Scorer.make({
+    name: 'ledger-filed',
+    description: "The ledger table is in the project's artifacts.",
+    query: ledgerTables,
+    score: ({ filedCount }) => filedCount > 0,
+  }),
+  Scorer.make({
+    name: 'ledger-deduped',
+    description: 'Exactly one table exists and it is filed exactly once (no duplicate ledger).',
+    query: ledgerTables,
+    score: ({ tableCount, filedCount }) => tableCount === 1 && filedCount === 1,
+  }),
+  Scorer.make({
+    name: 'row-upserted',
+    description: 'Exactly one sender row exists, with count 2 and lastSeen from the later message.',
+    query: senderRows,
+    score: (rows) => {
+      const [row] = rows;
+      const count = typeof row?.count === 'string' ? Number(row.count) : row?.count;
+      return rows.length === 1 && count === MESSAGES.length && String(row?.lastSeen ?? '').startsWith('2026-07-02');
+    },
+  }),
+];
+
 const task = createEvalRunner({
   instructions: INSTRUCTIONS,
   input: Schema.Unknown,
@@ -82,33 +143,7 @@ const task = createEvalRunner({
       yield* Database.flush();
       return { objects: [Ref.make(project)] };
     }),
-  dbQuery: () =>
-    Effect.gen(function* () {
-      const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-      const tables = yield* Database.query(Filter.type(Table.Table)).run;
-
-      // Row-level assertion, schema-agnostic (table rows are objects of a table-owned dynamic
-      // schema): scan every object carrying the sender's email and read its count/lastSeen
-      // properties. Exactly one such row with count 2 proves the upsert deduped.
-      const everything = yield* Database.query(Query.select(Filter.everything())).run;
-      const senderRows = everything.filter(
-        (candidate): candidate is Obj.Unknown & { count?: unknown; lastSeen?: unknown } =>
-          Obj.isObject(candidate) &&
-          !Obj.instanceOf(Table.Table, candidate) &&
-          Object.values(Obj.getSnapshot(candidate)).includes(SENDER_EMAIL),
-      );
-      const [row] = senderRows;
-      const rowCount = typeof row?.count === 'string' ? Number(row.count) : row?.count;
-      const rowUpserted =
-        senderRows.length === 1 && rowCount === MESSAGES.length && String(row?.lastSeen ?? '').startsWith('2026-07-02');
-
-      if (!project) {
-        return { tableCount: tables.length, filedCount: 0, senderRowCount: senderRows.length, rowUpserted };
-      }
-      const tableIds = new Set(tables.map((table) => entityId(Obj.getURI(table))));
-      const filedCount = project.artifacts.filter((ref) => tableIds.has(entityId(ref.uri))).length;
-      return { tableCount: tables.length, filedCount, senderRowCount: senderRows.length, rowUpserted };
-    }),
+  scorers: SCORERS,
 });
 
 // Skipped: `table.create` fails headless with `Invalid draft for org.dxos.type.table: view: Missing
@@ -117,26 +152,5 @@ const task = createEvalRunner({
 evalite.skip('Projects — sender-ledger routine maintains one filed table', {
   data: [{ input: { messages: MESSAGES } }],
   task,
-  scorers: [
-    {
-      name: 'ledger-created',
-      description: 'At least one Table exists after the run.',
-      scorer: ({ output }) => (output.dbQuery.tableCount > 0 ? 1 : 0),
-    },
-    {
-      name: 'ledger-filed',
-      description: "The ledger table is in the project's artifacts.",
-      scorer: ({ output }) => (output.dbQuery.filedCount > 0 ? 1 : 0),
-    },
-    {
-      name: 'ledger-deduped',
-      description: 'Exactly one table exists and it is filed exactly once (no duplicate ledger).',
-      scorer: ({ output }) => (output.dbQuery.tableCount === 1 && output.dbQuery.filedCount === 1 ? 1 : 0),
-    },
-    {
-      name: 'row-upserted',
-      description: 'Exactly one sender row exists, with count 2 and lastSeen from the later message.',
-      scorer: ({ output }) => (output.dbQuery.rowUpserted ? 1 : 0),
-    },
-  ],
+  scorers: Scorer.toEvalite(SCORERS),
 });

--- a/packages/core/compute/assistant-evals/src/evals/task-management.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/task-management.eval.ts
@@ -31,15 +31,17 @@ const TASK_TITLES = ['Ship the beacon', 'Tune the retry budget', 'Document the r
 
 const REQUIRED_TOOLS = ['space-query-objects', 'tasks-update', 'space-update-object'];
 
-/** The project's tasks, read outside the agent; empty if the ledger is gone. */
-const ledgerTasks = Effect.gen(function* () {
-  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-  const taskSet = project?.taskSet ? yield* Database.load(project.taskSet) : undefined;
-  if (!taskSet) {
-    return [] as Task.Task[];
-  }
-  return yield* Effect.forEach(taskSet.tasks, (ref) => Database.load(ref));
-});
+/** The project's tasks, read outside the agent; empty if the ledger is gone. Read once per run. */
+const ledgerTasks = Scorer.shared(
+  Effect.gen(function* () {
+    const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+    const taskSet = project?.taskSet ? yield* Database.load(project.taskSet) : undefined;
+    if (!taskSet) {
+      return [] as Task.Task[];
+    }
+    return yield* Effect.forEach(taskSet.tasks, (ref) => Database.load(ref));
+  }),
+);
 
 const byKeyword = (tasks: readonly Task.Task[], keyword: string): Task.Task | undefined =>
   tasks.find((candidate) => candidate.title?.toLowerCase().includes(keyword));
@@ -51,26 +53,26 @@ const SCORERS = [
   Scorer.make({
     name: 'task-completed',
     description: 'The retry task is done, reached through `tasks-update` rather than `tasks-complete`.',
-    query: ledgerTasks,
-    score: (tasks) => byKeyword(tasks, COMPLETE_KEYWORD)?.status === 'done',
+    score: ledgerTasks.pipe(Effect.map((tasks) => byKeyword(tasks, COMPLETE_KEYWORD)?.status === 'done')),
   }),
   Scorer.make({
     name: 'task-assigned',
     description: 'The rollout task carries the assignee, reached through `tasks-update`.',
-    query: ledgerTasks,
-    score: (tasks) => byKeyword(tasks, ASSIGN_KEYWORD)?.assignee?.email === ASSIGNEE_EMAIL,
+    score: ledgerTasks.pipe(
+      Effect.map((tasks) => byKeyword(tasks, ASSIGN_KEYWORD)?.assignee?.email === ASSIGNEE_EMAIL),
+    ),
   }),
   Scorer.make({
     name: 'milestone-dated',
     description: 'The milestone target date is set through the generic `space-update-object`.',
-    query: previewMilestone,
-    score: (milestone) => milestone?.targetDate === TARGET_DATE,
+    score: previewMilestone.pipe(Effect.map((milestone) => milestone?.targetDate === TARGET_DATE)),
   }),
   Scorer.make({
     name: 'left-the-rest-alone',
     description: 'Exactly two tasks remain open — the agent closed one task, not the ledger.',
-    query: ledgerTasks,
-    score: (tasks) => tasks.filter((candidate) => (candidate.status ?? 'todo') !== 'done').length === 2,
+    score: ledgerTasks.pipe(
+      Effect.map((tasks) => tasks.filter((candidate) => (candidate.status ?? 'todo') !== 'done').length === 2),
+    ),
   }),
   Scorer.toolCalls({
     name: 'generic-verbs-reached',
@@ -120,7 +122,7 @@ const task = createEvalRunner({
 
       return { objects: [], chat: Ref.make(chat) };
     }),
-  scorers: SCORERS,
+  scored: true,
 });
 
 evalite('Task management — the ledger verbs survive losing their type-specific sugar', {

--- a/packages/core/compute/assistant-evals/src/evals/task-management.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/task-management.eval.ts
@@ -15,8 +15,9 @@ import * as TasksPlugin from '@dxos/plugin-tasks/TasksPlugin';
 import { Milestone, Outline, Task, TaskSet } from '@dxos/types';
 import { trim } from '@dxos/util';
 
-import { findObject, toolInvocations } from '../assertions.ts';
+import { findObject } from '../assertions.ts';
 import { createEvalRunner } from '../runner.ts';
+import * as Scorer from '../Scorer.ts';
 import { getDefaultSkills } from '../skills.ts';
 
 const PROJECT_NAME = 'Beacon';
@@ -29,6 +30,57 @@ const ASSIGN_KEYWORD = 'rollout';
 const TASK_TITLES = ['Ship the beacon', 'Tune the retry budget', 'Document the rollout'];
 
 const REQUIRED_TOOLS = ['space-query-objects', 'tasks-update', 'space-update-object'];
+
+/** The project's tasks, read outside the agent; empty if the ledger is gone. */
+const ledgerTasks = Effect.gen(function* () {
+  const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
+  const taskSet = project?.taskSet ? yield* Database.load(project.taskSet) : undefined;
+  if (!taskSet) {
+    return [] as Task.Task[];
+  }
+  return yield* Effect.forEach(taskSet.tasks, (ref) => Database.load(ref));
+});
+
+const byKeyword = (tasks: readonly Task.Task[], keyword: string): Task.Task | undefined =>
+  tasks.find((candidate) => candidate.title?.toLowerCase().includes(keyword));
+
+/** The milestone the run is asked to date, or `undefined` if it never existed. */
+const previewMilestone = findObject(Milestone.Milestone, (candidate) => candidate.name === MILESTONE_NAME);
+
+const SCORERS = [
+  Scorer.make({
+    name: 'task-completed',
+    description: 'The retry task is done, reached through `tasks-update` rather than `tasks-complete`.',
+    query: ledgerTasks,
+    score: (tasks) => byKeyword(tasks, COMPLETE_KEYWORD)?.status === 'done',
+  }),
+  Scorer.make({
+    name: 'task-assigned',
+    description: 'The rollout task carries the assignee, reached through `tasks-update`.',
+    query: ledgerTasks,
+    score: (tasks) => byKeyword(tasks, ASSIGN_KEYWORD)?.assignee?.email === ASSIGNEE_EMAIL,
+  }),
+  Scorer.make({
+    name: 'milestone-dated',
+    description: 'The milestone target date is set through the generic `space-update-object`.',
+    query: previewMilestone,
+    score: (milestone) => milestone?.targetDate === TARGET_DATE,
+  }),
+  Scorer.make({
+    name: 'left-the-rest-alone',
+    description: 'Exactly two tasks remain open — the agent closed one task, not the ledger.',
+    query: ledgerTasks,
+    score: (tasks) => tasks.filter((candidate) => (candidate.status ?? 'todo') !== 'done').length === 2,
+  }),
+  Scorer.toolCalls({
+    name: 'generic-verbs-reached',
+    description: 'Discovery and both patches went through the generic verbs, and none errored.',
+    score: (invocations) => {
+      const called = new Set(invocations.map((invocation) => invocation.name));
+      return REQUIRED_TOOLS.every((name) => called.has(name)) && invocations.every(({ error }) => !error);
+    },
+  }),
+];
 
 const task = createEvalRunner({
   instructions: trim`
@@ -68,67 +120,11 @@ const task = createEvalRunner({
 
       return { objects: [], chat: Ref.make(chat) };
     }),
-  dbQuery: () =>
-    Effect.gen(function* () {
-      const invocations = yield* toolInvocations();
-      const called = new Set(invocations.map((invocation) => invocation.name));
-      const trace = {
-        missingTools: REQUIRED_TOOLS.filter((name) => !called.has(name)),
-        erroredTools: invocations.filter((invocation) => invocation.error).map((invocation) => invocation.name),
-      };
-      const empty = { ...trace, completed: false, assigned: false, milestoneDated: false, untouched: 0 };
-
-      const project = yield* findObject(Project.Project, (candidate) => candidate.name === PROJECT_NAME);
-      const taskSet = project?.taskSet ? yield* Database.load(project.taskSet) : undefined;
-      if (!taskSet) {
-        return empty;
-      }
-
-      const tasks = yield* Effect.forEach(taskSet.tasks, (ref) => Database.load(ref));
-      const byKeyword = (keyword: string) =>
-        tasks.find((candidate) => candidate.title?.toLowerCase().includes(keyword));
-
-      const milestone = yield* findObject(Milestone.Milestone, (candidate) => candidate.name === MILESTONE_NAME);
-
-      return {
-        ...trace,
-        completed: byKeyword(COMPLETE_KEYWORD)?.status === 'done',
-        assigned: byKeyword(ASSIGN_KEYWORD)?.assignee?.email === ASSIGNEE_EMAIL,
-        milestoneDated: milestone?.targetDate === TARGET_DATE,
-        untouched: tasks.filter((candidate) => (candidate.status ?? 'todo') !== 'done').length,
-      };
-    }),
+  scorers: SCORERS,
 });
 
 evalite('Task management — the ledger verbs survive losing their type-specific sugar', {
   data: [{ input: null }],
   task,
-  scorers: [
-    {
-      name: 'task-completed',
-      description: 'The retry task is done, reached through `tasks-update` rather than `tasks-complete`.',
-      scorer: ({ output }) => (output.dbQuery.completed ? 1 : 0),
-    },
-    {
-      name: 'task-assigned',
-      description: 'The rollout task carries the assignee, reached through `tasks-update`.',
-      scorer: ({ output }) => (output.dbQuery.assigned ? 1 : 0),
-    },
-    {
-      name: 'milestone-dated',
-      description: 'The milestone target date is set through the generic `space-update-object`.',
-      scorer: ({ output }) => (output.dbQuery.milestoneDated ? 1 : 0),
-    },
-    {
-      name: 'left-the-rest-alone',
-      description: 'Exactly two tasks remain open — the agent closed one task, not the ledger.',
-      scorer: ({ output }) => (output.dbQuery.untouched === 2 ? 1 : 0),
-    },
-    {
-      name: 'generic-verbs-reached',
-      description: 'Discovery and both patches went through the generic verbs, and none errored.',
-      scorer: ({ output }) =>
-        output.dbQuery.missingTools.length === 0 && output.dbQuery.erroredTools.length === 0 ? 1 : 0,
-    },
-  ],
+  scorers: Scorer.toEvalite(SCORERS),
 });

--- a/packages/core/compute/assistant-evals/src/evals/web-search.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/web-search.eval.ts
@@ -32,8 +32,7 @@ const SCORERS = [
   Scorer.make({
     name: 'answer-correct',
     description: 'The agent reports the capital of France (Paris) in its response.',
-    query: assistantText,
-    score: (text) => text.includes('Paris'),
+    score: assistantText.pipe(Effect.map((text) => text.includes('Paris'))),
   }),
   Scorer.toolCalls({
     name: 'only-web-search-used',
@@ -62,7 +61,7 @@ const task = createEvalRunner({
   output: Schema.Unknown,
   // TODO(dmaretskyi): Update to use skill keys and get skills from registry.
   skills: [Ref.make(WebSearchSkill.make())],
-  scorers: SCORERS,
+  scored: true,
 });
 
 evalite('Web — search the web', {

--- a/packages/core/compute/assistant-evals/src/evals/web-search.eval.ts
+++ b/packages/core/compute/assistant-evals/src/evals/web-search.eval.ts
@@ -10,12 +10,48 @@ import { WebSearchSkill } from '@dxos/assistant-toolkit';
 import { Ref } from '@dxos/echo';
 import { trim } from '@dxos/util';
 
-import { completedBlocks, toolInvocations } from '../assertions.ts';
+import { completedBlocks } from '../assertions.ts';
 import { createEvalRunner } from '../runner.ts';
+import * as Scorer from '../Scorer.ts';
 
 // Ported from the gated `Web` scenario (../testing/web-search.test.ts).
 // Grades the real tool-invocation and transcript effects directly instead of the agent's
 // self-reported `completedCriteria` — this is the first tool-match scorer (TESTING.md Phase 2).
+
+/** Everything the assistant said during the run, as one string. */
+const assistantText = completedBlocks().pipe(
+  Effect.map((blocks) =>
+    blocks
+      .filter(({ role, block }) => role === 'assistant' && block._tag === 'text')
+      .map(({ block }) => (block as { text: string }).text)
+      .join('\n'),
+  ),
+);
+
+const SCORERS = [
+  Scorer.make({
+    name: 'answer-correct',
+    description: 'The agent reports the capital of France (Paris) in its response.',
+    query: assistantText,
+    score: (text) => text.includes('Paris'),
+  }),
+  Scorer.toolCalls({
+    name: 'only-web-search-used',
+    description: 'The web search tool was the only tool invoked (besides completeJob).',
+    score: (invocations) => {
+      const names = new Set(
+        invocations.filter((invocation) => invocation.name !== 'completeJob').map((invocation) => invocation.name),
+      );
+      return (
+        names.size === 1 &&
+        [...names][0]
+          .toLowerCase()
+          .replace(/[^a-z]/g, '')
+          .includes('websearch')
+      );
+    },
+  }),
+];
 
 const task = createEvalRunner({
   instructions: trim`
@@ -26,45 +62,11 @@ const task = createEvalRunner({
   output: Schema.Unknown,
   // TODO(dmaretskyi): Update to use skill keys and get skills from registry.
   skills: [Ref.make(WebSearchSkill.make())],
-  dbQuery: () =>
-    Effect.gen(function* () {
-      const invocations = yield* toolInvocations();
-      const blocks = yield* completedBlocks();
-
-      const nonCompletionTools = new Set(
-        invocations.filter((invocation) => invocation.name !== 'completeJob').map((invocation) => invocation.name),
-      );
-
-      const assistantText = blocks
-        .filter(({ role, block }) => role === 'assistant' && block._tag === 'text')
-        .map(({ block }) => (block as { text: string }).text)
-        .join('\n');
-
-      return {
-        onlyWebSearchUsed:
-          nonCompletionTools.size === 1 &&
-          [...nonCompletionTools][0]
-            .toLowerCase()
-            .replace(/[^a-z]/g, '')
-            .includes('websearch'),
-        mentionsParis: assistantText.includes('Paris'),
-      };
-    }),
+  scorers: SCORERS,
 });
 
 evalite('Web — search the web', {
   data: [{ input: null }],
   task,
-  scorers: [
-    {
-      name: 'answer-correct',
-      description: 'The agent reports the capital of France (Paris) in its response.',
-      scorer: ({ output }) => (output.dbQuery.mentionsParis ? 1 : 0),
-    },
-    {
-      name: 'only-web-search-used',
-      description: 'The web search tool was the only tool invoked (besides completeJob).',
-      scorer: ({ output }) => (output.dbQuery.onlyWebSearchUsed ? 1 : 0),
-    },
-  ],
+  scorers: Scorer.toEvalite(SCORERS),
 });

--- a/packages/core/compute/assistant-evals/src/runner.ts
+++ b/packages/core/compute/assistant-evals/src/runner.ts
@@ -205,13 +205,13 @@ export interface CreateEvalRunnerOptions<I, O> {
   timeout?: number;
   /**
    * Grade the state a session reached when it runs out of `timeout` or fails, rather than throwing:
-   * the agent's output becomes an {@link AgentIncomplete} and `dbQuery` still runs. For a scenario
-   * long enough that where it got to is worth knowing. Requires `dbQuery`; a timed-out session is
-   * not stopped, so the query then reads a space the agent may still be writing to.
+   * the agent's output becomes an {@link AgentIncomplete} and the scorers still run. For a scenario
+   * long enough that where it got to is worth knowing. Requires `scorers`; a timed-out session is
+   * not stopped, so their queries then read a space the agent may still be writing to.
    */
   gradeIncomplete?: boolean;
   /**
-   * Additional ECHO types the scenario's seed/dbQuery touch, registered with the harness client.
+   * Additional ECHO types the scenario's seed and scorers touch, registered with the harness client.
    */
   types?: Type.AnyEntity[];
   /**
@@ -245,20 +245,6 @@ export type SeedResult = {
   chat?: Ref.Ref<Chat.Chat>;
 };
 
-/**
- * A deterministic DB-state assertion run after the agent completes, before the harness is disposed.
- * Runs with the runtime's capability services as the seed does, so a query can invoke an operation
- * of its own — fetching through the sandbox the agent built in, say.
- */
-export type DbQuery<I, D> = (
-  input: I,
-  spaceId: SpaceId,
-) => Effect.Effect<
-  D,
-  unknown,
-  Database.Service | FeedTraceSink.FeedTraceSink | Capabilities.ProcessManagerRuntimeServices
->;
-
 export type VariantConfig =
   | undefined
   | {
@@ -275,10 +261,9 @@ export type VariantConfig =
  * space. All execution is wrapped in an Effect scope; errors are
  * propagated to the caller via `EffectEx.runAndForwardErrors`.
  *
- * Pass `dbQuery` to additionally run a deterministic DB-state assertion (TESTING.md dimension G)
- * while the space is still open; the task then returns `{ agentOutput, dbQuery, durationMillis }` instead of the
- * bare agent output, so a Scorer can grade the real effect rather than the model's own
- * self-reported completion.
+ * Pass `scorers` to additionally grade the space while it is still open (TESTING.md dimension G);
+ * the task then returns `{ agentOutput, scores, durationMillis }` instead of the bare agent output,
+ * so each dimension grades the real effect rather than the model's own self-reported completion.
  *
  * Pass `expect: 'failure'` for scenarios that assert the agent correctly fails; the task then
  * returns `{ failed: boolean }` instead of throwing, so a Scorer can grade "failed as instructed".
@@ -298,30 +283,17 @@ export function createEvalRunner<I, O>(
   options: CreateEvalRunnerOptions<I, O> & { scorers: readonly Scorer.Any[] },
 ): Evalite.Task<I, { agentOutput: O | AgentIncomplete; scores: Scorer.Scores; durationMillis: number }, VariantConfig>;
 export function createEvalRunner<I, O>(options: CreateEvalRunnerOptions<I, O>): Evalite.Task<I, O, VariantConfig>;
-export function createEvalRunner<I, O, D>(
-  options: CreateEvalRunnerOptions<I, O> & { dbQuery: DbQuery<I, D> },
-): Evalite.Task<I, { agentOutput: O | AgentIncomplete; dbQuery: D; durationMillis: number }, VariantConfig>;
-export function createEvalRunner<I, O, D>(
-  options: CreateEvalRunnerOptions<I, O> & { dbQuery?: DbQuery<I, D> },
+export function createEvalRunner<I, O>(
+  options: CreateEvalRunnerOptions<I, O>,
 ): Evalite.Task<
   I,
-  | O
-  | { agentOutput: O | AgentIncomplete; dbQuery: D; durationMillis: number }
-  | { agentOutput: O | AgentIncomplete; scores: Scorer.Scores; durationMillis: number }
-  | { failed: boolean },
+  O | { agentOutput: O | AgentIncomplete; scores: Scorer.Scores; durationMillis: number } | { failed: boolean },
   VariantConfig
 > {
   const execute = async (input: I, variant: VariantConfig, record: (call: Usage.Call) => void) => {
-    // One grading path per scenario: with both, the result's shape would not be the one the
-    // overload promised the caller.
-    if (options.dbQuery && options.scorers?.length) {
-      throw new Error('createEvalRunner: pass either `dbQuery` or `scorers`, not both.');
-    }
-
     const model = variant?.model ?? options.model ?? DEFAULT_MODEL;
     const timeoutMillis = options.timeout ?? DEFAULT_EVAL_TIMEOUT_MILLIS;
-    const gradeIncomplete =
-      options.gradeIncomplete === true && (options.dbQuery !== undefined || (options.scorers?.length ?? 0) > 0);
+    const gradeIncomplete = options.gradeIncomplete === true && (options.scorers?.length ?? 0) > 0;
 
     const instructions = Instructions.make({
       text: options.instructions,
@@ -367,9 +339,8 @@ export function createEvalRunner<I, O, D>(
             runInstructions(harness, instructions, model, defaultSpace.id, input, options.sessionChat, seeded.chat),
           catch: (cause) => new AgentRunFailure({ cause }),
         });
-        const dbQueryFn = options.dbQuery;
         const scorers = options.scorers;
-        if (!dbQueryFn && !scorers?.length) {
+        if (!scorers?.length) {
           return yield* agentStep;
         }
 
@@ -388,29 +359,17 @@ export function createEvalRunner<I, O, D>(
           : yield* agentStep;
         const durationMillis = Date.now() - startedAt;
 
-        // Both read the space while it is still open, before the harness is disposed below.
+        // The scorers read the space while it is still open, before the harness is disposed below.
         const services = ServiceResolver.provide(
           { space: defaultSpace.id },
           Database.Service,
           FeedTraceSink.FeedTraceSink,
         );
 
-        // `scorers` first, so the branch taken matches the overload the options selected.
-        if (scorers?.length) {
-          const scores = yield* Effect.promise(() =>
-            harness.runPromise(Scorer.runAll(scorers, { durationMillis }).pipe(Effect.provide(services))),
-          );
-          return { agentOutput, scores, durationMillis };
-        }
-
-        if (dbQueryFn) {
-          const dbQuery = yield* Effect.promise(() =>
-            harness.runPromise(dbQueryFn(input, defaultSpace.id).pipe(Effect.provide(services))),
-          );
-          return { agentOutput, dbQuery, durationMillis };
-        }
-
-        return yield* Effect.fail(new Error('Unreachable: neither dbQuery nor scorers.'));
+        const scores = yield* Effect.promise(() =>
+          harness.runPromise(Scorer.runAll(scorers, { durationMillis }).pipe(Effect.provide(services))),
+        );
+        return { agentOutput, scores, durationMillis };
       }),
     );
 

--- a/packages/core/compute/assistant-evals/src/runner.ts
+++ b/packages/core/compute/assistant-evals/src/runner.ts
@@ -302,9 +302,18 @@ export function createEvalRunner<I, O>(
   afterAll(async () => {
     const disposals = [...open.entries()];
     open.clear();
-    for (const [runId, dispose] of disposals) {
+    // Every session is closed, and every harness disposed, before any failure is reported: one
+    // harness that will not go must not strand the rest of the file's.
+    for (const [runId] of disposals) {
       Scorer.closeSession(runId);
-      await dispose();
+    }
+    const results = await Promise.allSettled(disposals.map(([, dispose]) => dispose()));
+    const failures = results.filter((result) => result.status === 'rejected');
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        `Failed to dispose ${failures.length} of ${disposals.length} eval harnesses.`,
+      );
     }
   });
 
@@ -323,18 +332,16 @@ export function createEvalRunner<I, O>(
     // Scoped for the ungraded path's finalizer; a scored run's harness is not on this scope.
     const run = Effect.scoped(
       Effect.gen(function* () {
-        // Not `acquireRelease`: a scored run's harness outlives this effect, so that the eval's
-        // scorers can query the space it left. It is registered below and disposed by `afterAll`.
         const harness = yield* Effect.promise(async () =>
           createComposerTestApp({
             plugins: await createDefaultPlugins({ ...options, model, record }),
           }),
         );
-        if (options.scored) {
-          open.set(runId, () => harness.dispose());
-        } else {
-          yield* Effect.addFinalizer(() => Effect.promise(() => harness.dispose()));
-        }
+        // The scope owns the harness until a session that outlives this effect takes it over, so a
+        // run that fails before it has anything to grade releases its harness now rather than
+        // holding it — and the whole eval's memory — until the file ends.
+        let handedOver = false;
+        yield* Effect.addFinalizer(() => (handedOver ? Effect.void : Effect.promise(() => harness.dispose())));
 
         const { defaultSpace } = yield* Effect.promise(() =>
           EffectEx.runAndForwardErrors(initializeIdentity(harness.get(ClientCapabilities.Client))),
@@ -404,6 +411,8 @@ export function createEvalRunner<I, O>(
             return graded;
           },
         });
+        open.set(runId, () => harness.dispose());
+        handedOver = true;
         return { runId, agentOutput, durationMillis };
       }),
     );

--- a/packages/core/compute/assistant-evals/src/runner.ts
+++ b/packages/core/compute/assistant-evals/src/runner.ts
@@ -9,6 +9,7 @@ import * as Exit from 'effect/Exit';
 import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 import type { Evalite } from 'evalite';
+import { afterAll } from 'vitest';
 
 import { AiService, Model } from '@dxos/ai';
 import { AiServiceTestingPreset } from '@dxos/ai/testing';
@@ -60,8 +61,11 @@ export type AgentIncomplete =
 const describeCause = (cause: unknown): string =>
   cause instanceof Error ? `${cause.name}: ${cause.message}` : String(cause);
 
-/** Room after the agent's budget for the query to grade what it left, before the run is abandoned. */
+/** Room after the agent's budget for the harness to be stood up and torn down around it. */
 const GRADE_GRACE_MILLIS = 5 * 60 * 1_000;
+
+/** Distinguishes the open sessions of concurrently running rows, variants and files. */
+let nextRunId = 0;
 
 /**
  * Tags a failure as coming specifically from the agent's own `RunInstructions` invocation —
@@ -206,8 +210,8 @@ export interface CreateEvalRunnerOptions<I, O> {
   /**
    * Grade the state a session reached when it runs out of `timeout` or fails, rather than throwing:
    * the agent's output becomes an {@link AgentIncomplete} and the scorers still run. For a scenario
-   * long enough that where it got to is worth knowing. Requires `scorers`; a timed-out session is
-   * not stopped, so their queries then read a space the agent may still be writing to.
+   * long enough that where it got to is worth knowing. Requires `scored`; a timed-out session is not
+   * stopped, so the scorers then read a space the agent may still be writing to.
    */
   gradeIncomplete?: boolean;
   /**
@@ -220,11 +224,12 @@ export interface CreateEvalRunnerOptions<I, O> {
    */
   config?: Config;
   /**
-   * Graded dimensions, each running its own query against the space while it is still open (see
-   * {@link Scorer}). The task then reports `scores`, and `Scorer.toEvalite` turns the same list
-   * into the evalite scorers that read them.
+   * Keeps this run's space open past the task so the eval's own scorers can query it (see
+   * {@link Scorer}), and returns `{ runId, agentOutput, durationMillis }` in place of the bare agent
+   * output. The harness is disposed by the `afterAll` this runner registers, once every row of the
+   * eval has been graded. Leave it unset for an eval graded from the agent's output alone.
    */
-  scorers?: readonly Scorer.Any[];
+  scored?: boolean;
   /**
    * Seeds the space before the run (e.g. a Project the scenario operates on). Runs inside the
    * harness with `Database.Service` and the runtime's capability services provided (so a seed can
@@ -261,9 +266,9 @@ export type VariantConfig =
  * space. All execution is wrapped in an Effect scope; errors are
  * propagated to the caller via `EffectEx.runAndForwardErrors`.
  *
- * Pass `scorers` to additionally grade the space while it is still open (TESTING.md dimension G);
- * the task then returns `{ agentOutput, scores, durationMillis }` instead of the bare agent output,
- * so each dimension grades the real effect rather than the model's own self-reported completion.
+ * Pass `scored: true` to keep the space open past the task (TESTING.md dimension G); the task then
+ * returns `{ runId, agentOutput, durationMillis }` instead of the bare agent output, and the eval's
+ * `Scorer.toEvalite` dimensions grade the real effect rather than the model's self-reported one.
  *
  * Pass `expect: 'failure'` for scenarios that assert the agent correctly fails; the task then
  * returns `{ failed: boolean }` instead of throwing, so a Scorer can grade "failed as instructed".
@@ -280,36 +285,56 @@ export function createEvalRunner<I, O>(
   options: CreateEvalRunnerOptions<I, O> & { expect: 'failure' },
 ): Evalite.Task<I, { failed: boolean }, VariantConfig>;
 export function createEvalRunner<I, O>(
-  options: CreateEvalRunnerOptions<I, O> & { scorers: readonly Scorer.Any[] },
-): Evalite.Task<I, { agentOutput: O | AgentIncomplete; scores: Scorer.Scores; durationMillis: number }, VariantConfig>;
+  options: CreateEvalRunnerOptions<I, O> & { scored: true },
+): Evalite.Task<I, { runId: string; agentOutput: O | AgentIncomplete; durationMillis: number }, VariantConfig>;
 export function createEvalRunner<I, O>(options: CreateEvalRunnerOptions<I, O>): Evalite.Task<I, O, VariantConfig>;
 export function createEvalRunner<I, O>(
   options: CreateEvalRunnerOptions<I, O>,
 ): Evalite.Task<
   I,
-  O | { agentOutput: O | AgentIncomplete; scores: Scorer.Scores; durationMillis: number } | { failed: boolean },
+  O | { runId: string; agentOutput: O | AgentIncomplete; durationMillis: number } | { failed: boolean },
   VariantConfig
 > {
+  // The harnesses this eval's rows left open, by run id. Registered at collection time on the file's
+  // suite: evalite grades a row inside that row's own test, so a harness can only go once every row
+  // of this eval has been scored.
+  const open = new Map<string, () => Promise<void>>();
+  afterAll(async () => {
+    const disposals = [...open.entries()];
+    open.clear();
+    for (const [runId, dispose] of disposals) {
+      Scorer.closeSession(runId);
+      await dispose();
+    }
+  });
+
   const execute = async (input: I, variant: VariantConfig, record: (call: Usage.Call) => void) => {
     const model = variant?.model ?? options.model ?? DEFAULT_MODEL;
     const timeoutMillis = options.timeout ?? DEFAULT_EVAL_TIMEOUT_MILLIS;
-    const gradeIncomplete = options.gradeIncomplete === true && (options.scorers?.length ?? 0) > 0;
+    const gradeIncomplete = options.gradeIncomplete === true && options.scored === true;
 
     const instructions = Instructions.make({
       text: options.instructions,
       skills: (typeof options.skills === 'function' ? options.skills() : options.skills) ?? getDefaultSkills(),
     });
 
+    const runId = `${nextRunId++}`;
+
+    // Scoped for the ungraded path's finalizer; a scored run's harness is not on this scope.
     const run = Effect.scoped(
       Effect.gen(function* () {
-        const harness = yield* Effect.acquireRelease(
-          Effect.promise(async () =>
-            createComposerTestApp({
-              plugins: await createDefaultPlugins({ ...options, model, record }),
-            }),
-          ),
-          (testHarness) => Effect.promise(() => testHarness.dispose()),
+        // Not `acquireRelease`: a scored run's harness outlives this effect, so that the eval's
+        // scorers can query the space it left. It is registered below and disposed by `afterAll`.
+        const harness = yield* Effect.promise(async () =>
+          createComposerTestApp({
+            plugins: await createDefaultPlugins({ ...options, model, record }),
+          }),
         );
+        if (options.scored) {
+          open.set(runId, () => harness.dispose());
+        } else {
+          yield* Effect.addFinalizer(() => Effect.promise(() => harness.dispose()));
+        }
 
         const { defaultSpace } = yield* Effect.promise(() =>
           EffectEx.runAndForwardErrors(initializeIdentity(harness.get(ClientCapabilities.Client))),
@@ -339,8 +364,7 @@ export function createEvalRunner<I, O>(
             runInstructions(harness, instructions, model, defaultSpace.id, input, options.sessionChat, seeded.chat),
           catch: (cause) => new AgentRunFailure({ cause }),
         });
-        const scorers = options.scorers;
-        if (!scorers?.length) {
+        if (!options.scored) {
           return yield* agentStep;
         }
 
@@ -359,17 +383,28 @@ export function createEvalRunner<I, O>(
           : yield* agentStep;
         const durationMillis = Date.now() - startedAt;
 
-        // The scorers read the space while it is still open, before the harness is disposed below.
-        const services = ServiceResolver.provide(
+        // What a scorer runs against: the space and its trace feed, the runtime's operations, and
+        // what this run reports about itself.
+        const space = ServiceResolver.provide(
           { space: defaultSpace.id },
           Database.Service,
           FeedTraceSink.FeedTraceSink,
         );
+        const provideRun = Scorer.sessionServices({ durationMillis });
 
-        const scores = yield* Effect.promise(() =>
-          harness.runPromise(Scorer.runAll(scorers, { durationMillis }).pipe(Effect.provide(services))),
-        );
-        return { agentOutput, scores, durationMillis };
+        // Graded one dimension at a time: `Scorer.shared` memoizes a completed exit, so two
+        // dimensions naming one query must not be in flight together.
+        let queued: Promise<unknown> = Promise.resolve();
+        Scorer.openSession(runId, {
+          grade: (scorer) => {
+            const graded = queued.then(() =>
+              harness.runPromise(provideRun(Effect.exit(scorer.score)).pipe(Effect.provide(space))),
+            );
+            queued = graded.catch(() => undefined);
+            return graded;
+          },
+        });
+        return { runId, agentOutput, durationMillis };
       }),
     );
 


### PR DESCRIPTION
Every eval in `assistant-evals` now grades through `Scorer` rather than a single `dbQuery` callback whose result blob a list of evalite one-liners read fields off.

## A scorer is one effect

```ts
export type Scorer = {
  readonly name: string;
  readonly description?: string;
  readonly score: Effect.Effect<Result, unknown, Services>;
};
```

Reading and judging are one step — there is no separate `query` half — so a dimension is a single self-contained value that can be read, moved or deleted without disturbing anything else.

- `Scorer.make({ name, description, score })` — the general case; `score` is the effect.
- `Scorer.database({ name, query, score })` — an ECHO `Query` plus a plain function over its results.
- `Scorer.toolCalls({ name, score })` — a plain function over the run's `ToolInvocation[]`.
- `Scorer.duration({ …, delivered })` — grades the wall clock, gated on an effect proving the run produced the thing being timed. `Scorer.Run` is the service carrying `durationMillis`.
- `Scorer.shared(effect)` — wrap a query several dimensions read so the run pays for it once. Every multi-reader query and both judge calls sit behind one.

## The space outlives the task

A scored run's harness is no longer disposed when the task returns. It is registered instead, and the `afterAll` that `createEvalRunner` puts on the eval file's own suite disposes it once every row has been graded — evalite runs a row's scorers inside that row's test, after the task, so they can query the space the session actually left.

That lets the scorers move to the evalite side, so the list is declared **once**: `createEvalRunner` takes `scored: true` rather than a second copy of it, and returns `{ runId, agentOutput, durationMillis }` so `Scorer.toEvalite` can find the session. Grading is serialized per run, which is what makes `Scorer.shared`'s exit cache sound.

`Scorer.runAll` and the recorded `scores` remain for the staged `claude-harness` path (`mcp-server.eval.ts`): it disposes its own harness because the facts it scores are only true between two of its turns, and `toEvalite` falls back to the marks it recorded.

## Converted

`database`, `markdown`, `web-search`, `task-management`, `diagram`, `planning`, `projects`, `sender-ledger`, `crm-mailbox`, `incident-retro`, `chess-mcp`. Scoring semantics are preserved dimension for dimension; names and descriptions are unchanged, so trended scores stay comparable.

`dbQuery`, the `DbQuery` type, the "pass either, not both" guard and the unreachable branch are gone from the runner. The `agent-eval-tests` skill is updated to teach the new pattern.

## Verification

- `moon run assistant-evals:build` (with its full dependency graph) — pass
- `tsc --noEmit -p packages/core/compute/assistant-evals/tsconfig.json` — clean
- `moon run assistant-evals:lint` — pass
- `oxfmt` applied

Not run: the evals themselves, which need `DX_ANTHROPIC_API_KEY` and live model calls. They run nightly in the `Assistant evals` workflow.

## Known follow-up (pre-existing, deliberately not in scope)

Two scoring holes predate this PR and are preserved so the migration stays verifiable — `projects.eval.ts`'s per-keyword `Array.find` lets one task satisfy several plan items, and `task-management.eval.ts`'s `left-the-rest-alone` counts open tasks rather than pinning the seeded titles. Both are worth tightening in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hh1EagEmaWHSY748t879e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation runs can remain available for external scoring and now return a run ID, agent output, and execution duration.
  * Added reusable scoring options for database state, tool usage, response quality, duration, and invocation counts.
  * Shared scoring computations can be reused across multiple evaluation checks.
* **Documentation**
  * Updated evaluation guidance, examples, and scenarios to reflect the revised scoring workflow and scorer definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- composer-preview:begin -->
---
🚀 Composer preview: https://pr-13073-composer-dev.dxos.workers.dev
<!-- composer-preview:end -->
