### PR TITLE
assistant: separate the session gantt's events by task

### DIFF
--- a/.changeset/gantt-task-separation.md
+++ b/.changeset/gantt-task-separation.md
@@ -1,10 +1,6 @@
 ---
-'@dxos/assistant-toolkit': minor
 '@dxos/compute': minor
 '@dxos/plugin-assistant': minor
-'@dxos/plugin-projects': minor
-'@dxos/plugin-tasks': minor
-'@dxos/react-ui-components': minor
 ---
 
 The session gantt now separates a run's events by task.

--- a/.changeset/gantt-task-separation.md
+++ b/.changeset/gantt-task-separation.md
@@ -1,0 +1,12 @@
+---
+'@dxos/assistant': minor
+'@dxos/assistant-toolkit': minor
+'@dxos/plugin-assistant': minor
+'@dxos/react-ui-components': minor
+---
+
+The session gantt now separates a run's events by task.
+
+The planning tool writes a new `assistant.taskStatusChanged` trace event whenever a checklist task's status changes — the only in-trace record of which task an agent was working on. `buildSessionTimeline` reads those events to cut a session into one segment per task: the task lane gets a span of its own, nodes where it started and finished, and every marker inside the segment is attributed to it rather than piling onto the session bar.
+
+A task that is only ever closed — delegation marks everything it hands over `started` before the agent's first turn — is cut from the previous boundary, so a delegated run separates too.

--- a/.changeset/gantt-task-separation.md
+++ b/.changeset/gantt-task-separation.md
@@ -1,12 +1,16 @@
 ---
-'@dxos/assistant': minor
 '@dxos/assistant-toolkit': minor
+'@dxos/compute': minor
 '@dxos/plugin-assistant': minor
+'@dxos/plugin-projects': minor
+'@dxos/plugin-tasks': minor
 '@dxos/react-ui-components': minor
 ---
 
 The session gantt now separates a run's events by task.
 
-The planning tool writes a new `assistant.taskStatusChanged` trace event whenever a checklist task's status changes — the only in-trace record of which task an agent was working on. `buildSessionTimeline` reads those events to cut a session into one segment per task: the task lane gets a span of its own, nodes where it started and finished, and every marker inside the segment is attributed to it rather than piling onto the session bar.
+Both tools that move a task's status — the planning tool's `update-tasks` and `plugin-tasks`' `UpdateTask` — write a new `task.statusChanged` trace event. Nothing else in a trace says which task an agent was working on, so `buildSessionTimeline` reads those events to cut a session into one segment per task: the task lane gets a span of its own, nodes where it started and finished, and every marker inside the segment is attributed to it rather than piling onto the session bar.
 
-A task that is only ever closed — delegation marks everything it hands over `started` before the agent's first turn — is cut from the previous boundary, so a delegated run separates too.
+Only tasks on the session's own checklist take part in the cut, and a task that is only ever closed — delegation marks everything it hands over `started` before the agent's first turn — is cut from the previous boundary, but only on the transition out of `started`: a task merely dismissed claims nothing, and a second close (`review` → `done`) mints no segment overlapping the task then active. A delegated task is drawn as the child session that worked it, so its segment is dropped rather than moved onto a bar whose span does not contain those markers.
+
+The project's pipeline chart also draws its own lane names and per-lane totals: a ledger row is several lines tall and a chart row is one, so nothing lined up between them.

--- a/packages/core/compute/assistant-toolkit/src/skills/planning/operations/definitions.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/planning/operations/definitions.ts
@@ -7,6 +7,7 @@ import * as Schema from 'effect/Schema';
 import { AiService } from '@dxos/ai';
 import { Harness } from '@dxos/assistant';
 import * as Operation from '@dxos/compute/Operation';
+import * as Trace from '@dxos/compute/Trace';
 import { Database, Ref } from '@dxos/echo';
 import { DXN } from '@dxos/keys';
 import { Task } from '@dxos/types';
@@ -35,7 +36,7 @@ export const UpdateTasks = Operation.make({
     tasks: Schema.Array(SimpleTask),
   }),
   output: Schema.Any,
-  services: [Harness.HarnessService, Database.Service],
+  services: [Harness.HarnessService, Database.Service, Trace.TraceService],
 });
 
 const TaskRefs = Schema.Array(Ref.Ref(Task.Task));

--- a/packages/core/compute/assistant-toolkit/src/skills/planning/operations/update-tasks.test.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/planning/operations/update-tasks.test.ts
@@ -39,16 +39,6 @@ const TestLayer = AssistantTestLayer(layerOptions);
 /** Persists trace events so a test can read back what the tool emitted. */
 const TracingTestLayer = AssistantTestLayer({ ...layerOptions, tracing: 'feed' });
 
-/** The status events on the space's trace feed, in the order they were written. */
-const readStatusEvents = Effect.gen(function* () {
-  const feed = yield* FeedTraceSink.getOrCreateTraceFeed();
-  const messages = yield* Database.query(Query.select(Filter.type(Trace.Message)).from(feed)).run;
-  return messages
-    .flatMap((message) => message.events)
-    .filter((event) => event.type === Trace.TaskStatusChanged.key)
-    .map((event) => Schema.decodeUnknownSync(Trace.TaskStatusChanged.schema)(event.data));
-});
-
 describe('UpdateTasks', () => {
   it.effect(
     "adds tasks to the chat's checklist",
@@ -172,4 +162,14 @@ describe('UpdateTasks', () => {
       TestHelpers.provideTestContext,
     ),
   );
+});
+
+/** The status events on the space's trace feed, in the order they were written. */
+const readStatusEvents = Effect.gen(function* () {
+  const feed = yield* FeedTraceSink.getOrCreateTraceFeed();
+  const messages = yield* Database.query(Query.select(Filter.type(Trace.Message)).from(feed)).run;
+  return messages
+    .flatMap((message) => message.events)
+    .filter((event) => event.type === Trace.TaskStatusChanged.key)
+    .map((event) => Schema.decodeUnknownSync(Trace.TaskStatusChanged.schema)(event.data));
 });

--- a/packages/core/compute/assistant-toolkit/src/skills/planning/operations/update-tasks.test.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/planning/operations/update-tasks.test.ts
@@ -7,7 +7,7 @@ import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 
 import { AssistantTestLayer } from '@dxos/agent-runtime/testing';
-import { AiContext, TaskStatusChanged } from '@dxos/assistant';
+import { AiContext } from '@dxos/assistant';
 import * as Agent from '@dxos/assistant/Agent';
 import * as Chat from '@dxos/assistant/Chat';
 import { FeedTraceSink } from '@dxos/compute-runtime';
@@ -45,8 +45,8 @@ const readStatusEvents = Effect.gen(function* () {
   const messages = yield* Database.query(Query.select(Filter.type(Trace.Message)).from(feed)).run;
   return messages
     .flatMap((message) => message.events)
-    .filter((event) => event.type === TaskStatusChanged.key)
-    .map((event) => Schema.decodeUnknownSync(TaskStatusChanged.schema)(event.data));
+    .filter((event) => event.type === Trace.TaskStatusChanged.key)
+    .map((event) => Schema.decodeUnknownSync(Trace.TaskStatusChanged.schema)(event.data));
 });
 
 describe('UpdateTasks', () => {

--- a/packages/core/compute/assistant-toolkit/src/skills/planning/operations/update-tasks.test.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/planning/operations/update-tasks.test.ts
@@ -4,14 +4,17 @@
 
 import { describe, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
+import * as Schema from 'effect/Schema';
 
 import { AssistantTestLayer } from '@dxos/agent-runtime/testing';
-import { AiContext } from '@dxos/assistant';
+import { AiContext, TaskStatusChanged } from '@dxos/assistant';
 import * as Agent from '@dxos/assistant/Agent';
 import * as Chat from '@dxos/assistant/Chat';
+import { FeedTraceSink } from '@dxos/compute-runtime';
 import * as Operation from '@dxos/compute/Operation';
 import * as Skill from '@dxos/compute/Skill';
-import { Database, Feed, Obj, Ref } from '@dxos/echo';
+import * as Trace from '@dxos/compute/Trace';
+import { Database, Feed, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { TestHelpers } from '@dxos/effect/testing';
 import { invariant } from '@dxos/invariant';
 import { EntityId } from '@dxos/keys';
@@ -19,16 +22,31 @@ import { Text } from '@dxos/schema';
 import { Outline, Task } from '@dxos/types';
 
 import PlanningSkill from '../skill.ts';
-import { UpdateTasks } from './definitions.ts';
+import { AssignTasks, UpdateTasks } from './definitions.ts';
 import { PlanningHandlers } from './index.ts';
 
 EntityId.dangerouslyDisableRandomness();
 
-const TestLayer = AssistantTestLayer({
+const layerOptions = {
   operationHandlers: PlanningHandlers,
   types: [Agent.Agent, Outline.Outline, Task.Task, Text.Text, Chat.Chat, Skill.Skill, Feed.Feed],
   skills: [PlanningSkill.make()],
   disableLlmMemoization: true,
+};
+
+const TestLayer = AssistantTestLayer(layerOptions);
+
+/** Persists trace events so a test can read back what the tool emitted. */
+const TracingTestLayer = AssistantTestLayer({ ...layerOptions, tracing: 'feed' });
+
+/** The status events on the space's trace feed, in the order they were written. */
+const readStatusEvents = Effect.gen(function* () {
+  const feed = yield* FeedTraceSink.getOrCreateTraceFeed();
+  const messages = yield* Database.query(Query.select(Filter.type(Trace.Message)).from(feed)).run;
+  return messages
+    .flatMap((message) => message.events)
+    .filter((event) => event.type === TaskStatusChanged.key)
+    .map((event) => Schema.decodeUnknownSync(TaskStatusChanged.schema)(event.data));
 });
 
 describe('UpdateTasks', () => {
@@ -86,6 +104,71 @@ describe('UpdateTasks', () => {
         ]);
       },
       Effect.provide(TestLayer),
+      TestHelpers.provideTestContext,
+    ),
+  );
+
+  it.effect(
+    'emits a status trace event for every change, and none for a no-op update',
+    Effect.fnUntraced(
+      function* ({ expect }) {
+        const feed = yield* Database.add(Feed.make());
+        const chat = yield* Database.add(Chat.make({ feed: Ref.make(feed) }));
+        const runtime = yield* Effect.context<Database.Service>();
+        const binder = new AiContext.Binder({ feed, runtime });
+        yield* Effect.promise(() => binder.bind({ objects: [Ref.make(chat)] }));
+        const invoke = (tasks: { title: string; status: 'todo' | 'started' | 'done' }[]) =>
+          Operation.invoke(UpdateTasks, { tasks }).pipe(
+            Effect.provide(Operation.withInvocationOptions({ conversation: Obj.getURI(feed) })),
+          );
+
+        yield* invoke([{ title: 'Hello', status: 'todo' }]);
+        yield* invoke([{ title: 'Hello', status: 'started' }]);
+        // Same status twice: nothing changed, so nothing is traced.
+        yield* invoke([{ title: 'Hello', status: 'started' }]);
+        yield* invoke([{ title: 'Hello', status: 'done' }]);
+        yield* Database.flush();
+
+        const tasks = yield* Chat.loadTasks(chat);
+        const taskId = tasks[0]?.id;
+        const events = yield* readStatusEvents;
+        expect(events).toEqual([
+          { taskId, title: 'Hello', status: 'todo' },
+          { taskId, title: 'Hello', status: 'started', previousStatus: 'todo' },
+          { taskId, title: 'Hello', status: 'done', previousStatus: 'started' },
+        ]);
+      },
+      Effect.provide(TracingTestLayer),
+      TestHelpers.provideTestContext,
+    ),
+  );
+
+  it.effect(
+    'traces the status a task actually landed in, not the one requested',
+    Effect.fnUntraced(
+      function* ({ expect }) {
+        const feed = yield* Database.add(Feed.make());
+        const chat = yield* Database.add(Chat.make({ feed: Ref.make(feed) }));
+        const runtime = yield* Effect.context<Database.Service>();
+        const binder = new AiContext.Binder({ feed, runtime });
+        yield* Effect.promise(() => binder.bind({ objects: [Ref.make(chat)] }));
+        // A task with reviewers does not close on the model's word: `done` lands it in `review`.
+        const task = yield* Database.add(
+          Task.make({ title: 'Reviewed', status: 'started', reviewers: [{ name: 'Alice' }] }),
+        );
+        yield* Operation.invoke(AssignTasks, { add: [Ref.make(task)] }).pipe(
+          Effect.provide(Operation.withInvocationOptions({ conversation: Obj.getURI(feed) })),
+        );
+
+        yield* Operation.invoke(UpdateTasks, { tasks: [{ title: 'Reviewed', status: 'done' }] }).pipe(
+          Effect.provide(Operation.withInvocationOptions({ conversation: Obj.getURI(feed) })),
+        );
+        yield* Database.flush();
+
+        const events = yield* readStatusEvents;
+        expect(events).toEqual([{ taskId: task.id, title: 'Reviewed', status: 'review', previousStatus: 'started' }]);
+      },
+      Effect.provide(TracingTestLayer),
       TestHelpers.provideTestContext,
     ),
   );

--- a/packages/core/compute/assistant-toolkit/src/skills/planning/operations/update-tasks.test.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/planning/operations/update-tasks.test.ts
@@ -162,14 +162,14 @@ describe('UpdateTasks', () => {
       TestHelpers.provideTestContext,
     ),
   );
-});
 
-/** The status events on the space's trace feed, in the order they were written. */
-const readStatusEvents = Effect.gen(function* () {
-  const feed = yield* FeedTraceSink.getOrCreateTraceFeed();
-  const messages = yield* Database.query(Query.select(Filter.type(Trace.Message)).from(feed)).run;
-  return messages
-    .flatMap((message) => message.events)
-    .filter((event) => event.type === Trace.TaskStatusChanged.key)
-    .map((event) => Schema.decodeUnknownSync(Trace.TaskStatusChanged.schema)(event.data));
+  /** The status events on the space's trace feed, in the order they were written. */
+  const readStatusEvents = Effect.gen(function* () {
+    const feed = yield* FeedTraceSink.getOrCreateTraceFeed();
+    const messages = yield* Database.query(Query.select(Filter.type(Trace.Message)).from(feed)).run;
+    return messages
+      .flatMap((message) => message.events)
+      .filter((event) => event.type === Trace.TaskStatusChanged.key)
+      .map((event) => Schema.decodeUnknownSync(Trace.TaskStatusChanged.schema)(event.data));
+  });
 });

--- a/packages/core/compute/assistant-toolkit/src/skills/planning/operations/update-tasks.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/planning/operations/update-tasks.ts
@@ -4,7 +4,7 @@
 
 import * as Effect from 'effect/Effect';
 
-import { Harness, TaskStatusChanged } from '@dxos/assistant';
+import { Harness } from '@dxos/assistant';
 import * as Chat from '@dxos/assistant/Chat';
 import * as Operation from '@dxos/compute/Operation';
 import * as Trace from '@dxos/compute/Trace';
@@ -35,7 +35,7 @@ export default UpdateTasks.pipe(
           Task.setStatus(task, status);
           // The resolved status, not the requested one: a reviewed task lands in `review`.
           if (task.status !== undefined && task.status !== previousStatus) {
-            yield* Trace.write(TaskStatusChanged, {
+            yield* Trace.write(Trace.TaskStatusChanged, {
               taskId: task.id,
               title: task.title,
               status: task.status,
@@ -46,7 +46,7 @@ export default UpdateTasks.pipe(
           const created = Chat.addTask(db, chat, title, { status });
           existing.push(created);
           if (created.status !== undefined) {
-            yield* Trace.write(TaskStatusChanged, {
+            yield* Trace.write(Trace.TaskStatusChanged, {
               taskId: created.id,
               title: created.title,
               status: created.status,

--- a/packages/core/compute/assistant-toolkit/src/skills/planning/operations/update-tasks.ts
+++ b/packages/core/compute/assistant-toolkit/src/skills/planning/operations/update-tasks.ts
@@ -4,9 +4,10 @@
 
 import * as Effect from 'effect/Effect';
 
-import { Harness } from '@dxos/assistant';
+import { Harness, TaskStatusChanged } from '@dxos/assistant';
 import * as Chat from '@dxos/assistant/Chat';
 import * as Operation from '@dxos/compute/Operation';
+import * as Trace from '@dxos/compute/Trace';
 import { Database } from '@dxos/echo';
 import { Task } from '@dxos/types';
 import { trim } from '@dxos/util';
@@ -28,11 +29,29 @@ export default UpdateTasks.pipe(
       for (const { title, status } of tasks) {
         const task = existing.find((candidate) => candidate.title === title.trim());
         if (task) {
+          const previousStatus = task.status;
           // A task someone was named to review lands in `review` rather than closing; the rule is
           // `Task.update`'s, since the model naming `done` cannot know about reviewers.
           Task.setStatus(task, status);
+          // The resolved status, not the requested one: a reviewed task lands in `review`.
+          if (task.status !== undefined && task.status !== previousStatus) {
+            yield* Trace.write(TaskStatusChanged, {
+              taskId: task.id,
+              title: task.title,
+              status: task.status,
+              ...(previousStatus ? { previousStatus } : {}),
+            });
+          }
         } else {
-          existing.push(Chat.addTask(db, chat, title, { status }));
+          const created = Chat.addTask(db, chat, title, { status });
+          existing.push(created);
+          if (created.status !== undefined) {
+            yield* Trace.write(TaskStatusChanged, {
+              taskId: created.id,
+              title: created.title,
+              status: created.status,
+            });
+          }
         }
       }
       yield* Database.flush();

--- a/packages/core/compute/assistant/src/util/tracing.ts
+++ b/packages/core/compute/assistant/src/util/tracing.ts
@@ -7,7 +7,7 @@ import * as Schema from 'effect/Schema';
 
 import * as Trace from '@dxos/compute/Trace';
 import { Obj } from '@dxos/echo';
-import { Actor, ContentBlock, Task } from '@dxos/types';
+import { Actor, ContentBlock } from '@dxos/types';
 
 /**
  * Partial content block emitted.
@@ -54,22 +54,6 @@ export const DelegationSpawned = Trace.EventType('assistant.delegationSpawned', 
   schema: Schema.Struct({
     taskId: Schema.String,
     pid: Schema.String,
-  }),
-  isEphemeral: false,
-});
-
-/**
- * Emitted by the planning tool when a checklist task's status changes (a new task counts as a
- * change from nothing). The trace holds no other record of which task the agent was working on, so
- * these events are what cut a session's timeline into per-task segments.
- */
-export const TaskStatusChanged = Trace.EventType('assistant.taskStatusChanged', {
-  schema: Schema.Struct({
-    taskId: Obj.ID,
-    title: Schema.String,
-    status: Task.Status,
-    /** Absent when the task was just created, or held no status before. */
-    previousStatus: Schema.optional(Task.Status),
   }),
   isEphemeral: false,
 });

--- a/packages/core/compute/assistant/src/util/tracing.ts
+++ b/packages/core/compute/assistant/src/util/tracing.ts
@@ -7,7 +7,7 @@ import * as Schema from 'effect/Schema';
 
 import * as Trace from '@dxos/compute/Trace';
 import { Obj } from '@dxos/echo';
-import { Actor, ContentBlock } from '@dxos/types';
+import { Actor, ContentBlock, Task } from '@dxos/types';
 
 /**
  * Partial content block emitted.
@@ -54,6 +54,22 @@ export const DelegationSpawned = Trace.EventType('assistant.delegationSpawned', 
   schema: Schema.Struct({
     taskId: Schema.String,
     pid: Schema.String,
+  }),
+  isEphemeral: false,
+});
+
+/**
+ * Emitted by the planning tool when a checklist task's status changes (a new task counts as a
+ * change from nothing). The trace holds no other record of which task the agent was working on, so
+ * these events are what cut a session's timeline into per-task segments.
+ */
+export const TaskStatusChanged = Trace.EventType('assistant.taskStatusChanged', {
+  schema: Schema.Struct({
+    taskId: Obj.ID,
+    title: Schema.String,
+    status: Task.Status,
+    /** Absent when the task was just created, or held no status before. */
+    previousStatus: Schema.optional(Task.Status),
   }),
   isEphemeral: false,
 });

--- a/packages/core/compute/compute/src/Trace.ts
+++ b/packages/core/compute/compute/src/Trace.ts
@@ -12,6 +12,7 @@ import * as Schema from 'effect/Schema';
 import { Annotation, DXN, Obj, Ref, Type } from '@dxos/echo';
 import { EID } from '@dxos/keys';
 import { log } from '@dxos/log';
+import { Task } from '@dxos/types';
 
 import * as Trigger from './types/Trigger.ts';
 
@@ -533,6 +534,23 @@ export const OperationOutput = EventType('operation.output', {
     output: Schema.Unknown,
   }),
   isEphemeral: true,
+});
+
+/**
+ * Emitted when a task's status changes — a new task counts as a change from nothing.
+ *
+ * Nothing else in a trace says which task an agent was working on, so these events are what cut a
+ * session's timeline into per-task segments. Every tool that moves a task's status emits one.
+ */
+export const TaskStatusChanged = EventType('task.statusChanged', {
+  schema: Schema.Struct({
+    taskId: Obj.ID,
+    title: Schema.String,
+    status: Task.Status,
+    /** Absent when the task was just created, or held no status before. */
+    previousStatus: Schema.optional(Task.Status),
+  }),
+  isEphemeral: false,
 });
 
 /**

--- a/packages/core/compute/compute/src/testing/index.ts
+++ b/packages/core/compute/compute/src/testing/index.ts
@@ -11,6 +11,7 @@ export { default as FibonacciHandler } from './fib.ts';
 export { default as ReplyHandler } from './reply.ts';
 export { default as SleepHandler } from './sleep.ts';
 export * from './operation.ts';
+export * from './trace.ts';
 
 export const ExampleHandlers = OperationHandlerSet.lazy([
   Fibonacci.pipe(Operation.lazyHandler(() => import('./fib.ts'))),

--- a/packages/core/compute/compute/src/testing/trace.ts
+++ b/packages/core/compute/compute/src/testing/trace.ts
@@ -1,0 +1,75 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Context from 'effect/Context';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+
+import * as Trace from '../Trace.ts';
+
+interface Collector {
+  readonly messages: Trace.Message[];
+  /**
+   * Monotonic counter rather than `Date.now`: several writes land in the same millisecond, and a tie
+   * leaves the order of the trace — and anything built from it — undefined.
+   */
+  readonly clock: () => number;
+}
+
+/**
+ * Collects everything written to the trace so a test can read it back, in place of a feed or a
+ * hand-rolled sink:
+ *
+ * ```ts
+ * yield* Trace.write(SomeEvent, {});
+ * const messages = yield* TestTraceService.messages;
+ * ```
+ *
+ * {@link TestTraceService.layer} provides the collector together with the {@link Trace.TraceService}
+ * and {@link Trace.TraceSink} that feed it.
+ */
+export class TestTraceService extends Context.Service<TestTraceService, Collector>()('@dxos/compute/TestTraceService') {
+  /** The messages written so far, in write order. */
+  static readonly messages: Effect.Effect<readonly Trace.Message[], never, TestTraceService> = Effect.map(
+    TestTraceService,
+    ({ messages }) => [...messages],
+  );
+
+  /** The flattened events of every message written so far, in write order. */
+  static readonly events: Effect.Effect<readonly Trace.FlatEvent[], never, TestTraceService> = Effect.map(
+    TestTraceService,
+    ({ messages }) => messages.flatMap((message) => Trace.flatten(message)),
+  );
+
+  /** The collector, the writer, and the sink between them. */
+  static readonly layer: Layer.Layer<TestTraceService | Trace.TraceSink | Trace.TraceService> = Layer.suspend(() =>
+    Layer.unwrap(Effect.map(TestTraceService, ({ clock }) => Trace.testTraceService({ clock }))).pipe(
+      Layer.provideMerge(sinkLayer.pipe(Layer.provideMerge(collectorLayer))),
+    ),
+  );
+
+  /**
+   * Runs the effect writing under `meta` — the pid and conversation a real emitter would carry —
+   * keeping the collector's clock, so timestamps stay ordered across nested scopes.
+   */
+  static readonly withMeta = <A, E, R>(
+    meta: Trace.Meta,
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, Exclude<R, Trace.TraceService> | TestTraceService | Trace.TraceSink> =>
+    Effect.flatMap(TestTraceService, ({ clock }) => Effect.provide(effect, Trace.testTraceService({ meta, clock })));
+}
+
+const collectorLayer: Layer.Layer<TestTraceService> = Layer.sync(TestTraceService, () => {
+  let counter = 0;
+  return { messages: [], clock: () => ++counter };
+});
+
+const sinkLayer: Layer.Layer<Trace.TraceSink, never, TestTraceService> = Layer.effect(
+  Trace.TraceSink,
+  Effect.map(TestTraceService, ({ messages }) => ({
+    write: (message: Trace.Message) => {
+      messages.push(message);
+    },
+  })),
+);

--- a/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.test.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.test.ts
@@ -233,6 +233,131 @@ describe('buildSessionTimeline', () => {
     expect(lanesByLabel.get('Write file')).toBe(secondLane?.id);
   });
 
+  test('a task belonging to no lane on this chart cuts nothing', ({ expect }) => {
+    const mine = Task.make({ title: 'Mine', status: 'done' });
+    const other = Task.make({ title: 'Elsewhere', status: 'started' });
+    const chat = makeChat('Scoped', [mine]);
+    const messages = collectTraceEvents(
+      withMeta(
+        { pid: 'agent', conversation: chat.feed },
+        Effect.gen(function* () {
+          yield* Trace.write(AgentRequestBegin, {}); // 1
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: mine.id, title: 'Mine', status: 'started' }); // 2
+          yield* toolCall('Read file'); // 3
+          // A task on somebody else's list: it must neither close `Mine` nor move the boundary.
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: other.id, title: 'Elsewhere', status: 'started' }); // 4
+          yield* toolCall('Write file'); // 5
+          yield* Trace.write(Trace.TaskStatusChanged, {
+            taskId: mine.id,
+            title: 'Mine',
+            status: 'done',
+            previousStatus: 'started',
+          }); // 6
+        }),
+      ),
+    );
+
+    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [mine, other] });
+    const laneId = `task:${mine.id}`;
+    expect(timeline.lanes.find((lane) => lane.id === laneId)).toMatchObject({ start: 2, end: 6 });
+    const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
+    expect(lanesByLabel.get('Read file')).toBe(laneId);
+    expect(lanesByLabel.get('Write file')).toBe(laneId);
+  });
+
+  test('a task dismissed or re-closed claims no stretch of the run', ({ expect }) => {
+    const dismissed = Task.make({ title: 'Dismissed', status: 'blocked' });
+    const worked = Task.make({ title: 'Worked', status: 'done' });
+    const chat = makeChat('Closes', [dismissed, worked]);
+    const messages = collectTraceEvents(
+      withMeta(
+        { pid: 'agent', conversation: chat.feed },
+        Effect.gen(function* () {
+          yield* Trace.write(AgentRequestBegin, {}); // 1
+          // Never started, so it owns nothing — not the reading the agent did before it said so.
+          yield* Trace.write(Trace.TaskStatusChanged, {
+            taskId: dismissed.id,
+            title: 'Dismissed',
+            status: 'blocked',
+            previousStatus: 'todo',
+          }); // 2
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: worked.id, title: 'Worked', status: 'started' }); // 3
+          yield* Trace.write(Trace.TaskStatusChanged, {
+            taskId: worked.id,
+            title: 'Worked',
+            status: 'review',
+            previousStatus: 'started',
+          }); // 4
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: dismissed.id, title: 'Dismissed', status: 'started' }); // 5
+          yield* toolCall('Unblock'); // 6
+          // The sign-off on a task closed at 4: it must not stretch that lane over this one's work.
+          yield* Trace.write(Trace.TaskStatusChanged, {
+            taskId: worked.id,
+            title: 'Worked',
+            status: 'done',
+            previousStatus: 'review',
+          }); // 7
+        }),
+      ),
+    );
+
+    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [dismissed, worked] });
+    expect(timeline.lanes.find((lane) => lane.id === `task:${worked.id}`)).toMatchObject({ start: 3, end: 4 });
+    expect(timeline.lanes.find((lane) => lane.id === `task:${dismissed.id}`)).toMatchObject({
+      start: 5,
+      end: undefined,
+    });
+    const unblock = timeline.markers.find((marker) => marker.label === 'Unblock');
+    expect(unblock?.laneId).toBe(`task:${dismissed.id}`);
+  });
+
+  test('a delegated task keeps its markers on the session that handed it over', ({ expect }) => {
+    const task = Task.make({ title: 'Delegated', status: 'done' });
+    const chat = makeChat('Handover', [task]);
+    const messages = collectTraceEvents(
+      withMeta(
+        { pid: 'agent', conversation: chat.feed },
+        Effect.gen(function* () {
+          yield* Trace.write(AgentRequestBegin, {}); // 1
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: task.id, title: 'Delegated', status: 'started' }); // 2
+          yield* Trace.write(DelegationSpawned, { taskId: task.id, pid: 'sub' }); // 3
+          yield* toolCall('Wait'); // 4
+          yield* withMeta(
+            { pid: 'sub', parentPid: 'agent' },
+            Effect.gen(function* () {
+              yield* Trace.write(Trace.OperationStart, { key: 'run', name: 'Run Instructions' }); // 5
+              yield* Trace.write(CompleteBlock, {
+                messageId: MESSAGE_ID,
+                role: 'assistant',
+                block: { _tag: 'text', text: 'done' },
+              }); // 6
+              yield* Trace.write(Trace.OperationEnd, { key: 'run', outcome: 'success' }); // 7
+            }),
+          );
+          yield* Trace.write(Trace.TaskStatusChanged, {
+            taskId: task.id,
+            title: 'Delegated',
+            status: 'done',
+            previousStatus: 'started',
+          }); // 8
+        }),
+      ),
+    );
+
+    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [task] });
+    const sessionId = `session:${chat.id}`;
+    // The task lane was replaced by the child session, drawn with the child's own span.
+    expect(timeline.lanes.find((lane) => lane.id === `task:${task.id}`)).toBeUndefined();
+    const subSession = timeline.lanes.find((lane) => lane.id === 'session:sub');
+    expect(subSession).toMatchObject({ taskId: task.id, start: 5, end: 7 });
+    // The supervisor's own markers stay on the supervisor, rather than moving onto a bar whose
+    // span does not contain them.
+    const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
+    expect(lanesByLabel.get('Wait')).toBe(sessionId);
+    expect(lanesByLabel.get('Task started')).toBe(sessionId);
+    expect(lanesByLabel.get('Delegated')).toBe(sessionId);
+  });
+
   test('joins the sub-agent by the delegationSpawned event and sums tokens per lane', ({ expect }) => {
     const task = Task.make({ title: 'Write', status: 'done' });
     const chat = makeChat('Tokens', [task]);

--- a/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.test.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.test.ts
@@ -7,13 +7,7 @@ import * as Option from 'effect/Option';
 import { describe, test } from 'vitest';
 
 import { AGENT_PROCESS_KEY } from '@dxos/agent-runtime';
-import {
-  AgentRequestBegin,
-  AgentRequestEnd,
-  CompleteBlock,
-  DelegationSpawned,
-  TaskStatusChanged,
-} from '@dxos/assistant';
+import { AgentRequestBegin, AgentRequestEnd, CompleteBlock, DelegationSpawned } from '@dxos/assistant';
 import * as Chat from '@dxos/assistant/Chat';
 import * as Process from '@dxos/compute/Process';
 import * as Trace from '@dxos/compute/Trace';
@@ -159,16 +153,16 @@ describe('buildSessionTimeline', () => {
         Effect.gen(function* () {
           yield* Trace.write(AgentRequestBegin, {}); // 1
           yield* toolCall('Search'); // 2 — before any task started, stays on the session.
-          yield* Trace.write(TaskStatusChanged, { taskId: first.id, title: 'First', status: 'started' }); // 3
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: first.id, title: 'First', status: 'started' }); // 3
           yield* toolCall('Read file'); // 4
-          yield* Trace.write(TaskStatusChanged, {
+          yield* Trace.write(Trace.TaskStatusChanged, {
             taskId: first.id,
             title: 'First',
             status: 'done',
             previousStatus: 'started',
           }); // 5
           yield* toolCall('Think'); // 6 — between segments.
-          yield* Trace.write(TaskStatusChanged, { taskId: second.id, title: 'Second', status: 'started' }); // 7
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: second.id, title: 'Second', status: 'started' }); // 7
           yield* toolCall('Write file'); // 8
         }),
       ),
@@ -211,14 +205,14 @@ describe('buildSessionTimeline', () => {
         Effect.gen(function* () {
           yield* Trace.write(AgentRequestBegin, {}); // 1
           yield* toolCall('Read file'); // 2
-          yield* Trace.write(TaskStatusChanged, {
+          yield* Trace.write(Trace.TaskStatusChanged, {
             taskId: first.id,
             title: 'First',
             status: 'done',
             previousStatus: 'started',
           }); // 3
           yield* toolCall('Write file'); // 4
-          yield* Trace.write(TaskStatusChanged, {
+          yield* Trace.write(Trace.TaskStatusChanged, {
             taskId: second.id,
             title: 'Second',
             status: 'done',

--- a/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.test.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.test.ts
@@ -151,19 +151,19 @@ describe('buildSessionTimeline', () => {
       withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
-          yield* Trace.write(AgentRequestBegin, {}); // 1
+          yield* Trace.write(AgentRequestBegin, {}); // 1.
           yield* toolCall('Search'); // 2 — before any task started, stays on the session.
-          yield* Trace.write(Trace.TaskStatusChanged, { taskId: first.id, title: 'First', status: 'started' }); // 3
-          yield* toolCall('Read file'); // 4
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: first.id, title: 'First', status: 'started' }); // 3.
+          yield* toolCall('Read file'); // 4.
           yield* Trace.write(Trace.TaskStatusChanged, {
             taskId: first.id,
             title: 'First',
             status: 'done',
             previousStatus: 'started',
-          }); // 5
+          }); // 5.
           yield* toolCall('Think'); // 6 — between segments.
-          yield* Trace.write(Trace.TaskStatusChanged, { taskId: second.id, title: 'Second', status: 'started' }); // 7
-          yield* toolCall('Write file'); // 8
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: second.id, title: 'Second', status: 'started' }); // 7.
+          yield* toolCall('Write file'); // 8.
         }),
       ),
     );
@@ -203,22 +203,22 @@ describe('buildSessionTimeline', () => {
       withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
-          yield* Trace.write(AgentRequestBegin, {}); // 1
-          yield* toolCall('Read file'); // 2
+          yield* Trace.write(AgentRequestBegin, {}); // 1.
+          yield* toolCall('Read file'); // 2.
           yield* Trace.write(Trace.TaskStatusChanged, {
             taskId: first.id,
             title: 'First',
             status: 'done',
             previousStatus: 'started',
-          }); // 3
-          yield* toolCall('Write file'); // 4
+          }); // 3.
+          yield* toolCall('Write file'); // 4.
           yield* Trace.write(Trace.TaskStatusChanged, {
             taskId: second.id,
             title: 'Second',
             status: 'done',
             previousStatus: 'started',
-          }); // 5
-          yield* Trace.write(AgentRequestEnd, { status: 'success' }); // 6
+          }); // 5.
+          yield* Trace.write(AgentRequestEnd, { status: 'success' }); // 6.
         }),
       ),
     );
@@ -241,18 +241,18 @@ describe('buildSessionTimeline', () => {
       withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
-          yield* Trace.write(AgentRequestBegin, {}); // 1
-          yield* Trace.write(Trace.TaskStatusChanged, { taskId: mine.id, title: 'Mine', status: 'started' }); // 2
-          yield* toolCall('Read file'); // 3
+          yield* Trace.write(AgentRequestBegin, {}); // 1.
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: mine.id, title: 'Mine', status: 'started' }); // 2.
+          yield* toolCall('Read file'); // 3.
           // A task on somebody else's list: it must neither close `Mine` nor move the boundary.
-          yield* Trace.write(Trace.TaskStatusChanged, { taskId: other.id, title: 'Elsewhere', status: 'started' }); // 4
-          yield* toolCall('Write file'); // 5
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: other.id, title: 'Elsewhere', status: 'started' }); // 4.
+          yield* toolCall('Write file'); // 5.
           yield* Trace.write(Trace.TaskStatusChanged, {
             taskId: mine.id,
             title: 'Mine',
             status: 'done',
             previousStatus: 'started',
-          }); // 6
+          }); // 6.
         }),
       ),
     );
@@ -273,30 +273,30 @@ describe('buildSessionTimeline', () => {
       withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
-          yield* Trace.write(AgentRequestBegin, {}); // 1
+          yield* Trace.write(AgentRequestBegin, {}); // 1.
           // Never started, so it owns nothing — not the reading the agent did before it said so.
           yield* Trace.write(Trace.TaskStatusChanged, {
             taskId: dismissed.id,
             title: 'Dismissed',
             status: 'blocked',
             previousStatus: 'todo',
-          }); // 2
-          yield* Trace.write(Trace.TaskStatusChanged, { taskId: worked.id, title: 'Worked', status: 'started' }); // 3
+          }); // 2.
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: worked.id, title: 'Worked', status: 'started' }); // 3.
           yield* Trace.write(Trace.TaskStatusChanged, {
             taskId: worked.id,
             title: 'Worked',
             status: 'review',
             previousStatus: 'started',
-          }); // 4
-          yield* Trace.write(Trace.TaskStatusChanged, { taskId: dismissed.id, title: 'Dismissed', status: 'started' }); // 5
-          yield* toolCall('Unblock'); // 6
+          }); // 4.
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: dismissed.id, title: 'Dismissed', status: 'started' }); // 5.
+          yield* toolCall('Unblock'); // 6.
           // The sign-off on a task closed at 4: it must not stretch that lane over this one's work.
           yield* Trace.write(Trace.TaskStatusChanged, {
             taskId: worked.id,
             title: 'Worked',
             status: 'done',
             previousStatus: 'review',
-          }); // 7
+          }); // 7.
         }),
       ),
     );
@@ -311,6 +311,39 @@ describe('buildSessionTimeline', () => {
     expect(unblock?.laneId).toBe(`task:${dismissed.id}`);
   });
 
+  test('a close arriving after the next task started leaves that task the stretch', ({ expect }) => {
+    const first = Task.make({ title: 'First', status: 'done' });
+    const second = Task.make({ title: 'Second', status: 'started' });
+    const chat = makeChat('Interleaved', [first, second]);
+    const messages = collectTraceEvents(
+      withMeta(
+        { pid: 'agent', conversation: chat.feed },
+        Effect.gen(function* () {
+          yield* Trace.write(AgentRequestBegin, {}); // 1.
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: first.id, title: 'First', status: 'started' }); // 2.
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: second.id, title: 'Second', status: 'started' }); // 3.
+          yield* toolCall('Write file'); // 4.
+          // The first task's close lands after the second one is under way; the stretch is the
+          // second task's, so nothing may be minted over it.
+          yield* Trace.write(Trace.TaskStatusChanged, {
+            taskId: first.id,
+            title: 'First',
+            status: 'done',
+            previousStatus: 'started',
+          }); // 5.
+          yield* toolCall('Read file'); // 6.
+        }),
+      ),
+    );
+
+    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [first, second] });
+    expect(timeline.lanes.find((lane) => lane.id === `task:${first.id}`)).toMatchObject({ start: 2, end: 3 });
+    expect(timeline.lanes.find((lane) => lane.id === `task:${second.id}`)).toMatchObject({ start: 3, end: undefined });
+    const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
+    expect(lanesByLabel.get('Write file')).toBe(`task:${second.id}`);
+    expect(lanesByLabel.get('Read file')).toBe(`task:${second.id}`);
+  });
+
   test('a delegated task keeps its markers on the session that handed it over', ({ expect }) => {
     const task = Task.make({ title: 'Delegated', status: 'done' });
     const chat = makeChat('Handover', [task]);
@@ -318,20 +351,20 @@ describe('buildSessionTimeline', () => {
       withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
-          yield* Trace.write(AgentRequestBegin, {}); // 1
-          yield* Trace.write(Trace.TaskStatusChanged, { taskId: task.id, title: 'Delegated', status: 'started' }); // 2
-          yield* Trace.write(DelegationSpawned, { taskId: task.id, pid: 'sub' }); // 3
-          yield* toolCall('Wait'); // 4
+          yield* Trace.write(AgentRequestBegin, {}); // 1.
+          yield* Trace.write(Trace.TaskStatusChanged, { taskId: task.id, title: 'Delegated', status: 'started' }); // 2.
+          yield* Trace.write(DelegationSpawned, { taskId: task.id, pid: 'sub' }); // 3.
+          yield* toolCall('Wait'); // 4.
           yield* withMeta(
             { pid: 'sub', parentPid: 'agent' },
             Effect.gen(function* () {
-              yield* Trace.write(Trace.OperationStart, { key: 'run', name: 'Run Instructions' }); // 5
+              yield* Trace.write(Trace.OperationStart, { key: 'run', name: 'Run Instructions' }); // 5.
               yield* Trace.write(CompleteBlock, {
                 messageId: MESSAGE_ID,
                 role: 'assistant',
                 block: { _tag: 'text', text: 'done' },
-              }); // 6
-              yield* Trace.write(Trace.OperationEnd, { key: 'run', outcome: 'success' }); // 7
+              }); // 6.
+              yield* Trace.write(Trace.OperationEnd, { key: 'run', outcome: 'success' }); // 7.
             }),
           );
           yield* Trace.write(Trace.TaskStatusChanged, {
@@ -339,7 +372,7 @@ describe('buildSessionTimeline', () => {
             title: 'Delegated',
             status: 'done',
             previousStatus: 'started',
-          }); // 8
+          }); // 8.
         }),
       ),
     );

--- a/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.test.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.test.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
+import { it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 import { describe, test } from 'vitest';
@@ -10,11 +11,11 @@ import { AGENT_PROCESS_KEY } from '@dxos/agent-runtime';
 import { AgentRequestBegin, AgentRequestEnd, CompleteBlock, DelegationSpawned } from '@dxos/assistant';
 import * as Chat from '@dxos/assistant/Chat';
 import * as Process from '@dxos/compute/Process';
+import { TestTraceService } from '@dxos/compute/testing';
 import * as Trace from '@dxos/compute/Trace';
 import { Annotation, Feed, Obj, Ref } from '@dxos/echo';
 import { Task } from '@dxos/types';
 
-import { collectTraceEvents, withMeta } from '../execution-graph/testing/index.ts';
 import subAgentFixture from '../execution-graph/testing/sub-agent-delegation.json';
 import { buildSessionTimeline } from './session-timeline.ts';
 
@@ -87,12 +88,13 @@ describe('buildSessionTimeline', () => {
     expect(timeline.lanes[0]?.label).toBe('Agent');
   });
 
-  test('running session with a blocked and a running task', ({ expect }) => {
-    const first = Task.make({ title: 'First', status: 'started' });
-    const second = Task.make({ title: 'Second', status: 'todo', dependsOn: [Ref.make(first)] });
-    const chat = makeChat('Work', [first, second]);
-    const messages = collectTraceEvents(
-      withMeta(
+  it.effect(
+    'running session with a blocked and a running task',
+    Effect.fnUntraced(function* ({ expect }) {
+      const first = Task.make({ title: 'First', status: 'started' });
+      const second = Task.make({ title: 'Second', status: 'todo', dependsOn: [Ref.make(first)] });
+      const chat = makeChat('Work', [first, second]);
+      yield* TestTraceService.withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
           yield* Trace.write(AgentRequestBegin, {});
@@ -102,53 +104,55 @@ describe('buildSessionTimeline', () => {
             block: { _tag: 'text', text: 'go' },
           });
           yield* Trace.write(DelegationSpawned, { taskId: first.id, pid: 'sub' });
-          yield* withMeta(
+          yield* TestTraceService.withMeta(
             { pid: 'sub', parentPid: 'agent' },
             Trace.write(Trace.OperationStart, { key: 'run', name: 'Run Instructions' }),
           );
         }),
-      ),
-    );
+      );
 
-    const timeline = buildSessionTimeline({
-      traceMessages: messages,
-      chats: [chat],
-      tasks: [first, second],
-      processes: [
-        agentProcess('agent', chat, Process.State.RUNNING),
-        { ...agentProcess('sub', chat, Process.State.RUNNING), key: 'run', parentPid: Process.ID.make('agent') },
-      ],
-      now: 100,
-    });
+      const messages = yield* TestTraceService.messages;
+      const timeline = buildSessionTimeline({
+        traceMessages: messages,
+        chats: [chat],
+        tasks: [first, second],
+        processes: [
+          agentProcess('agent', chat, Process.State.RUNNING),
+          { ...agentProcess('sub', chat, Process.State.RUNNING), key: 'run', parentPid: Process.ID.make('agent') },
+        ],
+        now: 100,
+      });
 
-    // The delegated task is represented by its session alone — no task lane doubles it — and the
-    // dependency on it follows to that session.
-    const [session, subSession, secondLane] = timeline.lanes;
-    expect(timeline.lanes).toHaveLength(3);
-    expect(session).toMatchObject({ kind: 'session', status: 'running', start: 1, end: undefined });
-    expect(subSession).toMatchObject({
-      kind: 'session',
-      label: 'First',
-      status: 'running',
-      taskId: first.id,
-      pid: 'sub',
-      start: 4,
-      end: undefined,
-      delegatedFrom: {
-        laneId: session?.id,
-        markerId: timeline.markers.find((marker) => marker.kind === 'delegation')?.id,
-      },
-    });
-    expect(secondLane).toMatchObject({ kind: 'task', status: 'blocked', blockedOn: [subSession?.id] });
-    expect(timeline.range).toEqual({ start: 1, end: 100 });
-  });
+      // The delegated task is represented by its session alone — no task lane doubles it — and the
+      // dependency on it follows to that session.
+      const [session, subSession, secondLane] = timeline.lanes;
+      expect(timeline.lanes).toHaveLength(3);
+      expect(session).toMatchObject({ kind: 'session', status: 'running', start: 1, end: undefined });
+      expect(subSession).toMatchObject({
+        kind: 'session',
+        label: 'First',
+        status: 'running',
+        taskId: first.id,
+        pid: 'sub',
+        start: 4,
+        end: undefined,
+        delegatedFrom: {
+          laneId: session?.id,
+          markerId: timeline.markers.find((marker) => marker.kind === 'delegation')?.id,
+        },
+      });
+      expect(secondLane).toMatchObject({ kind: 'task', status: 'blocked', blockedOn: [subSession?.id] });
+      expect(timeline.range).toEqual({ start: 1, end: 100 });
+    }, Effect.provide(TestTraceService.layer)),
+  );
 
-  test('cuts the session into task segments from the status events', ({ expect }) => {
-    const first = Task.make({ title: 'First', status: 'done' });
-    const second = Task.make({ title: 'Second', status: 'started' });
-    const chat = makeChat('Segmented', [first, second]);
-    const messages = collectTraceEvents(
-      withMeta(
+  it.effect(
+    'cuts the session into task segments from the status events',
+    Effect.fnUntraced(function* ({ expect }) {
+      const first = Task.make({ title: 'First', status: 'done' });
+      const second = Task.make({ title: 'Second', status: 'started' });
+      const chat = makeChat('Segmented', [first, second]);
+      yield* TestTraceService.withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
           yield* Trace.write(AgentRequestBegin, {}); // 1.
@@ -165,42 +169,49 @@ describe('buildSessionTimeline', () => {
           yield* Trace.write(Trace.TaskStatusChanged, { taskId: second.id, title: 'Second', status: 'started' }); // 7.
           yield* toolCall('Write file'); // 8.
         }),
-      ),
-    );
+      );
 
-    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [first, second], now: 20 });
-    const sessionId = `session:${chat.id}`;
-    const firstLane = timeline.lanes.find((lane) => lane.id === `task:${first.id}`);
-    const secondLane = timeline.lanes.find((lane) => lane.id === `task:${second.id}`);
-    // The first task's lane is bounded by its status events; the second one is still open.
-    expect(firstLane).toMatchObject({ kind: 'task', status: 'done', start: 3, end: 5 });
-    expect(secondLane).toMatchObject({ kind: 'task', status: 'running', start: 7, end: undefined });
+      const messages = yield* TestTraceService.messages;
+      const timeline = buildSessionTimeline({
+        traceMessages: messages,
+        chats: [chat],
+        tasks: [first, second],
+        now: 20,
+      });
+      const sessionId = `session:${chat.id}`;
+      const firstLane = timeline.lanes.find((lane) => lane.id === `task:${first.id}`);
+      const secondLane = timeline.lanes.find((lane) => lane.id === `task:${second.id}`);
+      // The first task's lane is bounded by its status events; the second one is still open.
+      expect(firstLane).toMatchObject({ kind: 'task', status: 'done', start: 3, end: 5 });
+      expect(secondLane).toMatchObject({ kind: 'task', status: 'running', start: 7, end: undefined });
 
-    // Every event inside a segment is that task's; the rest stay on the session.
-    const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
-    expect(lanesByLabel.get('Search')).toBe(sessionId);
-    expect(lanesByLabel.get('Read file')).toBe(firstLane?.id);
-    expect(lanesByLabel.get('Think')).toBe(sessionId);
-    expect(lanesByLabel.get('Write file')).toBe(secondLane?.id);
-    expect(lanesByLabel.get('Request started')).toBe(sessionId);
+      // Every event inside a segment is that task's; the rest stay on the session.
+      const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
+      expect(lanesByLabel.get('Search')).toBe(sessionId);
+      expect(lanesByLabel.get('Read file')).toBe(firstLane?.id);
+      expect(lanesByLabel.get('Think')).toBe(sessionId);
+      expect(lanesByLabel.get('Write file')).toBe(secondLane?.id);
+      expect(lanesByLabel.get('Request started')).toBe(sessionId);
 
-    // Start and finish are drawn as nodes on the task's own lane.
-    const taskMarkers = timeline.markers.filter((marker) => marker.kind === 'task');
-    expect(taskMarkers.map(({ laneId, label, timestamp }) => ({ laneId, label, timestamp }))).toEqual([
-      { laneId: firstLane?.id, label: 'Task started', timestamp: 3 },
-      { laneId: firstLane?.id, label: 'Task done', timestamp: 5 },
-      { laneId: secondLane?.id, label: 'Task started', timestamp: 7 },
-    ]);
-  });
+      // Start and finish are drawn as nodes on the task's own lane.
+      const taskMarkers = timeline.markers.filter((marker) => marker.kind === 'task');
+      expect(taskMarkers.map(({ laneId, label, timestamp }) => ({ laneId, label, timestamp }))).toEqual([
+        { laneId: firstLane?.id, label: 'Task started', timestamp: 3 },
+        { laneId: firstLane?.id, label: 'Task done', timestamp: 5 },
+        { laneId: secondLane?.id, label: 'Task started', timestamp: 7 },
+      ]);
+    }, Effect.provide(TestTraceService.layer)),
+  );
 
-  test('cuts a delegated run, where a task is only ever closed', ({ expect }) => {
-    // Delegation marks every task it hands over `started`, so the agent's only event per task is
-    // the one closing it — the cut comes from the previous boundary instead.
-    const first = Task.make({ title: 'First', status: 'done' });
-    const second = Task.make({ title: 'Second', status: 'done' });
-    const chat = makeChat('Delegated', [first, second]);
-    const messages = collectTraceEvents(
-      withMeta(
+  it.effect(
+    'cuts a delegated run, where a task is only ever closed',
+    Effect.fnUntraced(function* ({ expect }) {
+      // Delegation marks every task it hands over `started`, so the agent's only event per task is
+      // the one closing it — the cut comes from the previous boundary instead.
+      const first = Task.make({ title: 'First', status: 'done' });
+      const second = Task.make({ title: 'Second', status: 'done' });
+      const chat = makeChat('Delegated', [first, second]);
+      yield* TestTraceService.withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
           yield* Trace.write(AgentRequestBegin, {}); // 1.
@@ -220,25 +231,27 @@ describe('buildSessionTimeline', () => {
           }); // 5.
           yield* Trace.write(AgentRequestEnd, { status: 'success' }); // 6.
         }),
-      ),
-    );
+      );
 
-    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [first, second] });
-    const firstLane = timeline.lanes.find((lane) => lane.id === `task:${first.id}`);
-    const secondLane = timeline.lanes.find((lane) => lane.id === `task:${second.id}`);
-    expect(firstLane).toMatchObject({ start: 1, end: 3 });
-    expect(secondLane).toMatchObject({ start: 3, end: 5 });
-    const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
-    expect(lanesByLabel.get('Read file')).toBe(firstLane?.id);
-    expect(lanesByLabel.get('Write file')).toBe(secondLane?.id);
-  });
+      const messages = yield* TestTraceService.messages;
+      const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [first, second] });
+      const firstLane = timeline.lanes.find((lane) => lane.id === `task:${first.id}`);
+      const secondLane = timeline.lanes.find((lane) => lane.id === `task:${second.id}`);
+      expect(firstLane).toMatchObject({ start: 1, end: 3 });
+      expect(secondLane).toMatchObject({ start: 3, end: 5 });
+      const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
+      expect(lanesByLabel.get('Read file')).toBe(firstLane?.id);
+      expect(lanesByLabel.get('Write file')).toBe(secondLane?.id);
+    }, Effect.provide(TestTraceService.layer)),
+  );
 
-  test('a task belonging to no lane on this chart cuts nothing', ({ expect }) => {
-    const mine = Task.make({ title: 'Mine', status: 'done' });
-    const other = Task.make({ title: 'Elsewhere', status: 'started' });
-    const chat = makeChat('Scoped', [mine]);
-    const messages = collectTraceEvents(
-      withMeta(
+  it.effect(
+    'a task belonging to no lane on this chart cuts nothing',
+    Effect.fnUntraced(function* ({ expect }) {
+      const mine = Task.make({ title: 'Mine', status: 'done' });
+      const other = Task.make({ title: 'Elsewhere', status: 'started' });
+      const chat = makeChat('Scoped', [mine]);
+      yield* TestTraceService.withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
           yield* Trace.write(AgentRequestBegin, {}); // 1.
@@ -254,23 +267,25 @@ describe('buildSessionTimeline', () => {
             previousStatus: 'started',
           }); // 6.
         }),
-      ),
-    );
+      );
 
-    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [mine, other] });
-    const laneId = `task:${mine.id}`;
-    expect(timeline.lanes.find((lane) => lane.id === laneId)).toMatchObject({ start: 2, end: 6 });
-    const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
-    expect(lanesByLabel.get('Read file')).toBe(laneId);
-    expect(lanesByLabel.get('Write file')).toBe(laneId);
-  });
+      const messages = yield* TestTraceService.messages;
+      const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [mine, other] });
+      const laneId = `task:${mine.id}`;
+      expect(timeline.lanes.find((lane) => lane.id === laneId)).toMatchObject({ start: 2, end: 6 });
+      const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
+      expect(lanesByLabel.get('Read file')).toBe(laneId);
+      expect(lanesByLabel.get('Write file')).toBe(laneId);
+    }, Effect.provide(TestTraceService.layer)),
+  );
 
-  test('a task dismissed or re-closed claims no stretch of the run', ({ expect }) => {
-    const dismissed = Task.make({ title: 'Dismissed', status: 'blocked' });
-    const worked = Task.make({ title: 'Worked', status: 'done' });
-    const chat = makeChat('Closes', [dismissed, worked]);
-    const messages = collectTraceEvents(
-      withMeta(
+  it.effect(
+    'a task dismissed or re-closed claims no stretch of the run',
+    Effect.fnUntraced(function* ({ expect }) {
+      const dismissed = Task.make({ title: 'Dismissed', status: 'blocked' });
+      const worked = Task.make({ title: 'Worked', status: 'done' });
+      const chat = makeChat('Closes', [dismissed, worked]);
+      yield* TestTraceService.withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
           yield* Trace.write(AgentRequestBegin, {}); // 1.
@@ -298,25 +313,27 @@ describe('buildSessionTimeline', () => {
             previousStatus: 'review',
           }); // 7.
         }),
-      ),
-    );
+      );
 
-    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [dismissed, worked] });
-    expect(timeline.lanes.find((lane) => lane.id === `task:${worked.id}`)).toMatchObject({ start: 3, end: 4 });
-    expect(timeline.lanes.find((lane) => lane.id === `task:${dismissed.id}`)).toMatchObject({
-      start: 5,
-      end: undefined,
-    });
-    const unblock = timeline.markers.find((marker) => marker.label === 'Unblock');
-    expect(unblock?.laneId).toBe(`task:${dismissed.id}`);
-  });
+      const messages = yield* TestTraceService.messages;
+      const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [dismissed, worked] });
+      expect(timeline.lanes.find((lane) => lane.id === `task:${worked.id}`)).toMatchObject({ start: 3, end: 4 });
+      expect(timeline.lanes.find((lane) => lane.id === `task:${dismissed.id}`)).toMatchObject({
+        start: 5,
+        end: undefined,
+      });
+      const unblock = timeline.markers.find((marker) => marker.label === 'Unblock');
+      expect(unblock?.laneId).toBe(`task:${dismissed.id}`);
+    }, Effect.provide(TestTraceService.layer)),
+  );
 
-  test('a close arriving after the next task started leaves that task the stretch', ({ expect }) => {
-    const first = Task.make({ title: 'First', status: 'done' });
-    const second = Task.make({ title: 'Second', status: 'started' });
-    const chat = makeChat('Interleaved', [first, second]);
-    const messages = collectTraceEvents(
-      withMeta(
+  it.effect(
+    'a close arriving after the next task started leaves that task the stretch',
+    Effect.fnUntraced(function* ({ expect }) {
+      const first = Task.make({ title: 'First', status: 'done' });
+      const second = Task.make({ title: 'Second', status: 'started' });
+      const chat = makeChat('Interleaved', [first, second]);
+      yield* TestTraceService.withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
           yield* Trace.write(AgentRequestBegin, {}); // 1.
@@ -333,29 +350,34 @@ describe('buildSessionTimeline', () => {
           }); // 5.
           yield* toolCall('Read file'); // 6.
         }),
-      ),
-    );
+      );
 
-    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [first, second] });
-    expect(timeline.lanes.find((lane) => lane.id === `task:${first.id}`)).toMatchObject({ start: 2, end: 3 });
-    expect(timeline.lanes.find((lane) => lane.id === `task:${second.id}`)).toMatchObject({ start: 3, end: undefined });
-    const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
-    expect(lanesByLabel.get('Write file')).toBe(`task:${second.id}`);
-    expect(lanesByLabel.get('Read file')).toBe(`task:${second.id}`);
-  });
+      const messages = yield* TestTraceService.messages;
+      const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [first, second] });
+      expect(timeline.lanes.find((lane) => lane.id === `task:${first.id}`)).toMatchObject({ start: 2, end: 3 });
+      expect(timeline.lanes.find((lane) => lane.id === `task:${second.id}`)).toMatchObject({
+        start: 3,
+        end: undefined,
+      });
+      const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
+      expect(lanesByLabel.get('Write file')).toBe(`task:${second.id}`);
+      expect(lanesByLabel.get('Read file')).toBe(`task:${second.id}`);
+    }, Effect.provide(TestTraceService.layer)),
+  );
 
-  test('a delegated task keeps its markers on the session that handed it over', ({ expect }) => {
-    const task = Task.make({ title: 'Delegated', status: 'done' });
-    const chat = makeChat('Handover', [task]);
-    const messages = collectTraceEvents(
-      withMeta(
+  it.effect(
+    'a delegated task keeps its markers on the session that handed it over',
+    Effect.fnUntraced(function* ({ expect }) {
+      const task = Task.make({ title: 'Delegated', status: 'done' });
+      const chat = makeChat('Handover', [task]);
+      yield* TestTraceService.withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
           yield* Trace.write(AgentRequestBegin, {}); // 1.
           yield* Trace.write(Trace.TaskStatusChanged, { taskId: task.id, title: 'Delegated', status: 'started' }); // 2.
           yield* Trace.write(DelegationSpawned, { taskId: task.id, pid: 'sub' }); // 3.
           yield* toolCall('Wait'); // 4.
-          yield* withMeta(
+          yield* TestTraceService.withMeta(
             { pid: 'sub', parentPid: 'agent' },
             Effect.gen(function* () {
               yield* Trace.write(Trace.OperationStart, { key: 'run', name: 'Run Instructions' }); // 5.
@@ -374,35 +396,37 @@ describe('buildSessionTimeline', () => {
             previousStatus: 'started',
           }); // 8.
         }),
-      ),
-    );
+      );
 
-    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [task] });
-    const sessionId = `session:${chat.id}`;
-    // The task lane was replaced by the child session, drawn with the child's own span.
-    expect(timeline.lanes.find((lane) => lane.id === `task:${task.id}`)).toBeUndefined();
-    const subSession = timeline.lanes.find((lane) => lane.id === 'session:sub');
-    expect(subSession).toMatchObject({ taskId: task.id, start: 5, end: 7 });
-    // The supervisor's own markers stay on the supervisor, rather than moving onto a bar whose
-    // span does not contain them.
-    const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
-    expect(lanesByLabel.get('Wait')).toBe(sessionId);
-    expect(lanesByLabel.get('Task started')).toBe(sessionId);
-    expect(lanesByLabel.get('Delegated')).toBe(sessionId);
-  });
+      const messages = yield* TestTraceService.messages;
+      const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [task] });
+      const sessionId = `session:${chat.id}`;
+      // The task lane was replaced by the child session, drawn with the child's own span.
+      expect(timeline.lanes.find((lane) => lane.id === `task:${task.id}`)).toBeUndefined();
+      const subSession = timeline.lanes.find((lane) => lane.id === 'session:sub');
+      expect(subSession).toMatchObject({ taskId: task.id, start: 5, end: 7 });
+      // The supervisor's own markers stay on the supervisor, rather than moving onto a bar whose
+      // span does not contain them.
+      const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
+      expect(lanesByLabel.get('Wait')).toBe(sessionId);
+      expect(lanesByLabel.get('Task started')).toBe(sessionId);
+      expect(lanesByLabel.get('Delegated')).toBe(sessionId);
+    }, Effect.provide(TestTraceService.layer)),
+  );
 
-  test('joins the sub-agent by the delegationSpawned event and sums tokens per lane', ({ expect }) => {
-    const task = Task.make({ title: 'Write', status: 'done' });
-    const chat = makeChat('Tokens', [task]);
-    const messages = collectTraceEvents(
-      withMeta(
+  it.effect(
+    'joins the sub-agent by the delegationSpawned event and sums tokens per lane',
+    Effect.fnUntraced(function* ({ expect }) {
+      const task = Task.make({ title: 'Write', status: 'done' });
+      const chat = makeChat('Tokens', [task]);
+      yield* TestTraceService.withMeta(
         { pid: 'agent', conversation: chat.feed },
         Effect.gen(function* () {
           yield* Trace.write(AgentRequestBegin, {});
           yield* stats(10, 20, 1);
           yield* Trace.write(DelegationSpawned, { taskId: task.id, pid: 'sub' });
           yield* Trace.write(AgentRequestEnd, { status: 'success' });
-          yield* withMeta(
+          yield* TestTraceService.withMeta(
             { pid: 'sub', parentPid: 'agent' },
             Effect.gen(function* () {
               yield* Trace.write(Trace.OperationStart, { key: 'run', name: 'Run Instructions' });
@@ -412,24 +436,25 @@ describe('buildSessionTimeline', () => {
             }),
           );
         }),
-      ),
-    );
+      );
 
-    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [task] });
-    const session = timeline.lanes.find((lane) => lane.id === `session:${chat.id}`);
-    const subSession = timeline.lanes.find((lane) => lane.id === 'session:sub');
-    expect(session).toMatchObject({ status: 'done', tokens: { input: 10, output: 20, total: 30 }, toolCalls: 1 });
-    expect(subSession).toMatchObject({
-      status: 'done',
-      start: 5,
-      end: 8,
-      tokens: { input: 101, output: 202, total: 303 },
-      toolCalls: 2,
-    });
-    const spawn = timeline.markers.find((marker) => marker.kind === 'delegation');
-    expect(spawn?.laneId).toBe(session?.id);
-    expect(subSession?.delegatedFrom).toEqual({ laneId: session?.id, markerId: spawn?.id });
-  });
+      const messages = yield* TestTraceService.messages;
+      const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [task] });
+      const session = timeline.lanes.find((lane) => lane.id === `session:${chat.id}`);
+      const subSession = timeline.lanes.find((lane) => lane.id === 'session:sub');
+      expect(session).toMatchObject({ status: 'done', tokens: { input: 10, output: 20, total: 30 }, toolCalls: 1 });
+      expect(subSession).toMatchObject({
+        status: 'done',
+        start: 5,
+        end: 8,
+        tokens: { input: 101, output: 202, total: 303 },
+        toolCalls: 2,
+      });
+      const spawn = timeline.markers.find((marker) => marker.kind === 'delegation');
+      expect(spawn?.laneId).toBe(session?.id);
+      expect(subSession?.delegatedFrom).toEqual({ laneId: session?.id, markerId: spawn?.id });
+    }, Effect.provide(TestTraceService.layer)),
+  );
 });
 
 const agentProcess = (pid: string, chat: Chat.Chat, state: Process.State): Process.Info => ({

--- a/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.test.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.test.ts
@@ -7,7 +7,13 @@ import * as Option from 'effect/Option';
 import { describe, test } from 'vitest';
 
 import { AGENT_PROCESS_KEY } from '@dxos/agent-runtime';
-import { AgentRequestBegin, AgentRequestEnd, CompleteBlock, DelegationSpawned } from '@dxos/assistant';
+import {
+  AgentRequestBegin,
+  AgentRequestEnd,
+  CompleteBlock,
+  DelegationSpawned,
+  TaskStatusChanged,
+} from '@dxos/assistant';
 import * as Chat from '@dxos/assistant/Chat';
 import * as Process from '@dxos/compute/Process';
 import * as Trace from '@dxos/compute/Trace';
@@ -143,6 +149,56 @@ describe('buildSessionTimeline', () => {
     expect(timeline.range).toEqual({ start: 1, end: 100 });
   });
 
+  test('cuts the session into task segments from the status events', ({ expect }) => {
+    const first = Task.make({ title: 'First', status: 'done' });
+    const second = Task.make({ title: 'Second', status: 'started' });
+    const chat = makeChat('Segmented', [first, second]);
+    const messages = collectTraceEvents(
+      withMeta(
+        { pid: 'agent', conversation: chat.feed },
+        Effect.gen(function* () {
+          yield* Trace.write(AgentRequestBegin, {}); // 1
+          yield* toolCall('Search'); // 2 — before any task started, stays on the session.
+          yield* Trace.write(TaskStatusChanged, { taskId: first.id, title: 'First', status: 'started' }); // 3
+          yield* toolCall('Read file'); // 4
+          yield* Trace.write(TaskStatusChanged, {
+            taskId: first.id,
+            title: 'First',
+            status: 'done',
+            previousStatus: 'started',
+          }); // 5
+          yield* toolCall('Think'); // 6 — between segments.
+          yield* Trace.write(TaskStatusChanged, { taskId: second.id, title: 'Second', status: 'started' }); // 7
+          yield* toolCall('Write file'); // 8
+        }),
+      ),
+    );
+
+    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [first, second], now: 20 });
+    const sessionId = `session:${chat.id}`;
+    const firstLane = timeline.lanes.find((lane) => lane.id === `task:${first.id}`);
+    const secondLane = timeline.lanes.find((lane) => lane.id === `task:${second.id}`);
+    // The first task's lane is bounded by its status events; the second one is still open.
+    expect(firstLane).toMatchObject({ kind: 'task', status: 'done', start: 3, end: 5 });
+    expect(secondLane).toMatchObject({ kind: 'task', status: 'running', start: 7, end: undefined });
+
+    // Every event inside a segment is that task's; the rest stay on the session.
+    const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
+    expect(lanesByLabel.get('Search')).toBe(sessionId);
+    expect(lanesByLabel.get('Read file')).toBe(firstLane?.id);
+    expect(lanesByLabel.get('Think')).toBe(sessionId);
+    expect(lanesByLabel.get('Write file')).toBe(secondLane?.id);
+    expect(lanesByLabel.get('Request started')).toBe(sessionId);
+
+    // Start and finish are drawn as nodes on the task's own lane.
+    const taskMarkers = timeline.markers.filter((marker) => marker.kind === 'task');
+    expect(taskMarkers.map(({ laneId, label, timestamp }) => ({ laneId, label, timestamp }))).toEqual([
+      { laneId: firstLane?.id, label: 'Task started', timestamp: 3 },
+      { laneId: firstLane?.id, label: 'Task done', timestamp: 5 },
+      { laneId: secondLane?.id, label: 'Task started', timestamp: 7 },
+    ]);
+  });
+
   test('joins the sub-agent by the delegationSpawned event and sums tokens per lane', ({ expect }) => {
     const task = Task.make({ title: 'Write', status: 'done' });
     const chat = makeChat('Tokens', [task]);
@@ -204,6 +260,13 @@ const agentProcess = (pid: string, chat: Chat.Chat, state: Process.State): Proce
 
 const makeChat = (name: string, tasks: readonly Task.Task[]) =>
   Chat.make({ name, feed: Ref.make(Feed.make()), tasks: tasks.map((task) => Ref.make(task)) });
+
+const toolCall = (name: string) =>
+  Trace.write(CompleteBlock, {
+    messageId: MESSAGE_ID,
+    role: 'assistant',
+    block: { _tag: 'toolCall', toolCallId: name, name, input: '{}', providerExecuted: false },
+  });
 
 const stats = (input: number, output: number, toolCalls: number) =>
   Trace.write(CompleteBlock, {

--- a/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.test.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.test.ts
@@ -199,6 +199,46 @@ describe('buildSessionTimeline', () => {
     ]);
   });
 
+  test('cuts a delegated run, where a task is only ever closed', ({ expect }) => {
+    // Delegation marks every task it hands over `started`, so the agent's only event per task is
+    // the one closing it — the cut comes from the previous boundary instead.
+    const first = Task.make({ title: 'First', status: 'done' });
+    const second = Task.make({ title: 'Second', status: 'done' });
+    const chat = makeChat('Delegated', [first, second]);
+    const messages = collectTraceEvents(
+      withMeta(
+        { pid: 'agent', conversation: chat.feed },
+        Effect.gen(function* () {
+          yield* Trace.write(AgentRequestBegin, {}); // 1
+          yield* toolCall('Read file'); // 2
+          yield* Trace.write(TaskStatusChanged, {
+            taskId: first.id,
+            title: 'First',
+            status: 'done',
+            previousStatus: 'started',
+          }); // 3
+          yield* toolCall('Write file'); // 4
+          yield* Trace.write(TaskStatusChanged, {
+            taskId: second.id,
+            title: 'Second',
+            status: 'done',
+            previousStatus: 'started',
+          }); // 5
+          yield* Trace.write(AgentRequestEnd, { status: 'success' }); // 6
+        }),
+      ),
+    );
+
+    const timeline = buildSessionTimeline({ traceMessages: messages, chats: [chat], tasks: [first, second] });
+    const firstLane = timeline.lanes.find((lane) => lane.id === `task:${first.id}`);
+    const secondLane = timeline.lanes.find((lane) => lane.id === `task:${second.id}`);
+    expect(firstLane).toMatchObject({ start: 1, end: 3 });
+    expect(secondLane).toMatchObject({ start: 3, end: 5 });
+    const lanesByLabel = new Map(timeline.markers.map((marker) => [marker.label, marker.laneId]));
+    expect(lanesByLabel.get('Read file')).toBe(firstLane?.id);
+    expect(lanesByLabel.get('Write file')).toBe(secondLane?.id);
+  });
+
   test('joins the sub-agent by the delegationSpawned event and sums tokens per lane', ({ expect }) => {
     const task = Task.make({ title: 'Write', status: 'done' });
     const chat = makeChat('Tokens', [task]);

--- a/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.ts
@@ -188,7 +188,9 @@ export const buildSessionTimeline = ({
           pids.add(event.meta.pid);
         }
       }
-      sources.push({ key: chat.id, label: chat.name?.trim() || feed || chat.id, chat, pids });
+      // A feed or object id is not a name: an unnamed chat reads as the session it is until the
+      // naming turn lands.
+      sources.push({ key: chat.id, label: chat.name?.trim() || 'Session', chat, pids });
     }
   } else {
     // Without chats, the conversation feed groups a session's pids; a trace with no conversation
@@ -306,9 +308,21 @@ export const buildSessionTimeline = ({
       lanes.push(taskLane);
     }
 
+    // Spawned pids without a trace yet still get a lane from their process.
+    const subAgentPids = new Set<string>([...subAgentSpans.map(({ pid }) => pid), ...taskByPid.keys()]);
+
     // The status events bound each task's stretch of the session, giving its lane a span of its own
-    // and a node where it started and finished.
-    const segments = buildTaskSegments(sessionEvents, begins[0]?.timestamp).filter((segment) =>
+    // and a node where it started and finished. A status tool runs as a child process of the agent,
+    // so its events carry their own pid and reach the session through `parentPid`; a spawned
+    // sub-agent's do too, and those belong to its own lane rather than cutting this one.
+    const ownEvents = events.filter(
+      (event) =>
+        (event.meta.pid !== undefined && source.pids.has(event.meta.pid)) ||
+        (event.meta.parentPid !== undefined &&
+          source.pids.has(event.meta.parentPid) &&
+          !(event.meta.pid !== undefined && subAgentPids.has(event.meta.pid))),
+    );
+    const segments = buildTaskSegments(ownEvents, begins[0]?.timestamp).filter((segment) =>
       taskLanes.has(segment.taskId),
     );
     segmentsBySession.set(laneId, segments);
@@ -322,8 +336,6 @@ export const buildSessionTimeline = ({
       taskLane.end = segment.end === undefined ? undefined : Math.max(taskLane.end ?? segment.end, segment.end);
     }
 
-    // Spawned pids without a trace yet still get a lane from their process.
-    const subAgentPids = new Set<string>([...subAgentSpans.map(({ pid }) => pid), ...taskByPid.keys()]);
     for (const subPid of subAgentPids) {
       const match = subAgentSpans.find((candidate) => candidate.pid === subPid);
       const process = processByPid.get(subPid);

--- a/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.ts
@@ -88,11 +88,24 @@ const TERMINAL_STATUS = new Set<Task.Status>(['done', 'review', 'failed', 'cance
 
 /**
  * Cuts a session's events into one segment per task worked, from the planning tool's status events.
- * The agent keeps exactly one task started, so a new `started` closes the segment still open.
+ *
+ * A `started` event opens a segment and closes the one still open — the agent keeps exactly one task
+ * in progress. A task can also finish without one: delegation marks every task it hands over
+ * `started` before the agent's first turn, so the run's only event for a task is the one closing it.
+ * Such a task gets the stretch since the last boundary, which is where its work actually happened.
  */
-const buildTaskSegments = (events: readonly Trace.FlatEvent[]): TaskSegment[] => {
+const buildTaskSegments = (events: readonly Trace.FlatEvent[], sessionStart: number | undefined): TaskSegment[] => {
   const segments: TaskSegment[] = [];
   let open: TaskSegment | undefined;
+  let boundary = sessionStart;
+  const close = (segment: TaskSegment, timestamp: number): void => {
+    segment.end = timestamp;
+    boundary = timestamp;
+    if (open === segment) {
+      open = undefined;
+    }
+  };
+
   for (const event of events) {
     if (event.type !== TaskStatusChanged.key) {
       continue;
@@ -103,20 +116,25 @@ const buildTaskSegments = (events: readonly Trace.FlatEvent[]): TaskSegment[] =>
     }
     if (data.status === 'started') {
       if (open && open.taskId !== data.taskId) {
-        open.end = event.timestamp;
-        open = undefined;
+        close(open, event.timestamp);
       }
       if (!open) {
         open = { taskId: data.taskId, laneId: taskLaneId(data.taskId), start: event.timestamp };
         segments.push(open);
+        boundary = event.timestamp;
       }
     } else if (TERMINAL_STATUS.has(data.status)) {
-      const segment = segments.findLast((candidate) => candidate.taskId === data.taskId);
-      if (segment && segment.end === undefined) {
-        segment.end = event.timestamp;
-      }
-      if (open?.taskId === data.taskId) {
-        open = undefined;
+      const started = segments.findLast((candidate) => candidate.taskId === data.taskId && candidate.end === undefined);
+      if (started) {
+        close(started, event.timestamp);
+      } else {
+        const segment = {
+          taskId: data.taskId,
+          laneId: taskLaneId(data.taskId),
+          start: Math.min(boundary ?? event.timestamp, event.timestamp),
+        };
+        segments.push(segment);
+        close(segment, event.timestamp);
       }
     }
   }
@@ -296,7 +314,9 @@ export const buildSessionTimeline = ({
 
     // The status events bound each task's stretch of the session, giving its lane a span of its own
     // and a node where it started and finished.
-    const segments = buildTaskSegments(sessionEvents).filter((segment) => taskLanes.has(segment.taskId));
+    const segments = buildTaskSegments(sessionEvents, begins[0]?.timestamp).filter((segment) =>
+      taskLanes.has(segment.taskId),
+    );
     segmentsBySession.set(laneId, segments);
     for (const segment of segments) {
       const taskLane = taskLanes.get(segment.taskId);

--- a/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.ts
@@ -81,14 +81,24 @@ interface TaskSegment {
 const TERMINAL_STATUS = new Set<Task.Status>(['done', 'review', 'failed', 'cancelled', 'duplicate', 'blocked']);
 
 /**
- * Cuts a session's events into one segment per task worked, from the planning tool's status events.
+ * Cuts a session's events into one segment per task worked, from the status events its task tools
+ * write. Only tasks in `taskIds` — the session's own checklist — take part: an agent is free to move
+ * a task belonging to nothing on this chart, and such an event must not close the segment that is
+ * open or move the boundary.
  *
  * A `started` event opens a segment and closes the one still open — the agent keeps exactly one task
  * in progress. A task can also finish without one: delegation marks every task it hands over
- * `started` before the agent's first turn, so the run's only event for a task is the one closing it.
- * Such a task gets the stretch since the last boundary, which is where its work actually happened.
+ * `started` before the agent's first turn, so the run's only event for that task is the one closing
+ * it. Such a task gets the stretch since the last boundary, which is where its work happened — but
+ * only on the transition out of `started`, so a task merely dismissed (`todo` → `blocked`) claims
+ * nothing, and a second close (`review` → `done`, arriving while another task is active) does not
+ * mint a segment overlapping it.
  */
-const buildTaskSegments = (events: readonly Trace.FlatEvent[], sessionStart: number | undefined): TaskSegment[] => {
+const buildTaskSegments = (
+  events: readonly Trace.FlatEvent[],
+  sessionStart: number | undefined,
+  taskIds: ReadonlySet<string>,
+): TaskSegment[] => {
   const segments: TaskSegment[] = [];
   let open: TaskSegment | undefined;
   let boundary = sessionStart;
@@ -105,7 +115,7 @@ const buildTaskSegments = (events: readonly Trace.FlatEvent[], sessionStart: num
       continue;
     }
     const data = decode(Trace.TaskStatusChanged.schema, event.data);
-    if (!data) {
+    if (!data || !taskIds.has(data.taskId)) {
       continue;
     }
     if (data.status === 'started') {
@@ -121,7 +131,7 @@ const buildTaskSegments = (events: readonly Trace.FlatEvent[], sessionStart: num
       const started = segments.findLast((candidate) => candidate.taskId === data.taskId && candidate.end === undefined);
       if (started) {
         close(started, event.timestamp);
-      } else {
+      } else if (data.previousStatus === 'started') {
         const segment = {
           taskId: data.taskId,
           laneId: taskLaneId(data.taskId),
@@ -322,9 +332,7 @@ export const buildSessionTimeline = ({
           source.pids.has(event.meta.parentPid) &&
           !(event.meta.pid !== undefined && subAgentPids.has(event.meta.pid))),
     );
-    const segments = buildTaskSegments(ownEvents, begins[0]?.timestamp).filter((segment) =>
-      taskLanes.has(segment.taskId),
-    );
+    const segments = buildTaskSegments(ownEvents, begins[0]?.timestamp, chatTaskIds);
     segmentsBySession.set(laneId, segments);
     for (const segment of segments) {
       const taskLane = taskLanes.get(segment.taskId);
@@ -375,11 +383,13 @@ export const buildSessionTimeline = ({
     }
   }
 
-  // A delegated task's lane was replaced by its child session, and its markers follow.
-  for (const segments of segmentsBySession.values()) {
-    for (const segment of segments) {
-      segment.laneId = replacedTaskLanes.get(segment.laneId) ?? segment.laneId;
-    }
+  // A delegated task IS its child session, drawn with the child's own span; the parent's markers in
+  // that stretch are the parent's work of handing it over, so the segment goes rather than moving.
+  for (const [sessionId, segments] of segmentsBySession) {
+    segmentsBySession.set(
+      sessionId,
+      segments.filter((segment) => !replacedTaskLanes.has(segment.laneId)),
+    );
   }
 
   // Dependencies named the task lane; they follow it to the session that replaced it.

--- a/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.ts
@@ -6,13 +6,7 @@ import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 
 import { AGENT_PROCESS_KEY } from '@dxos/agent-runtime';
-import {
-  AgentRequestBegin,
-  AgentRequestEnd,
-  CompleteBlock,
-  DelegationSpawned,
-  TaskStatusChanged,
-} from '@dxos/assistant';
+import { AgentRequestBegin, AgentRequestEnd, CompleteBlock, DelegationSpawned } from '@dxos/assistant';
 import * as Chat from '@dxos/assistant/Chat';
 import * as Process from '@dxos/compute/Process';
 import * as Trace from '@dxos/compute/Trace';
@@ -107,10 +101,10 @@ const buildTaskSegments = (events: readonly Trace.FlatEvent[], sessionStart: num
   };
 
   for (const event of events) {
-    if (event.type !== TaskStatusChanged.key) {
+    if (event.type !== Trace.TaskStatusChanged.key) {
       continue;
     }
-    const data = decode(TaskStatusChanged.schema, event.data);
+    const data = decode(Trace.TaskStatusChanged.schema, event.data);
     if (!data) {
       continue;
     }
@@ -497,8 +491,8 @@ const toMarker = (event: Trace.FlatEvent, id: string, laneId: string): Marker | 
         detail: data?.error,
       };
     }
-    case TaskStatusChanged.key: {
-      const data = decode(TaskStatusChanged.schema, event.data);
+    case Trace.TaskStatusChanged.key: {
+      const data = decode(Trace.TaskStatusChanged.schema, event.data);
       return {
         ...base,
         kind: 'task',

--- a/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.ts
@@ -90,9 +90,10 @@ const TERMINAL_STATUS = new Set<Task.Status>(['done', 'review', 'failed', 'cance
  * in progress. A task can also finish without one: delegation marks every task it hands over
  * `started` before the agent's first turn, so the run's only event for that task is the one closing
  * it. Such a task gets the stretch since the last boundary, which is where its work happened — but
- * only on the transition out of `started`, so a task merely dismissed (`todo` → `blocked`) claims
- * nothing, and a second close (`review` → `done`, arriving while another task is active) does not
- * mint a segment overlapping it.
+ * only on the transition out of `started` and only while no other task holds the stretch: a task
+ * merely dismissed (`todo` → `blocked`) claims nothing, a second close (`review` → `done`) mints
+ * nothing, and a close arriving after the next task has started leaves that task's segment alone
+ * rather than overlapping it.
  */
 const buildTaskSegments = (
   events: readonly Trace.FlatEvent[],
@@ -131,7 +132,7 @@ const buildTaskSegments = (
       const started = segments.findLast((candidate) => candidate.taskId === data.taskId && candidate.end === undefined);
       if (started) {
         close(started, event.timestamp);
-      } else if (data.previousStatus === 'started') {
+      } else if (data.previousStatus === 'started' && open === undefined) {
         const segment = {
           taskId: data.taskId,
           laneId: taskLaneId(data.taskId),

--- a/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/session-timeline.ts
@@ -6,7 +6,13 @@ import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 
 import { AGENT_PROCESS_KEY } from '@dxos/agent-runtime';
-import { AgentRequestBegin, AgentRequestEnd, CompleteBlock, DelegationSpawned } from '@dxos/assistant';
+import {
+  AgentRequestBegin,
+  AgentRequestEnd,
+  CompleteBlock,
+  DelegationSpawned,
+  TaskStatusChanged,
+} from '@dxos/assistant';
 import * as Chat from '@dxos/assistant/Chat';
 import * as Process from '@dxos/compute/Process';
 import * as Trace from '@dxos/compute/Trace';
@@ -62,6 +68,60 @@ interface SessionSource {
   chat?: Chat.Chat;
   pids: Set<string>;
 }
+
+/**
+ * The stretch of a session during which one task was the active one, bounded by the status events
+ * the planning tool writes. Everything the session did inside it belongs to that task.
+ */
+interface TaskSegment {
+  taskId: string;
+  laneId: string;
+  start: number;
+  end?: number;
+}
+
+/**
+ * A status that ends the agent's work on a task. `blocked` is one: the agent moved on, and whatever
+ * it does next is no longer that task's.
+ */
+const TERMINAL_STATUS = new Set<Task.Status>(['done', 'review', 'failed', 'cancelled', 'duplicate', 'blocked']);
+
+/**
+ * Cuts a session's events into one segment per task worked, from the planning tool's status events.
+ * The agent keeps exactly one task started, so a new `started` closes the segment still open.
+ */
+const buildTaskSegments = (events: readonly Trace.FlatEvent[]): TaskSegment[] => {
+  const segments: TaskSegment[] = [];
+  let open: TaskSegment | undefined;
+  for (const event of events) {
+    if (event.type !== TaskStatusChanged.key) {
+      continue;
+    }
+    const data = decode(TaskStatusChanged.schema, event.data);
+    if (!data) {
+      continue;
+    }
+    if (data.status === 'started') {
+      if (open && open.taskId !== data.taskId) {
+        open.end = event.timestamp;
+        open = undefined;
+      }
+      if (!open) {
+        open = { taskId: data.taskId, laneId: taskLaneId(data.taskId), start: event.timestamp };
+        segments.push(open);
+      }
+    } else if (TERMINAL_STATUS.has(data.status)) {
+      const segment = segments.findLast((candidate) => candidate.taskId === data.taskId);
+      if (segment && segment.end === undefined) {
+        segment.end = event.timestamp;
+      }
+      if (open?.taskId === data.taskId) {
+        open = undefined;
+      }
+    }
+  }
+  return segments;
+};
 
 interface SubAgentSpan {
   span: Span;
@@ -143,6 +203,8 @@ export const buildSessionTimeline = ({
   const markers: Marker[] = [];
   const childSessions: { lane: MutableLane; sessionLaneId: string }[] = [];
   const replacedTaskLanes = new Map<string, string>();
+  /** Per session lane: the task segments its markers are attributed to. */
+  const segmentsBySession = new Map<string, TaskSegment[]>();
 
   for (const source of sources) {
     const laneId = sessionLaneId(source.key);
@@ -232,6 +294,20 @@ export const buildSessionTimeline = ({
       lanes.push(taskLane);
     }
 
+    // The status events bound each task's stretch of the session, giving its lane a span of its own
+    // and a node where it started and finished.
+    const segments = buildTaskSegments(sessionEvents).filter((segment) => taskLanes.has(segment.taskId));
+    segmentsBySession.set(laneId, segments);
+    for (const segment of segments) {
+      const taskLane = taskLanes.get(segment.taskId);
+      if (!taskLane) {
+        continue;
+      }
+      taskLane.start = Math.min(taskLane.start ?? segment.start, segment.start);
+      // An open segment leaves the lane open, even if an earlier one closed.
+      taskLane.end = segment.end === undefined ? undefined : Math.max(taskLane.end ?? segment.end, segment.end);
+    }
+
     // Spawned pids without a trace yet still get a lane from their process.
     const subAgentPids = new Set<string>([...subAgentSpans.map(({ pid }) => pid), ...taskByPid.keys()]);
     for (const subPid of subAgentPids) {
@@ -273,6 +349,13 @@ export const buildSessionTimeline = ({
     }
   }
 
+  // A delegated task's lane was replaced by its child session, and its markers follow.
+  for (const segments of segmentsBySession.values()) {
+    for (const segment of segments) {
+      segment.laneId = replacedTaskLanes.get(segment.laneId) ?? segment.laneId;
+    }
+  }
+
   // Dependencies named the task lane; they follow it to the session that replaced it.
   for (const lane of lanes) {
     if (lane.blockedOn) {
@@ -291,7 +374,18 @@ export const buildSessionTimeline = ({
     if (laneId === undefined) {
       continue;
     }
-    const marker = toMarker(event, `${laneId}:${markers.length}`, laneId);
+    // Everything the session did while a task was active is that task's, so the session bar keeps
+    // only what brackets the whole run (its request markers) and the timeline reads per task.
+    const markerLaneId =
+      event.type === AgentRequestBegin.key || event.type === AgentRequestEnd.key
+        ? laneId
+        : (segmentsBySession
+            .get(laneId)
+            ?.find(
+              (segment) =>
+                event.timestamp >= segment.start && event.timestamp <= (segment.end ?? Number.MAX_SAFE_INTEGER),
+            )?.laneId ?? laneId);
+    const marker = toMarker(event, `${markerLaneId}:${markers.length}`, markerLaneId);
     if (marker) {
       markers.push(marker);
       if (marker.kind === 'delegation') {
@@ -381,6 +475,16 @@ const toMarker = (event: Trace.FlatEvent, id: string, laneId: string): Marker | 
         label: `Request ${data?.status ?? 'ended'}`,
         level: data?.status === 'error' ? 'error' : data?.status === 'interrupted' ? 'warn' : undefined,
         detail: data?.error,
+      };
+    }
+    case TaskStatusChanged.key: {
+      const data = decode(TaskStatusChanged.schema, event.data);
+      return {
+        ...base,
+        kind: 'task',
+        label: data?.status === 'started' ? 'Task started' : `Task ${data?.status ?? 'updated'}`,
+        level: data?.status === 'failed' ? 'error' : undefined,
+        detail: data,
       };
     }
     case DelegationSpawned.key: {

--- a/packages/plugins/plugin-assistant/src/session-timeline/types.ts
+++ b/packages/plugins/plugin-assistant/src/session-timeline/types.ts
@@ -51,7 +51,7 @@ export const Lane = Schema.Struct({
 });
 export type Lane = Schema.Schema.Type<typeof Lane>;
 
-export const MarkerKind = Schema.Literals(['request', 'operation', 'tool', 'message', 'error', 'delegation']);
+export const MarkerKind = Schema.Literals(['request', 'operation', 'tool', 'message', 'error', 'delegation', 'task']);
 export type MarkerKind = Schema.Schema.Type<typeof MarkerKind>;
 
 export const MarkerLevel = Schema.Literals(['info', 'warn', 'error']);

--- a/packages/plugins/plugin-projects/src/components/ProjectPipeline/ProjectPipeline.tsx
+++ b/packages/plugins/plugin-projects/src/components/ProjectPipeline/ProjectPipeline.tsx
@@ -47,7 +47,8 @@ export const ProjectPipeline = ({ space, project, tasks }: ProjectPipelineProps)
     );
   }
 
-  // The chart alone: the ledger above already names every lane.
+  // Named and totalled here rather than read off the ledger above: a ledger row is several lines
+  // tall and a chart row is one, so nothing lines up between them.
   return (
     <ScrollArea.Root>
       <ScrollArea.Viewport>
@@ -59,7 +60,9 @@ export const ProjectPipeline = ({ space, project, tasks }: ProjectPipelineProps)
           classNames='p-2'
           data-testid='projectsPlugin.pipeline.chart'
         >
+          <Gantt.Legend />
           <Gantt.Chart />
+          <Gantt.Meta />
         </Gantt.Root>
       </ScrollArea.Viewport>
     </ScrollArea.Root>

--- a/packages/plugins/plugin-projects/src/containers/ProjectArticle/ProjectArticle.stories.tsx
+++ b/packages/plugins/plugin-projects/src/containers/ProjectArticle/ProjectArticle.stories.tsx
@@ -395,10 +395,11 @@ export const DelegateCheckedTasks: Story = {
 
     // Checked in reverse reading order, so the assertion below distinguishes tick order from the
     // order the rows are shown in.
+    // Matched among all of the title's occurrences rather than expecting one: once the pipeline is
+    // open the chart names every lane too, so the title is on the page twice.
     const checkbox = async (title: string) => {
-      const row = (await canvas.findByText(title, undefined, { timeout: 10_000 })).closest(
-        '[data-testid="taskList.item"]',
-      );
+      const labels = await canvas.findAllByText(title, undefined, { timeout: 10_000 });
+      const row = labels.map((label) => label.closest('[data-testid="taskList.item"]')).find(Boolean);
       await expect(row).toBeTruthy();
       return within(row as HTMLElement).getByTestId('taskList.item.checkbox');
     };

--- a/packages/plugins/plugin-tasks/src/operations/list-milestones.test.ts
+++ b/packages/plugins/plugin-tasks/src/operations/list-milestones.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
+import * as Trace from '@dxos/compute/Trace';
 import { Database, Filter, Query, Ref } from '@dxos/echo';
 import { TestDatabaseLayer, testStoragePath } from '@dxos/echo-client/testing';
 import { PublicKey } from '@dxos/keys';
@@ -40,7 +41,10 @@ describe('list-milestones', () => {
       expect(milestones).toEqual([
         { id: milestone.id, name: 'Alpha', description: 'Ships to staging', targetDate: undefined, total: 2, done: 1 },
       ]);
-    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] }))),
+    }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    ),
   );
 
   it.effect(

--- a/packages/plugins/plugin-tasks/src/operations/list-tasks.test.ts
+++ b/packages/plugins/plugin-tasks/src/operations/list-tasks.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
 
+import * as Trace from '@dxos/compute/Trace';
 import { Database, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { TestDatabaseLayer, testStoragePath } from '@dxos/echo-client/testing';
 import { PublicKey, URI } from '@dxos/keys';
@@ -38,7 +39,10 @@ describe('list-tasks', () => {
 
       const byAssignee = yield* listTasks.handler({ taskSet: Ref.make(taskSet), assignee: 'KAI@example.com' });
       expect(titles(byAssignee.tasks)).toEqual(['Open thing']);
-    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] }))),
+    }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    ),
   );
 
   it.effect('pages with after/limit and stops issuing a cursor at the end', () =>
@@ -58,14 +62,20 @@ describe('list-tasks', () => {
       expect(second.nextCursor).toBeUndefined();
 
       expect([...titles(first.tasks), ...titles(second.tasks)].sort()).toEqual(['a', 'b', 'c']);
-    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] }))),
+    }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    ),
   );
 
   it.effect('requires a container', () =>
     Effect.gen(function* () {
       const exit = yield* Effect.exit(listTasks.handler({}));
       expect(exit._tag).toBe('Failure');
-    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] }))),
+    }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    ),
   );
 
   it.effect(
@@ -116,7 +126,10 @@ describe('list-tasks', () => {
       const filed = yield* listTasks.handler({ taskSet: Ref.make(taskSet), milestone: Ref.make(milestone) });
 
       expect(titles(filed.tasks)).toEqual(['Filed']);
-    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] }))),
+    }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    ),
   );
 });
 

--- a/packages/plugins/plugin-tasks/src/operations/update-task.test.ts
+++ b/packages/plugins/plugin-tasks/src/operations/update-task.test.ts
@@ -237,24 +237,6 @@ describe('update-task', () => {
   );
 });
 
-/** Collects what the handler wrote to the trace, so a status change can be asserted on. */
-const collectingTrace = (messages: Trace.Message[]) =>
-  Trace.testTraceService().pipe(
-    Layer.provide(
-      Layer.succeed(Trace.TraceSink, {
-        write: (message) => {
-          messages.push(message);
-        },
-      }),
-    ),
-  );
-
-const statusEvents = (messages: readonly Trace.Message[]) =>
-  messages
-    .flatMap((message) => message.events)
-    .filter((event) => event.type === Trace.TaskStatusChanged.key)
-    .map((event) => Schema.decodeUnknownSync(Trace.TaskStatusChanged.schema)(event.data));
-
 describe('update-task tracing', () => {
   it.effect('traces a status change, and stays silent when the status is unchanged', () => {
     const messages: Trace.Message[] = [];
@@ -279,3 +261,21 @@ describe('update-task tracing', () => {
     );
   });
 });
+
+/** Collects what the handler wrote to the trace, so a status change can be asserted on. */
+const collectingTrace = (messages: Trace.Message[]) =>
+  Trace.testTraceService().pipe(
+    Layer.provide(
+      Layer.succeed(Trace.TraceSink, {
+        write: (message) => {
+          messages.push(message);
+        },
+      }),
+    ),
+  );
+
+const statusEvents = (messages: readonly Trace.Message[]) =>
+  messages
+    .flatMap((message) => message.events)
+    .filter((event) => event.type === Trace.TaskStatusChanged.key)
+    .map((event) => Schema.decodeUnknownSync(Trace.TaskStatusChanged.schema)(event.data));

--- a/packages/plugins/plugin-tasks/src/operations/update-task.test.ts
+++ b/packages/plugins/plugin-tasks/src/operations/update-task.test.ts
@@ -260,22 +260,22 @@ describe('update-task tracing', () => {
       Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
     );
   });
+
+  /** Collects what the handler wrote to the trace, so a status change can be asserted on. */
+  const collectingTrace = (messages: Trace.Message[]) =>
+    Trace.testTraceService().pipe(
+      Layer.provide(
+        Layer.succeed(Trace.TraceSink, {
+          write: (message) => {
+            messages.push(message);
+          },
+        }),
+      ),
+    );
+
+  const statusEvents = (messages: readonly Trace.Message[]) =>
+    messages
+      .flatMap((message) => message.events)
+      .filter((event) => event.type === Trace.TaskStatusChanged.key)
+      .map((event) => Schema.decodeUnknownSync(Trace.TaskStatusChanged.schema)(event.data));
 });
-
-/** Collects what the handler wrote to the trace, so a status change can be asserted on. */
-const collectingTrace = (messages: Trace.Message[]) =>
-  Trace.testTraceService().pipe(
-    Layer.provide(
-      Layer.succeed(Trace.TraceSink, {
-        write: (message) => {
-          messages.push(message);
-        },
-      }),
-    ),
-  );
-
-const statusEvents = (messages: readonly Trace.Message[]) =>
-  messages
-    .flatMap((message) => message.events)
-    .filter((event) => event.type === Trace.TaskStatusChanged.key)
-    .map((event) => Schema.decodeUnknownSync(Trace.TaskStatusChanged.schema)(event.data));

--- a/packages/plugins/plugin-tasks/src/operations/update-task.test.ts
+++ b/packages/plugins/plugin-tasks/src/operations/update-task.test.ts
@@ -4,9 +4,9 @@
 
 import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
-import * as Layer from 'effect/Layer';
 import * as Schema from 'effect/Schema';
 
+import { TestTraceService } from '@dxos/compute/testing';
 import * as Trace from '@dxos/compute/Trace';
 import { Database, Filter, Obj, Ref } from '@dxos/echo';
 import { TestDatabaseLayer } from '@dxos/echo-client/testing';
@@ -238,44 +238,33 @@ describe('update-task', () => {
 });
 
 describe('update-task tracing', () => {
-  it.effect('traces a status change, and stays silent when the status is unchanged', () => {
-    const messages: Trace.Message[] = [];
-    return Effect.gen(function* () {
-      const taskSet = yield* Database.add(TaskSet.make({}));
-      yield* Database.flush();
-      const { task } = yield* createTask.handler({ taskSet: Ref.make(taskSet), title: 'Draft' });
+  it.effect(
+    'traces a status change, and stays silent when the status is unchanged',
+    Effect.fnUntraced(
+      function* () {
+        const taskSet = yield* Database.add(TaskSet.make({}));
+        yield* Database.flush();
+        const { task } = yield* createTask.handler({ taskSet: Ref.make(taskSet), title: 'Draft' });
 
-      yield* updateTask.handler({ task: Ref.make(task), status: 'started' });
-      // Only the status change is traced: a title edit moves nothing on the timeline.
-      yield* updateTask.handler({ task: Ref.make(task), title: 'Draft v2' });
-      yield* updateTask.handler({ task: Ref.make(task), status: 'started' });
-      yield* updateTask.handler({ task: Ref.make(task), status: 'done' });
+        yield* updateTask.handler({ task: Ref.make(task), status: 'started' });
+        // Only the status change is traced: a title edit moves nothing on the timeline.
+        yield* updateTask.handler({ task: Ref.make(task), title: 'Draft v2' });
+        yield* updateTask.handler({ task: Ref.make(task), status: 'started' });
+        yield* updateTask.handler({ task: Ref.make(task), status: 'done' });
 
-      expect(statusEvents(messages)).toEqual([
-        { taskId: task.id, title: 'Draft', status: 'started', previousStatus: 'todo' },
-        { taskId: task.id, title: 'Draft v2', status: 'done', previousStatus: 'started' },
-      ]);
-    }).pipe(
-      Effect.provide(collectingTrace(messages)),
+        const events = yield* TestTraceService.events;
+        expect(statusEvents(events)).toEqual([
+          { taskId: task.id, title: 'Draft', status: 'started', previousStatus: 'todo' },
+          { taskId: task.id, title: 'Draft v2', status: 'done', previousStatus: 'started' },
+        ]);
+      },
+      Effect.provide(TestTraceService.layer),
       Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
-    );
-  });
+    ),
+  );
 
-  /** Collects what the handler wrote to the trace, so a status change can be asserted on. */
-  const collectingTrace = (messages: Trace.Message[]) =>
-    Trace.testTraceService().pipe(
-      Layer.provide(
-        Layer.succeed(Trace.TraceSink, {
-          write: (message) => {
-            messages.push(message);
-          },
-        }),
-      ),
-    );
-
-  const statusEvents = (messages: readonly Trace.Message[]) =>
-    messages
-      .flatMap((message) => message.events)
+  const statusEvents = (events: readonly Trace.FlatEvent[]) =>
+    events
       .filter((event) => event.type === Trace.TaskStatusChanged.key)
       .map((event) => Schema.decodeUnknownSync(Trace.TaskStatusChanged.schema)(event.data));
 });

--- a/packages/plugins/plugin-tasks/src/operations/update-task.test.ts
+++ b/packages/plugins/plugin-tasks/src/operations/update-task.test.ts
@@ -4,7 +4,10 @@
 
 import { describe, expect, it } from '@effect/vitest';
 import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import * as Schema from 'effect/Schema';
 
+import * as Trace from '@dxos/compute/Trace';
 import { Database, Filter, Obj, Ref } from '@dxos/echo';
 import { TestDatabaseLayer } from '@dxos/echo-client/testing';
 import { Milestone, RemoteSession, Task, TaskSet } from '@dxos/types';
@@ -29,7 +32,10 @@ describe('update-task', () => {
       expect(task.priority).toBe('low');
       expect(task.status).toBe('started');
       expect(task.estimate).toBe('m');
-    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] }))),
+    }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    ),
   );
 
   it.effect('assigns a coding-agent session by its harness id, creating the session record', () =>
@@ -56,6 +62,7 @@ describe('update-task', () => {
       expect(task.assignee?.role).toBe('assistant');
       expect(Task.refEntityId(task.assignee!.subject!)).toBe(sessions[0].id);
     }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
       Effect.provide(
         TestDatabaseLayer({
           types: [Milestone.Milestone, RemoteSession.RemoteSession, Task.Task, TaskSet.TaskSet],
@@ -85,6 +92,7 @@ describe('update-task', () => {
       // since the session reports its own state and this call is not that report.
       expect(existing.title).toBe('Draft the thing');
     }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
       Effect.provide(
         TestDatabaseLayer({
           types: [Milestone.Milestone, RemoteSession.RemoteSession, Task.Task, TaskSet.TaskSet],
@@ -116,7 +124,10 @@ describe('update-task', () => {
       // Re-applying the same patch is not an event: it left the task exactly as it was.
       yield* updateTask.handler({ task: Ref.make(task), status: 'done' });
       expect(task.history).toHaveLength(1);
-    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] }))),
+    }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    ),
   );
 
   it.effect('clears an optional field with null', () =>
@@ -135,7 +146,10 @@ describe('update-task', () => {
 
       expect(task.assignee).toBeUndefined();
       expect(task.history?.at(-1)?.description).toEqual('Unassigned.');
-    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] }))),
+    }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    ),
   );
 
   it.effect('clearing parentTask clears the lifecycle edge, not just the ref', () =>
@@ -155,7 +169,10 @@ describe('update-task', () => {
       // Membership is untouched by promotion: the edge points at the set before and after.
       expect(child.parentTask).toBeUndefined();
       expect(Obj.getParent(child)?.id).toBe(taskSet.id);
-    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] }))),
+    }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    ),
   );
 
   it.effect('clears the lifecycle edge for a task belonging to no set', () =>
@@ -172,7 +189,10 @@ describe('update-task', () => {
 
       expect(child.parentTask).toBeUndefined();
       expect(Obj.getParent(child)).toBeUndefined();
-    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] }))),
+    }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    ),
   );
 
   it.effect('refuses to re-parent a task under its own sub-task', () =>
@@ -188,7 +208,10 @@ describe('update-task', () => {
 
       const exit = yield* Effect.exit(updateTask.handler({ task: Ref.make(parent), parentTask: Ref.make(child) }));
       expect(exit._tag).toBe('Failure');
-    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] }))),
+    }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    ),
   );
 
   it.effect('promotes a sub-task back to a root with a null parentTask', () =>
@@ -207,6 +230,52 @@ describe('update-task', () => {
       expect(child.parentTask).toBeUndefined();
       expect(Obj.getParent(child)?.id).toBe(taskSet.id);
       expect(taskSet.tasks.map((ref) => ref.target?.id)).toEqual([parent.id, child.id]);
-    }).pipe(Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] }))),
+    }).pipe(
+      Effect.provide(Trace.writerLayerNoop),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    ),
   );
+});
+
+/** Collects what the handler wrote to the trace, so a status change can be asserted on. */
+const collectingTrace = (messages: Trace.Message[]) =>
+  Trace.testTraceService().pipe(
+    Layer.provide(
+      Layer.succeed(Trace.TraceSink, {
+        write: (message) => {
+          messages.push(message);
+        },
+      }),
+    ),
+  );
+
+const statusEvents = (messages: readonly Trace.Message[]) =>
+  messages
+    .flatMap((message) => message.events)
+    .filter((event) => event.type === Trace.TaskStatusChanged.key)
+    .map((event) => Schema.decodeUnknownSync(Trace.TaskStatusChanged.schema)(event.data));
+
+describe('update-task tracing', () => {
+  it.effect('traces a status change, and stays silent when the status is unchanged', () => {
+    const messages: Trace.Message[] = [];
+    return Effect.gen(function* () {
+      const taskSet = yield* Database.add(TaskSet.make({}));
+      yield* Database.flush();
+      const { task } = yield* createTask.handler({ taskSet: Ref.make(taskSet), title: 'Draft' });
+
+      yield* updateTask.handler({ task: Ref.make(task), status: 'started' });
+      // Only the status change is traced: a title edit moves nothing on the timeline.
+      yield* updateTask.handler({ task: Ref.make(task), title: 'Draft v2' });
+      yield* updateTask.handler({ task: Ref.make(task), status: 'started' });
+      yield* updateTask.handler({ task: Ref.make(task), status: 'done' });
+
+      expect(statusEvents(messages)).toEqual([
+        { taskId: task.id, title: 'Draft', status: 'started', previousStatus: 'todo' },
+        { taskId: task.id, title: 'Draft v2', status: 'done', previousStatus: 'started' },
+      ]);
+    }).pipe(
+      Effect.provide(collectingTrace(messages)),
+      Effect.provide(TestDatabaseLayer({ types: [Milestone.Milestone, Task.Task, TaskSet.TaskSet] })),
+    );
+  });
 });

--- a/packages/plugins/plugin-tasks/src/operations/update-task.ts
+++ b/packages/plugins/plugin-tasks/src/operations/update-task.ts
@@ -5,6 +5,7 @@
 import * as Effect from 'effect/Effect';
 
 import * as Operation from '@dxos/compute/Operation';
+import * as Trace from '@dxos/compute/Trace';
 import { Database, Filter, Obj, Ref } from '@dxos/echo';
 import { Actor, RemoteSession, Task, TaskSet } from '@dxos/types';
 
@@ -48,7 +49,18 @@ const handler: Operation.WithHandler<typeof TaskOperation.UpdateTask> = TaskOper
 
       // Through `Task.edit`, so the change and the log entry that explains it land together and a
       // no-op patch records nothing. Milestone stays here: it is set membership, not a field edit.
+      const previousStatus = task.status;
       Task.update(task, { title, description, status, priority, estimate, assignee: sessionAssignee ?? assignee });
+      // The resolved status, not the requested one: a task with reviewers lands in `review`. This is
+      // what cuts an agent session's timeline into per-task segments.
+      if (task.status !== undefined && task.status !== previousStatus) {
+        yield* Trace.write(Trace.TaskStatusChanged, {
+          taskId: task.id,
+          title: task.title,
+          status: task.status,
+          ...(previousStatus ? { previousStatus } : {}),
+        });
+      }
 
       if (milestone !== undefined) {
         Obj.update(task, (task) => {

--- a/packages/plugins/plugin-tasks/src/types/TaskOperation.ts
+++ b/packages/plugins/plugin-tasks/src/types/TaskOperation.ts
@@ -7,6 +7,7 @@
 import * as Schema from 'effect/Schema';
 
 import * as Operation from '@dxos/compute/Operation';
+import * as Trace from '@dxos/compute/Trace';
 import { Database, Format, Obj, Ref, Type } from '@dxos/echo';
 import { DXN } from '@dxos/keys';
 // Person is referenced in Actor.Actor's inferred type (via the contact ref); importing it lets
@@ -73,7 +74,7 @@ export const UpdateTask = Operation.make({
       'creating the session record in the space if it is not there yet.',
     icon: 'ph--pencil-simple--regular',
   },
-  services: [Database.Service],
+  services: [Database.Service, Trace.TraceService],
   input: Schema.Struct({
     task: Ref.Ref(Task.Task),
     title: Schema.optional(Schema.String),

--- a/packages/ui/react-ui-components/src/components/Gantt/Gantt.tsx
+++ b/packages/ui/react-ui-components/src/components/Gantt/Gantt.tsx
@@ -12,7 +12,7 @@ import { Unit } from '@dxos/util';
 
 export type GanttLaneKind = 'session' | 'task';
 export type GanttLaneStatus = 'pending' | 'blocked' | 'running' | 'review' | 'done' | 'failed';
-export type GanttMarkerKind = 'request' | 'operation' | 'tool' | 'message' | 'error' | 'delegation';
+export type GanttMarkerKind = 'request' | 'operation' | 'tool' | 'message' | 'error' | 'delegation' | 'task';
 
 export type GanttLane = {
   id: string;


### PR DESCRIPTION
The session gantt drew every trace event of a run on one session bar, smooshed together, with the task lanes below it empty — there was no way to tell which task a tool call belonged to.

Nothing in a trace said which task an agent was working on, so both tools that move a task's status now write a new `task.statusChanged` trace event (`@dxos/compute/Trace`, emitted from the planning tool's `update-tasks` and from `plugin-tasks`' `UpdateTask` — the delegated project flow reaches for the latter). `buildSessionTimeline` reads those events to cut a session into one segment per task: the task lane gets a span of its own, nodes where it started and finished, and every marker inside the segment is attributed to it.

### Before / after

The chart region of the project's pipeline, in each case after a live agent run over the four tasks of the `Incident 0516 retrospective` template. **These are two separate runs** — the "before" was recorded on the pre-fix commit, so its totals differ (30 tools / 1,290.0k vs 34 / 939.4k); the flow and the template are the same.

Before — four empty task lanes, every node on the session bar:
https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-09-12-gantt-task-separation/chart-before.png

After — one bar per task, each carrying the events of its own stretch of the run:
https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-09-12-gantt-task-separation/chart-after.png

### Demo

[**Live run, 2:04**](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-09-12-gantt-task-separation/gantt-task-separation.webm) — recorded from `stories-assistant / Projects / Default` against a real EDGE agent, driven one gesture at a time: pick the template, select all four tasks, show the pipeline chart, assign them to an agent, and watch each task claim its lane as its status events land. The run itself took 5m11s; the recording is trimmed of still frames and ends on a hold of the finished chart. [Full frame](https://pub-39066a86073446d7b77b1c157b660bb5.r2.dev/demos/2026-09-12-gantt-task-separation/43-final.png).

The video shows only the after state — the before is the still linked above, from its own run.

### How the cut is scoped

Four ways it could go wrong, each guarded and pinned by a test:

- **Only tasks on the session's own checklist take part.** An agent is free to move a task belonging to nothing on this chart; such an event must not close the open segment or move the boundary, so the checklist is an allow-set inside `buildTaskSegments` rather than a filter over its result.
- **A task that is only ever closed** — delegation marks everything it hands over `started` before the agent's first turn — is cut from the previous boundary, but only on the transition out of `started`, so a task merely dismissed (`todo` → `blocked`) claims nothing and a second close (`review` → `done`) mints nothing.
- **A close can arrive after the next task has started.** That stretch is the next task's, so the close-only fallback never synthesizes a segment while another task is open.
- **A delegated task is drawn as the child session that worked it**, so its segment is dropped rather than moved onto a bar whose span does not contain those markers. One consequence worth knowing: for a fully delegated task, its `Task started` / `Task done` nodes stay on the supervisor bar, which is where that work (the handover) happened.

A status tool runs as a child process of the agent, so its trace events carry their own pid and reach the session through `parentPid`; segmenting on the session's own pids alone saw none of them.

The pipeline chart also draws its own lane names and per-lane totals now (`Gantt.Legend` + `Gantt.Meta`): a ledger row is several lines tall and a chart row is one, so nothing lined up between them.

### Tests

`session-timeline.test.ts` 10 passed — segmentation, the delegated-run cut, off-checklist scoping, dismissed/re-closed tasks, an interleaved close, and delegation × segmentation. Trace-emission tests in `update-tasks.test.ts` (assistant-toolkit, reading the events back off the trace feed) and `update-task.test.ts` (plugin-tasks). Both, and the timeline suite, now run on `TestTraceService` from `@dxos/compute/testing`: `TestTraceService.layer` provides the collector with the writer and sink that feed it, and `yield* TestTraceService.messages` reads back what a handler wrote.

Full suites green for `compute`, `assistant`, `assistant-toolkit`, `plugin-assistant`, `plugin-tasks`, `plugin-projects`, `react-ui-components`; lint and `oxfmt --check` clean.

The diff was reviewed adversarially by a second agent, which found three defects in the first cut of the segmentation; CodeRabbit found a fourth (the interleaved close). All four are the guards listed above.

### Open question

`Ref<Task.Task>` in the event instead of `taskId` was requested in review. The feed test says the trace path cannot carry a ref correctly today: the ref's target is inlined as a stale snapshot, the DXN loses its space (`echo:///<id>`), a ref read back has no resolver, and a live subscriber sees a `Ref` instance where a feed reader sees the envelope — because `Trace.Event.data` is `Schema.Unknown`. Details and options are on the `update-task.ts` review thread; the branch keeps `taskId` pending that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY9A67e56DV9CB1jB9PFGf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XY9A67e56DV9CB1jB9PFGf)_